### PR TITLE
pluginhandler: exclude `/snap/` from libraries.

### DIFF
--- a/snapcraft/internal/libraries.py
+++ b/snapcraft/internal/libraries.py
@@ -100,5 +100,8 @@ def get_dependencies(elf):
     # Now lets filter out what would be on the system
     system_libs = _get_system_libs()
     libs = [l for l in ldd_out if not os.path.basename(l) in system_libs]
+    # Classic confinement won't do what you want with library crawling
+    # and has a nasty side effect described in LP: #1670100
+    libs = [l for l in libs if not l.startswith('/snap/')]
 
     return libs

--- a/snapcraft/tests/test_libraries.py
+++ b/snapcraft/tests/test_libraries.py
@@ -83,6 +83,18 @@ class TestGetLibraries(tests.TestCase):
         libs = libraries.get_dependencies('foo')
         self.assertEqual(libs, ['/lib/foo.so.1', '/usr/lib/bar.so.2'])
 
+    def test_get_libraries_excludes_slash_snap(self):
+        lines = [
+            'foo.so.1 => /lib/foo.so.1 (0xdead)',
+            'bar.so.2 => /usr/lib/bar.so.2 (0xbeef)',
+            'barsnap.so.2 => /snap/snapcraft/current/bar.so.2 (0xbeef)',
+            '/lib/baz.so.2 (0x1234)',
+        ]
+        self.run_output_mock.return_value = '\t' + '\n\t'.join(lines) + '\n'
+
+        libs = libraries.get_dependencies('foo')
+        self.assertEqual(libs, ['/lib/foo.so.1', '/usr/lib/bar.so.2'])
+
     def test_get_libraries_filtered_by_system_libraries(self):
         self.get_system_libs_mock.return_value = frozenset(['foo.so.1'])
 


### PR DESCRIPTION
When collecting libraries when working with classic confinement
we currently collect snaps of our own doing if installed. This
small fix avoids that.

Ideally it would have been good to just add the `no-system-libs`
`build-attributes` but the side effects there are a bit too big
as some libraries are still collected when dealing with snaps
that depend on other snaps.

LP: #1670100

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>