### PR TITLE
Some plugins fixes

### DIFF
--- a/snapcraft/internal/sources.py
+++ b/snapcraft/internal/sources.py
@@ -182,9 +182,14 @@ class Git(Base):
             if self.source_tag or self.source_branch:
                 branch_opts = ['--branch',
                                self.source_tag or self.source_branch]
-            subprocess.check_call(['git', 'clone', '--depth', '1',
-                                  '--recursive'] + branch_opts +
-                                  [self.source, self.source_dir])
+            if self.source.startswith('git://'):
+                subprocess.check_call(['git', 'clone', '--depth', '1',
+                                      '--recursive'] + branch_opts +
+                                      [self.source, self.source_dir])
+            else:
+                subprocess.check_call(['git', 'clone',
+                                      '--recursive'] + branch_opts +
+                                      [self.source, self.source_dir])
 
 
 class Mercurial(Base):

--- a/snapcraft/internal/sources.py
+++ b/snapcraft/internal/sources.py
@@ -180,7 +180,7 @@ class Git(Base):
         else:
             branch_opts = []
             if self.source_tag or self.source_branch:
-                branch_opts = ['--branch',
+                branch_opts = ['--single-branch', '--branch',
                                self.source_tag or self.source_branch]
             if self.source.startswith('git://'):
                 subprocess.check_call(['git', 'clone', '--depth', '1',

--- a/snapcraft/plugins/copy.py
+++ b/snapcraft/plugins/copy.py
@@ -73,6 +73,9 @@ class CopyPlugin(snapcraft.BasePlugin):
                        "has been replaced by the 'dump' plugin, and it will "
                        "soon be removed.")
 
+    def enable_cross_compilation(self):
+        pass
+
     def build(self):
         super().build()
 

--- a/snapcraft/plugins/dump.py
+++ b/snapcraft/plugins/dump.py
@@ -32,6 +32,9 @@ import snapcraft
 
 class DumpPlugin(snapcraft.BasePlugin):
 
+    def enable_cross_compilation(self):
+        pass
+
     def build(self):
         super().build()
         snapcraft.file_utils.link_or_copy_tree(

--- a/snapcraft/tests/test_sources.py
+++ b/snapcraft/tests/test_sources.py
@@ -192,16 +192,16 @@ class TestGit(SourceTestCase):
         git.pull()
 
         self.mock_run.assert_called_once_with(
-            ['git', 'clone', '--depth', '1', '--recursive', '--branch',
-             'my-branch', 'git://my-source', 'source_dir'])
+            ['git', 'clone', '--depth', '1', '--recursive', '--single-branch',
+             '--branch', 'my-branch', 'git://my-source', 'source_dir'])
 
     def test_pull_tag(self):
         git = sources.Git('git://my-source', 'source_dir', source_tag='tag')
         git.pull()
 
         self.mock_run.assert_called_once_with(
-            ['git', 'clone', '--depth', '1', '--recursive', '--branch', 'tag',
-             'git://my-source', 'source_dir'])
+            ['git', 'clone', '--depth', '1', '--recursive', '--single-branch',
+             '--branch', 'tag', 'git://my-source', 'source_dir'])
 
     def test_pull_existing(self):
         self.mock_path_exists.return_value = True


### PR DESCRIPTION
This pull merge has three important modifications:

a) Enable crosscompilation for dump and copy plugins to be able to use them, for example, providing blobs after build a kernel snap for a different architecture.
b) Speed up the pull time of a git repository only downloading the commits of related branch thanks to `--single-branch` switch of Git.
c) Remove `--depth=1` of HTTP transport for Git due there are repositories as git.kernel.org that does not support that.

I would be happy to see these changes in the next version of Snapcraft.

Regards.