### PR TITLE
catkin plugin: include-roscore is a boolean

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -112,7 +112,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
         # minority.
         schema['properties']['include-roscore'] = {
             'type': 'boolean',
-            'default': 'true',
+            'default': True,
         }
 
         schema['properties']['underlay'] = {

--- a/snapcraft/tests/plugins/test_catkin.py
+++ b/snapcraft/tests/plugins/test_catkin.py
@@ -160,7 +160,7 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
         for prop in expected:
             self.assertThat(include_roscore, Contains(prop))
         self.assertThat(include_roscore['type'], Equals('boolean'))
-        self.assertThat(include_roscore['default'], Equals('true'))
+        self.assertThat(include_roscore['default'], Equals(True))
 
         # Check underlay property
         underlay = properties['underlay']


### PR DESCRIPTION
Change the string 'true' to the boolean True. Thankfully this had no bad side effects since the string 'true' is truthy, but it's still incorrect and a bad example.