### PR TITLE
file_utils: copy symlinks to directories as symlinks.

### DIFF
--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -109,6 +109,13 @@ def link_or_copy_tree(source_tree, destination_tree,
     for root, directories, files in os.walk(source_tree):
         for directory in directories:
             source = os.path.join(root, directory)
+            # os.walk doesn't by default follow symlinks (which is good), but
+            # it includes symlinks that are pointing to directories in the
+            # directories list. We want to treat it as a file, here.
+            if os.path.islink(source):
+                files.append(directory)
+                continue
+
             destination = os.path.join(
                 destination_tree, os.path.relpath(source, source_tree))
 

--- a/snapcraft/tests/__init__.py
+++ b/snapcraft/tests/__init__.py
@@ -65,6 +65,36 @@ class IsExecutable:
         return None
 
 
+class LinkExists:
+    """Match if a file path is a symlink."""
+
+    def __init__(self, expected_target=None):
+        self._expected_target = expected_target
+
+    def __str__(self):
+        return 'LinkExists()'
+
+    def match(self, file_path):
+        if not os.path.exists(file_path):
+            return testtools.matchers.Mismatch(
+                "Expected {!r} to be a symlink, but it doesn't exist".format(
+                    file_path))
+
+        if not os.path.islink(file_path):
+            return testtools.matchers.Mismatch(
+                'Expected {!r} to be a symlink, but it was not'.format(
+                    file_path))
+
+        target = os.readlink(file_path)
+        if target != self._expected_target:
+            return testtools.matchers.Mismatch(
+                'Expected {!r} to be a symlink pointing to {!r}, but it was '
+                'pointing to {!r}'.format(
+                    file_path, self._expected_target, target))
+
+        return None
+
+
 class TestCase(testscenarios.WithScenarios, testtools.TestCase):
 
     def setUp(self):

--- a/snapcraft/tests/test_file_utils.py
+++ b/snapcraft/tests/test_file_utils.py
@@ -133,6 +133,22 @@ class TestLinkOrCopyTree(tests.TestCase):
         self.assertTrue(os.path.isfile(os.path.join('qux', '3')))
         self.assertTrue(os.path.isfile(os.path.join('qux', 'baz', '4')))
 
+    def test_link_symlink_to_file(self):
+        # Create a symlink to a file
+        os.symlink('2', os.path.join('foo', '2-link'))
+        file_utils.link_or_copy_tree('foo', 'qux')
+
+        # Verify that the symlink remains a symlink
+        self.assertThat(os.path.join('qux', '2-link'), tests.LinkExists('2'))
+
+    def test_link_symlink_to_dir(self):
+        os.symlink('bar', os.path.join('foo', 'bar-link'))
+        file_utils.link_or_copy_tree('foo', 'qux')
+
+        # Verify that the symlink remains a symlink
+        self.assertThat(
+            os.path.join('qux', 'bar-link'), tests.LinkExists('bar'))
+
 
 class TestLinkOrCopy(tests.TestCase):
 


### PR DESCRIPTION
This PR fixes LP: [#1658155](https://bugs.launchpad.net/snapcraft/+bug/1658155) by ensuring that `file_utils.link_or_copy_tree()` handles symlinks to directories the same way it handles symlinks to files.