### PR TITLE
repo: apt-mark new build-packages as automatically installed

### DIFF
--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -75,14 +75,15 @@ class TestCase(testtools.TestCase):
             self.addDetail('output', content.text_content(e.output))
             raise
 
-        deb_env = os.environ.copy()
-        deb_env.update({
-            'DEBIAN_FRONTEND': 'noninteractive',
-            'DEBCONF_NONINTERACTIVE_SEEN': 'true',
-        })
-        self.addCleanup(
-            subprocess.check_call, ['sudo', 'apt-get', 'autoremove', '-qq'],
-            stderr=subprocess.STDOUT, env=deb_env)
+        if not os.getenv('SNAPCRAFT_IGNORE_APT_AUTOREMOVE', False):
+            deb_env = os.environ.copy()
+            deb_env.update({
+                'DEBIAN_FRONTEND': 'noninteractive',
+                'DEBCONF_NONINTERACTIVE_SEEN': 'true',
+            })
+            self.addCleanup(
+                subprocess.check_call, 'sudo apt-get autoremove -qq'.split(),
+                stderr=subprocess.STDOUT, env=deb_env)
 
         return ret_val
 

--- a/snapcraft/internal/repo.py
+++ b/snapcraft/internal/repo.py
@@ -110,7 +110,7 @@ def install_build_packages(packages):
         except subprocess.CalledProcessError as e:
                 logger.warning(
                     "Impossible to mark packages as auto-installed: {}"
-                    .format(str(e)))
+                    .format(e))
 
 
 class PackageNotFoundError(Exception):

--- a/snapcraft/internal/repo.py
+++ b/snapcraft/internal/repo.py
@@ -88,6 +88,7 @@ def install_build_packages(packages):
                     "Could not find a required package in "
                     "'build-packages': {}".format(str(e)))
     if new_packages:
+        new_packages.sort()
         logger.info(
             'Installing build dependencies: %s', ' '.join(new_packages))
         env = os.environ.copy()

