### PR TITLE
cache: snap revision caching on 'push'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     url='https://github.com/snapcore/snapcraft',
     packages=['snapcraft',
               'snapcraft.internal',
+              'snapcraft.internal.cache',
               'snapcraft.internal.states',
               'snapcraft.plugins',
               'snapcraft.storeapi'],

--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -30,7 +30,10 @@ from tabulate import tabulate
 import yaml
 
 from snapcraft import storeapi
-from snapcraft.internal import repo
+from snapcraft.internal import (
+    cache,
+    repo,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -393,6 +396,10 @@ def push(snap_filename, release_channels=None):
     else:
         logger.info('Uploaded {!r}'.format(snap_name))
     tracker.raise_for_code()
+
+    if os.environ.get('DELTA_UPLOADS_EXPERIMENTAL'):
+        snap_cache = cache.SnapCache()
+        snap_cache.cache(snap_filename, result['revision'])
 
     if release_channels:
         release(snap_name, result['revision'], release_channels)

--- a/snapcraft/internal/cache/__init__.py
+++ b/snapcraft/internal/cache/__init__.py
@@ -14,6 +14,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from snapcraft.internal import cache             # noqa
-from snapcraft.internal import states            # noqa
-from snapcraft.internal.project_loader import load_config  # noqa
+from ._snap import SnapCache  # noqa

--- a/snapcraft/internal/cache/_cache.py
+++ b/snapcraft/internal/cache/_cache.py
@@ -1,0 +1,45 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from xdg import BaseDirectory
+
+import snapcraft
+
+
+class SnapcraftCache:
+    """Generic cache base class.
+
+    This class is responsible for cache location, notification and pruning.
+    """
+    def __init__(self):
+        self.cache_root = os.path.join(
+            BaseDirectory.xdg_cache_home, 'snapcraft')
+
+    def cache(self):
+        raise NotImplementedError
+
+    def prune(self):
+        raise NotImplementedError
+
+
+class SnapcraftProjectCache(SnapcraftCache):
+    """Project specific cache"""
+    def __init__(self):
+        super().__init__()
+        self.project_cache_root = os.path.join(
+            self.cache_root, snapcraft.internal.load_config().data['name'])

--- a/snapcraft/internal/cache/_snap.py
+++ b/snapcraft/internal/cache/_snap.py
@@ -1,0 +1,62 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+import shutil
+
+from snapcraft.internal.cache._cache import SnapcraftProjectCache
+
+
+logger = logging.getLogger(__name__)
+
+
+class SnapCache(SnapcraftProjectCache):
+    """Cache for snap revisions."""
+    def __init__(self):
+        super().__init__()
+
+    def _setup_snap_cache(self):
+        snap_cache_path = os.path.join(self.project_cache_root, 'revisions')
+        os.makedirs(snap_cache_path, exist_ok=True)
+        return snap_cache_path
+
+    def cache(self, snap_filename, revision):
+        """Cache snap revision in XDG cache.
+
+        :returns: path to cached revision.
+        """
+        snap_cache_dir = self._setup_snap_cache()
+
+        cached_snap = _rewrite_snap_filename_with_revision(
+            snap_filename,
+            revision)
+        cached_snap_path = os.path.join(snap_cache_dir, cached_snap)
+        try:
+            shutil.copyfile(snap_filename, cached_snap_path)
+        except OSError:
+            logger.warning(
+                'Unable to cache snap {}.'.format(cached_snap))
+        return cached_snap_path
+
+
+def _rewrite_snap_filename_with_revision(snap_file, revision):
+    splitf = os.path.splitext(snap_file)
+    snap_with_revision = '{base}_{rev}{ext}'.format(
+        base=splitf[0],
+        rev=revision,
+        ext=splitf[1])
+    return snap_with_revision

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -56,6 +56,11 @@ class TempXDG(fixtures.Fixture):
             new=os.path.join(self.path, '.local'))
         patcher.start()
         self.addCleanup(patcher.stop)
