### PR TITLE
core: improve source caching logic

### DIFF
--- a/snapcraft/internal/sources/_base.py
+++ b/snapcraft/internal/sources/_base.py
@@ -60,6 +60,10 @@ class FileBase(Base):
             # this file and we don't want that.
             shutil.copy2(self.source, source_file)
 
+        # Verify before provisioning
+        if self.source_checksum:
+            verify_checksum(self.source_checksum, source_file)
+
         # We finally provision
         self.provision(self.source_dir, src=source_file)
 

--- a/snapcraft/tests/sources/test_tar.py
+++ b/snapcraft/tests/sources/test_tar.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2016 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -19,9 +19,10 @@ import tarfile
 import fixtures
 from unittest import mock
 
-from snapcraft.internal import sources
+import requests
 
 from snapcraft import tests
+from snapcraft.internal import sources
 
 
 class TestTar(tests.FakeFileHTTPServerBasedTestCase):
@@ -65,8 +66,8 @@ class TestTar(tests.FakeFileHTTPServerBasedTestCase):
 
         tar_source.pull()
         with mock.patch(
-                'snapcraft.sources.Tar.download',
-                new=mock.Mock(wraps=sources.Tar.download)) as download_spy:
+            'requests.get',
+                new=mock.Mock(wraps=requests.get)) as download_spy:
             tar_source.pull()
             self.assertEqual(download_spy.call_count, 0)
 


### PR DESCRIPTION
We only really need to cache downloaded files and not local files. This also transparently enables caching for plugins that don't call pull but instead use `download` and `provision`.