### PR TITLE
_filedir takes an extension, not a glob

### DIFF
--- a/debian/snapcraft-completion
+++ b/debian/snapcraft-completion
@@ -19,7 +19,7 @@ _snapcraft()
         return 0
         ;;
     upload | push | sign-build)
-        _filedir '*.snap'
+        _filedir 'snap'
         return 0
         ;;
     enable-ci)


### PR DESCRIPTION
`_filedir "*.snap"` means only files that match `*.*.snap` get tab-completed.