### PR TITLE
nodejs plugin: install during pull to support npm run

### DIFF
--- a/integration_tests/snaps/nodejs-with-run-commands/index.js
+++ b/integration_tests/snaps/nodejs-with-run-commands/index.js
@@ -1,9 +1,0 @@
-var http = require("http");
-
-http.createServer(function (request, response) {
-
-   response.writeHead(200, {'Content-Type': 'text/plain'});
-   response.end('Hello World\n');
-}).listen(8081);
-
-console.log('Server running at http://127.0.0.1:8081/');

--- a/integration_tests/snaps/nodejs-with-run-commands/package.json
+++ b/integration_tests/snaps/nodejs-with-run-commands/package.json
@@ -2,12 +2,16 @@
   "name": "simple-nodejs",
   "version": "1.0.0",
   "description": "Testing grounds for snapcraft integration tests",
-  "main": "index.js",
+  "main": "print.js",
+  "bin": {
+    "node-print": "print.js"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "run-command-one": "touch command-one-run",
     "run-command-two": "touch command-two-run",
-    "run-command-three": "test -f command-one-run -a -f command-two-run"
+    "run-command-three": "test -f command-one-run -a -f command-two-run",
+    "run-command-from-npm-install": "node-print"
   },
   "author": "",
   "license": "GPL-3.0"

--- a/integration_tests/snaps/nodejs-with-run-commands/print.js
+++ b/integration_tests/snaps/nodejs-with-run-commands/print.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log('echo test');

--- a/integration_tests/snaps/nodejs-with-run-commands/snapcraft.yaml
+++ b/integration_tests/snaps/nodejs-with-run-commands/snapcraft.yaml
@@ -14,3 +14,5 @@ parts:
         - run-command-one
         - run-command-two
         - run-command-three
+        # LP: #1633298
+        - run-command-from-npm-install

--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -110,7 +110,7 @@ class NodePlugin(snapcraft.BasePlugin):
         os.makedirs(self._npm_dir, exist_ok=True)
         self._nodejs_tar.download()
         # do the install in the pull phase to download all dependencies.
-        self._npm_install()
+        self._npm_install(rootdir=self.sourcedir)
 
     def clean_pull(self):
         super().clean_pull()
@@ -121,19 +121,19 @@ class NodePlugin(snapcraft.BasePlugin):
 
     def build(self):
         super().build()
-        self._npm_install()
+        self._npm_install(rootdir=self.builddir)
 
-    def _npm_install(self):
+    def _npm_install(self, rootdir):
         self._nodejs_tar.provision(
             self.installdir, clean_target=False, keep_tarball=True)
         npm_install = ['npm', '--cache-min=Infinity', 'install']
         for pkg in self.options.node_packages:
-            self.run(npm_install + ['--global'] + [pkg])
-        if os.path.exists(os.path.join(self.builddir, 'package.json')):
+            self.run(npm_install + ['--global'] + [pkg], cwd=rootdir)
+        if os.path.exists(os.path.join(rootdir, 'package.json')):
             self.run(npm_install)
-            self.run(npm_install + ['--global'])
+            self.run(npm_install + ['--global'], cwd=rootdir)
         for target in self.options.npm_run:
-            self.run(['npm', 'run', target])
+            self.run(['npm', 'run', target], cwd=rootdir)
 
 
 def _get_nodejs_base(node_engine):


### PR DESCRIPTION
Our install logic doesn't install dependencies during `pull` which makes
npm run commands that depend on these dependencies to fail.

LP: #1633298