### PR TITLE
ant plugin, gradle plugin: add support for authenticated proxies

### DIFF
--- a/snapcraft/plugins/ant.py
+++ b/snapcraft/plugins/ant.py
@@ -105,6 +105,10 @@ class AntPlugin(snapcraft.plugins.jdk.JdkPlugin):
                 yield '-D{}.proxyHost={}'.format(scheme, parsed.hostname)
             if parsed.port is not None:
                 yield '-D{}.proxyPort={}'.format(scheme, parsed.port)
+            if parsed.username is not None:
+                yield '-D{}.proxyUser={}'.format(scheme, parsed.username)
+            if parsed.password is not None:
+                yield '-D{}.proxyPassword={}'.format(scheme, parsed.password)
 
     def env(self, root):
         env = super().env(root)

--- a/snapcraft/plugins/gradle.py
+++ b/snapcraft/plugins/gradle.py
@@ -112,8 +112,6 @@ class GradlePlugin(snapcraft.plugins.jdk.JdkPlugin):
                 snapcraft.file_utils.link_or_copy(src, dst, self.installdir))
 
     def _get_proxy_options(self):
-        # XXX This doesn't yet support username and password.
-        # -- elopio - 2016-11-17
         proxy_options = []
         for var in ('http', 'https'):
             proxy = os.environ.get('{}_proxy'.format(var), False)
@@ -124,4 +122,11 @@ class GradlePlugin(snapcraft.plugins.jdk.JdkPlugin):
                 if parsed_url.port:
                     proxy_options.append(
                         '-D{}.proxyPort={}'.format(var, parsed_url.port))
+                if parsed_url.username:
+                    proxy_options.append(
+                        '-D{}.proxyUser={}'.format(var, parsed_url.username))
+                if parsed_url.password:
+                    proxy_options.append(
+                        '-D{}.proxyPassword={}'.format(
+                            var, parsed_url.password))
         return proxy_options

--- a/snapcraft/tests/plugins/test_ant.py
+++ b/snapcraft/tests/plugins/test_ant.py
@@ -123,11 +123,11 @@ class AntPluginTestCase(tests.TestCase):
 
     def test_env_proxies(self):
         env_vars = (
-            ('http_proxy', 'http://localhost:3132'),
-            ('https_proxy', 'http://localhost2:3133'),
+            ('http_proxy', 'http://user:pass@localhost:3132'),
+            ('https_proxy', 'http://user2:pass2@localhost2:3133'),
         )
-        for v in env_vars:
-            self.useFixture(fixtures.EnvironmentVariable(v[0], v[1]))
+        for key, value in env_vars:
+            self.useFixture(fixtures.EnvironmentVariable(key, value))
         plugin = ant.AntPlugin('test-part', self.options,
                                self.project_options)
 
@@ -135,5 +135,7 @@ class AntPluginTestCase(tests.TestCase):
         self.assertIn(
             "ANT_OPTS='"
             "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=3132 "
-            "-Dhttps.proxyHost=localhost2 -Dhttps.proxyPort=3133'",
+            "-Dhttp.proxyUser=user -Dhttp.proxyPassword=pass "
+            "-Dhttps.proxyHost=localhost2 -Dhttps.proxyPort=3133 "
+            "-Dhttps.proxyUser=user2 -Dhttps.proxyPassword=pass2'",
             env)

--- a/snapcraft/tests/plugins/test_gradle.py
+++ b/snapcraft/tests/plugins/test_gradle.py
@@ -217,6 +217,12 @@ class GradleProxyTestCase(BaseGradlePluginTestCase):
             env_var=('http_proxy', 'http://test_proxy:3000'),
             expected_args=['-Dhttp.proxyHost=test_proxy',
                            '-Dhttp.proxyPort=3000'])),
+        ('authenticated http proxy url', dict(
+            env_var=('http_proxy', 'http://user:pass@test_proxy:3000'),
+            expected_args=['-Dhttp.proxyHost=test_proxy',
+                           '-Dhttp.proxyPort=3000',
+                           '-Dhttp.proxyUser=user',
+                           '-Dhttp.proxyPassword=pass'])),
         ('https proxy url', dict(
             env_var=('https_proxy', 'https://test_proxy'),
             expected_args=['-Dhttps.proxyHost=test_proxy'])),
@@ -224,6 +230,12 @@ class GradleProxyTestCase(BaseGradlePluginTestCase):
             env_var=('https_proxy', 'https://test_proxy:3000'),
             expected_args=['-Dhttps.proxyHost=test_proxy',
                            '-Dhttps.proxyPort=3000'])),
+        ('authenticated https proxy url', dict(
+            env_var=('https_proxy', 'http://user:pass@test_proxy:3000'),
+            expected_args=['-Dhttps.proxyHost=test_proxy',
+                           '-Dhttps.proxyPort=3000',
+                           '-Dhttps.proxyUser=user',
+                           '-Dhttps.proxyPassword=pass'])),
     ]
 
     @mock.patch.object(gradle.GradlePlugin, 'run')
@@ -234,8 +246,7 @@ class GradleProxyTestCase(BaseGradlePluginTestCase):
                                      self.project_options)
 
         def side(l):
-            os.makedirs(os.path.join(plugin.builddir,
-                        'build', 'libs'))
+            os.makedirs(os.path.join(plugin.builddir, 'build', 'libs'))
             open(os.path.join(plugin.builddir,
                  'build', 'libs', 'dummy.war'), 'w').close()
 


### PR DESCRIPTION
LP: [#1682534](https://bugs.launchpad.net/snapcraft/+bug/1682534)

ant plugin, gradle plugin: Add support for authenticated proxies

Bring ant and gradle up to par with maven plugin wrt. authenticated proxies. Fixes #1485 and re-fixes the linked LP bug (AFAICT it doesn't need the unauthenticated proxy that @cjwatson suggested in the LP bug)