### PR TITLE
core: check SNAP_NAME to detect if snapcraft is a snap.

### DIFF
--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -148,8 +148,8 @@ def set_tourdir(tourdir):
 
 
 def get_tourdir():
-    snap = os.environ.get('SNAP')
-    if snap:
+    if os.environ.get('SNAP_NAME', '') == 'snapcraft':
+        snap = os.environ.get('SNAP')
         return os.path.join(snap, 'tour')
     return _tourdir
 

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -97,6 +97,10 @@ def format_snap_name(snap):
     return '{name}_{version}_{arch}.snap'.format(**snap)
 
 
+def is_snap():
+    return os.environ.get('SNAP_NAME') == 'snapcraft'
+
+
 def set_plugindir(plugindir):
     global _plugindir
     _plugindir = plugindir
@@ -112,7 +116,7 @@ def set_schemadir(schemadir):
 
 
 def get_schemadir():
-    if os.environ.get('SNAP_NAME', '') == 'snapcraft':
+    if is_snap():
         snap = os.environ.get('SNAP')
         return os.path.join(snap, 'share', 'snapcraft', 'schema')
     return _schemadir
@@ -148,7 +152,7 @@ def set_tourdir(tourdir):
 
 
 def get_tourdir():
-    if os.environ.get('SNAP_NAME', '') == 'snapcraft':
+    if is_snap():
         snap = os.environ.get('SNAP')
         return os.path.join(snap, 'tour')
     return _tourdir

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -112,8 +112,8 @@ def set_schemadir(schemadir):
 
 
 def get_schemadir():
-    snap = os.environ.get('SNAP')
-    if snap:
+    if os.environ.get('SNAP_NAME', '') == 'snapcraft':
+        snap = os.environ.get('SNAP')
         return os.path.join(snap, 'share', 'snapcraft', 'schema')
     return _schemadir
 

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -33,7 +33,7 @@ from xml.etree import ElementTree
 
 import snapcraft
 from snapcraft import file_utils
-from snapcraft.internal import cache, repo
+from snapcraft.internal import cache, repo, common
 from snapcraft.internal.indicators import is_dumb_terminal
 from ._base import BaseRepo
 from . import errors
@@ -68,7 +68,7 @@ class _AptCache:
         apt.apt_pkg.config.set('Apt::Install-Recommends', 'False')
 
         # Methods and solvers dir for when in the SNAP
-        if os.environ.get('SNAP_NAME', '') == 'snapcraft':
+        if common.is_snap():
             snap_dir = os.getenv('SNAP')
             apt_dir = os.path.join(snap_dir, 'apt')
             apt.apt_pkg.config.set('Dir', apt_dir)

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -68,7 +68,7 @@ class _AptCache:
         apt.apt_pkg.config.set('Apt::Install-Recommends', 'False')
 
         # Methods and solvers dir for when in the SNAP
-        if os.getenv('SNAP'):
+        if os.environ.get('SNAP_NAME', '') == 'snapcraft':
             snap_dir = os.getenv('SNAP')
             apt_dir = os.path.join(snap_dir, 'apt')
             apt.apt_pkg.config.set('Dir', apt_dir)


### PR DESCRIPTION
If snapcraft is used from another snap it won't work properly because it's guessing if it's itself a snap in a sloppy manner.

1. SNAP=/snap/doesntevenexist/123
2. export SNAP
3. $ snapcraft
Issues while validating snapcraft.yaml: snapcraft validation file is missing from installation path
snapcraft validation file is missing from installation path