### PR TITLE
sources: validate unknown source-type in yaml

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -243,6 +243,18 @@ properties:
           source-type:
             type: string
             default: ''
+            enum:
+              - bzr
+              - git
+              - hg
+              - mercurial
+              - subversion
+              - svn
+              - tar
+              - zip
+              - deb
+              - rpm
+              - 7z
           disable-parallel:
             type: boolean
             default: false

--- a/snapcraft/internal/sources/__init__.py
+++ b/snapcraft/internal/sources/__init__.py
@@ -151,7 +151,8 @@ _source_handler = {
     'svn': Subversion,
     'tar': Tar,
     'zip': Zip,
-    '7z': SevenZip
+    '7z': SevenZip,
+    '': Local
 }
 if sys.platform == 'linux':
     _source_handler['deb'] = Deb
@@ -167,7 +168,7 @@ def get_source_handler(source, *, source_type=''):
     if not source_type:
         source_type = _get_source_type_from_uri(source)
 
-    return _source_handler.get(source_type, Local)
+    return _source_handler[source_type]
 
 
 _tar_type_regex = re.compile(r'.*\.((tar(\.(xz|gz|bz2))?)|tgz)$')

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -1189,7 +1189,7 @@ class MissingAssetsTestCase(TestCase):
     @mock.patch('snapcraft.internal.sources._get_source_type_from_uri')
     def test_filenotfound_for_non_repos(self, mock_type, mock_pull):
         mock_pull.side_effect = FileNotFoundError()
-        mock_type.return_value = None
+        mock_type.return_value = ''
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
         self.useFixture(fake_logger)
 


### PR DESCRIPTION
Invalid source-type defaults to Local source (handler) and it doesn't print an error message

LP: [#1650943](https://bugs.launchpad.net/snapcraft/+bug/1650943)

I canceled previous PR cause I commited some changes using an incorrect email.

Based on the feedback provided on the canceled PR:

1. I added the list of valid source types in the snapcraft.yaml using an enum
2. I changed the way _source_handler dict is called, so we can get a KeyError if the source type is invalid for API users
3. I added the Local source type to the _source_handler dict, so it can be used as the default value
