### PR TITLE
catkin plugin: default to release build

### DIFF
--- a/demos/ros/snap/snapcraft.yaml
+++ b/demos/ros/snap/snapcraft.yaml
@@ -17,3 +17,4 @@ parts:
       - talker
       - listener
     include-roscore: true
+    build-attributes: [debug]

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -291,6 +291,7 @@ properties:
               enum:
                 - no-system-libraries
                 - no-install
+                - debug
             default: []
           organize:
             type: object

--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -355,6 +355,11 @@ of the choice of plugin.
         Do not run the install target provided by the plugin's build system.
 
         Supported by: kbuild
+
+      - debug:
+        Plugins that support the concept of build types build in Release mode
+        by default. Setting the 'debug' attribute requests that they instead
+        build in Debug mode.
 """
 
 from collections import OrderedDict                 # noqa

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -112,7 +112,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
         # minority.
         schema['properties']['include-roscore'] = {
             'type': 'boolean',
-            'default': True,
+            'default': 'true',
         }
 
         schema['properties']['underlay'] = {
@@ -147,7 +147,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
         # Inform Snapcraft of the properties associated with pulling. If these
         # change in the YAML Snapcraft will consider the pull step dirty.
         return ['rosdistro', 'catkin-packages', 'source-space',
-                'include-roscore', 'underlay', 'rosinstall-files']
+                'include-roscore', 'underlay']
 
     @classmethod
     def get_build_properties(cls):

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -38,6 +38,11 @@ Additionally, this plugin uses the following plugin-specific keywords:
       (list of strings)
       List of rosinstall files to merge while pulling. Paths are relative to
       the source.
+    - debug:
+      (boolean)
+      Whether or not to build the ROS packages with the Debug build type.
+      Defaults to false (i.e. the packages are built with the Release build
+      type).
     - underlay:
       (object)
       Used to inform Snapcraft that this snap isn't standalone, and is actually
@@ -112,7 +117,12 @@ class CatkinPlugin(snapcraft.BasePlugin):
         # minority.
         schema['properties']['include-roscore'] = {
             'type': 'boolean',
-            'default': 'true',
+            'default': True,
+        }
+
+        schema['properties']['debug'] = {
+            'type': 'boolean',
+            'default': False,
         }
 
         schema['properties']['underlay'] = {
@@ -147,7 +157,13 @@ class CatkinPlugin(snapcraft.BasePlugin):
         # Inform Snapcraft of the properties associated with pulling. If these
         # change in the YAML Snapcraft will consider the pull step dirty.
         return ['rosdistro', 'catkin-packages', 'source-space',
-                'include-roscore', 'underlay']
+                'include-roscore', 'underlay', 'rosinstall-files']
+
+    @classmethod
+    def get_build_properties(cls):
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        return ['debug']
 
     @property
     def PLUGIN_STAGE_SOURCES(self):
@@ -599,12 +615,16 @@ deb http://${{security}}.ubuntu.com/${{suffix}} {0}-security main universe
         # be the wrong version).
         compilers = _Compilers(
             self._compilers_path, self.PLUGIN_STAGE_SOURCES, self.project)
+        build_type = 'Release'
+        if self.options.debug:
+            build_type = 'Debug'
         catkincmd.extend([
             '-DCMAKE_C_FLAGS="$CFLAGS {}"'.format(compilers.cflags),
             '-DCMAKE_CXX_FLAGS="$CPPFLAGS {}"'.format(compilers.cxxflags),
             '-DCMAKE_LD_FLAGS="$LDFLAGS {}"'.format(compilers.ldflags),
             '-DCMAKE_C_COMPILER={}'.format(compilers.c_compiler_path),
-            '-DCMAKE_CXX_COMPILER={}'.format(compilers.cxx_compiler_path)
+            '-DCMAKE_CXX_COMPILER={}'.format(compilers.cxx_compiler_path),
+            '-DCMAKE_BUILD_TYPE={}'.format(build_type),
         ])
 
         # This command must run in bash due to a bug in Catkin that causes it

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -38,11 +38,6 @@ Additionally, this plugin uses the following plugin-specific keywords:
       (list of strings)
       List of rosinstall files to merge while pulling. Paths are relative to
       the source.
-    - debug:
-      (boolean)
-      Whether or not to build the ROS packages with the Debug build type.
-      Defaults to false (i.e. the packages are built with the Release build
-      type).
     - underlay:
       (object)
       Used to inform Snapcraft that this snap isn't standalone, and is actually
@@ -120,11 +115,6 @@ class CatkinPlugin(snapcraft.BasePlugin):
             'default': True,
         }
 
-        schema['properties']['debug'] = {
-            'type': 'boolean',
-            'default': False,
-        }
-
         schema['properties']['underlay'] = {
             'type': 'object',
             'properties': {
@@ -163,7 +153,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
     def get_build_properties(cls):
         # Inform Snapcraft of the properties associated with building. If these
         # change in the YAML Snapcraft will consider the build step dirty.
-        return ['debug']
+        return ['build-attributes']
 
     @property
     def PLUGIN_STAGE_SOURCES(self):
@@ -616,7 +606,7 @@ deb http://${{security}}.ubuntu.com/${{suffix}} {0}-security main universe
         compilers = _Compilers(
             self._compilers_path, self.PLUGIN_STAGE_SOURCES, self.project)
         build_type = 'Release'
-        if self.options.debug:
+        if 'debug' in self.options.build_attributes:
             build_type = 'Debug'
         catkincmd.extend([
             '-DCMAKE_C_FLAGS="$CFLAGS {}"'.format(compilers.cflags),

--- a/snapcraft/tests/plugins/test_catkin.py
+++ b/snapcraft/tests/plugins/test_catkin.py
@@ -70,9 +70,9 @@ class CatkinPluginBaseTestCase(tests.TestCase):
             source_space = 'src'
             source_subdir = None
             include_roscore = False
-            debug = False
             underlay = None
             rosinstall_files = None
+            build_attributes = []
 
         self.properties = props()
         self.project_options = snapcraft.ProjectOptions()
@@ -119,16 +119,13 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
 
         properties = schema['properties']
         expected = ('rosdistro', 'catkin-packages', 'source-space',
-                    'include-roscore', 'debug', 'underlay', 'rosinstall-files')
+                    'include-roscore', 'underlay', 'rosinstall-files')
         self.assertThat(properties, HasLength(len(expected)))
         for prop in expected:
             self.assertThat(properties, Contains(prop))
 
-    def test_schema_rosdistro(self):
-        schema = catkin.CatkinPlugin.schema()
-
         # Check rosdistro property
-        rosdistro = schema['properties']['rosdistro']
+        rosdistro = properties['rosdistro']
         expected = ('type', 'default')
         self.assertThat(rosdistro, HasLength(len(expected)))
         for prop in expected:
@@ -136,11 +133,8 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
         self.assertThat(rosdistro['type'], Equals('string'))
         self.assertThat(rosdistro['default'], Equals('indigo'))
 
-    def test_schema_catkin_packages(self):
-        schema = catkin.CatkinPlugin.schema()
-
         # Check catkin-packages property
-        catkin_packages = schema['properties']['catkin-packages']
+        catkin_packages = properties['catkin-packages']
         expected = ('type', 'default', 'minitems', 'uniqueItems', 'items')
         self.assertThat(catkin_packages, HasLength(len(expected)))
         for prop in expected:
@@ -157,11 +151,8 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
                         'Expected "catkin-packages" to be included in '
                         '"required"')
 
-    def test_schema_source_space(self):
-        schema = catkin.CatkinPlugin.schema()
-
         # Check source-space property
-        source_space = schema['properties']['source-space']
+        source_space = properties['source-space']
         expected = ('type', 'default')
         self.assertThat(source_space, HasLength(len(expected)))
         for prop in expected:
@@ -169,11 +160,8 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
         self.assertThat(source_space['type'], Equals('string'))
         self.assertThat(source_space['default'], Equals('src'))
 
-    def test_schema_include_roscore(self):
-        schema = catkin.CatkinPlugin.schema()
-
         # Check include-roscore property
-        include_roscore = schema['properties']['include-roscore']
+        include_roscore = properties['include-roscore']
         expected = ('type', 'default')
         self.assertThat(include_roscore, HasLength(len(expected)))
         for prop in expected:
@@ -181,23 +169,8 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
         self.assertThat(include_roscore['type'], Equals('boolean'))
         self.assertThat(include_roscore['default'], Equals(True))
 
-    def test_schema_debug(self):
-        schema = catkin.CatkinPlugin.schema()
-
-        # Check debug property
-        debug = schema['properties']['debug']
-        expected = ('type', 'default')
-        self.assertThat(debug, HasLength(len(expected)))
-        for prop in expected:
-            self.assertThat(debug, Contains(prop))
-        self.assertThat(debug['type'], Equals('boolean'))
-        self.assertThat(debug['default'], Equals(False))
-
-    def test_schema_underlay(self):
-        schema = catkin.CatkinPlugin.schema()
-
         # Check underlay property
-        underlay = schema['properties']['underlay']
+        underlay = properties['underlay']
         expected = ('type', 'properties', 'required')
         self.assertThat(underlay, HasLength(len(expected)))
         for prop in expected:
@@ -222,11 +195,8 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
         self.assertThat(underlay_run_path, Contains('type'))
         self.assertThat(underlay_run_path['type'], Equals('string'))
 
-    def test_schema_rosinstall_files(self):
-        schema = catkin.CatkinPlugin.schema()
-
         # Check rosinstall-files property
-        rosinstall_files = schema['properties']['rosinstall-files']
+        rosinstall_files = properties['rosinstall-files']
         expected = ('type', 'default', 'minitems', 'uniqueItems', 'items')
         self.assertThat(rosinstall_files, HasLength(len(expected)))
         for prop in expected:
@@ -251,7 +221,7 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
             self.assertIn(property, actual_pull_properties)
 
     def test_get_build_properties(self):
-        expected_build_properties = ['debug']
+        expected_build_properties = ['build-attributes']
         actual_build_properties = catkin.CatkinPlugin.get_build_properties()
 
         self.assertThat(actual_build_properties,
@@ -944,16 +914,16 @@ class BuildTestCase(CatkinPluginBaseTestCase):
 
     scenarios = [
         ('release', {
-            'debug': False,
+            'build_attributes': []
         }),
         ('debug', {
-            'debug': True
+            'build_attributes': ['debug']
         })
     ]
 
     def setUp(self):
         super().setUp()
-        self.properties.debug = self.debug
+        self.properties.build_attributes.extend(self.build_attributes)
 
     @mock.patch('snapcraft.plugins.catkin._Compilers')
     @mock.patch.object(catkin.CatkinPlugin, 'run')
@@ -973,12 +943,12 @@ class BuildTestCase(CatkinPluginBaseTestCase):
 
         # Matching like this for order independence (otherwise it would be
         # quite fragile)
-        debug = self.debug
+        build_attributes = self.build_attributes
 
         class check_build_command():
             def __eq__(self, args):
                 command = ' '.join(args)
-                if debug:
+                if 'debug' in build_attributes:
                     build_type_valid = re.match(
                         '.*--cmake-args.*-DCMAKE_BUILD_TYPE=Debug', command)
                 else:

--- a/snapcraft/tests/plugins/test_catkin.py
+++ b/snapcraft/tests/plugins/test_catkin.py
@@ -167,7 +167,7 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
         for prop in expected:
             self.assertThat(include_roscore, Contains(prop))
         self.assertThat(include_roscore['type'], Equals('boolean'))
-        self.assertThat(include_roscore['default'], Equals(True))
+        self.assertThat(include_roscore['default'], Equals('true'))
 
         # Check underlay property
         underlay = properties['underlay']
@@ -211,7 +211,7 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
     def test_get_pull_properties(self):
         expected_pull_properties = ['rosdistro', 'catkin-packages',
                                     'source-space', 'include-roscore',
-                                    'underlay', 'rosinstall-files']
+                                    'underlay']
         actual_pull_properties = catkin.CatkinPlugin.get_pull_properties()
 
         self.assertThat(actual_pull_properties,


### PR DESCRIPTION
This PR resolves LP: [#1709671](https://bugs.launchpad.net/snapcraft/+bug/1709671) by using the Release build type by default. It also adds a new boolean property called `debug` to support changing the build type to Debug.