### PR TITLE
core: switch to using rpath for clasic confinement.

### DIFF
--- a/snapcraft/internal/project_loader.py
+++ b/snapcraft/internal/project_loader.py
@@ -344,7 +344,6 @@ def _build_env(root, snap_name, confinement, arch_triplet,
                    # Building tools to continue the build becomes problematic
                    # with nodefaultlib.
                    '-Wl,-z,nodefaultlib '
-                   '-Wl,--enable-new-dtags '
                    '-Wl,--dynamic-linker={0} '
                    '-Wl,-rpath,{1}"'.format(core_dynamic_linker, rpaths))
 

--- a/snapcraft/tests/test_project_loader.py
+++ b/snapcraft/tests/test_project_loader.py
@@ -1442,7 +1442,6 @@ parts:
         environment = config.stage_env()
         self.assertIn(
             'LDFLAGS="$LDFLAGS -Wl,-z,nodefaultlib '
-            '-Wl,--enable-new-dtags '
             '-Wl,--dynamic-linker={core_dynamic_linker} '
             '-Wl,-rpath,'
             '/snap/core/current/lib:'


### PR DESCRIPTION
From _dl_map_object in elf/dl-load.c:

```
Unless loading object has RUNPATH:
    RPATH of the loading object,
        then the RPATH of its loader (unless it has a RUNPATH), ...,
        until the end of the chain, which is either the executable
        or an object loaded by dlopen
    Unless executable has RUNPATH:
        RPATH of the executable
LD_LIBRARY_PATH
RUNPATH of the loading object
ld.so.cache
default dirs
```

LP: #1657504

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>