### PR TITLE
Don't litter /tmp with test artifacts.

### DIFF
--- a/snapcraft/internal/parser.py
+++ b/snapcraft/internal/parser.py
@@ -69,6 +69,11 @@ BASE_DIR = "/tmp"
 PARTS_FILE = "snap-parts.yaml"
 
 
+def _get_base_dir():
+    """The location to which sources are downloaded"""
+    return BASE_DIR
+
+
 def _get_version():
     try:
         return pkg_resources.require('snapcraft-parser')[0].version
@@ -190,7 +195,7 @@ def _process_entry(data):
     except KeyError as e:
         raise InvalidEntryError('Missing key in wiki entry: {}'.format(e))
 
-    origin_dir = os.path.join(BASE_DIR, _encode_origin(origin))
+    origin_dir = os.path.join(_get_base_dir(), _encode_origin(origin))
     os.makedirs(origin_dir, exist_ok=True)
 
     class Options:

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -17,7 +17,6 @@
 import logging
 import os
 import shutil
-import tempfile
 from unittest import mock
 
 import requests
@@ -73,12 +72,13 @@ class TestParser(TestCase):
 
     def setUp(self):
         super().setUp()
-        tempdir = tempfile.mkdtemp()
+        tempdir = fixtures.TempDir()
+        tempdir.setUp()
         patcher = mock.patch('snapcraft.internal.parser._get_base_dir')
         base_dir = patcher.start()
-        base_dir.return_value = tempdir
+        base_dir.return_value = tempdir.path
         self.addCleanup(patcher.stop)
-        self.addCleanup(shutil.rmtree, tempdir)
+        self.addCleanup(tempdir.cleanUp)
 
     def test_ordereddict_yaml(self):
         from collections import OrderedDict
@@ -1017,30 +1017,34 @@ parts: [app1]
                          _get_part_list())
 
     def test__get_origin_data_both(self):
-        tempdir = tempfile.mkdtemp()
-        with open(os.path.join(tempdir, '.snapcraft.yaml'), 'w') as fp:
+        tempdir = fixtures.TempDir()
+        tempdir.setUp()
+        self.addCleanup(tempdir.cleanUp)
+        with open(os.path.join(tempdir.path, '.snapcraft.yaml'), 'w') as fp:
             fp.write("")
-        with open(os.path.join(tempdir, 'snapcraft.yaml'), 'w') as fp:
+        with open(os.path.join(tempdir.path, 'snapcraft.yaml'), 'w') as fp:
             fp.write("")
 
-        self.assertRaises(BadSnapcraftYAMLError, _get_origin_data, tempdir)
-        shutil.rmtree(tempdir)
+        self.assertRaises(BadSnapcraftYAMLError, _get_origin_data,
+                          tempdir.path)
 
     def test__get_origin_data_hidden_only(self):
-        tempdir = tempfile.mkdtemp()
-        with open(os.path.join(tempdir, '.snapcraft.yaml'), 'w') as fp:
+        tempdir = fixtures.TempDir()
+        tempdir.setUp()
+        self.addCleanup(tempdir.cleanUp)
+        with open(os.path.join(tempdir.path, '.snapcraft.yaml'), 'w') as fp:
             fp.write("")
 
-        _get_origin_data(tempdir)
-        shutil.rmtree(tempdir)
+        _get_origin_data(tempdir.path)
 
     def test__get_origin_data_normal_only(self):
-        tempdir = tempfile.mkdtemp()
-        with open(os.path.join(tempdir, 'snapcraft.yaml'), 'w') as fp:
+        tempdir = fixtures.TempDir()
+        tempdir.setUp()
+        self.addCleanup(tempdir.cleanUp)
+        with open(os.path.join(tempdir.path, 'snapcraft.yaml'), 'w') as fp:
             fp.write("")
 
-        _get_origin_data(tempdir)
-        shutil.rmtree(tempdir)
+        _get_origin_data(tempdir.path)
 
     def test__encode_origin_git(self):
         origin = 'git@github.com:testuser/testproject.git'

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -58,6 +58,11 @@ def _get_part_list_count(path=PARTS_FILE):
     return len(_get_part_list(path))
 
 
