### PR TITLE
sources: refactor local source into module.

### DIFF
--- a/snapcraft/internal/sources/__init__.py
+++ b/snapcraft/internal/sources/__init__.py
@@ -84,10 +84,9 @@ import libarchive
 from snapcraft.internal import common
 from . import errors
 from . import _base
-from ._deb import Deb  # noqa
 from ._bazaar import Bazaar  # noqa
-
-from ._local import Local  # noqa
+from ._deb import Deb        # noqa
+from ._local import Local    # noqa
 
 
 logging.getLogger('urllib3').setLevel(logging.CRITICAL)

--- a/snapcraft/internal/sources/__init__.py
+++ b/snapcraft/internal/sources/__init__.py
@@ -68,8 +68,6 @@ cases you want to refer to the help text for the specific plugin.
 
 """
 
-import copy
-import glob
 import logging
 import os
 import os.path
@@ -85,9 +83,10 @@ import apt_inst
 import libarchive
 
 from snapcraft.internal import common
-from snapcraft import file_utils
 from . import errors
 from . import _base
+
+from ._local import Local  # noqa
 
 
 logging.getLogger('urllib3').setLevel(logging.CRITICAL)
@@ -476,33 +475,6 @@ class Rpm(_base.FileBase):
 
         if not keep_rpm:
             os.remove(rpm_file)
-
-
-class Local(_base.Base):
-
-    def pull(self):
-        if os.path.islink(self.source_dir) or os.path.isfile(self.source_dir):
-            os.remove(self.source_dir)
-        elif os.path.isdir(self.source_dir):
-            shutil.rmtree(self.source_dir)
-
-        current_dir = os.getcwd()
-        source_abspath = os.path.abspath(self.source)
-
-        def ignore(directory, files):
-            if directory == source_abspath or \
-               directory == current_dir:
-                ignored = copy.copy(common.SNAPCRAFT_FILES)
-                snaps = glob.glob(os.path.join(directory, '*.snap'))
-                if snaps:
-                    snaps = [os.path.basename(s) for s in snaps]
-                    ignored += snaps
-                return ignored
-            else:
-                return []
-
-        shutil.copytree(source_abspath, self.source_dir,
-                        copy_function=file_utils.link_or_copy, ignore=ignore)
 
 
 def get(sourcedir, builddir, options):

--- a/snapcraft/internal/sources/_local.py
+++ b/snapcraft/internal/sources/_local.py
@@ -1,0 +1,51 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015, 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import copy
+import glob
+import os
+import shutil
+
+from snapcraft import file_utils
+from snapcraft.internal import common
+from ._base import Base
+
+
+class Local(Base):
+
+    def pull(self):
+        if os.path.islink(self.source_dir) or os.path.isfile(self.source_dir):
+            os.remove(self.source_dir)
+        elif os.path.isdir(self.source_dir):
+            shutil.rmtree(self.source_dir)
+
+        current_dir = os.getcwd()
+        source_abspath = os.path.abspath(self.source)
+
+        def ignore(directory, files):
+            if directory == source_abspath or \
+               directory == current_dir:
+                ignored = copy.copy(common.SNAPCRAFT_FILES)
+                snaps = glob.glob(os.path.join(directory, '*.snap'))
+                if snaps:
+                    snaps = [os.path.basename(s) for s in snaps]
+                    ignored += snaps
+                return ignored
+            else:
+                return []
+
+        shutil.copytree(source_abspath, self.source_dir,
+                        copy_function=file_utils.link_or_copy, ignore=ignore)

--- a/snapcraft/tests/sources/test_local.py
+++ b/snapcraft/tests/sources/test_local.py
@@ -1,0 +1,182 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015, 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import copy
+import os
+from unittest import mock
+
+from snapcraft.internal import common
+from snapcraft.internal import sources
+
+from snapcraft import tests
+
+
+class TestLocal(tests.TestCase):
+
+    @mock.patch('snapcraft.internal.sources._local.glob.glob')
+    def test_pull_does_not_change_snapcraft_files_list(self, mock_glob):
+        # Regression test for https://bugs.launchpad.net/snapcraft/+bug/1614913
+        # Verify that SNAPCRAFT_FILES was not modified by the pull when there
+        # are files to ignore.
+        snapcraft_files_before_pull = copy.copy(common.SNAPCRAFT_FILES)
+        mock_glob.return_value = ['a.snap', 'b.snap', 'c.snap']
+
+        local = sources.Local('.', 'destination')
+        local.pull()
+
+        self.assertEqual(
+            snapcraft_files_before_pull, common.SNAPCRAFT_FILES)
+
+    def test_pull_with_existing_empty_source_dir_creates_hardlinks(self):
+        os.makedirs(os.path.join('src', 'dir'))
+        open(os.path.join('src', 'dir', 'file'), 'w').close()
+
+        os.mkdir('destination')
+
+        local = sources.Local('src', 'destination')
+        local.pull()
+
+        # Verify that the directories are not symlinks, but the file is a
+        # hardlink.
+        self.assertFalse(os.path.islink('destination'))
+        self.assertFalse(os.path.islink(os.path.join('destination', 'dir')))
+        self.assertGreater(
+            os.stat(os.path.join('destination', 'dir', 'file')).st_nlink, 1)
+
+    def test_pull_with_existing_source_link_creates_symlink(self):
+        os.makedirs(os.path.join('src', 'dir'))
+        open(os.path.join('src', 'dir', 'file'), 'w').close()
+
+        # Note that this is a symlink now instead of a directory
+        os.symlink('dummy', 'destination')
+
+        local = sources.Local('src', 'destination')
+        local.pull()
+
+        self.assertFalse(os.path.islink('destination'))
+        self.assertFalse(os.path.islink(os.path.join('destination', 'dir')))
+        self.assertGreater(
+            os.stat(os.path.join('destination', 'dir', 'file')).st_nlink, 1)
+
+    def test_pull_with_existing_source_file_wipes_and_creates_hardlinks(self):
+        os.makedirs(os.path.join('src', 'dir'))
+        open(os.path.join('src', 'dir', 'file'), 'w').close()
+
+        # Note that this is a file now instead of a directory
+        open('destination', 'w').close()
+
+        local = sources.Local('src', 'destination')
+        local.pull()
+
+        self.assertFalse(os.path.isfile('destination'))
+        self.assertFalse(os.path.islink('destination'))
+        self.assertFalse(os.path.islink(os.path.join('destination', 'dir')))
+        self.assertGreater(
+            os.stat(os.path.join('destination', 'dir', 'file')).st_nlink, 1)
+
+    def test_pulling_twice_with_existing_source_dir_recreates_hardlinks(self):
+        os.makedirs(os.path.join('src', 'dir'))
+        open(os.path.join('src', 'dir', 'file'), 'w').close()
+
+        os.mkdir('destination')
+
+        local = sources.Local('src', 'destination')
+        local.pull()
+        local.pull()
+
+        # Verify that the directories are not symlinks, but the file is a
+        # hardlink.
+        self.assertFalse(os.path.islink('destination'))
+        self.assertFalse(os.path.islink(os.path.join('destination', 'dir')))
+        self.assertGreater(
+            os.stat(os.path.join('destination', 'dir', 'file')).st_nlink, 1)
+
+    def test_pull_ignores_snapcraft_specific_data(self):
+        # Make the snapcraft-specific directories
+        os.makedirs(os.path.join('src', 'parts'))
+        os.makedirs(os.path.join('src', 'stage'))
+        os.makedirs(os.path.join('src', 'prime'))
+
+        # Make the snapcraft.yaml (and hidden one) and a built snap
+        open(os.path.join('src', 'snapcraft.yaml'), 'w').close()
+        open(os.path.join('src', '.snapcraft.yaml'), 'w').close()
+        open(os.path.join('src', 'foo.snap'), 'w').close()
+
+        # Now make some real files
+        os.makedirs(os.path.join('src', 'dir'))
+        open(os.path.join('src', 'dir', 'file'), 'w').close()
+
+        os.mkdir('destination')
+
+        local = sources.Local('src', 'destination')
+        local.pull()
+
+        # Verify that the snapcraft-specific stuff got filtered out
+        self.assertFalse(os.path.exists(os.path.join('destination', 'parts')))
+        self.assertFalse(os.path.exists(os.path.join('destination', 'stage')))
+        self.assertFalse(os.path.exists(os.path.join('destination', 'prime')))
+        self.assertFalse(
+            os.path.exists(os.path.join('destination', 'snapcraft.yaml')))
+        self.assertFalse(
+            os.path.exists(os.path.join('destination', '.snapcraft.yaml')))
+        self.assertFalse(
+            os.path.exists(os.path.join('destination', 'foo.snap')))
+
+        # Verify that the real stuff made it in.
+        self.assertFalse(os.path.islink('destination'))
+        self.assertFalse(os.path.islink(os.path.join('destination', 'dir')))
+        self.assertGreater(
+            os.stat(os.path.join('destination', 'dir', 'file')).st_nlink, 1)
+
+
+class TestLocalIgnores(tests.TestCase):
+    """Verify that the snapcraft root dir does not get copied into itself."""
+
+    scenarios = [(f, dict(snapcraft_dir=f))
+                 for f in common.SNAPCRAFT_FILES if '.' not in f]
+
+    def test_pull_with_source_the_parent_of_current_dir(self):
+        os.makedirs('subdir')
+
+        cwd = os.getcwd()
+        os.chdir('subdir')
+        source_dir = os.path.join(self.snapcraft_dir, 'foo_src')
+        local = sources.Local('..', source_dir)
+        local.pull()
+        os.chdir(cwd)
+        self.assertFalse(
+            os.path.exists(os.path.join(
+                'subdir', source_dir, 'subdir', self.snapcraft_dir)))
+        self.assertTrue(
+            'subdir' in os.listdir(os.path.join('subdir', source_dir)))
+
+    def test_pull_with_source_a_parent_of_current_dir(self):
+        subdir = os.path.join('subdir', 'subsubdir', 'subsubsubdir')
+        os.makedirs(subdir)
+
+        cwd = os.getcwd()
+        os.chdir(subdir)
+        source = '../' * (subdir.count(os.sep)+1)
+        source_dir = os.path.join(self.snapcraft_dir, 'foo_src')
+        local = sources.Local(source, source_dir)
+        local.pull()
+        os.chdir(cwd)
+        self.assertFalse(
+            os.path.exists(os.path.join(
+                subdir, source_dir, subdir, self.snapcraft_dir)))
+        self.assertTrue(
+            os.path.basename(subdir) in os.listdir(
+                os.path.join(subdir, source_dir, os.path.dirname(subdir))))

--- a/snapcraft/tests/sources/test_sources.py
+++ b/snapcraft/tests/sources/test_sources.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import copy
 import os
 import shutil
 import tarfile
@@ -23,7 +22,7 @@ import unittest.mock
 import fixtures
 import libarchive
 
-from snapcraft.internal import common, sources
+from snapcraft.internal import sources
 from snapcraft import tests
 from . import SourceTestCase
 
@@ -676,164 +675,6 @@ class TestSubversion(SourceTestCase):
         expected_message = (
             'can\'t specify source-depth for a Subversion source')
         self.assertEqual(raised.message, expected_message)
-
-
-class TestLocal(tests.TestCase):
-
-    @unittest.mock.patch('snapcraft.internal.sources.glob.glob')
-    def test_pull_does_not_change_snapcraft_files_list(self, mock_glob):
-        # Regression test for https://bugs.launchpad.net/snapcraft/+bug/1614913
-        # Verify that SNAPCRAFT_FILES was not modified by the pull when there
-        # are files to ignore.
-        snapcraft_files_before_pull = copy.copy(common.SNAPCRAFT_FILES)
-        mock_glob.return_value = ['a.snap', 'b.snap', 'c.snap']
-
-        local = sources.Local('.', 'destination')
-        local.pull()
-
-        self.assertEqual(
-            snapcraft_files_before_pull, common.SNAPCRAFT_FILES)
-
-    def test_pull_with_existing_empty_source_dir_creates_hardlinks(self):
-        os.makedirs(os.path.join('src', 'dir'))
-        open(os.path.join('src', 'dir', 'file'), 'w').close()
-
-        os.mkdir('destination')
-
-        local = sources.Local('src', 'destination')
-        local.pull()
-
-        # Verify that the directories are not symlinks, but the file is a
-        # hardlink.
-        self.assertFalse(os.path.islink('destination'))
-        self.assertFalse(os.path.islink(os.path.join('destination', 'dir')))
-        self.assertGreater(
-            os.stat(os.path.join('destination', 'dir', 'file')).st_nlink, 1)
-
-    def test_pull_with_existing_source_link_creates_symlink(self):
-        os.makedirs(os.path.join('src', 'dir'))
-        open(os.path.join('src', 'dir', 'file'), 'w').close()
-
-        # Note that this is a symlink now instead of a directory
-        os.symlink('dummy', 'destination')
-
-        local = sources.Local('src', 'destination')
-        local.pull()
-
-        self.assertFalse(os.path.islink('destination'))
-        self.assertFalse(os.path.islink(os.path.join('destination', 'dir')))
-        self.assertGreater(
-            os.stat(os.path.join('destination', 'dir', 'file')).st_nlink, 1)
-
-    def test_pull_with_existing_source_file_wipes_and_creates_hardlinks(self):
-        os.makedirs(os.path.join('src', 'dir'))
-        open(os.path.join('src', 'dir', 'file'), 'w').close()
-
-        # Note that this is a file now instead of a directory
-        open('destination', 'w').close()
-
-        local = sources.Local('src', 'destination')
-        local.pull()
-
-        self.assertFalse(os.path.isfile('destination'))
-        self.assertFalse(os.path.islink('destination'))
-        self.assertFalse(os.path.islink(os.path.join('destination', 'dir')))
-        self.assertGreater(
-            os.stat(os.path.join('destination', 'dir', 'file')).st_nlink, 1)
-
-    def test_pulling_twice_with_existing_source_dir_recreates_hardlinks(self):
-        os.makedirs(os.path.join('src', 'dir'))
-        open(os.path.join('src', 'dir', 'file'), 'w').close()
-
-        os.mkdir('destination')
-
-        local = sources.Local('src', 'destination')
-        local.pull()
-        local.pull()
-
-        # Verify that the directories are not symlinks, but the file is a
-        # hardlink.
-        self.assertFalse(os.path.islink('destination'))
-        self.assertFalse(os.path.islink(os.path.join('destination', 'dir')))
-        self.assertGreater(
-            os.stat(os.path.join('destination', 'dir', 'file')).st_nlink, 1)
-
-    def test_pull_ignores_snapcraft_specific_data(self):
-        # Make the snapcraft-specific directories
-        os.makedirs(os.path.join('src', 'parts'))
-        os.makedirs(os.path.join('src', 'stage'))
-        os.makedirs(os.path.join('src', 'prime'))
-
-        # Make the snapcraft.yaml (and hidden one) and a built snap
-        open(os.path.join('src', 'snapcraft.yaml'), 'w').close()
-        open(os.path.join('src', '.snapcraft.yaml'), 'w').close()
-        open(os.path.join('src', 'foo.snap'), 'w').close()
-
-        # Now make some real files
-        os.makedirs(os.path.join('src', 'dir'))
-        open(os.path.join('src', 'dir', 'file'), 'w').close()
-
-        os.mkdir('destination')
-
-        local = sources.Local('src', 'destination')
-        local.pull()
-
-        # Verify that the snapcraft-specific stuff got filtered out
-        self.assertFalse(os.path.exists(os.path.join('destination', 'parts')))
-        self.assertFalse(os.path.exists(os.path.join('destination', 'stage')))
-        self.assertFalse(os.path.exists(os.path.join('destination', 'prime')))
-        self.assertFalse(
-            os.path.exists(os.path.join('destination', 'snapcraft.yaml')))
-        self.assertFalse(
-            os.path.exists(os.path.join('destination', '.snapcraft.yaml')))
-        self.assertFalse(
-            os.path.exists(os.path.join('destination', 'foo.snap')))
-
-        # Verify that the real stuff made it in.
-        self.assertFalse(os.path.islink('destination'))
-        self.assertFalse(os.path.islink(os.path.join('destination', 'dir')))
-        self.assertGreater(
-            os.stat(os.path.join('destination', 'dir', 'file')).st_nlink, 1)
-
-
-class TestLocalIgnores(tests.TestCase):
-    """Verify that the snapcraft root dir does not get copied into itself."""
-
-    scenarios = [(f, dict(snapcraft_dir=f))
-                 for f in common.SNAPCRAFT_FILES if '.' not in f]
-
-    def test_pull_with_source_the_parent_of_current_dir(self):
-        os.makedirs('subdir')
-
-        cwd = os.getcwd()
-        os.chdir('subdir')
-        source_dir = os.path.join(self.snapcraft_dir, 'foo_src')
-        local = sources.Local('..', source_dir)
-        local.pull()
-        os.chdir(cwd)
-        self.assertFalse(
-            os.path.exists(os.path.join(
-                'subdir', source_dir, 'subdir', self.snapcraft_dir)))
-        self.assertTrue(
-            'subdir' in os.listdir(os.path.join('subdir', source_dir)))
-
-    def test_pull_with_source_a_parent_of_current_dir(self):
-        subdir = os.path.join('subdir', 'subsubdir', 'subsubsubdir')
-        os.makedirs(subdir)
-
-        cwd = os.getcwd()
-        os.chdir(subdir)
-        source = '../' * (subdir.count(os.sep)+1)
-        source_dir = os.path.join(self.snapcraft_dir, 'foo_src')
-        local = sources.Local(source, source_dir)
-        local.pull()
-        os.chdir(cwd)
-        self.assertFalse(
-            os.path.exists(os.path.join(
-                subdir, source_dir, subdir, self.snapcraft_dir)))
-        self.assertTrue(
-            os.path.basename(subdir) in os.listdir(
-                os.path.join(subdir, source_dir, os.path.dirname(subdir))))
 
 
 class TestUri(tests.TestCase):


### PR DESCRIPTION
This PR makes more progress on LP: [#1648906](https://bugs.launchpad.net/snapcraft/+bug/1648906) by extracting the Local source into `sources/_local.py`.