### PR TITLE
autotools: extend Make plugin instead of repeating code

### DIFF
--- a/snapcraft/plugins/autotools.py
+++ b/snapcraft/plugins/autotools.py
@@ -42,10 +42,10 @@ In addition, this plugin uses the following plugin-specific keywords:
 import os
 import stat
 
-import snapcraft
+from snapcraft.plugins import make
 
 
-class AutotoolsPlugin(snapcraft.BasePlugin):
+class AutotoolsPlugin(make.MakePlugin):
 
     @classmethod
     def schema(cls):
@@ -71,7 +71,7 @@ class AutotoolsPlugin(snapcraft.BasePlugin):
     def get_build_properties(cls):
         # Inform Snapcraft of the properties associated with building. If these
         # change in the YAML Snapcraft will consider the build step dirty.
-        return ['configflags', 'install-via']
+        return super().get_build_properties() + ['configflags', 'install-via']
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
@@ -80,19 +80,17 @@ class AutotoolsPlugin(snapcraft.BasePlugin):
             'automake',
             'autopoint',
             'libtool',
-            'make',
         ])
 
         if options.install_via == 'destdir':
-            self.install_via_destdir = True
+            self.options.make_install_var = 'DESTDIR'
         elif options.install_via == 'prefix':
-            self.install_via_destdir = False
+            self.options.make_install_var = ''
         else:
             raise RuntimeError('Unsupported installation method: "{}"'.format(
                 options.install_via))
 
     def build(self):
-        super().build()
         if not os.path.exists(os.path.join(self.builddir, "configure")):
             generated = False
             scripts = ["autogen.sh", "bootstrap"]
@@ -113,18 +111,15 @@ class AutotoolsPlugin(snapcraft.BasePlugin):
                 self.run(['autoreconf', '-i'])
 
         configure_command = ['./configure']
-        make_install_command = ['make', 'install']
 
-        if self.install_via_destdir:
+        if self.options.make_install_var:
             # Use an empty prefix since we'll install via DESTDIR
             configure_command.append('--prefix=')
-            make_install_command.append('DESTDIR=' + self.installdir)
         else:
             configure_command.append('--prefix=' + self.installdir)
 
         self.run(configure_command + self.options.configflags)
-        self.run(['make', '-j{}'.format(self.parallel_build_count)])
-        self.run(make_install_command)
+        self.make()
 
     def snap_fileset(self):
         fileset = super().snap_fileset()

--- a/snapcraft/plugins/autotools.py
+++ b/snapcraft/plugins/autotools.py
@@ -91,9 +91,9 @@ class AutotoolsPlugin(make.MakePlugin):
                 options.install_via))
 
     def build(self):
-        if not os.path.exists(os.path.join(self.builddir, "configure")):
+        if not os.path.exists(os.path.join(self.builddir, 'configure')):
             generated = False
-            scripts = ["autogen.sh", "bootstrap"]
+            scripts = ['autogen.sh', 'bootstrap']
             for script in scripts:
                 path = os.path.join(self.builddir, script)
                 if not os.path.exists(path) or os.path.isdir(path):

--- a/snapcraft/plugins/make.py
+++ b/snapcraft/plugins/make.py
@@ -118,7 +118,7 @@ class MakePlugin(snapcraft.BasePlugin):
         else:
             command.append('install')
             if self.options.make_install_var:
-                command.append("{}={}".format(
+                command.append('{}={}'.format(
                     self.options.make_install_var, self.installdir))
 
             self.run(command, env=env)

--- a/snapcraft/plugins/make.py
+++ b/snapcraft/plugins/make.py
@@ -116,9 +116,12 @@ class MakePlugin(snapcraft.BasePlugin):
                     snapcraft.file_utils.link_or_copy(
                         source_path, destination_path)
         else:
-            install_param = self.options.make_install_var + '=' + \
-                self.installdir
-            self.run(command + ['install', install_param], env=env)
+            command.append('install')
+            if self.options.make_install_var:
+                command.append("{}={}".format(
+                    self.options.make_install_var, self.installdir))
+
+            self.run(command, env=env)
 
     def build(self):
         super().build()

--- a/snapcraft/tests/plugins/test_autotools.py
+++ b/snapcraft/tests/plugins/test_autotools.py
@@ -24,6 +24,7 @@ from testtools.matchers import HasLength
 import snapcraft
 from snapcraft import tests
 from snapcraft.plugins import autotools
+from snapcraft.plugins import make
 
 
 class AutotoolsPluginTestCase(tests.TestCase):
@@ -35,6 +36,10 @@ class AutotoolsPluginTestCase(tests.TestCase):
             configflags = []
             install_via = 'destdir'
             disable_parallel = False
+            makefile = None
+            make_parameters = []
+            make_install_var = 'DESTDIR'
+            artifacts = []
 
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
@@ -105,7 +110,8 @@ class AutotoolsPluginTestCase(tests.TestCase):
                          'but it was "{}"'.format(installvia_default))
 
     def test_get_build_properties(self):
-        expected_build_properties = ['configflags', 'install-via']
+        expected_build_properties = make.MakePlugin.get_build_properties() + \
+            ['configflags', 'install-via']
         resulting_build_properties = \
             autotools.AutotoolsPlugin.get_build_properties()
 
@@ -147,9 +153,9 @@ class AutotoolsPluginTestCase(tests.TestCase):
         self.assertEqual(3, run_mock.call_count)
         run_mock.assert_has_calls([
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make', '-j2']),
+            mock.call(['make', '-j2'], env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)])
+                       'DESTDIR={}'.format(plugin.installdir)], env=None)
         ])
 
     @mock.patch.object(autotools.AutotoolsPlugin, 'run')
