### PR TITLE
Fixed bug LP: #1607294 snapcraft search returns results in different order

### DIFF
--- a/snapcraft/internal/parts.py
+++ b/snapcraft/internal/parts.py
@@ -330,7 +330,7 @@ def search(part_match):
 
     print('{}  {}'.format(
         _HEADER_PART_NAME.ljust(part_length, ' '), _HEADER_DESCRIPTION))
-    for part_key in matches.keys():
+    for part_key in sorted(matches.keys()):
         description = matches[part_key]['description'].split('\n')[0]
         if len(description) > description_space:
             description = '{}...'.format(description[0:description_space])

--- a/snapcraft/tests/test_commands_search.py
+++ b/snapcraft/tests/test_commands_search.py
@@ -21,6 +21,7 @@ import fixtures
 from snapcraft import main, tests
 from snapcraft.tests import fixture_setup
 
+
 class SearchCommandTestCase(tests.TestWithFakeRemoteParts):
 
     def test_searching_for_a_part_that_exists(self):
@@ -97,7 +98,6 @@ curl       test entry for curl
         self.assertEqual(fake_terminal.getvalue(), expected_output)
 
     def test_search_output_alphabetical_order(self):
-        logger.info('My test')
         fake_terminal = fixture_setup.FakeTerminal()
         self.useFixture(fake_terminal)
 
@@ -106,7 +106,8 @@ curl       test entry for curl
         expected_output = (
             'PART NAME            DESCRIPTION\n'
             'curl                 test entry for curl\n'
-            'long-described-part  this is a repetitive description this is a repetitive de...\n'
+            'long-described-part  this is a repetitive description this is a '
+            'repetitive de...\n'
             'multiline-part       this is a multiline description\n'
             'part1                test entry for part1\n')
 

--- a/snapcraft/tests/test_commands_search.py
+++ b/snapcraft/tests/test_commands_search.py
@@ -21,7 +21,6 @@ import fixtures
 from snapcraft import main, tests
 from snapcraft.tests import fixture_setup
 
-
 class SearchCommandTestCase(tests.TestWithFakeRemoteParts):
 
     def test_searching_for_a_part_that_exists(self):
@@ -96,3 +95,19 @@ curl       test entry for curl
 curl       test entry for curl
 """
         self.assertEqual(fake_terminal.getvalue(), expected_output)
+
+    def test_search_output_alphabetical_order(self):
+        logger.info('My test')
+        fake_terminal = fixture_setup.FakeTerminal()
+        self.useFixture(fake_terminal)
+
+        main.main(['search'])
+        output = fake_terminal.getvalue()
+        expected_output = (
+            'PART NAME            DESCRIPTION\n'
+            'curl                 test entry for curl\n'
+            'long-described-part  this is a repetitive description this is a repetitive de...\n'
+            'multiline-part       this is a multiline description\n'
+            'part1                test entry for part1\n')
+
+        self.assertEqual(output, expected_output)


### PR DESCRIPTION

- Accessing search matches' keys in alphabetical order when listing them
- Added test


---

Hello,

I started exploring snapcraft trying to fix some simple bugs. Please let me know if this can be accepted or it needs some changes.

Best regards