### PR TITLE
Use block style for multiline YAML values.

### DIFF
--- a/integration_tests/test_parts.py
+++ b/integration_tests/test_parts.py
@@ -41,23 +41,23 @@ class PartsTestCase(integration_tests.TestCase):
 
         expected = (
             "Maintainer: 'Sergio Schvezov <sergio.schvezov@ubuntu.com>'\n"
-            "Description: 'A tool and a library (usable from many languages) "
+            "Description: A tool and a library (usable from many languages) "
             "for client side URL transfers, supporting FTP, FTPS, HTTP, "
-            "HTTPS, TELNET, DICT, FILE and LDAP.'\n\n"
+            "HTTPS, TELNET, DICT, FILE and LDAP.\n\n"
             "curl:\n"
+            "  plugin: autotools\n"
+            "  source: http://curl.haxx.se/download/curl-7.44.0.tar.bz2\n"
+            "  source-type: tar\n"
             "  configflags:\n"
             "  - --enable-static\n"
             "  - --enable-shared\n"
             "  - --disable-manual\n"
-            "  plugin: autotools\n"
             "  snap:\n"
             "  - -bin\n"
             "  - -lib/*.a\n"
             "  - -lib/pkgconfig\n"
             "  - -lib/*.la\n"
             "  - -include\n"
-            "  - -share\n"
-            "  source: http://curl.haxx.se/download/curl-7.44.0.tar.bz2\n"
-            "  source-type: tar\n")
+            "  - -share\n")
 
         self.assertEqual(expected, output)

