### PR TITLE
Enable crosscompilation for dump and copy plugins

### DIFF
--- a/snapcraft/plugins/copy.py
+++ b/snapcraft/plugins/copy.py
@@ -73,6 +73,9 @@ class CopyPlugin(snapcraft.BasePlugin):
                        "has been replaced by the 'dump' plugin, and it will "
                        "soon be removed.")
 
+    def enable_cross_compilation(self):
+        pass
+
     def build(self):
         super().build()
 

--- a/snapcraft/plugins/dump.py
+++ b/snapcraft/plugins/dump.py
@@ -32,6 +32,9 @@ import snapcraft
 
 class DumpPlugin(snapcraft.BasePlugin):
 
+    def enable_cross_compilation(self):
+        pass
+
     def build(self):
         super().build()
         snapcraft.file_utils.link_or_copy_tree(

--- a/snapcraft/tests/test_plugin_copy.py
+++ b/snapcraft/tests/test_plugin_copy.py
@@ -332,6 +332,10 @@ class TestCopyPlugin(TestCase):
                 with open(destination, 'r') as f:
                     self.assertEqual(f.read(), symlink['expected_contents'])
 
+    def test_copy_enable_cross_compilation(self):
+        c = CopyPlugin('copy', self.mock_options, self.project_options)
+        c.enable_cross_compilation()
+
 
 class TestRecursivelyLink(TestCase):
 

--- a/snapcraft/tests/test_plugin_dump.py
+++ b/snapcraft/tests/test_plugin_dump.py
@@ -194,3 +194,7 @@ class DumpPluginTestCase(TestCase):
             str(raised.exception),
             '{!r} is a broken symlink pointing outside the snap'.format(
                 os.path.join(plugin.builddir, 'bad_relative')))
+
+    def test_dump_enable_cross_compilation(self):
+        plugin = DumpPlugin('dump', self.options, self.project_options)
+        plugin.enable_cross_compilation()


### PR DESCRIPTION
This pull request enables crosscompilation for dump and copy plugins to be able to use them, for example, providing blobs after build a kernel snap for a different architecture.