### PR TITLE
lifecycle: hardcode test_core_snap's PATH.

### DIFF
--- a/snapcraft/tests/test_lifecycle.py
+++ b/snapcraft/tests/test_lifecycle.py
@@ -655,7 +655,7 @@ class CoreSetupTestCase(tests.TestCase):
         self.useFixture(fixtures.EnvironmentVariable(
             'SNAPCRAFT_SETUP_CORE', '1'))
         self.useFixture(fixtures.EnvironmentVariable(
-            'PATH', '{}:{}'.format(bin_override, os.path.expandvars('$PATH'))))
+            'PATH', '{}:/usr/bin'.format(bin_override)))
 
         self.project_options = snapcraft.ProjectOptions()
 


### PR DESCRIPTION
This PR fixes LP: [#1663396](https://bugs.launchpad.net/snapcraft/+bug/1663396) by no longer expanding the PATH but simply hardcoding the directory containing `mksquashfs`. Not an ideal fix because something is still making the PATH garbage, but the suite passes again.