### PR TITLE
Correct capitalisation for PyPI

### DIFF
--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -39,7 +39,7 @@ Additionally, this plugin uses the following plugin-specific keywords:
       Enable the processing of dependency links.
     - python-packages:
       (list)
-      A list of dependencies to get from PyPi
+      A list of dependencies to get from PyPI
     - python-version:
       (string; default: python3)
       The python version to use. Valid options are: python2 and python3

--- a/snapcraft/plugins/python2.py
+++ b/snapcraft/plugins/python2.py
@@ -42,7 +42,7 @@ Additionally, this plugin uses the following plugin-specific keywords:
       Enable the processing of dependency links.
     - python-packages:
       (list)
-      A list of dependencies to get from PyPi
+      A list of dependencies to get from PyPI
 """
 
 import logging

--- a/snapcraft/plugins/python3.py
+++ b/snapcraft/plugins/python3.py
@@ -42,7 +42,7 @@ Additionally, this plugin uses the following plugin-specific keywords:
       Enable the processing of dependency links.
     - python-packages:
       (list)
-      A list of dependencies to get from PyPi
+      A list of dependencies to get from PyPI
 """
 
 import logging


### PR DESCRIPTION
@thomir pointed out in https://github.com/CanonicalLtd/snappy-docs/pull/87 that PyPI is the correct capitalisation for the Python Package Index.