### PR TITLE
Also use INSTALLROOT for make plugin.

### DIFF
--- a/snapcraft/plugins/make.py
+++ b/snapcraft/plugins/make.py
@@ -78,4 +78,9 @@ class MakePlugin(snapcraft.BasePlugin):
             command.extend(self.options.make_parameters)
 
         self.run(command + ['-j{}'.format(self.project.parallel_build_count)])
-        self.run(command + ['install', 'DESTDIR=' + self.installdir])
+        install_command = command + [
+            'install',
+            'DESTDIR=' + self.installdir,
+            'INSTALLROOT=' + self.installdir,
+        ]
+        self.run(install_command)

--- a/snapcraft/tests/test_plugin_make.py
+++ b/snapcraft/tests/test_plugin_make.py
@@ -85,7 +85,8 @@ class MakePluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['make', '-j2']),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)])
+                       'DESTDIR={}'.format(plugin.installdir),
+                       'INSTALLROOT={}'.format(plugin.installdir)])
         ])
 
     @mock.patch.object(make.MakePlugin, 'run')
@@ -101,5 +102,6 @@ class MakePluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['make', '-f', 'makefile.linux', '-j2']),
             mock.call(['make', '-f', 'makefile.linux', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)])
+                       'DESTDIR={}'.format(plugin.installdir),
+                       'INSTALLROOT={}'.format(plugin.installdir)])
         ])


### PR DESCRIPTION
Some projects don't use DESTDIR - it's only a gnu convention.  make will ignore arguments that aren't used, so appending is cleaner than exposing a new option on the command line, and just works.