### PR TITLE
Added new maven-targets option to maven plugin.

### DIFF
--- a/snapcraft/plugins/maven.py
+++ b/snapcraft/plugins/maven.py
@@ -119,22 +119,19 @@ class MavenPlugin(snapcraft.plugins.jdk.JdkPlugin):
 
             jarfiles = glob.glob(os.path.join(src, '*.jar'))
             warfiles = glob.glob(os.path.join(src, '*.war'))
+            arfiles = glob.glob(os.path.join(src, '*.(j|w)ar'))
 
-            if len(f) > 0 and jarfiles:
+            if not (arfiles):
+                raise RuntimeError('could not find any built jar files for part')
+            elif len(f) > 0:
                 basedir = f
-                files = jarfiles
-            elif len(f) > 0 and warfiles:
-                basedir = f
-                files = warfiles
+                files = arfiles
             elif jarfiles:
                 basedir = 'jar'
                 files = jarfiles
-            elif warfiles:
+            else:
                 basedir = 'war'
                 files = jarfiles
-            else:
-                raise RuntimeError("could not find any"
-                                   "built jar files for part")
 
             targetdir = os.path.join(self.installdir, basedir)
             os.makedirs(targetdir, exist_ok=True)

--- a/snapcraft/plugins/maven.py
+++ b/snapcraft/plugins/maven.py
@@ -118,17 +118,16 @@ class MavenPlugin(snapcraft.plugins.jdk.JdkPlugin):
             src = os.path.join(self.builddir, f, 'target')
 
             jarfiles = glob.glob(os.path.join(src, '*.jar'))
-            warfiles = glob.glob(os.path.join(src, '*.war'))
             arfiles = glob.glob(os.path.join(src, '*.[jw]ar'))
 
             if not (arfiles):
-                raise RuntimeError('could not find any built jar files for part')
+                raise RuntimeError("could not find any"
+                                   "built jar files for part")
+            basedir = 'war'
             if len(f) > 0:
                 basedir = f
             elif jarfiles:
                 basedir = 'jar'
-            else:
-                basedir = 'war'
 
             targetdir = os.path.join(self.installdir, basedir)
             os.makedirs(targetdir, exist_ok=True)

--- a/snapcraft/plugins/maven.py
+++ b/snapcraft/plugins/maven.py
@@ -118,6 +118,7 @@ class MavenPlugin(snapcraft.plugins.jdk.JdkPlugin):
             src = os.path.join(self.builddir, f, 'target')
 
             jarfiles = glob.glob(os.path.join(src, '*.jar'))
+            warfiles = glob.glob(os.path.join(src, '*.war'))
             arfiles = glob.glob(os.path.join(src, '*.[jw]ar'))
 
             if not (arfiles):

--- a/snapcraft/plugins/maven.py
+++ b/snapcraft/plugins/maven.py
@@ -123,11 +123,8 @@ class MavenPlugin(snapcraft.plugins.jdk.JdkPlugin):
             if not (arfiles):
                 raise RuntimeError("could not find any"
                                    "built jar files for part")
-            basedir = 'war'
-            if len(f) > 0:
-                basedir = f
-            elif jarfiles:
-                basedir = 'jar'
+            basedir = 'jar' if jarfiles and len(f) == 0 else (
+                      'war' if warfiles and len(f) == 0 else f)
 
             targetdir = os.path.join(self.installdir, basedir)
             os.makedirs(targetdir, exist_ok=True)

--- a/snapcraft/plugins/maven.py
+++ b/snapcraft/plugins/maven.py
@@ -119,23 +119,20 @@ class MavenPlugin(snapcraft.plugins.jdk.JdkPlugin):
 
             jarfiles = glob.glob(os.path.join(src, '*.jar'))
             warfiles = glob.glob(os.path.join(src, '*.war'))
-            arfiles = glob.glob(os.path.join(src, '*.(j|w)ar'))
+            arfiles = glob.glob(os.path.join(src, '*.[jw]ar'))
 
             if not (arfiles):
                 raise RuntimeError('could not find any built jar files for part')
-            elif len(f) > 0:
+            if len(f) > 0:
                 basedir = f
