### PR TITLE
lxd: only pass target arch if specified explicitly

### DIFF
--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -150,6 +150,10 @@ class ProjectOptions:
         return self.__target_machine != self.__platform_arch
 
     @property
+    def target_arch(self):
+        return self.__target_arch
+
+    @property
     def cross_compiler_prefix(self):
         try:
             return self.__machine_info['cross-compiler-prefix']
@@ -248,6 +252,7 @@ class ProjectOptions:
 
     def _set_machine(self, target_deb_arch):
         self.__platform_arch = _get_platform_architecture()
+        self.__target_arch = target_deb_arch
         if not target_deb_arch:
             self.__target_machine = self.__platform_arch
         else:

--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -75,7 +75,6 @@ class Containerbuild:
         if not deb_arch:
             raise ContainerConnectionError(
                 'Unrecognized server architecture {}'.format(kernel))
-        self._host_arch = deb_arch
         self._image = 'ubuntu:xenial/{}'.format(deb_arch)
         # Use a temporary folder the 'lxd' snap can access
         lxd_common_dir = os.path.expanduser(
@@ -150,8 +149,10 @@ class Containerbuild:
             command = ['snapcraft', step]
             if step == 'snap':
                 command += ['--output', self._snap_output]
-            if self._host_arch != self._project_options.deb_arch:
-                command += ['--target-arch', self._project_options.deb_arch]
+            # Pass on target arch if specified
+            # If not specified it defaults to the LXD architecture
+            if self._project_options.target_arch:
+                command += ['--target-arch', self._project_options.target_arch]
             if args:
                 command += args
             try:

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -495,6 +495,7 @@ class FakeLXD(fixtures.Fixture):
 
     def __init__(self, fail_on_snapcraft_run=False):
         self.status = None
+        self.kernel_arch = 'x86_64'
         self.devices = '{}'
         self.fail_on_snapcraft_run = fail_on_snapcraft_run
 
@@ -529,8 +530,8 @@ class FakeLXD(fixtures.Fixture):
             elif args[0][:2] == ['lxc', 'info']:
                 return '''
                     environment:
-                      kernel_architecture: x86_64
-                    '''.encode('utf-8')
+                      kernel_architecture: {}
+                    '''.format(self.kernel_arch).encode('utf-8')
             elif args[0][:3] == ['lxc', 'list', '--format=json']:
                 if self.status and args[0][3] == self.name:
                     return string.Template('''

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -34,14 +34,18 @@ from snapcraft.internal.errors import (
     ContainerConnectionError,
     SnapdError,
 )
+from snapcraft._options import _get_deb_arch
 
 
 class LXDTestCase(tests.TestCase):
 
     scenarios = [
-        ('local', dict(remote='local', target_arch=None)),
-        ('remote', dict(remote='my-remote', target_arch=None)),
-        ('cross', dict(remote='local', target_arch='armhf')),
+        ('local', dict(remote='local', target_arch=None, server='x86_64')),
+        ('remote', dict(remote='myremote', target_arch=None, server='x86_64')),
+        ('cross', dict(remote='local', target_arch='armhf', server='x86_64')),
+        ('arm remote', dict(remote='pi', target_arch=None, server='armv7l')),
+        ('arm same', dict(remote='pi', target_arch='armhf', server='armv7l')),
+        ('arm cross', dict(remote='pi', target_arch='arm64', server='armv7l')),
     ]
 
     def setUp(self):
@@ -68,9 +72,11 @@ class LXDTestCase(tests.TestCase):
         mock_container_run.side_effect = lambda cmd, **kwargs: cmd
 
         mock_pet.return_value = 'my-pet'
+        self.fake_lxd.kernel_arch = self.server
+
         project_folder = '/root/build_project'
         self.make_cleanbuilder().execute()
-        expected_arch = 'amd64'
+        expected_arch = _get_deb_arch(self.server)
 
         self.assertIn('Setting up container with project assets\n'
                       'Waiting for a network connection...\n'


### PR DESCRIPTION
As [discussed in the forum discussion](https://forum.snapcraft.io/t/cleanbuild-remote-on-pi-grabs-wrong-arch-lxc-image/691/7) container builds should default to the architecture of the container rather than the client.

~~Alternative approach to #1498~~.