### PR TITLE
meta: override the version with version-script.

### DIFF
--- a/integration_tests/snaps/version-script/snap/snapcraft.yaml
+++ b/integration_tests/snaps/version-script/snap/snapcraft.yaml
@@ -1,0 +1,17 @@
+name: version-script-test
+architectures: [amd64]
+version: "0.1"
+version-script: echo 0.1
+summary: test variations of the version script
+description: |
+  Add different scripts for version-script and verify they do the right
+  thing.
+
+grade: devel
+confinement: devmode
+
+parts:
+  dummy:
+    plugin: nil
+    install: |
+      echo "test-build" > $SNAPCRAFT_PART_INSTALL/version

--- a/integration_tests/snaps/version-script/snap/snapcraft.yaml
+++ b/integration_tests/snaps/version-script/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: version-script-test
 architectures: [amd64]
 version: "0.1"
-version-script: echo 0.1
+version-script: exit 1
 summary: test variations of the version script
 description: |
   Add different scripts for version-script and verify they do the right

--- a/integration_tests/snaps/version-script/snap/snapcraft.yaml
+++ b/integration_tests/snaps/version-script/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: version-script-test
 architectures: [amd64]
 version: "0.1"
-version-script: exit 1
+version-script: echo 0.1
 summary: test variations of the version script
 description: |
   Add different scripts for version-script and verify they do the right

