### PR TITLE
go plugin: filter the main packages go-packages are defined

### DIFF
--- a/integration_tests/plugins/test_go_plugin.py
+++ b/integration_tests/plugins/test_go_plugin.py
@@ -39,11 +39,11 @@ class GoPluginTestCase(integration_tests.TestCase):
     def test_building_multiple_main_packages(self):
         self.run_snapcraft('stage', 'go-with-multiple-main-packages')
 
-    def test_building_multiple_main_packages_without_go_packages(self):
-        self.copy_project_to_cwd('go-with-multiple-main-packages')
-
         for bin in ['main1', 'main2', 'main3']:
             self.assertThat(os.path.join('stage', 'bin', bin), FileExists())
+
+    def test_building_multiple_main_packages_without_go_packages(self):
+        self.copy_project_to_cwd('go-with-multiple-main-packages')
 
         snapcraft_yaml_file = 'snapcraft.yaml'
         with open(snapcraft_yaml_file) as f:

--- a/snapcraft/plugins/go.py
+++ b/snapcraft/plugins/go.py
@@ -146,9 +146,9 @@ class GoPlugin(snapcraft.BasePlugin):
 
     def _get_local_main_packages(self):
         search_path = './{}/...'.format(self._get_local_go_package())
-        packages = self.run_output(['go', 'list', '-f',
-                                    '{{.ImportPath}} {{.Name}}',
-                                    search_path], cwd=self._gopath_src)
+        packages = self._run_output(['go', 'list', '-f',
+                                     '{{.ImportPath}} {{.Name}}',
+                                     search_path])
         packages_split = [p.split() for p in packages.splitlines()]
         main_packages = [p[0] for p in packages_split if p[1] == 'main']
         return main_packages


### PR DESCRIPTION
When no go packages are defined, `go build -o` is incompatible with `./...` so we need to provide it the main packages we want to build.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>