### PR TITLE
meta: properly get the icon extension from splitted name

### DIFF
--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -111,7 +111,7 @@ class _SnapPackaging:
 
         if 'icon' in self._config_data:
             # TODO: use developer.ubuntu.com once it has updated documentation.
-            icon_ext = self._config_data['icon'].split(os.path.extsep)[1]
+            icon_ext = self._config_data['icon'].split(os.path.extsep)[-1]
             icon_dir = os.path.join(self.meta_dir, 'gui')
             icon_path = os.path.join(icon_dir, 'icon.{}'.format(icon_ext))
             if not os.path.exists(icon_dir):

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -150,6 +150,35 @@ class CreateTestCase(CreateBaseTestCase):
         self.assertFalse('icon' in y,
                          'icon found in snap.yaml {}'.format(y))
 
+    def test_create_meta_with_declared_icon_with_dots(self):
+        open(os.path.join(os.curdir, 'com.my.icon.png'), 'w').close()
+        self.config_data['icon'] = 'com.my.icon.png'
+
+        y = self.generate_meta_yaml()
+
+        self.assertTrue(
+            os.path.exists(os.path.join(self.meta_dir, 'gui', 'icon.png')),
+            'icon.png was not setup correctly')
+
+        self.assertFalse('icon' in y,
+                         'icon found in snap.yaml {}'.format(y))
+
+    def test_create_meta_with_declared_icon_in_parent_dir(self):
+        open(os.path.join(os.curdir, 'my-icon.png'), 'w').close()
+        builddir = os.path.join(os.curdir, 'subdir')
+        os.mkdir(builddir)
+        os.chdir(builddir)
+        self.config_data['icon'] = '../my-icon.png'
+
+        y = self.generate_meta_yaml()
+
+        self.assertTrue(
+            os.path.exists(os.path.join(self.meta_dir, 'gui', 'icon.png')),
+            'icon.png was not setup correctly')
+
+        self.assertFalse('icon' in y,
+                         'icon found in snap.yaml {}'.format(y))
+
     def test_create_meta_with_declared_icon_and_setup(self):
         fake_logger = fixtures.FakeLogger(level=logging.INFO)
         self.useFixture(fake_logger)


### PR DESCRIPTION
Get the extension as the last item of the splitted file path

LP: [#1660377](https://bugs.launchpad.net/snapcraft/+bug/1660377)