### PR TITLE
deltas: Improved message returned when delta is too big

### DIFF
--- a/snapcraft/internal/deltas/_deltas.py
+++ b/snapcraft/internal/deltas/_deltas.py
@@ -103,7 +103,8 @@ class BaseDeltasGenerator:
 
         ratio = int((delta_size / target_size) * 100)
         if ratio >= self.delta_size_min_pct:
-            raise DeltaGenerationTooBigError
+            raise DeltaGenerationTooBigError(
+                    delta_min_percentage=100-self.delta_size_min_pct)
 
     def find_unique_file_name(self, path_hint):
         """Return a path on disk similar to 'path_hint' that does not exist.

--- a/snapcraft/internal/deltas/errors.py
+++ b/snapcraft/internal/deltas/errors.py
@@ -40,6 +40,7 @@ class DeltaGenerationTooBigError(SnapcraftError):
         'delta saving is less than {delta_min_percentage}%.'
     )
 
+
 class DeltaFormatError(SnapcraftError):
     """A delta format must be set."""
 

--- a/snapcraft/internal/deltas/errors.py
+++ b/snapcraft/internal/deltas/errors.py
@@ -37,9 +37,8 @@ class DeltaGenerationTooBigError(SnapcraftError):
     """The generated delta was too large."""
 
     fmt = (
-        'delta generated was too large.'
+        'delta saving is less than {delta_min_percentage}%.'
     )
-
 
 class DeltaFormatError(SnapcraftError):
     """A delta format must be set."""


### PR DESCRIPTION
Improved the big delta warning/error message when the user is trying to push changes, making it display the size of the delta before pushing the full snap.

LP: [1681692](https://bugs.launchpad.net/snapcraft/+bug/1681692)


