### PR TITLE
meta: version from git support.

### DIFF
--- a/integration_tests/test_git_source.py
+++ b/integration_tests/test_git_source.py
@@ -219,4 +219,3 @@ class GitGenerateVersionTestCase(GitSourceBaseTestCase):
             exception.output,
             Contains('fatal: Not a git repository (or any of the parent '
                      'directories): .git'))
-

--- a/integration_tests/test_git_source.py
+++ b/integration_tests/test_git_source.py
@@ -18,7 +18,7 @@ import subprocess
 import shutil
 from textwrap import dedent
 
-from testtools.matchers import FileExists
+from testtools.matchers import Contains, FileExists
 import integration_tests
 
 
@@ -209,3 +209,14 @@ class GitGenerateVersionTestCase(GitSourceBaseTestCase):
         revno = self.get_revno()[:7]
         expected_file = 'git-test_0+git.{}_amd64.snap'.format(revno)
         self.assertThat(expected_file, FileExists())
+
+    def test_no_git(self):
+        shutil.rmtree('.git')
+
+        exception = self.assertRaises(
+            subprocess.CalledProcessError, self.run_snapcraft, ['snap'])
+        self.assertThat(
+            exception.output,
+            Contains('fatal: Not a git repository (or any of the parent '
+                     'directories): .git'))
+

--- a/integration_tests/test_git_source.py
+++ b/integration_tests/test_git_source.py
@@ -13,27 +13,50 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+import os
 import subprocess
 import shutil
+from textwrap import dedent
 
+from testtools.matchers import FileExists
 import integration_tests
 
 
-class GitSourceTestCase(integration_tests.TestCase):
+class GitSourceBaseTestCase(integration_tests.TestCase):
 
     def setUp(self):
         super().setUp()
         if shutil.which('git') is None:
             self.skipTest('git is not installed')
 
-    def _init_and_config_git(self):
+    def init_and_config_git(self):
         subprocess.check_call(
             ['git', 'init', '.'], stdout=subprocess.DEVNULL)
         subprocess.check_call(
             ['git', 'config', '--local', 'user.name', '"Example Dev"'])
         subprocess.check_call(
             ['git', 'config', '--local', 'user.email', 'dev@example.com'])
+
+    def add_file(self, file_path):
+        subprocess.check_call(
+            ['git', 'add', file_path], stdout=subprocess.DEVNULL)
+
+    def commit(self, message):
+        subprocess.check_call(
+            ['git', 'commit', '-m', message], stdout=subprocess.DEVNULL)
+
+    def tag(self, tag_name):
+        subprocess.check_call(
+            ['git', 'tag', '-a', '-m', tag_name, tag_name],
+            stdout=subprocess.DEVNULL)
+
+    def get_revno(self):
+        return subprocess.check_output([
+            'git', 'rev-list', 'HEAD', '--max-count=1']
+            ).decode('utf-8').strip()
+
+
+class GitSourceTestCase(GitSourceBaseTestCase):
 
     def _get_git_revno(self, path, revrange='-1'):
         return subprocess.check_output(
@@ -44,7 +67,7 @@ class GitSourceTestCase(integration_tests.TestCase):
     def test_pull_git_head(self):
         self.copy_project_to_cwd('git-head')
 
-        self._init_and_config_git()
+        self.init_and_config_git()
         subprocess.check_call(
             ['git', 'commit', '-m', '"1"', '--allow-empty'],
             stdout=subprocess.DEVNULL)
@@ -63,7 +86,7 @@ class GitSourceTestCase(integration_tests.TestCase):
     def test_pull_git_tag(self):
         self.copy_project_to_cwd('git-tag')
 
-        self._init_and_config_git()
+        self.init_and_config_git()
         subprocess.check_call(
             ['git', 'commit', '-m', '"1"', '--allow-empty'],
             stdout=subprocess.DEVNULL)
@@ -85,7 +108,7 @@ class GitSourceTestCase(integration_tests.TestCase):
     def test_pull_git_commit(self):
         self.copy_project_to_cwd('git-commit')
 
-        self._init_and_config_git()
+        self.init_and_config_git()
         subprocess.check_call(
             ['git', 'commit', '-m', '"1"', '--allow-empty'],
             stdout=subprocess.DEVNULL)
@@ -101,7 +124,7 @@ class GitSourceTestCase(integration_tests.TestCase):
     def test_pull_git_branch(self):
         self.copy_project_to_cwd('git-branch')
 
-        self._init_and_config_git()
+        self.init_and_config_git()
         subprocess.check_call(
             ['git', 'commit', '-m', '"1"', '--allow-empty'],
             stdout=subprocess.DEVNULL)
@@ -133,7 +156,7 @@ class GitSourceTestCase(integration_tests.TestCase):
         """Regression test for LP: #1627772."""
         self.copy_project_to_cwd('git-depth')
 
-        self._init_and_config_git()
+        self.init_and_config_git()
         subprocess.check_call(
             ['git', 'commit', '-m', '"1"', '--allow-empty'],
             stdout=subprocess.DEVNULL)
@@ -142,3 +165,47 @@ class GitSourceTestCase(integration_tests.TestCase):
             stdout=subprocess.DEVNULL)
 
         self.run_snapcraft('pull')
