### PR TITLE
cleanbuild: packaging independent detection.

### DIFF
--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -325,14 +325,6 @@ def _create_tar_filter(tar_filename):
 
 
 def cleanbuild(project_options, remote=''):
-    if not repo.Repo.is_package_installed('lxd'):
-        raise EnvironmentError(
-            'The lxd package is not installed, in order to use `cleanbuild` '
-            'you must install lxd onto your system. Refer to the '
-            '"Ubuntu Desktop and Ubuntu Server" section on '
-            'https://linuxcontainers.org/lxd/getting-started-cli/'
-            '#ubuntu-desktop-and-ubuntu-server to enable a proper setup.')
-
     config = snapcraft.internal.load_config(project_options)
     tar_filename = '{}_{}_source.tar.bz2'.format(
         config.data['name'], config.data['version'])

--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -151,9 +151,10 @@ def _get_default_remote():
         default_remote = check_output(['lxc', 'remote', 'get-default'])
     except CalledProcessError:
         raise SnapcraftEnvironmentError(
-            'LXD is either not installed or configured properly, in order '
-            'to use `cleanbuild` you must have a proper LXD setup '
-            'on your system.\nRefer to the documentation at '
+            'You must have LXD installed in order to use cleanbuild. '
+            'However, it is either not installed or not configured '
+            'properly.\n'
+            'Refer to the documentation at '
             'https://linuxcontainers.org/lxd/getting-started-cli.')
     return default_remote.decode(sys.getfilesystemencoding()).strip()
 

--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -151,11 +151,10 @@ def _get_default_remote():
         default_remote = check_output(['lxc', 'remote', 'get-default'])
     except CalledProcessError:
         raise SnapcraftEnvironmentError(
-             'The lxd package is not installed, in order to use '
-             '`cleanbuild` you must install lxd onto your system. '
-             'Refer to the "Ubuntu Desktop and Ubuntu Server" section on '
-             'https://linuxcontainers.org/lxd/getting-started-cli/'
-             '#ubuntu-desktop-and-ubuntu-server to enable a proper setup.')
+            'LXD is either not installed or configured properly, in order '
+            'to use `cleanbuild` you must have a proper LXD setup '
+            'on your system.\nRefer to the documentation at '
+            'https://linuxcontainers.org/lxd/getting-started-cli.')
     return default_remote.decode(sys.getfilesystemencoding()).strip()
 
 
@@ -175,6 +174,6 @@ def _verify_remote(remote):
             'There are either no permissions or the remote {!r} '
             'does not exist.\n'
             'Verify the existing remotes by running `lxc remote list`\n'
-            'To setup a new remote, follow the instructions on\n'
+            'To setup a new remote, follow the instructions at\n'
             'https://linuxcontainers.org/lxd/getting-started-cli/'
             '#multiple-hosts'.format(remote)) from e

--- a/snapcraft/tests/commands/test_cleanbuild.py
+++ b/snapcraft/tests/commands/test_cleanbuild.py
@@ -17,13 +17,14 @@
 import logging
 import os
 import tarfile
-from unittest import mock
 from testtools.matchers import Contains
+from unittest import mock
 
 import fixtures
 
 from snapcraft.main import main
 from snapcraft import tests
+from snapcraft.tests.test_lxd import check_output_side_effect
 
 
 class CleanBuildCommandTestCase(tests.TestCase):
