### PR TITLE
kernel plugin: slightly improve the messaging of check_config()

### DIFF
--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -420,15 +420,12 @@ class KernelPlugin(kbuild.KBuildPlugin):
         if missing:
             warn = '\n{}\n'.format(msg)
             for opt in missing:
-                ver = ''
+                note = ''
                 if opt == 'CONFIG_CC_STACKPROTECTOR_STRONG':
-                    ver = '(4.1.x and later versions only)'
+                    note = '(4.1.x and later versions only)'
                 elif opt == 'CONFIG_DEVPTS_MULTIPLE_INSTANCES':
-                    ver = '(4.8.x and earlier versions only)'
-                warn += '{}'.format(opt)
-                if ver:
-                    warn += ' {}'.format(ver)
-                warn += '\n'
+                    note = '(4.8.x and earlier versions only)'
+                warn += '{} {}'.format(opt, note)
             logger.warn(warn)
 
     def _do_check_initrd(self, builtin, modules):

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -420,7 +420,15 @@ class KernelPlugin(kbuild.KBuildPlugin):
         if missing:
             warn = '\n{}\n'.format(msg)
             for opt in missing:
-                warn += '{}\n'.format(opt)
+                ver = ''
+                if opt == 'CONFIG_CC_STACKPROTECTOR_STRONG':
+                    ver = '(4.1.x and later versions only)'
+                elif opt == 'CONFIG_DEVPTS_MULTIPLE_INSTANCES':
+                    ver = '(4.8.x and earlier versions only)'
+                warn += '{}'.format(opt)
+                if ver:
+                    warn += ' {}'.format(ver)
+                warn += '\n'
             logger.warn(warn)
 
     def _do_check_initrd(self, builtin, modules):

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -81,25 +81,30 @@ default_kernel_image_target = {
     'arm64': 'Image.gz',
 }
 
-required_generic = ['DEVTMPFS', 'DEVTMPFS_MOUNT', 'TMPFS_POSIX_ACL', 'IPV6',
-                    'SYSVIPC', 'SYSVIPC_SYSCTL', 'VFAT_FS', 'NLS_CODEPAGE_437',
-                    'NLS_ISO8859_1']
+required_generic = {'DEVTMPFS': '', 'DEVTMPFS_MOUNT': '',
+                    'TMPFS_POSIX_ACL': '', 'IPV6': '', 'SYSVIPC': '',
+                    'SYSVIPC_SYSCTL': '', 'VFAT_FS': '',
+                    'NLS_CODEPAGE_437': '', 'NLS_ISO8859_1': ''}
 
-required_security = ['SECURITY', 'SECURITY_APPARMOR', 'SYN_COOKIES',
-                     'STRICT_DEVMEM', 'DEFAULT_SECURITY_APPARMOR', 'SECCOMP',
-                     'SECCOMP_FILTER', 'CC_STACKPROTECTOR',
-                     'CC_STACKPROTECTOR_STRONG', 'DEBUG_RODATA',
-                     'DEBUG_SET_MODULE_RONX']
+required_security = {'SECURITY': '', 'SECURITY_APPARMOR': '',
+                     'SYN_COOKIES': '', 'STRICT_DEVMEM': '',
+                     'DEFAULT_SECURITY_APPARMOR': '', 'SECCOMP': '',
+                     'SECCOMP_FILTER': '', 'CC_STACKPROTECTOR': '',
+                     'CC_STACKPROTECTOR_STRONG':
+                     '(4.1.x and later versions only)',
+                     'DEBUG_RODATA': '', 'DEBUG_SET_MODULE_RONX': ''}
 
-required_snappy = ['RD_LZMA', 'KEYS', 'ENCRYPTED_KEYS', 'SQUASHFS',
-                   'SQUASHFS_XATTR', 'SQUASHFS_XZ',
-                   'DEVPTS_MULTIPLE_INSTANCES']
+required_snappy = {'RD_LZMA': '', 'KEYS': '', 'ENCRYPTED_KEYS': '',
+                   'SQUASHFS': '', 'SQUASHFS_XATTR': '', 'SQUASHFS_XZ': '',
+                   'DEVPTS_MULTIPLE_INSTANCES':
+                   '(4.8.x and earlier versions only)'}
 
