### PR TITLE
Added "camera" plug into the example

### DIFF
--- a/demos/webcam-webui/snapcraft.yaml
+++ b/demos/webcam-webui/snapcraft.yaml
@@ -8,7 +8,7 @@ apps:
   webcam-webui:
     command: bin/webcam-webui
     daemon: simple
-    plugs: [network-bind]
+    plugs: [camera,network-bind]
 
 parts:
   cam:


### PR DESCRIPTION
"camera" plug is needed to get the example working, and we should do the manual connection like to make it working:

$ sudo snap connect webcam-webui:camera ubuntu-core:camera