### PR TITLE
cli: properly handle exceptions

### DIFF
--- a/integration_tests/store/test_store_close.py
+++ b/integration_tests/store/test_store_close.py
@@ -16,6 +16,10 @@
 
 from testtools.matchers import FileExists
 
+from testtools.matchers import (
+    Equals,
+)
+
 import integration_tests
 
 
@@ -24,7 +28,7 @@ class ChannelClosingTestCase(integration_tests.StoreTestCase):
     def test_missing_login(self):
         expected = 'run "snapcraft login"'
         status = self.close('basic', 'beta', expected=expected)
-        self.assertEqual(1, status)
+        self.assertThat(status, Equals(2))
 
     def test_missing_permission(self):
         self.addCleanup(self.logout)
@@ -33,7 +37,7 @@ class ChannelClosingTestCase(integration_tests.StoreTestCase):
             'Make sure the logged in account has upload permissions on '
             "'missing' in series '16'.")
         status = self.close('missing', 'beta', expected=expected)
-        self.assertEqual(1, status)
+        self.assertThat(status, Equals(2))
 
     def test_close_channel(self):
         self.addCleanup(self.logout)

--- a/integration_tests/store/test_store_sign_build.py
+++ b/integration_tests/store/test_store_sign_build.py
@@ -19,6 +19,7 @@ import fixtures
 import shutil
 
 from testtools.matchers import (
+    Equals,
     Contains,
     FileContains,
     FileExists,
@@ -47,7 +48,7 @@ class SignBuildTestCase(integration_tests.StoreTestCase):
 
         status = self.sign_build(
             self.snap_path, local=True, expect_success=False)
-        self.assertEqual(1, status)
+        self.assertThat(status, Equals(2))
         self.assertThat(self.snap_build_path, Not(FileExists()))
 
     def test_successful_sign_build_local(self):
@@ -77,7 +78,7 @@ class SignBuildTestCase(integration_tests.StoreTestCase):
         self.assertThat(self.snap_path, FileExists())
 
         status = self.sign_build(self.snap_path, expect_success=False)
-        self.assertEqual(1, status)
+        self.assertThat(status, Equals(2))
         self.assertThat(self.snap_build_path, Not(FileExists()))
 
     def test_successful_sign_build_push(self):

--- a/integration_tests/test_after.py
+++ b/integration_tests/test_after.py
@@ -17,7 +17,10 @@
 import os
 import subprocess
 
-from testtools.matchers import Contains
+from testtools.matchers import (
+    Equals,
+    Contains,
+)
 
 import integration_tests
 
@@ -51,7 +54,7 @@ class AfterTestCase(integration_tests.TestCase):
             subprocess.CalledProcessError,
             self.run_snapcraft, 'build')
 
-        self.assertEqual(1, exception.returncode)
+        self.assertThat(exception.returncode, Equals(2))
         expected = (
             'Issue detected while analyzing snapcraft.yaml: '
             'circular dependency chain found in parts definition\n')

--- a/integration_tests/test_build.py
+++ b/integration_tests/test_build.py
@@ -1,0 +1,47 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+
+from testtools.matchers import (
+    Contains,
+    Not,
+)
+
+import integration_tests
+
+
+class BuildTestCase(integration_tests.TestCase):
+
+    def _build_invalid_part(self, debug):
+        exception = self.assertRaises(
+            subprocess.CalledProcessError,
+            self.run_snapcraft, ['build', 'invalid-part-name'],
+            'go-hello', debug=debug)
+
+        self.assertEqual(2, exception.returncode)
+        self.assertThat(exception.output, Contains(
+            "part named 'invalid-part-name' is not defined"))
+
+        return exception.output
+
+    def test_build_invalid_part_no_traceback_without_debug(self):
+        self.assertThat(
+            self._build_invalid_part(False), Not(Contains("Traceback")))
+
+    def test_build_invalid_part_does_traceback_with_debug(self):
+        self.assertThat(
+            self._build_invalid_part(True), Contains("Traceback"))

--- a/integration_tests/test_clean.py
+++ b/integration_tests/test_clean.py
@@ -14,8 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import subprocess
+
 from testtools.matchers import (
+    Contains,
     DirExists,
+    Equals,
     Not
 )
 
@@ -35,6 +39,27 @@ class CleanTestCase(integration_tests.TestCase):
         self.run_snapcraft('clean')
         for dir_ in snap_dirs:
             self.assertThat(dir_, Not(DirExists()))
+
+    def _clean_invalid_part(self, debug):
+        self.copy_project_to_cwd('make-hello')
+        self.run_snapcraft('snap')
+
+        raised = self.assertRaises(
+            subprocess.CalledProcessError, self.run_snapcraft,
+            ['clean', 'invalid-part'], debug=debug)
+        self.assertThat(raised.returncode, Equals(2))
+        self.assertThat(
+            raised.output,
+            Contains("The part named 'invalid-part' is not defined"))
+        return raised.output
+
+    def test_clean_invalid_part_no_traceback_without_debug(self):
+        self.assertThat(
+            self._clean_invalid_part(False), Not(Contains("Traceback")))
+
+    def test_clean_invalid_part_traceback_with_debug(self):
+        self.assertThat(
+            self._clean_invalid_part(True), Contains("Traceback"))
 
     def test_clean_again(self):
         # Clean a second time doesn't fail.

--- a/integration_tests/test_prime.py
+++ b/integration_tests/test_prime.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import subprocess
 from textwrap import dedent
 
 import testscenarios
@@ -71,6 +72,26 @@ class PrimeTestCase(integration_tests.TestCase):
 
         self.expectThat(
             desktop_path, FileContains(matcher=Contains('non ascíí')))
