### PR TITLE
Pass --root to the python3 plugin on build

### DIFF
--- a/snapcraft/plugins/python3.py
+++ b/snapcraft/plugins/python3.py
@@ -149,7 +149,8 @@ class Python3Plugin(snapcraft.BasePlugin):
         os.makedirs(self.dist_packages_dir, exist_ok=True)
         self.run(
             ['python3', setup_file, 'install', '--install-layout=deb',
-             '--prefix={}/usr'.format(self.installdir)], cwd=self.builddir)
+             '--prefix={}/usr'.format(self.installdir),
+             '--root={}'.format(self.installdir)], cwd=self.builddir)
 
     @property
     def dist_packages_dir(self):


### PR DESCRIPTION
Pass --root to the python3 plugin on build so data_paths with absolute paths will be placed in the install directoy of the part.