### PR TITLE
ftp source support

### DIFF
--- a/debian/tests/snapstests
+++ b/debian/tests/snapstests
@@ -1,6 +1,6 @@
 #!/bin/sh
 snapd_config_dir=/etc/systemd/system/snapd.service.d
 sudo mkdir -p $snapd_config_dir
-echo "[Service]\nEnvironment='http_proxy=$http_proxy'\nEnvironment='https_proxy=$https_proxy'\nEnvironment='no_proxy=$no_proxy'\n" | sudo tee $snapd_config_dir/snapd.env.conf > /dev/null
+echo "[Service]\nEnvironment='http_proxy=$http_proxy'\nEnvironment='https_proxy=$https_proxy'\nEnvironment='ftp_proxy=$http_proxy'\nEnvironment='no_proxy=$no_proxy'\n" | sudo tee $snapd_config_dir/snapd.env.conf > /dev/null
 sudo systemctl daemon-reload
 SNAPCRAFT_FROM_INSTALLED=1 python3 -m snaps_tests --ip localhost

--- a/integration_tests/snaps/ftp-source/snapcraft.yaml
+++ b/integration_tests/snaps/ftp-source/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: ftp-source
+version: 3.20.1
+summary: Test downloading files from ftp source
+description: |
+  Make sure sources can be fetched from FTP servers.
+  LP: #1602323
+
+grade: devel
+confinement: devmode
+
+parts:
+  libwnck:
+    plugin: dump
+    source: ftp://ftp.gnome.org/pub/GNOME/sources/libwnck/3.20/libwnck-$SNAPCRAFT_PROJECT_VERSION.tar.xz

--- a/integration_tests/test_dump_plugin.py
+++ b/integration_tests/test_dump_plugin.py
@@ -63,3 +63,8 @@ class DumpPluginTestCase(integration_tests.TestCase):
         """Download a file with Content-Encoding: gzip LP: #1611776"""
         project_dir = 'compressed-content-encoding'
         self.run_snapcraft('pull', project_dir)
+
+    def test_download_file_from_ftp_source(self):
+        """Download a file from a FTP source, LP: #1602323"""
+        project_dir = 'ftp-source'
+        self.run_snapcraft('pull', project_dir)

--- a/integration_tests/test_dump_plugin.py
+++ b/integration_tests/test_dump_plugin.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import fixtures
 
 from testtools.matchers import (
     DirExists,
@@ -66,5 +67,11 @@ class DumpPluginTestCase(integration_tests.TestCase):
 
     def test_download_file_from_ftp_source(self):
         """Download a file from a FTP source, LP: #1602323"""
+
+        # This is needed since autopkgtest doesn't properly set it
+        if not os.getenv('ftp_proxy', None):
+            self.useFixture(fixtures.EnvironmentVariable(
+                'ftp_proxy', os.getenv('http_proxy', '')))
+
         project_dir = 'ftp-source'
         self.run_snapcraft('pull', project_dir)

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -154,8 +154,12 @@ def get_python2_path(root):
             'PYTHONPATH cannot be set for {!r}'.format(root))
 
 
+def get_url_scheme(url):
+    return urllib.parse.urlparse(url).scheme
+
+
 def isurl(url):
-    return urllib.parse.urlparse(url).scheme != ''
+    return get_url_scheme(url) != ''
 
 
 def reset_env():

--- a/snapcraft/internal/indicators.py
+++ b/snapcraft/internal/indicators.py
@@ -17,7 +17,7 @@
 import os
 import sys
 
-from urllib.request import FancyURLopener
+from urllib.request import urlretrieve
 from progressbar import (
     AnimatedMarker,
     Bar,
@@ -85,7 +85,7 @@ def download_urllib_source(uri, destination, message=None):
             min(total_read, total_length) if total_length > 0 else total_read)
 
     progress_bar = None
