### PR TITLE
cli: improve push output.

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -427,7 +427,7 @@ def push(snap_filename, release_channels=None):
     snap_name = snap_yaml['name']
     store = storeapi.StoreClient()
 
-    logger.info('Pushing {!r} to the store.'.format(snap_filename))
+    logger.info('Preparing to push {!r} to the store.'.format(snap_filename))
     with _requires_login():
         store.push_precheck(snap_name)
 

--- a/snapcraft/storeapi/__init__.py
+++ b/snapcraft/storeapi/__init__.py
@@ -762,16 +762,19 @@ class StatusTracker:
 
         content = {}
         for indicator_count in itertools.count():
+            progress_indicator.update(indicator_count)
             if not queue.empty():
                 content = queue.get()
                 if isinstance(content, Exception):
                     raise content
-                widgets[0] = self._get_message(content)
-            progress_indicator.update(indicator_count)
             if content.get('processed'):
                 break
+            else:
+                widgets[0] = self._get_message(content)
             sleep(0.1)
         progress_indicator.finish()
+        # Print at the end to avoid a left over spinner artifact
+        print(self._get_message(content))
 
         self.__content = content
 
@@ -782,7 +785,10 @@ class StatusTracker:
             raise errors.StoreReviewError(self.__content)
 
     def _get_message(self, content):
-        return self.__messages.get(content['code'], content['code'])
+        try:
+            return self.__messages.get(content['code'], content['code'])
+        except KeyError:
+            return self.__messages.get('being_processed')
 
     def _update_status(self, queue):
         for content in self._get_status():

--- a/snapcraft/storeapi/_upload.py
+++ b/snapcraft/storeapi/_upload.py
@@ -53,13 +53,10 @@ def upload_files(binary_filename, updown_client):
 
         # Create a progress bar that looks like: Uploading foo [==  ] 50%
         progress_bar = ProgressBar(
-            widgets=['Uploading {} '.format(binary_filename),
+            widgets=['Pushing {} '.format(os.path.basename(binary_filename)),
                      Bar(marker='=', left='[', right=']'), ' ', Percentage()],
             maxval=os.path.getsize(binary_filename))
         progress_bar.start()
-        # Print a newline so the progress bar has some breathing room.
-        logger.info('')
-
         # Create a monitor for this upload, so that progress can be displayed
         monitor = MultipartEncoderMonitor(
             encoder, functools.partial(_update_progress_bar, progress_bar,

--- a/snapcraft/tests/commands/test_push.py
+++ b/snapcraft/tests/commands/test_push.py
@@ -89,7 +89,7 @@ class PushCommandTestCase(tests.TestCase):
 
         self.assertRegexpMatches(
             self.fake_logger.output,
-            ".*Pushing 'my-snap-name_0\.1_\w*.snap' to the store\.\n"
+            ".*push 'my-snap-name_0\.1_\w*.snap' to the store\.\n"
             "Revision 9 of 'my-snap-name' created\.",
         )
 
@@ -190,7 +190,7 @@ class PushCommandTestCase(tests.TestCase):
 
         self.assertRegexpMatches(
             self.fake_logger.output,
-            ".*Pushing 'my-snap-name_0\.1_\w*.snap\' to the store\.\n"
+            ".*push 'my-snap-name_0\.1_\w*.snap\' to the store\.\n"
             "Revision 9 of 'my-snap-name' created.",
         )
 
@@ -244,7 +244,7 @@ class PushCommandTestCase(tests.TestCase):
 
         self.assertRegexpMatches(
             self.fake_logger.output,
-            ".*Pushing 'my-snap-name_0\.1_\w*\.snap\' to the store\.\n"
+            ".*push 'my-snap-name_0\.1_\w*\.snap\' to the store\.\n"
             "Revision 9 of 'my-snap-name' created\.\n"
             "The 'beta' channel is now open\.\n")
 
@@ -301,7 +301,7 @@ class PushCommandTestCase(tests.TestCase):
 
         self.assertRegexpMatches(
             self.fake_logger.output,
-            ".*Pushing 'my-snap-name_0\.1_\w*.snap\' to the store\.\n"
+            ".*push 'my-snap-name_0\.1_\w*.snap\' to the store\.\n"
             "Revision 9 of 'my-snap-name' created\.\n"
             "The 'beta,edge,candidate' channel is now open\.\n"
         )


### PR DESCRIPTION
Use basename of file to leave space for the widget (useful when pushing a delta).
Don't print the 'Upload' message twice and don't leave a trailing spinner after the release is complete.
Upload renamed to push to be more consistent.

LP: #1625784
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>