### PR TITLE
cleanbuild: include snap directory in tarball.

### DIFF
--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -271,7 +271,7 @@ def _create_tar_filter(tar_filename):
         fn = tarinfo.name
         if fn.startswith('./parts/') and not fn.startswith('./parts/plugins'):
             return None
-        elif fn in ('./stage', './prime', './snap', tar_filename):
+        elif fn in ('./stage', './prime', tar_filename):
             return None
         elif fn.endswith('.snap'):
             return None

--- a/snapcraft/tests/commands/test_cleanbuild.py
+++ b/snapcraft/tests/commands/test_cleanbuild.py
@@ -18,6 +18,7 @@ import logging
 import os
 import tarfile
 from unittest import mock
+from testtools.matchers import Contains
 
 import fixtures
 
@@ -97,6 +98,12 @@ parts:
             f = os.path.relpath(f)
             self.assertTrue('./{}'.format(f) in tar_members,
                             '{} should be in {}'.format(f, tar_members))
+
+        # Also assert that the snapcraft.yaml made it into the cleanbuild tar
+        self.assertThat(
+            tar_members,
+            Contains(os.path.join('.', 'snap', 'snapcraft.yaml')),
+            'snap/snapcraft unexpectedly excluded from tarball')
 
     @mock.patch('snapcraft.internal.repo.is_package_installed')
     def test_no_lxd(self, mock_installed):


### PR DESCRIPTION
The `prime/` directory was historically called `snap/`. As a result, snapcraft has code to ignore the `snap/` directory when creating a tarball for cleanbuild. However, the `snap/` directory has recently come back in another form, and it's necessary for building. This PR fixes LP: [#1661391](https://bugs.launchpad.net/snapcraft/+bug/1661391) by no longer ignoring it when creating the cleanbuild tarball.