### PR TITLE
Support "never" as a daemon restart condition.

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -111,6 +111,7 @@ properties:
                 - on-abnormal
                 - on-abort
                 - always
+                - never
           slots:
             type: array
             minitems: 1

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -1331,7 +1331,7 @@ class TestValidation(tests.TestCase):
             }
         }
         valid_conditions = ['always', 'on-success', 'on-failure',
-                            'on-abnormal', 'on-abort']
+                            'on-abnormal', 'on-abort', 'never']
 
         for condition in valid_conditions:
             with self.subTest(key=condition):
@@ -1353,7 +1353,7 @@ class TestValidation(tests.TestCase):
         self.assertEqual(
             "The 'restart-condition' property does not match the required "
             "schema: 'on-watchdog' is not one of ['on-success', "
-            "'on-failure', 'on-abnormal', 'on-abort', 'always']",
+            "'on-failure', 'on-abnormal', 'on-abort', 'always', 'never']",
             str(raised.exception))
 
     def test_invalid_app_names(self):


### PR DESCRIPTION
This PR fixes LP: [#1595661](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1595661) by allowing "never" as a restart condition. Note that "never" is not a valid systemd restart condition, but snapcore/snapd#1551 maps "never" into systemd's "no."