### PR TITLE
snap: use the gpg tarball instead of git://.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -108,9 +108,7 @@ parts:
         - zlib1g-dev
     after: [python]
   gpg:
-      source: git://git.gnupg.org/gnupg.git
-      source-tag: gnupg-1.4.20
-      source-depth: 1
+      source: https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.21.tar.bz2
       plugin: autotools
       configflags:
         - --enable-minimal


### PR DESCRIPTION
Since launchpad doesn't support git:// references in code and
the https handler for gnupg is currently broken it seems
appropriate to use the release tarball.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>