--- a/snapcraft/internal/repo.py
+++ b/snapcraft/internal/repo.py
@@ -85,8 +85,8 @@ def install_build_packages(packages):
                     new_packages.append(pkg)
             except KeyError as e:
                 raise EnvironmentError(
-                    "Could not find a required package in "
-                    "'build-packages': {}".format(str(e)))
+                    'Could not find a required package in '
+                    '\'build-packages\': {}'.format(str(e)))
     if new_packages:
         new_packages.sort()
         logger.info(
@@ -106,12 +106,12 @@ def install_build_packages(packages):
         subprocess.check_call(apt_command + new_packages, env=env)
 
         try:
-                subprocess.check_call(['sudo', 'apt-mark', 'auto'] +
-                                      new_packages, env=env)
+            subprocess.check_call(['sudo', 'apt-mark', 'auto'] +
+                                  new_packages, env=env)
         except subprocess.CalledProcessError as e:
-                logger.warning(
-                    "Impossible to mark packages as auto-installed: {}"
-                    .format(e))
+            logger.warning(
+                'Impossible to mark packages as auto-installed: {}'
+                .format(e))
 
 
 class PackageNotFoundError(Exception):

--- a/snapcraft/internal/repo.py
+++ b/snapcraft/internal/repo.py
@@ -99,7 +99,7 @@ def install_build_packages(packages):
 
         apt_command = ['sudo', 'apt-get',
                        '--no-install-recommends', '-y']
-        if not is_dumb_terminal:
+        if not is_dumb_terminal():
             apt_command.extend(['-o', 'Dpkg::Progress-Fancy=1'])
         apt_command.append('install')
 

--- a/snapcraft/internal/repo.py
+++ b/snapcraft/internal/repo.py
@@ -104,6 +104,14 @@ def install_build_packages(packages):
 
         subprocess.check_call(apt_command + new_packages, env=env)
 
+        try:
+                subprocess.check_call(['sudo', 'apt-mark', 'auto'] +
+                                      new_packages, env=env)
+        except subprocess.CalledProcessError as e:
+                logger.warning(
+                    "Impossible to mark packages as auto-installed: {}"
+                    .format(str(e)))
+
 
 class PackageNotFoundError(Exception):
 

--- a/snapcraft/tests/test_repo.py
+++ b/snapcraft/tests/test_repo.py
@@ -279,7 +279,7 @@ class BuildPackagesTestCase(tests.TestCase):
         mock_apt_cache_with = mock_apt_cache.__enter__.return_value
         mock_apt_cache_with.__getitem__.side_effect = lambda p: test_pkgs[p]
 
-        repo.install_build_packages(test_pkgs.keys())
+        repo.install_build_packages(sorted(test_pkgs.keys()))
 
     @patch('subprocess.check_call')
     def test_install_buid_package(self, mock_check_call):
@@ -289,7 +289,7 @@ class BuildPackagesTestCase(tests.TestCase):
         mock_check_call.assert_has_calls([
             call("sudo apt-get -o Dpkg::Progress-Fancy=1 "
                  "--no-install-recommends -y install".split() +
-                 [p for p in test_pkgs.keys() if not test_pkgs[p].installed],
+                 sorted([p for p in test_pkgs if not test_pkgs[p].installed]),
                  env={'DEBIAN_FRONTEND': 'noninteractive',
                       'DEBCONF_NONINTERACTIVE_SEEN': 'true'})
         ])
@@ -301,7 +301,7 @@ class BuildPackagesTestCase(tests.TestCase):
 
         mock_check_call.assert_has_calls([
             call("sudo apt-mark auto".split() +
-                 [p for p in test_pkgs.keys() if not test_pkgs[p].installed],
+                 sorted([p for p in test_pkgs if not test_pkgs[p].installed]),
                  env={'DEBIAN_FRONTEND': 'noninteractive',
                       'DEBCONF_NONINTERACTIVE_SEEN': 'true'})
         ])

--- a/snapcraft/tests/test_repo.py
+++ b/snapcraft/tests/test_repo.py
@@ -287,14 +287,32 @@ class BuildPackagesTestCase(tests.TestCase):
 
         repo.install_build_packages(test_pkgs.keys())
 
+    @patch('snapcraft.repo.is_dumb_terminal')
     @patch('subprocess.check_call')
-    def test_install_buid_package(self, mock_check_call):
+    def test_install_buid_package(
+            self, mock_check_call, mock_is_dumb_terminal):
+        mock_is_dumb_terminal.return_value = False
         self.install_test_packages(self.test_packages)
 
         installable = self.get_installable_packages(self.test_packages)
         mock_check_call.assert_has_calls([
-            call('sudo apt-get -o Dpkg::Progress-Fancy=1 '
-                 '--no-install-recommends -y install'.split() +
+            call('sudo apt-get --no-install-recommends -y '
+                 '-o Dpkg::Progress-Fancy=1 install'.split() +
+                 sorted(set(installable)),
+                 env={'DEBIAN_FRONTEND': 'noninteractive',
+                      'DEBCONF_NONINTERACTIVE_SEEN': 'true'})
+        ])
+
+    @patch('snapcraft.repo.is_dumb_terminal')
+    @patch('subprocess.check_call')
+    def test_install_buid_package_in_dumb_terminal(
+            self, mock_check_call, mock_is_dumb_terminal):
+        mock_is_dumb_terminal.return_value = True
+        self.install_test_packages(self.test_packages)
+
+        installable = self.get_installable_packages(self.test_packages)
+        mock_check_call.assert_has_calls([
+            call('sudo apt-get --no-install-recommends -y install'.split() +
                  sorted(set(installable)),
                  env={'DEBIAN_FRONTEND': 'noninteractive',
                       'DEBCONF_NONINTERACTIVE_SEEN': 'true'})

--- a/snapcraft/tests/test_repo.py
+++ b/snapcraft/tests/test_repo.py
@@ -283,25 +283,25 @@ class BuildPackagesTestCase(tests.TestCase):
 
     @patch('subprocess.check_call')
     def test_install_buid_package(self, mock_check_call):
-        test_packages = self.test_packages
-        self.install_test_packages(test_packages)
+        test_pkgs = self.test_packages
+        self.install_test_packages(test_pkgs)
 
         mock_check_call.assert_has_calls([
             call("sudo apt-get -o Dpkg::Progress-Fancy=1 "
                  "--no-install-recommends -y install".split() +
-                 [p for p in test_packages if not test_packages[p].installed],
+                 [p for p in test_pkgs.keys() if not test_pkgs[p].installed],
                  env={'DEBIAN_FRONTEND': 'noninteractive',
                       'DEBCONF_NONINTERACTIVE_SEEN': 'true'})
         ])
 
     @patch('subprocess.check_call')
     def test_install_buid_package_marks_auto_installed(self, mock_check_call):
-        test_packages = self.test_packages
-        self.install_test_packages(test_packages)
+        test_pkgs = self.test_packages
+        self.install_test_packages(test_pkgs)
 
         mock_check_call.assert_has_calls([
             call("sudo apt-mark auto".split() +
-                 [p for p in test_packages if not test_packages[p].installed],
+                 [p for p in test_pkgs.keys() if not test_pkgs[p].installed],
                  env={'DEBIAN_FRONTEND': 'noninteractive',
                       'DEBCONF_NONINTERACTIVE_SEEN': 'true'})
         ])

--- a/snapcraft/tests/test_repo.py
+++ b/snapcraft/tests/test_repo.py
@@ -19,7 +19,7 @@ import logging
 import os
 import stat
 import tempfile
-from unittest.mock import ANY, call, patch
+from unittest.mock import ANY, call, patch, MagicMock
 
 import snapcraft
 from snapcraft import repo
@@ -266,6 +266,30 @@ Requires: cairo gee-0.8 glib-2.0 gio-unix-2.0 gobject-2.0
 
 
 class BuildPackagesTestCase(tests.TestCase):
+
+    @patch('os.environ')
+    @patch('subprocess.check_call')
+    @patch('snapcraft.repo.apt')
+    def test_install_buid_package(self, mock_apt, mock_ceck_call, mock_env):
+        test_packages = {'package-not-installed': MagicMock(installed=False),
+                         'package-installed': MagicMock(installed=True),
+                         'another-uninstalled': MagicMock(installed=False)}
+
+        mock_env.copy.return_value = {}
+        mock_apt_cache = mock_apt.Cache.return_value
+        mock_apt_cache_with = mock_apt_cache.__enter__.return_value
+        mock_apt_cache_with.__getitem__.side_effect = lambda p: test_packages[p]
+
+        repo.install_build_packages(test_packages.keys())
+
+        mock_ceck_call.assert_has_calls([
+            call("sudo apt-get -o Dpkg::Progress-Fancy=1 "
+                 "--no-install-recommends -y install".split() +
+                 [p for p in test_packages if not test_packages[p].installed],
+                 env={'DEBIAN_FRONTEND': 'noninteractive',
+                      'DEBCONF_NONINTERACTIVE_SEEN': 'true'})
+        ])
+
 
     def test_invalid_package_requested(self):
         with self.assertRaises(EnvironmentError) as raised:

--- a/snapcraft/tests/test_repo.py
+++ b/snapcraft/tests/test_repo.py
@@ -307,9 +307,8 @@ class BuildPackagesTestCase(tests.TestCase):
     @patch('subprocess.check_call')
     def test_install_buid_package_marks_auto_installed_error_is_not_fatal(self, mock_check_call):
         error = snapcraft.repo.subprocess.CalledProcessError(101, "bad-cmd")
-        mock_check_call.side_effect = [None, error]
+        mock_check_call.side_effect = lambda c, env: error if "apt-mark" in c else None
         self.install_test_packages(self.test_packages)
-        self.assertEqual(2, mock_check_call.call_count)
 
     def test_invalid_package_requested(self):
         with self.assertRaises(EnvironmentError) as raised:

--- a/snapcraft/tests/test_repo.py
+++ b/snapcraft/tests/test_repo.py
@@ -293,8 +293,8 @@ class BuildPackagesTestCase(tests.TestCase):
 
         installable = self.get_installable_packages(self.test_packages)
         mock_check_call.assert_has_calls([
-            call("sudo apt-get -o Dpkg::Progress-Fancy=1 "
-                 "--no-install-recommends -y install".split() +
+            call('sudo apt-get -o Dpkg::Progress-Fancy=1 '
+                 '--no-install-recommends -y install'.split() +
                  sorted(set(installable)),
                  env={'DEBIAN_FRONTEND': 'noninteractive',
                       'DEBCONF_NONINTERACTIVE_SEEN': 'true'})
@@ -306,7 +306,7 @@ class BuildPackagesTestCase(tests.TestCase):
 
         installable = self.get_installable_packages(self.test_packages)
         mock_check_call.assert_has_calls([
-            call("sudo apt-mark auto".split() +
+            call('sudo apt-mark auto'.split() +
                  sorted(set(installable)),
                  env={'DEBIAN_FRONTEND': 'noninteractive',
                       'DEBCONF_NONINTERACTIVE_SEEN': 'true'})
@@ -314,9 +314,9 @@ class BuildPackagesTestCase(tests.TestCase):
 
     @patch('subprocess.check_call')
     def test_mark_installed_auto_error_is_not_fatal(self, mock_check_call):
-        error = snapcraft.repo.subprocess.CalledProcessError(101, "bad-cmd")
+        error = snapcraft.repo.subprocess.CalledProcessError(101, 'bad-cmd')
         mock_check_call.side_effect = \
-            lambda c, env: error if "apt-mark" in c else None
+            lambda c, env: error if 'apt-mark' in c else None
         self.install_test_packages(self.test_packages)
 
     def test_invalid_package_requested(self):


### PR DESCRIPTION
This allows to clean them up by just running `apt-get autoremove` once the snapcrafting is done, but in any case it's not breaking anything as it only applies to packages that were not previously installed.

A simpler solution for https://bugs.launchpad.net/snapcraft/+bug/1640143