### PR TITLE
waf: enable cross-compilation support 

### DIFF
--- a/integration_tests/plugins/test_waf_plugin.py
+++ b/integration_tests/plugins/test_waf_plugin.py
@@ -16,7 +16,6 @@
 
 import os
 
-
 import snapcraft
 import integration_tests
 from snapcraft.tests.matchers import HasArchitecture

--- a/integration_tests/plugins/test_waf_plugin.py
+++ b/integration_tests/plugins/test_waf_plugin.py
@@ -14,10 +14,25 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+
+
+import snapcraft
 import integration_tests
+from snapcraft.tests.matchers import HasArchitecture
 
 
 class WafPluginTestCase(integration_tests.TestCase):
 
     def test_build_waf_plugin(self):
         self.run_snapcraft('build', 'waf-with-configflags')
+
+    def test_cross_compiling(self):
+        if snapcraft.ProjectOptions().deb_arch != 'amd64':
+            self.skipTest('The test only handles amd64 to arm64')
+
+        self.run_snapcraft(['build', '--target-arch=arm64'],
+                           'waf-with-configflags')
+        binary = os.path.join(self.parts_dir, 'waf-project',
+                              'install', 'usr', 'local', 'bin', 'myprogram')
+        self.assertThat(binary, HasArchitecture('aarch64'))

--- a/integration_tests/snaps/waf-with-configflags/program/main.c
+++ b/integration_tests/snaps/waf-with-configflags/program/main.c
@@ -4,6 +4,9 @@
 
 #include "abc.h"
 
+#include <stdio.h>
+
 int main() {
+	printf("Hello Waf!\n");
 	return 0;
 }

--- a/integration_tests/snaps/waf-with-configflags/snapcraft.yaml
+++ b/integration_tests/snaps/waf-with-configflags/snapcraft.yaml
@@ -5,7 +5,7 @@ description: |
   This is a basic waf snap with configflags.
 confinement: strict
 
-build-packages: [gcc, libc6-dev]
+build-packages: [gcc]
 # so far there is no packaged waf, projects usually carry it in their git
 # for versioning, the plugin as well as this integration test reflect this
 

--- a/integration_tests/snaps/waf-with-configflags/snapcraft.yaml
+++ b/integration_tests/snaps/waf-with-configflags/snapcraft.yaml
@@ -5,6 +5,10 @@ description: |
   This is a basic waf snap with configflags.
 confinement: strict
 
+apps:
+  waf-with-configflags:
+    command: usr/local/bin/myprogram
+
 build-packages: [gcc]
 # so far there is no packaged waf, projects usually carry it in their git
 # for versioning, the plugin as well as this integration test reflect this

--- a/manual-tests.md
+++ b/manual-tests.md
@@ -94,6 +94,15 @@
 5. Run `autotools-hello`.
 
 
+# Test cross-compilation with Waf
+
+1. Go to integration_tests/snaps/waf-with-configflags.
+2. Run `snapcraft snap --target-arch=armhf`.
+3. Copy the snap to a Raspberry Pi.
+4. Install the snap.
+5. Run `waf-with-configflags`.
+
+
 # Test the PC kernel.
 
 1. Get the PC kernel source:

--- a/snapcraft/plugins/waf.py
+++ b/snapcraft/plugins/waf.py
@@ -75,6 +75,8 @@ class WafPlugin(snapcraft.BasePlugin):
         return env
 
     def enable_cross_compilation(self):
+        # Let snapcraft know that this plugin can cross-compile
+        # If the method isn't implemented an exception is raised
         pass
 
     def build(self):

--- a/snapcraft/plugins/waf.py
+++ b/snapcraft/plugins/waf.py
@@ -56,7 +56,7 @@ class WafPlugin(snapcraft.BasePlugin):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
         self.build_packages.extend([
-            'python-dev',
+            'python-dev:native',
         ])
 
     @classmethod
@@ -64,6 +64,18 @@ class WafPlugin(snapcraft.BasePlugin):
         # Inform Snapcraft of the properties associated with building. If these
         # change in the YAML Snapcraft will consider the build step dirty.
         return ['configflags']
+
+    def env(self, root):
+        env = super().env(root)
+        if self.project.is_cross_compiling:
+            env.extend([
+                'CC={}-gcc'.format(self.project.arch_triplet),
+                'CXX={}-g++'.format(self.project.arch_triplet),
+            ])
+        return env
+
+    def enable_cross_compilation(self):
+        pass
 
     def build(self):
         super().build()

--- a/snapcraft/tests/plugins/test_waf.py
+++ b/snapcraft/tests/plugins/test_waf.py
@@ -157,7 +157,9 @@ class WafCrossCompilePluginTestCase(tests.TestCase):
     def test_cross_compile(self):
         plugin = waf.WafPlugin('test-part', self.options,
                                self.project_options)
+        # This shouldn't raise an exception
         plugin.enable_cross_compilation()
+
         env = plugin.env(plugin.sourcedir)
         self.assertIn('CC={}-gcc'.format(
             self.project_options.arch_triplet), env)

--- a/snapcraft/tests/plugins/test_waf.py
+++ b/snapcraft/tests/plugins/test_waf.py
@@ -120,3 +120,46 @@ class WafPluginTestCase(tests.TestCase):
             mock.call(['./waf', 'install',
                        '--destdir={}'.format(plugin.installdir)])
         ])
+
+
+class WafCrossCompilePluginTestCase(tests.TestCase):
+
+    scenarios = [
+        ('armv7l', dict(deb_arch='armhf')),
+        ('aarch64', dict(deb_arch='arm64')),
+        ('i386', dict(deb_arch='i386')),
+        ('x86_64', dict(deb_arch='amd64')),
+        ('ppc64le', dict(deb_arch='ppc64el')),
+    ]
+
+    def setUp(self):
+        super().setUp()
+
+        class Options:
+            configflags = []
+
+        self.options = Options()
+        self.project_options = snapcraft.ProjectOptions(
+            target_deb_arch=self.deb_arch)
+
+        patcher = mock.patch('snapcraft.internal.common.run')
+        self.run_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch('snapcraft.ProjectOptions.is_cross_compiling')
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch.dict(os.environ, {})
+        self.env_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_cross_compile(self):
+        plugin = waf.WafPlugin('test-part', self.options,
+                               self.project_options)
+        plugin.enable_cross_compilation()
+        env = plugin.env(plugin.sourcedir)
+        self.assertIn('CC={}-gcc'.format(
+            self.project_options.arch_triplet), env)
+        self.assertIn('CXX={}-g++'.format(
+            self.project_options.arch_triplet), env)


### PR DESCRIPTION
CC and CXX environment variables need to be set accordingly to cross-compile with Waf.

