### PR TITLE
plainbox-provider plugin: filter out sitecustomize

### DIFF
--- a/integration_tests/snaps/plainbox-provider-with-stage-packages/2016.com.example:simple/manage.py
+++ b/integration_tests/snaps/plainbox-provider-with-stage-packages/2016.com.example:simple/manage.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+from plainbox.provider_manager import setup, N_
+
+
+setup(
+    name='plainbox-provider-simple',
+    namespace='2016.com.example',
+    version="1.0",
+    description=N_("A really simple Plainbox provider"),
+    gettext_domain="2016_com_example_simple",
+)

--- a/integration_tests/snaps/plainbox-provider-with-stage-packages/2016.com.example:simple/units/simple.pxu
+++ b/integration_tests/snaps/plainbox-provider-with-stage-packages/2016.com.example:simple/units/simple.pxu
@@ -1,0 +1,32 @@
+
+unit: category
+id: simple
+_name: Simple
+
+unit: job
+id: always-pass
+category_id: simple
+_summary: A test that always passes
+_description:
+   A test that always passes
+   .
+   This simple test will always succeed, assuming your
+   platform has a 'true' command that returns 0.
+plugin: shell
+estimated_duration: 0.01
+command: true
+flags: preserve-locale
+
+unit: job
+id: always-fail
+category_id: simple
+_summary: A test that always fails
+_description:
+   A test that always fails
+   .
+   This simple test will always fail, assuming your
+   platform has a 'false' command that returns 1.
+plugin: shell
+estimated_duration: 0.01
+command: false
+flags: preserve-locale

--- a/integration_tests/snaps/plainbox-provider-with-stage-packages/snapcraft.yaml
+++ b/integration_tests/snaps/plainbox-provider-with-stage-packages/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: test-package
+version: 0.1
+summary: Create a snap of a plainbox provider using python3 stage-packages
+description: |
+    This is a regression test for 'LP: #1663792' to verify that python3
+    based stage-packages can still work transparently with the python3
+    based plainbox-provider plugin.
+confinement: strict
+
+parts:
+    plainbox-local:
+        plugin: python3
+        python-packages:
+            - plainbox
+            - requests-oauthlib
+        build-packages:
+            - libxml2-dev
+            - libxslt1-dev
+            - zlib1g-dev
+            - build-essential
+    simple-plainbox-provider:
+        plugin: plainbox-provider
+        source: ./2016.com.example:simple
+        after: [plainbox-local]
+        stage-packages: [python3-petname]

--- a/integration_tests/test_plainbox_provider_plugin.py
+++ b/integration_tests/test_plainbox_provider_plugin.py
@@ -16,15 +16,23 @@
 
 import os
 
+import testscenarios
 from testtools.matchers import FileExists
 
 import integration_tests
 
 
-class PlainboxProviderPluginTestCase(integration_tests.TestCase):
+class PlainboxProviderPluginTestCase(testscenarios.WithScenarios,
+                                     integration_tests.TestCase):
 
-    def test_snap_simple_provider(self):
-        self.run_snapcraft('stage', 'plainbox-provider')
+    scenarios = [
+        ('basic', dict(project_directory='plainbox-provider')),
+        ('with-stage-packages',
+         dict(project_directory='plainbox-provider-with-stage-oackages')),
+    ]
+
+    def test_stage(self):
+        self.run_snapcraft('stage', self.project_directory)
 
         self.assertThat(
             os.path.join(

--- a/integration_tests/test_plainbox_provider_plugin.py
+++ b/integration_tests/test_plainbox_provider_plugin.py
@@ -28,7 +28,7 @@ class PlainboxProviderPluginTestCase(testscenarios.WithScenarios,
     scenarios = [
         ('basic', dict(project_directory='plainbox-provider')),
         ('with-stage-packages',
-         dict(project_directory='plainbox-provider-with-stage-oackages')),
+         dict(project_directory='plainbox-provider-with-stage-packages')),
     ]
 
     def test_stage(self):

--- a/snapcraft/plugins/plainbox_provider.py
+++ b/snapcraft/plugins/plainbox_provider.py
@@ -43,14 +43,24 @@ class PlainboxProviderPlugin(snapcraft.BasePlugin):
 
     def build(self):
         super().build()
-        self.run(["python3", "manage.py", "build"])
-        self.run(["python3", "manage.py", "i18n"])
+
+        self.run(['python3', 'manage.py', 'build'])
+        self.run(['python3', 'manage.py', 'i18n'])
         self.run([
-            "python3", "manage.py", "install", "--layout=relocatable",
-            "--prefix=/providers/{}".format(self.name),
-            "--root={}".format(self.installdir)])
+            'python3', 'manage.py', 'install', '--layout=relocatable',
+            '--prefix=/providers/{}'.format(self.name),
+            '--root={}'.format(self.installdir)])
 
         # Fix all shebangs to use the in-snap python.
         file_utils.replace_in_file(self.installdir, re.compile(r''),
                                    re.compile(r'^#!.*python'),
                                    r'#!/usr/bin/env python')
+
+    def snap_fileset(self):
+        fileset = super().snap_fileset()
+        # If a python package is added as a stage-packages it will include
+        # sitecustomize.py which is irrelevant and will cause unnecessary
+        # conflicts so instead we just ignore these entries.
+        fileset.append('-usr/lib/python*/sitecustomize.py')
+        fileset.append('-etc/python*/sitecustomize.py')
+        return fileset

--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -331,6 +331,11 @@ class PythonPlugin(snapcraft.BasePlugin):
         site_dir = self._get_user_site_dir()
         sitecustomize_path = self._get_sitecustomize_path()
 
+        # python from the archives has a sitecustomize symlinking to /etc which
+        # is distro specific and not needed for a snap.
+        if os.path.islink(sitecustomize_path):
+            os.unlink(sitecustomize_path)
+
         # Now create our sitecustomize
         os.makedirs(os.path.dirname(sitecustomize_path), exist_ok=True)
         with open(sitecustomize_path, 'w') as f:

--- a/snapcraft/tests/plugins/test_plainbox_provider.py
+++ b/snapcraft/tests/plugins/test_plainbox_provider.py
@@ -91,3 +91,14 @@ class PythonPluginTestCase(tests.TestCase):
             with open(os.path.join(plugin.installdir,
                                    file_info['path']), 'r') as f:
                 self.assertEqual(f.read(), file_info['expected'])
+
+    def test_fileset_ignores(self):
+        plugin = plainbox_provider.PlainboxProviderPlugin(
+            'test-part', self.options, self.project_options)
+
+        expected_fileset = [
+            '-usr/lib/python*/sitecustomize.py',
+            '-etc/python*/sitecustomize.py',
+        ]
+        fileset = plugin.snap_fileset()
+        self.assertListEqual(expected_fileset, fileset)


### PR DESCRIPTION
When a part that uses the plainbox-provider plugin adds a `stage-packages`
entry for a python3 package, conflicts will occur as this plugin
most likely always comes `after` a python part that actually
adds functionality.

Given that sitecustomize.py will be different and the one added
by `stage-packages` is not really useful in a snap we filter it out.

LP: #1663792

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>