### PR TITLE
Add snapcraft plugin for Qt Build Suite (qbs)

### DIFF
--- a/integration_tests/snaps/qbs-nil/main.cpp
+++ b/integration_tests/snaps/qbs-nil/main.cpp
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+int main(int argc, char *argv[])
+{
+#ifdef PRINT_STRING
+    printf("Hello Snapcraft World");
+#else
+    printf("Wrong snapcraft string");
+#endif
+    return 0;
+}

--- a/integration_tests/snaps/qbs-nil/qbs-nil-snap.qbs
+++ b/integration_tests/snaps/qbs-nil/qbs-nil-snap.qbs
@@ -1,0 +1,38 @@
+import qbs
+
+Project {
+    name: "Qbs Nil Snap"
+
+    property bool printString: false
+    PropertyOptions {
+        name: "printString"
+        description: "
+            Set in the qbs-options property of the snapcraft.yaml
+
+            Setting to true will print the required string for the test
+            if it remains false an incorrect string is returned.
+        "
+        allowedValues: ["true", "false"]
+    }
+
+    CppApplication {
+        name: "Snap Qbs Nil Binary"
+        targetName: "qbs-nil"
+        files: "*.cpp"
+
+        cpp.cxxLanguageVersion: "c++11";
+        cpp.cxxStandardLibrary: "libstdc++";
+        cpp.includePaths: [ path ]
+
+        Properties {
+            condition: project.printString == true
+            cpp.defines: ["PRINT_STRING"]
+        }
+
+        Group {
+            qbs.install: true
+            qbs.installDir: "bin"
+            fileTagsFilter: product.type
+        }
+    }
+}

--- a/integration_tests/snaps/qbs-nil/snapcraft.yaml
+++ b/integration_tests/snaps/qbs-nil/snapcraft.yaml
@@ -1,0 +1,13 @@
+name: test-qbs-plugin
+version: 0.1
+summary: qbs snapcraft plugin
+description: Tests if parts can be built using qbs and gcc
+confinement: strict
+
+parts:
+  qbs-project:
+    plugin: qbs
+    source: .
+    qbs-build-variant: debug
+    qbs-options: ['project.printString:false']
+    qbs-profile: gcc

--- a/integration_tests/snaps/qbs-qt/main.cpp
+++ b/integration_tests/snaps/qbs-qt/main.cpp
@@ -1,0 +1,14 @@
+#include <QCoreApplication>
+#include <QTextStream>
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+    QTextStream out(stdout);
+#ifdef PRINT_STRING
+    out << QByteArrayLiteral("Hello Snapcraft World");
+#else
+    out << QByteArrayLiteral("Wrong snapcraft string");
+#endif
+    return 0;
+}

--- a/integration_tests/snaps/qbs-qt/qbs-qt-snap.qbs
+++ b/integration_tests/snaps/qbs-qt/qbs-qt-snap.qbs
@@ -1,0 +1,38 @@
+import qbs
+
+Project {
+    name: "Snap QT"
+
+    property bool printString: false
+    PropertyOptions {
+        name: "printString"
+        description: "
+            Set in the qbs-options property of the snapcraft.yaml
+
+            Setting to true will print the required string for the test
+            if it remains false an incorrect string is returned.
+        "
+        allowedValues: ["true", "false"]
+    }
+
+    QtApplication {
+        name: "Snap Qt Binary"
+        targetName: "qbs-qt"
+        files: "*.cpp"
+
+        cpp.cxxLanguageVersion: "c++11";
+        cpp.cxxStandardLibrary: "libstdc++";
+        cpp.includePaths: [ path ]
+
+        Properties {
+            condition: project.printString == true
+            cpp.defines: ["PRINT_STRING"]
+        }
+
+        Group {
+            qbs.install: true
+            qbs.installDir: "bin"
+            fileTagsFilter: product.type
+        }
+    }
+}

--- a/integration_tests/snaps/qbs-qt/snapcraft.yaml
+++ b/integration_tests/snaps/qbs-qt/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: test-qbs-plugin
+version: 0.1
+summary: qbs snapcraft plugin
+description: Tests if Qt based parts can be built using qbs
+confinement: strict
+
+parts:
+  qbs-project:
+    plugin: qbs
+    source: .
+    qbs-options: ['project.printString:true']
+    qbs-profile: clang
+    qbs-build-variant: release
+    qt-version: qt5

