### PR TITLE
godeps plugin: add git to build-packages

### DIFF
--- a/snapcraft/plugins/godeps.py
+++ b/snapcraft/plugins/godeps.py
@@ -98,7 +98,10 @@ class GodepsPlugin(snapcraft.BasePlugin):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
-        self.build_packages.append('golang-go')
+        self.build_packages.extend([
+            'golang-go',
+            'git',
+        ])
         self._gopath = os.path.join(self.partdir, 'go')
         self._gopath_src = os.path.join(self._gopath, 'src')
         self._gopath_bin = os.path.join(self._gopath, 'bin')


### PR DESCRIPTION
The godeps plugin runs "go get github.com/rogpeppe/godeps", which
requires git to be installed.

LP: #1671546