### PR TITLE
repo: fixup with python, not sed

### DIFF
--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 def replace_in_file(directory, file_pattern, search_pattern, replacement):
     """Searches and replaces patterns that match a file pattern.
+
     :param str directory: The directory to look for files.
     :param str file_pattern: The file pattern to match inside directory.
     :param search_pattern: A re.compile'd pattern to search for within
@@ -49,8 +50,37 @@ def replace_in_file(directory, file_pattern, search_pattern, replacement):
     for root, directories, files in os.walk(directory):
         for file_name in files:
             if file_pattern.match(file_name):
-                _search_and_replace_contents(os.path.join(root, file_name),
-                                             search_pattern, replacement)
+                file_path = os.path.join(root, file_name)
+                # Don't bother trying to rewrite a symlink. It's either invalid
+                # or the linked file will be rewritten on its own.
+                if not os.path.islink(file_path):
+                    search_and_replace_contents(
+                        file_path, search_pattern, replacement)
+
+
+def search_and_replace_contents(file_path, search_pattern, replacement):
+    """Search file and replace any occurrence of pattern with replacement.
+
+    :param str file_path: Path of file to be searched.
+    :param re.RegexObject search_pattern: Pattern for which to search.
+    :param str replacement: The string to replace pattern.
+    """
+    try:
+        with open(file_path, 'r+') as f:
+            try:
+                original = f.read()
+            except UnicodeDecodeError:
+                # This was probably a binary file. Skip it.
+                return
+
+            replaced = search_pattern.sub(replacement, original)
+            if replaced != original:
+                f.seek(0)
+                f.truncate()
+                f.write(replaced)
+    except PermissionError as e:
+        logger.warning('Unable to open {path} for writing: {error}'.format(
+            path=file_path, error=e))
 
 
 def link_or_copy(source, destination, follow_symlinks=False):
@@ -155,30 +185,6 @@ def create_similar_directory(source, destination, follow_symlinks=False):
         logger.debug('Unable to chown {}: {}'.format(destination, exception))
 
     shutil.copystat(source, destination, follow_symlinks=follow_symlinks)
-
-
-def _search_and_replace_contents(file_path, search_pattern, replacement):
-    # Don't bother trying to rewrite a symlink. It's either invalid or the
-    # linked file will be rewritten on its own.
-    if os.path.islink(file_path):
-        return
-
-    try:
-        with open(file_path, 'r+') as f:
-            try:
-                original = f.read()
-            except UnicodeDecodeError:
-                # This was probably a binary file. Skip it.
-                return
-
-            replaced = search_pattern.sub(replacement, original)
-            if replaced != original:
-                f.seek(0)
-                f.truncate()
-                f.write(replaced)
-    except PermissionError as e:
-        logger.warning('Unable to open {path} for writing: {error}'.format(
-            path=file_path, error=e))
 
 
 def executable_exists(path):

--- a/snapcraft/internal/repo.py
+++ b/snapcraft/internal/repo.py
@@ -484,16 +484,16 @@ def _fix_artifacts(debdir):
 
 def _fix_xml_tools(root):
     xml2_config_path = os.path.join(root, 'usr', 'bin', 'xml2-config')
-    if os.path.isfile(xml2_config_path):
-        common.run(
-            ['sed', '-i', '-e', 's|prefix=/usr|prefix={}/usr|'.
-                format(root), xml2_config_path])
+    with contextlib.suppress(FileNotFoundError):
+        file_utils.search_and_replace_contents(
+            xml2_config_path, re.compile(r'prefix=/usr'),
+            'prefix={}/usr'.format(root))
 
     xslt_config_path = os.path.join(root, 'usr', 'bin', 'xslt-config')
-    if os.path.isfile(xslt_config_path):
-        common.run(
-            ['sed', '-i', '-e', 's|prefix=/usr|prefix={}/usr|'.
-                format(root), xslt_config_path])
+    with contextlib.suppress(FileNotFoundError):
+        file_utils.search_and_replace_contents(
+            xslt_config_path, re.compile(r'prefix=/usr'),
+            'prefix={}/usr'.format(root))
 
 
 def _fix_symlink(path, debdir, root):

--- a/snapcraft/tests/test_repo.py
+++ b/snapcraft/tests/test_repo.py
@@ -22,6 +22,7 @@ import tempfile
 from unittest.mock import ANY, call, patch, MagicMock
 from testtools.matchers import (
     Contains,
+    FileContains,
     FileExists,
 )
 
@@ -350,6 +351,89 @@ class FixShebangTestCase(RepoBaseTestCase):
 
         with open(self.file_path, 'r') as fd:
             self.assertEqual(fd.read(), self.expected)
+
+
+class FixXmlToolsTestCase(RepoBaseTestCase):
+
+    scenarios = [
+        ('xml2-config only should fix', {
+            'files': [
+                {
+                    'path': os.path.join('root', 'usr', 'bin', 'xml2-config'),
+                    'content': 'prefix=/usr/foo',
+                    'expected': 'prefix=root/usr/foo',
+                },
+            ]
+        }),
+        ('xml2-config only should not fix', {
+            'files': [
+                {
+                    'path': os.path.join('root', 'usr', 'bin', 'xml2-config'),
+                    'content': 'prefix=/foo',
+                    'expected': 'prefix=/foo',
+                },
+            ]
+        }),
+        ('xslt-config only should fix', {
+            'files': [
+                {
+                    'path': os.path.join('root', 'usr', 'bin', 'xslt-config'),
+                    'content': 'prefix=/usr/foo',
+                    'expected': 'prefix=root/usr/foo',
+                },
+            ]
+        }),
+        ('xslt-config only should not fix', {
+            'files': [
+                {
+                    'path': os.path.join('root', 'usr', 'bin', 'xslt-config'),
+                    'content': 'prefix=/foo',
+                    'expected': 'prefix=/foo',
+                },
+            ]
+        }),
+        ('xml2-config and xslt-config', {
+            'files': [
+                {
+                    'path': os.path.join('root', 'usr', 'bin', 'xml2-config'),
+                    'content': 'prefix=/usr/foo',
+                    'expected': 'prefix=root/usr/foo',
+                },
+                {
+                    'path': os.path.join('root', 'usr', 'bin', 'xslt-config'),
+                    'content': 'prefix=/usr/foo',
+                    'expected': 'prefix=root/usr/foo',
+                },
+            ]
+        }),
+        ('xml2-config and xslt-config should not fix', {
+            'files': [
+                {
+                    'path': os.path.join('root', 'usr', 'bin', 'xml2-config'),
+                    'content': 'prefix=/foo',
+                    'expected': 'prefix=/foo',
+                },
+                {
+                    'path': os.path.join('root', 'usr', 'bin', 'xslt-config'),
+                    'content': 'prefix=/foo',
+                    'expected': 'prefix=/foo',
+                },
+            ]
+        }),
+    ]
+
+    def test_fix_xml_tools(self):
+        for test_file in self.files:
+            path = test_file['path']
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, 'w') as f:
+                f.write(test_file['content'])
+
+        repo._fix_xml_tools('root')
+
+        for test_file in self.files:
+            self.assertThat(
+                test_file['path'], FileContains(test_file['expected']))
 
 
 class BuildPackagesTestCase(tests.TestCase):


### PR DESCRIPTION
After unpacking stage-packages, the repo runs a number of fixup steps. One of those steps is to rewrite `usr/bin/xml2-config` and `usr/bin/xslt-config` to look within the part instead of on the host. However, this rewrite is done with sed, which has performance issues as well as poor side effects when it comes to the plugin environment.

This PR fixes LP: [#1671675](https://bugs.launchpad.net/snapcraft/+bug/1671675) by using python to fix those files instead of sed.

**Note:** This PR affects the public `file_utils` API by exposing the previously private `file_utils._search_and_replace_contents` as `file_utils.search_and_replace_contents`.