### PR TITLE
Support having the snapcraft.yaml in a subdir.

### DIFF
--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -62,7 +62,7 @@ class TestCase(testtools.TestCase):
                 cwd = os.path.join(self.path, project_dir)
         else:
             cwd = None
-        
+
         if yaml_dir:
             cwd = os.path.join(self.path, yaml_dir)
 

--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -52,7 +52,7 @@ class TestCase(testtools.TestCase):
         self.useFixture(fixtures.EnvironmentVariable(
             'XDG_DATA_HOME', os.path.join(self.path, 'data')))
 
-    def run_snapcraft(self, command, project_dir=None):
+    def run_snapcraft(self, command, project_dir=None, yaml_dir=None):
         if isinstance(command, str):
             command = [command]
         if project_dir:
@@ -62,6 +62,10 @@ class TestCase(testtools.TestCase):
                 cwd = os.path.join(self.path, project_dir)
         else:
             cwd = None
+        
+        if yaml_dir:
+            cwd = os.path.join(self.path, yaml_dir)
+
         try:
             return subprocess.check_output(
                 [self.snapcraft_command, '-d'] + command, cwd=cwd,

--- a/integration_tests/snaps/yaml-in-subdir/file
+++ b/integration_tests/snaps/yaml-in-subdir/file
@@ -1,0 +1,1 @@
+I'm a file

--- a/integration_tests/snaps/yaml-in-subdir/subdir/snapcraft.yaml
+++ b/integration_tests/snaps/yaml-in-subdir/subdir/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: test-package
+version: 0.1
+summary: one line summary
+description: a longer description
+confinement: strict
+
+parts:
+  parent:
+    plugin: dump
+    source: ..
+
+  self:
+    plugin: dump
+    source: .

--- a/integration_tests/snaps/yaml-in-subdir/subdir/subdirfile
+++ b/integration_tests/snaps/yaml-in-subdir/subdir/subdirfile
@@ -1,0 +1,1 @@
+I'm in the subdir

--- a/integration_tests/test_yaml_in_subdir.py
+++ b/integration_tests/test_yaml_in_subdir.py
@@ -1,0 +1,43 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import time
+
+from testtools.matchers import (
+    FileExists,
+    Equals
+)
+
+import integration_tests
+
+
+class YamlInSubdirTestCase(integration_tests.TestCase):
+
+    def test_stage(self):
+        project_dir = 'yaml-in-subdir'
+        subdir = os.path.join(project_dir, 'subdir')
+        self.run_snapcraft('stage', project_dir, subdir)
+
+        expected_file = os.path.join(subdir, 'stage', 'file')
+        self.assertThat(expected_file, FileExists())
+        with open(expected_file) as f:
+            self.assertThat(f.read(), Equals("I'm a file\n"))
+
+        expected_file = os.path.join(subdir, 'stage', 'subdirfile')
+        self.assertThat(expected_file, FileExists())
+        with open(expected_file) as f:
+            self.assertThat(f.read(), Equals("I'm in the subdir\n"))

--- a/snapcraft/internal/sources.py
+++ b/snapcraft/internal/sources.py
@@ -356,12 +356,17 @@ class Local(Base):
 
         def ignore(directory, files):
             if directory is source_abspath:
+                ignored = common.SNAPCRAFT_FILES
+                relative_cwd = os.path.basename(os.getcwd())
+                if os.path.join(directory, relative_cwd) == os.getcwd():
+                    # Source is a parent of the working directory.
+                    # Do not recursively copy it into itself.
+                    ignored.append(relative_cwd)
                 snaps = glob.glob(os.path.join(directory, '*.snap'))
                 if snaps:
                     snaps = [os.path.basename(s) for s in snaps]
-                    return common.SNAPCRAFT_FILES + snaps
-                else:
-                    return common.SNAPCRAFT_FILES
+                    ignored += snaps
+                return ignored
             else:
                 return []
 

--- a/snapcraft/tests/test_sources.py
+++ b/snapcraft/tests/test_sources.py
@@ -384,6 +384,14 @@ class TestSubversion(SourceTestCase):
 
 class TestLocal(tests.TestCase):
 
+    def test_pull_with_source_a_parent_of_current_dir(self):
+        # Verify that the snapcraft root dir does not get copied into itself.
+        os.makedirs(os.path.join('src', 'snapcraft'))
+        local = sources.Local('..', 'src/snapcraft')
+        local.pull()
+
+        self.assertTrue('snapcraft' not in os.listdir('src/snapcraft'))
+
     def test_pull_with_existing_empty_source_dir_creates_hardlinks(self):
         os.makedirs(os.path.join('src', 'dir'))
         open(os.path.join('src', 'dir', 'file'), 'w').close()

--- a/snapcraft/tests/test_sources.py
+++ b/snapcraft/tests/test_sources.py
@@ -386,11 +386,16 @@ class TestLocal(tests.TestCase):
 
     def test_pull_with_source_a_parent_of_current_dir(self):
         # Verify that the snapcraft root dir does not get copied into itself.
-        os.makedirs(os.path.join('src', 'snapcraft'))
-        local = sources.Local('..', 'src/snapcraft')
-        local.pull()
+        os.makedirs('subdir')
 
-        self.assertTrue('snapcraft' not in os.listdir('src/snapcraft'))
+        cwd = os.getcwd()
+        os.chdir('subdir')
+        local = sources.Local('..', 'foo')
+        local.pull()
+        os.chdir(cwd)
+
+        self.assertTrue(
+            'subdir' not in os.listdir(os.path.join('subdir', 'foo')))
 
     def test_pull_with_existing_empty_source_dir_creates_hardlinks(self):
         os.makedirs(os.path.join('src', 'dir'))


### PR DESCRIPTION
Currently when one puts the `snapcraft.yaml` in a subdirectory of the project (using `source: ..` etc.) snapcraft dies in a sea of recursion. This PR fixes LP: [#1600428](https://bugs.launchpad.net/snapcraft/+bug/1600428) by skipping over the directory containing the snapcraft.yaml if it's a subdirectory of the project.