### PR TITLE
Add support for hooks.

### DIFF
--- a/demos/hooks/bin/configure.sh
+++ b/demos/hooks/bin/configure.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+output=$(snapctl get fail)
+if [ "$output" = "true" ]; then
+	echo "Failing as requested."
+	exit 1
+fi
+
+echo "I'm the configure hook!"

--- a/demos/hooks/snapcraft.yaml
+++ b/demos/hooks/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: hooks
+version: 1.0
+summary: summary
+description: description
+confinement: strict
+
+hooks:
+  configure:
+    command: configure.sh
+
+parts:
+  copy-hooks:
+    plugin: dump
+    source: .

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -123,6 +123,25 @@ properties:
             uniqueItems: true
             items:
               type: string
+  hooks:
+    type: object
+    additionalProperties: false
+    patternProperties:
+      "^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$":
+        type: object
+        required:
+          - command
+        additionalProperties: false
+        properties:
+          command:
+            type: string
+            description: command executed to run the hook
+          plugs:
+            type: array
+            minitems: 1
+            uniqueItems: true
+            items:
+              type: string
   parts:
     type: object
     minProperties: 1

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import contextlib
 import os
 import logging
 import re
@@ -148,6 +149,9 @@ class _SnapPackaging:
         if 'apps' in self._config_data:
             snap_yaml['apps'] = self._wrap_apps(self._config_data['apps'])
 
+        if 'hooks' in self._config_data:
+            snap_yaml['hooks'] = self._wrap_hooks(self._config_data['hooks'])
+
         return snap_yaml
 
     def _write_wrap_exe(self, wrapexec, wrappath,
@@ -207,6 +211,33 @@ class _SnapPackaging:
 
         return os.path.relpath(wrappath, self._snap_dir)
 
+    def _generate_hook(self, hook, command):
+        hooks_dir = os.path.join(self._snap_dir, 'meta', 'hooks')
+        os.makedirs(hooks_dir, exist_ok=True)
+
+        hook_path = os.path.join(hooks_dir, hook)
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(hook_path)
+
+        command_parts = shlex.split(command)
+
+        shebang = None
+        hook_exec = '$SNAP/{}'.format(command_parts[0])
+        exepath = os.path.join(self._snap_dir, command_parts[0])
+        if not os.path.exists(exepath) and '/' not in command_parts[0]:
+            _find_bin(command_parts[0], self._snap_dir)
+            hook_exec = command_parts[0]
+        else:
+            with open(exepath, 'rb') as f:
+                # If the file has a she-bang, the path might be pointing to
+                # the local 'parts' dir. Extract it so that _write_wrap_exe
+                # will have a chance to rewrite it.
+                if f.read(2) == b'#!':
+                    shebang = f.readline().strip().decode('utf-8')
+
+        self._write_wrap_exe(hook_exec, hook_path,
+                             shebang=shebang, args=command_parts[1:])
+
     def _wrap_apps(self, apps):
         for app in apps:
             cmds = (k for k in ('command', 'stop-command') if k in apps[app])
@@ -220,6 +251,25 @@ class _SnapPackaging:
                         'does not exist or is not executable'.format(
                             str(e), app))
         return apps
+
+    def _wrap_hooks(self, hooks):
+        for hook in hooks:
+            try:
+                command = hooks[hook]['command']
+
+                # The 'command' is for snapcraft only, not snapd. Remove it,
+                # and if that makes the dict empty, set it to None instead.
+                del hooks[hook]['command']
+                if len(hooks[hook]) == 0:
+                    hooks[hook] = None
+
+                self._generate_hook(hook, command)
+            except CommandError as e:
+                raise EnvironmentError(
+                    'The specified command {!r} defined in the hook {!r} '
+                    'does not exist or is not executable'.format(
+                        str(e), hook))
+        return hooks
 
 
 def _find_bin(binary, basedir):

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -45,14 +45,17 @@ class CreateTest(tests.TestCase):
         self.hooks_dir = os.path.join(self.meta_dir, 'hooks')
         self.snap_yaml = os.path.join(self.meta_dir, 'snap.yaml')
 
-    def test_create_meta(self):
+    def generate_meta_yaml(self):
         create_snap_packaging(self.config_data, self.snap_dir, self.parts_dir)
 
         self.assertTrue(
             os.path.exists(self.snap_yaml), 'snap.yaml was not created')
 
         with open(self.snap_yaml) as f:
