### PR TITLE
tests: Fix name registration window limit test to latest changes

### DIFF
--- a/integration_tests/test_store_register.py
+++ b/integration_tests/test_store_register.py
@@ -92,14 +92,17 @@ class RegisterTestCase(integration_tests.StoreTestCase):
         # This test has a potential to fail if working off a slow
         # network.
         self.login()
-        snap_name_1 = 'good-snap{}'.format(uuid.uuid4().int)
-        snap_name_2 = 'test-too-fast{}'.format(uuid.uuid4().int)
 
-        self.register(snap_name_1, wait=False)
+        error = None
+        for idx in range(self.test_store.register_count_limit + 1):
+            snap_name = 'test-too-fast{}-{}'.format(uuid.uuid4().int, idx)
+            try:
+                self.register(snap_name, wait=False)
+            except subprocess.CalledProcessError as exc:
+                error = exc
+                break
 
-        error = self.assertRaises(
-            subprocess.CalledProcessError,
-            self.register, snap_name_2, wait=False)
+        self.assertIsNotNone(error, 'An error must be raised.')
         expected = (
             '.*You must wait \d+ seconds before trying to register your '
             'next snap.*')

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -328,16 +328,19 @@ class TestStore(fixtures.Fixture):
         test_store = os.getenv('TEST_STORE', 'fake')
         if test_store == 'fake':
             self.useFixture(FakeStore())
+            self.register_count_limit = 10
             self.register_delay = 0
             self.reserved_snap_name = 'test-reserved-snap-name'
             self.already_owned_snap_name = 'test-already-owned-snap-name'
         elif test_store == 'staging':
             self.useFixture(StagingStore())
-            self.register_delay = 10
+            self.register_count_limit = 10
+            self.register_delay = 60 * 10
             self.reserved_snap_name = 'bash'
         elif test_store == 'production':
             # Use the default server URLs
-            self.register_delay = 180
+            self.register_count_limit = 10
+            self.register_delay = 60 * 10
             self.reserved_snap_name = 'bash'
         else:
             raise ValueError(


### PR DESCRIPTION
Now it's possible to register N names (currently 10) during the course
of a time window (currently 10 minutes). The integration test checking
for the limit now reflects that.