### PR TITLE
core: predetermine the magic path when a snap.

### DIFF
--- a/bin/snapcraft-classic
+++ b/bin/snapcraft-classic
@@ -16,5 +16,6 @@ arm64)
 esac
 
 export LD_LIBRARY_PATH=$SNAP/usr/lib:$SNAP/usr/lib/$TRIPLET
+export MAGIC=$SNAP/usr/share/file/magic.mgc
 
 exec $SNAP/usr/bin/python3 $SNAP/bin/snapcraft "$@"


### PR DESCRIPTION
LP: #[1685530](https://bugs.launchpad.net/snapcraft/+bug/1685530)

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>