### PR TITLE
lxd: pass original CLI arguments down to container

### DIFF
--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -150,8 +150,8 @@ class ProjectOptions:
         return self.__target_machine != self.__platform_arch
 
     @property
-    def target_arch_specified(self):
-        return self.__target_arch_specified
+    def target_arch(self):
+        return self.__target_arch
 
     @property
     def cross_compiler_prefix(self):
@@ -252,7 +252,7 @@ class ProjectOptions:
 
     def _set_machine(self, target_deb_arch):
         self.__platform_arch = _get_platform_architecture()
-        self.__target_arch_specified = target_deb_arch is not None
+        self.__target_arch = target_deb_arch
         if not target_deb_arch:
             self.__target_machine = self.__platform_arch
         else:

--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -206,8 +206,12 @@ class ProjectOptions:
     def debug(self):
         return self.__debug
 
+    @property
+    def args(self):
+        return self.__args
+
     def __init__(self, use_geoip=False, parallel_builds=True,
-                 target_deb_arch=None, debug=False):
+                 target_deb_arch=None, debug=False, args=[]):
         # TODO: allow setting a different project dir and check for
         #       snapcraft.yaml
         self.__project_dir = os.getcwd()
@@ -215,6 +219,7 @@ class ProjectOptions:
         self.__parallel_builds = parallel_builds
         self._set_machine(target_deb_arch)
         self.__debug = debug
+        self.__args = args
 
     def get_core_dynamic_linker(self):
         """Returns the dynamic linker used for the targetted core.

--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -150,6 +150,10 @@ class ProjectOptions:
         return self.__target_machine != self.__platform_arch
 
     @property
+    def target_arch_specified(self):
+        return self.__target_arch_specified
+
+    @property
     def cross_compiler_prefix(self):
         try:
             return self.__machine_info['cross-compiler-prefix']
@@ -248,6 +252,7 @@ class ProjectOptions:
 
     def _set_machine(self, target_deb_arch):
         self.__platform_arch = _get_platform_architecture()
+        self.__target_arch_specified = target_deb_arch is not None
         if not target_deb_arch:
             self.__target_machine = self.__platform_arch
         else:

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -59,10 +59,10 @@ def get_project_options(**kwargs):
             kwargs[key] = value
 
     project_args = dict(
-        debug=kwargs.pop('debug'),
-        use_geoip=kwargs.pop('enable_geoip'),
-        parallel_builds=not kwargs.pop('no_parallel_builds'),
-        target_deb_arch=kwargs.pop('target_arch'),
+        debug=kwargs.get('debug'),
+        use_geoip=kwargs.get('enable_geoip'),
+        parallel_builds=not kwargs.get('no_parallel_builds'),
+        target_deb_arch=kwargs.get('target_arch'),
     )
 
-    return ProjectOptions(**project_args)
+    return ProjectOptions(**project_args, args=kwargs)

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -57,12 +57,16 @@ def get_project_options(**kwargs):
     for key, value in ctx.parent.params.items():
         if not kwargs.get(key):
             kwargs[key] = value
+    # Retain the original arguments
+    args = kwargs.copy()
+    for key, value in ctx.params.items():
+        args[key] = value
 
     project_args = dict(
-        debug=kwargs.get('debug'),
-        use_geoip=kwargs.get('enable_geoip'),
-        parallel_builds=not kwargs.get('no_parallel_builds'),
-        target_deb_arch=kwargs.get('target_arch'),
+        debug=kwargs.pop('debug'),
+        use_geoip=kwargs.pop('enable_geoip'),
+        parallel_builds=not kwargs.pop('no_parallel_builds'),
+        target_deb_arch=kwargs.pop('target_arch'),
     )
 
-    return ProjectOptions(**project_args, args=kwargs)
+    return ProjectOptions(**project_args, args=args)

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -26,8 +26,7 @@ def _execute(command, parts, **kwargs):
     project_options = get_project_options(**kwargs)
 
     if env.is_containerbuild():
-        lifecycle.containerbuild(command, project_options,
-                                 project_options.args)
+        lifecycle.containerbuild(command, project_options)
     else:
         lifecycle.execute(command, project_options, parts)
     return project_options
@@ -127,7 +126,7 @@ def snap(directory, output, **kwargs):
     """
     project_options = get_project_options(**kwargs)
     if env.is_containerbuild():
-        lifecycle.containerbuild('snap', project_options, project_options.args)
+        lifecycle.containerbuild('snap', project_options, output)
     else:
         snap_name = lifecycle.snap(
             project_options, directory=directory, output=output)
