### PR TITLE
sources: refactor script source into module.

### DIFF
--- a/snapcraft/internal/sources/__init__.py
+++ b/snapcraft/internal/sources/__init__.py
@@ -71,7 +71,6 @@ cases you want to refer to the help text for the specific plugin.
 import logging
 import os
 import os.path
-import stat
 import re
 import shutil
 import subprocess
@@ -88,6 +87,7 @@ from ._git import Git              # noqa
 from ._local import Local          # noqa
 from ._mercurial import Mercurial  # noqa
 from ._rpm import Rpm              # noqa
+from ._script import Script        # noqa
 
 logging.getLogger('urllib3').setLevel(logging.CRITICAL)
 
@@ -105,19 +105,6 @@ __SOURCE_DEFAULTS = {
 
 def get_source_defaults():
     return __SOURCE_DEFAULTS.copy()
-
-
-class Script(_base.FileBase):
-
-    def __init__(self, source, source_dir, source_tag=None, source_commit=None,
-                 source_branch=None, source_depth=None):
-        super().__init__(source, source_dir, source_tag, source_commit,
-                         source_branch, source_depth)
-
-    def download(self):
-        super().download()
-        st = os.stat(self.file)
-        os.chmod(self.file, st.st_mode | stat.S_IEXEC)
 
 
 class Subversion(_base.Base):

--- a/snapcraft/internal/sources/_script.py
+++ b/snapcraft/internal/sources/_script.py
@@ -1,0 +1,33 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015, 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import stat
+
+from ._base import FileBase
+
+
+class Script(FileBase):
+
+    def __init__(self, source, source_dir, source_tag=None, source_commit=None,
+                 source_branch=None, source_depth=None):
+        super().__init__(source, source_dir, source_tag, source_commit,
+                         source_branch, source_depth)
+
+    def download(self):
+        super().download()
+        st = os.stat(self.file)
+        os.chmod(self.file, st.st_mode | stat.S_IEXEC)

--- a/snapcraft/tests/__init__.py
+++ b/snapcraft/tests/__init__.py
@@ -16,8 +16,9 @@
 
 import logging
 import os
-from unittest import mock
+import stat
 
+from unittest import mock
 import fixtures
 import http.server
 import progressbar
@@ -48,6 +49,20 @@ class MockOptions:
         self.source_tag = source_tag
         self.source_subdir = source_subdir
         self.disable_parallel = disable_parallel
+
+
+class IsExecutable:
+    """Match if a file path is executable."""
+
+    def __str__(self):
+        return 'IsExecutable()'
+
+    def match(self, file_path):
+        if not os.stat(file_path).st_mode & stat.S_IEXEC:
+            return testtools.matchers.Mismatch(
+                'Expected {!r} to be executable, but it was not'.format(
+                    file_path))
+        return None
 
 
 class TestCase(testscenarios.WithScenarios, testtools.TestCase):

--- a/snapcraft/tests/sources/test_script.py
+++ b/snapcraft/tests/sources/test_script.py
@@ -1,0 +1,40 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from unittest import mock
+from testtools.matchers import FileExists
+
+from snapcraft.internal.sources import Script
+from snapcraft import tests
+
+
+class TestScript(tests.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.source = Script('source', 'destination')
+
+        os.mkdir('destination')
+        self.source.file = os.path.join('destination', 'file')
+        open(self.source.file, 'w').close()
+
+    @mock.patch('snapcraft.internal.sources._script.FileBase.download')
+    def test_download_makes_executable(self, mock_download):
+        self.source.file = os.path.join('destination', 'file')
+        self.source.download()
+        self.assertThat(self.source.file, FileExists())
+        self.assertThat(self.source.file, tests.IsExecutable())


### PR DESCRIPTION
This PR makes more progress on LP: [#1648906](https://bugs.launchpad.net/snapcraft/+bug/1648906) by extracting the Script source into `sources/_script.py`.

It also implements some basic tests for the Script source.