### PR TITLE
cmake: extend parte build properties as it extends make

### DIFF
--- a/snapcraft/plugins/cmake.py
+++ b/snapcraft/plugins/cmake.py
@@ -57,7 +57,7 @@ class CMakePlugin(snapcraft.plugins.make.MakePlugin):
     def get_build_properties(cls):
         # Inform Snapcraft of the properties associated with building. If these
         # change in the YAML Snapcraft will consider the build step dirty.
-        return ['configflags']
+        return super().get_build_properties() + ['configflags']
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)

--- a/snapcraft/tests/test_plugin_cmake.py
+++ b/snapcraft/tests/test_plugin_cmake.py
@@ -54,7 +54,8 @@ class CMakeTestCase(tests.TestCase):
         self.addCleanup(patcher.stop)
 
     def test_get_build_properties(self):
-        expected_build_properties = ['configflags']
+        expected_build_properties = ['configflags', 'makefile',
+                                     'make-parameters', 'make-install-var']
         resulting_build_properties = cmake.CMakePlugin.get_build_properties()
 
         self.assertThat(resulting_build_properties,


### PR DESCRIPTION
I guess we want to properly update the builds properties extending partent's one too.

In case we don't care about those in cmake plugin, we should instead probably drop them from the schema too.