### PR TITLE
cli: implement `enable-ci travis --refresh` command

### DIFF
--- a/snapcraft/integrations/__init__.py
+++ b/snapcraft/integrations/__init__.py
@@ -47,9 +47,7 @@ def enable_ci(ci_system, refresh_only):
 
     if refresh_only:
         module.refresh()
-        return
-
-    print(module.__doc__)
-
-    if input('Continue (y/N): ') == 'y':
-        module.enable()
+    else:
+        print(module.__doc__)
+        if input('Continue (y/N): ') == 'y':
+            module.enable()

--- a/snapcraft/integrations/__init__.py
+++ b/snapcraft/integrations/__init__.py
@@ -27,7 +27,7 @@ SUPPORTED_CI_SYSTEMS = (
 )
 
 
-def enable_ci(ci_system):
+def enable_ci(ci_system, refresh_only):
     if not ci_system:
         # XXX cprov 20161116: we could possibly auto-detect currently
         # integration systems in master ?
@@ -44,6 +44,10 @@ def enable_ci(ci_system):
 
     module = importlib.import_module(
         'snapcraft.integrations.{}'.format(ci_system))
+
+    if refresh_only:
+        module.refresh()
+        return
 
     print(module.__doc__)
 

--- a/snapcraft/integrations/tests/test_travis.py
+++ b/snapcraft/integrations/tests/test_travis.py
@@ -79,7 +79,8 @@ class TravisPreconditionsTestCase(tests.TestCase):
             self.run_command(self.entry_point)
 
         self.assertEqual([
-            'Travis CLI (`travis version`) is not functional.',
+            'Travis CLI (`travis settings`) is not functional or you are '
+            'not allowed to access this repository settings.',
             'Make sure it works correctly in your system before trying this '
             'command again.',
         ], str(raised.exception).splitlines())

--- a/snapcraft/integrations/tests/test_travis.py
+++ b/snapcraft/integrations/tests/test_travis.py
@@ -52,15 +52,15 @@ class TravisPreconditionsTestCase(tests.TestCase):
         ('refresh', {'entry_point': 'refresh'}),
     ]
 
-    def run_command(self):
-        getattr(travis, self.entry_point)()
+    def run_command(self, cmd):
+        getattr(travis, cmd)()
 
     @mock.patch('subprocess.check_call')
     def test_missing_travis_cli(self, mock_check_call):
         mock_check_call.side_effect = [FileNotFoundError()]
 
         with self.assertRaises(RequiredCommandNotFound) as raised:
