### PR TITLE
options: use actual userspace architecture for building in 32bit

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -38,8 +38,7 @@ Standards-Version: 3.9.8
 
 Package: snapcraft
 Architecture: all
-Depends: gcc,
-         python3-apt,
+Depends: python3-apt,
          python3-debian,
          python3-docopt,
          python3-jsonschema,

--- a/debian/control
+++ b/debian/control
@@ -38,7 +38,8 @@ Standards-Version: 3.9.8
 
 Package: snapcraft
 Architecture: all
-Depends: python3-apt,
+Depends: gcc,
+         python3-apt,
          python3-debian,
          python3-docopt,
          python3-jsonschema,

--- a/integration_tests/test_hardlink_src_old_tree.py
+++ b/integration_tests/test_hardlink_src_old_tree.py
@@ -31,8 +31,8 @@ class HardlinkSrcOldTreeTestCase(integration_tests.TestCase):
     def test_build_old_tree_still_filters(self):
         project_dir = 'old-part-src'
         work_dir = self.copy_project_to_tmp(project_dir)
-        platform_machine = _options._get_platform_machine()
-        arch = _options._ARCH_TRANSLATIONS[platform_machine]['deb']
+        platform_architecture = _options._get_platform_architecture()
+        arch = _options._ARCH_TRANSLATIONS[platform_architecture]['deb']
         with fileinput.FileInput(
                 os.path.join(work_dir, 'parts', 'part-name', 'state', 'pull'),
                 inplace=True) as pull_state:

--- a/integration_tests/test_hardlink_src_old_tree.py
+++ b/integration_tests/test_hardlink_src_old_tree.py
@@ -16,7 +16,6 @@
 
 import fileinput
 import os
-import platform
 
 from testtools.matchers import (
     FileExists,
@@ -32,7 +31,8 @@ class HardlinkSrcOldTreeTestCase(integration_tests.TestCase):
     def test_build_old_tree_still_filters(self):
         project_dir = 'old-part-src'
         work_dir = self.copy_project_to_tmp(project_dir)
-        arch = _options._ARCH_TRANSLATIONS[platform.machine()]['deb']
+        platform_machine = _options._get_platform_machine()
+        arch = _options._ARCH_TRANSLATIONS[platform_machine]['deb']
         with fileinput.FileInput(
                 os.path.join(work_dir, 'parts', 'part-name', 'state', 'pull'),
                 inplace=True) as pull_state:

--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -76,6 +76,11 @@ _ARCH_TRANSLATIONS = {
     }
 }
 
+_32BIT_BACKWARD_COMPATIBILTY = {
+    'aarch64': 'armv7l',
+    'ppc64le': 'ppc',
+    'x86_64': 'i686',
+}
 
 class ProjectOptions:
 
@@ -183,6 +188,10 @@ class ProjectOptions:
 
     def _set_machine(self, target_deb_arch):
         self.__host_machine = platform.machine()
+        if platform.architecture()[0] == '32bit':
+            host32 = _32BIT_BACKWARD_COMPATIBILTY.get(self.__host_machine)
+            if host32:
+                self.__host_machine = host32
         if not target_deb_arch:
             self.__target_machine = self.__host_machine
         else:

--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -103,6 +103,11 @@ def _get_platform_from_gcc_triplet(arch_triplet):
             return platform_name
 
 
+def _get_platform_machine():
+    gcc_machine = _get_platform_from_gcc_triplet(_get_gcc_target())
+    return gcc_machine if gcc_machine else platform.machine()
+
+
 class ProjectOptions:
 
     @property
@@ -208,8 +213,7 @@ class ProjectOptions:
         return dynamic_linker_path
 
     def _set_machine(self, target_deb_arch):
-        gcc_plat = _get_platform_from_gcc_triplet(_get_gcc_target())
-        self.__host_machine = gcc_plat if gcc_plat else platform.machine()
+        self.__host_machine = _get_platform_machine()
         if not target_deb_arch:
             self.__target_machine = self.__host_machine
         else:

--- a/snapcraft/plugins/gulp.py
+++ b/snapcraft/plugins/gulp.py
@@ -81,7 +81,7 @@ class GulpPlugin(snapcraft.BasePlugin):
         super().__init__(name, options, project)
         self._npm_dir = os.path.join(self.partdir, 'npm')
         self._nodejs_tar = sources.Tar(nodejs.get_nodejs_release(
-            self.options.node_engine), self._npm_dir)
+            self.options.node_engine, self.project), self._npm_dir)
 
     def pull(self):
         super().pull()

--- a/snapcraft/plugins/gulp.py
+++ b/snapcraft/plugins/gulp.py
@@ -81,7 +81,7 @@ class GulpPlugin(snapcraft.BasePlugin):
         super().__init__(name, options, project)
         self._npm_dir = os.path.join(self.partdir, 'npm')
         self._nodejs_tar = sources.Tar(nodejs.get_nodejs_release(
-            self.options.node_engine, self.project), self._npm_dir)
+            self.options.node_engine, self.project.deb_arch), self._npm_dir)
 
     def pull(self):
         super().pull()

--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -107,7 +107,7 @@ class NodePlugin(snapcraft.BasePlugin):
         super().__init__(name, options, project)
         self._npm_dir = os.path.join(self.partdir, 'npm')
         self._nodejs_tar = sources.Tar(get_nodejs_release(
-            self.options.node_engine, self.project), self._npm_dir)
+            self.options.node_engine, self.project.deb_arch), self._npm_dir)
 
     def pull(self):
         super().pull()
@@ -140,8 +140,7 @@ class NodePlugin(snapcraft.BasePlugin):
             self.run(['npm', 'run', target], cwd=rootdir)
 
 
-def _get_nodejs_base(node_engine, project_options):
-    machine = project_options.deb_arch
+def _get_nodejs_base(node_engine, machine):
     if machine not in _NODEJS_ARCHES:
         raise EnvironmentError('architecture not supported ({})'.format(
             machine))
@@ -149,6 +148,6 @@ def _get_nodejs_base(node_engine, project_options):
                                arch=_NODEJS_ARCHES[machine])
 
 
-def get_nodejs_release(node_engine, project):
+def get_nodejs_release(node_engine, arch):
     return _NODEJS_TMPL.format(version=node_engine,
-                               base=_get_nodejs_base(node_engine, project))
+                               base=_get_nodejs_base(node_engine, arch))