-    FancyURLopener().retrieve(
+    urlretrieve(
         uri, destination, lambda n, s, l: progress_cb(progress_bar, n, s, l))
 
     if progress_bar:

--- a/snapcraft/internal/indicators.py
+++ b/snapcraft/internal/indicators.py
@@ -17,6 +17,7 @@
 import os
 import sys
 
+from urllib.request import FancyURLopener
 from progressbar import (
     AnimatedMarker,
     Bar,
@@ -26,10 +27,32 @@ from progressbar import (
 )
 
 
-def download_requests_stream(request_stream, destination, message=None):
-    """This is a facility to download a request with nice progress bars."""
+def _init_progress_bar(total_length, destination, message=None):
     if not message:
         message = 'Downloading {!r}'.format(os.path.basename(destination))
+
+    valid_length = total_length and total_length > 0
+
+    if valid_length and is_dumb_terminal():
+        widgets = [message, ' ', Percentage()]
+        maxval = total_length
+    elif valid_length and not is_dumb_terminal():
+        widgets = [message,
+                   Bar(marker='=', left='[', right=']'),
+                   ' ', Percentage()]
+        maxval = total_length
+    elif not valid_length and is_dumb_terminal():
+        widgets = [message]
+        maxval = UnknownLength
+    else:
+        widgets = [message, AnimatedMarker()]
+        maxval = UnknownLength
+
+    return ProgressBar(widgets=widgets, maxval=maxval)
+
+
+def download_requests_stream(request_stream, destination, message=None):
+    """This is a facility to download a request with nice progress bars."""
 
     # Doing len(request_stream.content) may defeat the purpose of a
     # progress bar
@@ -37,24 +60,8 @@ def download_requests_stream(request_stream, destination, message=None):
     if not request_stream.headers.get('Content-Encoding', ''):
         total_length = int(request_stream.headers.get('Content-Length', '0'))
 
-    if total_length and is_dumb_terminal():
-        widgets = [message, ' ', Percentage()]
-        maxval = total_length
-    elif total_length and not is_dumb_terminal():
-        widgets = [message,
-                   Bar(marker='=', left='[', right=']'),
-                   ' ', Percentage()]
-        maxval = total_length
-    elif not total_length and is_dumb_terminal():
-        widgets = [message]
-        maxval = UnknownLength
-    else:
-        widgets = [message, AnimatedMarker()]
-        maxval = UnknownLength
-
-    progress_bar = ProgressBar(widgets=widgets, maxval=maxval)
-
     total_read = 0
+    progress_bar = _init_progress_bar(total_length, destination, message)
     progress_bar.start()
     with open(destination, 'wb') as destination_file:
         for buf in request_stream.iter_content(1024):
@@ -62,6 +69,23 @@ def download_requests_stream(request_stream, destination, message=None):
             total_read += len(buf)
             progress_bar.update(total_read)
     progress_bar.finish()
+
+
+def download_urllib_source(uri, destination, message=None):
+    """This is a facility to download an uri with nice progress bars."""
+
+    def reporthook(block_num, block_size, total_length):
+        if not hasattr(reporthook, "progress_bar"):
+            reporthook.progress_bar = _init_progress_bar(
+                total_length, destination, message)
+            reporthook.progress_bar.start()
+
+        total_read = block_num * block_size
+        reporthook.progress_bar.update(
+            total_length if total_read > total_length else total_read)
+
+    FancyURLopener().retrieve(uri, destination, reporthook)
+    reporthook.progress_bar.finish()
 
 
 def is_dumb_terminal():

--- a/snapcraft/internal/indicators.py
+++ b/snapcraft/internal/indicators.py
@@ -82,7 +82,7 @@ def download_urllib_source(uri, destination, message=None):
 
         total_read = block_num * block_size
         reporthook.progress_bar.update(
-            total_length if total_read > total_length else total_read)
+            min(total_read, total_length) if total_length > 0 else total_read)
 
     FancyURLopener().retrieve(uri, destination, reporthook)
     if hasattr(reporthook, "progress_bar"):

--- a/snapcraft/internal/indicators.py
+++ b/snapcraft/internal/indicators.py
@@ -85,7 +85,8 @@ def download_urllib_source(uri, destination, message=None):
             total_length if total_read > total_length else total_read)
 
     FancyURLopener().retrieve(uri, destination, reporthook)
-    reporthook.progress_bar.finish()
+    if hasattr(reporthook, "progress_bar"):
+        reporthook.progress_bar.finish()
 
 
 def is_dumb_terminal():

--- a/snapcraft/internal/indicators.py
+++ b/snapcraft/internal/indicators.py
@@ -97,4 +97,3 @@ def is_dumb_terminal():
     is_stdout_tty = os.isatty(sys.stdout.fileno())
     is_term_dumb = os.environ.get('TERM', '') == 'dumb'
     return not is_stdout_tty or is_term_dumb
