### PR TITLE
parser: add support for origin-{branch,commit,tag}

### DIFF
--- a/docs/snapcraft-parts.md
+++ b/docs/snapcraft-parts.md
@@ -186,7 +186,10 @@ required fields:
 
 Optional fields are:
 
- * origin-type - A hint about the type of project that contains the part. (e.g. bzr, git, tar)
+ * origin-type - the type of project that contains the part. (e.g. bzr, git, tar)
+ * origin-branch - the source branch that contains the part.
+ * origin-commit - the source commit that contains the part.
+ * origin-tag - the source tag that contains the part.
 
 ### Note:
 

--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -80,6 +80,16 @@ class TestCase(testtools.TestCase):
 
         return snapcraft_output
 
+    def run_snapcraft_parser(self, arguments):
+        try:
+            snapcraft_output = subprocess.check_output(
+                [self.snapcraft_parser_command, '-d'] + arguments,
+                stderr=subprocess.STDOUT, universal_newlines=True)
+        except subprocess.CalledProcessError as e:
+            self.addDetail('output', content.text_content(e.output))
+            raise
+        return snapcraft_output
+
     def run_apt_autoremove(self):
         deb_env = os.environ.copy()
         deb_env.update({

--- a/integration_tests/origin_options_wiki
+++ b/integration_tests/origin_options_wiki
@@ -1,0 +1,8 @@
+---
+description: Wiki with origin modifiers
+maintainer: Marco Trevisan <marco@ubuntu.com>
+parts: [desktop-glib-only]
+origin: https://github.com/3v1n0/snapcraft-desktop-helpers.git
+origin-type: git
+origin-branch: snap-launcher-arch
+origin-commit: 91cc92f0a0c

--- a/integration_tests/test_parser.py
+++ b/integration_tests/test_parser.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import fixtures
 import subprocess
 
 import integration_tests
@@ -24,6 +25,13 @@ from snapcraft.tests import fixture_setup
 
 class ParserTestCase(integration_tests.TestCase):
     """Test bin/snapcraft-parser"""
+
+    def setUp(self):
+        super().setUp()
+
+        tempdir = fixtures.TempDir()
+        self.useFixture(tempdir)
+        self.useFixture(fixtures.EnvironmentVariable('TMPDIR', tempdir.path))
 
     def call_parser(self, wiki_path, expect_valid):
         args = [self.snapcraft_parser_command, '--index', wiki_path,

--- a/integration_tests/test_parser.py
+++ b/integration_tests/test_parser.py
@@ -28,15 +28,13 @@ class ParserTestCase(integration_tests.TestCase):
 
     def setUp(self):
         super().setUp()
+        self.useFixture(fixtures.EnvironmentVariable('TMPDIR', self.path))
 
-        tempdir = fixtures.TempDir()
-        self.useFixture(tempdir)
-        self.useFixture(fixtures.EnvironmentVariable('TMPDIR', tempdir.path))
-
-    def call_parser(self, wiki_path, expect_valid):
+    def call_parser(self, wiki_path, expect_valid, expect_output=True):
+        part_file = os.path.join(self.path, 'parts.yaml')
         args = [self.snapcraft_parser_command, '--index', wiki_path,
                 '--debug',
-                '--output', 'parts.yaml']
+                '--output', part_file]
 
         if expect_valid:
             subprocess.check_call(args, stderr=subprocess.DEVNULL,
@@ -47,7 +45,7 @@ class ParserTestCase(integration_tests.TestCase):
                 subprocess.check_call, args, stderr=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL)
 
-        self.assertTrue(os.path.exists('parts.yaml'))
+        self.assertEqual(os.path.exists(part_file), expect_output)
 
 
 class TestParser(ParserTestCase):

--- a/integration_tests/test_parser.py
+++ b/integration_tests/test_parser.py
@@ -32,18 +32,14 @@ class ParserTestCase(integration_tests.TestCase):
 
     def call_parser(self, wiki_path, expect_valid, expect_output=True):
         part_file = os.path.join(self.path, 'parts.yaml')
-        args = [self.snapcraft_parser_command, '--index', wiki_path,
-                '--debug',
-                '--output', part_file]
+        args = ['--index', wiki_path, '--output', part_file]
 
         if expect_valid:
-            subprocess.check_call(args, stderr=subprocess.DEVNULL,
-                                  stdout=subprocess.DEVNULL)
+            self.run_snapcraft_parser(args)
         else:
             self.assertRaises(
                 subprocess.CalledProcessError,
-                subprocess.check_call, args, stderr=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL)
+                self.run_snapcraft_parser, args)
 
         self.assertEqual(os.path.exists(part_file), expect_output)
 

--- a/integration_tests/test_parser.py
+++ b/integration_tests/test_parser.py
@@ -72,6 +72,8 @@ class TestParserWikis(testscenarios.WithScenarios, ParserTestCase):
             {'wiki_file': 'both_parts_wiki', 'expect_valid': False}),
         ('Missing .snapcraft.yaml file',
             {'wiki_file': 'missing_parts_wiki', 'expect_valid': False}),
