### PR TITLE
lxd: always remove existing device for project folder

### DIFF
--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -304,6 +304,12 @@ class Project(Containerbuild):
             check_call([
                 'lxc', 'config', 'set', self._container_name,
                 'raw.idmap', 'both {} 0'.format(os.getuid())])
+            # Remove existing device (to ensure we update old containers)
+            devices = self._get_container_status()['devices']
+            if self._project_folder in devices:
+                check_call([
+                    'lxc', 'config', 'device', 'remove', self._container_name,
+                    self._project_folder])
             check_call([
                 'lxc', 'start', self._container_name])
 

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -428,6 +428,7 @@ class FakeLXD(fixtures.Fixture):
 
     def __init__(self, fail_on_snapcraft_run=False):
         self.status = None
+        self.devices = '{}'
         self.fail_on_snapcraft_run = fail_on_snapcraft_run
 
     def _setUp(self):
@@ -468,11 +469,12 @@ class FakeLXD(fixtures.Fixture):
                     return string.Template('''
                         [{"name": "$NAME",
                           "status": "$STATUS",
-                          "devices": {"build-snap-test":[]}}]
+                          "devices": $DEVICES}]
                         ''').substitute({
                             # Container name without remote prefix
                             'NAME': self.name.split(':')[-1],
                             'STATUS': self.status,
+                            'DEVICES': self.devices,
                             }).encode('utf-8')
                 return '[]'.encode('utf-8')
             elif args[0][:2] == ['lxc', 'init']:


### PR DESCRIPTION
As a follow-up on #1483 this change removes an existing device for the project folder.