### PR TITLE
lxd: Setup image and target arch for cross-compilation

### DIFF
--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -233,6 +233,10 @@ class ProjectOptions:
         self.__machine_info = _ARCH_TRANSLATIONS[self.__target_machine]
 
 
+def _get_deb_arch(machine):
+    return _ARCH_TRANSLATIONS[machine].get('deb', None)
+
+
 def _find_machine(deb_arch):
     for machine in _ARCH_TRANSLATIONS:
         if _ARCH_TRANSLATIONS[machine].get('deb', '') == deb_arch:

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -394,6 +394,11 @@ def check_output_side_effect(fail_on_remote=False, fail_on_default=False):
                 return 'local'.encode('utf-8')
         elif args[0] == ['lxc', 'list', 'my-remote:'] and fail_on_remote:
             raise CalledProcessError(returncode=255, cmd=args[0])
+        elif args[0][:2] == ['lxc', 'info']:
+            return '''
+                environment:
+                  kernel_architecture: x86_64
+                '''.encode('utf-8')
         elif args[0][:3] == ['lxc', 'list', '--format=json']:
             return '''
                 [{"name": "snapcraft-snap-test",

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -39,19 +39,18 @@ class LXDTestCase(tests.TestCase):
     ]
 
     @patch('petname.Generate')
-    def test_cleanbuild(self, mock_pet):
+    @patch('platform.machine')
+    @patch('platform.architecture')
+    def test_cleanbuild(self, mock_arch, mock_machine, mock_pet):
         fake_lxd = tests.fixture_setup.FakeLXD()
         self.useFixture(fake_lxd)
         fake_logger = fixtures.FakeLogger(level=logging.INFO)
         self.useFixture(fake_logger)
 
         mock_pet.return_value = 'my-pet'
-
-        with patch('platform.machine') as machine_mock, \
-                patch('platform.architecture') as arch_mock:
-            arch_mock.return_value = ('64bit', 'ELF')
-            machine_mock.return_value = 'x86_64'
-            project_options = ProjectOptions(target_deb_arch=self.target_arch)
+        mock_arch.return_value = ('64bit', 'ELF')
+        mock_machine.return_value = 'x86_64'
+        project_options = ProjectOptions(target_deb_arch=self.target_arch)
         metadata = {'name': 'project'}
         project_folder = 'build_project'
         lxd.Cleanbuilder(output='snap.snap', source='project.tar',

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -33,8 +33,9 @@ from snapcraft.internal import lxd
 class LXDTestCase(tests.TestCase):
 
     scenarios = [
-        ('local', dict(remote='local')),
-        ('remote', dict(remote='my-remote')),
+        ('local', dict(remote='local', target_arch=None)),
+        ('remote', dict(remote='my-remote', target_arch=None)),
+        ('cross', dict(remote='local', target_arch='armhf')),
     ]
 
     @patch('petname.Generate')
@@ -46,20 +47,27 @@ class LXDTestCase(tests.TestCase):
 
         mock_pet.return_value = 'my-pet'
 
-        project_options = ProjectOptions()
+        with patch('platform.machine') as machine_mock, \
+                patch('platform.architecture') as arch_mock:
+            arch_mock.return_value = ('64bit', 'ELF')
+            machine_mock.return_value = 'x86_64'
+            project_options = ProjectOptions(target_deb_arch=self.target_arch)
         metadata = {'name': 'project'}
         project_folder = 'build_project'
         lxd.Cleanbuilder(output='snap.snap', source='project.tar',
                          metadata=metadata, remote=self.remote,
                          project_options=project_options).execute()
-        expected_arch = project_options.deb_arch
+        expected_arch = 'amd64'
 
-        self.assertEqual(
-            'Setting up container with project assets\n'
-            'Waiting for a network connection...\n'
-            'Network connection established\n'
-            'Retrieved snap.snap\n',
-            fake_logger.output)
+        self.assertIn('Setting up container with project assets\n'
+                      'Waiting for a network connection...\n'
+                      'Network connection established\n'
+                      'Retrieved snap.snap\n', fake_logger.output)
+        args = []
+        if self.target_arch:
+            self.assertIn('Setting target machine to \'{}\'\n'.format(
+                          self.target_arch), fake_logger.output)
+            args += ['--target-arch', self.target_arch]
 
         container_name = '{}:snapcraft-my-pet'.format(self.remote)
         fake_lxd.check_call_mock.assert_has_calls([
@@ -90,7 +98,7 @@ class LXDTestCase(tests.TestCase):
                   'apt-get', 'install', 'snapcraft', '-y']),
             call(['lxc', 'exec', container_name,
                   '--env', 'HOME=/{}'.format(project_folder), '--',
-                  'snapcraft', 'snap', '--output', 'snap.snap']),
+                  'snapcraft', 'snap', '--output', 'snap.snap', *args]),
             call(['lxc', 'file', 'pull',
                   '{}/{}/snap.snap'.format(container_name, project_folder),
                   'snap.snap']),


### PR DESCRIPTION
To support cross-compilation in LXD containers the image for the host architecture needs to be used, rather than for the target architecture, which would require slow qemu emulation. It's worth noting that host here means the host running LXD which may not be the same as the host running snapcraft eg. snapcraft executed on an armhf machine using an amd64 remote building for arm64.

Note: this is orthogonal to actual support for cross-compilation in individual plugins and only deals with the container setup.