### PR TITLE
parser - Handle malformed wiki entries.

### DIFF
--- a/integration_tests/test_parser.py
+++ b/integration_tests/test_parser.py
@@ -18,6 +18,7 @@ import os
 import subprocess
 
 import integration_tests
+from snapcraft.tests import fixture_setup
 
 
 class TestParser(integration_tests.TestCase):
@@ -25,10 +26,12 @@ class TestParser(integration_tests.TestCase):
 
     def test_parser_basic(self):
         """Test snapcraft-parser basic usage"""
+        fixture = fixture_setup.FakePartsWiki()
+        self.useFixture(fixture)
 
         args = [self.snapcraft_parser_command, '--index',
-                'https://wiki.ubuntu.com/snapcraft/parts?action=raw',
-                '--output', 'parts.yaml']
+                fixture.fake_parts_wiki_fixture.url,
+                '--debug', '--output', 'parts.yaml']
         subprocess.check_call(args, stderr=subprocess.DEVNULL,
                               stdout=subprocess.DEVNULL)
 

--- a/snapcraft/internal/parser.py
+++ b/snapcraft/internal/parser.py
@@ -224,7 +224,6 @@ def _process_index(output):
     # proceed when invalid yaml is found.
     entries = output.split(b'\n---\n')
     for entry in entries:
-        print("JOE: entry: {}".format(entry))
         if entry != b'':
             try:
                 data = yaml.load(entry)

--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -121,6 +121,35 @@ maintainer: none
         self.wfile.write(response.encode())
 
 
+class FakePartsWikiOriginServer(http.server.HTTPServer):
+
+    def __init__(self, server_address):
+        super().__init__(
+            server_address, FakePartsWikiOriginRequestHandler)
+
+
+class FakePartsWikiOriginRequestHandler(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        logger.debug('Handling getting part origin')
+        if self.headers.get('If-None-Match') == '1111':
+            self.send_response(304)
+            response = {}
+        else:
+            self.send_response(200)
+            response = """
+parts:
+  somepart:
+    source: https://github.com/someuser/somepart.git
+    plugin: nil
+"""
+        self.send_header('Content-Type', 'text/plain')
+        if 'NO_CONTENT_LENGTH' not in os.environ:
+            self.send_header('Content-Length', len(response.encode()))
+        self.end_headers()
+        self.wfile.write(response.encode())
+
+
 class FakeSSOServer(http.server.HTTPServer):
 
     def __init__(self, server_address):

--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -90,6 +90,38 @@ class FakePartsRequestHandler(BaseHTTPRequestHandler):
         self.wfile.write(yaml.dump(response).encode())
 
 
+class FakePartsWikiServer(http.server.HTTPServer):
+
+    def __init__(self, server_address):
+        super().__init__(
+            server_address, FakePartsWikiRequestHandler)
+
+
+class FakePartsWikiRequestHandler(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        logger.debug('Handling getting parts')
+        if self.headers.get('If-None-Match') == '1111':
+            self.send_response(304)
+            response = {}
+        else:
+            self.send_response(200)
+            response = """
+---
+origin: https://github.com/sergiusens/curl.git
+project-part: curl
+description:
+  Description here
+maintainer: none
+"""
+        self.send_header('Content-Type', 'text/plain')
+        if 'NO_CONTENT_LENGTH' not in os.environ:
+            self.send_header('Content-Length', len(response.encode()))
+        self.send_header('ETag', '1111')
+        self.end_headers()
+        self.wfile.write(response.encode())
+
+
 class FakeSSOServer(http.server.HTTPServer):
 
     def __init__(self, server_address):

--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -117,7 +117,6 @@ maintainer: none
         self.send_header('Content-Type', 'text/plain')
         if 'NO_CONTENT_LENGTH' not in os.environ:
             self.send_header('Content-Length', len(response.encode()))
-        self.send_header('ETag', '1111')
         self.end_headers()
         self.wfile.write(response.encode())
 

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -129,6 +129,17 @@ class FakePartsWiki(fixtures.Fixture):
             'no_proxy', 'localhost,127.0.0.1'))
 
 
+class FakePartsWikiOrigin(fixtures.Fixture):
+
+    def setUp(self):
+        super().setUp()
+
+        self.fake_parts_wiki_origin_fixture = FakePartsWikiOriginRunning()
+        self.useFixture(self.fake_parts_wiki_origin_fixture)
+        self.useFixture(fixtures.EnvironmentVariable(
+            'no_proxy', 'localhost,127.0.0.1'))
+
+
 class FakeParts(fixtures.Fixture):
 
     def setUp(self):
@@ -200,6 +211,11 @@ class _FakeServerRunning(fixtures.Fixture):
         self.server.shutdown()
         self.server.socket.close()
         thread.join()
