### PR TITLE
rust snaps can now use source-subdir without failing on pull

### DIFF
--- a/integration_tests/plugins/test_rust_plugin.py
+++ b/integration_tests/plugins/test_rust_plugin.py
@@ -69,7 +69,7 @@ class RustPluginTestCase(RustPluginBaseTestCase):
 
     def test_stage_rust_with_source_subdir(self):
         self.run_snapcraft('stage', 'rust-subdir')
-        
+
         binary_output = self.get_output_ignoring_non_zero_exit(
             os.path.join(self.stage_dir, 'bin', 'rust-subdir'))
         self.assertEqual('Rust in a subdirectory works\n', binary_output)

--- a/integration_tests/plugins/test_rust_plugin.py
+++ b/integration_tests/plugins/test_rust_plugin.py
@@ -89,7 +89,7 @@ class RustPluginTestCase(RustPluginBaseTestCase):
 
         self.assertThat(
             os.path.join('parts', 'rust-subdir', 'src', 'subdir',
-            'Cargo.lock'), FileExists())
+                         'Cargo.lock'), FileExists())
 
 
 class RustPluginConfinementTestCase(testscenarios.WithScenarios,

--- a/integration_tests/plugins/test_rust_plugin.py
+++ b/integration_tests/plugins/test_rust_plugin.py
@@ -69,13 +69,27 @@ class RustPluginTestCase(RustPluginBaseTestCase):
 
     def test_stage_rust_with_source_subdir(self):
         self.run_snapcraft('stage', 'rust-subdir')
-
+        
         binary_output = self.get_output_ignoring_non_zero_exit(
             os.path.join(self.stage_dir, 'bin', 'rust-subdir'))
         self.assertEqual('Rust in a subdirectory works\n', binary_output)
         # Test for bug https://bugs.launchpad.net/snapcraft/+bug/1654764
         self.assertThat('Cargo.lock', Not(FileExists()))
 
+    def test_stage_rust_with_source_and_source_subdir(self):
+        self.copy_project_to_cwd('rust-subdir')
+        with open('snapcraft.yaml') as snapcraft_yaml_file:
+            snapcraft_yaml = yaml.load(snapcraft_yaml_file)
+        snapcraft_yaml['parts']['rust-subdir']['source'] = '.'
+        snapcraft_yaml['parts']['rust-subdir']['source-subdir'] = 'subdir'
+        with open('snapcraft.yaml', 'w') as snapcraft_yaml_file:
+            yaml.dump(snapcraft_yaml, snapcraft_yaml_file)
+        
+        self.run_snapcraft('pull')
+        
+        self.assertThat(
+            os.path.join('parts', 'rust-subdir', 'src', 'subdir', 'Cargo.lock'), 
+            FileExists())
 
 class RustPluginConfinementTestCase(testscenarios.WithScenarios,
                                     RustPluginBaseTestCase):

--- a/integration_tests/plugins/test_rust_plugin.py
+++ b/integration_tests/plugins/test_rust_plugin.py
@@ -84,12 +84,13 @@ class RustPluginTestCase(RustPluginBaseTestCase):
         snapcraft_yaml['parts']['rust-subdir']['source-subdir'] = 'subdir'
         with open('snapcraft.yaml', 'w') as snapcraft_yaml_file:
             yaml.dump(snapcraft_yaml, snapcraft_yaml_file)
-        
+
         self.run_snapcraft('pull')
-        
+
         self.assertThat(
-            os.path.join('parts', 'rust-subdir', 'src', 'subdir', 'Cargo.lock'), 
-            FileExists())
+            os.path.join('parts', 'rust-subdir', 'src', 'subdir',
+            'Cargo.lock'), FileExists())
+
 
 class RustPluginConfinementTestCase(testscenarios.WithScenarios,
                                     RustPluginBaseTestCase):

--- a/snapcraft/plugins/rust.py
+++ b/snapcraft/plugins/rust.py
@@ -152,9 +152,8 @@ class RustPlugin(snapcraft.BasePlugin):
                   '--disable-sudo', '--save'] + options)
 
     def _fetch_deps(self):
-        source_subdir = getattr(self.options, 'source_subdir', None)
-        if source_subdir:
-            sourcedir = os.path.join(self.sourcedir, source_subdir)
+        if self.options.source_subdir:
+            sourcedir = os.path.join(self.sourcedir, self.options.source_subdir)
         else:
             sourcedir = self.sourcedir
 