-                files = arfiles
             elif jarfiles:
                 basedir = 'jar'
-                files = jarfiles
             else:
                 basedir = 'war'
-                files = jarfiles
 
             targetdir = os.path.join(self.installdir, basedir)
             os.makedirs(targetdir, exist_ok=True)
-            self.run(['cp', '-a'] + files + [targetdir])
+            self.run(['cp', '-a'] + arfiles + [targetdir])
 
 
 def _create_settings(settings_path):

--- a/snapcraft/plugins/maven.py
+++ b/snapcraft/plugins/maven.py
@@ -78,9 +78,20 @@ class MavenPlugin(snapcraft.plugins.jdk.JdkPlugin):
             'default': [],
         }
 
+        schema['properties']['maven-targets'] = {
+            'type': 'array',
+            'minitems': 1,
+            'uniqueItems': True,
+            'items': {
+                'type': 'string',
+            },
+            'default': [''],
+        }
+
         # Inform Snapcraft of the properties associated with building. If these
         # change in the YAML Snapcraft will consider the build step dirty.
         schema['build-properties'].append('maven-options')
+        schema['build-properties'].append('maven-targets')
 
         return schema
 
@@ -103,18 +114,31 @@ class MavenPlugin(snapcraft.plugins.jdk.JdkPlugin):
 
         self.run(mvn_cmd + self.options.maven_options)
 
-        jarfiles = glob.glob(os.path.join(self.builddir, 'target', '*.jar'))
-        warfiles = glob.glob(os.path.join(self.builddir, 'target', '*.war'))
-        if not (jarfiles or warfiles):
-            raise RuntimeError('could not find any built jar files for part')
-        if jarfiles:
-            jardir = os.path.join(self.installdir, 'jar')
-            os.makedirs(jardir, exist_ok=True)
-            self.run(['cp', '-a'] + jarfiles + [jardir])
-        if warfiles:
-            wardir = os.path.join(self.installdir, 'war')
-            os.makedirs(wardir, exist_ok=True)
-            self.run(['cp', '-a'] + warfiles + [wardir])
+        for f in self.options.maven_targets:
+            src = os.path.join(self.builddir, f, 'target')
+
+            jarfiles = glob.glob(os.path.join(src, '*.jar'))
+            warfiles = glob.glob(os.path.join(src, '*.war'))
+
+            if len(f) > 0 and jarfiles:
+                basedir = f
+                files = jarfiles
+            elif len(f) > 0 and warfiles:
+                basedir = f
+                files = warfiles
+            elif jarfiles:
+                basedir = 'jar'
+                files = jarfiles
+            elif warfiles:
+                basedir = 'war'
+                files = jarfiles
+            else:
+                raise RuntimeError("could not find any"
+                                   "built jar files for part")
+
+            targetdir = os.path.join(self.installdir, basedir)
+            os.makedirs(targetdir, exist_ok=True)
+            self.run(['cp', '-a'] + files + [targetdir])
 
 
 def _create_settings(settings_path):

--- a/snapcraft/tests/test_plugin_maven.py
+++ b/snapcraft/tests/test_plugin_maven.py
@@ -112,6 +112,9 @@ class MavenPluginTestCase(tests.TestCase):
             mock.call(['mvn', 'package']),
         ])
 
+    @mock.patch.object(maven.MavenPlugin, 'run')
+    @mock.patch('glob.glob')
+    def test_build_with_exception(self, glob_mock, run_mock):
         plugin = maven.MavenPlugin('test-part', self.options,
                                    self.project_options)
         os.makedirs(plugin.sourcedir)
@@ -119,11 +122,8 @@ class MavenPluginTestCase(tests.TestCase):
             os.path.join(plugin.builddir, 'target', 'dummy')]
 
         plugin.options.maven_targets = ['custom']
-        plugin.build()
-
-        run_mock.assert_has_calls([
-            mock.call(['mvn', 'package']),
-        ])
+        with self.assertRaises(RuntimeError) as raised:
+            plugin.build()
 
     @mock.patch.object(maven.MavenPlugin, 'run')
     @mock.patch('glob.glob')

