### PR TITLE
Fixed links to doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ many pieces. It can drive a very wide range of build and packaging systems,
 so that you can simply list all the upstream projects you want and have
 them built and installed together as a single tree.
 
-![Snapcraft Overview][overview-image]
-
 For example, say you want to make a product that includes PyPI packages,
 Node.js packages from NPM, Java, and a bunch of daemons written in C and
 C++ that are built with autotools, snapcraft would make assembling the
@@ -21,7 +19,7 @@ transactional update system.
 
 ## More Information
 
-* [Introduction](docs/intro.md) to all the details about the concepts behind snapcraft.
+* [Introduction](https://snapcraft.io/docs/) to all the details about the concepts behind snapcraft.
 * [Hacking guide](HACKING.md) to contribute if you're interested in developing Snapcraft.
 * [Launchpad](https://bugs.launchpad.net/snapcraft) to submit bugs or issues.
 
@@ -40,4 +38,3 @@ Get news and stay up to date on [Twitter](https://twitter.com/snapcraftio),
 [codecov-image]: https://codecov.io/github/snapcore/snapcraft/coverage.svg?branch=master
 [codecov-url]: https://codecov.io/github/snapcore/snapcraft?branch=master
 
-[overview-image]: https://rawgit.com/snapcore/snapcraft/master/docs/images/snapcraft_overview.svg


### PR DESCRIPTION
Thanks for helping us make a better Snapcraft!

Checklist:

- Have you signed the contributor licence agreement?
  https://www.ubuntu.com/legal/contributors

Yes.

- Is there a reported a bug for the problem you are fixing?
  https://bugs.launchpad.net/snapcraft/
  If there is none, please report it. Once you have the BUG_NUMBER,
  replace it here:

Nop... But it's just a minor fix in README....

- Have you read our contribution guide?
  [CONTRIBUTING.md](CONTRIBUTING.md)

Yes.

-----

The doc folder was removed in #1227. This fixes/removes the links in README.