### PR TITLE
tests: remove repo.Ubuntu patch for plugins

### DIFF
--- a/snapcraft/tests/plugins/test_ant.py
+++ b/snapcraft/tests/plugins/test_ant.py
@@ -36,10 +36,6 @@ class AntPluginTestCase(tests.TestCase):
 
         self.project_options = snapcraft.ProjectOptions()
 
-        patcher = mock.patch('snapcraft.repo.Ubuntu')
-        self.ubuntu_mock = patcher.start()
-        self.addCleanup(patcher.stop)
-
     def test_schema(self):
         schema = ant.AntPlugin.schema()
 

--- a/snapcraft/tests/plugins/test_autotools.py
+++ b/snapcraft/tests/plugins/test_autotools.py
@@ -44,10 +44,6 @@ class AutotoolsPluginTestCase(tests.TestCase):
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
 
-        patcher = mock.patch('snapcraft.repo.Ubuntu')
-        self.ubuntu_mock = patcher.start()
-        self.addCleanup(patcher.stop)
-
     def test_schema(self):
         schema = autotools.AutotoolsPlugin.schema()
 

--- a/snapcraft/tests/plugins/test_gradle.py
+++ b/snapcraft/tests/plugins/test_gradle.py
@@ -37,10 +37,6 @@ class BaseGradlePluginTestCase(tests.TestCase):
 
         self.project_options = snapcraft.ProjectOptions()
 
-        patcher = mock.patch('snapcraft.repo.Ubuntu')
-        self.ubuntu_mock = patcher.start()
-        self.addCleanup(patcher.stop)
-
         # unset http and https proxies.
         self.useFixture(fixtures.EnvironmentVariable('http_proxy', None))
         self.useFixture(fixtures.EnvironmentVariable('https_proxy', None))

--- a/snapcraft/tests/plugins/test_kbuild.py
+++ b/snapcraft/tests/plugins/test_kbuild.py
@@ -40,10 +40,6 @@ class KBuildPluginTestCase(tests.TestCase):
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
 
-        patcher = mock.patch('snapcraft.repo.Ubuntu')
-        self.ubuntu_mock = patcher.start()
-        self.addCleanup(patcher.stop)
-
     def test_schema(self):
         schema = kbuild.KBuildPlugin.schema()
 

--- a/snapcraft/tests/plugins/test_make.py
+++ b/snapcraft/tests/plugins/test_make.py
@@ -39,10 +39,6 @@ class MakePluginTestCase(tests.TestCase):
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
 
-        patcher = mock.patch('snapcraft.repo.Ubuntu')
-        self.ubuntu_mock = patcher.start()
-        self.addCleanup(patcher.stop)
-
     def test_schema(self):
         schema = make.MakePlugin.schema()
 

--- a/snapcraft/tests/plugins/test_maven.py
+++ b/snapcraft/tests/plugins/test_maven.py
@@ -39,10 +39,6 @@ class MavenPluginTestCase(tests.TestCase):
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
 
-        patcher = mock.patch('snapcraft.repo.Ubuntu')
-        self.ubuntu_mock = patcher.start()
-        self.addCleanup(patcher.stop)
-
     @staticmethod
     def _canonicalize_settings(settings):
         with io.StringIO(settings) as f:

--- a/snapcraft/tests/plugins/test_scons.py
+++ b/snapcraft/tests/plugins/test_scons.py
@@ -37,10 +37,6 @@ class SconsPluginTestCase(tests.TestCase):
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
 
-        patcher = mock.patch('snapcraft.repo.Ubuntu')
-        self.ubuntu_mock = patcher.start()
-        self.addCleanup(patcher.stop)
-
     def test_schema(self):
         """Test validity of the Scons Plugin schema"""
         schema = scons.SconsPlugin.schema()

--- a/snapcraft/tests/plugins/test_waf.py
+++ b/snapcraft/tests/plugins/test_waf.py
@@ -37,10 +37,6 @@ class WafPluginTestCase(tests.TestCase):
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
 
-        patcher = mock.patch('snapcraft.repo.Ubuntu')
-        self.ubuntu_mock = patcher.start()
-        self.addCleanup(patcher.stop)
-
     def test_schema(self):
         """Test validity of the Waf Plugin schema"""
         schema = waf.WafPlugin.schema()


### PR DESCRIPTION
`stage-packages` handling has been moved to the core of snapcraft so this patching is not needed anymore. We remove it for everything except the catkin tests as it uses its own Ubuntu instance to fetch in the plugin code.

LP: #1672909
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>