### PR TITLE
add multiple generator script options to autotools

### DIFF
--- a/snapcraft/plugins/autotools.py
+++ b/snapcraft/plugins/autotools.py
@@ -1,6 +1,7 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
 # Copyright (C) 2015, 2016 Canonical Ltd
+# Copyright (C) 2016 Harald Sitter <sitter@kde.org>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -91,17 +92,22 @@ class AutotoolsPlugin(snapcraft.BasePlugin):
     def build(self):
         super().build()
         if not os.path.exists(os.path.join(self.builddir, "configure")):
-            autogen_path = os.path.join(self.builddir, "autogen.sh")
-            if os.path.exists(autogen_path):
+            generated = False
+            scripts = ["autogen.sh", "bootstrap"]
+            for script in scripts:
+                path = os.path.join(self.builddir, script)
+                if not os.path.exists(path):
+                    continue
                 # Make sure it's executable
-                if not os.access(autogen_path, os.X_OK):
-                    os.chmod(autogen_path,
+                if not os.access(path, os.X_OK):
+                    os.chmod(path,
                              stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
                              stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP |
                              stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH)
-
-                self.run(['env', 'NOCONFIGURE=1', './autogen.sh'])
-            else:
+                self.run(['env', 'NOCONFIGURE=1', './{}'.format(script)])
+                generated = True
+                break
+            if not generated:
                 self.run(['autoreconf', '-i'])
 
         configure_command = ['./configure']

--- a/snapcraft/tests/test_plugin_autotools.py
+++ b/snapcraft/tests/test_plugin_autotools.py
@@ -1,6 +1,7 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
 # Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016 Harald Sitter <sitter@kde.org>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -156,15 +157,19 @@ class AutotoolsPluginTestCase(tests.TestCase):
             mock.call(['make', 'install'])
         ])
 
-    def build_with_autogen(self):
+    def build_with_autogen(self, files=None):
         plugin = autotools.AutotoolsPlugin('test-part', self.options,
                                            self.project_options)
         os.makedirs(plugin.sourcedir)
 
+        if not files:
+            files = ['autogen.sh']
+
         # No configure-- only autogen.sh. Make sure it's executable.
-        open(os.path.join(plugin.sourcedir, 'autogen.sh'), 'w').close()
-        os.chmod(os.path.join(plugin.sourcedir, 'autogen.sh'),
-                 stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+        for filename in files:
+            open(os.path.join(plugin.sourcedir, filename), 'w').close()
+            os.chmod(os.path.join(plugin.sourcedir, filename),
+                     stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
         plugin.build()
 
@@ -173,6 +178,32 @@ class AutotoolsPluginTestCase(tests.TestCase):
     @mock.patch.object(autotools.AutotoolsPlugin, 'run')
     def test_build_autogen_with_destdir(self, run_mock):
         plugin = self.build_with_autogen()
+
+        self.assertEqual(4, run_mock.call_count)
+        run_mock.assert_has_calls([
+            mock.call(['env', 'NOCONFIGURE=1', './autogen.sh']),
+            mock.call(['./configure', '--prefix=']),
+            mock.call(['make', '-j2']),
+            mock.call(['make', 'install',
+                       'DESTDIR={}'.format(plugin.installdir)])
+        ])
+
+    @mock.patch.object(autotools.AutotoolsPlugin, 'run')
+    def test_build_bootstrap_with_destdir(self, run_mock):
+        plugin = self.build_with_autogen(files=['bootstrap'])
+
+        self.assertEqual(4, run_mock.call_count)
+        run_mock.assert_has_calls([
+            mock.call(['env', 'NOCONFIGURE=1', './bootstrap']),
+            mock.call(['./configure', '--prefix=']),
+            mock.call(['make', '-j2']),
+            mock.call(['make', 'install',
+                       'DESTDIR={}'.format(plugin.installdir)])
+        ])
+
+    @mock.patch.object(autotools.AutotoolsPlugin, 'run')
+    def test_build_bootstrap_and_autogen_with_destdir(self, run_mock):
+        plugin = self.build_with_autogen(files=['bootstrap', 'autogen.sh'])
 
         self.assertEqual(4, run_mock.call_count)
         run_mock.assert_has_calls([


### PR DESCRIPTION
this enables vlc to build using the autotools plugin and have the plugin
transparently fall back from the regular autogen.sh to vlc's 'bootstrap'
script.