### PR TITLE
meta: icon is now dedeprecated

### DIFF
--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -94,12 +94,12 @@ class _SnapPackaging:
         return snap_yaml
 
     def setup_assets(self):
+        # We do _setup_from_setup first since it is legacy and let the
+        # declarative items take over.
+        self._setup_from_setup()
+
         if 'icon' in self._config_data:
             # TODO: use developer.ubuntu.com once it has updated documentation.
-            logger.warning(
-                "DEPRECATED: 'icon' defined in snapcraft.yaml. Look at "
-                "https://github.com/snapcore/snapcraft/blob/master/docs/"
-                "metadata.md#snap-icon for more information")
             icon_ext = self._config_data['icon'].split(os.path.extsep)[1]
             icon_dir = os.path.join(self.meta_dir, 'gui')
             icon_path = os.path.join(icon_dir, 'icon.{}'.format(icon_ext))
@@ -108,8 +108,6 @@ class _SnapPackaging:
             if os.path.exists(icon_path):
                 os.unlink(icon_path)
             os.link(self._config_data['icon'], icon_path)
-
-        self._setup_from_setup()
 
         if self._config_data.get('type', '') == 'gadget':
             if not os.path.exists('gadget.yaml'):

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -186,11 +186,13 @@ class CreateTest(tests.TestCase):
 
         gui_path = os.path.join('setup', 'gui')
         os.makedirs(gui_path)
-        icon_content = b'this is the icon'
+        setup_icon_content = b'setup icon'
         with open(os.path.join(gui_path, 'icon.png'), 'wb') as f:
-            f.write(icon_content)
+            f.write(setup_icon_content)
 
-        open(os.path.join(os.curdir, 'my-icon.png'), 'w').close()
+        declared_icon_content = b'declared icon'
+        with open('my-icon.png', 'wb') as f:
+            f.write(declared_icon_content)
         self.config_data['icon'] = 'my-icon.png'
 
         create_snap_packaging(self.config_data, self.snap_dir, self.parts_dir)
@@ -199,14 +201,10 @@ class CreateTest(tests.TestCase):
         self.assertTrue(os.path.exists(expected_icon),
                         'icon.png was not setup correctly')
         with open(expected_icon, 'rb') as f:
-            self.assertEqual(f.read(), icon_content)
+            self.assertEqual(f.read(), declared_icon_content)
 
         self.assertTrue(
             os.path.exists(self.snap_yaml), 'snap.yaml was not created')
-
-        self.assertTrue(
-            "DEPRECATED: 'icon' defined in snapcraft.yaml"
-            in fake_logger.output, 'Missing deprecation message for icon')
 
         with open(self.snap_yaml) as f:
             y = yaml.load(f)


### PR DESCRIPTION
The icon entry in snapcraft.yaml is now (again) the preferred
method to have an icon in a snap, overriding the one in
the `setup` directory if necessary too.

LP: #1610268
Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>