--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -39,11 +39,10 @@ Additionally, this plugin uses the following plugin-specific keywords:
 
 import logging
 import os
-import platform
 import shutil
 
 import snapcraft
-from snapcraft import sources
+from snapcraft import sources, _options
 
 logger = logging.getLogger(__name__)
 
@@ -142,7 +141,7 @@ class NodePlugin(snapcraft.BasePlugin):
 
 
 def _get_nodejs_base(node_engine):
-    machine = platform.machine()
+    machine = _options._get_platform_machine()
     if machine not in _NODEJS_ARCHES:
         raise EnvironmentError('architecture not supported ({})'.format(
             machine))

--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -42,7 +42,7 @@ import os
 import shutil
 
 import snapcraft
-from snapcraft import sources, _options
+from snapcraft import sources
 
 logger = logging.getLogger(__name__)
 
@@ -50,10 +50,10 @@ _NODEJS_BASE = 'node-v{version}-linux-{arch}'
 _NODEJS_VERSION = '4.4.4'
 _NODEJS_TMPL = 'https://nodejs.org/dist/v{version}/{base}.tar.gz'
 _NODEJS_ARCHES = {
-    'i686': 'x86',
-    'x86_64': 'x64',
-    'armv7l': 'armv7l',
-    'aarch64': 'arm64',
+    'i386': 'x86',
+    'amd64': 'x64',
+    'armhf': 'armv7l',
+    'arm64': 'arm64',
 }
 
 
@@ -107,7 +107,7 @@ class NodePlugin(snapcraft.BasePlugin):
         super().__init__(name, options, project)
         self._npm_dir = os.path.join(self.partdir, 'npm')
         self._nodejs_tar = sources.Tar(get_nodejs_release(
-            self.options.node_engine), self._npm_dir)
+            self.options.node_engine, self.project), self._npm_dir)
 
     def pull(self):
         super().pull()
@@ -140,8 +140,8 @@ class NodePlugin(snapcraft.BasePlugin):
             self.run(['npm', 'run', target], cwd=rootdir)
 
 
-def _get_nodejs_base(node_engine):
-    machine = _options._get_platform_architecture()
+def _get_nodejs_base(node_engine, project_options):
+    machine = project_options.deb_arch
     if machine not in _NODEJS_ARCHES:
         raise EnvironmentError('architecture not supported ({})'.format(
             machine))
@@ -149,6 +149,6 @@ def _get_nodejs_base(node_engine):
                                arch=_NODEJS_ARCHES[machine])
 
 
-def get_nodejs_release(node_engine):
+def get_nodejs_release(node_engine, project):
     return _NODEJS_TMPL.format(version=node_engine,
-                               base=_get_nodejs_base(node_engine))
+                               base=_get_nodejs_base(node_engine, project))

--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -141,7 +141,7 @@ class NodePlugin(snapcraft.BasePlugin):
 
 
 def _get_nodejs_base(node_engine):
-    machine = _options._get_platform_machine()
+    machine = _options._get_platform_architecture()
     if machine not in _NODEJS_ARCHES:
         raise EnvironmentError('architecture not supported ({})'.format(
             machine))

--- a/snapcraft/tests/plugins/test_gulp.py
+++ b/snapcraft/tests/plugins/test_gulp.py
@@ -61,7 +61,9 @@ class GulpPluginTestCase(tests.TestCase):
         self.assertFalse(self.run_mock.called, 'run() was called')
         self.tar_mock.assert_has_calls([
             mock.call(
-                nodejs.get_nodejs_release(plugin.options.node_engine),
+                nodejs.get_nodejs_release(
+                    plugin.options.node_engine,
+                    plugin.project),
                 path.join(os.path.abspath('.'), 'parts', 'test-part', 'npm')),
             mock.call().download()])
 
@@ -100,17 +102,15 @@ class GulpPluginTestCase(tests.TestCase):
 
         self.tar_mock.assert_has_calls([
             mock.call(
-                nodejs.get_nodejs_release(plugin.options.node_engine),
+                nodejs.get_nodejs_release(
+                    plugin.options.node_engine,
+                    plugin.project),
                 os.path.join(plugin._npm_dir)),
             mock.call().provision(
                 plugin._npm_dir, clean_target=False, keep_tarball=True)])
 
-    @mock.patch('platform.architecture')
-    @mock.patch('platform.machine')
-    def test_unsupported_arch_raises_exception(self, machine_mock, arch_mock):
-        machine_mock.return_value = 'fantasy-arch'
-        arch_mock.return_value = ('128bit', 'ELF')
-
+    @mock.patch('snapcraft.ProjectOptions.deb_arch', 'fantasy-arch')
+    def test_unsupported_arch_raises_exception(self):
         class Options:
             source = None
             gulp_tasks = []

--- a/snapcraft/tests/plugins/test_gulp.py
+++ b/snapcraft/tests/plugins/test_gulp.py
@@ -65,7 +65,8 @@ class GulpPluginTestCase(tests.TestCase):
                 path.join(os.path.abspath('.'), 'parts', 'test-part', 'npm')),
             mock.call().download()])
 
-    def test_build(self):
+    @mock.patch('snapcraft._options._get_platform_machine')
+    def test_build(self, platform_machine_mock):
         self.useFixture(tests.fixture_setup.CleanEnvironment())
         self.useFixture(fixtures.EnvironmentVariable(
             'PATH', '/bin'))
@@ -75,6 +76,7 @@ class GulpPluginTestCase(tests.TestCase):
             gulp_tasks = []
             node_engine = '4'
 
+        platform_machine_mock.return_value = 'x86_64'
         plugin = gulp.GulpPlugin('test-part', Options(), self.project_options)
 
         os.makedirs(plugin.builddir)
@@ -101,7 +103,7 @@ class GulpPluginTestCase(tests.TestCase):
             mock.call().provision(
                 plugin._npm_dir, clean_target=False, keep_tarball=True)])
 
-    @mock.patch('platform.machine')
+    @mock.patch('snapcraft._options._get_platform_machine')
     def test_unsupported_arch_raises_exception(self, machine_mock):
         machine_mock.return_value = 'fantasy-arch'
 

--- a/snapcraft/tests/plugins/test_gulp.py
+++ b/snapcraft/tests/plugins/test_gulp.py
@@ -65,8 +65,9 @@ class GulpPluginTestCase(tests.TestCase):
                 path.join(os.path.abspath('.'), 'parts', 'test-part', 'npm')),
             mock.call().download()])
 
