### PR TITLE
core: resolve ld link first.

### DIFF
--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -209,8 +209,7 @@ class ProjectOptions:
                     "found symlink loop resolving dynamic linker path")
 
             seen_paths.add(dynamic_linker_path)
-            if not (os.path.exists(dynamic_linker_path) or
-                    os.path.islink(dynamic_linker_path)):
+            if not os.path.lexists(dynamic_linker_path):
                 return None
             if not os.path.islink(dynamic_linker_path):
                 return dynamic_linker_path

--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -207,11 +207,14 @@ class ProjectOptions:
             if dynamic_linker_path in seen_paths:
                 raise SnapcraftEnvironmentError(
                     "found symlink loop resolving dynamic linker path")
+
             seen_paths.add(dynamic_linker_path)
-            if not os.path.exists(dynamic_linker_path):
+            if not (os.path.exists(dynamic_linker_path) or
+                    os.path.islink(dynamic_linker_path)):
                 return None
             if not os.path.islink(dynamic_linker_path):
                 return dynamic_linker_path
+
             link_contents = os.readlink(dynamic_linker_path)
             if os.path.isabs(link_contents):
                 dynamic_linker_path = os.path.join(


### PR DESCRIPTION
When building with classic confinement the logic was to check
if what was defined as ld existed, but it wouldn't if it was
a symbolic link so check for that in the first check as well.

LP: #1672496

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>