### PR TITLE
make: add support for cwd path to make() function

### DIFF
--- a/snapcraft/plugins/make.py
+++ b/snapcraft/plugins/make.py
@@ -95,7 +95,7 @@ class MakePlugin(snapcraft.BasePlugin):
         super().__init__(name, options, project)
         self.build_packages.append('make')
 
-    def make(self, env=None):
+    def make(self, cwd=None, env=None):
         command = ['make']
 
         if self.options.makefile:
@@ -104,9 +104,12 @@ class MakePlugin(snapcraft.BasePlugin):
         if self.options.make_parameters:
             command.extend(self.options.make_parameters)
 
-        self.run(command + ['-j{}'.format(self.parallel_build_count)], env=env)
+        self.run(
+            command + ['-j{}'.format(self.parallel_build_count)], cwd, env=env)
         if self.options.artifacts:
             for artifact in self.options.artifacts:
+                if cwd:
+                    artifact = os.path.join(cwd, artifact)
                 source_path = os.path.join(self.builddir, artifact)
                 destination_path = os.path.join(self.installdir, artifact)
                 if os.path.isdir(source_path):
@@ -121,7 +124,7 @@ class MakePlugin(snapcraft.BasePlugin):
                 command.append('{}={}'.format(
                     self.options.make_install_var, self.installdir))
 
-            self.run(command, env=env)
+            self.run(command, cwd, env=env)
 
     def build(self):
         super().build()

--- a/snapcraft/tests/plugins/test_autotools.py
+++ b/snapcraft/tests/plugins/test_autotools.py
@@ -153,9 +153,9 @@ class AutotoolsPluginTestCase(tests.TestCase):
         self.assertEqual(3, run_mock.call_count)
         run_mock.assert_has_calls([
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make', '-j2'], env=None),
+            mock.call(['make', '-j2'], None, env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)], env=None)
+                       'DESTDIR={}'.format(plugin.installdir)], None, env=None)
         ])
 
     @mock.patch.object(autotools.AutotoolsPlugin, 'run')
@@ -167,8 +167,8 @@ class AutotoolsPluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['./configure', '--prefix={}'.format(
                 plugin.installdir)]),
-            mock.call(['make', '-j2'], env=None),
-            mock.call(['make', 'install'], env=None)
+            mock.call(['make', '-j2'], None, env=None),
+            mock.call(['make', 'install'], None, env=None)
         ])
 
     def build_with_autogen(self, files=None, dirs=None):
@@ -201,9 +201,9 @@ class AutotoolsPluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['autoreconf', '-i']),
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make', '-j2'], env=None),
+            mock.call(['make', '-j2'], None, env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)], env=None)
+                       'DESTDIR={}'.format(plugin.installdir)], None, env=None)
         ])
 
     @mock.patch.object(autotools.AutotoolsPlugin, 'run')
@@ -214,9 +214,9 @@ class AutotoolsPluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['env', 'NOCONFIGURE=1', './autogen.sh']),
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make', '-j2'], env=None),
+            mock.call(['make', '-j2'], None, env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)], env=None)
+                       'DESTDIR={}'.format(plugin.installdir)], None, env=None)
         ])
 
     @mock.patch.object(autotools.AutotoolsPlugin, 'run')
@@ -227,9 +227,9 @@ class AutotoolsPluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['env', 'NOCONFIGURE=1', './bootstrap']),
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make', '-j2'], env=None),
+            mock.call(['make', '-j2'], None, env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)], env=None)
+                       'DESTDIR={}'.format(plugin.installdir)], None, env=None)
         ])
 
     @mock.patch.object(autotools.AutotoolsPlugin, 'run')
@@ -240,9 +240,9 @@ class AutotoolsPluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['env', 'NOCONFIGURE=1', './autogen.sh']),
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make', '-j2'], env=None),
+            mock.call(['make', '-j2'], None, env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)], env=None)
+                       'DESTDIR={}'.format(plugin.installdir)], None, env=None)
         ])
 
     @mock.patch.object(autotools.AutotoolsPlugin, 'run')
@@ -255,8 +255,8 @@ class AutotoolsPluginTestCase(tests.TestCase):
             mock.call(['env', 'NOCONFIGURE=1', './autogen.sh']),
             mock.call(['./configure', '--prefix={}'.format(
                 plugin.installdir)]),
