### PR TITLE
Ant properties, build target, and destination directory options

### DIFF
--- a/integration_tests/snaps/simple-ant/my-app/build.xml
+++ b/integration_tests/snaps/simple-ant/my-app/build.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project basedir="." default="jar" name="my-app"
+<project basedir="." default="init" name="my-app"
          xmlns:artifact="antlib:org.apache.maven.artifact.ant">
     <property environment="env"/>
     <property name="basedir" value="."/>
@@ -9,7 +9,6 @@
         <mkdir dir="${build.dir}"/>
         <mkdir dir="${dist.dir}"/>
     </target>
-
     <target name="clean">
         <delete dir="${build.dir}" />
     </target>

--- a/integration_tests/snaps/simple-ant/my-app/build.xml
+++ b/integration_tests/snaps/simple-ant/my-app/build.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project basedir="." default="jar" name="my-app"
+         xmlns:artifact="antlib:org.apache.maven.artifact.ant">
+    <property environment="env"/>
+    <property name="basedir" value="."/>
+    <property name="build.dir" value="${basedir}/build"/>
+    <property name="dist.dir" value="${build.dir}/dist"/>
+    <target name="init">
+        <mkdir dir="${build.dir}"/>
+        <mkdir dir="${dist.dir}"/>
+    </target>
+
+    <target name="clean">
+        <delete dir="${build.dir}" />
+    </target>
+    <target name="artifacts" depends="init">
+        <touch file="${dist.dir}/foo.jar"/>
+    </target>
+</project>

--- a/integration_tests/snaps/simple-ant/snapcraft.yaml
+++ b/integration_tests/snaps/simple-ant/snapcraft.yaml
@@ -1,0 +1,17 @@
+name: simple-ant
+version: 0
+summary: test ant builds
+description: |
+ Test ant builds and options.
+confinement: strict
+
+parts:
+  a:
+    plugin: ant
+    source: my-app
+    ant-properties:
+      foo: 'bar'
+    ant-dest-property: 'dist.dir'
+    ant-build-target: 'artifacts'
+    snap:
+      - foo.jar

--- a/integration_tests/snaps/simple-ant/snapcraft.yaml
+++ b/integration_tests/snaps/simple-ant/snapcraft.yaml
@@ -12,6 +12,7 @@ parts:
     ant-properties:
       foo: 'bar'
     ant-dest-property: 'dist.dir'
-    ant-build-target: 'artifacts'
+    ant-build-targets:
+      - artifacts
     snap:
       - foo.jar

--- a/integration_tests/snaps/simple-ant/snapcraft.yaml
+++ b/integration_tests/snaps/simple-ant/snapcraft.yaml
@@ -10,9 +10,6 @@ parts:
     plugin: ant
     source: my-app
     ant-properties:
-      foo: 'bar'
-    ant-dest-property: 'dist.dir'
+      dist.dir: 'target'
     ant-build-targets:
       - artifacts
-    snap:
-      - foo.jar

--- a/integration_tests/snaps/simple-ant/snapcraft.yaml
+++ b/integration_tests/snaps/simple-ant/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: test ant builds
 description: |
  Test ant builds and options.
 confinement: strict
+grade: stable
 
 parts:
   a:

--- a/integration_tests/test_ant_plugin.py
+++ b/integration_tests/test_ant_plugin.py
@@ -23,4 +23,5 @@ class AntPluginTestCase(integration_tests.TestCase):
     def test_build_ant_plugin(self):
         project_dir = 'simple-ant'
         self.run_snapcraft('prime', project_dir)
-        self.assertTrue(os.path.exists(os.path.join(project_dir, 'prime', 'jar', 'foo.jar')))
+        jar_path = os.path.join(project_dir, 'prime', 'jar', 'foo.jar')
+        self.assertTrue(os.path.exists(jar_path))

--- a/integration_tests/test_ant_plugin.py
+++ b/integration_tests/test_ant_plugin.py
@@ -1,0 +1,26 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015, 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import integration_tests
+
+
+class AntPluginTestCase(integration_tests.TestCase):
+
+    def test_build_ant_plugin(self):
+        project_dir = 'simple-ant'
+        self.run_snapcraft('prime', project_dir)
+        self.assertTrue(os.path.exists(os.path.join(project_dir, 'prime', 'foo.jar')))

--- a/integration_tests/test_ant_plugin.py
+++ b/integration_tests/test_ant_plugin.py
@@ -23,4 +23,4 @@ class AntPluginTestCase(integration_tests.TestCase):
     def test_build_ant_plugin(self):
         project_dir = 'simple-ant'
         self.run_snapcraft('prime', project_dir)
-        self.assertTrue(os.path.exists(os.path.join(project_dir, 'prime', 'foo.jar')))
+        self.assertTrue(os.path.exists(os.path.join(project_dir, 'prime', 'jar', 'foo.jar')))

