### PR TITLE
Fix trivial typo in warning for Go plugin (bug 1590245)

### DIFF
--- a/snapcraft/plugins/go.py
+++ b/snapcraft/plugins/go.py
@@ -127,7 +127,7 @@ class GoPlugin(snapcraft.BasePlugin):
             go_package = self.options.go_importpath
         else:
             logger.warning(
-                'Please consider setting `go-importpath for the {!r} '
+                'Please consider setting `go-importpath` for the {!r} '
                 'part'.format(self.name))
             go_package = os.path.basename(
                os.path.abspath(self.options.source))


### PR DESCRIPTION
This fixes the typo detailed in [bug 1590245](https://bugs.launchpad.net/snapcraft/+bug/1590245).