### PR TITLE
tests: workaround issue that causes failures to download core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services: [docker]
 language: bash
 
 before_install:
-  - sysctl net.netfilter.nf_conntrack_tcp_be_liberal=1
+  - sudo sysctl net.netfilter.nf_conntrack_tcp_be_liberal=1
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ services: [docker]
 
 language: bash
 
+before_install:
+  - sysctl net.netfilter.nf_conntrack_tcp_be_liberal=1
+
 jobs:
   include:
     # Tests, only when not triggered by the daily cron.


### PR DESCRIPTION
Following the suggestion from William Grant, here we disable the default behaviour for packets outside of the receive window. This should avoid the reset failures we see when downloading the core snap from the Internap CDN during the Travis test.

A better solution from the CDN is coming in July, so this change should be reverted soon.

More information: https://forum.snapcraft.io/t/101-connection-resets/775/19

LP: [#1666061](https://bugs.launchpad.net/snapcraft/+bug/1666061)
