### PR TITLE
Updated maven plugin to use get_build_properties()

### DIFF
--- a/snapcraft/plugins/maven.py
+++ b/snapcraft/plugins/maven.py
@@ -69,11 +69,6 @@ class MavenPlugin(snapcraft.plugins.jdk.JdkPlugin):
             'default': [''],
         }
 
-        # Inform Snapcraft of the properties associated with building. If these
-        # change in the YAML Snapcraft will consider the build step dirty.
-        schema['build-properties'].append('maven-options')
-        schema['build-properties'].append('maven-targets')
-
         return schema
 
     def __init__(self, name, options, project):
@@ -82,6 +77,12 @@ class MavenPlugin(snapcraft.plugins.jdk.JdkPlugin):
 
     def _use_proxy(self):
         return any(k in os.environ for k in ('http_proxy', 'https_proxy'))
+
+    @classmethod
+    def get_build_properties(cls):
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        return ['maven-options', 'maven-targets']
 
     def build(self):
         super().build()

--- a/snapcraft/tests/test_plugin_maven.py
+++ b/snapcraft/tests/test_plugin_maven.py
@@ -20,6 +20,7 @@ from unittest import mock
 from xml.etree import ElementTree
 
 import fixtures
+from testtools.matchers import HasLength
 
 import snapcraft
 from snapcraft import tests
@@ -58,13 +59,14 @@ class MavenPluginTestCase(tests.TestCase):
             return f.getvalue() + '\n'
 
     def test_get_build_properties(self):
-        plugin = maven.MavenPlugin('test-part', self.options,
-                                   self.project_options)
-        maven_build_properties = ['maven-options', 'maven-targets']
-        for prop in maven_build_properties:
-            self.assertTrue(prop in plugin.get_build_properties(),
-                            'Expected "' + prop + '" to be included in '
-                            'properties')
+        expected_build_properties = ['maven-options', 'maven-targets']
+        resulting_build_properties = maven.MavenPlugin.get_build_properties()
+
+        self.assertThat(resulting_build_properties,
+                        HasLength(len(expected_build_properties)))
+
+        for property in expected_build_properties:
+            self.assertIn(property, resulting_build_properties)
 
     def assertSettingsEqual(self, expected, observed):
         print(repr(self._canonicalize_settings(expected)))

--- a/snapcraft/tests/test_plugin_maven.py
+++ b/snapcraft/tests/test_plugin_maven.py
@@ -24,6 +24,7 @@ import fixtures
 import snapcraft
 from snapcraft import tests
 from snapcraft.plugins import maven
+from snapcraft.internal import pluginhandler
 
 
 class MavenPluginTestCase(tests.TestCase):
@@ -64,64 +65,19 @@ class MavenPluginTestCase(tests.TestCase):
             self._canonicalize_settings(expected),
             self._canonicalize_settings(observed))
 
+    def test_get_build_properties(self):
+        plugin = maven.MavenPlugin('test-part', self.options,
+                                   self.project_options)
+        maven_build_properties = ['maven-options', 'maven-targets']
+        plugin.get_build_properties()
+        for prop in maven_build_properties:
+            self.assertTrue(prop in plugin.get_build_properties(),
+                            'Expected "' + prop + '" to be included in '
+                            'properties')
+
     def test_schema(self):
         schema = maven.MavenPlugin.schema()
-
         properties = schema['properties']
-        self.assertTrue('maven-options' in properties,
-                        'Expected "maven-options" to be included in '
-                        'properties')
-
-        maven_options = properties['maven-options']
-
-        self.assertTrue(
-            'type' in maven_options,
-            'Expected "type" to be included in "maven-options"')
-        self.assertEqual(maven_options['type'], 'array',
-                         'Expected "maven-options" "type" to be "array", but '
-                         'it was "{}"'.format(maven_options['type']))
-
-        self.assertTrue(
-            'minitems' in maven_options,
-            'Expected "minitems" to be included in "maven-options"')
-        self.assertEqual(maven_options['minitems'], 1,
-                         'Expected "maven-options" "minitems" to be 1, but '
-                         'it was "{}"'.format(maven_options['minitems']))
-
-        self.assertTrue(
-            'uniqueItems' in maven_options,
-            'Expected "uniqueItems" to be included in "maven-options"')
-        self.assertTrue(
-            maven_options['uniqueItems'],
-            'Expected "maven-options" "uniqueItems" to be "True"')
-
-        maven_targets = properties['maven-targets']
-
-        self.assertTrue(
-            'type' in maven_targets,
-            'Expected "type" to be included in "maven-targets"')
-        self.assertEqual(maven_targets['type'], 'array',
-                         'Expected "maven-targets" "type" to be "array", but '
-                         'it was "{}"'.format(maven_targets['type']))
-
-        self.assertTrue(
-            'minitems' in maven_targets,
-            'Expected "minitems" to be included in "maven-targets"')
-        self.assertEqual(maven_targets['minitems'], 1,
-                         'Expected "maven-targets" "minitems" to be 1, but '
-                         'it was "{}"'.format(maven_targets['minitems']))
-
-        self.assertTrue(
-            'uniqueItems' in maven_targets,
-            'Expected "uniqueItems" to be included in "maven-targets"')
-        self.assertTrue(
-            maven_targets['uniqueItems'],
-            'Expected "maven-targets" "uniqueItems" to be "True"')
-
-        build_properties = schema['build-properties']
-        self.assertEqual(
-            ['maven-options', 'maven-targets'],
-            build_properties)
 
     @mock.patch.object(maven.MavenPlugin, 'run')
     def test_build(self, run_mock):

