### PR TITLE
demos: make ROS demos support exiting after success

### DIFF
--- a/demos/ros/src/listener/scripts/listener_node
+++ b/demos/ros/src/listener/scripts/listener_node
@@ -3,8 +3,14 @@
 import rospy
 from std_msgs.msg import String
 
+
 def callback(data):
     rospy.loginfo('I heard %s', data.data)
+
+    if rospy.get_param('~exit-after-receive', False):
+        rospy.signal_shutdown(
+            'Requested to exit after message received. Exiting now.')
+
 
 def listener():
     rospy.init_node('listener')

--- a/demos/ros/src/listener/talk_and_listen.launch
+++ b/demos/ros/src/listener/talk_and_listen.launch
@@ -1,9 +1,13 @@
 <launch>
+    <arg name = "exit-after-receive" default = "false"
+          doc = "exit system after listener receives a single message." />
+
     <node name = "talker" pkg = "talker" type = "talker_node"
-          output = "screen" />
+          required = "true" output = "screen" />
 
     <node name = "listener" pkg = "listener" type = "listener_node"
-          output = "screen">
+          required = "true" output = "screen">
         <remap from = "babble" to = "chatter" />
+        <param name = "exit-after-receive" value = "$(arg exit-after-receive)" />
     </node>
 </launch>

--- a/demos/shared-ros/ros-app/bin/run-system
+++ b/demos/shared-ros/ros-app/bin/run-system
@@ -2,11 +2,16 @@
 
 case $SNAP_ARCH in
 amd64)
-	export TRIPLET=x86_64-linux-gnu
+	TRIPLET="x86_64-linux-gnu"
+	;;
+armhf)
+	TRIPLET="arm-linux-gnueabihf"
+	;;
+arm64)
+	TRIPLET="aarch64-linux-gnu"
 	;;
 *)
-	echo "Unsupported arch: $SNAP_ARCH"
-	exit 1
+	TRIPLET="$SNAP_ARCH-linux-gnu"
 	;;
 esac
 
@@ -21,4 +26,4 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ROS_BASE/lib/$TRIPLET
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ROS_BASE/usr/lib
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ROS_BASE/usr/lib/$TRIPLET
 
-roslaunch listener talk_and_listen.launch
+roslaunch listener talk_and_listen.launch "$@"

--- a/demos/shared-ros/ros-app/src/listener/scripts/listener_node
+++ b/demos/shared-ros/ros-app/src/listener/scripts/listener_node
@@ -3,8 +3,14 @@
 import rospy
 from std_msgs.msg import String
 
+
 def callback(data):
     rospy.loginfo('I heard %s', data.data)
+
+    if rospy.get_param('~exit-after-receive', False):
+        rospy.signal_shutdown(
+            'Requested to exit after message received. Exiting now.')
+
 
 def listener():
     rospy.init_node('listener')

--- a/demos/shared-ros/ros-app/src/listener/talk_and_listen.launch
+++ b/demos/shared-ros/ros-app/src/listener/talk_and_listen.launch
@@ -1,9 +1,13 @@
 <launch>
+    <arg name = "exit-after-receive" default = "false"
+          doc = "exit system after listener receives a single message." />
+
     <node name = "talker" pkg = "talker" type = "talker_node"
-          output = "screen" />
+          required = "true" output = "screen" />
 
     <node name = "listener" pkg = "listener" type = "listener_node"
-          output = "screen">
+          required = "true" output = "screen">
         <remap from = "babble" to = "chatter" />
+        <param name = "exit-after-receive" value = "$(arg exit-after-receive)" />
     </node>
 </launch>

--- a/snaps_tests/demos_tests/test_ros.py
+++ b/snaps_tests/demos_tests/test_ros.py
@@ -21,7 +21,6 @@ import re
 import subprocess
 from platform import linux_distribution
 from unittest import skipUnless
-from testtools.matchers import MatchesRegex
 
 
 class ROSTestCase(snaps_tests.SnapsTestCase):
@@ -45,15 +44,12 @@ class ROSTestCase(snaps_tests.SnapsTestCase):
         # passed to rosaunch instead of being eaten by setup.sh.
         self.assert_command_in_snappy_testbed_with_regex([
             '/snap/bin/ros-example.launch-project', '--help'],
-            '.*Usage: roslaunch.*')
+            r'.*Usage: roslaunch.*')
 
-        # Make sure the talker/listener system actually comes up by verifying
-        # that the listener receives something after 5 seconds. `timeout` has
-        # a `--preserve-status` option, but it doesn't always work, so we'll
-        # leave it off and just catch the subprocess error.
-        try:
-            self.snappy_testbed.run_command(
-                ['timeout', '5s', '/snap/bin/ros-example.launch-project'])
-        except subprocess.CalledProcessError as e:
-            self.assertThat(e.output.decode('utf8'), MatchesRegex(
-                r'.*I heard Hello world.*', re.DOTALL))
+        # Run the ROS system. By default this will never exit, but the demo
+        # supports an `exit-after-receive` parameter that, if true, will cause
+        # the system to shutdown after the listener has successfully received
+        # a message.
+        self.assert_command_in_snappy_testbed_with_regex([
+            '/snap/bin/ros-example.launch-project',
+            'exit-after-receive:=true'], r'.*I heard Hello world.*', re.DOTALL)

--- a/snaps_tests/demos_tests/test_shared_ros.py
+++ b/snaps_tests/demos_tests/test_shared_ros.py
@@ -21,7 +21,6 @@ import re
 import subprocess
 from platform import linux_distribution
 from unittest import skipUnless
-from testtools.matchers import MatchesRegex
 
 
 class SharedROSTestCase(snaps_tests.SnapsTestCase):
@@ -52,13 +51,10 @@ class SharedROSTestCase(snaps_tests.SnapsTestCase):
         self.run_command_in_snappy_testbed(
             'sudo snap connect ros-app:ros-base ros-base:ros-base')
 
-        # Make sure the talker/listener system actually comes up by verifying
-        # that the listener receives something after 5 seconds. `timeout` has
-        # a `--preserve-status` option, but it doesn't always work, so we'll
-        # leave it off and just catch the subprocess error.
-        try:
-            self.snappy_testbed.run_command(
-                ['timeout', '30s', '/snap/bin/ros-app.launch-project'])
-        except subprocess.CalledProcessError as e:
-            self.assertThat(e.output.decode('utf8'), MatchesRegex(
-                r'.*I heard Hello world.*', re.DOTALL))
+        # Run the ROS system. By default this will never exit, but the demo
+        # supports an `exit-after-receive` parameter that, if true, will cause
+        # the system to shutdown after the listener has successfully received
+        # a message.
+        self.assert_command_in_snappy_testbed_with_regex([
+            '/snap/bin/ros-app.launch-project',
+            'exit-after-receive:=true'], r'.*I heard Hello world.*', re.DOTALL)


### PR DESCRIPTION
The ROS demos bring up their systems via `roslaunch`. Such systems come up together and are brought down together with `SIGINT`. However, while this makes them somewhat realistic demos, running forever makes them difficult to test in CI.

This PR fixes LP: [#1673621](https://bugs.launchpad.net/snapcraft/+bug/1673621) by adding a parameter to both ROS demos called `exit-after-receive` which, if set, will cause the demos to exit successfully after the listener receives one message. The tests then set this parameter and use regex on the output to verify success.