### PR TITLE
Download all Python packages in the python plugin using one command.

### DIFF
--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -191,23 +191,26 @@ class PythonPlugin(snapcraft.BasePlugin):
         return env
 
     def _get_commands(self, setup):
-        commands = []
+        args = []
+        cwd = None
         if self.options.requirements:
             requirements = self.options.requirements
             if not isurl(requirements):
                 requirements = os.path.join(self.sourcedir,
                                             self.options.requirements)
 
-            commands.append(dict(args=['--requirement', requirements]))
+            args.extend(['--requirement', requirements])
+        if os.path.exists(setup):
+            args.append('.')
+            cwd = os.path.dirname(setup)
 
         if self.options.python_packages:
-            commands.append(dict(args=self.options.python_packages))
+            args.extend(self.options.python_packages)
 
-        if os.path.exists(setup):
-            cwd = os.path.dirname(setup)
-            commands.append(dict(args=['.'], cwd=cwd))
-
-        return commands
+        if args:
+            return [dict(args=args, cwd=cwd)]
+        else:
+            return []
 
     def _run_pip(self, setup, download=False):
         self._install_pip(download)


### PR DESCRIPTION
Before, there was one command for downloading the packages in
requirements file, one for the ones in setup.py, and one for downloading
the manually specified packages.

That broke the case where you specify high-level dependencies in
setup.py without version-specific contstraints and use requirements.txt
to pin the packages to specific versions. The end result was that even
though packages were pinned in requirements.txt, snapcraft would
download the latest versions of packages.

LP: [#1659234](https://bugs.launchpad.net/snapcraft/+bug/1659234)