### PR TITLE
nodejs plugin: Add mechanism to run “npm run” commands.

### DIFF
--- a/integration_tests/snaps/nodejs-with-run-commands/index.js
+++ b/integration_tests/snaps/nodejs-with-run-commands/index.js
@@ -1,0 +1,9 @@
+var http = require("http");
+
+http.createServer(function (request, response) {
+
+   response.writeHead(200, {'Content-Type': 'text/plain'});
+   response.end('Hello World\n');
+}).listen(8081);
+
+console.log('Server running at http://127.0.0.1:8081/');

--- a/integration_tests/snaps/nodejs-with-run-commands/package.json
+++ b/integration_tests/snaps/nodejs-with-run-commands/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "run-command": "touch command-run"
+    "run-command-one": "touch command-one-run",
+    "run-command-two": "touch command-two-run",
+    "run-command-three": "test -f command-one-run -a -f command-two-run"
   },
   "author": "",
   "license": "GPL-3.0"

--- a/integration_tests/snaps/nodejs-with-run-commands/package.json
+++ b/integration_tests/snaps/nodejs-with-run-commands/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "simple-nodejs",
+  "version": "1.0.0",
+  "description": "Testing grounds for snapcraft integration tests",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "run-command": "touch command-run"
+  },
+  "author": "",
+  "license": "GPL-3.0"
+}

--- a/integration_tests/snaps/nodejs-with-run-commands/snapcraft.yaml
+++ b/integration_tests/snaps/nodejs-with-run-commands/snapcraft.yaml
@@ -10,4 +10,6 @@ parts:
     plugin: nodejs
     source: .
     npm-run:
-        - run-command
+        - run-command-one
+        - run-command-two
+        - run-command-three

--- a/integration_tests/snaps/nodejs-with-run-commands/snapcraft.yaml
+++ b/integration_tests/snaps/nodejs-with-run-commands/snapcraft.yaml
@@ -1,0 +1,13 @@
+name: test-package
+version: 0.1
+summary: A simple nodejs project.
+description: |
+  Proves that it is possible to build a snap using local nodejs sources.
+confinement: strict
+
+parts:
+  nodejs-with-run:
+    plugin: nodejs
+    source: .
+    npm-run:
+        - run-command

--- a/integration_tests/snaps/nodejs-with-run-commands/snapcraft.yaml
+++ b/integration_tests/snaps/nodejs-with-run-commands/snapcraft.yaml
@@ -1,8 +1,9 @@
 name: test-package
 version: 0.1
-summary: A simple nodejs project.
+summary: A more complex nodejs project.
 description: |
-  Proves that it is possible to build a snap using local nodejs sources.
+  Proves that it is possible to build a snap using local nodejs sources
+  and a set of “npm run” build steps.
 confinement: strict
 
 parts:

--- a/integration_tests/test_nodejs_plugin.py
+++ b/integration_tests/test_nodejs_plugin.py
@@ -18,6 +18,7 @@ import integration_tests
 import os
 from testtools.matchers import FileExists
 
+
 class NodeJSPluginTestCase(integration_tests.TestCase):
 
     def test_rebuilding_possible(self):
@@ -30,8 +31,10 @@ class NodeJSPluginTestCase(integration_tests.TestCase):
         project_dir = 'nodejs-with-run-commands'
         self.run_snapcraft('build', project_dir)
         self.assertThat(
-            os.path.join(project_dir, 'parts', 'nodejs-with-run', 'build', 'command-one-run'),
+            os.path.join(project_dir, 'parts', 'nodejs-with-run', 'build',
+                         'command-one-run'),
             FileExists())
         self.assertThat(
-            os.path.join(project_dir, 'parts', 'nodejs-with-run', 'build', 'command-two-run'),
+            os.path.join(project_dir, 'parts', 'nodejs-with-run', 'build',
+                         'command-two-run'),
             FileExists())

--- a/integration_tests/test_nodejs_plugin.py
+++ b/integration_tests/test_nodejs_plugin.py
@@ -30,5 +30,8 @@ class NodeJSPluginTestCase(integration_tests.TestCase):
         project_dir = 'nodejs-with-run-commands'
         self.run_snapcraft('build', project_dir)
         self.assertThat(
-            os.path.join(project_dir, 'parts', 'nodejs-with-run', 'build', 'command-run'),
+            os.path.join(project_dir, 'parts', 'nodejs-with-run', 'build', 'command-one-run'),
+            FileExists())
+        self.assertThat(
+            os.path.join(project_dir, 'parts', 'nodejs-with-run', 'build', 'command-two-run'),
             FileExists())

--- a/integration_tests/test_nodejs_plugin.py
+++ b/integration_tests/test_nodejs_plugin.py
@@ -15,7 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import integration_tests
-
+import os
+from testtools.matchers import FileExists
 
 class NodeJSPluginTestCase(integration_tests.TestCase):
 
@@ -24,3 +25,10 @@ class NodeJSPluginTestCase(integration_tests.TestCase):
         self.run_snapcraft('build', project_dir)
         self.run_snapcraft(['clean', '-s', 'build'], project_dir)
         self.run_snapcraft('build', project_dir)
+
+    def test_build_with_run_commands(self):
+        project_dir = 'nodejs-with-run-commands'
+        self.run_snapcraft('build', project_dir)
+        self.assertThat(
+            os.path.join(project_dir, 'parts', 'nodejs-with-run', 'build', 'command-run'),
+            FileExists())

--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -33,7 +33,8 @@ Additionally, this plugin uses the following plugin-specific keywords:
       The version of nodejs you want the snap to run on.
     - npm-run:
       (list)
