### PR TITLE
kbuild plugin: support Makefile without install target

### DIFF
--- a/integration_tests/plugins/test_kbuild_plugin.py
+++ b/integration_tests/plugins/test_kbuild_plugin.py
@@ -23,9 +23,6 @@ import integration_tests
 
 class KBuildPluginTestCase(integration_tests.TestCase):
 
-    def setUp(self):
-        super().setUp()
-
     def test_stage(self):
         self.run_snapcraft('stage', 'kbuild-hello')
 

--- a/integration_tests/plugins/test_kbuild_plugin.py
+++ b/integration_tests/plugins/test_kbuild_plugin.py
@@ -1,0 +1,34 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016-2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from testtools.matchers import FileExists
+
+import integration_tests
+
+
+class KBuildPluginTestCase(integration_tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+    def test_stage(self):
+        self.run_snapcraft('stage', 'kbuild-hello')
+
+        binary = os.path.join(self.parts_dir, 'kbuild-hello', 'install', 'bin',
+                              'myapp')
+        self.assertThat(binary, FileExists())

--- a/integration_tests/snaps/kbuild-hello/defconfig
+++ b/integration_tests/snaps/kbuild-hello/defconfig
@@ -1,0 +1,6 @@
+#
+# Compile-time checks and compiler options
+#
+CONFIG_CROSS_COMPILE=""
+CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE=y
+CONFIG_BAR=y

--- a/integration_tests/snaps/kbuild-hello/snap/snapcraft.yaml
+++ b/integration_tests/snaps/kbuild-hello/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: kbuild-hello
+version: 1.0
+summary: simple example using the kbuild build system
+description: this is a basic snap using kbuild to build a hello-world
+   example program
+confinement: strict
+
+parts:
+  kbuild-hello:
+    plugin: kbuild
+    source: https://github.com/embedded-it/kbuild-template
+    source-type: git
+    build-packages: [gcc, libc6-dev]
+    kconfigfile: defconfig
+    kconfigs:
+     - CONFIG_FOO=n
+    install-targets: []
+    install: |
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
+      cp myapp $SNAPCRAFT_PART_INSTALL/bin/

--- a/integration_tests/snaps/kbuild-hello/snap/snapcraft.yaml
+++ b/integration_tests/snaps/kbuild-hello/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ parts:
     kconfigfile: defconfig
     kconfigs:
      - CONFIG_FOO=n
-    install-targets: []
+    build-attributes: [no-install]
     install: |
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
       cp myapp $SNAPCRAFT_PART_INSTALL/bin/

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -288,7 +288,9 @@ properties:
             uniqueItems: true
             items:
               type: string
-              pattern: "(no-system-libraries|no-install)"
+              enum:
+                - no-system-libraries
+                - no-install
             default: []
           organize:
             type: object

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -288,6 +288,7 @@ properties:
             uniqueItems: true
             items:
               type: string
+              pattern: "(no-system-libraries|no-install)"
             default: []
           organize:
             type: object

--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -350,6 +350,11 @@ of the choice of plugin.
         the dependencies of this part. This might be useful if one knows these
         dependencies will be satisfied in other manner, e.g. via content
         sharing from other snaps.
+
+      - no-install:
+        Do not run the install target provided by the plugin's build system.
+
+        Supported by: kbuild
 """
 
 from collections import OrderedDict                 # noqa

--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -43,12 +43,6 @@ explained above:
       definitions.  If you don't want default for one or more implicit configs
       coming out of these, just add them to this list as well.
 
-    - build-attributes
-      (list of strings)
-      list of boolean build options:
-      - no-install
-        Don't run the 'make install' target
-
 The plugin applies your selected defconfig first by running
 
     make defconfig
@@ -107,16 +101,6 @@ class KBuildPlugin(BasePlugin):
         schema['properties']['kconfigflavour'] = {
             'type': 'string',
             'default': None,
-        }
-
-        schema['properties']['build-attributes'] = {
-            'type': 'array',
-            'minitems': 0,
-            'uniqueItems': True,
-            'items': {
-                'type': 'string',
-            },
-            'default': [],
         }
 
         return schema

--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -43,6 +43,10 @@ explained above:
       definitions.  If you don't want default for one or more implicit configs
       coming out of these, just add them to this list as well.
 
+    - install-targets
+      (list of strings)
+      list of install targets to run after building. default: [install]
+
 The plugin applies your selected defconfig first by running
 
     make defconfig
@@ -103,20 +107,30 @@ class KBuildPlugin(BasePlugin):
             'default': None,
         }
 
+        schema['properties']['install-targets'] = {
+            'type': 'array',
+            'minitems': 0,
+            'uniqueItems': True,
+            'items': {
+                'type': 'string',
+            },
+            'default': ['install'],
+        }
+
         return schema
 
     @classmethod
     def get_build_properties(cls):
         # Inform Snapcraft of the properties associated with building. If these
         # change in the YAML Snapcraft will consider the build step dirty.
-        return ['kdefconfig', 'kconfigfile', 'kconfigs', 'kconfigflavour']
+        return ['kdefconfig', 'kconfigfile', 'kconfigs', 'kconfigflavour',
+                'install-targets']
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
         self.build_packages.extend(['bc', 'gcc', 'make'])
 
         self.make_targets = []
-        self.make_install_targets = ['install']
         self.make_cmd = [
             'make', '-j{}'.format(self.parallel_build_count)]
         if logger.isEnabledFor(logging.DEBUG):
@@ -230,11 +244,12 @@ class KBuildPlugin(BasePlugin):
         # install to installdir
         self.run(self.make_cmd +
                  ['CONFIG_PREFIX={}'.format(self.installdir)] +
-                 self.make_install_targets)
+                 self.options.install_targets)
 
     def build(self):
         super().build()
 
         self.do_configure()
         self.do_build()
-        self.do_install()
+        if self.options.install_targets:
+            self.do_install()

--- a/snapcraft/tests/plugins/test_kbuild.py
+++ b/snapcraft/tests/plugins/test_kbuild.py
@@ -37,6 +37,7 @@ class KBuildPluginTestCase(tests.TestCase):
             kconfigflavour = None
             kdefconfig = []
             kconfigs = []
+            install_targets = ['install']
 
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
@@ -62,7 +63,8 @@ class KBuildPluginTestCase(tests.TestCase):
 
     def test_get_build_properties(self):
         expected_build_properties = ['kdefconfig', 'kconfigfile',
-                                     'kconfigflavour', 'kconfigs']
+                                     'kconfigflavour', 'kconfigs',
+                                     'install-targets']
         resulting_build_properties = kbuild.KBuildPlugin.get_build_properties()
 
         self.assertThat(resulting_build_properties,
@@ -251,3 +253,29 @@ SOMETHING=y
 ACCEPT=n
 """
         self.assertEqual(config_contents, expected_config)
+
+    @mock.patch('subprocess.check_call')
+    @mock.patch.object(kbuild.KBuildPlugin, 'run')
+    def test_build_without_install_target(self, run_mock, check_call_mock):
+        self.options.kconfigfile = 'config'
+        self.options.install_targets = []
+        with open(self.options.kconfigfile, 'w') as f:
+            f.write('ACCEPT=y\n')
+
+        plugin = kbuild.KBuildPlugin('test-part', self.options,
+                                     self.project_options)
+
+        os.makedirs(plugin.builddir)
+
+        plugin.build()
+
+        self.assertEqual(1, check_call_mock.call_count)
+        check_call_mock.assert_has_calls([
+            mock.call('yes "" | make -j2 oldconfig', shell=True,
+                      cwd=plugin.builddir),
+        ])
+
+        self.assertEqual(1, run_mock.call_count)
+        run_mock.assert_has_calls([
+            mock.call(['make', '-j2']),
+        ])

--- a/snapcraft/tests/plugins/test_kbuild.py
+++ b/snapcraft/tests/plugins/test_kbuild.py
@@ -37,7 +37,7 @@ class KBuildPluginTestCase(tests.TestCase):
             kconfigflavour = None
             kdefconfig = []
             kconfigs = []
-            install_targets = ['install']
+            build_attributes = []
 
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()
@@ -64,7 +64,7 @@ class KBuildPluginTestCase(tests.TestCase):
     def test_get_build_properties(self):
         expected_build_properties = ['kdefconfig', 'kconfigfile',
                                      'kconfigflavour', 'kconfigs',
-                                     'install-targets']
+                                     'build-attributes']
         resulting_build_properties = kbuild.KBuildPlugin.get_build_properties()
 
         self.assertThat(resulting_build_properties,
@@ -258,7 +258,7 @@ ACCEPT=n
     @mock.patch.object(kbuild.KBuildPlugin, 'run')
     def test_build_without_install_target(self, run_mock, check_call_mock):
         self.options.kconfigfile = 'config'
-        self.options.install_targets = []
+        self.options.build_attributes = ['no-install']
         with open(self.options.kconfigfile, 'w') as f:
             f.write('ACCEPT=y\n')
 

--- a/snapcraft/tests/plugins/test_kernel.py
+++ b/snapcraft/tests/plugins/test_kernel.py
@@ -49,6 +49,7 @@ class KernelPluginTestCase(tests.TestCase):
             kernel_initrd_firmware = []
             kernel_device_trees = []
             kernel_initrd_compression = 'gz'
+            build_attributes = []
 
         self.options = Options()
         self.project_options = snapcraft.ProjectOptions()


### PR DESCRIPTION
Projects using **KBuild** often have no install target in the Makefile.