### PR TITLE
Add a new build plugin 'shell' that runs arbitrary shell commands

### DIFF
--- a/snapcraft/plugins/shell.py
+++ b/snapcraft/plugins/shell.py
@@ -1,0 +1,58 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+The shell plugin is useful for projects that use esoteric or one-off build
+systems. It can run arbitrary commands to build and install the software.
+
+This plugin uses the common plugin keyword sas well as those for for 'sources'.
+For more information check the 'plugins' topic for the former and the 'sources'
+topic for the latter.
+
+Additionally, this plugin uses the following plugin-specific keywords:
+
+    - build-cmds
+      (list of strings)
+      The commands to run to build and install the software.
+"""
+
+import snapcraft
+import snapcraft.common
+
+
+class ShellPlugin(snapcraft.BasePlugin):
+
+    @classmethod
+    def schema(cls):
+        schema = super().schema()
+        schema['properties']['build-cmds'] = {
+            'type': 'array',
+            'minitems': 1,
+            'items': {
+                'type': 'string',
+            },
+            'default': [],
+        }
+        schema['build-properties'].extend(['build-cmds'])
+        return schema
+
+    def __init__(self, name, options, project):
+        super().__init__(name, options, project)
+
+    def build(self):
+        super().build()
+        for cmd in self.options.build_cmds:
+            self.run(cmd.split())

--- a/snapcraft/plugins/shell.py
+++ b/snapcraft/plugins/shell.py
@@ -34,7 +34,6 @@ import snapcraft.common
 
 
 class ShellPlugin(snapcraft.BasePlugin):
-
     @classmethod
     def schema(cls):
         schema = super().schema()
@@ -55,4 +54,4 @@ class ShellPlugin(snapcraft.BasePlugin):
     def build(self):
         super().build()
         for cmd in self.options.build_cmds:
-            self.run(cmd.split())
+            self.run(cmd.split() if ' ' in cmd else [cmd])

--- a/snapcraft/tests/test_commands_list_plugins.py
+++ b/snapcraft/tests/test_commands_list_plugins.py
@@ -24,9 +24,9 @@ class ListPluginsCommandTestCase(tests.TestCase):
     # plugin list when wrapper at MAX_CHARACTERS_WRAP
     default_plugin_output = (
         'ant        catkin  copy  go      gradle  jdk     kernel  maven  '
-        'nodejs             python2  qmake  scons      \n'
+        'nodejs             python2  qmake  scons  tar-content\n'
         'autotools  cmake   dump  godeps  gulp    kbuild  make    nil    '
-        'plainbox-provider  python3  rust   tar-content\n'
+        'plainbox-provider  python3  rust   shell\n'
     )
 
     def test_list_plugins_non_tty(self):
@@ -51,8 +51,8 @@ class ListPluginsCommandTestCase(tests.TestCase):
             'ant        dump    jdk     nil                qmake      \n'
             'autotools  go      kbuild  nodejs             rust       \n'
             'catkin     godeps  kernel  plainbox-provider  scons      \n'
-            'cmake      gradle  make    python2            tar-content\n'
-            'copy       gulp    maven   python3          \n'
+            'cmake      gradle  make    python2            shell      \n'
+            'copy       gulp    maven   python3            tar-content\n'
         )
 
         main(['list-plugins'])

--- a/snapcraft/tests/test_plugin_shell.py
+++ b/snapcraft/tests/test_plugin_shell.py
@@ -1,0 +1,73 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from unittest import mock
+
+import snapcraft
+from snapcraft import tests
+from snapcraft.plugins import shell
+
+
+class ShellPluginTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        class Options:
+            build_cmds = []
+            disable_parallel = False
+
+        self.options = Options()
+        self.project_options = snapcraft.ProjectOptions()
+
+    def test_schema(self):
+        schema = shell.ShellPlugin.schema()
+        properties = schema['properties']
+        self.assertIn('build-cmds', properties,
+                      'Expected "build-cmds" to be included in properties')
+        self.assertIn('type', properties['build-cmds'],
+                      'Expected "type" to be included in "build-cmds"')
+        self.assertEqual(properties['build-cmds']['type'], 'array',
+                         'Expected "build-cmds" "type" to be "array"')
+        self.assertEqual(properties['build-cmds']['minitems'], 1,
+                         'Expected "build-cmds" "minitems" to be 1')
+        self.assertEqual(properties['build-cmds']['default'], [],
+                         'Expected "build-cmds" "default" to be empty list')
+        self.assertIn('items', properties['build-cmds'],
+                      'Expected "items" to be included in "build-cmds"')
+        self.assertIsInstance(properties['build-cmds']['items'], dict,
+                              'Expected "build-cmds" "items" to be a dict')
+        self.assertEqual(properties['build-cmds']['items']['type'], 'string',
+                         'Expected "build-cmds" "items" "type" to be "string"')
+
+    @mock.patch.object(shell.ShellPlugin, 'run')
+    def test_build(self, mock_run):
+        cmds = [
+            ('singleword', ['singleword']),
+            ('three words three', ['three', 'words', 'three']),
+            ('make install', ['make', 'install']),
+            ('./waf', ['./waf'])
+        ]
+        self.options.build_cmds = list(cmd for (cmd, _) in cmds)
+        plugin = shell.ShellPlugin(
+            'test-part', self.options, self.project_options)
+        os.makedirs(plugin.sourcedir)
+        plugin.build()
+        self.assertEqual(len(cmds), mock_run.call_count)
+        for ((_, expected), actual) in zip(cmds, mock_run.call_args_list):
+            self.assertEqual(mock.call(expected), actual)


### PR DESCRIPTION
In order to support uncommon build systems and custom written build scripts it is useful to be able to run arbitrary commands to build and install, rather than just the commands hardcoded into the other snapcraft plugins.

This plugin accepts a list of commands and runs each of them with bash variables set to represent the source dir, build dir, and dest dir for the snapcraft part._

For example, here is a snapcraft file that compiles the video player mpv, which uses both a custom bootstrap script and the build system waf:
http://paste.ubuntu.com/23050131/

If there is anything you would like added to this plugin please let me know, thanks.
