### PR TITLE
Shout -> Lounge, the official fork

### DIFF
--- a/demos/lounge/snapcraft.yaml
+++ b/demos/lounge/snapcraft.yaml
@@ -1,17 +1,17 @@
-name: shout
-version: 0.52.0
+name: lounge
+version: 2.2
 summary: A self hosted web IRC client
 description: This example is not really production quality
 confinement: strict
 
 apps:
   server:
-    command: bin/shout --home $SNAP_DATA
+    command: bin/lounge --home $SNAP_DATA
     daemon: simple
     plugs: [network, network-bind]
 
 parts:
-  shout:
+  lounge:
     plugin: nodejs
     node-packages:
-      - shout
+      - thelounge

--- a/docs/snapcraft-advanced-features.md
+++ b/docs/snapcraft-advanced-features.md
@@ -253,16 +253,16 @@ in this case), meaning that files in these directories will not be installed.
 
 ### node.js
 
-Snapping node.js apps has never been this easy. Take a look at the `shout`
+Snapping node.js apps has never been this easy. Take a look at the `lounge`
 example and see how short and sweet it is. To bundle node packages, you simply
 do something like:
 
 ```yaml
 parts:
-  shout:
+  lounge:
     plugin: nodejs
     node-packages:
-      - shout
+      - thelounge
 ```
 
 `node-packages` simply lists which packages (including their dependencies) to

--- a/snaps_tests/demos_tests/test_lounge.py
+++ b/snaps_tests/demos_tests/test_lounge.py
@@ -17,12 +17,12 @@
 import snaps_tests
 
 
-class ShoutTestCase(snaps_tests.SnapsTestCase):
+class LoungeTestCase(snaps_tests.SnapsTestCase):
 
-    snap_content_dir = 'shout'
+    snap_content_dir = 'lounge'
 
-    def test_shout(self):
+    def test_lounge(self):
         snap_path = self.build_snap(self.snap_content_dir)
-        snap_name = 'shout'
-        self.install_snap(snap_path, snap_name, '0.52.0')
+        snap_name = 'lounge'
+        self.install_snap(snap_path, snap_name, '2.2.0')
         self.assert_service_running(snap_name, 'server')


### PR DESCRIPTION
Updated the shout snap to point to Lounge
LP: [#1659471](https://bugs.launchpad.net/snapcraft/+bug/1659471)
