### PR TITLE
Add source name to error message

### DIFF
--- a/snapcraft/internal/sources/__init__.py
+++ b/snapcraft/internal/sources/__init__.py
@@ -615,8 +615,8 @@ def _get_source_type_from_uri(source, ignore_errors=False):
     elif source.endswith('rpm'):
         source_type = 'rpm'
     elif common.isurl(source) and not ignore_errors:
-        raise ValueError('no handler to manage source')
+        raise ValueError('no handler to manage source ({})'.format(source))
     elif not os.path.isdir(source) and not ignore_errors:
-        raise ValueError('local source is not a directory')
+        raise ValueError('local source ({}) is not a directory'.format(source))
 
     return source_type

--- a/snapcraft/tests/pluginhandler/test_pluginhandler.py
+++ b/snapcraft/tests/pluginhandler/test_pluginhandler.py
@@ -137,7 +137,7 @@ class PluginTestCase(tests.TestCase):
         mock_isdir.assert_called_once_with('file')
 
         self.assertEqual(raised.__str__(),
-                         'local source is not a directory')
+                         'local source (file) is not a directory')
 
     def test_init_unknown_plugin_must_raise_exception(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
@@ -2445,7 +2445,8 @@ class SourcesTestCase(tests.TestCase):
             _load_plugin, 'test-part', part_properties=properties)
 
         self.assertEqual(raised.__str__(),
-                         'no handler to manage source')
+                         'no handler to manage source '
+                         '(unrecognized://test_source)')
 
 
 class CleanPullTestCase(tests.TestCase):


### PR DESCRIPTION
"no handler to manage source (gdsr://src)"
is a better error message than
"no handler to manage source"
since it makes easier to find out where the mistake is