-    @mock.patch('snapcraft._options._get_platform_machine')
-    def test_build(self, platform_machine_mock):
+    @mock.patch('platform.architecture')
+    @mock.patch('platform.machine')
+    def test_build(self, platform_machine_mock, platform_architecture_mock):
         self.useFixture(tests.fixture_setup.CleanEnvironment())
         self.useFixture(fixtures.EnvironmentVariable(
             'PATH', '/bin'))
@@ -77,6 +78,7 @@ class GulpPluginTestCase(tests.TestCase):
             node_engine = '4'
 
         platform_machine_mock.return_value = 'x86_64'
+        platform_architecture_mock.return_value = ('64bit', 'ELF')
         plugin = gulp.GulpPlugin('test-part', Options(), self.project_options)
 
         os.makedirs(plugin.builddir)
@@ -103,9 +105,11 @@ class GulpPluginTestCase(tests.TestCase):
             mock.call().provision(
                 plugin._npm_dir, clean_target=False, keep_tarball=True)])
 
-    @mock.patch('snapcraft._options._get_platform_machine')
-    def test_unsupported_arch_raises_exception(self, machine_mock):
+    @mock.patch('platform.architecture')
+    @mock.patch('platform.machine')
+    def test_unsupported_arch_raises_exception(self, machine_mock, arch_mock):
         machine_mock.return_value = 'fantasy-arch'
+        arch_mock.return_value = ('128bit', 'ELF')
 
         class Options:
             source = None

--- a/snapcraft/tests/plugins/test_gulp.py
+++ b/snapcraft/tests/plugins/test_gulp.py
@@ -63,7 +63,7 @@ class GulpPluginTestCase(tests.TestCase):
             mock.call(
                 nodejs.get_nodejs_release(
                     plugin.options.node_engine,
-                    plugin.project),
+                    plugin.project.deb_arch),
                 path.join(os.path.abspath('.'), 'parts', 'test-part', 'npm')),
             mock.call().download()])
 
@@ -104,7 +104,7 @@ class GulpPluginTestCase(tests.TestCase):
             mock.call(
                 nodejs.get_nodejs_release(
                     plugin.options.node_engine,
-                    plugin.project),
+                    plugin.project.deb_arch),
                 os.path.join(plugin._npm_dir)),
             mock.call().provision(
                 plugin._npm_dir, clean_target=False, keep_tarball=True)])

--- a/snapcraft/tests/plugins/test_nodejs.py
+++ b/snapcraft/tests/plugins/test_nodejs.py
@@ -61,7 +61,8 @@ class NodePluginTestCase(tests.TestCase):
         self.assertFalse(self.run_mock.called, 'run() was called')
         self.tar_mock.assert_has_calls([
             mock.call(
-                nodejs.get_nodejs_release(plugin.options.node_engine),
+                nodejs.get_nodejs_release(
+                    plugin.options.node_engine, plugin.project),
                 path.join(os.path.abspath('.'), 'parts', 'test-part', 'npm')),
             mock.call().download()])
 
@@ -87,7 +88,8 @@ class NodePluginTestCase(tests.TestCase):
                       cwd=plugin.builddir)])
         self.tar_mock.assert_has_calls([
             mock.call(
-                nodejs.get_nodejs_release(plugin.options.node_engine),
+                nodejs.get_nodejs_release(
+                    plugin.options.node_engine, plugin.project),
                 path.join(os.path.abspath('.'), 'parts', 'test-part', 'npm')),
             mock.call().provision(
                 plugin.installdir, clean_target=False, keep_tarball=True)])
@@ -112,7 +114,8 @@ class NodePluginTestCase(tests.TestCase):
                        'my-pkg'], cwd=plugin.builddir)])
         self.tar_mock.assert_has_calls([
             mock.call(
-                nodejs.get_nodejs_release(plugin.options.node_engine),
+                nodejs.get_nodejs_release(
+                    plugin.options.node_engine, plugin.project),
                 path.join(os.path.abspath('.'), 'parts', 'test-part', 'npm')),
             mock.call().download(),
             mock.call().provision(
@@ -139,12 +142,8 @@ class NodePluginTestCase(tests.TestCase):
             mock.call(['npm', 'run', 'avocado'],
                       cwd=plugin.builddir)])
 
-    @mock.patch('platform.architecture')
-    @mock.patch('platform.machine')
-    def test_unsupported_arch_raises_exception(self, machine_mock, arch_mock):
-        machine_mock.return_value = 'fantasy-arch'
-        arch_mock.return_value = ('128bit', 'ELF')
-
+    @mock.patch('snapcraft.ProjectOptions.deb_arch', 'fantasy-arch')
+    def test_unsupported_arch_raises_exception(self):
         class Options:
             source = None
             node_packages = []
@@ -327,5 +326,6 @@ class NodeReleaseTestCase(tests.TestCase):
     def test_get_nodejs_release(self, machine_mock, architecture_mock):
         machine_mock.return_value = self.machine
         architecture_mock.return_value = self.architecture
-        node_url = nodejs.get_nodejs_release(self.engine)
+        project_options = snapcraft.ProjectOptions()
+        node_url = nodejs.get_nodejs_release(self.engine, project_options)
         self.assertEqual(node_url, self.expected_url)

--- a/snapcraft/tests/plugins/test_nodejs.py
+++ b/snapcraft/tests/plugins/test_nodejs.py
@@ -292,6 +292,13 @@ class NodeReleaseTestCase(tests.TestCase):
             expected_url=(
                 'https://nodejs.org/dist/v4.4.4/'
                 'node-v4.4.4-linux-x64.tar.gz'))),
+        ('i686-on-x86_64', dict(
+            architecture=('32bit', 'ELF'),
+            machine='x86_64',
+            engine='4.4.4',
+            expected_url=(
+                'https://nodejs.org/dist/v4.4.4/'
+                'node-v4.4.4-linux-x86.tar.gz'))),
         ('armv7l', dict(
             architecture=('32bit', 'ELF'),
             machine='armv7l',
@@ -306,6 +313,13 @@ class NodeReleaseTestCase(tests.TestCase):
             expected_url=(
                 'https://nodejs.org/dist/v4.4.4/'
                 'node-v4.4.4-linux-arm64.tar.gz'))),
+        ('armv7l-on-aarch64', dict(
+            architecture=('32bit', 'ELF'),
+            machine='aarch64',
+            engine='4.4.4',
+            expected_url=(
+                'https://nodejs.org/dist/v4.4.4/'
+                'node-v4.4.4-linux-armv7l.tar.gz'))),
     ]
 
     @mock.patch('platform.architecture')

