### PR TITLE
Build-depend on git

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Snapcraft Team <snapcraft@lists.snapcraft.io>
 Build-Depends: bash-completion,
                debhelper (>= 9),
                dh-python,
+               git,
                pkg-config,
                python3 (>= 3.4),
                python3-apt,


### PR DESCRIPTION
snapcraft.tests.sources.test_git expects to be able to call git, so
snapcraft should build-depend on it directly.

LP: [#1663605](https://bugs.launchpad.net/snapcraft/+bug/1663605)