### PR TITLE
node plugin: run build in pull phase to download dependencies.

### DIFF
--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -96,6 +96,8 @@ class NodePlugin(snapcraft.BasePlugin):
         super().pull()
         os.makedirs(self._npm_dir, exist_ok=True)
         self._nodejs_tar.download()
+        # do the install in the pull phase to download all dependencies.
+        self._npm_install()
 
     def clean_pull(self):
         super().clean_pull()
@@ -106,12 +108,16 @@ class NodePlugin(snapcraft.BasePlugin):
 
     def build(self):
         super().build()
+        self._npm_install()
+
+    def _npm_install(self):
         self._nodejs_tar.provision(
             self.installdir, clean_target=False, keep_tarball=True)
+        npm_install = ['npm', '--cache-min=Infinity', 'install', '--global']
         for pkg in self.options.node_packages:
-            self.run(['npm', 'install', '-g', pkg])
+            self.run(npm_install + [pkg])
         if os.path.exists(os.path.join(self.builddir, 'package.json')):
-            self.run(['npm', 'install', '-g'])
+            self.run(npm_install)
 
 
 def _get_nodejs_base(node_engine):

--- a/snapcraft/tests/test_plugin_nodejs.py
+++ b/snapcraft/tests/test_plugin_nodejs.py
@@ -78,7 +78,8 @@ class NodePluginTestCase(tests.TestCase):
         plugin.build()
 
         self.run_mock.assert_has_calls([
-            mock.call(['npm', 'install', '-g'], cwd=plugin.builddir)])
+            mock.call(['npm', '--cache-min=Infinity', 'install', '--global'],
+                      cwd=plugin.builddir)])
         self.tar_mock.assert_has_calls([
             mock.call(
                 nodejs.get_nodejs_release(plugin.options.node_engine),
@@ -101,8 +102,8 @@ class NodePluginTestCase(tests.TestCase):
         plugin.build()
 
         self.run_mock.assert_has_calls([
-            mock.call(['npm', 'install', '-g', 'my-pkg'],
-                      cwd=plugin.builddir)])
+            mock.call(['npm', '--cache-min=Infinity', 'install', '--global',
+                       'my-pkg'], cwd=plugin.builddir)])
         self.tar_mock.assert_has_calls([
             mock.call(
                 nodejs.get_nodejs_release(plugin.options.node_engine),


### PR DESCRIPTION
This runs the build in the pull phase to download all needed dependencies.
There is no way to 'npm install --download-only'.

Additionally, we add the --cache-min=Infinity which is required.
Without it, the run in the build phase will try to reach the npm registry.

Lastly, instead of '-g', use the more self-documenting long form '--global'.