### PR TITLE
lxd: use built-in image streams.

### DIFF
--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -26,7 +26,6 @@ import petname
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_IMAGE_SERVER = 'https://images.linuxcontainers.org:8443'
 _NETWORK_PROBE_COMMAND = \
     'import urllib.request; urllib.request.urlopen("{}", timeout=5)'.format(
         'http://start.ubuntu.com/connectivity-check.html')
@@ -35,14 +34,12 @@ _PROXY_KEYS = ['http_proxy', 'https_proxy', 'no_proxy', 'ftp_proxy']
 
 class Cleanbuilder:
 
-    def __init__(self, snap_output, tar_filename, project_options,
-                 server=_DEFAULT_IMAGE_SERVER):
+    def __init__(self, snap_output, tar_filename, project_options):
         self._snap_output = snap_output
         self._tar_filename = tar_filename
         self._project_options = project_options
         self._container_name = 'snapcraft-{}'.format(
             petname.Generate(3, '-'))
-        self._server = server
 
     def _push_file(self, src, dst):
         check_call(['lxc', 'file', 'push',
@@ -58,19 +55,15 @@ class Cleanbuilder:
     @contextmanager
     def _create_container(self):
         try:
-            remote_tmp = petname.Generate(2, '-')
-            check_call(['lxc', 'remote', 'add', remote_tmp, self._server])
             check_call([
                 'lxc', 'launch', '-e',
-                '{}:ubuntu/xenial/{}'.format(
-                    remote_tmp, self._project_options.deb_arch),
+                'ubuntu:xenial/{}'.format(self._project_options.deb_arch),
                 self._container_name])
             yield
         finally:
             # Stopping takes a while and lxc doesn't print anything.
             print('Stopping {}'.format(self._container_name))
             check_call(['lxc', 'stop', '-f', self._container_name])
-            check_call(['lxc', 'remote', 'remove', remote_tmp])
 
     def execute(self):
         with self._create_container():

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -50,10 +50,8 @@ class LXDTestCase(tests.TestCase):
             fake_logger.output)
 
         mock_call.assert_has_calls([
-            call(['lxc', 'remote', 'add', 'my-pet',
-                  'https://images.linuxcontainers.org:8443']),
             call(['lxc', 'launch', '-e',
-                  'my-pet:ubuntu/xenial/{}'.format(expected_arch),
+                  'ubuntu:xenial/{}'.format(expected_arch),
                   'snapcraft-my-pet']),
             call(['lxc', 'file', 'push', 'project.tar',
                   'snapcraft-my-pet//root/project.tar']),
@@ -75,7 +73,7 @@ class LXDTestCase(tests.TestCase):
                   'snapcraft-my-pet//root/snap.snap',
                   'snap.snap']),
             call(['lxc', 'stop', '-f', 'snapcraft-my-pet']),
-            call(['lxc', 'remote', 'remove', 'my-pet'])])
+        ])
 
     @patch('snapcraft.internal.lxd.check_call')
     @patch('snapcraft.internal.lxd.sleep')


### PR DESCRIPTION
Instead of setting up our own remote for each cleanbuild
invocation use the provided built-in image streams from
lxd.

LP: #1625787

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>