--- a/integration_tests/test_version_script.py
+++ b/integration_tests/test_version_script.py
@@ -28,8 +28,9 @@ class VersionScriptPluginTestCase(testscenarios.WithScenarios,
 
     scripts = {
         'empty': '',  # this is 0.1
-        'simple': 'echo 0.1',
-        'exported-version': 'echo $SNAPCRAFT_PROJECT_VERSION',  # this is 0.1
+        'simple': 'echo from-version-script',
+        'exported-version': (
+            'echo from-variable-$SNAPCRAFT_PROJECT_VERSION'),  # this is 0.1
         'exported-version-and-grade': (
             'echo $SNAPCRAFT_PROJECT_VERSION-$SNAPCRAFT_PROJECT_GRADE'),
         'multi-line': dedent("""\
@@ -43,14 +44,23 @@ class VersionScriptPluginTestCase(testscenarios.WithScenarios,
     }
 
     scenarios = [
-        ('empty', dict(script='empty', expected_version='0.1')),
-        ('simple', dict(script='simple', expected_version='0.1')),
-        ('version', dict(script='exported-version', expected_version='0.1')),
-        ('version-and-grade', dict(script='exported-version-and-grade',
-                                   expected_version='0.1-devel')),
-        ('multi-line', dict(script='multi-line',
-                            expected_version='development-build')),
-        ('cat-file', dict(script='cat-file', expected_version='test-build')),
+        ('empty',
+         dict(script='empty', expected_version='0.1')),
+        ('simple',
+         dict(script='simple',
+              expected_version='from-version-script')),
+        ('version',
+         dict(script='exported-version',
+              expected_version='from-variable-0.1')),
+        ('version-and-grade',
+         dict(script='exported-version-and-grade',
+              expected_version='0.1-devel')),
+        ('multi-line',
+         dict(script='multi-line',
+              expected_version='development-build')),
+        ('cat-file',
+         dict(script='cat-file',
+              expected_version='test-build')),
     ]
 
     def _set_version_script(self, snapcraft_yaml_file):

--- a/integration_tests/test_version_script.py
+++ b/integration_tests/test_version_script.py
@@ -1,0 +1,71 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import os
+from textwrap import dedent
+
+import testscenarios
+import yaml
+from testtools.matchers import FileExists
+
+import integration_tests
+
+
+class VersionScriptPluginTestCase(testscenarios.WithScenarios,
+                                  integration_tests.TestCase):
+
+    scripts = {
+        'empty': '',  # this is 0.1
+        'simple': 'echo 0.1',
+        'exported-version': 'echo $SNAPCRAFT_PROJECT_VERSION',  # this is 0.1
+        'exported-version-and-grade': (
+            'echo $SNAPCRAFT_PROJECT_VERSION-$SNAPCRAFT_PROJECT_GRADE'),
+        'multi-line': dedent("""\
+            if [ "$SNAPCRAFT_PROJECT_GRADE" = "devel" ] ; then
+                echo "development-build"
+            else
+                exit 1
+            fi
+            """),
+        'cat-file': 'cat stage/version'
+    }
+
+    scenarios = [
+        ('empty', dict(script='empty', expected_version='0.1')),
+        ('simple', dict(script='simple', expected_version='0.1')),
+        ('version', dict(script='exported-version', expected_version='0.1')),
+        ('version-and-grade', dict(script='exported-version-and-grade',
+                                   expected_version='0.1-devel')),
+        ('multi-line', dict(script='multi-line',
+                            expected_version='development-build')),
+        ('cat-file', dict(script='cat-file', expected_version='test-build')),
+    ]
+
+    def _set_version_script(self, snapcraft_yaml_file):
+        with open(snapcraft_yaml_file) as f:
+            snapcraft_yaml = yaml.load(f)
+        snapcraft_yaml['version-script'] = self.scripts[self.script]
+        with open(snapcraft_yaml_file, 'w') as f:
+            yaml.dump(snapcraft_yaml, f)
+
+    def test_version(self):
+        self.copy_project_to_cwd('version-script')
+        self._set_version_script(os.path.join('snap', 'snapcraft.yaml'))
+
+        self.run_snapcraft('snap')
+
+        self.assertThat(
+            'version-script-test_{}_amd64.snap'.format(self.expected_version),
+            FileExists())

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -54,6 +54,9 @@ properties:
     # type: string
     description: package version
     pattern: "^[a-zA-Z0-9.+~-]*$"
+  version-script:
+    type: string
+    description: a script that echoes the version to set.
   icon:
     type: string
     description: path to a 512x512 icon representing the package.

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -249,7 +249,6 @@ class _Executor:
     def _create_meta(self, step, part_names):
         if step == 'prime' and part_names == self.config.part_names:
             common.env = self.config.snap_env()
-            common.env.extend(self.config.project_env())
             meta.create_snap_packaging(self.config.data,
                                        self.project_options)
 

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -249,6 +249,7 @@ class _Executor:
     def _create_meta(self, step, part_names):
         if step == 'prime' and part_names == self.config.part_names:
             common.env = self.config.snap_env()
+            common.env.extend(self.config.project_env())
             meta.create_snap_packaging(self.config.data,
                                        self.project_options)
 

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -257,7 +257,14 @@ class _SnapPackaging:
         if version_script:
             logger.info('Determining the version from the project '
                         'repo (version-script).')
-            new_version = shell_utils.run_script(version_script)
+            try:
+                new_version = shell_utils.run_script(version_script).strip()
+                if not new_version:
+                    raise CommandError('The version-script produced no output')
+            except subprocess.CalledProcessError as e:
+                raise CommandError(
+                    'The version-script failed to run (exit code {})'.format(
+                        e.returncode))
         # we want to whitelist what we support here.
         elif version == 'git':
             logger.info('Determining the version from the project '

--- a/snapcraft/internal/project_loader.py
+++ b/snapcraft/internal/project_loader.py
@@ -214,6 +214,7 @@ class Config:
             'SNAPCRAFT_STAGE={}'.format(self._project_options.stage_dir),
             'SNAPCRAFT_PROJECT_NAME={}'.format(self.data['name']),
             'SNAPCRAFT_PROJECT_VERSION={}'.format(self.data['version']),
+            'SNAPCRAFT_PROJECT_GRADE={}'.format(self.data['grade']),
         ]
 
     def _expand_env(self, snapcraft_yaml):

--- a/snapcraft/internal/project_loader.py
+++ b/snapcraft/internal/project_loader.py
@@ -121,13 +121,13 @@ class Config:
 
         snapcraft_yaml = self._process_remote_parts(snapcraft_yaml)
         snapcraft_yaml = self._expand_filesets(snapcraft_yaml)
-        self.data = self._expand_env(snapcraft_yaml)
-
-        self._ensure_no_duplicate_app_aliases()
 
         # both confinement type and build quality are optionals
-        _ensure_confinement_default(self.data, self._validator.schema)
-        _ensure_grade_default(self.data, self._validator.schema)
+        _ensure_confinement_default(snapcraft_yaml, self._validator.schema)
+        _ensure_grade_default(snapcraft_yaml, self._validator.schema)
+
+        self.data = self._expand_env(snapcraft_yaml)
+        self._ensure_no_duplicate_app_aliases()
 
         self.build_tools = self.data.get('build-packages', [])
         self.build_tools.extend(project_options.additional_build_packages)
@@ -227,6 +227,7 @@ class Config:
                 [
                     ('$SNAPCRAFT_PROJECT_NAME', snapcraft_yaml['name']),
                     ('$SNAPCRAFT_PROJECT_VERSION', snapcraft_yaml['version']),
+                    ('$SNAPCRAFT_PROJECT_GRADE', snapcraft_yaml['grade']),
                     ('$SNAPCRAFT_STAGE', self._project_options.stage_dir),
                 ])
         return snapcraft_yaml

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -257,6 +257,18 @@ class CreateTestCase(CreateBaseTestCase):
 
         self.assertThat(y['version'], Equals('10.1-devel'))
 
+    def test_version_script_exits_bad(self):
+        self.config_data['version-script'] = 'exit 1'
+
+        with testtools.ExpectedException(CommandError):
+            self.generate_meta_yaml()
+
+    def test_version_script_with_no_output(self):
+        self.config_data['version-script'] = 'echo'
+
+        with testtools.ExpectedException(CommandError):
+            self.generate_meta_yaml()
+
     def test_create_meta_with_app(self):
         os.mkdir(self.prime_dir)
         open(os.path.join(self.prime_dir, 'app.sh'), 'w').close()

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -250,6 +250,13 @@ class CreateTestCase(CreateBaseTestCase):
         self.assertFalse('icon' in y,
                          'icon found in snap.yaml {}'.format(y))
 
+    def test_version_script(self):
+        self.config_data['version-script'] = 'echo 10.1-devel'
+
+        y = self.generate_meta_yaml()
+
+        self.assertThat(y['version'], Equals('10.1-devel'))
+
     def test_create_meta_with_app(self):
         os.mkdir(self.prime_dir)
         open(os.path.join(self.prime_dir, 'app.sh'), 'w').close()

--- a/snapcraft/tests/test_project_loader.py
+++ b/snapcraft/tests/test_project_loader.py
@@ -455,6 +455,26 @@ parts:
         self.assertEqual(metadata['version'], '1')
         self.assertEqual(metadata['arch'], ['amd64'])
 
+    def test_version_script(self):
+        self.make_snapcraft_yaml("""name: test
+version: "1"
+version-script: echo $SNAPCRAFT_PROJECT_VERSION-devel
+summary: test
+description: nothing
+architectures: ['amd64']
+confinement: strict
+grade: stable
+
+parts:
+  part1:
+    plugin: go
+    stage-packages: [fswebcam]
+""")
+        config = project_loader.load_config()
+        metadata = config.get_metadata()
+        self.assertEqual(metadata['version-script'],
+                         '$SNAPCRAFT_PROJECT_VERSION')
+
     @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
     def test_invalid_yaml_invalid_name_as_number(self, mock_loadPlugin):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)

--- a/snapcraft/tests/test_project_loader.py
+++ b/snapcraft/tests/test_project_loader.py
@@ -457,13 +457,13 @@ parts:
 
     def test_version_script(self):
         self.make_snapcraft_yaml("""name: test
-version: "1"
-version-script: echo $SNAPCRAFT_PROJECT_VERSION-devel
+version: "1.0"
+version-script: echo $SNAPCRAFT_PROJECT_VERSION-$SNAPCRAFT_PROJECT_GRADE
 summary: test
 description: nothing
 architectures: ['amd64']
 confinement: strict
-grade: stable
+grade: devel
 
 parts:
   part1:
@@ -471,9 +471,7 @@ parts:
     stage-packages: [fswebcam]
 """)
         config = project_loader.load_config()
-        metadata = config.get_metadata()
-        self.assertEqual(metadata['version-script'],
-                         '$SNAPCRAFT_PROJECT_VERSION')
+        self.assertEqual(config.data['version-script'], 'echo 1.0-devel')
 
     @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
     def test_invalid_yaml_invalid_name_as_number(self, mock_loadPlugin):


### PR DESCRIPTION
If `version-script` is defined it will override the visible version that ends up in snap.yaml.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>