### PR TITLE
plugins: update make plugin to use get_build_properties() 

### DIFF
--- a/snapcraft/plugins/cmake.py
+++ b/snapcraft/plugins/cmake.py
@@ -57,7 +57,7 @@ class CMakePlugin(snapcraft.plugins.make.MakePlugin):
     def get_build_properties(cls):
         # Inform Snapcraft of the properties associated with building. If these
         # change in the YAML Snapcraft will consider the build step dirty.
-        return ['configflags']
+        return super().get_build_properties() + ['configflags']
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)

--- a/snapcraft/plugins/make.py
+++ b/snapcraft/plugins/make.py
@@ -89,7 +89,7 @@ class MakePlugin(snapcraft.BasePlugin):
     def get_build_properties(cls):
         # Inform Snapcraft of the properties associated with building. If these
         # change in the YAML Snapcraft will consider the build step dirty.
-        return ['makefile', 'make-parameters', 'make-install-var']
+        return ['makefile', 'make-parameters', 'make-install-var', 'artifacts']
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)

--- a/snapcraft/plugins/make.py
+++ b/snapcraft/plugins/make.py
@@ -83,12 +83,13 @@ class MakePlugin(snapcraft.BasePlugin):
             'default': [],
         }
 
+        return schema
+
+    @classmethod
+    def get_build_properties(cls):
         # Inform Snapcraft of the properties associated with building. If these
         # change in the YAML Snapcraft will consider the build step dirty.
-        schema['build-properties'].extend(
-            ['makefile', 'make-parameters', 'make-install-var'])
-
-        return schema
+        return ['makefile', 'make-parameters', 'make-install-var']
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)

--- a/snapcraft/tests/test_plugin_cmake.py
+++ b/snapcraft/tests/test_plugin_cmake.py
@@ -56,7 +56,8 @@ class CMakeTestCase(tests.TestCase):
     def test_get_build_properties(self):
         expected_build_properties = ['configflags']
         resulting_build_properties = cmake.CMakePlugin.get_build_properties()
-
+        expected_build_properties.extend(
+            snapcraft.plugins.make.MakePlugin.get_build_properties())
         self.assertThat(resulting_build_properties,
                         HasLength(len(expected_build_properties)))
 

--- a/snapcraft/tests/test_plugin_make.py
+++ b/snapcraft/tests/test_plugin_make.py
@@ -17,6 +17,7 @@
 import os
 
 from unittest import mock
+from testtools.matchers import HasLength
 
 import snapcraft
 from snapcraft import tests
@@ -91,11 +92,15 @@ class MakePluginTestCase(tests.TestCase):
             'Expected "make-install-var" "default" to be "DESTDIR", but it '
             'was "{}"'.format(make_install_var_default))
 
-        build_properties = schema['build-properties']
-        self.assertEqual(3, len(build_properties))
-        self.assertTrue('makefile' in build_properties)
-        self.assertTrue('make-parameters' in build_properties)
-        self.assertTrue('make-install-var' in build_properties)
+    def test_get_build_properties(self):
+        expected_build_properties = ['makefile', 'make-parameters', 'make-install-var']
+        resulting_build_properties = gradle.GradlePlugin.get_build_properties()
+
+        self.assertThat(resulting_build_properties,
+                        HasLength(len(expected_build_properties)))
+
+        for property in expected_build_properties:
+            self.assertIn(property, resulting_build_properties)
 
     @mock.patch.object(make.MakePlugin, 'run')
     def test_build(self, run_mock):

--- a/snapcraft/tests/test_plugin_make.py
+++ b/snapcraft/tests/test_plugin_make.py
@@ -93,8 +93,9 @@ class MakePluginTestCase(tests.TestCase):
             'was "{}"'.format(make_install_var_default))
 
     def test_get_build_properties(self):
-        expected_build_properties = ['makefile', 'make-parameters', 'make-install-var']
-        resulting_build_properties = gradle.GradlePlugin.get_build_properties()
+        expected_build_properties = ['makefile', 'make-parameters',
+                                     'make-install-var']
+        resulting_build_properties = make.MakePlugin.get_build_properties()
 
         self.assertThat(resulting_build_properties,
                         HasLength(len(expected_build_properties)))

--- a/snapcraft/tests/test_plugin_make.py
+++ b/snapcraft/tests/test_plugin_make.py
@@ -94,7 +94,7 @@ class MakePluginTestCase(tests.TestCase):
 
     def test_get_build_properties(self):
         expected_build_properties = ['makefile', 'make-parameters',
-                                     'make-install-var']
+                                     'make-install-var', 'artifacts']
         resulting_build_properties = make.MakePlugin.get_build_properties()
 
         self.assertThat(resulting_build_properties,


### PR DESCRIPTION
Updated make plugin to use get_build_properties().
Updated test_plugin_make as well to test this method.

https://bugs.launchpad.net/snapcraft/+bug/1650548