### PR TITLE
travis: allow to pass --channels parameter to generate proper config

### DIFF
--- a/snapcraft/integrations/__init__.py
+++ b/snapcraft/integrations/__init__.py
@@ -27,7 +27,7 @@ SUPPORTED_CI_SYSTEMS = (
 )
 
 
-def enable_ci(ci_system, refresh_only):
+def enable_ci(ci_system, refresh_only, channels):
     if not ci_system:
         # XXX cprov 20161116: we could possibly auto-detect currently
         # integration systems in master ?
@@ -46,8 +46,8 @@ def enable_ci(ci_system, refresh_only):
         'snapcraft.integrations.{}'.format(ci_system))
 
     if refresh_only:
-        module.refresh()
+        module.refresh(channels)
     else:
         print(module.__doc__)
         if input('Continue (y/N): ') == 'y':
-            module.enable()
+            module.enable(channels)

--- a/snapcraft/integrations/tests/test_travis.py
+++ b/snapcraft/integrations/tests/test_travis.py
@@ -139,7 +139,7 @@ class TravisSuccessfulTestCase(tests.TestCase):
 
     scenarios = [
         ('default', dict(
-            channels=None)),
+            channels=[])),
         ('edge', dict(
             channels=['edge'])),
         ('beta', dict(
@@ -166,7 +166,7 @@ class TravisSuccessfulTestCase(tests.TestCase):
 
         if not self.channels:
             self.use_default_arguments = True
-            self.channels = ['edge']
+            self.channels = travis.DEFAULT_CHANNELS
 
     def make_travis_yml(self, content):
         with open('.travis.yml', 'w') as fd:
@@ -193,7 +193,7 @@ class TravisSuccessfulTestCase(tests.TestCase):
         self.make_travis_yml('after_success: ["<travis-cli-decrypt>"]')
 
         if self.use_default_arguments:
-            travis.enable()
+            travis.enable(None)
         else:
             travis.enable(self.channels)
 
@@ -270,7 +270,7 @@ class TravisSuccessfulTestCase(tests.TestCase):
         self.make_travis_yml('after_success: ["<travis-cli-decrypt>"]')
 
         if self.use_default_arguments:
-            travis.refresh()
+            travis.refresh(None)
         else:
             travis.refresh(self.channels)
 

--- a/snapcraft/integrations/tests/test_travis.py
+++ b/snapcraft/integrations/tests/test_travis.py
@@ -208,7 +208,7 @@ class TravisSuccessfulTestCase(tests.TestCase):
         # Descriptive logging ...
         self.assertEqual([
             "Enabling Travis testbeds to push and release 'foo' snaps "
-            "to edge channel in series '16'",
+            "to channels 'edge' in series '16'",
             'Acquiring specific authorization information ...',
             'Login successful.',
             'Encrypting authorization for Travis and adjusting project '

--- a/snapcraft/integrations/tests/test_travis.py
+++ b/snapcraft/integrations/tests/test_travis.py
@@ -137,6 +137,25 @@ class TravisPreconditionsTestCase(tests.TestCase):
 
 class TravisSuccessfulTestCase(tests.TestCase):
 
+    scenarios = [
+        ('default', dict(
+            channels=None)),
+        ('edge', dict(
+            channels=['edge'])),
+        ('beta', dict(
+            channels=['beta'])),
+        ('candidate', dict(
+            channels=['candidate'])),
+        ('stable', dict(
+            channels=['stable'])),
+        ('edge, beta, candidate, stable', dict(
+            channels=['edge', 'beta', 'candidate', 'stable'])),
+        ('edge, beta', dict(
+            channels=['edge', 'beta'])),
+        ('beta, candidate, stable', dict(
+            channels=['beta', 'candidate'])),
+    ]
+
     def setUp(self):
         super().setUp()
         self.fake_logger = fixtures.FakeLogger(level=logging.DEBUG)
@@ -168,13 +187,17 @@ class TravisSuccessfulTestCase(tests.TestCase):
         self.make_snapcraft_yaml(test_snapcraft_yaml)
         self.make_travis_yml('after_success: ["<travis-cli-decrypt>"]')
 
-        travis.enable()
+        if self.channels:
+            travis.enable(self.channels)
+        else:
+            self.channels = ['edge']
+            travis.enable()
 
         # Attenuated credentials requested from the Store.
         mock_login.assert_called_with(
             'sample.person@canonical.com', 'secret',
             one_time_password='123456', acls=None, save=False,
-            channels=['edge'], packages=[{'series': '16', 'name': 'foo'}])
+            channels=self.channels, packages=[{'series': '16', 'name': 'foo'}])
 
         # Credentials encrypted with travis CLI.
         mock_check_output.assert_called_with(
@@ -199,7 +222,8 @@ class TravisSuccessfulTestCase(tests.TestCase):
                     'docker run -v $(pwd):$(pwd) -t ubuntu:xenial sh -c '
                     '"apt update -qq && apt install snapcraft -y && '
                     'cd $(pwd) && '
-                    'snapcraft && snapcraft push *.snap --release edge"'),
+                    'snapcraft && snapcraft push *.snap --release {}"'.format(
+                        ','.join(self.channels))),
                 'on': {
                     'branch': 'master',
                 },
@@ -208,7 +232,7 @@ class TravisSuccessfulTestCase(tests.TestCase):
         # Descriptive logging ...
         self.assertEqual([
             "Enabling Travis testbeds to push and release 'foo' snaps "
-            "to channels 'edge' in series '16'",
+            "to channels {!r} in series '16'".format(', '.join(self.channels)),
             'Acquiring specific authorization information ...',
             'Login successful.',
             'Encrypting authorization for Travis and adjusting project '
@@ -241,13 +265,17 @@ class TravisSuccessfulTestCase(tests.TestCase):
         self.make_snapcraft_yaml(test_snapcraft_yaml)
         self.make_travis_yml('after_success: ["<travis-cli-decrypt>"]')
 
-        travis.refresh()
+        if self.channels:
+            travis.refresh(self.channels)
+        else:
+            self.channels = ['edge']
+            travis.refresh()
 
         # Attenuated credentials requested from the Store.
         mock_login.assert_called_with(
             'sample.person@canonical.com', 'secret',
             one_time_password='123456', acls=None, save=False,
-            channels=['edge'], packages=[{'series': '16', 'name': 'foo'}])
+            channels=self.channels, packages=[{'series': '16', 'name': 'foo'}])
 
         # Credentials encrypted with travis CLI.
         mock_check_output.assert_called_with(
@@ -267,7 +295,7 @@ class TravisSuccessfulTestCase(tests.TestCase):
         # Descriptive logging ...
         self.assertEqual([
             'Refreshing credentials to push and release "foo" snaps to '
-            'edge channel in series 16',
+            'channels {!r} in series 16'.format(', '.join(self.channels)),
             'Acquiring specific authorization information ...',
             'Login successful.',
             'Encrypting authorization for Travis and adjusting project '

--- a/snapcraft/integrations/tests/test_travis.py
+++ b/snapcraft/integrations/tests/test_travis.py
@@ -162,6 +162,11 @@ class TravisSuccessfulTestCase(tests.TestCase):
         self.useFixture(self.fake_logger)
         self.fake_terminal = tests.fixture_setup.FakeTerminal()
         self.useFixture(self.fake_terminal)
+        self.use_default_arguments = False
+
+        if not self.channels:
+            self.use_default_arguments = True
+            self.channels = ['edge']
 
     def make_travis_yml(self, content):
         with open('.travis.yml', 'w') as fd:
@@ -187,11 +192,10 @@ class TravisSuccessfulTestCase(tests.TestCase):
         self.make_snapcraft_yaml(test_snapcraft_yaml)
         self.make_travis_yml('after_success: ["<travis-cli-decrypt>"]')
 
-        if self.channels:
-            travis.enable(self.channels)
-        else:
-            self.channels = ['edge']
+        if self.use_default_arguments:
             travis.enable()
+        else:
+            travis.enable(self.channels)
 
         # Attenuated credentials requested from the Store.
         mock_login.assert_called_with(
@@ -265,11 +269,10 @@ class TravisSuccessfulTestCase(tests.TestCase):
         self.make_snapcraft_yaml(test_snapcraft_yaml)
         self.make_travis_yml('after_success: ["<travis-cli-decrypt>"]')
 
-        if self.channels:
-            travis.refresh(self.channels)
-        else:
-            self.channels = ['edge']
+        if self.use_default_arguments:
             travis.refresh()
+        else:
+            travis.refresh(self.channels)
 
         # Attenuated credentials requested from the Store.
         mock_login.assert_called_with(

--- a/snapcraft/integrations/travis.py
+++ b/snapcraft/integrations/travis.py
@@ -172,16 +172,16 @@ def requires_travis_preconditions():
 
 
 @requires_travis_preconditions()
-def refresh():
+def refresh(channels=['edge']):
     series = storeapi.constants.DEFAULT_SERIES
     project_config = load_config()
     snap_name = project_config.data['name']
     logger.info(
         'Refreshing credentials to push and release "{}" snaps '
-        'to edge channel in series {}'.format(snap_name, series))
+        'to channels {!r} in series {}'.format(
+            snap_name, ', '.join(channels), series))
 
     packages = [{'name': snap_name, 'series': series}]
-    channels = ['edge']
     _acquire_and_encrypt_credentials(packages, channels)
 
     logger.info(
@@ -190,16 +190,16 @@ def refresh():
 
 
 @requires_travis_preconditions()
-def enable():
+def enable(channels=['edge']):
     series = storeapi.constants.DEFAULT_SERIES
     project_config = load_config()
     snap_name = project_config.data['name']
     logger.info(
         'Enabling Travis testbeds to push and release {!r} snaps '
-        'to edge channel in series {!r}'.format(snap_name, series))
+        'to channels {!r} in series {!r}'.format(
+            snap_name, ', '.join(channels), series))
 
     packages = [{'name': snap_name, 'series': series}]
-    channels = ['edge']
     _acquire_and_encrypt_credentials(packages, channels)
 
     logger.info(
@@ -220,7 +220,8 @@ def enable():
             'script': (
                 'docker run -v $(pwd):$(pwd) -t ubuntu:xenial sh -c '
                 '"apt update -qq && apt install snapcraft -y && cd $(pwd) && '
-                'snapcraft && snapcraft push *.snap --release edge"'),
+                'snapcraft && snapcraft push *.snap --release {}"'.format(
+                    ','.join(channels))),
             'on': {
                 'branch': 'master',
             },

--- a/snapcraft/integrations/travis.py
+++ b/snapcraft/integrations/travis.py
@@ -83,6 +83,7 @@ logger = logging.getLogger(__name__)
 
 TRAVIS_CONFIG_FILENAME = '.travis.yml'
 ENCRYPTED_CONFIG_FILENAME = '.snapcraft/travis_snapcraft.cfg'
+DEFAULT_CHANNELS = ['edge']
 
 
 class TravisRuntimeError(Exception):
@@ -172,7 +173,9 @@ def requires_travis_preconditions():
 
 
 @requires_travis_preconditions()
-def refresh(channels=['edge']):
+def refresh(channels):
+    if not channels:
+        channels = DEFAULT_CHANNELS
     series = storeapi.constants.DEFAULT_SERIES
     project_config = load_config()
     snap_name = project_config.data['name']
@@ -190,7 +193,9 @@ def refresh(channels=['edge']):
 
 
 @requires_travis_preconditions()
-def enable(channels=['edge']):
+def enable(channels):
+    if not channels:
+        channels = DEFAULT_CHANNELS
     series = storeapi.constants.DEFAULT_SERIES
     project_config = load_config()
     snap_name = project_config.data['name']

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -53,7 +53,7 @@ Usage:
   snapcraft [options] validate <snap-name> <validation>... [--key-name=<key-name>]
   snapcraft [options] define <part-name>
   snapcraft [options] search [<query> ...]
-  snapcraft [options] enable-ci [<ci-system>] [--refresh]
+  snapcraft [options] enable-ci [<ci-system>] [--refresh] [--channels <channels>]
   snapcraft [options] help (topics | <plugin> | <topic>) [--devel]
   snapcraft (-h | --help)
   snapcraft --version
@@ -90,6 +90,10 @@ Options specific to snapping:
 Options specific to store interaction:
   --release <channels>  Comma separated list of channels to release to.
   --series <series>     Snap series [default: {DEFAULT_SERIES}].
+
+Options specific to continuous-interaction system:
+  --refresh              Updates the project credentials
+  --channels <channels>  Comma separated list of channels to enable.
 
 The available commands are:
   help         Obtain help for a certain plugin or topic
@@ -284,7 +288,8 @@ def run(args, project_options):  # noqa
         snapcraft.topic_help(args['<topic>'] or args['<plugin>'],
                              args['--devel'], args['topics'])
     elif args['enable-ci']:
-        enable_ci(args['<ci-system>'], args['--refresh'])
+        channels = args['--channels'].split(',') if args['--channels'] else []
+        enable_ci(args['<ci-system>'], args['--refresh'], channels)
     elif args['update']:
         parts.update()
     elif args['define']:

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -91,9 +91,9 @@ Options specific to store interaction:
   --release <channels>  Comma separated list of channels to release to.
   --series <series>     Snap series [default: {DEFAULT_SERIES}].
 
-Options specific to continuous-interaction system:
-  --refresh              Updates the project credentials
-  --channels <channels>  Comma separated list of channels to enable.
+Options specific to continuous-integration system:
+  --refresh             Updates the project credentials
+  --channels <channels> Comma separated list of channels to enable.
 
 The available commands are:
   help         Obtain help for a certain plugin or topic

--- a/snapcraft/tests/commands/test_enable_ci.py
+++ b/snapcraft/tests/commands/test_enable_ci.py
@@ -67,10 +67,32 @@ class EnableCITestCase(tests.TestCase):
         self.assertEqual(
             '<module docstring>\n', self.fake_terminal.getvalue())
 
+    @mock.patch.object(travis, '__doc__')
+    @mock.patch.object(travis, 'enable')
+    @mock.patch('builtins.input')
+    def test_enable_ci_travis_channels(
+            self, mock_input, mock_enable, mock_doc):
+        mock_input.side_effect = ['y']
+        mock_doc.__str__.return_value = '<module docstring>'
+
+        main(['enable-ci', 'travis', '--channels=edge,stable'])
+
+        self.assertEqual(1, mock_enable.call_count)
+        self.assertEqual(
+            '<module docstring>\n', self.fake_terminal.getvalue())
+
     @mock.patch.object(travis, 'refresh')
     def test_enable_ci_travis_refresh(self, mock_refresh):
 
         main(['enable-ci', 'travis', '--refresh'])
+
+        self.assertEqual(1, mock_refresh.call_count)
+        self.assertEqual('', self.fake_terminal.getvalue())
+
+    @mock.patch.object(travis, 'refresh')
+    def test_enable_ci_travis_refresh_channels(self, mock_refresh):
+
+        main(['enable-ci', 'travis', '--refresh', '--channels=beta,candidate'])
 
         self.assertEqual(1, mock_refresh.call_count)
         self.assertEqual('', self.fake_terminal.getvalue())


### PR DESCRIPTION
This allows to generate credentials for uploading to other channels than 'edge'.
Although this is still experimental, having the ability to override the default edge channel is something to have IMHO.

LP: [#1659352](https://bugs.launchpad.net/snapcraft/+bug/1659352)
