### PR TITLE
kbuild plugin: use ARCH from environment if set

### DIFF
--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -125,7 +125,7 @@ class KBuildPlugin(BasePlugin):
 
     def enable_cross_compilation(self):
         self.make_cmd.append('ARCH={}'.format(
-            self.project.kernel_arch))
+            os.environ.get('ARCH', self.project.kernel_arch)))
         if 'CROSS_COMPILE' in os.environ:
             toolchain = os.environ['CROSS_COMPILE']
         else:


### PR DESCRIPTION
In some cases the required ARCH doesn't match the kernel architecture, for example **arm** versus **arm64** with [uboot](https://github.com/kubiko/dragonboard-gadget).

With this change `ARCH=arm snapcraft --target-arch=arm64` [does the right thing](https://github.com/kubiko/dragonboard-gadget/pull/1).

Discussion: https://forum.snapcraft.io/t/custom-environment-variables-for-kbuild-and-other-plugins/1639