### PR TITLE
parser - Don't allow duplicate wiki entries.

### DIFF
--- a/snapcraft/internal/parser.py
+++ b/snapcraft/internal/parser.py
@@ -230,6 +230,13 @@ def _process_index(output):
             except ScannerError as e:
                 logger.warning(
                     'Bad wiki entry, possibly malformed YAML: {}'.format(e))
+
+            part_name = data.get('project-part')
+            if part_name is not None and part_name in master_parts_list:
+                logger.warning("Duplicate part found in wiki: {}".format(
+                    part_name))
+                continue
+
             try:
                 parts_list, after_parts = _process_entry(data)
             except InvalidEntryError as e:

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -14,10 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import os
 from unittest import mock
 
 import requests
+import fixtures
 import yaml
 
 from snapcraft.internal.parser import (
@@ -652,6 +654,10 @@ project-part: 'somepart'
     @mock.patch('snapcraft.internal.sources.get')
     def test_duplicate_entries(self, mock_get, mock_get_origin_data):
         """Test duplicate parts are ignored."""
+
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
         _create_example_output("""
 ---
 maintainer: John Doe <john.doe@example.com>
@@ -679,3 +685,7 @@ project-part: main
         self.assertEqual('example main', part['description'])
 
         self.assertEqual(1, _get_part_list_count())
+
+        self.assertTrue(
+            'Duplicate part found in wiki: main'
+            in fake_logger.output, 'Missing duplicate part info in output')

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -647,3 +647,35 @@ project-part: 'somepart'
         self.assertEqual(1, _get_part_list_count())
         part = _get_part('somepart')
         self.assertTrue(part is not None)
+
+    @mock.patch('snapcraft.internal.parser._get_origin_data')
+    @mock.patch('snapcraft.internal.sources.get')
+    def test_duplicate_entries(self, mock_get, mock_get_origin_data):
+        """Test duplicate parts are ignored."""
+        _create_example_output("""
+---
+maintainer: John Doe <john.doe@example.com>
+origin: lp:snapcraft-parser-example
+description: example main
+project-part: main
+---
+maintainer: Jim Doe <jim.doe@example.com>
+origin: lp:snapcraft-parser-example
+description: example main duplicate
+project-part: main
+""")
+        mock_get_origin_data.return_value = {
+            'parts': {
+                'main': {
+                    'source': 'lp:project',
+                    'plugin': 'copy',
+                    'files': ['file1', 'file2'],
+                },
+            }
+        }
+        main(['--debug', '--index', TEST_OUTPUT_PATH])
+
+        part = _get_part('main')
+        self.assertEqual('example main', part['description'])
+
+        self.assertEqual(1, _get_part_list_count())


### PR DESCRIPTION
LP:#1597057

The first entry is retained and all duplicates are reported via a
warning and skipped.