### PR TITLE
Special handling for pc files for conflicts

### DIFF
--- a/integration_tests/snaps/simple-pkgconfig/snapcraft.yaml
+++ b/integration_tests/snaps/simple-pkgconfig/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: pkg-config-duplicates
+version: 0
+summary: This has 2 pkgconfig packages that would conflict
+description: "This is a regression test for LP: #1604472"
+confinement: strict
+
+parts:
+    my-part:
+        plugin: nil
+        stage-packages: [libglib2.0-dev]
+    my-part-2:
+        plugin: nil
+        stage-packages: [libglib2.0-dev]
+

--- a/integration_tests/test_pkg_config.py
+++ b/integration_tests/test_pkg_config.py
@@ -1,0 +1,32 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015, 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from testtools.matchers import (
+    DirExists,
+    Not
+)
+
+import integration_tests
+
+
+class PkgConfigTestCase(integration_tests.TestCase):
+
+    def test_pkgconfig_pc_conflicts_1604472(self):
+        """The same pc file from stage-packages should not conflict."""
+        project_dir = 'simple-pkgconfig'
+        self.run_snapcraft('stage', project_dir)


### PR DESCRIPTION
The .pc files can have a different prefix when coming from the the parts
installdir and messes up the conflict checker so we handle this case when
doing the check for .pc files.

To make this work correctly we need to skip os.linking when dealing with
.pc files.

LP: #1604472

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>