### PR TITLE
meta: support core libraries

### DIFF
--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -47,11 +47,16 @@ env = []
 logger = logging.getLogger(__name__)
 
 
-def assemble_env(include_ld_library_paths=True):
-    if include_ld_library_paths:
-        parse_env = env
+def assemble_env(include_core_library_paths=False, arch_triplet=''):
+    if include_core_library_paths:
+        core_paths = get_library_paths(
+            os.path.join('/snap', 'core', 'current'), arch_triplet,
+            existing_only=False)
+        core_library_paths = 'LD_LIBRARY_PATH="{}"'.format(
+            ':'.join(core_paths))
+        parse_env = [core_library_paths] + env
     else:
-        parse_env = [e for e in env if not e.startswith('LD_LIBRARY_PATH')]
+        parse_env = env
 
     return '\n'.join(['export ' + e for e in parse_env])
 

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -201,8 +201,7 @@ class _Executor:
         if step == 'prime' and part_names == self.config.part_names:
             common.env = self.config.snap_env()
             meta.create_snap_packaging(self.config.data,
-                                       self.project_options.snap_dir,
-                                       self.project_options.parts_dir)
+                                       self.project_options)
 
     def _handle_dirty(self, part, step, dirty_report):
         if step not in _STEPS_TO_AUTOMATICALLY_CLEAN_IF_DIRTY:

--- a/snapcraft/tests/__init__.py
+++ b/snapcraft/tests/__init__.py
@@ -102,6 +102,7 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         self.prime_dir = os.path.join(os.getcwd(), 'prime')
         self.stage_dir = os.path.join(os.getcwd(), 'stage')
         self.parts_dir = os.path.join(os.getcwd(), 'parts')
+        self.snap_dir = os.path.join(os.getcwd(), 'snap')
         self.local_plugins_dir = os.path.join(self.parts_dir, 'plugins')
 
     def make_snapcraft_yaml(self, content, encoding='utf-8'):

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -38,7 +38,7 @@ from snapcraft.internal.meta import (
 )
 from snapcraft.internal import common
 from snapcraft.internal.errors import MissingGadgetError
-from snapcraft import tests
+from snapcraft import ProjectOptions, tests
 
 
 class CreateBaseTestCase(tests.TestCase):
@@ -55,14 +55,13 @@ class CreateBaseTestCase(tests.TestCase):
             'confinement': 'devmode',
         }
 
-        self.snap_dir = os.path.join(os.path.abspath(os.curdir), 'snap')
-        self.prime_dir = os.path.join(os.path.abspath(os.curdir), 'prime')
+        self.project_options = ProjectOptions()
         self.meta_dir = os.path.join(self.prime_dir, 'meta')
         self.hooks_dir = os.path.join(self.meta_dir, 'hooks')
         self.snap_yaml = os.path.join(self.meta_dir, 'snap.yaml')
 
     def generate_meta_yaml(self):
-        create_snap_packaging(self.config_data, self.prime_dir, self.parts_dir)
+        create_snap_packaging(self.config_data, self.project_options)
 
         self.assertTrue(
             os.path.exists(self.snap_yaml), 'snap.yaml was not created')
@@ -109,7 +108,7 @@ class CreateTestCase(CreateBaseTestCase):
             f.write(gadget_yaml)
 
         self.config_data['type'] = 'gadget'
-        create_snap_packaging(self.config_data, self.prime_dir, self.parts_dir)
+        create_snap_packaging(self.config_data, self.project_options)
 
         expected_gadget = os.path.join(self.meta_dir, 'gadget.yaml')
         self.assertTrue(os.path.exists(expected_gadget))
@@ -124,8 +123,7 @@ class CreateTestCase(CreateBaseTestCase):
             MissingGadgetError,
             create_snap_packaging,
             self.config_data,
-            self.prime_dir,
-            self.parts_dir)
+            self.project_options)
 
     def test_create_meta_with_declared_icon(self):
         open(os.path.join(os.curdir, 'my-icon.png'), 'w').close()
@@ -176,10 +174,10 @@ class CreateTestCase(CreateBaseTestCase):
         open(os.path.join(os.curdir, 'my-icon.png'), 'w').close()
         self.config_data['icon'] = 'my-icon.png'
 
-        create_snap_packaging(self.config_data, self.prime_dir, self.parts_dir)
+        create_snap_packaging(self.config_data, self.project_options)
 
         # Running again should be good
-        create_snap_packaging(self.config_data, self.prime_dir, self.parts_dir)
+        create_snap_packaging(self.config_data, self.project_options)
 
     def test_create_meta_with_icon_in_setup(self):
         gui_path = os.path.join('setup', 'gui')
@@ -460,8 +458,7 @@ class WrapExeTestCase(tests.TestCase):
 
         # TODO move to use outer interface
         self.packager = _SnapPackaging({'confinement': 'devmode'},
-                                       self.prime_dir,
-                                       self.parts_dir)
+                                       ProjectOptions())
 
     @patch('snapcraft.internal.common.assemble_env')
     def test_wrap_exe_must_write_wrapper(self, mock_assemble_env):


### PR DESCRIPTION
When setting up the wrappers we need a mechanism so that LD_LIBRARY_PATH if set is set to not consume externally and use /snap/core/current as the alternate root.

LP: #1656187
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>