### PR TITLE
meta: support classic confinment

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -63,6 +63,7 @@ properties:
     description: the type of confinement supported by the snap
     default: strict
     enum:
+      - classic
       - devmode
       - strict
   grade:

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -262,7 +262,7 @@ class CreateTestCase(CreateBaseTestCase):
 class CreateWithConfinementTestCase(CreateBaseTestCase):
 
     scenarios = [(confinement, dict(confinement=confinement)) for
-                 confinement in ['strict', 'devmode']]
+                 confinement in ['strict', 'devmode', 'classic']]
 
     def test_create_meta_with_confinement(self):
         self.config_data['confinement'] = self.confinement

--- a/snapcraft/tests/test_project_loader.py
+++ b/snapcraft/tests/test_project_loader.py
@@ -817,7 +817,7 @@ parts:
 class ValidConfinmentTypesYamlTestCase(YamlBaseTestCase):
 
     scenarios = [(confinement, dict(confinement=confinement)) for
-                 confinement in ['strict', 'devmode']]
+                 confinement in ['strict', 'devmode', 'classic']]
 
     @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
     def test_yaml_valid_confinement_types(self, mock_loadPlugin):
@@ -868,8 +868,8 @@ parts:
         self.assertEqual(
             raised.exception.message,
             "The 'confinement' property does not match the required "
-            "schema: '{}' is not one of ['devmode', 'strict']".format(
-                self.confinement))
+            "schema: '{}' is not one of ['classic', 'devmode', "
+            "'strict']".format(self.confinement))
 
 
 class ValidGradeTypesYamlTestCase(YamlBaseTestCase):


### PR DESCRIPTION
The `confinement` property of `classic` should be supported.
<a href='https://bugs.launchpad.net/bugs/1647422'>LP: #1647422</a>

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>