+
+    def _prime_invalid_part(self, debug):
+        exception = self.assertRaises(
+            subprocess.CalledProcessError,
+            self.run_snapcraft, ['prime', 'invalid-part-name'],
+            'prime-from-stage', debug=debug)
+
+        self.assertEqual(2, exception.returncode)
+        self.assertThat(exception.output, Contains(
+            "part named 'invalid-part-name' is not defined"))
+
+        return exception.output
+
+    def test_prime_invalid_part_no_traceback_without_debug(self):
+        self.assertThat(
+            self._prime_invalid_part(False), Not(Contains("Traceback")))
+
+    def test_prime_invalid_part_does_traceback_with_debug(self):
+        self.assertThat(
+            self._prime_invalid_part(True), Contains("Traceback"))
 
 
 class PrimedAssetsTestCase(testscenarios.WithScenarios,

--- a/integration_tests/test_pull.py
+++ b/integration_tests/test_pull.py
@@ -1,0 +1,48 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+
+from testtools.matchers import (
+    Contains,
+    Equals,
+    Not,
+)
+
+import integration_tests
+
+
+class PullTestCase(integration_tests.TestCase):
+
+    def _pull_invalid_part(self, debug):
+        exception = self.assertRaises(
+            subprocess.CalledProcessError,
+            self.run_snapcraft, ['pull', 'invalid-part-name'],
+            'go-hello', debug=debug)
+
+        self.assertThat(exception.returncode, Equals(2))
+        self.assertThat(exception.output, Contains(
+            "part named 'invalid-part-name' is not defined"))
+
+        return exception.output
+
+    def test_pull_invalid_part_no_traceback_without_debug(self):
+        self.assertThat(
+            self._pull_invalid_part(False), Not(Contains("Traceback")))
+
+    def test_pull_invalid_part_does_traceback_with_debug(self):
+        self.assertThat(
+            self._pull_invalid_part(True), Contains("Traceback"))

--- a/integration_tests/test_stage.py
+++ b/integration_tests/test_stage.py
@@ -18,19 +18,55 @@ import os
 import subprocess
 
 import fixtures
-from testtools.matchers import Contains, FileExists
+from testtools.matchers import (
+    Contains,
+    FileExists,
+    Not
+)
 
 import integration_tests
 
 
 class StageTestCase(integration_tests.TestCase):
 
+    def _stage_conflicts(self, debug):
+        exception = self.assertRaises(
+            subprocess.CalledProcessError,
+            self.run_snapcraft, 'stage', 'conflicts', debug=debug)
+
+        self.assertEqual(2, exception.returncode)
+        expected_conflicts = (
+            "Parts 'p1' and 'p2' have the following file paths in common "
+            "which have different contents:\n    bin/test\n")
+        self.assertThat(exception.output, Contains(expected_conflicts))
+
+        expected_help = (
+            'Snapcraft offers some capabilities to solve this by use '
+            'of the following keywords:\n'
+            '    - `filesets`\n'
+            '    - `stage`\n'
+            '    - `snap`\n'
+            '    - `organize`\n\n'
+            'Learn more about these part keywords by running '
+            '`snapcraft help plugins`'
+        )
+        self.assertThat(exception.output, Contains(expected_help))
+        return exception.output
+
+    def test_conflicts_no_traceback_without_debug(self):
+        self.assertThat(
+            self._stage_conflicts(False), Not(Contains("Traceback")))
+
+    def test_conflicts_traceback_with_debug(self):
+        self.assertThat(
+            self._stage_conflicts(True), Contains("Traceback"))
+
     def test_conflicts(self):
         exception = self.assertRaises(
             subprocess.CalledProcessError,
             self.run_snapcraft, 'stage', 'conflicts')
 
-        self.assertEqual(1, exception.returncode)
+        self.assertEqual(2, exception.returncode)
         expected_conflicts = (
             "Parts 'p1' and 'p2' have the following file paths in common "
             "which have different contents:\n    bin/test\n")

--- a/snapcraft/cli/__init__.py
+++ b/snapcraft/cli/__init__.py
@@ -13,8 +13,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import functools
 import logging
 import os
+import sys
 
 import click
 
@@ -31,6 +33,7 @@ from .parts import partscli
 from .help import helpcli
 from .ci import cicli
 from ._options import add_build_options
+from ._errors import exception_handler
 
 
 command_groups = [
@@ -89,12 +92,17 @@ class SnapcraftGroup(click.Group):
 @click.option('--debug', '-d', is_flag=True)
 def run(ctx, debug, catch_exceptions=False, **kwargs):
     """Snapcraft is a delightful packaging tool."""
+
     if debug:
         log_level = logging.DEBUG
         click.echo('Starting snapcraft {} from {}.'.format(
             snapcraft.__version__, os.path.dirname(__file__)))
     else:
         log_level = logging.INFO
+
+    # Setup global exception handler (to be called for unhandled exceptions)
+    sys.excepthook = functools.partial(exception_handler, debug=debug)
+
     # In an ideal world, this logger setup would be replaced
     log.configure(log_level=log_level)
     # The default command

--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -1,0 +1,50 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import traceback
+
+from . import echo
+import snapcraft.internal.errors
+
+
+def exception_handler(exception_type, exception, exception_traceback, *,
+                      debug=False):
+    """Catch all Snapcraft exceptions unless debugging.
+
+    This function is the global excepthook, properly handling uncaught
+    exceptions. "Proper" being defined as:
+
+    When debug=False:
+        - If exception is a SnapcraftError, just display a nice error and exit
+          according to the exit_code in the exception.
+        - If exception is NOT a SnapcraftError, raise so traceback is shown.
+
+    When debug=True:
+        - If exception is a SnapcraftError, show traceback and exit according
+          to the exit_code in the exception.
+        - If exception is NOT a SnapcraftError, raise so traceback is shown.
+    """
+
+    if issubclass(exception_type, snapcraft.internal.errors.SnapcraftError):
+        if not debug:
+            echo.error(str(exception))
+        else:
+            traceback.print_exception(
+                exception_type, exception, exception_traceback)
+        sys.exit(exception.exit_code)
+    else:
+        raise exception

--- a/snapcraft/cli/assertions.py
+++ b/snapcraft/cli/assertions.py
@@ -14,13 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
-
 import click
 
 import snapcraft
-from snapcraft.storeapi import errors
-from . import echo
 
 
 @click.group()
@@ -35,33 +31,21 @@ def list_keys():
 
     This command has an alias of `keys`.
     """
-    try:
-        snapcraft.list_keys()
-    except Exception as e:
-        echo.error(e)
-        sys.exit(1)
+    snapcraft.list_keys()
 
 
 @assertionscli.command('create-key')
 @click.argument('key-name', metavar='<key-name>', required=False)
 def create_key(key_name):
     """Create a key to sign assertions."""
-    try:
-        snapcraft.create_key(key_name)
-    except Exception as e:
-        echo.error(e)
-        sys.exit(1)
+    snapcraft.create_key(key_name)
 
 
 @assertionscli.command('register-key')
 @click.argument('key-name', metavar='<key-name>', required=False)
 def register_key(key_name):
     """Register a key with the store to sign assertions."""
-    try:
-        snapcraft.register_key(key_name)
-    except Exception as e:
-        echo.error(e)
-        sys.exit(1)
+    snapcraft.register_key(key_name)
 
 
 @assertionscli.command('sign-build')
@@ -75,11 +59,7 @@ def register_key(key_name):
               help='Do not push the generated assertion to the store')
 def sign_build(snap_file, key_name, local):
     """Sign a built snap file and assert it using the developer's key."""
-    try:
-        snapcraft.sign_build(snap_file, key_name=key_name, local=local)
-    except Exception as e:
-        echo.error(e)
-        sys.exit(1)
+    snapcraft.sign_build(snap_file, key_name=key_name, local=local)
 
 
 @assertionscli.command()
@@ -89,25 +69,11 @@ def sign_build(snap_file, key_name, local):
 @click.option('--key-name', metavar='<key-name>')
 def validate(snap_name, validations, key_name):
     """Validate a gated snap."""
-    try:
-        snapcraft.validate(snap_name, validations, key=key_name)
-    except errors.StoreError as e:
-        echo.error(e)
-        sys.exit(1)
-    # This one is here until an assertions refactor
-    except RuntimeError:
-        sys.exit(1)
+    snapcraft.validate(snap_name, validations, key=key_name)
 
 
 @assertionscli.command()
 @click.argument('snap-name', metavar='<snap-name>')
 def gated(snap_name):
     """Get the list of snaps and revisions gating a snap."""
-    try:
-        snapcraft.gated(snap_name)
-    except errors.StoreError as e:
-        echo.error(e)
-        sys.exit(1)
-    # This one is here until an assertions refactor
-    except RuntimeError:
-        sys.exit(1)
+    snapcraft.gated(snap_name)

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -13,11 +13,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import sys
 
 import click
 
-from snapcraft.internal import errors, lifecycle
+from snapcraft.internal import lifecycle
 from ._options import add_build_options, get_project_options
 from . import echo
 from . import env
@@ -29,11 +28,7 @@ def _execute(command, parts, **kwargs):
     if env.is_containerbuild():
         lifecycle.containerbuild(command, project_options, parts)
     else:
-        try:
-            lifecycle.execute(command, project_options, parts)
-        except Exception as e:
-            echo.error(e)
-            sys.exit(1)
+        lifecycle.execute(command, project_options, parts)
     return project_options
 
 
@@ -47,11 +42,7 @@ def lifecyclecli(ctx, **kwargs):
 @lifecyclecli.command()
 def init():
     """Initialize a snapcraft project."""
-    try:
-        snapcraft_yaml_path = lifecycle.init()
-    except errors.SnapcraftEnvironmentError as e:
-        echo.error(e)
-        sys.exit(1)
+    snapcraft_yaml_path = lifecycle.init()
     echo.info('Created {}.'.format(snapcraft_yaml_path))
     echo.info(
         'Edit the file to your liking or run `snapcraft` to get started')
@@ -137,12 +128,8 @@ def snap(directory, output, **kwargs):
     if env.is_containerbuild():
         lifecycle.containerbuild('snap', project_options, output, directory)
     else:
-        try:
-            snap_name = lifecycle.snap(
-                project_options, directory=directory, output=output)
-        except Exception as e:
-            echo.error(e)
-            sys.exit(1)
+        snap_name = lifecycle.snap(
+            project_options, directory=directory, output=output)
         echo.info('Snapped {}'.format(snap_name))
 
 
@@ -171,11 +158,7 @@ def clean(parts, step, **kwargs):
             echo.warning('DEPRECATED: Use `prime` instead of `strip` '
                          'as the step to clean')
             step = 'prime'
-        try:
-            lifecycle.clean(project_options, parts, step)
-        except errors.SnapcraftEnvironmentError as e:
-            echo.error(e)
-            sys.exit(1)
+        lifecycle.clean(project_options, parts, step)
 
 
 @lifecyclecli.command()
@@ -202,11 +185,7 @@ def cleanbuild(remote, debug, **kwargs):
     https://linuxcontainers.org/lxd/getting-started-cli/#multiple-hosts
     """
     project_options = get_project_options(**kwargs, debug=debug)
-    try:
-        lifecycle.cleanbuild(project_options, remote)
-    except errors.SnapcraftEnvironmentError as e:
-        echo.error(e)
-        sys.exit(1)
+    lifecycle.cleanbuild(project_options, remote)
 
 
 if __name__ == '__main__':

--- a/snapcraft/cli/parts.py
+++ b/snapcraft/cli/parts.py
@@ -13,11 +13,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import sys
 import click
-
 from snapcraft.internal import parts
-from . import echo
 
 
 @click.group(context_settings={})
@@ -44,11 +41,7 @@ def define(ctx, part):
         snapcraft define my-part1
 
     """
-    try:
-        parts.define(part)
-    except RuntimeError as e:
-        echo.error(e)
-        sys.exit(1)
+    parts.define(part)
 
 
 @partscli.command()

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -74,11 +74,7 @@ def register(snap_name, private):
     if private:
         click.echo(_MESSAGE_REGISTER_PRIVATE.format(snap_name))
     if click.confirm(_MESSAGE_REGISTER_CONFIRM.format(snap_name)):
-        try:
-            snapcraft.register(snap_name, private)
-        except storeapi.errors.StoreError as e:
-            echo.error(e)
-            sys.exit(1)
+        snapcraft.register(snap_name, private)
         click.echo(_MESSAGE_REGISTER_SUCCESS.format(snap_name))
     else:
         click.echo(_MESSAGE_REGISTER_NO.format(snap_name))
@@ -119,11 +115,7 @@ def push(snap_file, release):
             'After pushing, an attempt to release to {} '
             'will be made'.format(channel_list))
 
-    try:
-        snapcraft.push(snap_file, channel_list)
-    except storeapi.errors.StoreError as e:
-        echo.error(e)
-        sys.exit(1)
+    snapcraft.push(snap_file, channel_list)
 
 
 @storecli.command()
@@ -161,11 +153,7 @@ def release(snap_name, revision, channels):
         snapcraft release my-snap 9 lts-channel/stable
         snapcraft release my-snap 9 lts-channel/stable/my-branch
     """
-    try:
-        snapcraft.release(snap_name, revision, channels.split(','))
-    except storeapi.errors.StoreError as e:
-        echo.error(e)
-        sys.exit(1)
+    snapcraft.release(snap_name, revision, channels.split(','))
 
 
 @storecli.command()
@@ -184,14 +172,7 @@ def close(snap_name, channels):
         snapcraft close my-snap beta
         snapcraft close my-snap beta edge
     """
-    try:
-        snapcraft.close(snap_name, channels)
-    except storeapi.errors.StoreError as e:
-        echo.error(e)
-        sys.exit(1)
-    # This one is here until an assertions refactor
-    except KeyError:
-        sys.exit(1)
+    snapcraft.close(snap_name, channels)
 
 
 @storecli.command()
@@ -209,11 +190,7 @@ def status(snap_name, series, arch):
         snapcraft status my-snap
         snapcraft status my-snap --arch armhf
     """
-    try:
-        snapcraft.status(snap_name, series, arch)
-    except storeapi.errors.StoreError as e:
-        echo.error(e)
-        sys.exit(1)
+    snapcraft.status(snap_name, series, arch)
 
 
 @storecli.command('list-revisions')
@@ -234,11 +211,7 @@ def list_revisions(snap_name, series, arch):
         snapcraft list-revisions my-snap --arch armhf
         snapcraft revisions my-snap
     """
-    try:
-        snapcraft.revisions(snap_name, series, arch)
-    except storeapi.errors.StoreError as e:
-        echo.error(e)
-        sys.exit(1)
+    snapcraft.revisions(snap_name, series, arch)
 
 
 @storecli.command('list-registered')
@@ -252,11 +225,7 @@ def list_registered():
         snapcraft list-registered
         snapcraft registered
     """
-    try:
-        snapcraft.list_registered()
-    except storeapi.errors.StoreError as e:
-        echo.error(e)
-        sys.exit(1)
+    snapcraft.list_registered()
 
 
 @storecli.command()

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -27,6 +27,8 @@ import sys
 import tempfile
 import urllib
 
+from snapcraft.internal import errors
+
 
 SNAPCRAFT_FILES = ['snapcraft.yaml', '.snapcraft.yaml', 'parts', 'stage',
                    'prime', 'snap']
@@ -121,18 +123,15 @@ def get_schemadir():
 
 
 def get_arch_triplet():
-    raise EnvironmentError(
-        "This plugin is outdated, use 'project.arch_triplet'")
+    raise errors.PluginOutdatedError("use 'project.arch_triplet'")
 
 
 def get_arch():
-    raise EnvironmentError(
-        "This plugin is outdated, use 'project.deb_arch'")
+    raise errors.PluginOutdatedError("use 'project.deb_arch'")
 
 
 def get_parallel_build_count():
-    raise EnvironmentError(
-        "This plugin is outdated, use 'parallel_build_count'")
+    raise errors.PluginOutdatedError("use 'parallel_build_count'")
 
 
 def set_librariesdir(librariesdir):
@@ -160,7 +159,7 @@ def get_python2_path(root):
     try:
         return python_paths[0]
     except IndexError:
-        raise EnvironmentError(
+        raise errors.SnapcraftEnvironmentError(
             'PYTHONPATH cannot be set for {!r}'.format(root))
 
 

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -86,6 +86,16 @@ class SnapcraftPartMissingError(SnapcraftError):
     )
 
 
+class PartNotInCacheError(SnapcraftError):
+
+    fmt = (
+        'Cannot find the part name {part_name!r} in the cache. Please '
+        'run `snapcraft update` and try again.\nIf it is indeed missing, '
+        'consider going to https://wiki.ubuntu.com/snapcraft/parts '
+        'to add it.'
+    )
+
+
 class SnapcraftLogicError(SnapcraftError):
 
     fmt = 'Issue detected while analyzing snapcraft.yaml: {message}'

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -51,8 +51,11 @@ class MissingState(Exception):
     pass
 
 
-class SnapcraftEnvironmentError(Exception):
-    pass
+class SnapcraftEnvironmentError(SnapcraftError):
+    fmt = '{message}'
+
+    def __init__(self, message):
+        super().__init__(message=message)
 
 
 class PrimeFileConflictError(SnapcraftError):

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -41,6 +41,11 @@ class SnapcraftError(Exception):
     def __str__(self):
         return self.fmt.format([], **self.__dict__)
 
+    @property
+    def exit_code(self):
+        """Exit code to use if this exception causes Snapcraft to exit."""
+        return 2
+
 
 class MissingState(Exception):
     pass

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -47,8 +47,14 @@ class SnapcraftError(Exception):
         return 2
 
 
-class MissingState(Exception):
-    pass
+class MissingStateCleanError(SnapcraftError):
+    fmt = (
+        "Failed to clean step {step!r}: Missing necessary state. This won't "
+        "work until a complete clean has occurred."
+    )
+
+    def __init__(self, step):
+        super().__init__(step=step)
 
 
 class SnapcraftEnvironmentError(SnapcraftError):
@@ -75,6 +81,27 @@ class DuplicateAliasError(SnapcraftError):
             self.aliases = ','.join(self.aliases)
 
         return super().__str__()
+
+
+class InvalidAppCommandError(SnapcraftError):
+
+    fmt = (
+        'The specified command {command!r} defined in the app {app!r} does '
+        'not exist or is not executable'
+    )
+
+    def __init__(self, command, app):
+        super().__init__(command=command, app=app)
+
+
+class InvalidDesktopFileError(SnapcraftError):
+
+    fmt = (
+        'Invalid desktop file {filename!r}: {message}'
+    )
+
+    def __init__(self, filename, message):
+        super().__init__(filename=filename, message=message)
 
 
 class SnapcraftPartMissingError(SnapcraftError):

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -166,6 +166,14 @@ class MissingGadgetError(SnapcraftError):
         'https://github.com/snapcore/snapd/wiki/Gadget-snap')
 
 
+class PluginOutdatedError(SnapcraftError):
+
+    fmt = 'This plugin is outdated: {message}'
+
+    def __init__(self, message):
+        super().__init__(message=message)
+
+
 class RequiredCommandFailure(SnapcraftError):
 
     fmt = '{command!r} failed.'

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -64,7 +64,7 @@ parts:
   my-part:
     # See 'snapcraft plugins'
     plugin: nil
-""" # noqa, lines too long.
+"""  # noqa, lines too long.
 
 _STEPS_TO_AUTOMATICALLY_CLEAN_IF_DIRTY = {'stage', 'prime'}
 

--- a/snapcraft/internal/parts.py
+++ b/snapcraft/internal/parts.py
@@ -323,11 +323,7 @@ def define(part_name):
     try:
         remote_part = _RemoteParts().get_part(part_name, full=True)
     except errors.SnapcraftPartMissingError as e:
-        raise RuntimeError(
-            'Cannot find the part name {!r} in the cache. Please '
-            'run `snapcraft update` and try again.\nIf it is indeed missing, '
-            'consider going to https://wiki.ubuntu.com/snapcraft/parts '
-            'to add it.'.format(part_name)) from e
+        raise errors.PartNotInCacheError(part_name=part_name) from e
     print('Maintainer: {!r}'.format(remote_part.pop('maintainer')))
     print('Description: {}'.format(remote_part.pop('description')))
     print('')

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -494,9 +494,7 @@ class PluginHandler:
             self._clean_shared_area(self.stagedir, state,
                                     project_staged_state)
         except AttributeError:
-            raise errors.MissingState(
-                "Failed to clean step 'stage': Missing necessary state. "
-                "This won't work until a complete clean has occurred.")
+            raise errors.MissingStateCleanError('stage')
 
         self.mark_cleaned('stage')
 
@@ -554,9 +552,7 @@ class PluginHandler:
             self._clean_shared_area(self.primedir, state,
                                     project_primed_state)
         except AttributeError:
-            raise errors.MissingState(
-                "Failed to clean step 'prime': Missing necessary state. "
-                "This won't work until a complete clean has occurred.")
+            raise errors.MissingStateCleanError('prime')
 
         self.mark_cleaned('prime')
 
@@ -602,7 +598,7 @@ class PluginHandler:
         try:
             self._clean_steps(project_staged_state, project_primed_state,
                               step, hint)
-        except errors.MissingState:
+        except errors.MissingStateCleanError:
             # If one of the step cleaning rules is missing state, it must be
             # running on the output of an old Snapcraft. In that case, if we
             # were specifically asked to clean that step we need to fail.
@@ -923,7 +919,7 @@ def _organize_filesets(fileset, base_dir):
                 # deletions.
                 shutil.rmtree(src)
             elif os.path.isfile(dst):
-                raise EnvironmentError(
+                raise errors.SnapcraftEnvironmentError(
                     'Trying to organize file {key!r} to {dst!r}, '
                     'but {dst!r} already exists'.format(
                         key=key, dst=os.path.relpath(dst, base_dir)))
@@ -1073,7 +1069,7 @@ def _file_collides(file_this, file_other):
 
 
 def check_for_collisions(parts):
-    """Raises an EnvironmentError if conflicts are found between two parts."""
+    """Raises a SnapcraftPartConflictError if conflicts are found."""
     parts_files = {}
     for part in parts:
         # Gather our own files up

--- a/snapcraft/internal/project_loader.py
+++ b/snapcraft/internal/project_loader.py
@@ -304,7 +304,7 @@ def _build_env(root, snap_name, confinement, arch_triplet,
 
     if confinement == 'classic':
         if not core_dynamic_linker:
-            raise EnvironmentError(
+            raise errors.SnapcraftEnvironmentError(
                 'classic confinement requires the core snap to be installed. '
                 'Install it by running `snap install core`.')
 

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -261,7 +261,7 @@ deb http://${{security}}.ubuntu.com/${{suffix}} {0}-security main universe
             # PYTHONPATH to include the dist-packages in /usr/lib as well.
             env.append('PYTHONPATH={0}:$PYTHONPATH'.format(
                 common.get_python2_path(root)))
-        except EnvironmentError as e:
+        except errors.SnapcraftEnvironmentError as e:
             logger.debug(e)
 
         # The setup.sh we source below requires the in-snap python. Here we

--- a/snapcraft/plugins/copy.py
+++ b/snapcraft/plugins/copy.py
@@ -39,6 +39,7 @@ import os
 import glob
 
 import snapcraft
+from snapcraft.internal import errors
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +91,8 @@ class CopyPlugin(snapcraft.BasePlugin):
         for src in globs:
             paths = glob.glob(os.path.join(self.builddir, src))
             if not paths:
-                raise EnvironmentError('no matches for {!r}'.format(src))
+                raise errors.SnapcraftEnvironmentError(
+                    'no matches for {!r}'.format(src))
             for path in paths:
                 filepaths.update(
                     {os.path.join(self.builddir, path): globs[src]})

--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -48,6 +48,7 @@ import shutil
 import snapcraft
 from snapcraft import sources
 from snapcraft.file_utils import link_or_copy_tree
+from snapcraft.internal import errors
 
 logger = logging.getLogger(__name__)
 
@@ -208,8 +209,8 @@ class NodePlugin(snapcraft.BasePlugin):
 
 def _get_nodejs_base(node_engine, machine):
     if machine not in _NODEJS_ARCHES:
-        raise EnvironmentError('architecture not supported ({})'.format(
-            machine))
+        raise errors.SnapcraftEnvironmentError(
+            'architecture not supported ({})'.format(machine))
     return _NODEJS_BASE.format(version=node_engine,
                                arch=_NODEJS_ARCHES[machine])
 

--- a/snapcraft/plugins/rust.py
+++ b/snapcraft/plugins/rust.py
@@ -40,6 +40,7 @@ import shutil
 import snapcraft
 from snapcraft import sources
 from snapcraft import shell_utils
+from snapcraft.internal import errors
 
 _RUSTUP = 'https://static.rust-lang.org/rustup.sh'
 
@@ -182,7 +183,7 @@ class RustPlugin(snapcraft.BasePlugin):
                 options.append(
                     '--channel={}'.format(self.options.rust_channel))
             else:
-                raise EnvironmentError(
+                raise errors.SnapcraftEnvironmentError(
                     '{} is not a valid rust channel'.format(
                         self.options.rust_channel))
         os.makedirs(self._rustpath, exist_ok=True)

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -386,8 +386,12 @@ class StoreSnapRevisionsError(StoreError):
             series=series or 'any', error=error)
 
 
-class StoreDeltaApplicationError(Exception):
-    pass
+class StoreDeltaApplicationError(StoreError):
+
+    fmt = '{message}'
+
+    def __init__(self, message):
+        super().__init__(message=message)
 
 
 class StoreSnapStatusError(StoreSnapRevisionsError):

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -35,6 +35,11 @@ class InvalidCredentialsError(StoreError):
         super().__init__(message=message)
 
 
+class LoginRequiredError(StoreError):
+
+    fmt = 'Cannot continue without logging in successfully.'
+
+
 class StoreRetryError(StoreError):
 
     fmt = 'There seems to be a network error: {error}'
@@ -407,6 +412,100 @@ class StoreChannelClosingError(StoreError):
         super().__init__(error=error)
 
 
+class StoreChannelClosingPermissionError(StoreError):
+
+    fmt = (
+        'Your account lacks permission to close channels for this snap. Make '
+        'sure the logged in account has upload permissions on {snap_name!r} '
+        'in series {snap_series!r}.'
+    )
+
+    def __init__(self, snap_name, snap_series):
+        super().__init__(snap_name=snap_name, snap_series=snap_series)
+
+
+class StoreBuildAssertionPermissionError(StoreError):
+
+    fmt = (
+        'Your account lacks permission to assert builds for this snap. Make '
+        'sure you are logged in as the publisher of {snap_name!r} '
+        'for series {snap_series!r}.'
+    )
+
+    def __init__(self, snap_name, snap_series):
+        super().__init__(snap_name=snap_name, snap_series=snap_series)
+
+
 class StoreAssertionError(StoreError):
 
     fmt = 'Error signing {endpoint} assertion for {snap_name}: {error!s}'
+
+
+class MissingSnapdError(StoreError):
+
+    fmt = (
+        'The snapd package is not installed. In order to use {command!r}, '
+        "you must run 'apt install snapd'."
+    )
+
+    def __init__(self, command):
+        super().__init__(command=command)
+
+
+class KeyAlreadyRegisteredError(StoreError):
+
+    fmt = 'You have already registered a key named {key_name!r}'
+
+    def __init__(self, key_name):
+        super().__init__(key_name=key_name)
+
+
+class NoKeysError(StoreError):
+
+    fmt = (
+        'You have no usable keys.\nPlease create at least one key with '
+        '`snapcraft create-key` for use with snap.'
+    )
+
+
+class NoSuchKeyError(StoreError):
+
+    fmt = (
+        'You have no usable key named {key_name!r}.\nSee the keys available '
+        'in your system with `snapcraft keys`.'
+    )
+
+    def __init__(self, key_name):
+        super().__init__(key_name=key_name)
+
+
+class KeyNotRegisteredError(StoreError):
+
+    fmt = (
+        'The key {key_name!r} is not registered in the Store.\nPlease '
+        'register it with `snapcraft register-key {key_name!r}` before '
+        'signing and pushing signatures to the Store.'
+    )
+
+    def __init__(self, key_name):
+        super().__init__(key_name=key_name)
+
+
+class InvalidValidationRequestsError(StoreError):
+
+    fmt = (
+        'Invalid validation requests (format must be name=revision): '
+        '{requests}'
+    )
+
+    def __init__(self, requests):
+        requests_str = ' '.join(requests)
+        super().__init__(requests=requests_str)
+
+
+class SignBuildAssertionError(StoreError):
+
+    fmt = 'Failed to sign build assertion for {snap_name!r}'
+
+    def __init__(self, snap_name):
+        super().__init__(snap_name=snap_name)

--- a/snapcraft/tests/cli/test_errors.py
+++ b/snapcraft/tests/cli/test_errors.py
@@ -1,0 +1,93 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+
+from snapcraft.cli._errors import exception_handler
+import snapcraft.internal.errors
+
+import testtools
+from unittest import mock
+
+from snapcraft import tests
+
+
+class TestSnapcraftError(snapcraft.internal.errors.SnapcraftError):
+
+    fmt = '{message}'
+
+    def __init__(self, message):
+        super().__init__(message=message)
+
+    @property
+    def exit_code(self):
+        return 123
+
+
+class ErrorsTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        patcher = mock.patch('sys.exit')
+        self.exit_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch('snapcraft.cli._errors.echo.error')
+        self.error_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch('traceback.print_exception')
+        self.print_exception_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def call_handler(self, exception, debug):
+        try:
+            raise exception
+        except Exception:
+            exception_handler(*sys.exc_info(), debug=debug)
+
+    def test_handler_raises_non_snapcraft_exceptions(self):
+        with testtools.ExpectedException(RuntimeError, 'not a SnapcraftError'):
+            self.call_handler(RuntimeError('not a SnapcraftError'), False)
+
+        with testtools.ExpectedException(RuntimeError, 'not a SnapcraftError'):
+            self.call_handler(RuntimeError('not a SnapcraftError'), True)
+
+        self.error_mock.assert_not_called
+        self.exit_mock.assert_not_called
+        self.print_exception_mock.assert_not_called
+
+    def test_handler_catches_snapcraft_exceptions_no_debug(self):
+        try:
+            self.call_handler(TestSnapcraftError('is a SnapcraftError'), False)
+        except Exception:
+            self.fail('Exception unexpectedly raised')
+
+        self.error_mock.assert_called_once_with('is a SnapcraftError')
+        self.exit_mock.assert_called_once_with(123)
+        self.print_exception_mock.assert_not_called
+
+    def test_handler_traces_snapcraft_exceptions_with_debug(self):
+        try:
+            self.call_handler(TestSnapcraftError('is a SnapcraftError'), True)
+        except Exception:
+            self.fail('Exception unexpectedly raised')
+
+        self.error_mock.assert_not_called
+        self.exit_mock.assert_not_called
+        self.print_exception_mock.assert_called_once_with(
+            TestSnapcraftError, mock.ANY, mock.ANY)

--- a/snapcraft/tests/commands/test_build.py
+++ b/snapcraft/tests/commands/test_build.py
@@ -13,7 +13,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 from testtools.matchers import Equals, DirExists, Not
+import snapcraft.internal.errors
 
 from . import LifecycleCommandsBaseTestCase
 
@@ -23,13 +25,13 @@ class BuildCommandTestCase(LifecycleCommandsBaseTestCase):
     def test_build_invalid_part(self):
         self.make_snapcraft_yaml('build')
 
-        result = self.run_command(['build', 'no-build'])
+        raised = self.assertRaises(
+            snapcraft.internal.errors.SnapcraftEnvironmentError,
+            self.run_command, ['build', 'no-build'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertEqual(
-            result.output,
+        self.assertThat(str(raised), Equals(
             "The part named 'no-build' is not defined in "
-            "'snap/snapcraft.yaml'\n")
+            "'snap/snapcraft.yaml'"))
 
     def test_build_defaults(self):
         parts = self.make_snapcraft_yaml('build')

--- a/snapcraft/tests/commands/test_clean.py
+++ b/snapcraft/tests/commands/test_clean.py
@@ -21,6 +21,7 @@ from unittest.mock import call
 from testtools.matchers import Contains, Equals, DirExists, FileExists, Not
 from snapcraft.tests import fixture_setup
 
+import snapcraft.internal.errors
 from snapcraft.internal import pluginhandler
 from snapcraft.internal import project_loader
 from . import CommandBaseTestCase
@@ -76,12 +77,13 @@ parts:
     def test_part_to_remove_not_defined_exits_with_error(self):
         self.make_snapcraft_yaml(n=3)
 
-        result = self.run_command(['clean', 'no-clean'])
+        raised = self.assertRaises(
+            snapcraft.internal.errors.SnapcraftEnvironmentError,
+            self.run_command, ['clean', 'no-clean'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Equals(
+        self.assertThat(str(raised), Equals(
             "The part named 'no-clean' is not defined in "
-            "'snap/snapcraft.yaml'\n"))
+            "'snap/snapcraft.yaml'"))
 
     def test_clean_all(self):
         self.make_snapcraft_yaml(n=3)

--- a/snapcraft/tests/commands/test_cleanbuild.py
+++ b/snapcraft/tests/commands/test_cleanbuild.py
@@ -18,6 +18,7 @@ import logging
 import os
 import tarfile
 from textwrap import dedent
+import snapcraft.internal.errors
 
 import fixtures
 from testtools.matchers import Contains, Equals
@@ -138,10 +139,11 @@ class CleanBuildFailuresCommandTestCase(CleanBuildCommandBaseTestCase):
         self.useFixture(fake_lxd)
         fake_lxd.check_output_mock.side_effect = FileNotFoundError('lxc')
 
-        result = self.run_command(['cleanbuild'])
+        raised = self.assertRaises(
+            snapcraft.internal.errors.SnapcraftEnvironmentError,
+            self.run_command, ['cleanbuild'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Equals(
+        self.assertThat(str(raised), Equals(
             'You must have LXD installed in order to use cleanbuild.\n'
             'Refer to the documentation at '
-            'https://linuxcontainers.org/lxd/getting-started-cli.\n'))
+            'https://linuxcontainers.org/lxd/getting-started-cli.'))

--- a/snapcraft/tests/commands/test_close.py
+++ b/snapcraft/tests/commands/test_close.py
@@ -18,6 +18,7 @@ from unittest import mock
 
 from testtools.matchers import Contains, Equals
 
+import snapcraft.storeapi.errors
 from snapcraft import storeapi
 from . import CommandBaseTestCase
 
@@ -32,10 +33,11 @@ class CloseCommandTestCase(CommandBaseTestCase):
             }
         }
 
-        result = self.run_command(['close', 'foo', 'beta'])
+        raised = self.assertRaises(
+            snapcraft.storeapi.errors.StoreChannelClosingPermissionError,
+            self.run_command, ['close', 'foo', 'beta'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Equals(
             'Your account lacks permission to close channels for this snap. '
             'Make sure the logged in account has upload permissions on '
             "'foo' in series '16'."))
@@ -208,4 +210,4 @@ class CloseCommandTestCase(CommandBaseTestCase):
                              edge             ^          ^
                              stable/hotfix-2  1.3        49          2017-05-21T18:52:14.578435
 
-            \x1b[0;32mThe stable/hotfix-1 channel is now closed.\x1b[0m"""))) # noqa
+            \x1b[0;32mThe stable/hotfix-1 channel is now closed.\x1b[0m""")))  # noqa

--- a/snapcraft/tests/commands/test_create_key.py
+++ b/snapcraft/tests/commands/test_create_key.py
@@ -31,11 +31,13 @@ class CreateKeyTestCase(CommandBaseTestCase):
                                             mock_check_call):
         mock_installed.return_value = False
 
-        result = self.run_command(['create-key'])
+        raised = self.assertRaises(
+            storeapi.errors.MissingSnapdError,
+            self.run_command, ['create-key'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Contains(
             'The snapd package is not installed.'))
+
         mock_installed.assert_called_with('snapd')
         self.assertEqual(0, mock_check_output.call_count)
         self.assertEqual(0, mock_check_call.call_count)
@@ -48,12 +50,12 @@ class CreateKeyTestCase(CommandBaseTestCase):
         mock_installed.return_value = True
         mock_check_output.side_effect = mock_snap_output
 
-        result = self.run_command(['create-key'])
+        raised = self.assertRaises(
+            storeapi.errors.KeyAlreadyRegisteredError,
+            self.run_command, ['create-key'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
-            'You already have a key named "default".'))
-        self.assertEqual(0, mock_check_call.call_count)
+        self.assertThat(str(raised), Equals(
+            "You have already registered a key named 'default'"))
 
     @mock.patch('subprocess.check_call')
     @mock.patch.object(storeapi.SCAClient, 'get_account_information')
@@ -76,11 +78,12 @@ class CreateKeyTestCase(CommandBaseTestCase):
             ],
         }
 
-        result = self.run_command(['create-key', 'new-key'])
+        raised = self.assertRaises(
+            storeapi.errors.KeyAlreadyRegisteredError,
+            self.run_command, ['create-key', 'new-key'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
-            'You have already registered a key named "new-key".'))
+        self.assertThat(str(raised), Equals(
+            "You have already registered a key named 'new-key'"))
         self.assertEqual(0, mock_check_call.call_count)
 
     @mock.patch('subprocess.check_call')

--- a/snapcraft/tests/commands/test_define.py
+++ b/snapcraft/tests/commands/test_define.py
@@ -17,6 +17,7 @@ from textwrap import dedent
 
 from testtools.matchers import Contains, Equals
 
+import snapcraft.internal.errors
 from snapcraft.tests import TestWithFakeRemoteParts
 from . import CommandBaseTestCase
 
@@ -36,13 +37,15 @@ class DefineCommandTestCase(CommandBaseTestCase, TestWithFakeRemoteParts):
               source: http://curl.org""")))
 
     def test_defining_a_part_that_doesnt_exist_helps_out(self):