--- a/snapcraft/tests/plugins/test_nodejs.py
+++ b/snapcraft/tests/plugins/test_nodejs.py
@@ -139,7 +139,7 @@ class NodePluginTestCase(tests.TestCase):
             mock.call(['npm', 'run', 'avocado'],
                       cwd=plugin.builddir)])
 
-    @mock.patch('platform.machine')
+    @mock.patch('snapcraft._options._get_platform_machine')
     def test_unsupported_arch_raises_exception(self, machine_mock):
         machine_mock.return_value = 'fantasy-arch'
 
@@ -302,8 +302,8 @@ class NodeReleaseTestCase(tests.TestCase):
                 'node-v4.4.4-linux-arm64.tar.gz'))),
     ]
 
-    @mock.patch('platform.machine')
-    def test_get_nodejs_release(self, machine_mock):
-        machine_mock.return_value = self.machine
+    @mock.patch('snapcraft._options._get_platform_machine')
+    def test_get_nodejs_release(self, platform_machine_mock):
+        platform_machine_mock.return_value = self.machine
         node_url = nodejs.get_nodejs_release(self.engine)
         self.assertEqual(node_url, self.expected_url)

--- a/snapcraft/tests/plugins/test_nodejs.py
+++ b/snapcraft/tests/plugins/test_nodejs.py
@@ -62,7 +62,7 @@ class NodePluginTestCase(tests.TestCase):
         self.tar_mock.assert_has_calls([
             mock.call(
                 nodejs.get_nodejs_release(
-                    plugin.options.node_engine, plugin.project),
+                    plugin.options.node_engine, plugin.project.deb_arch),
                 path.join(os.path.abspath('.'), 'parts', 'test-part', 'npm')),
             mock.call().download()])
 
@@ -89,7 +89,7 @@ class NodePluginTestCase(tests.TestCase):
         self.tar_mock.assert_has_calls([
             mock.call(
                 nodejs.get_nodejs_release(
-                    plugin.options.node_engine, plugin.project),
+                    plugin.options.node_engine, plugin.project.deb_arch),
                 path.join(os.path.abspath('.'), 'parts', 'test-part', 'npm')),
             mock.call().provision(
                 plugin.installdir, clean_target=False, keep_tarball=True)])
@@ -115,7 +115,7 @@ class NodePluginTestCase(tests.TestCase):
         self.tar_mock.assert_has_calls([
             mock.call(
                 nodejs.get_nodejs_release(
-                    plugin.options.node_engine, plugin.project),
+                    plugin.options.node_engine, plugin.project.deb_arch),
                 path.join(os.path.abspath('.'), 'parts', 'test-part', 'npm')),
             mock.call().download(),
             mock.call().provision(
@@ -326,6 +326,6 @@ class NodeReleaseTestCase(tests.TestCase):
     def test_get_nodejs_release(self, machine_mock, architecture_mock):
         machine_mock.return_value = self.machine
         architecture_mock.return_value = self.architecture
-        project_options = snapcraft.ProjectOptions()
-        node_url = nodejs.get_nodejs_release(self.engine, project_options)
+        project = snapcraft.ProjectOptions()
+        node_url = nodejs.get_nodejs_release(self.engine, project.deb_arch)
         self.assertEqual(node_url, self.expected_url)

--- a/snapcraft/tests/plugins/test_nodejs.py
+++ b/snapcraft/tests/plugins/test_nodejs.py
@@ -139,9 +139,11 @@ class NodePluginTestCase(tests.TestCase):
             mock.call(['npm', 'run', 'avocado'],
                       cwd=plugin.builddir)])
 
-    @mock.patch('snapcraft._options._get_platform_machine')
-    def test_unsupported_arch_raises_exception(self, machine_mock):
+    @mock.patch('platform.architecture')
+    @mock.patch('platform.machine')
+    def test_unsupported_arch_raises_exception(self, machine_mock, arch_mock):
         machine_mock.return_value = 'fantasy-arch'
+        arch_mock.return_value = ('128bit', 'ELF')
 
         class Options:
             source = None
@@ -277,24 +279,28 @@ class NodeReleaseTestCase(tests.TestCase):
 
     scenarios = [
         ('i686', dict(
+            architecture=('32bit', 'ELF'),
             machine='i686',
             engine='4.4.4',
             expected_url=(
                 'https://nodejs.org/dist/v4.4.4/'
                 'node-v4.4.4-linux-x86.tar.gz'))),
         ('x86_64', dict(
+            architecture=('64bit', 'ELF'),
             machine='x86_64',
             engine='4.4.4',
             expected_url=(
                 'https://nodejs.org/dist/v4.4.4/'
                 'node-v4.4.4-linux-x64.tar.gz'))),
         ('armv7l', dict(
-             machine='armv7l',
-             engine='4.4.4',
-             expected_url=(
-                 'https://nodejs.org/dist/v4.4.4/'
-                 'node-v4.4.4-linux-armv7l.tar.gz'))),
+            architecture=('32bit', 'ELF'),
+            machine='armv7l',
+            engine='4.4.4',
+            expected_url=(
+                'https://nodejs.org/dist/v4.4.4/'
+                'node-v4.4.4-linux-armv7l.tar.gz'))),
         ('aarch64', dict(
+            architecture=('64bit', 'ELF'),
             machine='aarch64',
             engine='4.4.4',
             expected_url=(
@@ -302,8 +308,10 @@ class NodeReleaseTestCase(tests.TestCase):
                 'node-v4.4.4-linux-arm64.tar.gz'))),
     ]
 
-    @mock.patch('snapcraft._options._get_platform_machine')
-    def test_get_nodejs_release(self, platform_machine_mock):
-        platform_machine_mock.return_value = self.machine
+    @mock.patch('platform.architecture')
+    @mock.patch('platform.machine')
+    def test_get_nodejs_release(self, machine_mock, architecture_mock):
+        machine_mock.return_value = self.machine
+        architecture_mock.return_value = self.architecture
         node_url = nodejs.get_nodejs_release(self.engine)
         self.assertEqual(node_url, self.expected_url)

--- a/snapcraft/tests/test_options.py
+++ b/snapcraft/tests/test_options.py
@@ -17,9 +17,7 @@
 from unittest import mock
 
 import snapcraft
