### PR TITLE
local source: preserve symlinks to directories.

### DIFF
--- a/snapcraft/internal/sources/_local.py
+++ b/snapcraft/internal/sources/_local.py
@@ -47,5 +47,5 @@ class Local(Base):
             else:
                 return []
 
-        shutil.copytree(source_abspath, self.source_dir,
+        shutil.copytree(source_abspath, self.source_dir, symlinks=True,
                         copy_function=file_utils.link_or_copy, ignore=ignore)


### PR DESCRIPTION
This PR fixes LP: [#1659653](https://bugs.launchpad.net/snapcraft/+bug/1659653) by preserving any symlinks to directories within local sources instead of creating a new directory.