### PR TITLE
state: save all the build packages as global

### DIFF
--- a/integration_tests/plugins/test_nil_plugin.py
+++ b/integration_tests/plugins/test_nil_plugin.py
@@ -26,7 +26,8 @@ class NilPluginTestCase(integration_tests.TestCase):
         self.run_snapcraft('snap', 'nil-basic')
 
         dirs = os.listdir(self.prime_dir)
-        self.assertEqual(['meta'], dirs)
+        dirs.sort()
+        self.assertEqual(['meta', 'snap'], dirs)
 
     def test_nil_no_additional_properties(self):
         exception = self.assertRaises(

--- a/integration_tests/plugins/test_nil_plugin.py
+++ b/integration_tests/plugins/test_nil_plugin.py
@@ -26,7 +26,6 @@ class NilPluginTestCase(integration_tests.TestCase):
         self.run_snapcraft('snap', 'nil-basic')
 
         dirs = os.listdir(self.prime_dir)
-        dirs.sort()
         self.assertEqual(['meta'], dirs)
 
     def test_nil_no_additional_properties(self):

--- a/integration_tests/plugins/test_nil_plugin.py
+++ b/integration_tests/plugins/test_nil_plugin.py
@@ -27,7 +27,7 @@ class NilPluginTestCase(integration_tests.TestCase):
 
         dirs = os.listdir(self.prime_dir)
         dirs.sort()
-        self.assertEqual(['meta', 'snap'], dirs)
+        self.assertEqual(['meta'], dirs)
 
     def test_nil_no_additional_properties(self):
         exception = self.assertRaises(

--- a/integration_tests/snaps/build-package-global/snap/snapcraft.yaml
+++ b/integration_tests/snaps/build-package-global/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
 
 grade: stable
 confinement: strict
-build-packages: ['hello']
+build-packages: ['grub-doc']
 
 parts:
   empty-part:

--- a/integration_tests/snaps/build-packages-missing-dependency/snap/snapcraft.yaml
+++ b/integration_tests/snaps/build-packages-missing-dependency/snap/snapcraft.yaml
@@ -4,9 +4,8 @@ summary: install a build package
 description: |
   Install a build package.
   This package has dependencies:
-    - gcc-6-base
-    - libc6
-    - libgcc1
+    - grub-legacy-doc
+    - multiboot-doc
 
 grade: stable
 confinement: strict
@@ -14,4 +13,4 @@ confinement: strict
 parts:
   part-with-build-packages:
     plugin: nil
-    build-packages: ['hello']
+    build-packages: ['grub-doc']

--- a/integration_tests/snaps/build-packages-without-dependencies/snap/snapcraft.yaml
+++ b/integration_tests/snaps/build-packages-without-dependencies/snap/snapcraft.yaml
@@ -12,7 +12,6 @@ parts:
   part-with-build-packages:
     plugin: nil
     build-packages:
-      - hello
-      - libc6
-      - libgcc1
-      - gcc-6-base
+      - grub-doc
+      - grub-legacy-doc
+      - multiboot-doc

--- a/integration_tests/snaps/build-virtual-package/snap/snapcraft.yaml
+++ b/integration_tests/snaps/build-virtual-package/snap/snapcraft.yaml
@@ -7,7 +7,8 @@ description: |
 grade: stable
 confinement: strict
 
+build-packages: ['fortunes-off']
+
 parts:
-  part-with-virtual-build-package:
+  empty-part:
     plugin: nil
-    build-packages: ['libc-dev']

--- a/integration_tests/test_build_package_version.py
+++ b/integration_tests/test_build_package_version.py
@@ -28,18 +28,20 @@ class BuildPackageVersionTestCase(testscenarios.WithScenarios,
                                   integration_tests.TestCase):
 
     scenarios = (
-        ('global', dict(project='build-package', part='hello')),
-        ('local', dict(project='build-package-global', part=None)),
+        ('global', dict(
+            project='build-package', package='hello', part='hello')),
+        ('local', dict(
+            project='build-package-global', package='grub-doc', part=None)),
     )
 
     def test_build_package_gets_version(self):
         self.copy_project_to_cwd(self.project)
         version = self.set_build_package_version(
-            os.path.join('snap', 'snapcraft.yaml'), self.part, package='hello')
+            os.path.join('snap', 'snapcraft.yaml'), self.part, package=self.package)
         self.run_snapcraft('pull')
 
         with apt.Cache() as apt_cache:
-            installed_version = apt_cache['hello'].candidate.version
+            installed_version = apt_cache[self.package].candidate.version
         self.assertThat(installed_version, Equals(version))
 
 

--- a/integration_tests/test_build_package_version.py
+++ b/integration_tests/test_build_package_version.py
@@ -46,14 +46,15 @@ class BuildPackageVersionTestCase(testscenarios.WithScenarios,
 class BuildPackageVersionErrorsTestCase(integration_tests.TestCase):
 
     def test_build_package_with_invalid_version_must_fail(self):
-        self.copy_project_to_cwd('build-package')
+        self.copy_project_to_cwd('build-package-global')
         self.set_build_package_version(
             os.path.join('snap', 'snapcraft.yaml'),
-            part='hello', package='hello', version='invalid')
+            part=None, package='grub-doc', version='invalid')
         error = self.assertRaises(
             subprocess.CalledProcessError,
             self.run_snapcraft, 'pull')
         self.assertIn(
-            "Version 'invalid' for 'hello' was not found",
+            "Could not find a required package in 'build-packages': "
+            "grub-doc=invalid",
             str(error.output)
         )

--- a/integration_tests/test_build_package_version.py
+++ b/integration_tests/test_build_package_version.py
@@ -37,7 +37,8 @@ class BuildPackageVersionTestCase(testscenarios.WithScenarios,
     def test_build_package_gets_version(self):
         self.copy_project_to_cwd(self.project)
         version = self.set_build_package_version(
-            os.path.join('snap', 'snapcraft.yaml'), self.part, package=self.package)
+            os.path.join('snap', 'snapcraft.yaml'), self.part,
+            package=self.package)
         self.run_snapcraft('pull')
 
         with apt.Cache() as apt_cache:

--- a/integration_tests/test_pull_properties.py
+++ b/integration_tests/test_pull_properties.py
@@ -16,6 +16,7 @@
 
 from collections import namedtuple
 import os
+import subprocess
 import yaml
 
 import testscenarios
@@ -117,13 +118,20 @@ class AssetTrackingTestCase(integration_tests.TestCase):
         self.assertIn('hello', state.assets['build-packages'][0])
 
     def test_pull_with_virtual_build_package(self):
+        virtual_package = 'fortunes-off'
+        self.addCleanup(
+            subprocess.call, ['sudo', 'apt-get', 'remove', virtual_package])
         self.run_snapcraft('pull', 'build-virtual-package')
 
         state_file = os.path.join(
-            self.parts_dir, 'part-with-virtual-build-package', 'state', 'pull')
+            'snap', '.snapcraft', 'state')
         with open(state_file) as f:
             state = yaml.load(f)