--- a/snapcraft/tests/test_plugin_maven.py
+++ b/snapcraft/tests/test_plugin_maven.py
@@ -24,7 +24,6 @@ import fixtures
 import snapcraft
 from snapcraft import tests
 from snapcraft.plugins import maven
-from snapcraft.internal import pluginhandler
 
 
 class MavenPluginTestCase(tests.TestCase):
@@ -58,13 +57,6 @@ class MavenPluginTestCase(tests.TestCase):
                 default_namespace='http://maven.apache.org/SETTINGS/1.0.0')
             return f.getvalue() + '\n'
 
-    def assertSettingsEqual(self, expected, observed):
-        print(repr(self._canonicalize_settings(expected)))
-        print(repr(self._canonicalize_settings(observed)))
-        self.assertEqual(
-            self._canonicalize_settings(expected),
-            self._canonicalize_settings(observed))
-
     def test_get_build_properties(self):
         plugin = maven.MavenPlugin('test-part', self.options,
                                    self.project_options)
@@ -75,9 +67,66 @@ class MavenPluginTestCase(tests.TestCase):
                             'Expected "' + prop + '" to be included in '
                             'properties')
 
+    def assertSettingsEqual(self, expected, observed):
+        print(repr(self._canonicalize_settings(expected)))
+        print(repr(self._canonicalize_settings(observed)))
+        self.assertEqual(
+            self._canonicalize_settings(expected),
+            self._canonicalize_settings(observed))
+
     def test_schema(self):
         schema = maven.MavenPlugin.schema()
+
         properties = schema['properties']
+        self.assertTrue('maven-options' in properties,
+                        'Expected "maven-options" to be included in '
+                        'properties')
+
+        maven_options = properties['maven-options']
+
+        self.assertTrue(
+            'type' in maven_options,
+            'Expected "type" to be included in "maven-options"')
+        self.assertEqual(maven_options['type'], 'array',
+                         'Expected "maven-options" "type" to be "array", but '
+                         'it was "{}"'.format(maven_options['type']))
+
+        self.assertTrue(
+            'minitems' in maven_options,
+            'Expected "minitems" to be included in "maven-options"')
+        self.assertEqual(maven_options['minitems'], 1,
+                         'Expected "maven-options" "minitems" to be 1, but '
+                         'it was "{}"'.format(maven_options['minitems']))
+
+        self.assertTrue(
+            'uniqueItems' in maven_options,
+            'Expected "uniqueItems" to be included in "maven-options"')
+        self.assertTrue(
+            maven_options['uniqueItems'],
+            'Expected "maven-options" "uniqueItems" to be "True"')
+
+        maven_targets = properties['maven-targets']
+
+        self.assertTrue(
+            'type' in maven_targets,
+            'Expected "type" to be included in "maven-targets"')
+        self.assertEqual(maven_targets['type'], 'array',
+                         'Expected "maven-targets" "type" to be "array", but '
+                         'it was "{}"'.format(maven_targets['type']))
+
+        self.assertTrue(
+            'minitems' in maven_targets,
+            'Expected "minitems" to be included in "maven-targets"')
+        self.assertEqual(maven_targets['minitems'], 1,
+                         'Expected "maven-targets" "minitems" to be 1, but '
+                         'it was "{}"'.format(maven_targets['minitems']))
+
+        self.assertTrue(
+            'uniqueItems' in maven_targets,
+            'Expected "uniqueItems" to be included in "maven-targets"')
+        self.assertTrue(
+            maven_targets['uniqueItems'],
+            'Expected "maven-targets" "uniqueItems" to be "True"')
 
     @mock.patch.object(maven.MavenPlugin, 'run')
     def test_build(self, run_mock):

--- a/snapcraft/tests/test_plugin_maven.py
+++ b/snapcraft/tests/test_plugin_maven.py
@@ -61,7 +61,6 @@ class MavenPluginTestCase(tests.TestCase):
         plugin = maven.MavenPlugin('test-part', self.options,
                                    self.project_options)
         maven_build_properties = ['maven-options', 'maven-targets']
-        plugin.get_build_properties()
         for prop in maven_build_properties:
             self.assertTrue(prop in plugin.get_build_properties(),
                             'Expected "' + prop + '" to be included in '


### PR DESCRIPTION
Updated the maven.py plugin to use the get_build_properties() method instead of modifying the schema.

https://bugs.launchpad.net/snapcraft/+bug/1649986