### PR TITLE
common: find data files via sys.prefix

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -4,7 +4,7 @@
 
 First install a few dependencies:
 
-    sudo apt install gcc g++ make python3-venv libffi-dev libsodium-dev libapt-pkg-dev libarchive13
+    sudo apt install gcc g++ make python3-dev python3-venv libffi-dev libsodium-dev libapt-pkg-dev libarchive13 squashfs-tools
 
 Create and activate a new virtual environment:
 

--- a/manual-tests.md
+++ b/manual-tests.md
@@ -180,3 +180,11 @@
   * Check that the user can be created.
   * Check that it's possible to ssh into the board.
   * Check that it's possible to install a snap.
+
+
+# Test installing with `pip`
+
+1. Follow HACKING.md to install using `pip` without using --editable.
+2. Make sure Snapcraft works by running `snapcraft init` followed by `snapcraft`.
+3. Follow HACKING.md to install using `pip` while using --editable.
+4. Repeat step 2.

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -31,13 +31,14 @@ import urllib
 SNAPCRAFT_FILES = ['snapcraft.yaml', '.snapcraft.yaml', 'parts', 'stage',
                    'prime', 'snap']
 COMMAND_ORDER = ['pull', 'build', 'stage', 'prime']
-_DEFAULT_PLUGINDIR = '/usr/share/snapcraft/plugins'
+_DEFAULT_PLUGINDIR = os.path.join(sys.prefix, 'share', 'snapcraft', 'plugins')
 _plugindir = _DEFAULT_PLUGINDIR
-_DEFAULT_SCHEMADIR = '/usr/share/snapcraft/schema'
+_DEFAULT_SCHEMADIR = os.path.join(sys.prefix, 'share', 'snapcraft', 'schema')
 _schemadir = _DEFAULT_SCHEMADIR
-_DEFAULT_LIBRARIESDIR = '/usr/share/snapcraft/libraries'
+_DEFAULT_LIBRARIESDIR = os.path.join(sys.prefix, 'share', 'snapcraft',
+                                     'libraries')
 _librariesdir = _DEFAULT_LIBRARIESDIR
-_DEFAULT_TOURDIR = '/usr/share/snapcraft/tour'
+_DEFAULT_TOURDIR = os.path.join(sys.prefix, 'share', 'snapcraft', 'tour')
 _tourdir = _DEFAULT_TOURDIR
 
 MAX_CHARACTERS_WRAP = 120


### PR DESCRIPTION
Currently Snapcraft hard-codes where it looks for its data files (schema, etc.) to support either running from a development tree or running from the Debian package. This actually works for when its installed via pip as well, but only if using an editable installation.

This PR fixes LP: [#1656884](https://bugs.launchpad.net/snapcraft/+bug/1656884) by using sys.prefix to also support being installed via pip (without being editable).