### PR TITLE
Add `snapcraft create-key`

### DIFF
--- a/debian/snapcraft-completion
+++ b/debian/snapcraft-completion
@@ -4,7 +4,7 @@ _snapcraft()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="help init list-plugins login logout register-key register tour push release clean cleanbuild pull build sign-build stage prime snap update define search gated validate"
+    opts="help init list-plugins login logout list-keys keys create-key register-key register tour push release clean cleanbuild pull build sign-build stage prime snap update define search gated validate"
 
     COMPREPLY=( $(compgen -W "$opts" -- $cur) )
     return 0

--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -230,6 +230,7 @@ from snapcraft._baseplugin import BasePlugin        # noqa
 from snapcraft._options import ProjectOptions       # noqa
 from snapcraft._help import topic_help              # noqa
 from snapcraft._store import (                      # noqa
+    create_key,
     download,
     gated,
     list_keys,

--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -164,7 +164,7 @@ def create_key(name):
         raise EnvironmentError(
             'The snapd package is not installed. In order to use '
             '`create-key`, you must run `apt install snapd`.')
-    if name is None:
+    if not name:
         name = 'default'
     keys = list(_get_usable_keys(name=name))
     if keys:

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -33,6 +33,7 @@ Usage:
   snapcraft [options] logout
   snapcraft [options] list-keys
   snapcraft [options] keys
+  snapcraft [options] create-key [<key-name>]
   snapcraft [options] register-key [<key-name>]
   snapcraft [options] register <snap-name> [--private]
   snapcraft [options] sign-build <snap-file> [--key-name=<key-name>] [--local]
@@ -90,6 +91,7 @@ The available commands are:
   logout       Clear session credentials.
   list-keys    List keys available for signing snaps.
   keys         Alias for list-keys.
+  create-key   Create a key pair for signing snaps.
   register-key Register a key for signing snaps.
   register     Register the package name in the store.
   tour         Setup the snapcraft examples tour in the specified directory,
@@ -292,8 +294,8 @@ def _run_clean(args, project_options):
 
 def _is_store_command(args):
     commands = (
-        'list-keys', 'keys', 'register-key', 'register', 'sign-build',
-        'upload', 'release', 'push', 'validate', 'gated')
+        'list-keys', 'keys', 'create-key', 'register-key', 'register',
+        'sign-build', 'upload', 'release', 'push', 'validate', 'gated')
     return any(args.get(command) for command in commands)
 
 
@@ -302,6 +304,8 @@ def _is_store_command(args):
 def _run_store_command(args):  # noqa: C901
     if args['list-keys'] or args['keys']:
         snapcraft.list_keys()
+    elif args['create-key']:
+        snapcraft.create_key(args['<key-name>'])
     elif args['register-key']:
         snapcraft.register_key(args['<key-name>'])
     elif args['register']:

