### PR TITLE
Fix trunk

### DIFF
--- a/snapcraft/internal/sources.py
+++ b/snapcraft/internal/sources.py
@@ -395,8 +395,9 @@ class Zip(FileBase):
 class Deb(FileBase):
 
     def __init__(self, source, source_dir, source_tag=None,
-                 source_branch=None):
-        super().__init__(source, source_dir, source_tag, source_branch)
+                 source_branch=None, source_depth=None):
+        super().__init__(source, source_dir, source_tag,
+                         source_branch, source_depth)
         if source_tag:
             raise IncompatibleOptionsError(
                 'can\'t specify a source-tag for a deb source')


### PR DESCRIPTION
Merging two branches without the branch updated caused issues
in the unit tests due to incompatible changes in
`snapcraft.internal.sources`

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>