### PR TITLE
Do not run the bootstrap directory as a script (autotools plugin).

### DIFF
--- a/snapcraft/plugins/autotools.py
+++ b/snapcraft/plugins/autotools.py
@@ -96,9 +96,7 @@ class AutotoolsPlugin(snapcraft.BasePlugin):
             scripts = ["autogen.sh", "bootstrap"]
             for script in scripts:
                 path = os.path.join(self.builddir, script)
-                if not os.path.exists(path):
-                    continue
-                if os.path.isdir(path):
+                if not os.path.exists(path) or os.path.isdir(path):
                     continue
                 # Make sure it's executable
                 if not os.access(path, os.X_OK):

--- a/snapcraft/plugins/autotools.py
+++ b/snapcraft/plugins/autotools.py
@@ -98,6 +98,8 @@ class AutotoolsPlugin(snapcraft.BasePlugin):
                 path = os.path.join(self.builddir, script)
                 if not os.path.exists(path):
                     continue
+                if os.path.isdir(path):
+                    continue
                 # Make sure it's executable
                 if not os.access(path, os.X_OK):
                     os.chmod(path,


### PR DESCRIPTION
Sometimes an autotools-using project has a bootstrap directory, such as Basho's fork of Erlang (https://github.com/basho/otp) as used in Riak.