-import subprocess
-
-from snapcraft import _options, tests
+from snapcraft import tests
 
 
 class OptionsTestCase(tests.TestCase):
@@ -27,196 +25,73 @@ class OptionsTestCase(tests.TestCase):
     scenarios = [
         ('amd64', dict(
             machine='x86_64',
-            gcc_target='x86_64-linux-gnu',
+            architecture=('64bit', 'ELF'),
             expected_arch_triplet='x86_64-linux-gnu',
             expected_deb_arch='amd64',
             expected_kernel_arch='x86')),
         ('amd64-kernel-i686-userspace', dict(
             machine='x86_64',
-            gcc_target='i386-linux-gnu',
+            architecture=('32bit', 'ELF'),
             expected_arch_triplet='i386-linux-gnu',
             expected_deb_arch='i386',
             expected_kernel_arch='x86')),
         ('i686', dict(
             machine='i686',
-            gcc_target='i686-linux-gnu',
+            architecture=('32bit', 'ELF'),
             expected_arch_triplet='i386-linux-gnu',
             expected_deb_arch='i386',
             expected_kernel_arch='x86')),
         ('armv7l', dict(
             machine='armv7l',
-            gcc_target='arm-linux-gnueabihf',
+            architecture=('32bit', 'ELF'),
             expected_arch_triplet='arm-linux-gnueabihf',
             expected_deb_arch='armhf',
             expected_kernel_arch='arm')),
         ('aarch64', dict(
             machine='aarch64',
-            gcc_target='aarch64-linux-gnu',
+            architecture=('64bit', 'ELF'),
             expected_arch_triplet='aarch64-linux-gnu',
             expected_deb_arch='arm64',
             expected_kernel_arch='arm64')),
         ('aarch64-kernel-armv7l-userspace', dict(
             machine='aarch64',
-            gcc_target='arm-linux-gnueabihf',
+            architecture=('32bit', 'ELF'),
             expected_arch_triplet='arm-linux-gnueabihf',
             expected_deb_arch='armhf',
             expected_kernel_arch='arm')),
         ('ppc', dict(
             machine='ppc',
-            gcc_target='powerpc-linux-gnu',
+            architecture=('32bit', 'ELF'),
             expected_arch_triplet='powerpc-linux-gnu',
             expected_deb_arch='powerpc',
             expected_kernel_arch='powerpc')),
         ('ppc64le', dict(
             machine='ppc64le',
-            gcc_target='powerpc64le-linux-gnu',
+            architecture=('64bit', 'ELF'),
             expected_arch_triplet='powerpc64le-linux-gnu',
             expected_deb_arch='ppc64el',
             expected_kernel_arch='powerpc')),
         ('ppc64le-kernel-ppc-userspace', dict(
             machine='ppc64le',
-            gcc_target='powerpc-linux-gnu',
+            architecture=('32bit', 'ELF'),
             expected_arch_triplet='powerpc-linux-gnu',
             expected_deb_arch='powerpc',
             expected_kernel_arch='powerpc')),
         ('s390x', dict(
             machine='s390x',
-            gcc_target='s390x-linux-gnu',
+            architecture=('64bit', 'ELF'),
             expected_arch_triplet='s390x-linux-gnu',
             expected_deb_arch='s390x',
             expected_kernel_arch='s390x'))
     ]
 
-    @mock.patch('subprocess.PIPE')
-    @mock.patch('subprocess.run')
+    @mock.patch('platform.architecture')
     @mock.patch('platform.machine')
     def test_architecture_options(
-            self, mock_platform_machine,
-            mock_subprocess_run, mock_subprocess_pipe):
+            self, mock_platform_machine, mock_platform_architecture):
         mock_platform_machine.return_value = self.machine
-        mock_subprocess_run.return_value = mock.MagicMock(stderr=str.encode("""
-COLLECT_GCC=gcc
-COLLECT_LTO_WRAPPER=/usr/lib/gcc/{target}/5/lto-wrapper
-Target: {target}
-Configured with: ../src/configure -v
-Thread model: posix
-gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)
-            """.format(target=self.gcc_target)))
-
+        mock_platform_architecture.return_value = self.architecture
         options = snapcraft.ProjectOptions()
-        mock_subprocess_run.assert_called_once_with(
-            ['gcc', '-v'], stderr=mock_subprocess_pipe)
         self.assertEqual(options.arch_triplet, self.expected_arch_triplet)
         self.assertEqual(options.deb_arch, self.expected_deb_arch)
         self.assertEqual(options.kernel_arch, self.expected_kernel_arch)
