### PR TITLE
The latest icon definition is deprecated

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -68,12 +68,12 @@ build a local project against the libraries in `./stage` by running `snapcraft
 shell make`. Though in general, you are encouraged to add even local
 projects to snapcraft.yaml with a local `source:` path.
 
-For rapid iteration one can run `snappy try` against this directory to have it
+For rapid iteration one can run `snap try` against this directory to have it
 mounted in a `snappy` capable system.
 
 ### Prime
 
-The prime step moves the data into a `./snap` directory. It contains only
+The prime step moves the data into a `./prime` directory. It contains only
 the content that will be put into the final snap package, unlike the staging
 area which may include some development files not destined for your package.
 
@@ -82,10 +82,10 @@ The Snappy metadata information about your project will also now be placed in
 expects. For a breakdown of what this is, have a look at our [Snappy developer
 reference](http://snapcraft.io/docs/build-snaps/metadata).
 
-This `./snap` directory is useful for inspecting what is going into your snap
+This `./prime` directory is useful for inspecting what is going into your snap
 and to make any final post-processing on snapcraft's output.
 
-For rapid iteration one can run `snappy try` against this directory to have it
+For rapid iteration one can run `snap try` against this directory to have it
 mounted in a `snappy` capable system.
 
 ### Snap

--- a/docs/snapcraft-syntax.md
+++ b/docs/snapcraft-syntax.md
@@ -58,8 +58,6 @@ contain.
       Requires `daemon` to be specified. It is the length of time in seconds
       that the system will wait for the service to stop before terminating it
       via `SIGTERM` (and `SIGKILL` if that doesn't work).
-* `icon` (string)
-  Path to the icon that will be used for the snap.
 * `license` (string)
   Path to a license file.
 * `license-agreement` (string)


### PR DESCRIPTION
"icon" is not supported in the latest snapcraft. The correct way is to define it in "setup/gui" like what is described in https://github.com/snapcore/snapcraft/blob/master/docs/your-first-snap.md