-        result = self.run_command(['define', 'curler'])
+        raised = self.assertRaises(
+            snapcraft.internal.errors.PartNotInCacheError,
+            self.run_command, ['define', 'curler'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(dedent("""\
-            Cannot find the part name 'curler' in the cache. Please run `snapcraft update` and try again.
-            If it is indeed missing, consider going to https://wiki.ubuntu.com/snapcraft/parts to add it.
-            """))) # noqa
+        self.assertThat(str(raised), Equals(
+            "Cannot find the part name 'curler' in the cache. Please run "
+            '`snapcraft update` and try again.\nIf it is indeed missing, '
+            'consider going to https://wiki.ubuntu.com/snapcraft/parts to add '
+            'it.'))
 
     def test_defining_a_part_with_multiline_description(self):
         result = self.run_command(['define', 'multiline-part'])

--- a/snapcraft/tests/commands/test_gated.py
+++ b/snapcraft/tests/commands/test_gated.py
@@ -17,6 +17,7 @@ import textwrap
 
 from testtools.matchers import Contains, Equals
 
+import snapcraft.storeapi.errors
 from . import StoreCommandsBaseTestCase
 
 
@@ -34,11 +35,11 @@ class GatedCommandTestCase(StoreCommandsBaseTestCase):
     def test_gated_unknown_snap(self):
         self.client.login('dummy', 'test correct password')
 
-        result = self.run_command(['gated', 'notfound'])
+        raised = self.assertRaises(
+            snapcraft.storeapi.errors.SnapNotFoundError,
+            self.run_command, ['gated', 'notfound'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
-            "Snap 'notfound' was not found."))
+        self.assertThat(str(raised), Equals("Snap 'notfound' was not found."))
 
     def test_gated_success(self):
         self.client.login('dummy', 'test correct password')
@@ -65,8 +66,8 @@ class GatedCommandTestCase(StoreCommandsBaseTestCase):
         self.assertThat(result.output, Contains(expected_output))
 
     def test_no_login(self):
-        result = self.run_command(['gated', 'notfound'])
+        raised = self.assertRaises(
+            snapcraft.storeapi.errors.InvalidCredentialsError,
+            self.run_command, ['gated', 'notfound'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
-            'No valid credentials found. Have you run'))
+        self.assertThat(str(raised), Contains('Invalid credentials'))

--- a/snapcraft/tests/commands/test_init.py
+++ b/snapcraft/tests/commands/test_init.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 
+import snapcraft.internal.errors
 from testtools.matchers import Equals, FileContains
 
 from . import CommandBaseTestCase
@@ -77,7 +78,9 @@ class InitCommandExistingProjectTestCase(CommandBaseTestCase):
 
         open(self.yaml_path, 'w').close()
 
-        result = self.run_command(['init'])
+        raised = self.assertRaises(
+            snapcraft.internal.errors.SnapcraftEnvironmentError,
+            self.run_command, ['init'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertEqual(result.output, self.message)
+        self.assertThat(str(raised), Equals(
+            '{} already exists!'.format(self.yaml_path)))

--- a/snapcraft/tests/commands/test_list_keys.py
+++ b/snapcraft/tests/commands/test_list_keys.py
@@ -35,10 +35,11 @@ class ListKeysCommandTestCase(CommandBaseTestCase):
                                            mock_check_output):
         mock_installed.return_value = False
 
-        result = self.run_command([self.command_name])
+        raised = self.assertRaises(
+            storeapi.errors.MissingSnapdError,
+            self.run_command, [self.command_name])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Contains(
             'The snapd package is not installed.'))
         mock_installed.assert_called_with('snapd')
         self.assertEqual(0, mock_check_output.call_count)
@@ -49,11 +50,11 @@ class ListKeysCommandTestCase(CommandBaseTestCase):
         mock_installed.return_value = True
         mock_check_output.side_effect = mock_snap_output
 
-        result = self.run_command([self.command_name])
+        raised = self.assertRaises(
+            storeapi.errors.InvalidCredentialsError,
+            self.run_command, [self.command_name])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
-            'No valid credentials found. Have you run "snapcraft login"?'))
+        self.assertThat(str(raised), Contains('Invalid credentials'))
 
     @mock.patch.object(storeapi.SCAClient, 'get_account_information')
     @mock.patch('subprocess.check_output')

