### PR TITLE
Fix Exec key in desktop files for apps named like their parent package (LP: #1658123).

### DIFF
--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -305,20 +305,18 @@ class _SnapPackaging:
         if desktop_file_name:
             desktop_file = _DesktopFile(
                 name=name, filename=desktop_file_name,
-                snap_name=self._config_data['name'], prime_dir=self._snap_dir,
-                gui_dir=os.path.join(self.meta_dir, 'gui'))
+                snap_name=self._config_data['name'], prime_dir=self._snap_dir)
             desktop_file.parse_and_reformat()
-            desktop_file.write()
+            desktop_file.write(gui_dir=os.path.join(self.meta_dir, 'gui'))
 
 
 class _DesktopFile:
 
-    def __init__(self, *, name, filename, snap_name, prime_dir, gui_dir):
+    def __init__(self, *, name, filename, snap_name, prime_dir):
         self._name = name
         self._filename = filename
         self._snap_name = snap_name
         self._prime_dir = prime_dir
-        self._gui_dir = gui_dir
         self._path = os.path.join(prime_dir, filename)
         if not os.path.exists(self._path):
             raise EnvironmentError(
@@ -355,8 +353,8 @@ class _DesktopFile:
                         'Icon {} specified in desktop file {} not found '
                         'in prime directory'.format(icon, self._filename))
 
-    def write(self):
-        target = os.path.join(self._gui_dir, os.path.basename(self._filename))
+    def write(self, *, gui_dir):
+        target = os.path.join(gui_dir, os.path.basename(self._filename))
         if os.path.exists(target):
             raise EnvironmentError(
                 'Conflicting desktop file referenced by more than one '

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -325,7 +325,9 @@ class _SnapPackaging:
                 'The specified desktop file {!r} is missing the '
                 '"Exec" key'.format(desktop_file))
         # XXX: do we want to allow more parameters for Exec?
-        exec_value = '{}.{} %U'.format(self._config_data['name'], name)
+        snap_name = self._config_data['name']
+        exec_value = '{} %U'.format(
+            name if name == snap_name else '{}.{}'.format(snap_name, name))
         desktop_contents[section]['Exec'] = exec_value
         if 'Icon' in desktop_contents[section]:
             icon = desktop_contents[section]['Icon']

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -256,9 +256,12 @@ class CreateTestCase(CreateBaseTestCase):
         open(os.path.join(icon_dir, 'app2.png'), 'w').close()
         with open(os.path.join(self.prime_dir, 'app2.desktop'), 'w') as f:
             f.write('[Desktop Entry]\nExec=app2.exe\nIcon=/usr/share/app2.png')
+        with open(os.path.join(self.prime_dir, 'app3.desktop'), 'w') as f:
+            f.write('[Desktop Entry]\nExec=app3.exe\nIcon=app3.png')
         self.config_data['apps'] = {
             'app1': {'command': 'app.sh', 'desktop': 'app1.desktop'},
-            'app2': {'command': 'app.sh', 'desktop': 'app2.desktop'}
+            'app2': {'command': 'app.sh', 'desktop': 'app2.desktop'},
+            'my-package': {'command': 'app.sh', 'desktop': 'app3.desktop'}
         }
 
         self.generate_meta_yaml()
@@ -284,10 +287,21 @@ class CreateTestCase(CreateBaseTestCase):
         self.assertEqual(contents[section].get('Icon'),
                          '${SNAP}/usr/share/app2.png')
 
+        desktop_file = os.path.join(self.meta_dir, 'gui', 'app3.desktop')
+        self.assertTrue(os.path.exists(desktop_file),
+                        'app3.desktop was not setup correctly')
+        contents = configparser.ConfigParser(interpolation=None)
+        contents.read(desktop_file)
+        section = 'Desktop Entry'
+        self.assertTrue(section in contents)
+        self.assertEqual(contents[section].get('Exec'), 'my-package %U')
+
         self.assertThat(os.path.join('prime', 'meta', 'snap.yaml'),
                         Not(FileContains('desktop: app1.desktop')))
         self.assertThat(os.path.join('prime', 'meta', 'snap.yaml'),
                         Not(FileContains('desktop: app2.desktop')))
+        self.assertThat(os.path.join('prime', 'meta', 'snap.yaml'),
+                        Not(FileContains('desktop: app3.desktop')))
 
     def test_create_meta_with_hook(self):
         hooksdir = os.path.join(self.snap_dir, 'hooks')


### PR DESCRIPTION
https://bugs.launchpad.net/snapcraft/+bug/1658123