### PR TITLE
kernel plugin: fix modprobe output parsing.

### DIFF
--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -244,6 +244,7 @@ class KernelPlugin(kbuild.KBuildPlugin):
         return initrd_unpacked_path
 
     def _make_initrd(self):
+
         logger.info('Generating driver initrd for kernel release: {}'.format(
             self.kernel_release))
 
@@ -256,9 +257,9 @@ class KernelPlugin(kbuild.KBuildPlugin):
                 '-S', self.kernel_release, module])
             modprobe_outs.extend(modprobe_out.split(os.linesep))
 
+        modprobe_outs = [_ for _ in modprobe_outs if _]
         modules_path = os.path.join('lib', 'modules', self.kernel_release)
-        for src in set(modprobe_outs):
-            src = src.split()[-1:][0]
+        for src in set(_.split()[1] for _ in modprobe_outs):
             dst = os.path.join(initrd_unpacked_path,
                                os.path.relpath(src, self.installdir))
             os.makedirs(os.path.dirname(dst), exist_ok=True)

--- a/snapcraft/tests/plugins/test_kernel.py
+++ b/snapcraft/tests/plugins/test_kernel.py
@@ -685,13 +685,17 @@ ACCEPT=n
 
         self.check_call_mock.side_effect = fake_unpack
 
-        def fake_modules(*args, **kwargs):
-            module_path = os.path.join(
-                plugin.installdir, 'lib', 'modules', '4.4.2', 'some-module.ko')
-            open(module_path, 'w').close()
-            return module_path
+        def fake_output(*args, **kwargs):
+            if args[0][:3] == ['modprobe', '-n', '--show-depends']:
+                module_path = os.path.join(
+                    plugin.installdir, 'lib', 'modules', '4.4.2',
+                    'some-module.ko')
+                open(module_path, 'w').close()
+                return ('insmod {} enable_fbdev=1\n'.format(module_path))
+            else:
+                raise Exception(args[0])
 
-        self.run_output_mock.side_effect = fake_modules
+        self.run_output_mock.side_effect = fake_output
 
         plugin.build()
 


### PR DESCRIPTION
The module path is always the second item.

LP: #1675029