### PR TITLE
catkin plugin: add `rosdistro` to help documentation.

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -28,6 +28,9 @@ Additionally, this plugin uses the following plugin-specific keywords:
     - source-space:
       (string)
       The source space containing Catkin packages. By default this is 'src'.
+    - rosdistro:
+      (string)
+      The ROS distro required by this system. Defaults to 'indigo'.
     - include-roscore:
       (boolean)
       Whether or not to include roscore with the part. Defaults to true.


### PR DESCRIPTION
This PR fixes LP: [#1629955](https://bugs.launchpad.net/snapcraft/+bug/1629955) by adding information about the `rosdistro` parameter to the documentation printed when one runs `snapcraft help catkin`.