### PR TITLE
Add `init-plugin` 

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -23,7 +23,7 @@ class CraftyPlugin(snapcraft.BasePlugin):
 
         # Add another option for our custom target.
         schema['properties']['crafty-target'] = {
-            type: 'string'
+            'type': 'string'
         }
 
         # Our custom target is required.
@@ -32,6 +32,9 @@ class CraftyPlugin(snapcraft.BasePlugin):
         return schema
 
     def build(self):
+        # Use base implementation to set up the 'build' directory.
+        super().build()
+        # Run custom build command.
         return self.run(['crafty', self.options.crafty_target])
 ```
 

--- a/snapcraft/tests/test_commands_init_plugin.py
+++ b/snapcraft/tests/test_commands_init_plugin.py
@@ -1,0 +1,108 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+import py_compile
+
+from snapcraft.main import main
+from snapcraft import tests
+
+import fixtures
+
+
+class InitPluginTestCase(tests.TestCase):
+
+    def test_init_plugin_invalid_name(self):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        with self.assertRaises(SystemExit) as raised:
+            main(['init-plugin', 'invalid-plugin'])
+
+        self.assertEqual(1, raised.exception.code)
+        self.assertEqual(
+          fake_logger.output,
+          "Plugin name must be valid Python identifier\n")
+
+    def test_init_plugin_defaults(self):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        main(['init-plugin', 'testplugin'])
+
+        plugin_path = os.path.join(self.parts_dir,
+                                   'plugins',
+                                   'x-testplugin.py')
+
+        self.assertTrue(os.path.exists(plugin_path),
+                        'Expected "parts/plugins/x-testplugin.py" to exist')
+
+        self.assertEqual(
+            fake_logger.output,
+            "Created new plugin at {}\n".format(plugin_path))
+
+    def test_plugin_compiles(self):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        main(['init-plugin', 'testplugin'])
+        result = py_compile.compile(
+                     os.path.join(self.parts_dir,
+                                  'plugins',
+                                  'x-testplugin.py'))
+
+        self.assertRegex(result,
+                         '{}/x-testplugin.*\.pyc'
+                         .format(
+                                 os.path.join(self.parts_dir,
+                                              'plugins',
+                                              '__pycache__')))
+
+    def test_plugin_no_overwrite_existing(self):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        main(['init-plugin', 'testplugin'])
+
+        with self.assertRaises(SystemExit) as raised:
+            main(['init-plugin', 'testplugin'])
+
+        self.assertEqual(1, raised.exception.code)
+
+        plugin_path = os.path.join(self.parts_dir,
+                                   'plugins',
+                                   'x-testplugin.py')
+
+        self.assertIn(
+            "{} already exists. Not overwriting\n".format(plugin_path),
+            fake_logger.output)
+
+    def test_preexisting_file_fails(self):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        os.makedirs(self.parts_dir)
+        plugin_dir = os.path.join(self.parts_dir, 'plugins')
+        open(plugin_dir, 'w').close()
+
+        with self.assertRaises(SystemExit) as raised:
+            main(['init-plugin', 'testplugin'])
+
+        self.assertEqual(1, raised.exception.code)
+        self.assertEqual(fake_logger.output,
+                         "{} is a file, can't be used as a "
+                         "destination\n".format(plugin_dir))


### PR DESCRIPTION
Hi: This PR adds 'init-plugin' (LP# 1629910), which creates a plugin in the appropriate place after running:

```snapcraft init-plugin <plugin-name>```

It includes test cases. A couple of comments:

* I tried to put a short example in the comments that provides some clues as to how to build a plugin, but it's also somewhat contrived, and could arguably be pared down a bit and/or have more relevant information. Any thoughts?

* Code -- would it be preferable for this code to go in a separate file rather than cluttering up main.py?

Any other suggestions would be most welcome -- I'd really like for this to be useful and maintainable.
