### PR TITLE
Add https_proxy support to maven plugin.

### DIFF
--- a/snapcraft/plugins/maven.py
+++ b/snapcraft/plugins/maven.py
@@ -51,12 +51,20 @@ _MVN_SETTINGS_FORMAT = (
     '  <interactiveMode>false</interactiveMode>\n'
     '  <proxies>\n'
     '    <proxy>\n'
-    '      <id>proxy</id>\n'
+    '      <id>http_proxy</id>\n'
     '      <active>true</active>\n'
     '      <protocol>http</protocol>\n'
-    '      <host>{}</host>\n'
-    '      <port>{}</port>\n'
-    '      <nonProxyHosts>{}</nonProxyHosts>\n'
+    '      <host>{http_host}</host>\n'
+    '      <port>{http_port}</port>\n'
+    '      <nonProxyHosts>{non_proxy_hosts}</nonProxyHosts>\n'
+    '    </proxy>\n'
+    '    <proxy>\n'
+    '      <id>https_proxy</id>\n'
+    '      <active>true</active>\n'
+    '      <protocol>https</protocol>\n'
+    '      <host>{https_host}</host>\n'
+    '      <port>{https_port}</port>\n'
+    '      <nonProxyHosts>{non_proxy_hosts}</nonProxyHosts>\n'
     '    </proxy>\n'
     '  </proxies>\n'
     '</settings>\n'
@@ -114,13 +122,16 @@ class MavenPlugin(snapcraft.plugins.jdk.JdkPlugin):
 
 
 def _create_settings(settings_path):
-    proxy = urlparse(os.environ['http_proxy'])
+    http_proxy = urlparse(os.environ['http_proxy'])
+    https_proxy = urlparse(os.environ['https_proxy'])
     os.makedirs(os.path.dirname(settings_path), exist_ok=True)
     with open(settings_path, 'w') as f:
         f.write(_MVN_SETTINGS_FORMAT.format(
-            proxy.hostname,
-            proxy.port,
-            _get_no_proxy_string()))
+            http_host=http_proxy.hostname,
+            http_port=http_proxy.port,
+            https_host=https_proxy.hostname,
+            https_port=https_proxy.port,
+            non_proxy_hosts=_get_no_proxy_string()))
 
 
 def _get_no_proxy_string():

