### PR TITLE
Prefer in-snap libraries to system libraries.

### DIFF
--- a/integration_tests/snaps/fake-curl-library/snapcraft.yaml
+++ b/integration_tests/snaps/fake-curl-library/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: test-package
+version: 0.1
+summary: Fake curl library test.
+description: A snap with two parts, a curl-like library and a user of it.
+confinement: strict
+grade: stable
+
+apps:
+  test-package:
+    command: main
+
+build-packages: [gcc, libc6-dev, libcurl4-openssl-dev]
+
+parts:
+  fake-curl:
+    plugin: cmake
+    source: src/fake-curl
+
+  main:
+    plugin: cmake
+    source: src/main
+    after: [fake-curl]

--- a/integration_tests/snaps/fake-curl-library/src/fake-curl/CMakeLists.txt
+++ b/integration_tests/snaps/fake-curl-library/src/fake-curl/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.2)
+project(fake_curl C)
+
+add_library(curl SHARED fake_curl.c)
+
+install(TARGETS curl DESTINATION lib)

--- a/integration_tests/snaps/fake-curl-library/src/fake-curl/fake_curl.c
+++ b/integration_tests/snaps/fake-curl-library/src/fake-curl/fake_curl.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+void *curl_easy_init()
+{
+	printf("Fake init\n");
+	return 1;
+}
+
+void curl_easy_cleanup(void *curl)
+{
+	printf("Fake cleanup\n");
+}

--- a/integration_tests/snaps/fake-curl-library/src/main/CMakeLists.txt
+++ b/integration_tests/snaps/fake-curl-library/src/main/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.2)
+project(main C)
+
+add_executable(main main.c)
+target_link_libraries(main curl)
+
+install(TARGETS main DESTINATION bin)

--- a/integration_tests/snaps/fake-curl-library/src/main/main.c
+++ b/integration_tests/snaps/fake-curl-library/src/main/main.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+#include <curl/curl.h>
+
+int main()
+{
+	printf("Starting\n");
+
+	CURL *curl = curl_easy_init();
+	if (curl)
+	{
+		curl_easy_cleanup(curl);
+	}
+
+	printf("Done\n");
+
+	return 0;
+}

--- a/integration_tests/test_library_precedence.py
+++ b/integration_tests/test_library_precedence.py
@@ -1,0 +1,52 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from testtools.matchers import (
+    DirExists,
+    FileExists,
+    Not
+)
+
+import integration_tests
+
+
+class LibraryPrecedenceTestCase(integration_tests.TestCase):
+
+    def test_snapped_library_takes_precedence_over_system(self):
+        project_dir = 'fake-curl-library'
+        self.run_snapcraft('stage', project_dir)
+        self.run_snapcraft(['prime', 'main'], project_dir)
+
+        # Verify that, while the binary was primed, no library was pulled in.
+        self.assertThat(
+            os.path.join(project_dir, 'prime', 'bin', 'main'), FileExists())
+        self.assertThat(
+            os.path.join(project_dir, 'prime', 'lib'), Not(DirExists()))
+        self.assertThat(
+            os.path.join(project_dir, 'prime', 'usr'), Not(DirExists()))
+
+        # Prime the rest of the way.
+        self.run_snapcraft('prime', project_dir)
+
+        # Now verify the lib we got was the one from the snap, not from the
+        # system.
+        self.assertThat(
+            os.path.join(project_dir, 'prime', 'lib', 'libcurl.so'),
+            FileExists())
+        self.assertThat(
+            os.path.join(project_dir, 'prime', 'usr'), Not(DirExists()))

--- a/snapcraft/internal/libraries.py
+++ b/snapcraft/internal/libraries.py
@@ -72,7 +72,8 @@ def _get_system_libs():
 
     if not os.path.exists(lib_path):
         logger.warning('No libraries to exclude from this release')
-        return frozenset()
+        # Always exclude libc.so.6
+        return frozenset(['libc.so.6'])
 
     with open(lib_path) as fn:
         _libraries = frozenset(fn.read().split())

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -482,42 +482,8 @@ class PluginHandler:
         self.notify_part_progress('Priming')
         snap_files, snap_dirs = self.migratable_fileset_for('snap')
         _migrate_files(snap_files, snap_dirs, self.stagedir, self.snapdir)