--- a/snapcraft/tests/commands/test_list_registered.py
+++ b/snapcraft/tests/commands/test_list_registered.py
@@ -30,11 +30,11 @@ class ListRegisteredTestCase(StoreCommandsBaseTestCase):
     ]
 
     def test_list_registered_without_login(self):
-        result = self.run_command([self.command_name])
+        raised = self.assertRaises(
+            storeapi.errors.InvalidCredentialsError,
+            self.run_command, [self.command_name])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
-            'No valid credentials found. Have you run'))
+        self.assertThat(str(raised), Contains('Invalid credentials'))
 
     @mock.patch.object(storeapi.SCAClient, 'get_account_information')
     def test_list_registered_empty(self, mock_get_account_information):

--- a/snapcraft/tests/commands/test_list_revisions.py
+++ b/snapcraft/tests/commands/test_list_revisions.py
@@ -62,42 +62,43 @@ class RevisionsCommandTestCase(RevisionsCommandBaseTestCase):
         self.assertThat(result.output, Contains('Usage:'))
 
     def test_revisions_with_no_permissions(self):
-        result = self.run_command([self.command_name, 'snap-test'])
+        raised = self.assertRaises(
+            storeapi.errors.InvalidCredentialsError,
+            self.run_command, [self.command_name, 'snap-test'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
-            'No valid credentials found. Have you run "snapcraft login"?'))
+        self.assertThat(str(raised), Contains('Invalid credentials'))
 
     @mock.patch.object(storeapi.StoreClient, 'get_account_information')
     def test_revisions_with_3rd_party_snap(self, mock_account_api):
         mock_account_api.return_value = {}
 
