### PR TITLE
Snap revision prune

### DIFF
--- a/integration_tests/snaps/compressed-content-encoding/snapcraft.yaml
+++ b/integration_tests/snaps/compressed-content-encoding/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: compressed-content-encoding
+version: '0.93.1'
+summary: Test downloading files with Content-Encoding gzip
+description: |
+  Make sure files served with Content-Encoding do not blow up.
+  LP: #1611776
+
+grade: devel
+confinement: devmode
+
+parts:
+  shutter:
+    plugin: dump
+    source: http://shutter-project.org/wp-content/uploads/releases/tars/shutter-$SNAPCRAFT_PROJECT_VERSION.tar.gz

--- a/integration_tests/test_dump_plugin.py
+++ b/integration_tests/test_dump_plugin.py
@@ -58,3 +58,8 @@ class DumpPluginTestCase(integration_tests.TestCase):
         # Regression test for
         # https://bugs.launchpad.net/snapcraft/+bug/1500728
         self.run_snapcraft('pull', project_dir)
+
+    def test_download_file_with_content_encoding_set(self):
+        """Download a file with Content-Encoding: gzip LP: #1611776"""
+        project_dir = 'compressed-content-encoding'
+        self.run_snapcraft('pull', project_dir)

--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -400,6 +400,7 @@ def push(snap_filename, release_channels=None):
     if os.environ.get('DELTA_UPLOADS_EXPERIMENTAL'):
         snap_cache = cache.SnapCache()
         snap_cache.cache(snap_filename, result['revision'])
+        snap_cache.prune(result['revision'])
 
     if release_channels:
         release(snap_name, result['revision'], release_channels)
@@ -546,6 +547,14 @@ def history(snap_name, series, arch):
         headers=['Rev.', 'Uploaded', 'Arch', 'Version', 'Channels'],
         tablefmt='plain')
     print(tabulated_revisions)
+
+
+def latest_rev(snap_name, series=None, arch=None):
+    store = storeapi.StoreClient()
+
+    with _requires_login():
+        history = store.get_snap_history(snap_name, series, arch)
+    return history[-1]
 
 
 def gated(snap_name):

--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -30,7 +30,10 @@ from tabulate import tabulate
 import yaml
 
 from snapcraft import storeapi
