### PR TITLE
qmake plugin: set default qt version

### DIFF
--- a/snapcraft/plugins/qmake.py
+++ b/snapcraft/plugins/qmake.py
@@ -28,8 +28,8 @@ Additionally, this plugin uses the following plugin-specific keywords:
       (list of strings)
       additional options to pass to the qmake invocation.
     - qt-version:
-      (enum, 'qt4' or 'qt5')
-      Version of Qt to use with qmake.
+      (string; default: qt5)
+      Version of Qt to use with qmake. Valid options are: qt4 and qt5
     - project-files:
       (list of strings)
       list of .pro files to pass to the qmake invocation.
@@ -56,7 +56,9 @@ class QmakePlugin(snapcraft.BasePlugin):
             'default': [],
         }
         schema['properties']['qt-version'] = {
+            'type': 'string',
             'enum': ['qt4', 'qt5'],
+            'default': 'qt5'
         }
         schema['properties']['project-files'] = {
             'type': 'array',
@@ -68,8 +70,7 @@ class QmakePlugin(snapcraft.BasePlugin):
             'default': [],
         }
 
-        # Qt version must be specified
-        schema['required'].append('qt-version')
+        schema.pop('required')
 
         return schema
 

--- a/snapcraft/tests/plugins/test_qmake.py
+++ b/snapcraft/tests/plugins/test_qmake.py
@@ -95,12 +95,15 @@ class QMakeTestCase(tests.TestCase):
         qt_version = properties['qt-version']
         self.assertTrue('enum' in qt_version,
                         'Expected "enum" to be included in "qt_version"')
-        self.assertFalse('default' in qt_version,
-                         '"default" was unexpectedly included in "qt_version"')
 
         qt_version_enum = qt_version['enum']
         # Using sets for order independence in the comparison
         self.assertEqual(set(['qt4', 'qt5']), set(qt_version_enum))
+
+        qt_version_default = qt_version['default']
+        self.assertEqual(qt_version_default, 'qt5',
+                         'Expected "qt_version" "default" to be "qt5", but '
+                         'it was {}'.format(qt_version_default))
 
         self.assertTrue('build-properties' in schema,
                         'Expected schema to include "build-properties"')
@@ -142,11 +145,6 @@ class QMakeTestCase(tests.TestCase):
                          'Expected "project_files" "items" "type" to be '
                          '"string", but it was "{}"'
                          .format(project_files_items_type))
-
-        # Finally, verify that qt-version is required
-        required = schema['required']
-        self.assertTrue('qt-version' in required,
-                        'Expected "qt-version" to be required')
 
     def test_get_build_properties(self):
         expected_build_properties = ['options', 'project-files']


### PR DESCRIPTION
Right now it is necessary to manually specify the Qt version to use for the QMake plugin.
For convenience however, the default value should be qt5, as discussed on Launchpad: 
[LP: #1633278](https://bugs.launchpad.net/snapcraft/+bug/1633278)