### PR TITLE
Use architectures field which existed in older LXD

### DIFF
--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -55,7 +55,7 @@ class Containerbuild:
         _verify_remote(remote)
         self._container_name = '{}:snapcraft-{}'.format(remote, container_name)
         # Use the server architecture to avoid emulation overhead
-        kernel = self._get_remote_info()['environment']['kernel_architecture']
+        kernel = self._get_remote_info()['environment']['architectures'][0]
         deb_arch = _get_deb_arch(kernel)
         if not deb_arch:
             raise SnapcraftEnvironmentError(

--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -54,8 +54,12 @@ class Containerbuild:
             remote = _get_default_remote()
         _verify_remote(remote)
         self._container_name = '{}:snapcraft-{}'.format(remote, container_name)
+        server_environment = self._get_remote_info()['environment']
         # Use the server architecture to avoid emulation overhead
-        kernel = self._get_remote_info()['environment']['architectures'][0]
+        try:
+            kernel = server_environment['kernel_architecture']
+        except KeyError:
+            kernel = server_environment['kernelarchitecture']
         deb_arch = _get_deb_arch(kernel)
         if not deb_arch:
             raise SnapcraftEnvironmentError(

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -398,7 +398,7 @@ def check_output_side_effect(fail_on_remote=False, fail_on_default=False):
         elif args[0][:2] == ['lxc', 'info']:
             return '''
                 environment:
-                  architectures: [x86_64, i686]
+                  kernel_architecture: x86_64
                 '''.encode('utf-8')
         elif args[0][:3] == ['lxc', 'list', '--format=json']:
             return '''

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -398,7 +398,7 @@ def check_output_side_effect(fail_on_remote=False, fail_on_default=False):
         elif args[0][:2] == ['lxc', 'info']:
             return '''
                 environment:
-                  kernel_architecture: x86_64
+                  architectures: [x86_64, i686]
                 '''.encode('utf-8')
         elif args[0][:3] == ['lxc', 'list', '--format=json']:
             return '''


### PR DESCRIPTION
LXD recently renamed the kernelarchitecture field to kernel-architecture so snapcraft is unwittingly not backwards-compatible.

This was filed as [bug 1689712](https://bugs.launchpad.net/snapcraft/+bug/1689712).