### PR TITLE
tests: allow to filter tests in docker

### DIFF
--- a/tools/travis/run_tests.sh
+++ b/tools/travis/run_tests.sh
@@ -27,6 +27,10 @@ fi
 
 test="$1"
 
+if [ "$#" -gt 1 ]; then
+    pattern="$2"
+fi
+
 if [ "$test" = "static" ]; then
     dependencies="apt install -y python3-pip && python3 -m pip install -r requirements-devel.txt"
 elif [ "$test" = "unit" ]; then
@@ -41,7 +45,7 @@ fi
 script_path="$(dirname "$0")"
 "$script_path/run_docker_container.sh" test-runner
 docker exec -i test-runner sh -c "$dependencies"
-docker exec -i test-runner ./runtests.sh $test
+docker exec -i test-runner ./runtests.sh $test $pattern
 
 if [ "$test" = "unit" ]; then
     # Report code coverage.

--- a/tools/travis/run_tests.sh
+++ b/tools/travis/run_tests.sh
@@ -27,9 +27,7 @@ fi
 
 test="$1"
 
-if [ "$#" -gt 1 ]; then
-    pattern="$2"
-fi
+pattern="$2"
 
 if [ "$test" = "static" ]; then
     dependencies="apt install -y python3-pip && python3 -m pip install -r requirements-devel.txt"

--- a/tools/travis/run_tests.sh
+++ b/tools/travis/run_tests.sh
@@ -20,8 +20,8 @@
 
 set -ev
 
-if [ "$#" -lt 1 ]; then
-    echo "Usage: "$0" <test>"
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ] ; then
+    echo "Usage: "$0" <test> [PATTERN]"
     exit 1
 fi
 


### PR DESCRIPTION
In runtests.sh we allow to filter the the name of the test file that will be run. It will be useful to pass that parameter also when running the tests in the docker containers that travis uses.