### PR TITLE
python plugins: add process-dependency-links option

### DIFF
--- a/snapcraft/plugins/python2.py
+++ b/snapcraft/plugins/python2.py
@@ -71,6 +71,10 @@ class Python2Plugin(snapcraft.BasePlugin):
             },
             'default': [],
         }
+        schema['properties']['process-dependency-links'] = {
+            'type': 'boolean',
+            'default': False,
+        }
         schema.pop('required')
 
         # Inform Snapcraft of the properties associated with pulling. If these
@@ -154,6 +158,9 @@ class Python2Plugin(snapcraft.BasePlugin):
                 '--constraint',
                 os.path.join(self.sourcedir, self.options.constraints),
             ]
+
+        if self.options.process_dependency_links:
+            pip_install.append('--process-dependency-links')
 
         if self.options.requirements:
             self.run(pip_install + [

--- a/snapcraft/plugins/python3.py
+++ b/snapcraft/plugins/python3.py
@@ -61,6 +61,10 @@ class Python3Plugin(snapcraft.BasePlugin):
             },
             'default': [],
         }
+        schema['properties']['process-dependency-links'] = {
+            'type': 'boolean',
+            'default': False,
+        }
         schema.pop('required')
 
         # Inform Snapcraft of the properties associated with pulling. If these
@@ -126,6 +130,9 @@ class Python3Plugin(snapcraft.BasePlugin):
         pip3 = os.path.join(self.installdir, 'usr', 'bin', 'pip3')
         pip_install = ['python3', pip3, 'install', '--root',
                        self.installdir, "--install-option=--prefix=usr"]
+
+        if self.options.process_dependency_links:
+            pip_install.append('--process-dependency-links')
 
         if self.options.requirements:
             self.run(pip_install + ['--requirement', requirements])

--- a/snapcraft/plugins/python3.py
+++ b/snapcraft/plugins/python3.py
@@ -96,27 +96,22 @@ class Python3Plugin(snapcraft.BasePlugin):
 
     def pull(self):
         super().pull()
-        self._pip()
 
-    def _pip(self):
         setup = 'setup.py'
         if os.listdir(self.sourcedir):
             setup = os.path.join(self.sourcedir, 'setup.py')
 
-        if self.options.requirements:
-            requirements = os.path.join(self.sourcedir,
-                                        self.options.requirements)
+        if (os.path.exists(setup) or self.options.requirements or
+                self.options.python_packages):
+            self._pip(setup)
 
-        if not os.path.exists(setup) and not \
-                (self.options.requirements or self.options.python_packages):
-            return
-
+    def _setup_pip(self):
         easy_install = os.path.join(
             self.installdir, 'usr', 'bin', 'easy_install3')
         prefix = os.path.join(self.installdir, 'usr')
+
         site_packages_dir = os.path.join(
             prefix, 'lib', self.python_version, 'site-packages')
-
         # If site-packages doesn't exist, make sure it points to the
         # python3 dist-packages (this is a relative link so that it's still
         # valid when the .snap is installed). Note that all python3 versions
@@ -127,6 +122,7 @@ class Python3Plugin(snapcraft.BasePlugin):
 
         self.run(['python3', easy_install, '--prefix', prefix, 'pip'])
 
+    def _get_pip_command(self):
         pip3 = os.path.join(self.installdir, 'usr', 'bin', 'pip3')
         pip_install = ['python3', pip3, 'install', '--root',
                        self.installdir, "--install-option=--prefix=usr"]
@@ -134,13 +130,21 @@ class Python3Plugin(snapcraft.BasePlugin):
         if self.options.process_dependency_links:
             pip_install.append('--process-dependency-links')
 
+        return pip_install
+
+    def _pip(self, setup):
+        self._setup_pip()
+        pip_install = self._get_pip_command()
+
         if self.options.requirements:
-            self.run(pip_install + ['--requirement', requirements])
+            self.run(pip_install + [
+                '--requirement',
+                os.path.join(self.sourcedir, self.options.requirements),
+            ])
 
         if self.options.python_packages:
             self.run(pip_install + ['--upgrade'] +
                      self.options.python_packages)
-
         if os.path.exists(setup):
             self.run(pip_install + ['.', ], cwd=self.sourcedir)
 

--- a/snapcraft/tests/test_plugin_python2.py
+++ b/snapcraft/tests/test_plugin_python2.py
@@ -29,7 +29,7 @@ def setup_directories(plugin):
         plugin.installdir, 'usr', 'lib', 'python2.7', 'dist-packages'))
     os.makedirs(os.path.join(
         plugin.installdir, 'usr', 'include', 'python2.7'))
-    open(os.path.join(plugin.sourcedir, 'setup.py'), 'w').close()
+    open('setup.py', 'w').close()
 
 
 class Python2PluginTestCase(tests.TestCase):