-            mock.call(['make', '-j2'], env=None),
-            mock.call(['make', 'install'], env=None)
+            mock.call(['make', '-j2'], None, env=None),
+            mock.call(['make', 'install'], None, env=None)
         ])
 
     def build_with_autoreconf(self):
@@ -278,9 +278,9 @@ class AutotoolsPluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['autoreconf', '-i']),
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make', '-j2'], env=None),
+            mock.call(['make', '-j2'], None, env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)], env=None)
+                       'DESTDIR={}'.format(plugin.installdir)], None, env=None)
         ])
 
     @mock.patch.object(autotools.AutotoolsPlugin, 'run')
@@ -293,8 +293,8 @@ class AutotoolsPluginTestCase(tests.TestCase):
             mock.call(['autoreconf', '-i']),
             mock.call(['./configure', '--prefix={}'.format(
                 plugin.installdir)]),
-            mock.call(['make', '-j2'], env=None),
-            mock.call(['make', 'install'], env=None)
+            mock.call(['make', '-j2'], None, env=None),
+            mock.call(['make', 'install'], None, env=None)
         ])
 
     @mock.patch.object(autotools.AutotoolsPlugin, 'run')
@@ -306,9 +306,9 @@ class AutotoolsPluginTestCase(tests.TestCase):
         run_mock.assert_has_calls([
             mock.call(['autoreconf', '-i']),
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make', '-j1'], env=None),
+            mock.call(['make', '-j1'], None, env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)], env=None)
+                       'DESTDIR={}'.format(plugin.installdir)], None, env=None)
         ])
 
     @mock.patch('sys.stdout')
@@ -325,10 +325,10 @@ class AutotoolsPluginTestCase(tests.TestCase):
         run_mock = patcher.start()
 
         # We want to mock out every run() call except the one to autogen
-        def _run(cmd, env=None):
+        def _run(cmd, cwd=None, env=None):
             if './autogen.sh' in cmd:
                 patcher.stop()
-                output = plugin.run(cmd, env=env)
+                output = plugin.run(cmd, cwd, env=env)
                 patcher.start()
                 return output
 

--- a/snapcraft/tests/plugins/test_make.py
+++ b/snapcraft/tests/plugins/test_make.py
@@ -113,9 +113,9 @@ class MakePluginTestCase(tests.TestCase):
 
         self.assertEqual(2, run_mock.call_count)
         run_mock.assert_has_calls([
-            mock.call(['make', '-j2'], env=None),
+            mock.call(['make', '-j2'], None, env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)], env=None)
+                       'DESTDIR={}'.format(plugin.installdir)], None, env=None)
         ])
 
     @mock.patch.object(make.MakePlugin, 'run')
@@ -129,9 +129,9 @@ class MakePluginTestCase(tests.TestCase):
 
         self.assertEqual(2, run_mock.call_count)
         run_mock.assert_has_calls([
-            mock.call(['make', '-j1'], env=None),
+            mock.call(['make', '-j1'], None, env=None),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)], env=None)
+                       'DESTDIR={}'.format(plugin.installdir)], None, env=None)
         ])
 
     @mock.patch.object(make.MakePlugin, 'run')
@@ -145,9 +145,9 @@ class MakePluginTestCase(tests.TestCase):
 
         self.assertEqual(2, run_mock.call_count)
         run_mock.assert_has_calls([
-            mock.call(['make', '-f', 'makefile.linux', '-j2'], env=None),
+            mock.call(['make', '-f', 'makefile.linux', '-j2'], None, env=None),
             mock.call(['make', '-f', 'makefile.linux', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)], env=None)
+                       'DESTDIR={}'.format(plugin.installdir)], None, env=None)
         ])
 
     @mock.patch.object(make.MakePlugin, 'run')
@@ -161,9 +161,9 @@ class MakePluginTestCase(tests.TestCase):
 
         self.assertEqual(2, run_mock.call_count)
         run_mock.assert_has_calls([
-            mock.call(['make', '-j2'], env=None),
+            mock.call(['make', '-j2'], None, env=None),
             mock.call(['make', 'install',
-                       'PREFIX={}'.format(plugin.installdir)], env=None)
+                       'PREFIX={}'.format(plugin.installdir)], None, env=None)
         ])
 
     @mock.patch.object(make.MakePlugin, 'run')
