### PR TITLE
Snap revision prune

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -400,6 +400,7 @@ def push(snap_filename, release_channels=None):
     if os.environ.get('DELTA_UPLOADS_EXPERIMENTAL'):
         snap_cache = cache.SnapCache()
         snap_cache.cache(snap_filename, result['revision'])
+        snap_cache.prune(keep_revision=result['revision'])
 
     if release_channels:
         release(snap_name, result['revision'], release_channels)

--- a/snapcraft/internal/cache/_cache.py
+++ b/snapcraft/internal/cache/_cache.py
@@ -33,7 +33,7 @@ class SnapcraftCache:
     def cache(self):
         raise NotImplementedError
 
-    def prune(self):
+    def prune(self, *args, **kwargs):
         raise NotImplementedError
 
 
@@ -41,5 +41,6 @@ class SnapcraftProjectCache(SnapcraftCache):
     """Project specific cache"""
     def __init__(self):
         super().__init__()
+        self.config = snapcraft.internal.load_config()
         self.project_cache_root = os.path.join(
-            self.cache_root, snapcraft.internal.load_config().data['name'])
+            self.cache_root, self.config.data['name'])

--- a/snapcraft/internal/cache/_snap.py
+++ b/snapcraft/internal/cache/_snap.py
@@ -16,9 +16,9 @@
 
 import logging
 import os
-import shutil
 
-from snapcraft.internal.cache._cache import SnapcraftProjectCache
+from snapcraft.file_utils import link_or_copy
+from ._cache import SnapcraftProjectCache
 
 
 logger = logging.getLogger(__name__)
@@ -28,6 +28,7 @@ class SnapCache(SnapcraftProjectCache):
     """Cache for snap revisions."""
     def __init__(self):
         super().__init__()
+        self.snap_cache_dir = self._setup_snap_cache()
 
     def _setup_snap_cache(self):
         snap_cache_path = os.path.join(self.project_cache_root, 'revisions')
@@ -39,18 +40,41 @@ class SnapCache(SnapcraftProjectCache):
 
         :returns: path to cached revision.
         """
-        snap_cache_dir = self._setup_snap_cache()
-
         cached_snap = _rewrite_snap_filename_with_revision(
             snap_filename,
             revision)
-        cached_snap_path = os.path.join(snap_cache_dir, cached_snap)
+        cached_snap_path = os.path.join(self.snap_cache_dir, cached_snap)
         try:
-            shutil.copyfile(snap_filename, cached_snap_path)
+            link_or_copy(snap_filename, cached_snap_path)
         except OSError:
             logger.warning(
                 'Unable to cache snap {}.'.format(cached_snap))
         return cached_snap_path
+
+    def prune(self, *, keep_revision):
+        """Prune the snap revisions beside the keep_revision in XDG cache.
+
+        :returns: pruned files paths list.
+        """
+        keep_revision = int(keep_revision)
+
+        pruned_files_list = []
+
+        for snap_filename in os.listdir(self.snap_cache_dir):
+            cached_snap = os.path.join(self.snap_cache_dir, snap_filename)
+
+            # get the file version from file name
+            rev_from_snap_file = _get_revision_from_snap_filename(
+                snap_filename)
+
+            if rev_from_snap_file != keep_revision:
+                try:
+                    os.remove(cached_snap)
+                    pruned_files_list.append(cached_snap)
+                except OSError:
+                    logger.warning(
+                        'Unable to purge snap {}.'.format(cached_snap))
+        return pruned_files_list
 
 
 def _rewrite_snap_filename_with_revision(snap_file, revision):
@@ -60,3 +84,22 @@ def _rewrite_snap_filename_with_revision(snap_file, revision):
         rev=revision,
         ext=splitf[1])
     return snap_with_revision
+
+
+def _get_revision_from_snap_filename(snap_filename):
+    """parse the filename to extract the revision info"""
+    # the cached snap filename should have the format:
+    # '{name}_{version}_{arch}_{revision}.snap'
+    filename, extname = os.path.splitext(snap_filename)
+    split_name_parts = filename.split('_')
+    if len(split_name_parts) != 4:
+        logger.debug('The cached snap filename {} is invalid.'.format(
+            snap_filename))
+        return None
+
+    try:
+        rev = int(split_name_parts[-1])
+    except ValueError:
+        logger.debug('The cached snap filename has an invalid revision.')
+        return None
+    return rev

--- a/snapcraft/tests/test_cache.py
+++ b/snapcraft/tests/test_cache.py
@@ -21,13 +21,14 @@ import fixtures
 
 from snapcraft import tests
 from snapcraft.internal import cache
-from snapcraft.internal.cache._snap import _rewrite_snap_filename_with_revision
+from snapcraft.internal.cache._snap import (
+    _rewrite_snap_filename_with_revision,
+    _get_revision_from_snap_filename
+)
 from snapcraft.tests import fixture_setup
 
 
-class SnapCacheTestCase(tests.TestCase):
-
-    yaml_content = """name: cache-test
+yaml_content = """name: cache-test
 version: 0.1
 summary: test cached snap
 description: test cached snap
@@ -38,9 +39,12 @@ parts:
     plugin: nil
 """
 