@@ -38,6 +38,7 @@ class Python2PluginTestCase(tests.TestCase):
         super().setUp()
 
         class Options:
+            source = '.'
             requirements = ''
             constraints = ''
             python_packages = []
@@ -54,7 +55,7 @@ class Python2PluginTestCase(tests.TestCase):
         plugin = python2.Python2Plugin('test-part', self.options,
                                        self.project_options)
         setup_directories(plugin)
-        plugin._pip()
+        plugin.pull()
 
         link = os.readlink(os.path.join(plugin.installdir, 'usr', 'lib',
                                         'python2.7', 'site-packages'))
@@ -111,7 +112,9 @@ class Python2PluginTestCase(tests.TestCase):
         plugin = python2.Python2Plugin('test-part', self.options,
                                        self.project_options)
         plugin.pull()
-        self.assertTrue(mock_pip.called)
+        # mock_pip should not be called as there is no setup.py,
+        # requirements or python-packages defined.
+        self.assertFalse(mock_pip.called)
 
     @mock.patch.object(python2.Python2Plugin, 'run')
     @mock.patch.object(os.path, 'exists', return_value=False)
@@ -119,7 +122,7 @@ class Python2PluginTestCase(tests.TestCase):
         plugin = python2.Python2Plugin('test-part', self.options,
                                        self.project_options)
         setup_directories(plugin)
-        plugin._pip()
+        plugin.pull()
         self.assertFalse(mock_run.called)
 
     @mock.patch.object(python2.Python2Plugin, 'run')
@@ -143,6 +146,7 @@ class Python2PluginTestCase(tests.TestCase):
 
         plugin = python2.Python2Plugin('test-part', self.options,
                                        self.project_options)
+        setup_directories(plugin)
 
         pip2 = os.path.join(plugin.installdir, 'usr', 'bin', 'pip2')
         include = os.path.join(
@@ -162,8 +166,7 @@ class Python2PluginTestCase(tests.TestCase):
             mock.call(pip_install + ['--upgrade', 'test', 'packages']),
             mock.call(pip_install + ['.'], cwd=plugin.sourcedir)
         ]
-        setup_directories(plugin)
-        plugin._pip()
+        plugin.pull()
         mock_run.assert_has_calls(calls)
 
     def test_get_python2_include_missing_raises_exception(self):
@@ -242,5 +245,5 @@ class Python2PluginTestCase(tests.TestCase):
         plugin = python2.Python2Plugin('test-part', self.options,
                                        self.project_options)
         setup_directories(plugin)
-        plugin._pip()
+        plugin.pull()
         self.assertIn('--process-dependency-links', run_mock.call_args[0][0])

--- a/snapcraft/tests/test_plugin_python2.py
+++ b/snapcraft/tests/test_plugin_python2.py
@@ -41,6 +41,7 @@ class Python2PluginTestCase(tests.TestCase):
             requirements = ''
             constraints = ''
             python_packages = []
+            process_dependency_links = False
 
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
@@ -234,3 +235,12 @@ class Python2PluginTestCase(tests.TestCase):
             with open(os.path.join(plugin.installdir,
                                    file_info['path']), 'r') as f:
                 self.assertEqual(f.read(), file_info['expected'])
+
+    @mock.patch.object(python2.Python2Plugin, 'run')
+    def test_process_dependency_links(self, run_mock):
+        self.options.process_dependency_links = True
+        plugin = python2.Python2Plugin('test-part', self.options,
+                                       self.project_options)
+        setup_directories(plugin)
+        plugin._pip()
+        self.assertIn('--process-dependency-links', run_mock.call_args[0][0])

--- a/snapcraft/tests/test_plugin_python3.py
+++ b/snapcraft/tests/test_plugin_python3.py
@@ -40,6 +40,7 @@ class Python3PluginTestCase(tests.TestCase):
         class Options:
             requirements = ''
             python_packages = []
+            process_dependency_links = False
 
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
@@ -182,3 +183,12 @@ class Python3PluginTestCase(tests.TestCase):
             with open(os.path.join(plugin.installdir,
                                    file_info['path']), 'r') as f:
                 self.assertEqual(f.read(), file_info['expected'])
+
+    @mock.patch.object(python3.Python3Plugin, 'run')
+    def test_process_dependency_links(self, run_mock):
+        self.options.process_dependency_links = True
+        plugin = python3.Python3Plugin('test-part', self.options,
+                                       self.project_options)
+        setup_directories(plugin)
+        plugin._pip()
+        self.assertIn('--process-dependency-links', run_mock.call_args[0][0])


### PR DESCRIPTION
This will run pip install with --process-dependency-links as per [0].

[0] https://pip.pypa.io/en/stable/reference/pip_wheel/#cmdoption--process-dependency-links

LP: #1614186