### PR TITLE
fix checker errors to let runtests.sh pass again

### DIFF
--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -270,7 +270,7 @@ def snap(project_options, directory=None, output=None):
         ret = None
         if os.isatty(sys.stdout.fileno()):
             message = '\033[0;32m\rSnapping {!r}\033[0;32m '.format(
-                    snap['name'])
+                snap['name'])
             progress_indicator = ProgressBar(
                 widgets=[message, AnimatedMarker()], maxval=7)
             progress_indicator.start()

--- a/snapcraft/plugins/cmake.py
+++ b/snapcraft/plugins/cmake.py
@@ -89,10 +89,10 @@ class CMakePlugin(snapcraft.plugins.make.MakePlugin):
         env['CMAKE_INCLUDE_PATH'] = '$CMAKE_INCLUDE_PATH:' + ':'.join(
             ['{0}/include', '{0}/usr/include', '{0}/include/{1}',
              '{0}/usr/include/{1}']).format(
-                self.project.stage_dir, self.project.arch_triplet)
+                 self.project.stage_dir, self.project.arch_triplet)
         env['CMAKE_LIBRARY_PATH'] = '$CMAKE_LIBRARY_PATH:' + ':'.join(
             ['{0}/lib', '{0}/usr/lib', '{0}/lib/{1}',
              '{0}/usr/lib/{1}']).format(
-                self.project.stage_dir, self.project.arch_triplet)
+                 self.project.stage_dir, self.project.arch_triplet)
 
         return env

--- a/snapcraft/tests/test_plugin_cmake.py
+++ b/snapcraft/tests/test_plugin_cmake.py
@@ -92,13 +92,13 @@ class CMakeTestCase(tests.TestCase):
         expected['CMAKE_INCLUDE_PATH'] = '$CMAKE_INCLUDE_PATH:' + ':'.join(
             ['{0}/include', '{0}/usr/include', '{0}/include/{1}',
              '{0}/usr/include/{1}']).format(
-                self.stage_dir,
-                plugin.project.arch_triplet)
+                 self.stage_dir,
+                 plugin.project.arch_triplet)
         expected['CMAKE_LIBRARY_PATH'] = '$CMAKE_LIBRARY_PATH:' + ':'.join(
             ['{0}/lib', '{0}/usr/lib', '{0}/lib/{1}',
              '{0}/usr/lib/{1}']).format(
-                self.stage_dir,
-                plugin.project.arch_triplet)
+                 self.stage_dir,
+                 plugin.project.arch_triplet)
 
         self.assertEqual(3, self.run_mock.call_count)
         for call_args in self.run_mock.call_args_list:

--- a/snaps_tests/demos_tests/test_plainbox_test_tool.py
+++ b/snaps_tests/demos_tests/test_plainbox_test_tool.py
@@ -35,5 +35,6 @@ class PlainboxTestCase(snaps_tests.SnapsTestCase):
             '/snap/bin/plainbox-test-tool.plainbox dev special -j',
             expected)
         # check can run the tests in the example provider
-        self.run_command_in_snappy_testbed(
-          '/snap/bin/plainbox-test-tool.plainbox run -i 2016.com.example::.*')
+        self.run_command_in_snappy_testbed('/snap/bin/plainbox-test-tool.'
+                                           'plainbox run '
+                                           '-i 2016.com.example::.*')


### PR DESCRIPTION
Fix indention errors that get the code checkers upset (LP: #1611402).

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>