### PR TITLE
ci: wait for apt/dpkg lock when setting lxd up

### DIFF
--- a/tools/travis/setup_lxd.sh
+++ b/tools/travis/setup_lxd.sh
@@ -18,7 +18,13 @@
 
 set -ev
 
+while fuser /var/lib/apt/lists/lock >/dev/null 2>&1; do
+    sleep 1
+done
 apt-get update
+while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do
+    sleep 1
+done
 apt-get install --yes snapd
 # Use edge because the feature to copy links to the container has not yet been
 # released to stable:


### PR DESCRIPTION
This is to fix this:

apt-get update
W: chmod 0700 of directory /var/lib/apt/lists/partial failed - SetupAPTPartialDirectory (1: Operation not permitted)
E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)
E: Unable to lock directory /var/lib/apt/lists/
W: Problem unlinking the file /var/cache/apt/pkgcache.bin - RemoveCaches (13: Permission denied)
W: Problem unlinking the file /var/cache/apt/srcpkgcache.bin - RemoveCaches (13: Permission denied)
E: Could not open lock file /var/lib/dpkg/lock - open (13: Permission denied)
E: Unable to lock the administration directory (/var/lib/dpkg/), are you root?