-        result = self.run_command([self.command_name, 'snap-test'])
+        raised = self.assertRaises(
+            storeapi.errors.SnapNotFoundError,
+            self.run_command, [self.command_name, 'snap-test'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Equals(
             "Snap 'snap-test' was not found in '16' series."))
 
     @mock.patch.object(storeapi.StoreClient, 'get_account_information')
     def test_revisions_with_3rd_party_snap_by_arch(self, mock_account_api):
         mock_account_api.return_value = {}
 
-        result = self.run_command([self.command_name, 'snap-test',
-                                   '--arch=arm64'])
+        raised = self.assertRaises(
+            storeapi.errors.SnapNotFoundError,
+            self.run_command, [self.command_name, 'snap-test', '--arch=arm64'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Equals(
             "Snap 'snap-test' for 'arm64' was not found in '16' series."))
 
     @mock.patch.object(storeapi.StoreClient, 'get_account_information')
     def test_revisions_with_3rd_party_snap_by_series(self, mock_account_api):
         mock_account_api.return_value = {}
 
-        result = self.run_command([self.command_name, 'snap-test',
-                                   '--series=18'])
+        raised = self.assertRaises(
+            storeapi.errors.SnapNotFoundError,
+            self.run_command, [self.command_name, 'snap-test', '--series=18'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Equals(
             "Snap 'snap-test' was not found in '18' series."))
 
     @mock.patch.object(storeapi.SCAClient, 'snap_revisions')
@@ -105,11 +106,12 @@ class RevisionsCommandTestCase(RevisionsCommandBaseTestCase):
     def test_revisions_by_unknown_arch(self, mock_account_api, mock_revisions):
         mock_revisions.return_value = {}
 
-        result = self.run_command([self.command_name, 'snap-test',
-                                   '--arch=some-arch'])
+        raised = self.assertRaises(
+            storeapi.errors.SnapNotFoundError,
+            self.run_command,
+            [self.command_name, 'snap-test', '--arch=some-arch'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Equals(
             "Snap 'snap-test' for 'some-arch' was not found in '16' series."))
 
     @mock.patch.object(storeapi.SCAClient, 'snap_revisions')
@@ -118,11 +120,12 @@ class RevisionsCommandTestCase(RevisionsCommandBaseTestCase):
                                          mock_account_api, mock_revisions):
         mock_revisions.return_value = {}
 
-        result = self.run_command([self.command_name, 'snap-test',
-                                   '--series=some-series'])
+        raised = self.assertRaises(
+            storeapi.errors.SnapNotFoundError,
+            self.run_command,
+            [self.command_name, 'snap-test', '--series=some-series'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Equals(
             "Snap 'snap-test' was not found in 'some-series' series."))
 
     @mock.patch.object(storeapi.StoreClient, 'get_snap_revisions')
@@ -136,7 +139,7 @@ class RevisionsCommandTestCase(RevisionsCommandBaseTestCase):
         self.assertThat(result.output, Contains(dedent("""\
             Rev.    Uploaded              Arch    Version    Channels
             2       2016-09-27T19:23:40Z  i386    2.0.1      -
-            1       2016-09-27T18:38:43Z  amd64   2.0.2      stable*, edge"""))) # noqa
+            1       2016-09-27T18:38:43Z  amd64   2.0.2      stable*, edge""")))  # noqa
         mock_revisions.assert_called_once_with('snap-test', '16', None)
 
     @mock.patch.object(storeapi.StoreClient, 'get_snap_revisions')
@@ -154,7 +157,7 @@ class RevisionsCommandTestCase(RevisionsCommandBaseTestCase):
         self.assertThat(result.exit_code, Equals(0))
         self.assertThat(result.output, Contains(dedent("""\
             Rev.    Uploaded              Arch    Version    Channels
-            1       2016-09-27T18:38:43Z  amd64   2.0.2      stable*, edge"""))) # noqa
+            1       2016-09-27T18:38:43Z  amd64   2.0.2      stable*, edge""")))  # noqa
         mock_revisions.assert_called_once_with('snap-test', '16', 'amd64')
 
     @mock.patch.object(storeapi.StoreClient, 'get_snap_revisions')
@@ -169,7 +172,7 @@ class RevisionsCommandTestCase(RevisionsCommandBaseTestCase):
         self.assertThat(result.output, Contains(dedent("""\
             Rev.    Uploaded              Arch    Version    Channels
             2       2016-09-27T19:23:40Z  i386    2.0.1      -
-            1       2016-09-27T18:38:43Z  amd64   2.0.2      stable*, edge"""))) # noqa
+            1       2016-09-27T18:38:43Z  amd64   2.0.2      stable*, edge""")))  # noqa
         mock_revisions.assert_called_once_with('snap-test', '16', None)
 
 

--- a/snapcraft/tests/commands/test_prime.py
+++ b/snapcraft/tests/commands/test_prime.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
+import snapcraft.internal.errors
 
 import fixtures
 from testtools.matchers import Equals, DirExists, Not
@@ -26,12 +27,13 @@ class PrimeCommandTestCase(LifecycleCommandsBaseTestCase):
     def test_prime_invalid_part(self):
         self.make_snapcraft_yaml('prime')
 
-        result = self.run_command(['prime', 'no-prime'])
+        raised = self.assertRaises(
+            snapcraft.internal.errors.SnapcraftEnvironmentError,
+            self.run_command, ['prime', 'no-prime'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Equals(
+        self.assertThat(str(raised), Equals(
             "The part named 'no-prime' is not defined in "
-            "'snap/snapcraft.yaml'\n"))
+            "'snap/snapcraft.yaml'"))
 
     def test_prime_defaults(self):
         parts = self.make_snapcraft_yaml('prime')

--- a/snapcraft/tests/commands/test_pull.py
+++ b/snapcraft/tests/commands/test_pull.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from unittest import mock
 from testtools.matchers import Equals, DirExists, Not
+import snapcraft.internal.errors
 
 from . import LifecycleCommandsBaseTestCase
 
@@ -24,13 +25,13 @@ class PullCommandTestCase(LifecycleCommandsBaseTestCase):
     def test_pull_invalid_part(self):
         self.make_snapcraft_yaml('pull')
 
-        result = self.run_command(['pull', 'no-pull'])
+        raised = self.assertRaises(
+            snapcraft.internal.errors.SnapcraftEnvironmentError,
+            self.run_command, ['pull', 'no-pull'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertEqual(
-            result.output,
+        self.assertThat(str(raised), Equals(
             "The part named 'no-pull' is not defined in "
-            "'snap/snapcraft.yaml'\n")
+            "'snap/snapcraft.yaml'"))
 
     def test_pull_defaults(self):
         parts = self.make_snapcraft_yaml('pull')

--- a/snapcraft/tests/commands/test_push.py
+++ b/snapcraft/tests/commands/test_push.py
@@ -85,11 +85,11 @@ class PushCommandTestCase(PushCommandBaseTestCase):
         mock_upload.assert_called_once_with('basic', self.snap_file)
 
     def test_push_without_login_must_raise_exception(self):
-        result = self.run_command(['push', self.snap_file])
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertIn(
-            'No valid credentials found. Have you run "snapcraft login"?\n',
-            self.fake_logger.output)
+        raised = self.assertRaises(
+            storeapi.errors.InvalidCredentialsError,
+            self.run_command, ['push', self.snap_file])
+
+        self.assertThat(str(raised), Contains('Invalid credentials'))
 
     def test_push_nonexisting_snap_must_raise_exception(self):
         result = self.run_command(['push', 'test-unexisting-snap'])
@@ -107,10 +107,11 @@ class PushCommandTestCase(PushCommandBaseTestCase):
         mock_precheck.side_effect = StorePushError(
             'basic', MockResponse())
 
-        result = self.run_command(['push', self.snap_file])
+        raised = self.assertRaises(
+            storeapi.errors.StorePushError,
+            self.run_command, ['push', self.snap_file])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Contains(
             'You are not the publisher or allowed to push revisions for this '
             'snap. To become the publisher, run `snapcraft register '
             'basic` and try to push again.'))
@@ -127,8 +128,9 @@ class PushCommandTestCase(PushCommandBaseTestCase):
         self.addCleanup(patcher.stop)
         mock_upload.side_effect = StoreUploadError(MockResponse())
 
-        result = self.run_command(['push', self.snap_file])
-        self.assertThat(result.exit_code, Equals(1))
+        self.assertRaises(
+            storeapi.errors.StoreUploadError,
+            self.run_command, ['push', self.snap_file])
 
     def test_upload_raises_deprecation_warning(self):
         mock_tracker = mock.Mock(storeapi.StatusTracker)

--- a/snapcraft/tests/commands/test_register.py
+++ b/snapcraft/tests/commands/test_register.py
@@ -31,11 +31,10 @@ class RegisterTestCase(CommandBaseTestCase):
         self.assertThat(result.output, Contains('Usage:'))
 
     def test_register_without_login_must_error(self):
-        result = self.run_command(['register', 'snap-test'], input='y\n')
-
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
-            'No valid credentials found. Have you run "snapcraft login"?'))
+        raised = self.assertRaises(
+            storeapi.errors.InvalidCredentialsError,
+            self.run_command, ['register', 'snap-test'], input='y\n')
+        self.assertThat(str(raised), Contains('Invalid credentials'))
 
     def test_register_name_successfully(self):
         with mock.patch.object(
@@ -73,11 +72,11 @@ class RegisterTestCase(CommandBaseTestCase):
                 storeapi.SCAClient, 'register') as mock_register:
             mock_register.side_effect = storeapi.errors.StoreRegistrationError(
                 'test-snap', response)
-            result = self.run_command(['register', 'test-snap'], input='y\n')
+            raised = self.assertRaises(
+                storeapi.errors.StoreRegistrationError,
+                self.run_command, ['register', 'test-snap'], input='y\n')
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains('Registering test-snap'))
-        self.assertThat(result.output, Contains('Registration failed'))
+        self.assertThat(str(raised), Equals('Registration failed.'))
 
     def test_registration_cancelled(self):
         response = mock.Mock()

--- a/snapcraft/tests/commands/test_release.py
+++ b/snapcraft/tests/commands/test_release.py
@@ -134,7 +134,7 @@ class ReleaseCommandTestCase(CommandBaseTestCase):
                              beta            0          19
                              edge            ^          ^
                              stable/hotfix1  1          20          2017-05-21T18:52:14.578435
-            \x1b[0;32mThe 'stable/hotfix1' channel is now open.\x1b[0m"""))) # noqa
+            \x1b[0;32mThe 'stable/hotfix1' channel is now open.\x1b[0m""")))  # noqa
         mock_release.assert_called_once_with(
             'nil-snap', '20', ['stable/hotfix1'])
 
@@ -169,7 +169,7 @@ class ReleaseCommandTestCase(CommandBaseTestCase):
                              candidate  -          -
                              beta       0          19
                              edge       ^          ^
-            \x1b[0;32mThe 'stable', 'beta' and 'edge' channels are now open.\x1b[0m"""))) # noqa
+            \x1b[0;32mThe 'stable', 'beta' and 'edge' channels are now open.\x1b[0m""")))  # noqa
         mock_release.assert_called_once_with('nil-snap', '19', ['beta'])
 
     def test_release_with_bad_channel_info(self):
@@ -213,8 +213,8 @@ class ReleaseCommandTestCase(CommandBaseTestCase):
             "'fake-bad-channel-info' in channel stable"))
 
     def test_release_without_login_must_raise_exception(self):
-        result = self.run_command(['release', 'nil-snap', '19', 'beta'])
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertIn(
-            'No valid credentials found. Have you run "snapcraft login"?\n',
-            self.fake_logger.output)
+        raised = self.assertRaises(
+            storeapi.errors.InvalidCredentialsError,
+            self.run_command, ['release', 'nil-snap', '19', 'beta'])
+
+        self.assertThat(str(raised), Contains('Invalid credentials'))

--- a/snapcraft/tests/commands/test_sign_build.py
+++ b/snapcraft/tests/commands/test_sign_build.py
@@ -57,11 +57,12 @@ class SignBuildTestCase(CommandBaseTestCase):
                                             mock_check_output):
         mock_installed.return_value = False
 
-        result = self.run_command(['sign-build', self.snap_test.snap_path,
-                                   '--local'])
+        raised = self.assertRaises(
+            storeapi.errors.MissingSnapdError,
+            self.run_command,
+            ['sign-build', self.snap_test.snap_path, '--local'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Contains(
             'The snapd package is not installed.'))
         mock_installed.assert_called_with('snapd')
         self.assertEqual(0, mock_check_output.call_count)
@@ -97,13 +98,14 @@ class SignBuildTestCase(CommandBaseTestCase):
             'grade': 'stable',
         }
 
-        result = self.run_command(['sign-build', self.snap_test.snap_path])
+        raised = self.assertRaises(
+            storeapi.errors.StoreBuildAssertionPermissionError,
+            self.run_command, ['sign-build', self.snap_test.snap_path])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Equals(
             'Your account lacks permission to assert builds for this '
             'snap. Make sure you are logged in as the publisher of '
-            "'test-snap' for series '16'"))
+            "'test-snap' for series '16'."))
         self.assertEqual(0, mock_check_output.call_count)
 
     @mock.patch.object(storeapi.SCAClient, 'get_account_information')
@@ -130,14 +132,14 @@ class SignBuildTestCase(CommandBaseTestCase):
             '[]',
         ]
 
-        result = self.run_command(['sign-build', self.snap_test.snap_path])
+        raised = self.assertRaises(
+            storeapi.errors.NoKeysError,
+            self.run_command, ['sign-build', self.snap_test.snap_path])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains('You have no usable keys.'))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Contains('You have no usable keys.'))
+        self.assertThat(str(raised), Contains(
             'Please create at least one key with `snapcraft create-key` '
             'for use with snap.'))
-
         snap_build_path = self.snap_test.snap_path + '-build'
         self.assertThat(snap_build_path, Not(FileExists()))
 
@@ -165,13 +167,14 @@ class SignBuildTestCase(CommandBaseTestCase):
             '[{"name": "default"}]',
         ]
 
-        result = self.run_command(['sign-build', '--key-name', 'zoing',
-                                   self.snap_test.snap_path])
+        raised = self.assertRaises(
+            storeapi.errors.NoSuchKeyError,
+            self.run_command,
+            ['sign-build', '--key-name', 'zoing', self.snap_test.snap_path])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
-            'You have no usable key named "zoing".'))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Contains(
+            "You have no usable key named 'zoing'."))
+        self.assertThat(str(raised), Contains(
             'See the keys available in your system with `snapcraft keys`.'))
 
         snap_build_path = self.snap_test.snap_path + '-build'
@@ -202,12 +205,13 @@ class SignBuildTestCase(CommandBaseTestCase):
             '[{"name": "default", "sha3-384": "a_hash"}]',
         ]
 
-        result = self.run_command(['sign-build', self.snap_test.snap_path])
+        raised = self.assertRaises(
+            storeapi.errors.KeyNotRegisteredError,
+            self.run_command, ['sign-build', self.snap_test.snap_path])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Contains(
             'The key \'default\' is not registered in the Store.'))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Contains(
             'Please register it with `snapcraft register-key \'default\'` '
             'before signing and pushing signatures to the Store.'))
         snap_build_path = self.snap_test.snap_path + '-build'
@@ -239,11 +243,12 @@ class SignBuildTestCase(CommandBaseTestCase):
             subprocess.CalledProcessError(1, ['a', 'b'])
         ]
 
-        result = self.run_command(['sign-build', self.snap_test.snap_path])
+        raised = self.assertRaises(
+            storeapi.errors.SignBuildAssertionError,
+            self.run_command, ['sign-build', self.snap_test.snap_path])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
-            'Failed to sign build assertion for {}.'.format(
+        self.assertThat(str(raised), Contains(
+            'Failed to sign build assertion for {!r}'.format(
                 self.snap_test.snap_path)))
         snap_build_path = self.snap_test.snap_path + '-build'
         self.assertThat(snap_build_path, Not(FileExists()))

--- a/snapcraft/tests/commands/test_snap.py
+++ b/snapcraft/tests/commands/test_snap.py
@@ -22,6 +22,7 @@ from textwrap import dedent
 import requests
 from unittest import mock
 from unittest.mock import call
+import snapcraft.internal.errors
 
 import fixtures
 from testtools.matchers import (
@@ -94,10 +95,11 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
     def test_snap_fails_with_bad_type(self):
         self.make_snapcraft_yaml(snap_type='bad-type')
 
-        result = self.run_command(['snap'])
+        raised = self.assertRaises(
+            snapcraft.internal.errors.SnapcraftSchemaError,
+            self.run_command, ['snap'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Contains(
             "bad-type' is not one of ['app', 'gadget', 'kernel', 'os']"))
 
     def test_snap_is_the_default(self):
@@ -528,10 +530,11 @@ type: os
                 plugin: does-not-exist
         """))
 
