### PR TITLE
core: find the correct libraries as a snap.

### DIFF
--- a/bin/snapcraft-classic
+++ b/bin/snapcraft-classic
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+case $SNAP_ARCH in
+amd64)
+        TRIPLET="x86_64-linux-gnu"
+        ;;
+armhf)
+        TRIPLET="arm-linux-gnueabihf"
+        ;;
+arm64)
+        TRIPLET="aarch64-linux-gnu"
+        ;;
+*)
+	TRIPLET="$(uname -p)-linux-gnu"
+        ;;
+esac
+
+export LD_LIBRARY_PATH=$SNAP/usr/lib:$SNAP/usr/lib/$TRIPLET
+
+exec $SNAP/usr/bin/python3 $SNAP/bin/snapcraft "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,9 +12,14 @@ confinement: classic
 
 apps:
   snapcraft:
-    command: bin/snapcraft
+    command: bin/snapcraft-classic
 
 parts:
+  snapcraft-bin:
+    source: bin
+    plugin: dump
+    organize:
+        snapcraft-classic: bin/snapcraft-classic
   snapcraft:
     source: .
     plugin: python
@@ -28,12 +33,17 @@ parts:
     stage-packages:
         - libarchive13
         - libffi6
+        - libmagic1
         - libsodium18
         - squashfs-tools
         - xdelta3
     prime:
         - '*'
         - '**/*.pyc'
+    install: |
+        TRIPLET_PATH=$(ls -d $SNAPCRAFT_PART_INSTALL/usr/lib/$(uname -p)-*)
+        ln -s libarchive.so.13.2.1 $TRIPLET_PATH/libarchive.so
+        ln -s libsodium.so.18.1.1 $TRIPLET_PATH/libsodium.so
     after: [python, apt]
   tour:
     source: tour

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,8 +42,10 @@ parts:
         - '**/*.pyc'
     install: |
         TRIPLET_PATH=$(ls -d $SNAPCRAFT_PART_INSTALL/usr/lib/$(uname -p)-*)
-        ln -s libarchive.so.13.2.1 $TRIPLET_PATH/libarchive.so
-        ln -s libsodium.so.18.1.1 $TRIPLET_PATH/libsodium.so
+        LIBARCHIVE=$(readlink -n $TRIPLET_PATH/libarchive.so.13)
+        ln -s $LIBARCHIVE $TRIPLET_PATH/libarchive.so
+        LIBSODIUM=$(readlink -n $TRIPLET_PATH/libsodium.so.18)
+        ln -s $LIBSODIUM $TRIPLET_PATH/libsodium.so
     after: [python, apt]
   tour:
     source: tour

--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -356,6 +356,28 @@ from collections import OrderedDict                 # noqa
 import pkg_resources                                # noqa
 import yaml                                         # noqa
 
+import os as _os
+if _os.environ.get('SNAP_NAME') == 'snapcraft':
+    # The current implementation as of 3.6 in for find_library in
+    # ctypes.util makes use of `ldconfig -p` which depends on the
+    # current ld cache which in effect has no knowledge of any library
+    # in $SNAP. What makes matters worse is that it will provide
+    # results for on host libraries we do NOT want.
+    import re as _re
+
+    def find_library(name):
+        regex = r'lib{name}\.[^\s]+'.format(name=_re.escape(name))
+        snap_root = _os.environ.get('SNAP')
+        for root, directories, files in _os.walk(snap_root):
+            for filename in files:
+                res = _re.search(regex, filename)
+                if res:
+                    return res.group(0)
+
+    from unittest.mock import patch as _patch
+    _p = _patch('ctypes.util.find_library').start()
+    _p.side_effect = find_library
+
 from snapcraft._baseplugin import BasePlugin        # noqa
 from snapcraft._options import ProjectOptions       # noqa
 from snapcraft._help import topic_help              # noqa

--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -374,9 +374,8 @@ if _os.environ.get('SNAP_NAME') == 'snapcraft':
                 if res:
                     return res.group(0)
 
-    from unittest.mock import patch as _patch
-    _p = _patch('ctypes.util.find_library').start()
-    _p.side_effect = find_library
+    import ctypes.util
+    ctypes.util.find_library = find_library
 
 from snapcraft._baseplugin import BasePlugin        # noqa
 from snapcraft._options import ProjectOptions       # noqa


### PR DESCRIPTION
The current implementation as of 3.6 in for find_library in ctypes.util makes use of `ldconfig -p` which depends on the current ld cache which in effect has no knowledge of any library in $SNAP. What makes matters worse is that it will provide results for on host libraries we do NOT want.

LP: #1678289

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>