### PR TITLE
Catkin plugin: build with in-snap python.

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -43,6 +43,7 @@ import subprocess
 import snapcraft
 from snapcraft import (
     common,
+    file_utils,
     repo,
 )
 
@@ -302,9 +303,9 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
             return '"' + ';'.join(paths) + '"'
 
         # Looking for any path-like string
-        common.replace_in_file(self.rosdir, re.compile(r'.*Config.cmake$'),
-                               re.compile(r'"(.*?/.*?)"'),
-                               rewrite_paths)
+        file_utils.replace_in_file(self.rosdir, re.compile(r'.*Config.cmake$'),
+                                   re.compile(r'"(.*?/.*?)"'),
+                                   rewrite_paths)
 
     def _finish_build(self):
         self._use_in_snap_python()
@@ -322,9 +323,9 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
 
     def _use_in_snap_python(self):
         # Fix all shebangs to use the in-snap python.
-        common.replace_in_file(self.rosdir, re.compile(r''),
-                               re.compile(r'^#!.*python'),
-                               r'#!/usr/bin/env python')
+        file_utils.replace_in_file(self.rosdir, re.compile(r''),
+                                   re.compile(r'^#!.*python'),
+                                   r'#!/usr/bin/env python')
 
         # Also replace the python usage in 10.ros.sh to use the in-snap python.
         ros10_file = os.path.join(self.rosdir,

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -101,6 +101,7 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
+        self.build_packages.extend(['gcc', 'libc6-dev', 'make'])
 
         # Get a unique set of packages
         self.catkin_packages = set(options.catkin_packages)
@@ -149,13 +150,6 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
             # and run-time.
             '_CATKIN_SETUP_DIR={}'.format(os.path.join(
                 root, 'opt', 'ros', self.options.rosdistro)),
-
-            # FIXME: Nasty hack to source ROS's setup.sh (since each of these
-            # lines is prepended with "export"). There's got to be a better way
-            # to do this.
-            'echo FOO=BAR\nif `test -e {0}` ; then\n. {0} ;\nfi\n'.format(
-                os.path.join(
-                    root, 'opt', 'ros', self.options.rosdistro, 'setup.sh'))
         ]
 
         # There's a chicken and egg problem here, everything run get's an
@@ -169,6 +163,18 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
                 common.get_python2_path(root)))
         except EnvironmentError as e:
             logger.debug(e)
+
+        # The setup.sh we source below requires the in-snap python. Here we
+        # make sure it's in the PATH before it's run.
+        env.append('PATH=$PATH:{}/usr/bin'.format(root))
+
+        # FIXME: Nasty hack to source ROS's setup.sh (since each of these
+        # lines is prepended with "export"). There's got to be a better way
+        # to do this.
+        env.append(
+            'echo FOO=BAR\nif `test -e {0}` ; then\n. {0} ;\nfi\n'.format(
+                os.path.join(
+                    root, 'opt', 'ros', self.options.rosdistro, 'setup.sh')))
 
         return env
 
@@ -277,6 +283,22 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
         self._finish_build()
 
     def _prepare_build(self):
+        # Fix all shebangs to use the in-snap python.
+        common.replace_in_file(self.rosdir, re.compile(r''),
+                               re.compile(r'#!.*python'),
+                               r'#!/usr/bin/env python')
+
+        # Also replace the python usage in 10.ros.sh to use the in-snap python.
+        ros10_file = os.path.join(self.rosdir,
+                                  'etc/catkin/profile.d/10.ros.sh')
+        if os.path.isfile(ros10_file):
+            with open(ros10_file, 'r+') as f:
+                pattern = re.compile(r'/usr/bin/python')
+                replaced = pattern.sub(r'python', f.read())
+                f.seek(0)
+                f.truncate()
+                f.write(replaced)
+
         # Each Catkin package distributes .cmake files so they can be found via
         # find_package(). However, the Ubuntu packages pulled down as
         # dependencies contain .cmake files pointing to system paths (e.g.

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -330,15 +330,13 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
         # Also replace the python usage in 10.ros.sh to use the in-snap python.
         ros10_file = os.path.join(self.rosdir,
                                   'etc/catkin/profile.d/10.ros.sh')
-        try:
+        if os.path.isfile(ros10_file):
             with open(ros10_file, 'r+') as f:
                 pattern = re.compile(r'/usr/bin/python')
                 replaced = pattern.sub(r'python', f.read())
                 f.seek(0)
                 f.truncate()
                 f.write(replaced)
-        except OSError:
-            pass
 
     def _build_catkin_packages(self):
         # Nothing to do if no packages were specified


### PR DESCRIPTION
Our test cases all had python installed on the system, so the fact that the plugin used it went unnoticed. This PR fixes LP: [#1628990](https://bugs.launchpad.net/snapcraft/+bug/1628990) by using the in-snap python for build-time as well as run-time. It also pulls in gcc, libc-dev, and make as build packages.