### PR TITLE
Implement "oneshot" daemon type

### DIFF
--- a/docs/snapcraft-syntax.md
+++ b/docs/snapcraft-syntax.md
@@ -36,9 +36,11 @@ contain.
       command is used to start the service.
     * `daemon` (string)
       If present, integrates the runnable as a system service. Valid values are
-      `forking` and `simple`.
+      `forking`, 'oneshot' and `simple`.
       If set to `simple`, it is expected that the command configured is the main
       process.
+      If set to 'oneshot', it is expected that the command configured
+      will exit once it's done (won't be a long-lasting process).
       If set to `forking`, it is expected that the configured command will call
       fork() as part of its start-up. The parent process is expected to exit
       when start-up is complete and all communication channels are set up.

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -103,6 +103,7 @@ properties:
             enum:
               - simple
               - forking
+              - oneshot
           restart-condition:
               type: string
               enum:


### PR DESCRIPTION
Snapd supports this daemon type already so just allow to set this and
have it sent through.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>