### PR TITLE
Use link_or_copy instead of just hard-links for deb cache.

### DIFF
--- a/manual-tests.md
+++ b/manual-tests.md
@@ -26,3 +26,5 @@
 4. Run `snapcraft pull` again and notice the download is minimal.
 5. Wipe the cached apt data.
 6. Run `snapcraft pull` again and notice the download is as in `1.`.
+7. Run this test again, but run snapcraft on a partition separated
+   from $HOME.

--- a/snapcraft/internal/repo.py
+++ b/snapcraft/internal/repo.py
@@ -190,7 +190,7 @@ class _AptCache:
             src = os.path.join(package_cache_dir, pkg.name)
             dst = os.path.join(download_dir, pkg.name)
             if os.path.exists(src):
-                os.link(src, dst)
+                common.link_or_copy(src, dst)
 
     def _store_cached_packages(self, package_cache_dir, download_dir):
         os.makedirs(package_cache_dir, exist_ok=True)
@@ -203,7 +203,7 @@ class _AptCache:
             # just in case.
             if os.path.exists(dst):
                 os.unlink(dst)
-            os.link(src, dst)
+            common.link_or_copy(src, dst)
 
     @contextmanager
     def archive(self, rootdir, download_dir):


### PR DESCRIPTION
This PR fixes LP: [#1612813](https://bugs.launchpad.net/snapcraft/+bug/1612813), making the cache work across filesystem boundaries.