### PR TITLE
Refresh discharge macaroon if necessary

### DIFF
--- a/snapcraft/storeapi/__init__.py
+++ b/snapcraft/storeapi/__init__.py
@@ -357,8 +357,8 @@ class SCAClient(Client):
     def _is_needs_refresh_response(response):
         return (
             response.status_code == requests.codes.unauthorized and
-            response.headers.get('WWW-Authenticate') ==
-                'Macaroon needs_refresh=1')
+            response.headers.get('WWW-Authenticate') == (
+                'Macaroon needs_refresh=1'))
 
     def request(self, *args, **kwargs):
         response = super().request(*args, **kwargs)

--- a/snapcraft/storeapi/__init__.py
+++ b/snapcraft/storeapi/__init__.py
@@ -149,14 +149,27 @@ class StoreClient():
         self.conf.clear()
         self.conf.save()
 
+    def _refresh_if_necessary(self, func, *args, **kwargs):
+        """Make a request, refreshing macaroons if necessary."""
+        try:
+            return func(*args, **kwargs)
+        except errors.StoreMacaroonNeedsRefreshError:
+            unbound_discharge = self.sso.refresh_unbound_discharge(
+                self.conf.get('unbound_discharge'))
+            self.conf.set('unbound_discharge', unbound_discharge)
+            self.conf.save()
+            return func(*args, **kwargs)
+
     def get_account_information(self):
-        return self.sca.get_account_information()
+        return self._refresh_if_necessary(self.sca.get_account_information)
 
     def register_key(self, account_key_request):
-        self.sca.register_key(account_key_request)
+        return self._refresh_if_necessary(
+            self.sca.register_key, account_key_request)
 
     def register(self, snap_name, is_private=False):
-        self.sca.register(snap_name, is_private, constants.DEFAULT_SERIES)
+        return self._refresh_if_necessary(
+            self.sca.register, snap_name, is_private, constants.DEFAULT_SERIES)
 
     def upload(self, snap_name, snap_filename):
         # FIXME This should be raised by the function that uses the
@@ -167,10 +180,12 @@ class StoreClient():
 
         updown_data = _upload.upload_files(snap_filename, self.updown)
 
-        return self.sca.snap_push_metadata(snap_name, updown_data)
+        return self._refresh_if_necessary(
+            self.sca.snap_push_metadata, snap_name, updown_data)
 
     def release(self, snap_name, revision, channels):
-        return self.sca.snap_release(snap_name, revision, channels)
+        return self._refresh_if_necessary(
+            self.sca.snap_release, snap_name, revision, channels)
 
     def download(self, snap_name, channel, download_path, arch=None):
         if arch is None:
@@ -246,7 +261,21 @@ class SSOClient(Client):
                 raise errors.StoreTwoFactorAuthenticationRequired()
             else:
                 raise errors.StoreAuthenticationError(
-                    'Failed to get unbound discharge: '.format(response.text))
+                    'Failed to get unbound discharge: {}'.format(
+                        response.text))
+
+    def refresh_unbound_discharge(self, unbound_discharge):
+        data = {'discharge_macaroon': unbound_discharge}
+        response = self.post(
+            'tokens/refresh', data=json.dumps(data),
+            headers={'Content-Type': 'application/json',
+                     'Accept': 'application/json'})
+        if response.ok:
+            return response.json()['discharge_macaroon']
+        else:
+            raise errors.StoreAuthenticationError(
+                'Failed to refresh unbound discharge: {}'.format(
+                    response.text))
 
 
 class SnapIndexClient(Client):
@@ -324,6 +353,19 @@ class SCAClient(Client):
         else:
             raise errors.StoreAuthenticationError('Failed to get macaroon')
 
