### PR TITLE
Support download and validate on branded stores.

### DIFF
--- a/snapcraft/storeapi/__init__.py
+++ b/snapcraft/storeapi/__init__.py
@@ -1,3 +1,4 @@
+
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
 # Copyright (C) 2016 Canonical Ltd
@@ -367,7 +368,7 @@ class SnapIndexClient(Client):
         with contextlib.suppress(errors.InvalidCredentialsError):
             headers['Authorization'] = _macaroon_auth(self.conf)
 
-        branded_store = os.getenv("SNAPCRAFT_UBUNTU_STORE")
+        branded_store = os.getenv('SNAPCRAFT_UBUNTU_STORE')
         if branded_store:
             headers['X-Ubuntu-Store'] = branded_store
 

--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -1036,16 +1036,26 @@ class FakeStoreSearchRequestHandler(BaseHTTPRequestHandler):
 
     def _get_details_response(self, package):
         # ubuntu-core is used in integration tests with fake servers.
+
+        # sha512sum snapcraft/tests/data/test-snap.snap
+        test_sha512 = (
+            '69d57dcacf4f126592d4e6ff689ad8bb8a083c7b9fe44f6e738ef'
+            'd22a956457f14146f7f067b47bd976cf0292f2993ad864ccb498b'
+            'fda4128234e4c201f28fe9')
+
         if package in ('test-snap', 'ubuntu-core'):
-            # sha512sum snapcraft/tests/data/test-snap.snap
-            sha512 = (
-                '69d57dcacf4f126592d4e6ff689ad8bb8a083c7b9fe44f6e738ef'
-                'd22a956457f14146f7f067b47bd976cf0292f2993ad864ccb498b'
-                'fda4128234e4c201f28fe9')
+            sha512 = test_sha512
         elif package == 'test-snap-with-wrong-sha':
             sha512 = 'wrong sha'
+        elif package == 'test-snap-branded-store':
+            # Branded-store snaps require Store pinning and authorization.
+            if (self.headers.get('X-Ubuntu-Store') != 'Test-Branded' or
+                    self.headers.get('Authorization') is None):
+                return None
+            sha512 = test_sha512
         else:
             return None
+
         response = {
             'anon_download_url': urllib.parse.urljoin(
                 'http://localhost:{}'.format(self.server.server_port),

--- a/snapcraft/tests/store/test_store_client.py
+++ b/snapcraft/tests/store/test_store_client.py
@@ -26,7 +26,8 @@ import pymacaroons
 from snapcraft import (
     config,
     storeapi,
-    tests
+    tests,
+    ProjectOptions,
 )
 from snapcraft.storeapi import errors
 from snapcraft.tests import fixture_setup
@@ -162,9 +163,10 @@ class DownloadTestCase(tests.TestCase):
             self.client.download,
             'test-snap-branded-store', 'test-channel', 'dummy')
 
+        arch = ProjectOptions().deb_arch
         self.assertEqual(
-            "Snap 'test-snap-branded-store' for 'amd64' cannot be found in "
-            "the 'test-channel' channel.",
+            "Snap 'test-snap-branded-store' for '{}' cannot be found in "
+            "the 'test-channel' channel.".format(arch),
             str(err))
 
     def test_download_from_branded_store_requires_store(self):
@@ -174,9 +176,10 @@ class DownloadTestCase(tests.TestCase):
             self.client.download,
             'test-snap-branded-store', 'test-channel', 'dummy')
 
+        arch = ProjectOptions().deb_arch
         self.assertEqual(
-            "Snap 'test-snap-branded-store' for 'amd64' cannot be found in "
-            "the 'test-channel' channel.",
+            "Snap 'test-snap-branded-store' for '{}' cannot be found in "
+            "the 'test-channel' channel.".format(arch),
             str(err))
 
     def test_download_from_branded_store(self):

--- a/snapcraft/tests/test_commands_validate.py
+++ b/snapcraft/tests/test_commands_validate.py
@@ -73,6 +73,19 @@ class ValidateTestCase(tests.TestCase):
         self.assertIn('Signing validation test-snap=4',
                       self.fake_terminal.getvalue())
 
+    def test_validate_from_branded_store(self):
+        # Validating snaps from a branded store requires setting
+        # `SNAPCRAFT_UBUNTU_STORE` environment variable to the store 'slug'.
+        self.client.login('dummy', 'test correct password')
+        self.useFixture(
+            fixtures.EnvironmentVariable(
+                'SNAPCRAFT_UBUNTU_STORE', 'Test-Branded'))
+
+        main([self.command_name, 'ubuntu-core', 'test-snap-branded-store=1'])
+
+        self.assertIn('Signing validation test-snap-branded-store=1',
+                      self.fake_terminal.getvalue())
+
     def test_validate_unknown_snap(self):
         self.client.login('dummy', 'test correct password')
 


### PR DESCRIPTION
Allow users to set `SNAPCRAFT_UBUNTU_STORE` and perform operations
on branded stores.

So far it only affects interactions with the Snap Index (CPI), which
already support the 'X-Ubuntu-Store' header and further permission
checks.

It will be probably used as the foundation for supporting push and
release for branded stores, instead of discrete '--store'.

LP: #1650210