-        dependencies = _find_dependencies(self.snapdir, snap_files)
-
-        # Split the necessary dependencies into their corresponding location.
-        # We'll both migrate and track the system dependencies, but we'll only
-        # track the part and staged dependencies, since they should have
-        # already been primed by other means, and migrating them again could
-        # potentially override the `stage` or `snap` filtering.
-        part_dependencies = set()
-        staged_dependencies = set()
-        primed_dependencies = set()
-        system_dependencies = set()
-        for file_path in dependencies:
-            if file_path.startswith(self.installdir):
-                part_dependencies.add(
-                    os.path.relpath(file_path, self.installdir))
-            elif file_path.startswith(self.stagedir):
-                staged_dependencies.add(
-                    os.path.relpath(file_path, self.stagedir))
-            elif file_path.startswith(self.snapdir):
-                primed_dependencies.add(
-                    os.path.relpath(file_path, self.snapdir))
-            else:
-                system_dependencies.add(file_path.lstrip('/'))
-
-        part_dependency_paths = {os.path.dirname(d) for d in part_dependencies}
-        staged_dependency_paths = {os.path.dirname(d) for d in
-                                   staged_dependencies}
-        system_dependency_paths = {os.path.dirname(d) for d in
-                                   system_dependencies}
-        # Lots of dependencies are linked with a symlink, so we need to make
-        # sure we follow those symlinks when we migrate the dependencies.
-        _migrate_files(system_dependencies, system_dependency_paths, '/',
-                       self.snapdir, follow_symlinks=True)
-
-        dependency_paths = (part_dependency_paths | staged_dependency_paths |
-                            system_dependency_paths)
+        dependency_paths = _migrate_system_dependencies(
+            self.installdir, self.stagedir, self.snapdir, snap_files)
 
         self.mark_prime_done(snap_files, snap_dirs, dependency_paths)
 
@@ -630,6 +596,70 @@ class PluginHandler:
 
         if not index or index <= common.COMMAND_ORDER.index('pull'):
             self.clean_pull(hint)
+
+
+def _migrate_system_dependencies(installdir, stagedir, snapdir, snap_files):
+    dependencies = _find_dependencies(snapdir, snap_files)
+
+    # Split the necessary dependencies into their corresponding location.
+    # We'll both migrate and track the system dependencies, but we'll only
+    # track the part and staged dependencies, since they should have
+    # already been primed by other means, and migrating them again could
+    # potentially override the `stage` or `snap` filtering.
+    (in_part, staged, primed, system) = _split_dependencies(
+        dependencies, installdir, stagedir, snapdir)
+
+    part_dependency_paths = {os.path.dirname(d) for d in in_part}
+    staged_dependency_paths = {os.path.dirname(d) for d in staged}
+    system_dependency_paths = {os.path.dirname(d) for d in system}
+
+    if system:
+        # Lots of dependencies are linked with a symlink, so we need to make
+        # sure we follow those symlinks when we migrate the dependencies.
+        _migrate_files(system, system_dependency_paths, '/', snapdir,
+                       follow_symlinks=True)
+
+    return (part_dependency_paths | staged_dependency_paths |
+            system_dependency_paths)
+
+
+def _split_dependencies(dependencies, installdir, stagedir, snapdir):
+    """Split dependencies into their corresponding location.
+
+    Return a tuple of sets for each location.
+    """
+
+    part_dependencies = set()
+    staged_dependencies = set()
+    primed_dependencies = set()
+    system_dependencies = set()
+
+    for file_path in dependencies:
+        if file_path.startswith(installdir):
+            part_dependencies.add(os.path.relpath(file_path, installdir))
+        elif file_path.startswith(stagedir):
+            staged_dependencies.add(os.path.relpath(file_path, stagedir))
+        elif file_path.startswith(snapdir):
+            primed_dependencies.add(os.path.relpath(file_path, snapdir))
+        else:
+            file_path = file_path.lstrip('/')
+
+            # This was a dependency that was resolved to be on the system.
+            # However, it's possible that this library is actually included in
+            # the snap and we just missed it because it's in a non-standard
+            # path. Let's make sure it isn't already in the part, stage dir, or
+            # prime dir. If so, add it to that set.
+            if os.path.exists(os.path.join(installdir, file_path)):
+                part_dependencies.add(file_path)
+            elif os.path.exists(os.path.join(stagedir, file_path)):
+                staged_dependencies.add(file_path)
+            elif os.path.exists(os.path.join(snapdir, file_path)):
+                primed_dependencies.add(file_path)
+            else:
+                system_dependencies.add(file_path)
+
+    return (part_dependencies, staged_dependencies, primed_dependencies,
+            system_dependencies)
 
 
 def _expand_part_properties(part_properties, part_schema):


### PR DESCRIPTION
This PR fixes LP: [#1587358](https://bugs.launchpad.net/snapcraft/+bug/1587358) by checking that a system library isn't already available in the snap before migrating it in. Note that it checks part's installdir, the stagedir, and the primedir.