### PR TITLE
meta: ensure snap.yaml is desktop free

### DIFF
--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -339,7 +339,6 @@ class _SnapPackaging:
                         'Icon {} specified in desktop file {} not found '
                         'in prime directory'.format(icon, desktop_file))
         target = os.path.join(gui_dir, os.path.basename(desktop_file))
-        print('target', target)
         if os.path.exists(target):
             raise EnvironmentError(
                 'Conflicting desktop file referenced by more than one '

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -284,6 +284,11 @@ class CreateTestCase(CreateBaseTestCase):
         self.assertEqual(contents[section].get('Icon'),
                          '${SNAP}/usr/share/app2.png')
 
+        self.assertThat(os.path.join('prime', 'meta', 'snap.yaml'),
+                        Not(FileContains('desktop: app1.desktop')))
+        self.assertThat(os.path.join('prime', 'meta', 'snap.yaml'),
+                        Not(FileContains('desktop: app2.desktop')))
+
     def test_create_meta_with_hook(self):
         hooksdir = os.path.join(self.snap_dir, 'hooks')
         os.makedirs(hooksdir)


### PR DESCRIPTION
snap.yaml has no concept of desktop files, this
is a by-convention mechanism in snap.

LP: #1656487
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>