--- a/snapcraft/plugins/rust.py
+++ b/snapcraft/plugins/rust.py
@@ -152,7 +152,6 @@ class RustPlugin(snapcraft.BasePlugin):
                   '--disable-sudo', '--save'] + options)
 
     def _fetch_deps(self):
-        
         source_subdir = getattr(self.options, 'source_subdir', None)
         if source_subdir:
             sourcedir = os.path.join(self.sourcedir, source_subdir)

--- a/snapcraft/plugins/rust.py
+++ b/snapcraft/plugins/rust.py
@@ -153,7 +153,8 @@ class RustPlugin(snapcraft.BasePlugin):
 
     def _fetch_deps(self):
         if self.options.source_subdir:
-            sourcedir = os.path.join(self.sourcedir, self.options.source_subdir)
+            sourcedir = os.path.join(self.sourcedir,
+                                     self.options.source_subdir)
         else:
             sourcedir = self.sourcedir
 

--- a/snapcraft/plugins/rust.py
+++ b/snapcraft/plugins/rust.py
@@ -152,6 +152,13 @@ class RustPlugin(snapcraft.BasePlugin):
                   '--disable-sudo', '--save'] + options)
 
     def _fetch_deps(self):
+        
+        source_subdir = getattr(self.options, 'source_subdir', None)
+        if source_subdir:
+            sourcedir = os.path.join(self.sourcedir, source_subdir)
+        else:
+            sourcedir = self.sourcedir
+
         self.run([self._cargo, 'fetch',
                   '--manifest-path',
-                  os.path.join(self.sourcedir, 'Cargo.toml')])
+                  os.path.join(sourcedir, 'Cargo.toml')])

--- a/snapcraft/tests/plugins/test_rust.py
+++ b/snapcraft/tests/plugins/test_rust.py
@@ -29,6 +29,8 @@ class RustPluginTestCase(tests.TestCase):
             makefile = None
             make_parameters = []
             rust_features = []
+            rust_revision = ''
+            rust_channel = ''
 
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
@@ -162,4 +164,22 @@ class RustPluginTestCase(tests.TestCase):
             mock.call([
                 plugin._cargo, 'fetch',
                 '--manifest-path', os.path.join(plugin.sourcedir, 'Cargo.toml')
+            ])])
+
+    @mock.patch.object(rust.sources, 'Script')
+    @mock.patch.object(rust.RustPlugin, 'run')
+    def test_pull_with_source_and_source_subdir(self, run_mock, script_mock):
+        plugin = rust.RustPlugin('test-part', self.options,
+                                 self.project_options)
+        os.makedirs(plugin.sourcedir)
+        plugin.options.source_subdir = 'test-subdir'
+
+        plugin.pull()
+
+        rustdir = os.path.join(plugin.partdir, 'rust')
+        run_mock.assert_has_calls([
+            mock.ANY,
+            mock.call([
+                plugin._cargo, 'fetch',
+                '--manifest-path', os.path.join(plugin.sourcedir, 'test-subdir', 'Cargo.toml')
             ])])

--- a/snapcraft/tests/plugins/test_rust.py
+++ b/snapcraft/tests/plugins/test_rust.py
@@ -176,10 +176,10 @@ class RustPluginTestCase(tests.TestCase):
 
         plugin.pull()
 
-        rustdir = os.path.join(plugin.partdir, 'rust')
         run_mock.assert_has_calls([
             mock.ANY,
             mock.call([
                 plugin._cargo, 'fetch',
-                '--manifest-path', os.path.join(plugin.sourcedir, 'test-subdir', 'Cargo.toml')
+                '--manifest-path',
+                os.path.join(plugin.sourcedir, 'test-subdir', 'Cargo.toml')
             ])])

--- a/snapcraft/tests/plugins/test_rust.py
+++ b/snapcraft/tests/plugins/test_rust.py
@@ -31,6 +31,7 @@ class RustPluginTestCase(tests.TestCase):
             rust_features = []
             rust_revision = ''
             rust_channel = ''
+            source_subdir = ''
 
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()


### PR DESCRIPTION

LP: [1685563](https://bugs.launchpad.net/snapcraft/+bug/1685563)
