### PR TITLE
Fix four typos in `snapcraft help`

### DIFF
--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -68,7 +68,7 @@ Note the install step - we might actually want to use built artifacts from
 one part in the build process of another, so the `parts/<part-name>/install`
 directory is useful as a 'working fresh install' of the part.
 
-Between the plugin, the part defintion YAML, and the build system of the
+Between the plugin, the part definition YAML, and the build system of the
 part, it is expected that the part can be built and installed in the right
 place.
 

--- a/snapcraft/internal/sources.py
+++ b/snapcraft/internal/sources.py
@@ -30,7 +30,7 @@ code for that part, and how to unpack it if necessary.
   - source-type: git, bzr, hg, svn, tar, or zip
 
     In some cases the source string is not enough to identify the version
-    control system or compression algorithim. The source-type key can tell
+    control system or compression algorithm. The source-type key can tell
     snapcraft exactly how to treat that content.
 
   - source-branch: <branch-name>

--- a/snapcraft/plugins/autotools.py
+++ b/snapcraft/plugins/autotools.py
@@ -26,7 +26,7 @@ This plugin uses the common plugin keywords as well as those for "sources".
 For more information check the 'plugins' topic for the former and the
 'sources' topic for the latter.
 
-In additon, this plugin uses the following plugin-specific keywords:
+In addition, this plugin uses the following plugin-specific keywords:
 
     - configflags:
       (list of strings)

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -29,7 +29,7 @@ The following kernel specific options are provided by this plugin:
     - kernel-initrd-modules:
       (array of string)
       list of modules to include in initrd; note that kernel snaps do not
-      provide the core bootlogic which comes from snappy Ubuntu Core
+      provide the core boot logic which comes from snappy Ubuntu Core
       OS snap. Include all modules you need for mounting rootfs here.
 
     - kernel-with-firmware:


### PR DESCRIPTION
This fixes four trivial bugs ([1604280](https://pad.lv/1604280), [1604278](https://pad.lv/1604278), [1604305](https://pad.lv/1604305), [1604308](https://pad.lv/1604308)) which are typos in `snapcraft help`.