### PR TITLE
Add process-dependency-links option to Python plugins

### DIFF
--- a/snapcraft/plugins/python2.py
+++ b/snapcraft/plugins/python2.py
@@ -71,6 +71,10 @@ class Python2Plugin(snapcraft.BasePlugin):
             },
             'default': [],
         }
+        schema['properties']['process-dependency-links'] = {
+            'type': 'boolean',
+            'default': False,
+        }
         schema.pop('required')
 
         # Inform Snapcraft of the properties associated with pulling. If these
@@ -154,6 +158,9 @@ class Python2Plugin(snapcraft.BasePlugin):
                 '--constraint',
                 os.path.join(self.sourcedir, self.options.constraints),
             ]
+
+        if self.options.process_dependency_links:
+            pip_install.append('--process-dependency-links')
 
         if self.options.requirements:
             self.run(pip_install + [

--- a/snapcraft/plugins/python3.py
+++ b/snapcraft/plugins/python3.py
@@ -61,6 +61,10 @@ class Python3Plugin(snapcraft.BasePlugin):
             },
             'default': [],
         }
+        schema['properties']['process-dependency-links'] = {
+            'type': 'boolean',
+            'default': False,
+        }
         schema.pop('required')
 
         # Inform Snapcraft of the properties associated with pulling. If these
@@ -126,6 +130,9 @@ class Python3Plugin(snapcraft.BasePlugin):
         pip3 = os.path.join(self.installdir, 'usr', 'bin', 'pip3')
         pip_install = ['python3', pip3, 'install', '--root',
                        self.installdir, "--install-option=--prefix=usr"]
+
+        if self.options.process_dependency_links:
+            pip_install.append('--process-dependency-links')
 
         if self.options.requirements:
             self.run(pip_install + ['--requirement', requirements])

--- a/snapcraft/tests/test_plugin_python2.py
+++ b/snapcraft/tests/test_plugin_python2.py
@@ -41,6 +41,7 @@ class Python2PluginTestCase(tests.TestCase):
             requirements = ''
             constraints = ''
             python_packages = []
+            process_dependency_links = False
 
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
@@ -234,3 +235,12 @@ class Python2PluginTestCase(tests.TestCase):
             with open(os.path.join(plugin.installdir,
                                    file_info['path']), 'r') as f:
                 self.assertEqual(f.read(), file_info['expected'])
+
+    @mock.patch.object(python2.Python2Plugin, 'run')
+    def test_process_dependency_links(self, run_mock):
+        self.options.process_dependency_links = True
+        plugin = python2.Python2Plugin('test-part', self.options,
+                                       self.project_options)
+        setup_directories(plugin)
+        plugin._pip()
+        self.assertIn('--process-dependency-links', run_mock.call_args[0][0])

--- a/snapcraft/tests/test_plugin_python3.py
+++ b/snapcraft/tests/test_plugin_python3.py
@@ -40,6 +40,7 @@ class Python3PluginTestCase(tests.TestCase):
         class Options:
             requirements = ''
             python_packages = []
+            process_dependency_links = False
 
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
@@ -182,3 +183,12 @@ class Python3PluginTestCase(tests.TestCase):
             with open(os.path.join(plugin.installdir,
                                    file_info['path']), 'r') as f:
                 self.assertEqual(f.read(), file_info['expected'])
+
+    @mock.patch.object(python3.Python3Plugin, 'run')
+    def test_process_dependency_links(self, run_mock):
+        self.options.process_dependency_links = True
+        plugin = python3.Python3Plugin('test-part', self.options,
+                                       self.project_options)
+        setup_directories(plugin)
+        plugin._pip()
+        self.assertIn('--process-dependency-links', run_mock.call_args[0][0])


### PR DESCRIPTION
This will run pip install with --process-dependency-links as per [0].

[0] https://pip.pypa.io/en/stable/reference/pip_wheel/#cmdoption--process-dependency-links