### PR TITLE
Updated gradle plugin to use get_build_properties() 

### DIFF
--- a/demos/gradle/snapcraft.yaml
+++ b/demos/gradle/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0
 summary: A java example
 description: this is not much more than an example
 confinement: strict
+grade: stable
 
 apps:
  hello:

--- a/snapcraft/plugins/gradle.py
+++ b/snapcraft/plugins/gradle.py
@@ -59,13 +59,17 @@ class GradlePlugin(snapcraft.plugins.jdk.JdkPlugin):
 
         # Inform Snapcraft of the properties associated with building. If these
         # change in the YAML Snapcraft will consider the build step dirty.
-        schema['build-properties'].append('gradle-options')
+        #schema['build-properties'].append('gradle-options')
 
         return schema
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
         self.build_packages.append('ca-certificates-java')
+
+    @classmethod
+    def get_build_properties(cls):
+        return ['gradle-options']
 
     def build(self):
         super().build()

--- a/snapcraft/plugins/gradle.py
+++ b/snapcraft/plugins/gradle.py
@@ -57,10 +57,6 @@ class GradlePlugin(snapcraft.plugins.jdk.JdkPlugin):
             'default': [],
         }
 
-        # Inform Snapcraft of the properties associated with building. If these
-        # change in the YAML Snapcraft will consider the build step dirty.
-        #schema['build-properties'].append('gradle-options')
-
         return schema
 
     def __init__(self, name, options, project):
@@ -69,6 +65,8 @@ class GradlePlugin(snapcraft.plugins.jdk.JdkPlugin):
 
     @classmethod
     def get_build_properties(cls):
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
         return ['gradle-options']
 
     def build(self):

--- a/snapcraft/tests/test_plugin_gradle.py
+++ b/snapcraft/tests/test_plugin_gradle.py
@@ -81,7 +81,6 @@ class GradlePluginTestCase(BaseGradlePluginTestCase):
         plugin = gradle.GradlePlugin('test-part', self.options,
                                      self.project_options)
         gradle_build_properties = ['gradle-options']
-        plugin.get_build_properties()
         for prop in gradle_build_properties:
             self.assertTrue(prop in plugin.get_build_properties(),
                             'Expected "' + prop + '" to be included in '

--- a/snapcraft/tests/test_plugin_gradle.py
+++ b/snapcraft/tests/test_plugin_gradle.py
@@ -18,6 +18,7 @@ import os
 from unittest import mock
 
 import fixtures
+from testtools.matchers import HasLength
 
 import snapcraft
 from snapcraft import tests
@@ -78,13 +79,14 @@ class GradlePluginTestCase(BaseGradlePluginTestCase):
             'Expected "gradle-options" "uniqueItems" to be "True"')
 
     def test_get_build_properties(self):
-        plugin = gradle.GradlePlugin('test-part', self.options,
-                                     self.project_options)
-        gradle_build_properties = ['gradle-options']
-        for prop in gradle_build_properties:
-            self.assertTrue(prop in plugin.get_build_properties(),
-                            'Expected "' + prop + '" to be included in '
-                            'properties')
+        expected_build_properties = ['gradle-options']
+        resulting_build_properties = gradle.GradlePlugin.get_build_properties()
+
+        self.assertThat(resulting_build_properties,
+                        HasLength(len(expected_build_properties)))
+
+        for property in expected_build_properties:
+            self.assertIn(property, resulting_build_properties)
 
     @mock.patch.object(gradle.GradlePlugin, 'run')
     def test_build(self, run_mock):

--- a/snapcraft/tests/test_plugin_gradle.py
+++ b/snapcraft/tests/test_plugin_gradle.py
@@ -77,6 +77,16 @@ class GradlePluginTestCase(BaseGradlePluginTestCase):
             gradle_options['uniqueItems'],
             'Expected "gradle-options" "uniqueItems" to be "True"')
 
+    def test_get_build_properties(self):
+        plugin = gradle.GradlePlugin('test-part', self.options,
+                                     self.project_options)
+        gradle_build_properties = ['gradle-options']
+        plugin.get_build_properties()
+        for prop in gradle_build_properties:
+            self.assertTrue(prop in plugin.get_build_properties(),
+                            'Expected "' + prop + '" to be included in '
+                            'properties')
+
     @mock.patch.object(gradle.GradlePlugin, 'run')
     def test_build(self, run_mock):
         plugin = gradle.GradlePlugin('test-part', self.options,


### PR DESCRIPTION
Updated the maven.py plugin to use the get_build_properties() method instead of modifying the schema.

https://bugs.launchpad.net/snapcraft/+bug/1649988