+
+
+class GitGenerateVersionTestCase(GitSourceBaseTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.init_and_config_git()
+        os.mkdir('snap')
+
+        with open(os.path.join('snap', 'snapcraft.yaml'), 'w') as f:
+            print(dedent("""\
+                name: git-test
+                version: git
+                summary: test git generated version
+                description: test git generated version with git hint
+                architectures: [amd64]
+                parts:
+                    nil:
+                        plugin: nil
+                """), file=f)
+
+        self.add_file(os.path.join('snap', 'snapcraft.yaml'))
+        self.commit('snapcraft.yaml added')
+
+    def test_tag(self):
+        self.tag('2.0')
+        self.run_snapcraft('snap')
+        self.assertThat('git-test_2.0_amd64.snap', FileExists())
+
+    def test_tag_with_commits_ahead(self):
+        self.tag('2.0')
+        open('stub_file', 'w').close()
+        self.add_file('stub_file')
+        self.commit('new stub file')
+        self.run_snapcraft('snap')
+        revno = self.get_revno()[:7]
+        expected_file = 'git-test_2.0+git1.{}_amd64.snap'.format(revno)
+        self.assertThat(expected_file, FileExists())
+
+    def test_no_tag(self):
+        self.run_snapcraft('snap')
+        revno = self.get_revno()[:7]
+        expected_file = 'git-test_0+git.{}_amd64.snap'.format(revno)
+        self.assertThat(expected_file, FileExists())

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -361,7 +361,8 @@ def snap(project_options, directory=None, output=None):
     else:
         # make sure the full lifecycle is executed
         snap_dir = project_options.snap_dir
-        snap = execute('prime', project_options)
+        execute('prime', project_options)
+        snap = _snap_data_from_dir(snap_dir)
 
     snap_name = output or common.format_snap_name(snap)
 

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -254,10 +254,12 @@ class _SnapPackaging:
     def _get_version(self, version):
         # we want to whitelist what we support here.
         if version == 'git':
+            logger.info('Determining the version from the project '
+                        'repo (version: git).')
             vcs_handler = get_source_handler_from_type('git')
-            return vcs_handler.generate_version()
-        else:
-            return version
+            version = vcs_handler.generate_version()
+            logger.info('The version has been set to {!r}'.format(version))
+        return version
 
     def _write_wrap_exe(self, wrapexec, wrappath,
                         shebang=None, args=None, cwd=None):

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -32,6 +32,7 @@ from snapcraft import shell_utils
 from snapcraft.internal import common, project_loader
 from snapcraft.internal.errors import MissingGadgetError
 from snapcraft.internal.deprecations import handle_deprecation_notice
+from snapcraft.internal.sources import get_source_handler_from_type
 
 
 logger = logging.getLogger(__name__)
@@ -39,7 +40,6 @@ logger = logging.getLogger(__name__)
 
 _MANDATORY_PACKAGE_KEYS = [
     'name',
-    'version',
     'description',
     'summary',
 ]
@@ -240,6 +240,8 @@ class _SnapPackaging:
         for key_name in _MANDATORY_PACKAGE_KEYS:
             snap_yaml[key_name] = self._config_data[key_name]
 
+        snap_yaml['version'] = self._get_version(self._config_data['version'])
+
         for key_name in _OPTIONAL_PACKAGE_KEYS:
             if key_name in self._config_data:
                 snap_yaml[key_name] = self._config_data[key_name]
@@ -248,6 +250,14 @@ class _SnapPackaging:
             snap_yaml['apps'] = self._wrap_apps(self._config_data['apps'])
 
         return snap_yaml
+
+    def _get_version(self, version):
+        # we want to whitelist what we support here.
+        if version == 'git':
+            vcs_handler = get_source_handler_from_type('git')
+            return vcs_handler.generate_version()
+        else:
+            return version
 
     def _write_wrap_exe(self, wrapexec, wrappath,
                         shebang=None, args=None, cwd=None):

--- a/snapcraft/internal/sources/__init__.py
+++ b/snapcraft/internal/sources/__init__.py
@@ -155,6 +155,11 @@ if sys.platform == 'linux':
     _source_handler['rpm'] = Rpm
 
 
+def get_source_handler_from_type(source_type):
+    """Return the source handler for source_type."""
+    return _source_handler.get(source_type)
+
+
 def get_source_handler(source, *, source_type=''):
     if not source_type:
         source_type = _get_source_type_from_uri(source)

--- a/snapcraft/internal/sources/_git.py
+++ b/snapcraft/internal/sources/_git.py
@@ -15,13 +15,53 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import re
 import subprocess
+import sys
 
 from . import errors
 from ._base import Base
 
 
 class Git(Base):
+
+    @classmethod
+    def generate_version(cls, *, source_dir=None):
+        """Return the latest git tag from PWD or defined source_dir.
+
+        The output depends on the use of annotated tags, an will return
+        something like: '2.28+git.10.abcdef' where '2.28 is the
+        tag, '+git' indicates there are commits ahead of the tag, in
+        this case it is '10' and the latest commit hash begins with
+        'abcdef'. If there are no tags or the revision cannot be
+        determined, this will return 0 as the tag and only the commit
+        hash of the latest commit.
+        """
+        if not source_dir:
+            source_dir = os.getcwd()
+
+        try:
+            output = subprocess.check_output([
+                'git', '-C', source_dir, 'describe',
+                '--dirty']).decode(sys.getfilesystemencoding()).strip()
+        except subprocess.CalledProcessError:
+            output = subprocess.check_output([
+                'git', '-C', source_dir, 'describe', '--tags', '--dirty',
+                '--always']).decode(sys.getfilesystemencoding()).strip()
+            return '0+git.{}'.format(output)
+
+        m = re.search(r'(?P<tag>.*)-(?P<revs_ahead>.*)-g(?P<commit>.*)',
+                      output)
+
+        if not m:
+            # This means we have a pure tag
+            return output
+
+        tag = m.group('tag')
+        revs_ahead = m.group('revs_ahead')
+        commit = m.group('commit')
+
+        return '{}+git{}.{}'.format(tag, revs_ahead, commit)
 
     def __init__(self, source, source_dir, source_tag=None, source_commit=None,
                  source_branch=None, source_depth=None, silent=False,

--- a/snapcraft/internal/sources/_git.py
+++ b/snapcraft/internal/sources/_git.py
@@ -45,8 +45,10 @@ class Git(Base):
                 'git', '-C', source_dir, 'describe',
                 '--dirty']).decode(sys.getfilesystemencoding()).strip()
         except subprocess.CalledProcessError:
