### PR TITLE
Fix bug lp:1586546 allowing setup.py to work on some projects.

### DIFF
--- a/integration_tests/snaps/python-pyyaml/snapcraft.yaml
+++ b/integration_tests/snaps/python-pyyaml/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: python-pyyaml
+version: 0
+summary: summary
+description: description
+confinement: strict
+
+parts:
+  python2:
+    plugin: python2
+    source: http://pyyaml.org/download/pyyaml/PyYAML-3.11.tar.gz
+
+  python3:
+    plugin: python3
+    source: http://pyyaml.org/download/pyyaml/PyYAML-3.11.tar.gz

--- a/integration_tests/test_python_plugin.py
+++ b/integration_tests/test_python_plugin.py
@@ -82,3 +82,18 @@ class PythonPluginTestCase(integration_tests.TestCase):
 
         self.assertEqual('#!/usr/bin/env python2', python2_shebang)
         self.assertEqual('#!/usr/bin/env python3', python3_shebang)
+
+    def test_build_doesnt_get_bad_install_directory_lp1586546(self):
+        """Verify that LP: #1586546 doesn't come back."""
+        project_dir = 'python-pyyaml'
+        self.run_snapcraft('stage', project_dir)
+        self.assertThat(
+            os.path.join(
+                project_dir, 'parts', 'python2', 'install', 'usr', 'lib',
+                'python2.7', 'dist-packages', 'yaml'),
+            DirExists())
+        self.assertThat(
+            os.path.join(
+                project_dir, 'parts', 'python3', 'install', 'usr', 'lib',
+                'python3', 'dist-packages', 'yaml'),
+            DirExists())

--- a/snapcraft/plugins/python3.py
+++ b/snapcraft/plugins/python3.py
@@ -80,7 +80,7 @@ class Python3Plugin(snapcraft.BasePlugin):
     def env(self, root):
         return [
             'PYTHONPATH={}'.format(os.path.join(
-                root, 'usr', 'lib', self.python_version, 'dist-packages')),
+                root, 'usr', 'lib', self.python_version, 'site-packages')),
             # This is until we figure out how to get pip to download only
             # and then build in the build step or split out pulling
             # stage-packages in an internal private step.

--- a/snapcraft/tests/test_plugin_python3.py
+++ b/snapcraft/tests/test_plugin_python3.py
@@ -68,7 +68,7 @@ class Python3PluginTestCase(tests.TestCase):
         plugin = python3.Python3Plugin('test-part', self.options,
                                        self.project_options)
         expected_env = [
-            'PYTHONPATH=/testpath/usr/lib/python3.5/dist-packages',
+            'PYTHONPATH=/testpath/usr/lib/python3.5/site-packages',
             'CPPFLAGS="-I/testpath/usr/include $CPPFLAGS"',
             'CFLAGS="-I/testpath/usr/include $CFLAGS"',
         ]


### PR DESCRIPTION
I only ran into this issue with python3 and not python2. I tested this with:

pyyaml:
    plugin: python2
    source: http://pyyaml.org/download/pyyaml/PyYAML-3.11.tar.gz

and

pyyaml:
    plugin: python3
    source: http://pyyaml.org/download/pyyaml/PyYAML-3.11.tar.gz

This branch only changes the python3 plugin as no issues occurred using the python2 plugin.