### PR TITLE
cleanbuild: allow talking to a remote.

### DIFF
--- a/manual-tests.md
+++ b/manual-tests.md
@@ -42,6 +42,15 @@
 6. Ensure you are dropped back into your original shell session.
 
 
+# Test cleanbuild with a remote.
+
+1. Setup a remote as described on
+   https://linuxcontainers.org/lxd/getting-started-cli/#multiple-hosts
+2. Select a project to build.
+3. Run `snapcraft cleanbuild --remote <remote>` where `<remote>` is
+   the name you gave the remote on step 1.
+
+
 # Test that the Catkin plugin doesn't pass args to setup.sh
 
 This is a regression test for bug #1660852.

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -324,7 +324,7 @@ def _create_tar_filter(tar_filename):
     return _tar_filter
 
 
-def cleanbuild(project_options):
+def cleanbuild(project_options, remote=''):
     if not repo.is_package_installed('lxd'):
         raise EnvironmentError(
             'The lxd package is not installed, in order to use `cleanbuild` '
@@ -341,7 +341,8 @@ def cleanbuild(project_options):
         t.add(os.path.curdir, filter=_create_tar_filter(tar_filename))
 
     snap_filename = common.format_snap_name(config.data)
-    lxd.Cleanbuilder(snap_filename, tar_filename, project_options).execute()
+    lxd.Cleanbuilder(snap_filename, tar_filename, project_options,
+                     remote=remote).execute()
 
 
 def _snap_data_from_dir(directory):

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -28,7 +28,7 @@ Usage:
   snapcraft [options] strip [<part> ...]
   snapcraft [options] clean [<part> ...] [--step <step>]
   snapcraft [options] snap [<directory> --output <snap-file>]
-  snapcraft [options] cleanbuild
+  snapcraft [options] cleanbuild [--remote=<remote>]
   snapcraft [options] login
   snapcraft [options] logout
   snapcraft [options] list-registered
@@ -68,6 +68,11 @@ Options:
   --target-arch ARCH                    EXPERIMENTAL: sets the target
                                         architecture. Very few plugins support
                                         this.
+
+Options specific to cleanbuild:
+  --remote <remote> Use a specific lxd remote to run the cleanbuild on.
+                    This requires prior setup which is described on:
+                    https://linuxcontainers.org/lxd/getting-started-cli/#multiple-hosts
 
 Options specific to pulling:
   --enable-geoip         enables geoip for the pull step if stage-packages
@@ -278,7 +283,7 @@ def run(args, project_options):  # noqa
     elif args['clean']:
         _run_clean(args, project_options)
     elif args['cleanbuild']:
-        lifecycle.cleanbuild(project_options),
+        lifecycle.cleanbuild(project_options, remote=args['--remote']),
     elif _is_store_command(args):
         _run_store_command(args)
     elif args['tour']:


### PR DESCRIPTION
Add the --remote option to cleanbuild which would build the
project on the selected lxd remote.

LP: #1599578

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>