### PR TITLE
snapcraft.yaml: 96boards: minimal changes to get a working kernel snap

### DIFF
--- a/demos/96boards-kernel/snap/snapcraft.yaml
+++ b/demos/96boards-kernel/snap/snapcraft.yaml
@@ -14,7 +14,14 @@ parts:
     kconfigs:
       - CONFIG_LOCALVERSION="-96boards"
       - CONFIG_DEBUG_INFO=n
+      - CONFIG_EXT4_FS=y
+      - CONFIG_BLK_DEV_LOOP=y
+      - CONFIG_BLK_DEV_LOOP_MIN_COUNT=256
       - CONFIG_SQUASHFS=m
+      - CONFIG_MMC_SDHCI=y
+      - CONFIG_MMC_SDHCI_PLTFM=y
+      - CONFIG_MMC_SDHCI_MSM=y
+      - CONFIG_PINCTRL_MSM8916=y
     kernel-initrd-modules:
       - squashfs
     kernel-initrd-firmware:
@@ -29,4 +36,4 @@ parts:
   410c-firmware:
     plugin: tar-content
     source: firmware.tar # from developer.qualcomm.com v1.2
-    destination: lib/firmware
+    destination: firmware


### PR DESCRIPTION
The 96boards example doesn't produce a kernel snap that boots on the Dragonboard410c, and these are the required changes to get a working kernel snap:

CONFIG_MMC*: to avoid hanging during boot when initrd can't find a valid /dev/disk... paritition

CONFIG_EXT4: this is self explanatory

CONFIG_BLK_DEV_LOOP: to avoid a "can't mount loop device: no space left on device" error on boot

And while here, unpack firmware.tar to /firmware.

Tested on my dragonbroard, generating a new image from scratch.

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>

Thanks for helping us make a better Snapcraft!

LP: #1665650

