### PR TITLE
Implementing 'grade' support in snapcraft.yaml

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -74,6 +74,13 @@ properties:
     enum:
       - devmode
       - strict
+  grade:
+    type: string
+    description: the quality grade of the snap
+    default: stable
+    enum:
+      - stable
+      - devel
   epoch:
     description: the snap epoch, used to specify upgrade paths
     format: epoch

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -46,6 +46,7 @@ summary: This is my-snap's summary  # 79 char long summary
 description: This is my-snap's description  # a longer description for the snap
 confinement: devmode  # use "strict" to enforce system access only via \
 declared interfaces
+grade: devel # use "stable" to assert the snap quality
 
 parts:
     my-part:  # Replace with a part name of your liking

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -47,6 +47,7 @@ _OPTIONAL_PACKAGE_KEYS = [
     'slots',
     'confinement',
     'epoch',
+    'grade',
 ]
 
 _KERNEL_KEYS = {

--- a/snapcraft/internal/project_loader.py
+++ b/snapcraft/internal/project_loader.py
@@ -340,6 +340,7 @@ def _ensure_confinement_default(yaml_data, schema):
                        'to "strict"')
         yaml_data['confinement'] = schema['confinement']['default']
 
+
 def _ensure_grade_default(yaml_data, schema):
     # Provide hint if the grade property is missing, and add the
     # default. We use the schema here so we don't have to hard-code defaults.

--- a/snapcraft/internal/project_loader.py
+++ b/snapcraft/internal/project_loader.py
@@ -119,7 +119,9 @@ class Config:
         self._validator.validate()
         self.data = self._expand_env(snapcraft_yaml)
 
+        # both confinement type and build quality are optionals
         _ensure_confinement_default(self.data, self._validator.schema)
+        _ensure_grade_default(self.data, self._validator.schema)
 
         self.build_tools = self.data.get('build-packages', [])
         self.build_tools.extend(project_options.additional_build_packages)
@@ -337,3 +339,11 @@ def _ensure_confinement_default(yaml_data, schema):
         logger.warning('"confinement" property not specified: defaulting '
                        'to "strict"')
         yaml_data['confinement'] = schema['confinement']['default']
+
+def _ensure_grade_default(yaml_data, schema):
+    # Provide hint if the grade property is missing, and add the
+    # default. We use the schema here so we don't have to hard-code defaults.
+    if 'grade' not in yaml_data:
+        logger.warning('"grade" property not specified: defaulting '
+                       'to "stable"')
+        yaml_data['grade'] = schema['grade']['default']

--- a/snapcraft/tests/test_cmds.py
+++ b/snapcraft/tests/test_cmds.py
@@ -43,6 +43,7 @@ summary: test
 description: test
 icon: my-icon.png
 confinement: strict
+grade: stable
 
 parts:
   part1:

--- a/snapcraft/tests/test_commands_build.py
+++ b/snapcraft/tests/test_commands_build.py
@@ -31,6 +31,7 @@ version: 1.0
 summary: test build
 description: if the build is succesful the state file will be updated
 confinement: strict
+grade: stable
 
 parts:
 {parts}"""

--- a/snapcraft/tests/test_commands_clean.py
+++ b/snapcraft/tests/test_commands_clean.py
@@ -38,6 +38,7 @@ summary: test clean
 description: if the clean is succesful the state file will be updated
 icon: icon.png
 confinement: strict
+grade: stable
 
 parts:
 {parts}"""
@@ -209,6 +210,7 @@ version: 1.0
 summary: test clean
 description: test clean
 confinement: strict
+grade: stable
 
 parts:
   main:

--- a/snapcraft/tests/test_commands_cleanbuild.py
+++ b/snapcraft/tests/test_commands_cleanbuild.py
@@ -33,6 +33,7 @@ summary: test cleanbuild
 description: if snap is succesful a snap package will be available
 architectures: ['amd64']
 confinement: strict