-

--- a/snapcraft/internal/indicators.py
+++ b/snapcraft/internal/indicators.py
@@ -71,25 +71,34 @@ def download_requests_stream(request_stream, destination, message=None):
     progress_bar.finish()
 
 
-def download_urllib_source(uri, destination, message=None):
+class UrllibDownloader(object):
     """This is a facility to download an uri with nice progress bars."""
 
-    def progress_cb(progress_bar, block_num, block_size, total_length):
-        if not progress_bar:
-            progress_bar = _init_progress_bar(
-                total_length, destination, message)
-            progress_bar.start()
+    def __init__(self, uri, destination, message=None):
+        self.uri = uri
+        self.destination = destination
+        self.message = message
+        self.progress_bar = None
+
+    def download(self):
+        urlretrieve(self.uri, self.destination, self._progress_callback)
+
+        if self.progress_bar:
+            self.progress_bar.finish()
+
+    def _progress_callback(self, block_num, block_size, total_length):
+        if not self.progress_bar:
+            self.progress_bar = _init_progress_bar(
+                total_length, self.destination, self.message)
+            self.progress_bar.start()
 
         total_read = block_num * block_size
-        progress_bar.update(
+        self.progress_bar.update(
             min(total_read, total_length) if total_length > 0 else total_read)
 
-    progress_bar = None
-    urlretrieve(
-        uri, destination, lambda n, s, l: progress_cb(progress_bar, n, s, l))
 
-    if progress_bar:
-        progress_bar.finish()
+def download_urllib_source(uri, destination, message=None):
+    UrllibDownloader(uri, destination, message).download()
 
 
 def is_dumb_terminal():

--- a/snapcraft/internal/sources.py
+++ b/snapcraft/internal/sources.py
@@ -87,7 +87,10 @@ import libarchive
 
 from snapcraft.internal import common
 from snapcraft import file_utils
-from snapcraft.internal.indicators import download_requests_stream
+from snapcraft.internal.indicators import (
+    download_requests_stream,
+    download_urllib_source
+)
 
 
 logging.getLogger('urllib3').setLevel(logging.CRITICAL)
@@ -140,12 +143,17 @@ class FileBase(Base):
         self.provision(self.source_dir)
 
     def download(self):
-        request = requests.get(self.source, stream=True, allow_redirects=True)
-        request.raise_for_status()
-
         self.file = os.path.join(
-            self.source_dir, os.path.basename(self.source))
-        download_requests_stream(request, self.file)
+                self.source_dir, os.path.basename(self.source))
+
+        if common.get_url_scheme(self.source) == 'ftp':
+            download_urllib_source(self.source, self.file)
+        else:
+            request = requests.get(
+                self.source, stream=True, allow_redirects=True)
+            request.raise_for_status()
+
+            download_requests_stream(request, self.file)
 
 
 class Script(FileBase):

--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -38,6 +38,17 @@ class BaseHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
         logger.debug(args)
 
 
