### PR TITLE
Use newer distro module with no tuple

### DIFF
--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -14,9 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import distro
 import fileinput
 import os
-import platform
 import re
 import shutil
 import subprocess
@@ -107,7 +107,7 @@ class TestCase(testtools.TestCase):
         self.prime_dir = 'prime'
 
         self.deb_arch = _ProjectOptions().deb_arch
-        self.distro_series = platform.linux_distribution()[2]
+        self.distro_series = distro.codename().split()[0].lower()
 
     def run_snapcraft(
             self, command, project_dir=None, debug=True,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 click>=6.2
+distro==1.0.4
 configparser==3.5.0
 docopt==0.6.2
 file-magic==0.3.0

--- a/snapcraft/internal/libraries.py
+++ b/snapcraft/internal/libraries.py
@@ -14,11 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import distro
 import re
 import glob
 import logging
 import os
-import platform
 import subprocess
 
 from snapcraft.internal import common
@@ -67,8 +67,7 @@ def _get_system_libs():
     if _libraries:
         return _libraries
 
-    release = platform.linux_distribution()[1]
-    lib_path = os.path.join(common.get_librariesdir(), release)
+    lib_path = os.path.join(common.get_librariesdir(), distro.version())
 
     if not os.path.exists(lib_path):
         logger.debug('No libraries to exclude from this release')

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -15,11 +15,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import contextlib
+import distro
 import glob
 import hashlib
 import logging
 import os
-import platform
 import shutil
 import stat
 import string
@@ -147,7 +147,7 @@ class _AptCache:
 
     def _collected_sources_list(self):
         if self._use_geoip or self._sources_list:
-            release = platform.linux_distribution()[2]
+            release = distro.codename().split()[0].lower()
             return _format_sources_list(
                 self._sources_list, deb_arch=self._deb_arch,
                 use_geoip=self._use_geoip, release=release)

--- a/snapcraft/internal/repo/_platform.py
+++ b/snapcraft/internal/repo/_platform.py
@@ -16,15 +16,12 @@
 
 import logging
 import sys as _sys
-from platform import linux_distribution as _linux_distribution
+import distro as _distro
 
 logger = logging.getLogger(__name__)
 _DEB_BASED_PLATFORM = [
-    'Ubuntu',
-    'Debian',
+    'ubuntu',
     'elementary',
-    # Not sure what was going on when this was added.
-    '"elementary"',
     'debian',
     'neon',
 ]
@@ -32,12 +29,12 @@ _DEB_BASED_PLATFORM = [
 
 def _is_deb_based(distro=None):
     if not distro:
-        distro = _linux_distribution()[0]
+        distro = _distro.id()
     return distro in _DEB_BASED_PLATFORM
 
 
 def _get_repo_for_platform():
-    distro = _linux_distribution()[0]
+    distro = _distro.id()
     if _is_deb_based(distro):
         from ._deb import Ubuntu
         return Ubuntu

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from platform import linux_distribution as _linux_distribution
 from ._platform import _is_deb_based
 
 
@@ -35,8 +34,7 @@ class PackageNotFoundError(Exception):
         message = 'The package {!r} was not found.'.format(
             self.package_name)
         # If the package was multiarch, try to help.
-        distro = _linux_distribution()[0]
-        if _is_deb_based(distro) and ':' in self.package_name:
+        if _is_deb_based() and ':' in self.package_name:
             (name, arch) = self.package_name.split(':', 2)
             if arch:
                 message += (

--- a/snapcraft/tests/test_libraries.py
+++ b/snapcraft/tests/test_libraries.py
@@ -116,9 +116,9 @@ class TestSystemLibsOnNewRelease(tests.TestCase):
     def setUp(self):
         super().setUp()
 
-        patcher = mock.patch('platform.linux_distribution')
+        patcher = mock.patch('distro.version')
         distro_mock = patcher.start()
-        distro_mock.return_value = ('Ubuntu', '16.05', 'xenial')
+        distro_mock.return_value = '16.05'
         self.addCleanup(patcher.stop)
 
         patcher = mock.patch('snapcraft.internal.common.run_output')

--- a/snaps_tests/demos_tests/test_ros.py
+++ b/snaps_tests/demos_tests/test_ros.py
@@ -14,10 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import distro
 import os
 import re
 import subprocess
-from platform import linux_distribution
 from unittest import skipUnless
 
 import snapcraft
@@ -28,7 +28,7 @@ class ROSTestCase(snaps_tests.SnapsTestCase):
 
     snap_content_dir = 'ros'
 
-    @skipUnless(linux_distribution()[2] == 'xenial',
+    @skipUnless(distro.codename() == 'Xenial Xerus',
                 'This test fails on yakkety LP: #1614476')
     def test_ros(self):
         try:

--- a/snaps_tests/demos_tests/test_rosinstall.py
+++ b/snaps_tests/demos_tests/test_rosinstall.py
@@ -14,8 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import distro
 import re
-from platform import linux_distribution
 from unittest import skipUnless
 
 import snaps_tests
@@ -25,7 +25,7 @@ class RosinstallTestCase(snaps_tests.SnapsTestCase):
 
     snap_content_dir = 'rosinstall'
 
-    @skipUnless(linux_distribution()[2] == 'xenial',
+    @skipUnless(distro.codename() == 'Xenial Xerus',
                 'This test fails on yakkety LP: #1614476')
     def test_rosinstall(self):
         snap_path = self.build_snap(self.snap_content_dir, timeout=1800)

--- a/snaps_tests/demos_tests/test_shared_ros.py
+++ b/snaps_tests/demos_tests/test_shared_ros.py
@@ -16,10 +16,10 @@
 
 import snaps_tests
 
+import distro
 import os
 import re
 import subprocess
-from platform import linux_distribution
 from unittest import skipUnless
 
 
@@ -27,7 +27,7 @@ class SharedROSTestCase(snaps_tests.SnapsTestCase):
 
     snap_content_dir = 'shared-ros'
 
-    @skipUnless(linux_distribution()[2] == 'xenial',
+    @skipUnless(distro.codename() == 'Xenial Xerus',
                 'This test fails on yakkety LP: #1614476')
     def test_shared_ros(self):
         ros_base_path = os.path.join(self.snap_content_dir, 'ros-base')


### PR DESCRIPTION
Currently there's constant deprecation warning spam that can be seen in Travis and elsewhere:

```
/home/travis/build/snapcore/snapcraft/integration_tests/__init__.py:110: PendingDeprecationWarning: dist() and linux_distribution() functions are deprecated in Python 3.5
  self.distro_series = platform.linux_distribution()[2]
```

The code is also hard to read because it uses tuple indices.

We should be using the newer **distro** module with proper method names.