-        result = self.run_command(['snap'])
+        raised = self.assertRaises(
+            snapcraft.internal.errors.PluginError,
+            self.run_command, ['snap'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Equals(
             "Issue while loading part: unknown plugin: 'does-not-exist'"))
 
     @mock.patch('time.time')

--- a/snapcraft/tests/commands/test_stage.py
+++ b/snapcraft/tests/commands/test_stage.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
+import snapcraft.internal.errors
 
 import fixtures
 from testtools.matchers import Equals, DirExists, Not
@@ -23,16 +24,15 @@ from . import LifecycleCommandsBaseTestCase
 
 class StageCommandTestCase(LifecycleCommandsBaseTestCase):
 
-    def test_stage_invalid_part(self):
+    def test_stage_invalid_part_raises(self):
         self.make_snapcraft_yaml('stage')
 
-        result = self.run_command(['stage', 'no-stage'])
-
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertEqual(
-            result.output,
+        raised = self.assertRaises(
+            snapcraft.internal.errors.SnapcraftEnvironmentError,
+            self.run_command, ['stage', 'no-stage'])
+        self.assertThat(str(raised), Equals(
             "The part named 'no-stage' is not defined in "
-            "'snap/snapcraft.yaml'\n")
+            "'snap/snapcraft.yaml'"))
 
     def test_stage_defaults(self):
         parts = self.make_snapcraft_yaml('stage')

--- a/snapcraft/tests/commands/test_status.py
+++ b/snapcraft/tests/commands/test_status.py
@@ -70,40 +70,43 @@ class StatusCommandTestCase(CommandBaseTestCase):
         self.assertThat(result.output, Contains('Usage:'))
 
     def test_status_with_no_permissions(self):
-        result = self.run_command(['status', 'snap-test'])
+        raised = self.assertRaises(
+            storeapi.errors.InvalidCredentialsError,
+            self.run_command, ['status', 'snap-test'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
-            'No valid credentials found. Have you run "snapcraft login"?'))
+        self.assertThat(str(raised), Contains('Invalid credentials'))
 
     @mock.patch.object(storeapi.StoreClient, 'get_account_information')
     def test_status_with_3rd_party_snap(self, mock_account_api):
         mock_account_api.return_value = {}
 
-        result = self.run_command(['status', 'snap-test'])
+        raised = self.assertRaises(
+            storeapi.errors.SnapNotFoundError,
+            self.run_command, ['status', 'snap-test'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Equals(
             "Snap 'snap-test' was not found in '16' series."))
 
     @mock.patch.object(storeapi.StoreClient, 'get_account_information')
     def test_status_with_3rd_party_snap_by_arch(self, mock_account_api):
         mock_account_api.return_value = {}
 
-        result = self.run_command(['status', 'snap-test', '--arch=arm64'])
+        raised = self.assertRaises(
+            storeapi.errors.SnapNotFoundError,
+            self.run_command, ['status', 'snap-test', '--arch=arm64'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Equals(
             "Snap 'snap-test' for 'arm64' was not found in '16' series."))
 
     @mock.patch.object(storeapi.StoreClient, 'get_account_information')
     def test_status_with_3rd_party_snap_by_series(self, mock_account_api):
         mock_account_api.return_value = {}
 
-        result = self.run_command(['status', 'snap-test', '--series=18'])
+        raised = self.assertRaises(
+            storeapi.errors.SnapNotFoundError,
+            self.run_command, ['status', 'snap-test', '--series=18'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Equals(
             "Snap 'snap-test' was not found in '18' series."))
 
     @mock.patch.object(storeapi.SCAClient, 'snap_status')
@@ -111,10 +114,11 @@ class StatusCommandTestCase(CommandBaseTestCase):
     def test_status_by_unknown_arch(self, mock_account_api, mock_status):
         mock_status.return_value = {}
 
-        result = self.run_command(['status', 'snap-test', '--arch=some-arch'])
+        raised = self.assertRaises(
+            storeapi.errors.SnapNotFoundError,
+            self.run_command, ['status', 'snap-test', '--arch=some-arch'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Equals(
             "Snap 'snap-test' for 'some-arch' was not found in '16' series."))
 
     @mock.patch.object(storeapi.SCAClient, 'snap_status')
@@ -124,11 +128,11 @@ class StatusCommandTestCase(CommandBaseTestCase):
 
         mock_status.return_value = {}
 
-        result = self.run_command(['status', 'snap-test',
-                                   '--series=some-series'])
+        raised = self.assertRaises(
+            storeapi.errors.SnapNotFoundError,
+            self.run_command, ['status', 'snap-test', '--series=some-series'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
+        self.assertThat(str(raised), Equals(
             "Snap 'snap-test' was not found in 'some-series' series."))
 
     @mock.patch.object(storeapi.StoreClient, 'get_snap_status')
@@ -240,5 +244,5 @@ class StatusCommandTestCase(CommandBaseTestCase):
             latest   i386    stable         -          -
                              beta           -          -
                              stable/hotfix  1.0-i386   3           2017-05-21T18:52:14.578435
-            """))) # noqa
+            """)))  # noqa
         mock_status.assert_called_once_with('snap-test', '16', None)

--- a/snapcraft/tests/commands/test_validate.py
+++ b/snapcraft/tests/commands/test_validate.py
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from unittest import mock
 
+import snapcraft.storeapi.errors
+
 import fixtures
 from testtools.matchers import Contains, Equals
 
@@ -79,27 +81,27 @@ class ValidateCommandTestCase(StoreCommandsBaseTestCase):
     def test_validate_unknown_snap(self):
         self.client.login('dummy', 'test correct password')
 
-        result = self.run_command(
+        raised = self.assertRaises(
+            snapcraft.storeapi.errors.SnapNotFoundError,
+            self.run_command,
             ['validate', 'notfound', 'ubuntu-core=3', 'test-snap=4'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
-            "Snap 'notfound' was not found"))
+        self.assertThat(str(raised), Equals("Snap 'notfound' was not found."))
 
     def test_validate_bad_argument(self):
         self.client.login('dummy', 'test correct password')
 
-        result = self.run_command(
+        raised = self.assertRaises(
+            snapcraft.storeapi.errors.InvalidValidationRequestsError,
+            self.run_command,
             ['validate', 'ubuntu-core', 'ubuntu-core=foo'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
-            'format must be name=revision'))
+        self.assertThat(str(raised), Contains('format must be name=revision'))
 
     def test_no_login(self):
-        result = self.run_command(
+        raised = self.assertRaises(
+            snapcraft.storeapi.errors.InvalidCredentialsError,
+            self.run_command,
             ['validate', 'ubuntu-core', 'ubuntu-core=3', 'test-snap=4'])
 
-        self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(result.output, Contains(
-            'No valid credentials found. Have you run'))
+        self.assertThat(str(raised), Contains('Invalid credentials'))

--- a/snapcraft/tests/pluginhandler/test_pluginhandler.py
+++ b/snapcraft/tests/pluginhandler/test_pluginhandler.py
@@ -720,7 +720,7 @@ class OrganizeTestCase(tests.TestCase):
             setup_dirs=[],
             setup_files=['foo', 'bar'],
             organize_set={'foo': 'bar'},
-            expected=EnvironmentError,
+            expected=errors.SnapcraftEnvironmentError,
         )),
         ('*_for_files', dict(
             setup_dirs=[],
@@ -735,7 +735,7 @@ class OrganizeTestCase(tests.TestCase):
             setup_dirs=[],
             setup_files=['foo.conf', 'bar.conf'],
             organize_set={'*.conf': 'dir'},
-            expected=EnvironmentError,
+            expected=errors.SnapcraftEnvironmentError,
         )),
         ('*_for_directories', dict(
             setup_dirs=['dir1', 'dir2'],
@@ -1218,7 +1218,7 @@ class StateTestCase(StateBaseTestCase):
     def test_clean_stage_old_state(self):
         self.handler.mark_done('stage', None)
         raised = self.assertRaises(
-            errors.MissingState,
+            errors.MissingStateCleanError,
             self.handler.clean_stage, {})
 
         self.assertEqual(
@@ -1549,7 +1549,7 @@ class StateTestCase(StateBaseTestCase):
     def test_clean_prime_old_state(self):
         self.handler.mark_done('prime', None)
         raised = self.assertRaises(
-            errors.MissingState,
+            errors.MissingStateCleanError,
             self.handler.clean_prime, {})
 
         self.assertEqual(
@@ -1905,7 +1905,7 @@ class CleanTestCase(CleanBaseTestCase):
         handler.mark_done('prime', None)
 
         raised = self.assertRaises(
-            errors.MissingState,
+            errors.MissingStateCleanError,
             handler.clean, step='prime')
 
         self.assertEqual(
@@ -2019,7 +2019,7 @@ class CleanTestCase(CleanBaseTestCase):
         handler.mark_done('stage', None)
 
         raised = self.assertRaises(
-            errors.MissingState,
+            errors.MissingStateCleanError,
             handler.clean, step='stage')
 
         self.assertEqual(

--- a/snapcraft/tests/plugins/test_copy.py
+++ b/snapcraft/tests/plugins/test_copy.py
@@ -26,6 +26,7 @@ from snapcraft.plugins.copy import (
     CopyPlugin,
     _recursively_link
 )
+from snapcraft.internal import errors
 from snapcraft import tests
 
 
@@ -63,7 +64,7 @@ class TestCopyPlugin(tests.TestCase):
         c = CopyPlugin('copy', self.mock_options, self.project_options)
         c.pull()
 
-        raised = self.assertRaises(EnvironmentError, c.build)
+        raised = self.assertRaises(FileNotFoundError, c.build)
 
         self.assertEqual(
             str(raised),
@@ -79,7 +80,7 @@ class TestCopyPlugin(tests.TestCase):
         c = CopyPlugin('copy', self.mock_options, self.project_options)
         c.pull()
 
-        raised = self.assertRaises(EnvironmentError, c.build)
+        raised = self.assertRaises(errors.SnapcraftEnvironmentError, c.build)
 
         self.assertEqual(raised.__str__(), "no matches for 'src*'")
 

--- a/snapcraft/tests/plugins/test_gulp.py
+++ b/snapcraft/tests/plugins/test_gulp.py
@@ -24,6 +24,7 @@ from testtools.matchers import HasLength
 
 import snapcraft
 from snapcraft.plugins import gulp, nodejs
+from snapcraft.internal import errors
 from snapcraft import tests
 
 
@@ -117,7 +118,7 @@ class GulpPluginTestCase(tests.TestCase):
             node_engine = '4'
 
         raised = self.assertRaises(
-            EnvironmentError,
+            errors.SnapcraftEnvironmentError,
             gulp.GulpPlugin, 'test-part', Options(), self.project_options)
 
         self.assertEqual(raised.__str__(),

--- a/snapcraft/tests/plugins/test_nodejs.py
+++ b/snapcraft/tests/plugins/test_nodejs.py
@@ -21,6 +21,7 @@ from testtools.matchers import DirExists, HasLength
 
 import snapcraft
 from snapcraft.plugins import nodejs
+from snapcraft.internal import errors
 from snapcraft import tests
 
 
@@ -240,7 +241,7 @@ class NodePluginTestCase(NodePluginBaseTestCase):
             source = '.'
 
         raised = self.assertRaises(
-            EnvironmentError,
+            errors.SnapcraftEnvironmentError,
             nodejs.NodePlugin,
             'test-part', Options(),
             self.project_options)

--- a/snapcraft/tests/test_common.py
+++ b/snapcraft/tests/test_common.py
@@ -16,7 +16,10 @@
 
 import os
 
-from snapcraft.internal import common
+from snapcraft.internal import (
+    common,
+    errors
+)
 from snapcraft import tests
 
 
@@ -44,31 +47,30 @@ class CommonMigratedTestCase(tests.TestCase):
 
     def test_parallel_build_count_migration_message(self):
         raised = self.assertRaises(
-            EnvironmentError,
+            errors.PluginOutdatedError,
             common.get_parallel_build_count)
 
         self.assertEqual(
             str(raised),
-            "This plugin is outdated, use "
-            "'parallel_build_count'")
+            "This plugin is outdated: use 'parallel_build_count'")
 
     def test_deb_arch_migration_message(self):
         raised = self.assertRaises(
-            EnvironmentError,
+            errors.PluginOutdatedError,
             common.get_arch)
 
         self.assertEqual(
             str(raised),
-            "This plugin is outdated, use 'project.deb_arch'")
+            "This plugin is outdated: use 'project.deb_arch'")
 
     def test_arch_triplet_migration_message(self):
         raised = self.assertRaises(
-            EnvironmentError,
+            errors.PluginOutdatedError,
             common.get_arch_triplet)
 
         self.assertEqual(
             str(raised),
-            "This plugin is outdated, use 'project.arch_triplet'")
+            "This plugin is outdated: use 'project.arch_triplet'")
 
 
 class FormatInColumnsTestCase(tests.TestCase):

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -37,10 +37,7 @@ from snapcraft.internal.meta import (
     _SnapPackaging
 )
 from snapcraft.internal import common
-from snapcraft.internal.errors import (
-    MissingGadgetError,
-    SnapcraftPathEntryError,
-)
+from snapcraft.internal import errors
 from snapcraft import ProjectOptions, tests
 
 
@@ -136,7 +133,7 @@ class CreateTestCase(CreateBaseTestCase):
         self.config_data['type'] = 'gadget'
 
         self.assertRaises(
-            MissingGadgetError,
+            errors.MissingGadgetError,
             create_snap_packaging,
             self.config_data,
             self.project_options,
@@ -562,7 +559,8 @@ class EnsureFilePathsTestCaseFails(CreateBaseTestCase):
     def test_file_path_entry(self):
         self.config_data['apps'] = {'app': {self.key: self.filepath}}
 
-        self.assertRaises(SnapcraftPathEntryError, self.generate_meta_yaml)
+        self.assertRaises(
+            errors.SnapcraftPathEntryError, self.generate_meta_yaml)
 
 
 class CreateWithGradeTestCase(CreateBaseTestCase):
@@ -733,7 +731,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         apps = {'app1': {'command': 'command-does-not-exist'}}
 
         raised = self.assertRaises(
-            EnvironmentError,
+            errors.InvalidAppCommandError,
             self.packager._wrap_apps, apps)
         self.assertEqual(
             "The specified command 'command-does-not-exist' defined in the "
@@ -749,7 +747,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         _create_file(cmd_path)
 
         raised = self.assertRaises(
-            EnvironmentError,
+            errors.InvalidAppCommandError,
             self.packager._wrap_apps, apps)
         self.assertEqual(
             "The specified command 'command-not-executable' defined in the "


### PR DESCRIPTION
This PR is an alternative to #1429. Instead of using click-specific decorators for every command, it simply installs a `sys.excepthandler` to deal properly with exceptions.

Advantages over #1429:
- Simpler
- Covers the store CLI with no additional work
- Covers future CLI additions automatically, nothing special needed

Disadvantages compared to #1429:
- Can no longer unit test CLI exit codes since the CLI is run within the same python process, the test catches the exception, and `excepthook` is never called. Integrations tests are needed instead.
- Global behavior can cause unexpected things to happen (i.e. the simple fact that some exceptions are masked by a global handler may be unexpected a year down the road when we add a new command)