--- a/snapcraft/tests/test_commands_create_key.py
+++ b/snapcraft/tests/test_commands_create_key.py
@@ -1,0 +1,146 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from unittest import mock
+
+import fixtures
+
+from snapcraft.main import main
+from snapcraft import (
+    storeapi,
+    tests,
+)
+from snapcraft.tests.test_commands_register_key import (
+    get_sample_key,
+    mock_snap_output,
+)
+
+
+class CreateKeyTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.fake_logger = fixtures.FakeLogger(level=logging.INFO)
+        self.useFixture(self.fake_logger)
+
+    @mock.patch('subprocess.check_call')
+    @mock.patch('subprocess.check_output')
+    @mock.patch('snapcraft.internal.repo.is_package_installed')
+    def test_create_key_snapd_not_installed(self, mock_installed,
+                                            mock_check_output,
+                                            mock_check_call):
+        mock_installed.return_value = False
+
+        with self.assertRaises(SystemExit) as raised:
+            main(['create-key'])
+
+        mock_installed.assert_called_with('snapd')
+        self.assertEqual(0, mock_check_output.call_count)
+        self.assertEqual(0, mock_check_call.call_count)
+        self.assertEqual(1, raised.exception.code)
+        self.assertIn(
+            'The snapd package is not installed.', self.fake_logger.output)
+
+    @mock.patch('subprocess.check_call')
+    @mock.patch('subprocess.check_output')
+    @mock.patch('snapcraft.internal.repo.is_package_installed')
+    def test_create_key_already_exists(self, mock_installed, mock_check_output,
+                                       mock_check_call):
+        mock_installed.return_value = True
+        mock_check_output.side_effect = mock_snap_output
+
+        with self.assertRaises(SystemExit) as raised:
+            main(['create-key'])
+
+        self.assertEqual(0, mock_check_call.call_count)
+        self.assertEqual(1, raised.exception.code)
+        self.assertIn(
+            'You already have a key named "default".', self.fake_logger.output)
+
+    @mock.patch('subprocess.check_call')
+    @mock.patch.object(storeapi.SCAClient, 'get_account_information')
+    @mock.patch('subprocess.check_output')
+    @mock.patch('snapcraft.internal.repo.is_package_installed')
+    def test_create_key_already_registered(self, mock_installed,
+                                           mock_check_output,
+                                           mock_get_account_information,
+                                           mock_check_call):
+        mock_installed.return_value = True
+        mock_check_output.side_effect = mock_snap_output
+        mock_get_account_information.return_value = {
+            'account_id': 'abcd',
+            'account_keys': [
+                {
+                    'name': 'new-key',
+                    'public-key-sha3-384': (
+                        get_sample_key('default')['sha3-384']),
+                },
+            ],
+        }
+
+        with self.assertRaises(SystemExit) as raised:
+            main(['create-key', 'new-key'])
+
+        self.assertEqual(0, mock_check_call.call_count)
+        self.assertEqual(1, raised.exception.code)
+        self.assertIn(
+            'You have already registered a key named "new-key".',
+            self.fake_logger.output)
+
+    @mock.patch('subprocess.check_call')
+    @mock.patch.object(storeapi.SCAClient, 'get_account_information')
+    @mock.patch('subprocess.check_output')
+    @mock.patch('snapcraft.internal.repo.is_package_installed')
+    def test_create_key_successfully(self, mock_installed, mock_check_output,
+                                     mock_get_account_information,
+                                     mock_check_call):
+        mock_installed.return_value = True
+        mock_check_output.side_effect = mock_snap_output
+        mock_get_account_information.return_value = {
+            'account_id': 'abcd',
+            'account_keys': [
+                {
+                    'name': 'old-key',
+                    'public-key-sha3-384': (
+                        get_sample_key('default')['sha3-384']),
+                },
+            ],
+        }
+
+        main(['create-key', 'new-key'])
+
+        mock_check_call.assert_called_once_with(
+            ['snap', 'create-key', 'new-key'])
+        self.assertEqual('', self.fake_logger.output)
+
+    @mock.patch('subprocess.check_call')
+    @mock.patch.object(storeapi.SCAClient, 'get_account_information')
+    @mock.patch('subprocess.check_output')
+    @mock.patch('snapcraft.internal.repo.is_package_installed')
+    def test_create_key_without_login(self, mock_installed, mock_check_output,
+                                      mock_get_account_information,
+                                      mock_check_call):
+        mock_installed.return_value = True
+        mock_check_output.side_effect = mock_snap_output
+        mock_get_account_information.side_effect = (
+            storeapi.errors.InvalidCredentialsError('Test'))
+
+        main(['create-key', 'new-key'])
+
+        mock_check_call.assert_called_once_with(
+            ['snap', 'create-key', 'new-key'])
+        self.assertEqual('', self.fake_logger.output)


### PR DESCRIPTION
Wrapping `snap create-key` means that we don't confuse users by
expecting them to use two similar-but-different commands during the key
creation and registration workflow.  In addition, this augments
`snap create-key` by failing if a key with the same name is already
registered with the store, since a later registration attempt would fail
in that case.