### PR TITLE
Adjust login to conform to UX specification

### DIFF
--- a/docs/upload-your-snap.md
+++ b/docs/upload-your-snap.md
@@ -22,8 +22,8 @@ store on your behalf:
     Enter your Ubuntu One SSO credentials.
     Email: me@example.com
     Password:
-    One-time password (just press enter if you don't use two-factor authentication):
-    Authenticating against Ubuntu One SSO.
+    Second-factor auth:
+
     Login successful.
 
 These credentials will remain valid until you revoke them, which you can do

--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -111,11 +111,9 @@ class StoreTestCase(TestCase):
         process.sendline(email)
         process.expect_exact('Password: ')
         process.sendline(password)
-        process.expect_exact(
-            "One-time password (just press enter if you don't use two-factor "
-            "authentication): ")
-        process.sendline('')
-        process.expect_exact('Authenticating against Ubuntu One SSO.')
+        if expect_success:
+            process.expect_exact(
+                'We strongly recommend enabling multi-factor authentication:')
         result = 'successful' if expect_success else 'failed'
         process.expect_exact('Login {}.'.format(result))
 
@@ -146,12 +144,9 @@ class StoreTestCase(TestCase):
         process.sendline(email)
         process.expect_exact('Password: ')
         process.sendline(password)
-        process.expect_exact(
-            "One-time password (just press enter if you don't use two-factor "
-            "authentication): ")
-        process.sendline('')
-        process.expect_exact('Authenticating against Ubuntu One SSO.')
         if expect_success:
+            process.expect_exact(
+                'We strongly recommend enabling multi-factor authentication:')
             process.expect_exact('Login successful.')
             process.expect(
                 r'Done\. The key "{}" .* may be used to sign your '

--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -51,20 +51,26 @@ def _login(store, acls=None, save=True):
     print('Enter your Ubuntu One SSO credentials.')
     email = input('Email: ')
     password = getpass.getpass('Password: ')
-    one_time_password = input(
-        'One-time password (just press enter if you don\'t use two-factor '
-        'authentication): ')
 
-    logger.info('Authenticating against Ubuntu One SSO.')
     try:
-        store.login(
-            email, password, one_time_password=one_time_password, acls=acls,
-            save=save)
+        try:
+            store.login(email, password, acls=acls, save=save)
+            print()
+            logger.info(
+                'We strongly recommend enabling multi-factor authentication: '
+                'https://help.ubuntu.com/community/SSO/FAQs/2FA')
+        except storeapi.errors.StoreTwoFactorAuthenticationRequired:
+            one_time_password = input('Second-factor auth: ')
+            store.login(
+                email, password, one_time_password=one_time_password,
+                acls=acls, save=save)
     except (storeapi.errors.InvalidCredentialsError,
             storeapi.errors.StoreAuthenticationError):
+        print()
         logger.info('Login failed.')
         return False
     else:
+        print()
         logger.info('Login successful.')
         return True
 

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -59,6 +59,12 @@ class StoreAuthenticationError(StoreError):
         super().__init__(message=message)
 
 
+class StoreTwoFactorAuthenticationRequired(StoreAuthenticationError):
+
+    def __init__(self):
+        super().__init__("Two-factor authentication required.")
+
+
 class StoreAccountInformationError(StoreError):
 
     fmt = 'Error fetching account information from store: {error}'

--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -216,11 +216,8 @@ class FakeSSORequestHandler(BaseHTTPRequestHandler):
             ('otp' not in data or
              data['otp'] == 'test correct one-time password')):
             self._send_tokens_discharge(data)
-        elif data['password'] == 'test requires 2fa' and 'otp' not in data:
+        elif data['password'] == 'test requires 2fa':
             self._send_twofactor_required_error()
-        elif (data['password'] == 'test requires 2fa' and
-              data['otp'] == 'test correct one-time password'):
-            self._send_tokens_discharge(data)
         else:
             self._send_invalid_credentials_error()
 

--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -216,6 +216,11 @@ class FakeSSORequestHandler(BaseHTTPRequestHandler):
             ('otp' not in data or
              data['otp'] == 'test correct one-time password')):
             self._send_tokens_discharge(data)
+        elif data['password'] == 'test requires 2fa' and 'otp' not in data:
+            self._send_twofactor_required_error()
+        elif (data['password'] == 'test requires 2fa' and
+              data['otp'] == 'test correct one-time password'):
+            self._send_tokens_discharge(data)
         else:
             self._send_invalid_credentials_error()
 
@@ -229,14 +234,27 @@ class FakeSSORequestHandler(BaseHTTPRequestHandler):
         self.wfile.write(
             json.dumps(response).encode())
 
+    def _send_twofactor_required_error(self):
+        self.send_response(401)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        response = {
+            'error_list': [{
+                'code': 'twofactor-required',
+                'message': '2-factor authentication required.',
+            }],
+        }
+        self.wfile.write(json.dumps(response).encode())
+
     def _send_invalid_credentials_error(self):
         self.send_response(401)
         self.send_header('Content-Type', 'application/json')
         self.end_headers()
         response = {
-            'code': 'INVALID_CREDENTIALS',
-            'message': 'Provided email/password is not correct.',
-            'message': 'Provided email/password is not correct.',
+            'error_list': [{
+                'code': 'invalid-credentials',
+                'message': 'Provided email/password is not correct.',
+            }],
         }
         self.wfile.write(json.dumps(response).encode())
 

