### PR TITLE
Remove store dispute logic

### DIFF
--- a/integration_tests/test_store_register.py
+++ b/integration_tests/test_store_register.py
@@ -46,7 +46,7 @@ class RegisterTestCase(integration_tests.StoreTestCase):
             'users expect for \'test-already-registered-snap-name\' then '
             'claim the name at')
         self.assertThat(str(error.output), Contains(expected))
-        self.assertThat(str(error.output), Contains('register-name-dispute'))
+        self.assertThat(str(error.output), Contains('register-name'))
 
     def test_registration_of_reserved_name(self):
         self.login()
@@ -60,7 +60,7 @@ class RegisterTestCase(integration_tests.StoreTestCase):
             'then please claim the name at').format(
                 self.test_store.reserved_snap_name)
         self.assertThat(str(error.output), Contains(expected))
-        self.assertThat(str(error.output), Contains('register-name-dispute'))
+        self.assertThat(str(error.output), Contains('register-name'))
 
     def test_registrations_in_a_row_fail_if_too_fast(self):
         # Wait after the registration attempts, so the following registrations

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -83,12 +83,12 @@ class StoreRegistrationError(StoreError):
         'The name {snap_name!r} is already taken.\n\n'
         'We can if needed rename snaps to ensure they match the expectations '
         'of most users. If you are the publisher most users expect for '
-        '{snap_name!r} then claim the name at {register_claim_url!r}')
+        '{snap_name!r} then claim the name at {register_name_url!r}')
 
     __FMT_RESERVED = (
         'The name {snap_name!r} is reserved.\n\n'
         'If you are the publisher most users expect for '
-        '{snap_name!r} then please claim the name at {register_claim_url!r}')
+        '{snap_name!r} then please claim the name at {register_name_url!r}')
 
     __FMT_RETRY_WAIT = (
         'You must wait {retry_after} seconds before trying to register '
@@ -108,21 +108,12 @@ class StoreRegistrationError(StoreError):
         except JSONDecodeError:
             response_json = {}
 
-        if response_json.get('status') == 409:
-            response_json['register_claim_url'] = self.__get_claim_url(
-                response_json.get('register_name_url', ''))
-
         error_code = response_json.get('code')
         if error_code:
             # we default to self.fmt in case error_code is not mapped yet.
             self.fmt = self.__error_messages.get(error_code, self.fmt)
 
         super().__init__(snap_name=snap_name, **response_json)
-
-    def __get_claim_url(self, url):
-        # TODO use the store provided claim url once it is there
-        # LP: #1598905
-        return re.sub('register-name', 'register-name-dispute', url, count=0)
 
 
 class StorePushError(StoreError):

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -15,8 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import re
-
 from simplejson.scanner import JSONDecodeError
 
 

--- a/snapcraft/tests/store/test_store_client.py
+++ b/snapcraft/tests/store/test_store_client.py
@@ -180,7 +180,7 @@ class RegisterTestCase(tests.TestCase):
             "We can if needed rename snaps to ensure they match the "
             "expectations of most users. If you are the publisher most users "
             "expect for 'test-already-registered-snap-name' then claim the "
-            "name at 'https://myapps.com/register-name-dispute/'")
+            "name at 'https://myapps.com/register-name/'")
 
     def test_register_a_reserved_name(self):
         self.client.login('dummy', 'test correct password')
@@ -192,7 +192,7 @@ class RegisterTestCase(tests.TestCase):
             "\n\n"
             "If you are the publisher most users expect for "
             "'test-reserved-snap-name' then please claim the "
-            "name at 'https://myapps.com/register-name-dispute/'")
+            "name at 'https://myapps.com/register-name/'")
 
     def test_registering_too_fast_in_a_row(self):
         self.client.login('dummy', 'test correct password')


### PR DESCRIPTION
The `-dispute` URL when registering is no longer valid as the register
and dispute URLs have been merged into one.

LP: #1613609

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>