--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -223,6 +223,9 @@ of the choice of plugin.
 
 """
 
+from collections import OrderedDict                 # noqa
+import yaml                                         # noqa
+
 from snapcraft._baseplugin import BasePlugin        # noqa
 from snapcraft._options import ProjectOptions       # noqa
 from snapcraft._help import topic_help              # noqa
@@ -239,3 +242,29 @@ from snapcraft import plugins                       # noqa
 from snapcraft import sources                       # noqa
 from snapcraft import file_utils                    # noqa
 from snapcraft.internal import repo                 # noqa
+
+
+# Setup yaml module globally
+# yaml OrderedDict loading and dumping
+# from http://stackoverflow.com/a/21048064 Wed Jun 22 16:05:34 UTC 2016
+_mapping_tag = yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG
+
+
+def dict_representer(dumper, data):
+    return dumper.represent_dict(data.items())
+
+
+def dict_constructor(loader, node):
+    return OrderedDict(loader.construct_pairs(node))
+
+
+def str_presenter(dumper, data):
+    if len(data.splitlines()) > 1:  # check for multiline string
+        return dumper.represent_scalar('tag:yaml.org,2002:str', data,
+                                       style='|')
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data)
+
+
+yaml.add_representer(str, str_presenter)
+yaml.add_representer(OrderedDict, dict_representer)
+yaml.add_constructor(_mapping_tag, dict_constructor)

--- a/snapcraft/internal/parser.py
+++ b/snapcraft/internal/parser.py
@@ -68,23 +68,6 @@ BASE_DIR = "/tmp"
 PARTS_FILE = "snap-parts.yaml"
 
 
-# yaml OrderedDict loading and dumping
-# from http://stackoverflow.com/a/21048064 Wed Jun 22 16:05:34 UTC 2016
-_mapping_tag = yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG
-
-
-def dict_representer(dumper, data):
-    return dumper.represent_dict(data.items())
-
-
-def dict_constructor(loader, node):
-    return OrderedDict(loader.construct_pairs(node))
-
-
-yaml.add_representer(OrderedDict, dict_representer)
-yaml.add_constructor(_mapping_tag, dict_constructor)
-
-
 def _get_version():
     try:
         return pkg_resources.require('snapcraft-parser')[0].version
@@ -307,7 +290,6 @@ def run(args):
     if wiki_errors:
         logger.warning("{} wiki errors found!".format(wiki_errors))
 
-    yaml.add_representer(str, str_presenter)
     _write_parts_list(path, master_parts_list)
 
     if args['--debug']:
@@ -324,13 +306,6 @@ def is_valid_parts_list(parts_list, parts):
             return False
 
     return True
-
-
-def str_presenter(dumper, data):
-    if len(data.splitlines()) > 1:  # check for multiline string
-        return dumper.represent_scalar('tag:yaml.org,2002:str', data,
-                                       style='|')
-    return dumper.represent_scalar('tag:yaml.org,2002:str', data)
 
 
 def _write_parts_list(path, master_parts_list):

--- a/snapcraft/internal/parser.py
+++ b/snapcraft/internal/parser.py
@@ -272,8 +272,7 @@ def _process_index(output):
                     wiki_errors += 1
                 entry = ''
         else:
-            # remove trailing white space
-            entry = '\n'.join([entry, line.rstrip()])
+            entry = '\n'.join([entry, line])
 
     if entry:
         try:

--- a/snapcraft/internal/parser.py
+++ b/snapcraft/internal/parser.py
@@ -272,7 +272,8 @@ def _process_index(output):
                     wiki_errors += 1
                 entry = ''
         else:
-            entry = '\n'.join([entry, line])
+            # remove trailing white space
+            entry = '\n'.join([entry, line.rstrip()])
 
     if entry:
         try:
@@ -307,6 +308,7 @@ def run(args):
     if wiki_errors:
         logger.warning("{} wiki errors found!".format(wiki_errors))
 
+    yaml.add_representer(str, str_presenter)
     _write_parts_list(path, master_parts_list)
 
     if args['--debug']:
@@ -323,6 +325,14 @@ def is_valid_parts_list(parts_list, parts):
             return False
 
     return True
+
+
+def str_presenter(dumper, data):
+    if len(data.splitlines()) > 1:  # check for multiline string
+        data = data.rstrip()
+        return dumper.represent_scalar('tag:yaml.org,2002:str', data,
+                                       style='|')
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data)
 
 
 def _write_parts_list(path, master_parts_list):

--- a/snapcraft/internal/parser.py
+++ b/snapcraft/internal/parser.py
@@ -329,7 +329,6 @@ def is_valid_parts_list(parts_list, parts):
 
 def str_presenter(dumper, data):
     if len(data.splitlines()) > 1:  # check for multiline string
-        data = data.rstrip()
         return dumper.represent_scalar('tag:yaml.org,2002:str', data,
                                        style='|')
     return dumper.represent_scalar('tag:yaml.org,2002:str', data)

--- a/snapcraft/internal/parts.py
+++ b/snapcraft/internal/parts.py
@@ -359,7 +359,7 @@ def define(part_name):
             'consider going to https://wiki.ubuntu.com/snapcraft/parts '
             'to add it.') from e
     print('Maintainer: {!r}'.format(remote_part.pop('maintainer')))
-    print('Description: {!r}'.format(remote_part.pop('description')))
+    print('Description: {}'.format(remote_part.pop('description')))
     print('')
     yaml.dump({part_name: remote_part},
               default_flow_style=False, stream=sys.stdout)
@@ -383,7 +383,7 @@ def search(part_match):
     print('{}  {}'.format(
         _HEADER_PART_NAME.ljust(part_length, ' '), _HEADER_DESCRIPTION))
     for part_key in matches.keys():
-        description = matches[part_key]['description']
+        description = matches[part_key]['description'].split('\n')[0]
         if len(description) > description_space:
             description = '{}...'.format(description[0:description_space])
         print('{}  {}'.format(

--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from collections import OrderedDict
 from datetime import datetime
 import json
 import logging
@@ -60,26 +61,32 @@ class FakePartsRequestHandler(BaseHTTPRequestHandler):
             response = {}
         else:
             self.send_response(200)
-            response = {
-                'curl': {
-                    'source': 'http://curl.org',
-                    'plugin': 'autotools',
-                    'description': 'test entry for curl',
-                    'maintainer': 'none',
-                },
-                'part1': {
-                    'plugin': 'go',
-                    'source': 'http://source.tar.gz',
-                    'description': 'test entry for part1',
-                    'maintainer': 'none',
-                },
-                'long-described-part': {
-                    'plugin': 'go',
-                    'source': 'http://source.tar.gz',
-                    'description': 'this is a repetitive description ' * 3,
-                    'maintainer': 'none',
-                },
-            }
+            response = OrderedDict((
+                ('curl', OrderedDict((
+                    ('plugin', 'autotools'),
+                    ('source', 'http://curl.org'),
+                    ('description', 'test entry for curl'),
+                    ('maintainer', 'none'),
+                ))),
+                ('part1', OrderedDict((
+                    ('plugin', 'go'),
+                    ('source', 'http://source.tar.gz'),
+                    ('description', 'test entry for part1'),
+                    ('maintainer', 'none'),
+                ))),
+                ('long-described-part', OrderedDict((
+                    ('plugin', 'go'),
+                    ('source', 'http://source.tar.gz'),
+                    ('description', 'this is a repetitive description ' * 3),
+                    ('maintainer', 'none'),
+                ))),
+                ('multiline-part', OrderedDict((
+                    ('plugin', 'go'),
+                    ('source', 'http://source.tar.gz'),
+                    ('description', 'this is a multiline description\n' * 3),
+                    ('maintainer', 'none'),
+                ))),
+            ))
         self.send_header('Content-Type', 'text/plain')
         if 'NO_CONTENT_LENGTH' not in os.environ:
             self.send_header('Content-Length', '1000')

--- a/snapcraft/tests/test_commands_define.py
+++ b/snapcraft/tests/test_commands_define.py
@@ -28,7 +28,7 @@ class DefineCommandTestCase(tests.TestWithFakeRemoteParts):
         main.main(['define', 'curl'])
 
         expected_output = """Maintainer: 'none'
