### PR TITLE
cleanbuild: don't copy cache into container.

### DIFF
--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -25,8 +25,6 @@ from time import sleep
 import petname
 
 from snapcraft.internal.errors import SnapcraftEnvironmentError
-from snapcraft.internal import cache
-
 
 logger = logging.getLogger(__name__)
 
@@ -100,20 +98,6 @@ class Cleanbuilder:
         dst = os.path.join('/root', os.path.basename(self._tar_filename))
         self._push_file(self._tar_filename, dst)
         self._container_run(['tar', 'xvf', dst])
-
-        logger.info('Copying snapcraft cache into container')
-        snapcraft_cache = cache.SnapcraftCache()
-        # Later versions have a `push --recursive`. For now we have to do it
-        # the hard way and walk the cache ourselves.
-        for root, dirs, files in os.walk(snapcraft_cache.cache_root):
-            destination_root = os.path.join(
-                '/root', '.cache', 'snapcraft', os.path.relpath(
-                    root, snapcraft_cache.cache_root))
-            self._container_run(['mkdir', '-p', destination_root])
-            for file_path in files:
-                source = os.path.join(root, file_path)
-                destination = os.path.join(destination_root, file_path)
-                self._push_file(source, destination)
 
     def _pull_snap(self):
         src = os.path.join('/root', self._snap_output)

--- a/snapcraft/tests/commands/test_cleanbuild.py
+++ b/snapcraft/tests/commands/test_cleanbuild.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -93,7 +93,6 @@ parts:
 
         self.assertIn(
             'Setting up container with project assets\n'
-            'Copying snapcraft cache into container\n'
             'Waiting for a network connection...\n'
             'Network connection established\n'
             'Retrieved snap-test_1.0_amd64.snap\n',


### PR DESCRIPTION
The cache copy logic needs some more design. Currently it copies in the cache regardless of the  target. We need to be smart and only copy the matching hashes. It also needs to weigh in non local remotes and provide user visible feedback in the case where the cache is copied to a non local remote.

LP: #1669730
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>