### PR TITLE
kernel plugin: allow collecting the same mod deps

### DIFF
--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -249,7 +249,7 @@ class KernelPlugin(kbuild.KBuildPlugin):
             modprobe_outs.extend(modprobe_out.split(os.linesep))
 
         modules_path = os.path.join('lib', 'modules', self.kernel_release)
-        for src in modprobe_outs:
+        for src in set(modprobe_outs):
             src = src.split()[-1:][0]
             dst = os.path.join(initrd_unpacked_path,
                                os.path.relpath(src, self.installdir))

--- a/snapcraft/tests/test_plugin_kernel.py
+++ b/snapcraft/tests/test_plugin_kernel.py
@@ -306,6 +306,41 @@ class KernelPluginTestCase(tests.TestCase):
         self.run_output_mock.assert_has_calls([
             mock.call(modprobe_cmd + ['vfat'])])
 
+    def test_pack_initrd_modules_return_same_deps(self):
+        self.options.kernel_initrd_modules = [
+            'squashfs',
+            'vfat'
+        ]
+
+        plugin = kernel.KernelPlugin('test-part', self.options,
+                                     self.project_options)
+
+        # Fake some assets
+        plugin.kernel_release = '4.4'
+        modules_path = os.path.join(plugin.installdir, 'lib', 'modules', '4.4')
+        initrd_modules_staging_path = os.path.join(
+            'staging', 'lib', 'modules', '4.4')
+        os.makedirs(modules_path)
+        open(os.path.join(modules_path, 'modules.dep'), 'w').close()
+        open(os.path.join(modules_path, 'modules.dep.bin'), 'w').close()
+        os.makedirs(initrd_modules_staging_path)
+        open(os.path.join(plugin.installdir, 'initrd-4.4.img'), 'w').close()
+        open(os.path.join(plugin.installdir, 'serport.ko'), 'w').close()
+
+        self.run_output_mock.return_value = 'insmod {}/serport.ko'.format(
+            plugin.installdir)
+
+        with mock.patch.object(plugin, '_unpack_generic_initrd') as m_unpack:
+            m_unpack.return_value = 'staging'
+            plugin._make_initrd()
+
+        modprobe_cmd = ['modprobe', '-n', '--show-depends', '-d',
+                        plugin.installdir, '-S', '4.4', ]
+        self.run_output_mock.assert_has_calls([
+            mock.call(modprobe_cmd + ['squashfs'])])
+        self.run_output_mock.assert_has_calls([
+            mock.call(modprobe_cmd + ['vfat'])])
+
     def test_build_with_kconfigfile(self):
         self.options.kconfigfile = 'config'
         with open(self.options.kconfigfile, 'w') as f:


### PR DESCRIPTION
If modules end up having the same dependencies they would
of been copied twice, this transforms it into a set to
avoid duplicates.

LP: #1627923

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>