### PR TITLE
parser - Handle project name and version variables

### DIFF
--- a/snapcraft/internal/parser.py
+++ b/snapcraft/internal/parser.py
@@ -134,18 +134,17 @@ def _update_source(part, origin):
     return part
 
 
-def _replace_variables(item, name, version):
+def _replace_variables(item, replacements):
     if isinstance(item, dict):
         for key, value in item.items():
-            item[key] = _replace_variables(value, name, version)
+            item[key] = _replace_variables(value, replacements)
     elif isinstance(item, list):
         for index in range(len(item)):
-            item[index] = _replace_variables(item[index], name, version)
+            item[index] = _replace_variables(item[index], replacements)
     elif isinstance(item, str):
-        if name:
-            item = item.replace('$SNAPCRAFT_PROJECT_NAME', name)
-        if version:
-            item = item.replace('$SNAPCRAFT_PROJECT_VERSION', version)
+        for replacement in replacements:
+            if replacement[1]:
+                item = item.replace(replacement[0], replacement[1])
 
     return item
 
@@ -160,8 +159,12 @@ def _process_entry_parts(entry_parts, parts, origin, maintainer, description,
                 'DEPRECATED: Found a "/" in the name of the {!r} part'.format(
                     part_name))
         source_part = parts.get(part_name)
-        source_part = _replace_variables(source_part, origin_name,
-                                         origin_version)
+        replacements = [
+            ('$SNAPCRAFT_PROJECT_NAME', origin_name),
+            ('$SNAPCRAFT_PROJECT_VERSION', origin_version),
+        ]
+
+        source_part = _replace_variables(source_part, replacements)
 
         if source_part:
             source_part = _update_source(source_part, origin)

--- a/snapcraft/internal/parser.py
+++ b/snapcraft/internal/parser.py
@@ -42,6 +42,7 @@ from docopt import docopt
 from collections import OrderedDict
 
 from snapcraft.internal import log, sources
+from snapcraft.internal.project_loader import replace_attr
 
 
 class InvalidEntryError(Exception):
@@ -134,21 +135,6 @@ def _update_source(part, origin):
     return part
 
 
-def _replace_variables(item, replacements):
-    if isinstance(item, dict):
-        for key, value in item.items():
-            item[key] = _replace_variables(value, replacements)
-    elif isinstance(item, list):
-        for index in range(len(item)):
-            item[index] = _replace_variables(item[index], replacements)
-    elif isinstance(item, str):
-        for replacement in replacements:
-            if replacement[1]:
-                item = item.replace(replacement[0], replacement[1])
-
-    return item
-
-
 def _process_entry_parts(entry_parts, parts, origin, maintainer, description,
                          origin_name, origin_version):
     after_parts = set()
@@ -164,7 +150,7 @@ def _process_entry_parts(entry_parts, parts, origin, maintainer, description,
             ('$SNAPCRAFT_PROJECT_VERSION', origin_version),
         ]
 
-        source_part = _replace_variables(source_part, replacements)
+        source_part = replace_attr(source_part, replacements)
 
         if source_part:
             source_part = _update_source(source_part, origin)

--- a/snapcraft/internal/project_loader.py
+++ b/snapcraft/internal/project_loader.py
@@ -190,25 +190,26 @@ class Config:
         for key in snapcraft_yaml:
             if any((key == env_key for env_key in environment_keys)):
                 continue
-            snapcraft_yaml[key] = _replace_attr(
+            snapcraft_yaml[key] = replace_attr(
                 snapcraft_yaml[key],
-                snapcraft_yaml['name'],
-                snapcraft_yaml['version'],
-                self._project_options.stage_dir)
+                [
+                    ('$SNAPCRAFT_PROJECT_NAME', snapcraft_yaml['name']),
+                    ('$SNAPCRAFT_PROJECT_VERSION', snapcraft_yaml['version']),
+                    ('$SNAPCRAFT_STAGE', self._project_options.stage_dir),
+                ])
         return snapcraft_yaml
 
 
-def _replace_attr(attr, name, version, stage_dir):
+def replace_attr(attr, replacements):
     if isinstance(attr, str):
-        attr = attr.replace('$SNAPCRAFT_STAGE', stage_dir)
-        attr = attr.replace('$SNAPCRAFT_PROJECT_NAME', name)
-        attr = attr.replace('$SNAPCRAFT_PROJECT_VERSION', str(version))
+        for replacement in replacements:
+            attr = attr.replace(replacement[0], str(replacement[1]))
         return attr
     elif isinstance(attr, list) or isinstance(attr, tuple):
