### PR TITLE
make: add support for cwd path

### DIFF
--- a/snapcraft/plugins/make.py
+++ b/snapcraft/plugins/make.py
@@ -95,7 +95,7 @@ class MakePlugin(snapcraft.BasePlugin):
         super().__init__(name, options, project)
         self.build_packages.append('make')
 
-    def make(self, env=None):
+    def make(self, cwd=None, env=None):
         command = ['make']
 
         if self.options.makefile:
@@ -104,9 +104,12 @@ class MakePlugin(snapcraft.BasePlugin):
         if self.options.make_parameters:
             command.extend(self.options.make_parameters)
 
-        self.run(command + ['-j{}'.format(self.parallel_build_count)], env=env)
+        self.run(
+            command + ['-j{}'.format(self.parallel_build_count)], cwd, env=env)
         if self.options.artifacts:
             for artifact in self.options.artifacts:
+                if cwd:
+                    artifact = os.path.join(cwd, artifact)
                 source_path = os.path.join(self.builddir, artifact)
                 destination_path = os.path.join(self.installdir, artifact)
                 if os.path.isdir(source_path):
@@ -118,7 +121,7 @@ class MakePlugin(snapcraft.BasePlugin):
         else:
             install_param = self.options.make_install_var + '=' + \
                 self.installdir
-            self.run(command + ['install', install_param], env=env)
+            self.run(command + ['install', install_param], cwd, env=env)
 
     def build(self):
         super().build()

--- a/snapcraft/tests/test_plugin_make.py
+++ b/snapcraft/tests/test_plugin_make.py
@@ -113,9 +113,9 @@ class MakePluginTestCase(tests.TestCase):
 
         self.assertEqual(2, run_mock.call_count)
         run_mock.assert_has_calls([
-            mock.call(['make', '-j2'], env=None),
+            mock.call(['make', '-j2'], None, env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)], env=None)
+                       'DESTDIR={}'.format(plugin.installdir)], None, env=None)
         ])
 
     @mock.patch.object(make.MakePlugin, 'run')
@@ -129,9 +129,9 @@ class MakePluginTestCase(tests.TestCase):
 
         self.assertEqual(2, run_mock.call_count)
         run_mock.assert_has_calls([
-            mock.call(['make', '-j1'], env=None),
+            mock.call(['make', '-j1'], None, env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)], env=None)
+                       'DESTDIR={}'.format(plugin.installdir)], None, env=None)
         ])
 
     @mock.patch.object(make.MakePlugin, 'run')
@@ -145,9 +145,9 @@ class MakePluginTestCase(tests.TestCase):
 
         self.assertEqual(2, run_mock.call_count)
         run_mock.assert_has_calls([
-            mock.call(['make', '-f', 'makefile.linux', '-j2'], env=None),
+            mock.call(['make', '-f', 'makefile.linux', '-j2'], None, env=None),
             mock.call(['make', '-f', 'makefile.linux', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)], env=None)
+                       'DESTDIR={}'.format(plugin.installdir)], None, env=None)
         ])
 
     @mock.patch.object(make.MakePlugin, 'run')
@@ -161,9 +161,9 @@ class MakePluginTestCase(tests.TestCase):
 
         self.assertEqual(2, run_mock.call_count)
         run_mock.assert_has_calls([
-            mock.call(['make', '-j2'], env=None),
+            mock.call(['make', '-j2'], None, env=None),
             mock.call(['make', 'install',
-                       'PREFIX={}'.format(plugin.installdir)], env=None)
+                       'PREFIX={}'.format(plugin.installdir)], None, env=None)
         ])
 
     @mock.patch.object(make.MakePlugin, 'run')
@@ -181,7 +181,7 @@ class MakePluginTestCase(tests.TestCase):
 
         self.assertEqual(1, run_mock.call_count)
         run_mock.assert_has_calls([
-            mock.call(['make', '-j2'], env=None),
+            mock.call(['make', '-j2'], None, env=None),
         ])
         self.assertEqual(1, link_or_copy_mock.call_count)
         link_or_copy_mock.assert_has_calls([
@@ -207,7 +207,7 @@ class MakePluginTestCase(tests.TestCase):
 
         self.assertEqual(2, run_mock.call_count)
         run_mock.assert_has_calls([
-            mock.call(['make', '-j2'], env=env),
+            mock.call(['make', '-j2'], None, env=env),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)], env=env)
+                       'DESTDIR={}'.format(plugin.installdir)], None, env=env)
         ])


### PR DESCRIPTION
This can be useful for plugins that extends Make so that they can define a subfolder where to run make