### PR TITLE
project loader: better error message for classic

### DIFF
--- a/snapcraft/internal/project_loader.py
+++ b/snapcraft/internal/project_loader.py
@@ -327,8 +327,9 @@ def _build_env(root, snap_name, confinement, arch_triplet,
 
     if confinement == 'classic':
         if not core_dynamic_linker:
-            raise EnvironmentError('classic confinement requires the '
-                                   'core_dynamic_linker to be set')
+            raise EnvironmentError(
+                'classic confinement requires the core snap to be installed. '
+                'Install it by running `snap install core`.')
 
         core_path = os.path.join('/snap', 'core', 'current')
         core_rpaths = common.get_library_paths(core_path, arch_triplet,


### PR DESCRIPTION
When compiling using classic confinement the core snap is needed, the check is correct but the error message is confusing.

LP: #1650946
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>