--- a/integration_tests/test_qbs_plugin.py
+++ b/integration_tests/test_qbs_plugin.py
@@ -1,0 +1,41 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Dan Chapman <dpniel@ubuntu.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import os
+
+import testscenarios
+import integration_tests
+
+
+class QbsPluginTestCase(testscenarios.WithScenarios,
+                        integration_tests.TestCase):
+
+    scenarios = [
+        # we expect qbs-nil to output the wrong string here as
+        # 'project.printString' is set to false in the yaml file.
+        ('qbs-nil', dict(project_dir='qbs-nil',
+                         expected_value='Wrong snapcraft string')),
+        ('qbs-qt', dict(project_dir='qbs-qt',
+                        expected_value='Hello Snapcraft World')),
+    ]
+
+    def test_stage_qbs_plugin(self):
+
+        self.run_snapcraft('stage', self.project_dir)
+
+        # The test binaries have the same name as the project dir
+        binary_output = self.get_output_ignoring_non_zero_exit(
+            os.path.join(self.stage_dir, 'bin', self.project_dir))
+        self.assertEqual(self.expected_value, binary_output)

--- a/snapcraft/plugins/qbs.py
+++ b/snapcraft/plugins/qbs.py
@@ -1,0 +1,153 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Dan Chapman <dpniel@ubuntu.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The QBS plugin is useful for building parts that use the Qt Build Suite.
+
+These are projects that are built using .qbs files and are using gcc or
+clang based toolchains.
+
+This plugin uses the common plugin keywords as well as those for "sources".
+For more information check the 'plugins' topic for the former and the
+'sources' topic for the latter.
+
+Additionally, this plugin uses the following plugin-specific keywords:
+
+    - qbs-build-variant:
+      (enum, 'debug' or 'release')
+      Set either debug or release build variant. Default is release.
+    - qbs-options:
+      (list of strings)
+      Additional options to pass to the qbs invocation.
+    - qbs-profile:
+      (enum, 'gcc' or 'clang')
+      Set either gcc or clang as the base build profile. Default is gcc.
+    - qt-version:
+      (enum, 'qt4' or 'qt5')
+      Optionally you can set up profiles for qt4 and qt5 applications.
+      If no qt version is set then the base gcc/clang profile will be used.
+"""
+import os
+import shutil
+import snapcraft
+
+
+class QbsPlugin(snapcraft.BasePlugin):
+
+    @classmethod
+    def schema(cls):
+        schema = super().schema()
+
+        schema['properties']['qbs-build-variant'] = {
+            'enum': ['debug', 'release'],
+            'default': 'release',
+        }
+
+        schema['properties']['qbs-options'] = {
+            'type': 'array',
+            'minitems': 1,
+            'uniqueItems': True,
+            'items': {
+                'type': 'string',
+            },
+            'default': [],
+        }
+
+        schema['properties']['qbs-profile'] = {
+            'enum': ['gcc', 'clang'],
+            'default': 'gcc',
+        }
+
+        schema['properties']['qt-version'] = {
+            'enum': ['qt4', 'qt5'],
+            'default': None
+        }
+
+        return schema
+
+    @classmethod
+    def get_pull_properties(cls):
+        # Inform Snapcraft of the properties associated with pulling. If these
+        # change in the YAML Snapcraft will consider the pull step dirty.
+        return ['qt-version', 'qbs-profile']
+
+    @classmethod
+    def get_build_properties(cls):
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        return ['qbs-options', 'qbs-build-variant']
+
+    def __init__(self, name, options, project):
+        super().__init__(name, options, project)
+        self.build_packages.extend(['qbs', 'gcc', 'clang'])
+
+        if self.options.qt_version == 'qt5':
+            self.build_packages.extend(['qt5-qmake', 'qtbase5-dev'])
+        elif self.options.qt_version == 'qt4':
+            self.build_packages.extend(['qt4-qmake', 'libqt4-dev'])
+        elif self.options.qt_version is not None:
+            raise RuntimeError('Unsupported Qt version: {!r}'.format(
+                self.options.qt_version))
+
+    def build(self):
+        super().build()
+
+        env = self._build_environment()
+
+        # Setup the toolchains, there will only be gcc or clang by default
+        self.run(['qbs', 'setup-toolchains', '--detect'], env=env)
+
+        build_profile = ''
+
+        if self.options.qt_version is None:
+            build_profile = self.options.qbs_profile
+        else:
+            # a unique'ish name for snap builds. Hopefully this shouldn't clash
+            # with any other local profiles. Each profile should look something
+            # like: profiles.snapcraft-qbs-qt5-clang
+            build_profile = 'snapcraft-qbs-{}-{}'.format(
+                self.options.qt_version,
+                self.options.qbs_profile)
+
+            # Find full qmake path as qbs setup-qt requires it
+            qmake = shutil.which('qmake')
+            if qmake is None:
+                raise RuntimeError('The qbs plugin requires qmake be on PATH')
+
+            # Setup the Qt profile.
+            self.run(['qbs', 'setup-qt', qmake, build_profile], env=env)
+
+            # Switch buildprofile to clang if required
+            # we don't need to set gcc as that is the default baseProfile
+            if self.options.qbs_profile == 'clang':
+                self.run(['qbs', 'config',
+                          'profiles.{}.baseProfile'.format(build_profile),
+                          self.options.qbs_profile],
+                         env=env)
+
+        # Run the build.
+        self.run(['qbs', 'build',
+                  '-d', self.builddir,
+                  '-f', self.sourcedir,
+                  self.options.qbs_build_variant,
+                  'qbs.installRoot:' + self.installdir,
+                  'profile:' + build_profile] + self.options.qbs_options,
+                 env=env)
+
+    def _build_environment(self):
+        env = os.environ.copy()
+        if self.options.qt_version is not None:
+            env['QT_SELECT'] = self.options.qt_version
+        return env

--- a/snapcraft/tests/commands/test_list_plugins.py
+++ b/snapcraft/tests/commands/test_list_plugins.py
@@ -28,10 +28,12 @@ class ListPluginsCommandTestCase(tests.TestCase):
 
     # plugin list when wrapper at MAX_CHARACTERS_WRAP
     default_plugin_output = (
-        'ant        catkin  copy  go      gradle  jdk     kernel  maven  '
-        'nodejs             python   python3  rust   tar-content\n'
-        'autotools  cmake   dump  godeps  gulp    kbuild  make    '
-        'nil    plainbox-provider  python2  qmake    scons  waf        \n'
+        'ant        cmake  go      gulp    kernel  nil                '
+        'python   qbs    scons      \n'
+        'autotools  copy   godeps  jdk     make    nodejs             '
+        'python2  qmake  tar-content\n'
+        'catkin     dump   gradle  kbuild  maven   plainbox-provider  '
+        'python3  rust   waf        \n'
     )
 
     def test_list_plugins_non_tty(self):
@@ -56,12 +58,12 @@ class ListPluginsCommandTestCase(tests.TestCase):
         self.useFixture(fake_terminal)
 
         expected_output = (
-            'ant        go      kernel             python   tar-content\n'
-            'autotools  godeps  make               python2  waf        \n'
-            'catkin     gradle  maven              python3\n'
-            'cmake      gulp    nil                qmake  \n'
-            'copy       jdk     nodejs             rust   \n'
-            'dump       kbuild  plainbox-provider  scons  \n'
+            'ant        go      kernel             python   scons      \n'
+            'autotools  godeps  make               python2  tar-content\n'
+            'catkin     gradle  maven              python3  waf        \n'
+            'cmake      gulp    nil                qbs    \n'
+            'copy       jdk     nodejs             qmake  \n'
+            'dump       kbuild  plainbox-provider  rust   \n'
         )
 
         main([self.command_name])

--- a/snapcraft/tests/plugins/test_qbs.py
+++ b/snapcraft/tests/plugins/test_qbs.py
@@ -1,0 +1,236 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Dan Chapman <dpniel@ubuntu.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import os
+import shutil
+from unittest import mock
+from testtools.matchers import HasLength
+
+import snapcraft
+from snapcraft import tests
+from snapcraft.plugins import qbs
+
+
+class QbsPluginTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.project_options = snapcraft.ProjectOptions()
+
+        class Options:
+            qbs_options = []
+            qt_version = 'qt5'
+            qbs_profile = 'clang'
+            qbs_build_variant = 'release'
+
+        self.options = Options()
+
+    def test_schema(self):
+        schema = qbs.QbsPlugin.schema()
+
+        # Check all properties exist.
+        properties = schema['properties']
+        self.assertTrue('qbs-options' in properties,
+                        'Expected "options" to be in properties')
+        self.assertTrue('qt-version' in properties,
+                        'Expected "qt-version" to be in properties')
+        self.assertTrue('qbs-profile' in properties,
+                        'Expected "profile" to be in properties')
+        self.assertTrue('qbs-build-variant' in properties,
+                        'Expected "build-variant" to be in properties')
+
+        # Check the options property
+        options = properties['qbs-options']
+        for item in ['type', 'minitems', 'uniqueItems', 'items', 'default']:
+            self.assertTrue(item in options,
+                            'Expected {!r} to be included in "options"'
+                            .format(item))
+
+        options_type = options['type']
+        self.assertEqual(options_type, 'array',
+                         'Expected "options" "type" to be "array", but it '
+                         'was "{}"'.format(options_type))
+
+        options_minitems = options['minitems']
+        self.assertEqual(options_minitems, 1,
+                         'Expected "options" "minitems" to be 1, but '
+                         'it was {}'.format(options_minitems))
+
+        self.assertTrue(options['uniqueItems'])
+
+        options_default = options['default']
+        self.assertEqual(options_default, [],
+                         'Expected "options" "default" to be [], but '
+                         'it was {}'.format(options_default))
+
+        options_items = options['items']
+        self.assertTrue('type' in options_items,
+                        'Expected "type" to be included in "options" '
+                        '"items"')
+
+        options_items_type = options_items['type']
+        self.assertEqual(options_items_type, 'string',
+                         'Expected "options" "items" "type" to be '
+                         '"string", but it was "{}"'
+                         .format(options_items_type))
+
+        # check the qt-version property
+        qt_version = properties['qt-version']
+        self.assertTrue('enum' in qt_version,
+                        'Expected "enum" to be included in "qt_version"')
+        self.assertTrue('default' in qt_version,
+                        '"default" was unexpectedly included in "qt_version"')
+
+        qt_version_enum = qt_version['enum']
+        # Using sets for order independence in the comparison
+        self.assertEqual(set(['qt4', 'qt5']), set(qt_version_enum))
+
+        # Check the profile property
+        profile = properties['qbs-profile']
+        self.assertTrue('enum' in profile,
+                        'Expected "enum" to be included in "profile"')
+        self.assertTrue('default' in profile,
+                        'Expected "default" to be included in "profile"')
+        profile_enum = profile['enum']
+        self.assertEqual(set(['gcc', 'clang']), set(profile_enum))
+        profile_default = profile['default']
+        self.assertEqual('gcc', profile_default)
+        # check the build-variant property
+        build_variant = properties['qbs-build-variant']
+        self.assertTrue('enum' in build_variant,
+                        'Expected "enum" to be included in "profile"')
+        self.assertTrue('default' in build_variant,
+                        'Expected "default" to be included in "profile"')
+        build_variant_enum = build_variant['enum']
+        self.assertEqual(set(['debug', 'release']), set(build_variant_enum))
+        build_variant_default = build_variant['default']
+        self.assertEqual('release', build_variant_default)
+        # Check build and pull properties
+        self.assertTrue('build-properties' in schema,
+                        'Expected schema to include "build-properties"')
+
+        self.assertTrue('pull-properties' in schema,
+                        'Expected schema to include "pull-properties"')
+
+    def test_get_build_properties(self):
+        expected_build_properties = ['qbs-options', 'qbs-build-variant']
+        resulting_build_properties = qbs.QbsPlugin.get_build_properties()
+
+        self.assertThat(resulting_build_properties,
+                        HasLength(len(expected_build_properties)))
+
+        for property in expected_build_properties:
+            self.assertIn(property, resulting_build_properties)
+
+    def test_get_pull_properties(self):
+        expected_pull_properties = ['qt-version', 'qbs-profile']
+        resulting_pull_properties = qbs.QbsPlugin.get_pull_properties()
+
+        self.assertThat(resulting_pull_properties,
+                        HasLength(len(expected_pull_properties)))
+
+        for property in expected_pull_properties:
+            self.assertIn(property, resulting_pull_properties)
+
+    def test_unsupported_qt_version(self):
+        self.options.qt_version = 'qt3'
+        raised = self.assertRaises(
+            RuntimeError,
+            qbs.QbsPlugin,
+            'test-part', self.options, self.project_options)
+
+        self.assertEqual(str(raised),
+                         "Unsupported Qt version: 'qt3'")
+
+    @mock.patch.object(qbs.QbsPlugin, 'run')
+    def test_build_nil(self, run_mock):
+        self.options.qt_version = None
+        plugin = qbs.QbsPlugin('test-part', self.options,
+                               self.project_options)
+
+        os.makedirs(plugin.sourcedir)
+        plugin.build()
+
+        run_mock.assert_has_calls([
+            mock.call(['qbs', 'setup-toolchains', '--detect'], env=mock.ANY),
+            mock.call(['qbs', 'build', '-d', plugin.builddir,
+                       '-f', plugin.sourcedir, 'release',
+                       'qbs.installRoot:' + plugin.installdir,
+                       'profile:clang'], env=mock.ANY)
+        ])
+
+    @mock.patch.object(qbs.QbsPlugin, 'run')
+    def test_build_qt(self, run_mock):
+        self.options.qt_version = 'qt5'
+        plugin = qbs.QbsPlugin('test-part', self.options,
+                               self.project_options)
+
+        os.makedirs(plugin.sourcedir)
+
+        # Check to see if there is a qmake on path
+        # or create one if there isn't
+        qmake_path = self._find_or_create_qmake(plugin)
+        self.assertIsNotNone(qmake_path)
+
+        plugin.build()
+
+        run_mock.assert_has_calls([
+            mock.call(['qbs', 'setup-toolchains', '--detect'], env=mock.ANY),
+            mock.call(['qbs', 'setup-qt', qmake_path,
+                       'snapcraft-qbs-qt5-clang'], env=mock.ANY),
+            mock.call(['qbs', 'config',
+                       'profiles.snapcraft-qbs-qt5-clang.baseProfile',
+                       self.options.qbs_profile], env=mock.ANY),
+            mock.call(['qbs', 'build', '-d', plugin.builddir,
+                       '-f', plugin.sourcedir, 'release',
+                       'qbs.installRoot:' + plugin.installdir,
+                       'profile:snapcraft-qbs-qt5-clang'], env=mock.ANY),
+        ])
+
+    @mock.patch.object(qbs.QbsPlugin, 'run')
+    def test_build_with_options(self, run_mock):
+        self.options.qt_version = None
+        self.options.qbs_options = ['project.someBoolProperty:true']
+        plugin = qbs.QbsPlugin('test-part', self.options,
+                               self.project_options)
+
+        os.makedirs(plugin.sourcedir)
+        plugin.build()
+
+        run_mock.assert_has_calls([
+            mock.call(['qbs', 'setup-toolchains', '--detect'], env=mock.ANY),
+            mock.call(['qbs', 'build', '-d', plugin.builddir,
+                       '-f', plugin.sourcedir, 'release',
+                       'qbs.installRoot:' + plugin.installdir,
+                       'profile:clang', 'project.someBoolProperty:true'],
+                      env=mock.ANY),
+        ])
+
+    def _find_or_create_qmake(self, plugin):
+        qmake_path = shutil.which('qmake')
+        if qmake_path is None:
+            tmp_path = os.pathsep + plugin.sourcedir
+            # Create PATH if it isn't set. This seems to
+            # occur in the travis docker containers.
+            if 'PATH' not in os.environ.keys():
+                os.environ.setdefault('PATH', os.defpath + tmp_path)
+            else:
+                os.environ['PATH'] += tmp_path
+
+            qmake_path = os.path.join(plugin.sourcedir, 'qmake')
+            open(qmake_path, 'w').close()
+            os.chmod(qmake_path, 0o755)
+        return qmake_path


### PR DESCRIPTION
This plugin supports building any applications that use gcc or clang
toolchains, as well as Qt(4&5) based applications.

LP: [#1659537](https://bugs.launchpad.net/snapcraft/+bug/1659537)

