### PR TITLE
Revert "Allow for architecture-specific packages (#876)"

### DIFF
--- a/docs/snapcraft-syntax.md
+++ b/docs/snapcraft-syntax.md
@@ -79,11 +79,9 @@ contain.
       be staged before the dependent part starts its lifecycle.*
     * `stage-packages` (list of strings)
       A list of Ubuntu packages to use that would support the part creation.
-      To restrict to a specific architecture, use `pkg:arch`.
     * `build-packages` (list of strings)
       A list of Ubuntu packages to be installed on the host to aid in building
       the part. These packages will not go into the final snap.
-      To restrict to a specific architecture, use `pkg:arch`.
     * `filesets` (yaml subsection)
       A dictionary with filesets, the key being a recognizable user defined
       string and its value a list of strings of files to be included or

--- a/snapcraft/internal/repo.py
+++ b/snapcraft/internal/repo.py
@@ -245,18 +245,8 @@ class Ubuntu:
 
     def _get(self, apt_cache, package_names):
         manifest_dep_names = self._manifest_dep_names(apt_cache)
-        deb_arch = snapcraft.ProjectOptions().deb_arch
 
         for name in package_names:
-            fields = name.split(":", 2)
-            name = fields[0]
-
-            # Skip if the architecture doesn't match deb_arch
-            if len(fields) == 2 and fields[1] != deb_arch:
-                logger.debug('Skipping {!r} based on architecture filter'
-                             .format(name))
-                continue
-
             try:
                 logger.debug('Marking {!r} as to install'.format(name))
                 apt_cache[name].mark_install()

--- a/snapcraft/tests/test_repo.py
+++ b/snapcraft/tests/test_repo.py
@@ -41,8 +41,7 @@ class UbuntuTestCase(tests.TestCase):
         project_options = snapcraft.ProjectOptions(
             use_geoip=False)
         ubuntu = repo.Ubuntu(self.tempdir, project_options=project_options)
-        ubuntu.get(['fake-package', 'fake-package-arch1:test',
-                    'fake-package-arch2:%s' % project_options.deb_arch])
+        ubuntu.get(['fake-package'])
 
         mock_apt.assert_has_calls([
             call.apt_pkg.config.set('Dir::Cache::Archives',
@@ -65,14 +64,7 @@ class UbuntuTestCase(tests.TestCase):
 
         # __getitem__ is tricky
         self.assertIn(
-            call('fake-package'),
-            mock_apt.Cache().__getitem__.call_args_list)
-        self.assertNotIn(
-            call('fake-package-arch1'),
-            mock_apt.Cache().__getitem__.call_args_list)
-        self.assertIn(
-            call('fake-package-arch2'),
-            mock_apt.Cache().__getitem__.call_args_list)
+            call('fake-package'), mock_apt.Cache().__getitem__.call_args_list)
 
     @patch('snapcraft.repo._get_geoip_country_code_prefix')
     def test_sources_is_none_uses_default(self, mock_cc):


### PR DESCRIPTION
This reverts LP: #1637282 as the syntax does not allow us to
do deb multiarch.

This reverts commit 9d6f953a18214a5ed39a6461a2cad07ef01f906f.