### PR TITLE
Setup the FakeParts store for all unit tests

### DIFF
--- a/snapcraft/tests/__init__.py
+++ b/snapcraft/tests/__init__.py
@@ -57,6 +57,8 @@ class TestCase(testscenarios.WithScenarios, fixtures.TestWithFixtures):
                              '..', '..', '..', 'schema'))
         self.useFixture(fixtures.FakeLogger(level=logging.ERROR))
 
+        self.useFixture(fixture_setup.FakeParts())
+
         patcher = mock.patch('multiprocessing.cpu_count')
         self.cpu_count = patcher.start()
         self.cpu_count.return_value = 2

--- a/snapcraft/tests/test_commands_define.py
+++ b/snapcraft/tests/test_commands_define.py
@@ -19,14 +19,9 @@ from unittest import mock
 
 from snapcraft import main, tests
 from snapcraft.internal import parts
-from snapcraft.tests import fixture_setup
 
 
 class DefineCommandTestCase(tests.TestCase):
-
-    def setUp(self):
-        super().setUp()
-        self.useFixture(fixture_setup.FakeParts())
 
     @mock.patch('sys.stdout', new_callable=io.StringIO)
     def test_defining_a_part_that_exists(self, mock_stdout):

--- a/snapcraft/tests/test_commands_search.py
+++ b/snapcraft/tests/test_commands_search.py
@@ -24,10 +24,6 @@ from snapcraft.tests import fixture_setup
 
 class SearchCommandTestCase(tests.TestCase):
 
-    def setUp(self):
-        super().setUp()
-        self.useFixture(fixture_setup.FakeParts())
-
     def test_searching_for_a_part_that_exists(self):
         fake_terminal = fixture_setup.FakeTerminal()
         self.useFixture(fake_terminal)

--- a/snapcraft/tests/test_commands_update.py
+++ b/snapcraft/tests/test_commands_update.py
@@ -23,15 +23,12 @@ import yaml
 from xdg import BaseDirectory
 
 from snapcraft import main, tests
-from snapcraft.tests import fixture_setup
 
 
 class UpdateCommandTestCase(tests.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.useFixture(fixture_setup.FakeParts())
-
         self.parts_dir = os.path.join(BaseDirectory.xdg_data_home, 'snapcraft')
         self.parts_yaml = os.path.join(self.parts_dir, 'parts.yaml')
         self.headers_yaml = os.path.join(self.parts_dir, 'headers.yaml')

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -28,8 +28,6 @@ import snapcraft
 from snapcraft.internal import dirs, parts
 from snapcraft.internal import yaml as internal_yaml
 from snapcraft import tests
-from snapcraft.tests import fixture_setup
-
 from snapcraft._schema import SnapcraftSchemaError
 
 
@@ -92,8 +90,6 @@ parts:
 
     @unittest.mock.patch('snapcraft.internal.yaml.Config.load_plugin')
     def test_config_composes_with_remote_parts(self, mock_loadPlugin):
-        self.useFixture(fixture_setup.FakeParts())
-
         self.make_snapcraft_yaml("""name: test
 version: "1"
 summary: test
@@ -113,8 +109,6 @@ parts:
             'stage': [], 'snap': []})
 
     def test_config_composes_with_a_non_existent_remote_part(self):
-        self.useFixture(fixture_setup.FakeParts())
-
         self.make_snapcraft_yaml("""name: test
 version: "1"
 summary: test
@@ -137,8 +131,6 @@ parts:
             'to refresh'.format('non-existing-part'))
 
     def test_config_after_is_an_undefined_part(self):
-        self.useFixture(fixture_setup.FakeParts())
-
         self.make_snapcraft_yaml("""name: test
 version: "1"
 summary: test
@@ -163,8 +155,6 @@ parts:
 
     @unittest.mock.patch('snapcraft.internal.pluginhandler.load_plugin')
     def test_config_uses_remote_part_from_after(self, mock_load):
-        self.useFixture(fixture_setup.FakeParts())
-
         self.make_snapcraft_yaml("""name: test
 version: "1"
 summary: test


### PR DESCRIPTION
Now that we run snapcraft update by deftault to get an initial
remote parts cache, most (not all) test require the FakeParts
fixture to be setup.

LP: #1600273

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>