### PR TITLE
core: reexec as root for `os` snaps if necessary

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import subprocess
 import sys
 
 import click
@@ -23,6 +24,14 @@ from . import echo
 from . import env
 
 
+def _reexec_as_root():
+    click.echo('Reexecuting the build as root')
+    try:
+        subprocess.check_call(['sudo'] + sys.argv)
+    except subprocess.CalledProcessError:
+        sys.exit(1)
+
+
 def _execute(command, parts, **kwargs):
     project_options = get_project_options(**kwargs)
 
@@ -31,6 +40,9 @@ def _execute(command, parts, **kwargs):
     else:
         try:
             lifecycle.execute(command, project_options, parts)
+        except errors.SnapcraftUserPermissionError as user_error:
+            if user_error.user == 'root':
+                _reexec_as_root()
         except Exception as e:
             echo.error(e)
             sys.exit(1)
@@ -140,10 +152,13 @@ def snap(directory, output, **kwargs):
         try:
             snap_name = lifecycle.snap(
                 project_options, directory=directory, output=output)
+            echo.info('Snapped {}'.format(snap_name))
+        except errors.SnapcraftUserPermissionError as user_error:
+            if user_error.user == 'root':
+                _reexec_as_root()
         except Exception as e:
             echo.error(e)
             sys.exit(1)
-        echo.info('Snapped {}'.format(snap_name))
 
 
 @lifecyclecli.command()
@@ -173,6 +188,9 @@ def clean(parts, step, **kwargs):
             step = 'prime'
         try:
             lifecycle.clean(project_options, parts, step)
+        except errors.SnapcraftUserPermissionError as user_error:
+            if user_error.user == 'root':
+                _reexec_as_root()
         except errors.SnapcraftEnvironmentError as e:
             echo.error(e)
             sys.exit(1)

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -222,6 +222,11 @@ class SnapcraftSchemaError(SnapcraftError):
         super().__init__(message=message, snapcraft_yaml=snapcraft_yaml)
 
 
+class SnapcraftUserPermissionError(SnapcraftError):
+
+    fmt = '{user} privilidges are required to continue'
+
+
 def _determine_cause(error):
     """Attempt to determine a cause from validation error.
 

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -111,6 +111,7 @@ def execute(step, project_options, part_names=None):
     :returns: A dict with the snap name, version, type and architectures.
     """
     config = snapcraft.internal.load_config(project_options)
+    _ensure_user(config.data.get('type'))
     installed_packages = repo.Repo.install_build_packages(
         config.build_tools)
     if installed_packages is None:
@@ -375,6 +376,8 @@ def snap(project_options, directory=None, output=None):
         execute('prime', project_options)
         snap = _snap_data_from_dir(prime_dir)
 
+    _ensure_user(snap['type'])
+
     snap_name = output or common.format_snap_name(snap)
 
     # If a .snap-build exists at this point, when we are about to override
@@ -570,11 +573,15 @@ def clean(project_options, parts, step=None):
     if not step:
         step = 'pull'
 
+    # We won't be able to easily capture the root case without loading the
+    # config which is why we wrap in try/except.
     if not parts and step == 'pull':
-        _cleanup_common_directories_for_step(step, project_options)
-        return
+        with contextlib.suppress(PermissionError):
+            _cleanup_common_directories_for_step(step, project_options)
+            return
 
     config = snapcraft.internal.load_config()
+    _ensure_user(config.data.get('type'))
 
     if not parts and (step == 'stage' or step == 'prime'):
         # If we've been asked to clean stage or prime without being given
@@ -595,3 +602,11 @@ def clean(project_options, parts, step=None):
     _clean_parts(parts, step, config, staged_state, primed_state)
 
     _cleanup_common_directories(config, project_options)
+
+
+_TYPE_REQUIRES_ROOT = ['os']
+
+
+def _ensure_user(snap_type):
+    if (snap_type in _TYPE_REQUIRES_ROOT and os.getuid() != 0):
+        raise errors.SnapcraftUserPermissionError(user='root')


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>
