### PR TITLE
catkin plugin: rosinstall-files is a pull property

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -147,7 +147,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
         # Inform Snapcraft of the properties associated with pulling. If these
         # change in the YAML Snapcraft will consider the pull step dirty.
         return ['rosdistro', 'catkin-packages', 'source-space',
-                'include-roscore', 'underlay']
+                'include-roscore', 'underlay', 'rosinstall-files']
 
     @property
     def PLUGIN_STAGE_SOURCES(self):

--- a/snapcraft/tests/plugins/test_catkin.py
+++ b/snapcraft/tests/plugins/test_catkin.py
@@ -212,7 +212,6 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
         expected_pull_properties = ['rosdistro', 'catkin-packages',
                                     'source-space', 'include-roscore',
                                     'underlay', 'rosinstall-files']
-        resulting_pull_properties = catkin.CatkinPlugin.get_pull_properties()
         actual_pull_properties = catkin.CatkinPlugin.get_pull_properties()
 
         self.assertThat(actual_pull_properties,

--- a/snapcraft/tests/plugins/test_catkin.py
+++ b/snapcraft/tests/plugins/test_catkin.py
@@ -209,7 +209,7 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
     def test_get_pull_properties(self):
         expected_pull_properties = ['rosdistro', 'catkin-packages',
                                     'source-space', 'include-roscore',
-                                    'underlay']
+                                    'underlay', 'rosinstall-files']
         resulting_pull_properties = catkin.CatkinPlugin.get_pull_properties()
 
         self.assertThat(resulting_pull_properties,


### PR DESCRIPTION
Missed this when adding the `rosinstall-files` feature, sorry about that.