### PR TITLE
Only show chown warnings with --debug.

### DIFF
--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -68,7 +68,7 @@ def link_or_copy(source, destination, follow_symlinks=False):
         try:
             os.chown(destination, uid, gid, follow_symlinks=follow_symlinks)
         except PermissionError as e:
-            logger.debug('unable to chown {destination}: {error}'.format(
+            logger.debug('Unable to chown {destination}: {error}'.format(
                 destination=destination, error=e))
 
 

--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -68,7 +68,7 @@ def link_or_copy(source, destination, follow_symlinks=False):
         try:
             os.chown(destination, uid, gid, follow_symlinks=follow_symlinks)
         except PermissionError as e:
-            logger.warning('unable to chown {destination}: {error}'.format(
+            logger.debug('unable to chown {destination}: {error}'.format(
                 destination=destination, error=e))
 
 
@@ -127,7 +127,7 @@ def create_similar_directory(source, destination, follow_symlinks=False):
     try:
         os.chown(destination, uid, gid, follow_symlinks=follow_symlinks)
     except PermissionError as exception:
-        logger.warning('Unable to chown {}: {}'.format(destination, exception))
+        logger.debug('Unable to chown {}: {}'.format(destination, exception))
 
     shutil.copystat(source, destination, follow_symlinks=follow_symlinks)
 

--- a/snapcraft/internal/parts.py
+++ b/snapcraft/internal/parts.py
@@ -161,9 +161,6 @@ def _expand_filesets_for(step, properties):
 
 
 class PartsConfig:
-    @property
-    def part_names(self):
-        return self._part_names
 
     def __init__(self, parts_data, project_options, validator, build_tools,
                  snapcraft_yaml):
@@ -178,8 +175,17 @@ class PartsConfig:
         self._part_names = []
         self.after_requests = {}
 
-        self._remote_parts = get_remote_parts()
         self._process_parts()
+
+    @property
+    def part_names(self):
+        return self._part_names
+
+    @property
+    def _remote_parts(self):
+        if getattr(self, '_remote_parts_attr', None) is None:
+            self._remote_parts_attr = get_remote_parts()
+        return self._remote_parts_attr
 
     def _process_parts(self):
         for part_name in self._parts_data:


### PR DESCRIPTION
Use logger.debug() for chown warnings since they are expected to
fail for most use cases.

LP:#1614524