+    @staticmethod
+    def _is_needs_refresh_response(response):
+        return (
+            response.status_code == requests.codes.unauthorized and
+            response.headers.get('WWW-Authenticate') ==
+                'Macaroon needs_refresh=1')
+
+    def request(self, *args, **kwargs):
+        response = super().request(*args, **kwargs)
+        if self._is_needs_refresh_response(response):
+            raise errors.StoreMacaroonNeedsRefreshError()
+        return response
+
     def get_account_information(self):
         auth = _macaroon_auth(self.conf)
         response = self.get(
@@ -345,7 +387,6 @@ class SCAClient(Client):
                      'Accept': 'application/json'})
         if not response.ok:
             raise errors.StoreKeyRegistrationError(response)
-        # TODO handle macaroon refresh
 
     def register(self, snap_name, is_private, series):
         auth = _macaroon_auth(self.conf)
@@ -357,7 +398,6 @@ class SCAClient(Client):
                      'Content-Type': 'application/json'})
         if not response.ok:
             raise errors.StoreRegistrationError(snap_name, response)
-        # TODO handle macaroon refresh
 
     def snap_push_metadata(self, snap_name, updown_data):
         data = {

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -65,6 +65,11 @@ class StoreTwoFactorAuthenticationRequired(StoreAuthenticationError):
         super().__init__("Two-factor authentication required.")
 
 
+class StoreMacaroonNeedsRefreshError(StoreError):
+
+    fmt = 'Authentication macaroon needs to be refreshed.'
+
+
 class StoreAccountInformationError(StoreError):
 
     fmt = 'Error fetching account information from store: {error}'

--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -185,9 +185,10 @@ parts:
 
 class FakeSSOServer(http.server.HTTPServer):
 
-    def __init__(self, server_address):
+    def __init__(self, fake_store, server_address):
         super().__init__(
             server_address, FakeSSORequestHandler)
+        self.fake_store = fake_store
 
 
 class FakeSSORequestHandler(BaseHTTPRequestHandler):
@@ -198,8 +199,12 @@ class FakeSSORequestHandler(BaseHTTPRequestHandler):
         parsed_path = urllib.parse.urlparse(self.path)
         tokens_discharge_path = urllib.parse.urljoin(
             self._API_PATH, 'tokens/discharge')
+        tokens_refresh_path = urllib.parse.urljoin(
+            self._API_PATH, 'tokens/refresh')
         if parsed_path.path.startswith(tokens_discharge_path):
             self._handle_tokens_discharge_request()
+        elif parsed_path.path.startswith(tokens_refresh_path):
+            self._handle_tokens_refresh_request()
         else:
             logger.error('Not implemented path in fake SSO server: {}'.format(
                 self.path))
@@ -215,7 +220,7 @@ class FakeSSORequestHandler(BaseHTTPRequestHandler):
         if (data['password'] == 'test correct password' and
             ('otp' not in data or
              data['otp'] == 'test correct one-time password')):
-            self._send_tokens_discharge(data)
+            self._send_tokens_discharge()
         elif data['password'] == 'test requires 2fa':
             self._send_twofactor_required_error()
         elif data['password'] == 'test 401 invalid json':
@@ -223,7 +228,7 @@ class FakeSSORequestHandler(BaseHTTPRequestHandler):
         else:
             self._send_invalid_credentials_error()
 
-    def _send_tokens_discharge(self, data):
+    def _send_tokens_discharge(self):
         self.send_response(200)
         self.send_header('Content-Type', 'application/json')
         self.end_headers()
@@ -263,6 +268,10 @@ class FakeSSORequestHandler(BaseHTTPRequestHandler):
         }
         self.wfile.write(json.dumps(response).encode())
 
+    def _handle_tokens_refresh_request(self):
+        self._send_tokens_discharge()
+        self.server.fake_store.needs_refresh = False
+
 
 class FakeStoreUploadServer(http.server.HTTPServer):
 
@@ -301,9 +310,10 @@ class FakeStoreUploadRequestHandler(BaseHTTPRequestHandler):
 
 class FakeStoreAPIServer(http.server.HTTPServer):
 
