### PR TITLE
cache: cleanup logic to pass project name

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -398,7 +398,7 @@ def push(snap_filename, release_channels=None):
     tracker.raise_for_code()
 
     if os.environ.get('DELTA_UPLOADS_EXPERIMENTAL'):
-        snap_cache = cache.SnapCache()
+        snap_cache = cache.SnapCache(project_name=snap_name)
         snap_cache.cache(snap_filename, result['revision'])
         snap_cache.prune(keep_revision=result['revision'])
 

--- a/snapcraft/internal/cache/_cache.py
+++ b/snapcraft/internal/cache/_cache.py
@@ -18,8 +18,6 @@ import os
 
 from xdg import BaseDirectory
 
-import snapcraft
-
 
 class SnapcraftCache:
     """Generic cache base class.
@@ -39,8 +37,7 @@ class SnapcraftCache:
 
 class SnapcraftProjectCache(SnapcraftCache):
     """Project specific cache"""
-    def __init__(self):
+    def __init__(self, *, project_name):
         super().__init__()
-        self.config = snapcraft.internal.load_config()
         self.project_cache_root = os.path.join(
-            self.cache_root, self.config.data['name'])
+            self.cache_root, project_name)

--- a/snapcraft/internal/cache/_snap.py
+++ b/snapcraft/internal/cache/_snap.py
@@ -26,8 +26,8 @@ logger = logging.getLogger(__name__)
 
 class SnapCache(SnapcraftProjectCache):
     """Cache for snap revisions."""
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *, project_name):
+        super().__init__(project_name=project_name)
         self.snap_cache_dir = self._setup_snap_cache()
 
     def _setup_snap_cache(self):

--- a/snapcraft/tests/test_cache.py
+++ b/snapcraft/tests/test_cache.py
@@ -58,7 +58,7 @@ class SnapCacheTestCase(tests.TestCase):
 
     def test_snap_cache(self):
         self.useFixture(fixture_setup.FakeTerminal())
-        snap_cache = cache.SnapCache()
+        snap_cache = cache.SnapCache(project_name='my-snap-name')
         snap_file = 'my-snap-name_0.1_amd64.snap'
 
         # create dummy snap
@@ -106,7 +106,7 @@ class SnapCachedFilePruneTestCase(tests.TestCase):
 
     def test_prune_snap_cache(self):
         self.useFixture(fixture_setup.FakeTerminal())
-        snap_cache = cache.SnapCache()
+        snap_cache = cache.SnapCache(project_name='my-snap-name')
 
         snap_revision = 9
         snap_file = 'my-snap-name_0.1_amd64.snap'


### PR DESCRIPTION
Instances shouldn't need to have knowledge of the full config. Cleanup the logic a bit.

LP: #1642773
Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>