### PR TITLE
Updated ant plugin to use get_build_properties()

### DIFF
--- a/demos/java-hello-world/snapcraft.yaml
+++ b/demos/java-hello-world/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0
 summary: A java example
 description: this is not much more than an example
 confinement: strict
+grade: stable
 
 apps:
  hello:

--- a/snapcraft/plugins/ant.py
+++ b/snapcraft/plugins/ant.py
@@ -70,6 +70,12 @@ class AntPlugin(snapcraft.plugins.jdk.JdkPlugin):
         super().__init__(name, options, project)
         self.build_packages.append('ant')
 
+    @classmethod
+    def get_build_properties(cls):
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        return ['ant-build-targets', 'ant-properties']
+
     def build(self):
         super().build()
 

--- a/snapcraft/tests/test_plugin_ant.py
+++ b/snapcraft/tests/test_plugin_ant.py
@@ -17,6 +17,7 @@
 import os
 import copy
 from unittest import mock
+from testtools.matchers import HasLength
 
 import snapcraft
 from snapcraft import tests
@@ -56,6 +57,16 @@ class AntPluginTestCase(tests.TestCase):
         self.assertEqual(build_targets_type, 'array',
                          'Expected "ant-build-targets" "type" to be "object", '
                          'but it was "{}"'.format(build_targets_type))
+
+    def test_get_build_properties(self):
+        expected_build_properties = ['ant-build-targets', 'ant-properties']
+        resulting_build_properties = ant.AntPlugin.get_build_properties()
+
+        self.assertThat(resulting_build_properties,
+                        HasLength(len(expected_build_properties)))
+
+        for property in expected_build_properties:
+            self.assertIn(property, resulting_build_properties)
 
     @mock.patch.object(ant.AntPlugin, 'run')
     def test_build(self, run_mock):


### PR DESCRIPTION
Missed this plugin with my other batch because it never added to ['build-properties'] to throw the warning.

https://bugs.launchpad.net/snapcraft/+bug/1650547