+        patcher = mock.patch(
+            'xdg.BaseDirectory.xdg_cache_home',
+            new=os.path.join(self.path, '.cache'))
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
         patcher_dirs = mock.patch(
             'xdg.BaseDirectory.xdg_config_dirs',
@@ -317,3 +322,11 @@ class TestStore(fixtures.Fixture):
             self.user_password = 'test correct password'
         else:
             self.user_password = os.getenv('TEST_USER_PASSWORD')
+
+
+class DeltaUploads(fixtures.Fixture):
+    """Enable the Delta Uploads Experimental flag."""
+    def setUp(self):
+        super().setUp()
+        self.useFixture(fixtures.EnvironmentVariable(
+            'DELTA_UPLOADS_EXPERIMENTAL', 'True'))

--- a/snapcraft/tests/test_cache.py
+++ b/snapcraft/tests/test_cache.py
@@ -1,0 +1,69 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+
+import fixtures
+
+from snapcraft import tests
+from snapcraft.internal import cache
+from snapcraft.internal.cache._snap import _rewrite_snap_filename_with_revision
+from snapcraft.tests import fixture_setup
+
+
+class SnapCacheTestCase(tests.TestCase):
+
+    yaml_content = """name: cache-test
+version: 0.1
+summary: test cached snap
+description: test cached snap
+grade: devel
+
+parts:
+  my-part:
+    plugin: nil
+"""
+
+    def setUp(self):
+        super().setUp()
+        super().make_snapcraft_yaml(self.yaml_content)
+        self.fake_logger = fixtures.FakeLogger(level=logging.INFO)
+        self.useFixture(self.fake_logger)
+
+    def test_rewrite_snap_filename(self):
+        revision = 10
+        snap_file = 'my-snap-name_0.1_amd64.snap'
+
+        self.assertEqual(
+            'my-snap-name_0.1_amd64_10.snap',
+            _rewrite_snap_filename_with_revision(snap_file, revision))
+
+    def test_snap_cache(self):
+        self.useFixture(fixture_setup.FakeTerminal())
+        snap_cache = cache.SnapCache()
+        snap_file = 'my-snap-name_0.1_amd64.snap'
+
+        # create dummy snap
+        open(os.path.join(self.path, snap_file), 'a').close()
+
+        # cache snap
+        cached_snap_path = snap_cache.cache(snap_file, 10)
+
+        _, expected_snap = os.path.split(cached_snap_path)
+
+        self.assertEqual('my-snap-name_0.1_amd64_10.snap', expected_snap)
+        self.assertTrue(os.path.isfile(cached_snap_path))

--- a/snapcraft/tests/test_commands_push.py
+++ b/snapcraft/tests/test_commands_push.py
@@ -22,11 +22,13 @@ from unittest import mock
 
 import docopt
 import fixtures
+from xdg import BaseDirectory
 
 from snapcraft import (
     storeapi,
     tests
 )
+from snapcraft.internal.cache._snap import _rewrite_snap_filename_with_revision
 from snapcraft.main import main
 from snapcraft.storeapi.errors import StoreUploadError
 from snapcraft.tests import fixture_setup
@@ -245,3 +247,51 @@ class PushCommandTestCase(tests.TestCase):
         mock_upload.assert_called_once_with('my-snap-name', snap_file)
         mock_release.assert_called_once_with('my-snap-name', 9,
                                              ['edge', 'beta', 'candidate'])
+
+
+class PushCommandDeltasTestCase(tests.TestCase):
+
+    scenarios = [
+        ('with deltas', dict(enable_deltas=True)),
+        ('without deltas', dict(enable_deltas=False)),
+    ]
+
+    def test_push_revision_cached_with_experimental_deltas(self):
+        self.useFixture(fixture_setup.FakeTerminal())
+        if self.enable_deltas:
+            self.useFixture(fixture_setup.DeltaUploads())
+
+        mock_tracker = mock.Mock(storeapi.StatusTracker)
+        snap_revision = 9
+        mock_tracker.track.return_value = {
+            'code': 'ready_to_release',
+            'processed': True,
+            'can_release': True,
+            'url': '/fake/url',
+            'revision': snap_revision,
+        }
+        patcher = mock.patch.object(storeapi.StoreClient, 'upload')
+        mock_upload = patcher.start()
+        self.addCleanup(patcher.stop)
+        mock_upload.return_value = mock_tracker
+
+        # Create a snap
+        main(['init'])
+        main(['snap'])
+        snap_file = glob.glob('*.snap')[0]
+
+        # Upload
+        with mock.patch('snapcraft.storeapi.StatusTracker') as mock_tracker:
+            main(['push', snap_file])
+
+        revision_cache = os.path.join(
+            BaseDirectory.xdg_cache_home,
+            'snapcraft',
+            'my-snap-name',
+            'revisions')
+        cached_snap = _rewrite_snap_filename_with_revision(
+            snap_file,
+            snap_revision)
+
+        self.assertEqual(self.enable_deltas, os.path.isfile(
+            os.path.join(revision_cache, cached_snap)))


### PR DESCRIPTION
This feature will only be enabled with the `DELTA_UPLOADS_EXPERIMENTAL` environment variable set.

I was a little uncertain where `cache_snap()` should live; `repo` seemed like the most appropriate place, but perhaps you could provide some guidance there. Other thoughts are perhaps this should be SnapCache (similar to AptCache), rather than a solitary func, as we'll be providing pruning in a following branch (see discussion on Rocketchat)?

LP: #1639672