### PR TITLE
go plugin: don't put debugging symbols in generated binaries

### DIFF
--- a/snapcraft/plugins/go.py
+++ b/snapcraft/plugins/go.py
@@ -144,12 +144,12 @@ class GoPlugin(snapcraft.BasePlugin):
         super().build()
 
         for go_package in self.options.go_packages:
-            self._run(['go', 'install', go_package])
+            self._run(['go', 'install', '--ldflags=-s -w', go_package])
         if not self.options.go_packages:
             tags = []
             if self.options.go_buildtags:
                 tags = ['-tags={}'.format(','.join(self.options.go_buildtags))]
-            self._run(['go', 'install'] + tags +
+            self._run(['go', 'install', '--ldflags=-s -w'] + tags +
                       ['./{}/...'.format(self._get_local_go_package())])
 
         install_bin_path = os.path.join(self.installdir, 'bin')

--- a/snapcraft/tests/test_plugin_go.py
+++ b/snapcraft/tests/test_plugin_go.py
@@ -227,7 +227,7 @@ class GoPluginTestCase(tests.TestCase):
         plugin.build()
 
         self.run_mock.assert_called_once_with(
-            ['go', 'install', './dir/...'],
+            ['go', 'install', '--ldflags=-s -w', './dir/...'],
             cwd=plugin._gopath_src, env=mock.ANY)
 
         self.assertTrue(os.path.exists(plugin._gopath))
@@ -256,7 +256,8 @@ class GoPluginTestCase(tests.TestCase):
         plugin.build()
 
         self.run_mock.assert_called_once_with(
-            ['go', 'install', plugin.options.go_packages[0]],
+            ['go', 'install', '--ldflags=-s -w',
+             plugin.options.go_packages[0]],
             cwd=plugin._gopath_src, env=mock.ANY)
 
         self.assertTrue(os.path.exists(plugin._gopath))
@@ -363,7 +364,8 @@ class GoPluginTestCase(tests.TestCase):
             mock.call(['go', 'get', '-t', '-d',
                        './github.com/snapcore/launcher/...'],
                       cwd=plugin._gopath_src, env=mock.ANY),
-            mock.call(['go', 'install', './github.com/snapcore/launcher/...'],
+            mock.call(['go', 'install', '--ldflags=-s -w',
+                       './github.com/snapcore/launcher/...'],
                       cwd=plugin._gopath_src, env=mock.ANY),
         ])
 
@@ -429,6 +431,6 @@ class GoPluginTestCase(tests.TestCase):
         plugin.build()
 
         self.run_mock.assert_called_once_with(
-            ['go', 'install',
+            ['go', 'install', '--ldflags=-s -w',
              '-tags=testbuildtag1,testbuildtag2', './dir/...'],
             cwd=plugin._gopath_src, env=mock.ANY)


### PR DESCRIPTION
Go binaries should never stripped or they can behave badly,
but it's possible to avoid debugging symbol generation at build time.
The binaries are roughly half the size