### PR TITLE
support dest-subdir on dump plugin

### DIFF
--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -57,13 +57,17 @@ class BasePlugin:
                 'source-subdir': {
                     'type': 'string',
                     'default': None,
+                },
+                'dest-subdir': {
+                    'type': 'string',
+                    'default': None,
                 }
             },
             'required': [
                 'source',
             ],
             'pull-properties': ['source', 'source-type', 'source-branch',
-                                'source-tag', 'source-subdir'],
+                                'source-tag', 'source-subdir', 'dest-subdir'],
             'build-properties': []
         }
 
@@ -104,6 +108,7 @@ class BasePlugin:
             self.builddir = os.path.join(self.build_basedir, source_subdir)
         else:
             self.builddir = self.build_basedir
+        self.dest_subdir = getattr(self.options, 'dest_subdir', None)
 
     # The API
     def pull(self):

--- a/snapcraft/plugins/dump.py
+++ b/snapcraft/plugins/dump.py
@@ -37,5 +37,9 @@ class DumpPlugin(snapcraft.BasePlugin):
         super().build()
         if os.path.exists(self.installdir):
             os.rmdir(self.installdir)
-        shutil.copytree(self.builddir, self.installdir,
+        if self.dest_subdir:
+            shutil.copytree(self.builddir, self.installdir + os.sep + self.dest_subdir,
+                        copy_function=snapcraft.common.link_or_copy)
+        else:
+            shutil.copytree(self.builddir, self.installdir,
                         copy_function=snapcraft.common.link_or_copy)


### PR DESCRIPTION
add "dest-subdir" option for dump plugin.

it's useful for target like tomcat, that we might want then to install to /opt/tomcat directory.