### PR TITLE
Add support for hooks.

### DIFF
--- a/demos/hooks/snap/hooks/configure
+++ b/demos/hooks/snap/hooks/configure
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+output=$(snapctl get fail)
+if [ "$output" = "true" ]; then
+	echo "Failing as requested."
+	exit 1
+fi
+
+echo "I'm the configure hook!"

--- a/demos/hooks/snapcraft.yaml
+++ b/demos/hooks/snapcraft.yaml
@@ -1,0 +1,10 @@
+name: hooks
+version: 1.0
+summary: Snap containing a configure hook
+description: This snap contains a configure hook that fails upon command
+confinement: strict
+grade: stable
+
+parts:
+  nil-part:
+    plugin: nil

--- a/demos/pyhooks/configure_hook.py
+++ b/demos/pyhooks/configure_hook.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+
+
+def main():
+    output = subprocess.check_output(['snapctl', 'get', 'fail']).decode('utf8').strip()
+    if output == 'true':
+        print('Failing as requested.')
+        sys.exit(1)
+
+    print("I'm the configure hook!")
+
+if __name__ == '__main__':
+    main()

--- a/demos/pyhooks/snapcraft.yaml
+++ b/demos/pyhooks/snapcraft.yaml
@@ -1,0 +1,15 @@
+name: pyhooks
+version: 1.0
+confinement: strict
+grade: stable
+summary: Snap containing a configure hook written in python
+description: |
+  This snap contains a configure hook written in python that fails upon
+  command
+
+parts:
+  hook:
+    plugin: python
+    install: |
+      mkdir -p $SNAPCRAFT_PART_INSTALL/snap/hooks
+      cp configure_hook.py $SNAPCRAFT_PART_INSTALL/snap/hooks/configure

--- a/integration_tests/snaps/hooks/another-hook/another-hook
+++ b/integration_tests/snaps/hooks/another-hook/another-hook
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "I'm another hook. I'm not actually valid, but snapcraft doesn't care."

--- a/integration_tests/snaps/hooks/configure-again/configure
+++ b/integration_tests/snaps/hooks/configure-again/configure
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "I'm another configure hook. I should be overwritten by the other one."

--- a/integration_tests/snaps/hooks/snap/hooks/configure
+++ b/integration_tests/snaps/hooks/snap/hooks/configure
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "I'm the configure hook"

--- a/integration_tests/snaps/hooks/snapcraft.yaml
+++ b/integration_tests/snaps/hooks/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: hooks-test
+version: '0.1'
+summary: Hooks test
+description: |
+  This snap simply includes a few hooks. It does so via two methods:
+
+    1) Simply distributing hook scripts in snap/hooks.
+    2) Installing hook scripts into snap/hooks from parts.
+
+  Both of these methods should work, and the first should overwrite the second
+  if the same hook is supplied via both methods (as it is here).
+
+grade: devel
+confinement: strict
+
+parts:
+  another-hook:
+    plugin: dump
+    source: another-hook/
+    organize:
+      another-hook: snap/hooks/another-hook
+
+  configure-hook:
+    plugin: dump
+    source: configure-again/
+    organize:
+      configure: snap/hooks/configure

--- a/integration_tests/test_hooks.py
+++ b/integration_tests/test_hooks.py
@@ -1,0 +1,59 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import subprocess
+
+from testtools.matchers import (
+    Contains,
+    Equals,
+    FileExists
+)
+
+import integration_tests
+
+
+class HookTestCase(integration_tests.TestCase):
+
+    def test_hooks(self):
+        project_dir = 'hooks'
+        self.run_snapcraft('prime', project_dir)
+
+        primedir = os.path.join(project_dir, 'prime')
+
+        for hook in ('configure', 'another-hook'):
+            # Assert that the hooks as supplied to snapcraft was copied into
+            # the snap.
+            self.assertThat(
+                os.path.join(primedir, 'snap', 'hooks', hook), FileExists())
+
+            # Assert that the real hooks were generated as well (they're just
+            # wrappers that call the one given to snapcraft).
+            self.assertThat(
+                os.path.join(primedir, 'meta', 'hooks', hook), FileExists())
+
+            # Assert that the hook itself was the static one in snap/, not the
+            # one from the part.
+            output = subprocess.check_output(
+                os.path.join(primedir, 'snap', 'hooks', 'configure')).decode(
+                    'utf8')
+            self.assertThat(output, Equals("I'm the configure hook\n"))
+
+            # Assert that the wrapper execs the correct thing
+            with open(os.path.join(primedir, 'meta', 'hooks', hook)) as f:
+                self.assertThat(
+                    f.read(),
+                    Contains('exec "$SNAP/snap/hooks/{}"'.format(hook)))

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -133,6 +133,20 @@ properties:
             items:
               type: string
               pattern: "^[a-zA-Z0-9][-_.a-zA-Z0-9]*$"