+            # If we fall into this exception it is because the repo is not
+            # tagged at all.
             output = subprocess.check_output([
-                'git', '-C', source_dir, 'describe', '--tags', '--dirty',
+                'git', '-C', source_dir, 'describe', '--dirty',
                 '--always']).decode(sys.getfilesystemencoding()).strip()
             return '0+git.{}'.format(output)
 

--- a/snapcraft/internal/sources/_git.py
+++ b/snapcraft/internal/sources/_git.py
@@ -50,8 +50,11 @@ class Git(Base):
                 '--always']).decode(sys.getfilesystemencoding()).strip()
             return '0+git.{}'.format(output)
 
-        m = re.search(r'(?P<tag>.*)-(?P<revs_ahead>.*)-g(?P<commit>.*)',
-                      output)
+        m = re.search(
+            r'^(?P<tag>[a-zA-Z0-9.+~-]+)-'
+            r'(?P<revs_ahead>\d+)-'
+            r'g(?P<commit>[0-9a-fA-F]+)$',
+            output)
 
         if not m:
             # This means we have a pure tag

--- a/snapcraft/internal/sources/_git.py
+++ b/snapcraft/internal/sources/_git.py
@@ -41,9 +41,10 @@ class Git(Base):
             source_dir = os.getcwd()
 
         try:
