### PR TITLE
Revert "tests: remove the reusable parts tour test (#1321)"

### DIFF
--- a/snaps_tests/tour_tests/20-PARTS-PLUGINS/test_01_reusable_part.py
+++ b/snaps_tests/tour_tests/20-PARTS-PLUGINS/test_01_reusable_part.py
@@ -1,0 +1,28 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import snaps_tests
+
+
+class ReusablePartTestCase(snaps_tests.SnapsTestCase):
+
+    snap_content_dir = '01-reusable-part'
+
+    def test_hello(self):
+        snap_path = self.build_snap(self.snap_content_dir)
+        self.install_snap(snap_path, 'hello-world-desktop', '0.1')
+        self.run_command_in_snappy_testbed('ls /snap/bin/hello-world-desktop')


### PR DESCRIPTION
This reverts commit 2bd87c5afe5322951647366f61af2ff8281f9e2c.
It was originally thought to be a problem with the tested code, but
in the end it was a snapcraft problem.