--- a/snapcraft/tests/test_plugin_maven.py
+++ b/snapcraft/tests/test_plugin_maven.py
@@ -112,6 +112,19 @@ class MavenPluginTestCase(tests.TestCase):
             mock.call(['mvn', 'package']),
         ])
 
+        plugin = maven.MavenPlugin('test-part', self.options,
+                                   self.project_options)
+        os.makedirs(plugin.sourcedir)
+        glob_mock.return_value = [
+            os.path.join(plugin.builddir, 'target', 'dummy')]
+
+        plugin.options.maven_targets = ['custom']
+        plugin.build()
+
+        run_mock.assert_has_calls([
+            mock.call(['mvn', 'package']),
+        ])
+
     @mock.patch.object(maven.MavenPlugin, 'run')
     @mock.patch('glob.glob')
     def test_build_with_snapcraft_proxy(self, glob_mock, run_mock):

--- a/snapcraft/tests/test_plugin_maven.py
+++ b/snapcraft/tests/test_plugin_maven.py
@@ -31,6 +31,7 @@ class MavenPluginTestCase(tests.TestCase):
 
         class Options:
             maven_options = []
+            maven_targets = ['']
 
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
@@ -70,8 +71,31 @@ class MavenPluginTestCase(tests.TestCase):
             maven_options['uniqueItems'],
             'Expected "maven-options" "uniqueItems" to be "True"')
 
+        maven_targets = properties['maven-targets']
+
+        self.assertTrue(
+            'type' in maven_targets,
+            'Expected "type" to be included in "maven-targets"')
+        self.assertEqual(maven_targets['type'], 'array',
+                         'Expected "maven-targets" "type" to be "array", but '
+                         'it was "{}"'.format(maven_targets['type']))
+
+        self.assertTrue(
+            'minitems' in maven_targets,
+            'Expected "minitems" to be included in "maven-targets"')
+        self.assertEqual(maven_targets['minitems'], 1,
+                         'Expected "maven-targets" "minitems" to be 1, but '
+                         'it was "{}"'.format(maven_targets['minitems']))
+
+        self.assertTrue(
+            'uniqueItems' in maven_targets,
+            'Expected "uniqueItems" to be included in "maven-targets"')
+        self.assertTrue(
+            maven_targets['uniqueItems'],
+            'Expected "maven-targets" "uniqueItems" to be "True"')
+
         build_properties = schema['build-properties']
-        self.assertEqual(['maven-options'], build_properties)
+        self.assertEqual(['maven-options', 'maven-targets'], build_properties)
 
     @mock.patch.object(maven.MavenPlugin, 'run')
     @mock.patch('glob.glob')

--- a/snapcraft/tests/test_plugin_maven.py
+++ b/snapcraft/tests/test_plugin_maven.py
@@ -114,19 +114,6 @@ class MavenPluginTestCase(tests.TestCase):
 
     @mock.patch.object(maven.MavenPlugin, 'run')
     @mock.patch('glob.glob')
-    def test_build_with_exception(self, glob_mock, run_mock):
-        plugin = maven.MavenPlugin('test-part', self.options,
-                                   self.project_options)
-        os.makedirs(plugin.sourcedir)
-        glob_mock.return_value = [
-            os.path.join(plugin.builddir, 'target', 'dummy')]
-
-        plugin.options.maven_targets = ['custom']
-        with self.assertRaises(RuntimeError) as raised:
-            plugin.build()
-
-    @mock.patch.object(maven.MavenPlugin, 'run')
-    @mock.patch('glob.glob')
     def test_build_with_snapcraft_proxy(self, glob_mock, run_mock):
         env_vars = (
             ('SNAPCRAFT_SETUP_PROXIES', '1',),


### PR DESCRIPTION
Composite maven projects do not build to 'target'. This update allows the user to specify the child target to copy.

```yml
parts:
  algolink-mvn:
    plugin: maven
    source: .
    maven-targets:
      - algolink-gui
      - algolink-cli
```
By default, the basedir/target directory is searched, otherwise it uses the 'target' directory of each specified value.
The installdir for each child project is the name of the child project. If no values are specified, it reverts to the default of 'jar' or 'war' depending on the target type of the project.