### PR TITLE
Catkin plugin: Support ROS Kinetic.

### DIFF
--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -75,6 +75,11 @@ class BasePlugin:
             'build-properties': ['disable-parallel']
         }
 
+    @property
+    def PLUGIN_STAGE_SOURCES(self):
+        """Define alternative sources.list."""
+        return getattr(self, '_PLUGIN_STAGE_SOURCES', [])
+
     def __init__(self, name, options, project=None):
         self.name = name
         self.build_packages = []
@@ -221,10 +226,6 @@ class BasePlugin:
             'Building for a different target architecture requires '
             'a plugin specific implementation in the '
             '{!r} plugin'.format(self.name))
-
-    def get_stage_sources(self):
-        """Define additional sources.list entries (as a string template)."""
-        return ""
 
     @property
     def parallel_build_count(self):

--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -75,11 +75,6 @@ class BasePlugin:
             'build-properties': ['disable-parallel']
         }
 
-    @property
-    def PLUGIN_STAGE_SOURCES(self):
-        """Define additional sources.list."""
-        return getattr(self, '_PLUGIN_STAGE_SOURCES', [])
-
     def __init__(self, name, options, project=None):
         self.name = name
         self.build_packages = []
@@ -226,6 +221,10 @@ class BasePlugin:
             'Building for a different target architecture requires '
             'a plugin specific implementation in the '
             '{!r} plugin'.format(self.name))
+
+    def get_stage_sources(self):
+        """Define additional sources.list entries (as a string template)."""
+        return ""
 
     @property
     def parallel_build_count(self):

--- a/snapcraft/internal/pluginhandler.py
+++ b/snapcraft/internal/pluginhandler.py
@@ -58,7 +58,7 @@ class PluginHandler:
     def ubuntu(self):
         if not self._ubuntu:
             self._ubuntu = repo.Ubuntu(
-                self.ubuntudir, sources=self.code.PLUGIN_STAGE_SOURCES,
+                self.ubuntudir, sources=self.code.get_stage_sources(),
                 project_options=self._project_options)
 
         return self._ubuntu

--- a/snapcraft/internal/pluginhandler.py
+++ b/snapcraft/internal/pluginhandler.py
@@ -58,7 +58,7 @@ class PluginHandler:
     def ubuntu(self):
         if not self._ubuntu:
             self._ubuntu = repo.Ubuntu(
-                self.ubuntudir, sources=self.code.get_stage_sources(),
+                self.ubuntudir, sources=self.code.PLUGIN_STAGE_SOURCES,
                 project_options=self._project_options)
 
         return self._ubuntu

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -99,6 +99,16 @@ class CatkinPlugin(snapcraft.BasePlugin):
 
         return schema
 
+    @property
+    def PLUGIN_STAGE_SOURCES(self):
+        return """
+deb http://packages.ros.org/ros/${{suffix}}/ {0} main
+deb http://${{prefix}}.ubuntu.com/${{suffix}}/ {0} main universe
+deb http://${{prefix}}.ubuntu.com/${{suffix}}/ {0}-updates main universe
+deb http://${{prefix}}.ubuntu.com/${{suffix}}/ {0}-security main universe
+deb http://${{security}}.ubuntu.com/${{suffix}} {0}-security main universe
+""".format(_ROS_RELEASE_MAP[self.options.rosdistro])
+
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
         self.build_packages.extend(['gcc', 'libc6-dev', 'make'])
@@ -178,15 +188,6 @@ class CatkinPlugin(snapcraft.BasePlugin):
 
         return env
 
