### PR TITLE
Remove dangling symlink from JDK plugin

### DIFF
--- a/snapcraft/plugins/jdk.py
+++ b/snapcraft/plugins/jdk.py
@@ -34,4 +34,5 @@ class JdkPlugin(snapcraft.BasePlugin):
                  '-usr/lib/jvm/default-java/include',
                  '-usr/lib/jvm/default-java/lib',
                  '-usr/share/doc',
+                 '-usr/lib/jvm/*/jre/lib/security/cacerts',
                  ])


### PR DESCRIPTION
Using the JDK plugin results in a dangling symlink which in turn
causes lint-snap-v2_external_symlinks to fail:

package contains external symlinks:
usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts
lint-snap-v2_external_symlinks

This pull request removes the symlink from the snap
LP Bug #1617296
