### PR TITLE
Handle 'broken' validations that don't match refresh-control

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -502,10 +502,19 @@ def gated(snap_name):
     if validations:
         table_data = []
         for v in validations:
-            table_data.append([v['approved-snap-name'],
-                               v['approved-snap-revision']])
-        tabulated = tabulate(table_data, headers=['Name', 'Approved'],
-                             tablefmt="plain")
+            name = v['approved-snap-name']
+            revision = v['approved-snap-revision']
+            if revision == '-':
+                revision = None
+            required = str(v.get('required', True))
+            # Currently timestamps have microseconds, which look bad
+            timestamp = v['timestamp']
+            if '.' in timestamp:
+                timestamp = timestamp.split('.')[0] + 'Z'
+            table_data.append([name, revision, required, timestamp])
+        tabulated = tabulate(
+            table_data, headers=['Name', 'Revision', 'Required', 'Approved'],
+            tablefmt="plain", missingval='-')
         print(tabulated)
     else:
         print('There are no validations for snap {!r}'.format(snap_name))

--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -729,7 +729,8 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
                 "snap-id": "snap-id-gating",
                 "timestamp": "2016-09-19T21:07:27.756001Z",
                 "type": "validation",
-                "revoked": "false"
+                "revoked": "false",
+                "required": True,
             }, {
                 "approved-snap-id": "snap-id-2",
                 "approved-snap-revision": "5",
@@ -740,7 +741,20 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
                 "snap-id": "snap-id-gating",
                 "timestamp": "2016-09-19T21:07:27.756001Z",
                 "type": "validation",
-                "revoked": "false"
+                "revoked": "false",
+                "required": False,
+            }, {
+                "approved-snap-id": "snap-id-3",
+                "approved-snap-revision": "-",
+                "approved-snap-name": "snap-3",
+                "authority-id": "dev-1",
+                "series": "16",
+                "sign-key-sha3-384": "1234567890",
+                "snap-id": "snap-id-gating",
+                "timestamp": "2016-09-19T21:07:27.756001Z",
+                "type": "validation",
+                "revoked": "false",
+                "required": True,
             }]
             response = json.dumps(response).encode()
             status = 200

--- a/snapcraft/tests/store/test_store_client.py
+++ b/snapcraft/tests/store/test_store_client.py
@@ -390,7 +390,8 @@ class ValidationsTestCase(tests.TestCase):
             "snap-id": "snap-id-gating",
             "timestamp": "2016-09-19T21:07:27.756001Z",
             "type": "validation",
-            "revoked": "false"
+            "revoked": "false",
+            "required": True,
         }, {
             "approved-snap-id": "snap-id-2",
             "approved-snap-revision": "5",
@@ -401,7 +402,20 @@ class ValidationsTestCase(tests.TestCase):
             "snap-id": "snap-id-gating",
             "timestamp": "2016-09-19T21:07:27.756001Z",
             "type": "validation",
-            "revoked": "false"
+            "revoked": "false",
+            "required": False,
+        }, {
+            "approved-snap-id": "snap-id-3",
+            "approved-snap-revision": "-",
+            "approved-snap-name": "snap-3",
+            "authority-id": "dev-1",
+            "series": "16",
+            "sign-key-sha3-384": "1234567890",
+            "snap-id": "snap-id-gating",
+            "timestamp": "2016-09-19T21:07:27.756001Z",
+            "type": "validation",
+            "revoked": "false",
+            "required": True,
         }]
         result = self.client.get_validations('good')
         self.assertEqual(result, expected)

--- a/snapcraft/tests/test_commands_gated.py
+++ b/snapcraft/tests/test_commands_gated.py
@@ -63,9 +63,10 @@ class GatedTestCase(tests.TestCase):
         main([self.command_name, 'ubuntu-core'])
 
         expected_output = textwrap.dedent("""\
-            Name      Approved
-            snap-1           3
-            snap-2           5""")
+            Name      Revision  Required    Approved
+            snap-1           3  True        2016-09-19T21:07:27Z
+            snap-2           5  False       2016-09-19T21:07:27Z
+            snap-3           -  True        2016-09-19T21:07:27Z""")
         self.assertIn(expected_output, self.fake_terminal.getvalue())
 
     def test_gated_no_validations(self):


### PR DESCRIPTION
LP: #1634173

* Show gated snaps that have no active validation
* Mark validations that don't match refresh-control as "not required"
* Show a date marking when validation was done.