-    def get_stage_sources(self):
-        return '''
-deb http://packages.ros.org/ros/${{suffix}}/ {0} main
-deb http://${{prefix}}.ubuntu.com/${{suffix}}/ {0} main universe
-deb http://${{prefix}}.ubuntu.com/${{suffix}}/ {0}-updates main universe
-deb http://${{prefix}}.ubuntu.com/${{suffix}}/ {0}-security main universe
-deb http://${{security}}.ubuntu.com/${{suffix}} {0}-security main universe
-'''.format(_ROS_RELEASE_MAP[self.options.rosdistro])
-
     def pull(self):
         """Copy source into build directory and fetch dependencies.
 
@@ -207,7 +208,7 @@ deb http://${{security}}.ubuntu.com/${{suffix}} {0}-security main universe
 
         # Use rosdep for dependency detection and resolution
         rosdep = _Rosdep(self.options.rosdistro, self._ros_package_path,
-                         self._rosdep_path, self.get_stage_sources(),
+                         self._rosdep_path, self.PLUGIN_STAGE_SOURCES,
                          self.project)
         rosdep.setup()
 
@@ -233,7 +234,7 @@ deb http://${{security}}.ubuntu.com/${{suffix}} {0}-security main universe
             logger.info('Preparing to fetch package dependencies...')
             ubuntu = repo.Ubuntu(
                 ubuntudir, self.project,
-                sources=self.get_stage_sources(),
+                sources=self.PLUGIN_STAGE_SOURCES,
                 project_options=self.project)
 
             logger.info('Fetching package dependencies...')

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -49,16 +49,15 @@ from snapcraft import (
 
 logger = logging.getLogger(__name__)
 
+# Map ROS releases to Ubuntu releases
+_ROS_RELEASE_MAP = {
+    'indigo': 'trusty',
+    'jade': 'trusty',
+    'kinetic': 'xenial'
+}
+
 
 class CatkinPlugin(snapcraft.BasePlugin):
-
-    _PLUGIN_STAGE_SOURCES = '''
-deb http://packages.ros.org/ros/ubuntu/ trusty main
-deb http://${prefix}.ubuntu.com/${suffix}/ trusty main universe
-deb http://${prefix}.ubuntu.com/${suffix}/ trusty-updates main universe
-deb http://${prefix}.ubuntu.com/${suffix}/ trusty-security main universe
-deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
-'''
 
     @classmethod
     def schema(cls):
@@ -179,6 +178,15 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
 
         return env
 
+    def get_stage_sources(self):
+        return '''
+deb http://packages.ros.org/ros/${{suffix}}/ {0} main
+deb http://${{prefix}}.ubuntu.com/${{suffix}}/ {0} main universe
+deb http://${{prefix}}.ubuntu.com/${{suffix}}/ {0}-updates main universe
+deb http://${{prefix}}.ubuntu.com/${{suffix}}/ {0}-security main universe
+deb http://${{security}}.ubuntu.com/${{suffix}} {0}-security main universe
+'''.format(_ROS_RELEASE_MAP[self.options.rosdistro])
+
     def pull(self):
         """Copy source into build directory and fetch dependencies.
 
@@ -199,7 +207,7 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
 
         # Use rosdep for dependency detection and resolution
         rosdep = _Rosdep(self.options.rosdistro, self._ros_package_path,
-                         self._rosdep_path, self.PLUGIN_STAGE_SOURCES,
+                         self._rosdep_path, self.get_stage_sources(),
                          self.project)
         rosdep.setup()
 
@@ -225,7 +233,7 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
             logger.info('Preparing to fetch package dependencies...')
             ubuntu = repo.Ubuntu(
                 ubuntudir, self.project,
-                sources=self.PLUGIN_STAGE_SOURCES,
+                sources=self.get_stage_sources(),
                 project_options=self.project)
 
             logger.info('Fetching package dependencies...')
@@ -507,12 +515,14 @@ class _Rosdep:
             #
             # 1) The dependency we're trying to lookup.
             # 2) The rosdistro being used.
