### PR TITLE
options: fix s390 kernel arch

### DIFF
--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -81,7 +81,7 @@ _ARCH_TRANSLATIONS = {
         'core-dynamic-linker': 'lib64/ld-linux-x86-64.so.2',
     },
     's390x': {
-        'kernel': 's390x',
+        'kernel': 's390',
         'deb': 's390x',
         'uts_machine': 's390x',
         'cross-compiler-prefix': 's390x-linux-gnu-',

--- a/snapcraft/tests/test_options.py
+++ b/snapcraft/tests/test_options.py
@@ -88,7 +88,7 @@ class OptionsTestCase(tests.TestCase):
             architecture=('64bit', 'ELF'),
             expected_arch_triplet='s390x-linux-gnu',
             expected_deb_arch='s390x',
-            expected_kernel_arch='s390x'))
+            expected_kernel_arch='s390'))
     ]
 
     @mock.patch('platform.architecture')


### PR DESCRIPTION
The correct kernel arch for s390x is 's390', fix it - kernel snap doesn't even start without this patch.

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>

LP: #1700068