+
+class SnapCacheTestCase(tests.TestCase):
+
     def setUp(self):
         super().setUp()
-        super().make_snapcraft_yaml(self.yaml_content)
+        super().make_snapcraft_yaml(yaml_content)
         self.fake_logger = fixtures.FakeLogger(level=logging.INFO)
         self.useFixture(self.fake_logger)
 
@@ -67,3 +71,88 @@ parts:
 
         self.assertEqual('my-snap-name_0.1_amd64_10.snap', expected_snap)
         self.assertTrue(os.path.isfile(cached_snap_path))
+
+    def test_get_revision_from_snap_filename(self):
+        revision = 10
+        valid_snap_file = 'my-snap_0.1_amd64_{}.snap'.format(revision)
+
+        self.assertEqual(
+            revision,
+            _get_revision_from_snap_filename(valid_snap_file))
+
+        invalid_snap_list = [
+            'cached-snap-without-revision_1.0_arm64.snap',
+            'another-cached-snap-without-version_arm64.snap',
+            'a-snap-with-no-number-revision_1.0_arm64_xx.snap'
+        ]
+        for invalid_snap_file in invalid_snap_list:
+            self.assertEqual(
+                None,
+                _get_revision_from_snap_filename(invalid_snap_file))
+
+
+class SnapCachedFilePruneTestCase(tests.TestCase):
+
+    scenarios = [
+        ('valid revision for prune', dict(valid_revision=True)),
+        ('invalid revision for prune', dict(valid_revision=False)),
+    ]
+
+    def setUp(self):
+        super().setUp()
+        super().make_snapcraft_yaml(yaml_content)
+        self.fake_logger = fixtures.FakeLogger(level=logging.INFO)
+        self.useFixture(self.fake_logger)
+
+    def test_prune_snap_cache(self):
+        self.useFixture(fixture_setup.FakeTerminal())
+        snap_cache = cache.SnapCache()
+
+        snap_revision = 9
+        snap_file = 'my-snap-name_0.1_amd64.snap'
+
+        # create dummy snap
+        open(os.path.join(self.path, snap_file), 'a').close()
+
+        # cache snap
+        snap_cache.cache(snap_file, snap_revision)
+
+        # create other cached snap revisions
+        to_be_deleted_files = []
+        cached_snaps = ['a-cached-snap_0.3_amd64_8.snap',
+                        'another-cached-snap_1.0_arm64_6.snap']
+
+        for cached_snap in cached_snaps:
+            cached_snap_path = os.path.join(snap_cache.snap_cache_dir,
+                                            cached_snap)
+            to_be_deleted_files.append(cached_snap_path)
+            open(cached_snap_path, 'a').close()
+
+        real_cached_snap = _rewrite_snap_filename_with_revision(snap_file,
+                                                                snap_revision)
+
+        # confirm expected snap cached
+        self.assertEqual(3, len(os.listdir(snap_cache.snap_cache_dir)))
+        self.assertTrue(
+            os.path.isfile(os.path.join(snap_cache.snap_cache_dir,
+                                        real_cached_snap)))
+
+        if not self.valid_revision:
+            with self.assertRaises(ValueError):
+                snap_cache.prune(keep_revision='invalid-revision')
+            with self.assertRaises(TypeError):
+                snap_cache.prune(keep_revision=None)
+        else:
+            # prune cached snaps
+            purned_file_list = snap_cache.prune(keep_revision=snap_revision)
+
+            # confirm other snaps are purged
+            self.assertEqual(set(purned_file_list), set(to_be_deleted_files))
+            for snap in purned_file_list:
+                self.assertFalse(os.path.isfile(snap))
+
+            # confirm the expected cached file still exist
+            self.assertEqual(1, len(os.listdir(snap_cache.snap_cache_dir)))
+            self.assertTrue(
+                os.path.isfile(os.path.join(snap_cache.snap_cache_dir,
+                                            real_cached_snap)))


### PR DESCRIPTION
This prune function will remove all the cached revision files expect the latest revision under the snapcraft’s xdg cache(XDG_CACHE_HOME/snapcraft/{project_name}/revisions),

So far I'm uncertain where should this revision prune function be invoked. now it's called right after the revision cache function is triggered in "snap push".

It's the following branch for PR: #889

LP: #1641512