-            # 3) The version of Ubuntu being used. We're currently using only
-            #    the Trusty ROS sources, so we're telling rosdep to resolve
-            #    dependencies using Trusty (even if we're running on something
-            #    else).
+            # 3) The version of Ubuntu being used. We're telling rosdep to
+            #    resolve dependencies using the version of Ubuntu that
+            #    corresponds to the ROS release (even if we're running on
+            #    something else).
             output = self._run(['resolve', dependency_name, '--rosdistro',
-                                self._ros_distro, '--os', 'ubuntu:trusty'])
+                                self._ros_distro, '--os',
+                                'ubuntu:{}'.format(
+                                    _ROS_RELEASE_MAP[self._ros_distro])])
         except subprocess.CalledProcessError:
             raise SystemDependencyNotFound(
                 '{!r} does not resolve to a system dependency'.format(

--- a/snapcraft/tests/test_plugin_catkin.py
+++ b/snapcraft/tests/test_plugin_catkin.py
@@ -215,19 +215,19 @@ class CatkinPluginTestCase(tests.TestCase):
         self.properties.rosdistro = 'indigo'
         plugin = catkin.CatkinPlugin('test-part', self.properties,
                                      self.project_options)
-        self.assertTrue('trusty' in plugin.get_stage_sources())
+        self.assertTrue('trusty' in plugin.PLUGIN_STAGE_SOURCES)
 
     def test_get_stage_sources_jade(self):
         self.properties.rosdistro = 'jade'
         plugin = catkin.CatkinPlugin('test-part', self.properties,
                                      self.project_options)
-        self.assertTrue('trusty' in plugin.get_stage_sources())
+        self.assertTrue('trusty' in plugin.PLUGIN_STAGE_SOURCES)
 
     def test_get_stage_sources_kinetic(self):
         self.properties.rosdistro = 'kinetic'
         plugin = catkin.CatkinPlugin('test-part', self.properties,
                                      self.project_options)
-        self.assertTrue('xenial' in plugin.get_stage_sources())
+        self.assertTrue('xenial' in plugin.PLUGIN_STAGE_SOURCES)
 
     def test_pull_debian_dependencies(self):
         plugin = catkin.CatkinPlugin('test-part', self.properties,
@@ -242,7 +242,7 @@ class CatkinPluginTestCase(tests.TestCase):
             self.properties.rosdistro,
             os.path.join(plugin.sourcedir, 'src'),
             os.path.join(plugin.partdir, 'rosdep'),
-            plugin.get_stage_sources())
+            plugin.PLUGIN_STAGE_SOURCES)
 
         # Verify that dependencies were found as expected. TODO: Would really
         # like to use ANY here instead of verifying explicit arguments, but
@@ -273,7 +273,7 @@ class CatkinPluginTestCase(tests.TestCase):
             self.properties.rosdistro,
             os.path.join(plugin.sourcedir, 'src'),
             os.path.join(plugin.partdir, 'rosdep'),
-            plugin.get_stage_sources())
+            plugin.PLUGIN_STAGE_SOURCES)
 
         # Verify that dependencies were found as expected. TODO: Would really
         # like to use ANY here instead of verifying explicit arguments, but
@@ -324,7 +324,7 @@ class CatkinPluginTestCase(tests.TestCase):
             self.properties.rosdistro,
             os.path.join(plugin.sourcedir, 'src'),
             os.path.join(plugin.partdir, 'rosdep'),
-            plugin.get_stage_sources())
+            plugin.PLUGIN_STAGE_SOURCES)
 
         # Verify that roscore was installed
         self.ubuntu_mock.return_value.get.assert_called_with(

--- a/snapcraft/tests/test_plugin_catkin.py
+++ b/snapcraft/tests/test_plugin_catkin.py
@@ -650,17 +650,19 @@ class CatkinPluginTestCase(tests.TestCase):
             }
         ]
 
-        for fileInfo in files:
-            with open(os.path.join(plugin.rosdir, fileInfo['path']), 'w') as f:
-                f.write(fileInfo['contents'])
+        for file_info in files:
+            path = os.path.join(plugin.rosdir, file_info['path'])
+            with open(path, 'w') as f:
+                f.write(file_info['contents'])
 
         plugin._prepare_build()
 
         self.assertTrue(use_in_snap_python_mock.called)
 
-        for fileInfo in files:
-            with open(os.path.join(plugin.rosdir, fileInfo['path']), 'r') as f:
-                self.assertEqual(f.read(), fileInfo['expected'])
+        for file_info in files:
+            path = os.path.join(plugin.rosdir, file_info['path'])
+            with open(path, 'r') as f:
+                self.assertEqual(f.read(), file_info['expected'])
 
     @mock.patch.object(catkin.CatkinPlugin, 'run')
     @mock.patch.object(catkin.CatkinPlugin, 'run_output', return_value='foo')


### PR DESCRIPTION
Resolve LP: [#1629003](https://bugs.launchpad.net/snapcraft/+bug/1629003) by refactoring the repository source handling into a function that could be re-implemented by subclasses, as well as adding a map of ROS releases to Ubuntu releases. Should make it easy to support newer ROS releases, too.