### PR TITLE
Fix the store integration tests

### DIFF
--- a/integration_tests/test_store_register.py
+++ b/integration_tests/test_store_register.py
@@ -80,9 +80,11 @@ class RegisterTestCase(integration_tests.TestCase):
 
         self.register(snap_name_1, wait=False)
 
+        # Wait after the registration attempt, so the following registrations
+        # don't get the error.
         error = self.assertRaises(
             subprocess.CalledProcessError,
-            self.register, snap_name_2, wait=False)
+            self.register, snap_name_2, wait=True)
         expected = (
             '.*You must wait \d+ seconds before trying to register your '
             'next snap.*')

--- a/integration_tests/test_store_register.py
+++ b/integration_tests/test_store_register.py
@@ -17,6 +17,7 @@
 import os
 import re
 import subprocess
+import time
 import uuid
 
 from testtools.matchers import Contains, MatchesRegex
@@ -72,6 +73,9 @@ class RegisterTestCase(integration_tests.TestCase):
         self.assertThat(str(error.output), Contains('register-name-dispute'))
 
     def test_registrations_in_a_row_fail_if_too_fast(self):
+        # Wait after the registration attempts, so the following registrations
+        # don't get the error.
+        self.addCleanup(time.sleep, 10)
         # This test has a potential to fail if working off a slow
         # network.
         self.login(expect_success=True)
@@ -80,11 +84,9 @@ class RegisterTestCase(integration_tests.TestCase):
 
         self.register(snap_name_1, wait=False)
 
-        # Wait after the registration attempt, so the following registrations
-        # don't get the error.
         error = self.assertRaises(
             subprocess.CalledProcessError,
-            self.register, snap_name_2, wait=True)
+            self.register, snap_name_2, wait=False)
         expected = (
             '.*You must wait \d+ seconds before trying to register your '
             'next snap.*')


### PR DESCRIPTION
The tests were failing because we added a new one that attempts to register
two snaps too fast, in order to check the error the store sends for too many
attempts. After the second registration, we need to wait a little so the
following tests can register without getting the same error.

LP: #1599268