### PR TITLE
In the downloader demo test, use https

### DIFF
--- a/demos/downloader-with-wiki-parts/test.c
+++ b/demos/downloader-with-wiki-parts/test.c
@@ -7,7 +7,7 @@ int main(void)
 
   curl = curl_easy_init();
   if(curl) {
-    curl_easy_setopt(curl, CURLOPT_URL, "www.ubuntu.com");
+    curl_easy_setopt(curl, CURLOPT_URL, "https://www.ubuntu.com");
     curl_easy_perform(curl);
 
     curl_easy_cleanup(curl);


### PR DESCRIPTION
This prevents the redirect from http to https.

LP: #1631463