### PR TITLE
sources: add current dir to ignore list if we're iterating on parent

### DIFF
--- a/integration_tests/snaps/local-source-subfolders/packaging/snap-package/snapcraft.yaml
+++ b/integration_tests/snaps/local-source-subfolders/packaging/snap-package/snapcraft.yaml
@@ -1,0 +1,12 @@
+name: lets-dump
+version: '0.1'
+summary: Let's dump parent folders
+description: Dumping up-folder
+
+grade: devel
+confinement: strict
+
+parts:
+  dump-part:
+    plugin: dump
+    source: ../..

--- a/integration_tests/snaps/local-source-subfolders/packaging/snap-package/yes-really-deep/snapcraft.yaml
+++ b/integration_tests/snaps/local-source-subfolders/packaging/snap-package/yes-really-deep/snapcraft.yaml
@@ -1,0 +1,12 @@
+name: lets-dump
+version: '0.1'
+summary: Let's dump parent folders
+description: Dumping up-folder
+
+grade: devel
+confinement: strict
+
+parts:
+  dump-part:
+    plugin: dump
+    source: ../../..

--- a/integration_tests/snaps/local-source-subfolders/packaging/snapcraft.yaml
+++ b/integration_tests/snaps/local-source-subfolders/packaging/snapcraft.yaml
@@ -1,0 +1,12 @@
+name: lets-dump
+version: '0.1'
+summary: Let's dump parent folders
+description: Dumping up-folder
+
+grade: devel
+confinement: strict
+
+parts:
+  dump-part:
+    plugin: dump
+    source: ..

--- a/integration_tests/snaps/local-source-subfolders/snapcraft.yaml
+++ b/integration_tests/snaps/local-source-subfolders/snapcraft.yaml
@@ -1,0 +1,12 @@
+name: lets-dump
+version: '0.1'
+summary: Let's dump parent folders
+description: Dumping up-folder
+
+grade: devel
+confinement: strict
+
+parts:
+  dump-part:
+    plugin: dump
+    source: .

--- a/integration_tests/test_local_source.py
+++ b/integration_tests/test_local_source.py
@@ -19,6 +19,7 @@ import os
 from testtools.matchers import FileExists
 
 import integration_tests
+import testscenarios
 
 
 class LocalSourceTestCase(integration_tests.TestCase):
@@ -41,3 +42,25 @@ class LocalSourceTestCase(integration_tests.TestCase):
                 project_dir, 'parts', 'make-project', 'build',
                 'stamp-install'),
             FileExists())
+
+
+class LocalSourceSubfoldersTestCase(
+        testscenarios.WithScenarios, integration_tests.TestCase):
+
+    scenarios = [
+        ('Top folder',
+            {'subfolder': '.'}),
+        ('Sub folder Level 1',
+            {'subfolder': 'packaging'}),
+        ('Sub folder Level 2',
+            {'subfolder': os.path.join('packaging', 'snap-package')}),
+        ('Sub folder Level 3',
+            {'subfolder': os.path.join(
+                'packaging', 'snap-package', 'yes-really-deep')}),
+    ]
+
+    def test_pull_local_source(self):
+        project_dir = 'local-source-subfolders'
+        self.run_snapcraft(
+            'pull', project_dir,
+            yaml_dir=os.path.join(project_dir, self.subfolder))

--- a/snapcraft/internal/sources.py
+++ b/snapcraft/internal/sources.py
@@ -529,21 +529,22 @@ class Local(Base):
         current_parent_folder = os.path.dirname(os.getcwd())
 
         def ignore(directory, files):
+            ignored = []
             if directory is source_abspath or \
                directory == current_parent_folder:
-                ignored = copy.copy(common.SNAPCRAFT_FILES)
                 relative_cwd = os.path.basename(os.getcwd())
                 if os.path.join(directory, relative_cwd) == os.getcwd():
                     # Source is a parent of the working directory.
                     # Do not recursively copy it into itself.
                     ignored.append(relative_cwd)
+
+            if directory is source_abspath:
+                ignored.extend(common.SNAPCRAFT_FILES)
                 snaps = glob.glob(os.path.join(directory, '*.snap'))
                 if snaps:
                     snaps = [os.path.basename(s) for s in snaps]
                     ignored += snaps
