### PR TITLE
Make maven plugin honour https_proxy and proxy authentication

### DIFF
--- a/integration_tests/test_maven_plugin.py
+++ b/integration_tests/test_maven_plugin.py
@@ -14,17 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import fixtures
-
 import integration_tests
 
 
 class MavenPluginTestCase(integration_tests.TestCase):
-
-    def setUp(self):
-        super().setUp()
-        self.useFixture(
-            fixtures.EnvironmentVariable('SNAPCRAFT_SETUP_PROXIES', '1'))
 
     def test_build_maven_plugin(self):
         project_dir = 'simple-maven'

--- a/snapcraft/plugins/maven.py
+++ b/snapcraft/plugins/maven.py
@@ -34,6 +34,7 @@ import glob
 import logging
 import os
 from urllib.parse import urlparse
+from xml.etree import ElementTree
 
 import snapcraft
 import snapcraft.common
@@ -41,26 +42,6 @@ import snapcraft.plugins.jdk
 
 
 logger = logging.getLogger(__name__)
-
-
-_MVN_SETTINGS_FORMAT = (
-    '<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"\n'
-    '          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n'
-    '          xsi:schemaLocation="http://maven.apache.org/SETTINGS/'
-    '1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">\n'
-    '  <interactiveMode>false</interactiveMode>\n'
-    '  <proxies>\n'
-    '    <proxy>\n'
-    '      <id>proxy</id>\n'
-    '      <active>true</active>\n'
-    '      <protocol>http</protocol>\n'
-    '      <host>{}</host>\n'
-    '      <port>{}</port>\n'
-    '      <nonProxyHosts>{}</nonProxyHosts>\n'
-    '    </proxy>\n'
-    '  </proxies>\n'
-    '</settings>\n'
-)
 
 
 class MavenPlugin(snapcraft.plugins.jdk.JdkPlugin):
@@ -89,8 +70,7 @@ class MavenPlugin(snapcraft.plugins.jdk.JdkPlugin):
         self.build_packages.append('maven')
 
     def _use_proxy(self):
-        return all([k in os.environ for k in
-                    ('SNAPCRAFT_SETUP_PROXIES', 'http_proxy')])
+        return any(k in os.environ for k in ('http_proxy', 'https_proxy'))
 
     def build(self):
         super().build()
@@ -118,13 +98,47 @@ class MavenPlugin(snapcraft.plugins.jdk.JdkPlugin):
 
 
 def _create_settings(settings_path):
-    proxy = urlparse(os.environ['http_proxy'])
+    settings = ElementTree.Element('settings', attrib={
+        'xmlns': 'http://maven.apache.org/SETTINGS/1.0.0',
+        'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+        'xsi:schemaLocation': (
+            'http://maven.apache.org/SETTINGS/1.0.0 '
+            'http://maven.apache.org/xsd/settings-1.0.0.xsd'),
+        })
+    element = ElementTree.Element('interactiveMode')
+    element.text = 'false'
+    settings.append(element)
+    proxies = ElementTree.Element('proxies')
+    for protocol in ('http', 'https'):
+        env_name = '{}_proxy'.format(protocol)
+        if env_name not in os.environ:
+            continue
+        proxy_url = urlparse(os.environ[env_name])
+        proxy = ElementTree.Element('proxy')
+        proxy_tags = [
+            ('id', env_name),
+            ('active', 'true'),
+            ('protocol', protocol),
+            ('host', proxy_url.hostname),
+            ('port', str(proxy_url.port)),
+            ]
+        if proxy_url.username is not None:
+            proxy_tags.extend([
+                ('username', proxy_url.username),
+                ('password', proxy_url.password),
+                ])
+        proxy_tags.append(('nonProxyHosts', _get_no_proxy_string()))
+        for tag, text in proxy_tags:
+            element = ElementTree.Element(tag)
+            element.text = text
+            proxy.append(element)
+        proxies.append(proxy)
+    settings.append(proxies)
+    tree = ElementTree.ElementTree(settings)
     os.makedirs(os.path.dirname(settings_path), exist_ok=True)
     with open(settings_path, 'w') as f:
