### PR TITLE
nodejs plugin: switch to the newer LTS. (#1228)

### DIFF
--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -47,7 +47,7 @@ from snapcraft import sources
 logger = logging.getLogger(__name__)
 
 _NODEJS_BASE = 'node-v{version}-linux-{arch}'
-_NODEJS_VERSION = '6.10.1'
+_NODEJS_VERSION = '6.10.2'
 _NODEJS_TMPL = 'https://nodejs.org/dist/v{version}/{base}.tar.gz'
 _NODEJS_ARCHES = {
     'i386': 'x86',


### PR DESCRIPTION
Move from 6.10.1 to 6.10.2 as 6.10.1 404s

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>