-
-    @mock.patch('subprocess.PIPE')
-    @mock.patch('subprocess.run')
-    @mock.patch('platform.machine')
-    def test_architecture_options_from_platform(
-            self, mock_platform_machine, mock_subprocess_run,
-            mock_subprocess_pipe):
-        mock_platform_machine.return_value = self.machine
-        mock_subprocess_run.side_effect = subprocess.CalledProcessError(
-            returncode=1, cmd=['gcc', '-v'])
-
-        options = snapcraft.ProjectOptions()
-        mock_subprocess_run.assert_called_once_with(
-            ['gcc', '-v'], stderr=mock_subprocess_pipe)
-
-        if self.id().endswith('-userspace)'):
-            self.skipTest(
-                reason='unsupported platform with mismatching userspace')
-
-        self.assertEqual(options.arch_triplet, self.expected_arch_triplet)
-        self.assertEqual(options.deb_arch, self.expected_deb_arch)
-        self.assertEqual(options.kernel_arch, self.expected_kernel_arch)
-
-
-class GccTargetTests(tests.TestCase):
-
-    @mock.patch('subprocess.PIPE')
-    @mock.patch('subprocess.run')
-    def test_gcc_target_parsing(
-            self, mock_subprocess_run, mock_subprocess_pipe):
-        mock_subprocess_run.return_value = mock.MagicMock(stderr=(b"""
-COLLECT_GCC=gcc
-COLLECT_LTO_WRAPPER=/usr/lib/gcc/my-awesome-target/5/lto-wrapper
-Target: my-awesome-target
-Configured with: ../src/configure -v
-Thread model: posix
-gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)
-            """))
-
-        self.assertEqual(_options._get_gcc_target(), 'my-awesome-target')
-
-    @mock.patch('subprocess.PIPE')
-    @mock.patch('subprocess.run')
-    def test_gcc_target_missing(
-            self, mock_subprocess_run, mock_subprocess_pipe):
-        mock_subprocess_run.return_value = mock.MagicMock(stderr=(b"""
-COLLECT_GCC=gcc
-Configured with: ../src/configure -v
-Thread model: posix
-gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)
-            """))
-
-        self.assertIsNone(_options._get_gcc_target())
-
-    @mock.patch('subprocess.PIPE')
-    @mock.patch('subprocess.run')
-    def test_gcc_target_empty(
-            self, mock_subprocess_run, mock_subprocess_pipe):
-        mock_subprocess_run.return_value = mock.MagicMock(stderr=(b"""
-COLLECT_GCC=gcc
-Target:
-Configured with: ../src/configure -v
-Thread model: posix
-gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)
-            """))
-
-        self.assertIsNone(_options._get_gcc_target())
-
-    @mock.patch('subprocess.PIPE')
-    @mock.patch('subprocess.run')
-    def test_get_gcc_target_call_fails(
-            self, mock_subprocess_run, mock_subprocess_pipe):
-        mock_subprocess_run.side_effect = subprocess.CalledProcessError(
-            returncode=1, cmd=['gcc', '-v'])
-
-        self.assertIsNone(_options._get_gcc_target())
-        mock_subprocess_run.assert_called_once_with(
-            ['gcc', '-v'], stderr=mock_subprocess_pipe)
-
-    @mock.patch('snapcraft._options._ARCH_TRANSLATIONS')
-    def test_get_platform_from_gcc_triplet(self, mock_arch_translations):
-        archs = {'foo': {'triplet': 'bar-linux-gnu'}}
-        mock_arch_translations.items.side_effect = archs.items
-        self.assertEqual(
-            _options._get_platform_from_gcc_triplet('bar-linux-gnu'), 'foo')
-
-    @mock.patch('snapcraft._options._ARCH_TRANSLATIONS')
-    def test_get_platform_from_gcc_triplet_overriding(
-            self, mock_arch_translations):
-        archs = {
-            'foo': {
-                'triplet': 'bar-linux-gnu',
-                'gcc_triplet': 'barbar-linux-gnu'
-            }
-        }
-        mock_arch_translations.items.side_effect = archs.items
-        self.assertEqual(
-            _options._get_platform_from_gcc_triplet('barbar-linux-gnu'), 'foo')
-
-    @mock.patch('snapcraft._options._ARCH_TRANSLATIONS')
-    def test_get_platform_from_gcc_triplet_invalid(
-            self, mock_arch_translations):
-        archs = {
-            'foo': {
-                'triplet': 'bar-linux-gnu',
-                'gcc_triplet': 'barbar-linux-gnu'
-            }
-        }
-        mock_arch_translations.items.side_effect = archs.items
-        self.assertIsNone(
-            _options._get_platform_from_gcc_triplet('foo-linux-gnu'))

--- a/snapcraft/tests/test_options.py
+++ b/snapcraft/tests/test_options.py
@@ -29,6 +29,12 @@ class OptionsTestCase(tests.TestCase):
             expected_arch_triplet='x86_64-linux-gnu',
             expected_deb_arch='amd64',
             expected_kernel_arch='x86')),
+        ('amd64-kernel-i686-userspace', dict(
+            machine='x86_64',
+            architecture=('32bit', 'ELF'),
+            expected_arch_triplet='i386-linux-gnu',
+            expected_deb_arch='i386',
+            expected_kernel_arch='x86')),
         ('i686', dict(
             machine='i686',
             architecture=('32bit', 'ELF'),
@@ -47,6 +53,12 @@ class OptionsTestCase(tests.TestCase):
             expected_arch_triplet='aarch64-linux-gnu',
             expected_deb_arch='arm64',
             expected_kernel_arch='arm64')),
