### PR TITLE
demos: do not force arch for the tomcat demo

### DIFF
--- a/demos/tomcat-maven-webapp/snapcraft.yaml
+++ b/demos/tomcat-maven-webapp/snapcraft.yaml
@@ -1,7 +1,5 @@
 name: tomcat-webapp-demo
 version: 1.0
-architectures:
- - amd64
 summary: Demo of Tomcat-hosted Webapp
 description: This is a demo snap of a Tomcat-hosted webapp produced by snapcraft with maven.
 confinement: strict


### PR DESCRIPTION
The `architectures` keyword just forces an architecture to be set on a built snap regardless the contents of the snap. This is effectively useless in this case.

LP: #1591414