### PR TITLE
kernel plugin: check_config() and check_initrd() support

### DIFF
--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -163,6 +163,8 @@ class KBuildPlugin(BasePlugin):
         except OSError as e:
             raise RuntimeError('Unable to access {!r}: '
                                '{}'.format(e.filename, e.strerror))
+    def get_config_path(self):
+        return os.path.join(self.builddir, '.config')
 
     def do_base_config(self, config_path):
         # if kconfigfile is provided use that
@@ -222,13 +224,19 @@ class KBuildPlugin(BasePlugin):
                  ['CONFIG_PREFIX={}'.format(self.installdir)] +
                  self.make_install_targets)
 
-    def build(self):
+    def prep_build(self):
         super().build()
 
-        config_path = os.path.join(self.builddir, '.config')
+        config_path = self.get_config_path()
 
         self.do_base_config(config_path)
         self.do_patch_config(config_path)
         self.do_remake_config()
+
+    def finish_build(self):
         self.do_build()
         self.do_install()
+
+    def build(self):
+        self.prep_build()
+        self.finish_build()

--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -224,7 +224,7 @@ class KBuildPlugin(BasePlugin):
                  ['CONFIG_PREFIX={}'.format(self.installdir)] +
                  self.make_install_targets)
 
-    def prep_build(self):
+    def do_configure(self):
         super().build()
 
         config_path = self.get_config_path()
@@ -238,5 +238,5 @@ class KBuildPlugin(BasePlugin):
         self.do_install()
 
     def build(self):
-        self.prep_build()
+        self.do_configure()
         self.finish_build()

--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -233,10 +233,7 @@ class KBuildPlugin(BasePlugin):
         self.do_patch_config(config_path)
         self.do_remake_config()
 
-    def finish_build(self):
-        self.do_build()
-        self.do_install()
-
     def build(self):
         self.do_configure()
-        self.finish_build()
+        self.do_build()
+        self.do_install()

--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -163,6 +163,7 @@ class KBuildPlugin(BasePlugin):
         except OSError as e:
             raise RuntimeError('Unable to access {!r}: '
                                '{}'.format(e.filename, e.strerror))
+
     def get_config_path(self):
         return os.path.join(self.builddir, '.config')
 

--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -208,6 +208,13 @@ class KBuildPlugin(BasePlugin):
         cmd = 'yes "" | {} oldconfig'.format(' '.join(self.make_cmd))
         subprocess.check_call(cmd, shell=True, cwd=self.builddir)
 
+    def do_configure(self):
+        config_path = self.get_config_path()
+
+        self.do_base_config(config_path)
+        self.do_patch_config(config_path)
+        self.do_remake_config()
+
     def do_build(self):
         # Linux's kernel Makefile gets confused if it is invoked with the
         # environment setup by another Linux's Makefile:
@@ -225,16 +232,9 @@ class KBuildPlugin(BasePlugin):
                  ['CONFIG_PREFIX={}'.format(self.installdir)] +
                  self.make_install_targets)
 
-    def do_configure(self):
+    def build(self):
         super().build()
 
-        config_path = self.get_config_path()
-
-        self.do_base_config(config_path)
-        self.do_patch_config(config_path)
-        self.do_remake_config()
-
-    def build(self):
         self.do_configure()
         self.do_build()
         self.do_install()

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -399,11 +399,11 @@ class KernelPlugin(kbuild.KBuildPlugin):
 
     def _do_check_config(self, builtin, modules):
         # check the resulting .config has all the necessary options
-        msg = ("**** WARNING **** WARNING **** WARNING **** WARNING ****\n"
-               "Your kernel config is missing some features that ubuntu\n"
-               "core recommends / requires, and while we won\'t prevent\n"
-               "you from building this kernel snap, we suggest you take\n"
-               "a look at these:\n")
+        msg = ('**** WARNING **** WARNING **** WARNING **** WARNING ****\n'
+               'Your kernel config is missing some features that Ubuntu Core '
+               'recommends or requires.\n'
+               'While we will not prevent you from building this kernel snap, '
+               'we suggest you take a look at these:\n')
         required_opts = (required_generic + required_security +
                          required_snappy + required_systemd)
         missing = []