+class FakeFileHTTPRequestHandler(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        data = 'Test fake compressed file'
+        self.send_response(200)
+        self.send_header('Content-Length', len(data))
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+        self.wfile.write(data.encode())
+
+
 class FakePartsServer(http.server.HTTPServer):
 
     def __init__(self, server_address):

--- a/snapcraft/tests/test_indicators.py
+++ b/snapcraft/tests/test_indicators.py
@@ -14,13 +14,38 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import fixtures
 import os
 import progressbar
 import requests
-from unittest.mock import patch
 
 from snapcraft import tests
 from snapcraft.internal import indicators
+from unittest.mock import patch
+
+
+class DumbTerminalTests(tests.TestCase):
+
+    @patch('os.isatty')
+    def setUp(self, mock_os_isatty):
+        super().setUp()
+        self.mock_os_isatty = mock_os_isatty
+        self.mock_os_isatty.return_value = True
+
+    def test_tty_terminal(self):
+        self.assertTrue(indicators.is_dumb_terminal())
+
+    def test_not_a_tty_terminal(self):
+        self.mock_os_isatty.return_value = False
+        self.assertFalse(indicators.is_dumb_terminal())
+
+    def test_dumb_terminal_environment(self):
+        self.useFixture(fixtures.EnvironmentVariable('TERM', 'dumb'))
+        self.assertTrue(indicators.is_dumb_terminal())
+
+    def test_vt100_terminal_environmment(self):
+        self.useFixture(fixtures.EnvironmentVariable('TERM', 'vt100'))
+        self.assertFalse(indicators.is_dumb_terminal())
 
 
 class ProgressBarInitializationTests(tests.TestCase):

--- a/snapcraft/tests/test_indicators.py
+++ b/snapcraft/tests/test_indicators.py
@@ -51,34 +51,32 @@ class DumbTerminalTests(tests.TestCase):
 class ProgressBarInitializationTests(tests.TestCase):
 
     scenarios = [
-        ('Terminal', dict(dumb=True)),
-        ('Dumb Terminal', dict(dumb=False)),
+        ('Terminal', {'dumb': True}),
+        ('Dumb Terminal', {'dumb': False}),
     ]
 
     @patch('snapcraft.internal.indicators.is_dumb_terminal')
-    def setUp(self, mock_is_dumb_terminal):
-        super().setUp()
+    def test_init_progress_bar_with_length(self, mock_is_dumb_terminal):
         mock_is_dumb_terminal.return_value = self.dumb
-
-    def test_init_progress_bar_with_length(self):
         pb = indicators._init_progress_bar(10, "destination", "message")
         self.assertEqual(pb.maxval, 10)
         self.assertTrue("message" in pb.widgets)
         pb_widgets_types = [type(w) for w in pb.widgets]
-        self.assertTrue(type(progressbar.Bar()) in pb_widgets_types)
+        self.assertTrue(type(progressbar.Percentage()) in pb_widgets_types)
+        self.assertEqual(
+            type(progressbar.Bar()) in pb_widgets_types, not self.dumb)
 
-        if not self.dumb:
-            self.assertTrue(type(progressbar.Percentage()) in pb_widgets_types)
-
-    def test_init_progress_bar_with_unknown_length(self):
+    @patch('snapcraft.internal.indicators.is_dumb_terminal')
+    def test_init_progress_bar_with_unknown_length(
+            self, mock_is_dumb_terminal):
+        mock_is_dumb_terminal.return_value = self.dumb
         pb = indicators._init_progress_bar(0, "destination", "message")
         self.assertEqual(pb.maxval, progressbar.UnknownLength)
         self.assertTrue("message" in pb.widgets)
         pb_widgets_types = [type(w) for w in pb.widgets]
-
-        if not self.dumb:
-            self.assertTrue(
-                type(progressbar.AnimatedMarker()) in pb_widgets_types)
+        self.assertEqual(
+            type(progressbar.AnimatedMarker()) in pb_widgets_types,
+            not self.dumb)
 
 
 class IndicatorsDownloadTests(tests.FakeFileHTTPServerBasedTestCase):

--- a/snapcraft/tests/test_indicators.py
+++ b/snapcraft/tests/test_indicators.py
@@ -1,0 +1,65 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import progressbar
+import requests
+# import unittest.mock
+
+from snapcraft import tests
+from snapcraft.internal import indicators
+
+
+class IndicatorsTests(tests.TestCase):
+
+    def test_init_progress_bar_with_length(self):
+        pb = indicators._init_progress_bar(10, "destination", "message")
+        self.assertEqual(pb.maxval, 10)
+        self.assertTrue("message" in pb.widgets)
+        pb_widgets_types = [type(w) for w in pb.widgets]
+        self.assertTrue(type(progressbar.Bar()) in pb_widgets_types)
+        self.assertTrue(type(progressbar.Percentage()) in pb_widgets_types)
+
+    def test_init_progress_bar_with_unknown_length(self):
+        pb = indicators._init_progress_bar(0, "destination", "message")
+        self.assertEqual(pb.maxval, progressbar.UnknownLength)
+        self.assertTrue("message" in pb.widgets)
+        pb_widgets_types = [type(w) for w in pb.widgets]
+        self.assertTrue(type(progressbar.AnimatedMarker()) in pb_widgets_types)
+
+
+class IndicatorsDownloadTests(tests.FakeFileHTTPServerBasedTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        dest_dir = 'dst'
+        os.makedirs(dest_dir)
+        self.file_name = 'snapcraft.yaml'
+        self.dest_file = os.path.join(dest_dir, self.file_name)
+        self.source = 'http://{}:{}/{file_name}'.format(
+            *self.server.server_address, file_name=self.file_name)
+
+    def test_download_request_stream(self):
+        request = requests.get(self.source, stream=True, allow_redirects=True)
+        indicators.download_requests_stream(request, self.dest_file)
+
+        self.assertTrue(os.path.exists(self.dest_file))
+
+    def test_download_urllib_source(self):
+        indicators.download_urllib_source(self.source, self.dest_file)
+
+        self.assertTrue(os.path.exists(self.dest_file))

--- a/snapcraft/tests/test_sources.py
+++ b/snapcraft/tests/test_sources.py
@@ -90,18 +90,16 @@ class TestFileBase(tests.TestCase):
 
         mock_download.assert_called_once_with(file_src.source, file_src.file)
 
-    @unittest.mock.patch('snapcraft.internal.indicators.FancyURLopener')
-    def test_download_ftp_url_opener(self, mock_url_opener):
+    @unittest.mock.patch('snapcraft.internal.indicators.urlretrieve')
+    def test_download_ftp_url_opener(self, mock_urlretrieve):
         file_src = self.get_mock_file_base(
             'ftp://snapcraft.io/snapcraft.yaml', 'dir')
 
         file_src.pull()
 
-        self.assertEqual(mock_url_opener().retrieve.call_count, 1)
-        self.assertEqual(
-            mock_url_opener().retrieve.call_args[0][0], file_src.source)
-        self.assertEqual(
-            mock_url_opener().retrieve.call_args[0][1], file_src.file)
+        self.assertEqual(mock_urlretrieve.call_count, 1)
+        self.assertEqual(mock_urlretrieve.call_args[0][0], file_src.source)
+        self.assertEqual(mock_urlretrieve.call_args[0][1], file_src.file)
 
 
 class TestTar(tests.FakeFileHTTPServerBasedTestCase):

--- a/snapcraft/tests/test_sources.py
+++ b/snapcraft/tests/test_sources.py
@@ -71,7 +71,8 @@ class TestFileBase(tests.TestCase):
 
     @unittest.mock.patch('snapcraft.internal.sources.requests')
     @unittest.mock.patch('snapcraft.internal.sources.download_requests_stream')
-    def test_download_file_destination(self, drs, req):
+    @unittest.mock.patch('snapcraft.internal.sources.download_urllib_source')
+    def test_download_file_destination(self, dus, drs, req):
         file_src = self.get_mock_file_base(
             'http://snapcraft.io/snapcraft.yaml', 'dir')
         self.assertFalse(hasattr(file_src, "file"))
@@ -96,6 +97,16 @@ class TestFileBase(tests.TestCase):
             file_src.source, stream=True, allow_redirects=True)
         mock_request.raise_for_status.assert_called_once_with()
         mock_download.assert_called_once_with(mock_request, file_src.file)
+
+    @unittest.mock.patch('snapcraft.internal.sources.download_urllib_source')
+    @unittest.mock.patch('snapcraft.internal.sources.requests')
+    def test_download_ftp(self, mock_requests, mock_download):
+        file_src = self.get_mock_file_base(
+            'ftp://snapcraft.io/snapcraft.yaml', 'dir')
+
+        file_src.pull()
+
+        mock_download.assert_called_once_with(file_src.source, file_src.file)
 
 
 class TestTar(tests.TestCase):

--- a/snapcraft/tests/test_sources.py
+++ b/snapcraft/tests/test_sources.py
@@ -16,10 +16,8 @@
 
 import copy
 import os
-import http.server
 import shutil
 import tarfile
-import threading
 import unittest.mock
 
 import fixtures
@@ -106,23 +104,7 @@ class TestFileBase(tests.TestCase):
             mock_url_opener().retrieve.call_args[0][1], file_src.file)
 
 
