### PR TITLE
Rename desktop files to match the app names.

### DIFF
--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -354,11 +354,14 @@ class _DesktopFile:
                         'in prime directory'.format(icon, self._filename))
 
     def write(self, *, gui_dir):
-        target = os.path.join(gui_dir, os.path.basename(self._filename))
+        # Rename the desktop file to match the app name. This will help
+        # unity8 associate them (https://launchpad.net/bugs/1659330).
+        target_filename = '{}.desktop'.format(self._name)
+        target = os.path.join(gui_dir, target_filename)
         if os.path.exists(target):
-            raise EnvironmentError(
-                'Conflicting desktop file referenced by more than one '
-                'app: {!r}'.format(self._filename))
+            # Unlikely. A desktop file in setup/gui/ already existed for
+            # this app. Let's pretend it wasn't there and overwrite it.
+            os.remove(target)
         with open(target, 'w') as f:
             self._parser.write(f, space_around_delimiters=False)
 

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -287,9 +287,9 @@ class CreateTestCase(CreateBaseTestCase):
         self.assertEqual(contents[section].get('Icon'),
                          '${SNAP}/usr/share/app2.png')
 
-        desktop_file = os.path.join(self.meta_dir, 'gui', 'app3.desktop')
+        desktop_file = os.path.join(self.meta_dir, 'gui', 'my-package.desktop')
         self.assertTrue(os.path.exists(desktop_file),
-                        'app3.desktop was not setup correctly')
+                        'my-package.desktop was not setup correctly')
         contents = configparser.ConfigParser(interpolation=None)
         contents.read(desktop_file)
         section = 'Desktop Entry'
@@ -302,6 +302,8 @@ class CreateTestCase(CreateBaseTestCase):
                         Not(FileContains('desktop: app2.desktop')))
         self.assertThat(os.path.join('prime', 'meta', 'snap.yaml'),
                         Not(FileContains('desktop: app3.desktop')))
+        self.assertThat(os.path.join('prime', 'meta', 'snap.yaml'),
+                        Not(FileContains('desktop: my-package.desktop')))
 
     def test_create_meta_with_hook(self):
         hooksdir = os.path.join(self.snap_dir, 'hooks')

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -267,8 +267,7 @@ class CreateTestCase(CreateBaseTestCase):
         self.generate_meta_yaml()
 
         desktop_file = os.path.join(self.meta_dir, 'gui', 'app1.desktop')
-        self.assertTrue(os.path.exists(desktop_file),
-                        'app1.desktop was not setup correctly')
+        self.assertThat(desktop_file, FileExists())
         contents = configparser.ConfigParser(interpolation=None)
         contents.read(desktop_file)
         section = 'Desktop Entry'
@@ -277,8 +276,7 @@ class CreateTestCase(CreateBaseTestCase):
         self.assertEqual(contents[section].get('Icon'), 'app1.png')
 
         desktop_file = os.path.join(self.meta_dir, 'gui', 'app2.desktop')
-        self.assertTrue(os.path.exists(desktop_file),
-                        'app2.desktop was not setup correctly')
+        self.assertThat(desktop_file, FileExists())
         contents = configparser.ConfigParser(interpolation=None)
         contents.read(desktop_file)
         section = 'Desktop Entry'
@@ -288,21 +286,18 @@ class CreateTestCase(CreateBaseTestCase):
                          '${SNAP}/usr/share/app2.png')
 
         desktop_file = os.path.join(self.meta_dir, 'gui', 'my-package.desktop')
-        self.assertTrue(os.path.exists(desktop_file),
-                        'my-package.desktop was not setup correctly')
+        self.assertThat(desktop_file, FileExists())
         contents = configparser.ConfigParser(interpolation=None)
         contents.read(desktop_file)
         section = 'Desktop Entry'
         self.assertTrue(section in contents)
         self.assertEqual(contents[section].get('Exec'), 'my-package %U')
 
-        self.assertThat(os.path.join('prime', 'meta', 'snap.yaml'),
-                        Not(FileContains('desktop: app1.desktop')))
-        self.assertThat(os.path.join('prime', 'meta', 'snap.yaml'),
-                        Not(FileContains('desktop: app2.desktop')))
-        self.assertThat(os.path.join('prime', 'meta', 'snap.yaml'),
-                        Not(FileContains('desktop: app3.desktop')))
-        self.assertThat(os.path.join('prime', 'meta', 'snap.yaml'),
+        snap_yaml = os.path.join('prime', 'meta', 'snap.yaml')
+        self.assertThat(snap_yaml, Not(FileContains('desktop: app1.desktop')))
+        self.assertThat(snap_yaml, Not(FileContains('desktop: app2.desktop')))
+        self.assertThat(snap_yaml, Not(FileContains('desktop: app3.desktop')))
+        self.assertThat(snap_yaml,
                         Not(FileContains('desktop: my-package.desktop')))
 
     def test_create_meta_with_hook(self):


### PR DESCRIPTION
This will help unity8 associate them (LP: #1659330).