### PR TITLE
Gradle plugin fix for command invocation.

### DIFF
--- a/snapcraft/plugins/gradle.py
+++ b/snapcraft/plugins/gradle.py
@@ -69,9 +69,9 @@ class GradlePlugin(snapcraft.plugins.jdk.JdkPlugin):
     def build(self):
         super().build()
 
-        gradle_cmd = ['./gradlew', 'jar']
+        gradle_cmd = ['./gradlew']
 
-        self.run(gradle_cmd + self.options.gradle_options)
+        self.run(gradle_cmd + self.options.gradle_options + ['jar'])
 
         src = os.path.join(self.builddir, 'build', 'libs')
         jarfiles = glob.glob(os.path.join(src, '*.jar'))


### PR DESCRIPTION
Put options before jar task in command.

https://bugs.launchpad.net/snapcraft/+bug/1602829