### PR TITLE
errors: use function for exit code

### DIFF
--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -45,6 +45,6 @@ def exception_handler(exception_type, exception, exception_traceback, *,
         else:
             traceback.print_exception(
                 exception_type, exception, exception_traceback)
-        sys.exit(exception.exit_code)
+        sys.exit(exception.get_exit_code())
     else:
         raise exception

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -41,8 +41,7 @@ class SnapcraftError(Exception):
     def __str__(self):
         return self.fmt.format([], **self.__dict__)
 
-    @property
-    def exit_code(self):
+    def get_exit_code(self):
         """Exit code to use if this exception causes Snapcraft to exit."""
         return 2
 

--- a/snapcraft/tests/cli/test_errors.py
+++ b/snapcraft/tests/cli/test_errors.py
@@ -32,8 +32,7 @@ class TestSnapcraftError(snapcraft.internal.errors.SnapcraftError):
     def __init__(self, message):
         super().__init__(message=message)
 
-    @property
-    def exit_code(self):
+    def get_exit_code(self):
         return 123
 
 


### PR DESCRIPTION
Just a quick change to the error API before it's actually used.