### PR TITLE
kernel plugin: fix kernel snap layout

### DIFF
--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -102,7 +102,7 @@ class KBuildPlugin(BasePlugin):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
-        self.build_packages.append('make')
+        self.build_packages.extend(['bc', 'gcc', 'make'])
 
         self.make_targets = []
         self.make_install_targets = ['install']

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -351,3 +351,11 @@ class KernelPlugin(kbuild.KBuildPlugin):
         self._copy_vmlinuz()
         self._copy_system_map()
         self._copy_dtbs()
+
+        # upstream kernel installs under $INSTALL_MOD_PATH/lib/modules/
+        # but snapd expects modules/ and firmware/
+        shutil.move(
+            os.path.join(self.installdir, 'lib', 'modules'), self.installdir)
+        shutil.move(
+            os.path.join(self.installdir, 'lib', 'firmware'), self.installdir)
+        os.rmdir(os.path.join(self.installdir, 'lib'))

--- a/snapcraft/tests/plugins/test_kernel.py
+++ b/snapcraft/tests/plugins/test_kernel.py
@@ -754,7 +754,7 @@ ACCEPT=n
         self.assertEqual(config_contents, 'ACCEPT=y\n')
         self._assert_common_assets(plugin.installdir)
         self.assertTrue(os.path.exists(os.path.join(
-            plugin.installdir, 'lib', 'firmware', 'fake-fw-dir')))
+            plugin.installdir, 'firmware', 'fake-fw-dir')))
 
     def test_build_with_kconfigfile_and_no_firmware(self):
         self.options.kconfigfile = 'config'


### PR DESCRIPTION
Hi,

This fixes the kernel snap layout for firmware/ and modules/; I've build tested this against the ONL example linked in the bug and prime/ now properly contains a modules/ and firmware/ toplevel.

(Also small fix to list of required packages; these packages were missing on top of a clean Ubuntu 16.04 EC2 instance)

Cheers,
-- Loïc