### PR TITLE
snapcraft: fix or ignore PEP8 static errors

### DIFF
--- a/snapcraft/internal/deltas/__init__.py
+++ b/snapcraft/internal/deltas/__init__.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-
-from . import errors # noqa
-from ._deltas import BaseDeltasGenerator # noqa
-from ._xdelta3 import XDelta3Generator # noqa
+from . import errors  # noqa
+from ._deltas import BaseDeltasGenerator  # noqa
+from ._xdelta3 import XDelta3Generator  # noqa

--- a/snapcraft/internal/sources/__init__.py
+++ b/snapcraft/internal/sources/__init__.py
@@ -147,7 +147,7 @@ def get_source_handler(source, *, source_type=''):
 _tar_type_regex = re.compile(r'.*\.((tar(\.(xz|gz|bz2))?)|tgz)$')
 
 
-def _get_source_type_from_uri(source, ignore_errors=False):
+def _get_source_type_from_uri(source, ignore_errors=False):  # noqa: C901
     source_type = ''
     if source.startswith('bzr:') or source.startswith('lp:'):
         source_type = 'bzr'

--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -333,7 +333,7 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
 
     _DEV_API_PATH = '/dev/api/'
 
-    def do_POST(self):
+    def do_POST(self):  # noqa: C901
         self._handle_refresh()
         parsed_path = urllib.parse.urlparse(self.path)
         acl_path = urllib.parse.urljoin(self._DEV_API_PATH, 'acl/')

--- a/snapcraft/tests/test_deltas_xdelta3.py
+++ b/snapcraft/tests/test_deltas_xdelta3.py
@@ -26,7 +26,7 @@ from testtools import TestCase
 from testtools import matchers as m
 
 from snapcraft import file_utils, tests
-from snapcraft.internal import deltas # noqa
+from snapcraft.internal import deltas  # noqa
 from snapcraft.tests import fixture_setup
 
 


### PR DESCRIPTION
I was annoyed by these warnings... 

LP: [#1659816](https://bugs.launchpad.net/snapcraft/+bug/1659816)