### PR TITLE
tests: replace grub-doc with haskell-doc in build-packages tests

### DIFF
--- a/integration_tests/snaps/build-package-global/snap/snapcraft.yaml
+++ b/integration_tests/snaps/build-package-global/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
 
 grade: stable
 confinement: strict
-build-packages: ['grub-doc']
+build-packages: ['haskell-doc']
 
 parts:
   empty-part:

--- a/integration_tests/snaps/build-packages-missing-dependency/snap/snapcraft.yaml
+++ b/integration_tests/snaps/build-packages-missing-dependency/snap/snapcraft.yaml
@@ -4,8 +4,8 @@ summary: install a build package
 description: |
   Install a build package.
   This package has dependencies:
-    - grub-legacy-doc
-    - multiboot-doc
+    - haskell98-report
+    - haskell98-tutorial
 
 grade: stable
 confinement: strict
@@ -13,4 +13,4 @@ confinement: strict
 parts:
   part-with-build-packages:
     plugin: nil
-    build-packages: ['grub-doc']
+    build-packages: ['haskell-doc']

--- a/integration_tests/snaps/build-packages-without-dependencies/snap/snapcraft.yaml
+++ b/integration_tests/snaps/build-packages-without-dependencies/snap/snapcraft.yaml
@@ -12,6 +12,6 @@ parts:
   part-with-build-packages:
     plugin: nil
     build-packages:
-      - grub-doc
-      - grub-legacy-doc
-      - multiboot-doc
+      - haskell-doc
+      - haskell98-report
+      - haskell98-tutorial

--- a/integration_tests/snaps/stage-packages-missing-dependency/snap/snapcraft.yaml
+++ b/integration_tests/snaps/stage-packages-missing-dependency/snap/snapcraft.yaml
@@ -3,7 +3,9 @@ version: '0.1'
 summary: install a stage package
 description: |
   Install a stage package.
-  This package has one dependency: gcc-6-base.
+  This package has dependencies:
+    - haskell98-report
+    - haskell98-tutorial
 
 grade: stable
 confinement: strict
@@ -11,4 +13,4 @@ confinement: strict
 parts:
   part-with-stage-packages:
     plugin: nil
-    stage-packages: ['hello']
+    stage-packages: ['haskell-doc']

--- a/integration_tests/snaps/stage-packages-without-dependencies/snap/snapcraft.yaml
+++ b/integration_tests/snaps/stage-packages-without-dependencies/snap/snapcraft.yaml
@@ -13,5 +13,5 @@ parts:
     plugin: nil
     stage-packages:
       - haskell-doc
-      - haskell98-report
       - haskell98-tutorial
+      - haskell98-report

--- a/integration_tests/snaps/stage-packages-without-dependencies/snap/snapcraft.yaml
+++ b/integration_tests/snaps/stage-packages-without-dependencies/snap/snapcraft.yaml
@@ -11,4 +11,7 @@ confinement: strict
 parts:
   part-with-stage-packages:
     plugin: nil
-    stage-packages: [gcc-6-base, hello]
+    stage-packages:
+      - haskell-doc
+      - haskell98-report
+      - haskell98-tutorial

--- a/integration_tests/test_build_package_version.py
+++ b/integration_tests/test_build_package_version.py
@@ -31,7 +31,7 @@ class BuildPackageVersionTestCase(testscenarios.WithScenarios,
         ('global', dict(
             project='build-package', package='hello', part='hello')),
         ('local', dict(
-            project='build-package-global', package='grub-doc', part=None)),
+            project='build-package-global', package='haskell-doc', part=None)),
     )
 
     def test_build_package_gets_version(self):
@@ -52,12 +52,12 @@ class BuildPackageVersionErrorsTestCase(integration_tests.TestCase):
         self.copy_project_to_cwd('build-package-global')
         self.set_build_package_version(
             os.path.join('snap', 'snapcraft.yaml'),
-            part=None, package='grub-doc', version='invalid')
+            part=None, package='haskell-doc', version='invalid')
         error = self.assertRaises(
             subprocess.CalledProcessError,
             self.run_snapcraft, 'pull')
         self.assertIn(
             "Could not find a required package in 'build-packages': "
-            "grub-doc=invalid",
+            "haskell-doc=invalid",
             str(error.output)
         )

