### PR TITLE
snap: remove completer entry

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,6 @@ confinement: classic
 apps:
   snapcraft:
     command: bin/snapcraft-classic
-    completer: snapcraft-completion
 
 parts:
   snapcraft-bin:


### PR DESCRIPTION
We should rever tthis as soon as 2.33 hits xenial.
There's a catch-22 since 2.32 does not accept a completer entry in the yaml.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>