### PR TITLE
options: add armv8l to list of translations.

### DIFF
--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -79,8 +79,9 @@ _ARCH_TRANSLATIONS = {
 }
 
 
-_USERSPACE_ARCHITECTURE = {
+_32BIT_USERSPACE_ARCHITECTURE = {
     'aarch64': 'armv7l',
+    'armv8l': 'armv7l',
     'ppc64le': 'ppc',
     'x86_64': 'i686',
 }
@@ -89,7 +90,7 @@ _USERSPACE_ARCHITECTURE = {
 def _get_platform_architecture():
     architecture = platform.machine()
     if platform.architecture()[0] == '32bit':
-        userspace = _USERSPACE_ARCHITECTURE.get(architecture)
+        userspace = _32BIT_USERSPACE_ARCHITECTURE.get(architecture)
         if userspace:
             architecture = userspace
 

--- a/snapcraft/tests/test_options.py
+++ b/snapcraft/tests/test_options.py
@@ -59,6 +59,12 @@ class OptionsTestCase(tests.TestCase):
             expected_arch_triplet='arm-linux-gnueabihf',
             expected_deb_arch='armhf',
             expected_kernel_arch='arm')),
+        ('armv8l-kernel-armv7l-userspace', dict(
+            machine='armv8l',
+            architecture=('32bit', 'ELF'),
+            expected_arch_triplet='arm-linux-gnueabihf',
+            expected_deb_arch='armhf',
+            expected_kernel_arch='arm')),
         ('ppc', dict(
             machine='ppc',
             architecture=('32bit', 'ELF'),
@@ -103,7 +109,8 @@ class OptionsTestCase(tests.TestCase):
         mock_platform_machine.return_value = self.machine
         mock_platform_architecture.return_value = self.architecture
         platform_arch = snapcraft._options._get_platform_architecture()
-        userspace_conversions = snapcraft._options._USERSPACE_ARCHITECTURE
+        userspace_conversions = \
+            snapcraft._options._32BIT_USERSPACE_ARCHITECTURE
 
         if self.architecture[0] == '32bit' and \
            self.machine in userspace_conversions:


### PR DESCRIPTION
platform.machine() is returning armv8l instead of aarch64 on
some architectures when on a 32bit userspace. This addresses that
problem.

LP: #1641123

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>