### PR TITLE
store: implement push pre-check.

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -409,11 +409,14 @@ def push(snap_filename, release_channels=None):
         raise FileNotFoundError(
             'The file {!r} does not exist.'.format(snap_filename))
 
-    logger.info('Uploading {}.'.format(snap_filename))
-
     snap_yaml = _get_data_from_snap_file(snap_filename)
     snap_name = snap_yaml['name']
     store = storeapi.StoreClient()
+
+    with _requires_login():
+        store.push_precheck(snap_name)
+
+    logger.info('Uploading {}.'.format(snap_filename))
     with _requires_login():
         tracker = store.upload(snap_name, snap_filename)
 

--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -413,10 +413,10 @@ def push(snap_filename, release_channels=None):
     snap_name = snap_yaml['name']
     store = storeapi.StoreClient()
 
+    logger.info('Pushing {!r} to the store.'.format(snap_filename))
     with _requires_login():
         store.push_precheck(snap_name)
 
-    logger.info('Uploading {}.'.format(snap_filename))
     with _requires_login():
         tracker = store.upload(snap_name, snap_filename)
 

--- a/snapcraft/storeapi/__init__.py
+++ b/snapcraft/storeapi/__init__.py
@@ -185,6 +185,10 @@ class StoreClient():
         return self._refresh_if_necessary(
             self.sca.register, snap_name, is_private, constants.DEFAULT_SERIES)
 
+    def push_precheck(self, snap_name):
+        return self._refresh_if_necessary(
+            self.sca.snap_push_precheck, snap_name)
+
     def push_snap_build(self, snap_id, snap_build):
         return self._refresh_if_necessary(
             self.sca.push_snap_build, snap_id, snap_build)
@@ -493,6 +497,20 @@ class SCAClient(Client):
                      'Content-Type': 'application/json'})
         if not response.ok:
             raise errors.StoreRegistrationError(snap_name, response)
+
+    def snap_push_precheck(self, snap_name):
+        data = {
+            'name': snap_name,
+            'dry_run': True,
+        }
+        auth = _macaroon_auth(self.conf)
+        response = self.post(
+            'snap-push/', data=json.dumps(data),
+            headers={'Authorization': auth,
+                     'Content-Type': 'application/json',
+                     'Accept': 'application/json'})
+        if not response.ok:
+            raise errors.StorePushError(data['name'], response)
 
     def snap_push_metadata(self, snap_name, updown_data):
         data = {

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -200,7 +200,9 @@ class StoreUploadError(StoreError):
 class StorePushError(StoreError):
 
     __FMT_NOT_REGISTERED = (
-        'Sorry, try `snapcraft register {snap_name}` before pushing again.')
+        'You are not the publisher or allowed to push revisions for this '
+        'snap. To become the publisher, run `snapcraft register {snap_name}` '
+        'and try to push again.')
 
     fmt = 'Received {status_code!r}: {text!r}'
 

--- a/snapcraft/tests/commands/test_push.py
+++ b/snapcraft/tests/commands/test_push.py
@@ -132,8 +132,9 @@ class PushCommandTestCase(tests.TestCase):
             main, ['push', snap_file])
 
         self.assertIn(
-            'Sorry, try `snapcraft register my-snap-name` '
-            'before pushing again.',
+            'You are not the publisher or allowed to push revisions for this '
+            'snap. To become the publisher, run `snapcraft register '
+            'my-snap-name` and try to push again.',
             self.fake_logger.output)
 
     def test_push_with_updown_error(self):

--- a/snapcraft/tests/commands/test_push.py
+++ b/snapcraft/tests/commands/test_push.py
@@ -86,7 +86,7 @@ class PushCommandTestCase(tests.TestCase):
 
         self.assertRegexpMatches(
             self.fake_logger.output,
-            ".*Uploading my-snap-name_0\.1_\w*.snap\.\n"
+            ".*Pushing 'my-snap-name_0\.1_\w*.snap' to the store\.\n"
             "Revision 9 of 'my-snap-name' created\.",
         )
 
@@ -186,7 +186,7 @@ class PushCommandTestCase(tests.TestCase):
 
         self.assertRegexpMatches(
             self.fake_logger.output,
-            ".*Uploading my-snap-name_0\.1_\w*.snap\.\n"
+            ".*Pushing 'my-snap-name_0\.1_\w*.snap\' to the store.\n"
             "Revision 9 of 'my-snap-name' created\.",
         )
 
@@ -233,7 +233,7 @@ class PushCommandTestCase(tests.TestCase):
 
         self.assertRegexpMatches(
             self.fake_logger.output,
-            ".*Uploading my-snap-name_0\.1_\w*\.snap\.\n"
+            ".*Pushing 'my-snap-name_0\.1_\w*\.snap\' to the store.\n"
             "Revision 9 of 'my-snap-name' created\.\n"
             "The 'beta' channel is now open\.\n")
 
@@ -283,7 +283,7 @@ class PushCommandTestCase(tests.TestCase):
 
         self.assertRegexpMatches(
             self.fake_logger.output,
-            ".*Uploading my-snap-name_0\.1_\w*.snap\.\n"
+            ".*Pushing 'my-snap-name_0\.1_\w*.snap\' to the store.\n"
             "Revision 9 of 'my-snap-name' created.\n"
             "The 'beta,edge,candidate' channel is now open\.\n"
         )

--- a/snapcraft/tests/store/test_store_client.py
+++ b/snapcraft/tests/store/test_store_client.py
@@ -695,15 +695,16 @@ class UploadTestCase(tests.TestCase):
             errors.StoreReviewError,
             tracker.raise_for_code)
 
-    def test_upload_unregistered_snap(self):
+    def test_push_unregistered_snap(self):
         self.client.login('dummy', 'test correct password')
         raised = self.assertRaises(
             errors.StorePushError,
             self.client.upload, 'test-snap-unregistered', self.snap_path)
         self.assertEqual(
             str(raised),
-            'Sorry, try `snapcraft register '
-            'test-snap-unregistered` before pushing again.')
+            'You are not the publisher or allowed to push revisions for this '
+            'snap. To become the publisher, run `snapcraft register '
+            'test-snap-unregistered` and try to push again.')
 
     def test_upload_with_invalid_credentials_raises_exception(self):
         conf = config.Config()


### PR DESCRIPTION
LP: #1610776

This branch adds a precheck request to the store to `snapcraft push`, which in the case of an unregistered snap will report the error to the user before attempting a full upload.