-            y = yaml.load(f)
+            return yaml.load(f)
+
+    def test_create_meta(self):
+        y = self.generate_meta_yaml()
 
         expected = {'architectures': ['amd64'],
                     'description': 'my description',
@@ -72,15 +75,8 @@ class CreateTest(tests.TestCase):
             with self.subTest(key=confinement_type):
                 self.config_data['confinement'] = confinement_type
 
-                create_snap_packaging(
-                    self.config_data, self.snap_dir, self.parts_dir)
+                y = self.generate_meta_yaml()
 
-                self.assertTrue(
-                    os.path.exists(self.snap_yaml),
-                    'snap.yaml was not created')
-
-                with open(self.snap_yaml) as f:
-                    y = yaml.load(f)
                 self.assertTrue(
                     'confinement' in y,
                     'Expected "confinement" property to be in snap.yaml')
@@ -96,15 +92,8 @@ class CreateTest(tests.TestCase):
             with self.subTest(key=grade_type):
                 self.config_data['grade'] = grade_type
 
-                create_snap_packaging(
-                    self.config_data, self.snap_dir, self.parts_dir)
+                y = self.generate_meta_yaml()
 
-                self.assertTrue(
-                    os.path.exists(self.snap_yaml),
-                    'snap.yaml was not created')
-
-                with open(self.snap_yaml) as f:
-                    y = yaml.load(f)
                 self.assertTrue(
                     'grade' in y,
                     'Expected "grade" property to be in snap.yaml')
@@ -113,13 +102,8 @@ class CreateTest(tests.TestCase):
     def test_create_meta_with_epoch(self):
         self.config_data['epoch'] = '1*'
 
-        create_snap_packaging(self.config_data, self.snap_dir, self.parts_dir)
+        y = self.generate_meta_yaml()
 
-        self.assertTrue(
-            os.path.exists(self.snap_yaml), 'snap.yaml was not created')
-
-        with open(self.snap_yaml) as f:
-            y = yaml.load(f)
         self.assertTrue(
             'epoch' in y,
             'Expected "epoch" property to be copied into snap.yaml')
@@ -128,13 +112,8 @@ class CreateTest(tests.TestCase):
     def test_create_meta_with_assumes(self):
         self.config_data['assumes'] = ['feature1', 'feature2']
 
-        create_snap_packaging(self.config_data, self.snap_dir, self.parts_dir)
+        y = self.generate_meta_yaml()
 
-        self.assertTrue(
-            os.path.exists(self.snap_yaml), 'snap.yaml was not created')
-
-        with open(self.snap_yaml) as f:
-            y = yaml.load(f)
         self.assertTrue(
             'assumes' in y,
             'Expected "assumes" property to be copied into snap.yaml')
@@ -166,17 +145,12 @@ class CreateTest(tests.TestCase):
         open(os.path.join(os.curdir, 'my-icon.png'), 'w').close()
         self.config_data['icon'] = 'my-icon.png'
 
-        create_snap_packaging(self.config_data, self.snap_dir, self.parts_dir)
+        y = self.generate_meta_yaml()
 
         self.assertTrue(
             os.path.exists(os.path.join(self.meta_dir, 'gui', 'icon.png')),
             'icon.png was not setup correctly')
 
-        self.assertTrue(
-            os.path.exists(self.snap_yaml), 'snap.yaml was not created')
-
-        with open(self.snap_yaml) as f:
-            y = yaml.load(f)
         self.assertFalse('icon' in y,
                          'icon found in snap.yaml {}'.format(y))
 
@@ -195,7 +169,7 @@ class CreateTest(tests.TestCase):
             f.write(declared_icon_content)
         self.config_data['icon'] = 'my-icon.png'
 
-        create_snap_packaging(self.config_data, self.snap_dir, self.parts_dir)
+        y = self.generate_meta_yaml()
 
         expected_icon = os.path.join(self.meta_dir, 'gui', 'icon.png')
         self.assertTrue(os.path.exists(expected_icon),
@@ -203,11 +177,6 @@ class CreateTest(tests.TestCase):
         with open(expected_icon, 'rb') as f:
             self.assertEqual(f.read(), declared_icon_content)
 
-        self.assertTrue(
-            os.path.exists(self.snap_yaml), 'snap.yaml was not created')
-
-        with open(self.snap_yaml) as f:
-            y = yaml.load(f)
         self.assertFalse('icon' in y,
                          'icon found in snap.yaml {}'.format(y))
 
@@ -233,7 +202,7 @@ class CreateTest(tests.TestCase):
         with open(os.path.join(gui_path, 'icon.png'), 'wb') as f:
             f.write(icon_content)
 
-        create_snap_packaging(self.config_data, self.snap_dir, self.parts_dir)
+        y = self.generate_meta_yaml()
 
         expected_icon = os.path.join(self.meta_dir, 'gui', 'icon.png')
         self.assertTrue(os.path.exists(expected_icon),
@@ -241,11 +210,6 @@ class CreateTest(tests.TestCase):
         with open(expected_icon, 'rb') as f:
             self.assertEqual(f.read(), icon_content)
 
-        self.assertTrue(
-            os.path.exists(self.snap_yaml), 'snap.yaml was not created')
-
-        with open(self.snap_yaml) as f:
-            y = yaml.load(f)
         self.assertFalse('icon' in y,
                          'icon found in snap.yaml {}'.format(y))
 
@@ -260,7 +224,7 @@ class CreateTest(tests.TestCase):
         self.config_data['plugs'] = {
             'network-server': {'interface': 'network-bind'}}
 
-        create_snap_packaging(self.config_data, self.snap_dir, self.parts_dir)
+        y = self.generate_meta_yaml()
 
         for app in ['app1', 'app2', 'app3']:
             app_wrapper_path = os.path.join(
@@ -268,12 +232,6 @@ class CreateTest(tests.TestCase):
             self.assertTrue(
                 os.path.exists(app_wrapper_path),
                 'the wrapper for {!r} was not setup correctly'.format(app))
-
-        self.assertTrue(
-            os.path.exists(self.snap_yaml), 'snap.yaml was not created')
-
-        with open(self.snap_yaml) as f:
-            y = yaml.load(f)
 
         expected = {
             'architectures': ['amd64'],
@@ -302,6 +260,44 @@ class CreateTest(tests.TestCase):
         }
 
         self.assertEqual(y, expected)
+
+    def test_create_meta_with_hook(self):
+        os.mkdir(self.snap_dir)
+        open(os.path.join(self.snap_dir, 'run-foo.sh'), 'w').close()
+        open(os.path.join(self.snap_dir, 'run-bar.sh'), 'w').close()
+        self.config_data['hooks'] = {
+            'foo': {'command': 'run-foo.sh', 'plugs': ['plug']},
+            'bar': {'command': 'run-bar.sh'}
+        }
+
+        y = self.generate_meta_yaml()
+
+        for hook in ['foo', 'bar']:
+            generated_hook_path = os.path.join(
+                self.snap_dir, 'meta', 'hooks', hook)
+            self.assertTrue(
+                os.path.exists(generated_hook_path),
+                'The {!r} hook was not setup correctly'.format(hook))
+
+        self.assertTrue(
+            'hooks' in y, "Expected generated YAML to contain 'hooks'")
+        for hook in {'foo', 'bar'}:
+            self.assertTrue(
+                hook in y['hooks'],
+                'Expected generated hooks to contain {!r}'.format(hook))
+
+            generated_hook = y['hooks'][hook]
+            if generated_hook:
+                self.assertFalse(
+                    'command' in generated_hook,
+                    'Expected generated {!r} hook to not contain '
+                    "'command'".format(hook))
+
+        self.assertTrue(
+            'plugs' in y['hooks']['foo'],
+            "Expected generated 'foo' hook to contain 'plugs'".format(hook))
+        self.assertEqual(len(y['hooks']['foo']['plugs']), 1)
+        self.assertEqual(y['hooks']['foo']['plugs'][0], 'plug')
 
 
 # TODO this needs more tests.

--- a/snaps_tests/demos_tests/test_hooks.py
+++ b/snaps_tests/demos_tests/test_hooks.py
@@ -1,0 +1,36 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015, 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+import snaps_tests
+
+
+class HookCase(snaps_tests.SnapsTestCase):
+
+    snap_content_dir = 'hooks'
+
+    def test_hooks(self):
+        snap_path = self.build_snap(self.snap_content_dir)
+        self.install_snap(snap_path, 'hooks', '1.0')
+
+        # Regular `snap set` should succeed.
+        self.run_command_in_snappy_testbed('sudo snap set hooks foo=bar')
+
+        # Setting fail=true should fail.
+        self.assertRaises(
+            subprocess.CalledProcessError,
+            self.run_command_in_snappy_testbed,
+            'sudo snap set hooks fail=true')


### PR DESCRIPTION
Hooks are now supported in snapd and the click reviewer tools. Time to finish off LP: [#1586465](https://bugs.launchpad.net/snapcraft/+bug/1586465) by supporting them in snapcraft as well. This is done declaratively via a `hooks` option in the snapcraft.yaml, for example:

    hooks:
      configure:
        command: run-my-hook
        plugs: [network]

This works exactly like apps, where `run-my-hook` should be a binary available within the snap. Then during the prime step, snapcraft will generate the hook (the configure hook in this example), which calls the command supplied.