### PR TITLE
Cache apt related files (config, packages) in 'apt' parent directory.

### DIFF
--- a/snapcraft/internal/repo.py
+++ b/snapcraft/internal/repo.py
@@ -166,7 +166,7 @@ class _AptCache:
         sources_list_digest = hashlib.sha384(
             sources_list.encode(sys.getfilesystemencoding())).hexdigest()
 
-        cache_dir = os.path.join(self._cache_dir, sources_list_digest)
+        cache_dir = os.path.join(self._cache_dir, 'apt', sources_list_digest)
         apt_cache_dir = os.path.join(cache_dir, 'apt')
         package_cache_dir = os.path.join(cache_dir, 'packages')
 


### PR DESCRIPTION
LP: #1635611

Apt related cache now lives in `$HOME/.cache/snapcraft/apt/sources-list-digest/[apt, packages]` allowing for new top-level cache dirs for snapcraft unrelated to apt.