### PR TITLE
Update broken links to https://snapcraft.io

### DIFF
--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -168,7 +168,7 @@ def _scaffold_examples(directory):
 
     print("Snapcraft tour initialized in {}\n"
           "Instructions are in the README, or "
-          "https://snapcraft.io/create/#begin".format(directory))
+          "http://snapcraft.io/create/#tour".format(directory))
 
 
 def _list_plugins():

--- a/tour/00-SNAPCRAFT/01-easy-start/snapcraft.yaml
+++ b/tour/00-SNAPCRAFT/01-easy-start/snapcraft.yaml
@@ -2,7 +2,7 @@ name: hello
 version: "2.10"
 summary: GNU Hello, the "hello world" snap
 description: GNU hello prints a friendly greeting.
-  This is part of the snapcraft tour at https://snapcraft.io/create/
+  This is part of the snapcraft tour at http://snapcraft.io/create/
 confinement: strict
 
 apps:

--- a/tour/00-SNAPCRAFT/02-parts/snapcraft.yaml
+++ b/tour/00-SNAPCRAFT/02-parts/snapcraft.yaml
@@ -2,7 +2,7 @@ name: hello-debug
 version: "2.10"
 summary: GNU Hello, the "hello world" snap
 description: GNU hello prints a friendly greeting.
-  This is part of the snapcraft tour at https://snapcraft.io/create/
+  This is part of the snapcraft tour at http://snapcraft.io/create/
 confinement: strict
 
 apps:

--- a/tour/10-SNAPS/01-service/snapcraft.yaml
+++ b/tour/10-SNAPS/01-service/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: A hello world style nodejs webserver app
 description: 
   This example demonstrates how to have nodejs webserver.
-  This is part of the snapcraft tour at https://snapcraft.io/create/
+  This is part of the snapcraft tour at http://snapcraft.io/create/
 confinement: devmode
 
 apps:

--- a/tour/10-SNAPS/02-service-confined/snapcraft.yaml
+++ b/tour/10-SNAPS/02-service-confined/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: A hello world style nodejs webserver app
 description: 
   This example demonstrates how to have nodejs webserver.
-  This is part of the snapcraft tour at https://snapcraft.io/create/
+  This is part of the snapcraft tour at http://snapcraft.io/create/
 confinement: strict
 
 apps:

--- a/tour/20-PARTS-PLUGINS/01-reusable-part/snapcraft.yaml
+++ b/tour/20-PARTS-PLUGINS/01-reusable-part/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: Qt Hello World example
 description:
   A simple cmake-based project showing Qt graphics.
-  This is part of the snapcraft tour at https://snapcraft.io/create/
+  This is part of the snapcraft tour at http://snapcraft.io/create/
 confinement: strict
 
 apps:

--- a/tour/README.md
+++ b/tour/README.md
@@ -1,6 +1,6 @@
 # Welcome to the Snapcraft Tour!
 
-All content related to this tour is located at https://snapcraft.io/create/.
+All content related to this tour is located at http://snapcraft.io/create/.
 
 It's about a morning's work to get through the tour, by the end of it you
 can easily make a snap of a well-behaved application for which you have


### PR DESCRIPTION
https://snapcraft.io doesn't work. We should link to http://snapcraft.io instead.

Also, `/create#begin` doesn't exist. I think `/create#tour` probably makes sense instead.

This came out of [two](https://github.com/ubuntudesign/snapcraft.io/issues/111) [bugs](https://github.com/ubuntudesign/snapcraft.io/issues/112) filed on the snapcraft.io project.