### PR TITLE
cli: provide a whoami command

### DIFF
--- a/integration_tests/store/test_store_whoami.py
+++ b/integration_tests/store/test_store_whoami.py
@@ -1,0 +1,36 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+
+import integration_tests
+
+from testtools.matchers import MatchesRegex
+
+
+class WhoamiTestCase(integration_tests.StoreTestCase):
+
+    def test_whoami_must_print_email_and_developer_id(self):
+        self.addCleanup(self.logout)
+        self.login(expect_success=True)
+        output = self.run_snapcraft('whoami')
+        self.assertThat(
+            output,
+            MatchesRegex(
+                '.*email: +{}\n'
+                'developer-id: +.+\n'.format(
+                    re.escape(self.test_store.user_email)),
+                flags=re.DOTALL))

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -273,3 +273,22 @@ def logout():
     store = storeapi.StoreClient()
     store.logout()
     echo.info('Credentials cleared.')
+
+
+@storecli.command()
+def whoami():
+    """Returns your login information relevant to the store."""
+    try:
+        account_data = storeapi.StoreClient().whoami()
+    except storeapi.errors.InvalidCredentialsError:
+        echo.error('You need to first login to use this command.')
+        sys.exit(1)
+
+    click.echo(dedent("""\
+        email:        {email}
+        developer-id: {account_id}""".format(**account_data)))
+
+    # This is needed because we originally did not store the login information.
+    if account_data['email'] == 'unknown':
+        echo.warning('In order to view the correct email you will need to '
+                     'logout and login again.')

--- a/snapcraft/storeapi/__init__.py
+++ b/snapcraft/storeapi/__init__.py
@@ -160,6 +160,7 @@ class StoreClient():
         # The macaroon has been discharged, save it in the config
         self.conf.set('macaroon', macaroon)
         self.conf.set('unbound_discharge', unbound_discharge)
+        self.conf.set('email', email)
         if save:
             self.conf.save()
 
@@ -187,6 +188,25 @@ class StoreClient():
             self.conf.set('unbound_discharge', unbound_discharge)
             self.conf.save()
             return func(*args, **kwargs)
+
+    def whoami(self):
+        """Return user relevant login information."""
+        account_data = {}
+
+        for k in ('email', 'account_id'):
+            try:
+                value = self.conf.get(k)
+            except KeyError as e:
+                value = None
+            finally:
+                if not value:
+                    account_info = self.get_account_information()
+                    value = account_info.get(k, 'unknown')
+                    self.conf.set(k, value)
+                    self.conf.save()
+            account_data[k] = value
+
+        return account_data
 
     def get_account_information(self):
         return self._refresh_if_necessary(self.sca.get_account_information)

--- a/snapcraft/storeapi/__init__.py
+++ b/snapcraft/storeapi/__init__.py
@@ -194,16 +194,12 @@ class StoreClient():
         account_data = {}
 
         for k in ('email', 'account_id'):
-            try:
-                value = self.conf.get(k)
-            except KeyError as e:
-                value = None
-            finally:
-                if not value:
-                    account_info = self.get_account_information()
-                    value = account_info.get(k, 'unknown')
-                    self.conf.set(k, value)
-                    self.conf.save()
+            value = self.conf.get(k)
+            if not value:
+                account_info = self.get_account_information()
+                value = account_info.get(k, 'unknown')
+                self.conf.set(k, value)
+                self.conf.save()
             account_data[k] = value
 
         return account_data

--- a/snapcraft/tests/commands/test_whoami.py
+++ b/snapcraft/tests/commands/test_whoami.py
@@ -1,0 +1,72 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import re
+from unittest import mock
+
+from snapcraft import storeapi
+
+import fixtures
+from testtools.matchers import MatchesRegex
+
+
+from snapcraft.tests import commands
+
+
+class WhoamiCommandBaseTestCase(commands.CommandBaseTestCase):
+
+    @mock.patch.object(storeapi.SCAClient, 'get_account_information')
+    def test_unknown_email_must_suggest_logout_and_login(
+            self, mock_get_account_information):
+        mock_get_account_information.return_value = {}
+        self.useFixture(fixtures.EnvironmentVariable('HOME', self.path))
+        config_file_path = os.path.join(
+            self.path, '.config', 'snapcraft', 'snapcraft.cfg')
+        os.makedirs(os.path.dirname(config_file_path))
+        with open(config_file_path, 'w') as config_file:
+            config_file.write('[login.ubuntu.com]\n')
+            config_file.write('account_id = test_account_id\n')
+
+        result = self.run_command(['whoami'])
+        self.assertThat(
+            result.output,
+            MatchesRegex(
+                '.*email: +unknown\n'
+                'developer-id: +test_account_id\n'
+                '.*logout and login again.*',
+                flags=re.DOTALL))
+
+    @mock.patch.object(storeapi.SCAClient, 'get_account_information')
+    def test_whoami_must_print_email_and_developer_id(
+            self, mock_get_account_information):
+        mock_get_account_information.return_value = {}
+        self.useFixture(fixtures.EnvironmentVariable('HOME', self.path))
+        config_file_path = os.path.join(
+            self.path, '.config', 'snapcraft', 'snapcraft.cfg')
+        os.makedirs(os.path.dirname(config_file_path))
+        with open(config_file_path, 'w') as config_file:
+            config_file.write('[login.ubuntu.com]\n')
+            config_file.write('email = test@example.com\n')
+            config_file.write('account_id = test_account_id\n')
+
+        result = self.run_command(['whoami'])
+        self.assertThat(
+            result.output,
+            MatchesRegex(
+                '.*email: +test@example.com\n'
+                'developer-id: +test_account_id\n',
+                flags=re.DOTALL))

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -357,8 +357,9 @@ class TestStore(fixtures.Fixture):
             raise ValueError(
                 'Unknown test store option: {}'.format(test_store))
 
-        self.user_email = os.getenv(
-            'TEST_USER_EMAIL', 'u1test+snapcraft@canonical.com')
+        self.user_email = (
+            os.getenv('TEST_USER_EMAIL') or
+            'u1test+snapcraft@canonical.com')
         self.test_track_snap = os.getenv(
             'TEST_SNAP_WITH_TRACKS', 'test-snapcraft-tracks')
         if test_store == 'fake':


### PR DESCRIPTION
There are proper fallbacks here as we never
stored the email in our original credentail config location. This provides the proper messaging so this is correct for users wanting to know this.

In some distant future, the account info from the store will also provide this information which is why we loop over the account information .

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>