### PR TITLE
Start the fake parts server only in the tests that need it

### DIFF
--- a/snapcraft/internal/yaml.py
+++ b/snapcraft/internal/yaml.py
@@ -109,10 +109,6 @@ class PluginNotDefinedError(Exception):
 
 class Config:
 
-    @property
-    def part_names(self):
-        return self._part_names
-
     def __init__(self, project_options=None):
         if project_options is None:
             project_options = snapcraft.ProjectOptions()
@@ -132,9 +128,17 @@ class Config:
 
         self.build_tools = self.data.get('build-packages', [])
         self.build_tools.extend(project_options.additional_build_packages)
-
-        self._remote_parts = parts.get_remote_parts()
         self._process_parts()
+
+    @property
+    def part_names(self):
+        return self._part_names
+
+    @property
+    def _remote_parts(self):
+        if getattr(self, '_remote_parts_attr', None) is None:
+            self._remote_parts_attr = parts.get_remote_parts()
+        return self._remote_parts_attr
 
     def _process_parts(self):
         for part_name in self.data.get('parts', []):

--- a/snapcraft/tests/__init__.py
+++ b/snapcraft/tests/__init__.py
@@ -57,8 +57,6 @@ class TestCase(testscenarios.WithScenarios, fixtures.TestWithFixtures):
                              '..', '..', '..', 'schema'))
         self.useFixture(fixtures.FakeLogger(level=logging.ERROR))
 
-        self.useFixture(fixture_setup.FakeParts())
-
         patcher = mock.patch('multiprocessing.cpu_count')
         self.cpu_count = patcher.start()
         self.cpu_count.return_value = 2
@@ -90,6 +88,13 @@ class TestCase(testscenarios.WithScenarios, fixtures.TestWithFixtures):
             self.assertTrue(os.path.exists(os.path.join(state_dir, step)),
                             'Expected {!r} to be run for {}'.format(
                                 step, part_name))
+
+
+class TestWithFakeRemoteParts(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.useFixture(fixture_setup.FakeParts())
 
 
 class SilentProgressBar(progressbar.ProgressBar):

--- a/snapcraft/tests/test_commands_define.py
+++ b/snapcraft/tests/test_commands_define.py
@@ -21,7 +21,7 @@ from snapcraft import main, tests
 from snapcraft.internal import parts
 
 
-class DefineCommandTestCase(tests.TestCase):
+class DefineCommandTestCase(tests.TestWithFakeRemoteParts):
 
     @mock.patch('sys.stdout', new_callable=io.StringIO)
     def test_defining_a_part_that_exists(self, mock_stdout):

--- a/snapcraft/tests/test_commands_search.py
+++ b/snapcraft/tests/test_commands_search.py
@@ -22,7 +22,7 @@ from snapcraft import main, tests
 from snapcraft.tests import fixture_setup
 
 
-class SearchCommandTestCase(tests.TestCase):
+class SearchCommandTestCase(tests.TestWithFakeRemoteParts):
 
     def test_searching_for_a_part_that_exists(self):
         fake_terminal = fixture_setup.FakeTerminal()

--- a/snapcraft/tests/test_commands_update.py
+++ b/snapcraft/tests/test_commands_update.py
@@ -25,7 +25,7 @@ from xdg import BaseDirectory
 from snapcraft import main, tests
 
 
-class UpdateCommandTestCase(tests.TestCase):
+class UpdateCommandTestCase(tests.TestWithFakeRemoteParts):
 
     def setUp(self):
         super().setUp()

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -28,6 +28,7 @@ import snapcraft
 from snapcraft.internal import dirs, parts
 from snapcraft.internal import yaml as internal_yaml
 from snapcraft import tests
+from snapcraft.tests import fixture_setup
 from snapcraft._schema import SnapcraftSchemaError
 
 
@@ -90,6 +91,7 @@ parts:
 
     @unittest.mock.patch('snapcraft.internal.yaml.Config.load_plugin')
     def test_config_composes_with_remote_parts(self, mock_loadPlugin):
+        self.useFixture(fixture_setup.FakeParts())
         self.make_snapcraft_yaml("""name: test
 version: "1"
 summary: test
@@ -110,6 +112,7 @@ parts:
 
     @unittest.mock.patch('snapcraft.internal.yaml.Config.load_plugin')
     def test_config_composes_with_remote_subpart(self, mock_loadPlugin):
+        self.useFixture(fixture_setup.FakeParts())
         self.make_snapcraft_yaml("""name: test
 version: "1"
 summary: test
@@ -129,6 +132,7 @@ parts:
             'stage': [], 'snap': []})
 
     def test_config_composes_with_a_non_existent_remote_part(self):
+        self.useFixture(fixture_setup.FakeParts())
         self.make_snapcraft_yaml("""name: test
 version: "1"
 summary: test
@@ -151,6 +155,7 @@ parts:
             'to refresh'.format('non-existing-part'))
 
     def test_config_after_is_an_undefined_part(self):
+        self.useFixture(fixture_setup.FakeParts())
         self.make_snapcraft_yaml("""name: test
 version: "1"
 summary: test
@@ -175,6 +180,7 @@ parts:
 
     @unittest.mock.patch('snapcraft.internal.pluginhandler.load_plugin')
     def test_config_uses_remote_part_from_after(self, mock_load):
+        self.useFixture(fixture_setup.FakeParts())
         self.make_snapcraft_yaml("""name: test
 version: "1"
 summary: test


### PR DESCRIPTION
Load the remote parts in the config lazily.

LP: #1611828