### PR TITLE
Add some initial checks to intelligently build the initial snapcraft.yaml

### DIFF
--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -20,7 +20,7 @@ snapcraft
 
 Usage:
   snapcraft [options] [--enable-geoip --no-parallel-build]
-  snapcraft [options] init
+  snapcraft [options] init [<source>]
   snapcraft [options] pull [<part> ...]  [--enable-geoip]
   snapcraft [options] build [<part> ...] [--no-parallel-build]
   snapcraft [options] stage [<part> ...]
@@ -260,7 +260,6 @@ def _get_lifecycle_command(args):
 
 def _get_command_from_arg(args):
     functions = {
-        'init': lifecycle.init,
         'login': snapcraft.login,
         'logout': snapcraft.logout,
         'list-plugins': _list_plugins,
@@ -278,6 +277,8 @@ def run(args, project_options):  # noqa
     if lifecycle_command:
         lifecycle.execute(
             lifecycle_command, project_options, args['<part>'])
+    elif args['init']:
+        lifecycle.init(args['<source>'])
     elif argless_command:
         argless_command()
     elif args['clean']:


### PR DESCRIPTION
Creating a PR for comments, this is not ready to merge yet.

This extends the 'init' command to take an optional source argument, for example:
    snapcraft init https://github.com/snapcore/snapcraft.git

It will then check the source's name (URL or local directory) for the snap's name, and introspect it's top-level files for hints as to what kind of plugin it might need.

This is a very limited proof of concept, it would need to be expanded to support a wider variety of sources and plugins before landing.