--- a/snapcraft/plugins/maven.py
+++ b/snapcraft/plugins/maven.py
@@ -56,6 +56,8 @@ _MVN_SETTINGS_FORMAT = (
     '      <protocol>http</protocol>\n'
     '      <host>{http_host}</host>\n'
     '      <port>{http_port}</port>\n'
+    '      <username>{http_username}</username>\n'
+    '      <password>{http_password}</password>\n'
     '      <nonProxyHosts>{non_proxy_hosts}</nonProxyHosts>\n'
     '    </proxy>\n'
     '    <proxy>\n'
@@ -64,6 +66,8 @@ _MVN_SETTINGS_FORMAT = (
     '      <protocol>https</protocol>\n'
     '      <host>{https_host}</host>\n'
     '      <port>{https_port}</port>\n'
+    '      <username>{https_username}</username>\n'
+    '      <password>{https_password}</password>\n'
     '      <nonProxyHosts>{non_proxy_hosts}</nonProxyHosts>\n'
     '    </proxy>\n'
     '  </proxies>\n'
@@ -129,8 +133,12 @@ def _create_settings(settings_path):
         f.write(_MVN_SETTINGS_FORMAT.format(
             http_host=http_proxy.hostname,
             http_port=http_proxy.port,
+            http_username=http_proxy.username or '',
+            http_password=http_proxy.password or '',
             https_host=https_proxy.hostname,
             https_port=https_proxy.port,
+            https_username=https_proxy.username or '',
+            https_password=https_proxy.password or '',
             non_proxy_hosts=_get_no_proxy_string()))
 
 

--- a/snapcraft/tests/test_plugin_maven.py
+++ b/snapcraft/tests/test_plugin_maven.py
@@ -88,6 +88,7 @@ class MavenPluginTestCase(tests.TestCase):
         env_vars = (
             ('SNAPCRAFT_SETUP_PROXIES', '1',),
             ('http_proxy', 'http://localhost:3132'),
+            ('https_proxy', 'https://localhost:3132'),
             ('no_proxy', None),
         )
         for v in env_vars:
@@ -121,9 +122,17 @@ class MavenPluginTestCase(tests.TestCase):
             '  <interactiveMode>false</interactiveMode>\n'
             '  <proxies>\n'
             '    <proxy>\n'
-            '      <id>proxy</id>\n'
+            '      <id>http_proxy</id>\n'
             '      <active>true</active>\n'
             '      <protocol>http</protocol>\n'
+            '      <host>localhost</host>\n'
+            '      <port>3132</port>\n'
+            '      <nonProxyHosts>localhost</nonProxyHosts>\n'
+            '    </proxy>\n'
+            '    <proxy>\n'
+            '      <id>https_proxy</id>\n'
+            '      <active>true</active>\n'
+            '      <protocol>https</protocol>\n'
             '      <host>localhost</host>\n'
             '      <port>3132</port>\n'
             '      <nonProxyHosts>localhost</nonProxyHosts>\n'
@@ -138,6 +147,7 @@ class MavenPluginTestCase(tests.TestCase):
         env_vars = (
             ('SNAPCRAFT_SETUP_PROXIES', '1',),
             ('http_proxy', 'http://localhost:3132'),
+            ('https_proxy', 'https://localhost:3132'),
             ('no_proxy', 'internal'),
         )
         for v in env_vars:
@@ -171,9 +181,17 @@ class MavenPluginTestCase(tests.TestCase):
             '  <interactiveMode>false</interactiveMode>\n'
             '  <proxies>\n'
             '    <proxy>\n'
-            '      <id>proxy</id>\n'
+            '      <id>http_proxy</id>\n'
             '      <active>true</active>\n'
             '      <protocol>http</protocol>\n'
+            '      <host>localhost</host>\n'
+            '      <port>3132</port>\n'
+            '      <nonProxyHosts>internal</nonProxyHosts>\n'
+            '    </proxy>\n'
+            '    <proxy>\n'
+            '      <id>https_proxy</id>\n'
+            '      <active>true</active>\n'
+            '      <protocol>https</protocol>\n'
             '      <host>localhost</host>\n'
             '      <port>3132</port>\n'
             '      <nonProxyHosts>internal</nonProxyHosts>\n'
@@ -188,6 +206,7 @@ class MavenPluginTestCase(tests.TestCase):
         env_vars = (
             ('SNAPCRAFT_SETUP_PROXIES', '1',),
             ('http_proxy', 'http://localhost:3132'),
+            ('https_proxy', 'https://localhost:3132'),
             ('no_proxy', 'internal, pseudo-dmz'),
         )
         for v in env_vars:
@@ -221,9 +240,17 @@ class MavenPluginTestCase(tests.TestCase):
             '  <interactiveMode>false</interactiveMode>\n'
             '  <proxies>\n'
             '    <proxy>\n'
-            '      <id>proxy</id>\n'
+            '      <id>http_proxy</id>\n'
             '      <active>true</active>\n'
             '      <protocol>http</protocol>\n'
+            '      <host>localhost</host>\n'
+            '      <port>3132</port>\n'
+            '      <nonProxyHosts>internal|pseudo-dmz</nonProxyHosts>\n'
+            '    </proxy>\n'
+            '    <proxy>\n'
+            '      <id>https_proxy</id>\n'
+            '      <active>true</active>\n'
+            '      <protocol>https</protocol>\n'
             '      <host>localhost</host>\n'
             '      <port>3132</port>\n'
             '      <nonProxyHosts>internal|pseudo-dmz</nonProxyHosts>\n'

--- a/snapcraft/tests/test_plugin_maven.py
+++ b/snapcraft/tests/test_plugin_maven.py
@@ -87,8 +87,8 @@ class MavenPluginTestCase(tests.TestCase):
     def test_build_with_snapcraft_proxy(self, glob_mock, run_mock):
         env_vars = (
             ('SNAPCRAFT_SETUP_PROXIES', '1',),
-            ('http_proxy', 'http://localhost:3132'),
-            ('https_proxy', 'https://localhost:3132'),
+            ('http_proxy', 'http://foo:bar@localhost:3132'),
+            ('https_proxy', 'https://baz:qux@localhost:3132'),
             ('no_proxy', None),
         )
         for v in env_vars:
@@ -127,6 +127,8 @@ class MavenPluginTestCase(tests.TestCase):
             '      <protocol>http</protocol>\n'
             '      <host>localhost</host>\n'
             '      <port>3132</port>\n'
+            '      <username>foo</username>\n'
+            '      <password>bar</password>\n'
             '      <nonProxyHosts>localhost</nonProxyHosts>\n'
             '    </proxy>\n'
             '    <proxy>\n'
@@ -135,6 +137,8 @@ class MavenPluginTestCase(tests.TestCase):
             '      <protocol>https</protocol>\n'
             '      <host>localhost</host>\n'
             '      <port>3132</port>\n'
+            '      <username>baz</username>\n'
+            '      <password>qux</password>\n'
             '      <nonProxyHosts>localhost</nonProxyHosts>\n'
             '    </proxy>\n'
             '  </proxies>\n'
@@ -186,6 +190,8 @@ class MavenPluginTestCase(tests.TestCase):
             '      <protocol>http</protocol>\n'
             '      <host>localhost</host>\n'
             '      <port>3132</port>\n'
+            '      <username></username>\n'
+            '      <password></password>\n'
             '      <nonProxyHosts>internal</nonProxyHosts>\n'
             '    </proxy>\n'
             '    <proxy>\n'
@@ -194,6 +200,8 @@ class MavenPluginTestCase(tests.TestCase):
             '      <protocol>https</protocol>\n'
             '      <host>localhost</host>\n'
             '      <port>3132</port>\n'
+            '      <username></username>\n'
+            '      <password></password>\n'
             '      <nonProxyHosts>internal</nonProxyHosts>\n'
             '    </proxy>\n'
             '  </proxies>\n'
@@ -245,6 +253,8 @@ class MavenPluginTestCase(tests.TestCase):
             '      <protocol>http</protocol>\n'
             '      <host>localhost</host>\n'
             '      <port>3132</port>\n'
+            '      <username></username>\n'
+            '      <password></password>\n'
             '      <nonProxyHosts>internal|pseudo-dmz</nonProxyHosts>\n'
             '    </proxy>\n'
             '    <proxy>\n'
@@ -253,6 +263,8 @@ class MavenPluginTestCase(tests.TestCase):
             '      <protocol>https</protocol>\n'
             '      <host>localhost</host>\n'
             '      <port>3132</port>\n'
+            '      <username></username>\n'
+            '      <password></password>\n'
             '      <nonProxyHosts>internal|pseudo-dmz</nonProxyHosts>\n'
             '    </proxy>\n'
             '  </proxies>\n'


### PR DESCRIPTION
No https_proxy configuration is written to the maven configuration file.

Snaps using the maven plugin which fetch dependencies over https can't currently be built on launchpad. Ideally I would like to test this change against a ppa on launchpad's test build infrastructure before this is considered for merging. 

lpbug: https://bugs.launchpad.net/snapcraft/+bug/1592218