-Description: 'test entry for curl'
+Description: test entry for curl
 
 curl:
   plugin: autotools

--- a/snapcraft/tests/test_commands_define.py
+++ b/snapcraft/tests/test_commands_define.py
@@ -44,3 +44,19 @@ curl:
             str(raised.exception),
             'Cannot find the part name {!r} in the cache. Please consider '
             'going to https://wiki.ubuntu.com/snapcraft/parts to add it.')
+
+    @mock.patch('sys.stdout', new_callable=io.StringIO)
+    def test_defining_a_part_with_multiline_description(self, mock_stdout):
+        main.main(['define', 'multiline-part'])
+
+        expected_output = """Maintainer: 'none'
+Description: this is a multiline description
+this is a multiline description
+this is a multiline description
+
+
+multiline-part:
+  plugin: go
+  source: http://source.tar.gz
+"""
+        self.assertEqual(mock_stdout.getvalue(), expected_output)

--- a/snapcraft/tests/test_commands_search.py
+++ b/snapcraft/tests/test_commands_search.py
@@ -62,6 +62,17 @@ curl       test entry for curl
             'repetitive de...\n')
         self.assertEqual(fake_terminal.getvalue(), expected_output)
 
+    def test_search_only_first_line_of_description(self):
+        fake_terminal = fixture_setup.FakeTerminal()
+        self.useFixture(fake_terminal)
+
+        main.main(['search', 'mulitline-part'])
+
+        expected_output = (
+            'PART NAME       DESCRIPTION\n'
+            'multiline-part  this is a multiline description\n')
+        self.assertEqual(fake_terminal.getvalue(), expected_output)
+
     def test_searching_for_a_part_that_doesnt_exist_helps_out(self):
         self.useFixture(fixture_setup.FakeTerminal())
 

--- a/snapcraft/tests/test_commands_update.py
+++ b/snapcraft/tests/test_commands_update.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from collections import OrderedDict
 import logging
 import os
 
@@ -39,32 +40,31 @@ class UpdateCommandTestCase(tests.TestWithFakeRemoteParts):
         self.assertTrue(os.path.exists(self.parts_yaml))
         self.assertTrue(os.path.exists(self.headers_yaml))
 
-        expected_parts = {
-            'curl': {
-                'source': 'http://curl.org',
-                'plugin': 'autotools',
-                'description': 'test entry for curl',
-                'maintainer': 'none',
-            },
-            'part1': {
-                'plugin': 'go',
-                'source': 'http://source.tar.gz',
-                'description': 'test entry for part1',
-                'maintainer': 'none',
-            },
-            'part1': {
-                'plugin': 'go',
-                'source': 'http://source.tar.gz',
-                'description': 'test entry for part1',
-                'maintainer': 'none',
-            },
-            'long-described-part': {
-                'plugin': 'go',
-                'source': 'http://source.tar.gz',
-                'description': 'this is a repetitive description ' * 3,
-                'maintainer': 'none',
-            },
-        }
+        expected_parts = OrderedDict()
+        expected_parts['curl'] = p = OrderedDict()
+        p['plugin'] = 'autotools'
+        p['source'] = 'http://curl.org'
+        p['description'] = 'test entry for curl'
+        p['maintainer'] = 'none'
+
+        expected_parts['part1'] = p = OrderedDict()
+        p['plugin'] = 'go'
+        p['source'] = 'http://source.tar.gz'
+        p['description'] = 'test entry for part1'
+        p['maintainer'] = 'none'
+
+        expected_parts['long-described-part'] = p = OrderedDict()
+        p['plugin'] = 'go'
+        p['source'] = 'http://source.tar.gz'
+        p['description'] = 'this is a repetitive description ' * 3
+        p['maintainer'] = 'none'
+
+        expected_parts['multiline-part'] = p = OrderedDict()
+        p['plugin'] = 'go'
+        p['source'] = 'http://source.tar.gz'
+        p['description'] = 'this is a multiline description\n' * 3
+        p['maintainer'] = 'none'
+
         expected_headers = {
             'If-Modified-Since': 'Thu, 07 Jul 2016 10:00:20 GMT',
         }

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -642,15 +642,10 @@ origin: lp:snapcraft-parser-example
 description: |
   example
 
