### PR TITLE
tour: use https for source urls

### DIFF
--- a/tour/00-SNAPCRAFT/01-easy-start/snapcraft.yaml
+++ b/tour/00-SNAPCRAFT/01-easy-start/snapcraft.yaml
@@ -12,5 +12,4 @@ apps:
 parts:
   gnu-hello:
     plugin: autotools
-    source: http://ftp.gnu.org/gnu/hello/hello-2.10.tar.gz
-
+    source: https://ftp.gnu.org/gnu/hello/hello-2.10.tar.gz

--- a/tour/00-SNAPCRAFT/02-parts/snapcraft.yaml
+++ b/tour/00-SNAPCRAFT/02-parts/snapcraft.yaml
@@ -14,9 +14,8 @@ apps:
 parts:
   gnu-hello:
     plugin: autotools
-    source: http://ftp.gnu.org/gnu/hello/hello-2.10.tar.gz
+    source: https://ftp.gnu.org/gnu/hello/hello-2.10.tar.gz
   gnu-bash:
     plugin: autotools
     configflags: ["--infodir=/var/bash/info"]
-    source: http://ftp.gnu.org/gnu/bash/bash-4.3.tar.gz
-
+    source: https://ftp.gnu.org/gnu/bash/bash-4.3.tar.gz


### PR DESCRIPTION
Snapcraft tour should download sources
via https instead of http.

See [LP: #1634415](https://bugs.launchpad.net/snapcraft/+bug/1634415)

Should the `source-checksum` feature be used in addition?