### PR TITLE
Meta: Version from deb

### DIFF
--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -280,6 +280,12 @@ class _SnapPackaging:
                         'repo (version: git).')
             vcs_handler = get_source_handler_from_type('git')
             new_version = vcs_handler.generate_version()
+        elif version == 'deb':
+            logger.info('Determining the version from the debian/'
+                        'changelog file (version: deb).')
+            vcs_handler = get_source_handler_from_type('deb')
+            new_version = vcs_handler.generate_version(
+                deb_arch=self._config_data['architectures'][0])
 
         if new_version != version:
             logger.info('The version has been set to {!r}'.format(new_version))

--- a/snapcraft/internal/sources/_deb.py
+++ b/snapcraft/internal/sources/_deb.py
@@ -16,7 +16,9 @@
 
 import debian.debfile
 import os
+import re
 import shutil
+import subprocess
 import tempfile
 
 from . import errors
@@ -25,6 +27,42 @@ from snapcraft.internal import sources
 
 
 class Deb(FileBase):
+
+    @classmethod
+    def generate_version(cls, *, source_dir=None, deb_arch=None):
+
+        if not source_dir:
+            source_dir = os.getcwd()
+
+        cmd = 'fakeroot debian/rules clean'
+        if deb_arch:
+            prep = 'export $(dpkg-architecture -a{}); '.format(deb_arch)
+            cmd = prep + cmd
+
+        subprocess.check_call(cmd, shell=True, cwd=source_dir)
+        # read a line
+        path = os.path.join(source_dir, 'debian/changelog')
+        try:
+            changelog = open(path)
+        except OSError as e:
+            raise RuntimeError('Unable to access {}: {}'.format(e.filename,
+                                                                e.strerror))
+
+        output = changelog.readline()
+        # parse the string between (..)
+        m = re.search(
+            r'^(?P<pkg>[a-zA-Z0-9\s.+-]+\({1})'
+            r'(?P<version>[a-zA-Z0-9.-]+[~a-zA-Z0-9]*)'
+            r'(?P<leftover>\){1}.+)$',
+            output)
+        if not m:
+            # the debian/changelog history wasn't properly 'closed'
+            raise errors.VCSError(message='{} wasn\'t properly'
+                                  ' closed'.format(path))
+
+        version = m.group('version')
+        # return version
+        return '{}'.format(version)
 
     def __init__(self, source, source_dir, source_tag=None, source_commit=None,
                  source_branch=None, source_depth=None, source_checksum=None):


### PR DESCRIPTION
If `version: deb` is set, snapcraft will determine the version parsing the head of debian/changelog.

LP: #[1690409](https://bugs.launchpad.net/snapcraft/+bug/1690409)