### PR TITLE
repo: enable KDE Neon.

### DIFF
--- a/snapcraft/internal/repo/_platform.py
+++ b/snapcraft/internal/repo/_platform.py
@@ -25,6 +25,7 @@ _DEB_BASED_PLATFORM = [
     # Not sure what was going on when this was added.
     '"elementary"',
     'debian',
+    'neon',
 ]
 
 


### PR DESCRIPTION
Currently Snapcraft doesn't work on KDE Neon, an Ubuntu-based distribution which includes latest KDE software. This PR fixes it.

Distribution ID is `neon`. See following for evidence:

```shell
$ python
Python 2.7.12 (default, Nov 19 2016, 06:48:10) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import platform
>>> platform.linux_distribution()
('neon', '16.04', 'xenial')
```