@@ -151,8 +150,7 @@ def clean(parts, step, **kwargs):
     """
     project_options = get_project_options(**kwargs)
     if env.is_containerbuild():
-        lifecycle.containerbuild('clean', project_options,
-                                 project_options.args)
+        lifecycle.containerbuild('clean', project_options)
     else:
         if step == 'strip':
             echo.warning('DEPRECATED: Use `prime` instead of `strip` '

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -26,7 +26,8 @@ def _execute(command, parts, **kwargs):
     project_options = get_project_options(**kwargs)
 
     if env.is_containerbuild():
-        lifecycle.containerbuild(command, project_options, parts)
+        lifecycle.containerbuild(command, project_options,
+                                 project_options.args)
     else:
         lifecycle.execute(command, project_options, parts)
     return project_options
@@ -126,7 +127,7 @@ def snap(directory, output, **kwargs):
     """
     project_options = get_project_options(**kwargs)
     if env.is_containerbuild():
-        lifecycle.containerbuild('snap', project_options, output, directory)
+        lifecycle.containerbuild('snap', project_options, project_options.args)
     else:
         snap_name = lifecycle.snap(
             project_options, directory=directory, output=output)
@@ -150,9 +151,8 @@ def clean(parts, step, **kwargs):
     """
     project_options = get_project_options(**kwargs)
     if env.is_containerbuild():
-        step = step or 'pull'
         lifecycle.containerbuild('clean', project_options,
-                                 args=['--step', step, *parts])
+                                 project_options.args)
     else:
         if step == 'strip':
             echo.warning('DEPRECATED: Use `prime` instead of `strip` '

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -338,11 +338,11 @@ def _create_tar_filter(tar_filename):
     return _tar_filter
 
 
-def containerbuild(step, project_options, args, output=None):
+def containerbuild(step, project_options, output):
     config = snapcraft.internal.load_config(project_options)
     lxd.Project(output=output, source=os.path.curdir,
                 project_options=project_options,
-                metadata=config.get_metadata()).execute(step, args)
+                metadata=config.get_metadata()).execute(step)
 
 
 def cleanbuild(project_options, remote=''):

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -338,7 +338,7 @@ def _create_tar_filter(tar_filename):
     return _tar_filter
 
 
-def containerbuild(step, project_options, output=None, args=[]):
+def containerbuild(step, project_options, args, output=None):
     config = snapcraft.internal.load_config(project_options)
     lxd.Project(output=output, source=os.path.curdir,
                 project_options=project_options,

--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -140,6 +140,8 @@ class Containerbuild:
             command = ['snapcraft', step]
             if step == 'snap':
                 command += ['--output', self._snap_output]
+            # Pass on target arch if specified
+            # If not specified it defaults to the LXD architecture
             if self._project_options.target_arch:
                 command += ['--target-arch', self._project_options.target_arch]
             if args:

--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -71,7 +71,6 @@ class Containerbuild:
         if not deb_arch:
             raise SnapcraftEnvironmentError(
                 'Unrecognized server architecture {}'.format(kernel))
-        self._host_arch = deb_arch
         self._image = 'ubuntu:xenial/{}'.format(deb_arch)
 
     def _get_remote_info(self):
@@ -141,7 +140,7 @@ class Containerbuild:
             command = ['snapcraft', step]
             if step == 'snap':
                 command += ['--output', self._snap_output]
-            if self._host_arch != self._project_options.deb_arch:
+            if self._project_options.target_arch_specified:
                 command += ['--target-arch', self._project_options.deb_arch]
             if args:
                 command += args

--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -140,8 +140,8 @@ class Containerbuild:
             command = ['snapcraft', step]
             if step == 'snap':
                 command += ['--output', self._snap_output]
-            if self._project_options.target_arch_specified:
-                command += ['--target-arch', self._project_options.deb_arch]
+            if self._project_options.target_arch:
+                command += ['--target-arch', self._project_options.target_arch]
             if args:
                 command += args
             try:

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -428,6 +428,7 @@ class FakeLXD(fixtures.Fixture):
 
     def __init__(self, fail_on_snapcraft_run=False):
         self.status = None
+        self.kernel_arch = 'x86_64'
         self.fail_on_snapcraft_run = fail_on_snapcraft_run
 
     def _setUp(self):
@@ -461,8 +462,8 @@ class FakeLXD(fixtures.Fixture):
             elif args[0][:2] == ['lxc', 'info']:
                 return '''
                     environment:
-                      kernel_architecture: x86_64
-                    '''.encode('utf-8')
+                      kernel_architecture: {}
+                    '''.format(self.kernel_arch).encode('utf-8')
             elif args[0][:3] == ['lxc', 'list', '--format=json']:
                 if self.status and args[0][3] == self.name:
                     return string.Template('''


### PR DESCRIPTION
Originally trying to fix the --target-arch default as [discussed in the forum](https://forum.snapcraft.io/t/cleanbuild-remote-on-pi-grabs-wrong-arch-lxc-image/691/7) so container builds default to the architecture of the container rather than the client, I followed up [on a suggestion](https://github.com/snapcore/snapcraft/pull/1493) to pass the original commands instead of picking options we need by hand.
This also addresses [`--no-parallel-build` being ignored when building in a container](https://forum.snapcraft.io/t/cleanbuild-no-parallel-build-exclusive/614/4).


**Alternative approach to #1493**.