-        return [_replace_attr(i, name, version, stage_dir)
+        return [replace_attr(i, replacements)
                 for i in attr]
     elif isinstance(attr, dict):
-        return {k: _replace_attr(attr[k], name, version, stage_dir)
+        return {k: replace_attr(attr[k], replacements)
                 for k in attr}
 
     return attr

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -177,6 +177,37 @@ parts: [main]
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     @mock.patch('snapcraft.internal.sources.get')
+    def test_main_valid_variable_substition(self, mock_get,
+                                            mock_get_origin_data):
+        _create_example_output("""
+---
+maintainer: John Doe <john.doe@example.com
+origin: lp:snapcraft-parser-example
+description: example
+parts: [main]
+""")
+        mock_get_origin_data.return_value = {
+            'name': 'something',
+            'version': '0.1',
+            'parts': {
+                'main': {
+                    'source': 'lp:$SNAPCRAFT_PROJECT_NAME'
+                              '/r$SNAPCRAFT_PROJECT_VERSION',
+
+                    'plugin': 'copy',
+                    'files': ['$SNAPCRAFT_PROJECT_NAME/file1', 'file2'],
+                },
+            }
+        }
+        retval = main(['--debug', '--index', TEST_OUTPUT_PATH])
+        self.assertEqual(1, _get_part_list_count())
+        part = _get_part('main')
+        self.assertEqual(part['source'], 'lp:something/r0.1')
+        self.assertIn('something/file1', part['files'])
+        self.assertEqual(0, retval)
+
+    @mock.patch('snapcraft.internal.parser._get_origin_data')
+    @mock.patch('snapcraft.internal.sources.get')
     def test_main_valid(self, mock_get, mock_get_origin_data):
         _create_example_output("""
 ---

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -965,21 +965,27 @@ parts: [app1]
         parts = OrderedDict()
 
         parts_main = OrderedDict()
-        parts_main['source'] = 'lp:project'
-        parts_main['plugin'] = 'copy'
+        parts_main['description'] = 'example main'
         parts_main['files'] = ['file1', 'file2']
+        parts_main['maintainer'] = 'John Doe <john.doe@example.com>'
+        parts_main['plugin'] = 'copy'
+        parts_main['source'] = 'lp:project'
         parts['main'] = parts_main
 
         parts_main2 = OrderedDict()
-        parts_main2['source'] = 'lp:project'
-        parts_main2['plugin'] = 'copy'
+        parts_main2['description'] = 'example main2'
         parts_main2['files'] = ['file1', 'file2']
+        parts_main2['maintainer'] = 'Jim Doe <jim.doe@example.com>'
+        parts_main2['plugin'] = 'copy'
+        parts_main2['source'] = 'lp:project'
         parts['main2'] = parts_main2
 
         parts_app1 = OrderedDict()
-        parts_app1['source'] = 'lp:project'
-        parts_app1['plugin'] = 'copy'
+        parts_app1['description'] = 'example main2'
         parts_app1['files'] = ['file1', 'file2']
+        parts_app1['maintainer'] = 'Jim Doe <jim.doe@example.com>'
+        parts_app1['plugin'] = 'copy'
+        parts_app1['source'] = 'lp:project'
         parts['app1'] = parts_app1
 
         mock_get_origin_data.return_value = {

--- a/snapcraft/tests/test_project_loader.py
+++ b/snapcraft/tests/test_project_loader.py
@@ -1740,8 +1740,10 @@ class SnapcraftEnvTestCase(tests.TestCase):
 
         for test_name, subject, expected in replacements:
             self.subTest(key=test_name)
-            self.assertEqual(project_loader._replace_attr(
-                subject, 'project_name', 'version', self.stage_dir), expected)
+            self.assertEqual(project_loader.replace_attr(
+                subject, [('$SNAPCRAFT_PROJECT_NAME', 'project_name'),
+                          ('$SNAPCRAFT_PROJECT_VERSION', 'version'),
+                          ('$SNAPCRAFT_STAGE', self.stage_dir)]), expected)
 
     def test_lists_with_string_replacements(self):
         replacements = (
@@ -1782,8 +1784,10 @@ class SnapcraftEnvTestCase(tests.TestCase):
 
         for test_name, subject, expected in replacements:
             self.subTest(key=test_name)
-            self.assertEqual(project_loader._replace_attr(
-                subject, 'project_name', 'version', self.stage_dir), expected)
+            self.assertEqual(project_loader.replace_attr(
+                subject, [('$SNAPCRAFT_PROJECT_NAME', 'project_name'),
+                          ('$SNAPCRAFT_PROJECT_VERSION', 'version'),
+                          ('$SNAPCRAFT_STAGE', self.stage_dir)]), expected)
 
     def test_tuples_with_string_replacements(self):
         replacements = (
@@ -1824,8 +1828,10 @@ class SnapcraftEnvTestCase(tests.TestCase):
 
         for test_name, subject, expected in replacements:
             self.subTest(key=test_name)
-            self.assertEqual(project_loader._replace_attr(
-                subject, 'project_name', 'version', self.stage_dir), expected)
+            self.assertEqual(project_loader.replace_attr(
+                subject, [('$SNAPCRAFT_PROJECT_NAME', 'project_name'),
+                          ('$SNAPCRAFT_PROJECT_VERSION', 'version'),
+                          ('$SNAPCRAFT_STAGE', self.stage_dir)]), expected)
 
     def test_dict_with_string_replacements(self):
         replacements = (
@@ -1866,8 +1872,10 @@ class SnapcraftEnvTestCase(tests.TestCase):
 
         for test_name, subject, expected in replacements:
             self.subTest(key=test_name)
-            self.assertEqual(project_loader._replace_attr(
-                subject, 'project_name', 'version', self.stage_dir), expected)
+            self.assertEqual(project_loader.replace_attr(
+                subject, [('$SNAPCRAFT_PROJECT_NAME', 'project_name'),
+                          ('$SNAPCRAFT_PROJECT_VERSION', 'version'),
+                          ('$SNAPCRAFT_STAGE', self.stage_dir)]), expected)
 
     def test_string_replacement_with_complex_data(self):
         subject = {
@@ -1898,5 +1906,7 @@ class SnapcraftEnvTestCase(tests.TestCase):
             ],
         }
 
-        self.assertEqual(project_loader._replace_attr(
-            subject, 'project_name', 'version', self.stage_dir), expected)
+        self.assertEqual(project_loader.replace_attr(
+            subject, [('$SNAPCRAFT_PROJECT_NAME', 'project_name'),
+                      ('$SNAPCRAFT_PROJECT_VERSION', 'version'),
+                      ('$SNAPCRAFT_STAGE', self.stage_dir)]), expected)


### PR DESCRIPTION
Replace $SNAPCRAFT_PROJECT_VERSION and $SNAPCRAFT_PROJECT_NAME
with their respective values from the origin's snapcraft.yaml
in remote parts definitions.

LP:#1619418