### PR TITLE
tests: do not print coverage check message.

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -51,7 +51,7 @@ parseargs(){
     fi
 }
 
-python3 -m coverage && coverage="true"
+python3 -m coverage 1>/dev/null 2>&1 && coverage="true"
 
 run_static_tests(){
     SRC_PATHS="bin snapcraft integration_tests snaps_tests external_snaps_tests"


### PR DESCRIPTION
Filter the output when running ./runtests.sh where we check if coverage is
available by running `python3 -m coverage`.

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>