### PR TITLE
go plugin: Add support for cross-compilation

### DIFF
--- a/integration_tests/plugins/test_go_plugin.py
+++ b/integration_tests/plugins/test_go_plugin.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import magic
 import os
 import subprocess
 
@@ -45,6 +46,7 @@ class GoPluginTestCase(integration_tests.TestCase):
                            'go-hello')
         binary = os.path.join(self.parts_dir, 'go-hello', 'install', 'bin',
                               os.path.basename(self.path))
-        arch = subprocess.check_output(['file', '-b', binary],
-                                       universal_newlines=True)
+        ms = magic.open(magic.NONE)
+        ms.load()
+        arch = ms.file(binary)
         self.assertThat(arch, Contains('aarch64'))

--- a/integration_tests/plugins/test_go_plugin.py
+++ b/integration_tests/plugins/test_go_plugin.py
@@ -40,10 +40,10 @@ class GoPluginTestCase(integration_tests.TestCase):
         if snapcraft.ProjectOptions().deb_arch != 'amd64':
             self.skipTest('The test only handles amd64 to armhf')
 
-        expected_arch = 'armhf'
-        self.run_snapcraft('build', 'go-hello',
-                           '--target={}'.format(expected_arch))
-        binary = os.path.join(self.stage_dir, 'bin',
+        expected_arch = 'arm64'
+        self.run_snapcraft(['build', '--target-arch={}'.format(expected_arch)],
+                           'go-hello')
+        binary = os.path.join(self.parts_dir, 'go-hello', 'install', 'bin',
                               os.path.basename(self.path))
         arch = subprocess.check_output(['file', '-b', binary],
                                        universal_newlines=True)

--- a/integration_tests/plugins/test_go_plugin.py
+++ b/integration_tests/plugins/test_go_plugin.py
@@ -14,13 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import magic
 import os
 import subprocess
 
 import integration_tests
 import snapcraft
-from testtools.matchers import Contains
+from snapcraft.tests.matchers import HasArchitecture
 
 
 class GoPluginTestCase(integration_tests.TestCase):
@@ -41,12 +40,9 @@ class GoPluginTestCase(integration_tests.TestCase):
         if snapcraft.ProjectOptions().deb_arch != 'amd64':
             self.skipTest('The test only handles amd64 to armhf')
 
-        expected_arch = 'arm64'
-        self.run_snapcraft(['build', '--target-arch={}'.format(expected_arch)],
+        target_arch = 'arm64'
+        self.run_snapcraft(['build', '--target-arch={}'.format(target_arch)],
                            'go-hello')
         binary = os.path.join(self.parts_dir, 'go-hello', 'install', 'bin',
                               os.path.basename(self.path))
-        ms = magic.open(magic.NONE)
-        ms.load()
-        arch = ms.file(binary)
-        self.assertThat(arch, Contains('aarch64'))
+        self.assertThat(binary, HasArchitecture('aarch64'))

--- a/integration_tests/snaps/go-hello/snapcraft.yaml
+++ b/integration_tests/snaps/go-hello/snapcraft.yaml
@@ -13,6 +13,10 @@ description: |
 icon: icon.png
 confinement: strict
 
+apps:
+  go-hello:
+    command: go-hello
+
 parts:
   go-hello:
     plugin: go

--- a/manual-tests.md
+++ b/manual-tests.md
@@ -67,6 +67,15 @@
    build folders as well as the container `snapcraft-<project>` is gone.
 
 
+# Test cross-compilation
+
+1. Go to integration_tests/snaps/go-hello.
+2. Run `snapcraft snap --target-arch=armhf`.
+3. Copy the snap to a Raspberry Pi.
+4. Install the snap.
+5. Run `go-hello`.
+
+
 # Test the PC kernel.
 
 1. Get the PC kernel source:

--- a/snapcraft/plugins/go.py
+++ b/snapcraft/plugins/go.py
@@ -151,18 +151,22 @@ class GoPlugin(snapcraft.BasePlugin):
         if self.options.go_buildtags:
             tags = ['-tags={}'.format(','.join(self.options.go_buildtags))]
 
-        for go_package in self.options.go_packages:
-            self._run(['go', 'install'] + tags + [go_package])
-        if not self.options.go_packages:
-            self._run(['go', 'install'] + tags +
-                      ['./{}/...'.format(self._get_local_go_package())])
+        packages = self.options.go_packages
+        if not packages:
+            packages = ['./{}/...'.format(self._get_local_go_package())]
+        for package in packages:
+            binary = os.path.join(self._gopath_bin, self._binary_name(package))
+            self._run(['go', 'build', '-o', binary] + tags + [package])
 
         install_bin_path = os.path.join(self.installdir, 'bin')
         os.makedirs(install_bin_path, exist_ok=True)
-        os.makedirs(self._gopath_bin, exist_ok=True)
         for binary in os.listdir(self._gopath_bin):
             binary_path = os.path.join(self._gopath_bin, binary)
             shutil.copy2(binary_path, install_bin_path)
+
+    def _binary_name(self, package):
+        package = package.replace('/...', '')
+        return package.split('/')[-1]
 
     def clean_build(self):
         super().clean_build()
@@ -191,4 +195,18 @@ class GoPlugin(snapcraft.BasePlugin):
         env['CGO_LDFLAGS'] = '{} {} {}'.format(
             env.get('CGO_LDFLAGS', ''), flags, env.get('LDFLAGS', ''))
 
+        if self.project.is_cross_compiling:
+            # See https://golang.org/doc/install/source#environment
+            go_archs = {
+                'armhf': 'arm',
+                'i386': '386',
+                'ppc64el': 'ppc64le',
+            }
+            env['GOARCH'] = go_archs.get(self.project.deb_arch,
+                                         self.project.deb_arch)
+            if self.project.deb_arch == 'armhf':
+                env['GOARM'] = '7'
         return env
+
+    def enable_cross_compilation(self):
+        pass

--- a/snapcraft/tests/matchers.py
+++ b/snapcraft/tests/matchers.py
@@ -1,0 +1,37 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import magic
+import testtools
+
+
+class HasArchitecture:
+    """Match if the file was built for the expected architecture"""
+
+    def __init__(self, expected_arch):
+        self._expected_arch = expected_arch
+        self._ms = magic.open(magic.NONE)
+        self._ms.load()
+
+    def __str__(self):
+        return 'HasArchitecture()'
+
+    def match(self, file_path):
+        arch = self._ms.file(file_path).split(',')[1]
+        if self._expected_arch not in arch:
+            return testtools.matchers.Mismatch(
+                'Expected {!r} to be in {!r}'.format(
+                    self._expected_arch, arch))

--- a/snapcraft/tests/plugins/test_go.py
+++ b/snapcraft/tests/plugins/test_go.py
@@ -44,10 +44,6 @@ class GoPluginCrossCompileTestCase(tests.TestCase):
         self.run_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = mock.patch('sys.stdout')
-        patcher.start()
-        self.addCleanup(patcher.stop)
-
         patcher = mock.patch('snapcraft.ProjectOptions.is_cross_compiling')
         patcher.start()
         self.addCleanup(patcher.stop)


### PR DESCRIPTION
Support doing `snapcraft snap --target-arch=` with parts using the **go** plugin