-      A list of targets to `npm run`
+      A list of targets to `npm run`.
+      These targets will be run in order, after `npm install`
 """
 
 import logging

--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -31,6 +31,9 @@ Additionally, this plugin uses the following plugin-specific keywords:
     - node-engine:
       (string)
       The version of nodejs you want the snap to run on.
+    - npm-run:
+      (list)
+      A list of targets to `npm run`
 """
 
 import logging
@@ -73,13 +76,22 @@ class NodePlugin(snapcraft.BasePlugin):
             'type': 'string',
             'default': _NODEJS_VERSION
         }
+        schema['properties']['npm-run'] = {
+            'type': 'array',
+            'minitems': 1,
+            'uniqueItems': False,
+            'items': {
+                'type': 'string'
+            },
+            'default': []
+        }
 
         if 'required' in schema:
             del schema['required']
 
         # Inform Snapcraft of the properties associated with building. If these
         # change in the YAML Snapcraft will consider the build step dirty.
-        schema['build-properties'].append('node-packages')
+        schema['build-properties'].extend(['node-packages', 'npm-run'])
         # Inform Snapcraft of the properties associated with pulling. If these
         # change in the YAML Snapcraft will consider the build step dirty.
         schema['pull-properties'].append('node-engine')
@@ -119,6 +131,8 @@ class NodePlugin(snapcraft.BasePlugin):
         if os.path.exists(os.path.join(self.builddir, 'package.json')):
             self.run(npm_install)
             self.run(npm_install + ['--global'])
+        for target in self.options.npm_run:
+            self.run(['npm', 'run', target])
 
 
 def _get_nodejs_base(node_engine):

--- a/snapcraft/tests/test_plugin_nodejs.py
+++ b/snapcraft/tests/test_plugin_nodejs.py
@@ -48,6 +48,7 @@ class NodePluginTestCase(tests.TestCase):
             source = '.'
             node_packages = []
             node_engine = '4'
+            npm_run = []
 
         plugin = nodejs.NodePlugin('test-part', Options(),
                                    self.project_options)
@@ -68,6 +69,7 @@ class NodePluginTestCase(tests.TestCase):
             source = '.'
             node_packages = []
             node_engine = '4'
+            npm_run = []
 
         plugin = nodejs.NodePlugin('test-part', Options(),
                                    self.project_options)
@@ -94,6 +96,7 @@ class NodePluginTestCase(tests.TestCase):
             source = None
             node_packages = ['my-pkg']
             node_engine = '4'
+            npm_run = []
 
         plugin = nodejs.NodePlugin('test-part', Options(),
                                    self.project_options)
@@ -114,6 +117,27 @@ class NodePluginTestCase(tests.TestCase):
             mock.call().provision(
                 plugin.installdir, clean_target=False, keep_tarball=True)])
 
+    def test_build_executes_npm_run_commands(self):
+        class Options:
+            source = '.'
+            node_packages = []
+            node_engine = '4'
+            npm_run = ['command_one', 'avocado']
+
+        plugin = nodejs.NodePlugin('test-part', Options(),
+                                   self.project_options)
+
+        os.makedirs(plugin.sourcedir)
+        open(os.path.join(plugin.sourcedir, 'package.json'), 'w').close()
+
+        plugin.build()
+
+        self.run_mock.assert_has_calls([
+            mock.call(['npm', 'run', 'command_one'],
+                      cwd=plugin.builddir),
+            mock.call(['npm', 'run', 'avocado'],
+                      cwd=plugin.builddir)])
+
     @mock.patch('platform.machine')
     def test_unsupported_arch_raises_exception(self, machine_mock):
         machine_mock.return_value = 'fantasy-arch'
@@ -122,6 +146,7 @@ class NodePluginTestCase(tests.TestCase):
             source = None
             node_packages = []
             node_engine = '4'
+            npm_run = []
 
         with self.assertRaises(EnvironmentError) as raised:
             nodejs.NodePlugin('test-part', Options(),
@@ -142,6 +167,11 @@ class NodePluginTestCase(tests.TestCase):
                                   'minitems': 1,
                                   'type': 'array',
                                   'uniqueItems': True},
+                'npm-run': {'default': [],
+                            'items': {'type': 'string'},
+                            'minitems': 1,
+                            'type': 'array',
+                            'uniqueItems': False},
                 'source': {'type': 'string'},
                 'source-branch': {'default': '', 'type': 'string'},
                 'source-subdir': {'default': None, 'type': 'string'},
@@ -150,7 +180,8 @@ class NodePluginTestCase(tests.TestCase):
                 'disable-parallel': {'default': False, 'type': 'boolean'}},
             'pull-properties': ['source', 'source-type', 'source-branch',
                                 'source-tag', 'source-subdir', 'node-engine'],
-            'build-properties': ['disable-parallel', 'node-packages'],
+            'build-properties': ['disable-parallel', 'node-packages',
+                                 'npm-run'],
             'type': 'object'}
 
         self.assertEqual(nodejs.NodePlugin.schema(), plugin_schema)
@@ -169,6 +200,7 @@ class NodePluginTestCase(tests.TestCase):
             source = '.'
             node_packages = []
             node_engine = '4'
+            npm_run = []
 
         plugin = nodejs.NodePlugin('test-part', Options(),
                                    self.project_options)


### PR DESCRIPTION
Some complex projects don't install with “npm install”; rather they use “npm run” commands to drive their build, assembly, and packaging.

This support is required to build a snap from (at least) https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL- 
