### PR TITLE
plugins: clarify wording of cross-compilation unsupported error

### DIFF
--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -166,9 +166,8 @@ class BasePlugin:
     def enable_cross_compilation(self):
         """Enable cross compilation for the plugin."""
         raise NotImplementedError(
-            'Building for a different target architecture requires '
-            'a plugin specific implementation in the '
-            '{!r} plugin'.format(self.name))
+            'The plugin used by {!r} does not support cross-compiling '
+            'to a different target architecture'.format(self.name))
 
     @property
     def parallel_build_count(self):


### PR DESCRIPTION
The wording in case of using a plugin that doesn't implement enable_cross_compilation confusingly refers to the parts name - it should state that the used plugin lacks support.