--- a/integration_tests/test_pull_properties.py
+++ b/integration_tests/test_pull_properties.py
@@ -93,7 +93,7 @@ class AssetTrackingTestCase(integration_tests.TestCase):
         self.copy_project_to_cwd('build-package-global')
         self.set_build_package_version(
             os.path.join('snap', 'snapcraft.yaml'),
-            part=None, package='grub-doc')
+            part=None, package='haskell-doc')
         self.run_snapcraft('pull')
 
         state_file = os.path.join(

--- a/integration_tests/test_snapcraft_recording.py
+++ b/integration_tests/test_snapcraft_recording.py
@@ -91,7 +91,7 @@ class SnapcraftRecordingBuildPackagesTestCase(
 
         """
         expected_packages = [
-            'haskell-doc', 'haskell98-report', 'haskell98-tutorial']
+            'haskell-doc', 'haskell98-tutorial', 'haskell98-report']
         self.addCleanup(
             subprocess.call,
             ['sudo', 'apt', 'remove', '-y'] + expected_packages)

--- a/integration_tests/test_snapcraft_recording.py
+++ b/integration_tests/test_snapcraft_recording.py
@@ -123,7 +123,8 @@ class SnapcraftRecordingStagePackagesTestCase(SnapcraftRecordingBaseTestCase):
         This snap declares all the packages that it requires, there are
         no additional dependencies. The packages specify their version.
         """
-        expected_packages = ['gcc-6-base', 'hello']
+        expected_packages = [
+            'haskell-doc', 'haskell98-tutorial', 'haskell98-report']
         self.copy_project_to_cwd('stage-packages-without-dependencies')
         part_name = 'part-with-stage-packages'
         for package in expected_packages:
@@ -181,7 +182,8 @@ class SnapcraftRecordingStagePackagesTestCase(SnapcraftRecordingBaseTestCase):
         self.copy_project_to_cwd('stage-packages-missing-dependency')
         part_name = 'part-with-stage-packages'
         self.set_stage_package_version(
-            os.path.join('snap', 'snapcraft.yaml'), part_name, package='hello')
+            os.path.join('snap', 'snapcraft.yaml'),
+            part_name, package='haskell-doc')
         self.run_snapcraft('prime')
 
         expected_packages = [
@@ -189,7 +191,8 @@ class SnapcraftRecordingStagePackagesTestCase(SnapcraftRecordingBaseTestCase):
                 package,
                 integration_tests.get_package_version(
                     package, self.distro_series, self.deb_arch))
-            for package in ['gcc-6-base', 'hello']
+            for package in [
+                'haskell-doc', 'haskell98-tutorial', 'haskell98-report']
         ]
 
         recorded_yaml_path = os.path.join(

--- a/integration_tests/test_snapcraft_recording.py
+++ b/integration_tests/test_snapcraft_recording.py
@@ -90,7 +90,8 @@ class SnapcraftRecordingBuildPackagesTestCase(
         dependencies.
 
         """
-        expected_packages = ['grub-doc', 'grub-legacy-doc', 'multiboot-doc']
+        expected_packages = [
+            'haskell-doc', 'haskell98-report', 'haskell98-tutorial']
         self.addCleanup(
             subprocess.call,
             ['sudo', 'apt', 'remove', '-y'] + expected_packages)

--- a/integration_tests/test_stage_package_version.py
+++ b/integration_tests/test_stage_package_version.py
@@ -27,13 +27,13 @@ class StagePackageVersionTestCase(integration_tests.TestCase):
         self.set_stage_package_version(
             os.path.join('snap', 'snapcraft.yaml'),
             part='part-with-stage-packages',
-            package='hello', version='invalid')
+            package='haskell-doc', version='invalid')
         error = self.assertRaises(
             subprocess.CalledProcessError,
             self.run_snapcraft, 'pull')
         self.assertIn(
             "Error downloading stage packages for part "
             "'part-with-stage-packages': "
-            "The package 'hello=invalid' was not found.",
+            "The package 'haskell-doc=invalid' was not found.",
             str(error.output)
         )


### PR DESCRIPTION
Grub-docs was removed from artful. We need to test using a different package that will work on all the supported versions.