-from snapcraft.internal import repo
+from snapcraft.internal import (
+    cache,
+    repo,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -393,6 +396,10 @@ def push(snap_filename, release_channels=None):
     else:
         logger.info('Uploaded {!r}'.format(snap_name))
     tracker.raise_for_code()
+
+    if os.environ.get('DELTA_UPLOADS_EXPERIMENTAL'):
+        snap_cache = cache.SnapCache()
+        snap_cache.cache(snap_filename, result['revision'])
 
     if release_channels:
         release(snap_name, result['revision'], release_channels)

--- a/snapcraft/internal/cache.py
+++ b/snapcraft/internal/cache.py
@@ -1,0 +1,135 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+import shutil
+
+from xdg import BaseDirectory
+
+import snapcraft
+
+
+logger = logging.getLogger(__name__)
+
+
+class SnapcraftCache:
+    """Generic cache base class.
+
+    This class is responsible for cache location, notification and pruning.
+    """
+    def __init__(self):
+        self.cache_root = os.path.join(
+            BaseDirectory.xdg_cache_home, 'snapcraft')
+
+    def cache(self):
+        raise NotImplementedError
+
+    def prune(self):
+        raise NotImplementedError
+
+
+class SnapcraftProjectCache(SnapcraftCache):
+    """Project specific cache"""
+    def __init__(self):
+        super().__init__()
+        self.config = snapcraft.internal.load_config()
+        self.project_cache_root = os.path.join(
+            self.cache_root, snapcraft.internal.load_config().data['name'])
+
+
+class SnapCache(SnapcraftProjectCache):
+    """Cache for snap revisions."""
+    def __init__(self):
+        super().__init__()
+        self.snap_cache_dir = self._setup_snap_cache()
+
+    def _setup_snap_cache(self):
+        snap_cache_path = os.path.join(self.project_cache_root, 'revisions')
+        os.makedirs(snap_cache_path, exist_ok=True)
+        return snap_cache_path
+
+    def cache(self, snap_filename, revision):
+        """Cache snap revision in XDG cache.
+
+        :returns: path to cached revision.
+        """
+        cached_snap = rewrite_snap_filename_with_revision(
+            snap_filename,
+            revision)
+        cached_snap_path = os.path.join(self.snap_cache_dir, cached_snap)
+        try:
+            shutil.copyfile(snap_filename, cached_snap_path)
+        except OSError:
+            logger.warning(
+                'Unable to cache snap {}.'.format(cached_snap))
+        return cached_snap_path
+
+    def prune(self, revision=None):
+        """Prune the snap revisions beside the head revision in XDG cache."""
+
+        name = self.config.data['name']
+        arch = self.config.data['architectures']
+
+        if revision is None:
+
+            # get the latest history info from store if
+            # revision is not specified
+            latest_history = snapcraft._store.latest_rev(snap_name=name,
+                                                         arch=arch)
+            revision = latest_history['revision']
+
+        for snap_filename in os.listdir(self.snap_cache_dir):
+            cached_snap = os.path.join(self.snap_cache_dir, snap_filename)
+
+            # get the file version from file name
+            rev_from_snap_file = get_revision_from_snap_filename(
+                snap_filename)
+
+            if rev_from_snap_file != revision:
+                try:
+                    os.remove(cached_snap)
+                except OSError:
+                    logger.warning(
+                        'Unable to purge snap {}.'.format(cached_snap))
+
+
+def rewrite_snap_filename_with_revision(snap_file, revision):
+    splitf = os.path.splitext(snap_file)
+    snap_with_revision = '{base}_{rev}{ext}'.format(
+        base=splitf[0],
+        rev=revision,
+        ext=splitf[1])
+    return snap_with_revision
+
+
+def get_revision_from_snap_filename(snap_filename):
+    """parse the filename to extract the revision info"""
+    # the cached snap filename should have the format:
+    # '{name}_{version}_{arch}_{revision}.snap'
+    filename, extname = os.path.splitext(snap_filename)
+    split_name_parts = filename.split('_')
+    if len(split_name_parts) != 4:
+        logger.debug('The cached snap filename {} is invalid.'.format(
+            snap_filename))
+        return None
+
+    try:
+        rev = int(split_name_parts[-1])
+    except ValueError:
+        logger.debug('The cached snap filename has invalid revision.')
+        return None
+    return rev

--- a/snapcraft/internal/cache/__init__.py
+++ b/snapcraft/internal/cache/__init__.py
@@ -14,6 +14,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from snapcraft.internal import cache             # noqa
-from snapcraft.internal import states            # noqa
-from snapcraft.internal.project_loader import load_config  # noqa
+from snapcraft.internal.cache._snap import SnapCache  # noqa

--- a/snapcraft/internal/cache/_cache.py
+++ b/snapcraft/internal/cache/_cache.py
@@ -41,5 +41,6 @@ class SnapcraftProjectCache(SnapcraftCache):
     """Project specific cache"""
     def __init__(self):
         super().__init__()
+        self.config = snapcraft.internal.load_config()
         self.project_cache_root = os.path.join(
             self.cache_root, snapcraft.internal.load_config().data['name'])

--- a/snapcraft/internal/cache/_cache.py
+++ b/snapcraft/internal/cache/_cache.py
@@ -1,0 +1,45 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from xdg import BaseDirectory
+
+import snapcraft
+
+
+class SnapcraftCache:
+    """Generic cache base class.
+
+    This class is responsible for cache location, notification and pruning.
+    """
+    def __init__(self):
+        self.cache_root = os.path.join(
+            BaseDirectory.xdg_cache_home, 'snapcraft')
+
+    def cache(self):
+        raise NotImplementedError
+
+    def prune(self):
+        raise NotImplementedError
+
+
+class SnapcraftProjectCache(SnapcraftCache):
+    """Project specific cache"""
+    def __init__(self):
+        super().__init__()
+        self.project_cache_root = os.path.join(
+            self.cache_root, snapcraft.internal.load_config().data['name'])

--- a/snapcraft/internal/cache/_snap.py
+++ b/snapcraft/internal/cache/_snap.py
@@ -1,0 +1,62 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+import shutil
+
+from snapcraft.internal.cache._cache import SnapcraftProjectCache
+
+
+logger = logging.getLogger(__name__)
+
+
+class SnapCache(SnapcraftProjectCache):
+    """Cache for snap revisions."""
+    def __init__(self):
+        super().__init__()
+
+    def _setup_snap_cache(self):
+        snap_cache_path = os.path.join(self.project_cache_root, 'revisions')
+        os.makedirs(snap_cache_path, exist_ok=True)
+        return snap_cache_path
+
+    def cache(self, snap_filename, revision):
+        """Cache snap revision in XDG cache.
+
+        :returns: path to cached revision.
+        """
+        snap_cache_dir = self._setup_snap_cache()
+
+        cached_snap = _rewrite_snap_filename_with_revision(
+            snap_filename,
+            revision)
+        cached_snap_path = os.path.join(snap_cache_dir, cached_snap)
+        try:
+            shutil.copyfile(snap_filename, cached_snap_path)
+        except OSError:
+            logger.warning(
+                'Unable to cache snap {}.'.format(cached_snap))
+        return cached_snap_path
+
+
+def _rewrite_snap_filename_with_revision(snap_file, revision):
+    splitf = os.path.splitext(snap_file)
+    snap_with_revision = '{base}_{rev}{ext}'.format(
+        base=splitf[0],
+        rev=revision,
+        ext=splitf[1])
+    return snap_with_revision

--- a/snapcraft/internal/indicators.py
+++ b/snapcraft/internal/indicators.py
@@ -30,7 +30,12 @@ def download_requests_stream(request_stream, destination, message=None):
     if not message:
         message = 'Downloading {!r}'.format(os.path.basename(destination))
 
-    total_length = int(request_stream.headers.get('Content-Length', '0'))
+    # Doing len(request_stream.content) may defeat the purpose of a
+    # progress bar
+    total_length = 0
+    if not request_stream.headers.get('Content-Encoding', ''):
+        total_length = int(request_stream.headers.get('Content-Length', '0'))
+
     if total_length:
         progress_bar = ProgressBar(
             widgets=[message,

--- a/snapcraft/storeapi/__init__.py
+++ b/snapcraft/storeapi/__init__.py
@@ -286,6 +286,9 @@ class StoreClient():
     def get_validations(self, snap_id):
         return self.sca.get_validations(snap_id)
 
+    def sign_developer_agreement(self, latest_tos_accepted=False):
+        return self.sca.sign_developer_agreement(latest_tos_accepted)
+
 
 class SSOClient(Client):
     """The Single Sign On server deals with authentication.
@@ -617,6 +620,19 @@ class SCAClient(Client):
                 '{} {}\n{}'.format(response.status_code, response.reason,
                                    response.content))
             raise errors.StoreChannelClosingError(response)
+
+    def sign_developer_agreement(self, latest_tos_accepted=False):
+        auth = _macaroon_auth(self.conf)
+        data = {'latest_tos_accepted': latest_tos_accepted}
+        response = self.post(
+            'agreement/', data=json.dumps(data),
+            headers={'Authorization': auth,
+                     'Content-Type': 'application/json',
+                     'Accept': 'application/json'})
+
+        if not response.ok:
+            raise errors.DeveloperAgreementSignError(response)
+        return response.json()
 
 
 class StatusTracker:

--- a/snapcraft/storeapi/constants.py
+++ b/snapcraft/storeapi/constants.py
@@ -25,3 +25,29 @@ UBUNTU_SSO_API_ROOT_URL = 'https://login.ubuntu.com/api/v2/'
 UBUNTU_STORE_API_ROOT_URL = 'https://myapps.developer.ubuntu.com/dev/api/'
 UBUNTU_STORE_SEARCH_ROOT_URL = 'https://search.apps.ubuntu.com/'
 UBUNTU_STORE_UPLOAD_ROOT_URL = 'https://upload.apps.ubuntu.com/'
+UBUNTU_STORE_TOS_URL = 'https://myapps.developer.ubuntu.com/dev/tos/'
+UBUNTU_STORE_ACCOUNT_URL = 'https://myapps.developer.ubuntu.com/dev/account/'
+
+# Messages and warnings.
+MISSING_AGREEMENT = 'Developer has not signed agreement.'
+MISSING_NAMESPACE = 'Developer profile is missing short namespace.'
+AGREEMENT_ERROR = (
+    'You must agree to the developer terms and conditions to upload snaps.')
+NAMESPACE_ERROR = (
+    'You need to set a username. It will appear in the developer field '
+    'alongside the other details for your snap. Please visit {} and login '
+    'again.')
+AGREEMENT_INPUT_MSG = (
+    'Do you agree to the developer terms and conditions. ({})? [y/N]')
+AGREEMENT_SIGN_ERROR = (
+    'Unexpected error encountered during signing the developer terms and '
+    'conditions. Please visit {} and agree to the terms and conditions before '
+    'continuing.')
+TWO_FACTOR_WARNING = (
+    'We strongly recommend enabling multi-factor authentication: '
+    'https://help.ubuntu.com/community/SSO/FAQs/2FA')
+INVALID_CREDENTIALS = 'Invalid credentials supplied.'
+AUTHENTICATION_ERROR = ('Problems encountered when authenticating your '
+                        'credentials.')
+ACCOUNT_INFORMATION_ERROR = ('Unexpected error when obtaining your account '
+                             'information.')

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -87,20 +87,45 @@ class StoreMacaroonNeedsRefreshError(StoreError):
     fmt = 'Authentication macaroon needs to be refreshed.'
 
 
+class DeveloperAgreementSignError(StoreError):
+
+    fmt = (
+        'There was an error while signing developer agreement.\n'
+        'Reason: {reason!r}\n'
+        'Text: {text!r}')
+
+    def __init__(self, response):
+        super().__init__(reason=response.reason, text=response.text)
+
+
+class NeedTermsSignedError(StoreError):
+
+    fmt = (
+        'Developer Terms of Service agreement must be signed '
+        'before continuing: {message}')
+
+    def __init__(self, message):
+        super().__init__(message=message)
+
+
 class StoreAccountInformationError(StoreError):
 
     fmt = 'Error fetching account information from store: {error}'
 
     def __init__(self, response):
         error = '{} {}'.format(response.status_code, response.reason)
+        extra = []
         try:
             response_json = response.json()
             if 'error_list' in response_json:
                 error = ' '.join(
                     error['message'] for error in response_json['error_list'])
+                extra = [
+                    error['extra'] for error in response_json[
+                        'error_list'] if 'extra' in error]
         except JSONDecodeError:
             pass
-        super().__init__(error=error)
+        super().__init__(error=error, extra=extra)
 
 
 class StoreKeyRegistrationError(StoreError):

--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -323,9 +323,7 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
     _DEV_API_PATH = '/dev/api/'
 
     def do_POST(self):
-        if self.server.fake_store.needs_refresh:
-            self._handle_needs_refresh()
-            return
+        self._handle_refresh()
         parsed_path = urllib.parse.urlparse(self.path)
         acl_path = urllib.parse.urljoin(self._DEV_API_PATH, 'acl/')
         account_key_path = urllib.parse.urljoin(
@@ -338,6 +336,8 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
             self._DEV_API_PATH, 'snap-push/')
         release_path = urllib.parse.urljoin(
             self._DEV_API_PATH, 'snap-release/')
+        agreement_path = urllib.parse.urljoin(
+            self._DEV_API_PATH, 'agreement/')
 
         if parsed_path.path.startswith(acl_path):
             permission = parsed_path.path[len(acl_path):].strip('/')
@@ -355,11 +355,18 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
             self._handle_upload_request()
         elif parsed_path.path.startswith(release_path):
             self._handle_release_request()
+        elif parsed_path.path.startswith(agreement_path):
+            self._handle_sign_request()
         else:
             logger.error(
                 'Not implemented path in fake Store API server: {}'.format(
                     self.path))
             raise NotImplementedError(self.path)
+
+    def _handle_refresh(self):
+        if self.server.fake_store.needs_refresh:
+            self._handle_needs_refresh()
+            return
 
     def _handle_needs_refresh(self):
         self.send_response(401)
@@ -668,6 +675,42 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
         self.wfile.write(data)
+
+    def _handle_sign_request(self):
+        string_data = self.rfile.read(
+            int(self.headers['Content-Length'])).decode('utf8')
+        data = json.loads(string_data)
+
+        if 'STORE_DOWN' in os.environ:
+            response_code = 500
+            content_type = 'text/plain'
+            response = b'Broken'
+        else:
+            if data['latest_tos_accepted'] is not True:
+                response_code = 400
+                content_type = 'application/json'
+                content = {
+                    "error_list": [{
+                        "message": "`latest_tos_accepted` must be `true`",
+                        "code": "bad-request",
+                        "extra": {"latest_tos_accepted": "true"}}]}
+                response = json.dumps(content).encode()
+            else:
+                response_code = 200
+                content_type = 'application/json'
+                content = {"content": {
+                    "latest_tos_accepted": True,
+                    "tos_url": 'http://fake-url.com',
+                    "latest_tos_date": '2000-01-01',
+                    "accepted_tos_date": '2010-10-10'
+                    }
+                }
+                response = json.dumps(content).encode()
+
+        self.send_response(response_code)
+        self.send_header('Content-Type', content_type)
+        self.end_headers()
+        self.wfile.write(response)
 
     # This function's complexity is correlated to the number of
     # url paths, no point in checking that.

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -56,6 +56,11 @@ class TempXDG(fixtures.Fixture):
             new=os.path.join(self.path, '.local'))
         patcher.start()
         self.addCleanup(patcher.stop)
+        patcher = mock.patch(
+            'xdg.BaseDirectory.xdg_cache_home',
+            new=os.path.join(self.path, '.cache'))
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
         patcher_dirs = mock.patch(
             'xdg.BaseDirectory.xdg_config_dirs',
@@ -317,3 +322,11 @@ class TestStore(fixtures.Fixture):
             self.user_password = 'test correct password'
         else:
             self.user_password = os.getenv('TEST_USER_PASSWORD')
+
+
+class DeltaUploads(fixtures.Fixture):
+    """Enable the Delta Uploads Experimental flag."""
+    def setUp(self):
+        super().setUp()
+        self.useFixture(fixtures.EnvironmentVariable(
+            'DELTA_UPLOADS_EXPERIMENTAL', 'True'))

--- a/snapcraft/tests/store/test_store_client.py
+++ b/snapcraft/tests/store/test_store_client.py
@@ -958,3 +958,45 @@ class GetSnapStatusTestCase(tests.TestCase):
             "Error fetching status of snap id 'my_snap_id' for 'any arch' "
             "in '16' series: 500 Server error.",
             str(e.exception))
+
+
+class SignDeveloperAgreementTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.fake_store = self.useFixture(fixture_setup.FakeStore())
+        self.client = storeapi.StoreClient()
+
+    def test_sign_dev_agreement_success(self):
+        self.client.login('dummy', 'test correct password')
+        response = {
+            "content": {
+                "latest_tos_accepted": True,
+                "tos_url": "http://fake-url.com",
+                "latest_tos_date": "2000-01-01",
+                "accepted_tos_date": "2010-10-10"
+                }
+            }
+        self.assertEqual(
+            response,
+            self.client.sign_developer_agreement(latest_tos_accepted=True))
+
+    def test_sign_dev_agreement_exception(self):
+        self.client.login('dummy', 'test correct password')
+        with self.assertRaises(errors.DeveloperAgreementSignError) as raised:
+            self.client.sign_developer_agreement(False)
+        self.assertIn(
+            'There was an error while signing developer agreement.\n'
+            'Reason: \'Bad Request\'\n',
+            str(raised.exception))
+
+    def test_sign_dev_agreement_exception_store_down(self):
+        self.useFixture(fixtures.EnvironmentVariable('STORE_DOWN', '1'))
+        self.client.login('dummy', 'test correct password')
+        with self.assertRaises(errors.DeveloperAgreementSignError) as raised:
+            self.client.sign_developer_agreement(latest_tos_accepted=True)
+        self.assertEqual(
+            str(raised.exception),
+            'There was an error while signing developer agreement.\n'
+            'Reason: \'Internal Server Error\'\n'
+            'Text: \'Broken\'')

--- a/snapcraft/tests/test_cache.py
+++ b/snapcraft/tests/test_cache.py
@@ -1,0 +1,69 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+
+import fixtures
+
+from snapcraft import tests
+from snapcraft.internal import cache
+from snapcraft.internal.cache._snap import _rewrite_snap_filename_with_revision
+from snapcraft.tests import fixture_setup
+
+
+class SnapCacheTestCase(tests.TestCase):
+
+    yaml_content = """name: cache-test
+version: 0.1
+summary: test cached snap
+description: test cached snap
+grade: devel
+
+parts:
+  my-part:
+    plugin: nil
+"""
+
+    def setUp(self):
+        super().setUp()
+        super().make_snapcraft_yaml(self.yaml_content)
+        self.fake_logger = fixtures.FakeLogger(level=logging.INFO)
+        self.useFixture(self.fake_logger)
+
+    def test_rewrite_snap_filename(self):
+        revision = 10
+        snap_file = 'my-snap-name_0.1_amd64.snap'
+
+        self.assertEqual(
+            'my-snap-name_0.1_amd64_10.snap',
+            _rewrite_snap_filename_with_revision(snap_file, revision))
+
+    def test_snap_cache(self):
+        self.useFixture(fixture_setup.FakeTerminal())
+        snap_cache = cache.SnapCache()
+        snap_file = 'my-snap-name_0.1_amd64.snap'
+
+        # create dummy snap
+        open(os.path.join(self.path, snap_file), 'a').close()
+
+        # cache snap
+        cached_snap_path = snap_cache.cache(snap_file, 10)
+
+        _, expected_snap = os.path.split(cached_snap_path)
+
+        self.assertEqual('my-snap-name_0.1_amd64_10.snap', expected_snap)
+        self.assertTrue(os.path.isfile(cached_snap_path))

--- a/snapcraft/tests/test_cache.py
+++ b/snapcraft/tests/test_cache.py
@@ -21,7 +21,10 @@ import fixtures
 
 from snapcraft import tests
 from snapcraft.internal import cache
-from snapcraft.internal.cache._snap import _rewrite_snap_filename_with_revision
+from snapcraft.internal.cache._snap import (
+    _rewrite_snap_filename_with_revision,
+    _get_revision_from_snap_filename
+)
 from snapcraft.tests import fixture_setup
 
 
@@ -67,3 +70,61 @@ parts:
 
         self.assertEqual('my-snap-name_0.1_amd64_10.snap', expected_snap)
         self.assertTrue(os.path.isfile(cached_snap_path))
+
+    def test_get_revision_from_snap_filename(self):
+        revision = 10
+        valid_snap_file = 'my-snap_0.1_amd64_{}.snap'.format(revision)
+
+        self.assertEqual(
+            revision,
+            _get_revision_from_snap_filename(valid_snap_file))
+
+        invalid_snap_file1 = 'cached-snap-without-revision_1.0_arm64.snap'
+        self.assertEqual(
+            None,
+            _get_revision_from_snap_filename(invalid_snap_file1))
+
+        invalid_snap_file2 = 'another-cached-snap-without-version_arm64.snap'
+        self.assertEqual(
+            None,
+            _get_revision_from_snap_filename(invalid_snap_file2))
+
+    def test_prune_snap_cache(self):
+        self.useFixture(fixture_setup.FakeTerminal())
+        snap_cache = cache.SnapCache()
+
+        snap_revision = 9
+        snap_file = 'my-snap-name_0.1_amd64_{}.snap'.format(snap_revision)
+
+        # create dummy snap
+        open(os.path.join(self.path, snap_file), 'a').close()
+
+        # cache snap
+        snap_cache.cache(snap_file, snap_revision)
+
+        # create other cached snap revisions
+        cached_snaps = ['a-cached-snap_0.3_amd64_8.snap',
+                        'another-cached-snap_1.0_arm64_6.snap']
+
+        for cached_snap in cached_snaps:
+            open(os.path.join(snap_cache.snap_cache_dir, cached_snap),
+                 'a').close()
+
+        real_cached_snap = _rewrite_snap_filename_with_revision(
+            snap_file,
+            snap_revision
+        )
+
+        # confirm expected snap cached
+        self.assertTrue(
+            os.path.isfile(os.path.join(snap_cache.snap_cache_dir,
+                                        real_cached_snap)))
+        self.assertEqual(3, len(os.listdir(snap_cache.snap_cache_dir)))
+
+        # prune cached snaps
+        snap_cache.prune(snap_revision)
+
+        # confirm other snaps are purged
+        for snap in cached_snaps:
+            self.assertFalse(
+                os.path.isfile(os.path.join(snap_cache.snap_cache_dir, snap)))

--- a/snapcraft/tests/test_commands_login.py
+++ b/snapcraft/tests/test_commands_login.py
@@ -18,6 +18,7 @@ import logging
 from unittest import mock
 
 import fixtures
+from simplejson.scanner import JSONDecodeError
 
 from snapcraft.main import main
 from snapcraft import (
@@ -45,8 +46,10 @@ class LoginCommandTestCase(tests.TestCase):
         patcher.start()
         self.addCleanup(patcher.stop)
 
+    @mock.patch.object(storeapi.SCAClient, 'get_account_information')
     @mock.patch.object(storeapi.StoreClient, 'login')
-    def test_successful_login(self, mock_login):
+    def test_successful_login(
+            self, mock_login, mock_get_account_information):
         self.mock_input.return_value = 'user@example.com'
 
         # no exception raised.
@@ -56,16 +59,18 @@ class LoginCommandTestCase(tests.TestCase):
         mock_login.assert_called_once_with(
             'user@example.com', mock.ANY, acls=None, save=True)
         self.assertEqual(
-            'We strongly recommend enabling multi-factor authentication: '
-            'https://help.ubuntu.com/community/SSO/FAQs/2FA\n'
+            storeapi.constants.TWO_FACTOR_WARNING + '\n' +
             'Login successful.\n',
             self.fake_logger.output)
 
+    @mock.patch.object(storeapi.SCAClient, 'get_account_information')
     @mock.patch.object(storeapi.StoreClient, 'login')
-    def test_successful_login_with_2fa(self, mock_login):
+    def test_successful_login_with_2fa(
+            self, mock_login, mock_get_account_information):
         self.mock_input.side_effect = ('user@example.com', '123456')
         mock_login.side_effect = [
-            storeapi.errors.StoreTwoFactorAuthenticationRequired(), None]
+            storeapi.errors.StoreTwoFactorAuthenticationRequired(),
+            None]
 
         # no exception raised.
         main(['login'])
@@ -88,7 +93,10 @@ class LoginCommandTestCase(tests.TestCase):
 
         main(['login'])
 
-        self.assertEqual('Login failed.\n', self.fake_logger.output)
+        self.assertEqual(
+            storeapi.constants.INVALID_CREDENTIALS +
+            '\nLogin failed.\n',
+            self.fake_logger.output)
 
     @mock.patch.object(storeapi.StoreClient, 'login')
     def test_failed_login_with_store_authentication_error(self, mock_login):
@@ -97,4 +105,206 @@ class LoginCommandTestCase(tests.TestCase):
 
         main(['login'])
 
-        self.assertEqual('Login failed.\n', self.fake_logger.output)
+        self.assertEqual(
+            storeapi.constants.AUTHENTICATION_ERROR +
+            '\nLogin failed.\n',
+            self.fake_logger.output)
+
+    @mock.patch.object(storeapi.StoreClient, 'login')
+    def test_failed_login_with_store_account_info_error(self, mock_login):
+        response = mock.Mock()
+        response.json.side_effect = JSONDecodeError('mock-fail', 'doc', 1)
+        response.status_code = 500
+        response.reason = 'Internal Server Error'
+        mock_login.side_effect = storeapi.errors.StoreAccountInformationError(
+            response)
+
+        main(['login'])
+
+        self.assertEqual(
+            storeapi.constants.ACCOUNT_INFORMATION_ERROR +
+            '\nLogin failed.\n',
+            self.fake_logger.output)
+
+    @mock.patch.object(storeapi.StoreClient, 'get_account_information')
+    @mock.patch.object(storeapi.StoreClient, 'login')
+    def test_failed_login_with_dev_agreement_error(
+            self, mock_login, mock_acc_info):
+        response = mock.Mock()
+        response.status_code = 403
+        response.reason = storeapi.constants.MISSING_AGREEMENT
+        content = {'error_list': [{
+            'message': storeapi.constants.MISSING_AGREEMENT,
+            'extra': {
+                'url': 'http://fake-url.com',
+                'api': 'fake-api'}}]}
+        response.json.return_value = content
+        account_info_exception = storeapi.errors.StoreAccountInformationError(
+            response)
+        mock_acc_info.side_effect = account_info_exception
+
+        main(['login'])
+
+        self.assertEqual((
+            storeapi.constants.TWO_FACTOR_WARNING + '\n' +
+            storeapi.constants.AGREEMENT_ERROR +
+            '\nLogin failed.\n'),
+            self.fake_logger.output)
+
+    @mock.patch.object(storeapi.StoreClient, 'get_account_information')
+    @mock.patch.object(storeapi.StoreClient, 'login')
+    def test_failed_login_with_dev_namespace_error(
+            self, mock_login, mock_acc_info):
+        response = mock.Mock()
+        response.status_code = 403
+        response.reason = storeapi.constants.MISSING_NAMESPACE
+        content = {'error_list': [{
+            'message': storeapi.constants.MISSING_NAMESPACE,
+            'extra': {
+                'url': 'http://fake-url.com',
+                'api': 'fake-api'}}]}
+        response.json.return_value = content
+        account_info_exception = storeapi.errors.StoreAccountInformationError(
+            response)
+        mock_acc_info.side_effect = account_info_exception
+
+        main(['login'])
+
+        self.assertEqual((
+            storeapi.constants.TWO_FACTOR_WARNING + '\n' +
+            storeapi.constants.NAMESPACE_ERROR.format('http://fake-url.com') +
+            '\nLogin failed.\n'),
+            self.fake_logger.output)
+
+    @mock.patch.object(storeapi.StoreClient, 'get_account_information')
+    @mock.patch.object(storeapi.StoreClient, 'login')
+    def test_failed_login_with_unexpected_account_error(
+            self, mock_login, mock_acc_info):
+        # Test to simulate get_account_info raising unexpected errors.
+        response = mock.Mock()
+        response.status_code = 500
+        response.reason = 'Internal Server Error'
+        content = {'error_list': [{
+            'message': "Just another error",
+            'extra': {
+                'url': 'http://fake-url.com',
+                'api': 'fake-api'}}]}
+        response.json.return_value = content
+        side_effect = storeapi.errors.StoreAccountInformationError(response)
+        mock_acc_info.side_effect = side_effect
+
+        main(['login'])
+
+        self.assertEqual(
+            storeapi.constants.TWO_FACTOR_WARNING + '\n' +
+            storeapi.constants.ACCOUNT_INFORMATION_ERROR +
+            '\nLogin failed.\n',
+            self.fake_logger.output)
+
+    @mock.patch.object(storeapi.StoreClient, 'get_account_information')
+    @mock.patch.object(storeapi.StoreClient, 'login')
+    def test_failed_login_with_dev_agreement_error_with_choice(
+            self, mock_login, mock_acc_info):
+        response = mock.Mock()
+        response.status_code = 403
+        response.reason = storeapi.constants.MISSING_AGREEMENT
+        content = {'error_list': [{
+            'message': storeapi.constants.MISSING_AGREEMENT,
+            'extra': {
+                'url': 'http://fake-url.com',
+                'api': 'fake-api'}}]}
+        response.json.return_value = content
+        account_info_exception = storeapi.errors.StoreAccountInformationError(
+            response)
+        mock_acc_info.side_effect = account_info_exception
+
+        main(['login'])
+        self.mock_input.assert_called_with(
+            storeapi.constants.AGREEMENT_INPUT_MSG.format(
+                'http://fake-url.com'))
+
+        self.assertEqual((
+            storeapi.constants.TWO_FACTOR_WARNING + '\n' +
+            storeapi.constants.AGREEMENT_ERROR +
+            '\nLogin failed.\n'),
+            self.fake_logger.output)
+
+    @mock.patch.object(storeapi.StoreClient, 'get_account_information')
+    @mock.patch.object(storeapi.StoreClient, 'login')
+    def test_failed_login_with_dev_agreement_error_with_choice_no(
+            self, mock_login, mock_acc_info):
+        response = mock.Mock()
+        response.status_code = 403
+        response.reason = storeapi.constants.MISSING_AGREEMENT
+        content = {'error_list': [{
+            'message': storeapi.constants.MISSING_AGREEMENT,
+            'extra': {
+                'url': 'http://fake-url.com',
+                'api': 'fake-api'}}]}
+        response.json.return_value = content
+        account_info_exception = storeapi.errors.StoreAccountInformationError(
+            response)
+        mock_acc_info.side_effect = account_info_exception
+
+        self.mock_input.return_value = 'n'
+        main(['login'])
+
+        self.assertEqual((
+            storeapi.constants.TWO_FACTOR_WARNING + '\n' +
+            storeapi.constants.AGREEMENT_ERROR +
+            '\nLogin failed.\n'),
+            self.fake_logger.output)
+
+    @mock.patch.object(storeapi.StoreClient, 'get_account_information')
+    @mock.patch.object(storeapi.StoreClient, 'login')
+    def test_failed_login_with_dev_agreement_error_with_choice_yes(
+            self, mock_login, mock_acc_info):
+        response = mock.Mock()
+        response.status_code = 403
+        response.reason = storeapi.constants.MISSING_AGREEMENT
+        content = {'error_list': [{
+            'message': storeapi.constants.MISSING_AGREEMENT,
+            'extra': {
+                'url': 'http://fake-url.com',
+                'api': 'fake-api'}}]}
+        response.json.return_value = content
+        account_info_exception = storeapi.errors.StoreAccountInformationError(
+            response)
+        mock_acc_info.side_effect = account_info_exception
+
+        self.mock_input.return_value = 'y'
+        main(['login'])
+
+        self.assertEqual((
+            storeapi.constants.TWO_FACTOR_WARNING + '\n' +
+            storeapi.constants.AGREEMENT_SIGN_ERROR.format(
+                'http://fake-url.com') +
+            '\nLogin failed.\n'),
+            self.fake_logger.output)
+
+    @mock.patch.object(storeapi.StoreClient, 'sign_developer_agreement')
+    @mock.patch.object(storeapi.StoreClient, 'get_account_information')
+    @mock.patch.object(storeapi.StoreClient, 'login')
+    def test_failed_login_with_dev_agreement_error_with_sign_success(
+            self, mock_login, mock_acc_info, mock_sign_agreement):
+        response = mock.Mock()
+        response.status_code = 403
+        response.reason = storeapi.constants.MISSING_AGREEMENT
+        content = {'error_list': [{
+            'message': storeapi.constants.MISSING_AGREEMENT,
+            'extra': {
+                'url': 'http://fake-url.com',
+                'api': 'fake-api'}}]}
+        response.json.return_value = content
+        account_info_exception = storeapi.errors.StoreAccountInformationError(
+            response)
+        mock_acc_info.side_effect = account_info_exception
+
+        self.mock_input.return_value = 'y'
+        main(['login'])
+
+        self.assertEqual((
+            storeapi.constants.TWO_FACTOR_WARNING + '\n' +
+            storeapi.constants.ACCOUNT_INFORMATION_ERROR +
+            '\nLogin failed.\n'),
+            self.fake_logger.output)

--- a/snapcraft/tests/test_commands_push.py
+++ b/snapcraft/tests/test_commands_push.py
@@ -275,6 +275,16 @@ class PushCommandDeltasTestCase(tests.TestCase):
         self.addCleanup(patcher.stop)
         mock_upload.return_value = mock_tracker
 
+        patcher = mock.patch.object(storeapi.StoreClient, 'get_snap_history')
+        mock_latest_rev = patcher.start()
+        self.addCleanup(patcher.stop)
+        mock_latest_rev.return_value = [{
+            'timestamp': 'now',
+            'arch': 'some_arch',
+            'version': '0.1',
+            'revision': snap_revision,
+        }]
+
         # Create a snap
         main(['init'])
         main(['snap'])
@@ -295,3 +305,82 @@ class PushCommandDeltasTestCase(tests.TestCase):
 
         self.assertEqual(self.enable_deltas, os.path.isfile(
             os.path.join(revision_cache, cached_snap)))
+
+
+class PushCommandDeltasWithPruneTestCase(tests.TestCase):
+
+    scenarios = [
+        ('delete other cache files with valid name', {
+            'cached_snaps': [
+                'a-cached-snap_0.3_amd64_8.snap',
+                'another-cached-snap_1.0_arm64_6.snap']
+        }),
+        ('delete other cache files with invalid name', {
+            'cached_snaps': [
+                'a-cached-snap_0.3_amd64.snap',
+                'cached-snap-without-revision_1.0_arm64.snap',
+                'another-cached-snap-without-version_arm64.snap']
+        })
+    ]
+
+    def test_push_revision_prune_snap_cache(self):
+        self.useFixture(fixture_setup.FakeTerminal())
+        self.useFixture(fixture_setup.DeltaUploads())
+
+        snap_revision = 9
+
+        mock_tracker = mock.Mock(storeapi.StatusTracker)
+        mock_tracker.track.return_value = {
+            'code': 'ready_to_release',
+            'processed': True,
+            'can_release': True,
+            'url': '/fake/url',
+            'revision': snap_revision,
+        }
+
+        patcher = mock.patch.object(storeapi.StoreClient, 'upload')
+        mock_upload = patcher.start()
+        self.addCleanup(patcher.stop)
+        mock_upload.return_value = mock_tracker
+
+        patcher = mock.patch.object(storeapi.StoreClient, 'get_snap_history')
+        mock_latest_rev = patcher.start()
+        self.addCleanup(patcher.stop)
+        mock_latest_rev.return_value = [{
+            'timestamp': 'now',
+            'arch': 'some_arch',
+            'version': '0.1',
+            'revision': snap_revision,
+        }]
+
+        revision_cache = os.path.join(
+            BaseDirectory.xdg_cache_home,
+            'snapcraft', 'my-snap-name', 'revisions')
+
+        os.makedirs(revision_cache)
+        # Create cached snap revisions
+        cached_snaps = ['a-cached-snap_0.3_amd64_8.snap',
+                        'another-cached-snap_1.0_arm64_6.snap']
+
+        for cached_snap in cached_snaps:
+            open(os.path.join(revision_cache, cached_snap), 'a').close()
+
+        # Create a snap
+        main(['init'])
+        main(['snap'])
+        snap_file = glob.glob('*.snap')[0]
+
+        # Upload
+        with mock.patch('snapcraft.storeapi.StatusTracker'):
+            main(['push', snap_file])
+
+        real_cached_snap = _rewrite_snap_filename_with_revision(
+            snap_file,
+            snap_revision
+        )
+        self.assertTrue(
+            os.path.isfile(os.path.join(revision_cache, real_cached_snap)))
+
+        for snap in cached_snaps:
+            self.assertFalse(
+                os.path.isfile(os.path.join(revision_cache, snap)))

--- a/snapcraft/tests/test_commands_push.py
+++ b/snapcraft/tests/test_commands_push.py
@@ -22,11 +22,13 @@ from unittest import mock
 
 import docopt
 import fixtures
+from xdg import BaseDirectory
 
 from snapcraft import (
     storeapi,
     tests
 )
+from snapcraft.internal.cache._snap import _rewrite_snap_filename_with_revision
 from snapcraft.main import main
 from snapcraft.storeapi.errors import StoreUploadError
 from snapcraft.tests import fixture_setup
@@ -245,3 +247,51 @@ class PushCommandTestCase(tests.TestCase):
         mock_upload.assert_called_once_with('my-snap-name', snap_file)
         mock_release.assert_called_once_with('my-snap-name', 9,
                                              ['edge', 'beta', 'candidate'])
+
+
+class PushCommandDeltasTestCase(tests.TestCase):
+
+    scenarios = [
+        ('with deltas', dict(enable_deltas=True)),
+        ('without deltas', dict(enable_deltas=False)),
+    ]
+
+    def test_push_revision_cached_with_experimental_deltas(self):
+        self.useFixture(fixture_setup.FakeTerminal())
+        if self.enable_deltas:
+            self.useFixture(fixture_setup.DeltaUploads())
+
+        mock_tracker = mock.Mock(storeapi.StatusTracker)
+        snap_revision = 9
+        mock_tracker.track.return_value = {
+            'code': 'ready_to_release',
+            'processed': True,
+            'can_release': True,
+            'url': '/fake/url',
+            'revision': snap_revision,
+        }
+        patcher = mock.patch.object(storeapi.StoreClient, 'upload')
+        mock_upload = patcher.start()
+        self.addCleanup(patcher.stop)
+        mock_upload.return_value = mock_tracker
+
+        # Create a snap
+        main(['init'])
+        main(['snap'])
+        snap_file = glob.glob('*.snap')[0]
+
+        # Upload
+        with mock.patch('snapcraft.storeapi.StatusTracker') as mock_tracker:
+            main(['push', snap_file])
+
+        revision_cache = os.path.join(
+            BaseDirectory.xdg_cache_home,
+            'snapcraft',
+            'my-snap-name',
+            'revisions')
+        cached_snap = _rewrite_snap_filename_with_revision(
+            snap_file,
+            snap_revision)
+
+        self.assertEqual(self.enable_deltas, os.path.isfile(
+            os.path.join(revision_cache, cached_snap)))

--- a/snapcraft/tests/test_commands_register_key.py
+++ b/snapcraft/tests/test_commands_register_key.py
@@ -216,6 +216,7 @@ class RegisterKeyTestCase(tests.TestCase):
             'Cannot continue without logging in successfully.\n',
             self.fake_logger.output)
 
+    @mock.patch('snapcraft._store._login')
     @mock.patch.object(storeapi.SCAClient, 'register_key')
     @mock.patch.object(storeapi.SCAClient, 'get_account_information')
     @mock.patch.object(storeapi.StoreClient, 'login')
@@ -227,9 +228,11 @@ class RegisterKeyTestCase(tests.TestCase):
                                               mock_getpass, mock_check_output,
                                               mock_login,
                                               mock_get_account_information,
-                                              mock_register_key):
+                                              mock_register_key,
+                                              mock__login):
         mock_installed.return_value = True
         mock_check_output.side_effect = mock_snap_output
+        mock__login.return_value = True
         response = mock.Mock()
         response.json.side_effect = JSONDecodeError('mock-fail', 'doc', 1)
         response.status_code = 500


### PR DESCRIPTION
This prune function will remove all the cached revision files expect the latest revision under the snapcraft’s xdg cache(XDG_CACHE_HOME/snapcraft/{project_name}/revisions), 

So far I'm uncertain where should this revision prune function be invoked. now it's called right after the revision cache function is triggered in "snap push".

It's the following branch for PR: https://github.com/snapcore/snapcraft/pull/889

LP: #1641512