### PR TITLE
tests: update the ftp source for integration test

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -13,6 +13,7 @@ Depends: @,
          python-flake8,
          python3-fixtures,
          python3-pexpect,
+         python3-pyftpdlib,
          python3-testscenarios
 
 Tests: snapstests

--- a/integration_tests/snaps/ftp-source/snapcraft.yaml
+++ b/integration_tests/snaps/ftp-source/snapcraft.yaml
@@ -9,6 +9,6 @@ grade: devel
 confinement: devmode
 
 parts:
-  libwnck:
+  ftp-part:
     plugin: dump
-    source: ftp://ftp.ubuntu.com/ubuntu/pool/main/a/a11y-profile-manager/a11y-profile-manager_0.1.11.orig.tar.xz
+    source: ftp://localhost:2121/test.tar.gz

--- a/integration_tests/snaps/ftp-source/snapcraft.yaml
+++ b/integration_tests/snaps/ftp-source/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ftp-source
-version: 0.2.3
+version: 0.1
 summary: Test downloading files from ftp source
 description: |
   Make sure sources can be fetched from FTP servers.
@@ -11,4 +11,4 @@ confinement: devmode
 parts:
   libwnck:
     plugin: dump
-    source: ftp://ftp.kernel.org/pub/software/admin/A3Com/A3Com-0.2.3.tar.gz
+    source: ftp://ftp.ubuntu.com/ubuntu/pool/main/a/a11y-profile-manager/a11y-profile-manager_0.1.11.orig.tar.xz

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -5,3 +5,4 @@ mccabe==0.5.2
 requests_unixsocket==0.1.5
 testscenarios==0.5.0
 pexpect==4.2.0
+pyftpdlib==1.4.0


### PR DESCRIPTION
kernel.org has just shut down the ftp server, so we need to use a different one.
To avoid this happening again, the test starts a local ftp server.

This adds python3-pyftpdlib to the autopkgtest dependencies.

LP: [#1669541](https://bugs.launchpad.net/snapcraft/+bug/1669541)