-    def __init__(self, server_address):
+    def __init__(self, fake_store, server_address):
         super().__init__(
             server_address, FakeStoreAPIRequestHandler)
+        self.fake_store = fake_store
         self.account_keys = []
 
 
@@ -312,6 +322,9 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
     _DEV_API_PATH = '/dev/api/'
 
     def do_POST(self):
+        if self.server.fake_store.needs_refresh:
+            self._handle_needs_refresh()
+            return
         parsed_path = urllib.parse.urlparse(self.path)
         acl_path = urllib.parse.urljoin(self._DEV_API_PATH, 'acl/')
         account_key_path = urllib.parse.urljoin(
@@ -337,6 +350,17 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
                 'Not implemented path in fake Store API server: {}'.format(
                     self.path))
             raise NotImplementedError(self.path)
+
+    def _handle_needs_refresh(self):
+        self.send_response(401)
+        self.send_header('WWW-Authenticate', 'Macaroon needs_refresh=1')
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        error = {
+            'code': 'macaroon-permission-required',
+            'message': 'Authorization Required',
+        }
+        self.wfile.write(json.dumps({'error_list': [error]}).encode())
 
     def _handle_acl_request(self, permission):
         logger.debug(
@@ -539,6 +563,9 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
         self.wfile.write(data)
 
     def do_GET(self):
+        if self.server.fake_store.needs_refresh:
+            self._handle_needs_refresh()
+            return
         parsed_path = urllib.parse.urlparse(self.path)
         details_good = urllib.parse.urljoin(
             self._DEV_API_PATH, '/details/upload-id/good-snap')

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -14,8 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
+from functools import partial
 import io
+import os
 import threading
 import urllib.parse
 from unittest import mock
@@ -172,7 +173,9 @@ class FakeStore(fixtures.Fixture):
     def setUp(self):
         super().setUp()
 
-        self.fake_sso_server_fixture = FakeSSOServerRunning()
+        self.needs_refresh = False
+
+        self.fake_sso_server_fixture = FakeSSOServerRunning(self)
         self.useFixture(self.fake_sso_server_fixture)
         self.useFixture(fixtures.EnvironmentVariable(
             'UBUNTU_SSO_API_ROOT_URL',
@@ -185,7 +188,7 @@ class FakeStore(fixtures.Fixture):
             'UBUNTU_STORE_UPLOAD_ROOT_URL',
             self.fake_store_upload_server_fixture.url))
 
-        self.fake_store_api_server_fixture = FakeStoreAPIServerRunning()
+        self.fake_store_api_server_fixture = FakeStoreAPIServerRunning(self)
         self.useFixture(self.fake_store_api_server_fixture)
         self.useFixture(fixtures.EnvironmentVariable(
             'UBUNTU_STORE_API_ROOT_URL',
@@ -247,7 +250,9 @@ class FakePartsServerRunning(_FakeServerRunning):
 
 class FakeSSOServerRunning(_FakeServerRunning):
 
-    fake_server = fake_servers.FakeSSOServer
+    def __init__(self, fake_store):
+        super().__init__()
+        self.fake_server = partial(fake_servers.FakeSSOServer, fake_store)
 
 
 class FakeStoreUploadServerRunning(_FakeServerRunning):
@@ -257,7 +262,9 @@ class FakeStoreUploadServerRunning(_FakeServerRunning):
 
 class FakeStoreAPIServerRunning(_FakeServerRunning):
 
-    fake_server = fake_servers.FakeStoreAPIServer
+    def __init__(self, fake_store):
+        super().__init__()
+        self.fake_server = partial(fake_servers.FakeStoreAPIServer, fake_store)
 
 
 class FakeStoreSearchServerRunning(_FakeServerRunning):


### PR DESCRIPTION
"WWW-Authenticate: Macaroon needs_refresh=1" tells us that we need to
ask SSO to refresh our discharge macaroon, so do that.

LP: #1621171