### PR TITLE
Set GOBIN in go plugin build environment.

### DIFF
--- a/snapcraft/plugins/go.py
+++ b/snapcraft/plugins/go.py
@@ -175,6 +175,7 @@ class GoPlugin(snapcraft.BasePlugin):
     def _build_environment(self):
         env = os.environ.copy()
         env['GOPATH'] = self._gopath
+        env['GOBIN'] = self._gopath_bin
 
         include_paths = []
         for root in [self.installdir, self.project.stage_dir]:


### PR DESCRIPTION
Fixes #1553215. If the user's environment has GOBIN set, it will interfere
with the go plugin, forcing the end result executables to end up there instead of
the expected location.