### PR TITLE
core: a clean command should clean.

### DIFF
--- a/integration_tests/test_clean_dependents.py
+++ b/integration_tests/test_clean_dependents.py
@@ -15,11 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import subprocess
 
 from testtools.matchers import (
     DirExists,
-    EndsWith,
     Not
 )
 
@@ -104,69 +102,35 @@ class CleanDependentsTestCase(integration_tests.TestCase):
         self.run_snapcraft('prime')
         self.assert_not_clean(['p1', 'p2', 'p3', 'p4'], True)
 
-    def test_clean_dependent_without_nested_dependents_raises(self):
-        # Test that p2 (which has both dependencies and dependents) fails to
-        # clean if its dependents (p3 and p4) are not also specified
-        exception = self.assertRaises(
-            subprocess.CalledProcessError, self.run_snapcraft, ['clean', 'p2'])
-        self.assertThat(
-            exception.output,
-            EndsWith(
-                "Requested clean of 'p2' but 'p3' and 'p4' depend upon it. "
-                "Please add each to the clean command if that's what you "
-                "intended.\n"))
-        self.assert_not_clean(['p1', 'p2', 'p3', 'p4'], True)
+    def test_clean_dependent_without_nested_dependents(self):
+        # Test that p2 (which has both dependencies and dependents)
+        # cleans its dependents (p3 and p4) are not specified
+        self.run_snapcraft(['clean', 'p2'])
+        self.assert_not_clean(['p1'], False)
+        self.assert_clean(['p2', 'p3', 'p4'], False)
 
-    def test_clean_dependent_without_nested_dependent_raises(self):
-        # Test that p2 (which has both dependencies and dependents) fails to
-        # clean if one of its dependents (p4) is not also specified
-        exception = self.assertRaises(
-            subprocess.CalledProcessError, self.run_snapcraft,
-            ['clean', 'p2', 'p3'])
-        self.assertThat(
-            exception.output,
-            EndsWith(
-                "Requested clean of 'p2' but 'p3' and 'p4' depend upon it. "
-                "Please add each to the clean command if that's what you "
-                "intended.\n"))
-        self.assert_not_clean(['p1', 'p2', 'p3', 'p4'], True)
+    def test_clean_dependent_without_nested_dependent(self):
+        # Test that p2 (which has both dependencies and dependents)
+        # cleans its dependents (p4) is not specified
+        self.run_snapcraft(['clean', 'p2', 'p3'])
+        self.assert_not_clean(['p1'], False)
+        self.assert_clean(['p2', 'p3', 'p4'], False)
 
-    def test_clean_main_without_any_dependent_raises(self):
-        # Test that p1 (which has no dependencies but dependents) fails to
-        # clean if none of its dependents are also specified.
-        exception = self.assertRaises(
-            subprocess.CalledProcessError, self.run_snapcraft, ['clean', 'p1'])
-        self.assertThat(
-            exception.output,
-            EndsWith(
-                "Requested clean of 'p1' but 'p2' depends upon it. Please add "
-                "each to the clean command if that's what you intended.\n"))
-        self.assert_not_clean(['p1', 'p2', 'p3', 'p4'], True)
+    def test_clean_main_without_any_dependent(self):
+        # Test that p1 (which has no dependencies but dependents)
+        # cleans if none of its dependents are also specified.
+        self.run_snapcraft(['clean', 'p1'])
+        self.assert_clean(['p1', 'p2', 'p3', 'p4'], True)
 
-    def test_clean_main_without_dependent_raises(self):
-        # Test that p1 (which has no dependencies but dependents) fails to
-        # clean if its dependent (p2) is not also specified
-        exception = self.assertRaises(
-            subprocess.CalledProcessError, self.run_snapcraft,
-            ['clean', 'p1', 'p3', 'p4'])
-        self.assertThat(
-            exception.output,
-            EndsWith(
-                "Requested clean of 'p1' but 'p2' depends upon it. Please add "
-                "each to the clean command if that's what you intended.\n"))
-        self.assert_not_clean(['p1', 'p2', 'p3', 'p4'], True)
+    def test_clean_main_without_dependent(self):
+        # Test that p1 (which has no dependencies but dependents)
+        # cleans if its dependent (p2) is not specified
+        self.run_snapcraft(['clean', 'p1', 'p3', 'p4'])
+        self.assert_clean(['p1', 'p2', 'p3', 'p4'], True)
 
-    def test_clean_main_without_nested_dependent_raises(self):
-        # Test that p1 (which has no dependencies but dependents) fails to
-        # clean if its nested dependent (p3, by way of p2) is not also
+    def test_clean_main_without_nested_dependent(self):
+        # Test that p1 (which has no dependencies but dependents)
+        # cleans if its nested dependent (p3, by way of p2) is not
         # specified