-            output = subprocess.check_output([
-                'git', '-C', source_dir, 'describe',
-                '--dirty']).decode(sys.getfilesystemencoding()).strip()
+            output = subprocess.check_output(
+                ['git', '-C', source_dir, 'describe', '--dirty'],
+                stderr=subprocess.DEVNULL).decode(
+                    sys.getfilesystemencoding()).strip()
         except subprocess.CalledProcessError:
             # If we fall into this exception it is because the repo is not
             # tagged at all.

--- a/snapcraft/internal/sources/_git.py
+++ b/snapcraft/internal/sources/_git.py
@@ -29,7 +29,7 @@ class Git(Base):
     def generate_version(cls, *, source_dir=None):
         """Return the latest git tag from PWD or defined source_dir.
 
-        The output depends on the use of annotated tags, an will return
+        The output depends on the use of annotated tags and will return
         something like: '2.28+git.10.abcdef' where '2.28 is the
         tag, '+git' indicates there are commits ahead of the tag, in
         this case it is '10' and the latest commit hash begins with

--- a/snapcraft/internal/sources/_git.py
+++ b/snapcraft/internal/sources/_git.py
@@ -53,7 +53,7 @@ class Git(Base):
         m = re.search(
             r'^(?P<tag>[a-zA-Z0-9.+~-]+)-'
             r'(?P<revs_ahead>\d+)-'
-            r'g(?P<commit>[0-9a-fA-F]+)$',
+            r'g(?P<commit>[0-9a-fA-F]+(?:-dirty)?)$',
             output)
 
         if not m:

--- a/snapcraft/internal/sources/errors.py
+++ b/snapcraft/internal/sources/errors.py
@@ -17,6 +17,10 @@
 from snapcraft.internal import errors
 
 
+class VCSError(errors.SnapcraftError):
+    fmt = '{message}'
+
+
 class IncompatibleOptionsError(errors.SnapcraftError):
 
     fmt = '{message}'

--- a/snapcraft/tests/sources/test_git.py
+++ b/snapcraft/tests/sources/test_git.py
@@ -411,7 +411,7 @@ class GitGenerateVersionTestCase(tests.TestCase):
         self.output_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
-    def test_only_tag(self):
+    def test_version(self):
         if self.tag:
             self.output_mock.return_value = self.return_value.encode('utf-8')
         else:


### PR DESCRIPTION
If `version: git` is set, snapcraft will determine
the version using git and its tags.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>