### PR TITLE
tests: do not break a systems `bzr whoami`

### DIFF
--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -16,6 +16,7 @@
 
 import collections
 import contextlib
+import copy
 import io
 import os
 import string
@@ -134,8 +135,8 @@ class CleanEnvironment(fixtures.Fixture):
     def setUp(self):
         super().setUp()
 
-        current_environment = os.environ.copy()
-        os.environ = {}
+        current_environment = copy.deepcopy(os.environ.copy)
+        os.environ.clear()
 
         self.addCleanup(os.environ.update, current_environment)
 

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -135,7 +135,7 @@ class CleanEnvironment(fixtures.Fixture):
     def setUp(self):
         super().setUp()
 
-        current_environment = copy.deepcopy(os.environ.copy)
+        current_environment = copy.deepcopy(os.environ)
         os.environ.clear()
 
         self.addCleanup(os.environ.update, current_environment)

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -543,11 +543,15 @@ class BzrRepo(fixtures.Fixture):
     def setUp(self):
         super().setUp()
 
+        bzr_home = self.useFixture(fixtures.TempDir()).path
+        self.useFixture(fixtures.EnvironmentVariable('BZR_HOME', bzr_home))
+        self.useFixture(fixtures.EnvironmentVariable(
+            'BZR_EMAIL',  'Test User <test.user@example.com>'))
+
         with return_to_cwd():
             os.makedirs(self.name)
             os.chdir(self.name)
             call(['bzr', 'init'])
-            call(['bzr', 'whoami', 'Test User <test.user@example.com>'])
             with open('testing', 'w') as fp:
                 fp.write('testing')
 

--- a/snapcraft/tests/sources/test_bazaar.py
+++ b/snapcraft/tests/sources/test_bazaar.py
@@ -17,6 +17,8 @@
 import os
 from unittest import mock
 
+import fixtures
+
 from snapcraft.internal import sources
 from snapcraft import tests
 from snapcraft.tests.subprocess_utils import (
@@ -136,13 +138,16 @@ class BazaarDetailsTestCase(tests.TestCase):
 
     def setUp(self):
         super().setUp()
+        bzr_home = self.useFixture(fixtures.TempDir()).path
+        self.useFixture(fixtures.EnvironmentVariable('BZR_HOME', bzr_home))
+        self.useFixture(fixtures.EnvironmentVariable(
+            'BZR_EMAIL',  'Test User <test.user@example.com>'))
         self.working_tree = 'bzr-test'
         self.source_dir = 'bzr-checkout'
         os.mkdir(self.working_tree)
         os.mkdir(self.source_dir)
         os.chdir(self.working_tree)
         call(['bzr', 'init'])
-        call(['bzr', 'whoami', 'Test User <test.user@example.com>'])
         with open('testing', 'w') as fp:
             fp.write('testing')
         call(['bzr', 'add', 'testing'])

--- a/snapcraft/tests/sources/test_bazaar.py
+++ b/snapcraft/tests/sources/test_bazaar.py
@@ -20,10 +20,6 @@ from unittest import mock
 from snapcraft.internal import sources
 from snapcraft import tests
 from snapcraft.tests import fixture_setup
-from snapcraft.tests.subprocess_utils import (
-    call,
-    call_with_output,
-)
 
 
 class TestBazaar(tests.sources.SourceTestCase):


### PR DESCRIPTION
When running tests we shouldn't be affect an existing bzr configuration.

LP: #1693839
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>