### PR TITLE
sources: missing command instead of package

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -71,15 +71,15 @@ class SnapcraftPartConflictError(SnapcraftError):
                          file_paths='\n'.join(sorted(spaced_conflict_files)))
 
 
-class MissingPackageError(SnapcraftError):
+class MissingCommandError(SnapcraftError):
 
     fmt = (
-        'One or more required packages are missing, please install:'
-        ' {required_packages!r}'
+        'One or more required commands are missing, please install:'
+        ' {required_commands!r}'
     )
 
-    def __init__(self, required_packages):
-        super().__init__(required_packages=required_packages)
+    def __init__(self, required_commands):
+        super().__init__(required_commands=required_commands)
 
 
 class InvalidWikiEntryError(SnapcraftError):

--- a/snapcraft/internal/sources.py
+++ b/snapcraft/internal/sources.py
@@ -87,7 +87,7 @@ import libarchive
 
 from snapcraft.internal import common
 from snapcraft import file_utils
-from snapcraft.internal.errors import MissingPackageError
+from snapcraft.internal.errors import MissingCommandError
 from snapcraft.internal.indicators import download_requests_stream
 
 
@@ -100,13 +100,9 @@ class IncompatibleOptionsError(Exception):
         self.message = message
 
 
-def _check_for_package(command):
-    try:
-        subprocess.check_call(['which', command],
-                              stderr=subprocess.DEVNULL,
-                              stdout=subprocess.DEVNULL)
-    except subprocess.CalledProcessError:
-        raise MissingPackageError([command])
+def _check_for_command(command):
+    if not shutil.which(command):
+        raise MissingCommandError([command])
 
 
 class Base:
@@ -124,7 +120,7 @@ class Base:
         self.command = command
 
         if self.command:
-            _check_for_package(self.command)
+            _check_for_command(self.command)
 
 
 class FileBase(Base):

--- a/snapcraft/tests/test_base_plugin.py
+++ b/snapcraft/tests/test_base_plugin.py
@@ -150,7 +150,7 @@ class GetSourceWithBranches(tests.TestCase):
         }),
     ]
 
-    @unittest.mock.patch('snapcraft.internal.sources._check_for_package')
+    @unittest.mock.patch('snapcraft.internal.sources._check_for_command')
     def test_get_source_with_branch_and_tag_must_raise_error(self, mock_check):
         mock_check.side_effect = None
         options = tests.MockOptions('lp:source', self.source_type,
@@ -212,7 +212,7 @@ class GetSourceTestCase(tests.TestCase):
             'error': 'source-commit'})
     ]
 
-    @unittest.mock.patch('snapcraft.internal.sources._check_for_package')
+    @unittest.mock.patch('snapcraft.internal.sources._check_for_command')
     def test_get_source_with_branch_must_raise_error(self, mock_check):
         mock_check.side_effect = None
         options = tests.MockOptions('lp:this', self.source_type,
@@ -231,7 +231,7 @@ class GetSourceTestCase(tests.TestCase):
 
 class BuildTestCase(tests.TestCase):
 
-    @unittest.mock.patch('snapcraft.internal.sources._check_for_package')
+    @unittest.mock.patch('snapcraft.internal.sources._check_for_command')
     def test_do_not_follow_links(self, mock_check):
         mock_check.side_effect = None
         options = tests.MockOptions(source='.')

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -24,7 +24,7 @@ import yaml
 from collections import OrderedDict
 
 import snapcraft                           # noqa, initialize yaml
-from snapcraft.internal.errors import MissingPackageError
+from snapcraft.internal.errors import MissingCommandError
 from snapcraft.internal import parser
 from snapcraft.internal.parser import (
     _get_origin_data,
@@ -1024,7 +1024,7 @@ parts: [main]
 
     @mock.patch('snapcraft.internal.sources.Bazaar.__init__')
     def test_missing_packages(self, mock_init):
-        mock_init.side_effect = MissingPackageError('bzr')
+        mock_init.side_effect = MissingCommandError('bzr')
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
         self.useFixture(fake_logger)
 
@@ -1044,5 +1044,5 @@ parts: [main2]
         self.assertEqual(2, retval)
 
         self.assertTrue(
-            'One or more required packages are missing, please install'
+            'One or more required commands are missing, please install'
             in fake_logger.output, 'No missing package info in output')

--- a/snapcraft/tests/test_sources.py
+++ b/snapcraft/tests/test_sources.py
@@ -229,7 +229,7 @@ class SourceTestCase(tests.TestCase):
         self.addCleanup(patcher.stop)
 
         patcher = unittest.mock.patch(
-            'snapcraft.internal.sources._check_for_package')
+            'snapcraft.internal.sources._check_for_command')
         self.mock_check = patcher.start()
         self.mock_check.side_effect = None
         self.addCleanup(patcher.stop)
@@ -786,7 +786,7 @@ class TestUri(tests.TestCase):
         super().setUp()
 
         patcher = unittest.mock.patch(
-            'snapcraft.internal.sources._check_for_package')
+            'snapcraft.internal.sources._check_for_command')
         patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -859,11 +859,11 @@ class TestUri(tests.TestCase):
                 mock_pull.reset_mock()
 
 
-class PackageCheckTestCase(tests.TestCase):
+class CommandCheckTestCase(tests.TestCase):
 
-    def test__check_for_package_not_installed(self):
-        with self.assertRaises(errors.MissingPackageError):
-            sources._check_for_package('not-a-package')
+    def test__check_for_command_not_installed(self):
+        with self.assertRaises(errors.MissingCommandError):
+            sources._check_for_command('missing-command')
 
-    def test__check_for_package_installed(self):
-        sources._check_for_package('sh')
+    def test__check_for_command_installed(self):
+        sources._check_for_command('sh')


### PR DESCRIPTION
We are checking for missing commands and calling them packages. So
commands is what needs to be exposed. In addition to that, use `shutil.which`
instead of a straight out `subprocess` call.

LP: #1642799
Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>