### PR TITLE
schema,copy plugin: better errors when item has no value.

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -221,9 +221,15 @@ properties:
           organize:
             type: object
             default: {}
+            additionalProperties:
+              type: string
+              minLength: 1
           filesets:
             type: object
             default: {}
+            additionalProperties:
+              type: array
+              minitems: 1
           stage:
             type: array
             minitems: 1

--- a/snapcraft/_schema.py
+++ b/snapcraft/_schema.py
@@ -15,30 +15,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import contextlib
 import os
 
 import jsonschema
 import yaml
 
-from snapcraft.internal import common
-
-# dict of validator -> cause pairs. Wish jsonschema just gave us better
-# messages.
-_VALIDATION_ERROR_CAUSES = {
-    'maxLength': 'maximum length is {validator_value}',
-    'minLength': 'minimum length is {validator_value}',
-}
-
-
-class SnapcraftSchemaError(Exception):
-
-    @property
-    def message(self):
-        return self._message
-
-    def __init__(self, message):
-        self._message = message
+from snapcraft.internal import (
+    common,
+    errors
+)
 
 
 class Validator:
@@ -69,7 +54,7 @@ class Validator:
             with open(schema_file) as fp:
                 self._schema = yaml.load(fp)
         except FileNotFoundError:
-            raise SnapcraftSchemaError(
+            raise errors.SnapcraftSchemaError(
                 'snapcraft validation file is missing from installation path')
 
     def validate(self):
@@ -78,48 +63,4 @@ class Validator:
             jsonschema.validate(
                 self._snapcraft, self._schema, format_checker=format_check)
         except jsonschema.ValidationError as e:
-            _handle_validation_error(e)
-
-
-def _handle_validation_error(error):
-    """Take a jsonschema.ValidationError and raise a SnapcraftSchemaError.
-
-    The validation errors coming from jsonschema are a nightmare. This function
-    tries to make them a bit more understandable.
-    """
-
-    messages = [error.message]
-
-    # error.validator_value may contain a custom validation error message. If
-    # so, use it instead of the garbage message jsonschema gives us.
-    with contextlib.suppress(TypeError, KeyError):
-        messages = [error.validator_value['validation-failure'].format(error)]
-
-    path = []
-    while error.absolute_path:
-        element = error.absolute_path.popleft()
-        # assume numbers are indices and use 'xxx[123]' notation.
-        if isinstance(element, int):
-            path[-1] = '{}[{}]'.format(path[-1], element)
-        else:
-            path.append(str(element))
-    if path:
-        messages.insert(0, "The '{}' property does not match the "
-                           "required schema:".format('/'.join(path)))
-    cause = error.cause or _determine_cause(error)
-    if cause:
-        messages.append('({})'.format(cause))
-
-    raise SnapcraftSchemaError(' '.join(messages))
-
-
-def _determine_cause(error):
-    """Attempt to determine a cause from validation error.
-
-    Returns:
-        A string representing the cause of the error (it may be empty if no
-        cause can be determined).
-    """
-
-    return _VALIDATION_ERROR_CAUSES.get(error.validator, '').format(
-        validator_value=error.validator_value)
+            raise errors.SnapcraftSchemaError.from_validation_error(e)

--- a/snapcraft/_schema.py
+++ b/snapcraft/_schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016, 2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -14,6 +14,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import contextlib
+
+# dict of jsonschema validator -> cause pairs. Wish jsonschema just gave us
+# better messages.
+_VALIDATION_ERROR_CAUSES = {
+    'maxLength': 'maximum length is {validator_value}',
+    'minLength': 'minimum length is {validator_value}',
+}
+
 
 class SnapcraftError(Exception):
     """Base class for all snapcraft exceptions.
@@ -135,3 +144,56 @@ class RequiredCommandNotFound(SnapcraftError):
 class RequiredPathDoesNotExist(SnapcraftError):
 
     fmt = 'Required path does not exist: {path!r}'
+
+
+class SnapcraftSchemaError(SnapcraftError):
+
+    fmt = '{message}'
+
+    @classmethod
+    def from_validation_error(cls, error):
+        """Take a jsonschema.ValidationError and create a SnapcraftSchemaError.
+
+        The validation errors coming from jsonschema are a nightmare. This
+        class tries to make them a bit more understandable.
+        """
+
+        messages = [error.message]
+
+        # error.validator_value may contain a custom validation error message.
+        # If so, use it instead of the garbage message jsonschema gives us.
+        with contextlib.suppress(TypeError, KeyError):
+            messages = [error.validator_value['validation-failure'].format(
+                error)]
+
+        path = []
+        while error.absolute_path:
+            element = error.absolute_path.popleft()
+            # assume numbers are indices and use 'xxx[123]' notation.
+            if isinstance(element, int):
+                path[-1] = '{}[{}]'.format(path[-1], element)
+            else:
+                path.append(str(element))
+        if path:
+            messages.insert(0, "The '{}' property does not match the "
+                               "required schema:".format('/'.join(path)))
+        cause = error.cause or _determine_cause(error)
+        if cause:
+            messages.append('({})'.format(cause))
+
+        return cls(' '.join(messages))
+
+    def __init__(self, message):
+        super().__init__(message=message)
+
+
+def _determine_cause(error):
+    """Attempt to determine a cause from validation error.
+
+    Returns:
+        A string representing the cause of the error (it may be empty if no
+        cause can be determined).
+    """
+
+    return _VALIDATION_ERROR_CAUSES.get(error.validator, '').format(
+        validator_value=error.validator_value)

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016, 2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -35,6 +35,7 @@ from snapcraft.internal.errors import (
     PluginError,
     MissingState,
     SnapcraftPartConflictError,
+    SnapcraftSchemaError
 )
 from snapcraft.internal import (
     common,
@@ -110,8 +111,9 @@ class PluginHandler:
         try:
             self._load_code(plugin_name, self._part_properties, part_schema)
         except jsonschema.ValidationError as e:
+            error = SnapcraftSchemaError.from_validation_error(e)
             raise PluginError('properties failed to load for {}: {}'.format(
-                part_name, e.message))
+                part_name, error.message))
 
     def _load_code(self, plugin_name, properties, part_schema):
         module_name = plugin_name.replace('-', '_')

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015, 2016 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/snapcraft/internal/project_loader.py
+++ b/snapcraft/internal/project_loader.py
@@ -33,20 +33,11 @@ from snapcraft.internal import (
     parts,
     pluginhandler,
 )
-from snapcraft._schema import Validator, SnapcraftSchemaError
+from snapcraft._schema import Validator
 from snapcraft.internal.parts import SnapcraftLogicError, get_remote_parts
 
 
 logger = logging.getLogger(__name__)
-
-
-@jsonschema.FormatChecker.cls_checks('file-path')
-def _validate_file_exists(instance):
-    if not os.path.exists(instance):
-        raise jsonschema.exceptions.ValidationError(
-            "Specified file '{}' does not exist".format(instance))
-
-    return True
 
 
 @jsonschema.FormatChecker.cls_checks('icon-path')
@@ -402,7 +393,7 @@ def _snapcraft_yaml_load(yaml_file):
         with open(yaml_file, encoding=encoding) as fp:
             return yaml.load(fp)
     except yaml.scanner.ScannerError as e:
-        raise SnapcraftSchemaError(
+        raise errors.SnapcraftSchemaError(
             '{} on line {} of {}'.format(
                 e.problem, e.problem_mark.line + 1, yaml_file))
 
@@ -415,7 +406,7 @@ def load_config(project_options=None):
             "Could not find {}. Are you sure you're in the right directory?\n"
             "To start a new project, use 'snapcraft init'".format(e.file))
         sys.exit(1)
-    except SnapcraftSchemaError as e:
+    except errors.SnapcraftSchemaError as e:
         msg = 'Issues while validating snapcraft.yaml: {}'.format(e.message)
         logger.error(msg)
         sys.exit(1)

--- a/snapcraft/plugins/copy.py
+++ b/snapcraft/plugins/copy.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015, 2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/snapcraft/plugins/copy.py
+++ b/snapcraft/plugins/copy.py
@@ -52,6 +52,10 @@ class CopyPlugin(snapcraft.BasePlugin):
 
         schema['properties']['files'] = {
             'type': 'object',
+            'additionalProperties': {
+                'type': 'string',
+                'minLength': 1
+            }
         }
 
         # The `files` keyword is required here, but the `source` keyword is

--- a/snapcraft/tests/plugins/test_copy.py
+++ b/snapcraft/tests/plugins/test_copy.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015, 2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/snapcraft/tests/plugins/test_copy.py
+++ b/snapcraft/tests/plugins/test_copy.py
@@ -15,7 +15,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os.path
+import jsonschema
+
 from unittest.mock import Mock, patch
+import testtools
 from testtools.matchers import HasLength
 
 import snapcraft
@@ -326,6 +329,17 @@ class TestCopyPlugin(TestCase):
     def test_copy_enable_cross_compilation(self):
         c = CopyPlugin('copy', self.mock_options, self.project_options)
         c.enable_cross_compilation()
+
+    def test_schema_catches_missing_destination(self):
+        with testtools.ExpectedException(
+                jsonschema.exceptions.ValidationError,
+                ".*None is not of type 'string'.*"):
+            jsonschema.validate({'files': {'foo': None}}, CopyPlugin.schema())
+
+        with testtools.ExpectedException(
+                jsonschema.exceptions.ValidationError,
+                ".*'' is too short.*"):
+            jsonschema.validate({'files': {'foo': ''}}, CopyPlugin.schema())
 
 
 class TestRecursivelyLink(TestCase):

--- a/snapcraft/tests/test_project_loader.py
+++ b/snapcraft/tests/test_project_loader.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2016 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/snapcraft/tests/test_project_loader.py
+++ b/snapcraft/tests/test_project_loader.py
@@ -23,6 +23,7 @@ import unittest
 import unittest.mock
 import fixtures
 from testtools import ExpectedException
+from testtools.matchers import Equals
 
 import snapcraft
 from snapcraft.internal import dirs, parts
@@ -30,7 +31,6 @@ from snapcraft.internal import project_loader
 from snapcraft.internal import errors
 from snapcraft import tests
 from snapcraft.tests import fixture_setup
-from snapcraft._schema import SnapcraftSchemaError
 
 
 class YamlBaseTestCase(tests.TestCase):
@@ -132,7 +132,7 @@ parts:
     stage-packages: [fswebcam]
 """)
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Config)
         expected = (
             'The {path!r} property does not match the required schema: '
@@ -424,7 +424,7 @@ parts:
     stage-packages: [fswebcam]
 """)
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Config)
 
         self.assertEqual(raised.message,
@@ -448,7 +448,7 @@ parts:
     stage-packages: [fswebcam]
 """)
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Config)
 
         self.assertEqual(raised.message,
@@ -474,7 +474,7 @@ parts:
     stage-packages: [fswebcam]
 """)
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Config)
 
         self.assertEqual(raised.message,
@@ -499,7 +499,7 @@ parts:
     stage-packages: [fswebcam]
 """)
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Config)
 
         self.assertEqual(raised.message,
@@ -523,7 +523,7 @@ parts:
     stage-packages: [fswebcam]
 """)
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Config)
 
         self.assertEqual(
@@ -548,7 +548,7 @@ parts:
     stage-packages: [fswebcam]
 """)
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Config)
 
         self.assertEqual(
@@ -625,13 +625,61 @@ parts:
 """)
 
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Config)
 
         self.assertEqual(
             raised.message,
             'found character \'\\t\' that cannot start any token '
             'on line 5 of snap/snapcraft.yaml')
+
+    @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
+    def test_yaml_organize_value_none(self, mock_loadPlugin):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        self.make_snapcraft_yaml("""name: test
+version: "1"
+summary: test
+description: nothing
+confinement: strict
+
+parts:
+  part1:
+    plugin: nil
+    organize:
+      foo:
+""")
+        raised = self.assertRaises(
+            errors.SnapcraftSchemaError,
+            project_loader.Config)
+        self.assertThat(str(raised), Equals(
+            "The 'parts/part1/organize/foo' property does not match the "
+            "required schema: None is not of type 'string'"))
+
+    @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
+    def test_yaml_organize_value_empty(self, mock_loadPlugin):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        self.make_snapcraft_yaml("""name: test
+version: "1"
+summary: test
+description: nothing
+confinement: strict
+
+parts:
+  part1:
+    plugin: nil
+    organize:
+      foo: ''
+""")
+        raised = self.assertRaises(
+            errors.SnapcraftSchemaError,
+            project_loader.Config)
+        self.assertThat(str(raised), Equals(
+            "The 'parts/part1/organize/foo' property does not match the "
+            "required schema: '' is too short (minimum length is 1)"))
 
     @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
     def test_config_expands_filesets(self, mock_loadPlugin):
@@ -911,7 +959,7 @@ parts:
     plugin: nil
 """.format(self.name))
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Config)
 
         self.assertRegex(
@@ -969,7 +1017,7 @@ parts:
     stage-packages: [fswebcam]
 """.format(self.confinement))
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Config)
 
         self.assertEqual(
@@ -1028,7 +1076,7 @@ parts:
     stage-packages: [fswebcam]
 """.format(self.grade))
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Config)
 
         self.assertEqual(
@@ -1141,7 +1189,7 @@ parts:
     stage-packages: [fswebcam]
 """.format(self.epoch))
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Config)
 
         self.assertRegex(
@@ -1653,7 +1701,7 @@ class ValidationTestCase(ValidationBaseTestCase):
     def test_summary_too_long(self):
         self.data['summary'] = 'a' * 80
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Validator(self.data).validate)
 
         expected_message = (
@@ -1667,7 +1715,7 @@ class ValidationTestCase(ValidationBaseTestCase):
         self.data['apps'] = {'service1': {}}
 
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Validator(self.data).validate)
 
         expected_message = ("The 'apps/service1' property does not match the "
@@ -1683,7 +1731,7 @@ class ValidationTestCase(ValidationBaseTestCase):
         with unittest.mock.patch('snapcraft._schema.open',
                                  mock_the_open, create=True):
             raised = self.assertRaises(
-                SnapcraftSchemaError,
+                errors.SnapcraftSchemaError,
                 project_loader.Validator,
                 self.data)
 
@@ -1700,7 +1748,7 @@ class ValidationTestCase(ValidationBaseTestCase):
         self.data['parts']['plugins'] = {'type': 'go'}
 
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Validator(self.data).validate)
 
         expected_message = ("The 'parts' property does not match the "
@@ -1744,7 +1792,7 @@ class ValidationTestCase(ValidationBaseTestCase):
         }
 
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Validator(self.data).validate)
 
         self.assertEqual(
@@ -1758,7 +1806,7 @@ class ValidationTestCase(ValidationBaseTestCase):
         self.data['parts']['part1']['prime'] = ['bar']
 
         with ExpectedException(
-                SnapcraftSchemaError,
+                errors.SnapcraftSchemaError,
                 "The 'parts/part1' property does not match the required "
                 "schema: .* cannot contain both 'snap' and 'prime' keywords."):
             project_loader.Validator(self.data).validate()
@@ -1774,7 +1822,7 @@ class RequiredPropertiesTestCase(ValidationBaseTestCase):
         del data[self.key]
 
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Validator(data).validate)
 
         expected_message = '\'{}\' is a required property'.format(self.key)
@@ -1792,7 +1840,7 @@ class InvalidNamesTestCase(ValidationBaseTestCase):
         data['name'] = self.name
 
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Validator(data).validate)
 
         expected_message = ("The 'name' property does not match the "
@@ -1823,7 +1871,7 @@ class InvalidTypesTestCase(ValidationBaseTestCase):
         data['type'] = self.type_
 
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Validator(data).validate)
 
         expected_message = (
@@ -1861,7 +1909,7 @@ class InvalidAppNamesTestCase(ValidationBaseTestCase):
         data['apps'] = {self.name: {'command': '1'}}
 
         raised = self.assertRaises(
-            SnapcraftSchemaError,
+            errors.SnapcraftSchemaError,
             project_loader.Validator(data).validate)
 
         expected_message = (


### PR DESCRIPTION
Snapcraft supports a few different objects in its schema that don't enforce the actual presence of a vaue in its items. Of interest in this PR is the `organize` keyword in the core, as well as the `files` keyword in the copy plugin.

This PR fixes LP: [#1587455](https://bugs.launchpad.net/snapcraft/+bug/1587455) by modifying the schema of both the core and the copy plugin to enforce both the type and the presence of values.