### PR TITLE
tour: make it work when its a snap.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,6 +35,11 @@ parts:
         - '*'
         - '**/*.pyc'
     after: [python, apt]
+  tour:
+    source: tour
+    plugin: dump
+    organize:
+      "*": tour/
   python:
     source: https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tar.xz
     plugin: autotools

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -148,6 +148,9 @@ def set_tourdir(tourdir):
 
 
 def get_tourdir():
+    snap = os.environ.get('SNAP')
+    if snap:
+        return os.path.join(snap, 'tour')
     return _tourdir
 
 

--- a/snapcraft/internal/repo/_platform.py
+++ b/snapcraft/internal/repo/_platform.py
@@ -21,6 +21,7 @@ from ._deb import Ubuntu
 _DEB_BASED_PLATFORM = [
     'Ubuntu',
     'Debian',
+    'debian',
 ]
 
 


### PR DESCRIPTION
The tour did not have the brains to properly bootstrap itself when snapcraft was used as a snap.

This also fixes a blcoker for the snap wrt the repo detection.

LP: #1674952
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>