### PR TITLE
add support for the "contact" field in snapcraft

### DIFF
--- a/demos/godd/snap/snapcraft.yaml
+++ b/demos/godd/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description:
  Written in go with support for device auto-detection via libgudev,
  you would need to use hw-assign to access devices.
 confinement: strict
+contact: mailto:michaelvogt+godd@imap.cc
 
 apps:
   godd:

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -116,6 +116,9 @@ properties:
         - type: string
           minLength: 1
         - type: number
+  contact:
+    type: string
+    description: contact information for the given snap
   apps:
     type: object
     additionalProperties: false


### PR DESCRIPTION
This allows a snapcraft.yaml to have a new "contact" field. This is part of a wider meta-data improvement, outlined in https://forum.snapcraft.io/t/development-sprint-june-26th-2017/415/48. The idea is that the metadata is part of snapcraft.yaml and that snapcraft pushes the metadata via some new store API to the store. The idea is that the metadata can be changed on the store side (e.g. to add new translations without having to push a new snap revision) but to still make it transparent for people who do not use the web-ui. A conflict mechanism is also planned. 

This PR is one (important) first step because right now the other metadata (summary, description) can already be part of snapcraft.yaml but `contact` is currently not supported.

LP: #1624829 (partly)