--- a/snapcraft/plugins/ant.py
+++ b/snapcraft/plugins/ant.py
@@ -68,9 +68,6 @@ class AntPlugin(snapcraft.plugins.jdk.JdkPlugin):
             },
             'default': [],
         }
-        schema['properties']['ant-dest-property'] = {
-            'type': 'string',
-        }
         return schema
 
     def __init__(self, name, options, project):
@@ -85,20 +82,12 @@ class AntPlugin(snapcraft.plugins.jdk.JdkPlugin):
         if self.options.ant_build_targets:
             command.extend(self.options.ant_build_targets)
 
-        if self.options.ant_dest_property:
-            destination = '-D{}={}'.format(self.options.ant_dest_property,
-                                           self.installdir)
-            command.extend([destination])
-
         for prop, value in self.options.ant_properties.items():
             command.extend(['-D{}={}'.format(prop, value)])
 
         self.run(command)
-        if not self.options.ant_dest_property:
-            files = glob.glob(os.path.join(self.builddir, 'target', '*.jar'))
-            if not files:
-                raise RuntimeError(
-                    'Could not find any built jar files for part')
+        files = glob.glob(os.path.join(self.builddir, 'target', '*.jar'))
+        if files:
             jardir = os.path.join(self.installdir, 'jar')
             os.makedirs(jardir)
             for f in files:

--- a/snapcraft/plugins/ant.py
+++ b/snapcraft/plugins/ant.py
@@ -25,12 +25,12 @@ For more information check the 'plugins' topic for the former and the
 
 Additionally, this plugin uses the following plugin-specific keywords:
 
-    - properties:
+    - ant-properties:
       (object)
       A dictionary of key-value pairs. Set the following properties when
       running ant.
 
-    - targets:
+    - ant-build-targets:
       (list of strings)
       Run the given ant targets.
 """

--- a/snapcraft/plugins/ant.py
+++ b/snapcraft/plugins/ant.py
@@ -33,10 +33,6 @@ Additionally, this plugin uses the following plugin-specific keywords:
     - targets:
       (list of strings)
       Run the given ant targets.
-
-    - dest-property:
-      (string)
-      The ant property for the destination directory.
 """
 
 import glob

--- a/snapcraft/plugins/ant.py
+++ b/snapcraft/plugins/ant.py
@@ -30,9 +30,9 @@ Additionally, this plugin uses the following plugin-specific keywords:
       A dictionary of key-value pairs. Set the following properties when
       running ant.
 
-    - target:
-      (string)
-      Run the given ant target.
+    - targets:
+      (list of strings)
+      Run the given ant targets.
 
     - dest-property:
       (string)
@@ -60,8 +60,13 @@ class AntPlugin(snapcraft.plugins.jdk.JdkPlugin):
             'type': 'object',
             'default': {},
         }