-  Usage :
+  Usage:
     blahblahblah
 project-part: 'main'
 """
-        # add a blank at the end of the line, some editors
-        # automatically removes trailing newlines on write so
-        # get around it programatically.
-        output = output.replace('Usage :', 'Usage : ')
-        print('JOE: output: {!r}'.format(output.replace(' ', 'X')))
         _create_example_output(output)
         mock_get_origin_data.return_value = {
             'parts': {
@@ -664,7 +659,6 @@ project-part: 'main'
         main(['--debug', '--index', TEST_OUTPUT_PATH])
         with open('snap-parts.yaml') as fp:
             data = fp.read()
-            print("JOE: data: {!r}".format(data))
             self.assertNotIn('description: "', data)
             self.assertIn('description: |', data)
         self.assertEqual(1, _get_part_list_count())

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -644,7 +644,7 @@ description: |
 
   Usage:
     blahblahblah
-project-part: 'main'
+parts: [main]
 """
         _create_example_output(output)
         mock_get_origin_data.return_value = {

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -632,6 +632,45 @@ parts: [main2]
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     @mock.patch('snapcraft.internal.sources.get')
+    def test_descriptions_get_block_quotes(self,
+                                           mock_get,
+                                           mock_get_origin_data):
+        output = """
+---
+maintainer: John Doe <john.doe@example.com>
+origin: lp:snapcraft-parser-example
+description: |
+  example
+
+  Usage :
+    blahblahblah
+project-part: 'main'
+"""
+        # add a blank at the end of the line, some editors
+        # automatically removes trailing newlines on write so
+        # get around it programatically.
+        output = output.replace('Usage :', 'Usage : ')
+        print('JOE: output: {!r}'.format(output.replace(' ', 'X')))
+        _create_example_output(output)
+        mock_get_origin_data.return_value = {
+            'parts': {
+                'main': {
+                    'source': 'lp:something',
+                    'plugin': 'copy',
+                    'files': ['file1', 'file2'],
+                },
+            }
+        }
+        main(['--debug', '--index', TEST_OUTPUT_PATH])
+        with open('snap-parts.yaml') as fp:
+            data = fp.read()
+            print("JOE: data: {!r}".format(data))
+            self.assertNotIn('description: "', data)
+            self.assertIn('description: |', data)
+        self.assertEqual(1, _get_part_list_count())
+
+    @mock.patch('snapcraft.internal.parser._get_origin_data')
+    @mock.patch('snapcraft.internal.sources.get')
     def test_wiki_interactions_with_fake(self,
                                          mock_get,
                                          mock_get_origin_data):

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -25,6 +25,7 @@ import fixtures
 import yaml
 from collections import OrderedDict
 
+import snapcraft                           # noqa, initialize yaml
 from snapcraft.internal.parser import (
     _get_origin_data,
     _encode_origin,
@@ -64,6 +65,17 @@ class TestParser(TestCase):
             os.remove(TEST_OUTPUT_PATH)
         except FileNotFoundError:
             pass
+
+    def test_ordereddict_yaml(self):
+        from collections import OrderedDict
+        data = OrderedDict()
+
+        data['name'] = 'test'
+        data['description'] = 'description'
+
+        output = yaml.dump(data)
+
+        self.assertTrue(isinstance(yaml.load(output), OrderedDict))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     @mock.patch('snapcraft.internal.sources.get')


### PR DESCRIPTION
Make the parts.yaml, 'search', and 'define' output nicer.

* Use block style for multiline strings
* Support OrderedDict for all yaml usage.
* Only show the first line of the description in 'search' output.

LP:#1614651