### PR TITLE
kernel plugin: add default targets per powerpc, ppc64el and s390x

### DIFF
--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -79,6 +79,9 @@ default_kernel_image_target = {
     'i386': 'bzImage',
     'armhf': 'zImage',
     'arm64': 'Image.gz',
+    'powerpc': 'uImage',
+    'ppc64el': 'vmlinux.strip',
+    's390x': 'bzImage',
 }
 
 required_generic = ['DEVTMPFS', 'DEVTMPFS_MOUNT', 'TMPFS_POSIX_ACL', 'IPV6',


### PR DESCRIPTION
Without this patch, it's always necessary to explicit a kernel target - this patch adds an implicit / default target for these arches too, like for arm, x86, etc.

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>

LP: #1700069