-        exception = self.assertRaises(
-            subprocess.CalledProcessError, self.run_snapcraft,
-            ['clean', 'p1', 'p2'])
-        self.assertThat(
-            exception.output,
-            EndsWith(
-                "Requested clean of 'p2' but 'p3' and 'p4' depend upon it. "
-                "Please add each to the clean command if that's what you "
-                "intended.\n"))
-        self.assert_not_clean(['p1', 'p2', 'p3', 'p4'], True)
+        self.run_snapcraft(['clean', 'p1', 'p2'])
+        self.assert_clean(['p1', 'p2', 'p3', 'p4'], True)

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -465,7 +465,7 @@ def _verify_dependents_will_be_cleaned(part_name, clean_part_names, step,
                 additional_dependents.append(part_name)
 
                 logger.warning(
-                    'Requested clean of {!r} which require also cleaning '
+                    'Requested clean of {!r} which requires also cleaning '
                     'the part{} {}'.format(part_name,
                                            '' if len(dependents) == 1 else 's',
                                            humanized_parts))

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -454,6 +454,7 @@ def _verify_dependents_will_be_cleaned(part_name, clean_part_names, step,
                                        config):
     # Get the name of the parts that depend upon this one
     dependents = config.parts.get_dependents(part_name)
+    additional_dependents = []
 
     # Verify that they're either already clean, or that they will be cleaned.
     if not dependents.issubset(clean_part_names):
@@ -461,12 +462,13 @@ def _verify_dependents_will_be_cleaned(part_name, clean_part_names, step,
             if part.name in dependents and not part.is_clean(step):
                 humanized_parts = formatting_utils.humanize_list(
                     dependents, 'and')
+                additional_dependents.append(part_name)
 
-                raise errors.SnapcraftEnvironmentError(
-                    'Requested clean of {!r} but {} depend{} upon it. Please '
-                    "add each to the clean command if that's what you "
-                    'intended.'.format(part_name, humanized_parts,
-                                       's' if len(dependents) == 1 else ''))
+                logger.warning(
+                    'Requested clean of {!r} which require also cleaning '
+                    'the part{} {}'.format(part_name,
+                                           '' if len(dependents) == 1 else 's',
+                                           humanized_parts))
 
 
 def _clean_parts(part_names, step, config, staged_state, primed_state):
@@ -474,7 +476,8 @@ def _clean_parts(part_names, step, config, staged_state, primed_state):
         step = 'pull'
 
     # Before doing anything, verify that we weren't asked to clean only the
-    # root of a dependency tree (the entire tree must be specified).
+    # root of a dependency tree and hint that more parts would be cleaned
+    # if not.
     for part_name in part_names:
         _verify_dependents_will_be_cleaned(part_name, part_names, step, config)
 

--- a/snapcraft/tests/commands/test_clean.py
+++ b/snapcraft/tests/commands/test_clean.py
@@ -255,7 +255,7 @@ parts:
 
         self.assertThat(result.exit_code, Equals(0))
         self.assertThat(result.output, Contains(
-            "Requested clean of 'dependent' which require also cleaning the "
+            "Requested clean of 'dependent' which requires also cleaning the "
             "part 'nested-dependent'"))
         self.assert_clean(['dependent', 'nested-dependent'])
 
@@ -295,7 +295,7 @@ parts:
 
         self.assertThat(result.exit_code, Equals(0))
         self.assertThat(result.output, Contains(
-            "Requested clean of 'main' which require also cleaning the "
+            "Requested clean of 'main' which requires also cleaning the "
             "part 'dependent'"))
         self.assert_clean(['main', 'dependent'])
 
@@ -306,6 +306,6 @@ parts:
 
         self.assertThat(result.exit_code, Equals(0))
         self.assertThat(result.output, Contains(
-            "Requested clean of 'dependent' which require also cleaning the "
+            "Requested clean of 'dependent' which requires also cleaning the "
             "part 'nested-dependent'"))
         self.assert_clean(['main', 'dependent', 'nested-dependent'])

--- a/snapcraft/tests/commands/test_clean.py
+++ b/snapcraft/tests/commands/test_clean.py
@@ -248,16 +248,16 @@ parts:
         self.assertThat(result.exit_code, Equals(0))
         self.assert_clean(['dependent', 'nested-dependent'])
 
-    def test_clean_part_unspecified_uncleaned_dependent_raises(self):
+    def test_clean_part_unspecified_uncleaned_dependent_notifies(self):
         # Not specifying nested-dependent here should result in clean raising
         # an exception, saying that it has dependents.
         result = self.run_command(['clean', 'dependent'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Equals(
-            "Requested clean of 'dependent' but 'nested-dependent' depends "
-            "upon it. Please add each to the clean command if that's what you "
-            "intended.\n"))
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(result.output, Contains(
+            "Requested clean of 'dependent' which require also cleaning the "
+            "part 'nested-dependent'"))
+        self.assert_clean(['dependent', 'nested-dependent'])
 
     def test_clean_nested_dependent_parts(self):
         result = self.run_command([
@@ -288,24 +288,24 @@ parts:
         self.assertThat(result.exit_code, Equals(0))
         self.assert_clean(['main', 'dependent', 'nested-dependent'])
 
-    def test_clean_part_unspecified_uncleaned_dependent_with_nest_raises(self):
+    def test_clean_part_unspecified_uncleaned_dependent_nested_notifies(self):
         # Not specifying dependent here should result in clean raising
         # an exception, saying that it has dependents.
         result = self.run_command(['clean', 'main'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Equals(
-            "Requested clean of 'main' but 'dependent' depends upon it. "
-            "Please add each to the clean command if that's what you "
-            "intended.\n"))
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(result.output, Contains(
+            "Requested clean of 'main' which require also cleaning the "
+            "part 'dependent'"))
+        self.assert_clean(['main', 'dependent'])
 
-    def test_clean_part_unspecified_uncleaned_nested_dependent_raises(self):
+    def test_clean_part_unspecified_uncleaned_nested_dependent_notifies(self):
         # Not specifying nested-dependent here should result in clean raising
         # an exception, saying that it has dependents.
         result = self.run_command(['clean', 'main', 'dependent'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Equals(
-            "Requested clean of 'dependent' but 'nested-dependent' depends "
-            "upon it. Please add each to the clean command if that's what you "
-            "intended.\n"))
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(result.output, Contains(
+            "Requested clean of 'dependent' which require also cleaning the "
+            "part 'nested-dependent'"))
+        self.assert_clean(['main', 'dependent', 'nested-dependent'])


### PR DESCRIPTION
When running clean it sometimes does not clean to avoid cleaning some things
you might not want to clean but that has proven to be a cumbersome user
facing feature so now it would just clean everything in the path.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>