### PR TITLE
python plugin: only replace proper shebangs.

### DIFF
--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -226,7 +226,7 @@ class PythonPlugin(snapcraft.BasePlugin):
 
         # Fix all shebangs to use the in-snap python.
         file_utils.replace_in_file(self.installdir, re.compile(r''),
-                                   re.compile(r'#!.*python'),
+                                   re.compile(r'^#!.*python'),
                                    r'#!/usr/bin/env python')
 
     def snap_fileset(self):

--- a/snapcraft/tests/test_plugin_python.py
+++ b/snapcraft/tests/test_plugin_python.py
@@ -217,6 +217,11 @@ class PythonPluginTestCase(tests.TestCase):
                 'path': os.path.join(plugin.installdir, 'foo'),
                 'contents': 'foo',
                 'expected': 'foo',
+            },
+            {
+                'path': os.path.join(plugin.installdir, 'bar'),
+                'contents': 'bar\n#!/usr/bin/python3',
+                'expected': 'bar\n#!/usr/bin/python3',
             }
         ]
 


### PR DESCRIPTION
Only replace shebangs at the beginning of a file.

LP: #1626587

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>