### PR TITLE
kernel plugin: vmlinuz -> kernel.img hard link

### DIFF
--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -311,6 +311,7 @@ class KernelPlugin(kbuild.KBuildPlugin):
         os.link(src, dst)
         # why oh why?
         os.link(src, os.path.join(self.installdir, 'vmlinuz'))
+        os.link(src, os.path.join(self.installdir, 'kernel.img'))
 
     def _copy_system_map(self):
         src = os.path.join(self.builddir, 'System.map')


### PR DESCRIPTION
Adhere to the new naming scheme decided in Heidelberg, and create a kernel.img copy of vmlinuz.

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>