### PR TITLE
nodejs plugin: switch to the newer LTS.

### DIFF
--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -47,7 +47,7 @@ from snapcraft import sources
 logger = logging.getLogger(__name__)
 
 _NODEJS_BASE = 'node-v{version}-linux-{arch}'
-_NODEJS_VERSION = '4.4.4'
+_NODEJS_VERSION = '6.10.1'
 _NODEJS_TMPL = 'https://nodejs.org/dist/v{version}/{base}.tar.gz'
 _NODEJS_ARCHES = {
     'i386': 'x86',


### PR DESCRIPTION
Move from 4.4.4 to 6.10.1

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>