### PR TITLE
Set owner/group for directories in stage and prime

### DIFF
--- a/manual-tests.md
+++ b/manual-tests.md
@@ -15,7 +15,7 @@
 1. 'snapcraft build' a simple snap
 2. sudo touch install/test-owner-file
 3. sudo chown nobody:nogroup install/test-owner-file
-4. snapcraft prime
+4. sudo snapcraft prime
 5. ensure that prime/test-owner-file is owned by nobody and nogroup
 
 # Test stage package caching

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -187,6 +187,13 @@ def link_or_copy(source, destination, follow_symlinks=False):
         os.link(source_path, destination, follow_symlinks=False)
     except OSError:
         shutil.copy2(source, destination, follow_symlinks=follow_symlinks)
+        uid = os.stat(source, follow_symlinks=follow_symlinks).st_uid
+        gid = os.stat(source, follow_symlinks=follow_symlinks).st_gid
+        try:
+            os.chown(destination, uid, gid, follow_symlinks=follow_symlinks)
+        except PermissionError as e:
+            logger.warning('unable to chown {destination}: {error}'.format(
+                destination=destination, error=e))
 
 
 def replace_in_file(directory, file_pattern, search_pattern, replacement):

--- a/snapcraft/internal/pluginhandler.py
+++ b/snapcraft/internal/pluginhandler.py
@@ -657,7 +657,7 @@ def _migrate_files(snap_files, snap_dirs, srcdir, dstdir, missing_ok=False,
         src = os.path.join(srcdir, directory)
         dst = os.path.join(dstdir, directory)
 
-        dir_stat = os.stat(src)
+        dir_stat = os.stat(src, follow_symlinks=follow_symlinks)
         uid = dir_stat.st_uid
         gid = dir_stat.st_gid
         os.makedirs(dst, exist_ok=True)
@@ -668,12 +668,15 @@ def _migrate_files(snap_files, snap_dirs, srcdir, dstdir, missing_ok=False,
         src = os.path.join(srcdir, snap_file)
         dst = os.path.join(dstdir, snap_file)
 
-        dir_stat = os.stat(srcdir)
+        dir_stat = os.stat(os.path.dirname(src),
+                           follow_symlinks=follow_symlinks)
         uid = dir_stat.st_uid
         gid = dir_stat.st_gid
-        os.makedirs(dstdir, exist_ok=True)
-        shutil.copystat(srcdir, dstdir, follow_symlinks=follow_symlinks)
-        os.chown(dstdir, uid, gid, follow_symlinks=follow_symlinks)
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        shutil.copystat(os.path.dirname(src), os.path.dirname(dst),
+                        follow_symlinks=follow_symlinks)
+        os.chown(os.path.dirname(dst), uid, gid,
+                 follow_symlinks=follow_symlinks)
 
         if missing_ok and not os.path.exists(src):
             continue

--- a/snapcraft/internal/pluginhandler.py
+++ b/snapcraft/internal/pluginhandler.py
@@ -662,6 +662,7 @@ def _migrate_files(snap_files, snap_dirs, srcdir, dstdir, missing_ok=False,
         gid = dir_stat.st_gid
         os.makedirs(dst, exist_ok=True)
         os.chown(dst, uid, gid, follow_symlinks=follow_symlinks)
+        shutil.copystat(src, dst, follow_symlinks=follow_symlinks)
 
     for snap_file in snap_files:
         src = os.path.join(srcdir, snap_file)
@@ -671,6 +672,7 @@ def _migrate_files(snap_files, snap_dirs, srcdir, dstdir, missing_ok=False,
         uid = dir_stat.st_uid
         gid = dir_stat.st_gid
         os.makedirs(dstdir, exist_ok=True)
+        shutil.copystat(srcdir, dstdir, follow_symlinks=follow_symlinks)
         os.chown(dstdir, uid, gid, follow_symlinks=follow_symlinks)
 
         if missing_ok and not os.path.exists(src):

--- a/snapcraft/internal/pluginhandler.py
+++ b/snapcraft/internal/pluginhandler.py
@@ -658,7 +658,8 @@ def _create_dirs(srcdir, dstdir, follow_symlinks=False):
     try:
         os.chown(dstdir, uid, gid, follow_symlinks=follow_symlinks)
     except PermissionError as e:
-        logger.warning(e)
+        logger.warning('unable to chown {dstdir}: {error}'.format(
+            dstdir=dstdir, error=e))
 
     shutil.copystat(srcdir, dstdir, follow_symlinks=follow_symlinks)
 

--- a/snapcraft/internal/pluginhandler.py
+++ b/snapcraft/internal/pluginhandler.py
@@ -656,15 +656,22 @@ def _migrate_files(snap_files, snap_dirs, srcdir, dstdir, missing_ok=False,
     for directory in snap_dirs:
         src = os.path.join(srcdir, directory)
         dst = os.path.join(dstdir, directory)
+
+        dir_stat = os.stat(src)
+        uid = dir_stat.st_uid
+        gid = dir_stat.st_gid
         os.makedirs(dst, exist_ok=True)
-        shutil.copystat(src, dst, follow_symlinks=follow_symlinks)
+        os.chown(dst, uid, gid, follow_symlinks=follow_symlinks)
 
     for snap_file in snap_files:
         src = os.path.join(srcdir, snap_file)
         dst = os.path.join(dstdir, snap_file)
-        os.makedirs(os.path.dirname(dst), exist_ok=True)
-        shutil.copystat(os.path.dirname(src), os.path.dirname(dst),
-                        follow_symlinks=follow_symlinks)
+
+        dir_stat = os.stat(srcdir)
+        uid = dir_stat.st_uid
+        gid = dir_stat.st_gid
+        os.makedirs(dstdir, exist_ok=True)
+        os.chown(dstdir, uid, gid, follow_symlinks=follow_symlinks)
 
         if missing_ok and not os.path.exists(src):
             continue

--- a/snapcraft/internal/pluginhandler.py
+++ b/snapcraft/internal/pluginhandler.py
@@ -655,7 +655,11 @@ def _create_dirs(srcdir, dstdir, follow_symlinks=False):
     uid = dir_stat.st_uid
     gid = dir_stat.st_gid
     os.makedirs(dstdir, exist_ok=True)
-    os.chown(dstdir, uid, gid, follow_symlinks=follow_symlinks)
+    try:
+        os.chown(dstdir, uid, gid, follow_symlinks=follow_symlinks)
+    except PermissionError as e:
+        logger.warning(e)
+
     shutil.copystat(srcdir, dstdir, follow_symlinks=follow_symlinks)
 
 

--- a/snapcraft/tests/test_plugin_copy.py
+++ b/snapcraft/tests/test_plugin_copy.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os.path
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import snapcraft
 from snapcraft.plugins.copy import (
@@ -352,6 +352,16 @@ class TestRecursivelyLink(TestCase):
         os.mkdir('qux')
         _recursively_link('1', 'qux', os.getcwd())
         self.assertTrue(os.path.isfile(os.path.join('qux', '1')))
+
+    @patch('os.chown')
+    def test_recursively_link_file_into_dir_chown_permissions(self,
+                                                              chown_mock):
+        chown_mock.side_effect = PermissionError('Nope')
+        os.mkdir('qux')
+        _recursively_link('1', 'qux', os.getcwd())
+        self.assertTrue(os.path.isfile(os.path.join('qux', '1')))
+
+        self.assertTrue(chown_mock.called)
 
     def test_recursively_link_directory_to_directory(self):
         _recursively_link('foo', 'qux', os.getcwd())

--- a/snapcraft/tests/test_pluginhandler.py
+++ b/snapcraft/tests/test_pluginhandler.py
@@ -19,6 +19,7 @@ import copy
 import logging
 import os
 import shutil
+import stat
 import tempfile
 from unittest.mock import (
     call,
@@ -273,8 +274,8 @@ class PluginTestCase(tests.TestCase):
             self.assertEqual(f.read(), 'installed',
                              "Expected migrated 'bar' to be a copy of 'foo'")
 
-    @patch('shutil.copystat')
-    def test_migrate_files_preserves_ownership(self, copystat_mock):
+    @patch('os.chown')
+    def test_migrate_files_preserves_ownership(self, chown_mock):
         os.makedirs('install')
         os.makedirs('stage')
 
@@ -287,8 +288,54 @@ class PluginTestCase(tests.TestCase):
         pluginhandler._migrate_files(
             files, dirs, 'install', 'stage', follow_symlinks=True)
 
-        copystat_mock.assert_called_with('install', 'stage',
-                                         follow_symlinks=True)
+        self.assertTrue(chown_mock.called)
+
+    def test_migrate_files_preserves_file_mode(self):
+        os.makedirs('install')
+        os.makedirs('stage')
+
+        foo = os.path.join('install', 'foo')
+
+        with open(foo, 'w') as f:
+            f.write('installed')
+
+        mode = os.stat(foo).st_mode
+
+        new_mode = 0o777
+        os.chmod(foo, new_mode)
+        self.assertNotEqual(mode, new_mode)
+
+        files, dirs = pluginhandler._migratable_filesets(['*'], 'install')
+        pluginhandler._migrate_files(
+            files, dirs, 'install', 'stage', follow_symlinks=True)
+
+        self.assertEqual(stat.S_IMODE(
+            os.stat(os.path.join('stage', 'foo')).st_mode), new_mode)
+
+    def test_migrate_files_preserves_directory_mode(self):
+        os.makedirs('install/foo')
+        os.makedirs('stage')
+
+        foo = os.path.join('install', 'foo', 'bar')
+
+        with open(foo, 'w') as f:
+            f.write('installed')
+
+        mode = os.stat(foo).st_mode
+
+        new_mode = 0o777
+        self.assertNotEqual(mode, new_mode)
+        os.chmod(os.path.dirname(foo), new_mode)
+        os.chmod(foo, new_mode)
+
+        files, dirs = pluginhandler._migratable_filesets(['*'], 'install')
+        pluginhandler._migrate_files(
+            files, dirs, 'install', 'stage', follow_symlinks=True)
+
+        self.assertEqual(stat.S_IMODE(
+            os.stat(os.path.join('stage', 'foo')).st_mode), new_mode)
+        self.assertEqual(stat.S_IMODE(
+            os.stat(os.path.join('stage', 'foo', 'bar')).st_mode), new_mode)
 
     @patch('importlib.import_module')
     @patch('snapcraft.internal.pluginhandler._load_local')

--- a/snapcraft/tests/test_pluginhandler.py
+++ b/snapcraft/tests/test_pluginhandler.py
@@ -290,6 +290,24 @@ class PluginTestCase(tests.TestCase):
 
         self.assertTrue(chown_mock.called)
 
+    @patch('os.chown')
+    def test_migrate_files_chown_permissions(self, chown_mock):
+        os.makedirs('install')
+        os.makedirs('stage')
+
+        chown_mock.side_effect = PermissionError("No no no")
+
+        foo = os.path.join('install', 'foo')
+
+        with open(foo, 'w') as f:
+            f.write('installed')
+
+        files, dirs = pluginhandler._migratable_filesets(['*'], 'install')
+        pluginhandler._migrate_files(
+            files, dirs, 'install', 'stage', follow_symlinks=True)
+
+        self.assertTrue(chown_mock.called)
+
     def test_migrate_files_preserves_file_mode(self):
         os.makedirs('install')
         os.makedirs('stage')


### PR DESCRIPTION
shutil.copystat doesn't preserve owner/group so do it manually with
os.stat() and os.chown()

LP:#1605903