### PR TITLE
parser: support remote dependencies

### DIFF
--- a/snapcraft/internal/parser.py
+++ b/snapcraft/internal/parser.py
@@ -238,7 +238,8 @@ def _process_wiki_entry(entry, master_parts_list):
 
     parts_list, after_parts = _process_entry(data)
 
-    if is_valid_parts_list(parts_list, after_parts):
+    known_parts = list(parts_list.keys()) + list(master_parts_list.keys())
+    if is_valid_parts_list(after_parts, known_parts):
         master_parts_list.update(parts_list)
 
 
@@ -308,9 +309,9 @@ def run(args):
     return wiki_errors
 
 
-def is_valid_parts_list(parts_list, parts):
+def is_valid_parts_list(parts, known_parts):
     for partname in parts:
-        if partname not in parts_list.keys():
+        if partname not in known_parts:
             logging.error('Part {!r} is missing from the parts entry'.format(
                 partname))
             return False

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -968,6 +968,80 @@ parts: [app1]
         self.assertEqual(parts,
                          _get_part_list())
 
+    @mock.patch('snapcraft.internal.parser._get_origin_data')
+    def test_remote_after_parts(self, mock_get_origin_data):
+        _create_example_output("""
+---
+maintainer: John Doe <john.doe@example.com>
+origin: lp:snapcraft-parser-example
+description: example part on which parent depends on
+parts: [child]
+---
+maintainer: Marco Trevisan <marco@ubuntu.com>
+origin: lp:snapcraft-parser-example
+description: parent part that depends on child
+parts: [parent]
+""")
+        parts = OrderedDict()
+
+        child_part = OrderedDict()
+        child_part['description'] = 'parent part that depends on child'
+        child_part['maintainer'] = 'John Doe <john.doe@example.com>'
+        child_part['plugin'] = 'dump'
+        child_part['source'] = 'lp:project'
+        parts['child'] = child_part
+
+        parent_part = OrderedDict()
+        parent_part['description'] = 'example part on which parent depends on'
+        parent_part['maintainer'] = 'Marco Trevisan <marco@ubuntu.com>'
+        parent_part['plugin'] = 'dump'
+        parent_part['source'] = 'lp:project'
+        parent_part['after'] = ['child']
+        parts['parent'] = parent_part
+
+        mock_get_origin_data.return_value = {
+            'parts': parts,
+        }
+        main(['--index', TEST_OUTPUT_PATH])
+        self.assertEqual(2, _get_part_list_count())
+
+    @mock.patch('snapcraft.internal.parser._get_origin_data')
+    def test_remote_after_parts_unordered(self, mock_get_origin_data):
+        _create_example_output("""
+---
+maintainer: Marco Trevisan <marco@ubuntu.com>
+origin: lp:snapcraft-parser-example
+description: parent part that depends on child
+parts: [parent]
+---
+maintainer: John Doe <john.doe@example.com>
+origin: lp:snapcraft-parser-example
+description: example part on which parent depends on
+parts: [child]
+""")
+        parts = OrderedDict()
+
+        parent_part = OrderedDict()
+        parent_part['description'] = 'example part on which parent depends on'
+        parent_part['maintainer'] = 'Marco Trevisan <marco@ubuntu.com>'
+        parent_part['plugin'] = 'dump'
+        parent_part['source'] = 'lp:project'
+        parent_part['after'] = ['child']
+        parts['parent'] = parent_part
+
+        child_part = OrderedDict()
+        child_part['description'] = 'parent part that depends on child'
+        child_part['maintainer'] = 'John Doe <john.doe@example.com>'
+        child_part['plugin'] = 'dump'
+        child_part['source'] = 'lp:project'
+        parts['child'] = child_part
+
+        mock_get_origin_data.return_value = {
+            'parts': parts,
+        }
+        main(['--index', TEST_OUTPUT_PATH])
+        self.assertEqual(2, _get_part_list_count())
+
     def test__get_origin_data_both(self):
         with open(os.path.join(self.tempdir_path,
                   '.snapcraft.yaml'), 'w') as fp:


### PR DESCRIPTION
Ensure that we re-parse the parts that have missing dependencies after we've added all the valid ones to the `master_parts_list`

I would have fixed this in a cleaner way (allowing to include parts of a snapcraft.yaml that are good, and ignoring the bad ones only) but it would have caused a major refactor of the parser which probably is better to avoid.

Fixes [LP: #1645350](https://bugs.launchpad.net/snapcraft/+bug/1645350)

@josepht, please have a look to this.