### PR TITLE
Add cx_Freeze options targeting bin/snapcraft

### DIFF
--- a/bin/snapcraft
+++ b/bin/snapcraft
@@ -19,7 +19,11 @@ import os
 import sys
 
 # make running from bzr snapshot easy
-topdir = os.path.abspath(os.path.join(__file__, '..', '..'))
+if getattr(sys, 'frozen', False):
+	topdir = os.path.dirname(sys.executable)
+else:
+	topdir = os.path.abspath(os.path.join(__file__, '..', '..'))
+	
 if os.path.exists(os.path.join(topdir, 'setup.py')):
     sys.path = [topdir] + sys.path
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ simplejson==3.8.2
 tabulate==0.7.5
 python-debian==0.1.28
 chardet==2.3.0
+cx_Freeze>=5.0.2; sys_platform == 'win32'

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ packages = [
 	'snapcraft.internal.sources',
 	'snapcraft.internal.states',
 	'snapcraft.plugins',
-  'snapcraft.plugins._ros',
+        'snapcraft.plugins._ros',
 	'snapcraft.storeapi'
 	]
 package_data = {'snapcraft.internal.repo': ['manifest.txt']}

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,46 @@
 import codecs
 import os
 import re
+import sys
 
-from setuptools import setup
 
+# Common distribution data
+name='snapcraft'
 version = 'devel'
+description = 'Easily craft snaps from multiple sources'
+author_email = 'snapcraft@lists.snapcraft.io'
+url = 'https://github.com/snapcore/snapcraft'
+packages = [
+	'snapcraft',
+	'snapcraft.cli',
+	'snapcraft.integrations',
+	'snapcraft.internal',
+	'snapcraft.internal.cache',
+	'snapcraft.internal.deltas',
+	'snapcraft.internal.pluginhandler',
+	'snapcraft.internal.pluginhandler.stage_package_grammar',
+	'snapcraft.internal.repo',
+	'snapcraft.internal.sources',
+	'snapcraft.internal.states',
+	'snapcraft.plugins',
+	'snapcraft.storeapi'
+	]
+package_data = {'snapcraft.internal.repo': ['manifest.txt']}
+license = 'GPL v3'
+classifiers = (
+	'Development Status :: 4 - Beta',
+	'Environment :: Console',
+	'Intended Audience :: Developers',
+	'Intended Audience :: System Administrators',
+	'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+	'Natural Language :: English',
+	'Programming Language :: Python',
+	'Programming Language :: Python :: 3',
+	'Programming Language :: Python :: 3.5',
+	'Topic :: Software Development :: Build Tools',
+	'Topic :: System :: Software Distribution',
+)
+
 # look/set what version we have
 changelog = 'debian/changelog'
 if os.path.exists(changelog):
@@ -31,57 +67,84 @@ if os.path.exists(changelog):
         version = match.group(1)
 
 
-setup(
-    name='snapcraft',
-    version=version,
-    description='Easily craft snaps from multiple sources',
-    author_email='snapcraft@lists.snapcraft.io',
-    url='https://github.com/snapcore/snapcraft',
-    packages=['snapcraft',
-              'snapcraft.cli',
-              'snapcraft.integrations',
-              'snapcraft.internal',
-              'snapcraft.internal.cache',
-              'snapcraft.internal.deltas',
-              'snapcraft.internal.pluginhandler',
-              'snapcraft.internal.pluginhandler.stage_package_grammar',
-              'snapcraft.internal.repo',
-              'snapcraft.internal.sources',
-              'snapcraft.internal.states',
-              'snapcraft.plugins',
-              'snapcraft.storeapi'],
-    package_data={'snapcraft.internal.repo': ['manifest.txt']},
-    entry_points={
-        'console_scripts': [
-            'snapcraft = snapcraft.cli.__main__:run',
-            'snapcraft-parser = snapcraft.internal.parser:main',
-        ],
-    },
-    data_files=[
-        ('share/snapcraft/schema',
-            ['schema/' + x for x in os.listdir('schema')]),
-        ('share/snapcraft/libraries',
-            ['libraries/' + x for x in os.listdir('libraries')]),
-    ],
-    install_requires=[
-        'pysha3',
-        'pyxdg',
-        'requests',
-        'libarchive-c',
-    ],
-    test_suite='snapcraft.tests',
-    license='GPL v3',
-    classifiers=(
-        'Development Status :: 4 - Beta',
-        'Environment :: Console',
-        'Intended Audience :: Developers',
-        'Intended Audience :: System Administrators',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Natural Language :: English',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Topic :: Software Development :: Build Tools',
-        'Topic :: System :: Software Distribution',
-    ),
-)
+
+# If on Windows, construct an exe distribution
+if sys.platform == 'win32':
+	from cx_Freeze import setup, Executable
+	
+	# cx_Freeze relevant options
+	build_exe_options = {
+		# Explicitly add any missed packages that are not found at runtime
+		'packages': [
+			'pkg_resources',
+			'pymacaroons',
+			'click',
+			'responses',
+			'configparser',
+			'docopt',
+			'cffi',
+		],
+		# Explicit inclusion of tour and other data, which is then clobbered.
+		'include_files' : [
+			('tour', os.path.join('share', 'snapcraft', 'tour')),
+			('libraries', os.path.join('share', 'snapcraft', 'libraries')),
+			('schema', os.path.join('share', 'snapcraft', 'schema')),
+		],
+	}
+		
+	exe = Executable(
+		script='bin/snapcraft', 
+		base=None # console subsystem
+	)
+	
+	setup(
+		name=name,
+		version=version,
+		description=description,
+		author_email=author_email,
+		url=url,
+		packages=packages,
+		package_data=package_data,
+		license=license,
+		classifiers=classifiers,
+		# cx_Freeze-specific arguments
+		options={'build_exe': build_exe_options},
+		executables=[exe],
+	)
+
+# On other platforms, continue as normal
+else:
+	from setuptools import setup
+	
+	setup(
+		name=name,
+		version=version,
+		description=description,
+		author_email=author_email,
+		url=url,
+		packages=packages,
+		package_data=package_data,
+		license=license,
+		classifiers=classifiers,
+		# non-cx_Freeze arguments
+		entry_points={
+			'console_scripts': [
+				'snapcraft = snapcraft.cli.__main__:run',
+				'snapcraft-parser = snapcraft.internal.parser:main',
+			],
+		},
+		data_files=[
+			('share/snapcraft/schema',
+				['schema/' + x for x in os.listdir('schema')]),
+			('share/snapcraft/libraries',
+				['libraries/' + x for x in os.listdir('libraries')]),
+		],
+		install_requires=[
+			'pysha3',
+			'pyxdg',
+			'requests',
+			'libarchive-c',
+		],
+		test_suite='snapcraft.tests',
+	)
+


### PR DESCRIPTION
This is a clean repeat of #1427 in order to address Github metadata issues and eliminate overall noise. 

This adds minimal win32 cx_Freeze support and refactors setup.py to account for incompatibilities in `setup()` while eliminating redundant packaging data. Ideally, this should not impact the current setup.py behavior beyond using cx_Freeze. 

This work is not exhaustively tested but should produce a working snapcraft.exe. I also tested `bdist_msi` and found that this can be deployed with an installer.

At this time, I'm targeting `bin/snapcraft` despite the fact that this is supposedly deprecated because it is far easier to pass to cx_Freeze as an entry point. I'd welcome a more future-proof approach. 