@@ -161,8 +167,8 @@ class AutotoolsPluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['./configure', '--prefix={}'.format(
                 plugin.installdir)]),
-            mock.call(['make', '-j2']),
-            mock.call(['make', 'install'])
+            mock.call(['make', '-j2'], env=None),
+            mock.call(['make', 'install'], env=None)
         ])
 
     def build_with_autogen(self, files=None, dirs=None):
@@ -195,9 +201,9 @@ class AutotoolsPluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['autoreconf', '-i']),
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make', '-j2']),
+            mock.call(['make', '-j2'], env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)])
+                       'DESTDIR={}'.format(plugin.installdir)], env=None)
         ])
 
     @mock.patch.object(autotools.AutotoolsPlugin, 'run')
@@ -208,9 +214,9 @@ class AutotoolsPluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['env', 'NOCONFIGURE=1', './autogen.sh']),
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make', '-j2']),
+            mock.call(['make', '-j2'], env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)])
+                       'DESTDIR={}'.format(plugin.installdir)], env=None)
         ])
 
     @mock.patch.object(autotools.AutotoolsPlugin, 'run')
@@ -221,9 +227,9 @@ class AutotoolsPluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['env', 'NOCONFIGURE=1', './bootstrap']),
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make', '-j2']),
+            mock.call(['make', '-j2'], env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)])
+                       'DESTDIR={}'.format(plugin.installdir)], env=None)
         ])
 
     @mock.patch.object(autotools.AutotoolsPlugin, 'run')
@@ -234,9 +240,9 @@ class AutotoolsPluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['env', 'NOCONFIGURE=1', './autogen.sh']),
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make', '-j2']),
+            mock.call(['make', '-j2'], env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)])
+                       'DESTDIR={}'.format(plugin.installdir)], env=None)
         ])
 
     @mock.patch.object(autotools.AutotoolsPlugin, 'run')
@@ -249,8 +255,8 @@ class AutotoolsPluginTestCase(tests.TestCase):
             mock.call(['env', 'NOCONFIGURE=1', './autogen.sh']),
             mock.call(['./configure', '--prefix={}'.format(
                 plugin.installdir)]),
-            mock.call(['make', '-j2']),
-            mock.call(['make', 'install'])
+            mock.call(['make', '-j2'], env=None),
+            mock.call(['make', 'install'], env=None)
         ])
 
     def build_with_autoreconf(self):
@@ -272,9 +278,9 @@ class AutotoolsPluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['autoreconf', '-i']),
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make', '-j2']),
+            mock.call(['make', '-j2'], env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)])
+                       'DESTDIR={}'.format(plugin.installdir)], env=None)
         ])
 
     @mock.patch.object(autotools.AutotoolsPlugin, 'run')
@@ -287,8 +293,8 @@ class AutotoolsPluginTestCase(tests.TestCase):
             mock.call(['autoreconf', '-i']),
             mock.call(['./configure', '--prefix={}'.format(
                 plugin.installdir)]),
-            mock.call(['make', '-j2']),
-            mock.call(['make', 'install'])
+            mock.call(['make', '-j2'], env=None),
+            mock.call(['make', 'install'], env=None)
         ])
 
     @mock.patch.object(autotools.AutotoolsPlugin, 'run')
@@ -300,9 +306,9 @@ class AutotoolsPluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['autoreconf', '-i']),
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make', '-j1']),
+            mock.call(['make', '-j1'], env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)])
+                       'DESTDIR={}'.format(plugin.installdir)], env=None)
         ])
 
     @mock.patch('sys.stdout')
@@ -319,10 +325,10 @@ class AutotoolsPluginTestCase(tests.TestCase):
         run_mock = patcher.start()
 
         # We want to mock out every run() call except the one to autogen
-        def _run(cmd):
+        def _run(cmd, env=None):
             if './autogen.sh' in cmd:
                 patcher.stop()
-                output = plugin.run(cmd)
+                output = plugin.run(cmd, env=env)
                 patcher.start()
                 return output
 

--- a/snapcraft/tests/plugins/test_autotools.py
+++ b/snapcraft/tests/plugins/test_autotools.py
@@ -110,8 +110,8 @@ class AutotoolsPluginTestCase(tests.TestCase):
                          'but it was "{}"'.format(installvia_default))
 
     def test_get_build_properties(self):
-        expected_build_properties = make.MakePlugin.get_build_properties() + \
-            ['configflags', 'install-via']
+        expected_build_properties = make.MakePlugin.get_build_properties() + (
+            ['configflags', 'install-via'])
         resulting_build_properties = \
             autotools.AutotoolsPlugin.get_build_properties()
 

--- a/snapcraft/tests/plugins/test_make.py
+++ b/snapcraft/tests/plugins/test_make.py
@@ -167,6 +167,21 @@ class MakePluginTestCase(tests.TestCase):
         ])
 
     @mock.patch.object(make.MakePlugin, 'run')
+    def test_build_empty_install_var(self, run_mock):
+        self.options.make_install_var = ''
+        plugin = make.MakePlugin('test-part', self.options,
+                                 self.project_options)
+        os.makedirs(plugin.sourcedir)
+
+        plugin.build()
+
+        self.assertEqual(2, run_mock.call_count)
+        run_mock.assert_has_calls([
+            mock.call(['make', '-j2'], env=None),
+            mock.call(['make', 'install'], env=None)
+        ])
+
+    @mock.patch.object(make.MakePlugin, 'run')
     @mock.patch('snapcraft.file_utils.link_or_copy_tree')
     @mock.patch('snapcraft.file_utils.link_or_copy')
     def test_build_artifacts(self, link_or_copy_mock,


### PR DESCRIPTION
We can use the self.make function from make instead of redefining the build process again here.

LP: #1659363