-required_systemd = ['DEVTMPFS', 'CGROUPS', 'INOTIFY_USER', 'SIGNALFD',
-                    'TIMERFD', 'EPOLL', 'NET', 'SYSFS', 'PROC_FS', 'FHANDLE',
-                    'DMIID', 'BLK_DEV_BSG', 'NET_NS',
-                    'IPV6', 'AUTOFS4_FS',
-                    'TMPFS_POSIX_ACL', 'TMPFS_XATTR', 'SECCOMP']
+required_systemd = {'DEVTMPFS': '', 'CGROUPS': '', 'INOTIFY_USER': '',
+                    'SIGNALFD': '', 'TIMERFD': '', 'EPOLL': '',
+                    'NET': '', 'SYSFS': '', 'PROC_FS': '', 'FHANDLE': '',
+                    'DMIID': '', 'BLK_DEV_BSG': '', 'NET_NS': '',
+                    'IPV6': '', 'AUTOFS4_FS': '',
+                    'TMPFS_POSIX_ACL': '', 'TMPFS_XATTR': '', 'SECCOMP': ''}
 
 required_boot = ['squashfs']
 
@@ -404,23 +409,31 @@ class KernelPlugin(kbuild.KBuildPlugin):
                'recommends or requires.\n'
                'While we will not prevent you from building this kernel snap, '
                'we suggest you take a look at these:\n')
-        required_opts = (required_generic + required_security +
-                         required_snappy + required_systemd)
+
+        required_opts = {}
+        for dictionary in (required_generic, required_security,
+                           required_snappy, required_systemd):
+            required_opts.update(dictionary)
+
         missing = []
 
-        for code in required_opts:
+        for code in required_opts.keys():
             opt = 'CONFIG_{}'.format(code)
             if opt in builtin:
                 continue
             elif opt in modules:
                 continue
             else:
-                missing.append(opt)
+                missing.append(code)
 
         if missing:
             warn = '\n{}\n'.format(msg)
             for opt in missing:
-                warn += '{}\n'.format(opt)
+                warn += 'CONFIG_{}'.format(opt)
+                note = required_opts[opt]
+                if note:
+                    warn += ' {}'.format(note)
+                warn += '\n'
             logger.warn(warn)
 
     def _do_check_initrd(self, builtin, modules):

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -425,7 +425,7 @@ class KernelPlugin(kbuild.KBuildPlugin):
                     note = '(4.1.x and later versions only)'
                 elif opt == 'CONFIG_DEVPTS_MULTIPLE_INSTANCES':
                     note = '(4.8.x and earlier versions only)'
-                warn += '{} {}'.format(opt, note)
+                warn += '{} {}\n'.format(opt, note)
             logger.warn(warn)
 
     def _do_check_initrd(self, builtin, modules):

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -81,30 +81,25 @@ default_kernel_image_target = {
     'arm64': 'Image.gz',
 }
 
-required_generic = {'DEVTMPFS': '', 'DEVTMPFS_MOUNT': '',
-                    'TMPFS_POSIX_ACL': '', 'IPV6': '', 'SYSVIPC': '',
-                    'SYSVIPC_SYSCTL': '', 'VFAT_FS': '',
-                    'NLS_CODEPAGE_437': '', 'NLS_ISO8859_1': ''}
+required_generic = ['DEVTMPFS', 'DEVTMPFS_MOUNT', 'TMPFS_POSIX_ACL', 'IPV6',
+                    'SYSVIPC', 'SYSVIPC_SYSCTL', 'VFAT_FS', 'NLS_CODEPAGE_437',
+                    'NLS_ISO8859_1']
 
-required_security = {'SECURITY': '', 'SECURITY_APPARMOR': '',
-                     'SYN_COOKIES': '', 'STRICT_DEVMEM': '',
-                     'DEFAULT_SECURITY_APPARMOR': '', 'SECCOMP': '',
-                     'SECCOMP_FILTER': '', 'CC_STACKPROTECTOR': '',
-                     'CC_STACKPROTECTOR_STRONG':
-                     '(4.1.x and later versions only)',
-                     'DEBUG_RODATA': '', 'DEBUG_SET_MODULE_RONX': ''}
+required_security = ['SECURITY', 'SECURITY_APPARMOR', 'SYN_COOKIES',
+                     'STRICT_DEVMEM', 'DEFAULT_SECURITY_APPARMOR', 'SECCOMP',
+                     'SECCOMP_FILTER', 'CC_STACKPROTECTOR',
+                     'CC_STACKPROTECTOR_STRONG', 'DEBUG_RODATA',
+                     'DEBUG_SET_MODULE_RONX']
 
-required_snappy = {'RD_LZMA': '', 'KEYS': '', 'ENCRYPTED_KEYS': '',
-                   'SQUASHFS': '', 'SQUASHFS_XATTR': '', 'SQUASHFS_XZ': '',
-                   'DEVPTS_MULTIPLE_INSTANCES':
-                   '(4.8.x and earlier versions only)'}
+required_snappy = ['RD_LZMA', 'KEYS', 'ENCRYPTED_KEYS', 'SQUASHFS',
+                   'SQUASHFS_XATTR', 'SQUASHFS_XZ',
+                   'DEVPTS_MULTIPLE_INSTANCES']
 
