### PR TITLE
Add support for use of pip constraints

### DIFF
--- a/snapcraft/plugins/python2.py
+++ b/snapcraft/plugins/python2.py
@@ -35,6 +35,10 @@ Additionally, this plugin uses the following plugin-specific keywords:
     - python-packages:
       (list)
       A list of dependencies to get from PyPi
+    - constraints:
+      (string)
+      path or url to a constraints file to constrain installed module
+      versions.
 """
 
 import glob
@@ -65,11 +69,15 @@ class Python2Plugin(snapcraft.BasePlugin):
             },
             'default': [],
         }
+        schema['properties']['constraints'] = {
+            'type': 'string',
+        }
         schema.pop('required')
 
         # Inform Snapcraft of the properties associated with pulling. If these
         # change in the YAML Snapcraft will consider the pull step dirty.
-        schema['pull-properties'].extend(['requirements', 'python-packages'])
+        schema['pull-properties'].extend(['requirements', 'python-packages',
+                                          'constraints'])
 
         return schema
 
@@ -139,6 +147,9 @@ class Python2Plugin(snapcraft.BasePlugin):
                        '--global-option=-I{}'.format(
                            _get_python2_include(self.installdir)),
                        '--target', site_packages_dir]
+
+        if self.options.constraints:
+            pip_install += ['-c{}'.format(self.options.constraints)]
 
         if self.options.requirements:
             self.run(pip_install + ['--requirement', requirements])

--- a/snapcraft/plugins/python3.py
+++ b/snapcraft/plugins/python3.py
@@ -35,6 +35,10 @@ Additionally, this plugin uses the following plugin-specific keywords:
     - python-packages:
       (list)
       A list of dependencies to get from PyPi
+    - constraints:
+      (string)
+      path or url to a constraints file to constrain installed module
+      versions.
 """
 
 import os
@@ -61,11 +65,15 @@ class Python3Plugin(snapcraft.BasePlugin):
             },
             'default': [],
         }
+        schema['properties']['constraints'] = {
+            'type': 'string',
+        }
         schema.pop('required')
 
         # Inform Snapcraft of the properties associated with pulling. If these
         # change in the YAML Snapcraft will consider the pull step dirty.
-        schema['pull-properties'].extend(['requirements', 'python-packages'])
+        schema['pull-properties'].extend(['requirements', 'python-packages',
+                                          'constraints'])
 
         return schema
 
@@ -125,6 +133,9 @@ class Python3Plugin(snapcraft.BasePlugin):
         pip3 = os.path.join(self.installdir, 'usr', 'bin', 'pip3')
         pip_install = ['python3', pip3, 'install', '--root',
                        self.installdir, "--install-option=--prefix=usr"]
+
+        if self.options.constraints:
+            pip_install += ['-c{}'.format(self.options.constraints)]
 
         if self.options.requirements:
             self.run(pip_install + ['--requirement', requirements])

--- a/snapcraft/tests/test_plugin_python2.py
+++ b/snapcraft/tests/test_plugin_python2.py
@@ -40,6 +40,7 @@ class Python2PluginTestCase(tests.TestCase):
         class Options:
             requirements = ''
             python_packages = []
+            constraints = ''
 
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
@@ -71,12 +72,16 @@ class Python2PluginTestCase(tests.TestCase):
             'items': {'type': 'string'},
             'default': [],
         }
-        extend_pull = ['requirements', 'python-packages']
+        expected_constraints = {'type': 'string'}
+        extend_pull = ['requirements', 'python-packages',
+                       'constraints']
 
         self.assertDictEqual(expected_requirements,
                              schema['properties']['requirements'])
         self.assertDictEqual(expected_python_packages,
                              schema['properties']['python-packages'])
+        self.assertDictEqual(expected_constraints,
+                             schema['properties']['constraints'])
         self.assertTrue(
             set(extend_pull).issubset(set(schema['pull-properties']))
         )
@@ -121,6 +126,8 @@ class Python2PluginTestCase(tests.TestCase):
     def test_pip(self, mock_run):
         self.options.requirements = 'requirements.txt'
         self.options.python_packages = ['test', 'packages']
+        self.options.constraints = \
+            'https://github.com/myproject/myrepo/constraints.txt'
 
         plugin = python2.Python2Plugin('test-part', self.options,
                                        self.project_options)
@@ -137,7 +144,8 @@ class Python2PluginTestCase(tests.TestCase):
         pip_install = ['python2', pip2, 'install',
                        '--global-option=build_ext',
                        '--global-option=-I{}'.format(include),
-                       '--target', target]
+                       '--target', target,
+                       '-chttps://github.com/myproject/myrepo/constraints.txt']
         requirements_path = os.path.join(os.getcwd(), 'requirements.txt')
         calls = [
             mock.call(['python2', easy_install, '--prefix', prefix, 'pip']),

--- a/snapcraft/tests/test_plugin_python3.py
+++ b/snapcraft/tests/test_plugin_python3.py
@@ -31,6 +31,7 @@ class Python3PluginTestCase(tests.TestCase):
         class Options:
             requirements = ''
             python_packages = []
+            constraints = ''
 
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()


### PR DESCRIPTION
Pip supports use of constraints to limit/fix the versions of
Python modules that should be installed; this is used extensively
within the OpenStack community to limit transient dependency
issues causing functional issues.

Add optional 'upper-constraints' support for Python 2 and 3
plugins.