@@ -454,13 +454,12 @@ class KernelPlugin(kbuild.KBuildPlugin):
         snapcraft.download(
             'ubuntu-core', 'edge', self.os_snap, self.project.deb_arch)
 
-    def build(self):
+    def do_configure(self):
         super().do_configure()
+
         builtin, modules = self._do_parse_config(self.get_config_path())
         self._do_check_config(builtin, modules)
         self._do_check_initrd(builtin, modules)
-        super().do_build()
-        self.do_install()
 
     def do_install(self):
         super().do_install()

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -425,8 +425,10 @@ class KernelPlugin(kbuild.KBuildPlugin):
 
     def _do_check_initrd(self, builtin, modules):
         # check all required_boot[] items are either builtin or part of initrd
-        msg = ("The following feature is boot essential, consider making\n"
-               "it static or adding the relevant module to initrd:")
+        msg = ("**** WARNING **** WARNING **** WARNING **** WARNING ****\n"
+               "The following features are deemed boot essential for\n"
+               "ubuntu core, consider making them static[=Y] or adding\n"
+               "the corresponding module to initrd:\n")
         missing = []
 
         for code in required_boot:
@@ -442,10 +444,11 @@ class KernelPlugin(kbuild.KBuildPlugin):
                 missing.append(opt)
 
         if missing:
-            logger.warn('\n{}\n'.format(msg))
+            warn = '\n{}\n'.format(msg)
             for opt in missing:
-                logger.warn('  - {}'.format(opt))
-            logger.warn('')
+                warn += '{}\n'.format(opt)
+            warn += '\n'
+            logger.warn(warn)
 
     def pull(self):
         super().pull()

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -451,7 +451,7 @@ class KernelPlugin(kbuild.KBuildPlugin):
             'ubuntu-core', 'edge', self.os_snap, self.project.deb_arch)
 
     def build(self):
-        super().prep_build()
+        super().do_configure()
         self._do_parse_config(self.get_config_path())
         self._do_check_config()
         self._do_check_initrd()

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -438,6 +438,8 @@ class KernelPlugin(kbuild.KBuildPlugin):
                     continue
                 else:
                     missing.append(opt)
+            else:
+                missing.append(opt)
 
         if missing:
             logger.warn('\n{}\n'.format(msg))

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -398,11 +398,12 @@ class KernelPlugin(kbuild.KBuildPlugin):
 
     def _do_check_config(self):
         # check the resulting .config has all the necessary options
-        msg = 'Your kernel config is missing some feature that ubuntu core \
-recommend / requires,\nand while we won\'t prevent you from building this\
-kernel snap,\n we suggest you take a look at these:'
-        required_opts = required_generic + required_security + \
-            required_snappy + required_systemd
+        msg = ("Your kernel config is missing some features that ubuntu core "
+               "recommends / requires,\n"
+               "and while we won\'t prevent you from building this "
+               "kernel snap, we suggest\nyou take a look at these:\n")
+        required_opts = (required_generic + required_security +
+            required_snappy + required_systemd)
         missing = []
 
         for code in required_opts:
@@ -415,15 +416,15 @@ kernel snap,\n we suggest you take a look at these:'
                 missing.append(opt)
 
         if missing:
-            logger.warn('\n{}\n'.format(msg))
+            warn = '\n{}\n'.format(msg)
             for opt in missing:
-                logger.warn('  - {}'.format(opt))
-            logger.warn('')
+                warn += '{}'.format(opt)
+            logger.warn(warn)
 
     def _do_check_initrd(self):
         # check all required_boot[] items are either builtin or part of initrd
-        msg = 'The following feature is boot essential, consider making\n\
-it static or adding the relevant module to initrd:'
+        msg = ("The following feature is boot essential, consider making\n"
+               "it static or adding the relevant module to initrd:")
         missing = []
 
         for code in required_boot:

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -398,10 +398,11 @@ class KernelPlugin(kbuild.KBuildPlugin):
 
     def _do_check_config(self):
         # check the resulting .config has all the necessary options
