### PR TITLE
cli: don't raise from excepthook

### DIFF
--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -30,21 +30,26 @@ def exception_handler(exception_type, exception, exception_traceback, *,
 
     When debug=False:
         - If exception is a SnapcraftError, just display a nice error and exit
-          according to the exit_code in the exception.
-        - If exception is NOT a SnapcraftError, raise so traceback is shown.
+          according to the exit code in the exception.
+        - If exception is NOT a SnapcraftError, show traceback and exit 1
 
     When debug=True:
         - If exception is a SnapcraftError, show traceback and exit according
-          to the exit_code in the exception.
-        - If exception is NOT a SnapcraftError, raise so traceback is shown.
+          to the exit code in the exception.
+        - If exception is NOT a SnapcraftError, show traceback and exit 1
     """
 
-    if issubclass(exception_type, snapcraft.internal.errors.SnapcraftError):
+    exit_code = 1
+    is_snapcraft_error = issubclass(
+        exception_type, snapcraft.internal.errors.SnapcraftError)
+
+    if debug or not is_snapcraft_error:
+        traceback.print_exception(
+            exception_type, exception, exception_traceback)
+
+    if is_snapcraft_error:
+        exit_code = exception.get_exit_code()
         if not debug:
             echo.error(str(exception))
-        else:
-            traceback.print_exception(
-                exception_type, exception, exception_traceback)
-        sys.exit(exception.get_exit_code())
-    else:
-        raise exception
+
+    sys.exit(exit_code)

--- a/snapcraft/tests/cli/test_errors.py
+++ b/snapcraft/tests/cli/test_errors.py
@@ -19,7 +19,6 @@ import sys
 from snapcraft.cli._errors import exception_handler
 import snapcraft.internal.errors
 
-import testtools
 from unittest import mock
 
 from snapcraft import tests
@@ -59,16 +58,27 @@ class ErrorsTestCase(tests.TestCase):
         except Exception:
             exception_handler(*sys.exc_info(), debug=debug)
 
-    def test_handler_raises_non_snapcraft_exceptions(self):
-        with testtools.ExpectedException(RuntimeError, 'not a SnapcraftError'):
-            self.call_handler(RuntimeError('not a SnapcraftError'), False)
-
-        with testtools.ExpectedException(RuntimeError, 'not a SnapcraftError'):
-            self.call_handler(RuntimeError('not a SnapcraftError'), True)
-
+    def assert_exception_traceback_exit_1(self):
         self.error_mock.assert_not_called
-        self.exit_mock.assert_not_called
-        self.print_exception_mock.assert_not_called
+        self.exit_mock.assert_called_once_with(1)
+        self.print_exception_mock.assert_called_once_with(
+            RuntimeError, mock.ANY, mock.ANY)
+
+    def test_handler_traceback_non_snapcraft_exceptions_no_debug(self):
+        try:
+            self.call_handler(RuntimeError('not a SnapcraftError'), False)
+        except Exception:
+            self.fail('Exception unexpectedly raised')
+
+        self.assert_exception_traceback_exit_1()
+
+    def test_handler_traceback_non_snapcraft_exceptions_debug(self):
+        try:
+            self.call_handler(RuntimeError('not a SnapcraftError'), True)
+        except Exception:
+            self.fail('Exception unexpectedly raised')
+
+        self.assert_exception_traceback_exit_1()
 
     def test_handler_catches_snapcraft_exceptions_no_debug(self):
         try:


### PR DESCRIPTION
Raising exceptions from `excepthook` does not seem to be expected by Python, causing it to print "Error in sys.excepthook: [...]" which may look a little confusing, as the `excepthook` has nothing to do with the error. Instead of raising again and relying on Python to further handle the exception, print the traceback ourselves and exit appropriately.