### PR TITLE
Migration from ubuntu-core to snapcore

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -37,7 +37,7 @@ You can install the daily build PPA by running:
 
 We'd love the help!
 
-- Submit pull requests against [snapcraft](https://github.com/ubuntu-core/snapcraft/pulls)
+- Submit pull requests against [snapcraft](https://github.com/snapcore/snapcraft/pulls)
 - Make sure to read the [contribution guide](CONTRIBUTING.md)
 - Our mailing list is snapcraft@lists.ubuntu.com
 - We can also be found on the #snappy IRC channel on Freenode

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ transactional update system.
 * [Introduction](docs/intro.md) to all the details about the concepts behind snapcraft.
 * [Hacking guide](HACKING.md) to contribute if you're interested in developing Snapcraft.
 
-[travis-image]: https://travis-ci.org/ubuntu-core/snapcraft.svg?branch=master
-[travis-url]: https://travis-ci.org/ubuntu-core/snapcraft
+[travis-image]: https://travis-ci.org/snapcore/snapcraft.svg?branch=master
+[travis-url]: https://travis-ci.org/snapcore/snapcraft
 
-[coveralls-image]: https://coveralls.io/repos/ubuntu-core/snapcraft/badge.svg?branch=master&service=github
-[coveralls-url]: https://coveralls.io/github/ubuntu-core/snapcraft?branch=master
+[coveralls-image]: https://coveralls.io/repos/snapcore/snapcraft/badge.svg?branch=master&service=github
+[coveralls-url]: https://coveralls.io/github/snapcore/snapcraft?branch=master
 
-[overview-image]: https://rawgit.com/ubuntu-core/snapcraft/master/docs/images/snapcraft_overview.svg
+[overview-image]: https://rawgit.com/snapcore/snapcraft/master/docs/images/snapcraft_overview.svg

--- a/debian/control
+++ b/debian/control
@@ -27,8 +27,8 @@ Build-Depends: bash-completion,
                python3-xdg,
                python3-yaml,
                squashfs-tools,
-Homepage: https://github.com/ubuntu-core/snapcraft
-Vcs-Git: https://github.com/ubuntu-core/snapcraft
+Homepage: https://github.com/snapcore/snapcraft
+Vcs-Git: https://github.com/snapcore/snapcraft
 Standards-Version: 3.9.7
 
 Package: snapcraft

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,7 +1,7 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: Snapcraft
 Upstream-Contact: Snapcraft Team <snappy-devel@lists.ubuntu.com>
-Source: https://github.com/ubuntu-core/snapcraft
+Source: https://github.com/snapcore/snapcraft
 
 Files: *
 Copyright: 2015, 2016 Canonical Ltd

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -22,4 +22,4 @@ Once your Ubuntu system is up and running, simply install Snapcraft:
 
 How about putting together [your first snap](your-first-snap.md) now?
 
-[1]: https://github.com/ubuntu-core/snapcraft/blob/1.x/docs/get-started.md
+[1]: https://github.com/snapcore/snapcraft/blob/1.x/docs/get-started.md

--- a/docs/mir-snaps.md
+++ b/docs/mir-snaps.md
@@ -135,6 +135,6 @@ image size. For example:
 $ qemu-img resize xenial_core_amd64.img +1G
 ```
 
-[vm-image]: https://raw.githubusercontent.com/ubuntu-core/snapcraft/master/docs/images/ubuntucore_in_vmm.png
-[core-image]: https://raw.githubusercontent.com/ubuntu-core/snapcraft/master/docs/images/core_running_mir.png
-[clock-image]: https://raw.githubusercontent.com/ubuntu-core/snapcraft/master/docs/images/clocks_on_mir_on_ubuntucore.png
+[vm-image]: https://raw.githubusercontent.com/snapcore/snapcraft/master/docs/images/ubuntucore_in_vmm.png
+[core-image]: https://raw.githubusercontent.com/snapcore/snapcraft/master/docs/images/core_running_mir.png
+[clock-image]: https://raw.githubusercontent.com/snapcore/snapcraft/master/docs/images/clocks_on_mir_on_ubuntucore.png

--- a/docs/snapcraft-advanced-features.md
+++ b/docs/snapcraft-advanced-features.md
@@ -10,12 +10,12 @@ of what is possible and generally relevant.
 Our showcase can be found in the actual source of `snapcraft` itself. Check
 it out by simply running:
 
-	git clone https://github.com/ubuntu-core/snapcraft
+	git clone https://github.com/snapcore/snapcraft
 	cd snapcraft/demos
 
 Inspecting the source locally will make easier to build the demos and
 play around with them. (You can
-[view them online](https://github.com/ubuntu-core/snapcraft/tree/master/demos)
+[view them online](https://github.com/snapcore/snapcraft/tree/master/demos)
 as well.)
 
 ### Playing around with the demos

--- a/docs/your-first-snap.md
+++ b/docs/your-first-snap.md
@@ -23,7 +23,7 @@ Namely, we'll combine a web server with a webcam program and combine
 them to serve a new frame every ten seconds.
 
 > The resulting package is also part of the demos directory in the
-> [snapcraft sources](https://github.com/ubuntu-core/snapcraft/tree/master/demos/webcam-webui)
+> [snapcraft sources](https://github.com/snapcore/snapcraft/tree/master/demos/webcam-webui)
 
 ### The Web Server
 
@@ -314,7 +314,7 @@ Well done, your first snap using snapcraft is ready. If you want to check out
 a few demos for reference or to get inspired, have a look at the
 `demos` directory in the source directory of snapcraft:
 
-    git clone https://github.com/ubuntu-core/snapcraft
+    git clone https://github.com/snapcore/snapcraft
     cd snapcraft/demos
 
 In `demos/` you can find a diverse set of examples which should help you

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     version=version,
     description='Easily craft snaps from multiple sources',
     author_email='snappy-devel@lists.ubuntu.com',
-    url='https://github.com/ubuntu-core/snapcraft',
+    url='https://github.com/snapcore/snapcraft',
     packages=['snapcraft',
               'snapcraft.internal',
               'snapcraft.internal.states',

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -110,7 +110,7 @@ class _SnapPackaging:
             # TODO: use developer.ubuntu.com once it has updated documentation.
             logger.warning(
                 "DEPRECATED: 'icon' defined in snapcraft.yaml. Look at "
-                "https://github.com/ubuntu-core/snapcraft/blob/master/docs/"
+                "https://github.com/snapcore/snapcraft/blob/master/docs/"
                 "metadata.md#snap-icon for more information")
             icon_ext = self._config_data['icon'].split(os.path.extsep)[1]
             icon_dir = os.path.join(self.meta_dir, 'gui')

--- a/snapcraft/internal/pluginhandler.py
+++ b/snapcraft/internal/pluginhandler.py
@@ -127,7 +127,7 @@ class PluginHandler:
             logger.warning(
                 'DEPRECATED: the plugin used by part {!r} needs to be updated '
                 'to accept project options in its initializer. See '
-                'https://github.com/ubuntu-core/snapcraft/blob/master/docs/'
+                'https://github.com/snapcore/snapcraft/blob/master/docs/'
                 'plugins.md#initializing-a-plugin for more information'.format(
                     self.name))
             self.code = plugin(self.name, options)


### PR DESCRIPTION
Update debian packaging, docs and links to point to snapcore
instead of ubuntu-core

LP: #1597006

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>