### PR TITLE
`sign-build` to prompt users for key selection

### DIFF
--- a/integration_tests/test_store_sign_build.py
+++ b/integration_tests/test_store_sign_build.py
@@ -96,6 +96,7 @@ class SignBuildTestCase(integration_tests.StoreTestCase):
         os.chdir(self.project_dir)
         self.assertThat(self.snap_path, FileExists())
 
+        self.assertEqual(0, self.register_key('default'))
         self.addCleanup(self.logout)
         self.login()
 

--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -152,7 +152,7 @@ def list_keys():
     tabulated_keys = tabulate(
         [('*' if key['sha3-384'] in enabled_keys else '-',
           key['name'], key['sha3-384'],
-          '' if key['sha3-384'] in enabled_keys else '(not enabled)')
+          '' if key['sha3-384'] in enabled_keys else '(not registered)')
          for key in keys],
         headers=["", "Name", "SHA3-384 fingerprint", ""],
         tablefmt="plain")
@@ -189,19 +189,26 @@ def create_key(name):
     subprocess.check_call(['snap', 'create-key', name])
 
 
+def _maybe_prompt_for_key(name):
+    keys = list(_get_usable_keys(name=name))
+    if not keys:
+        if name is not None:
+            raise RuntimeError(
+                'You have no usable key named "{}".\nSee the keys available '
+                'in your system with `snapcraft keys`.'.format(name))
+        else:
+            raise RuntimeError(
+                'You have no usable keys.\nPlease create at least one key '
+                'with `snapcraft create-key` for use with snap.')
+    return _select_key(keys)
+
+
 def register_key(name):
     if not repo.is_package_installed('snapd'):
         raise EnvironmentError(
             'The snapd package is not installed. In order to use '
             '`register-key`, you must run `apt install snapd`.')
-    keys = list(_get_usable_keys(name=name))
-    if not keys:
-        if name is not None:
-            raise RuntimeError(
-                'You have no usable key named "{}".'.format(name))
-        else:
-            raise RuntimeError('You have no usable keys.')
-    key = _select_key(keys)
+    key = _maybe_prompt_for_key(name)
     store = storeapi.StoreClient()
     if not _login(store, acls=['modify_account_key'], save=False):
         raise RuntimeError('Cannot continue without logging in successfully.')
@@ -242,7 +249,7 @@ def _generate_snap_build(authority_id, snap_id, grade, key_name,
             'Failed to sign build assertion for {}.'.format(snap_filename))
 
 
-def sign_build(snap_filename, key_name='default', local=False):
+def sign_build(snap_filename, key_name=None, local=False):
     if not repo.is_package_installed('snapd'):
         raise EnvironmentError(
             'The snapd package is not installed. In order to use '
@@ -259,26 +266,39 @@ def sign_build(snap_filename, key_name='default', local=False):
 
     store = storeapi.StoreClient()
     with _requires_login():
-        try:
-            info = store.get_account_information()
-            authority_id = info['account_id']
-            snap_id = info['snaps'][snap_series][snap_name]['snap-id']
-        except KeyError:
-            raise RuntimeError(
-                'Your account lacks permission to assert builds for this '
-                'snap. Make sure you are logged in as the publisher of '
-                '\'{}\' for series \'{}\'.'.format(snap_name, snap_series))
+        account_info = store.get_account_information()
+
+    try:
+        authority_id = account_info['account_id']
+        snap_id = account_info['snaps'][snap_series][snap_name]['snap-id']
+    except KeyError:
+        raise RuntimeError(
+            'Your account lacks permission to assert builds for this '
+            'snap. Make sure you are logged in as the publisher of '
+            '\'{}\' for series \'{}\'.'.format(snap_name, snap_series))
 
     snap_build_path = snap_filename + '-build'
     if os.path.isfile(snap_build_path):
-        with open(snap_build_path, 'rb') as fd:
-            snap_build_content = fd.read()
         logger.info(
             'A signed build assertion for this snap already exists.')
+        with open(snap_build_path, 'rb') as fd:
+            snap_build_content = fd.read()
     else:
+        key = _maybe_prompt_for_key(key_name)
+        if not local:
+            is_registered = [
+                a for a in account_info['account_keys']
+                if a['public-key-sha3-384'] == key['sha3-384']
+            ]
+            if not is_registered:
+                raise RuntimeError(
+                    'The key "{}" is not registered in the Store.\n'
+                    'Please register it with `snapcraft register-key {}` '
+                    'before signing and pushing signatures to the '
+                    'Store.'.format(key['name'], key['name']))
+        snap_build_content = _generate_snap_build(
+            authority_id, snap_id, grade, key['name'], snap_filename)
         with open(snap_build_path, 'w+') as fd:
-            snap_build_content = _generate_snap_build(
-                authority_id, snap_id, grade, key_name, snap_filename)
             fd.write(snap_build_content.decode())
         logger.info(
             'Build assertion {} saved to disk.'.format(snap_build_path))

--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -292,8 +292,8 @@ def sign_build(snap_filename, key_name=None, local=False):
             ]
             if not is_registered:
                 raise RuntimeError(
-                    'The key "{}" is not registered in the Store.\n'
-                    'Please register it with `snapcraft register-key {}` '
+                    'The key {!r} is not registered in the Store.\n'
+                    'Please register it with `snapcraft register-key {!r}` '
                     'before signing and pushing signatures to the '
                     'Store.'.format(key['name'], key['name']))
         snap_build_content = _generate_snap_build(

--- a/snapcraft/tests/test_commands_list_keys.py
+++ b/snapcraft/tests/test_commands_list_keys.py
@@ -97,7 +97,7 @@ class ListKeysTestCase(tests.TestCase):
         expected_output = dedent('''\
                 Name     SHA3-384 fingerprint
             *   default  {default_sha3_384}
-            -   another  {another_sha3_384}  (not enabled)
+            -   another  {another_sha3_384}  (not registered)
             ''').format(
                 default_sha3_384=get_sample_key('default')['sha3-384'],
                 another_sha3_384=get_sample_key('another')['sha3-384'])

--- a/snapcraft/tests/test_commands_sign_build.py
+++ b/snapcraft/tests/test_commands_sign_build.py
@@ -222,8 +222,8 @@ class SignBuildTestCase(tests.TestCase):
 
         self.assertEqual(1, raised.exception.code)
         self.assertEqual([
-            'The key "default" is not registered in the Store.',
-            'Please register it with `snapcraft register-key default` '
+            'The key \'default\' is not registered in the Store.',
+            'Please register it with `snapcraft register-key \'default\'` '
             'before signing and pushing signatures to the Store.',
         ], self.fake_logger.output.splitlines())
         snap_build_path = self.snap_test.snap_path + '-build'


### PR DESCRIPTION
This way we can handle cases when the keyring is not setup, the selected key name is not present or selected key is not registered (LP #1629966).

Also prevent `snap sign-build` failures to create stray/empty '-build' files (LP #1629984).