### PR TITLE
catkin plugin: fix pythonpath for catkin_find

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -617,7 +617,6 @@ def _find_system_dependencies(catkin_packages, rosdep, catkin):
                 try:
                     catkin.find(dependency)
                 except CatkinPackageNotFoundError:
-                    logger.info("No underlay package: {}".format(dependency))
                     # No package by that name is available
                     pass
                 else:

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -889,9 +889,11 @@ class _Catkin:
 
     def _run(self, arguments):
         with tempfile.NamedTemporaryFile(mode='w+') as f:
-            lines = ['export PYTHONPATH={}'.format(os.path.join(
-                self._catkin_install_path, 'usr', 'lib', 'python2.7',
-                'dist-packages'))]
+            lines = ['export PYTHONPATH={}:{}'.format(
+                os.path.join(self._catkin_install_path, 'usr', 'lib',
+                             'python2.7', 'dist-packages'),
+                os.path.join(self._catkin_install_path, 'opt', 'ros',
+                             'kinetic', 'lib', 'python2.7', 'dist-packages'))]
 
             ros_path = os.path.join(
                 self._catkin_install_path, 'opt', 'ros', self._ros_distro)

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -617,6 +617,7 @@ def _find_system_dependencies(catkin_packages, rosdep, catkin):
                 try:
                     catkin.find(dependency)
                 except CatkinPackageNotFoundError:
+                    logger.info("No underlay package: {}".format(dependency))
                     # No package by that name is available
                     pass
                 else:
@@ -893,7 +894,8 @@ class _Catkin:
                 os.path.join(self._catkin_install_path, 'usr', 'lib',
                              'python2.7', 'dist-packages'),
                 os.path.join(self._catkin_install_path, 'opt', 'ros',
-                             'kinetic', 'lib', 'python2.7', 'dist-packages'))]
+                             self._ros_distro, 'lib', 'python2.7',
+                             'dist-packages'))]
 
             ros_path = os.path.join(
                 self._catkin_install_path, 'opt', 'ros', self._ros_distro)


### PR DESCRIPTION
ROS has separate python package location that needs to be on PYTHONPATH before calling catkin_find in the generated bash script. Fixes false script failures, which the plugin interprets as not finding the specified package.

LP: [#1696014](https://bugs.launchpad.net/snapcraft/+bug/1696014)