### PR TITLE
kernel plugin: config check: remove DMIID option

### DIFF
--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -97,8 +97,7 @@ required_snappy = ['RD_LZMA', 'KEYS', 'ENCRYPTED_KEYS', 'SQUASHFS',
 
 required_systemd = ['DEVTMPFS', 'CGROUPS', 'INOTIFY_USER', 'SIGNALFD',
                     'TIMERFD', 'EPOLL', 'NET', 'SYSFS', 'PROC_FS', 'FHANDLE',
-                    'DMIID', 'BLK_DEV_BSG', 'NET_NS',
-                    'IPV6', 'AUTOFS4_FS',
+                    'BLK_DEV_BSG', 'NET_NS', 'IPV6', 'AUTOFS4_FS',
                     'TMPFS_POSIX_ACL', 'TMPFS_XATTR', 'SECCOMP']
 
 required_boot = ['squashfs']


### PR DESCRIPTION
The DMIID config option is only present if a DMI EFI table is present, and since some ubuntu core targets (e.g. armhf) don't support EFI, it's better to stop warning about its absence.

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>

LP: #1691116