+        ('aarch64-kernel-armv7l-userspace', dict(
+            machine='aarch64',
+            architecture=('32bit', 'ELF'),
+            expected_arch_triplet='arm-linux-gnueabihf',
+            expected_deb_arch='armhf',
+            expected_kernel_arch='arm')),
         ('ppc', dict(
             machine='ppc',
             architecture=('32bit', 'ELF'),
@@ -58,6 +70,12 @@ class OptionsTestCase(tests.TestCase):
             architecture=('64bit', 'ELF'),
             expected_arch_triplet='powerpc64le-linux-gnu',
             expected_deb_arch='ppc64el',
+            expected_kernel_arch='powerpc')),
+        ('ppc64le-kernel-ppc-userspace', dict(
+            machine='ppc64le',
+            architecture=('32bit', 'ELF'),
+            expected_arch_triplet='powerpc-linux-gnu',
+            expected_deb_arch='powerpc',
             expected_kernel_arch='powerpc')),
         ('s390x', dict(
             machine='s390x',

--- a/snapcraft/tests/test_options.py
+++ b/snapcraft/tests/test_options.py
@@ -17,7 +17,9 @@
 from unittest import mock
 
 import snapcraft
-from snapcraft import tests
+import subprocess
+
+from snapcraft import _options, tests
 
 
 class OptionsTestCase(tests.TestCase):
@@ -25,73 +27,196 @@ class OptionsTestCase(tests.TestCase):
     scenarios = [
         ('amd64', dict(
             machine='x86_64',
-            architecture=('64bit', 'ELF'),
+            gcc_target='x86_64-linux-gnu',
             expected_arch_triplet='x86_64-linux-gnu',
             expected_deb_arch='amd64',
             expected_kernel_arch='x86')),
         ('amd64-kernel-i686-userspace', dict(
             machine='x86_64',
-            architecture=('32bit', 'ELF'),
+            gcc_target='i386-linux-gnu',
             expected_arch_triplet='i386-linux-gnu',
             expected_deb_arch='i386',
             expected_kernel_arch='x86')),
         ('i686', dict(
             machine='i686',
-            architecture=('32bit', 'ELF'),
+            gcc_target='i686-linux-gnu',
             expected_arch_triplet='i386-linux-gnu',
             expected_deb_arch='i386',
             expected_kernel_arch='x86')),
         ('armv7l', dict(
             machine='armv7l',
-            architecture=('32bit', 'ELF'),
+            gcc_target='arm-linux-gnueabihf',
             expected_arch_triplet='arm-linux-gnueabihf',
             expected_deb_arch='armhf',
             expected_kernel_arch='arm')),
         ('aarch64', dict(
             machine='aarch64',
-            architecture=('64bit', 'ELF'),
+            gcc_target='aarch64-linux-gnu',
             expected_arch_triplet='aarch64-linux-gnu',
             expected_deb_arch='arm64',
             expected_kernel_arch='arm64')),
         ('aarch64-kernel-armv7l-userspace', dict(
             machine='aarch64',
-            architecture=('32bit', 'ELF'),
+            gcc_target='arm-linux-gnueabihf',
             expected_arch_triplet='arm-linux-gnueabihf',
             expected_deb_arch='armhf',
             expected_kernel_arch='arm')),
         ('ppc', dict(
             machine='ppc',
-            architecture=('32bit', 'ELF'),
+            gcc_target='powerpc-linux-gnu',
             expected_arch_triplet='powerpc-linux-gnu',
             expected_deb_arch='powerpc',
             expected_kernel_arch='powerpc')),
         ('ppc64le', dict(
             machine='ppc64le',
-            architecture=('64bit', 'ELF'),
+            gcc_target='powerpc64le-linux-gnu',
             expected_arch_triplet='powerpc64le-linux-gnu',
             expected_deb_arch='ppc64el',
             expected_kernel_arch='powerpc')),
         ('ppc64le-kernel-ppc-userspace', dict(
             machine='ppc64le',
-            architecture=('32bit', 'ELF'),
+            gcc_target='powerpc-linux-gnu',
             expected_arch_triplet='powerpc-linux-gnu',
             expected_deb_arch='powerpc',
             expected_kernel_arch='powerpc')),
         ('s390x', dict(
             machine='s390x',
-            architecture=('64bit', 'ELF'),
+            gcc_target='s390x-linux-gnu',
             expected_arch_triplet='s390x-linux-gnu',
             expected_deb_arch='s390x',
             expected_kernel_arch='s390x'))
     ]
 
-    @mock.patch('platform.architecture')
+    @mock.patch('subprocess.PIPE')
+    @mock.patch('subprocess.run')
     @mock.patch('platform.machine')
-    def test_architecture_options(self,
-            mock_platform_machine, mock_platform_architecture):
+    def test_architecture_options(
+            self, mock_platform_machine,
+            mock_subprocess_run, mock_subprocess_pipe):
         mock_platform_machine.return_value = self.machine
-        mock_platform_architecture.return_value = self.architecture
+        mock_subprocess_run.return_value = mock.MagicMock(stderr=str.encode("""
+COLLECT_GCC=gcc
+COLLECT_LTO_WRAPPER=/usr/lib/gcc/{target}/5/lto-wrapper
+Target: {target}
+Configured with: ../src/configure -v
+Thread model: posix
+gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)
+            """.format(target=self.gcc_target)))
+
         options = snapcraft.ProjectOptions()
+        mock_subprocess_run.assert_called_once_with(
+            ['gcc', '-v'], stderr=mock_subprocess_pipe)
         self.assertEqual(options.arch_triplet, self.expected_arch_triplet)
         self.assertEqual(options.deb_arch, self.expected_deb_arch)
         self.assertEqual(options.kernel_arch, self.expected_kernel_arch)
+
+    @mock.patch('subprocess.PIPE')
+    @mock.patch('subprocess.run')
+    @mock.patch('platform.machine')
+    def test_architecture_options_from_platform(
+            self, mock_platform_machine, mock_subprocess_run,
+            mock_subprocess_pipe):
+        mock_platform_machine.return_value = self.machine
+        mock_subprocess_run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd=['gcc', '-v'])
+
+        options = snapcraft.ProjectOptions()
+        mock_subprocess_run.assert_called_once_with(
+            ['gcc', '-v'], stderr=mock_subprocess_pipe)
+
+        if self.id().endswith('-userspace)'):
+            self.skipTest(
+                reason='unsupported platform with mismatching userspace')
+
+        self.assertEqual(options.arch_triplet, self.expected_arch_triplet)
+        self.assertEqual(options.deb_arch, self.expected_deb_arch)
+        self.assertEqual(options.kernel_arch, self.expected_kernel_arch)
+
+
+class GccTargetTests(tests.TestCase):
+
+    @mock.patch('subprocess.PIPE')
+    @mock.patch('subprocess.run')
+    def test_gcc_target_parsing(
+            self, mock_subprocess_run, mock_subprocess_pipe):
+        mock_subprocess_run.return_value = mock.MagicMock(stderr=(b"""
+COLLECT_GCC=gcc
+COLLECT_LTO_WRAPPER=/usr/lib/gcc/my-awesome-target/5/lto-wrapper
+Target: my-awesome-target
+Configured with: ../src/configure -v
+Thread model: posix
+gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)
+            """))
+
+        self.assertEqual(_options._get_gcc_target(), 'my-awesome-target')
+
+    @mock.patch('subprocess.PIPE')
+    @mock.patch('subprocess.run')
+    def test_gcc_target_missing(
+            self, mock_subprocess_run, mock_subprocess_pipe):
+        mock_subprocess_run.return_value = mock.MagicMock(stderr=(b"""
+COLLECT_GCC=gcc
+Configured with: ../src/configure -v
+Thread model: posix
+gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)
+            """))
+
+        self.assertIsNone(_options._get_gcc_target())
+
+    @mock.patch('subprocess.PIPE')
+    @mock.patch('subprocess.run')
+    def test_gcc_target_empty(
+            self, mock_subprocess_run, mock_subprocess_pipe):
+        mock_subprocess_run.return_value = mock.MagicMock(stderr=(b"""
+COLLECT_GCC=gcc
+Target:
+Configured with: ../src/configure -v
+Thread model: posix
+gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)
+            """))
+
+        self.assertIsNone(_options._get_gcc_target())
+
+    @mock.patch('subprocess.PIPE')
+    @mock.patch('subprocess.run')
+    def test_get_gcc_target_call_fails(
+            self, mock_subprocess_run, mock_subprocess_pipe):
+        mock_subprocess_run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd=['gcc', '-v'])
+
+        self.assertIsNone(_options._get_gcc_target())
+        mock_subprocess_run.assert_called_once_with(
+            ['gcc', '-v'], stderr=mock_subprocess_pipe)
+
+    @mock.patch('snapcraft._options._ARCH_TRANSLATIONS')
+    def test_get_platform_from_gcc_triplet(self, mock_arch_translations):
+        archs = {'foo': {'triplet': 'bar-linux-gnu'}}
+        mock_arch_translations.items.side_effect = archs.items
+        self.assertEqual(
+            _options._get_platform_from_gcc_triplet('bar-linux-gnu'), 'foo')
+
+    @mock.patch('snapcraft._options._ARCH_TRANSLATIONS')
+    def test_get_platform_from_gcc_triplet_overriding(
+            self, mock_arch_translations):
+        archs = {
+            'foo': {
+                'triplet': 'bar-linux-gnu',
+                'gcc_triplet': 'barbar-linux-gnu'
+            }
+        }
+        mock_arch_translations.items.side_effect = archs.items
+        self.assertEqual(
+            _options._get_platform_from_gcc_triplet('barbar-linux-gnu'), 'foo')
+
+    @mock.patch('snapcraft._options._ARCH_TRANSLATIONS')
+    def test_get_platform_from_gcc_triplet_invalid(
+            self, mock_arch_translations):
+        archs = {
+            'foo': {
+                'triplet': 'bar-linux-gnu',
+                'gcc_triplet': 'barbar-linux-gnu'
+            }
+        }
+        mock_arch_translations.items.side_effect = archs.items
+        self.assertIsNone(
+            _options._get_platform_from_gcc_triplet('foo-linux-gnu'))