-class FakeFileHttpServerBasedTestCase(tests.TestCase):
-
-    def setUp(self):
-        super().setUp()
-
-        self.useFixture(fixtures.EnvironmentVariable(
-            'no_proxy', 'localhost,127.0.0.1'))
-        self.server = http.server.HTTPServer(
-            ('127.0.0.1', 0), tests.fake_servers.FakeFileHTTPRequestHandler)
-        server_thread = threading.Thread(target=self.server.serve_forever)
-        self.addCleanup(server_thread.join)
-        self.addCleanup(self.server.server_close)
-        self.addCleanup(self.server.shutdown)
-        server_thread.start()
-
-
-class TestTar(FakeFileHttpServerBasedTestCase):
+class TestTar(tests.FakeFileHTTPServerBasedTestCase):
 
     scenarios = [
         ('TERM=dumb', dict(term='dumb')),
@@ -227,7 +209,7 @@ class TestTar(FakeFileHttpServerBasedTestCase):
         self.assertTrue(os.path.exists(os.path.join('dst', 'link.txt')))
 
 
-class TestZip(FakeFileHttpServerBasedTestCase):
+class TestZip(tests.FakeFileHTTPServerBasedTestCase):
 
     @unittest.mock.patch('zipfile.ZipFile')
     def test_pull_zipfile_must_download_and_extract(self, mock_zip):
@@ -261,7 +243,7 @@ class TestZip(FakeFileHttpServerBasedTestCase):
             self.assertEqual('Test fake compressed file', zip_file.read())
 
 
-class TestDeb(FakeFileHttpServerBasedTestCase):
+class TestDeb(tests.FakeFileHTTPServerBasedTestCase):
 
     def setUp(self):
         super().setUp()

--- a/snapcraft/tests/test_sources.py
+++ b/snapcraft/tests/test_sources.py
@@ -99,14 +99,26 @@ class TestFileBase(tests.TestCase):
         mock_download.assert_called_once_with(mock_request, file_src.file)
 
     @unittest.mock.patch('snapcraft.internal.sources.download_urllib_source')
-    @unittest.mock.patch('snapcraft.internal.sources.requests')
-    def test_download_ftp(self, mock_requests, mock_download):
+    def test_download_ftp(self, mock_download):
         file_src = self.get_mock_file_base(
             'ftp://snapcraft.io/snapcraft.yaml', 'dir')
 
         file_src.pull()
 
         mock_download.assert_called_once_with(file_src.source, file_src.file)
+
+    @unittest.mock.patch('snapcraft.internal.indicators.FancyURLopener')
+    def test_download_ftp(self, mock_url_opener):
+        file_src = self.get_mock_file_base(
+            'ftp://snapcraft.io/snapcraft.yaml', 'dir')
+
+        file_src.pull()
+
+        self.assertEqual(mock_url_opener().retrieve.call_count, 1)
+        self.assertEqual(mock_url_opener().retrieve.call_args[0][0],
+            file_src.source)
+        self.assertEqual(mock_url_opener().retrieve.call_args[0][1],
+            file_src.file)
 
 
 class TestTar(tests.TestCase):

--- a/snapcraft/tests/test_sources.py
+++ b/snapcraft/tests/test_sources.py
@@ -108,17 +108,17 @@ class TestFileBase(tests.TestCase):
         mock_download.assert_called_once_with(file_src.source, file_src.file)
 
     @unittest.mock.patch('snapcraft.internal.indicators.FancyURLopener')
-    def test_download_ftp(self, mock_url_opener):
+    def test_download_ftp_url_opener(self, mock_url_opener):
         file_src = self.get_mock_file_base(
             'ftp://snapcraft.io/snapcraft.yaml', 'dir')
 
         file_src.pull()
 
         self.assertEqual(mock_url_opener().retrieve.call_count, 1)
-        self.assertEqual(mock_url_opener().retrieve.call_args[0][0],
-            file_src.source)
-        self.assertEqual(mock_url_opener().retrieve.call_args[0][1],
-            file_src.file)
+        self.assertEqual(
+            mock_url_opener().retrieve.call_args[0][0], file_src.source)
+        self.assertEqual(
+            mock_url_opener().retrieve.call_args[0][1], file_src.file)
 
 
 class TestTar(tests.TestCase):


### PR DESCRIPTION
As requested on bug https://bugs.launchpad.net/snappy/+bug/1602323

This adds support for FTP sources, using urllib was the quickest choice, and with some refactor of the indicator module, adding a progressbar was possible too. If using ftplib or others is preferred let me know, but I went for the fastest and safer way.

In theory this path could be used also for http(s) downloads, but not to change what we've done so far, I've left that job to the nicer `requests` library. `requests` being an HTTP only library has no native suppot for this, while trying to use something like [requests-ftp](https://pypi.python.org/pypi/requests-ftp) I don't think is a choice (looking quite immature).