+
+
+class FakePartsWikiOriginRunning(_FakeServerRunning):
+
+    fake_server = fake_servers.FakePartsWikiOriginServer
 
 
 class FakePartsWikiRunning(_FakeServerRunning):

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -119,6 +119,7 @@ class FakeTerminal(fixtures.Fixture):
 
 
 class FakePartsWiki(fixtures.Fixture):
+
     def setUp(self):
         super().setUp()
 

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -118,6 +118,16 @@ class FakeTerminal(fixtures.Fixture):
         return self.mock_stdout.getvalue()
 
 
+class FakePartsWiki(fixtures.Fixture):
+    def setUp(self):
+        super().setUp()
+
+        self.fake_parts_wiki_fixture = FakePartsWikiRunning()
+        self.useFixture(self.fake_parts_wiki_fixture)
+        self.useFixture(fixtures.EnvironmentVariable(
+            'no_proxy', 'localhost,127.0.0.1'))
+
+
 class FakeParts(fixtures.Fixture):
 
     def setUp(self):
@@ -189,6 +199,11 @@ class _FakeServerRunning(fixtures.Fixture):
         self.server.shutdown()
         self.server.socket.close()
         thread.join()
+
+
+class FakePartsWikiRunning(_FakeServerRunning):
+
+    fake_server = fake_servers.FakePartsWikiServer
 
 
 class FakePartsServerRunning(_FakeServerRunning):

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -556,3 +556,45 @@ description: example
         }
         main(['--debug', '--index', TEST_OUTPUT_PATH])
         self.assertEqual(0, _get_part_list_count())
+
+    @mock.patch('snapcraft.internal.parser._get_origin_data')
+    @mock.patch('snapcraft.internal.sources.get')
+    def test_partial_processing_for_malformed_yaml(self,
+                                                   mock_get,
+                                                   mock_get_origin_data):
+        _create_example_output("""
+---
+maintainer: John Doe <john.doe@example.com>
+origin: lp:snapcraft-parser-example
+description:
+  example
+
+  Usage
+    blahblahblah
+project-part: 'main'
+---
+maintainer: John Doeson <john.doeson@example.com>
+origin: lp:snapcraft-parser-example
+description:
+  example
+
+  Usage:
+    blahblahblah
+project-part: 'main2'
+""")
+        mock_get_origin_data.return_value = {
+            'parts': {
+                'main': {
+                    'source': 'lp:something',
+                    'plugin': 'copy',
+                    'files': ['file1', 'file2'],
+                },
+                'main2': {
+                    'source': 'lp:something',
+                    'plugin': 'copy',
+                    'files': ['file1', 'file2'],
+                },
+            }
+        }
+        main(['--debug', '--index', TEST_OUTPUT_PATH])
+        self.assertEqual(1, _get_part_list_count())

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -64,7 +64,6 @@ class TestParser(TestCase):
         subpart = 'subpart'
 
         result = _get_namespaced_partname(partname, subpart)
-        logging.warn('JOE: result: {}'.format(result))
 
         self.assertEqual('{p}{s}{sp}'.format(p=partname,
                                              s=PART_NAMESPACE_SEP,

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -26,8 +26,7 @@ from snapcraft.internal.parser import (
     PARTS_FILE,
     main,
 )
-from snapcraft.tests import TestCase
-
+from snapcraft.tests import TestCase, fixture_setup
 
 TEST_OUTPUT_PATH = os.path.join(os.getcwd(), 'test_output.wiki')
 
@@ -596,4 +595,25 @@ project-part: 'main2'
             }
         }
         main(['--debug', '--index', TEST_OUTPUT_PATH])
+        self.assertEqual(1, _get_part_list_count())
+
+    @mock.patch('snapcraft.internal.parser._get_origin_data')
+    @mock.patch('snapcraft.internal.sources.get')
+    def test_wiki_interactions_with_fake(self,
+                                         mock_get,
+                                         mock_get_origin_data):
+
+        fixture = fixture_setup.FakePartsWiki()
+        self.useFixture(fixture)
+
+        mock_get_origin_data.return_value = {
+            'parts': {
+                'curl': {
+                    'source': 'lp:something',
+                    'plugin': 'copy',
+                    'files': ['file1', 'file2'],
+                },
+            }
+        }
+        main(['--debug', '--index', fixture.fake_parts_wiki_fixture.url])
         self.assertEqual(1, _get_part_list_count())


### PR DESCRIPTION
* Split wiki into separate entries so that a YAML error in
  one document does not stop the parser from parsing the rest
  of the documents.

* Use a FakeServer for integration tests.

LP:#1599598