### PR TITLE
Correctly check !# for commands in PATH

### DIFF
--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -217,15 +217,14 @@ class _SnapPackaging:
 
         wrapexec = '$SNAP/{}'.format(execparts[0])
         if not os.path.exists(exepath) and '/' not in execparts[0]:
-            _find_bin(execparts[0], self._snap_dir)
-            wrapexec = execparts[0]
-        else:
-            with open(exepath, 'rb') as exefile:
-                # If the file has a she-bang, the path might be pointing to
-                # the local 'parts' dir. Extract it so that _write_wrap_exe
-                # will have a chance to rewrite it.
-                if exefile.read(2) == b'#!':
-                    shebang = exefile.readline().strip().decode('utf-8')
+            exepath = _find_bin(execparts[0], self._snap_dir)
+
+        with open(exepath, 'rb') as exefile:
+            # If the file has a she-bang, the path might be pointing to
+            # the local 'parts' dir. Extract it so that _write_wrap_exe
+            # will have a chance to rewrite it.
+            if exefile.read(2) == b'#!':
+                shebang = exefile.readline().strip().decode('utf-8')
 
         self._write_wrap_exe(wrapexec, wrappath,
                              shebang=shebang, args=execparts[1:])
@@ -257,7 +256,7 @@ def _find_bin(binary, basedir):
         tempf.write(script)
         tempf.flush()
         try:
-            common.run(['/bin/sh', tempf.name], cwd=basedir,
-                       stdout=subprocess.DEVNULL)
-        except subprocess.CalledProcessError:
-            raise CommandError(binary)
+            output = common.run_output(['/bin/sh', tempf.name], cwd=basedir)
+            return output
+        except subprocess.CalledProcessError as e:
+            raise CommandError(binary) from e

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -472,9 +472,10 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         with open(os.path.join(self.snap_dir, relative_exe_path), 'rb') as exe:
             self.assertEqual(exe_contents, exe.read())
 
-    @patch('snapcraft.internal.common.run')
-    def test_exe_is_in_path(self, run_mock):
+    @patch('snapcraft.internal.common.run_output')
+    def test_exe_is_in_path(self, run_mock_output):
         app_path = os.path.join(self.snap_dir, 'bin', 'app1')
+        run_mock_output.return_value = app_path
         os.mkdir(os.path.dirname(app_path))
         open(app_path, 'w').close()
 
@@ -484,7 +485,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         expected = ('#!/bin/sh\n'
                     '\n\n'
                     'LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n'
-                    'exec "app1" "$@"\n')
+                    'exec "$SNAP/app1" "$@"\n')
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
 


### PR DESCRIPTION
Commands that were in PATH weren't hashbang checked. This
makes it always the case and makes the `command` always
relative to the $SNAP.

LP: #1597919

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>