+  hooks:
+    type: object
+    additionalProperties: false
+    patternProperties:
+      "^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$":
+        type: object
+        additionalProperties: false
+        properties:
+          plugs:
+            type: array
+            minitems: 1
+            uniqueItems: true
+            items:
+              type: string
   parts:
     type: object
     minProperties: 1

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -61,8 +61,10 @@ class CommandError(Exception):
 
 def create_snap_packaging(config_data, snap_dir, parts_dir):
     """Create snap.yaml and related assets in meta.
-    Create the meta directory and provision it with snap.yaml
-    in the snap dir using information from config_data.
+
+    Create the meta directory and provision it with snap.yaml in the snap dir
+    using information from config_data. Also copy in the local 'snap'
+    directory, and generate wrappers for hooks coming from parts.
 
     :param dict config_data: project values defined in snapcraft.yaml.
     :return: meta_dir.

--- a/snapcraft/tests/__init__.py
+++ b/snapcraft/tests/__init__.py
@@ -99,7 +99,7 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         self.addCleanup(patcher.stop)
 
         # These are what we expect by default
-        self.snap_dir = os.path.join(os.getcwd(), 'prime')
+        self.prime_dir = os.path.join(os.getcwd(), 'prime')
         self.stage_dir = os.path.join(os.getcwd(), 'stage')
         self.parts_dir = os.path.join(os.getcwd(), 'parts')
         self.local_plugins_dir = os.path.join(self.parts_dir, 'plugins')

--- a/snapcraft/tests/commands/test_clean.py
+++ b/snapcraft/tests/commands/test_clean.py
@@ -83,7 +83,7 @@ parts:
 
         self.assertFalse(os.path.exists(self.parts_dir))
         self.assertFalse(os.path.exists(self.stage_dir))
-        self.assertFalse(os.path.exists(self.snap_dir))
+        self.assertFalse(os.path.exists(self.prime_dir))
 
     def test_local_plugin_not_removed(self):
         self.make_snapcraft_yaml(n=3)
@@ -95,7 +95,7 @@ parts:
         main(['clean'])
 
         self.assertFalse(os.path.exists(self.stage_dir))
-        self.assertFalse(os.path.exists(self.snap_dir))
+        self.assertFalse(os.path.exists(self.prime_dir))
         self.assertTrue(os.path.exists(self.parts_dir))
         self.assertTrue(os.path.isfile(local_plugin))
 
@@ -106,7 +106,7 @@ parts:
 
         self.assertFalse(os.path.exists(self.parts_dir))
         self.assertFalse(os.path.exists(self.stage_dir))
-        self.assertFalse(os.path.exists(self.snap_dir))
+        self.assertFalse(os.path.exists(self.prime_dir))
 
     def test_partial_clean(self):
         parts = self.make_snapcraft_yaml(n=3)
@@ -123,7 +123,7 @@ parts:
 
         self.assertTrue(os.path.exists(self.parts_dir))
         self.assertTrue(os.path.exists(self.stage_dir))
-        self.assertTrue(os.path.exists(self.snap_dir))
+        self.assertTrue(os.path.exists(self.prime_dir))
 
         # Now clean it the rest of the way
         main(['clean', 'clean1'])
@@ -135,7 +135,7 @@ parts:
 
         self.assertFalse(os.path.exists(self.parts_dir))
         self.assertFalse(os.path.exists(self.stage_dir))
-        self.assertFalse(os.path.exists(self.snap_dir))
+        self.assertFalse(os.path.exists(self.prime_dir))
 
     def test_everything_is_clean(self):
         """Don't crash if everything is already clean."""
@@ -237,7 +237,7 @@ parts:
                  'w').close()
 
         os.makedirs(self.stage_dir)