+grade: stable
 
 parts:
     part1:

--- a/snapcraft/tests/test_commands_init.py
+++ b/snapcraft/tests/test_commands_init.py
@@ -62,6 +62,7 @@ summary: This is my-snap's summary  # 79 char long summary
 description: This is my-snap's description  # a longer description for the snap
 confinement: devmode  # use "strict" to enforce system access only via \
 declared interfaces
+grade: devel # use "stable" to assert the snap quality
 
 parts:
     my-part:  # Replace with a part name of your liking

--- a/snapcraft/tests/test_commands_prime.py
+++ b/snapcraft/tests/test_commands_prime.py
@@ -31,6 +31,7 @@ version: 1.0
 summary: test prime
 description: if the prime is succesful the state file will be updated
 confinement: strict
+grade: stable
 
 parts:
 {parts}"""

--- a/snapcraft/tests/test_commands_pull.py
+++ b/snapcraft/tests/test_commands_pull.py
@@ -33,6 +33,7 @@ version: 1.0
 summary: test pull
 description: if the pull is succesful the state file will be updated
 confinement: strict
+grade: stable
 
 parts:
 {parts}"""

--- a/snapcraft/tests/test_commands_snap.py
+++ b/snapcraft/tests/test_commands_snap.py
@@ -37,6 +37,7 @@ description: if snap is succesful a snap package will be available
 architectures: ['amd64']
 type: {}
 confinement: strict
+grade: stable
 
 parts:
     part1:

--- a/snapcraft/tests/test_commands_stage.py
+++ b/snapcraft/tests/test_commands_stage.py
@@ -31,6 +31,7 @@ version: 1.0
 summary: test stage
 description: if the build is succesful the state file will be updated
 confinement: strict
+grade: stable
 
 parts:
 {parts}"""

--- a/snapcraft/tests/test_lifecycle.py
+++ b/snapcraft/tests/test_lifecycle.py
@@ -42,6 +42,7 @@ version: 0
 summary: test
 description: test
 confinement: strict
+grade: stable
 {type}
 
 {parts}

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -85,6 +85,30 @@ class CreateTest(tests.TestCase):
                     'Expected "confinement" property to be in snap.yaml')
                 self.assertEqual(y['confinement'], confinement_type)
 
+    def test_create_meta_with_grade(self):
+        grade_types = [
+            'stable',
+            'devel',
+        ]
+
+        for grade_type in grade_types:
+            with self.subTest(key=grade_type):
+                self.config_data['grade'] = grade_type
+
+                create_snap_packaging(
+                    self.config_data, self.snap_dir, self.parts_dir)
+
+                self.assertTrue(
+                    os.path.exists(self.snap_yaml),
+                    'snap.yaml was not created')
+
+                with open(self.snap_yaml) as f:
+                    y = yaml.load(f)
+                self.assertTrue(
+                    'grade' in y,
+                    'Expected "grade" property to be in snap.yaml')
+                self.assertEqual(y['grade'], grade_type)
+
     def test_create_meta_with_declared_license(self):
         open(os.path.join(os.curdir, 'LICENSE'), 'w').close()
         self.config_data['license'] = 'LICENSE'

--- a/snapcraft/tests/test_pluginhandler.py
+++ b/snapcraft/tests/test_pluginhandler.py
@@ -639,6 +639,7 @@ version: 1.0
 summary: test pkg-config .pc
 description: when the .pc files reach stage the should be reprefixed
 confinement: strict
+grade: stable
 
 parts:
     stage-pc:


### PR DESCRIPTION
...to assert the built snap quality as per the snappy design doc, see https://docs.google.com/document/d/1MOwyQXkrmMjTJnMsiisfv5Y1lrr5mwNrTxaIbMpNngc/edit#heading=h.4wp4anfwdwtq for the explanation on the purpose of grade.

An upcoming subsequent PR (still depending on snapd changes) will introduce snap-build support that use this new grade parameter.