@@ -196,7 +196,7 @@ class MakePluginTestCase(tests.TestCase):
 
         self.assertEqual(1, run_mock.call_count)
         run_mock.assert_has_calls([
-            mock.call(['make', '-j2'], env=None),
+            mock.call(['make', '-j2'], None, env=None),
         ])
         self.assertEqual(1, link_or_copy_mock.call_count)
         link_or_copy_mock.assert_has_calls([
@@ -222,7 +222,7 @@ class MakePluginTestCase(tests.TestCase):
 
         self.assertEqual(2, run_mock.call_count)
         run_mock.assert_has_calls([
-            mock.call(['make', '-j2'], env=env),
+            mock.call(['make', '-j2'], None, env=env),
             mock.call(['make', 'install',
-                       'DESTDIR={}'.format(plugin.installdir)], env=env)
+                       'DESTDIR={}'.format(plugin.installdir)], None, env=env)
         ])

--- a/snapcraft/tests/plugins/test_make.py
+++ b/snapcraft/tests/plugins/test_make.py
@@ -177,8 +177,8 @@ class MakePluginTestCase(tests.TestCase):
 
         self.assertEqual(2, run_mock.call_count)
         run_mock.assert_has_calls([
-            mock.call(['make', '-j2'], env=None),
-            mock.call(['make', 'install'], env=None)
+            mock.call(['make', '-j2'], None, env=None),
+            mock.call(['make', 'install'], None, env=None)
         ])
 
     @mock.patch.object(make.MakePlugin, 'run')
@@ -226,3 +226,51 @@ class MakePluginTestCase(tests.TestCase):
             mock.call(['make', 'install',
                        'DESTDIR={}'.format(plugin.installdir)], None, env=env)
         ])
+
+    @mock.patch.object(make.MakePlugin, 'run')
+    def test_make_with_cwd(self, run_mock):
+        plugin = make.MakePlugin('test-part', self.options,
+                                 self.project_options)
+        os.makedirs(plugin.sourcedir)
+
+        cwd = '/foo/snapcraft/dir'
+        plugin.make(cwd=cwd)
+
+        self.assertEqual(2, run_mock.call_count)
+        run_mock.assert_has_calls([
+            mock.call(['make', '-j2'], cwd, env=None),
+            mock.call(['make', 'install',
+                       'DESTDIR={}'.format(plugin.installdir)], cwd, env=None)
+        ])
+
+    @mock.patch.object(make.MakePlugin, 'run')
+    @mock.patch('snapcraft.file_utils.link_or_copy_tree')
+    @mock.patch('snapcraft.file_utils.link_or_copy')
+    def test_make_artifacts_with_cwd(self, link_or_copy_mock,
+                                     link_or_copy_tree_mock, run_mock):
+        self.options.artifacts = ['dir_artifact', 'file_artifact']
+        plugin = make.MakePlugin('test-part', self.options,
+                                 self.project_options)
+        os.makedirs(plugin.sourcedir)
+
+        cwd = 'test/cwd/subdir'
+        os.makedirs(os.path.join(plugin.builddir, cwd, 'dir_artifact'))
+
+        plugin.make(cwd=cwd)
+
+        self.assertEqual(1, run_mock.call_count)
+        run_mock.assert_has_calls([
+            mock.call(['make', '-j2'], cwd, env=None),
+        ])
+        self.assertEqual(1, link_or_copy_mock.call_count)
+        link_or_copy_mock.assert_has_calls([
+            mock.call(
+                os.path.join(plugin.builddir, cwd, 'file_artifact'),
+                os.path.join(plugin.installdir, cwd, 'file_artifact'),
+            )])
+        self.assertEqual(1, link_or_copy_tree_mock.call_count)
+        link_or_copy_tree_mock.assert_has_calls([
+            mock.call(
+                os.path.join(plugin.builddir, cwd, 'dir_artifact'),
+                os.path.join(plugin.installdir, cwd, 'dir_artifact'),
+            )])


### PR DESCRIPTION
This can be useful for plugins that extends Make so that they can define a subfolder where to run make.

LP: [#1659810](https://bugs.launchpad.net/snapcraft/+bug/1659810)
