### PR TITLE
snapcraft.yaml: add support for reload-command and completer directives

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -127,6 +127,7 @@ properties:
         dependencies:
           stop-command: ["daemon"]
           post-stop-command: ["daemon"]
+          reload-command: ["daemon"]
         additionalProperties: false
         properties:
           desktop:
@@ -146,6 +147,8 @@ properties:
             description: command executed after stopping a service
           stop-timeout:
             description: timeout in seconds
+          reload-command:
+            description: command executed to reload a service
           daemon:
             type: string
             description: signals that the app is a service.

--- a/snapcraft/tests/test_project_loader.py
+++ b/snapcraft/tests/test_project_loader.py
@@ -1929,6 +1929,11 @@ class ValidationTestCase(ValidationBaseTestCase):
                 'post-stop-command': 'binary6 --post-stop',
                 'daemon': 'simple'
             },
+            'service7': {
+                'command': 'binary7',
+                'reload-command': 'binary7 --reload',
+                'daemon': 'simple'
+            },
         }
 
         project_loader.Validator(self.data).validate()


### PR DESCRIPTION
reload-command and completer fields are supported in snapd, but not snapcraft

Checklist:

- Have you signed the contributor licence agreement?

Yes, am canonical employee

- Is there a reported a bug for the problem you are fixing?

LP: [#1699507](https://bugs.launchpad.net/snapcraft/+bug/1699507)

- Have you read our contribution guide?

yes