@@ -41,16 +42,26 @@ parts:
       plugin: nil
 """
 
+    def setUp(self):
+        super().setUp()
+        patcher = mock.patch('snapcraft.internal.lxd.check_call')
+        self.check_call_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch('snapcraft.internal.lxd.check_output')
+        self.check_output_mock = patcher.start()
+        self.check_output_mock.side_effect = check_output_side_effect()
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch('snapcraft.internal.lxd.sleep', lambda _: None)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def make_snapcraft_yaml(self, n=1):
         super().make_snapcraft_yaml(self.yaml_template)
         self.state_dir = os.path.join(self.parts_dir, 'part1', 'state')
 
-    @mock.patch('snapcraft.internal.lxd.sleep', lambda _: None)
-    @mock.patch('snapcraft.internal.lxd.check_call')
-    @mock.patch('snapcraft.internal.repo.Repo.is_package_installed')
-    def test_cleanbuild(self, mock_installed, mock_call):
-        mock_installed.return_value = True
-
+    def test_cleanbuild(self):
         fake_logger = fixtures.FakeLogger(level=logging.INFO)
         self.useFixture(fake_logger)
 
@@ -106,12 +117,15 @@ parts:
             Contains(os.path.join('.', 'snap', 'snapcraft.yaml')),
             'snap/snapcraft unexpectedly excluded from tarball')
 
-    @mock.patch('snapcraft.internal.repo.Repo.is_package_installed')
-    def test_no_lxd(self, mock_installed):
+    def test_no_lxd(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
         self.useFixture(fake_logger)
 
-        mock_installed.return_value = False
+        self.make_snapcraft_yaml()
+
+        self.check_output_mock.side_effect = check_output_side_effect(
+            fail_on_default=True)
+
         raised = self.assertRaises(
             SystemExit,
             main, ['cleanbuild'])

--- a/snapcraft/tests/commands/test_cleanbuild.py
+++ b/snapcraft/tests/commands/test_cleanbuild.py
@@ -134,8 +134,7 @@ parts:
         self.assertEqual(1, raised.code)
         self.assertEqual(
             fake_logger.output,
-            'The lxd package is not installed, in order to use `cleanbuild` '
-            'you must install lxd onto your system. Refer to the '
-            '"Ubuntu Desktop and Ubuntu Server" section on '
-            'https://linuxcontainers.org/lxd/getting-started-cli/'
-            '#ubuntu-desktop-and-ubuntu-server to enable a proper setup.\n')
+            'LXD is either not installed or configured properly, in order '
+            'to use `cleanbuild` you must have a proper LXD setup '
+            'on your system.\nRefer to the documentation at '
+            'https://linuxcontainers.org/lxd/getting-started-cli.\n')

--- a/snapcraft/tests/commands/test_cleanbuild.py
+++ b/snapcraft/tests/commands/test_cleanbuild.py
@@ -134,7 +134,8 @@ parts:
         self.assertEqual(1, raised.code)
         self.assertEqual(
             fake_logger.output,
-            'LXD is either not installed or configured properly, in order '
-            'to use `cleanbuild` you must have a proper LXD setup '
-            'on your system.\nRefer to the documentation at '
+            'You must have LXD installed in order to use cleanbuild. '
+            'However, it is either not installed or not configured '
+            'properly.\n'
+            'Refer to the documentation at '
             'https://linuxcontainers.org/lxd/getting-started-cli.\n')

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -263,15 +263,12 @@ class LXDTestCase(tests.TestCase):
               fail_on_default=True)
 
         project_options = ProjectOptions(debug=False)
-        with ExpectedException(lxd.SnapcraftEnvironmentError,
-                               'The lxd package is not installed, in order '
-                               'to use `cleanbuild` you must install lxd '
-                               'onto your system. Refer to the '
-                               '"Ubuntu Desktop and Ubuntu Server" '
-                               'section on '
-                               'https://linuxcontainers.org/lxd/getting-'
-                               'started-cli/#ubuntu-desktop-and-ubuntu-'
-                               'server to enable a proper setup.'):
+        with ExpectedException(
+                lxd.SnapcraftEnvironmentError,
+                'LXD is either not installed or configured properly, in order '
+                'to use `cleanbuild` you must have a proper LXD setup '
+                'on your system.\nRefer to the documentation at '
+                'https://linuxcontainers.org/lxd/getting-started-cli.'):
             lxd.Cleanbuilder('snap.snap', 'project.tar',
                              project_options)
 

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -265,9 +265,10 @@ class LXDTestCase(tests.TestCase):
         project_options = ProjectOptions(debug=False)
         with ExpectedException(
                 lxd.SnapcraftEnvironmentError,
-                'LXD is either not installed or configured properly, in order '
-                'to use `cleanbuild` you must have a proper LXD setup '
-                'on your system.\nRefer to the documentation at '
+                'You must have LXD installed in order to use cleanbuild. '
+                'However, it is either not installed or not configured '
+                'properly.\n'
+                'Refer to the documentation at '
                 'https://linuxcontainers.org/lxd/getting-started-cli.'):
             lxd.Cleanbuilder('snap.snap', 'project.tar',
                              project_options)


### PR DESCRIPTION
Don't use the repo to detect if lxd is available as this will prevent use when lxd is provided as a snap or manually installed.

It also makes the logic packaging , agnosting, meaning that a translation layer to figure out what provides the `lxc` command is not necessary.

The work here also migrates the detection out of the lifecycle and into the lxd module.

LP: #1666735
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>