### PR TITLE
Add make-install-var field to the make plugin.

### DIFF
--- a/snapcraft/plugins/make.py
+++ b/snapcraft/plugins/make.py
@@ -32,6 +32,10 @@ Additionally, this plugin uses the following plugin-specific keyword:
     - make-parameters:
       (list of strings)
       Pass the given parameters to the make command.
+
+    - make-install-var:
+      (string; default: DESTDIR)
+      Use the variable as the install target.
 """
 
 import snapcraft
@@ -55,10 +59,15 @@ class MakePlugin(snapcraft.BasePlugin):
             },
             'default': [],
         }
+        schema['properties']['make-install-var'] = {
+            'type': 'string',
+            'default': 'DESTDIR',
+        }
 
         # Inform Snapcraft of the properties associated with building. If these
         # change in the YAML Snapcraft will consider the build step dirty.
-        schema['build-properties'].extend(['makefile', 'make-parameters'])
+        schema['build-properties'].extend(
+            ['makefile', 'make-parameters', 'make-install-var'])
 
         return schema
 
@@ -78,4 +87,5 @@ class MakePlugin(snapcraft.BasePlugin):
             command.extend(self.options.make_parameters)
 
         self.run(command + ['-j{}'.format(self.project.parallel_build_count)])
-        self.run(command + ['install', 'DESTDIR=' + self.installdir])
+        self.run(command + [
+            'install', self.options.make_install_var + '=' + self.installdir])

--- a/snapcraft/plugins/make.py
+++ b/snapcraft/plugins/make.py
@@ -35,7 +35,7 @@ Additionally, this plugin uses the following plugin-specific keyword:
 
     - make-install-var:
       (string; default: DESTDIR)
-      Use the variable as the install target.
+      Use this variable to redirect the installation into the snap.
 """
 
 import snapcraft

--- a/snapcraft/tests/test_plugin_make.py
+++ b/snapcraft/tests/test_plugin_make.py
@@ -31,6 +31,7 @@ class MakePluginTestCase(tests.TestCase):
         class Options:
             makefile = None
             make_parameters = []
+            make_install_var = "DESTDIR"
 
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
@@ -48,6 +49,10 @@ class MakePluginTestCase(tests.TestCase):
         self.assertTrue(
             'make-parameters' in properties,
             'Expected "make-parameters" to be included in properties')
+
+        self.assertTrue(
+            'make-install-var' in properties,
+            'Expected "make-install-var" to be included in properties')
 
         makefile = properties['makefile']
         self.assertTrue('type' in makefile,
@@ -68,10 +73,27 @@ class MakePluginTestCase(tests.TestCase):
             'Expected "make-parameters" "type" to be "array", but it '
             'was "{}"'.format(make_parameters_type))
 
+        make_install_var = properties['make-install-var']
+        self.assertTrue('type' in make_install_var,
+                        'Expected "type" to be included in "make-install-var"')
+
+        make_install_var_type = make_install_var['type']
+        self.assertEqual(
+            make_install_var_type, 'string',
+            'Expected "make-install-var" "type" to be "string", but it '
+            'was "{}"'.format(make_install_var_type))
+
+        make_install_var_default = make_install_var['default']
+        self.assertEqual(
+            make_install_var_default, 'DESTDIR',
+            'Expected "make-install-var" "default" to be "DESTDIR", but it '
+            'was "{}"'.format(make_install_var_default))
+
         build_properties = schema['build-properties']
-        self.assertEqual(2, len(build_properties))
+        self.assertEqual(3, len(build_properties))
         self.assertTrue('makefile' in build_properties)
         self.assertTrue('make-parameters' in build_properties)
+        self.assertTrue('make-install-var' in build_properties)
 
     @mock.patch.object(make.MakePlugin, 'run')
     def test_build(self, run_mock):
@@ -102,4 +124,20 @@ class MakePluginTestCase(tests.TestCase):
             mock.call(['make', '-f', 'makefile.linux', '-j2']),
             mock.call(['make', '-f', 'makefile.linux', 'install',
                        'DESTDIR={}'.format(plugin.installdir)])
+        ])
+
+    @mock.patch.object(make.MakePlugin, 'run')
+    def test_build_install_var(self, run_mock):
+        self.options.make_install_var = 'PREFIX'
+        plugin = make.MakePlugin('test-part', self.options,
+                                 self.project_options)
+        os.makedirs(plugin.sourcedir)
+
+        plugin.build()
+
+        self.assertEqual(2, run_mock.call_count)
+        run_mock.assert_has_calls([
+            mock.call(['make', '-j2']),
+            mock.call(['make', 'install',
+                       'PREFIX={}'.format(plugin.installdir)])
         ])

--- a/snapcraft/tests/test_plugin_make.py
+++ b/snapcraft/tests/test_plugin_make.py
@@ -31,7 +31,7 @@ class MakePluginTestCase(tests.TestCase):
         class Options:
             makefile = None
             make_parameters = []
-            make_install_var = "DESTDIR"
+            make_install_var = 'DESTDIR'
 
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()


### PR DESCRIPTION
Each project is different on the install flag for the Makefile. Allow changing the make-install-var when building with snapcraft.