### PR TITLE
target-arch: decouple target arch from deb, and use a separate field …

### DIFF
--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -31,6 +31,7 @@ _ARCH_TRANSLATIONS = {
     'armv7l': {
         'kernel': 'arm',
         'deb': 'armhf',
+        'uts_machine': 'arm',
         'cross-compiler-prefix': 'arm-linux-gnueabihf-',
         'cross-build-packages': ['gcc-arm-linux-gnueabihf'],
         'triplet': 'arm-linux-gnueabihf',
@@ -39,6 +40,7 @@ _ARCH_TRANSLATIONS = {
     'aarch64': {
         'kernel': 'arm64',
         'deb': 'arm64',
+        'uts_machine': 'aarch64',
         'cross-compiler-prefix': 'aarch64-linux-gnu-',
         'cross-build-packages': ['gcc-aarch64-linux-gnu'],
         'triplet': 'aarch64-linux-gnu',
@@ -47,11 +49,13 @@ _ARCH_TRANSLATIONS = {
     'i686': {
         'kernel': 'x86',
         'deb': 'i386',
+        'uts_machine': 'i686',
         'triplet': 'i386-linux-gnu',
     },
     'ppc64le': {
         'kernel': 'powerpc',
         'deb': 'ppc64el',
+        'uts_machine': 'ppc64el',
         'cross-compiler-prefix': 'powerpc64le-linux-gnu-',
         'cross-build-packages': ['gcc-powerpc64le-linux-gnu'],
         'triplet': 'powerpc64le-linux-gnu',
@@ -60,6 +64,7 @@ _ARCH_TRANSLATIONS = {
     'ppc': {
         'kernel': 'powerpc',
         'deb': 'powerpc',
+        'uts_machine': 'powerpc',
         'cross-compiler-prefix': 'powerpc-linux-gnu-',
         'cross-build-packages': ['gcc-powerpc-linux-gnu'],
         'triplet': 'powerpc-linux-gnu',
@@ -67,12 +72,14 @@ _ARCH_TRANSLATIONS = {
     'x86_64': {
         'kernel': 'x86',
         'deb': 'amd64',
+        'uts_machine': 'x86_64',
         'triplet': 'x86_64-linux-gnu',
         'core-dynamic-linker': 'lib64/ld-linux-x86-64.so.2',
     },
     's390x': {
         'kernel': 's390x',
         'deb': 's390x',
+        'uts_machine': 's390x',
         'cross-compiler-prefix': 's390x-linux-gnu-',
         'cross-build-packages': ['gcc-s390x-linux-gnu'],
         'triplet': 's390x-linux-gnu',
@@ -236,6 +243,8 @@ class ProjectOptions:
 def _find_machine(deb_arch):
     for machine in _ARCH_TRANSLATIONS:
         if _ARCH_TRANSLATIONS[machine].get('deb', '') == deb_arch:
+            return machine
+        elif _ARCH_TRANSLATIONS[machine].get('uts_machine', '') == deb_arch:
             return machine
 
     raise EnvironmentError(

--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 
 _ARCH_TRANSLATIONS = {
     'armv7l': {
-        'aliases': ['armhf', 'arm'],
         'kernel': 'arm',
         'deb': 'armhf',
         'cross-compiler-prefix': 'arm-linux-gnueabihf-',
@@ -38,7 +37,6 @@ _ARCH_TRANSLATIONS = {
         'core-dynamic-linker': 'lib/ld-linux-armhf.so.3',
     },
     'aarch64': {
-        'aliases': ['arm64', 'aarch64'],
         'kernel': 'arm64',
         'deb': 'arm64',
         'cross-compiler-prefix': 'aarch64-linux-gnu-',
@@ -47,13 +45,11 @@ _ARCH_TRANSLATIONS = {
         'core-dynamic-linker': 'lib/ld-linux-aarch64.so.1',
     },
     'i686': {
-        'aliases': ['i386', 'i686'],
         'kernel': 'x86',
         'deb': 'i386',
         'triplet': 'i386-linux-gnu',
     },
     'ppc64le': {
-        'aliases': ['ppc64el'],
         'kernel': 'powerpc',
         'deb': 'ppc64el',
         'cross-compiler-prefix': 'powerpc64le-linux-gnu-',
@@ -62,7 +58,6 @@ _ARCH_TRANSLATIONS = {
         'core-dynamic-linker': '/lib64/ld64.so.2',
     },
     'ppc': {
-        'aliases': ['powerpc'],
         'kernel': 'powerpc',
         'deb': 'powerpc',
         'cross-compiler-prefix': 'powerpc-linux-gnu-',
@@ -70,14 +65,12 @@ _ARCH_TRANSLATIONS = {
         'triplet': 'powerpc-linux-gnu',
     },
     'x86_64': {
-        'aliases': ['amd64', 'x86_64'],
         'kernel': 'x86',
         'deb': 'amd64',
         'triplet': 'x86_64-linux-gnu',
         'core-dynamic-linker': 'lib64/ld-linux-x86-64.so.2',
     },
     's390x': {
-        'aliases': ['s390x'],
         'kernel': 's390x',
         'deb': 's390x',
         'cross-compiler-prefix': 's390x-linux-gnu-',
@@ -242,9 +235,8 @@ class ProjectOptions:
 
 def _find_machine(deb_arch):
     for machine in _ARCH_TRANSLATIONS:
-        for arch in _ARCH_TRANSLATIONS[machine]['aliases']:
-            if arch == deb_arch:
-                return machine
+        if _ARCH_TRANSLATIONS[machine].get('deb', '') == deb_arch:
+            return machine
 
     raise EnvironmentError(
         'Cannot set machine from deb_arch {!r}'.format(deb_arch))

--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 _ARCH_TRANSLATIONS = {
     'armv7l': {
+        'aliases': ['armhf', 'arm'],
         'kernel': 'arm',
         'deb': 'armhf',
         'cross-compiler-prefix': 'arm-linux-gnueabihf-',
@@ -37,6 +38,7 @@ _ARCH_TRANSLATIONS = {
         'core-dynamic-linker': 'lib/ld-linux-armhf.so.3',
     },
     'aarch64': {
+        'aliases': ['arm64', 'aarch64'],
         'kernel': 'arm64',
         'deb': 'arm64',
         'cross-compiler-prefix': 'aarch64-linux-gnu-',
@@ -45,11 +47,13 @@ _ARCH_TRANSLATIONS = {
         'core-dynamic-linker': 'lib/ld-linux-aarch64.so.1',
     },
     'i686': {
+        'aliases': ['i386', 'i686'],
         'kernel': 'x86',
         'deb': 'i386',
         'triplet': 'i386-linux-gnu',
     },
     'ppc64le': {
+        'aliases': ['ppc64el'],
         'kernel': 'powerpc',
         'deb': 'ppc64el',
         'cross-compiler-prefix': 'powerpc64le-linux-gnu-',
@@ -58,6 +62,7 @@ _ARCH_TRANSLATIONS = {
         'core-dynamic-linker': '/lib64/ld64.so.2',
     },
     'ppc': {
+        'aliases': ['powerpc'],
         'kernel': 'powerpc',
         'deb': 'powerpc',
         'cross-compiler-prefix': 'powerpc-linux-gnu-',
@@ -65,12 +70,14 @@ _ARCH_TRANSLATIONS = {
         'triplet': 'powerpc-linux-gnu',
     },
     'x86_64': {
+        'aliases': ['amd64', 'x86_64'],
         'kernel': 'x86',
         'deb': 'amd64',
         'triplet': 'x86_64-linux-gnu',
         'core-dynamic-linker': 'lib64/ld-linux-x86-64.so.2',
     },
     's390x': {
+        'aliases': ['s390x'],
         'kernel': 's390x',
         'deb': 's390x',
         'cross-compiler-prefix': 's390x-linux-gnu-',
@@ -235,8 +242,9 @@ class ProjectOptions:
 
 def _find_machine(deb_arch):
     for machine in _ARCH_TRANSLATIONS:
-        if _ARCH_TRANSLATIONS[machine].get('deb', '') == deb_arch:
-            return machine
+        for arch in _ARCH_TRANSLATIONS[machine]['aliases']:
+            if arch == deb_arch:
+                return machine
 
     raise EnvironmentError(
         'Cannot set machine from deb_arch {!r}'.format(deb_arch))

--- a/snapcraft/tests/test_target_arch.py
+++ b/snapcraft/tests/test_target_arch.py
@@ -1,0 +1,61 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import snapcraft
+from snapcraft import tests
+
+
+class OptionsTestCase(tests.TestCase):
+
+    scenarios = [
+        ('x86_64', dict(
+            machine='x86_64',
+            expected_machine='x86_64')),
+        ('amd64', dict(
+            machine='amd64',
+            expected_machine='x86_64')),
+        ('i386', dict(
+            machine='i386',
+            expected_machine='i686')),
+        ('i686', dict(
+            machine='i686',
+            expected_machine='i686')),
+        ('armhf', dict(
+            machine='armhf',
+            expected_machine='armv7l')),
+        ('arm', dict(
+            machine='arm',
+            expected_machine='armv7l')),
+        ('aarch64', dict(
+            machine='aarch64',
+            expected_machine='aarch64')),
+        ('arm64', dict(
+            machine='arm64',
+            expected_machine='aarch64')),
+        ('ppc64el', dict(
+            machine='ppc64el',
+            expected_machine='ppc64le')),
+        ('ppc', dict(
+            machine='powerpc',
+            expected_machine='ppc')),
+        ('s390x', dict(
+            machine='s390x',
+            expected_machine='s390x')),
+    ]
+
+    def test_find_machine(self):
+        machine = snapcraft._options._find_machine(self.machine)
+        self.assertEqual(machine, self.expected_machine)


### PR DESCRIPTION
target field for better matching - aka introduce aliases for some archs

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>

LP: #1674752