### PR TITLE
nodjs, gulp plugins: use http_proxy to connect npm registry

### DIFF
--- a/snapcraft/plugins/gulp.py
+++ b/snapcraft/plugins/gulp.py
@@ -99,6 +99,14 @@ class GulpPlugin(snapcraft.BasePlugin):
         env = os.environ.copy()
         env['PATH'] = '{}:{}'.format(
             os.path.join(self._npm_dir, 'bin'), env['PATH'])
+
+        # make npm use http proxy to access registry via https
+        # ref. https://github.com/npm/npm/issues/2050
+        if 'http_proxy' in os.environ:
+            logger.info('Set http_proxy environment variable to "https-proxy"')
+            self.run(['npm', 'config', '-g', 'set', 'https-proxy',
+                     os.environ['http_proxy']], env=env)
+
         self.run(['npm', 'install', '-g', 'gulp-cli'], env=env)
         if os.path.exists(os.path.join(self.builddir, 'package.json')):
             self.run(['npm', 'install', '--only-development'], env=env)

--- a/snapcraft/plugins/gulp.py
+++ b/snapcraft/plugins/gulp.py
@@ -100,9 +100,11 @@ class GulpPlugin(snapcraft.BasePlugin):
         env['PATH'] = '{}:{}'.format(
             os.path.join(self._npm_dir, 'bin'), env['PATH'])
 
-        # make npm use http proxy to access registry via https
+        # Setting the "npm_config_https_proxy" environment variable with the
+        # value of "http_proxy".
         # ref. https://github.com/npm/npm/issues/2050
-        if 'http_proxy' in os.environ:
+        if ('http_proxy' in os.environ and
+                'npm_config_https_proxy' not in os.environ):
             logger.info('Set http_proxy environment variable to "https-proxy"')
             env['npm_config_https_proxy'] = os.environ['http_proxy']
 

--- a/snapcraft/plugins/gulp.py
+++ b/snapcraft/plugins/gulp.py
@@ -104,8 +104,7 @@ class GulpPlugin(snapcraft.BasePlugin):
         # ref. https://github.com/npm/npm/issues/2050
         if 'http_proxy' in os.environ:
             logger.info('Set http_proxy environment variable to "https-proxy"')
-            self.run(['npm', 'config', '-g', 'set', 'https-proxy',
-                     os.environ['http_proxy']], env=env)
+            env['npm_config_https_proxy'] = os.environ['http_proxy']
 
         self.run(['npm', 'install', '-g', 'gulp-cli'], env=env)
         if os.path.exists(os.path.join(self.builddir, 'package.json')):

--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -107,6 +107,14 @@ class NodePlugin(snapcraft.BasePlugin):
         super().build()
         self._nodejs_tar.provision(
             self.installdir, clean_target=False, keep_tarball=True)
+
+        # make npm use http proxy to access registry via https
+        # ref. https://github.com/npm/npm/issues/2050
+        if 'http_proxy' in os.environ:
+            logger.info('Set http_proxy environment variable to "https-proxy"')
+            self.run(['npm', 'config', '-g', 'set', 'https-proxy',
+                     os.environ['http_proxy']])
+
         for pkg in self.options.node_packages:
             self.run(['npm', 'install', '-g', pkg])
         if os.path.exists(os.path.join(self.builddir, 'package.json')):

--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -110,9 +110,11 @@ class NodePlugin(snapcraft.BasePlugin):
 
         env = os.environ.copy()
 
-        # make npm use http proxy to access registry via https
+        # Setting the "npm_config_https_proxy" environment variable with the
+        # value of "http_proxy".
         # ref. https://github.com/npm/npm/issues/2050
-        if 'http_proxy' in os.environ:
+        if ('http_proxy' in os.environ and
+                'npm_config_https_proxy' not in os.environ):
             logger.info('Set http_proxy environment variable to "https-proxy"')
             env['npm_config_https_proxy'] = os.environ['http_proxy']
 

--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -108,17 +108,18 @@ class NodePlugin(snapcraft.BasePlugin):
         self._nodejs_tar.provision(
             self.installdir, clean_target=False, keep_tarball=True)
 
+        env = os.environ.copy()
+
         # make npm use http proxy to access registry via https
         # ref. https://github.com/npm/npm/issues/2050
         if 'http_proxy' in os.environ:
             logger.info('Set http_proxy environment variable to "https-proxy"')
