### PR TITLE
Catkin plugin: Python nodes require gcc/g++ too.

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -117,6 +117,8 @@ deb http://${{security}}.ubuntu.com/${{suffix}} {0}-security main universe
         super().__init__(name, options, project)
         self.build_packages.extend(['gcc', 'libc6-dev', 'make'])
 
+        self.stage_packages.extend(['gcc', 'g++'])
+
         # Get a unique set of packages
         self.catkin_packages = set(options.catkin_packages)
         self._rosdep_path = os.path.join(self.partdir, 'rosdep')
@@ -444,12 +446,6 @@ def _find_system_dependencies(catkin_packages, rosdep):
                     "rosdep database.".format(dependency))
 
             system_dependencies[dependency] = these_dependencies
-
-            # TODO: Not sure why this isn't pulled in by roscpp. Can it
-            # be compiled by clang, etc.? If so, perhaps this should be
-            # left up to the developer.
-            if dependency == 'roscpp':
-                system_dependencies['g++'] = ['g++']
 
     # Finally, return a list of all system dependencies
     return set(item for sublist in system_dependencies.values()

--- a/snapcraft/tests/test_plugin_catkin.py
+++ b/snapcraft/tests/test_plugin_catkin.py
@@ -823,18 +823,6 @@ class FindSystemDependenciesTestCase(tests.TestCase):
                          "stage-packages until you can get it into the rosdep "
                          "database.")
 
-    def test_find_system_dependencies_roscpp_includes_gplusplus(self):
-        rosdep_mock = mock.MagicMock()
-        rosdep_mock.get_dependencies.return_value = ['roscpp']
-        rosdep_mock.resolve_dependency.return_value = ['baz']
-
-        self.assertEqual(_CompareContainers(self, {'baz', 'g++'}),
-                         catkin._find_system_dependencies({'foo'},
-                                                          rosdep_mock))
-
-        rosdep_mock.get_dependencies.assert_called_once_with('foo')
-        rosdep_mock.resolve_dependency.assert_called_once_with('roscpp')
-
 
 class RosdepTestCase(tests.TestCase):
 


### PR DESCRIPTION
This PR fixes LP: [#1638317](https://bugs.launchpad.net/snapcraft/+bug/1638317) by staging them at the beginning instead of doing so dependent upon whether `roscpp` is in the dependency list.