### PR TITLE
Don't filter .pth files in python plugin

### DIFF
--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -234,9 +234,6 @@ class PythonPlugin(snapcraft.BasePlugin):
         fileset.append('-bin/pip*')
         fileset.append('-bin/easy_install*')
         fileset.append('-bin/wheel')
-        # .pth files are only read from the built-in site-packages directory.
-        # We use PYTHONPATH for everything so not needed.
-        fileset.append('-**/*.pth')
         # Holds all the .pyc files. It is a major cause of inter part
         # conflict.
         fileset.append('-**/__pycache__')

--- a/snapcraft/tests/test_plugin_python.py
+++ b/snapcraft/tests/test_plugin_python.py
@@ -175,7 +175,6 @@ class PythonPluginTestCase(tests.TestCase):
             '-bin/pip*',
             '-bin/easy_install*',
             '-bin/wheel',
-            '-**/*.pth',
             '-**/__pycache__',
             '-**/*.pyc',
         ]


### PR DESCRIPTION
The .pth files are needed by some projects to help with importing. We
currently filter them out, breaking imports for those projects.

LP: #1626668