### PR TITLE
add missing VCS dependencies to HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -58,7 +58,7 @@ If you don't have python3 installed, you can use the one from the archives:
 
 Install the needed dependencies.
 
-    sudo apt install build-essential python3-dev python3-debian libapt-pkg-dev libsodium-dev gcc libffi-dev libarchive13 squashfs-tools xdelta3
+    sudo apt install build-essential python3-dev python3-debian libapt-pkg-dev libsodium-dev gcc libffi-dev libarchive13 squashfs-tools xdelta3 bzr git mercurial subversion
 
 If installing to `PYTHONHOME` run:
 


### PR DESCRIPTION
Noticed that these packages were missing when I ran `./runtests.sh`.