### PR TITLE
meta: do not quote the command wrapper args.

### DIFF
--- a/manual-tests.md
+++ b/manual-tests.md
@@ -59,3 +59,14 @@ This is a regression test for bug #1660852.
 2. Run `ros-example.launch-project --help`.
 3. Verify that you actually get the help info for `roslaunch`, not a barf of
    errors.
+
+# Test command wrapper quoting
+
+This is a regression test for LP: #1671674
+
+1. Build the lxd snap.
+2. Install the lxd snap.
+3. Setup the lxd snap by running `sudo /snap/bin/lxd init`
+4. Create a container by running `/snap/bin/lxc launch ubuntu:xenial my-container`
+5. Verify that the following command runs succesfully
+   `/snap/bin/lxc exec my-container -- python3 -c 'import urllib.request; urllib.request.urlopen("http://start.ubuntu.com/connectivity-check.html", timeout=5)'`

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -251,7 +251,7 @@ class _SnapPackaging:
 
     def _write_wrap_exe(self, wrapexec, wrappath,
                         shebang=None, args=None, cwd=None):
-        args = ' '.join(args) + ' "$@"' if args else '"$@"'
+        args = ' '.join(args) + ' $@' if args else '$@'
         cwd = 'cd {}'.format(cwd) if cwd else ''
 
         # If we are dealing with classic confinement it means all our

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -577,7 +577,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
                     'PATH=$SNAP/usr/bin:$SNAP/bin\n\n'
                     'export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:'
                     '$LD_LIBRARY_PATH\n'
-                    'exec "$SNAP/test_relexepath" "$@"\n')
+                    'exec "$SNAP/test_relexepath" $@\n')
 
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
@@ -603,7 +603,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
                     'PATH=$SNAP/usr/bin:$SNAP/bin\n\n'
                     'export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:'
                     '$LD_LIBRARY_PATH\n'
-                    'exec "$SNAP/test_relexepath" "$@"\n')
+                    'exec "$SNAP/test_relexepath" $@\n')
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
 
@@ -633,7 +633,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
 
         expected = (
             '#!/bin/sh\n'
-            'exec "$SNAP/snap_exe" "$SNAP/test_relexepath" "$@"\n')
+            'exec "$SNAP/snap_exe" "$SNAP/test_relexepath" $@\n')
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
         self.assertEqual(expected, wrapper_contents)
@@ -658,7 +658,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         wrapper_path = os.path.join(self.prime_dir, relative_wrapper_path)
 
         expected = ('#!/bin/sh\n'
-                    'exec "$SNAP/test_relexepath" "$@"\n')
+                    'exec "$SNAP/test_relexepath" $@\n')
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
 
@@ -684,7 +684,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         wrapper_path = os.path.join(self.prime_dir, relative_wrapper_path)
 
         expected = ('#!/bin/sh\n'
-                    'exec "$SNAP/test_relexepath" "$@"\n')
+                    'exec "$SNAP/test_relexepath" $@\n')
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
 
@@ -702,7 +702,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         wrapper_path = os.path.join(self.prime_dir, relative_wrapper_path)
 
         expected = ('#!/bin/sh\n'
-                    'exec "app1" "$@"\n')
+                    'exec "app1" $@\n')
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
 


### PR DESCRIPTION
The arguments for the command wrapper should not be quoted, that is
`$@` should not be surrounded by quotes.

LP: #1671674

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>