### PR TITLE
Include /sbin and usr/sbin in wrappers

### DIFF
--- a/integration_tests/snaps/assemble/binary1.after
+++ b/integration_tests/snaps/assemble/binary1.after
@@ -1,5 +1,5 @@
 #!/bin/sh
-export PATH="$SNAP/bin:$SNAP/usr/bin:$PATH"
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 
 LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 exec "$SNAP/binary1" "$@"

--- a/snapcraft/internal/project_loader.py
+++ b/snapcraft/internal/project_loader.py
@@ -219,8 +219,10 @@ def _runtime_env(root, arch_triplet):
     env = []
 
     env.append('PATH="' + ':'.join([
-        '{0}/bin',
+        '{0}/usr/sbin',
         '{0}/usr/bin',
+        '{0}/sbin',
+        '{0}/bin',
         '$PATH'
     ]).format(root) + '"')
 

--- a/snapcraft/tests/test_project_loader.py
+++ b/snapcraft/tests/test_project_loader.py
@@ -1081,7 +1081,8 @@ parts:
 
         environment = config.snap_env()
         self.assertTrue(
-            'PATH="{0}/bin:{0}/usr/bin:$PATH"'.format(self.snap_dir)
+            'PATH="{0}/usr/sbin:{0}/usr/bin:{0}/sbin:{0}/bin:$PATH"'.format(
+                self.snap_dir)
             in environment)
 
         # Ensure that LD_LIBRARY_PATH is present and it contains only the
@@ -1110,7 +1111,8 @@ parts:
 
         environment = config.snap_env()
         self.assertTrue(
-            'PATH="{0}/bin:{0}/usr/bin:$PATH"'.format(self.snap_dir)
+            'PATH="{0}/usr/sbin:{0}/usr/bin:{0}/sbin:{0}/bin:$PATH"'.format(
+                self.snap_dir)
             in environment,
             'Current PATH is {!r}'.format(environment))
         for e in environment:
@@ -1223,7 +1225,7 @@ parts:
         environment = config.stage_env()
 
         self.assertTrue(
-            'PATH="{0}/bin:{0}/usr/bin:$PATH"'.format(
+            'PATH="{0}/usr/sbin:{0}/usr/bin:{0}/sbin:{0}/bin:$PATH"'.format(
                 self.stage_dir) in environment)
         self.assertTrue(
             'LD_LIBRARY_PATH="$LD_LIBRARY_PATH:{stage_dir}/lib:'


### PR DESCRIPTION
Hi,

This adds $SNAP/sbin and $SNAP/usr/sbin to the PATH in wrapper scripts generated by snapcraft. This is useful when staging packages with binaries in /sbin.

Cheers,
- Loïc Minier