-        self.assertIn('libc6-dev', state.assets['build-packages'][0])
+        self.assertIn(
+            '{}={}'.format(
+                virtual_package, integration_tests.get_package_version(
+                    virtual_package, self.distro_series, self.deb_arch)),
+            state.assets['build-packages'])
 
 
 TestDetail = namedtuple('TestDetail', ['field', 'value'])

--- a/integration_tests/test_pull_properties.py
+++ b/integration_tests/test_pull_properties.py
@@ -91,7 +91,7 @@ class AssetTrackingTestCase(integration_tests.TestCase):
         build-packages data.
         """
         self.copy_project_to_cwd('build-package-global')
-        version = self.set_build_package_version(
+        self.set_build_package_version(
             os.path.join('snap', 'snapcraft.yaml'),
             part=None, package='grub-doc')
         self.run_snapcraft('pull')

--- a/integration_tests/test_pull_properties.py
+++ b/integration_tests/test_pull_properties.py
@@ -92,7 +92,7 @@ class AssetTrackingTestCase(integration_tests.TestCase):
         self.copy_project_to_cwd('build-package-global')
         version = self.set_build_package_version(
             os.path.join('snap', 'snapcraft.yaml'),
-            part=None, package='hello')
+            part=None, package='grub-doc')
         self.run_snapcraft('pull')
 
         state_file = os.path.join(
@@ -102,8 +102,6 @@ class AssetTrackingTestCase(integration_tests.TestCase):
             state = yaml.load(f)
 
         self.assertTrue(len(state.assets['build-packages']) == 0)
-        self.assertNotIn(
-            'hello={}'.format(version), state.assets['build-packages'])
 
     def test_pull_build_package_with_any_architecture(self):
         self.copy_project_to_cwd('build-package')

--- a/integration_tests/test_snap.py
+++ b/integration_tests/test_snap.py
@@ -124,7 +124,7 @@ class SnapTestCase(integration_tests.TestCase):
             subprocess.CalledProcessError, self.run_snapcraft, 'snap')
         expected = (
             "Could not find a required package in 'build-packages': "
-            '"The cache has no package named \'inexistent-package\'"\n')
+            "inexistent-package\n")
         self.assertThat(exception.output, EndsWith(expected))
 
     def test_snap_with_exposed_files(self):

--- a/integration_tests/test_snapcraft_recording.py
+++ b/integration_tests/test_snapcraft_recording.py
@@ -78,15 +78,21 @@ class SnapcraftRecordingTestCase(SnapcraftRecordingBaseTestCase):
 
         This snap declares one global build package that has undeclared
         dependencies.
+
         """
