### PR TITLE
repo: make errors based on SnapcraftError

### DIFF
--- a/integration_tests/test_build_package_version.py
+++ b/integration_tests/test_build_package_version.py
@@ -57,7 +57,7 @@ class BuildPackageVersionErrorsTestCase(integration_tests.TestCase):
             subprocess.CalledProcessError,
             self.run_snapcraft, 'pull')
         self.assertIn(
-            "Could not find a required package in 'build-packages': The "
-            "package 'haskell-doc=invalid' was not found",
+            "Could not find a required package in 'build-packages': "
+            "haskell-doc=invalid",
             str(error.output)
         )

--- a/integration_tests/test_build_package_version.py
+++ b/integration_tests/test_build_package_version.py
@@ -57,7 +57,7 @@ class BuildPackageVersionErrorsTestCase(integration_tests.TestCase):
             subprocess.CalledProcessError,
             self.run_snapcraft, 'pull')
         self.assertIn(
-            "Could not find a required package in 'build-packages': "
-            "haskell-doc=invalid",
+            "Could not find a required package in 'build-packages': The "
+            "package 'haskell-doc=invalid' was not found",
             str(error.output)
         )

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -197,7 +197,7 @@ class Ubuntu(BaseRepo):
             try:
                 cls._mark_install(apt_cache, package_names)
             except errors.PackageNotFoundError as e:
-                raise errors.BuildPackageNotFoundError(e)
+                raise errors.BuildPackageNotFoundError(e.package_name)
             for package in apt_cache.get_changes():
                 new_packages.append((package.name, package.candidate.version))
 

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -16,19 +16,22 @@
 
 from platform import linux_distribution as _linux_distribution
 from ._platform import _is_deb_based
+from snapcraft.internal import errors
 
 
-class BuildPackageNotFoundError(Exception):
-
-    def __init__(self, package_name):
-        self.package_name = package_name
-
-    def __str__(self):
-        return ('Could not find a required package in '
-                '\'build-packages\': {}'.format(str(self.package_name)))
+class RepoError(errors.SnapcraftError):
+    pass
 
 
-class PackageNotFoundError(Exception):
+class BuildPackageNotFoundError(RepoError):
+
+    fmt = "Could not find a required package in 'build-packages': {package}"
+
+    def __init__(self, package):
+        super().__init__(package=package)
+
+
+class PackageNotFoundError(RepoError):
 
     @property
     def message(self):
@@ -47,12 +50,13 @@ class PackageNotFoundError(Exception):
     def __init__(self, package_name):
         self.package_name = package_name
 
+    def __str__(self):
+        return self.message
 
-class UnpackError(Exception):
 
-    @property
-    def message(self):
-        return 'Error while provisioning "{}"'.format(self.package_name)
+class UnpackError(RepoError):
 
-    def __init__(self, package_name):
-        self.package_name = package_name
+    fmt = 'Error while provisioning {package!r}'
+
+    def __init__(self, package):
+        super().__init__(package=package)


### PR DESCRIPTION
Without this change, repo-based errors result in a traceback even when not in debug mode. This should have been caught in #1436, but alas, it was not.