### PR TITLE
lxd: clean with no parts should only delete

### DIFF
--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -225,11 +225,13 @@ class Project(Containerbuild):
         pass
 
     def execute(self, step='snap', args=None):
-        super().execute(step, args)
         # clean with no parts deletes the container
         if step == 'clean' and args == ['--step', 'pull']:
-            print('Deleting {}'.format(self._container_name))
-            check_call(['lxc', 'delete', '-f', self._container_name])
+            if self._get_container_status():
+                print('Deleting {}'.format(self._container_name))
+                check_call(['lxc', 'delete', '-f', self._container_name])
+        else:
+            super().execute(step, args)
 
 
 def _get_default_remote():


### PR DESCRIPTION
There's no reason to ever run commands inside a LXD container when `SNAPCRAFT_CONTAINER_BUILDS=1 snapcraft clean` is run without any arguments.