### PR TITLE
Fixing 'sign-build' integration tests.

### DIFF
--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -315,6 +315,7 @@ class FakeStoreAPIServer(http.server.HTTPServer):
             server_address, FakeStoreAPIRequestHandler)
         self.fake_store = fake_store
         self.account_keys = []
+        self.registered_names = []
 
 
 class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
@@ -390,19 +391,29 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
 
         if snap_build == 'test-not-implemented':
             self.send_response(501)
-            self.send_header('Content-Type', 'text/plain')
-            content = b'Not Implemented'
+            self.send_header('Content-Type', 'application/json')
+            error = {
+                'error_list': [
+                    {'code': 'feature-disabled',
+                     'message': ('The snap-build assertions are currently '
+                                 'disabled.')},
+                ],
+            }
+            content = json.dumps(error).encode()
         elif snap_build == 'test-invalid-data':
             self.send_response(400)
             self.send_header('Content-Type', 'application/json')
             error = {
                 'error_list': [
-                    # XXX cprov 20160922: fix endpoint error handler.
-                    {'code': None,
+                    {'code': 'invalid-field',
                      'message': 'The snap-build assertion is not valid.'},
                 ],
             }
             content = json.dumps(error).encode()
+        elif snap_build == 'test-unexpected-data':
+            self.send_response(500)
+            self.send_header('Content-Type', 'text/plain')
+            content = b'unexpected chunk of data'
         else:
             self.send_response(200)
             self.send_header('Content-Type', 'application/json')
@@ -473,6 +484,7 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
         data = json.loads(string_data)
         logger.debug(
             'Handling registration request with content {}'.format(data))
+        snap_name = data['snap_name']
 
         if data['snap_name'] == 'test-already-registered-snap-name':
             self._handle_register_409('already_registered')
@@ -483,9 +495,10 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
         elif data['snap_name'] == 'snap-name-no-clear-error':
             self._handle_unclear_registration_error()
         else:
-            self._handle_successful_registration()
+            self._handle_successful_registration(snap_name)
 
-    def _handle_successful_registration(self):
+    def _handle_successful_registration(self, name):
+        self.server.registered_names.append(name)
         self.send_response(201)
         self.send_header('Content-Type', 'application/json')
         self.end_headers()
@@ -639,10 +652,14 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header('Content-Type', 'application/json')
         self.end_headers()
+        snaps = {'basic': {'snap-id': 'snap-id'}}
+        snaps.update({
+            n: {'snap-id': 'fake-snap-id'}
+            for n in self.server.registered_names})
         self.wfile.write(json.dumps({
             'account_id': 'abcd',
             'account_keys': self.server.account_keys,
-            'snaps': {'16': {'basic': {'snap-id': 'snap-id'}}},
+            'snaps': {'16': snaps},
         }).encode())
 
 

--- a/snapcraft/tests/store/test_store_client.py
+++ b/snapcraft/tests/store/test_store_client.py
@@ -185,13 +185,14 @@ class PushSnapBuildTestCase(tests.TestCase):
 
     def test_push_snap_build_not_implemented(self):
         # If the "enable_snap_build" feature switch is off in the store, we
-        # will get a 501 Not Implemented response.
+        # will get a descriptive error message.
         self.client.login('dummy', 'test correct password')
         with self.assertRaises(errors.StoreSnapBuildError) as raised:
             self.client.push_snap_build('snap-id', 'test-not-implemented')
         self.assertEqual(
             str(raised.exception),
-            'Could not assert build: 501 Not Implemented')
+            'Could not assert build: The snap-build assertions are '
+            'currently disabled.')
 
     def test_push_snap_build_invalid_data(self):
         self.client.login('dummy', 'test correct password')
@@ -200,6 +201,16 @@ class PushSnapBuildTestCase(tests.TestCase):
         self.assertEqual(
             str(raised.exception),
             'Could not assert build: The snap-build assertion is not valid.')
+
+    def test_push_snap_build_unexpected_data(self):
+        # The endpoint in SCA would never return plain/text, however anything
+        # might happen in the internet, so we are a little defensive.
+        self.client.login('dummy', 'test correct password')
+        with self.assertRaises(errors.StoreSnapBuildError) as raised:
+            self.client.push_snap_build('snap-id', 'test-unexpected-data')
+        self.assertEqual(
+            str(raised.exception),
+            'Could not assert build: 500 Internal Server Error')
 
     def test_push_snap_build_successfully(self):
         self.client.login('dummy', 'test correct password')


### PR DESCRIPTION
Even for building the local assertion, the command actually checks if the
account logged in has upload permission on the targeted snap (resolving
name to snap-id via account-info).

The test now builds an random snap, register the name in the store and
only then signs the snap. The fake server was extended to record registered
names and return them in the account-info endpoint.