### PR TITLE
sources: refactor subversion source into module.

### DIFF
--- a/snapcraft/internal/sources/__init__.py
+++ b/snapcraft/internal/sources/__init__.py
@@ -73,7 +73,6 @@ import os
 import os.path
 import re
 import shutil
-import subprocess
 import tempfile
 import tarfile
 import zipfile
@@ -81,13 +80,14 @@ import zipfile
 from snapcraft.internal import common
 from . import errors
 from . import _base
-from ._bazaar import Bazaar        # noqa
-from ._deb import Deb              # noqa
-from ._git import Git              # noqa
-from ._local import Local          # noqa
-from ._mercurial import Mercurial  # noqa
-from ._rpm import Rpm              # noqa
-from ._script import Script        # noqa
+from ._bazaar import Bazaar          # noqa
+from ._deb import Deb                # noqa
+from ._git import Git                # noqa
+from ._local import Local            # noqa
+from ._mercurial import Mercurial    # noqa
+from ._rpm import Rpm                # noqa
+from ._script import Script          # noqa
+from ._subversion import Subversion  # noqa
 
 logging.getLogger('urllib3').setLevel(logging.CRITICAL)
 
@@ -105,48 +105,6 @@ __SOURCE_DEFAULTS = {
 
 def get_source_defaults():
     return __SOURCE_DEFAULTS.copy()
-
-
-class Subversion(_base.Base):
-
-    def __init__(self, source, source_dir, source_tag=None, source_commit=None,
-                 source_branch=None, source_depth=None):
-        super().__init__(source, source_dir, source_tag, source_commit,
-                         source_branch, source_depth, 'svn')
-        if source_tag:
-            if source_branch:
-                raise errors.IncompatibleOptionsError(
-                    "Can't specify source-tag OR source-branch for a "
-                    "Subversion source")
-            else:
-                raise errors.IncompatibleOptionsError(
-                    "Can't specify source-tag for a Subversion source")
-        elif source_branch:
-            raise errors.IncompatibleOptionsError(
-                "Can't specify source-branch for a Subversion source")
-        if source_depth:
-            raise errors.IncompatibleOptionsError(
-                'can\'t specify source-depth for a Subversion source')
-
-    def pull(self):
-        opts = []
-
-        if self.source_commit:
-            opts = ["-r", self.source_commit]
-
-        if os.path.exists(os.path.join(self.source_dir, '.svn')):
-            subprocess.check_call(
-                [self.command, 'update'] + opts, cwd=self.source_dir)
-        else:
-            if os.path.isdir(self.source):
-                subprocess.check_call(
-                    [self.command, 'checkout',
-                     'file://{}'.format(os.path.abspath(self.source)),
-                     self.source_dir] + opts)
-            else:
-                subprocess.check_call(
-                    [self.command, 'checkout', self.source, self.source_dir] +
-                    opts)
 
 
 class Tar(_base.FileBase):

--- a/snapcraft/internal/sources/_subversion.py
+++ b/snapcraft/internal/sources/_subversion.py
@@ -1,0 +1,63 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015, 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import subprocess
+
+from . import errors
+from ._base import Base
+
+
+class Subversion(Base):
+
+    def __init__(self, source, source_dir, source_tag=None, source_commit=None,
+                 source_branch=None, source_depth=None):
+        super().__init__(source, source_dir, source_tag, source_commit,
+                         source_branch, source_depth, 'svn')
+        if source_tag:
+            if source_branch:
+                raise errors.IncompatibleOptionsError(
+                    "Can't specify source-tag OR source-branch for a "
+                    "Subversion source")
+            else:
+                raise errors.IncompatibleOptionsError(
+                    "Can't specify source-tag for a Subversion source")
+        elif source_branch:
+            raise errors.IncompatibleOptionsError(
+                "Can't specify source-branch for a Subversion source")
+        if source_depth:
+            raise errors.IncompatibleOptionsError(
+                'can\'t specify source-depth for a Subversion source')
+
+    def pull(self):
+        opts = []
+
+        if self.source_commit:
+            opts = ["-r", self.source_commit]
+
+        if os.path.exists(os.path.join(self.source_dir, '.svn')):
+            subprocess.check_call(
+                [self.command, 'update'] + opts, cwd=self.source_dir)
+        else:
+            if os.path.isdir(self.source):
+                subprocess.check_call(
+                    [self.command, 'checkout',
+                     'file://{}'.format(os.path.abspath(self.source)),
+                     self.source_dir] + opts)
+            else:
+                subprocess.check_call(
+                    [self.command, 'checkout', self.source, self.source_dir] +
+                    opts)

--- a/snapcraft/tests/sources/test_sources.py
+++ b/snapcraft/tests/sources/test_sources.py
@@ -22,7 +22,6 @@ import fixtures
 
 from snapcraft.internal import sources
 from snapcraft import tests
-from . import SourceTestCase
 
 
 class TestTar(tests.FakeFileHTTPServerBasedTestCase):
@@ -162,84 +161,6 @@ class TestZip(tests.FakeFileHTTPServerBasedTestCase):
 
         with open(zip_download, 'r') as zip_file:
             self.assertEqual('Test fake compressed file', zip_file.read())
-
-
-class TestSubversion(SourceTestCase):
-
-    def test_pull_remote(self):
-        svn = sources.Subversion('svn://my-source', 'source_dir')
-        svn.pull()
-        self.mock_run.assert_called_once_with(
-            ['svn', 'checkout', 'svn://my-source', 'source_dir'])
-
-    def test_pull_remote_commit(self):
-        svn = sources.Subversion('svn://my-source', 'source_dir',
-                                 source_commit="2")
-        svn.pull()
-        self.mock_run.assert_called_once_with(
-            ['svn', 'checkout', 'svn://my-source', 'source_dir', '-r', '2'])
-
-    def test_pull_local_absolute_path(self):
-        svn = sources.Subversion(self.path, 'source_dir')
-        svn.pull()
-        self.mock_run.assert_called_once_with(
-            ['svn', 'checkout', 'file://'+self.path, 'source_dir'])
-
-    def test_pull_local_relative_path(self):
-        os.mkdir("my-source")
-        svn = sources.Subversion('my-source', 'source_dir')
-        svn.pull()
-        self.mock_run.assert_called_once_with(
-            ['svn', 'checkout',
-             'file://{}'.format(os.path.join(self.path, 'my-source')),
-             'source_dir'])
-
-    def test_pull_existing(self):
-        self.mock_path_exists.return_value = True
-        svn = sources.Subversion('svn://my-source', 'source_dir')
-        svn.pull()
-        self.mock_run.assert_called_once_with(
-            ['svn', 'update'], cwd=svn.source_dir)
-
-    def test_init_with_source_tag_raises_exception(self):
-        raised = self.assertRaises(
-            sources.errors.IncompatibleOptionsError,
-            sources.Subversion,
-            'svn://mysource', 'source_dir', source_tag='tag')
-        expected_message = (
-            "Can't specify source-tag for a Subversion source")
-        self.assertEqual(raised.message, expected_message)
-
-    def test_init_with_source_branch_raises_exception(self):
-        raised = self.assertRaises(
-            sources.errors.IncompatibleOptionsError,
-            sources.Subversion,
-            'svn://mysource', 'source_dir', source_branch='branch')
-        expected_message = (
-            "Can't specify source-branch for a Subversion source")
-        self.assertEqual(raised.message, expected_message)
-
-    def test_init_with_source_branch_and_tag_raises_exception(self):
-        raised = self.assertRaises(
-            sources.errors.IncompatibleOptionsError,
-            sources.Subversion,
-            'svn://mysource', 'source_dir', source_tag='tag',
-            source_branch='branch')
-
-        expected_message = (
-            "Can't specify source-tag OR source-branch for a Subversion "
-            "source")
-        self.assertEqual(raised.message, expected_message)
-
-    def test_init_with_source_depth_raises_exception(self):
-        raised = self.assertRaises(
-            sources.errors.IncompatibleOptionsError,
-            sources.Subversion,
-            'svn://mysource', 'source_dir', source_depth=2)
-
-        expected_message = (
-            'can\'t specify source-depth for a Subversion source')
-        self.assertEqual(raised.message, expected_message)
 
 
 class TestUri(tests.TestCase):

--- a/snapcraft/tests/sources/test_subversion.py
+++ b/snapcraft/tests/sources/test_subversion.py
@@ -1,0 +1,99 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015, 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from snapcraft.internal import sources
+
+from snapcraft.tests.sources import SourceTestCase
+
+
+class TestSubversion(SourceTestCase):
+
+    def test_pull_remote(self):
+        svn = sources.Subversion('svn://my-source', 'source_dir')
+        svn.pull()
+        self.mock_run.assert_called_once_with(
+            ['svn', 'checkout', 'svn://my-source', 'source_dir'])
+
+    def test_pull_remote_commit(self):
+        svn = sources.Subversion('svn://my-source', 'source_dir',
+                                 source_commit="2")
+        svn.pull()
+        self.mock_run.assert_called_once_with(
+            ['svn', 'checkout', 'svn://my-source', 'source_dir', '-r', '2'])
+
+    def test_pull_local_absolute_path(self):
+        svn = sources.Subversion(self.path, 'source_dir')
+        svn.pull()
+        self.mock_run.assert_called_once_with(
+            ['svn', 'checkout', 'file://'+self.path, 'source_dir'])
+
+    def test_pull_local_relative_path(self):
+        os.mkdir("my-source")
+        svn = sources.Subversion('my-source', 'source_dir')
+        svn.pull()
+        self.mock_run.assert_called_once_with(
+            ['svn', 'checkout',
+             'file://{}'.format(os.path.join(self.path, 'my-source')),
+             'source_dir'])
+
+    def test_pull_existing(self):
+        self.mock_path_exists.return_value = True
+        svn = sources.Subversion('svn://my-source', 'source_dir')
+        svn.pull()
+        self.mock_run.assert_called_once_with(
+            ['svn', 'update'], cwd=svn.source_dir)
+
+    def test_init_with_source_tag_raises_exception(self):
+        raised = self.assertRaises(
+            sources.errors.IncompatibleOptionsError,
+            sources.Subversion,
+            'svn://mysource', 'source_dir', source_tag='tag')
+        expected_message = (
+            "Can't specify source-tag for a Subversion source")
+        self.assertEqual(raised.message, expected_message)
+
+    def test_init_with_source_branch_raises_exception(self):
+        raised = self.assertRaises(
+            sources.errors.IncompatibleOptionsError,
+            sources.Subversion,
+            'svn://mysource', 'source_dir', source_branch='branch')
+        expected_message = (
+            "Can't specify source-branch for a Subversion source")
+        self.assertEqual(raised.message, expected_message)
+
+    def test_init_with_source_branch_and_tag_raises_exception(self):
+        raised = self.assertRaises(
+            sources.errors.IncompatibleOptionsError,
+            sources.Subversion,
+            'svn://mysource', 'source_dir', source_tag='tag',
+            source_branch='branch')
+
+        expected_message = (
+            "Can't specify source-tag OR source-branch for a Subversion "
+            "source")
+        self.assertEqual(raised.message, expected_message)
+
+    def test_init_with_source_depth_raises_exception(self):
+        raised = self.assertRaises(
+            sources.errors.IncompatibleOptionsError,
+            sources.Subversion,
+            'svn://mysource', 'source_dir', source_depth=2)
+
+        expected_message = (
+            'can\'t specify source-depth for a Subversion source')
+        self.assertEqual(raised.message, expected_message)


### PR DESCRIPTION
This PR makes more progress on LP: [#1648906](https://bugs.launchpad.net/snapcraft/+bug/1648906) by extracting the Subversion source into `sources/_subversion.py`.