### PR TITLE
store: don't recommend 2FA as it's not available.

### DIFF
--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -155,9 +155,6 @@ class StoreTestCase(TestCase):
         process.sendline(email)
         process.expect_exact('Password: ')
         process.sendline(password)
-        if expect_success:
-            process.expect_exact(
-                'We strongly recommend enabling multi-factor authentication:')
         result = 'successful' if expect_success else 'failed'
         process.expect_exact('Login {}.'.format(result))
 
@@ -192,8 +189,6 @@ class StoreTestCase(TestCase):
         process.expect_exact('Password: ')
         process.sendline(password)
         if expect_success:
-            process.expect_exact(
-                'We strongly recommend enabling multi-factor authentication:')
             process.expect_exact('Login successful.')
             process.expect(
                 r'Done\. The key "{}" .* may be used to sign your '

--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -116,8 +116,6 @@ def _login(store, packages=None, acls=None, channels=None, save=True):
         try:
             store.login(email, password, packages=packages, acls=acls,
                         channels=channels, save=save)
-            print()
-            logger.info(storeapi.constants.TWO_FACTOR_WARNING)
         except storeapi.errors.StoreTwoFactorAuthenticationRequired:
             one_time_password = input('Second-factor auth: ')
             store.login(

--- a/snapcraft/storeapi/constants.py
+++ b/snapcraft/storeapi/constants.py
@@ -43,9 +43,6 @@ AGREEMENT_SIGN_ERROR = (
     'Unexpected error encountered during signing the developer terms and '
     'conditions. Please visit {} and agree to the terms and conditions before '
     'continuing.')
-TWO_FACTOR_WARNING = (
-    'We strongly recommend enabling multi-factor authentication: '
-    'https://help.ubuntu.com/community/SSO/FAQs/2FA')
 INVALID_CREDENTIALS = 'Invalid credentials supplied.'
 AUTHENTICATION_ERROR = ('Problems encountered when authenticating your '
                         'credentials.')

--- a/snapcraft/tests/commands/test_login.py
+++ b/snapcraft/tests/commands/test_login.py
@@ -60,7 +60,6 @@ class LoginCommandTestCase(tests.TestCase):
             'user@example.com', mock.ANY, acls=None, packages=None,
             channels=None, save=True)
         self.assertEqual(
-            storeapi.constants.TWO_FACTOR_WARNING + '\n' +
             'Login successful.\n',
             self.fake_logger.output)
 
@@ -149,7 +148,6 @@ class LoginCommandTestCase(tests.TestCase):
         main(['login'])
 
         self.assertEqual((
-            storeapi.constants.TWO_FACTOR_WARNING + '\n' +
             storeapi.constants.AGREEMENT_ERROR +
             '\nLogin failed.\n'),
             self.fake_logger.output)
@@ -174,7 +172,6 @@ class LoginCommandTestCase(tests.TestCase):
         main(['login'])
 
         self.assertEqual((
-            storeapi.constants.TWO_FACTOR_WARNING + '\n' +
             storeapi.constants.NAMESPACE_ERROR.format('http://fake-url.com') +
             '\nLogin failed.\n'),
             self.fake_logger.output)
@@ -199,7 +196,6 @@ class LoginCommandTestCase(tests.TestCase):
         main(['login'])
 
         self.assertEqual(
-            storeapi.constants.TWO_FACTOR_WARNING + '\n' +
             storeapi.constants.ACCOUNT_INFORMATION_ERROR +
             '\nLogin failed.\n',
             self.fake_logger.output)
@@ -227,7 +223,6 @@ class LoginCommandTestCase(tests.TestCase):
                 'http://fake-url.com'))
 
         self.assertEqual((
-            storeapi.constants.TWO_FACTOR_WARNING + '\n' +
             storeapi.constants.AGREEMENT_ERROR +
             '\nLogin failed.\n'),
             self.fake_logger.output)
@@ -253,7 +248,6 @@ class LoginCommandTestCase(tests.TestCase):
         main(['login'])
 
         self.assertEqual((
-            storeapi.constants.TWO_FACTOR_WARNING + '\n' +
             storeapi.constants.AGREEMENT_ERROR +
             '\nLogin failed.\n'),
             self.fake_logger.output)
@@ -279,7 +273,6 @@ class LoginCommandTestCase(tests.TestCase):
         main(['login'])
 
         self.assertEqual((
-            storeapi.constants.TWO_FACTOR_WARNING + '\n' +
             storeapi.constants.AGREEMENT_SIGN_ERROR.format(
                 'http://fake-url.com') +
             '\nLogin failed.\n'),
@@ -307,7 +300,6 @@ class LoginCommandTestCase(tests.TestCase):
         main(['login'])
 
         self.assertEqual((
-            storeapi.constants.TWO_FACTOR_WARNING + '\n' +
             storeapi.constants.ACCOUNT_INFORMATION_ERROR +
             '\nLogin failed.\n'),
             self.fake_logger.output)

--- a/snapcraft/tests/commands/test_register_key.py
+++ b/snapcraft/tests/commands/test_register_key.py
@@ -278,8 +278,6 @@ class RegisterKeyTestCase(tests.TestCase):
             [mock.call('Key number: '), mock.call('Key number: ')])
 
         self.assertEqual(
-            'We strongly recommend enabling multi-factor authentication: '
-            'https://help.ubuntu.com/community/SSO/FAQs/2FA\n'
             'Login successful.\n'
             'Registering key ...\n'
             'Done. The key "another" ({}) may be used to sign your '


### PR DESCRIPTION
This PR fixes LP: [#1635567](https://bugs.launchpad.net/snapcraft/+bug/1635567) by removing the strong recommendation to use two-factor authentication. Ideally that would simply be made available for everyone to use, but until then, we shouldn't recommend it.