### PR TITLE
lxd: Stop setting $HOME in containers

### DIFF
--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -190,14 +190,17 @@ class Project(Containerbuild):
         if not self._get_container_status():
             check_call([
                 'lxc', 'init', self._image, self._container_name])
+        if self._get_container_status()['status'] == 'Stopped':
             check_call([
                 'lxc', 'config', 'set', self._container_name,
                 'environment.SNAPCRAFT_SETUP_CORE', '1'])
+            check_call([
+                'lxc', 'config', 'set', self._container_name,
+                'environment.XDG_CACHE_HOME', '/run/'])
             # Map host user to root inside container
             check_call([
                 'lxc', 'config', 'set', self._container_name,
                 'raw.idmap', 'both {} 0'.format(os.getuid())])
-        if self._get_container_status()['status'] == 'Stopped':
             check_call([
                 'lxc', 'start', self._container_name])
 

--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -83,12 +83,10 @@ class Containerbuild:
 
     def _container_run(self, cmd, cwd=None):
         if cwd:
-            check_call(['lxc', 'exec', self._container_name, '--',
-                        'bash', '-c', 'cd {}; {}'.format(
-                            cwd,
-                            ' '.join(pipes.quote(arg) for arg in cmd))])
-        else:
-            check_call(['lxc', 'exec', self._container_name, '--'] + cmd)
+            cmd = ['bash', '-c', 'cd {}; {}'.format(
+                      cwd,
+                      ' '.join(pipes.quote(arg) for arg in cmd))]
+        check_call(['lxc', 'exec', self._container_name, '--'] + cmd)
 
     def _ensure_container(self):
         check_call([

--- a/snapcraft/tests/commands/test_snap.py
+++ b/snapcraft/tests/commands/test_snap.py
@@ -135,36 +135,31 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
             fake_logger.output)
 
         container_name = 'local:snapcraft-snap-test'
-        project_folder = 'build_snap-test'
+        project_folder = '/root/build_snap-test'
         fake_lxd.check_call_mock.assert_has_calls([
             call(['lxc', 'init', 'ubuntu:xenial/amd64', container_name]),
             call(['lxc', 'config', 'set', container_name,
                   'environment.SNAPCRAFT_SETUP_CORE', '1']),
-            call(['lxc', 'config', 'set', container_name,
-                  'environment.XDG_CACHE_HOME', '/run/']),
             call(['lxc', 'config', 'set', container_name,
                   'raw.idmap', 'both {} 0'.format(mock_getuid.return_value)]),
             call(['lxc', 'start', container_name]),
             call(['lxc', 'config', 'device', 'add', container_name,
                   project_folder, 'disk', 'source={}'.format(source),
                   'path=/{}'.format(project_folder)]),
-            call(['lxc', 'exec', container_name,
-                  '--env', 'HOME=/{}'.format(project_folder), '--',
+            call(['lxc', 'exec', container_name, '--',
                   'python3', '-c',
                   'import urllib.request; '
                   'urllib.request.urlopen('
                   '"http://start.ubuntu.com/connectivity-check.html", '
                   'timeout=5)']),
-            call(['lxc', 'exec', container_name,
-                  '--env', 'HOME=/{}'.format(project_folder), '--',
+            call(['lxc', 'exec', container_name, '--',
                   'apt-get', 'update']),
-            call(['lxc', 'exec', container_name,
-                  '--env', 'HOME=/{}'.format(project_folder), '--',
+            call(['lxc', 'exec', container_name, '--',
                   'apt-get', 'install', 'snapcraft', '-y']),
-            call(['lxc', 'exec', container_name,
-                  '--env', 'HOME=/{}'.format(project_folder), '--',
-                  'snapcraft', 'snap', '--output',
-                  'snap-test_1.0_amd64.snap']),
+            call(['lxc', 'exec', container_name, '--',
+                  'bash', '-c',
+                  'cd {}; snapcraft snap --output {}'.format(
+                      project_folder, 'snap-test_1.0_amd64.snap')]),
             call(['lxc', 'stop', '-f', container_name]),
         ])
 

--- a/snapcraft/tests/commands/test_snap.py
+++ b/snapcraft/tests/commands/test_snap.py
@@ -141,6 +141,8 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
             call(['lxc', 'config', 'set', container_name,
                   'environment.SNAPCRAFT_SETUP_CORE', '1']),
             call(['lxc', 'config', 'set', container_name,
+                  'environment.XDG_CACHE_HOME', '/run/']),
+            call(['lxc', 'config', 'set', container_name,
                   'raw.idmap', 'both {} 0'.format(mock_getuid.return_value)]),
             call(['lxc', 'start', container_name]),
             call(['lxc', 'config', 'device', 'add', container_name,

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -480,7 +480,7 @@ class FakeLXD(fixtures.Fixture):
                 self.status = 'Stopped'
             # Fail on an actual snapcraft command and not the command
             # for the installation of it.
-            elif ('snapcraft' in args[0] and 'apt-get' not in args[0]
+            elif ('snapcraft snap' in ' '.join(args[0])
                   and self.fail_on_snapcraft_run):
                 raise CalledProcessError(returncode=255, cmd=args[0])
             else:

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -49,7 +49,7 @@ class LXDTestCase(tests.TestCase):
         mock_pet.return_value = 'my-pet'
         project_options = ProjectOptions(target_deb_arch=self.target_arch)
         metadata = {'name': 'project'}
-        project_folder = 'build_project'
+        project_folder = '/root/build_project'
         lxd.Cleanbuilder(output='snap.snap', source='project.tar',
                          metadata=metadata, remote=self.remote,
                          project_options=project_options).execute()
@@ -59,11 +59,11 @@ class LXDTestCase(tests.TestCase):
                       'Waiting for a network connection...\n'
                       'Network connection established\n'
                       'Retrieved snap.snap\n', fake_logger.output)
-        args = []
+        args = ''
         if self.target_arch:
             self.assertIn('Setting target machine to \'{}\'\n'.format(
                           self.target_arch), fake_logger.output)
-            args += ['--target-arch', self.target_arch]
+            args = ' --target-arch {}'.format(self.target_arch)
 
         container_name = '{}:snapcraft-my-pet'.format(self.remote)
         fake_lxd.check_call_mock.assert_has_calls([
@@ -73,32 +73,29 @@ class LXDTestCase(tests.TestCase):
                   'environment.SNAPCRAFT_SETUP_CORE', '1']),
             call(['lxc', 'config', 'set', container_name,
                   'environment.LC_ALL', 'C.UTF-8']),
-            call(['lxc', 'exec', container_name,
-                  '--env', 'HOME=/{}'.format(project_folder), '--',
+            call(['lxc', 'exec', container_name, '--',
                   'mkdir', project_folder]),
             call(['lxc', 'file', 'push', os.path.realpath('project.tar'),
-                  '{}/build_project/project.tar'.format(container_name)]),
-            call(['lxc', 'exec', container_name,
-                  '--env', 'HOME=/{}'.format(project_folder), '--',
-                  'tar', 'xvf', 'project.tar']),
-            call(['lxc', 'exec', container_name,
-                  '--env', 'HOME=/{}'.format(project_folder), '--',
+                  '{}{}/project.tar'.format(container_name, project_folder)]),
+            call(['lxc', 'exec', container_name, '--',
+                  'bash', '-c',
+                  'cd {}; tar xvf project.tar'.format(project_folder)]),
+            call(['lxc', 'exec', container_name, '--',
                   'python3', '-c',
                   'import urllib.request; '
                   'urllib.request.urlopen('
                   '"http://start.ubuntu.com/connectivity-check.html", '
                   'timeout=5)']),
-            call(['lxc', 'exec', container_name,
-                  '--env', 'HOME=/{}'.format(project_folder), '--',
+            call(['lxc', 'exec', container_name, '--',
                   'apt-get', 'update']),
-            call(['lxc', 'exec', container_name,
-                  '--env', 'HOME=/{}'.format(project_folder), '--',
+            call(['lxc', 'exec', container_name, '--',
                   'apt-get', 'install', 'snapcraft', '-y']),
-            call(['lxc', 'exec', container_name,
-                  '--env', 'HOME=/{}'.format(project_folder), '--',
-                  'snapcraft', 'snap', '--output', 'snap.snap', *args]),
+            call(['lxc', 'exec', container_name, '--',
+                  'bash', '-c',
+                  'cd {}; snapcraft snap --output snap.snap{}'.format(
+                      project_folder, args)]),
             call(['lxc', 'file', 'pull',
-                  '{}/{}/snap.snap'.format(container_name, project_folder),
+                  '{}{}/snap.snap'.format(container_name, project_folder),
                   'snap.snap']),
             call(['lxc', 'stop', '-f', container_name]),
         ])


### PR DESCRIPTION
Because the project folder is mounted into the container and `$HOME` points at it, .cache ends up in the project folder. We need to stop setting `$HOME`.

This addresses one aspect of bug [1703642](https://bugs.launchpad.net/snapcraft/+bug/1703642).