### PR TITLE
lxd: Only remove container if one exists

### DIFF
--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -102,9 +102,17 @@ class Containerbuild:
             self._ensure_container()
             yield
         finally:
-            # Stopping takes a while and lxc doesn't print anything.
-            print('Stopping {}'.format(self._container_name))
-            check_call(['lxc', 'stop', '-f', self._container_name])
+            if self._get_container_status():
+                # Stopping takes a while and lxc doesn't print anything.
+                print('Stopping {}'.format(self._container_name))
+                check_call(['lxc', 'stop', '-f', self._container_name])
+
+    def _get_container_status(self):
+        containers = json.loads(check_output([
+            'lxc', 'list', '--format=json', self._container_name]).decode())
+        for container in containers:
+            if container['name'] == self._container_name.split(':')[-1]:
+                return container
 
     def execute(self, step='snap', args=None):
         with self._ensure_started():
@@ -178,13 +186,6 @@ class Project(Containerbuild):
                          project_options=project_options,
                          metadata=metadata, container_name=metadata['name'],
                          remote=remote)
-
-    def _get_container_status(self):
-        containers = json.loads(check_output([
-            'lxc', 'list', '--format=json', self._container_name]).decode())
-        for container in containers:
-            if container['name'] == self._container_name.split(':')[-1]:
-                return container
 
     def _ensure_container(self):
         if not self._get_container_status():

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -481,10 +481,9 @@ class FakeLXD(fixtures.Fixture):
             elif args[0][:2] == ['lxc', 'launch']:
                 self.name = args[0][4]
                 self.status = 'Running'
-            elif args[0][:2] == ['lxc', 'stop']:
-                if not self.status:
-                    # error: not found
-                    raise CalledProcessError(returncode=1, cmd=args[0])
+            elif args[0][:2] == ['lxc', 'stop'] and not self.status:
+                # error: not found
+                raise CalledProcessError(returncode=1, cmd=args[0])
             # Fail on an actual snapcraft command and not the command
             # for the installation of it.
             elif ('snapcraft snap' in ' '.join(args[0])

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -486,6 +486,13 @@ class FakeLXD(fixtures.Fixture):
             elif args[0][:2] == ['lxc', 'init']:
                 self.name = args[0][3]
                 self.status = 'Stopped'
+            elif args[0][:2] == ['lxc', 'launch']:
+                self.name = args[0][4]
+                self.status = 'Running'
+            elif args[0][:2] == ['lxc', 'stop']:
+                if not self.status:
+                    # error: not found
+                    raise CalledProcessError(returncode=1, cmd=args[0])
             # Fail on an actual snapcraft command and not the command
             # for the installation of it.
             elif ('snapcraft' in args[0] and 'apt-get' not in args[0]

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -120,6 +120,27 @@ class LXDTestCase(tests.TestCase):
 
         self.assertThat(str(raised), Contains("Command '['my-cmd']'"))
 
+    def test_failed_container_never_created(self):
+        fake_lxd = tests.fixture_setup.FakeLXD()
+        self.useFixture(fake_lxd)
+
+        def call_effect(*args, **kwargs):
+            if args[0][:2] == ['lxc', 'launch']:
+                raise CalledProcessError(returncode=255, cmd=args[0])
+            return fake_lxd.check_output_side_effect()(*args, **kwargs)
+
+        fake_lxd.check_call_mock.side_effect = call_effect
+
+        metadata = {'name': 'project'}
+        raised = self.assertRaises(
+            CalledProcessError,
+            lxd.Cleanbuilder(output='snap.snap', source='project.tar',
+                             metadata=metadata,
+                             project_options=ProjectOptions()).execute)
+        self.assertEquals(fake_lxd.status, None)
+        # lxc launch should fail and no further commands should come after that
+        self.assertThat(str(raised), Contains("Command '['lxc', 'launch'"))
+
     @patch('snapcraft.internal.lxd.Cleanbuilder._container_run')
     def test_failed_build_with_debug(self, mock_run):
         self.useFixture(tests.fixture_setup.FakeLXD())


### PR DESCRIPTION
If creating a LXD container fails snapcraft always produces two exceptions because it will attempt to remove the non-existing container - this adds a check to avoid that.

Not sure about unit tests... we'd need to know that no exception was raised for 'lxc stop'.