### PR TITLE
store: better retry strategy for GETs.

### DIFF
--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -198,7 +198,7 @@ class StoreTestCase(TestCase):
 
     def logout(self):
         output = self.run_snapcraft('logout')
-        expected = (r'.*Clearing credentials for Ubuntu One SSO.\n.*\n'
+        expected = (r'.*Clearing credentials for Ubuntu One SSO.\n'
                     r'Credentials cleared.\n.*')
         self.assertThat(output, MatchesRegex(expected, flags=re.DOTALL))
 

--- a/snapcraft/internal/indicators.py
+++ b/snapcraft/internal/indicators.py
@@ -16,9 +16,7 @@
 
 import os
 import sys
-from time import sleep
 
-import requests
 from urllib.request import urlretrieve
 from progressbar import (
     AnimatedMarker,
@@ -62,27 +60,15 @@ def download_requests_stream(request_stream, destination, message=None):
     if not request_stream.headers.get('Content-Encoding', ''):
         total_length = int(request_stream.headers.get('Content-Length', '0'))
 
-    # HttpAdapter cannot help here.
-    not_downloaded = True
-    retry_count = 5
-    while not_downloaded and retry_count:
-        total_read = 0
-        progress_bar = _init_progress_bar(total_length, destination, message)
-        progress_bar.start()
-        try:
-            with open(destination, 'wb') as destination_file:
-                for buf in request_stream.iter_content(1024):
-                    destination_file.write(buf)
-                    total_read += len(buf)
-                    progress_bar.update(total_read)
-            not_downloaded = False
-        except requests.exceptions.ChunkedEncodingError as e:
-            if not retry_count:
-                raise e
-            retry_count -= 1
-            sleep(1)
-        finally:
-            progress_bar.finish()
+    total_read = 0
+    progress_bar = _init_progress_bar(total_length, destination, message)
+    progress_bar.start()
+    with open(destination, 'wb') as destination_file:
+        for buf in request_stream.iter_content(1024):
+            destination_file.write(buf)
+            total_read += len(buf)
+            progress_bar.update(total_read)
+    progress_bar.finish()
 
 
 class UrllibDownloader(object):

--- a/snapcraft/storeapi/__init__.py
+++ b/snapcraft/storeapi/__init__.py
@@ -34,6 +34,8 @@ from progressbar import (
 import pymacaroons
 import requests
 from requests.adapters import HTTPAdapter
+from requests.exceptions import RetryError
+from requests.packages.urllib3.util.retry import Retry
 from simplejson.scanner import JSONDecodeError
 
 import snapcraft
@@ -94,8 +96,11 @@ class Client():
         self.root_url = root_url
         self.session = requests.Session()
         # Setup max retries for all store URLs and the CDN
-        self.session.mount('http://', HTTPAdapter(max_retries=5))
-        self.session.mount('https://', HTTPAdapter(max_retries=5))
+        retries = Retry(total=int(os.environ.get('STORE_RETRIES', 5)),
+                        backoff_factor=int(os.environ.get('STORE_BACKOFF', 2)),
+                        status_forcelist=[104, 500, 502, 503, 504])
+        self.session.mount('http://', HTTPAdapter(max_retries=retries))
+        self.session.mount('https://', HTTPAdapter(max_retries=retries))
 
         self._snapcraft_headers = {
             'User-Agent': _agent.get_user_agent(),
@@ -112,9 +117,12 @@ class Client():
             headers = self._snapcraft_headers
 
         final_url = urllib.parse.urljoin(self.root_url, url)
-        response = self.session.request(
-            method, final_url, headers=headers,
-            params=params, **kwargs)
+        try:
+            response = self.session.request(
+                method, final_url, headers=headers,
+                params=params, **kwargs)
+        except RetryError as e:
+            raise errors.StoreRetryError(e) from e
         return response
 
     def get(self, url, **kwargs):

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -35,6 +35,14 @@ class StoreError(SnapcraftError):
     """
 
 
+class StoreRetryError(StoreError):
+
+    fmt = 'There seems to be a network error: {error}'
+
+    def __init__(self, exception):
+        super().__init__(error=str(exception))
+
+
 class SnapNotFoundError(StoreError):
 
     __FMT_ARCH_CHANNEL = (

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -215,6 +215,11 @@ class FakeStore(fixtures.Fixture):
             urllib.parse.urljoin(
                 self.fake_sso_server_fixture.url, 'api/v2/')))
 
+        self.useFixture(fixtures.EnvironmentVariable(
+            'STORE_RETRIES', '1'))
+        self.useFixture(fixtures.EnvironmentVariable(
+            'STORE_BACKOFF', '0'))
+
         self.fake_store_upload_server_fixture = FakeStoreUploadServerRunning()
         self.useFixture(self.fake_store_upload_server_fixture)
         self.useFixture(fixtures.EnvironmentVariable(


### PR DESCRIPTION
Use the retry class which allows for more fine grained settings such as forcing a retry when a status code is returned.

LP: #1671817