### PR TITLE
store: enable retries for store calls.

### DIFF
--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -16,6 +16,7 @@
 
 import fileinput
 import os
+import re
 import subprocess
 import time
 import uuid
@@ -27,7 +28,7 @@ import pexpect
 from unittest import mock
 import testtools
 from testtools import content
-from testtools.matchers import Contains
+from testtools.matchers import MatchesRegex
 
 from snapcraft.tests import fixture_setup
 
@@ -194,9 +195,9 @@ class StoreTestCase(TestCase):
 
     def logout(self):
         output = self.run_snapcraft('logout')
-        expected = ('Clearing credentials for Ubuntu One SSO.\n'
-                    'Credentials cleared.\n')
-        self.assertThat(output, Contains(expected))
+        expected = (r'.*Clearing credentials for Ubuntu One SSO.\n.*\n'
+                    r'Credentials cleared.\n.*')
+        self.assertThat(output, MatchesRegex(expected, flags=re.DOTALL))
 
     def register(self, snap_name, private=False, wait=True):
         command = ['register', snap_name]

--- a/snapcraft/storeapi/__init__.py
+++ b/snapcraft/storeapi/__init__.py
@@ -1,7 +1,7 @@
 
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -33,6 +33,7 @@ from progressbar import (
 )
 import pymacaroons
 import requests
+from requests.adapters import HTTPAdapter
 from simplejson.scanner import JSONDecodeError
 
 import snapcraft
@@ -91,6 +92,10 @@ class Client():
         self.conf = conf
         self.root_url = root_url
         self.session = requests.Session()
+        # Setup max retries for all store URLs and the CDN
+        self.session.mount('http://', HTTPAdapter(max_retries=5))
+        self.session.mount('https://', HTTPAdapter(max_retries=5))
+
         self._snapcraft_headers = {
             'X-SNAPCRAFT-VERSION': snapcraft.__version__
         }


### PR DESCRIPTION
Calling anything related to the store, more so when dealing with CDNs
has become extremely flaky. This registers an adapter to enabled a
maximum retry count of 5 before giving up on connection resets.

LP: #1671817

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>