-required_systemd = {'DEVTMPFS': '', 'CGROUPS': '', 'INOTIFY_USER': '',
-                    'SIGNALFD': '', 'TIMERFD': '', 'EPOLL': '',
-                    'NET': '', 'SYSFS': '', 'PROC_FS': '', 'FHANDLE': '',
-                    'DMIID': '', 'BLK_DEV_BSG': '', 'NET_NS': '',
-                    'IPV6': '', 'AUTOFS4_FS': '',
-                    'TMPFS_POSIX_ACL': '', 'TMPFS_XATTR': '', 'SECCOMP': ''}
+required_systemd = ['DEVTMPFS', 'CGROUPS', 'INOTIFY_USER', 'SIGNALFD',
+                    'TIMERFD', 'EPOLL', 'NET', 'SYSFS', 'PROC_FS', 'FHANDLE',
+                    'DMIID', 'BLK_DEV_BSG', 'NET_NS',
+                    'IPV6', 'AUTOFS4_FS',
+                    'TMPFS_POSIX_ACL', 'TMPFS_XATTR', 'SECCOMP']
 
 required_boot = ['squashfs']
 
@@ -409,31 +404,23 @@ class KernelPlugin(kbuild.KBuildPlugin):
                'recommends or requires.\n'
                'While we will not prevent you from building this kernel snap, '
                'we suggest you take a look at these:\n')
-
-        required_opts = {}
-        for dictionary in (required_generic, required_security,
-                           required_snappy, required_systemd):
-            required_opts.update(dictionary)
-
+        required_opts = (required_generic + required_security +
+                         required_snappy + required_systemd)
         missing = []
 
-        for code in required_opts.keys():
+        for code in required_opts:
             opt = 'CONFIG_{}'.format(code)
             if opt in builtin:
                 continue
             elif opt in modules:
                 continue
             else:
-                missing.append(code)
+                missing.append(opt)
 
         if missing:
             warn = '\n{}\n'.format(msg)
             for opt in missing:
-                warn += 'CONFIG_{}'.format(opt)
-                note = required_opts[opt]
-                if note:
-                    warn += ' {}'.format(note)
-                warn += '\n'
+                warn += '{}\n'.format(opt)
             logger.warn(warn)
 
     def _do_check_initrd(self, builtin, modules):

--- a/snapcraft/tests/plugins/test_kernel.py
+++ b/snapcraft/tests/plugins/test_kernel.py
@@ -470,9 +470,12 @@ class KernelPluginTestCase(tests.TestCase):
         builtin, modules = plugin._do_parse_config(self.options.kconfigfile)
         plugin._do_check_config(builtin, modules)
 
-        required_opts = (kernel.required_generic + kernel.required_security +
-                         kernel.required_snappy + kernel.required_systemd)
-        for warn in required_opts:
+        required_opts = {}
+        for dictionary in (kernel.required_generic, kernel.required_security,
+                           kernel.required_snappy, kernel.required_systemd):
+            required_opts.update(dictionary)
+
+        for warn in required_opts.keys():
             self.assertIn('CONFIG_{}'.format(warn), fake_logger.output)
 
     @mock.patch.object(

--- a/snapcraft/tests/plugins/test_kernel.py
+++ b/snapcraft/tests/plugins/test_kernel.py
@@ -470,12 +470,9 @@ class KernelPluginTestCase(tests.TestCase):
         builtin, modules = plugin._do_parse_config(self.options.kconfigfile)
         plugin._do_check_config(builtin, modules)
 
-        required_opts = {}
-        for dictionary in (kernel.required_generic, kernel.required_security,
-                           kernel.required_snappy, kernel.required_systemd):
-            required_opts.update(dictionary)
-
-        for warn in required_opts.keys():
+        required_opts = (kernel.required_generic + kernel.required_security +
+                         kernel.required_snappy + kernel.required_systemd)
+        for warn in required_opts:
             self.assertIn('CONFIG_{}'.format(warn), fake_logger.output)
 
     @mock.patch.object(


### PR DESCRIPTION
Slightly improve the messaging of check_config(), by specifying if a kernel option applies only to a certain kernel version:

...
CONFIG_CC_STACKPROTECTOR_STRONG (4.1.x and later versions only)
...
CONFIG_DEVPTS_MULTIPLE_INSTANCES (4.8.x and earlier versions only)
...

No functional changes were introduced in this diff, just the messaging text.

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>

LP: #1689564