### PR TITLE
Improve lifecycle execution of steps

### DIFF
--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -156,8 +156,8 @@ class _Executor:
                             if 'stage' not in self._steps_run[p]}
 
         if unstaged_prereqs and not unstaged_prereqs.issubset(part_names):
-            missing_parts = [part.name for part in self.config.all_parts
-                             if part.name in unstaged_prereqs]
+            missing_parts = [part_name for part_name in self.config.part_names
+                             if part_name in unstaged_prereqs]
             if any(missing_parts):
                 raise RuntimeError(
                     'Requested {!r} of {!r} but there are unsatisfied '

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -132,6 +132,8 @@ class _Executor:
     def run(self, step, part_names=None):
         if part_names:
             self.parts_config.validate(part_names)
+            # self.config.all_parts is already ordered, let's not lose that
+            # and keep using a list.
             parts = [p for p in self.config.all_parts if p.name in part_names]
         else:
             parts = self.config.all_parts
@@ -158,7 +160,7 @@ class _Executor:
         if unstaged_prereqs and not unstaged_prereqs.issubset(part_names):
             missing_parts = [part_name for part_name in self.config.part_names
                              if part_name in unstaged_prereqs]
-            if any(missing_parts):
+            if missing_parts:
                 raise RuntimeError(
                     'Requested {!r} of {!r} but there are unsatisfied '
                     'prerequisites: {!r}'.format(

--- a/snapcraft/tests/test_lifecycle.py
+++ b/snapcraft/tests/test_lifecycle.py
@@ -101,6 +101,10 @@ grade: stable
     plugin: nil
     after:
       - part1
+  part3:
+    plugin: nil
+    after:
+      - part2
 """)
 
         snap_info = lifecycle.execute('pull', self.project_options)
@@ -117,12 +121,17 @@ grade: stable
             'Preparing to pull part1 \n'
             'Pulling part1 \n'
             '\'part2\' has prerequisites that need to be staged: part1\n'
-            'Skipping pull part1 (already ran)\n'
             'Preparing to build part1 \n'
             'Building part1 \n'
             'Staging part1 \n'
             'Preparing to pull part2 \n'
-            'Pulling part2 \n',
+            'Pulling part2 \n'
+            '\'part3\' has prerequisites that need to be staged: part2\n'
+            'Preparing to build part2 \n'
+            'Building part2 \n'
+            'Staging part2 \n'
+            'Preparing to pull part3 \n'
+            'Pulling part3 \n',
             self.fake_logger.output)
 
     def test_os_type_returned_by_lifecycle(self):

--- a/snapcraft/tests/test_lifecycle.py
+++ b/snapcraft/tests/test_lifecycle.py
@@ -89,6 +89,10 @@ grade: stable
                               part_names=['part2'])
 
         self.assertEqual(
+            'Skipping pull part1 (already ran)\n'
+            'Skipping build part1 (already ran)\n'
+            'Skipping stage part1 (already ran)\n'
+            'Skipping prime part1 (already ran)\n'
             'Preparing to pull part2 \n'
             'Pulling part2 \n',
             self.fake_logger.output)
@@ -421,6 +425,10 @@ grade: stable
             'Skipping cleaning priming area for part1 (out of date) '
             '(already clean)\n'
             'Cleaning staging area for part1 (out of date)\n'
+            'Skipping cleaning priming area for part2 (out of date) '
+            '(already clean)\n'
+            'Skipping cleaning staging area for part2 (out of date) '
+            '(already clean)\n'
             'Staging part1 \n',
             self.fake_logger.output)
 


### PR DESCRIPTION
Execute the steps in order and skip early by keeping checks
in runtime. The parts to run are a list instead of a set to not lose
the sort order

LP: #1590599

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>