### PR TITLE
meta: correct the deprecation for `setup/gui` use.

### DIFF
--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -215,7 +215,7 @@ class _SnapPackaging:
         if not os.path.exists(setup_dir):
             return
 
-        handle_deprecation_notice('dn2')
+        handle_deprecation_notice('dn3')
 
         gui_src = os.path.join(setup_dir, 'gui')
         gui_dst = os.path.join(self.meta_dir, 'gui')

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -205,6 +205,14 @@ class CreateTestCase(CreateBaseTestCase):
         self.assertFalse('icon' in y,
                          'icon found in snap.yaml {}'.format(y))
 
+        # Check for the correct deprecation message.
+        self.assertIn(
+            "Assets in 'setup/gui' should now be placed in 'snap/gui'.",
+            fake_logger.output)
+        self.assertIn(
+            "See http://snapcraft.io/docs/deprecation-notices/dn3",
+            fake_logger.output)
+
     def test_create_meta_with_declared_icon_and_setup_ran_twice_ok(self):
         gui_path = os.path.join('setup', 'gui')
         os.makedirs(gui_path)


### PR DESCRIPTION
dn2 was incorrectly setup when it should have been dn3.

LP: #1661956

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>