### PR TITLE
Only install golang-go if it is not found in PATH.

### DIFF
--- a/snapcraft/plugins/go.py
+++ b/snapcraft/plugins/go.py
@@ -45,6 +45,7 @@ Additionally, this plugin uses the following plugin-specific keywords:
 import logging
 import os
 import shutil
+import subprocess
 from glob import iglob
 
 import snapcraft
@@ -101,7 +102,13 @@ class GoPlugin(snapcraft.BasePlugin):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
-        self.build_packages.append('golang-go')
+
+        # Do not try to install golang if it is already available in our PATH.
+        try:
+            subprocess.check_output(['go', 'version'])
+        except OSError:
+            self.build_packages.append('golang-go')
+
         self._gopath = os.path.join(self.partdir, 'go')
         self._gopath_src = os.path.join(self._gopath, 'src')
         self._gopath_bin = os.path.join(self._gopath, 'bin')


### PR DESCRIPTION
Do not install golang-go if "go" is already present in the system's
PATH. For example, a user might specifically want a golang program to be
built with the go executable in their PATH and not the golang version
installed by the golang-go package.

This should solve the problem for people like in the linked bug, as well as (like me) people who want to specifically use golang 1.8 (and golang-go installs 1.7).

LP: [#1618720](https://bugs.launchpad.net/snapcraft/+bug/1618720)