-        schema['properties']['ant-build-target'] = {
-            'type': 'string',
+        schema['properties']['ant-build-targets'] = {
+            'type': 'array',
+            'uniqueItems': True,
+            'items': {
+                'type': 'string',
+            },
+            'default': [],
         }
         schema['properties']['ant-dest-property'] = {
             'type': 'string',
@@ -77,8 +82,8 @@ class AntPlugin(snapcraft.plugins.jdk.JdkPlugin):
 
         command = ['ant']
 
-        if self.options.ant_build_target:
-            command.extend([self.options.ant_build_target])
+        if self.options.ant_build_targets:
+            command.extend(self.options.ant_build_targets)
 
         if self.options.ant_dest_property:
             destination = '-D{}={}'.format(self.options.ant_dest_property,

--- a/snapcraft/tests/test_plugin_ant.py
+++ b/snapcraft/tests/test_plugin_ant.py
@@ -50,12 +50,12 @@ class AntPluginTestCase(tests.TestCase):
 
         properties_type = schema['properties']['ant-properties']['type']
         self.assertEqual(properties_type, 'object',
-            'Expected "ant-properties" "type" to be "object", but '
-            'it was "{}"'.format(properties_type))
+                         'Expected "ant-properties" "type" to be "object", '
+                         'but it was "{}"'.format(properties_type))
         build_targets_type = schema['properties']['ant-build-targets']['type']
         self.assertEqual(build_targets_type, 'array',
-            'Expected "ant-build-targets" "type" to be "object", but '
-            'it was "{}"'.format(build_targets_type))
+                         'Expected "ant-build-targets" "type" to be "object", '
+                         'but it was "{}"'.format(build_targets_type))
 
     @mock.patch.object(ant.AntPlugin, 'run')
     def test_build(self, run_mock):

--- a/snapcraft/tests/test_plugin_ant.py
+++ b/snapcraft/tests/test_plugin_ant.py
@@ -31,7 +31,6 @@ class AntPluginTestCase(tests.TestCase):
         class Options:
             ant_properties = {}
             ant_build_targets = None
-            ant_dest_property = None
         self.options = Options()
 
         self.project_options = snapcraft.ProjectOptions()

--- a/snapcraft/tests/test_plugin_ant.py
+++ b/snapcraft/tests/test_plugin_ant.py
@@ -30,7 +30,7 @@ class AntPluginTestCase(tests.TestCase):
 
         class Options:
             ant_properties = {}
-            ant_build_target = None
+            ant_build_targets = None
             ant_dest_property = None
         self.options = Options()
 
@@ -75,7 +75,7 @@ class AntPluginTestCase(tests.TestCase):
     @mock.patch.object(ant.AntPlugin, 'run')
     def test_build_with_options(self, run_mock):
         options = copy.deepcopy(self.options)
-        options.ant_build_target = 'artifacts'
+        options.ant_build_targets = ['artifacts', 'jar']
         options.ant_dest_property = 'dist.dir'
         options.ant_properties = {'basedir': '.'}
         plugin = ant.AntPlugin('test-part', options,
@@ -89,6 +89,7 @@ class AntPluginTestCase(tests.TestCase):
         args = run_mock.call_args[0][0]
         self.assertEqual(args[0], 'ant')
         self.assertEqual(args[1], 'artifacts')
+        self.assertEqual(args[2], 'jar')
         self.assertIn(destination, args)
         self.assertIn(basedir, args)
 

--- a/snapcraft/tests/test_plugin_ant.py
+++ b/snapcraft/tests/test_plugin_ant.py
@@ -65,7 +65,8 @@ class AntPluginTestCase(tests.TestCase):
         plugin = ant.AntPlugin('test-part', options,
                                self.project_options)
         options.ant_build_targets = ['artifacts', 'jar']
-        options.ant_properties = {'basedir': '.', 'dist.dir': plugin.installdir}
+        options.ant_properties = {'basedir': '.',
+                                  'dist.dir': plugin.installdir}
 
         os.makedirs(plugin.sourcedir)
         plugin.build()

--- a/snapcraft/tests/test_plugin_ant.py
+++ b/snapcraft/tests/test_plugin_ant.py
@@ -39,6 +39,24 @@ class AntPluginTestCase(tests.TestCase):
         self.ubuntu_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
+    def test_schema(self):
+        schema = ant.AntPlugin.schema()
+
+        properties = schema['properties']
+        for expected in ['ant-properties', 'ant-build-targets']:
+            self.assertTrue(
+                expected in properties,
+                'Expected {!r} to be included in properties'.format(expected))
+
+        properties_type = schema['properties']['ant-properties']['type']
+        self.assertEqual(properties_type, 'object',
+            'Expected "ant-properties" "type" to be "object", but '
+            'it was "{}"'.format(properties_type))
+        build_targets_type = schema['properties']['ant-build-targets']['type']
+        self.assertEqual(build_targets_type, 'array',
+            'Expected "ant-build-targets" "type" to be "object", but '
+            'it was "{}"'.format(build_targets_type))
+
     @mock.patch.object(ant.AntPlugin, 'run')
     def test_build(self, run_mock):
         plugin = ant.AntPlugin('test-part', self.options,

--- a/snapcraft/tests/test_plugin_ant.py
+++ b/snapcraft/tests/test_plugin_ant.py
@@ -60,26 +60,12 @@ class AntPluginTestCase(tests.TestCase):
         ])
 
     @mock.patch.object(ant.AntPlugin, 'run')
-    def test_build_fail(self, run_mock):
-        plugin = ant.AntPlugin('test-part', self.options,
-                               self.project_options)
-
-        os.makedirs(plugin.sourcedir)
-        with self.assertRaises(RuntimeError):
-            plugin.build()
-
-        run_mock.assert_has_calls([
-            mock.call(['ant']),
-        ])
-
-    @mock.patch.object(ant.AntPlugin, 'run')
     def test_build_with_options(self, run_mock):
         options = copy.deepcopy(self.options)
-        options.ant_build_targets = ['artifacts', 'jar']
-        options.ant_dest_property = 'dist.dir'
-        options.ant_properties = {'basedir': '.'}
         plugin = ant.AntPlugin('test-part', options,
                                self.project_options)
+        options.ant_build_targets = ['artifacts', 'jar']
+        options.ant_properties = {'basedir': '.', 'dist.dir': plugin.installdir}
 
         os.makedirs(plugin.sourcedir)
         plugin.build()


### PR DESCRIPTION
Add options for setting ant properties, an ant build target, and the destination directory for ant build artifacts (point the right property at the snapcraft installdir). This change preserves compatibility with the old method of assuming jars will end up in target/.

The motivation was the Cassandra snap. It currently uses a [custom plugin](https://github.com/evandandrea/cassandra-snap/blob/e7f88807c9c0887f3df3dc5a7ca15b196b0cd604/parts/plugins/x-cassandra.py), which can be replaced with the following two settings to the ant plugin:
```
ant-dest-property: dist.dir
ant-build-target: artifacts
```

I'm completely open to changing the name of these options or altering their behaviour.