### PR TITLE
LP: #1623509 nodejs: fix to install dev-deps in build phase

### DIFF
--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -113,11 +113,12 @@ class NodePlugin(snapcraft.BasePlugin):
     def _npm_install(self):
         self._nodejs_tar.provision(
             self.installdir, clean_target=False, keep_tarball=True)
-        npm_install = ['npm', '--cache-min=Infinity', 'install', '--global']
+        npm_install = ['npm', '--cache-min=Infinity', 'install']
         for pkg in self.options.node_packages:
-            self.run(npm_install + [pkg])
+            self.run(npm_install + ['--global'] + [pkg])
         if os.path.exists(os.path.join(self.builddir, 'package.json')):
             self.run(npm_install)
+            self.run(npm_install + ['--global'])
 
 
 def _get_nodejs_base(node_engine):

--- a/snapcraft/tests/test_plugin_nodejs.py
+++ b/snapcraft/tests/test_plugin_nodejs.py
@@ -78,6 +78,8 @@ class NodePluginTestCase(tests.TestCase):
         plugin.build()
 
         self.run_mock.assert_has_calls([
+            mock.call(['npm', '--cache-min=Infinity', 'install'],
+                      cwd=plugin.builddir),
             mock.call(['npm', '--cache-min=Infinity', 'install', '--global'],
                       cwd=plugin.builddir)])
         self.tar_mock.assert_has_calls([


### PR DESCRIPTION
this PR makes the nodejs plugin download the devDependencies from package.json during the build phase.

https://bugs.launchpad.net/snapcraft/+bug/1623509

i have submitted the contributor agreement as well.