-        f.write(_MVN_SETTINGS_FORMAT.format(
-            proxy.hostname,
-            proxy.port,
-            _get_no_proxy_string()))
+        tree.write(f, encoding='unicode')
+        f.write('\n')
 
 
 def _get_no_proxy_string():

--- a/snapcraft/tests/test_plugin_maven.py
+++ b/snapcraft/tests/test_plugin_maven.py
@@ -14,8 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import io
 import os
 from unittest import mock
+from xml.etree import ElementTree
 
 import fixtures
 
@@ -38,6 +40,28 @@ class MavenPluginTestCase(tests.TestCase):
         patcher = mock.patch('snapcraft.repo.Ubuntu')
         self.ubuntu_mock = patcher.start()
         self.addCleanup(patcher.stop)
+
+    @staticmethod
+    def _canonicalize_settings(settings):
+        with io.StringIO(settings) as f:
+            tree = ElementTree.parse(f)
+        for element in tree.iter():
+            if element.text is not None and element.text.isspace():
+                element.text = None
+            if element.tail is not None and element.tail.isspace():
+                element.tail = None
+        with io.StringIO() as f:
+            tree.write(
+                f, encoding='unicode',
+                default_namespace='http://maven.apache.org/SETTINGS/1.0.0')
+            return f.getvalue() + '\n'
+
+    def assertSettingsEqual(self, expected, observed):
+        print(repr(self._canonicalize_settings(expected)))
+        print(repr(self._canonicalize_settings(observed)))
+        self.assertEqual(
+            self._canonicalize_settings(expected),
+            self._canonicalize_settings(observed))
 
     def test_schema(self):
         schema = maven.MavenPlugin.schema()
@@ -76,6 +100,13 @@ class MavenPluginTestCase(tests.TestCase):
     @mock.patch.object(maven.MavenPlugin, 'run')
     @mock.patch('glob.glob')
     def test_build(self, glob_mock, run_mock):
+        env_vars = (
+            ('http_proxy', None),
+            ('https_proxy', None),
+        )
+        for v in env_vars:
+            self.useFixture(fixtures.EnvironmentVariable(v[0], v[1]))
+
         plugin = maven.MavenPlugin('test-part', self.options,
                                    self.project_options)
         os.makedirs(plugin.sourcedir)
@@ -90,10 +121,10 @@ class MavenPluginTestCase(tests.TestCase):
 
     @mock.patch.object(maven.MavenPlugin, 'run')
     @mock.patch('glob.glob')
-    def test_build_with_snapcraft_proxy(self, glob_mock, run_mock):
+    def test_build_with_http_proxy(self, glob_mock, run_mock):
         env_vars = (
-            ('SNAPCRAFT_SETUP_PROXIES', '1',),
             ('http_proxy', 'http://localhost:3132'),
+            ('https_proxy', None),
             ('no_proxy', None),
         )
         for v in env_vars:
@@ -128,7 +159,7 @@ class MavenPluginTestCase(tests.TestCase):
             '  <interactiveMode>false</interactiveMode>\n'
             '  <proxies>\n'
             '    <proxy>\n'
-            '      <id>proxy</id>\n'
+            '      <id>http_proxy</id>\n'
             '      <active>true</active>\n'
             '      <protocol>http</protocol>\n'
             '      <host>localhost</host>\n'
@@ -137,14 +168,14 @@ class MavenPluginTestCase(tests.TestCase):
             '    </proxy>\n'
             '  </proxies>\n'
             '</settings>\n')
-        self.assertEqual(settings_contents, expected_contents)
+        self.assertSettingsEqual(expected_contents, settings_contents)
 
     @mock.patch.object(maven.MavenPlugin, 'run')
     @mock.patch('glob.glob')
-    def test_build_with_proxy_and_no_proxy(self, glob_mock, run_mock):
+    def test_build_with_http_proxy_and_no_proxy(self, glob_mock, run_mock):
         env_vars = (
-            ('SNAPCRAFT_SETUP_PROXIES', '1',),
             ('http_proxy', 'http://localhost:3132'),
+            ('https_proxy', None),
             ('no_proxy', 'internal'),
         )
         for v in env_vars:
@@ -179,7 +210,7 @@ class MavenPluginTestCase(tests.TestCase):
             '  <interactiveMode>false</interactiveMode>\n'
             '  <proxies>\n'
             '    <proxy>\n'
-            '      <id>proxy</id>\n'
+            '      <id>http_proxy</id>\n'
             '      <active>true</active>\n'
             '      <protocol>http</protocol>\n'
             '      <host>localhost</host>\n'
@@ -188,14 +219,14 @@ class MavenPluginTestCase(tests.TestCase):
             '    </proxy>\n'
             '  </proxies>\n'
             '</settings>\n')
-        self.assertEqual(settings_contents, expected_contents)
+        self.assertSettingsEqual(expected_contents, settings_contents)
 
     @mock.patch.object(maven.MavenPlugin, 'run')
     @mock.patch('glob.glob')
-    def test_build_with_proxy_and_no_proxies(self, glob_mock, run_mock):
+    def test_build_with_http_proxy_and_no_proxies(self, glob_mock, run_mock):
         env_vars = (
-            ('SNAPCRAFT_SETUP_PROXIES', '1',),
             ('http_proxy', 'http://localhost:3132'),
+            ('https_proxy', None),
             ('no_proxy', 'internal, pseudo-dmz'),
         )
         for v in env_vars:
@@ -230,7 +261,7 @@ class MavenPluginTestCase(tests.TestCase):
             '  <interactiveMode>false</interactiveMode>\n'
             '  <proxies>\n'
             '    <proxy>\n'
-            '      <id>proxy</id>\n'
+            '      <id>http_proxy</id>\n'
             '      <active>true</active>\n'
             '      <protocol>http</protocol>\n'
             '      <host>localhost</host>\n'
@@ -239,4 +270,126 @@ class MavenPluginTestCase(tests.TestCase):
             '    </proxy>\n'
             '  </proxies>\n'
             '</settings>\n')