-        os.makedirs(self.snap_dir)
+        os.makedirs(self.prime_dir)
 
     def assert_clean(self, parts):
         for part in parts:

--- a/snapcraft/tests/commands/test_cleanbuild.py
+++ b/snapcraft/tests/commands/test_cleanbuild.py
@@ -58,7 +58,7 @@ parts:
         dirs = [
             os.path.join(self.parts_dir, 'part1', 'src'),
             self.stage_dir,
-            self.snap_dir,
+            self.prime_dir,
             os.path.join(self.parts_dir, 'plugins'),
         ]
         files_tar = [
@@ -67,7 +67,7 @@ parts:
         ]
         files_no_tar = [
             os.path.join(self.stage_dir, 'binary'),
-            os.path.join(self.snap_dir, 'binary'),
+            os.path.join(self.prime_dir, 'binary'),
             'snap-test.snap',
             'snap-test_1.0_source.tar.bz2',
         ]

--- a/snapcraft/tests/commands/test_prime.py
+++ b/snapcraft/tests/commands/test_prime.py
@@ -75,11 +75,11 @@ parts:
 
         main(['prime'])
 
-        self.assertTrue(os.path.exists(self.snap_dir),
+        self.assertTrue(os.path.exists(self.prime_dir),
                         'Expected a prime directory')
         self.assertTrue(
             os.path.exists(
-                os.path.join(self.snap_dir, 'meta', 'snap.yaml')),
+                os.path.join(self.prime_dir, 'meta', 'snap.yaml')),
             'Expected a snap.yaml')
         self.assertTrue(os.path.exists(self.stage_dir),
                         'Expected a stage directory')
@@ -99,9 +99,9 @@ parts:
 
         self.assertFalse(
             os.path.exists(
-                os.path.join(self.snap_dir, 'meta', 'snap.yaml')),
+                os.path.join(self.prime_dir, 'meta', 'snap.yaml')),
             'There should not be a snap.yaml')
