### PR TITLE
Implement API packaging plugin as requested in #1638508

### DIFF
--- a/integration_tests/snaps/simple-development/Makefile
+++ b/integration_tests/snaps/simple-development/Makefile
@@ -1,0 +1,27 @@
+# -*- Mode: Makefile; indent-tabs-mode:t; tab-width: 4 -*-
+
+LIBNAME      = apitest
+BINNAME      = testapp
+CFLAGS       = -fPIC -c #-pedantic -Wall -Wextra -ggdb3
+LDFLAGS      = -shared -Wl
+CC           = gcc
+
+all: libapitest #main 
+
+libapitest: 
+	$(CC) $(CFLAGS)  libapitest.c -o libapitest.o
+	$(CC) $(LDFLAGS),-soname,libapitest.so.1 -o libapitest.so.1.0.1 libapitest.o
+	ln -s lib$(LIBNAME).so.1.0.1 lib$(LIBNAME).so.1
+	ln -s lib$(LIBNAME).so.1.0.1 lib$(LIBNAME).so
+
+main:
+	$(CC) main.c -L. -l$(LIBNAME) -o $(BINNAME)
+
+install:
+	cp -a * $(DESTDIR)
+
+.PHONY: clean
+
+clean:
+	rm -f *.o *$(LIBNAME).so* core *~ $(BINNAME)
+

--- a/integration_tests/snaps/simple-development/libapitest.c
+++ b/integration_tests/snaps/simple-development/libapitest.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+void hello(void) {
+  printf("Hello, library world.\n");
+}
+

--- a/integration_tests/snaps/simple-development/libapitest.h
+++ b/integration_tests/snaps/simple-development/libapitest.h
@@ -1,0 +1,1 @@
+void hello(void);

--- a/integration_tests/snaps/simple-development/main.c
+++ b/integration_tests/snaps/simple-development/main.c
@@ -1,0 +1,6 @@
+#include "libapitest.h"
+
+int main(void) {
+ hello();
+ return 0;
+}

--- a/integration_tests/snaps/simple-development/snapcraft.yaml
+++ b/integration_tests/snaps/simple-development/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: libapitest
+version: 0.1
+summary: Testing api packaging
+description: Testing api packaging
+confinement: strict
+
+build-packages: [gcc, libc6-dev]
+
+parts:
+  project:
+    plugin: make
+    source: .
+
+  api:
+    plugin: development
+    source: .
+    exclude:  ['Makefile','*.c','*.o', '*tar.gz', '*.snap']
+    extension: api
+    after:
+      - project
+ 
+

--- a/integration_tests/test_development_plugin.py
+++ b/integration_tests/test_development_plugin.py
@@ -1,0 +1,49 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015, 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from testtools.matchers import (
+    DirExists,
+    FileExists
+)
+
+import integration_tests
+
+
+class DevelopmentPluginTestCase(integration_tests.TestCase):
+
+    def test_stage_developer_plugin(self):
+        project_dir = 'simple-development'
+        self.run_snapcraft('stage', project_dir)
+
+        expected_files = [
+            'libapitest.c',
+            'libapitest.h',
+            'libapitest.o',
+            'libapitest.so',
+            'libapitest.so.1',
+            'libapitest.so.1.0.1',
+            'main.c',
+            'Makefile',
+        ]
+        for expected_file in expected_files:
+            self.assertThat(
+                os.path.join(project_dir, 'stage', expected_file),
+                FileExists())
+        self.assertThat(
+            'libapitest-api.tar.gz',
+            FileExists())