-        msg = ("Your kernel config is missing some features that ubuntu core "
-               "recommends / requires,\n"
-               "and while we won\'t prevent you from building this "
-               "kernel snap, we suggest\nyou take a look at these:\n")
+        msg = ("**** WARNING **** WARNING **** WARNING **** WARNING ****\n"
+               "Your kernel config is missing some features that ubuntu\n"
+               "core recommends / requires, and while we won\'t prevent\n"
+               "you from building this kernel snap, we suggest you take\n"
+               "a look at these:\n")
         required_opts = (required_generic + required_security +
             required_snappy + required_systemd)
         missing = []
@@ -419,6 +420,7 @@ class KernelPlugin(kbuild.KBuildPlugin):
             warn = '\n{}\n'.format(msg)
             for opt in missing:
                 warn += '{}'.format(opt)
+            warn += '\n'
             logger.warn(warn)
 
     def _do_check_initrd(self):

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -455,7 +455,8 @@ class KernelPlugin(kbuild.KBuildPlugin):
         self._do_parse_config(self.get_config_path())
         self._do_check_config()
         self._do_check_initrd()
-        super().finish_build()
+        super().do_build()
+        self.do_install()
 
     def do_install(self):
         super().do_install()

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -88,11 +88,12 @@ required_generic = ['DEVTMPFS', 'DEVTMPFS_MOUNT', 'TMPFS_POSIX_ACL', 'IPV6',
 required_security = ['SECURITY', 'SECURITY_APPARMOR', 'SYN_COOKIES',
                      'STRICT_DEVMEM', 'DEFAULT_SECURITY_APPARMOR', 'SECCOMP',
                      'SECCOMP_FILTER', 'CC_STACKPROTECTOR',
-                     'CC_STACKPROTECTOR_REGULAR', 'DEBUG_RODATA',
+                     'CC_STACKPROTECTOR_STRONG', 'DEBUG_RODATA',
                      'DEBUG_SET_MODULE_RONX']
 
 required_snappy = ['RD_LZMA', 'KEYS', 'ENCRYPTED_KEYS', 'SQUASHFS',
-                   'SQUASHFS_XATTR', 'SQUASHFS_XZ']
+                   'SQUASHFS_XATTR', 'SQUASHFS_XZ',
+                   'DEVPTS_MULTIPLE_INSTANCES']
 
 required_systemd = ['DEVTMPFS', 'CGROUPS', 'INOTIFY_USER', 'SIGNALFD',
                     'TIMERFD', 'EPOLL', 'NET', 'SYSFS', 'PROC_FS', 'FHANDLE',

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -419,7 +419,7 @@ class KernelPlugin(kbuild.KBuildPlugin):
         if missing:
             warn = '\n{}\n'.format(msg)
             for opt in missing:
-                warn += '{}'.format(opt)
+                warn += '{}\n'.format(opt)
             warn += '\n'
             logger.warn(warn)
 

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -420,7 +420,6 @@ class KernelPlugin(kbuild.KBuildPlugin):
             warn = '\n{}\n'.format(msg)
             for opt in missing:
                 warn += '{}\n'.format(opt)
-            warn += '\n'
             logger.warn(warn)
 
     def _do_check_initrd(self, builtin, modules):
@@ -447,7 +446,6 @@ class KernelPlugin(kbuild.KBuildPlugin):
             warn = '\n{}\n'.format(msg)
             for opt in missing:
                 warn += '{}\n'.format(opt)
-            warn += '\n'
             logger.warn(warn)
 
     def pull(self):

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -404,7 +404,7 @@ class KernelPlugin(kbuild.KBuildPlugin):
                "you from building this kernel snap, we suggest you take\n"
                "a look at these:\n")
         required_opts = (required_generic + required_security +
-            required_snappy + required_systemd)
+                         required_snappy + required_systemd)
         missing = []
 
         for code in required_opts:


### PR DESCRIPTION
Make snapcraft smarter by parsing .config and initrd modules list and printing out if there are mandatory options missing, or if a boot required piece of code is not builtin or part packaged into initrd

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>

LP: #1676806