+        expected_packages = ['grub-doc', 'grub-legacy-doc', 'multiboot-doc']
+        self.addCleanup(
+            subprocess.call,
+            ['sudo', 'apt', 'remove', '-y'] + expected_packages)
+
         self.run_snapcraft('prime', 'build-package-global')
 
-        expected_packages = [
+        expected_packages_with_version = [
             '{}={}'.format(
                 package,
                 integration_tests.get_package_version(
                     package, self.distro_series, self.deb_arch))
-            for package in ['hello', 'libc6', 'libgcc1', 'gcc-6-base']
+            for package in expected_packages
         ]
 
         recorded_yaml_path = os.path.join(
@@ -94,7 +100,8 @@ class SnapcraftRecordingTestCase(SnapcraftRecordingBaseTestCase):
         with open(recorded_yaml_path) as recorded_yaml_file:
             recorded_yaml = yaml.load(recorded_yaml_file)
 
-        self.assertEqual(recorded_yaml['build-packages'], expected_packages)
+        self.assertEqual(
+            recorded_yaml['build-packages'], expected_packages_with_version)
 
 
 class SnapcraftRecordingPackagesTestCase(

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -111,8 +111,9 @@ def execute(step, project_options, part_names=None):
     config = snapcraft.internal.load_config(project_options)
     installed_packages = repo.Repo.install_build_packages(
         config.build_tools)
-    os.makedirs('snap/.snapcraft', exist_ok=True)
-    with open('snap/.snapcraft/state', 'w') as f:
+    snapcraft_state_dir = os.path.join('snap', '.snapcraft')
+    os.makedirs(snapcraft_state_dir, exist_ok=True)
+    with open(os.path.join(snapcraft_state_dir, 'state'), 'w') as f:
         f.write(yaml.dump(states.GlobalState(installed_packages)))
 
     if (os.environ.get('SNAPCRAFT_SETUP_CORE') and

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -111,6 +111,9 @@ def execute(step, project_options, part_names=None):
     config = snapcraft.internal.load_config(project_options)
     installed_packages = repo.Repo.install_build_packages(
         config.build_tools)
+    if installed_packages is None:
+        raise ValueError(
+            'The repo backed is not returning the list of installed packages')
     snapcraft_state_dir = os.path.join('snap', '.snapcraft')
     os.makedirs(snapcraft_state_dir, exist_ok=True)
     with open(os.path.join(snapcraft_state_dir, 'state'), 'w') as f:

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -35,6 +35,7 @@ from snapcraft.internal import (
     meta,
     pluginhandler,
     repo,
+    states
 )
 from snapcraft.internal import errors
 from snapcraft.internal.cache import SnapCache
@@ -108,7 +109,11 @@ def execute(step, project_options, part_names=None):
     :returns: A dict with the snap name, version, type and architectures.
     """
     config = snapcraft.internal.load_config(project_options)
-    repo.Repo.install_build_packages(config.build_tools)
+    installed_packages = repo.Repo.install_build_packages(
+        config.build_tools)
+    os.makedirs('snap/.snapcraft', exist_ok=True)
+    with open('snap/.snapcraft/state', 'w') as f:
+        f.write(yaml.dump(states.GlobalState(installed_packages)))
 
     if (os.environ.get('SNAPCRAFT_SETUP_CORE') and
             config.data['confinement'] == 'classic'):

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -113,7 +113,7 @@ def execute(step, project_options, part_names=None):
         config.build_tools)
     if installed_packages is None:
         raise ValueError(
-            'The repo backed is not returning the list of installed packages')
+            'The repo backend is not returning the list of installed packages')
     snapcraft_state_dir = os.path.join('snap', '.snapcraft')
     os.makedirs(snapcraft_state_dir, exist_ok=True)
     with open(os.path.join(snapcraft_state_dir, 'state'), 'w') as f:

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -165,6 +165,8 @@ class _SnapPackaging:
         # First migrate the snap directory. It will overwrite any conflicting
         # files.
         for root, directories, files in os.walk('snap'):
+            if '.snapcraft' in directories:
+                directories.remove('.snapcraft')
             for directory in directories:
                 source = os.path.join(root, directory)
                 destination = os.path.join(self._prime_dir, source)

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -29,10 +29,7 @@ import yaml
 
 from snapcraft import file_utils
 from snapcraft import shell_utils
-from snapcraft.internal import (
-    common,
-    repo
-)
+from snapcraft.internal import common
 from snapcraft.internal.errors import MissingGadgetError
 from snapcraft.internal.deprecations import handle_deprecation_notice
 from snapcraft.internal.sources import get_source_handler_from_type
@@ -147,8 +144,10 @@ class _SnapPackaging:
                 yaml.dump(annotated_snapcraft, record_file)
 
     def _annotate_snapcraft(self, data):
-        data['build-packages'] = repo.Repo.get_installed_build_packages(
-            data.get('build-packages', []))
+        with open('snap/.snapcraft/state', 'r') as global_state_file:
+            global_state = yaml.load(global_state_file)
+        data['build-packages'] = global_state.assets.get(
+            'build-packages', [])
         for part in data['parts']:
             pull_state = get_state(
                 os.path.join(self._parts_dir, part, 'state'), 'pull')

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -33,7 +33,10 @@ from snapcraft.internal import common
 from snapcraft.internal.errors import MissingGadgetError
 from snapcraft.internal.deprecations import handle_deprecation_notice
 from snapcraft.internal.sources import get_source_handler_from_type
-from snapcraft.internal.states import get_state
+from snapcraft.internal.states import (
+    get_global_state,
+    get_state
+)
 
 
 logger = logging.getLogger(__name__)
@@ -144,9 +147,7 @@ class _SnapPackaging:
                 yaml.dump(annotated_snapcraft, record_file)
 
     def _annotate_snapcraft(self, data):
-        with open('snap/.snapcraft/state', 'r') as global_state_file:
-            global_state = yaml.load(global_state_file)
-        data['build-packages'] = global_state.assets.get(
+        data['build-packages'] = get_global_state().assets.get(
             'build-packages', [])
         for part in data['parts']:
             pull_state = get_state(

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -71,7 +71,6 @@ class PluginHandler:
         self._part_properties = _expand_part_properties(
             part_properties, part_schema)
         self.stage_packages = []
-        self.build_packages = []
 
         # Some legacy parts can have a '/' in them to separate the main project
         # part with the subparts. This is rather unfortunate as it affects the
@@ -321,13 +320,10 @@ class PluginHandler:
         # Add the annotated list of build packages
         part_build_packages = self._part_properties.get('build-packages', [])
 
-        build_packages = repo.Repo.get_installed_build_packages(
-            part_build_packages)
-
         self.mark_done('pull', states.PullState(
             pull_properties, part_properties=self._part_properties,
             project=self._project_options, stage_packages=self.stage_packages,
-            build_packages=build_packages,
+            build_packages=part_build_packages,
             source_details=self.source_handler.source_details
         ))
 

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -187,6 +187,11 @@ class Ubuntu(BaseRepo):
 
     @classmethod
     def install_build_packages(cls, package_names):
+        """Install build packages on the building machine.
+
+        :return: a list with the packages installed and their versions.
+
+        """
         new_packages = []
         with apt.Cache() as apt_cache:
             try:
@@ -205,7 +210,9 @@ class Ubuntu(BaseRepo):
     @classmethod
     def _mark_install(cls, apt_cache, package_names):
         for name in package_names:
-            if apt_cache.is_virtual(name):
+            if name.endswith(':any'):
+                name = name[:-4]
+            if apt_cache.is_virtual_package(name):
                 name = apt_cache.get_providing_packages(name)[0].name
             logger.debug('Marking {!r} (and its dependencies) to be '
                          'fetched'.format(name))
@@ -441,5 +448,4 @@ def _set_pkg_version(pkg, version):
         version = pkg.versions.get(version)
         pkg.candidate = version
     else:
-        raise Exception(pkg.versions.keys())
         raise errors.PackageNotFoundError('{}={}'.format(pkg.name, version))

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -202,6 +202,8 @@ class Ubuntu(BaseRepo):
     @classmethod
     def _mark_install(cls, apt_cache, package_names):
         for name in package_names:
+            if apt_cache.is_virtual(name):
+                name = apt_cache.get_providing_packages(name)[0].name
             logger.debug('Marking {!r} (and its dependencies) to be '
                          'fetched'.format(name))
             name_arch, version = repo.get_pkg_name_parts(name)

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -189,7 +189,10 @@ class Ubuntu(BaseRepo):
     def install_build_packages(cls, package_names):
         new_packages = []
         with apt.Cache() as apt_cache:
-            cls._mark_install(apt_cache, package_names)
+            try:
+                cls._mark_install(apt_cache, package_names)
+            except errors.PackageNotFoundError as e:
+                raise errors.BuildPackageNotFoundError(e)
             for package in apt_cache.get_changes():
                 new_packages.append((package.name, package.candidate.version))
 
@@ -438,4 +441,5 @@ def _set_pkg_version(pkg, version):
         version = pkg.versions.get(version)
         pkg.candidate = version
     else:
+        raise Exception(pkg.versions.keys())
         raise errors.PackageNotFoundError('{}={}'.format(pkg.name, version))

--- a/snapcraft/internal/states/__init__.py
+++ b/snapcraft/internal/states/__init__.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,9 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from snapcraft.internal.states._prime_state import PrimeState    # noqa
-from snapcraft.internal.states._stage_state import StageState    # noqa
-from snapcraft.internal.states._build_state import BuildState    # noqa
-from snapcraft.internal.states._pull_state import PullState      # noqa
-from snapcraft.internal.states._state import get_state           # noqa
-from snapcraft.internal.states._state import get_step_state_file # noqa
+from snapcraft.internal.states._build_state import BuildState  # noqa
+from snapcraft.internal.states._global_state import GlobalState  # noqa
+from snapcraft.internal.states._prime_state import PrimeState  # noqa
+from snapcraft.internal.states._pull_state import PullState  # noqa
+from snapcraft.internal.states._stage_state import StageState  # noqa
+from snapcraft.internal.states._state import get_state  # noqa
+from snapcraft.internal.states._state import get_step_state_file  # noqa

--- a/snapcraft/internal/states/__init__.py
+++ b/snapcraft/internal/states/__init__.py
@@ -19,5 +19,6 @@ from snapcraft.internal.states._global_state import GlobalState  # noqa
 from snapcraft.internal.states._prime_state import PrimeState  # noqa
 from snapcraft.internal.states._pull_state import PullState  # noqa
 from snapcraft.internal.states._stage_state import StageState  # noqa
+from snapcraft.internal.states._state import get_global_state  # noqa
 from snapcraft.internal.states._state import get_state  # noqa
 from snapcraft.internal.states._state import get_step_state_file  # noqa

--- a/snapcraft/internal/states/_build_state.py
+++ b/snapcraft/internal/states/_build_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-buildnil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -16,7 +16,7 @@
 
 import yaml
 
-from snapcraft.internal.states._state import State
+from snapcraft.internal.states._state import PartState
 
 
 def _build_state_constructor(loader, node):
@@ -36,7 +36,7 @@ def _schema_properties():
     }
 
 
-class BuildState(State):
+class BuildState(PartState):
     yaml_tag = u'!BuildState'
 
     def __init__(self, property_names, part_properties=None, project=None):

--- a/snapcraft/internal/states/_global_state.py
+++ b/snapcraft/internal/states/_global_state.py
@@ -1,0 +1,37 @@
+# -*- Mode:Python; indent-tabs-buildnil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import yaml
+
+from snapcraft.internal.states._state import State
+
+
+def _global_state_constructor(loader, node):
+    parameters = loader.construct_mapping(node)
+    return GlobalState(**parameters)
+
+yaml.add_constructor(u'!GlobalState', _global_state_constructor)
+
+
+class GlobalState(State):
+
+    yaml_tag = u'!GlobalState'
+
+    def __init__(self, build_packages):
+        super().__init__()
+        self.assets = {
+            'build-packages': build_packages,
+        }

--- a/snapcraft/internal/states/_prime_state.py
+++ b/snapcraft/internal/states/_prime_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -16,7 +16,7 @@
 
 import yaml
 
-from snapcraft.internal.states._state import State
+from snapcraft.internal.states._state import PartState
 
 
 def _prime_state_constructor(loader, node):
@@ -26,7 +26,7 @@ def _prime_state_constructor(loader, node):
 yaml.add_constructor(u'!PrimeState', _prime_state_constructor)
 
 
-class PrimeState(State):
+class PrimeState(PartState):
     yaml_tag = u'!PrimeState'
 
     def __init__(self, files, directories, dependency_paths=None,

--- a/snapcraft/internal/states/_pull_state.py
+++ b/snapcraft/internal/states/_pull_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-buildnil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -16,7 +16,7 @@
 
 import yaml
 
-from snapcraft.internal.states._state import State
+from snapcraft.internal.states._state import PartState
 
 
 def _pull_state_constructor(loader, node):
@@ -40,7 +40,7 @@ def _schema_properties():
     }
 
 
-class PullState(State):
+class PullState(PartState):
     yaml_tag = u'!PullState'
 
     def __init__(self, property_names, part_properties=None, project=None,

--- a/snapcraft/internal/states/_stage_state.py
+++ b/snapcraft/internal/states/_stage_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -16,7 +16,7 @@
 
 import yaml
 
-from snapcraft.internal.states._state import State
+from snapcraft.internal.states._state import PartState
 
 
 def _stage_state_constructor(loader, node):
@@ -26,7 +26,7 @@ def _stage_state_constructor(loader, node):
 yaml.add_constructor(u'!StageState', _stage_state_constructor)
 
 
-class StageState(State):
+class StageState(PartState):
     yaml_tag = u'!StageState'
 
     def __init__(self, files, directories, part_properties=None, project=None):

--- a/snapcraft/internal/states/_state.py
+++ b/snapcraft/internal/states/_state.py
@@ -86,6 +86,11 @@ def _get_differing_keys(dict1, dict2):
     return differing_keys
 
 
+def get_global_state():
+    with open(os.path.join('snap', '.snapcraft', 'state'), 'r') as state_file:
+        return yaml.load(state_file)
+
+
 def get_state(state_dir, step):
     state = None
     state_file = get_step_state_file(state_dir, step)

--- a/snapcraft/internal/states/_state.py
+++ b/snapcraft/internal/states/_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -19,7 +19,25 @@ import yaml
 
 
 class State(yaml.YAMLObject):
+
+    def __repr__(self):
+        items = sorted(self.__dict__.items())
+        strings = (': '.join((key, repr(value))) for key, value in items)
+        representation = ', '.join(strings)
+
+        return '{}({})'.format(self.__class__.__name__, representation)
+
+    def __eq__(self, other):
+        if type(other) is type(self):
+            return self.__dict__ == other.__dict__
+
+        return False
+
+
+class PartState(State):
+
     def __init__(self, part_properties, project):
+        super().__init__()
         if not part_properties:
             part_properties = {}
 
@@ -51,19 +69,6 @@ class State(yaml.YAMLObject):
         return _get_differing_keys(
             self.project_options, self.project_options_of_interest(
                 other_project_options))
-
-    def __repr__(self):
-        items = sorted(self.__dict__.items())
-        strings = (': '.join((key, repr(value))) for key, value in items)
-        representation = ', '.join(strings)
-
-        return '{}({})'.format(self.__class__.__name__, representation)
-
-    def __eq__(self, other):
-        if type(other) is type(self):
-            return self.__dict__ == other.__dict__
-
-        return False
 
 
 def _get_differing_keys(dict1, dict2):

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -611,6 +611,15 @@ class FakeAptCache(fixtures.Fixture):
                     providing_packages.append(self.packages[package])
             return providing_packages
 
+        def is_virtual(self, package_name):
+            is_virtual = False
+            if package_name not in self.packages:
+                for package in self.packages:
+                    if package_name in self.packages[package].provides:
+                        return True
+            return is_virtual
+
+
     def __init__(self, packages=None):
         super().__init__()
         self.packages = packages if packages else []
@@ -651,8 +660,11 @@ class FakeAptCachePackage():
         super().__init__()
         self.temp_dir = temp_dir
         self.name = name
-        self.version = version
-        self.versions = {version: self}
+        if version is None and '=' in name:
+            self.version = name.split('=')[1]
+        else:
+            self.version = version
+        self.versions = {self.version: self}
         self.candidate = self
         self.installed = version
         self.provides = provides if provides else []
@@ -661,7 +673,13 @@ class FakeAptCachePackage():
         self.marked_install = False
 
     def __str__(self):
-        return '{}={}'.format(self.name, self.version)
+        if '=' in self.name:
+            return self.name
+        else:
+            return '{}={}'.format(self.name, self.version)
+
+    @property
+    def
 
     def mark_install(self):
         self.marked_install = True

--- a/snapcraft/tests/repo/test_deb.py
+++ b/snapcraft/tests/repo/test_deb.py
@@ -66,7 +66,7 @@ class UbuntuTestCase(RepoBaseTestCase):
 
     @patch('snapcraft.internal.repo._deb.apt.apt_pkg')
     def test_get_package(self, mock_apt_pkg):
-        self.mock_cache().is_virtual.return_value = False
+        self.mock_cache().is_virtual_package.return_value = False
 
         project_options = snapcraft.ProjectOptions(
             use_geoip=False)
@@ -105,7 +105,7 @@ class UbuntuTestCase(RepoBaseTestCase):
 
     @patch('snapcraft.repo._deb.apt.apt_pkg')
     def test_get_multiarch_package(self, mock_apt_pkg):
-        self.mock_cache().is_virtual.return_value = False
+        self.mock_cache().is_virtual_package.return_value = False
 
         project_options = snapcraft.ProjectOptions(
             use_geoip=False)
@@ -238,8 +238,8 @@ class BuildPackagesTestCase(tests.TestCase):
         self.fake_apt_cache.cache['versioned-package'].version = '0.1'
 
     def get_installable_packages(self, packages):
-        return [package for package in packages
-                if not self.fake_apt_cache.cache[package].installed]
+        return ['package-not-installed', 'another-uninstalled',
+                'repeated-package', 'versioned-package=0.2']
 
     @patch('os.environ')
     def install_test_packages(self, test_pkgs, mock_env):

--- a/snapcraft/tests/repo/test_deb.py
+++ b/snapcraft/tests/repo/test_deb.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -66,6 +66,8 @@ class UbuntuTestCase(RepoBaseTestCase):
 
     @patch('snapcraft.internal.repo._deb.apt.apt_pkg')
     def test_get_package(self, mock_apt_pkg):
+        self.mock_cache().is_virtual.return_value = False
+
         project_options = snapcraft.ProjectOptions(
             use_geoip=False)
         ubuntu = repo.Ubuntu(self.tempdir, project_options=project_options)
@@ -103,6 +105,8 @@ class UbuntuTestCase(RepoBaseTestCase):
 
     @patch('snapcraft.repo._deb.apt.apt_pkg')
     def test_get_multiarch_package(self, mock_apt_pkg):
+        self.mock_cache().is_virtual.return_value = False
+
         project_options = snapcraft.ProjectOptions(
             use_geoip=False)
         ubuntu = repo.Ubuntu(self.tempdir, project_options=project_options)
@@ -290,7 +294,7 @@ class BuildPackagesTestCase(tests.TestCase):
         error = CalledProcessError(101, 'bad-cmd')
         mock_check_call.side_effect = \
             lambda c, env: error if 'apt-mark' in c else None
-        self.install_test_packages(self.test_packages)
+        self.install_test_packages(['package-not-installed'])
 
     def test_invalid_package_requested(self):
         self.assertRaises(

--- a/snapcraft/tests/states/test_state.py
+++ b/snapcraft/tests/states/test_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016, 2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,11 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from snapcraft.internal.states._state import State
+from snapcraft.internal.states._state import PartState
 from snapcraft import tests
 
 
-class _TestState(State):
+class _TestState(PartState):
     def properties_of_interest(self, part_properties):
         return {
             'foo': part_properties.get('foo'),

--- a/snapcraft/tests/test_lifecycle.py
+++ b/snapcraft/tests/test_lifecycle.py
@@ -841,13 +841,13 @@ confinement: strict
 grade: stable
 parts:
   test-part:
-    build-packages: [test-provider-package=test-version]
+    build-packages: [test-virtual-package]
     plugin: nil
     prime: []
     stage: []
     stage-packages: []
 architectures: [{}]
-build-packages: []
+build-packages: [test-provider-package=test-version]
 """.format(self.project_options.deb_arch))
         self.assertThat(
             os.path.join('prime', 'snap', 'snapcraft.yaml'),

--- a/snapcraft/tests/test_lifecycle.py
+++ b/snapcraft/tests/test_lifecycle.py
@@ -590,6 +590,7 @@ class ExecutionTestCase(BaseExecutionTestCase):
     @mock.patch('snapcraft.repo.Repo.install_build_packages')
     def test_pull_is_dirty_if_target_arch_changes(
             self, mock_install_build_packages, mock_enable_cross_compilation):
+        mock_install_build_packages.return_value = []
         self.make_snapcraft_yaml("""parts:
   part1:
     plugin: nil
@@ -801,13 +802,13 @@ confinement: strict
 grade: stable
 parts:
   test-part:
-    build-packages: [test-package=test-version]
+    build-packages: ['test-package:any']
     plugin: nil
     prime: []
     stage: []
     stage-packages: []
 architectures: [{}]
-build-packages: []
+build-packages: [test-package=test-version]
 """.format(self.project_options.deb_arch))
         self.assertThat(
             os.path.join('prime', 'snap', 'snapcraft.yaml'),

--- a/snapcraft/tests/test_lifecycle.py
+++ b/snapcraft/tests/test_lifecycle.py
@@ -661,7 +661,7 @@ class RecordSnapcraftTestCase(BaseLifecycleTestCase):
         lifecycle.execute('prime', self.project_options)
         self.assertThat(
             os.path.join('prime', 'snap', 'snapcraft.yaml'),
-            Not(DirExists()))
+            Not(FileExists()))
 
     def test_prime_with_build_info_records_snapcraft_yaml(self):
         self.useFixture(fixtures.EnvironmentVariable(


### PR DESCRIPTION
We install all the build packages before pulling the individual parts.
Before this branch, we first installed all the build packages, then pulled each individual part, and then the individual parts saved the versions of packages installed inspecting the dependency chain in the cache.

With this change, we save all the build packages and their versions when they are installed. So this changes a few things:

 * If a build package is already installed, it won't be saved as an asset. So in the end, the recorded annotated snapcraft.yaml will be accurate only in cleanbuild, and requires that we also record the image used during cleanbuild.
 * The recorded annotated snapcraft.yaml will be slightly different than the original, with all the build packages for all the parts as global packages. As we install all the build packages before any part anyways, this is equivalent.