--- a/snapcraft/plugins/development.py
+++ b/snapcraft/plugins/development.py
@@ -1,0 +1,92 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This plugin extracts the development files from the stage and packs
+   them up to a tar.gz archive
+
+This plugin uses the common plugin keywords as well as those for "sources".
+For more information check the 'plugins' topic for the former and the
+'sources' topic for the latter.
+
+Additionally, this plugin uses the following plugin-specific keywords:
+
+    - exclude:
+      (list of strings)
+      additional options to pass to the tar command.
+    - name:
+      string what will be used as name of the tar.gz archive
+"""
+
+import os
+import snapcraft
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+class DevelopmentPackage(snapcraft.BasePlugin):
+
+    @classmethod
+    def schema(cls):
+        schema = super().schema()
+        schema['properties']['exclude'] = {
+            'type': 'array',
+            'minitems': 0,
+            'uniqueItems': True,
+            'items': {
+                'type': 'string',
+            },
+            'default': [],
+        }
+        schema['properties']['extension'] = {
+            'type': 'string',
+            'default': 'api'
+        }
+        # The name must be specified
+        schema['required'].append('extension')
+        return schema
+
+    def __init__(self, name, options, project):
+        super().__init__(name, options, project)
+
+        logger.warning("EXPERIMENTAL: The 'development' plugin's "
+                       "functionality is under development and all features"
+                       "are experimental.")
+
+    def enable_cross_compilation(self):
+        pass
+
+    def build(self):
+        super().build()
+        self.archive_name = os.getcwd() +\
+            "/" +\
+            snapcraft.internal.load_config(self.project).data['name'] +\
+            "-" +\
+            self.options.extension +\
+            ".tar.gz"
+        for i, p in enumerate(self.options.exclude):
+            self.options.exclude[i] = "--exclude={}".format(p.strip())
+
+        if os.path.isdir(self.project.stage_dir):
+            self.run(['/bin/tar',
+                      'czf',
+                      self.archive_name] +
+                     self.options.exclude +
+                     ['-C',
+                      '%s' % self.project.stage_dir, '.'])
+        else:
+            logger.warning("The stage does not exist")

--- a/snapcraft/tests/test_plugin_development.py
+++ b/snapcraft/tests/test_plugin_development.py
@@ -1,0 +1,159 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+import os.path
+import fixtures
+import subprocess
+import fnmatch
+import re
+
+import snapcraft
+from snapcraft.plugins import development
+from snapcraft.plugins.development import DevelopmentPackage
+from snapcraft.tests import TestCase
+from snapcraft.main import main
+
+from snapcraft.plugins import development
+
+
+from unittest import mock
+
+
+class DevelopmentPackagePluginTestCase(TestCase):
+    yaml_template = """name: stage-test
+version: 1.0
+summary: test stage
+description: if the build is succesful the state file will be updated
+confinement: strict
+grade: stable
+
+parts:
+{parts}"""
+    libapitest_header = """void hello(void);"""
+    libapitest_main = """#include <stdio.h>
+void hello(void) {
+  printf("Hello, library world.\n");
+}"""
+
+    yaml_part = """  stage{:d}:
+    plugin: nil"""
+
+    def make_snapcraft_yaml(self, n=1):
+        parts = '\n'.join([self.yaml_part.format(i) for i in range(n)])
+        super().make_snapcraft_yaml(self.yaml_template.format(parts=parts))
+
+        parts = []
+        for i in range(n):
+            part_dir = os.path.join(self.parts_dir, 'stage{}'.format(i))
+            state_dir = os.path.join(part_dir, 'state')
+            parts.append({
+                'part_dir': part_dir,
+                'state_dir': state_dir,
+            })
+
+        return parts
+
+    def setUp(self):
+        super().setUp()
+        self.project_options = snapcraft.ProjectOptions()
+
+        class Options:
+            source = '.'
+            extension = 'api'
+            exclude = ['*.c', '*.o']
+
+        self.options = Options()
+        self.project_options = snapcraft.ProjectOptions()
+
+        patcher = mock.patch('snapcraft.BasePlugin.build')
+        self.base_build_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_schema(self):
+        schema = development.DevelopmentPackage.schema()
+        properties = schema['properties']
+        self.assertEqual(properties['exclude']['type'],
+                         'array',
+                         'The exclude is not an array')
+        self.assertEqual(properties['extension']['type'],
+                         'string',
+                         'The extension is not string')
+
+    def test_development_packaging(self):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+        self.make_snapcraft_yaml()
+        plugin = development.DevelopmentPackage('development',
+                                                self.options,
+                                                self.project_options)
+        plugin.pull()
+        os.makedirs('stage')
+        with open(os.path.join('stage', 'libapitest.h'), 'w') as f:
+            f.write(self.libapitest_header)
+            f.close
+        with open(os.path.join('stage', 'libapitest.c'), 'w') as f:
+            f.write(self.libapitest_main)
+            f.close
+        open(os.path.join('stage', 'Makefile'), 'w').close()
+        open(os.path.join('stage', 'libapitest.so'), 'w').close()
+        plugin.build()
+        # Test if the archive file is created
+        self.assertTrue(os.path.isfile(plugin.archive_name),
+                        'The %s archive was not created' % plugin.archive_name)
+        tar_process = subprocess.Popen(["/bin/tar",
+                                        "tzf",
+                                        "%s" % plugin.archive_name],
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE)
+        stdout_value, stderr_value = tar_process.communicate()
+
+        # Test if the package is a valid tar.gz file
+        self.assertFalse(tar_process.returncode,
+                         'The %s archive is broken' % plugin.archive_name)
+
+        tar_content = stdout_value.decode("utf-8").split('\n')
+        for fname in tar_content:
+            for pattern in self.options.exclude:
+                # Test if there is file in the archive what should be excluded
+                self.assertFalse(fnmatch.fnmatch(fname,
+                                                 re.sub('--exclude=',
+                                                        '',
+                                                        pattern)),
+                                 'Excluded file in archive')
+
+    def test_stage_defaults(self):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+        parts = self.make_snapcraft_yaml()
+
+        main(['stage'])
+
+        self.assertTrue(os.path.exists(self.stage_dir),
+                        'Expected a stage directory')
+        self.assertTrue(os.path.exists(self.parts_dir),
+                        'Expected a parts directory')
+        self.assertTrue(os.path.exists(parts[0]['part_dir']),
+                        'Expected a part directory for the build0 part')
+
+        self.verify_state('build0', parts[0]['state_dir'], 'stage')
+
+    def test_dump_enable_cross_compilation(self):
+        plugin = DevelopmentPackage('development',
+                                    self.options,
+                                    self.project_options)
+        plugin.enable_cross_compilation()


### PR DESCRIPTION
We have discussed with Sergio/Colin on the sprint about the need of API packages.

The conclusion was that since we do not want -dev snaps in the store we must provide an alternative way to publish API packages.

The story is that an upstream content interface plug developer (for example Qt or Gtk)  produces boththe runtime interface and the development interfaces. The runtime interfaces go with the snap package. This PR contains the simple implementation of a snapcraft plugin (development) what creates a tar.gz of the stage space. This tar.gz can be published as the development interfac counterpart of the runtime interfaces.