### PR TITLE
Python plugin: remove pip packages when cleaning pull.

### DIFF
--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -47,6 +47,7 @@ Additionally, this plugin uses the following plugin-specific keywords:
 
 import os
 import re
+import shutil
 import stat
 import subprocess
 import tempfile
@@ -153,6 +154,12 @@ class PythonPlugin(snapcraft.BasePlugin):
             setup = os.path.join(self.sourcedir, 'setup.py')
         with simple_env_bzr(os.path.join(self.installdir, 'bin')):
             self._run_pip(setup, download=True)
+
+    def clean_pull(self):
+        super().clean_pull()
+
+        if os.path.isdir(self._python_package_dir):
+            shutil.rmtree(self._python_package_dir)
 
     def _install_pip(self, download):
         env = os.environ.copy()

--- a/snapcraft/tests/test_plugin_python.py
+++ b/snapcraft/tests/test_plugin_python.py
@@ -145,6 +145,17 @@ class PythonPluginTestCase(tests.TestCase):
         plugin.pull()
         mock_run.assert_has_calls(calls)
 
+    @mock.patch.object(python.PythonPlugin, 'run')
+    def test_clean_pull(self, mock_run):
+        plugin = python.PythonPlugin('test-part', self.options,
+                                     self.project_options)
+
+        # Pretend pip downloaded packages
+        os.makedirs(os.path.join(plugin.partdir, 'packages'))
+        plugin.clean_pull()
+        self.assertFalse(
+            os.path.isdir(os.path.join(plugin.partdir, 'packages')))
+
     @mock.patch.object(python.PythonPlugin, 'run_output')
     @mock.patch.object(python.PythonPlugin, 'run')
     @mock.patch.object(python.snapcraft.BasePlugin, 'build')


### PR DESCRIPTION
This PR fixes LP: [#1630005](https://bugs.launchpad.net/snapcraft/+bug/1630005) by removing the `<partdir>/packages` when cleaning the pull step.