-            self.run(['npm', 'config', '-g', 'set', 'https-proxy',
-                     os.environ['http_proxy']])
+            env['npm_config_https_proxy'] = os.environ['http_proxy']
 
         for pkg in self.options.node_packages:
-            self.run(['npm', 'install', '-g', pkg])
+            self.run(['npm', 'install', '-g', pkg], env=env)
         if os.path.exists(os.path.join(self.builddir, 'package.json')):
-            self.run(['npm', 'install', '-g'])
+            self.run(['npm', 'install', '-g'], env=env)
 
 
 def _get_nodejs_base(node_engine):

--- a/snapcraft/tests/test_plugin_nodejs.py
+++ b/snapcraft/tests/test_plugin_nodejs.py
@@ -66,6 +66,8 @@ class NodePluginTestCase(tests.TestCase):
             mock.call().download()])
 
     def test_build_local_sources(self):
+        self.useFixture(tests.fixture_setup.CleanEnvironment())
+
         class Options:
             source = '.'
             node_packages = []
@@ -80,7 +82,7 @@ class NodePluginTestCase(tests.TestCase):
         plugin.build()
 
         self.run_mock.assert_has_calls([
-            mock.call(['npm', 'install', '-g'], cwd=plugin.builddir)])
+            mock.call(['npm', 'install', '-g'], cwd=plugin.builddir, env={})])
         self.tar_mock.assert_has_calls([
             mock.call(
                 nodejs.get_nodejs_release(plugin.options.node_engine),
@@ -89,6 +91,8 @@ class NodePluginTestCase(tests.TestCase):
                 plugin.installdir, clean_target=False, keep_tarball=True)])
 
     def test_pull_and_build_node_packages_sources(self):
+        self.useFixture(tests.fixture_setup.CleanEnvironment())
+
         class Options:
             source = None
             node_packages = ['my-pkg']
@@ -104,7 +108,7 @@ class NodePluginTestCase(tests.TestCase):
 
         self.run_mock.assert_has_calls([
             mock.call(['npm', 'install', '-g', 'my-pkg'],
-                      cwd=plugin.builddir)])
+                      cwd=plugin.builddir, env={})])
         self.tar_mock.assert_has_calls([
             mock.call(
                 nodejs.get_nodejs_release(plugin.options.node_engine),
@@ -114,9 +118,11 @@ class NodePluginTestCase(tests.TestCase):
                 plugin.installdir, clean_target=False, keep_tarball=True)])
 
     def test_pull_and_build_node_packages_sources_via_proxy(self):
+        self.useFixture(tests.fixture_setup.CleanEnvironment())
+
         env_vars = (
             ('http_proxy', 'http://localhost:3132'),
-            ('https_proxy', 'http://localhost:3133'),
+            ('https_proxy', 'https://localhost:3133'),
         )
         for v in env_vars:
             self.useFixture(fixtures.EnvironmentVariable(v[0], v[1]))
@@ -134,12 +140,19 @@ class NodePluginTestCase(tests.TestCase):
         plugin.pull()
         plugin.build()
 
-        self.run_mock.assert_has_calls([
-            mock.call(['npm', 'config', '-g', 'set', 'https-proxy',
-                      env_vars[0][1]], cwd=plugin.builddir)])
+        for call_args in self.run_mock.call_args_list:
+            env = call_args[1]['env']
+            self.assertTrue('npm_config_https_proxy' in env,
+                            'Expected environment to include '
+                            'npm_config_https_proxy')
+            self.assertEqual(env['npm_config_https_proxy'], env_vars[0][1])
+
         self.run_mock.assert_has_calls([
             mock.call(['npm', 'install', '-g', 'my-pkg'],
-                      cwd=plugin.builddir)])
+                      cwd=plugin.builddir, env={
+                            env_vars[0][0]: env_vars[0][1],
+                            env_vars[1][0]: env_vars[1][1],
+                            'npm_config_https_proxy': env_vars[0][1]})])
 
     @mock.patch('platform.machine')
     def test_unsupported_arch_raises_exception(self, machine_mock):


### PR DESCRIPTION
npm regigstry server doesn't support to connect via HTTPS proxy.
However if https_proxy env is set, npm command access to registry via
HTTPS proxy.  Avoid to this, if https_proxy env is set, then
nodejs/gulp plugin will change https-proxy property by "npm config".

LP: #1611372