### PR TITLE
store: send X-Ubuntu-Series, not X-Ubuntu-Release

### DIFF
--- a/snapcraft/storeapi/__init__.py
+++ b/snapcraft/storeapi/__init__.py
@@ -416,7 +416,7 @@ class SnapIndexClient(Client):
         headers = self.get_default_headers()
         headers.update({
             'Accept': 'application/hal+json',
-            'X-Ubuntu-Release': constants.DEFAULT_SERIES,
+            'X-Ubuntu-Series': constants.DEFAULT_SERIES,
         })
         if arch:
             headers['X-Ubuntu-Architecture'] = arch


### PR DESCRIPTION
In June 2016, the store added support for an X-Ubuntu-Series header to
be used in preference to X-Ubuntu-Release.

LP: #1691351