-                return ignored
-            else:
-                return []
+            return ignored
 
         shutil.copytree(source_abspath, self.source_dir,
                         copy_function=file_utils.link_or_copy, ignore=ignore)

--- a/snapcraft/internal/sources.py
+++ b/snapcraft/internal/sources.py
@@ -530,7 +530,7 @@ class Local(Base):
         source_abspath = os.path.abspath(self.source)
 
         def ignore(directory, files):
-            if directory is source_abspath or \
+            if directory == source_abspath or \
                directory == current_dir:
                 ignored = copy.copy(common.SNAPCRAFT_FILES)
                 snaps = glob.glob(os.path.join(directory, '*.snap'))

--- a/snapcraft/internal/sources.py
+++ b/snapcraft/internal/sources.py
@@ -68,6 +68,7 @@ cases you want to refer to the help text for the specific plugin.
 
 """
 
+import copy
 import glob
 import logging
 import os
@@ -525,26 +526,20 @@ class Local(Base):
         elif os.path.isdir(self.source_dir):
             shutil.rmtree(self.source_dir)
 
+        current_dir = os.getcwd()
         source_abspath = os.path.abspath(self.source)
-        current_parent_folder = os.path.dirname(os.getcwd())
 
         def ignore(directory, files):
-            ignored = []
             if directory is source_abspath or \
-               directory == current_parent_folder:
-                relative_cwd = os.path.basename(os.getcwd())
-                if os.path.join(directory, relative_cwd) == os.getcwd():
-                    # Source is a parent of the working directory.
-                    # Do not recursively copy it into itself.
-                    ignored.append(relative_cwd)
-
-            if directory is source_abspath:
-                ignored.extend(common.SNAPCRAFT_FILES)
+               directory == current_dir:
+                ignored = copy.copy(common.SNAPCRAFT_FILES)
                 snaps = glob.glob(os.path.join(directory, '*.snap'))
                 if snaps:
                     snaps = [os.path.basename(s) for s in snaps]
                     ignored += snaps
-            return ignored
+                return ignored
+            else:
+                return []
 
         shutil.copytree(source_abspath, self.source_dir,
                         copy_function=file_utils.link_or_copy, ignore=ignore)

--- a/snapcraft/internal/sources.py
+++ b/snapcraft/internal/sources.py
@@ -68,7 +68,6 @@ cases you want to refer to the help text for the specific plugin.
 
 """
 
-import copy
 import glob
 import logging
 import os
@@ -527,9 +526,11 @@ class Local(Base):
             shutil.rmtree(self.source_dir)
 
         source_abspath = os.path.abspath(self.source)
+        current_parent_folder = os.path.dirname(os.getcwd())
 
         def ignore(directory, files):
-            if directory is source_abspath:
+            if directory is source_abspath or \
+               directory == current_parent_folder:
                 ignored = copy.copy(common.SNAPCRAFT_FILES)
                 relative_cwd = os.path.basename(os.getcwd())
                 if os.path.join(directory, relative_cwd) == os.getcwd():

--- a/snapcraft/tests/test_sources.py
+++ b/snapcraft/tests/test_sources.py
@@ -742,7 +742,7 @@ class TestLocal(tests.TestCase):
                 os.path.exists(os.path.join(
                     'subdir', source_dir, 'subdir', snap_dir)))
             self.assertTrue(
-                'subdir' not in os.listdir(os.path.join('subdir', source_dir)))
+                'subdir' in os.listdir(os.path.join('subdir', source_dir)))
 
         # Regression test for https://bugs.launchpad.net/snapcraft/+bug/1614913
         # Verify that SNAPCRAFT_FILES was not modified by the pull when there
