### PR TITLE
cli: stop leaking green text

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -143,7 +143,7 @@ def snap(directory, output, **kwargs):
         except Exception as e:
             echo.error(e)
             sys.exit(1)
-        click.echo('Snapped {}'.format(snap_name))
+        echo.info('Snapped {}'.format(snap_name))
 
 
 @lifecyclecli.command()


### PR DESCRIPTION
This PR fixes LP: [#1692754](https://bugs.launchpad.net/snapcraft/+bug/1692754) by changing a `click.echo` call into `echo.info`.