### PR TITLE
Fix `git clone` when transport is http and it does not support --depth

### DIFF
--- a/snapcraft/internal/sources.py
+++ b/snapcraft/internal/sources.py
@@ -183,9 +183,14 @@ class Git(Base):
             if self.source_tag or self.source_branch:
                 branch_opts = ['--branch',
                                self.source_tag or self.source_branch]
-            subprocess.check_call(['git', 'clone', '--depth', '1',
-                                  '--recursive'] + branch_opts +
-                                  [self.source, self.source_dir])
+            if self.source.startswith('git://'):
+                subprocess.check_call(['git', 'clone', '--depth', '1',
+                                      '--recursive'] + branch_opts +
+                                      [self.source, self.source_dir])
+            else:
+                subprocess.check_call(['git', 'clone',
+                                      '--recursive'] + branch_opts +
+                                      [self.source, self.source_dir])
 
 
 class Mercurial(Base):


### PR DESCRIPTION
This pull request remove ``--depth=1`` of HTTP transport for Git due there are repositories as git.kernel.org that does not support that.

Signed-off-by: Enrique Hernández Bello <ehbello@gmail.com>