### PR TITLE
Integration tests for snap command with target arch

### DIFF
--- a/integration_tests/test_build_properties.py
+++ b/integration_tests/test_build_properties.py
@@ -49,3 +49,23 @@ class BuildPropertiesTestCase(integration_tests.TestCase):
         self.assertTrue('stage-packages' in state.properties)
         self.assertEqual('bar', state.properties['foo'])
         self.assertEqual(['curl'], state.properties['stage-packages'])
+
+    def test_build_with_arch(self):
+        self.run_snapcraft(['build', '--target-arch=i386', 'go-hello'],
+                           'go-hello')
+        state_file = os.path.join(self.parts_dir,
+                                  'go-hello', 'state', 'build')
+        self.assertThat(state_file, FileExists())
+        with open(state_file) as f:
+            state = yaml.load(f)
+        self.assertEqual(state.project_options['deb_arch'], 'i386')
+
+    def test_arch_with_build(self):
+        self.run_snapcraft(['--target-arch=i386', 'build', 'go-hello'],
+                           'go-hello')
+        state_file = os.path.join(self.parts_dir,
+                                  'go-hello', 'state', 'build')
+        self.assertThat(state_file, FileExists())
+        with open(state_file) as f:
+            state = yaml.load(f)
+        self.assertEqual(state.project_options['deb_arch'], 'i386')

--- a/integration_tests/test_pull_properties.py
+++ b/integration_tests/test_pull_properties.py
@@ -58,6 +58,26 @@ class PullPropertiesTestCase(integration_tests.TestCase):
         self.assertEqual('bar', state.properties['foo'])
         self.assertEqual(['curl'], state.properties['stage-packages'])
 
+    def test_pull_with_arch(self):
+        self.run_snapcraft(['pull', '--target-arch=i386', 'go-hello'],
+                           'go-hello')
+        state_file = os.path.join(self.parts_dir,
+                                  'go-hello', 'state', 'pull')
+        self.assertThat(state_file, FileExists())
+        with open(state_file) as f:
+            state = yaml.load(f)
+        self.assertEqual(state.project_options['deb_arch'], 'i386')
+
+    def test_arch_with_pull(self):
+        self.run_snapcraft(['--target-arch=i386', 'pull', 'go-hello'],
+                           'go-hello')
+        state_file = os.path.join(self.parts_dir,
+                                  'go-hello', 'state', 'pull')
+        self.assertThat(state_file, FileExists())
+        with open(state_file) as f:
+            state = yaml.load(f)
+        self.assertEqual(state.project_options['deb_arch'], 'i386')
+
 
 class AssetTrackingTestCase(integration_tests.TestCase):
 

--- a/integration_tests/test_snap.py
+++ b/integration_tests/test_snap.py
@@ -149,6 +149,18 @@ class SnapTestCase(integration_tests.TestCase):
 
         self.run_snapcraft('snap')
 
+    def test_snap_with_arch(self):
+        self.run_snapcraft('init')
+
+        self.run_snapcraft(['snap', '--target-arch=i386'])
+        self.assertThat('my-snap-name_0.1_i386.snap', FileExists())
+
+    def test_arch_with_snap(self):
+        self.run_snapcraft('init')
+
+        self.run_snapcraft(['--target-arch=i386', 'snap'])
+        self.assertThat('my-snap-name_0.1_i386.snap', FileExists())
+
     def test_implicit_command_with_arch(self):
         self.run_snapcraft('init')
 

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -53,6 +53,11 @@ def add_build_options(hidden=False):
 
 
 def get_project_options(**kwargs):
+    ctx = click.get_current_context()
+    for key, value in ctx.parent.params.items():
+        if not kwargs.get(key):
+            kwargs[key] = value
+
     project_args = dict(
         use_geoip=kwargs.pop('enable_geoip'),
         parallel_builds=not kwargs.pop('no_parallel_builds'),

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -18,16 +18,10 @@ import click
 from snapcraft import ProjectOptions
 
 
-class OptionWithHidden(click.Option):
-
-    def __init__(self, *args, **kwargs):
-        self.hidden = kwargs.pop('hidden', False)
-        super().__init__(*args, **kwargs)
+class HiddenOption(click.Option):
 
     def get_help_record(self, ctx):
-        if self.hidden:
-            return
-        super().get_help_record(ctx)
+        pass
 
 
 _BUILD_OPTION_NAMES = [
@@ -52,7 +46,7 @@ def add_build_options(hidden=False):
         for name, params in zip(reversed(_BUILD_OPTION_NAMES),
                                 reversed(_BUILD_OPTIONS)):
             option = click.option(name, **params,
-                                  cls=OptionWithHidden, hidden=hidden)
+                                  cls=HiddenOption if hidden else click.Option)
             func = option(func)
         return func
     return _add_build_options

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -119,11 +119,10 @@ def prime(parts, **kwargs):
 
 
 @lifecyclecli.command()
-@click.pass_context
 @add_build_options()
 @click.argument('directory', required=False)
 @click.option('--output', '-o', help='path to the resulting snap.')
-def snap(ctx, directory, output, **kwargs):
+def snap(directory, output, **kwargs):
     """Create a snap.
 
     \b
@@ -134,9 +133,6 @@ def snap(ctx, directory, output, **kwargs):
     If you want to snap a directory, you should use the snap-dir command
     instead.
     """
-    for key, value in ctx.parent.params.items():
-        if not kwargs.get(key):
-            kwargs[key] = value
     project_options = get_project_options(**kwargs)
     if env.is_containerbuild():
         lifecycle.containerbuild('snap', project_options, output, directory)

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -119,10 +119,11 @@ def prime(parts, **kwargs):
 
 
 @lifecyclecli.command()
+@click.pass_context
 @add_build_options()
 @click.argument('directory', required=False)
 @click.option('--output', '-o', help='path to the resulting snap.')
-def snap(directory, output, **kwargs):
+def snap(ctx, directory, output, **kwargs):
     """Create a snap.
 
     \b
@@ -133,6 +134,9 @@ def snap(directory, output, **kwargs):
     If you want to snap a directory, you should use the snap-dir command
     instead.
     """
+    for key, value in ctx.parent.params.items():
+        if not kwargs.get(key):
+            kwargs[key] = value
     project_options = get_project_options(**kwargs)
     if env.is_containerbuild():
         lifecycle.containerbuild('snap', project_options, output, directory)


### PR DESCRIPTION
Raised [in the forum](https://forum.snapcraft.io/t/kernel-cross-compile-problem-missing-snapcraft-target-arch-options/1083/5) the `--target-arch` option seems to be silently ignored depending on where it's specified, specifically if it's specified before the **snap** command.
Additionally the argument never shows up in `--help`.

We're also lacking integration tests for the different methods of invocation.