### PR TITLE
Feature/ant plugin test

### DIFF
--- a/snapcraft/plugins/ant.py
+++ b/snapcraft/plugins/ant.py
@@ -27,6 +27,7 @@ For more information check the 'plugins' topic for the former and the
 import glob
 import logging
 import os
+import shutil
 
 import snapcraft
 import snapcraft.common
@@ -49,8 +50,9 @@ class AntPlugin(snapcraft.plugins.jdk.JdkPlugin):
         if not files:
             raise RuntimeError('could not find any built jar files for part')
         jardir = os.path.join(self.installdir, 'jar')
-        self.run(['mkdir', '-p', jardir])
-        self.run(['cp', '-a'] + files + [jardir])
+        os.makedirs(jardir)
+        for f in files:
+            shutil.copy(f, jardir)
 
     def env(self, root):
         env = super().env(root)

--- a/snapcraft/plugins/ant.py
+++ b/snapcraft/plugins/ant.py
@@ -52,7 +52,7 @@ class AntPlugin(snapcraft.plugins.jdk.JdkPlugin):
         os.makedirs(jardir)
         for f in files:
             base = os.path.basename(f)
-            os.link(f, os.path.join(targetdir, base))
+            os.link(f, os.path.join(jardir, base))
 
     def env(self, root):
         env = super().env(root)

--- a/snapcraft/plugins/ant.py
+++ b/snapcraft/plugins/ant.py
@@ -27,7 +27,6 @@ For more information check the 'plugins' topic for the former and the
 import glob
 import logging
 import os
-import shutil
 
 import snapcraft
 import snapcraft.common
@@ -52,7 +51,8 @@ class AntPlugin(snapcraft.plugins.jdk.JdkPlugin):
         jardir = os.path.join(self.installdir, 'jar')
         os.makedirs(jardir)
         for f in files:
-            shutil.copy(f, jardir)
+            base = os.path.basename(f)
+            os.link(f, os.path.join(targetdir, base))
 
     def env(self, root):
         env = super().env(root)

--- a/snapcraft/tests/test_plugin_ant.py
+++ b/snapcraft/tests/test_plugin_ant.py
@@ -17,26 +17,30 @@
 import os
 from unittest import mock
 
-import fixtures
-
 import snapcraft
 from snapcraft import tests
 from snapcraft.plugins import ant
 
 
-class MavenPluginTestCase(tests.TestCase):
+class AntPluginTestCase(tests.TestCase):
 
     def setUp(self):
         super().setUp()
+
+        class Options:
+            ant_options = []
+        self.options = Options()
+
+        self.project_options = snapcraft.ProjectOptions()
 
         patcher = mock.patch('snapcraft.repo.Ubuntu')
         self.ubuntu_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
-    @mock.patch.object(maven.MavenPlugin, 'run')
-    def test_build(self, glob_mock, run_mock):
+    @mock.patch.object(ant.AntPlugin, 'run')
+    def test_build(self, run_mock):
         plugin = ant.AntPlugin('test-part', self.options,
-                                   self.project_options)
+                               self.project_options)
 
         def side(l):
             os.makedirs(os.path.join(plugin.builddir, 'target'))
@@ -52,10 +56,10 @@ class MavenPluginTestCase(tests.TestCase):
             mock.call(['ant']),
         ])
 
-    @mock.patch.object(maven.MavenPlugin, 'run')
-    def test_build_fail(self, glob_mock, run_mock):
+    @mock.patch.object(ant.AntPlugin, 'run')
+    def test_build_fail(self, run_mock):
         plugin = ant.AntPlugin('test-part', self.options,
-                                   self.project_options)
+                               self.project_options)
 
         os.makedirs(plugin.sourcedir)
         with self.assertRaises(RuntimeError):

--- a/snapcraft/tests/test_plugin_ant.py
+++ b/snapcraft/tests/test_plugin_ant.py
@@ -69,8 +69,7 @@ class AntPluginTestCase(tests.TestCase):
             mock.call(['ant']),
         ])
 
-    @mock.patch.object(ant.AntPlugin, 'run')
-    def test_env(self, run_mock):
+    def test_env(self):
         plugin = ant.AntPlugin('test-part', self.options,
                                self.project_options)
 

--- a/snapcraft/tests/test_plugin_ant.py
+++ b/snapcraft/tests/test_plugin_ant.py
@@ -1,0 +1,66 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from unittest import mock
+
+import fixtures
+
+import snapcraft
+from snapcraft import tests
+from snapcraft.plugins import ant
+
+
+class MavenPluginTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        patcher = mock.patch('snapcraft.repo.Ubuntu')
+        self.ubuntu_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    @mock.patch.object(maven.MavenPlugin, 'run')
+    def test_build(self, glob_mock, run_mock):
+        plugin = ant.AntPlugin('test-part', self.options,
+                                   self.project_options)
+
+        def side(l):
+            os.makedirs(os.path.join(plugin.builddir, 'target'))
+            open(os.path.join(plugin.builddir,
+                 'target', 'dummy.jar'), 'w').close()
+
+        run_mock.side_effect = side
+        os.makedirs(plugin.sourcedir)
+
+        plugin.build()
+
+        run_mock.assert_has_calls([
+            mock.call(['ant']),
+        ])
+
+    @mock.patch.object(maven.MavenPlugin, 'run')
+    def test_build_fail(self, glob_mock, run_mock):
+        plugin = ant.AntPlugin('test-part', self.options,
+                                   self.project_options)
+
+        os.makedirs(plugin.sourcedir)
+        with self.assertRaises(RuntimeError):
+            plugin.build()
+
+        run_mock.assert_has_calls([
+            mock.call(['ant']),
+        ])

--- a/snapcraft/tests/test_plugin_ant.py
+++ b/snapcraft/tests/test_plugin_ant.py
@@ -68,3 +68,15 @@ class AntPluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['ant']),
         ])
+
+    @mock.patch.object(ant.AntPlugin, 'run')
+    def test_env(self, run_mock):
+        plugin = ant.AntPlugin('test-part', self.options,
+                               self.project_options)
+
+        os.makedirs(plugin.installdir)
+        open(os.path.join(plugin.installdir,
+             'jar', 'lib1.jar'), 'w').close()
+        open(os.path.join(plugin.installdir,
+             'jar', 'lib2.jar'), 'w').close()
+        plugin.env(plugin.partdir)

--- a/snapcraft/tests/test_plugin_ant.py
+++ b/snapcraft/tests/test_plugin_ant.py
@@ -74,7 +74,7 @@ class AntPluginTestCase(tests.TestCase):
         plugin = ant.AntPlugin('test-part', self.options,
                                self.project_options)
 
-        os.makedirs(plugin.installdir)
+        os.makedirs(os.path.join(plugin.installdir, 'jar'))
         open(os.path.join(plugin.installdir,
              'jar', 'lib1.jar'), 'w').close()
         open(os.path.join(plugin.installdir,


### PR DESCRIPTION
Updated the ant plugin to remove calls to self.run() for copy and mkdir -p
Use of shutil.copy() and os.makedirs.

Added ant test file.

https://bugs.launchpad.net/snapcraft/+bug/1600410