### PR TITLE
plugins: update copy plugin to use get_build_properties().

### DIFF
--- a/snapcraft/plugins/copy.py
+++ b/snapcraft/plugins/copy.py
@@ -54,15 +54,17 @@ class CopyPlugin(snapcraft.BasePlugin):
             'type': 'object',
         }
 
-        # Inform Snapcraft of the properties associated with building. If these
-        # change in the YAML Snapcraft will consider the build step dirty.
-        schema['build-properties'].append('files')
-
         # The `files` keyword is required here, but the `source` keyword is
         # not. It should default to the current working directory.
         schema['required'].append('files')
 
         return schema
+
+    @classmethod
+    def get_build_properties(cls):
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        return super().get_build_properties() + ['files']
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)

--- a/snapcraft/tests/test_plugin_copy.py
+++ b/snapcraft/tests/test_plugin_copy.py
@@ -16,6 +16,7 @@
 
 import os.path
 from unittest.mock import Mock, patch
+from testtools.matchers import HasLength
 
 import snapcraft
 from snapcraft.plugins.copy import (
@@ -37,6 +38,16 @@ class TestCopyPlugin(TestCase):
         self.dst_prefix = 'parts/copy/install/'
         os.makedirs(self.dst_prefix)
         self.project_options = snapcraft.ProjectOptions()
+
+    def test_get_build_properties(self):
+        expected_build_properties = ['files']
+        resulting_build_properties = CopyPlugin.get_build_properties()
+
+        self.assertThat(resulting_build_properties,
+                        HasLength(len(expected_build_properties)))
+
+        for property in expected_build_properties:
+            self.assertIn(property, resulting_build_properties)
 
     def test_copy_plugin_any_missing_src_raises_exception(self):
         # ensure that a bad file causes a warning and fails the build even


### PR DESCRIPTION
This PR finishes LP: [#1647899](https://bugs.launchpad.net/snapcraft/+bug/1647899) as this is the last of the plugins using the deprecated properties.