### PR TITLE
Reduces download time of `git clone` fetching just a single branch.

### DIFF
--- a/snapcraft/internal/sources.py
+++ b/snapcraft/internal/sources.py
@@ -181,7 +181,7 @@ class Git(Base):
         else:
             branch_opts = []
             if self.source_tag or self.source_branch:
-                branch_opts = ['--branch',
+                branch_opts = ['--single-branch', '--branch',
                                self.source_tag or self.source_branch]
             subprocess.check_call(['git', 'clone', '--depth', '1',
                                   '--recursive'] + branch_opts +

--- a/snapcraft/tests/test_sources.py
+++ b/snapcraft/tests/test_sources.py
@@ -196,16 +196,16 @@ class TestGit(SourceTestCase):
         git.pull()
 
         self.mock_run.assert_called_once_with(
-            ['git', 'clone', '--depth', '1', '--recursive', '--branch',
-             'my-branch', 'git://my-source', 'source_dir'])
+            ['git', 'clone', '--depth', '1', '--recursive', '--single-branch',
+             '--branch', 'my-branch', 'git://my-source', 'source_dir'])
 
     def test_pull_tag(self):
         git = sources.Git('git://my-source', 'source_dir', source_tag='tag')
         git.pull()
 
         self.mock_run.assert_called_once_with(
-            ['git', 'clone', '--depth', '1', '--recursive', '--branch', 'tag',
-             'git://my-source', 'source_dir'])
+            ['git', 'clone', '--depth', '1', '--recursive', '--single-branch',
+             '--branch', 'tag', 'git://my-source', 'source_dir'])
 
     def test_pull_existing(self):
         self.mock_path_exists.return_value = True


### PR DESCRIPTION
This pull request speed up the pull time of a git repository only downloading the commits of related branch thanks to --single-branch switch of Git.

Signed-off-by: Enrique Hernández Bello <ehbello@gmail.com>