### PR TITLE
kernel plugin: learn how to assemble the ubuntu config using kconfigflavour

### DIFF
--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -127,15 +127,13 @@ class KBuildPlugin(BasePlugin):
         try:
             env = open('debian/debian.env', 'r').read()
         except OSError as e:
-            logger.error('Unable to access {}: {}'.format(e.filename,
-                                                          e.strerror))
-            sys.exit(1)
+            raise RuntimeError('Unable to access {}: {}'.format(e.filename,
+                                                                e.strerror))
         arch = self.project.deb_arch
         try:
             branch = env.split('.')[1].strip()
         except:
-            logger.error('Malformed debian.env, cannot extract branch name')
-            sys.exit(1)
+            raise RuntimeError('Malformed debian.env, cannot extract branch name')
         flavour = self.options.kconfigflavour
 
         configfiles = []
@@ -158,10 +156,8 @@ class KBuildPlugin(BasePlugin):
             for f in configfiles:
                 configfds.append(open(f, "r"))
         except OSError as e:
-            logger.error('Unable to access {}: {}'.format(e.filename,
+            raise RuntimeError('Unable to access {}: {}'.format(e.filename,
                                                           e.strerror))
-            sys.exit(1)
-
         # assemble .config
         config = open(config_path, "w")
         for f in configfds:

--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -64,7 +64,6 @@ import logging
 import os
 import shutil
 import subprocess
-import sys
 import re
 
 from snapcraft import BasePlugin
@@ -133,7 +132,8 @@ class KBuildPlugin(BasePlugin):
         try:
             branch = env.split('.')[1].strip()
         except:
-            raise RuntimeError('Malformed debian.env, cannot extract branch name')
+            raise RuntimeError('Malformed debian.env, cannot extract'
+                               ' branch name')
         flavour = self.options.kconfigflavour
 
         configfiles = []
@@ -156,8 +156,8 @@ class KBuildPlugin(BasePlugin):
             for f in configfiles:
                 configfds.append(open(f, "r"))
         except OSError as e:
-            raise RuntimeError('Unable to access {}: {}'.format(e.filename,
-                                                          e.strerror))
+            raise RuntimeError('Unable to access {}: '
+                               '{}'.format(e.filename, e.strerror))
         # assemble .config
         config = open(config_path, "w")
         for f in configfds:

--- a/snapcraft/tests/plugins/test_kbuild.py
+++ b/snapcraft/tests/plugins/test_kbuild.py
@@ -34,6 +34,7 @@ class KBuildPluginTestCase(tests.TestCase):
         class Options:
             build_parameters = []
             kconfigfile = None
+            kconfigflavour = None
             kdefconfig = []
             kconfigs = []
 
@@ -50,6 +51,9 @@ class KBuildPluginTestCase(tests.TestCase):
         self.assertEqual(properties['kconfigfile']['type'], 'string')
         self.assertEqual(properties['kconfigfile']['default'], None)
 
+        self.assertEqual(properties['kconfigflavour']['type'], 'string')
+        self.assertEqual(properties['kconfigflavour']['default'], None)
+
         self.assertEqual(properties['kconfigs']['type'], 'array')
         self.assertEqual(properties['kconfigs']['default'], [])
         self.assertEqual(properties['kconfigs']['minitems'], 1)
@@ -57,7 +61,8 @@ class KBuildPluginTestCase(tests.TestCase):
         self.assertTrue(properties['kconfigs']['uniqueItems'])
 
     def test_get_build_properties(self):
-        expected_build_properties = ['kdefconfig', 'kconfigfile', 'kconfigs']
+        expected_build_properties = ['kdefconfig', 'kconfigfile',
+                                     'kconfigflavour', 'kconfigs']
         resulting_build_properties = kbuild.KBuildPlugin.get_build_properties()
 
         self.assertThat(resulting_build_properties,

--- a/snapcraft/tests/plugins/test_kernel.py
+++ b/snapcraft/tests/plugins/test_kernel.py
@@ -38,6 +38,7 @@ class KernelPluginTestCase(tests.TestCase):
         class Options:
             build_parameters = []
             kconfigfile = None
+            kconfigflavour = None
             kdefconfig = []
             kconfigs = []
             kernel_image_target = 'bzImage'
@@ -91,6 +92,9 @@ class KernelPluginTestCase(tests.TestCase):
 
         self.assertEqual(properties['kconfigfile']['type'], 'string')
         self.assertEqual(properties['kconfigfile']['default'], None)
+
+        self.assertEqual(properties['kconfigflavour']['type'], 'string')
+        self.assertEqual(properties['kconfigflavour']['default'], None)
 
         for prop in ['kconfigs', 'kernel-initrd-modules',
                      'kernel-initrd-firmware', 'kernel-device-trees']:

--- a/snapcraft/tests/plugins/test_kernel.py
+++ b/snapcraft/tests/plugins/test_kernel.py
@@ -881,7 +881,8 @@ ACCEPT=n
             config_contents = f.read()
 
         self.assertEqual(config_contents,
-            'ACCEPT=y\nACCEPT=m\nACCEPT=y\n# ACCEPT is not set\n')
+                         'ACCEPT=y\nACCEPT=m\nACCEPT=y\n'
+                         '# ACCEPT is not set\n')
         self._assert_common_assets(plugin.installdir)
 
     def test_build_with_missing_kernel_fails(self):

--- a/snapcraft/tests/plugins/test_kernel.py
+++ b/snapcraft/tests/plugins/test_kernel.py
@@ -20,7 +20,9 @@ import os
 from unittest import mock
 
 import fixtures
-from testtools.matchers import Equals, HasLength
+from testtools.matchers import Equals, FileContains, HasLength
+
+from textwrap import dedent
 
 import snapcraft
 from snapcraft import (
@@ -877,12 +879,12 @@ ACCEPT=n
         config_file = os.path.join(plugin.builddir, '.config')
         self.assertTrue(os.path.exists(config_file))
 
-        with open(config_file) as f:
-            config_contents = f.read()
-
-        self.assertEqual(config_contents,
-                         'ACCEPT=y\nACCEPT=m\nACCEPT=y\n'
-                         '# ACCEPT is not set\n')
+        self.assertThat(config_file, FileContains(dedent("""\
+        ACCEPT=y
+        ACCEPT=m
+        ACCEPT=y
+        # ACCEPT is not set
+        """)))
         self._assert_common_assets(plugin.installdir)
 
     def test_build_with_missing_kernel_fails(self):

--- a/snapcraft/tests/plugins/test_kernel.py
+++ b/snapcraft/tests/plugins/test_kernel.py
@@ -835,8 +835,8 @@ ACCEPT=n
         with open('debian/debian.env', 'w') as f:
             f.write('DEBIAN=debian.{}'.format(branch))
         os.mkdir('debian.{}'.format(branch))
-        basedir = 'debian.{}/config'.format(branch)
-        archdir = 'debian.{}/config/{}'.format(branch, arch)
+        basedir = os.path.join('debian.{}'.format(branch), 'config')
+        archdir = os.path.join('debian.{}'.format(branch), 'config', arch)
         os.mkdir(basedir)
         os.mkdir(archdir)
         commoncfg = os.path.join(basedir, 'config.common.ports')

--- a/snapcraft/tests/plugins/test_kernel.py
+++ b/snapcraft/tests/plugins/test_kernel.py
@@ -837,7 +837,7 @@ ACCEPT=n
         archdir = 'debian.{}/config/{}'.format(branch, arch)
         os.mkdir(basedir)
         os.mkdir(archdir)
-        commoncfg = os.path.join(basedir, 'config.common.ubuntu')
+        commoncfg = os.path.join(basedir, 'config.common.ports')
         ubuntucfg = os.path.join(basedir, 'config.common.ubuntu')
         archcfg = os.path.join(archdir, 'config.common.{}'.format(arch))
         flavourcfg = os.path.join(archdir, 'config.flavour.{}'.format(flavour))
@@ -845,11 +845,11 @@ ACCEPT=n
         with open(commoncfg, 'w') as f:
             f.write('ACCEPT=y\n')
         with open(ubuntucfg, 'w') as f:
-            f.write('ACCEPT=y\n')
+            f.write('ACCEPT=m\n')
         with open(archcfg, 'w') as f:
             f.write('ACCEPT=y\n')
         with open(flavourcfg, 'w') as f:
-            f.write('ACCEPT=y\n')
+            f.write('# ACCEPT is not set\n')
 
         plugin = kernel.KernelPlugin('test-part', self.options,
                                      self.project_options)
@@ -880,7 +880,8 @@ ACCEPT=n
         with open(config_file) as f:
             config_contents = f.read()
 
-        self.assertEqual(config_contents, 'ACCEPT=y\n')
+        self.assertEqual(config_contents,
+            'ACCEPT=y\nACCEPT=m\nACCEPT=y\n# ACCEPT is not set\n')
         self._assert_common_assets(plugin.installdir)
 
     def test_build_with_missing_kernel_fails(self):


### PR DESCRIPTION
Instead of using shell scripts wrapper, simply teach snapcraft how to extract the entire ubuntu config from debian.$branch/config/ and debian.$branch/config/$arch/config*$flavour files.

To test this, checkout an ubuntu kernel tree:

$ git clone git://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/xenial
$ cd xenial

And use a snapcraft.yaml like this:
$ rm snapcraft.yaml
$ cat >> snapcraft.yaml << EOF
name: ubuntu-generic-kernel
version: 4.4.0
summary: The generic kernel for snappy
description: This is a generic snapped kernel, based off the xenial src and config
type: kernel

parts:
  kernel:
    plugin: kernel
    source: .
    source-type: git
    kconfigflavour: generic
    kconfigs:
      - CONFIG_LOCALVERSION="-xenial_generic"
      - CONFIG_DEBUG_INFO=n
    kernel-image-target: bzImage
EOF

and snap it:
$ snapcraft

And you will get a kernel snap with the same config as the Xenial ubuntu kernel.

The key here is the line:
...
kconfigflavour: generic
...

that instructs the kernel plugin to generate the kernel config starting from:

debian.$branch/config/config.common.ports
debian.$branch/config/config.common.ubuntu

and

debian.$branch/config/$arch/config.common.$arch
debian.$branch/config/$arch/config.flavour.$flavour

where:

$branch is extracted from 'debian/debian.env'
$arch is deb_arch
$flavour is the string in 'kconfigflavour'

Signed-off-by: Paolo Pisati paolo.pisati@canonical.com

LP: #1675454