### PR TITLE
tests: avoid snapping progress to leak into report

### DIFF
--- a/snapcraft/tests/__init__.py
+++ b/snapcraft/tests/__init__.py
@@ -106,6 +106,7 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         self.useFixture(fixture_setup.TempXDG(self.path))
         self.fake_terminal = fixture_setup.FakeTerminal()
         self.useFixture(self.fake_terminal)
+        self.useFixture(fixture_setup.SilentSnapProgress())
         # Some tests will directly or indirectly change the plugindir, which
         # is a module variable. Make sure that it is returned to the original
         # value when a test ends.

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -77,6 +77,16 @@ class TempXDG(fixtures.Fixture):
         self.addCleanup(patcher_dirs.stop)
 
 
+class SilentSnapProgress(fixtures.Fixture):
+
+    def setUp(self):
+        super().setUp()
+
+        patcher = mock.patch('snapcraft.internal.lifecycle.ProgressBar')
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+
 class CleanEnvironment(fixtures.Fixture):
 
     def setUp(self):


### PR DESCRIPTION
The unit tests have a glitch where the progress bar when snapping
gets leaked into the reporting. This adds a fixture to silence it.

LP: #1662652

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>