### PR TITLE
core: classic with no exported variables.

### DIFF
--- a/integration_tests/snaps/assemble/binary1.after
+++ b/integration_tests/snaps/assemble/binary1.after
@@ -1,5 +1,4 @@
 #!/bin/sh
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
-
-LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 exec "$SNAP/binary1" "$@"

--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -43,8 +43,9 @@ def replace_in_file(directory, file_pattern, search_pattern, replacement):
     for root, directories, files in os.walk(directory):
         for file_name in files:
             if file_pattern.match(file_name):
-                _search_and_replace_contents(os.path.join(root, file_name),
-                                             search_pattern, replacement)
+                search_and_replace_contents(os.path.join(root, file_name),
+                                            search_pattern=search_pattern,
+                                            replacement=replacement)
 
 
 def link_or_copy(source, destination, follow_symlinks=False):
@@ -151,7 +152,7 @@ def create_similar_directory(source, destination, follow_symlinks=False):
     shutil.copystat(source, destination, follow_symlinks=follow_symlinks)
 
 
-def _search_and_replace_contents(file_path, search_pattern, replacement):
+def search_and_replace_contents(file_path, *, search_pattern, replacement):
     # Don't bother trying to rewrite a symlink. It's either invalid or the
     # linked file will be rewritten on its own.
     if os.path.islink(file_path):

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -47,18 +47,8 @@ env = []
 logger = logging.getLogger(__name__)
 
 
-def assemble_env(include_core_library_paths=False, arch_triplet=''):
-    if include_core_library_paths:
-        core_paths = get_library_paths(
-            os.path.join('/snap', 'core', 'current'), arch_triplet,
-            existing_only=False)
-        core_library_paths = 'LD_LIBRARY_PATH="{}"'.format(
-            ':'.join(core_paths))
-        parse_env = [core_library_paths] + env
-    else:
-        parse_env = env
-
-    return '\n'.join(['export ' + e for e in parse_env])
+def assemble_env():
+    return '\n'.join(['export ' + e for e in env])
 
 
 def run(cmd, **kwargs):

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -250,33 +250,45 @@ class _SnapPackaging:
         cwd = 'cd {}'.format(cwd) if cwd else ''
 
         # If we are dealing with classic confinement it means all our
-        # binaries are linked with `nodefaultlib` so this is harmless.
-        # We do however want to be on the safe side and make sure no
-        # ABI breakage happens by accidentally loading a library from
-        # the classic system.
-        classic_library_paths = self._config_data['confinement'] == 'classic'
-        assembled_env = common.assemble_env(classic_library_paths,
-                                            self._arch_triplet)
-        assembled_env = assembled_env.replace(self._snap_dir, '$SNAP')
+        # binaries are linked with `nodefaultlib` but we still do
+        # not want to leak PATH or other environment variables
+        # that would affect the applications view of the classic
+        # environment it is dropped into.
         replace_path = r'{}/[a-z0-9][a-z0-9+-]*/install'.format(
             self._parts_dir)
-        assembled_env = re.sub(replace_path, '$SNAP', assembled_env)
+        if self._config_data['confinement'] == 'classic':
+            assembled_env = None
+        else:
+            assembled_env = common.assemble_env()
+            assembled_env = assembled_env.replace(self._snap_dir, '$SNAP')
+            assembled_env = re.sub(replace_path, '$SNAP', assembled_env)
+
         executable = '"{}"'.format(wrapexec)
-        if shebang is not None:
+
+        if shebang:
+            if shebang.startswith('/usr/bin/env '):
+                with tempfile.NamedTemporaryFile('w+') as tempf:
+                    tempf.write('#!/bin/sh\n')
+                    tempf.write('which {}'.format(shebang.split()[1]))
+                    tempf.flush()
+                    shebang = common.run_output(['/bin/sh', tempf.name])
             new_shebang = re.sub(replace_path, '$SNAP', shebang)
+            new_shebang = re.sub(self._snap_dir, '$SNAP', new_shebang)
             if new_shebang != shebang:
                 # If the shebang was pointing to and executable within the
                 # local 'parts' dir, have the wrapper script execute it
                 # directly, since we can't use $SNAP in the shebang itself.
                 executable = '"{}" "{}"'.format(new_shebang, wrapexec)
-        script = ('#!/bin/sh\n' +
-                  '{}\n'.format(assembled_env) +
-                  '{}\n'.format(cwd) +
-                  'LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n'
-                  'exec {} {}\n'.format(executable, args))
 
         with open(wrappath, 'w+') as f:
-            f.write(script)
+            f.write('#!/bin/sh\n')
+            if assembled_env:
+                f.write('{}\n'.format(assembled_env))
+                f.write('export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:'
+                        '$LD_LIBRARY_PATH\n')
+            if cwd:
+                f.write('{}\n'.format(cwd))
+            f.write('exec {} {}\n'.format(executable, args))
 
         os.chmod(wrappath, 0o755)
 

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -522,9 +522,9 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         wrapper_path = os.path.join(self.prime_dir, relative_wrapper_path)
 
         expected = ('#!/bin/sh\n'
-                    'PATH=$SNAP/usr/bin:$SNAP/bin\n'
-                    '\n\n'
-                    'LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n'
+                    'PATH=$SNAP/usr/bin:$SNAP/bin\n\n'
+                    'export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:'
+                    '$LD_LIBRARY_PATH\n'
                     'exec "$SNAP/test_relexepath" "$@"\n')
 
         with open(wrapper_path) as wrapper_file:
@@ -548,9 +548,9 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         self.assertEqual(relative_wrapper_path, 'new-name.wrapper')
 
         expected = ('#!/bin/sh\n'
-                    'PATH=$SNAP/usr/bin:$SNAP/bin\n'
-                    '\n\n'
-                    'LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n'
+                    'PATH=$SNAP/usr/bin:$SNAP/bin\n\n'
+                    'export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:'
+                    '$LD_LIBRARY_PATH\n'
                     'exec "$SNAP/test_relexepath" "$@"\n')
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
@@ -581,14 +581,11 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
 
         expected = (
             '#!/bin/sh\n'
-            '\n\n'
-            'LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n'
-            'exec "$SNAP/snap_exe"'
-            ' "$SNAP/test_relexepath" "$@"\n')
+            'exec "$SNAP/snap_exe" "$SNAP/test_relexepath" "$@"\n')
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
-
         self.assertEqual(expected, wrapper_contents)
+
         with open(os.path.join(self.prime_dir, relative_exe_path), 'r') as exe:
             # The shebang wasn't changed, since we don't know what the
             # path will be on the installed system.
@@ -609,8 +606,6 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         wrapper_path = os.path.join(self.prime_dir, relative_wrapper_path)
 
         expected = ('#!/bin/sh\n'
-                    '\n\n'
-                    'LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n'
                     'exec "$SNAP/test_relexepath" "$@"\n')
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
@@ -637,8 +632,6 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         wrapper_path = os.path.join(self.prime_dir, relative_wrapper_path)
 
         expected = ('#!/bin/sh\n'
-                    '\n\n'
-                    'LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n'
                     'exec "$SNAP/test_relexepath" "$@"\n')
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
@@ -657,8 +650,6 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         wrapper_path = os.path.join(self.prime_dir, relative_wrapper_path)
 
         expected = ('#!/bin/sh\n'
-                    '\n\n'
-                    'LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n'
                     'exec "app1" "$@"\n')
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()


### PR DESCRIPTION
To avoid unexpected errors we wipe clean the envrionment
variables inside the wrappers, if a developer needs it
they could export it themselves.

LP: #1657504

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>