### PR TITLE
cli: proper error for failed snap command

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -137,8 +137,12 @@ def snap(directory, output, **kwargs):
     if env.is_containerbuild():
         lifecycle.containerbuild('snap', project_options, output, directory)
     else:
-        snap_name = lifecycle.snap(
-            project_options, directory=directory, output=output)
+        try:
+            snap_name = lifecycle.snap(
+                project_options, directory=directory, output=output)
+        except Exception as e:
+            echo.error(e)
+            sys.exit(1)
         click.echo('Snapped {}'.format(snap_name))
 
 

--- a/snapcraft/tests/commands/test_snap.py
+++ b/snapcraft/tests/commands/test_snap.py
@@ -83,6 +83,15 @@ parts:
             '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
+    def test_snap_fails_with_bad_type(self):
+        self.make_snapcraft_yaml(snap_type='bad-type')
+
+        result = self.run_command(['snap'])
+
+        self.assertThat(result.exit_code, Equals(1))
+        self.assertThat(result.output, Contains(
+            "bad-type' is not one of ['app', 'gadget', 'kernel', 'os']"))
+
     def test_snap_is_the_default(self):
         self.make_snapcraft_yaml()
 


### PR DESCRIPTION
Return a proper error code when failing to snap

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>