### PR TITLE
store: return specific error when already owned

### DIFF
--- a/integration_tests/test_store_register.py
+++ b/integration_tests/test_store_register.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import re
 import subprocess
 import time
@@ -50,6 +51,23 @@ class RegisterTestCase(integration_tests.StoreTestCase):
             'expectations of most users. If you are the publisher most '
             'users expect for \'test-already-registered-snap-name\' then '
             'claim the name at')
+        self.assertThat(str(error.output), Contains(expected))
+        self.assertThat(str(error.output), Contains('register-name'))
+
+    def test_registration_of_already_owned_name(self):
+        self.login()
+        self.addCleanup(self.logout)
+        if os.getenv('TEST_STORE', 'fake') != 'fake':
+            unique_id = uuid.uuid4().int
+            snap_name = 'u1test-{}'.format(unique_id)
+            self.register(snap_name)
+        else:
+            snap_name = self.test_store.already_owned_snap_name
+
+        # The snap name is already registered and you are the owner.
+        error = self.assertRaises(
+            subprocess.CalledProcessError, self.register, snap_name)
+        expected = 'You already own the name {0!r}'.format(snap_name)
         self.assertThat(str(error.output), Contains(expected))
         self.assertThat(str(error.output), Contains('register-name'))
 

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -152,6 +152,8 @@ class StoreRegistrationError(StoreError):
         'of most users. If you are the publisher most users expect for '
         '{snap_name!r} then claim the name at {register_name_url!r}')
 
+    __FMT_ALREADY_OWNED = 'You already own the name {snap_name!r}.'
+
     __FMT_RESERVED = (
         'The name {snap_name!r} is reserved.\n\n'
         'If you are the publisher most users expect for '
@@ -165,6 +167,7 @@ class StoreRegistrationError(StoreError):
 
     __error_messages = {
         'already_registered': __FMT_ALREADY_REGISTERED,
+        'already_owned': __FMT_ALREADY_OWNED,
         'reserved_name': __FMT_RESERVED,
         'register_window': __FMT_RETRY_WAIT,
     }

--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -555,6 +555,8 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
             self._handle_register_409('already_registered')
         elif data['snap_name'] == 'test-reserved-snap-name':
             self._handle_register_409('reserved_name')
+        elif data['snap_name'] == 'test-already-owned-snap-name':
+            self._handle_register_409('already_owned')
         elif data['snap_name'].startswith('test-too-fast'):
             self._handle_register_429('register_window')
         elif data['snap_name'] == 'snap-name-no-clear-error':

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -320,6 +320,7 @@ class TestStore(fixtures.Fixture):
             self.useFixture(FakeStore())
             self.register_delay = 0
             self.reserved_snap_name = 'test-reserved-snap-name'
+            self.already_owned_snap_name = 'test-already-owned-snap-name'
         elif test_store == 'staging':
             self.useFixture(StagingStore())
             self.register_delay = 10

--- a/snapcraft/tests/store/test_store_client.py
+++ b/snapcraft/tests/store/test_store_client.py
@@ -373,6 +373,14 @@ class RegisterTestCase(tests.TestCase):
             "'test-reserved-snap-name' then please claim the "
             "name at 'https://myapps.com/register-name/'")
 
+    def test_register_already_owned_name(self):
+        self.client.login('dummy', 'test correct password')
+        with self.assertRaises(errors.StoreRegistrationError) as raised:
+            self.client.register('test-already-owned-snap-name')
+        self.assertEqual(
+            str(raised.exception),
+            "You already own the name 'test-already-owned-snap-name'.")
+
     def test_registering_too_fast_in_a_row(self):
         self.client.login('dummy', 'test correct password')
         with self.assertRaises(errors.StoreRegistrationError) as raised:

--- a/tools/staging_env.sh
+++ b/tools/staging_env.sh
@@ -5,6 +5,7 @@ deactivate() {
     unset UBUNTU_STORE_SEARCH_ROOT_URL
     unset UBUNTU_STORE_UPLOAD_ROOT_URL
     unset UBUNTU_SSO_API_ROOT_URL
+    unset TEST_STORE
     export PS1="$ORIGINAL_PS1"
     unset ORIGINAL_PS1
     unset deactivate
@@ -14,6 +15,7 @@ export UBUNTU_STORE_API_ROOT_URL="https://myapps.developer.staging.ubuntu.com/de
 export UBUNTU_STORE_SEARCH_ROOT_URL="https://search.apps.staging.ubuntu.com/"
 export UBUNTU_STORE_UPLOAD_ROOT_URL="https://upload.apps.staging.ubuntu.com/"
 export UBUNTU_SSO_API_ROOT_URL="https://login.staging.ubuntu.com/api/v2/"
+export TEST_STORE="staging"
 
 export ORIGINAL_PS1="$PS1"
 export PS1="$PS1 snapcraft staging servers> "


### PR DESCRIPTION
On `snapcraft register` of a snap we already own we can just say
it is already owned by using the specific error code returned by
the store for this.

LP: #1602091
Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>