### PR TITLE
Ignore .tox directories when creating cleanbuild tar

### DIFF
--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -275,6 +275,8 @@ def _create_tar_filter(tar_filename):
             return None
         elif fn.endswith('.snap'):
             return None
+        elif fn.startswith('./.tox'):
+            return None
         return tarinfo
     return _tar_filter
 

--- a/snapcraft/tests/commands/test_cleanbuild.py
+++ b/snapcraft/tests/commands/test_cleanbuild.py
@@ -61,6 +61,7 @@ parts:
             self.stage_dir,
             self.prime_dir,
             os.path.join(self.parts_dir, 'plugins'),
+            '.tox',
         ]
         files_tar = [
             os.path.join(self.parts_dir, 'plugins', 'x-plugin.py'),
@@ -71,6 +72,7 @@ parts:
             os.path.join(self.prime_dir, 'binary'),
             'snap-test.snap',
             'snap-test_1.0_source.tar.bz2',
+            '.tox/some_virtualenv_stuff',
         ]
         for d in dirs:
             os.makedirs(d)


### PR DESCRIPTION
Thanks for helping us make a better Snapcraft!

Checklist:

- Have you signed the contributor licence agreement?
  https://www.ubuntu.com/legal/contributors

I'm a Canonical employee.

- Is there a reported a bug for the problem you are fixing?

LP: [#1661064](https://bugs.launchpad.net/snapcraft/+bug/1661064)

- Have you read our contribution guide?
  [CONTRIBUTING.md](CONTRIBUTING.md)

Yes.