### PR TITLE
Fix gulp plugin's npm install prefix

### DIFF
--- a/snapcraft/plugins/gulp.py
+++ b/snapcraft/plugins/gulp.py
@@ -99,6 +99,7 @@ class GulpPlugin(snapcraft.BasePlugin):
         env = os.environ.copy()
         env['PATH'] = '{}:{}'.format(
             os.path.join(self._npm_dir, 'bin'), env['PATH'])
+        env['NPM_CONFIG_PREFIX'] = self._npm_dir
         self.run(['npm', 'install', '-g', 'gulp-cli'], env=env)
         if os.path.exists(os.path.join(self.builddir, 'package.json')):
             self.run(['npm', 'install', '--only-development'], env=env)

--- a/snapcraft/tests/test_plugin_gulp.py
+++ b/snapcraft/tests/test_plugin_gulp.py
@@ -85,10 +85,12 @@ class GulpPluginTestCase(tests.TestCase):
         self.run_mock.assert_has_calls([
             mock.call(['npm', 'install', '-g', 'gulp-cli'],
                       cwd=plugin.builddir,
-                      env={'PATH': path, 'NPM_CONFIG_PREFIX': plugin._npm_dir}),
+                      env={'PATH': path,
+                           'NPM_CONFIG_PREFIX': plugin._npm_dir}),
             mock.call(['npm', 'install', '--only-development'],
                       cwd=plugin.builddir,
-                      env={'PATH': path, 'NPM_CONFIG_PREFIX': plugin._npm_dir}),
+                      env={'PATH': path,
+                           'NPM_CONFIG_PREFIX': plugin._npm_dir}),
         ])
 
         self.tar_mock.assert_has_calls([

--- a/snapcraft/tests/test_plugin_gulp.py
+++ b/snapcraft/tests/test_plugin_gulp.py
@@ -84,9 +84,11 @@ class GulpPluginTestCase(tests.TestCase):
         path = '{}:/bin'.format(os.path.join(plugin._npm_dir, 'bin'))
         self.run_mock.assert_has_calls([
             mock.call(['npm', 'install', '-g', 'gulp-cli'],
-                      cwd=plugin.builddir, env={'PATH': path}),
+                      cwd=plugin.builddir,
+                      env={'PATH': path, 'NPM_CONFIG_PREFIX': plugin._npm_dir}),
             mock.call(['npm', 'install', '--only-development'],
-                      cwd=plugin.builddir, env={'PATH': path}),
+                      cwd=plugin.builddir,
+                      env={'PATH': path, 'NPM_CONFIG_PREFIX': plugin._npm_dir}),
         ])
 
         self.tar_mock.assert_has_calls([


### PR DESCRIPTION
Fix the gulp plugin npm prefix install, by default gult is being installed globally in /usr/local/bin which is not a proper install prefix for a local snap,

One can easily test with e.g. the snapweb snapcraft install,

LP: #1621921