### PR TITLE
cli: get_project_options must not discard kwargs

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -65,4 +65,4 @@ def get_project_options(**kwargs):
         target_deb_arch=kwargs.pop('target_arch'),
     )
 
-    return ProjectOptions(**project_args)
+    return ProjectOptions(**project_args, **kwargs)

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -59,10 +59,10 @@ def add_build_options(hidden=False):
 
 
 def get_project_options(**kwargs):
-    project_args = dict(
+    kwargs.update(
         use_geoip=kwargs.pop('enable_geoip'),
         parallel_builds=not kwargs.pop('no_parallel_builds'),
         target_deb_arch=kwargs.pop('target_arch'),
     )
 
-    return ProjectOptions(**project_args, **kwargs)
+    return ProjectOptions(**kwargs)


### PR DESCRIPTION
The function get_project_options aliases certain options. But the remainder of kwargs is ignored so debug=debug coming from snapcraft/cli/lifecycle.py would have no effect.