### PR TITLE
Don't wait for lxd networking in cleanbuild test

### DIFF
--- a/snapcraft/tests/commands/test_cleanbuild.py
+++ b/snapcraft/tests/commands/test_cleanbuild.py
@@ -44,6 +44,7 @@ parts:
         super().make_snapcraft_yaml(self.yaml_template)
         self.state_dir = os.path.join(self.parts_dir, 'part1', 'state')
 
+    @mock.patch('snapcraft.internal.lxd.sleep', lambda _: None)
     @mock.patch('snapcraft.internal.lxd.check_call')
     @mock.patch('snapcraft.internal.repo.is_package_installed')
     def test_cleanbuild(self, mock_installed, mock_call):


### PR DESCRIPTION
It's not relevant to the test.  This strips 5 seconds off the test
run-time.

Checklist:

- Have you signed the contributor licence agreement?
  https://www.ubuntu.com/legal/contributors

I assume being a Canonical employee is sufficient?

- Is there a reported a bug for the problem you are fixing?

Given this is a test cleanup, I'm assuming I don't need one.

- Have you read our contribution guide?
  [CONTRIBUTING.md](CONTRIBUTING.md)

I have now!