### PR TITLE
repo: enable elementary.

### DIFF
--- a/snapcraft/internal/repo/_platform.py
+++ b/snapcraft/internal/repo/_platform.py
@@ -14,24 +14,29 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import platform
+from platform import linux_distribution as _linux_distribution
 
 from ._deb import Ubuntu
 
 _DEB_BASED_PLATFORM = [
     'Ubuntu',
     'Debian',
+    'elementary',
+    # Not sure what was going on when this was added.
+    '"elementary"',
     'debian',
 ]
 
 
-def _is_deb_based():
-    return platform.linux_distribution()[0] in _DEB_BASED_PLATFORM
+def _is_deb_based(distro):
+    return distro in _DEB_BASED_PLATFORM
 
 
 def _get_repo_for_platform():
-    if _is_deb_based():
+    distro = _linux_distribution()[0]
+    if _is_deb_based(distro):
         return Ubuntu
     else:
         raise RuntimeError(
-            'snapcraft is not supported on this operating system')
+            'snapcraft is not supported on this operating system '
+            '({!r})'.format(distro))

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from platform import linux_distribution as _linux_distribution
 from ._platform import _is_deb_based
 
 
@@ -34,7 +35,8 @@ class PackageNotFoundError(Exception):
         message = 'The package {!r} was not found.'.format(
             self.package_name)
         # If the package was multiarch, try to help.
-        if _is_deb_based() and ':' in self.package_name:
+        distro = _linux_distribution()[0]
+        if _is_deb_based(distro) and ':' in self.package_name:
             (name, arch) = self.package_name.split(':', 2)
             if arch:
                 message += (


### PR DESCRIPTION
Added `elementary` and `"elementary"`. The former for when the
latter is fixed if at all.

LP: #1678286

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>