@@ -767,7 +767,7 @@ class TestLocal(tests.TestCase):
                 os.path.exists(os.path.join(
                     subdir, source_dir, subdir, snap_dir)))
             self.assertTrue(
-                os.path.basename(subdir) not in os.listdir(
+                os.path.basename(subdir) in os.listdir(
                     os.path.join(subdir, source_dir, os.path.dirname(subdir))))
 
     def test_pull_with_existing_empty_source_dir_creates_hardlinks(self):

--- a/snapcraft/tests/test_sources.py
+++ b/snapcraft/tests/test_sources.py
@@ -739,43 +739,6 @@ class TestLocal(tests.TestCase):
         self.assertEqual(
             snapcraft_files_before_pull, common.SNAPCRAFT_FILES)
 
-    def test_pull_with_source_the_parent_of_current_dir(self):
-        # Verify that the snapcraft root dir does not get copied into itself.
-        os.makedirs('subdir')
-
-        for snap_dir in [f for f in common.SNAPCRAFT_FILES if '.' not in f]:
-            cwd = os.getcwd()
-            os.chdir('subdir')
-            source_dir = os.path.join(snap_dir, 'foo')
-            local = sources.Local('..', source_dir)
-            local.pull()
-            os.chdir(cwd)
-            self.assertFalse(
-                os.path.exists(os.path.join(
-                    'subdir', source_dir, 'subdir', snap_dir)))
-            self.assertTrue(
-                'subdir' in os.listdir(os.path.join('subdir', source_dir)))
-
-    def test_pull_with_source_a_parent_of_current_dir(self):
-        # Verify that the snapcraft root dir does not get copied into itself.
-        subdir = os.path.join('subdir', 'subsubdir', 'subsubsubdir')
-        os.makedirs(subdir)
-
-        for snap_dir in [f for f in common.SNAPCRAFT_FILES if '.' not in f]:
-            cwd = os.getcwd()
-            os.chdir(subdir)
-            source = '../' * (subdir.count(os.sep)+1)
-            source_dir = os.path.join(snap_dir, 'foo')
-            local = sources.Local(source, source_dir)
-            local.pull()
-            os.chdir(cwd)
-            self.assertFalse(
-                os.path.exists(os.path.join(
-                    subdir, source_dir, subdir, snap_dir)))
-            self.assertTrue(
-                os.path.basename(subdir) in os.listdir(
-                    os.path.join(subdir, source_dir, os.path.dirname(subdir))))
-
     def test_pull_with_existing_empty_source_dir_creates_hardlinks(self):
         os.makedirs(os.path.join('src', 'dir'))
         open(os.path.join('src', 'dir', 'file'), 'w').close()
@@ -876,6 +839,46 @@ class TestLocal(tests.TestCase):
         self.assertFalse(os.path.islink(os.path.join('destination', 'dir')))
         self.assertGreater(
             os.stat(os.path.join('destination', 'dir', 'file')).st_nlink, 1)
+
+
+class TestLocalIgnores(tests.TestCase):
+    """Verify that the snapcraft root dir does not get copied into itself."""
+
+    scenarios = [(f, dict(snapcraft_dir=f))
+                 for f in common.SNAPCRAFT_FILES if '.' not in f]
+
+    def test_pull_with_source_the_parent_of_current_dir(self):
+        os.makedirs('subdir')
+
+        cwd = os.getcwd()
+        os.chdir('subdir')
+        source_dir = os.path.join(self.snapcraft_dir, 'foo_src')
+        local = sources.Local('..', source_dir)
+        local.pull()
+        os.chdir(cwd)
+        self.assertFalse(
+            os.path.exists(os.path.join(
+                'subdir', source_dir, 'subdir', self.snapcraft_dir)))
+        self.assertTrue(
+            'subdir' in os.listdir(os.path.join('subdir', source_dir)))
+
+    def test_pull_with_source_a_parent_of_current_dir(self):
+        subdir = os.path.join('subdir', 'subsubdir', 'subsubsubdir')
+        os.makedirs(subdir)
+
+        cwd = os.getcwd()
+        os.chdir(subdir)
+        source = '../' * (subdir.count(os.sep)+1)
+        source_dir = os.path.join(self.snapcraft_dir, 'foo_src')
+        local = sources.Local(source, source_dir)
+        local.pull()
+        os.chdir(cwd)
+        self.assertFalse(
+            os.path.exists(os.path.join(
+                subdir, source_dir, subdir, self.snapcraft_dir)))
+        self.assertTrue(
+            os.path.basename(subdir) in os.listdir(
+                os.path.join(subdir, source_dir, os.path.dirname(subdir))))
 
 
 class TestUri(tests.TestCase):


### PR DESCRIPTION
This avoids to iterate over and over our ignored folders when launching snapcraft from a sub-sub-folder of the sources.

Added integration tests. Rewritten unit tests.

Fixes <a href='http://pad.lv/1644350'>LP: #1644350</a>