+        ('Origin type, branch and commit options',
+            {'wiki_file': 'origin_options_wiki', 'expect_valid': True}),
     ]
 
     def test_parse_wiki(self):

--- a/integration_tests/test_parser.py
+++ b/integration_tests/test_parser.py
@@ -65,15 +65,19 @@ class TestParserWikis(testscenarios.WithScenarios, ParserTestCase):
 
     scenarios = [
         ('Hidden .snapcraft.yaml file',
-            {'wiki_file': 'hidden_parts_wiki', 'expect_valid': True}),
+            {'wiki_file': 'hidden_parts_wiki',
+             'expect_valid': True, 'expect_output': True}),
         ('Both snapcraft.yaml and .snapcraft.yaml files',
-            {'wiki_file': 'both_parts_wiki', 'expect_valid': False}),
+            {'wiki_file': 'both_parts_wiki',
+             'expect_valid': False, 'expect_output': True}),
         ('Missing .snapcraft.yaml file',
-            {'wiki_file': 'missing_parts_wiki', 'expect_valid': False}),
+            {'wiki_file': 'missing_parts_wiki',
+             'expect_valid': False, 'expect_output': True}),
         ('Origin type, branch and commit options',
-            {'wiki_file': 'origin_options_wiki', 'expect_valid': True}),
+            {'wiki_file': 'origin_options_wiki',
+             'expect_valid': True, 'expect_output': True}),
     ]
 
     def test_parse_wiki(self):
         wiki_file = os.path.join(os.path.dirname(__file__), self.wiki_file)
-        self.call_parser(wiki_file, self.expect_valid)
+        self.call_parser(wiki_file, self.expect_valid, self.expect_output)

--- a/integration_tests/test_parser.py
+++ b/integration_tests/test_parser.py
@@ -18,10 +18,31 @@ import os
 import subprocess
 
 import integration_tests
+import testscenarios
 from snapcraft.tests import fixture_setup
 
 
-class TestParser(integration_tests.TestCase):
+class ParserTestCase(integration_tests.TestCase):
+    """Test bin/snapcraft-parser"""
+
+    def call_parser(self, wiki_path, expect_valid):
+        args = [self.snapcraft_parser_command, '--index', wiki_path,
+                '--debug',
+                '--output', 'parts.yaml']
+
+        if expect_valid:
+            subprocess.check_call(args, stderr=subprocess.DEVNULL,
+                                  stdout=subprocess.DEVNULL)
+        else:
+            self.assertRaises(
+                subprocess.CalledProcessError,
+                subprocess.check_call, args, stderr=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL)
+
+        self.assertTrue(os.path.exists('parts.yaml'))
+
+
+class TestParser(ParserTestCase):
     """Test bin/snapcraft-parser"""
 
     def test_parser_basic(self):
@@ -29,50 +50,22 @@ class TestParser(integration_tests.TestCase):
         fixture = fixture_setup.FakePartsWiki()
         self.useFixture(fixture)
 
-        args = [self.snapcraft_parser_command, '--index',
-                fixture.fake_parts_wiki_fixture.url,
-                '--debug', '--output', 'parts.yaml']
-        subprocess.check_call(args, stderr=subprocess.DEVNULL,
-                              stdout=subprocess.DEVNULL)
+        self.call_parser(
+            fixture.fake_parts_wiki_fixture.url, expect_valid=True)
 
-        self.assertTrue(os.path.exists('parts.yaml'))
 
-    def test_hidden_snapcraft_yaml(self):
-        """Test hidden .snapcraft.yaml file."""
+class TestParserWikis(testscenarios.WithScenarios, ParserTestCase):
+    """Test bin/snapcraft-parser"""
 
-        args = [self.snapcraft_parser_command, '--index',
-                os.path.join(os.path.dirname(__file__), 'hidden_parts_wiki'),
-                '--debug',
-                '--output', 'parts.yaml']
-        subprocess.check_call(args, stderr=subprocess.DEVNULL,
-                              stdout=subprocess.DEVNULL)
+    scenarios = [
+        ('Hidden .snapcraft.yaml file',
+            {'wiki_file': 'hidden_parts_wiki', 'expect_valid': True}),
+        ('Both snapcraft.yaml and .snapcraft.yaml files',
+            {'wiki_file': 'both_parts_wiki', 'expect_valid': False}),
+        ('Missing .snapcraft.yaml file',
+            {'wiki_file': 'missing_parts_wiki', 'expect_valid': False}),
+    ]
 
