### PR TITLE
schema: print allowed length for length failures.

### DIFF
--- a/snapcraft/tests/test_project_loader.py
+++ b/snapcraft/tests/test_project_loader.py
@@ -1612,7 +1612,8 @@ class ValidationTestCase(ValidationBaseTestCase):
 
         expected_message = (
             "The 'summary' property does not match the required schema: "
-            "'{}' is too long").format(self.data['summary'])
+            "'{}' is too long (maximum length is 78)").format(
+                self.data['summary'])
         self.assertEqual(raised.message, expected_message,
                          message=self.data)
 


### PR DESCRIPTION
This PR fixes LP: [#1621726](https://bugs.launchpad.net/snapcraft/+bug/1621726) by adding hints for length-related schema validation errors.