### PR TITLE
tests: take into account the new current link.

### DIFF
--- a/snaps_tests/demos_tests/test_busybox.py
+++ b/snaps_tests/demos_tests/test_busybox.py
@@ -34,7 +34,7 @@ class BusyBoxTestCase(snaps_tests.SnapsTestCase):
             '')
         self.addCleanup(
             self.run_command_in_snappy_testbed,
-            ['rm', '~/snap/busybox/*/busybox.test'])
+            ['rm', '~/snap/busybox/x*/busybox.test'])
         self.assert_command_in_snappy_testbed(
             ['/snap/bin/busybox.ls', '~/snap/busybox/x*/'],
             'busybox.test\n')

--- a/snaps_tests/demos_tests/test_mosquitto.py
+++ b/snaps_tests/demos_tests/test_mosquitto.py
@@ -41,7 +41,7 @@ class MosquittoTestCase(snaps_tests.SnapsTestCase):
                 ['/snap/bin/mosquitto.publish', 'test-mosquitto-topic',
                  'exit'], '')
             self.assert_command_in_snappy_testbed(
-                ['cat', '/home/ubuntu/snap/mosquitto/*/'
+                ['cat', '~/snap/mosquitto/x*/'
                  'mosquitto.subscriber.log'],
                 'MQTT subscriber connected.\n'
                 "test-mosquitto-topic b'test-message'\n"


### PR DESCRIPTION
snapd in zesty now creates a symlink from `~/snap/<name>/current`
to `~/snap/<name>/<revision>`. We need to take this into account
when searching for files in the snaps directories.

LP: #1672463