-        self.assertTrue(os.path.exists('parts.yaml'))
-
-    def test_both_snapcraft_yaml(self):
-        """Test hidden .snapcraft.yaml file."""
-
-        args = [self.snapcraft_parser_command, '--index',
-                os.path.join(os.path.dirname(__file__), 'both_parts_wiki'),
-                '--debug',
-                '--output', 'parts.yaml']
-        self.assertRaises(
-            subprocess.CalledProcessError,
-            subprocess.check_call, args, stderr=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL)
-
-        self.assertTrue(os.path.exists('parts.yaml'))
-
-    def test_missing_snapcraft_yaml(self):
-        """Test missing .snapcraft.yaml file."""
-
-        args = [self.snapcraft_parser_command, '--index',
-                os.path.join(os.path.dirname(__file__), 'missing_parts_wiki'),
-                '--debug',
-                '--output', 'parts.yaml']
-        self.assertRaises(
-            subprocess.CalledProcessError,
-            subprocess.check_call, args, stderr=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL)
-
-        self.assertTrue(os.path.exists('parts.yaml'))
+    def test_parse_wiki(self):
+        wiki_file = os.path.join(os.path.dirname(__file__), self.wiki_file)
+        self.call_parser(wiki_file, self.expect_valid)

--- a/integration_tests/test_parser.py
+++ b/integration_tests/test_parser.py
@@ -76,6 +76,9 @@ class TestParserWikis(testscenarios.WithScenarios, ParserTestCase):
         ('Origin type, branch and commit options',
             {'wiki_file': 'origin_options_wiki',
              'expect_valid': True, 'expect_output': True}),
+        ('Origin type, branch and commit options (wrong values)',
+            {'wiki_file': 'wrong_origin_options_wiki',
+             'expect_valid': False, 'expect_output': False}),
     ]
 
     def test_parse_wiki(self):

--- a/integration_tests/wrong_origin_options_wiki
+++ b/integration_tests/wrong_origin_options_wiki
@@ -1,0 +1,8 @@
+---
+description: Wiki with invalid origin modifiers
+maintainer: Marco Trevisan <marco@ubuntu.com>
+parts: [desktop-glib-only]
+origin: https://github.com/3v1n0/snapcraft-desktop-helpers.git
+origin-type: git
+origin-branch: really-I-don-t-have-this-branch
+origin-commit: ThisIsNotACommitID

--- a/snapcraft/internal/parser.py
+++ b/snapcraft/internal/parser.py
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
 
 
 # TODO: make this a temporary directory that get's removed when finished
-BASE_DIR = "/tmp"
+BASE_DIR = os.getenv('TMPDIR', '/tmp')
 PARTS_FILE = "snap-parts.yaml"
 
 

--- a/snapcraft/internal/parser.py
+++ b/snapcraft/internal/parser.py
@@ -178,6 +178,9 @@ def _process_entry(data):
 
     # Get optional wiki entry fields.
     origin_type = data.get('origin-type')
+    origin_branch = data.get('origin-branch')
+    origin_commit = data.get('origin-commit')
+    origin_tag = data.get('origin-tag')
 
     # Get required wiki entry fields.
     try:
@@ -195,6 +198,9 @@ def _process_entry(data):
                                                 source_type=origin_type)
     handler = source_handler(origin, source_dir=origin_dir)
     repo.check_for_command(handler.command)
+    handler.source_branch = origin_branch
+    handler.source_commit = origin_commit
+    handler.source_tag = origin_tag
     handler.pull()
 
     try:

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -195,6 +195,50 @@ parts: [main]
         self.assertEqual(1, _get_part_list_count())
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
+    def test_origin_options(self, mock_get_origin_data):
+        _create_example_output("""
+{{{
+---
+maintainer: John Doe <john.doe@example.com
+origin: lp:snapcraft-parser-example
+origin-type: bzr
+origin-branch: stable-branch
+origin-commit: 123
+origin-tag: source-tag
+description: example
+parts: [main]
+}}}
+""")
+        mock_get_origin_data.return_value = {
+            'parts': {
+                'main': {
+                    'source': 'lp:something',
+                    'plugin': 'copy',
+                    'files': ['file1', 'file2'],
+                },
+            }
+        }
+        main(['--debug', '--index', TEST_OUTPUT_PATH])
+
+        self.mock_get.assert_has_calls([
+            mock.call('lp:snapcraft-parser-example', source_type='bzr')
+        ])
+
+        mock_source_handler = self.mock_get.return_value
+        mock_source_handler.assert_has_calls([
+            mock.call(
+                'lp:snapcraft-parser-example',
+                source_dir=os.path.join(
+                    parser._get_base_dir(),
+                    _encode_origin('lp:snapcraft-parser-example')))
+        ])
+
+        mock_handler = mock_source_handler.return_value
+        self.assertEqual(mock_handler.source_branch, 'stable-branch')
+        self.assertEqual(mock_handler.source_commit, 123)
+        self.assertEqual(mock_handler.source_tag, 'source-tag')
+
+    @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_main_valid_variable_substition(self, mock_get_origin_data):
         _create_example_output("""
 ---


### PR DESCRIPTION
Add support for more sources options, so that you can use multiple branches on remote part repositories.

@josepht