-        self.assertTrue(os.path.exists(self.snap_dir),
+        self.assertTrue(os.path.exists(self.prime_dir),
                         'Expected a prime directory')
         self.assertTrue(os.path.exists(self.stage_dir),
                         'Expected a stage directory')

--- a/snapcraft/tests/commands/test_snap.py
+++ b/snapcraft/tests/commands/test_snap.py
@@ -95,7 +95,7 @@ parts:
         self.verify_state('part1', self.state_dir, 'prime')
 
         self.popen_spy.assert_called_once_with([
-            'mksquashfs', self.snap_dir, 'snap-test_1.0_amd64.snap',
+            'mksquashfs', self.prime_dir, 'snap-test_1.0_amd64.snap',
             '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
@@ -124,7 +124,7 @@ parts:
         self.verify_state('part1', self.state_dir, 'prime')
 
         self.popen_spy.assert_called_once_with([
-            'mksquashfs', self.snap_dir, 'snap-test_1.0_amd64.snap',
+            'mksquashfs', self.prime_dir, 'snap-test_1.0_amd64.snap',
             '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
@@ -154,7 +154,7 @@ parts:
         self.verify_state('part1', self.state_dir, 'prime')
 
         self.popen_spy.assert_called_once_with([
-            'mksquashfs', self.snap_dir, 'snap-test_1.0_amd64.snap',
+            'mksquashfs', self.prime_dir, 'snap-test_1.0_amd64.snap',
             '-noappend', '-comp', 'xz', '-no-xattrs'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
@@ -181,7 +181,7 @@ parts:
             fake_logger.output)
 
         self.popen_spy.assert_called_once_with([
-            'mksquashfs', self.snap_dir, 'snap-test_1.0_amd64.snap',
+            'mksquashfs', self.prime_dir, 'snap-test_1.0_amd64.snap',
             '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
@@ -289,7 +289,7 @@ type: os
         self.verify_state('part1', self.state_dir, 'prime')
 
         self.popen_spy.assert_called_once_with([
-            'mksquashfs', self.snap_dir, 'mysnap.snap',
+            'mksquashfs', self.prime_dir, 'mysnap.snap',
             '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 

--- a/snapcraft/tests/pluginhandler/test_pluginhandler.py
+++ b/snapcraft/tests/pluginhandler/test_pluginhandler.py
@@ -1459,7 +1459,7 @@ class StateTestCase(StateBaseTestCase):
 
     def test_clean_prime_state(self):
         self.assertEqual(None, self.handler.last_step())
-        bindir = os.path.join(self.snap_dir, 'bin')
+        bindir = os.path.join(self.prime_dir, 'bin')
         os.makedirs(bindir)
         open(os.path.join(bindir, '1'), 'w').close()
         open(os.path.join(bindir, '2'), 'w').close()
@@ -1476,7 +1476,7 @@ class StateTestCase(StateBaseTestCase):
 
     def test_clean_prime_state_multiple_parts(self):
         self.assertEqual(None, self.handler.last_step())
-        bindir = os.path.join(self.snap_dir, 'bin')
+        bindir = os.path.join(self.prime_dir, 'bin')
         os.makedirs(bindir)
         open(os.path.join(bindir, '1'), 'w').close()
         open(os.path.join(bindir, '2'), 'w').close()
@@ -1498,7 +1498,7 @@ class StateTestCase(StateBaseTestCase):
 
     def test_clean_prime_state_common_files(self):
         self.assertEqual(None, self.handler.last_step())
-        bindir = os.path.join(self.snap_dir, 'bin')
+        bindir = os.path.join(self.prime_dir, 'bin')
         os.makedirs(bindir)
         open(os.path.join(bindir, '1'), 'w').close()
         open(os.path.join(bindir, '2'), 'w').close()
@@ -1710,8 +1710,8 @@ class CleanBaseTestCase(tests.TestCase):
         if os.path.exists(self.stage_dir):
             shutil.rmtree(self.stage_dir)
 
-        if os.path.exists(self.snap_dir):
-            shutil.rmtree(self.snap_dir)
+        if os.path.exists(self.prime_dir):
+            shutil.rmtree(self.prime_dir)
 
 
 class CleanTestCase(CleanBaseTestCase):
@@ -1804,23 +1804,23 @@ class CleanTestCase(CleanBaseTestCase):
 
         # Verify that part1's file has been primeped
         self.assertTrue(
-            os.path.exists(os.path.join(self.snap_dir, 'bin', '1')))
+            os.path.exists(os.path.join(self.prime_dir, 'bin', '1')))
 
         # Verify that part2's file has been primeped
         self.assertTrue(
-            os.path.exists(os.path.join(self.snap_dir, 'bin', '2')))
+            os.path.exists(os.path.join(self.prime_dir, 'bin', '2')))
 
         # Now clean the prime step for part1
         handler1.clean_prime({})
 
         # Verify that part1's file is no longer primeped
         self.assertFalse(
-            os.path.exists(os.path.join(self.snap_dir, 'bin', '1')),
+            os.path.exists(os.path.join(self.prime_dir, 'bin', '1')),
             "Expected part1's primeped files to be cleaned")
 
         # Verify that part2's file is still there
         self.assertTrue(
-            os.path.exists(os.path.join(self.snap_dir, 'bin', '2')),
+            os.path.exists(os.path.join(self.prime_dir, 'bin', '2')),
             "Expected part2's primeped files to be untouched")
 
     def test_clean_prime_after_fileset_change(self):
@@ -1839,9 +1839,9 @@ class CleanTestCase(CleanBaseTestCase):
 
         # Verify that both files have been primeped
         self.assertTrue(
-            os.path.exists(os.path.join(self.snap_dir, 'bin', '1')))
+            os.path.exists(os.path.join(self.prime_dir, 'bin', '1')))
         self.assertTrue(
-            os.path.exists(os.path.join(self.snap_dir, 'bin', '2')))
+            os.path.exists(os.path.join(self.prime_dir, 'bin', '2')))
 
         # Now update the `snap` fileset to only snap one of these files
         handler.code.options.snap = ['bin/1']
@@ -1851,10 +1851,10 @@ class CleanTestCase(CleanBaseTestCase):
 
         # Verify that part1's file is no longer primeped
         self.assertFalse(
-            os.path.exists(os.path.join(self.snap_dir, 'bin', '1')),
+            os.path.exists(os.path.join(self.prime_dir, 'bin', '1')),
             'Expected bin/1 to be cleaned')
         self.assertFalse(
-            os.path.exists(os.path.join(self.snap_dir, 'bin', '2')),
+            os.path.exists(os.path.join(self.prime_dir, 'bin', '2')),
             'Expected bin/2 to be cleaned as well, even though the filesets '
             'changed since it was primeped.')
 
@@ -1862,7 +1862,7 @@ class CleanTestCase(CleanBaseTestCase):
         handler = mocks.loadplugin('test-part')
         handler.makedirs()
 
-        open(os.path.join(self.snap_dir, '1'), 'w').close()
+        open(os.path.join(self.prime_dir, '1'), 'w').close()
 
         handler.mark_done('prime', None)
 
@@ -1876,7 +1876,7 @@ class CleanTestCase(CleanBaseTestCase):
         handler = mocks.loadplugin('test-part')
         handler.makedirs()
 
-        primed_file = os.path.join(self.snap_dir, '1')
+        primed_file = os.path.join(self.prime_dir, '1')
         open(primed_file, 'w').close()
 
         handler.mark_done('prime', None)
@@ -2042,11 +2042,11 @@ class CleanPrimeTestCase(CleanBaseTestCase):
         # Now prime them
         handler.prime()
 
-        self.assertTrue(os.listdir(self.snap_dir))
+        self.assertTrue(os.listdir(self.prime_dir))
 
         handler.clean_prime({})
 
-        self.assertFalse(os.listdir(self.snap_dir),
+        self.assertFalse(os.listdir(self.prime_dir),
                          'Expected snapdir to be completely cleaned')
 
 

--- a/snapcraft/tests/test_project_loader.py
+++ b/snapcraft/tests/test_project_loader.py
@@ -1239,11 +1239,11 @@ parts:
     def test_config_snap_environment(self):
         config = project_loader.Config()
 
-        lib_paths = [os.path.join(self.snap_dir, 'lib'),
-                     os.path.join(self.snap_dir, 'usr', 'lib'),
-                     os.path.join(self.snap_dir, 'lib',
+        lib_paths = [os.path.join(self.prime_dir, 'lib'),
+                     os.path.join(self.prime_dir, 'usr', 'lib'),
+                     os.path.join(self.prime_dir, 'lib',
                                   self.arch_triplet),
-                     os.path.join(self.snap_dir, 'usr', 'lib',
+                     os.path.join(self.prime_dir, 'usr', 'lib',
                                   self.arch_triplet)]
         for lib_path in lib_paths:
             os.makedirs(lib_path)
@@ -1251,7 +1251,7 @@ parts:
         environment = config.snap_env()
         self.assertTrue(
             'PATH="{0}/usr/sbin:{0}/usr/bin:{0}/sbin:{0}/bin:$PATH"'.format(
-                self.snap_dir)
+                self.prime_dir)
             in environment)
 
         # Ensure that LD_LIBRARY_PATH is present and it contains only the
@@ -1265,7 +1265,7 @@ parts:
         self.assertTrue(len(paths) > 0,
                         'Expected LD_LIBRARY_PATH to be in environment')
 
-        expected = (os.path.join(self.snap_dir, i) for i in
+        expected = (os.path.join(self.prime_dir, i) for i in
                     ['lib', os.path.join('usr', 'lib'),
                      os.path.join('lib', self.arch_triplet),
                      os.path.join('usr', 'lib', self.arch_triplet)])
@@ -1281,7 +1281,7 @@ parts:
         environment = config.snap_env()
         self.assertTrue(
             'PATH="{0}/usr/sbin:{0}/usr/bin:{0}/sbin:{0}/bin:$PATH"'.format(
-                self.snap_dir)
+                self.prime_dir)
             in environment,
             'Current PATH is {!r}'.format(environment))
         for e in environment:
@@ -1293,8 +1293,8 @@ parts:
     def test_config_snap_environment_with_dependencies(self,
                                                        mock_get_dependencies):
         library_paths = {
-            os.path.join(self.snap_dir, 'lib1'),
-            os.path.join(self.snap_dir, 'lib2'),
+            os.path.join(self.prime_dir, 'lib1'),
+            os.path.join(self.prime_dir, 'lib2'),
         }
         mock_get_dependencies.return_value = library_paths
         config = project_loader.Config()
@@ -1313,7 +1313,7 @@ parts:
         self.assertTrue(len(paths) > 0,
                         'Expected LD_LIBRARY_PATH to be in environment')
 
-        expected = (os.path.join(self.snap_dir, i) for i in ['lib1', 'lib2'])
+        expected = (os.path.join(self.prime_dir, i) for i in ['lib1', 'lib2'])
         for item in expected:
             self.assertTrue(
                 item in paths,
@@ -1325,8 +1325,8 @@ parts:
     def test_config_snap_environment_with_dependencies_but_no_paths(
             self, mock_get_dependencies):
         library_paths = {
-            os.path.join(self.snap_dir, 'lib1'),
-            os.path.join(self.snap_dir, 'lib2'),
+            os.path.join(self.prime_dir, 'lib1'),
+            os.path.join(self.prime_dir, 'lib2'),
         }
         mock_get_dependencies.return_value = library_paths
         config = project_loader.Config()
@@ -1342,13 +1342,13 @@ parts:
         # Place a few ld.so.conf files in supported locations. We expect the
         # contents of these to make it into the LD_LIBRARY_PATH.
         mesa_dir = os.path.join(
-            self.snap_dir, 'usr', 'lib', 'my_arch', 'mesa')
+            self.prime_dir, 'usr', 'lib', 'my_arch', 'mesa')
         os.makedirs(mesa_dir)
         with open(os.path.join(mesa_dir, 'ld.so.conf'), 'w') as f:
             f.write('/mesa')
 
         mesa_egl_dir = os.path.join(
-            self.snap_dir, 'usr', 'lib', 'my_arch', 'mesa-egl')
+            self.prime_dir, 'usr', 'lib', 'my_arch', 'mesa-egl')
         os.makedirs(mesa_egl_dir)
         with open(os.path.join(mesa_egl_dir, 'ld.so.conf'), 'w') as f:
             f.write('# Standalone comment\n')
@@ -1367,7 +1367,7 @@ parts:
         self.assertTrue(len(paths) > 0,
                         'Expected LD_LIBRARY_PATH to be in environment')
 
-        expected = (os.path.join(self.snap_dir, i) for i in
+        expected = (os.path.join(self.prime_dir, i) for i in
                     ['mesa', 'mesa-egl'])
         for item in expected:
             self.assertTrue(item in paths,

--- a/snaps_tests/demos_tests/test_hooks.py
+++ b/snaps_tests/demos_tests/test_hooks.py
@@ -1,0 +1,36 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+import snaps_tests
+
+
+class HookCase(snaps_tests.SnapsTestCase):
+
+    snap_content_dir = 'hooks'
+
+    def test_hooks(self):
+        snap_path = self.build_snap(self.snap_content_dir)
+        self.install_snap(snap_path, 'hooks', '1.0')
+
+        # Regular `snap set` should succeed.
+        self.run_command_in_snappy_testbed('sudo snap set hooks foo=bar')
+
+        # Setting fail=true should fail.
+        self.assertRaises(
+            subprocess.CalledProcessError,
+            self.run_command_in_snappy_testbed,
+            'sudo snap set hooks fail=true')

--- a/snaps_tests/demos_tests/test_pyhooks.py
+++ b/snaps_tests/demos_tests/test_pyhooks.py
@@ -1,0 +1,36 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+import snaps_tests
+
+
+class PyHookCase(snaps_tests.SnapsTestCase):
+
+    snap_content_dir = 'pyhooks'
+
+    def test_pyhooks(self):
+        snap_path = self.build_snap(self.snap_content_dir)
+        self.install_snap(snap_path, 'pyhooks', '1.0')
+
+        # Regular `snap set` should succeed.
+        self.run_command_in_snappy_testbed('sudo snap set pyhooks foo=bar')
+
+        # Setting fail=true should fail.
+        self.assertRaises(
+            subprocess.CalledProcessError,
+            self.run_command_in_snappy_testbed,
+            'sudo snap set pyhooks fail=true')


### PR DESCRIPTION
Hooks are now supported in snapd and the click reviewer tools. Time to finish off LP: [#1586465](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1586465) by supporting them in snapcraft as well. This is done by convention, and two methods are supported:

1. Place hook executables in the `snap/hooks/` directory, and they will be copied into the snap automatically.
2. Install hook executables from parts into the `snap/hooks/` directory.