--- a/snapcraft/tests/test_options.py
+++ b/snapcraft/tests/test_options.py
@@ -95,3 +95,19 @@ class OptionsTestCase(tests.TestCase):
         self.assertEqual(options.arch_triplet, self.expected_arch_triplet)
         self.assertEqual(options.deb_arch, self.expected_deb_arch)
         self.assertEqual(options.kernel_arch, self.expected_kernel_arch)
+
+    @mock.patch('platform.architecture')
+    @mock.patch('platform.machine')
+    def test_get_platform_architecture(
+            self, mock_platform_machine, mock_platform_architecture):
+        mock_platform_machine.return_value = self.machine
+        mock_platform_architecture.return_value = self.architecture
+        platform_arch = snapcraft._options._get_platform_architecture()
+        userspace_conversions = snapcraft._options._USERSPACE_ARCHITECTURE
+
+        if self.architecture[0] == '32bit' and \
+           self.machine in userspace_conversions:
+            self.assertEqual(
+                platform_arch, userspace_conversions[self.machine])
+        else:
+            self.assertEqual(platform_arch, self.machine)

--- a/snapcraft/tests/test_options.py
+++ b/snapcraft/tests/test_options.py
@@ -25,44 +25,54 @@ class OptionsTestCase(tests.TestCase):
     scenarios = [
         ('amd64', dict(
             machine='x86_64',
+            architecture=('64bit', 'ELF'),
             expected_arch_triplet='x86_64-linux-gnu',
             expected_deb_arch='amd64',
             expected_kernel_arch='x86')),
         ('i686', dict(
             machine='i686',
+            architecture=('32bit', 'ELF'),
             expected_arch_triplet='i386-linux-gnu',
             expected_deb_arch='i386',
             expected_kernel_arch='x86')),
         ('armv7l', dict(
             machine='armv7l',
+            architecture=('32bit', 'ELF'),
             expected_arch_triplet='arm-linux-gnueabihf',
             expected_deb_arch='armhf',
             expected_kernel_arch='arm')),
         ('aarch64', dict(
             machine='aarch64',
+            architecture=('64bit', 'ELF'),
             expected_arch_triplet='aarch64-linux-gnu',
             expected_deb_arch='arm64',
             expected_kernel_arch='arm64')),
         ('ppc', dict(
             machine='ppc',
+            architecture=('32bit', 'ELF'),
             expected_arch_triplet='powerpc-linux-gnu',
             expected_deb_arch='powerpc',
             expected_kernel_arch='powerpc')),
         ('ppc64le', dict(
             machine='ppc64le',
+            architecture=('64bit', 'ELF'),
             expected_arch_triplet='powerpc64le-linux-gnu',
             expected_deb_arch='ppc64el',
             expected_kernel_arch='powerpc')),
         ('s390x', dict(
             machine='s390x',
+            architecture=('64bit', 'ELF'),
             expected_arch_triplet='s390x-linux-gnu',
             expected_deb_arch='s390x',
             expected_kernel_arch='s390x'))
     ]
 
+    @mock.patch('platform.architecture')
     @mock.patch('platform.machine')
-    def test_architecture_options(self, mock_platform_machine):
+    def test_architecture_options(self,
+            mock_platform_machine, mock_platform_architecture):
         mock_platform_machine.return_value = self.machine
+        mock_platform_architecture.return_value = self.architecture
         options = snapcraft.ProjectOptions()
         self.assertEqual(options.arch_triplet, self.expected_arch_triplet)
         self.assertEqual(options.deb_arch, self.expected_deb_arch)

--- a/snapcraft/tests/test_project_loader.py
+++ b/snapcraft/tests/test_project_loader.py
@@ -332,8 +332,9 @@ parts:
         mock_load.assert_has_calls([call1, call2], any_order=True)
 
     def test_config_adds_extra_build_tools_when_cross_compiling(self):
-        with unittest.mock.patch('platform.machine') as machine_mock:
-            machine_mock.return_value = 'x86_64'
+        with unittest.mock.patch(
+                'snapcraft._options._get_platform_machine') as mock_platform:
+            mock_platform.return_value = 'x86_64'
             project_options = snapcraft.ProjectOptions(target_deb_arch='armhf')
 
         yaml = """name: test

--- a/snapcraft/tests/test_project_loader.py
+++ b/snapcraft/tests/test_project_loader.py
@@ -332,9 +332,10 @@ parts:
         mock_load.assert_has_calls([call1, call2], any_order=True)
 
     def test_config_adds_extra_build_tools_when_cross_compiling(self):
-        with unittest.mock.patch(
-                'snapcraft._options._get_platform_machine') as mock_platform:
-            mock_platform.return_value = 'x86_64'
+        with unittest.mock.patch('platform.machine') as machine_mock, \
+             unittest.mock.patch('platform.architecture') as arch_mock:
+            arch_mock.return_value = ('64bit', 'ELF')
+            machine_mock.return_value = 'x86_64'
             project_options = snapcraft.ProjectOptions(target_deb_arch='armhf')
 
         yaml = """name: test


### PR DESCRIPTION
It might happen in 32bit containers running on 64bit hosts, that
they are detected as 64bit systems since platform's machine()
returns the kernel's architecture, not the userspace one.

Using `gcc -v` `Target:`'s value instead

LP: [#1641123](https://bugs.launchpad.net/snapcraft/+bug/1641123)