+class TestParserBaseDir(TestCase):
+    def test__get_base_dir(self):
+        self.assertEqual('/tmp', parser._get_base_dir())
+
+
 class TestParser(TestCase):
     def tearDown(self):
         try:

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -73,12 +73,12 @@ class TestParser(TestCase):
     def setUp(self):
         super().setUp()
         tempdir = fixtures.TempDir()
-        tempdir.setUp()
+        self.useFixture(tempdir)
+        self.tempdir_path = tempdir.path
         patcher = mock.patch('snapcraft.internal.parser._get_base_dir')
         base_dir = patcher.start()
         base_dir.return_value = tempdir.path
         self.addCleanup(patcher.stop)
-        self.addCleanup(tempdir.cleanUp)
 
     def test_ordereddict_yaml(self):
         from collections import OrderedDict
@@ -1017,34 +1017,29 @@ parts: [app1]
                          _get_part_list())
 
     def test__get_origin_data_both(self):
-        tempdir = fixtures.TempDir()
-        tempdir.setUp()
-        self.addCleanup(tempdir.cleanUp)
-        with open(os.path.join(tempdir.path, '.snapcraft.yaml'), 'w') as fp:
+        with open(os.path.join(self.tempdir_path,
+                  '.snapcraft.yaml'), 'w') as fp:
             fp.write("")
-        with open(os.path.join(tempdir.path, 'snapcraft.yaml'), 'w') as fp:
+        with open(os.path.join(self.tempdir_path,
+                  'snapcraft.yaml'), 'w') as fp:
             fp.write("")
 
         self.assertRaises(BadSnapcraftYAMLError, _get_origin_data,
-                          tempdir.path)
+                          self.tempdir_path)
 
     def test__get_origin_data_hidden_only(self):
-        tempdir = fixtures.TempDir()
-        tempdir.setUp()
-        self.addCleanup(tempdir.cleanUp)
-        with open(os.path.join(tempdir.path, '.snapcraft.yaml'), 'w') as fp:
+        with open(os.path.join(self.tempdir_path,
+                  '.snapcraft.yaml'), 'w') as fp:
             fp.write("")
 
-        _get_origin_data(tempdir.path)
+        _get_origin_data(self.tempdir_path)
 
     def test__get_origin_data_normal_only(self):
-        tempdir = fixtures.TempDir()
-        tempdir.setUp()
-        self.addCleanup(tempdir.cleanUp)
-        with open(os.path.join(tempdir.path, 'snapcraft.yaml'), 'w') as fp:
+        with open(os.path.join(self.tempdir_path,
+                  'snapcraft.yaml'), 'w') as fp:
             fp.write("")
 
-        _get_origin_data(tempdir.path)
+        _get_origin_data(self.tempdir_path)
 
     def test__encode_origin_git(self):
         origin = 'git@github.com:testuser/testproject.git'

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -16,7 +16,6 @@
 
 import logging
 import os
-import shutil
 from unittest import mock
 
 import requests
@@ -818,8 +817,7 @@ parts: [somepart]
         self.assertEqual(0, _get_part_list_count())
 
     @mock.patch('snapcraft.internal.sources.get')
-    def test_wiki_with_fake_origin_with_bad_snapcraft_yaml(
-            self, mock_get):
+    def test_wiki_with_fake_origin_with_bad_snapcraft_yaml(self, mock_get):
 
         fixture = fixture_setup.FakePartsWikiOrigin()
         self.useFixture(fixture)
@@ -839,7 +837,6 @@ parts: [somepart]
         origin_dir = os.path.join(parser._get_base_dir(),
                                   _encode_origin(origin_url))
         os.makedirs(origin_dir, exist_ok=True)
-        self.addCleanup(shutil.rmtree, origin_dir)
 
         # Create a fake snapcraft.yaml for _get_origin_data() to parse
         with open(os.path.join(origin_dir, 'snapcraft.yaml'),
@@ -871,7 +868,6 @@ parts: [somepart]
         origin_dir = os.path.join(parser._get_base_dir(),
                                   _encode_origin(origin_url))
         os.makedirs(origin_dir, exist_ok=True)
-        self.addCleanup(shutil.rmtree, origin_dir)
 
         # Create a fake snapcraft.yaml for _get_origin_data() to parse
         with open(os.path.join(origin_dir, 'snapcraft.yaml'),


### PR DESCRIPTION
* Make the download location for source/origins mockable to
  make cleaning up after tests easier.

LP:#1624099