### PR TITLE
indicators: work with Content-Encoding set

### DIFF
--- a/integration_tests/snaps/compressed-content-encoding/snapcraft.yaml
+++ b/integration_tests/snaps/compressed-content-encoding/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: compressed-content-encoding
+version: '0.93.1'
+summary: Test downloading files with Content-Encoding gzip
+description: |
+  Make sure files served with Content-Encoding do not blow up.
+  LP: #1611776
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+parts:
+  shutter:
+    plugin: dump
+    source: http://shutter-project.org/wp-content/uploads/releases/tars/shutter-$SNAPCRAFT_PROJECT_VERSION.tar.gz

--- a/integration_tests/snaps/compressed-content-encoding/snapcraft.yaml
+++ b/integration_tests/snaps/compressed-content-encoding/snapcraft.yaml
@@ -5,8 +5,8 @@ description: |
   Make sure files served with Content-Encoding do not blow up.
   LP: #1611776
 
-grade: devel # must be 'stable' to release into candidate/stable channels
-confinement: devmode # use 'strict' once you have the right plugs and slots
+grade: devel
+confinement: devmode
 
 parts:
   shutter:

--- a/integration_tests/test_dump_plugin.py
+++ b/integration_tests/test_dump_plugin.py
@@ -58,3 +58,8 @@ class DumpPluginTestCase(integration_tests.TestCase):
         # Regression test for
         # https://bugs.launchpad.net/snapcraft/+bug/1500728
         self.run_snapcraft('pull', project_dir)
+
+    def test_download_file_with_content_encoding_set(self):
+        """Download a file with Content-Encoding: gzip LP: #1611776"""
+        project_dir = 'compressed-content-encoding'
+        self.run_snapcraft('pull', project_dir)

--- a/snapcraft/internal/indicators.py
+++ b/snapcraft/internal/indicators.py
@@ -30,7 +30,12 @@ def download_requests_stream(request_stream, destination, message=None):
     if not message:
         message = 'Downloading {!r}'.format(os.path.basename(destination))
 
-    total_length = int(request_stream.headers.get('Content-Length', '0'))
+    # Doing len(request_stream.content) may defeat the purpose of a
+    # progress bar
+    total_length = 0
+    if not request_stream.headers.get('Content-Encoding', ''):
+        total_length = int(request_stream.headers.get('Content-Length', '0'))
+
     if total_length:
         progress_bar = ProgressBar(
             widgets=[message,


### PR DESCRIPTION
If Content-Encoding is set to a compressed stream we
currently crash badly, this handles it correctly.

LP: #1611776
Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>