### PR TITLE
lxd: path cannot have extra forward slashes

### DIFF
--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -317,7 +317,7 @@ class Project(Containerbuild):
             check_call([
                 'lxc', 'config', 'device', 'add', self._container_name,
                 destination, 'disk', 'source={}'.format(source),
-                'path=/{}'.format(destination)])
+                'path={}'.format(destination)])
 
     def _finish(self):
         # Nothing to do

--- a/snapcraft/tests/commands/test_snap.py
+++ b/snapcraft/tests/commands/test_snap.py
@@ -153,7 +153,7 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
             call(['lxc', 'start', container_name]),
             call(['lxc', 'config', 'device', 'add', container_name,
                   project_folder, 'disk', 'source={}'.format(source),
-                  'path=/{}'.format(project_folder)]),
+                  'path={}'.format(project_folder)]),
             call(['lxc', 'stop', '-f', container_name]),
         ])
         mock_container_run.assert_has_calls([


### PR DESCRIPTION
After double-checking that the logic for mounting the project folder on the Snapcraft side I ended up finding that LXD can end up claiming the device exists without actually mounting it. In that case `lxc device remove` aborts with internal errors.
Apparently the LXD issue can be avoided by getting rid of a leading / in the mounted path.

This fixes [Could not find snap/snapcraft.yaml](https://forum.snapcraft.io/t/repeated-container-builds-fail-to-find-snapcraft-yaml/1649).

Notes:
* I'm not especially happy with the test side of this, it's a virtually invisible change. Suggestions would be welcome.
* Maybe we should be moving to using `lxc edit` for configuration as it can be used to fix containers that would be stuck using dedicated commands.