-        self.assertEqual(settings_contents, expected_contents)
+        self.assertSettingsEqual(expected_contents, settings_contents)
+
+    @mock.patch.object(maven.MavenPlugin, 'run')
+    @mock.patch('glob.glob')
+    def test_build_with_http_and_https_proxy(self, glob_mock, run_mock):
+        env_vars = (
+            ('http_proxy', 'http://localhost:3132'),
+            ('https_proxy', 'http://localhost:3133'),
+            ('no_proxy', None),
+        )
+        for v in env_vars:
+            self.useFixture(fixtures.EnvironmentVariable(v[0], v[1]))
+
+        plugin = maven.MavenPlugin('test-part', self.options,
+                                   self.project_options)
+
+        settings_path = os.path.join(plugin.partdir, 'm2', 'settings.xml')
+        os.makedirs(plugin.sourcedir)
+        glob_mock.return_value = [
+            os.path.join(plugin.builddir, 'target', 'dummy')]
+
+        plugin.build()
+
+        run_mock.assert_has_calls([
+            mock.call(['mvn', 'package', '-s', settings_path]),
+        ])
+
+        self.assertTrue(
+            os.path.exists(settings_path),
+            'expected {!r} to exist'.format(settings_path))
+
+        with open(settings_path) as f:
+            settings_contents = f.read()
+
+        expected_contents = (
+            '<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"\n'
+            '          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n'
+            '          xsi:schemaLocation="http://maven.apache.org/SETTINGS/'
+            '1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">\n'
+            '  <interactiveMode>false</interactiveMode>\n'
+            '  <proxies>\n'
+            '    <proxy>\n'
+            '      <id>http_proxy</id>\n'
+            '      <active>true</active>\n'
+            '      <protocol>http</protocol>\n'
+            '      <host>localhost</host>\n'
+            '      <port>3132</port>\n'
+            '      <nonProxyHosts>localhost</nonProxyHosts>\n'
+            '    </proxy>\n'
+            '    <proxy>\n'
+            '      <id>https_proxy</id>\n'
+            '      <active>true</active>\n'
+            '      <protocol>https</protocol>\n'
+            '      <host>localhost</host>\n'
+            '      <port>3133</port>\n'
+            '      <nonProxyHosts>localhost</nonProxyHosts>\n'
+            '    </proxy>\n'
+            '  </proxies>\n'
+            '</settings>\n')
+        self.assertSettingsEqual(expected_contents, settings_contents)
+
+    @mock.patch.object(maven.MavenPlugin, 'run')
+    @mock.patch('glob.glob')
+    def test_build_with_authenticated_proxies(self, glob_mock, run_mock):
+        env_vars = (
+            ('http_proxy', 'http://user1:pass1@localhost:3132'),
+            ('https_proxy', 'http://user2:pass2@localhost:3133'),
+            ('no_proxy', None),
+        )
+        for v in env_vars:
+            self.useFixture(fixtures.EnvironmentVariable(v[0], v[1]))
+
+        plugin = maven.MavenPlugin('test-part', self.options,
+                                   self.project_options)
+
+        settings_path = os.path.join(plugin.partdir, 'm2', 'settings.xml')
+        os.makedirs(plugin.sourcedir)
+        glob_mock.return_value = [
+            os.path.join(plugin.builddir, 'target', 'dummy')]
+
+        plugin.build()
+
+        run_mock.assert_has_calls([
+            mock.call(['mvn', 'package', '-s', settings_path]),
+        ])
+
+        self.assertTrue(
+            os.path.exists(settings_path),
+            'expected {!r} to exist'.format(settings_path))
+
+        with open(settings_path) as f:
+            settings_contents = f.read()
+
+        expected_contents = (
+            '<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"\n'
+            '          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n'
+            '          xsi:schemaLocation="http://maven.apache.org/SETTINGS/'
+            '1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">\n'
+            '  <interactiveMode>false</interactiveMode>\n'
+            '  <proxies>\n'
+            '    <proxy>\n'
+            '      <id>http_proxy</id>\n'
+            '      <active>true</active>\n'
+            '      <protocol>http</protocol>\n'
+            '      <host>localhost</host>\n'
+            '      <port>3132</port>\n'
+            '      <username>user1</username>\n'
+            '      <password>pass1</password>\n'
+            '      <nonProxyHosts>localhost</nonProxyHosts>\n'
+            '    </proxy>\n'
+            '    <proxy>\n'
+            '      <id>https_proxy</id>\n'
+            '      <active>true</active>\n'
+            '      <protocol>https</protocol>\n'
+            '      <host>localhost</host>\n'
+            '      <port>3133</port>\n'
+            '      <username>user2</username>\n'
+            '      <password>pass2</password>\n'
+            '      <nonProxyHosts>localhost</nonProxyHosts>\n'
+            '    </proxy>\n'
+            '  </proxies>\n'
+            '</settings>\n')
+        self.assertSettingsEqual(expected_contents, settings_contents)

--- a/snaps_tests/__init__.py
+++ b/snaps_tests/__init__.py
@@ -25,7 +25,6 @@ import shutil
 import subprocess
 import sys
 
-import fixtures
 import pexpect
 import testtools
 from testtools import content
@@ -118,9 +117,6 @@ class SnapsTestCase(testtools.TestCase):
         else:
             self.snapcraft_command = os.path.join(
                 os.getcwd(), 'bin', 'snapcraft')
-
-        self.useFixture(
-            fixtures.EnvironmentVariable('SNAPCRAFT_SETUP_PROXIES', '1'))
 
         self.snappy_testbed = None
         if not config.get('skip-install', False):


### PR DESCRIPTION
Builds in Launchpad require use of an authenticated proxy, and honouring
https_proxy also seems like a good idea on general principles.  I've
switched to using xml.etree.ElementTree to construct settings.xml, as it
was getting more complicated and I'm not a big fan of constructing
non-trivial XML by concatenating strings; this requires the tests to
cope with differing whitespace.

I've dropped the SNAPCRAFT_SETUP_PROXIES environment variable.  Having
one environment variable that tells snapcraft to honour another
environment variable seems rather pointless, especially when it doesn't
actually change the contents of the resulting snap, but rather is just
part of the local networking environment that snapcraft needs to work
within.

LP: #1598193