### PR TITLE
Allow / in parts

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -129,7 +129,7 @@ properties:
     minProperties: 1
     additionalProperties: false
     patternProperties:
-      ^(?!plugins$)[a-z0-9][a-z0-9+-]*$:
+      ^(?!plugins$)[a-z0-9][a-z0-9+-\/]*$:
         type: object
         minProperties: 1
         properties:

--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -85,6 +85,10 @@ class BasePlugin:
         self.project = project
         self.options = options
 
+        # The remote parts can have a '/' in them to separate the main project
+        # part with the subparts. This is rather unfortunate as it affects the
+        # the layout of parts inside the parts directory causing collisions
+        # between the main project part and its subparts.
         part_dir = name.replace('/', '\N{BIG SOLIDUS}')
         if project:
             self.partdir = os.path.join(project.parts_dir, part_dir)

--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -85,10 +85,11 @@ class BasePlugin:
         self.project = project
         self.options = options
 
+        part_dir = name.replace('/', '\N{BIG SOLIDUS}')
         if project:
-            self.partdir = os.path.join(project.parts_dir, self.name)
+            self.partdir = os.path.join(project.parts_dir, part_dir)
         else:
-            self.partdir = os.path.join(os.getcwd(), 'parts', self.name)
+            self.partdir = os.path.join(os.getcwd(), 'parts', part_dir)
 
         self.sourcedir = os.path.join(self.partdir, 'src')
         self.installdir = os.path.join(self.partdir, 'install')

--- a/snapcraft/_schema.py
+++ b/snapcraft/_schema.py
@@ -51,7 +51,7 @@ class Validator:
         """Return part-specific schema properties."""
 
         sub = self.schema['parts']['patternProperties']
-        properties = sub['^(?!plugins$)[a-z0-9][a-z0-9+-]*$']['properties']
+        properties = sub['^(?!plugins$)[a-z0-9][a-z0-9+-\/]*$']['properties']
         return properties
 
     def _load_schema(self):

--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -73,6 +73,12 @@ class FakePartsRequestHandler(BaseHTTPRequestHandler):
                     'description': 'test entry for part1',
                     'maintainer': 'none',
                 },
+                'project-part/part1': {
+                    'plugin': 'go',
+                    'source': 'http://source.tar.gz',
+                    'description': 'test entry for part1',
+                    'maintainer': 'none',
+                },
                 'long-described-part': {
                     'plugin': 'go',
                     'source': 'http://source.tar.gz',

--- a/snapcraft/tests/test_base_plugin.py
+++ b/snapcraft/tests/test_base_plugin.py
@@ -85,6 +85,13 @@ class TestBasePlugin(tests.TestCase):
         self.assertTrue(
             os.path.exists(os.path.join(plugin.build_basedir, 'file')))
 
+    def test_part_name_with_forward_slash_is_one_directory(self):
+        plugin = snapcraft.BasePlugin('test/part', options=None)
+
+        os.makedirs(plugin.sourcedir)
+
+        self.assertIn('test\N{BIG SOLIDUS}part', os.listdir('parts'))
+
 
 class GetSourceWithBranches(tests.TestCase):
 

--- a/snapcraft/tests/test_cmds.py
+++ b/snapcraft/tests/test_cmds.py
@@ -53,6 +53,6 @@ parts:
             snapcraft.internal.load_config()
 
         self.assertEqual(raised.exception.code, 1, 'Wrong exit code returned.')
-        self.assertEqual(
+        self.assertIn(
             'Issue while loading plugin: unknown plugin: does-not-exist\n',
             fake_logger.output)

--- a/snapcraft/tests/test_commands_update.py
+++ b/snapcraft/tests/test_commands_update.py
@@ -52,6 +52,12 @@ class UpdateCommandTestCase(tests.TestCase):
                 'description': 'test entry for part1',
                 'maintainer': 'none',
             },
+            'project-part/part1': {
+                'plugin': 'go',
+                'source': 'http://source.tar.gz',
+                'description': 'test entry for part1',
+                'maintainer': 'none',
+            },
             'long-described-part': {
                 'plugin': 'go',
                 'source': 'http://source.tar.gz',

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -108,6 +108,26 @@ parts:
             'source': 'http://source.tar.gz', 'stage-packages': ['fswebcam'],
             'stage': [], 'snap': []})
 
+    @unittest.mock.patch('snapcraft.internal.yaml.Config.load_plugin')
+    def test_config_composes_with_remote_subpart(self, mock_loadPlugin):
+        self.make_snapcraft_yaml("""name: test
+version: "1"
+summary: test
+description: test
+confinement: strict
+
+parts:
+  project-part/part1:
+    stage-packages: [fswebcam]
+""")
+
+        parts.update()
+        internal_yaml.Config()
+
+        mock_loadPlugin.assert_called_with('project-part/part1', 'go', {
+            'source': 'http://source.tar.gz', 'stage-packages': ['fswebcam'],
+            'stage': [], 'snap': []})
+
     def test_config_composes_with_a_non_existent_remote_part(self):
         self.make_snapcraft_yaml("""name: test
 version: "1"


### PR DESCRIPTION
Subparts from remote parts are separated by a / so we now need
too support this scenario in the parts definition.

LP: #1602728

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>