-            self.run_command()
+            self.run_command(self.entry_point)
 
         self.assertEqual([
             'Travis CLI (`travis`) is not available.',
@@ -76,7 +76,7 @@ class TravisPreconditionsTestCase(tests.TestCase):
             subprocess.CalledProcessError(1, 'test')]
 
         with self.assertRaises(RequiredCommandFailure) as raised:
-            self.run_command()
+            self.run_command(self.entry_point)
 
         self.assertEqual([
             'Travis CLI (`travis version`) is not functional.',
@@ -89,7 +89,7 @@ class TravisPreconditionsTestCase(tests.TestCase):
         mock_check_call.side_effect = [None, FileNotFoundError()]
 
         with self.assertRaises(RequiredCommandNotFound) as raised:
-            self.run_command()
+            self.run_command(self.entry_point)
 
         self.assertEqual([
             'Git (`git`) is not available, this tool cannot verify its '
@@ -105,7 +105,7 @@ class TravisPreconditionsTestCase(tests.TestCase):
             None, subprocess.CalledProcessError(1, 'test')]
 
         with self.assertRaises(RequiredCommandFailure) as raised:
-            self.run_command()
+            self.run_command(self.entry_point)
 
         self.assertEqual([
             'The current directory is not a Git repository.',
@@ -118,7 +118,7 @@ class TravisPreconditionsTestCase(tests.TestCase):
         mock_check_call.side_effect = [None, None]
 
         with self.assertRaises(RequiredPathDoesNotExist) as raised:
-            self.run_command()
+            self.run_command(self.entry_point)
 
         self.assertEqual([
             'Travis project is not initialized for the current directory.',

--- a/snapcraft/integrations/tests/test_travis.py
+++ b/snapcraft/integrations/tests/test_travis.py
@@ -45,7 +45,89 @@ parts:
 """
 
 
-class TravisTestCase(tests.TestCase):
+class TravisPreconditionsTestCase(tests.TestCase):
+
+    scenarios = [
+        ('enable', {'entry_point': 'enable'}),
+        ('refresh', {'entry_point': 'refresh'}),
+    ]
+
+    def run_command(self):
+        getattr(travis, self.entry_point)()
+
+    @mock.patch('subprocess.check_call')
+    def test_missing_travis_cli(self, mock_check_call):
+        mock_check_call.side_effect = [FileNotFoundError()]
+
+        with self.assertRaises(RequiredCommandNotFound) as raised:
+            self.run_command()
+
+        self.assertEqual([
+            'Travis CLI (`travis`) is not available.',
+            'Please install it before trying this command again:',
+            '',
+            '    $ sudo apt install ruby-dev ruby-ffi libffi-dev',
+            '    $ sudo gem install travis'
+        ], str(raised.exception).splitlines())
+
+    @mock.patch('subprocess.check_call')
+    def test_broken_travis_cli(self, mock_check_call):
+        mock_check_call.side_effect = [
+            subprocess.CalledProcessError(1, 'test')]
+
+        with self.assertRaises(RequiredCommandFailure) as raised:
+            self.run_command()
+
+        self.assertEqual([
+            'Travis CLI (`travis version`) is not functional.',
+            'Make sure it works correctly in your system before trying this '
+            'command again.',
+        ], str(raised.exception).splitlines())
+
+    @mock.patch('subprocess.check_call')
+    def test_missing_git(self, mock_check_call):
+        mock_check_call.side_effect = [None, FileNotFoundError()]
+
+        with self.assertRaises(RequiredCommandNotFound) as raised:
+            self.run_command()
+
+        self.assertEqual([
+            'Git (`git`) is not available, this tool cannot verify its '
+            'prerequisites.',
+            'Please install it before trying this command again:',
+            '',
+            '    $ sudo apt install git',
+        ], str(raised.exception).splitlines())
+
+    @mock.patch('subprocess.check_call')
+    def test_broken_git_repo(self, mock_check_call):
+        mock_check_call.side_effect = [
+            None, subprocess.CalledProcessError(1, 'test')]
+
+        with self.assertRaises(RequiredCommandFailure) as raised:
+            self.run_command()
+
+        self.assertEqual([
+            'The current directory is not a Git repository.',
+            'Please switch to the desired project repository where '
+            'Travis should be enabled.',
+        ], str(raised.exception).splitlines())
+
+    @mock.patch('subprocess.check_call')
+    def test_missing_travis_setup(self, mock_check_call):
+        mock_check_call.side_effect = [None, None]
+
+        with self.assertRaises(RequiredPathDoesNotExist) as raised:
+            self.run_command()
+
+        self.assertEqual([
+            'Travis project is not initialized for the current directory.',
+            'Please initialize Travis project (e.g. `travis init`) with '
+            'appropriate parameters.',
+        ], str(raised.exception).splitlines())
+
+
+class TravisSuccessfulTestCase(tests.TestCase):
 
     def setUp(self):
         super().setUp()
@@ -57,77 +139,6 @@ class TravisTestCase(tests.TestCase):
     def make_travis_yml(self, content):
         with open('.travis.yml', 'w') as fd:
             fd.write(content)
-
-    @mock.patch('subprocess.check_call')
-    def test_enable_missing_travis_cli(self, mock_check_call):
-        mock_check_call.side_effect = [FileNotFoundError()]
-
-        with self.assertRaises(RequiredCommandNotFound) as raised:
-            travis.enable()
-
-        self.assertEqual([
-            'Travis CLI (`travis`) is not available.',
-            'Please install it before trying this command again:',
-            '',
-            '    $ sudo apt install ruby-dev ruby-ffi libffi-dev',
-            '    $ sudo gem install travis'
-        ], str(raised.exception).splitlines())
-
-    @mock.patch('subprocess.check_call')
-    def test_enable_broken_travis_cli(self, mock_check_call):
-        mock_check_call.side_effect = [
-            subprocess.CalledProcessError(1, 'test')]
-
-        with self.assertRaises(RequiredCommandFailure) as raised:
-            travis.enable()
-
-        self.assertEqual([
-            'Travis CLI (`travis version`) is not functional.',
-            'Make sure it works correctly in your system before trying this '
-            'command again.',
-        ], str(raised.exception).splitlines())
-
-    @mock.patch('subprocess.check_call')
-    def test_enable_missing_git(self, mock_check_call):
-        mock_check_call.side_effect = [None, FileNotFoundError()]
-
-        with self.assertRaises(RequiredCommandNotFound) as raised:
-            travis.enable()
-
-        self.assertEqual([
-            'Git (`git`) is not available, this tool cannot verify its '
-            'prerequisites.',
-            'Please install it before trying this command again:',
-            '',
-            '    $ sudo apt install git',
-        ], str(raised.exception).splitlines())
-
-    @mock.patch('subprocess.check_call')
-    def test_enable_broken_git_repo(self, mock_check_call):
-        mock_check_call.side_effect = [
-            None, subprocess.CalledProcessError(1, 'test')]
-
-        with self.assertRaises(RequiredCommandFailure) as raised:
-            travis.enable()
-
-        self.assertEqual([
-            'The current directory is not a Git repository.',
-            'Please switch to the desired project repository where '
-            'Travis should be enabled.',
-        ], str(raised.exception).splitlines())
-
-    @mock.patch('subprocess.check_call')
-    def test_enable_missing_travis_setup(self, mock_check_call):
-        mock_check_call.side_effect = [None, None]
-
-        with self.assertRaises(RequiredPathDoesNotExist) as raised:
-            travis.enable()
-
-        self.assertEqual([
-            'Travis project is not initialized for the current directory.',
-            'Please initialize Travis project (e.g. `travis init`) with '
-            'appropriate parameters.',
-        ], str(raised.exception).splitlines())
 
     @mock.patch('subprocess.check_output')
     @mock.patch('subprocess.check_call')
@@ -199,5 +210,60 @@ class TravisTestCase(tests.TestCase):
             'Done. Now you just have to review and commit changes in your '
             'Travis project (`.travis.yml`).',
             'Also make sure you add the new '
+            '`.snapcraft/travis_snapcraft.cfg` file.',
+        ], self.fake_logger.output.splitlines()[1:])
+
+    @mock.patch('subprocess.check_output')
+    @mock.patch('subprocess.check_call')
+    @mock.patch('builtins.input')
+    @mock.patch('getpass.getpass')
+    @mock.patch.object(storeapi.StoreClient, 'login')
+    @mock.patch.object(storeapi.SCAClient, 'get_account_information')
+    def test_refresh_successfully(
+            self, mock_get_account_information, mock_login, mock_getpass,
+            mock_input, mock_check_call, mock_check_output):
+        mock_input.side_effect = ['sample.person@canonical.com', '123456']
+        mock_getpass.return_value = 'secret'
+        mock_login.side_effect = [
+            storeapi.errors.StoreTwoFactorAuthenticationRequired(), None]
+        mock_get_account_information.return_value = {'account_id': 'abcd'}
+
+        mock_check_call.side_effect = [None, None]
+        mock_check_output.side_effect = [None]
+        self.make_snapcraft_yaml(test_snapcraft_yaml)
+        self.make_travis_yml('after_success: ["<travis-cli-decrypt>"]')
+
+        travis.refresh()
+
+        # Attenuated credentials requested from the Store.
+        mock_login.assert_called_with(
+            'sample.person@canonical.com', 'secret',
+            one_time_password='123456', acls=None, save=False,
+            channels=['edge'], packages=[{'series': '16', 'name': 'foo'}])
+
+        # Credentials encrypted with travis CLI.
+        mock_check_output.assert_called_with(
+            ['travis', 'encrypt-file', '--force',
+             '--add', 'after_success', '--decrypt-to',
+             travis.LOCAL_CONFIG_FILENAME,
+             mock.ANY, travis.ENCRYPTED_CONFIG_FILENAME],
+            stderr=subprocess.PIPE)
+
+        # '.travis.yml' updated only with the decrypt command.
+        with open('.travis.yml') as fd:
+            travis_conf = yaml.load(fd)
+            self.assertEqual([
+                '<travis-cli-decrypt>',
+            ], travis_conf['after_success'])
+
+        # Descriptive logging ...
+        self.assertEqual([
+            'Refreshing credentials to push and release "foo" snaps to '
+            'edge channel in series 16',
+            'Acquiring specific authorization information ...',
+            'Login successful.',
+            'Encrypting authorization for Travis and adjusting project '
+            'to automatically decrypt and use it during "after_success".',
+            'Done. Please commit the changes to '
             '`.snapcraft/travis_snapcraft.cfg` file.',
         ], self.fake_logger.output.splitlines()[1:])

--- a/snapcraft/integrations/tests/test_travis.py
+++ b/snapcraft/integrations/tests/test_travis.py
@@ -199,8 +199,8 @@ class TravisSuccessfulTestCase(tests.TestCase):
 
         # Descriptive logging ...
         self.assertEqual([
-            'Enabling Travis testbeds to push and release "foo" snaps '
-            'to edge channel in series 16',
+            "Enabling Travis testbeds to push and release 'foo' snaps "
+            "to edge channel in series '16'",
             'Acquiring specific authorization information ...',
             'Login successful.',
             'Encrypting authorization for Travis and adjusting project '

--- a/snapcraft/integrations/travis.py
+++ b/snapcraft/integrations/travis.py
@@ -53,7 +53,17 @@ See the example below::
         snapcraft && snapcraft push *.snap --release edge"
       on:
         branch: master
+
+The dedicated credentials will be functional for exactly 1 year or until
+a password change on the related Ubuntu One SSO account. In order to
+refresh the project credentials, please run the following command::
+
+    $ snapcraft enable-ci travis --refresh
 """
+from contextlib import (
+    ExitStack,
+    contextmanager,
+)
 import logging
 import os
 import subprocess
@@ -75,68 +85,12 @@ TRAVIS_CONFIG_FILENAME = '.travis.yml'
 ENCRYPTED_CONFIG_FILENAME = '.snapcraft/travis_snapcraft.cfg'
 
 
-def _encrypt_config(config_path):
-    """Encrypt given snapcraft config file for Travis jobs."""
-    cmd = [
-        'travis', 'encrypt-file',
-        '--force',
-        '--add', 'after_success',
-        '--decrypt-to', LOCAL_CONFIG_FILENAME,
-        config_path, ENCRYPTED_CONFIG_FILENAME,
-    ]
-    try:
-        subprocess.check_output(cmd, stderr=subprocess.PIPE)
-    except subprocess.CalledProcessError as err:
-        raise RuntimeError(
-            '`travis encrypt-file` failed: {}\n{}'.format(
-                err.returncode, err.stderr.decode()))
-
-
-@requires_command_success(
-    'travis version',
-    not_found_fmt=(
-        'Travis CLI (`{cmd_list[0]}`) is not available.\n'
-        'Please install it before trying this command again:\n\n'
-        '    $ sudo apt install ruby-dev ruby-ffi libffi-dev\n'
-        '    $ sudo gem install travis\n'),
-    failure_fmt=(
-        'Travis CLI (`{command}`) is not functional.\n'
-        'Make sure it works correctly in your system '
-        'before trying this command again.'))
-@requires_command_success(
-    'git status',
-    not_found_fmt=(
-        'Git (`{cmd_list[0]}`) is not available, this tool cannot verify '
-        'its prerequisites.\n'
-        'Please install it before trying this command again:\n\n'
-        '    $ sudo apt install git\n'),
-    failure_fmt=(
-        'The current directory is not a Git repository.\n'
-        'Please switch to the desired project repository where '
-        'Travis should be enabled.'))
-@requires_path_exists(
-    TRAVIS_CONFIG_FILENAME,
-    error_fmt=(
-        'Travis project is not initialized for the current directory.\n'
-        'Please initialize Travis project (e.g. `travis init`) with '
-        'appropriate parameters.'))
-def enable():
-    series = storeapi.constants.DEFAULT_SERIES
-    project_config = load_config()
-    snap_name = project_config.data['name']
-    logger.info(
-        'Enabling Travis testbeds to push and release "{}" snaps '
-        'to edge channel in series {}'.format(snap_name, series)
-    )
-
-    packages = [{'name': snap_name, 'series': series}]
-    channels = ['edge']
-
-    # XXX cprov 20161116: Needs caveat syntax for restricting
-    # origins (IP or reverse-dns) but Travis sudo-enabled containers
-    # do not have static egress routes.
+def _acquire_and_encrypt_credentials(packages, channels):
+    """Acquire and encrypt Store credentials for Travis jobs."""
+    # XXX cprov 20161116: Needs caveat syntax for restricting origins
+    # (IP or reverse-dns) but Travis sudo-enabled containers, needed for
+    # running xenial snapcraft, do not have static egress routes.
     # See https://docs.travis-ci.com/user/ip-addresses.
-
     logger.info('Acquiring specific authorization information ...')
     store = storeapi.StoreClient()
     if not _login(store, packages=packages, channels=channels, save=False):
@@ -146,12 +100,98 @@ def enable():
     logger.info(
         'Encrypting authorization for Travis and adjusting project to '
         'automatically decrypt and use it during "after_success".')
-
-    os.makedirs(os.path.dirname(LOCAL_CONFIG_FILENAME), exist_ok=True)
     with tempfile.NamedTemporaryFile(mode='w') as fd:
         store.conf.parser.write(fd)
         fd.flush()
-        _encrypt_config(fd.name)
+        os.makedirs(
+            os.path.dirname(LOCAL_CONFIG_FILENAME), exist_ok=True)
+        cmd = [
+            'travis', 'encrypt-file',
+            '--force',
+            '--add', 'after_success',
+            '--decrypt-to', LOCAL_CONFIG_FILENAME,
+            fd.name, ENCRYPTED_CONFIG_FILENAME,
+        ]
+        try:
+            subprocess.check_output(cmd, stderr=subprocess.PIPE)
+        except subprocess.CalledProcessError as err:
+            raise RuntimeError(
+                '`travis encrypt-file` failed: {}\n{}'.format(
+                    err.returncode, err.stderr.decode()))
+
+
+@contextmanager
+def requires_travis_preconditions():
+    """Verify all Travis CI integration preconditions."""
+    required = (
+        requires_command_success(
+            'travis version',
+            not_found_fmt=(
+                'Travis CLI (`{cmd_list[0]}`) is not available.\n'
+                'Please install it before trying this command again:\n\n'
+                '    $ sudo apt install ruby-dev ruby-ffi libffi-dev\n'
+                '    $ sudo gem install travis\n'),
+            failure_fmt=(
+                'Travis CLI (`{command}`) is not functional.\n'
+                'Make sure it works correctly in your system '
+                'before trying this command again.')
+        ),
+        requires_command_success(
+            'git status',
+            not_found_fmt=(
+                'Git (`{cmd_list[0]}`) is not available, this tool cannot '
+                'verify its prerequisites.\n'
+                'Please install it before trying this command again:\n\n'
+                '    $ sudo apt install git\n'),
+            failure_fmt=(
+                'The current directory is not a Git repository.\n'
+                'Please switch to the desired project repository where '
+                'Travis should be enabled.')
+        ),
+        requires_path_exists(
+            TRAVIS_CONFIG_FILENAME,
+            error_fmt=(
+                'Travis project is not initialized for the current '
+                'directory.\n'
+                'Please initialize Travis project (e.g. `travis init`) with '
+                'appropriate parameters.')
+        ),
+    )
+    with ExitStack() as cm:
+        [cm.enter_context(c) for c in required]
+        yield
+
+
+@requires_travis_preconditions()
+def refresh():
+    series = storeapi.constants.DEFAULT_SERIES
+    project_config = load_config()
+    snap_name = project_config.data['name']
+    logger.info(
+        'Refreshing credentials to push and release "{}" snaps '
+        'to edge channel in series {}'.format(snap_name, series))
+
+    packages = [{'name': snap_name, 'series': series}]
+    channels = ['edge']
+    _acquire_and_encrypt_credentials(packages, channels)
+
+    logger.info(
+        'Done. Please commit the changes to `{}` file.'.format(
+            ENCRYPTED_CONFIG_FILENAME))
+
+
+@requires_travis_preconditions()
+def enable():
+    series = storeapi.constants.DEFAULT_SERIES
+    project_config = load_config()
+    snap_name = project_config.data['name']
+    logger.info(
+        'Enabling Travis testbeds to push and release "{}" snaps '
+        'to edge channel in series {}'.format(snap_name, series))
+
+    packages = [{'name': snap_name, 'series': series}]
+    channels = ['edge']
+    _acquire_and_encrypt_credentials(packages, channels)
 
     logger.info(
         'Configuring "deploy" phase to build and release the snap in the '

--- a/snapcraft/integrations/travis.py
+++ b/snapcraft/integrations/travis.py
@@ -186,8 +186,8 @@ def enable():
     project_config = load_config()
     snap_name = project_config.data['name']
     logger.info(
-        'Enabling Travis testbeds to push and release "{}" snaps '
-        'to edge channel in series {}'.format(snap_name, series))
+        'Enabling Travis testbeds to push and release {!r} snaps '
+        'to edge channel in series {!r}'.format(snap_name, series))
 
     packages = [{'name': snap_name, 'series': series}]
     channels = ['edge']

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -50,7 +50,7 @@ Usage:
   snapcraft [options] validate <snap-name> <validation>... [--key-name=<key-name>]
   snapcraft [options] define <part-name>
   snapcraft [options] search [<query> ...]
-  snapcraft [options] enable-ci [<ci-system>]
+  snapcraft [options] enable-ci [<ci-system>] [--refresh]
   snapcraft [options] help (topics | <plugin> | <topic>) [--devel]
   snapcraft (-h | --help)
   snapcraft --version
@@ -111,6 +111,7 @@ The available commands are:
   close        Close one or more channels of a snap.
   enable-ci    EXPERIMENTAL enable continuous-integration systems to build and
                release snaps to the Ubuntu Store.
+
 The available lifecycle commands are:
   clean        Remove content - cleans downloads, builds or install artifacts.
   cleanbuild   Create a snap using a clean environment managed by lxd.
@@ -276,7 +277,7 @@ def run(args, project_options):  # noqa
         snapcraft.topic_help(args['<topic>'] or args['<plugin>'],
                              args['--devel'], args['topics'])
     elif args['enable-ci']:
-        enable_ci(args['<ci-system>'])
+        enable_ci(args['<ci-system>'], args['--refresh'])
     elif args['update']:
         parts.update()
     elif args['define']:

--- a/snapcraft/tests/test_commands_enable_ci.py
+++ b/snapcraft/tests/test_commands_enable_ci.py
@@ -52,63 +52,23 @@ class EnableCITestCase(tests.TestCase):
             'Please select one of the supported integration systems: travis.'
         ], self.fake_logger.output.splitlines())
 
+    @mock.patch.object(travis, '__doc__')
     @mock.patch.object(travis, 'enable')
     @mock.patch('builtins.input')
-    def test_enable_ci_travis(self, mock_input, mock_enable):
+    def test_enable_ci_travis(self, mock_input, mock_enable, mock_doc):
         mock_input.side_effect = ['y']
+        mock_doc.__str__.return_value = '<module docstring>'
+
         main(['enable-ci', 'travis'])
 
         self.assertEqual(1, mock_enable.call_count)
-        self.assertEqual([
-            'Snapcraft integration for Travis (CI).',
-            '',
-            'This is an *EXPERIMENTAL* feature and subject to incompatible '
-            'changes in',
-            'the future, please use with caution.',
-            '',
-            'This command currently depends on a working `travis` CLI '
-            'environment and',
-            'a previously initialized Travis project (`.travis.yml`).',
-            '',
-            'Make sure your Travis project is also configured to '
-            '"Build pushes", this',
-            'way every new push to `master` will result in a new snap '
-            'revision in the',
-            'Store.',
-            '',
-            'This operation will acquire properly attenuated Store '
-            'credentials and',
-            'encrypt them for use in your testbed '
-            '(`.snapcraft/travis_snapcraft.cfg`),',
-            'only Travis has the private key to decrypt it and will '
-            'be only available',
-            'to branches of the same repository, not forks.',
-            '',
-            "Then it will adjust Travis configuration ('.travis.yml') with "
-            'the commands',
-            "to decrypt credentials during 'after_success' phase and install "
-            'latest',
-            '`snapcraft` to build and release your snap (inside a '
-            'ubuntu:xenial docker',
-            "container) during the 'deploy' phase.",
-            '',
-            'See the example below::',
-            '',
-            '    sudo: required',
-            '    services:',
-            '    - docker',
-            '    after_success:',
-            '    - openssl aes-256-cbc -K <travis-key> -iv <travis-iv>',
-            '      -in .snapcraft/travis_snapcraft.cfg',
-            '      -out .snapcraft/snapcraft.cfg -d',
-            '    deploy:',
-            '      skip_cleanup: true',
-            '      provider: script',
-            '      script: docker run -v $(pwd):$(pwd) -t ubuntu:xenial sh -c',
-            '        "apt update -qq && apt install snapcraft -y && '
-            'cd $(pwd) &&',
-            '        snapcraft && snapcraft push *.snap --release edge"',
-            '      on:',
-            '        branch: master',
-            ''
-        ], self.fake_terminal.getvalue().splitlines())
+        self.assertEqual(
+            '<module docstring>\n', self.fake_terminal.getvalue())
+
+    @mock.patch.object(travis, 'refresh')
+    def test_enable_ci_travis_refresh(self, mock_refresh):
+
+        main(['enable-ci', 'travis', '--refresh'])
+
+        self.assertEqual(1, mock_refresh.call_count)
+        self.assertEqual('', self.fake_terminal.getvalue())


### PR DESCRIPTION
This will allow users to refresh credentials bound to expire after 1 year
(clock-ticking bomb) or more likely when there is a SSO password change
(rotation).

Travis 'deploy' phase will fail on expired credentials, so users will know
when it's case to refresh.

We could issue macaroons that never expire (age or passwd-changes), but I guess it ends up being a lot more difficult to handle in case of compromise.

LP: #1646660