--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -218,6 +218,8 @@ class FakeSSORequestHandler(BaseHTTPRequestHandler):
             self._send_tokens_discharge(data)
         elif data['password'] == 'test requires 2fa':
             self._send_twofactor_required_error()
+        elif data['password'] == 'test 401 invalid json':
+            self._send_401_invalid_json()
         else:
             self._send_invalid_credentials_error()
 
@@ -242,6 +244,12 @@ class FakeSSORequestHandler(BaseHTTPRequestHandler):
             }],
         }
         self.wfile.write(json.dumps(response).encode())
+
+    def _send_401_invalid_json(self):
+        self.send_response(401)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(b'invalid{json')
 
     def _send_invalid_credentials_error(self):
         self.send_response(401)

--- a/snapcraft/tests/store/test_store_client.py
+++ b/snapcraft/tests/store/test_store_client.py
@@ -61,6 +61,12 @@ class LoginTestCase(tests.TestCase):
 
         self.assertTrue(config.Config().is_empty())
 
+    def test_failed_login_requires_one_time_password(self):
+        with self.assertRaises(errors.StoreTwoFactorAuthenticationRequired):
+            self.client.login('dummy email', 'test requires 2fa')
+
+        self.assertTrue(config.Config().is_empty())
+
     def test_failed_login_with_wrong_one_time_password(self):
         with self.assertRaises(errors.StoreAuthenticationError):
             self.client.login(

--- a/snapcraft/tests/store/test_store_client.py
+++ b/snapcraft/tests/store/test_store_client.py
@@ -76,6 +76,12 @@ class LoginTestCase(tests.TestCase):
 
         self.assertTrue(config.Config().is_empty())
 
+    def test_failed_login_with_invalid_json(self):
+        with self.assertRaises(errors.StoreAuthenticationError):
+            self.client.login('dummy email', 'test 401 invalid json')
+
+        self.assertTrue(config.Config().is_empty())
+
 
 class DownloadTestCase(tests.TestCase):
 

--- a/snapcraft/tests/test_commands_register_key.py
+++ b/snapcraft/tests/test_commands_register_key.py
@@ -114,19 +114,20 @@ class RegisterKeyTestCase(tests.TestCase):
         mock_input.side_effect = ['sample.person@canonical.com', '123456']
         mock_getpass.return_value = 'secret'
         mock_check_output.side_effect = mock_snap_output
+        mock_login.side_effect = [
+            storeapi.errors.StoreTwoFactorAuthenticationRequired(), None]
         mock_get_account_information.return_value = {'account_id': 'abcd'}
 
         main(['register-key', 'default'])
 
         self.assertEqual(
-            'Authenticating against Ubuntu One SSO.\n'
             'Login successful.\n'
             'Registering key ...\n'
             'Done. The key "default" ({}) may be used to sign your '
             'assertions.\n'.format(get_sample_key('default')['sha3-384']),
             self.fake_logger.output)
 
-        mock_login.assert_called_once_with(
+        mock_login.assert_called_with(
             'sample.person@canonical.com', 'secret',
             one_time_password='123456', acls=['modify_account_key'],
             save=False)
@@ -286,7 +287,7 @@ class RegisterKeyTestCase(tests.TestCase):
                                      mock_login, mock_get_account_information,
                                      mock_register_key):
         mock_installed.return_value = True
-        mock_input.side_effect = ['x', '2', 'sample.person@canonical.com', '']
+        mock_input.side_effect = ['x', '2', 'sample.person@canonical.com']
         mock_getpass.return_value = 'secret'
         mock_check_output.side_effect = mock_snap_output
         mock_get_account_information.return_value = {'account_id': 'abcd'}
@@ -308,7 +309,8 @@ class RegisterKeyTestCase(tests.TestCase):
             [mock.call('Key number: '), mock.call('Key number: ')])
 
         self.assertEqual(
-            'Authenticating against Ubuntu One SSO.\n'
+            'We strongly recommend enabling multi-factor authentication: '
+            'https://help.ubuntu.com/community/SSO/FAQs/2FA\n'
             'Login successful.\n'
             'Registering key ...\n'
             'Done. The key "another" ({}) may be used to sign your '


### PR DESCRIPTION
The store now returns an unambiguous error to indicate that two-factor
authentication is required, so we can use that to make the login process
behave how the UX specification says it should: only prompt for 2fa if
necessary, and provide a hint on a successful login without 2fa.

One obvious hack in this change is that we don't yet provide a
convenient per-store link for enabling 2fa, but instead just hardcode a
link to the SSO FAQ for now.  At the moment, people have to explicitly
opt into 2fa by joining a Launchpad team, which is a deliberate decision
because we don't have a good recovery facility and can't afford the
support bandwidth of doing manual recovery for millions of users.  When
this changes then we can also update snapcraft to do something more
graceful here, but for the moment I think this is tolerable.

LP: #1621710