### PR TITLE
python plugin: install six before using setuptools

### DIFF
--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -219,7 +219,8 @@ class PythonPlugin(snapcraft.BasePlugin):
         if not self._get_python_command().startswith(self.project.stage_dir):
             env['PYTHONHOME'] = '/usr'
 
-        args = ['pip', 'setuptools', 'wheel']
+        # With the release of setuptools v36.0.0, six is needed here.
+        args = ['pip', 'six', 'setuptools', 'wheel']
 
         pip_command = [self._get_python_command(), '-m', 'pip']
 


### PR DESCRIPTION
setuptools v36.0.0 (released today) requires that six is installed before it can be used. This PR fixes LP: [#1694945](https://bugs.launchpad.net/snapcraft/+bug/1694945) by doing exactly that.