### PR TITLE
lxd: Distingish FileNotFoundError if not installed

### DIFF
--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -238,11 +238,14 @@ def _get_default_remote():
     """
     try:
         default_remote = check_output(['lxc', 'remote', 'get-default'])
+    except FileNotFoundError:
+        raise SnapcraftEnvironmentError(
+            'You must have LXD installed in order to use cleanbuild.\n'
+            'Refer to the documentation at '
+            'https://linuxcontainers.org/lxd/getting-started-cli.')
     except CalledProcessError:
         raise SnapcraftEnvironmentError(
-            'You must have LXD installed in order to use cleanbuild. '
-            'However, it is either not installed or not configured '
-            'properly.\n'
+            'Something seems to be wrong with your installation of LXD.\n'
             'Refer to the documentation at '
             'https://linuxcontainers.org/lxd/getting-started-cli.')
     return default_remote.decode(sys.getfilesystemencoding()).strip()

--- a/snapcraft/tests/commands/test_cleanbuild.py
+++ b/snapcraft/tests/commands/test_cleanbuild.py
@@ -20,6 +20,7 @@ import tarfile
 from textwrap import dedent
 
 import fixtures
+from testtools.matchers import Contains, Equals
 
 from snapcraft import tests
 from . import CommandBaseTestCase
@@ -51,6 +52,7 @@ class CleanBuildCommandBaseTestCase(CommandBaseTestCase):
         fake_logger = fixtures.FakeLogger(level=logging.INFO)
         self.useFixture(fake_logger)
         self.useFixture(tests.fixture_setup.FakeLXD())
+
 
 class CleanBuildCommandTestCase(CleanBuildCommandBaseTestCase):
 

--- a/snapcraft/tests/commands/test_cleanbuild.py
+++ b/snapcraft/tests/commands/test_cleanbuild.py
@@ -107,14 +107,14 @@ parts:
 
         self.make_snapcraft_yaml()
 
-        self.useFixture(tests.fixture_setup.FakeLXD(fail_on_default=True))
+        fake_lxd = tests.fixture_setup.FakeLXD()
+        self.useFixture(fake_lxd)
+        fake_lxd.check_output_mock.side_effect = FileNotFoundError('lxc')
 
         result = self.run_command(['cleanbuild'])
 
         self.assertThat(result.exit_code, Equals(1))
         self.assertThat(result.output, Equals(
-            'You must have LXD installed in order to use cleanbuild. '
-            'However, it is either not installed or not configured '
-            'properly.\n'
+            'You must have LXD installed in order to use cleanbuild.\n'
             'Refer to the documentation at '
             'https://linuxcontainers.org/lxd/getting-started-cli.\n'))

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -25,7 +25,6 @@ import urllib.parse
 from functools import partial
 from types import ModuleType
 from unittest import mock
-from subprocess import CalledProcessError
 
 import fixtures
 import xdg
@@ -396,10 +395,8 @@ class FakePlugin(fixtures.Fixture):
 class FakeLXD(fixtures.Fixture):
     '''...'''
 
-    def __init__(self, fail_on_remote=False, fail_on_default=False):
+    def __init__(self):
         self.status = None
-        self.fail_on_remote = fail_on_remote
-        self.fail_on_default = fail_on_default
 
     def _setUp(self):
         patcher = mock.patch('snapcraft.internal.lxd.check_call')
@@ -428,10 +425,7 @@ class FakeLXD(fixtures.Fixture):
     def check_output_side_effect(self):
         def call_effect(*args, **kwargs):
             if args[0] == ['lxc', 'remote', 'get-default']:
-                if self.fail_on_default:
-                    raise CalledProcessError(returncode=255, cmd=args[0])
-                else:
-                    return 'local'.encode('utf-8')
+                return 'local'.encode('utf-8')
             elif args[0][:2] == ['lxc', 'info']:
                 return '''
                     environment:
@@ -449,8 +443,6 @@ class FakeLXD(fixtures.Fixture):
                             'STATUS': self.status,
                             }).encode('utf-8')
                 return '[]'.encode('utf-8')
-            elif args[0][:2] == ['lxc', 'list'] and self.fail_on_remote:
-                    raise CalledProcessError(returncode=255, cmd=args[0])
             elif args[0][:2] == ['lxc', 'init']:
                 self.name = args[0][3]
                 self.status = 'Stopped'

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -166,15 +166,15 @@ class LXDTestCase(tests.TestCase):
 
     @patch('snapcraft.internal.lxd.Cleanbuilder._container_run')
     def test_lxc_check_fails(self, mock_run):
-        self.useFixture(tests.fixture_setup.FakeLXD(fail_on_default=True))
+        fake_lxd = tests.fixture_setup.FakeLXD()
+        self.useFixture(fake_lxd)
+        fake_lxd.check_output_mock.side_effect = FileNotFoundError('lxc')
 
         project_options = ProjectOptions(debug=False)
         metadata = {'name': 'project'}
         with ExpectedException(
                 lxd.SnapcraftEnvironmentError,
-                'You must have LXD installed in order to use cleanbuild. '
-                'However, it is either not installed or not configured '
-                'properly.\n'
+                'You must have LXD installed in order to use cleanbuild.\n'
                 'Refer to the documentation at '
                 'https://linuxcontainers.org/lxd/getting-started-cli.'):
             lxd.Cleanbuilder(output='snap.snap', source='project.tar',
@@ -183,7 +183,10 @@ class LXDTestCase(tests.TestCase):
 
     @patch('snapcraft.internal.lxd.Cleanbuilder._container_run')
     def test_remote_does_not_exist(self, mock_run):
-        self.useFixture(tests.fixture_setup.FakeLXD(fail_on_remote=True))
+        fake_lxd = tests.fixture_setup.FakeLXD()
+        self.useFixture(fake_lxd)
+        fake_lxd.check_output_mock.side_effect = CalledProcessError(
+            255, ['lxd', 'list', 'my-remote'])
 
         project_options = ProjectOptions(debug=False)
         metadata = {'name': 'project'}


### PR DESCRIPTION
If LXD is not installed the exception FileNotFoundError will be raised because the 'lxc' executable doesn't exist. The code currently only handles CalledProcessError.

Fixes: [bug 1703344](https://bugs.launchpad.net/snapcraft/+bug/1703344)