### PR TITLE
tests: use assertThat instead of assertEqual

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -1,4 +1,4 @@
-# Snapcraft code style guidelines
+# Snapcraft coding style guidelines
 
 When writing code for snapcraft, we try to follow a set of rules that will lead
 to consistency and readability.

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -1,0 +1,28 @@
+# Snapcraft code style guidelines
+
+When writing code for snapcraft, we try to follow a set of rules that will lead
+to consistency and readability.
+
+This is a permanent work in progress, and sometimes being too strict with the
+rules can end up making things actually less readable. So when you disagree
+with one of the rules, please talk to us and help us making it better.
+
+Some of the rules are enforced with static tests. You can read the [TESTING][1]
+document for more information and details about how to run the static suite of
+tests. Some other rules are only socially enforced during code reviews.
+
+## PEP 8
+
+We adhere to the Style Guide for Python Code documented in the [PEP 8][2].
+
+## Tests
+
+* When asserting for equality, we prefer to use the `Equals` matcher from
+  testtools:
+
+    ```
+    self.assertThat(actual, Equals(expected))
+    ```
+
+[1]: TESTING.md
+[2]: https://www.python.org/dev/peps/pep-0008

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,13 @@ give us permission to use your contributions.
    Make a fork of Snapcraft, and create a branch named specifically for the
    feature on which you'd like to work. Make your changes there, adding new
    tests as needed, and make sure the existing tests continue to pass when your
-   changes are complete (for information about running the tests, see the
-   [HACKING][3] document).
+   changes are complete (for information see the [HACKING][3] and [TESTING][4]
+   documents).
 
-3. Squash commits into one, well-formatted commit. If you really feel like there
+3. We try to follow a consistent and readable code style. Read the
+   [CODE_STYLE][5] document and please make sure that your code complies.
+
+4. Squash commits into one, well-formatted commit. If you really feel like there
    should be more than one commit in your branch, then you're probably trying to
    introduce more than one feature and you should make another branch for
    it.
@@ -48,10 +51,12 @@ give us permission to use your contributions.
        If applied, this commit will <insert summary here>.
        ```
 
-4. Submit a pull request to get changes from your branch into master. Mention
+5. Submit a pull request to get changes from your branch into master. Mention
    which bug is being resolved in the description of the pull request (bonus
    points if it's a hyperlink to the bug itself).
 
 [1]: http://www.ubuntu.com/legal/contributors/
 [2]: https://bugs.launchpad.net/snapcraft
 [3]: HACKING.md
+[4]: TESTING.md
+[5]: CODE_STYLE.md

--- a/integration_tests/plugins/test_autotools_plugin.py
+++ b/integration_tests/plugins/test_autotools_plugin.py
@@ -16,6 +16,8 @@
 
 import os
 
+from testtools.matchers import Equals
+
 import snapcraft
 import integration_tests
 from snapcraft.tests.matchers import HasArchitecture
@@ -28,7 +30,7 @@ class AutotoolsPluginTestCase(integration_tests.TestCase):
 
         binary_output = self.get_output_ignoring_non_zero_exit(
             os.path.join(self.stage_dir, 'bin', 'test'))
-        self.assertEqual('Hello world\n', binary_output)
+        self.assertThat(binary_output, Equals('Hello world\n'))
 
     def test_cross_compiling(self):
         if snapcraft.ProjectOptions().deb_arch != 'amd64':

--- a/integration_tests/plugins/test_cmake_plugin.py
+++ b/integration_tests/plugins/test_cmake_plugin.py
@@ -16,6 +16,8 @@
 
 import os
 
+from testtools.matchers import Equals
+
 import integration_tests
 
 
@@ -26,4 +28,4 @@ class CmakePluginTestCase(integration_tests.TestCase):
 
         binary_output = self.get_output_ignoring_non_zero_exit(
             os.path.join(self.stage_dir, 'bin', 'cmake-hello'))
-        self.assertEqual("It's a CMake world\n", binary_output)
+        self.assertThat(binary_output, Equals("It's a CMake world\n"))

--- a/integration_tests/plugins/test_go_plugin.py
+++ b/integration_tests/plugins/test_go_plugin.py
@@ -18,7 +18,7 @@ import os
 import subprocess
 
 import yaml
-from testtools.matchers import FileContains, FileExists, Not
+from testtools.matchers import Equals, FileContains, FileExists, Not
 
 import integration_tests
 import snapcraft
@@ -34,7 +34,7 @@ class GoPluginTestCase(integration_tests.TestCase):
         binary_output = subprocess.check_output(
             os.path.join(self.stage_dir, 'bin', os.path.basename(self.path)),
             universal_newlines=True)
-        self.assertEqual('Hello snapcrafter\n', binary_output)
+        self.assertThat(binary_output, Equals('Hello snapcrafter\n'))
 
     def test_building_multiple_main_packages(self):
         self.run_snapcraft('stage', 'go-with-multiple-main-packages')

--- a/integration_tests/plugins/test_godeps_plugin.py
+++ b/integration_tests/plugins/test_godeps_plugin.py
@@ -19,7 +19,7 @@ import subprocess
 
 import fixtures
 import testscenarios
-from testtools.matchers import FileExists, Not
+from testtools.matchers import Equals, FileExists, Not
 
 import integration_tests
 
@@ -39,7 +39,7 @@ class GodepsPluginTestCase(testscenarios.WithScenarios,
         check_hash_command = [binary, 'check', output, 'password']
         output = subprocess.check_output(check_hash_command)
 
-        self.assertEqual('Equal', output.decode('UTF-8').strip(' \n'))
+        self.assertThat(output.decode('UTF-8').strip(' \n'), Equals('Equal'))
 
     def test_stage(self):
         if self.set_gobin:

--- a/integration_tests/plugins/test_gulp_plugin.py
+++ b/integration_tests/plugins/test_gulp_plugin.py
@@ -17,6 +17,8 @@
 import os
 import subprocess
 
+from testtools.matchers import Equals
+
 import integration_tests
 
 
@@ -27,4 +29,4 @@ class GulpPluginTestCase(integration_tests.TestCase):
 
         binary_output = subprocess.check_output(
             [os.path.join(self.stage_dir, 'hello-world')])
-        self.assertEqual(b'I was installed with gulp\n', binary_output)
+        self.assertThat(binary_output, Equals(b'I was installed with gulp\n'))

--- a/integration_tests/plugins/test_make_plugin.py
+++ b/integration_tests/plugins/test_make_plugin.py
@@ -18,6 +18,7 @@ import os
 
 from testtools.matchers import (
     DirExists,
+    Equals,
     Not
 )
 
@@ -31,7 +32,7 @@ class MakePluginTestCase(integration_tests.TestCase):
 
         binary_output = self.get_output_ignoring_non_zero_exit(
             os.path.join(self.stage_dir, 'bin', 'test'))
-        self.assertEqual('Hello world\n', binary_output)
+        self.assertThat(binary_output, Equals('Hello world\n'))
 
     def test_clean_make_plugin(self):
         self.run_snapcraft('snap', 'make-hello')
@@ -49,11 +50,11 @@ class MakePluginTestCase(integration_tests.TestCase):
 
         binary_output = self.get_output_ignoring_non_zero_exit(
             os.path.join(self.stage_dir, 'bin', 'test'))
-        self.assertEqual('Hello world\n', binary_output)
+        self.assertThat(binary_output, Equals('Hello world\n'))
 
     def test_stage_make_with_artifacts(self):
         self.run_snapcraft('stage', 'make-with-artifacts')
 
         binary_output = self.get_output_ignoring_non_zero_exit(
             os.path.join(self.stage_dir, 'test'))
-        self.assertEqual('Hello World!\n', binary_output)
+        self.assertThat(binary_output, Equals('Hello World!\n'))

--- a/integration_tests/plugins/test_meson_plugin.py
+++ b/integration_tests/plugins/test_meson_plugin.py
@@ -16,6 +16,8 @@
 
 import os
 
+from testtools.matchers import Equals
+
 import integration_tests
 
 
@@ -26,4 +28,4 @@ class MesonPluginTestCase(integration_tests.TestCase):
 
         binary_output = self.get_output_ignoring_non_zero_exit(
             os.path.join(self.stage_dir, 'opt', 'bin', 'meson-hello'))
-        self.assertEqual('Hello world\n', binary_output)
+        self.assertThat(binary_output, Equals('Hello world\n'))

--- a/integration_tests/plugins/test_nil_plugin.py
+++ b/integration_tests/plugins/test_nil_plugin.py
@@ -17,6 +17,8 @@
 import os
 import subprocess
 
+from testtools.matchers import Equals
+
 import integration_tests
 
 
@@ -26,7 +28,7 @@ class NilPluginTestCase(integration_tests.TestCase):
         self.run_snapcraft('snap', 'nil-basic')
 
         dirs = os.listdir(self.prime_dir)
-        self.assertEqual(['meta'], dirs)
+        self.assertThat(dirs, Equals(['meta']))
 
     def test_nil_no_additional_properties(self):
         exception = self.assertRaises(

--- a/integration_tests/plugins/test_python_plugin.py
+++ b/integration_tests/plugins/test_python_plugin.py
@@ -21,6 +21,7 @@ from textwrap import dedent
 
 from testtools.matchers import (
     DirExists,
+    Equals,
     FileContains,
     FileExists
 )
@@ -83,9 +84,9 @@ class PythonPluginTestCase(integration_tests.TestCase):
         with open(python_entry_point) as f:
             python_shebang = f.readline().strip()
 
-        self.assertEqual('#!/usr/bin/env python2', python2_shebang)
-        self.assertEqual('#!/usr/bin/env python3', python3_shebang)
-        self.assertEqual('#!/usr/bin/env python3', python_shebang)
+        self.assertThat(python2_shebang, Equals('#!/usr/bin/env python2'))
+        self.assertThat(python3_shebang, Equals('#!/usr/bin/env python3'))
+        self.assertThat(python_shebang, Equals('#!/usr/bin/env python3'))
 
     def test_pbr_console_scripts(self):
         """Verify that LP: #1670852 doesn't come back."""
@@ -145,8 +146,8 @@ class PythonPluginTestCase(integration_tests.TestCase):
             pyc_files.extend([f for f in files if f.endswith('pyc')])
             pth_files.extend([f for f in files if f.endswith('pth')])
 
-        self.assertEqual([], pyc_files)
-        self.assertEqual([], pth_files)
+        self.assertThat(pyc_files, Equals([]))
+        self.assertThat(pth_files, Equals([]))
 
     def test_build_doesnt_get_bad_install_directory_lp1586546(self):
         """Verify that LP: #1586546 doesn't come back."""
@@ -175,11 +176,11 @@ class PythonPluginTestCase(integration_tests.TestCase):
                 self.parts_dir, 'python2', 'install', 'usr', 'lib',
                 'python2*', 'dist-packages', 'yaml'))[0],
             DirExists())
-        self.assertEqual(
+        self.assertThat(
             glob(os.path.join(
                 self.parts_dir, 'python2', 'install', 'lib',
                 'python2*', 'site-packages', 'yaml')),
-            [])
+            Equals([]))
 
         self.assertThat(
             glob(os.path.join(
@@ -191,11 +192,11 @@ class PythonPluginTestCase(integration_tests.TestCase):
                 self.parts_dir, 'python3', 'install', 'usr', 'lib',
                 'python3*', 'dist-packages', 'yaml'))[0],
             DirExists())
-        self.assertEqual(
+        self.assertThat(
             glob(os.path.join(
                 self.parts_dir, 'python3', 'install', 'lib',
                 'python3*', 'site-packages', 'yaml')),
-            [])
+            Equals([]))
 
     def test_pull_a_package_from_bzr(self):
         self.run_snapcraft('pull', 'pip-bzr')

--- a/integration_tests/plugins/test_rust_plugin.py
+++ b/integration_tests/plugins/test_rust_plugin.py
@@ -21,7 +21,7 @@ import subprocess
 import fixtures
 import testscenarios
 import yaml
-from testtools.matchers import FileExists, MatchesRegex, Not
+from testtools.matchers import Equals, FileExists, MatchesRegex, Not
 
 import snapcraft
 import integration_tests
@@ -52,7 +52,7 @@ class RustPluginTestCase(RustPluginBaseTestCase):
 
         binary_output = self.get_output_ignoring_non_zero_exit(
             os.path.join(self.stage_dir, 'bin', 'rust-hello'))
-        self.assertEqual('There is rust on snaps!\n', binary_output)
+        self.assertThat(binary_output, Equals('There is rust on snaps!\n'))
 
     def test_stage_rust_with_revision(self):
         self.run_snapcraft('stage', 'rust-with-revision')
@@ -66,14 +66,16 @@ class RustPluginTestCase(RustPluginBaseTestCase):
 
         binary_output = self.get_output_ignoring_non_zero_exit(
             os.path.join(self.stage_dir, 'bin', 'simple-rust'))
-        self.assertEqual('Conditional features work!\n', binary_output)
+        self.assertThat(binary_output, Equals('Conditional features work!\n'))
 
     def test_stage_rust_with_source_subdir(self):
         self.run_snapcraft('stage', 'rust-subdir')
 
         binary_output = self.get_output_ignoring_non_zero_exit(
             os.path.join(self.stage_dir, 'bin', 'rust-subdir'))
-        self.assertEqual('Rust in a subdirectory works\n', binary_output)
+        self.assertThat(
+            binary_output,
+            Equals('Rust in a subdirectory works\n'))
         # Test for bug https://bugs.launchpad.net/snapcraft/+bug/1654764
         self.assertThat('Cargo.lock', Not(FileExists()))
 

--- a/integration_tests/plugins/test_scons_plugin.py
+++ b/integration_tests/plugins/test_scons_plugin.py
@@ -16,6 +16,8 @@
 
 import os
 
+from testtools.matchers import Equals
+
 import integration_tests
 
 
@@ -26,4 +28,4 @@ class SconsPluginTestCase(integration_tests.TestCase):
 
         binary_output = self.get_output_ignoring_non_zero_exit(
             os.path.join(self.stage_dir, 'opt', 'bin', 'main'))
-        self.assertEqual('Hello world\n', binary_output)
+        self.assertThat(binary_output, Equals('Hello world\n'))

--- a/integration_tests/plugins/test_tar_plugin.py
+++ b/integration_tests/plugins/test_tar_plugin.py
@@ -18,6 +18,7 @@ import os
 
 from testtools.matchers import (
     DirExists,
+    Equals,
     FileExists
 )
 
@@ -59,7 +60,7 @@ class TarPluginTestCase(integration_tests.TestCase):
 
         binary_output = self.get_output_ignoring_non_zero_exit(
             os.path.join(self.stage_dir, 'bin', 'test'))
-        self.assertEqual('tarproject\n', binary_output)
+        self.assertThat(binary_output, Equals('tarproject\n'))
 
         # Regression test for
         # https://bugs.launchpad.net/snapcraft/+bug/1500728

--- a/integration_tests/store/test_store_close.py
+++ b/integration_tests/store/test_store_close.py
@@ -52,8 +52,8 @@ class ChannelClosingTestCase(integration_tests.StoreTestCase):
         snap_path = '{}_{}_{}.snap'.format(name, version, 'all')
         self.assertThat(snap_path, FileExists())
         self.register(name)
-        self.assertEqual(0, self.push(snap_path, release='edge,beta'))
+        self.assertThat(self.push(snap_path, release='edge,beta'), Equals(0))
 
         expected = 'The beta channel is now closed.'
         status = self.close(name, 'beta', expected=expected)
-        self.assertEqual(0, status)
+        self.assertThat(status, Equals(0))

--- a/integration_tests/store/test_store_gated.py
+++ b/integration_tests/store/test_store_gated.py
@@ -16,6 +16,8 @@
 
 import os
 
+from testtools.matchers import Equals
+
 import integration_tests
 
 
@@ -31,23 +33,32 @@ class GatedTestCase(integration_tests.StoreTestCase):
         self.addCleanup(self.logout)
         self.login()
         validations = [('snap-1', '3'), ('snap-2', '5')]
-        self.assertEqual(0, self.gated('ubuntu-core', validations))
+        self.assertThat(self.gated('ubuntu-core', validations), Equals(0))
 
     def test_gated_no_login_failure(self):
-        self.assertEqual(1, self.gated(
-            'ubuntu-core', expected_output='Have you run "snapcraft login'))
+        self.assertThat(
+            self.gated(
+                'ubuntu-core',
+                expected_output='Have you run "snapcraft login'),
+            Equals(1))
 
     def test_gated_unknown_snap_failure(self):
         self.addCleanup(self.logout)
         self.login()
-        self.assertEqual(1, self.gated(
-            'unknown', expected_output="Snap 'unknown' was not found"))
+        self.assertThat(
+            self.gated(
+                'unknown',
+                expected_output="Snap 'unknown' was not found"),
+            Equals(1))
 
     def test_gated_no_validations(self):
         self.addCleanup(self.logout)
         self.login()
         snap_name = 'test-snap-with-no-validations'
-        self.assertEqual(0, self.gated(
-            snap_name,
-            expected_output="There are no validations for snap '{}'".format(
-                snap_name)))
+        self.assertThat(
+            self.gated(
+                snap_name,
+                expected_output=(
+                    "There are no validations for snap '{}'".format(
+                        snap_name))),
+            Equals(0))

--- a/integration_tests/store/test_store_register_key.py
+++ b/integration_tests/store/test_store_register_key.py
@@ -18,6 +18,7 @@ import os.path
 import shutil
 
 import fixtures
+from testtools.matchers import Equals
 
 import integration_tests
 
@@ -38,17 +39,17 @@ class RegisterKeyTestCase(integration_tests.StoreTestCase):
             self.skipTest(
                 'Cannot register test keys against staging/production until '
                 'we have a way to delete them again.')
-        self.assertEqual(0, self.register_key('default'))
+        self.assertThat(self.register_key('default'), Equals(0))
         self.addCleanup(self.logout)
         self.login()
-        self.assertEqual(0, self.list_keys([
+        self.assertThat(self.list_keys([
             (True, 'default',
              '2MEtiEuR7eCBUocloPokPhqPSTpkj7Kk'
              'TPQNZYOiZshFHdfzxlEhc8ITzpHq5azq'),
             (False, 'another',
              'OR59L-ompOW_CHbQ4pNDW5B-7BVY_V3Q'
              'kPu5-7uOFrZEEEAoI4h3yc_RQv3qmAFJ'),
-        ]))
+        ]), Equals(0))
 
     def test_failed_login_for_key_registration(self):
         status = self.register_key(

--- a/integration_tests/store/test_store_revisions.py
+++ b/integration_tests/store/test_store_revisions.py
@@ -19,7 +19,7 @@ import re
 import subprocess
 import unittest
 
-from testtools.matchers import Contains, FileExists, MatchesRegex
+from testtools.matchers import Contains, Equals, FileExists, MatchesRegex
 
 import integration_tests
 
@@ -125,7 +125,8 @@ class RevisionsTestCase(integration_tests.StoreTestCase):
         snap_path = '{}_{}_{}.snap'.format(name, version, 'all')
         self.assertThat(snap_path, FileExists())
         self.register(name)
-        self.assertEqual(0, self.push(snap_path, release='candidate,beta'))
+        self.assertThat(
+            self.push(snap_path, release='candidate,beta'), Equals(0))
 
         output = self.run_snapcraft(['revisions', name])
 

--- a/integration_tests/store/test_store_sign_build.py
+++ b/integration_tests/store/test_store_sign_build.py
@@ -66,7 +66,7 @@ class SignBuildTestCase(integration_tests.StoreTestCase):
         self.register(name)
 
         status = self.sign_build(snap_path, local=True)
-        self.assertEqual(0, status)
+        self.assertThat(status, Equals(0))
 
         snap_build_path = '{}-build'.format(snap_path)
         self.assertThat(snap_build_path, FileExists())
@@ -91,12 +91,12 @@ class SignBuildTestCase(integration_tests.StoreTestCase):
         self.run_snapcraft('snap', self.project)
         self.assertThat(self.snap_path, FileExists())
 
-        self.assertEqual(0, self.register_key('default'))
+        self.assertThat(self.register_key('default'), Equals(0))
         self.addCleanup(self.logout)
         self.login()
 
         status = self.sign_build(self.snap_path)
-        self.assertEqual(0, status)
+        self.assertThat(status, Equals(0))
         self.assertThat(self.snap_build_path, FileExists())
         self.assertThat(self.snap_build_path,
                         FileContains(matcher=Contains('type: snap-build')))

--- a/integration_tests/store/test_store_status.py
+++ b/integration_tests/store/test_store_status.py
@@ -18,7 +18,7 @@ import os
 import subprocess
 import unittest
 
-from testtools.matchers import Contains, FileExists
+from testtools.matchers import Equals, Contains, FileExists
 
 import integration_tests
 
@@ -95,7 +95,9 @@ class StatusTestCase(integration_tests.StoreTestCase):
         snap_path = '{}_{}_{}.snap'.format(name, version, 'all')
         self.assertThat(snap_path, FileExists())
         self.register(name)
-        self.assertEqual(0, self.push(snap_path, release='candidate,beta'))
+        self.assertThat(
+            self.push(snap_path, release='candidate,beta'),
+            Equals(0))
 
         output = self.run_snapcraft(['status', name])
         expected = '\n'.join((

--- a/integration_tests/store/test_store_validate.py
+++ b/integration_tests/store/test_store_validate.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016, 2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -18,6 +18,7 @@ import os
 import shutil
 
 import fixtures
+from testtools.matchers import Equals
 
 import integration_tests
 
@@ -38,24 +39,29 @@ class ValidateTestCase(integration_tests.StoreTestCase):
     def test_validate_success(self):
         self.addCleanup(self.logout)
         self.login()
-        self.assertEqual(0, self.validate('ubuntu-core', [
-            "ubuntu-core=3", "test-snap=4"]))
+        self.assertThat(
+            self.validate('ubuntu-core', [
+                "ubuntu-core=3", "test-snap=4"]),
+            Equals(0))
 
     def test_validate_unknown_snap_failure(self):
         self.addCleanup(self.logout)
         self.login()
-        self.assertEqual(1, self.validate('unknown', [
-            "ubuntu-core=3", "test-snap=4"],
-            expected_error="Snap 'unknown' was not found."))
+        self.assertThat(
+            self.validate('unknown', ["ubuntu-core=3", "test-snap=4"],
+                          expected_error="Snap 'unknown' was not found."),
+            Equals(1))
 
     def test_validate_bad_argument(self):
         self.addCleanup(self.logout)
         self.login()
-        self.assertEqual(1, self.validate('ubuntu-core', [
-            "ubuntu-core=foo"],
-            expected_error='format must be name=revision'))
+        self.assertThat(
+            self.validate('ubuntu-core', ["ubuntu-core=foo"],
+                          expected_error='format must be name=revision'),
+            Equals(1))
 
     def test_validate_no_login_failure(self):
-        self.assertEqual(1, self.validate('ubuntu-core', [
-            "ubuntu-core=3", "test-snap=4"],
-            expected_error='Have you run "snapcraft login"'))
+        self.assertThat(
+            self.validate('ubuntu-core', ["ubuntu-core=3", "test-snap=4"],
+                          expected_error='Have you run "snapcraft login"'),
+            Equals(1))

--- a/integration_tests/test_after.py
+++ b/integration_tests/test_after.py
@@ -78,7 +78,7 @@ class AfterTestCase(integration_tests.TestCase):
             subprocess.CalledProcessError,
             self.run_snapcraft, 'build')
 
-        self.assertEqual(1, exception.returncode)
+        self.assertThat(exception.returncode, Equals(1))
 
     def test_pull_with_tree_of_dependencies(self):
         self.run_snapcraft(

--- a/integration_tests/test_alias.py
+++ b/integration_tests/test_alias.py
@@ -20,7 +20,7 @@ import stat
 import yaml
 
 import integration_tests
-from testtools.matchers import FileExists
+from testtools.matchers import Equals, FileExists
 
 
 # FIXME: Ideally this would be a snaps test so we can run the aliases, but that
@@ -43,5 +43,6 @@ class AliasTestCase(integration_tests.TestCase):
             data = yaml.load(fp)
 
         expected_aliases = ['hi.sh', 'howdy.sh']
-        self.assertEqual(set(expected_aliases),
-                         set(data['apps']['hello']['aliases']))
+        self.assertThat(
+            set(data['apps']['hello']['aliases']),
+            Equals(set(expected_aliases)))

--- a/integration_tests/test_asset_recording.py
+++ b/integration_tests/test_asset_recording.py
@@ -21,6 +21,7 @@ import yaml
 
 import fixtures
 import testscenarios
+from testtools.matchers import Equals
 
 import snapcraft
 import integration_tests
@@ -67,7 +68,7 @@ class ManifestRecordingTestCase(AssetRecordingBaseTestCase):
         with open(recorded_yaml_path) as recorded_yaml_file:
             recorded_yaml = yaml.load(recorded_yaml_file)
 
-        self.assertEqual(recorded_yaml['architectures'], ['all'])
+        self.assertThat(recorded_yaml['architectures'], Equals(['all']))
 
     def test_prime_without_architectures_records_current_arch(self):
         """Test the recorded manifest for a basic snap
@@ -83,9 +84,9 @@ class ManifestRecordingTestCase(AssetRecordingBaseTestCase):
         with open(recorded_yaml_path) as recorded_yaml_file:
             recorded_yaml = yaml.load(recorded_yaml_file)
 
-        self.assertEqual(
+        self.assertThat(
             recorded_yaml['architectures'],
-            [snapcraft.ProjectOptions().deb_arch])
+            Equals([snapcraft.ProjectOptions().deb_arch]))
 
 
 class ManifestRecordingBuildPackagesTestCase(
@@ -125,8 +126,9 @@ class ManifestRecordingBuildPackagesTestCase(
         with open(recorded_yaml_path) as recorded_yaml_file:
             recorded_yaml = yaml.load(recorded_yaml_file)
 
-        self.assertEqual(
-            recorded_yaml['build-packages'], expected_packages_with_version)
+        self.assertThat(
+            recorded_yaml['build-packages'],
+            Equals(expected_packages_with_version))
 
 
 class ManifestRecordingStagePackagesTestCase(AssetRecordingBaseTestCase):
@@ -155,9 +157,9 @@ class ManifestRecordingStagePackagesTestCase(AssetRecordingBaseTestCase):
         with open(recorded_yaml_path) as recorded_yaml_file:
             recorded_yaml = yaml.load(recorded_yaml_file)
 
-        self.assertEqual(
+        self.assertThat(
             recorded_yaml['parts'][part_name]['stage-packages'],
-            source_yaml['parts'][part_name]['stage-packages'])
+            Equals(source_yaml['parts'][part_name]['stage-packages']))
 
     def test_prime_without_packages_version(self):
         """Test the recorded manifest for a snap with packages
@@ -184,9 +186,9 @@ class ManifestRecordingStagePackagesTestCase(AssetRecordingBaseTestCase):
         with open(recorded_yaml_path) as recorded_yaml_file:
             recorded_yaml = yaml.load(recorded_yaml_file)
 
-        self.assertEqual(
+        self.assertThat(
             recorded_yaml['parts'][part_name]['stage-packages'],
-            expected_packages)
+            Equals(expected_packages))
 
     def test_prime_with_packages_missing_dependency(self):
         """Test the recorded manifest for a snap with packages
@@ -214,9 +216,9 @@ class ManifestRecordingStagePackagesTestCase(AssetRecordingBaseTestCase):
         with open(recorded_yaml_path) as recorded_yaml_file:
             recorded_yaml = yaml.load(recorded_yaml_file)
 
-        self.assertEqual(
+        self.assertThat(
             recorded_yaml['parts'][part_name]['stage-packages'],
-            expected_packages)
+            Equals(expected_packages))
 
 
 class ManifestRecordingBzrSourceTestCase(
@@ -237,8 +239,8 @@ class ManifestRecordingBzrSourceTestCase(
             recorded_yaml = yaml.load(recorded_yaml_file)
 
         commit = self.get_revno()
-        self.assertEqual(
-            recorded_yaml['parts']['bzr']['source-commit'], commit)
+        self.assertThat(
+            recorded_yaml['parts']['bzr']['source-commit'], Equals(commit))
 
 
 class ManifestRecordingGitSourceTestCase(
@@ -259,8 +261,9 @@ class ManifestRecordingGitSourceTestCase(
             recorded_yaml = yaml.load(recorded_yaml_file)
 
         commit = self.get_revno()
-        self.assertEqual(
-            recorded_yaml['parts']['git']['source-commit'], commit)
+        self.assertThat(
+            recorded_yaml['parts']['git']['source-commit'],
+            Equals(commit))
 
 
 class ManifestRecordingHgSourceTestCase(
@@ -282,8 +285,9 @@ class ManifestRecordingHgSourceTestCase(
             recorded_yaml = yaml.load(recorded_yaml_file)
 
         commit = self.get_id()
-        self.assertEqual(
-            recorded_yaml['parts']['mercurial']['source-commit'], commit)
+        self.assertThat(
+            recorded_yaml['parts']['mercurial']['source-commit'],
+            Equals(commit))
 
 
 class ManifestRecordingSubversionSourceTestCase(
@@ -311,5 +315,5 @@ class ManifestRecordingSubversionSourceTestCase(
         with open(recorded_yaml_path) as recorded_yaml_file:
             recorded_yaml = yaml.load(recorded_yaml_file)
 
-        self.assertEqual(
-            recorded_yaml['parts']['svn']['source-commit'], '1')
+        self.assertThat(
+            recorded_yaml['parts']['svn']['source-commit'], Equals('1'))

--- a/integration_tests/test_build.py
+++ b/integration_tests/test_build.py
@@ -18,6 +18,7 @@ import subprocess
 
 from testtools.matchers import (
     Contains,
+    Equals,
     Not,
 )
 
@@ -32,7 +33,7 @@ class BuildTestCase(integration_tests.TestCase):
             self.run_snapcraft, ['build', 'invalid-part-name'],
             'go-hello', debug=debug)
 
-        self.assertEqual(2, exception.returncode)
+        self.assertThat(exception.returncode, Equals(2))
         self.assertThat(exception.output, Contains(
             "part named 'invalid-part-name' is not defined"))
 

--- a/integration_tests/test_build_properties.py
+++ b/integration_tests/test_build_properties.py
@@ -17,7 +17,7 @@
 import os
 import yaml
 
-from testtools.matchers import FileExists
+from testtools.matchers import Equals, FileExists
 
 import integration_tests
 
@@ -47,8 +47,8 @@ class BuildPropertiesTestCase(integration_tests.TestCase):
         # Verify that the contents of the dependencies made it in as well.
         self.assertTrue('foo' in state.properties)
         self.assertTrue('stage-packages' in state.properties)
-        self.assertEqual('bar', state.properties['foo'])
-        self.assertEqual(['curl'], state.properties['stage-packages'])
+        self.assertThat(state.properties['foo'], Equals('bar'))
+        self.assertThat(state.properties['stage-packages'], Equals(['curl']))
 
     def test_build_with_arch(self):
         self.run_snapcraft(['build', '--target-arch=i386', 'go-hello'],
@@ -58,7 +58,7 @@ class BuildPropertiesTestCase(integration_tests.TestCase):
         self.assertThat(state_file, FileExists())
         with open(state_file) as f:
             state = yaml.load(f)
-        self.assertEqual(state.project_options['deb_arch'], 'i386')
+        self.assertThat(state.project_options['deb_arch'], Equals('i386'))
 
     def test_arch_with_build(self):
         self.run_snapcraft(['--target-arch=i386', 'build', 'go-hello'],
@@ -68,4 +68,4 @@ class BuildPropertiesTestCase(integration_tests.TestCase):
         self.assertThat(state_file, FileExists())
         with open(state_file) as f:
             state = yaml.load(f)
-        self.assertEqual(state.project_options['deb_arch'], 'i386')
+        self.assertThat(state.project_options['deb_arch'], Equals('i386'))

--- a/integration_tests/test_bzr_source.py
+++ b/integration_tests/test_bzr_source.py
@@ -16,6 +16,8 @@
 
 import subprocess
 
+from testtools.matchers import Equals
+
 import integration_tests
 
 
@@ -32,13 +34,13 @@ class BzrSourceTestCase(integration_tests.BzrSourceBaseTestCase):
         revno = subprocess.check_output(
             ['bzr', 'revno', '-r', '-1', 'parts/bzr/src'],
             universal_newlines=True).strip()
-        self.assertEqual('2', revno)
+        self.assertThat(revno, Equals('2'))
         # test pull doesn't fail
         self.run_snapcraft('pull')
         revno = subprocess.check_output(
             ['bzr', 'revno', '-r', '-1', 'parts/bzr/src'],
             universal_newlines=True).strip()
-        self.assertEqual('2', revno)
+        self.assertThat(revno, Equals('2'))
 
     def test_pull_bzr_tag(self):
         self.copy_project_to_cwd('bzr-tag')
@@ -52,11 +54,11 @@ class BzrSourceTestCase(integration_tests.BzrSourceBaseTestCase):
         # test initial branch
         self.run_snapcraft('pull')
         revno = self.get_revno('parts/bzr/src')
-        self.assertEqual('1', revno)
+        self.assertThat(revno, Equals('1'))
         # test pull doesn't fail
         self.run_snapcraft('pull')
         revno = self.get_revno('parts/bzr/src')
-        self.assertEqual('1', revno)
+        self.assertThat(revno, Equals('1'))
 
     def test_pull_bzr_commit(self):
         self.copy_project_to_cwd('bzr-commit')
@@ -67,8 +69,8 @@ class BzrSourceTestCase(integration_tests.BzrSourceBaseTestCase):
         # test initial branch
         self.run_snapcraft('pull')
         revno = self.get_revno('parts/bzr/src')
-        self.assertEqual('1', revno)
+        self.assertThat(revno, Equals('1'))
         # test pull doesn't fail
         self.run_snapcraft('pull')
         revno = self.get_revno('parts/bzr/src')
-        self.assertEqual('1', revno)
+        self.assertThat(revno, Equals('1'))

--- a/integration_tests/test_environment.py
+++ b/integration_tests/test_environment.py
@@ -17,7 +17,7 @@
 import os
 import subprocess
 
-from testtools.matchers import FileContains
+from testtools.matchers import Equals, FileContains
 
 import integration_tests
 
@@ -62,6 +62,6 @@ class EnvironmentTestCase(integration_tests.TestCase):
             os.path.join(self.stage_dir, 'bin', 'cmake-with-env-var')])
         path = os.path.join(
             self.path, self.parts_dir, 'cmake-project', 'install')
-        self.assertEqual(
-            "When I was built I was installed to {}\n".format(path),
-            binary_output.decode('utf-8'))
+        self.assertThat(
+            binary_output.decode('utf-8'),
+            Equals("When I was built I was installed to {}\n".format(path)))

--- a/integration_tests/test_git_source.py
+++ b/integration_tests/test_git_source.py
@@ -19,7 +19,7 @@ import subprocess
 import shutil
 from textwrap import dedent
 
-from testtools.matchers import Contains, FileExists
+from testtools.matchers import Contains, Equals, FileExists
 import integration_tests
 
 
@@ -40,11 +40,11 @@ class GitSourceTestCase(integration_tests.GitSourceBaseTestCase):
 
         self.run_snapcraft('pull')
         revno = self._get_git_revno('parts/git/src')
-        self.assertEqual('"2"', revno)
+        self.assertThat(revno, Equals('"2"'))
 
         self.run_snapcraft('pull')
         revno = self._get_git_revno('parts/git/src')
-        self.assertEqual('"2"', revno)
+        self.assertThat(revno, Equals('"2"'))
 
     def test_pull_git_tag(self):
         self.copy_project_to_cwd('git-tag')
@@ -58,11 +58,11 @@ class GitSourceTestCase(integration_tests.GitSourceBaseTestCase):
 
         self.run_snapcraft('pull')
         revno = self._get_git_revno('parts/git/src')
-        self.assertEqual('"1"', revno)
+        self.assertThat(revno, Equals('"1"'))
 
         self.run_snapcraft('pull')
         revno = self._get_git_revno('parts/git/src')
-        self.assertEqual('"1"', revno)
+        self.assertThat(revno, Equals('"1"'))
 
     def test_pull_git_commit(self):
         self.copy_project_to_cwd('git-commit')
@@ -74,7 +74,7 @@ class GitSourceTestCase(integration_tests.GitSourceBaseTestCase):
         # The test uses "HEAD^" so we can only test it once
         self.run_snapcraft('pull')
         revno = self._get_git_revno('parts/git/src')
-        self.assertEqual('"1"', revno)
+        self.assertThat(revno, Equals('"1"'))
 
     def test_pull_git_branch(self):
         self.copy_project_to_cwd('git-branch')
@@ -95,11 +95,11 @@ class GitSourceTestCase(integration_tests.GitSourceBaseTestCase):
 
         self.run_snapcraft('pull')
         revno = self._get_git_revno('parts/git/src', revrange='-2')
-        self.assertEqual('"3"\n"1"', revno)
+        self.assertThat(revno, Equals('"3"\n"1"'))
 
         self.run_snapcraft('pull')
         revno = self._get_git_revno('parts/git/src', revrange='-2')
-        self.assertEqual('"3"\n"1"', revno)
+        self.assertThat(revno, Equals('"3"\n"1"'))
 
     def test_pull_git_with_depth(self):
         """Regression test for LP: #1627772."""

--- a/integration_tests/test_hg_source.py
+++ b/integration_tests/test_hg_source.py
@@ -17,7 +17,7 @@
 import os
 import subprocess
 
-from testtools.matchers import FileExists
+from testtools.matchers import Equals, FileExists
 
 import integration_tests
 
@@ -36,12 +36,12 @@ class HgSourceTestCase(integration_tests.HgSourceBaseTestCase):
         self.run_snapcraft('pull')
         revno = self.get_revno(
             os.path.join(self.parts_dir, 'mercurial', 'src'))
-        self.assertEqual('"2"', revno)
+        self.assertThat(revno, Equals('"2"'))
 
         self.run_snapcraft('pull')
         revno = self.get_revno(
             os.path.join(self.parts_dir, 'mercurial', 'src'))
-        self.assertEqual('"2"', revno)
+        self.assertThat(revno, Equals('"2"'))
 
     def test_pull_hg_tag(self):
         self.copy_project_to_cwd('hg-tag')
@@ -59,14 +59,14 @@ class HgSourceTestCase(integration_tests.HgSourceBaseTestCase):
             'ls -1 {} | wc -l '.format(
                 os.path.join(self.parts_dir, 'mercurial', 'src')),
             shell=True, universal_newlines=True).strip()
-        self.assertEqual('1', revno)
+        self.assertThat(revno, Equals('1'))
 
         self.run_snapcraft('pull')
         revno = subprocess.check_output(
             'ls -1 {} | wc -l '.format(
                 os.path.join(self.parts_dir, 'mercurial', 'src')),
             shell=True, universal_newlines=True).strip()
-        self.assertEqual('1', revno)
+        self.assertThat(revno, Equals('1'))
 
     def test_pull_hg_commit(self):
         self.copy_project_to_cwd('hg-commit')
@@ -82,14 +82,14 @@ class HgSourceTestCase(integration_tests.HgSourceBaseTestCase):
             'ls -1 {} | wc -l '.format(
                 os.path.join(self.parts_dir, 'mercurial', 'src')),
             shell=True, universal_newlines=True).strip()
-        self.assertEqual('1', revno)
+        self.assertThat(revno, Equals('1'))
 
         self.run_snapcraft('pull')
         revno = subprocess.check_output(
             'ls -1 {} | wc -l '.format(
                 os.path.join(self.parts_dir, 'mercurial', 'src')),
             shell=True, universal_newlines=True).strip()
-        self.assertEqual('1', revno)
+        self.assertThat(revno, Equals('1'))
 
     def test_pull_hg_branch(self):
         self.copy_project_to_cwd('hg-branch')

--- a/integration_tests/test_parser.py
+++ b/integration_tests/test_parser.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016, 2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -20,6 +20,8 @@ import subprocess
 
 import integration_tests
 import testscenarios
+
+from testtools.matchers import Equals
 from snapcraft.tests import fixture_setup
 
 
@@ -41,7 +43,7 @@ class ParserTestCase(integration_tests.TestCase):
                 subprocess.CalledProcessError,
                 self.run_snapcraft_parser, args)
 
-        self.assertEqual(os.path.exists(part_file), expect_output)
+        self.assertThat(os.path.exists(part_file), Equals(expect_output))
 
 
 class TestParser(ParserTestCase):

--- a/integration_tests/test_parts.py
+++ b/integration_tests/test_parts.py
@@ -16,8 +16,8 @@
 
 import os
 
-from testtools.matchers import Contains
 import yaml
+from testtools.matchers import Contains, Equals
 
 import integration_tests
 
@@ -70,7 +70,7 @@ class PartsTestCase(integration_tests.TestCase):
                 ],
             },
         }
-        self.assertEqual(expected_part, part)
+        self.assertThat(part, Equals(expected_part))
 
 
 class PartsWithFilesetsTestCase(integration_tests.TestCase):
@@ -113,6 +113,6 @@ class PartsWithFilesetsTestCase(integration_tests.TestCase):
                 "source": "https://github.com/jocave/simple-make-filesets.git",
             },
         }
-        self.assertEqual(expected_part, part)
+        self.assertThat(part, Equals(expected_part))
 
         self.run_snapcraft('snap', 'wiki-filesets')

--- a/integration_tests/test_prime.py
+++ b/integration_tests/test_prime.py
@@ -21,6 +21,7 @@ from textwrap import dedent
 import testscenarios
 from testtools.matchers import (
     Contains,
+    Equals,
     FileContains,
     FileExists,
     Not,
@@ -79,7 +80,7 @@ class PrimeTestCase(integration_tests.TestCase):
             self.run_snapcraft, ['prime', 'invalid-part-name'],
             'prime-from-stage', debug=debug)
 
-        self.assertEqual(2, exception.returncode)
+        self.assertThat(exception.returncode, Equals(2))
         self.assertThat(exception.output, Contains(
             "part named 'invalid-part-name' is not defined"))
 

--- a/integration_tests/test_pull_properties.py
+++ b/integration_tests/test_pull_properties.py
@@ -55,8 +55,8 @@ class PullPropertiesTestCase(integration_tests.TestCase):
         self.assertTrue(len(state.assets['stage-packages']) > 0)
         self.assertIn('build-packages', state.assets)
         self.assertTrue('stage-packages' in state.properties)
-        self.assertEqual('bar', state.properties['foo'])
-        self.assertEqual(['curl'], state.properties['stage-packages'])
+        self.assertThat(state.properties['foo'], Equals('bar'))
+        self.assertThat(state.properties['stage-packages'], Equals(['curl']))
 
     def test_pull_with_arch(self):
         self.run_snapcraft(['pull', '--target-arch=i386', 'go-hello'],
@@ -66,7 +66,7 @@ class PullPropertiesTestCase(integration_tests.TestCase):
         self.assertThat(state_file, FileExists())
         with open(state_file) as f:
             state = yaml.load(f)
-        self.assertEqual(state.project_options['deb_arch'], 'i386')
+        self.assertThat(state.project_options['deb_arch'], Equals('i386'))
 
     def test_arch_with_pull(self):
         self.run_snapcraft(['--target-arch=i386', 'pull', 'go-hello'],
@@ -76,7 +76,7 @@ class PullPropertiesTestCase(integration_tests.TestCase):
         self.assertThat(state_file, FileExists())
         with open(state_file) as f:
             state = yaml.load(f)
-        self.assertEqual(state.project_options['deb_arch'], 'i386')
+        self.assertThat(state.project_options['deb_arch'], Equals('i386'))
 
 
 class AssetTrackingTestCase(integration_tests.TestCase):
@@ -295,5 +295,6 @@ class SubversionAssetTrackingTestCase(integration_tests.TestCase):
             state = yaml.load(f)
 
         self.assertIn('source-details', state.assets)
-        self.assertEqual(expected_commit,
-                         state.assets['source-details']['source-commit'])
+        self.assertThat(
+            state.assets['source-details']['source-commit'],
+            Equals(expected_commit))

--- a/integration_tests/test_snap.py
+++ b/integration_tests/test_snap.py
@@ -20,6 +20,7 @@ import subprocess
 import fixtures
 import testtools
 from testtools.matchers import (
+    Equals,
     EndsWith,
     FileContains,
     FileExists,
@@ -62,7 +63,7 @@ class SnapTestCase(integration_tests.TestCase):
         for binary, expected_output in binary_scenarios:
             output = subprocess.check_output(
                 os.path.join(self.prime_dir, binary), universal_newlines=True)
-            self.assertEqual(expected_output, output)
+            self.assertThat(output, Equals(expected_output))
 
         with testtools.ExpectedException(subprocess.CalledProcessError):
             subprocess.check_output(

--- a/integration_tests/test_stage.py
+++ b/integration_tests/test_stage.py
@@ -20,6 +20,7 @@ import subprocess
 import fixtures
 from testtools.matchers import (
     Contains,
+    Equals,
     FileExists,
     Not
 )
@@ -34,7 +35,7 @@ class StageTestCase(integration_tests.TestCase):
             subprocess.CalledProcessError,
             self.run_snapcraft, 'stage', 'conflicts', debug=debug)
 
-        self.assertEqual(2, exception.returncode)
+        self.assertThat(exception.returncode, Equals(2))
         expected_conflicts = (
             "Parts 'p1' and 'p2' have the following file paths in common "
             "which have different contents:\n    bin/test\n")
@@ -66,7 +67,7 @@ class StageTestCase(integration_tests.TestCase):
             subprocess.CalledProcessError,
             self.run_snapcraft, 'stage', 'conflicts')
 
-        self.assertEqual(2, exception.returncode)
+        self.assertThat(exception.returncode, Equals(2))
         expected_conflicts = (
             "Parts 'p1' and 'p2' have the following file paths in common "
             "which have different contents:\n    bin/test\n")

--- a/integration_tests/test_svn_pull.py
+++ b/integration_tests/test_svn_pull.py
@@ -17,7 +17,7 @@
 import os
 import subprocess
 
-from testtools.matchers import FileExists
+from testtools.matchers import Equals, FileExists
 
 import integration_tests
 
@@ -41,7 +41,7 @@ class SubversionSourceTestCase(integration_tests.SubversionSourceBaseTestCase):
         self.run_snapcraft('pull')
         part_src_path = os.path.join(self.parts_dir, 'svn', 'src')
         revno = subprocess.check_output(['svnversion', part_src_path]).strip()
-        self.assertEqual(b'1', revno)
+        self.assertThat(revno, Equals(b'1'))
         self.assertThat(os.path.join(part_src_path, 'file'), FileExists())
 
     def test_pull_svn_update(self):
@@ -75,6 +75,6 @@ class SubversionSourceTestCase(integration_tests.SubversionSourceBaseTestCase):
 
         self.run_snapcraft('pull')
         revno = subprocess.check_output(['svnversion', part_src_path]).strip()
-        self.assertEqual(b'2', revno)
+        self.assertThat(revno, Equals(b'2'))
         self.assertThat(os.path.join(part_src_path, 'file'), FileExists())
         self.assertThat(os.path.join(part_src_path, 'filetwo'), FileExists())

--- a/snapcraft/tests/cache/test_snap.py
+++ b/snapcraft/tests/cache/test_snap.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015, 2016, 2017 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -62,10 +62,9 @@ class SnapCacheTestCase(SnapCacheBaseTestCase):
             file_utils.calculate_sha3_384(self.snap_path)
         )
 
-        self.assertEqual(
-            expected_snap_path,
-            cached_snap_path
-        )
+        self.assertThat(
+            cached_snap_path,
+            Equals(expected_snap_path))
         self.assertTrue(os.path.isfile(cached_snap_path))
 
     def test_snap_cache_get_latest(self):
@@ -121,7 +120,7 @@ parts:
             latest_hash
         )
 
-        self.assertEqual(expected_snap_path, latest_snap)
+        self.assertThat(latest_snap, Equals(expected_snap_path))
 
     def test_snap_cache_get_by_hash(self):
         self.useFixture(fixture_setup.FakeTerminal())
@@ -135,9 +134,9 @@ parts:
         # get snap by hash
         snap = snap_cache.get(deb_arch='amd64', snap_hash=snap_hash)
 
-        self.assertEqual(
-            os.path.join(snap_cache.snap_cache_root, 'amd64', snap_hash),
-            snap
+        self.assertThat(
+            snap, Equals(
+                os.path.join(snap_cache.snap_cache_root, 'amd64', snap_hash))
         )
 
 
@@ -195,13 +194,13 @@ parts:
         snap_file_2_dir, snap_file_2_hash = os.path.split(snap_file_2_path)
 
         # confirm expected snap cached
-        self.assertEqual(2, len(os.listdir(snap_file_2_dir)))
+        self.assertThat(len(os.listdir(snap_file_2_dir)), Equals(2))
 
         # prune
         pruned_files = snap_cache.prune(deb_arch=self.deb_arch,
                                         keep_hash=snap_file_2_hash)
 
-        self.assertEqual(1, len(pruned_files))
+        self.assertThat(len(pruned_files), Equals(1))
         self.assertIn(
             os.path.join(
                 snap_cache.snap_cache_root,

--- a/snapcraft/tests/commands/test_clean.py
+++ b/snapcraft/tests/commands/test_clean.py
@@ -126,7 +126,7 @@ parts:
             call(['lxc', 'delete', '-f', fake_lxd.name]),
         ])
         # no other commands should be run in the container
-        self.assertEquals(fake_lxd.check_call_mock.call_count, 1)
+        self.assertThat(fake_lxd.check_call_mock.call_count, Equals(1))
 
     def test_clean_containerized_with_part(self):
         fake_lxd = fixture_setup.FakeLXD()

--- a/snapcraft/tests/commands/test_collaborate.py
+++ b/snapcraft/tests/commands/test_collaborate.py
@@ -15,16 +15,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-
 from unittest import mock
 
 import fixtures
+from testtools.matchers import Equals
 
 from snapcraft import (
     storeapi,
     tests
 )
-
 from snapcraft import _store
 
 
@@ -105,9 +104,10 @@ class CollaborateErrorsTestCase(CollaborateBaseTestCase):
             _store.collaborate,
             'badrequest', 'keyname')
 
-        self.assertEqual(
-                'Received error 400: "The given `snap-id` does not match '
-                'the assertion\'s."', str(err))
+        self.assertThat(
+            str(err),
+            Equals('Received error 400: "The given `snap-id` does not match '
+                   'the assertion\'s."'))
 
     def test_collaborate_unchanged_collaborators(self):
         self.edit_collaborators_mock.return_value = [{

--- a/snapcraft/tests/commands/test_create_key.py
+++ b/snapcraft/tests/commands/test_create_key.py
@@ -39,8 +39,8 @@ class CreateKeyTestCase(CommandBaseTestCase):
             'The snapd package is not installed.'))
 
         mock_installed.assert_called_with('snapd')
-        self.assertEqual(0, mock_check_output.call_count)
-        self.assertEqual(0, mock_check_call.call_count)
+        self.assertThat(mock_check_output.call_count, Equals(0))
+        self.assertThat(mock_check_call.call_count, Equals(0))
 
     @mock.patch('subprocess.check_call')
     @mock.patch('subprocess.check_output')
@@ -84,7 +84,7 @@ class CreateKeyTestCase(CommandBaseTestCase):
 
         self.assertThat(str(raised), Equals(
             "You have already registered a key named 'new-key'"))
-        self.assertEqual(0, mock_check_call.call_count)
+        self.assertThat(mock_check_call.call_count, Equals(0))
 
     @mock.patch('subprocess.check_call')
     @mock.patch.object(storeapi.SCAClient, 'get_account_information')

--- a/snapcraft/tests/commands/test_enable_ci.py
+++ b/snapcraft/tests/commands/test_enable_ci.py
@@ -47,7 +47,7 @@ class EnableCITestCase(CommandBaseTestCase):
         self.assertThat(result.exit_code, Equals(0))
         self.assertThat(result.output, Contains(
             '<module docstring>'))
-        self.assertEqual(1, mock_enable.call_count)
+        self.assertThat(mock_enable.call_count, Equals(1))
 
     @mock.patch.object(travis, 'refresh')
     def test_enable_ci_travis_refresh(self, mock_refresh):
@@ -55,4 +55,4 @@ class EnableCITestCase(CommandBaseTestCase):
 
         self.assertThat(result.exit_code, Equals(0))
         self.assertThat(result.output, Equals(''))
-        self.assertEqual(1, mock_refresh.call_count)
+        self.assertThat(mock_refresh.call_count, Equals(1))

--- a/snapcraft/tests/commands/test_help.py
+++ b/snapcraft/tests/commands/test_help.py
@@ -45,7 +45,7 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
 
         result = self.run_command(['help', 'does-not-exist'])
 
-        self.assertEqual(1, result.exit_code)
+        self.assertThat(result.exit_code, Equals(1))
         self.assertThat(
             'The plugin does not exist. Run `snapcraft '
             'list-plugins` to see the available plugins.\n',
@@ -54,16 +54,18 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
     def test_print_module_help_when_no_help_for_valid_plugin(self):
         result = self.run_command(['help', 'jdk'])
 
-        self.assertEqual('The plugin has no documentation\n', result.output)
+        self.assertThat(
+            result.output,
+            Equals('The plugin has no documentation\n'))
 
     def test_print_module_help_for_valid_plugin(self):
         result = self.run_command(['help', 'nil'])
 
         expected = 'The nil plugin is'
         output = result.output[:len(expected)]
-        self.assertEqual(output, expected,
-                         'The help message does not start with {!r} but with '
-                         '{!r} instead'.format(expected, output))
+        self.assertThat(output, Equals(expected),
+                        'The help message does not start with {!r} but with '
+                        '{!r} instead'.format(expected, output))
 
     def test_print_module_named_with_dashes_help_for_valid_plugin(self):
         result = self.run_command(['help', 'plainbox-provider'])
@@ -77,9 +79,9 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
         expected = 'Help on module snapcraft.plugins.nil in snapcraft.plugins'
         output = result.output[:len(expected)]
 
-        self.assertEqual(output, expected,
-                         'The help message does not start with {!r} but with '
-                         '{!r} instead'.format(expected, output))
+        self.assertThat(output, Equals(expected),
+                        'The help message does not start with {!r} but with '
+                        '{!r} instead'.format(expected, output))
 
     def test_print_topics(self):
         result = self.run_command(['help', 'topics'])
@@ -94,9 +96,9 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
 
         expected = "Common 'source' options."
         output = result.output[:len(expected)]
-        self.assertEqual(output, expected,
-                         'The help message does not start with {!r} but with '
-                         '{!r} instead'.format(expected, output))
+        self.assertThat(output, Equals(expected),
+                        'The help message does not start with {!r} but with '
+                        '{!r} instead'.format(expected, output))
 
     def test_no_unicode_in_help_strings(self):
         helps = ['topics']
@@ -133,7 +135,7 @@ class TopicWithDevelTestCase(HelpCommandBaseTestCase):
 
         result = self.run_command(['help', self.topic, '--devel'])
         output = result.output[:len(expected[self.topic])]
-        self.assertEqual(
-            output, expected[self.topic],
+        self.assertThat(
+            output, Equals(expected[self.topic]),
             'The help message does not start with {!r} but with '
             '{!r} instead'.format(expected[self.topic], output))

--- a/snapcraft/tests/commands/test_list_keys.py
+++ b/snapcraft/tests/commands/test_list_keys.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 from textwrap import dedent
 from unittest import mock
 
@@ -42,7 +43,7 @@ class ListKeysCommandTestCase(CommandBaseTestCase):
         self.assertThat(str(raised), Contains(
             'The snapd package is not installed.'))
         mock_installed.assert_called_with('snapd')
-        self.assertEqual(0, mock_check_output.call_count)
+        self.assertThat(mock_check_output.call_count, Equals(0))
 
     @mock.patch('subprocess.check_output')
     @mock.patch('snapcraft.internal.repo.Repo.is_package_installed')

--- a/snapcraft/tests/commands/test_login.py
+++ b/snapcraft/tests/commands/test_login.py
@@ -75,10 +75,10 @@ class LoginCommandTestCase(CommandBaseTestCase):
             storeapi.constants.TWO_FACTOR_WARNING)))
         self.assertThat(result.output, Contains('Login successful.'))
 
-        self.assertEqual(2, self.mock_input.call_count)
+        self.assertThat(self.mock_input.call_count, Equals(2))
         self.mock_input.assert_has_calls([
             mock.call('Email: '), mock.call('Second-factor auth: ')])
-        self.assertEqual(2, mock_login.call_count)
+        self.assertThat(mock_login.call_count, Equals(2))
         mock_login.assert_has_calls([
             mock.call(
                 'user@example.com', mock.ANY, acls=None, packages=None,

--- a/snapcraft/tests/commands/test_prime.py
+++ b/snapcraft/tests/commands/test_prime.py
@@ -70,14 +70,14 @@ class PrimeCommandTestCase(LifecycleCommandsBaseTestCase):
         result = self.run_command(['prime'])
 
         self.assertThat(result.exit_code, Equals(0))
-        self.assertEqual(
-            'Preparing to pull prime0 \n'
-            'Pulling prime0 \n'
-            'Preparing to build prime0 \n'
-            'Building prime0 \n'
-            'Staging prime0 \n'
-            'Priming prime0 \n',
-            fake_logger.output)
+        self.assertThat(
+            fake_logger.output,
+            Equals('Preparing to pull prime0 \n'
+                   'Pulling prime0 \n'
+                   'Preparing to build prime0 \n'
+                   'Building prime0 \n'
+                   'Staging prime0 \n'
+                   'Priming prime0 \n'))
 
         self.assertThat(self.prime_dir, DirExists())
         self.assertThat(self.parts_dir, DirExists())
@@ -91,9 +91,9 @@ class PrimeCommandTestCase(LifecycleCommandsBaseTestCase):
         result = self.run_command(['prime'])
 
         self.assertThat(result.exit_code, Equals(0))
-        self.assertEqual(
-            'Skipping pull prime0 (already ran)\n'
-            'Skipping build prime0 (already ran)\n'
-            'Skipping stage prime0 (already ran)\n'
-            'Skipping prime prime0 (already ran)\n',
-            fake_logger.output)
+        self.assertThat(
+            fake_logger.output,
+            Equals('Skipping pull prime0 (already ran)\n'
+                   'Skipping build prime0 (already ran)\n'
+                   'Skipping stage prime0 (already ran)\n'
+                   'Skipping prime prime0 (already ran)\n'))

--- a/snapcraft/tests/commands/test_push.py
+++ b/snapcraft/tests/commands/test_push.py
@@ -322,7 +322,7 @@ class PushCommandDeltasTestCase(PushCommandBaseTestCase):
 
         self.assertThat(result.exit_code, Equals(0))
         _, kwargs = self.mock_upload.call_args
-        self.assertEqual(kwargs.get('delta_format'), 'xdelta3')
+        self.assertThat(kwargs.get('delta_format'), Equals('xdelta3'))
 
     def test_push_with_upload_failure_falls_back(self):
         # Upload
@@ -432,4 +432,4 @@ class PushCommandDeltasWithPruneTestCase(PushCommandBaseTestCase):
             snap = snap.format(deb_arch)
             self.assertThat(os.path.join(snap_cache, snap),
                             Not(FileExists()))
-        self.assertEqual(1, len(os.listdir(snap_cache)))
+        self.assertThat(len(os.listdir(snap_cache)), Equals(1))

--- a/snapcraft/tests/commands/test_register_key.py
+++ b/snapcraft/tests/commands/test_register_key.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import json
 from simplejson.scanner import JSONDecodeError
 from textwrap import dedent
@@ -39,7 +40,7 @@ class RegisterKeyTestCase(CommandBaseTestCase):
         self.assertThat(str(raised), Contains(
             'The snapd package is not installed.'))
         mock_installed.assert_called_with('snapd')
-        self.assertEqual(0, mock_check_output.call_count)
+        self.assertThat(mock_check_output.call_count, Equals(0))
 
     @mock.patch.object(storeapi.SCAClient, 'register_key')
     @mock.patch.object(storeapi.SCAClient, 'get_account_information')
@@ -75,7 +76,7 @@ class RegisterKeyTestCase(CommandBaseTestCase):
             'sample.person@canonical.com', 'secret',
             one_time_password='123456', acls=['modify_account_key'],
             packages=None, channels=None, save=False)
-        self.assertEqual(1, mock_register_key.call_count)
+        self.assertThat(mock_register_key.call_count, Equals(1))
         expected_assertion = dedent('''\
             type: account-key-request
             account-id: abcd
@@ -97,7 +98,7 @@ class RegisterKeyTestCase(CommandBaseTestCase):
             self.run_command, ['register-key'])
 
         self.assertThat(str(raised), Contains('You have no usable keys'))
-        self.assertEqual(0, mock_input.call_count)
+        self.assertThat(mock_input.call_count, Equals(0))
 
     @mock.patch('subprocess.check_output')
     @mock.patch('builtins.input')
@@ -114,7 +115,7 @@ class RegisterKeyTestCase(CommandBaseTestCase):
             self.run_command, ['register-key'])
 
         self.assertThat(str(raised), Contains('You have no usable keys'))
-        self.assertEqual(0, mock_input.call_count)
+        self.assertThat(mock_input.call_count, Equals(0))
 
     @mock.patch('subprocess.check_output')
     @mock.patch('builtins.input')
@@ -130,7 +131,7 @@ class RegisterKeyTestCase(CommandBaseTestCase):
 
         self.assertThat(str(raised), Contains(
             "You have no usable key named 'nonexistent'"))
-        self.assertEqual(0, mock_input.call_count)
+        self.assertThat(mock_input.call_count, Equals(0))
 
     @mock.patch.object(storeapi.SCAClient, 'register_key')
     @mock.patch.object(storeapi.SCAClient, 'get_account_information')
@@ -155,7 +156,7 @@ class RegisterKeyTestCase(CommandBaseTestCase):
 
         self.assertThat(str(raised), Equals(
             'Cannot continue without logging in successfully.'))
-        self.assertEqual(1, mock_input.call_count)
+        self.assertThat(mock_input.call_count, Equals(1))
 
     @mock.patch('snapcraft._store._login')
     @mock.patch.object(storeapi.SCAClient, 'register_key')
@@ -249,15 +250,16 @@ class RegisterKeyTestCase(CommandBaseTestCase):
         mock_input.assert_has_calls(
             [mock.call('Key number: '), mock.call('Key number: ')])
 
-        self.assertEqual(
-            'We strongly recommend enabling multi-factor authentication: '
-            'https://help.ubuntu.com/community/SSO/FAQs/2FA\n'
-            'Registering key ...\n'
-            'Done. The key "another" ({}) may be used to sign your '
-            'assertions.\n'.format(get_sample_key('another')['sha3-384']),
-            self.fake_logger.output)
+        self.assertThat(
+            self.fake_logger.output,
+            Equals(
+                'We strongly recommend enabling multi-factor authentication: '
+                'https://help.ubuntu.com/community/SSO/FAQs/2FA\n'
+                'Registering key ...\n'
+                'Done. The key "another" ({}) may be used to sign your '
+                'assertions.\n'.format(get_sample_key('another')['sha3-384'])))
 
-        self.assertEqual(1, mock_register_key.call_count)
+        self.assertThat(mock_register_key.call_count, Equals(1))
         expected_assertion = dedent('''\
             type: account-key-request
             account-id: abcd

--- a/snapcraft/tests/commands/test_sign_build.py
+++ b/snapcraft/tests/commands/test_sign_build.py
@@ -65,7 +65,7 @@ class SignBuildTestCase(CommandBaseTestCase):
         self.assertThat(str(raised), Contains(
             'The snapd package is not installed.'))
         mock_installed.assert_called_with('snapd')
-        self.assertEqual(0, mock_check_output.call_count)
+        self.assertThat(mock_check_output.call_count, Equals(0))
 
     @mock.patch('subprocess.check_output')
     @mock.patch('snapcraft.internal.repo.Repo.is_package_installed')
@@ -78,7 +78,7 @@ class SignBuildTestCase(CommandBaseTestCase):
         self.assertThat(result.exit_code, Equals(2))
         self.assertThat(result.output, Contains(
             'Path "nonexisting.snap" does not exist'))
-        self.assertEqual(0, mock_check_output.call_count)
+        self.assertThat(mock_check_output.call_count, Equals(0))
 
     @mock.patch.object(storeapi.SCAClient, 'get_account_information')
     @mock.patch('subprocess.check_output')
@@ -106,7 +106,7 @@ class SignBuildTestCase(CommandBaseTestCase):
             'Your account lacks permission to assert builds for this '
             'snap. Make sure you are logged in as the publisher of '
             "'test-snap' for series '16'."))
-        self.assertEqual(0, mock_check_output.call_count)
+        self.assertThat(mock_check_output.call_count, Equals(0))
 
     @mock.patch.object(storeapi.SCAClient, 'get_account_information')
     @mock.patch('subprocess.check_output')

--- a/snapcraft/tests/commands/test_snap.py
+++ b/snapcraft/tests/commands/test_snap.py
@@ -456,12 +456,13 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
         self.assertThat(result.output, Contains(
             'Snapped snap-test_1.0_amd64.snap\n'))
 
-        self.assertEqual(
-            'Skipping pull part1 (already ran)\n'
-            'Skipping build part1 (already ran)\n'
-            'Skipping stage part1 (already ran)\n'
-            'Skipping prime part1 (already ran)\n',
-            fake_logger.output)
+        self.assertThat(
+            fake_logger.output,
+            Equals(
+                'Skipping pull part1 (already ran)\n'
+                'Skipping build part1 (already ran)\n'
+                'Skipping stage part1 (already ran)\n'
+                'Skipping prime part1 (already ran)\n'))
 
         self.popen_spy.assert_called_once_with([
             'mksquashfs', self.prime_dir, 'snap-test_1.0_amd64.snap',
@@ -612,15 +613,18 @@ type: os
             'Snapped snap-test_1.0_amd64.snap\n'))
 
         snap_build_renamed = snap_build + '.1234'
-        self.assertEqual([
-            'Preparing to pull part1 ',
-            'Pulling part1 ',
-            'Preparing to build part1 ',
-            'Building part1 ',
-            'Staging part1 ',
-            'Priming part1 ',
-            'Renaming stale build assertion to {}'.format(snap_build_renamed),
-            ], fake_logger.output.splitlines())
+        self.assertThat(
+            fake_logger.output.splitlines(),
+            Equals([
+                'Preparing to pull part1 ',
+                'Pulling part1 ',
+                'Preparing to build part1 ',
+                'Building part1 ',
+                'Staging part1 ',
+                'Priming part1 ',
+                'Renaming stale build assertion to {}'.format(
+                    snap_build_renamed),
+            ]))
 
         self.assertThat('snap-test_1.0_amd64.snap', FileExists())
         self.assertThat(snap_build, Not(FileExists()))

--- a/snapcraft/tests/commands/test_stage.py
+++ b/snapcraft/tests/commands/test_stage.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import logging
 import snapcraft.internal.errors
 
@@ -69,13 +70,13 @@ class StageCommandTestCase(LifecycleCommandsBaseTestCase):
         result = self.run_command(['stage'])
 
         self.assertThat(result.exit_code, Equals(0))
-        self.assertEqual(
-            'Preparing to pull stage0 \n'
-            'Pulling stage0 \n'
-            'Preparing to build stage0 \n'
-            'Building stage0 \n'
-            'Staging stage0 \n',
-            fake_logger.output)
+        self.assertThat(
+            fake_logger.output,
+            Equals('Preparing to pull stage0 \n'
+                   'Pulling stage0 \n'
+                   'Preparing to build stage0 \n'
+                   'Building stage0 \n'
+                   'Staging stage0 \n'))
 
         self.assertThat(self.stage_dir, DirExists())
         self.assertThat(self.parts_dir, DirExists())
@@ -89,8 +90,9 @@ class StageCommandTestCase(LifecycleCommandsBaseTestCase):
         result = self.run_command(['stage'])
 
         self.assertThat(result.exit_code, Equals(0))
-        self.assertEqual(
-            'Skipping pull stage0 (already ran)\n'
-            'Skipping build stage0 (already ran)\n'
-            'Skipping stage stage0 (already ran)\n',
-            fake_logger.output)
+        self.assertThat(
+            fake_logger.output,
+            Equals(
+                'Skipping pull stage0 (already ran)\n'
+                'Skipping build stage0 (already ran)\n'
+                'Skipping stage stage0 (already ran)\n'))

--- a/snapcraft/tests/commands/test_update.py
+++ b/snapcraft/tests/commands/test_update.py
@@ -74,8 +74,8 @@ class UpdateCommandTestCase(CommandBaseTestCase, TestWithFakeRemoteParts):
         with open(self.headers_yaml) as headers_file:
             headers = yaml.load(headers_file)
 
-        self.assertEqual(parts, expected_parts)
-        self.assertEqual(headers, expected_headers)
+        self.assertThat(parts, Equals(expected_parts))
+        self.assertThat(headers, Equals(expected_headers))
 
     def test_update_with_unchanged_date_does_not_download_again(self):
         result = self.run_command(['update'])

--- a/snapcraft/tests/pluginhandler/test_pluginhandler.py
+++ b/snapcraft/tests/pluginhandler/test_pluginhandler.py
@@ -61,9 +61,9 @@ class PluginTestCase(tests.TestCase):
         open(os.path.join(sourcedir, 'file1'), 'w').close()
         open(os.path.join(subdir, 'file2'), 'w').close()
 
-        self.assertEqual(
-            os.path.join(handler.code.build_basedir, source_subdir),
-            handler.code.builddir)
+        self.assertThat(
+            handler.code.builddir,
+            Equals(os.path.join(handler.code.build_basedir, source_subdir)))
 
         handler.build()
 
@@ -78,7 +78,8 @@ class PluginTestCase(tests.TestCase):
         os.makedirs(handler.sourcedir)
         open(os.path.join(handler.sourcedir, 'file'), 'w').close()
 
-        self.assertEqual(handler.code.build_basedir, handler.code.builddir)
+        self.assertThat(
+            handler.code.builddir, Equals(handler.code.build_basedir))
 
         handler.build()
 
@@ -112,7 +113,7 @@ class PluginTestCase(tests.TestCase):
             "Issue while loading part: unknown plugin: 'test_unexisting'"))
 
         # Make sure that nothing was added to sys.path.
-        self.assertEqual(path, sys.path)
+        self.assertThat(path, Equals(sys.path))
 
     def test_init_known_module_but_unknown_plugin_must_raise_exception(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
@@ -131,7 +132,7 @@ class PluginTestCase(tests.TestCase):
             "Issue while loading part: no plugin found in module '_ros'"))
 
         # Make sure that nothing was added to sys.path.
-        self.assertEqual(path, sys.path)
+        self.assertThat(path, Equals(sys.path))
 
     def test_fileset_include_excludes(self):
         stage_set = [
@@ -145,9 +146,10 @@ class PluginTestCase(tests.TestCase):
 
         include, exclude = pluginhandler._get_file_list(stage_set)
 
-        self.assertEqual(include, ['opt/something', 'usr/bin',
-                                   '-everything', r'\a'])
-        self.assertEqual(exclude, ['etc', 'usr/lib/*.a'])
+        self.assertThat(
+            include,
+            Equals(['opt/something', 'usr/bin', '-everything', r'\a']))
+        self.assertThat(exclude, Equals(['etc', 'usr/lib/*.a']))
 
     @patch.object(snapcraft.plugins.nil.NilPlugin, 'snap_fileset')
     def test_migratable_fileset_for_no_options_modification(
@@ -162,14 +164,16 @@ class PluginTestCase(tests.TestCase):
         expected_options = copy.deepcopy(handler.code.options)
 
         handler.migratable_fileset_for('stage')
-        self.assertEqual(vars(expected_options),
-                         vars(handler.code.options),
-                         'Expected options to be unmodified')
+        self.assertThat(
+            vars(handler.code.options),
+            Equals(vars(expected_options)),
+            'Expected options to be unmodified')
 
         handler.migratable_fileset_for('prime')
-        self.assertEqual(vars(expected_options),
-                         vars(handler.code.options),
-                         'Expected options to be unmodified')
+        self.assertThat(
+            vars(handler.code.options),
+            Equals(vars(expected_options)),
+            'Expected options to be unmodified')
 
     def test_fileset_only_includes(self):
         stage_set = [
@@ -179,8 +183,8 @@ class PluginTestCase(tests.TestCase):
 
         include, exclude = pluginhandler._get_file_list(stage_set)
 
-        self.assertEqual(include, ['opt/something', 'usr/bin'])
-        self.assertEqual(exclude, [])
+        self.assertThat(include, Equals(['opt/something', 'usr/bin']))
+        self.assertThat(exclude, Equals([]))
 
     def test_fileset_only_excludes(self):
         stage_set = [
@@ -190,8 +194,8 @@ class PluginTestCase(tests.TestCase):
 
         include, exclude = pluginhandler._get_file_list(stage_set)
 
-        self.assertEqual(include, ['*'])
-        self.assertEqual(exclude, ['etc', 'usr/lib/*.a'])
+        self.assertThat(include, Equals(['*']))
+        self.assertThat(exclude, Equals(['etc', 'usr/lib/*.a']))
 
     def test_migrate_snap_files_already_exists(self):
         os.makedirs('install')
@@ -210,9 +214,9 @@ class PluginTestCase(tests.TestCase):
 
         # Verify that the staged file is the one that was staged last
         with open('stage/foo', 'r') as f:
-            self.assertEqual(f.read(), 'installed',
-                             'Expected staging to allow overwriting of '
-                             'already-staged files')
+            self.assertThat(f.read(), Equals('installed'),
+                            'Expected staging to allow overwriting of '
+                            'already-staged files')
 
     def test_migrate_files_supports_no_follow_symlinks(self):
         os.makedirs('install')
@@ -230,8 +234,9 @@ class PluginTestCase(tests.TestCase):
         # Verify that the symlink was preserved
         self.assertTrue(os.path.islink(os.path.join('stage', 'bar')),
                         "Expected migrated 'bar' to still be a symlink.")
-        self.assertEqual('foo', os.readlink(os.path.join('stage', 'bar')),
-                         "Expected migrated 'bar' to point to 'foo'")
+        self.assertThat(os.readlink(os.path.join('stage', 'bar')),
+                        Equals('foo'),
+                        "Expected migrated 'bar' to point to 'foo'")
 
     def test_migrate_files_supports_follow_symlinks(self):
         os.makedirs('install')
@@ -250,8 +255,8 @@ class PluginTestCase(tests.TestCase):
         self.assertFalse(os.path.islink(os.path.join('stage', 'bar')),
                          "Expected migrated 'bar' to no longer be a symlink.")
         with open(os.path.join('stage', 'bar'), 'r') as f:
-            self.assertEqual(f.read(), 'installed',
-                             "Expected migrated 'bar' to be a copy of 'foo'")
+            self.assertThat(f.read(), Equals('installed'),
+                            "Expected migrated 'bar' to be a copy of 'foo'")
 
     @patch('os.chown')
     def test_migrate_files_preserves_ownership(self, chown_mock):
@@ -306,8 +311,10 @@ class PluginTestCase(tests.TestCase):
         pluginhandler._migrate_files(
             files, dirs, 'install', 'stage', follow_symlinks=True)
 
-        self.assertEqual(stat.S_IMODE(
-            os.stat(os.path.join('stage', 'foo')).st_mode), new_mode)
+        self.assertThat(
+            new_mode,
+            Equals(
+                stat.S_IMODE(os.stat(os.path.join('stage', 'foo')).st_mode)))
 
     @patch('os.chown')
     def test_migrate_files_preserves_file_mode_chown_permissions(self,
@@ -331,8 +338,10 @@ class PluginTestCase(tests.TestCase):
         pluginhandler._migrate_files(
             files, dirs, 'install', 'stage', follow_symlinks=True)
 
-        self.assertEqual(stat.S_IMODE(
-            os.stat(os.path.join('stage', 'foo')).st_mode), new_mode)
+        self.assertThat(
+            new_mode,
+            Equals(
+                stat.S_IMODE(os.stat(os.path.join('stage', 'foo')).st_mode)))
 
         self.assertTrue(chown_mock.called)
 
@@ -356,10 +365,14 @@ class PluginTestCase(tests.TestCase):
         pluginhandler._migrate_files(
             files, dirs, 'install', 'stage', follow_symlinks=True)
 
-        self.assertEqual(stat.S_IMODE(
-            os.stat(os.path.join('stage', 'foo')).st_mode), new_mode)
-        self.assertEqual(stat.S_IMODE(
-            os.stat(os.path.join('stage', 'foo', 'bar')).st_mode), new_mode)
+        self.assertThat(
+            new_mode,
+            Equals(
+                stat.S_IMODE(os.stat(os.path.join('stage', 'foo')).st_mode)))
+        self.assertThat(
+            new_mode,
+            Equals(stat.S_IMODE(
+                os.stat(os.path.join('stage', 'foo', 'bar')).st_mode)))
 
     @patch('importlib.import_module')
     @patch('snapcraft.internal.pluginhandler._load_local')
@@ -488,9 +501,10 @@ class PluginTestCase(tests.TestCase):
             mocks.loadplugin,
             'fake-part', 'plugin')
 
-        self.assertEqual(
-            "Invalid pull properties specified by 'plugin' plugin: ['bar']",
-            str(raised))
+        self.assertThat(
+            str(raised),
+            Equals("Invalid pull properties specified by 'plugin' plugin: "
+                   "['bar']"))
 
     def test_plugin_schema_invalid_build_hint(self):
         class Plugin(snapcraft.BasePlugin):
@@ -509,9 +523,10 @@ class PluginTestCase(tests.TestCase):
             ValueError,
             mocks.loadplugin, 'fake-part', 'plugin')
 
-        self.assertEqual(
-            "Invalid build properties specified by 'plugin' plugin: ['bar']",
-            str(raised))
+        self.assertThat(
+            str(raised),
+            Equals("Invalid build properties specified by 'plugin' plugin: "
+                   "['bar']"))
 
     def test_filesets_includes_without_relative_paths(self):
         raised = self.assertRaises(
@@ -630,7 +645,7 @@ class MigratePluginTestCase(tests.TestCase):
                 result.append(os.path.join(root, item))
         result.sort()
 
-        self.assertEqual(expected, result)
+        self.assertThat(result, Equals(expected))
 
 
 class MigratableFilesetsTestCase(tests.TestCase):
@@ -645,40 +660,44 @@ class MigratableFilesetsTestCase(tests.TestCase):
 
     def test_migratable_filesets_everything(self):
         files, dirs = pluginhandler._migratable_filesets(['*'], 'install')
-        self.assertEqual({'1', 'foo/2', 'foo/bar/3', 'foo/bar/baz/4'}, files)
-        self.assertEqual({'foo', 'foo/bar', 'foo/bar/baz'}, dirs)
+        self.assertThat(
+            files, Equals({'1', 'foo/2', 'foo/bar/3', 'foo/bar/baz/4'}))
+        self.assertThat(
+            dirs, Equals({'foo', 'foo/bar', 'foo/bar/baz'}))
 
     def test_migratable_filesets_foo(self):
         files, dirs = pluginhandler._migratable_filesets(['foo'], 'install')
-        self.assertEqual({'foo/2', 'foo/bar/3', 'foo/bar/baz/4'}, files)
-        self.assertEqual({'foo', 'foo/bar', 'foo/bar/baz'}, dirs)
+        self.assertThat(
+            files, Equals({'foo/2', 'foo/bar/3', 'foo/bar/baz/4'}))
+        self.assertThat(dirs, Equals({'foo', 'foo/bar', 'foo/bar/baz'}))
 
     def test_migratable_filesets_everything_in_foo(self):
         files, dirs = pluginhandler._migratable_filesets(['foo/*'], 'install')
-        self.assertEqual({'foo/2', 'foo/bar/3', 'foo/bar/baz/4'}, files)
-        self.assertEqual({'foo', 'foo/bar', 'foo/bar/baz'}, dirs)
+        self.assertThat(
+            files, Equals({'foo/2', 'foo/bar/3', 'foo/bar/baz/4'}))
+        self.assertThat(dirs, Equals({'foo', 'foo/bar', 'foo/bar/baz'}))
 
     def test_migratable_filesets_root_file(self):
         files, dirs = pluginhandler._migratable_filesets(['1'], 'install')
-        self.assertEqual({'1'}, files)
-        self.assertEqual(set(), dirs)
+        self.assertThat(files, Equals({'1'}))
+        self.assertThat(dirs, Equals(set()))
 
     def test_migratable_filesets_single_nested_file(self):
         files, dirs = pluginhandler._migratable_filesets(['foo/2'], 'install')
-        self.assertEqual({'foo/2'}, files)
-        self.assertEqual({'foo'}, dirs)
+        self.assertThat(files, Equals({'foo/2'}))
+        self.assertThat(dirs, Equals({'foo'}))
 
     def test_migratable_filesets_single_really_nested_file(self):
         files, dirs = pluginhandler._migratable_filesets(['foo/bar/2'],
                                                          'install')
-        self.assertEqual({'foo/bar/2'}, files)
-        self.assertEqual({'foo', 'foo/bar'}, dirs)
+        self.assertThat(files, Equals({'foo/bar/2'}))
+        self.assertThat(dirs, Equals({'foo', 'foo/bar'}))
 
     def test_migratable_filesets_single_really_really_nested_file(self):
         files, dirs = pluginhandler._migratable_filesets(['foo/bar/baz/3'],
                                                          'install')
-        self.assertEqual({'foo/bar/baz/3'}, files)
-        self.assertEqual({'foo', 'foo/bar', 'foo/bar/baz'}, dirs)
+        self.assertThat(files, Equals({'foo/bar/baz/3'}))
+        self.assertThat(dirs, Equals({'foo', 'foo/bar', 'foo/bar/baz'}))
 
 
 class OrganizeTestCase(tests.TestCase):
@@ -794,7 +813,7 @@ class OrganizeTestCase(tests.TestCase):
                 dir_path = os.path.join(base_dir, expect[1])
                 dir_contents = os.listdir(dir_path)
                 dir_contents.sort()
-                self.assertEqual(expect[0], dir_contents)
+                self.assertThat(dir_contents, Equals(expect[0]))
 
 
 class RealStageTestCase(tests.TestCase):
@@ -978,18 +997,18 @@ class StateTestCase(StateBaseTestCase):
 
     @patch('snapcraft.internal.repo.Repo')
     def test_pull_state(self, repo_mock):
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
         repo_mock.get_installed_build_packages.return_value = []
 
         self.handler.pull()
 
-        self.assertEqual('pull', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('pull'))
         state = states.get_state(self.handler.statedir, 'pull')
 
         self.assertTrue(state, 'Expected pull to save state YAML')
         self.assertTrue(type(state) is states.PullState)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertEqual(9, len(state.properties))
+        self.assertThat(len(state.properties), Equals(9))
         for expected in ['source', 'source-branch', 'source-commit',
                          'source-depth', 'source-subdir', 'source-tag',
                          'source-type', 'plugin', 'stage-packages']:
@@ -1006,24 +1025,24 @@ class StateTestCase(StateBaseTestCase):
         self.handler.code.options.foo = 'bar'
         self.handler._part_properties = {'foo': 'bar'}
 
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
 
         self.handler.pull()
 
-        self.assertEqual('pull', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('pull'))
         state = states.get_state(self.handler.statedir, 'pull')
 
         self.assertTrue(state, 'Expected pull to save state YAML')
         self.assertTrue(type(state) is states.PullState)
         self.assertTrue(type(state.properties) is OrderedDict)
         self.assertTrue('foo' in state.properties)
-        self.assertEqual(state.properties['foo'], 'bar')
+        self.assertThat(state.properties['foo'], Equals('bar'))
         self.assertTrue(type(state.project_options) is OrderedDict)
         self.assertTrue('deb_arch' in state.project_options)
 
     @patch.object(nil.NilPlugin, 'clean_pull')
     def test_clean_pull_state(self, mock_clean_pull):
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
 
         self.handler.pull()
 
@@ -1032,20 +1051,20 @@ class StateTestCase(StateBaseTestCase):
         # Verify that the plugin had clean_pull() called
         mock_clean_pull.assert_called_once_with()
 
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
 
     def test_build_state(self):
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
 
         self.handler.build()
 
-        self.assertEqual('build', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('build'))
         state = states.get_state(self.handler.statedir, 'build')
 
         self.assertTrue(state, 'Expected build to save state YAML')
         self.assertTrue(type(state) is states.BuildState)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertEqual(5, len(state.properties))
+        self.assertThat(len(state.properties), Equals(5))
         for expected in ['after', 'build-attributes', 'build-packages',
                          'disable-parallel', 'organize']:
             self.assertTrue(expected in state.properties)
@@ -1061,24 +1080,24 @@ class StateTestCase(StateBaseTestCase):
         self.handler.code.options.foo = 'bar'
         self.handler._part_properties = {'foo': 'bar'}
 
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
 
         self.handler.build()
 
-        self.assertEqual('build', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('build'))
         state = states.get_state(self.handler.statedir, 'build')
 
         self.assertTrue(state, 'Expected build to save state YAML')
         self.assertTrue(type(state) is states.BuildState)
         self.assertTrue(type(state.properties) is OrderedDict)
         self.assertTrue('foo' in state.properties)
-        self.assertEqual(state.properties['foo'], 'bar')
+        self.assertThat(state.properties['foo'], Equals('bar'))
         self.assertTrue(type(state.project_options) is OrderedDict)
         self.assertTrue('deb_arch' in state.project_options)
 
     @patch.object(nil.NilPlugin, 'clean_build')
     def test_clean_build_state(self, mock_clean_build):
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
 
         self.handler.mark_done('pull')
         self.handler.build()
@@ -1088,10 +1107,10 @@ class StateTestCase(StateBaseTestCase):
         # Verify that the plugin had clean_build() called
         mock_clean_build.assert_called_once_with()
 
-        self.assertEqual('pull', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('pull'))
 
     def test_stage_state(self):
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
 
         bindir = os.path.join(self.handler.code.installdir, 'bin')
         os.makedirs(bindir)
@@ -1101,7 +1120,7 @@ class StateTestCase(StateBaseTestCase):
         self.handler.mark_done('build')
         self.handler.stage()
 
-        self.assertEqual('stage', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('stage'))
         state = states.get_state(self.handler.statedir, 'stage')
 
         self.assertTrue(state, 'Expected stage to save state YAML')
@@ -1109,23 +1128,23 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(type(state.files) is set)
         self.assertTrue(type(state.directories) is set)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertEqual(2, len(state.files))
+        self.assertThat(len(state.files), Equals(2))
         self.assertTrue('bin/1' in state.files)
         self.assertTrue('bin/2' in state.files)
-        self.assertEqual(1, len(state.directories))
+        self.assertThat(len(state.directories), Equals(1))
         self.assertTrue('bin' in state.directories)
         self.assertTrue('stage' in state.properties)
-        self.assertEqual(state.properties['stage'], ['*'])
+        self.assertThat(state.properties['stage'], Equals(['*']))
         self.assertTrue('filesets' in state.properties)
-        self.assertEqual(state.properties['filesets'], {})
+        self.assertThat(state.properties['filesets'], Equals({}))
         self.assertTrue(type(state.project_options) is OrderedDict)
-        self.assertEqual(0, len(state.project_options))
+        self.assertThat(len(state.project_options), Equals(0))
 
     def test_stage_state_with_stage_keyword(self):
         self.handler.code.options.stage = ['bin/1']
         self.handler._part_properties = {'stage': ['bin/1']}
 
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
 
         bindir = os.path.join(self.handler.code.installdir, 'bin')
         os.makedirs(bindir)
@@ -1135,7 +1154,7 @@ class StateTestCase(StateBaseTestCase):
         self.handler.mark_done('build')
         self.handler.stage()
 
-        self.assertEqual('stage', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('stage'))
         state = states.get_state(self.handler.statedir, 'stage')
 
         self.assertTrue(state, 'Expected stage to save state YAML')
@@ -1143,19 +1162,19 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(type(state.files) is set)
         self.assertTrue(type(state.directories) is set)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertEqual(1, len(state.files))
+        self.assertThat(len(state.files), Equals(1))
         self.assertTrue('bin/1' in state.files)
-        self.assertEqual(1, len(state.directories))
+        self.assertThat(len(state.directories), Equals(1))
         self.assertTrue('bin' in state.directories)
         self.assertTrue('stage' in state.properties)
-        self.assertEqual(state.properties['stage'], ['bin/1'])
+        self.assertThat(state.properties['stage'], Equals(['bin/1']))
         self.assertTrue(type(state.project_options) is OrderedDict)
-        self.assertEqual(0, len(state.project_options))
+        self.assertThat(len(state.project_options), Equals(0))
 
-        self.assertEqual('stage', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('stage'))
 
     def test_clean_stage_state(self):
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
         bindir = os.path.join(self.stage_dir, 'bin')
         os.makedirs(bindir)
         open(os.path.join(bindir, '1'), 'w').close()
@@ -1168,11 +1187,11 @@ class StateTestCase(StateBaseTestCase):
 
         self.handler.clean_stage({})
 
-        self.assertEqual('build', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('build'))
         self.assertFalse(os.path.exists(bindir))
 
     def test_clean_stage_state_multiple_parts(self):
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
         bindir = os.path.join(self.stage_dir, 'bin')
         os.makedirs(bindir)
         open(os.path.join(bindir, '1'), 'w').close()
@@ -1186,7 +1205,7 @@ class StateTestCase(StateBaseTestCase):
 
         self.handler.clean_stage({})
 
-        self.assertEqual('build', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('build'))
         self.assertFalse(os.path.exists(os.path.join(bindir, '1')))
         self.assertFalse(os.path.exists(os.path.join(bindir, '2')))
         self.assertTrue(
@@ -1194,7 +1213,7 @@ class StateTestCase(StateBaseTestCase):
             "Expected 'bin/3' to remain as it wasn't staged by this part")
 
     def test_clean_stage_state_common_files(self):
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
         bindir = os.path.join(self.stage_dir, 'bin')
         os.makedirs(bindir)
         open(os.path.join(bindir, '1'), 'w').close()
@@ -1209,7 +1228,7 @@ class StateTestCase(StateBaseTestCase):
             'other_part': states.StageState({'bin/2'}, {'bin'})
         })
 
-        self.assertEqual('build', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('build'))
         self.assertFalse(os.path.exists(os.path.join(bindir, '1')))
         self.assertTrue(
             os.path.exists(os.path.join(bindir, '2')),
@@ -1221,17 +1240,17 @@ class StateTestCase(StateBaseTestCase):
             errors.MissingStateCleanError,
             self.handler.clean_stage, {})
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            "Failed to clean step 'stage': Missing necessary state. "
-            "This won't work until a complete clean has occurred.")
+            Equals("Failed to clean step 'stage': Missing necessary state. "
+                   "This won't work until a complete clean has occurred."))
 
     @patch('snapcraft.internal.pluginhandler._find_dependencies')
     @patch('shutil.copy')
     def test_prime_state(self, mock_copy, mock_find_dependencies):
         mock_find_dependencies.return_value = set()
 
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
 
         bindir = os.path.join(self.handler.code.installdir, 'bin')
         os.makedirs(bindir)
@@ -1242,7 +1261,7 @@ class StateTestCase(StateBaseTestCase):
         self.handler.stage()
         self.handler.prime()
 
-        self.assertEqual('prime', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('prime'))
         mock_find_dependencies.assert_called_once_with(self.handler.primedir,
                                                        {'bin/1', 'bin/2'})
         self.assertFalse(mock_copy.called)
@@ -1254,16 +1273,16 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(type(state.directories) is set)
         self.assertTrue(type(state.dependency_paths) is set)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertEqual(2, len(state.files))
+        self.assertThat(len(state.files), Equals(2))
         self.assertTrue('bin/1' in state.files)
         self.assertTrue('bin/2' in state.files)
-        self.assertEqual(1, len(state.directories))
+        self.assertThat(len(state.directories), Equals(1))
         self.assertTrue('bin' in state.directories)
-        self.assertEqual(0, len(state.dependency_paths))
+        self.assertThat(len(state.dependency_paths), Equals(0))
         self.assertTrue('prime' in state.properties)
-        self.assertEqual(state.properties['prime'], ['*'])
+        self.assertThat(state.properties['prime'], Equals(['*']))
         self.assertTrue(type(state.project_options) is OrderedDict)
-        self.assertEqual(0, len(state.project_options))
+        self.assertThat(len(state.project_options), Equals(0))
 
     @patch('snapcraft.internal.pluginhandler._find_dependencies')
     @patch('shutil.copy')
@@ -1271,7 +1290,7 @@ class StateTestCase(StateBaseTestCase):
                                                    mock_find_dependencies):
         mock_find_dependencies.return_value = set()
 
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
 
         bindir = os.path.join(self.handler.code.installdir, 'bin')
         os.makedirs(bindir)
@@ -1284,7 +1303,7 @@ class StateTestCase(StateBaseTestCase):
         self.handler.stage()
         self.handler.prime()
 
-        self.assertEqual('prime', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('prime'))
         # bin/2 shouldn't be in this list as it was already primed by another
         # part.
         mock_find_dependencies.assert_called_once_with(self.handler.primedir,
@@ -1298,15 +1317,15 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(type(state.directories) is set)
         self.assertTrue(type(state.dependency_paths) is set)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertEqual(1, len(state.files))
+        self.assertThat(len(state.files), Equals(1))
         self.assertTrue('bin/1' in state.files)
-        self.assertEqual(1, len(state.directories))
+        self.assertThat(len(state.directories), Equals(1))
         self.assertTrue('bin' in state.directories)
-        self.assertEqual(0, len(state.dependency_paths))
+        self.assertThat(len(state.dependency_paths), Equals(0))
         self.assertTrue('prime' in state.properties)
-        self.assertEqual(state.properties['prime'], ['*'])
+        self.assertThat(state.properties['prime'], Equals(['*']))
         self.assertTrue(type(state.project_options) is OrderedDict)
-        self.assertEqual(0, len(state.project_options))
+        self.assertThat(len(state.project_options), Equals(0))
 
     @patch('snapcraft.internal.pluginhandler._find_dependencies')
     @patch('snapcraft.internal.pluginhandler._migrate_files')
@@ -1318,7 +1337,7 @@ class StateTestCase(StateBaseTestCase):
             '{}/lib2/staged'.format(self.handler.stagedir),
         }
 
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
 
         bindir = os.path.join(self.handler.code.installdir, 'bin')
         os.makedirs(bindir)
@@ -1329,7 +1348,7 @@ class StateTestCase(StateBaseTestCase):
         self.handler.stage()
         self.handler.prime()
 
-        self.assertEqual('prime', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('prime'))
         mock_find_dependencies.assert_called_once_with(
             self.handler.primedir, {'bin/1', 'bin/2'})
         mock_migrate_files.assert_has_calls([
@@ -1346,19 +1365,19 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(type(state.directories) is set)
         self.assertTrue(type(state.dependency_paths) is set)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertEqual(2, len(state.files))
+        self.assertThat(len(state.files), Equals(2))
         self.assertTrue('bin/1' in state.files)
         self.assertTrue('bin/2' in state.files)
-        self.assertEqual(1, len(state.directories))
+        self.assertThat(len(state.directories), Equals(1))
         self.assertTrue('bin' in state.directories)
-        self.assertEqual(3, len(state.dependency_paths))
+        self.assertThat(len(state.dependency_paths), Equals(3))
         self.assertTrue('foo/bar' in state.dependency_paths)
         self.assertTrue('lib1' in state.dependency_paths)
         self.assertTrue('lib2' in state.dependency_paths)
         self.assertTrue('prime' in state.properties)
-        self.assertEqual(state.properties['prime'], ['*'])
+        self.assertThat(state.properties['prime'], Equals(['*']))
         self.assertTrue(type(state.project_options) is OrderedDict)
-        self.assertEqual(0, len(state.project_options))
+        self.assertThat(len(state.project_options), Equals(0))
 
     @patch('snapcraft.internal.pluginhandler._find_dependencies')
     @patch('snapcraft.internal.pluginhandler._migrate_files')
@@ -1377,7 +1396,7 @@ class StateTestCase(StateBaseTestCase):
             '{}/lib2/staged'.format(self.handler.stagedir),
         }
 
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
 
         bindir = os.path.join(self.handler.code.installdir, 'bin')
         os.makedirs(bindir)
@@ -1388,7 +1407,7 @@ class StateTestCase(StateBaseTestCase):
         mock_migrate_files.reset_mock()
         self.handler.prime()
 
-        self.assertEqual('prime', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('prime'))
         mock_find_dependencies.assert_called_once_with(
             self.handler.primedir, {'bin/file'})
         # Verify that only the part's files were migrated-- not the system
@@ -1402,7 +1421,7 @@ class StateTestCase(StateBaseTestCase):
         # Verify that only the part and staged libraries were saved into the
         # dependency paths, not the system dependency.
         self.assertTrue(type(state.dependency_paths) is set)
-        self.assertEqual(2, len(state.dependency_paths))
+        self.assertThat(len(state.dependency_paths), Equals(2))
         self.assertTrue('lib1' in state.dependency_paths)
         self.assertTrue('lib2' in state.dependency_paths)
 
@@ -1414,7 +1433,7 @@ class StateTestCase(StateBaseTestCase):
             '/foo/bar/baz'
         }
 
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
 
         bindir = os.path.join(self.handler.code.installdir, 'bin')
         foobardir = os.path.join(self.handler.code.installdir, 'foo', 'bar')
@@ -1431,7 +1450,7 @@ class StateTestCase(StateBaseTestCase):
         mock_migrate_files.reset_mock()
         self.handler.prime()
 
-        self.assertEqual('prime', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('prime'))
         mock_find_dependencies.assert_called_once_with(
             self.handler.primedir, {'bin/1', 'foo/bar/baz'})
         mock_migrate_files.assert_called_once_with(
@@ -1441,7 +1460,7 @@ class StateTestCase(StateBaseTestCase):
         state = states.get_state(self.handler.statedir, 'prime')
 
         self.assertTrue(type(state) is states.PrimeState)
-        self.assertEqual(1, len(state.dependency_paths))
+        self.assertThat(len(state.dependency_paths), Equals(1))
         self.assertTrue('foo/bar' in state.dependency_paths)
 
     @patch('snapcraft.internal.pluginhandler._find_dependencies')
@@ -1452,7 +1471,7 @@ class StateTestCase(StateBaseTestCase):
         self.handler = mocks.loadplugin(
             'test_part', part_properties={'prime': ['bin/1']})
 
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
 
         bindir = os.path.join(self.handler.code.installdir, 'bin')
         os.makedirs(bindir)
@@ -1463,7 +1482,7 @@ class StateTestCase(StateBaseTestCase):
         self.handler.stage()
         self.handler.prime()
 
-        self.assertEqual('prime', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('prime'))
         mock_find_dependencies.assert_called_once_with(self.handler.primedir,
                                                        {'bin/1'})
         self.assertFalse(mock_copy.called)
@@ -1475,18 +1494,18 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(type(state.directories) is set)
         self.assertTrue(type(state.dependency_paths) is set)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertEqual(1, len(state.files))
+        self.assertThat(len(state.files), Equals(1))
         self.assertTrue('bin/1' in state.files)
-        self.assertEqual(1, len(state.directories))
+        self.assertThat(len(state.directories), Equals(1))
         self.assertTrue('bin' in state.directories)
-        self.assertEqual(0, len(state.dependency_paths))
+        self.assertThat(len(state.dependency_paths), Equals(0))
         self.assertTrue('prime' in state.properties)
-        self.assertEqual(state.properties['prime'], ['bin/1'])
+        self.assertThat(state.properties['prime'], Equals(['bin/1']))
         self.assertTrue(type(state.project_options) is OrderedDict)
-        self.assertEqual(0, len(state.project_options))
+        self.assertThat(len(state.project_options), Equals(0))
 
     def test_clean_prime_state(self):
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
         bindir = os.path.join(self.prime_dir, 'bin')
         os.makedirs(bindir)
         open(os.path.join(bindir, '1'), 'w').close()
@@ -1499,11 +1518,11 @@ class StateTestCase(StateBaseTestCase):
 
         self.handler.clean_prime({})
 
-        self.assertEqual('stage', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('stage'))
         self.assertFalse(os.path.exists(bindir))
 
     def test_clean_prime_state_multiple_parts(self):
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
         bindir = os.path.join(self.prime_dir, 'bin')
         os.makedirs(bindir)
         open(os.path.join(bindir, '1'), 'w').close()
@@ -1517,7 +1536,7 @@ class StateTestCase(StateBaseTestCase):
 
         self.handler.clean_prime({})
 
-        self.assertEqual('stage', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('stage'))
         self.assertFalse(os.path.exists(os.path.join(bindir, '1')))
         self.assertFalse(os.path.exists(os.path.join(bindir, '2')))
         self.assertTrue(
@@ -1525,7 +1544,7 @@ class StateTestCase(StateBaseTestCase):
             "Expected 'bin/3' to remain as it wasn't primed by this part")
 
     def test_clean_prime_state_common_files(self):
-        self.assertEqual(None, self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals(None))
         bindir = os.path.join(self.prime_dir, 'bin')
         os.makedirs(bindir)
         open(os.path.join(bindir, '1'), 'w').close()
@@ -1540,7 +1559,7 @@ class StateTestCase(StateBaseTestCase):
             'other_part': states.PrimeState({'bin/2'}, {'bin'})
         })
 
-        self.assertEqual('stage', self.handler.last_step())
+        self.assertThat(self.handler.last_step(), Equals('stage'))
         self.assertFalse(os.path.exists(os.path.join(bindir, '1')))
         self.assertTrue(
             os.path.exists(os.path.join(bindir, '2')),
@@ -1552,10 +1571,10 @@ class StateTestCase(StateBaseTestCase):
             errors.MissingStateCleanError,
             self.handler.clean_prime, {})
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            "Failed to clean step 'prime': Missing necessary state. "
-            "This won't work until a complete clean has occurred.")
+            Equals("Failed to clean step 'prime': Missing necessary state. "
+                   "This won't work until a complete clean has occurred."))
 
 
 class StateFileMigrationTestCase(StateBaseTestCase):
@@ -1572,7 +1591,7 @@ class StateFileMigrationTestCase(StateBaseTestCase):
             f.write(self.step)
 
         handler = mocks.loadplugin(part_name)
-        self.assertEqual(self.step, handler.last_step())
+        self.assertThat(handler.last_step(), Equals(self.step))
 
 
 class IsDirtyTestCase(tests.TestCase):
@@ -1908,10 +1927,10 @@ class CleanTestCase(CleanBaseTestCase):
             errors.MissingStateCleanError,
             handler.clean, step='prime')
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            "Failed to clean step 'prime': Missing necessary state. "
-            "This won't work until a complete clean has occurred.")
+            Equals("Failed to clean step 'prime': Missing necessary state. "
+                   "This won't work until a complete clean has occurred."))
 
         self.assertTrue(os.path.isfile(primed_file))
 
@@ -2022,10 +2041,10 @@ class CleanTestCase(CleanBaseTestCase):
             errors.MissingStateCleanError,
             handler.clean, step='stage')
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            "Failed to clean step 'stage': Missing necessary state. "
-            "This won't work until a complete clean has occurred.")
+            Equals("Failed to clean step 'stage': Missing necessary state. "
+                   "This won't work until a complete clean has occurred."))
 
         self.assertTrue(os.path.isfile(staged_file))
 
@@ -2142,7 +2161,7 @@ class PerStepCleanTestCase(tests.TestCase):
         self.handler.clean(step='pull', hint='foo')
 
         # Verify the step cleaning order
-        self.assertEqual(4, len(self.manager_mock.mock_calls))
+        self.assertThat(len(self.manager_mock.mock_calls), Equals(4))
         self.manager_mock.assert_has_calls([
             call.clean_prime({}, 'foo'),
             call.clean_stage({}, 'foo'),
@@ -2154,7 +2173,7 @@ class PerStepCleanTestCase(tests.TestCase):
         self.handler.clean(step='pull')
 
         # Verify the step cleaning order
-        self.assertEqual(4, len(self.manager_mock.mock_calls))
+        self.assertThat(len(self.manager_mock.mock_calls), Equals(4))
         self.manager_mock.assert_has_calls([
             call.clean_prime({}, ''),
             call.clean_stage({}, ''),
@@ -2166,7 +2185,7 @@ class PerStepCleanTestCase(tests.TestCase):
         self.handler.clean(step='build')
 
         # Verify the step cleaning order
-        self.assertEqual(3, len(self.manager_mock.mock_calls))
+        self.assertThat(len(self.manager_mock.mock_calls), Equals(3))
         self.manager_mock.assert_has_calls([
             call.clean_prime({}, ''),
             call.clean_stage({}, ''),
@@ -2177,7 +2196,7 @@ class PerStepCleanTestCase(tests.TestCase):
         self.handler.clean(step='stage')
 
         # Verify the step cleaning order
-        self.assertEqual(2, len(self.manager_mock.mock_calls))
+        self.assertThat(len(self.manager_mock.mock_calls), Equals(2))
         self.manager_mock.assert_has_calls([
             call.clean_prime({}, ''),
             call.clean_stage({}, ''),
@@ -2187,7 +2206,7 @@ class PerStepCleanTestCase(tests.TestCase):
         self.handler.clean(step='prime')
 
         # Verify the step cleaning order
-        self.assertEqual(1, len(self.manager_mock.mock_calls))
+        self.assertThat(len(self.manager_mock.mock_calls), Equals(1))
         self.manager_mock.assert_has_calls([
             call.clean_prime({}, ''),
         ])
@@ -2303,10 +2322,10 @@ class StagePackagesTestCase(tests.TestCase):
             RuntimeError,
             part.prepare_pull)
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            "Error downloading stage packages for part 'stage-test': "
-            "The package 'non-existing' was not found.")
+            Equals("Error downloading stage packages for part 'stage-test': "
+                   "The package 'non-existing' was not found."))
 
 
 class FindDependenciesTestCase(tests.TestCase):
@@ -2335,7 +2354,7 @@ class FindDependenciesTestCase(tests.TestCase):
         dependencies = pluginhandler._find_dependencies(workdir, {'linked'})
 
         mock_ms.file.assert_called_once_with(linked_elf_path_b)
-        self.assertEqual(dependencies, {'/usr/lib/libDepends.so'})
+        self.assertThat(dependencies, Equals({'/usr/lib/libDepends.so'}))
 
     @patch('magic.open')
     @patch('snapcraft.internal.libraries.get_dependencies')
@@ -2360,7 +2379,7 @@ class FindDependenciesTestCase(tests.TestCase):
 
         self.assertFalse(mock_ms.file.called,
                          'Expected object file to be skipped')
-        self.assertEqual(dependencies, set())
+        self.assertThat(dependencies, Equals(set()))
 
     @patch('magic.open')
     @patch('snapcraft.internal.libraries.get_dependencies')
@@ -2458,8 +2477,8 @@ class FindDependenciesTestCase(tests.TestCase):
             RuntimeError,
             pluginhandler._find_dependencies, '.', set())
 
-        self.assertEqual(
-            raised.__str__(), 'Cannot load magic header detection')
+        self.assertThat(
+            raised.__str__(), Equals('Cannot load magic header detection'))
 
     def test__combine_filesets_explicit_wildcard(self):
         fileset_1 = ['a', 'b']
@@ -2468,7 +2487,7 @@ class FindDependenciesTestCase(tests.TestCase):
         expected_fileset = ['a', 'b']
         combined_fileset = pluginhandler._combine_filesets(
             fileset_1, fileset_2)
-        self.assertEqual(set(expected_fileset), set(combined_fileset))
+        self.assertThat(set(combined_fileset), Equals(set(expected_fileset)))
 
     def test__combine_filesets_implicit_wildcard(self):
         fileset_1 = ['a', 'b']
@@ -2477,7 +2496,7 @@ class FindDependenciesTestCase(tests.TestCase):
         expected_fileset = ['a', '-c', 'b']
         combined_fileset = pluginhandler._combine_filesets(
             fileset_1, fileset_2)
-        self.assertEqual(set(expected_fileset), set(combined_fileset))
+        self.assertThat(set(combined_fileset), Equals(set(expected_fileset)))
 
     def test__combine_filesets_no_wildcard(self):
         fileset_1 = ['a', 'b']
@@ -2486,7 +2505,7 @@ class FindDependenciesTestCase(tests.TestCase):
         expected_fileset = ['a']
         combined_fileset = pluginhandler._combine_filesets(
             fileset_1, fileset_2)
-        self.assertEqual(set(expected_fileset), set(combined_fileset))
+        self.assertThat(set(combined_fileset), Equals(set(expected_fileset)))
 
     def test__combine_filesets_with_contradiciton(self):
         fileset_1 = ['-a']
@@ -2496,10 +2515,10 @@ class FindDependenciesTestCase(tests.TestCase):
             errors.PrimeFileConflictError,
             pluginhandler._combine_filesets, fileset_1, fileset_2
         )
-        self.assertEqual(
+        self.assertThat(
             raised.__str__(),
-            "The following files have been excluded by the `stage` keyword, "
-            "but included by the `prime` keyword: {'a'}"
+            Equals("The following files have been excluded by the `stage` "
+                   "keyword, but included by the `prime` keyword: {'a'}")
         )
 
     def test__get_includes(self):
@@ -2507,14 +2526,14 @@ class FindDependenciesTestCase(tests.TestCase):
         expected_includes = ['b']
 
         includes = pluginhandler._get_includes(fileset)
-        self.assertEqual(set(expected_includes), set(includes))
+        self.assertThat(set(includes), Equals(set(expected_includes)))
 
     def test__get_excludes(self):
         fileset = ['-a', 'b']
         expected_excludes = ['a']
 
         excludes = pluginhandler._get_excludes(fileset)
-        self.assertEqual(set(expected_excludes), set(excludes))
+        self.assertThat(set(excludes), Equals(set(expected_excludes)))
 
 
 class SourcesTestCase(tests.TestCase):
@@ -2579,9 +2598,9 @@ class SourcesTestCase(tests.TestCase):
             ValueError,
             mocks.loadplugin, 'test-part', part_properties=properties)
 
-        self.assertEqual(raised.__str__(),
-                         'no handler to manage source '
-                         '(unrecognized://test_source)')
+        self.assertThat(raised.__str__(),
+                        Equals('no handler to manage source '
+                               '(unrecognized://test_source)'))
 
 
 class CleanPullTestCase(tests.TestCase):

--- a/snapcraft/tests/plugins/ros/test_rosdep.py
+++ b/snapcraft/tests/plugins/ros/test_rosdep.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015, 2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -57,9 +57,11 @@ class RosdepTestCase(tests.TestCase):
         self.rosdep.setup()
 
         # Verify that only rosdep was installed (no other .debs)
-        self.assertEqual(self.ubuntu_mock.call_count, 1)
-        self.assertEqual(self.ubuntu_mock.return_value.get.call_count, 1)
-        self.assertEqual(self.ubuntu_mock.return_value.unpack.call_count, 1)
+        self.assertThat(self.ubuntu_mock.call_count, Equals(1))
+        self.assertThat(
+            self.ubuntu_mock.return_value.get.call_count, Equals(1))
+        self.assertThat(
+            self.ubuntu_mock.return_value.unpack.call_count, Equals(1))
         self.ubuntu_mock.assert_has_calls([
             mock.call(self.rosdep._rosdep_path, sources='sources',
                       project_options=self.project),
@@ -67,7 +69,7 @@ class RosdepTestCase(tests.TestCase):
             mock.call().unpack(self.rosdep._rosdep_install_path)])
 
         # Verify that rosdep was initialized and updated
-        self.assertEqual(self.check_output_mock.call_count, 2)
+        self.assertThat(self.check_output_mock.call_count, Equals(2))
         self.check_output_mock.assert_has_calls([
             mock.call(['rosdep', 'init'], env=mock.ANY),
             mock.call(['rosdep', 'update'], env=mock.ANY)
@@ -90,8 +92,8 @@ class RosdepTestCase(tests.TestCase):
 
         raised = self.assertRaises(RuntimeError, self.rosdep.setup)
 
-        self.assertEqual(str(raised),
-                         'Error initializing rosdep database:\nbar')
+        self.assertThat(str(raised),
+                        Equals('Error initializing rosdep database:\nbar'))
 
     def test_setup_update_failure(self):
         def run(args, **kwargs):
@@ -104,14 +106,14 @@ class RosdepTestCase(tests.TestCase):
 
         raised = self.assertRaises(RuntimeError, self.rosdep.setup)
 
-        self.assertEqual(str(raised),
-                         'Error updating rosdep database:\nbar')
+        self.assertThat(str(raised),
+                        Equals('Error updating rosdep database:\nbar'))
 
     def test_get_dependencies(self):
         self.check_output_mock.return_value = b'foo\nbar\nbaz'
 
-        self.assertEqual(self.rosdep.get_dependencies('foo'),
-                         ['foo', 'bar', 'baz'])
+        self.assertThat(self.rosdep.get_dependencies('foo'),
+                        Equals(['foo', 'bar', 'baz']))
 
         self.check_output_mock.assert_called_with(['rosdep', 'keys', 'foo'],
                                                   env=mock.ANY)
@@ -119,7 +121,7 @@ class RosdepTestCase(tests.TestCase):
     def test_get_dependencies_no_dependencies(self):
         self.check_output_mock.return_value = b''
 
-        self.assertEqual(self.rosdep.get_dependencies('foo'), [])
+        self.assertThat(self.rosdep.get_dependencies('foo'), Equals([]))
 
     def test_get_dependencies_invalid_package(self):
         self.check_output_mock.side_effect = subprocess.CalledProcessError(
@@ -129,8 +131,8 @@ class RosdepTestCase(tests.TestCase):
             FileNotFoundError,
             self.rosdep.get_dependencies, 'bar')
 
-        self.assertEqual(str(raised),
-                         'Unable to find Catkin package "bar"')
+        self.assertThat(str(raised),
+                        Equals('Unable to find Catkin package "bar"'))
 
     def test_resolve_dependency(self):
         self.check_output_mock.return_value = b'#apt\nmylib-dev'

--- a/snapcraft/tests/plugins/test_ant.py
+++ b/snapcraft/tests/plugins/test_ant.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -19,7 +19,7 @@ import copy
 from unittest import mock
 
 import fixtures
-from testtools.matchers import HasLength
+from testtools.matchers import Equals, HasLength
 
 import snapcraft
 from snapcraft import tests
@@ -48,13 +48,13 @@ class AntPluginTestCase(tests.TestCase):
                 'Expected {!r} to be included in properties'.format(expected))
 
         properties_type = schema['properties']['ant-properties']['type']
-        self.assertEqual(properties_type, 'object',
-                         'Expected "ant-properties" "type" to be "object", '
-                         'but it was "{}"'.format(properties_type))
+        self.assertThat(properties_type, Equals('object'),
+                        'Expected "ant-properties" "type" to be "object", '
+                        'but it was "{}"'.format(properties_type))
         build_targets_type = schema['properties']['ant-build-targets']['type']
-        self.assertEqual(build_targets_type, 'array',
-                         'Expected "ant-build-targets" "type" to be "object", '
-                         'but it was "{}"'.format(build_targets_type))
+        self.assertThat(build_targets_type, Equals('array'),
+                        'Expected "ant-build-targets" "type" to be "object", '
+                        'but it was "{}"'.format(build_targets_type))
 
     def test_get_build_properties(self):
         expected_build_properties = ['ant-build-targets', 'ant-properties']
@@ -100,9 +100,9 @@ class AntPluginTestCase(tests.TestCase):
         destination = '-Ddist.dir={}'.format(plugin.installdir)
         basedir = '-Dbasedir=.'
         args = run_mock.call_args[0][0]
-        self.assertEqual(args[0], 'ant')
-        self.assertEqual(args[1], 'artifacts')
-        self.assertEqual(args[2], 'jar')
+        self.assertThat(args[0], Equals('ant'))
+        self.assertThat(args[1], Equals('artifacts'))
+        self.assertThat(args[2], Equals('jar'))
         self.assertIn(destination, args)
         self.assertIn(basedir, args)
 

--- a/snapcraft/tests/plugins/test_autotools.py
+++ b/snapcraft/tests/plugins/test_autotools.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 # Copyright (C) 2016 Harald Sitter <sitter@kde.org>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -19,7 +19,7 @@ import os
 import stat
 
 from unittest import mock
-from testtools.matchers import HasLength
+from testtools.matchers import Equals, HasLength
 
 import snapcraft
 from snapcraft import tests
@@ -62,19 +62,19 @@ class AutotoolsPluginTestCase(tests.TestCase):
                             .format(item))
 
         configflags_type = configflags['type']
-        self.assertEqual(configflags_type, 'array',
-                         'Expected "configflags" "type" to be "array", but it '
-                         'was "{}"'.format(configflags_type))
+        self.assertThat(configflags_type, Equals('array'),
+                        'Expected "configflags" "type" to be "array", but it '
+                        'was "{}"'.format(configflags_type))
 
         configflags_minitems = configflags['minitems']
-        self.assertEqual(configflags_minitems, 1,
-                         'Expected "configflags" "minitems" to be 1, but '
-                         'it was {}'.format(configflags_minitems))
+        self.assertThat(configflags_minitems, Equals(1),
+                        'Expected "configflags" "minitems" to be 1, but '
+                        'it was {}'.format(configflags_minitems))
 
         configflags_default = configflags['default']
-        self.assertEqual(configflags_default, [],
-                         'Expected "configflags" "default" to be [], but '
-                         'it was {}'.format(configflags_default))
+        self.assertThat(configflags_default, Equals([]),
+                        'Expected "configflags" "default" to be [], but '
+                        'it was {}'.format(configflags_default))
 
         configflags_items = configflags['items']
         self.assertTrue('type' in configflags_items,
@@ -82,10 +82,10 @@ class AutotoolsPluginTestCase(tests.TestCase):
                         '"items"')
 
         configflags_items_type = configflags_items['type']
-        self.assertEqual(configflags_items_type, 'string',
-                         'Expected "configflags" "items" "type" to be '
-                         '"string", but it was "{}"'
-                         .format(configflags_items_type))
+        self.assertThat(configflags_items_type, Equals('string'),
+                        'Expected "configflags" "items" "type" to be '
+                        '"string", but it was "{}"'
+                        .format(configflags_items_type))
 
         # Check install-via property
         installvia = properties['install-via']
@@ -96,12 +96,13 @@ class AutotoolsPluginTestCase(tests.TestCase):
 
         installvia_enum = installvia['enum']
         # Using sets for order independence in the comparison
-        self.assertEqual(set(['destdir', 'prefix']), set(installvia_enum))
+        self.assertThat(
+            set(installvia_enum), Equals(set(['destdir', 'prefix'])))
 
         installvia_default = installvia['default']
-        self.assertEqual(installvia_default, 'destdir',
-                         'Expected "install-via" "default" to be "destdir", '
-                         'but it was "{}"'.format(installvia_default))
+        self.assertThat(installvia_default, Equals('destdir'),
+                        'Expected "install-via" "default" to be "destdir", '
+                        'but it was "{}"'.format(installvia_default))
 
     def test_get_build_properties(self):
         expected_build_properties = make.MakePlugin.get_build_properties() + (
@@ -123,8 +124,8 @@ class AutotoolsPluginTestCase(tests.TestCase):
             'test-part', self.options,
             self.project_options)
 
-        self.assertEqual(str(raised),
-                         'Unsupported installation method: "invalid"')
+        self.assertThat(str(raised),
+                        Equals('Unsupported installation method: "invalid"'))
 
     def build_with_configure(self):
         plugin = autotools.AutotoolsPlugin('test-part', self.options,
@@ -144,7 +145,7 @@ class AutotoolsPluginTestCase(tests.TestCase):
     def test_build_configure_with_destdir(self, run_mock):
         plugin = self.build_with_configure()
 
-        self.assertEqual(3, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(3))
         run_mock.assert_has_calls([
             mock.call(['./configure', '--prefix=']),
             mock.call(['make', '-j2'], env=None),
@@ -157,7 +158,7 @@ class AutotoolsPluginTestCase(tests.TestCase):
         self.options.install_via = 'prefix'
         plugin = self.build_with_configure()
 
-        self.assertEqual(3, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(3))
         run_mock.assert_has_calls([
             mock.call(['./configure', '--prefix={}'.format(
                 plugin.installdir)]),
@@ -191,7 +192,7 @@ class AutotoolsPluginTestCase(tests.TestCase):
     def test_build_autogen_with_bootstrap_dir(self, run_mock):
         plugin = self.build_with_autogen(files=['README'], dirs=['bootstrap'])
 
-        self.assertEqual(4, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(4))
         run_mock.assert_has_calls([
             mock.call(['autoreconf', '-i']),
             mock.call(['./configure', '--prefix=']),
@@ -204,7 +205,7 @@ class AutotoolsPluginTestCase(tests.TestCase):
     def test_build_autogen_with_destdir(self, run_mock):
         plugin = self.build_with_autogen()
 
-        self.assertEqual(4, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(4))
         run_mock.assert_has_calls([
             mock.call(['env', 'NOCONFIGURE=1', './autogen.sh']),
             mock.call(['./configure', '--prefix=']),
@@ -217,7 +218,7 @@ class AutotoolsPluginTestCase(tests.TestCase):
     def test_build_bootstrap_with_destdir(self, run_mock):
         plugin = self.build_with_autogen(files=['bootstrap'])
 
-        self.assertEqual(4, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(4))
         run_mock.assert_has_calls([
             mock.call(['env', 'NOCONFIGURE=1', './bootstrap']),
             mock.call(['./configure', '--prefix=']),
@@ -230,7 +231,7 @@ class AutotoolsPluginTestCase(tests.TestCase):
     def test_build_bootstrap_and_autogen_with_destdir(self, run_mock):
         plugin = self.build_with_autogen(files=['bootstrap', 'autogen.sh'])
 
-        self.assertEqual(4, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(4))
         run_mock.assert_has_calls([
             mock.call(['env', 'NOCONFIGURE=1', './autogen.sh']),
             mock.call(['./configure', '--prefix=']),
@@ -244,7 +245,7 @@ class AutotoolsPluginTestCase(tests.TestCase):
         self.options.install_via = 'prefix'
         plugin = self.build_with_autogen()
 
-        self.assertEqual(4, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(4))
         run_mock.assert_has_calls([
             mock.call(['env', 'NOCONFIGURE=1', './autogen.sh']),
             mock.call(['./configure', '--prefix={}'.format(
@@ -268,7 +269,7 @@ class AutotoolsPluginTestCase(tests.TestCase):
     def test_build_autoreconf_with_destdir(self, run_mock):
         plugin = self.build_with_autoreconf()
 
-        self.assertEqual(4, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(4))
         run_mock.assert_has_calls([
             mock.call(['autoreconf', '-i']),
             mock.call(['./configure', '--prefix=']),
@@ -282,7 +283,7 @@ class AutotoolsPluginTestCase(tests.TestCase):
         self.options.install_via = 'prefix'
         plugin = self.build_with_autoreconf()
 
-        self.assertEqual(4, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(4))
         run_mock.assert_has_calls([
             mock.call(['autoreconf', '-i']),
             mock.call(['./configure', '--prefix={}'.format(
@@ -296,7 +297,7 @@ class AutotoolsPluginTestCase(tests.TestCase):
         self.options.disable_parallel = True
         plugin = self.build_with_autoreconf()
 
-        self.assertEqual(4, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(4))
         run_mock.assert_has_calls([
             mock.call(['autoreconf', '-i']),
             mock.call(['./configure', '--prefix=']),

--- a/snapcraft/tests/plugins/test_base.py
+++ b/snapcraft/tests/plugins/test_base.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2016 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -17,6 +17,8 @@
 import os
 import unittest.mock
 
+from testtools.matchers import Equals
+
 import snapcraft
 from snapcraft import tests
 
@@ -31,7 +33,7 @@ class TestBasePlugin(tests.TestCase):
         options = tests.MockOptions(disable_parallel=True)
         plugin = snapcraft.BasePlugin('test_plugin', options,
                                       self.project_options)
-        self.assertEqual(plugin.parallel_build_count, 1)
+        self.assertThat(plugin.parallel_build_count, Equals(1))
 
     def test_parallel_build_count_returns_build_count_from_project(self):
         options = tests.MockOptions(disable_parallel=False)
@@ -39,7 +41,7 @@ class TestBasePlugin(tests.TestCase):
                                       self.project_options)
         unittest.mock.patch.object(
             self.project_options, 'parallel_build_count', 2)
-        self.assertEqual(plugin.parallel_build_count, 2)
+        self.assertThat(plugin.parallel_build_count, Equals(2))
 
     def test_part_name_with_forward_slash_is_one_directory(self):
         plugin = snapcraft.BasePlugin('test/part', options=None)

--- a/snapcraft/tests/plugins/test_catkin.py
+++ b/snapcraft/tests/plugins/test_catkin.py
@@ -47,10 +47,10 @@ class _CompareContainers():
         self.expected = expected
 
     def __eq__(self, container):
-        self.test.assertEqual(len(container), len(self.expected),
-                              'Expected {} items to be in container, '
-                              'got {}'.format(len(self.expected),
-                                              len(container)))
+        self.test.assertThat(len(container), Equals(len(self.expected)),
+                             'Expected {} items to be in container, '
+                             'got {}'.format(len(self.expected),
+                                             len(container)))
 
         for expectation in self.expected:
             self.test.assertTrue(expectation in container,
@@ -281,10 +281,11 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
             'test-part', self.properties,
             self.project_options)
 
-        self.assertEqual(str(raised),
-                         "Unsupported rosdistro: 'invalid'. The supported ROS "
-                         "distributions are 'indigo', 'jade', 'kinetic', and "
-                         "'lunar'")
+        self.assertThat(
+            str(raised),
+            Equals("Unsupported rosdistro: 'invalid'. The supported ROS "
+                   "distributions are 'indigo', 'jade', 'kinetic', and "
+                   "'lunar'"))
 
     def test_get_stage_sources_indigo(self):
         self.properties.rosdistro = 'indigo'
@@ -325,9 +326,9 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
             RuntimeError,
             plugin.pull)
 
-        self.assertEqual(str(raised),
-                         'Failed to fetch system dependencies: The '
-                         "package 'foo' was not found.")
+        self.assertThat(str(raised),
+                        Equals('Failed to fetch system dependencies: The '
+                               "package 'foo' was not found."))
 
     def test_pull_unable_to_resolve_roscore(self):
         self.properties.include_roscore = True
@@ -342,8 +343,9 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
 
         raised = self.assertRaises(RuntimeError, plugin.pull)
 
-        self.assertEqual(str(raised),
-                         'Unable to determine system dependency for roscore')
+        self.assertThat(
+            str(raised),
+            Equals('Unable to determine system dependency for roscore'))
 
     @mock.patch.object(catkin.CatkinPlugin, '_generate_snapcraft_setup_sh')
     def test_pull_invalid_underlay(self, generate_setup_mock):
@@ -396,10 +398,10 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
                                      self.project_options)
         raised = self.assertRaises(FileNotFoundError, plugin.pull)
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'Unable to find package path: "{}"'.format(os.path.join(
-                plugin.sourcedir, 'src')))
+            Equals('Unable to find package path: "{}"'.format(os.path.join(
+                plugin.sourcedir, 'src'))))
 
     def test_valid_catkin_workspace_source_space(self):
         self.properties.source_space = 'foo'
@@ -424,10 +426,10 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
                                      self.project_options)
         raised = self.assertRaises(FileNotFoundError, plugin.pull)
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'Unable to find package path: "{}"'.format(os.path.join(
-                plugin.sourcedir, self.properties.source_space)))
+            Equals('Unable to find package path: "{}"'.format(os.path.join(
+                plugin.sourcedir, self.properties.source_space))))
 
     def test_invalid_catkin_workspace_source_space_same_as_source(self):
         self.properties.source_space = '.'
@@ -441,9 +443,9 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
             'test-part', self.properties,
             self.project_options)
 
-        self.assertEqual(str(raised),
-                         'source-space cannot be the root of the Catkin '
-                         'workspace')
+        self.assertThat(
+            str(raised),
+            Equals('source-space cannot be the root of the Catkin workspace'))
 
     @mock.patch('snapcraft.plugins.catkin._Compilers')
     @mock.patch.object(catkin.CatkinPlugin, 'run')
@@ -569,9 +571,9 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
 
         # Verify that the absolute path in 10.ros.sh was rewritten correctly
         with open(ros_profile, 'r') as f:
-            self.assertEqual(f.read(), 'python foo',
-                             'The absolute path to python was not replaced as '
-                             'expected')
+            self.assertThat(f.read(), Equals('python foo'),
+                            'The absolute path to python was not replaced as '
+                            'expected')
 
     def _verify_run_environment(self, plugin):
         python_path = os.path.join(
@@ -825,9 +827,10 @@ class PullTestCase(CatkinPluginBaseTestCase):
         # Verify that dependencies were found as expected. TODO: Would really
         # like to use ANY here instead of verifying explicit arguments, but
         # Python issue #25195 won't let me.
-        self.assertEqual(1, self.dependencies_mock.call_count)
-        self.assertEqual({'my_package'},
-                         self.dependencies_mock.call_args[0][0])
+        self.assertThat(self.dependencies_mock.call_count, Equals(1))
+        self.assertThat(
+            self.dependencies_mock.call_args[0][0],
+            Equals({'my_package'}))
 
         # Verify that the dependencies were installed
         self.ubuntu_mock.return_value.get.assert_called_with(
@@ -867,9 +870,10 @@ class PullTestCase(CatkinPluginBaseTestCase):
         # Verify that dependencies were found as expected. TODO: Would really
         # like to use ANY here instead of verifying explicit arguments, but
         # Python issue #25195 won't let me.
-        self.assertEqual(1, self.dependencies_mock.call_count)
-        self.assertEqual({'my_package', 'package_2'},
-                         self.dependencies_mock.call_args[0][0])
+        self.assertThat(self.dependencies_mock.call_count, Equals(1))
+        self.assertThat(
+            self.dependencies_mock.call_args[0][0],
+            Equals({'my_package', 'package_2'}))
 
         # Verify that no .deb packages were installed
         self.assertTrue(mock.call().unpack(plugin.installdir) not in
@@ -1150,8 +1154,8 @@ class FinishBuildTestCase(CatkinPluginBaseTestCase):
         expected = 'CMAKE_PREFIX_PATH = []\n'
 
         with open(setup_file, 'r') as f:
-            self.assertEqual(
-                f.read(), expected,
+            self.assertThat(
+                f.read(), Equals(expected),
                 'The absolute path to python or the CMAKE_PREFIX_PATH '
                 'was not replaced as expected')
 
@@ -1310,9 +1314,11 @@ class CompilersTestCase(tests.TestCase):
         self.compilers.setup()
 
         # Verify that both gcc and g++ were installed (no other .debs)
-        self.assertEqual(self.ubuntu_mock.call_count, 1)
-        self.assertEqual(self.ubuntu_mock.return_value.get.call_count, 1)
-        self.assertEqual(self.ubuntu_mock.return_value.unpack.call_count, 1)
+        self.assertThat(self.ubuntu_mock.call_count, Equals(1))
+        self.assertThat(
+            self.ubuntu_mock.return_value.get.call_count, Equals(1))
+        self.assertThat(
+            self.ubuntu_mock.return_value.unpack.call_count, Equals(1))
         self.ubuntu_mock.assert_has_calls([
             mock.call(self.compilers._compilers_path, sources='sources',
                       project_options=self.project),
@@ -1480,9 +1486,11 @@ class WstoolTestCase(tests.TestCase):
         self.wstool.setup()
 
         # Verify that only wstool was installed (no other .debs)
-        self.assertEqual(self.ubuntu_mock.call_count, 1)
-        self.assertEqual(self.ubuntu_mock.return_value.get.call_count, 1)
-        self.assertEqual(self.ubuntu_mock.return_value.unpack.call_count, 1)
+        self.assertThat(self.ubuntu_mock.call_count, Equals(1))
+        self.assertThat(
+            self.ubuntu_mock.return_value.get.call_count, Equals(1))
+        self.assertThat(
+            self.ubuntu_mock.return_value.unpack.call_count, Equals(1))
         self.ubuntu_mock.assert_has_calls([
             mock.call(self.wstool._wstool_path, sources='sources',
                       project_options=self.project),

--- a/snapcraft/tests/plugins/test_cmake.py
+++ b/snapcraft/tests/plugins/test_cmake.py
@@ -1,7 +1,6 @@
-
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015, 2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -18,7 +17,7 @@
 import os
 
 from unittest import mock
-from testtools.matchers import HasLength
+from testtools.matchers import Equals, HasLength
 
 import snapcraft
 from snapcraft.plugins import cmake
@@ -117,7 +116,7 @@ class CMakeTestCase(tests.TestCase):
                  self.stage_dir,
                  plugin.project.arch_triplet)
 
-        self.assertEqual(3, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(3))
         for call_args in self.run_mock.call_args_list:
             environment = call_args[1]['env']
             for variable, value in expected.items():
@@ -126,6 +125,6 @@ class CMakeTestCase(tests.TestCase):
                     'Expected variable "{}" to be in environment'.format(
                         variable))
 
-                self.assertEqual(environment[variable], value,
-                                 'Expected ${}={}, but it was {}'.format(
-                                 variable, value, environment[variable]))
+                self.assertThat(environment[variable], Equals(value),
+                                'Expected ${}={}, but it was {}'.format(
+                                    variable, value, environment[variable]))

--- a/snapcraft/tests/plugins/test_copy.py
+++ b/snapcraft/tests/plugins/test_copy.py
@@ -19,7 +19,7 @@ import jsonschema
 
 from unittest.mock import Mock, patch
 import testtools
-from testtools.matchers import HasLength
+from testtools.matchers import Equals, HasLength
 
 import snapcraft
 from snapcraft.plugins.copy import (
@@ -66,10 +66,10 @@ class TestCopyPlugin(tests.TestCase):
 
         raised = self.assertRaises(FileNotFoundError, c.build)
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            "[Errno 2] No such file or directory: '{}/src'".format(
-                c.builddir))
+            Equals("[Errno 2] No such file or directory: '{}/src'".format(
+                c.builddir)))
 
     def test_copy_glob_does_not_match_anything(self):
         # ensure that a bad file causes a warning and fails the build even
@@ -82,7 +82,7 @@ class TestCopyPlugin(tests.TestCase):
 
         raised = self.assertRaises(errors.SnapcraftEnvironmentError, c.build)
 
-        self.assertEqual(raised.__str__(), "no matches for 'src*'")
+        self.assertThat(raised.__str__(), Equals("no matches for 'src*'"))
 
     def test_copy_plugin_copies(self):
         self.mock_options.files = {
@@ -259,7 +259,7 @@ class TestCopyPlugin(tests.TestCase):
         self.assertTrue(os.path.isdir(destination),
                         "Expected foo's contents to be copied into baz/")
         with open(os.path.join(destination, 'file'), 'r') as f:
-            self.assertEqual(f.read(), 'foo')
+            self.assertThat(f.read(), Equals('foo'))
 
         for symlink in symlinks:
             destination = symlink['destination']
@@ -267,14 +267,14 @@ class TestCopyPlugin(tests.TestCase):
                 os.path.islink(destination),
                 'Expected {!r} to be a symlink'.format(destination))
 
-            self.assertEqual(
+            self.assertThat(
                 os.path.realpath(destination),
-                symlink['expected_realpath'],
+                Equals(symlink['expected_realpath']),
                 'Expected {!r} to be a relative path to {!r}'.format(
                     destination, symlink['expected_realpath']))
 
             with open(destination, 'r') as f:
-                self.assertEqual(f.read(), symlink['expected_contents'])
+                self.assertThat(f.read(), Equals(symlink['expected_contents']))
 
     def test_copy_symlinks_that_should_be_followed(self):
         self.mock_options.files = {'foo/*': '.'}
@@ -315,7 +315,7 @@ class TestCopyPlugin(tests.TestCase):
         c.build()
 
         with open(os.path.join(c.installdir, 'file'), 'r') as f:
-            self.assertEqual(f.read(), 'foo')
+            self.assertThat(f.read(), Equals('foo'))
 
         for symlink in symlinks:
             destination = symlink['destination']
@@ -324,7 +324,7 @@ class TestCopyPlugin(tests.TestCase):
                              'symlink'.format(destination))
 
             with open(destination, 'r') as f:
-                self.assertEqual(f.read(), symlink['expected_contents'])
+                self.assertThat(f.read(), Equals(symlink['expected_contents']))
 
     def test_copy_symlinks_to_libc(self):
         self.mock_options.files = {'*': '.'}
@@ -414,9 +414,10 @@ class TestRecursivelyLink(tests.TestCase):
             NotADirectoryError,
             _recursively_link, 'foo', 'qux', os.getcwd())
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            "Cannot overwrite non-directory 'qux' with directory 'foo'")
+            Equals(
+                "Cannot overwrite non-directory 'qux' with directory 'foo'"))
 
     def test_recursively_link_subtree(self):
         _recursively_link('foo/bar', 'qux', os.getcwd())

--- a/snapcraft/tests/plugins/test_dump.py
+++ b/snapcraft/tests/plugins/test_dump.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015, 2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+
+from testtools.matchers import Equals
 
 import snapcraft
 from snapcraft.plugins.dump import DumpPlugin
@@ -37,7 +39,7 @@ class DumpPluginTestCase(tests.TestCase):
         os.makedirs(plugin.builddir)
         plugin.build()
 
-        self.assertEqual(os.listdir(plugin.installdir), [])
+        self.assertThat(os.listdir(plugin.installdir), Equals([]))
 
     def test_dumping_with_contents(self):
         plugin = DumpPlugin('dump', self.options, self.project_options)
@@ -52,9 +54,9 @@ class DumpPluginTestCase(tests.TestCase):
 
         contents = os.listdir(plugin.installdir)
         contents.sort()
-        self.assertEqual(contents, ['dir1', 'file1', 'file2'])
-        self.assertEqual(os.listdir(os.path.join(plugin.installdir, 'dir1')),
-                         ['subfile1'])
+        self.assertThat(contents, Equals(['dir1', 'file1', 'file2']))
+        self.assertThat(os.listdir(os.path.join(plugin.installdir, 'dir1')),
+                        Equals(['subfile1']))
 
     def test_dump_symlinks(self):
         plugin = DumpPlugin('dump', self.options, self.project_options)
@@ -97,7 +99,7 @@ class DumpPluginTestCase(tests.TestCase):
         plugin.build()
 
         with open(os.path.join(plugin.installdir, 'file'), 'r') as f:
-            self.assertEqual(f.read(), 'foo')
+            self.assertThat(f.read(), Equals('foo'))
 
         for symlink in symlinks:
             destination = symlink['destination']
@@ -105,14 +107,14 @@ class DumpPluginTestCase(tests.TestCase):
                 os.path.islink(destination),
                 'Expected {!r} to be a symlink'.format(destination))
 
-            self.assertEqual(
+            self.assertThat(
                 os.path.realpath(destination),
-                symlink['expected_realpath'],
+                Equals(symlink['expected_realpath']),
                 'Expected {!r} to be a relative path to {!r}'.format(
                     destination, symlink['expected_realpath']))
 
             with open(destination, 'r') as f:
-                self.assertEqual(f.read(), symlink['expected_contents'])
+                self.assertThat(f.read(), Equals(symlink['expected_contents']))
 
     def test_dump_symlinks_that_should_be_followed(self):
         # TODO: Move to an integration test
@@ -153,7 +155,7 @@ class DumpPluginTestCase(tests.TestCase):
         plugin.build()
 
         with open(os.path.join(plugin.installdir, 'src', 'file'), 'r') as f:
-            self.assertEqual(f.read(), 'foo')
+            self.assertThat(f.read(), Equals('foo'))
 
         for symlink in symlinks:
             destination = symlink['destination']
@@ -162,7 +164,7 @@ class DumpPluginTestCase(tests.TestCase):
                              'symlink'.format(destination))
 
             with open(destination, 'r') as f:
-                self.assertEqual(f.read(), symlink['expected_contents'])
+                self.assertThat(f.read(), Equals(symlink['expected_contents']))
 
     def test_dump_symlinks_to_libc(self):
         plugin = DumpPlugin('dump', self.options, self.project_options)
@@ -213,10 +215,10 @@ class DumpPluginTestCase(tests.TestCase):
 
         raised = self.assertRaises(FileNotFoundError, plugin.build)
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            '{!r} is a broken symlink pointing outside the snap'.format(
-                os.path.join(plugin.builddir, 'src', 'bad_relative')))
+            Equals('{!r} is a broken symlink pointing outside the snap'.format(
+                os.path.join(plugin.builddir, 'src', 'bad_relative'))))
 
     def test_dump_enable_cross_compilation(self):
         plugin = DumpPlugin('dump', self.options, self.project_options)

--- a/snapcraft/tests/plugins/test_go.py
+++ b/snapcraft/tests/plugins/test_go.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2016 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
 import os
 
 from unittest import mock
-from testtools.matchers import HasLength
+from testtools.matchers import Equals, HasLength
 
 import snapcraft
 from snapcraft.plugins import go
@@ -61,22 +61,22 @@ class GoPluginCrossCompileTestCase(tests.TestCase):
 
         plugin.pull()
 
-        self.assertEqual(1, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(1))
         for call_args in self.run_mock.call_args_list:
             env = call_args[1]['env']
             self.assertIn('CC', env)
-            self.assertEqual(env['CC'], '{}-gcc'.format(
-                self.project_options.arch_triplet))
+            self.assertThat(env['CC'], Equals('{}-gcc'.format(
+                self.project_options.arch_triplet)))
             self.assertIn('CXX', env)
-            self.assertEqual(env['CXX'], '{}-g++'.format(
-                self.project_options.arch_triplet))
+            self.assertThat(env['CXX'], Equals('{}-g++'.format(
+                self.project_options.arch_triplet)))
             self.assertIn('CGO_ENABLED', env)
-            self.assertEqual(env['CGO_ENABLED'], '1')
+            self.assertThat(env['CGO_ENABLED'], Equals('1'))
             self.assertIn('GOARCH', env)
-            self.assertEqual(env['GOARCH'], self.go_arch)
+            self.assertThat(env['GOARCH'], Equals(self.go_arch))
             if self.deb_arch == 'armhf':
                 self.assertIn('GOARM', env)
-                self.assertEqual(env['GOARM'], '7')
+                self.assertThat(env['GOARM'], Equals('7'))
 
 
 class GoPluginTestCase(tests.TestCase):
@@ -120,20 +120,20 @@ class GoPluginTestCase(tests.TestCase):
                     expected))
 
         go_packages_type = go_packages['type']
-        self.assertEqual(go_packages_type, 'array',
-                         'Expected "go-packages" "type" to be "array", but '
-                         'it was "{}"'.format(go_packages_type))
+        self.assertThat(go_packages_type, Equals('array'),
+                        'Expected "go-packages" "type" to be "array", but '
+                        'it was "{}"'.format(go_packages_type))
 
         go_packages_default = go_packages['default']
-        self.assertEqual(go_packages_default, [],
-                         'Expected "go-packages" "default" to be '
-                         '"d[]", but it was "{}"'.format(
-                             go_packages_default))
+        self.assertThat(go_packages_default, Equals([]),
+                        'Expected "go-packages" "default" to be '
+                        '"d[]", but it was "{}"'.format(
+                            go_packages_default))
 
         go_packages_minitems = go_packages['minitems']
-        self.assertEqual(go_packages_minitems, 1,
-                         'Expected "go-packages" "minitems" to be 1, but '
-                         'it was {}'.format(go_packages_minitems))
+        self.assertThat(go_packages_minitems, Equals(1),
+                        'Expected "go-packages" "minitems" to be 1, but '
+                        'it was {}'.format(go_packages_minitems))
 
         self.assertTrue(go_packages['uniqueItems'])
 
@@ -143,10 +143,10 @@ class GoPluginTestCase(tests.TestCase):
                         '"items"')
 
         go_packages_items_type = go_packages_items['type']
-        self.assertEqual(go_packages_items_type, 'string',
-                         'Expected "go-packages" "item" "type" to be '
-                         '"string", but it was "{}"'
-                         .format(go_packages_items_type))
+        self.assertThat(go_packages_items_type, Equals('string'),
+                        'Expected "go-packages" "item" "type" to be '
+                        '"string", but it was "{}"'
+                        .format(go_packages_items_type))
 
         # Check go-importpath
         go_importpath = properties['go-importpath']
@@ -157,14 +157,14 @@ class GoPluginTestCase(tests.TestCase):
                     expected))
 
         go_importpath_type = go_importpath['type']
-        self.assertEqual(go_importpath_type, 'string',
-                         'Expected "go-importpath" "type" to be "string", but '
-                         'it was "{}"'.format(go_importpath_type))
+        self.assertThat(go_importpath_type, Equals('string'),
+                        'Expected "go-importpath" "type" to be "string", but '
+                        'it was "{}"'.format(go_importpath_type))
 
         go_importpath_default = go_importpath['default']
-        self.assertEqual(go_importpath_default, '',
-                         'Expected "go-default" "default" to be "''", but '
-                         'it was "{}"'.format(go_importpath_default))
+        self.assertThat(go_importpath_default, Equals(''),
+                        'Expected "go-default" "default" to be "''", but '
+                        'it was "{}"'.format(go_importpath_default))
 
         # Check go-buildtags
         go_buildtags = properties['go-buildtags']
@@ -176,19 +176,19 @@ class GoPluginTestCase(tests.TestCase):
                     expected))
 
         go_buildtags_type = go_buildtags['type']
-        self.assertEqual(go_buildtags_type, 'array',
-                         'Expected "go-buildtags" "type" to be "array", but '
-                         'it was "{}"'.format(go_buildtags_type))
+        self.assertThat(go_buildtags_type, Equals('array'),
+                        'Expected "go-buildtags" "type" to be "array", but '
+                        'it was "{}"'.format(go_buildtags_type))
 
         go_buildtags_default = go_buildtags['default']
-        self.assertEqual(go_buildtags_default, [],
-                         'Expected "go-buildtags" "default" to be "[]", but '
-                         'it was "{}"'.format(go_buildtags_type))
+        self.assertThat(go_buildtags_default, Equals([]),
+                        'Expected "go-buildtags" "default" to be "[]", but '
+                        'it was "{}"'.format(go_buildtags_type))
 
         go_buildtags_minitems = go_buildtags['minitems']
-        self.assertEqual(go_buildtags_minitems, 1,
-                         'Expected "go-buildtags" "minitems" to be 1, but '
-                         'it was {}'.format(go_buildtags_minitems))
+        self.assertThat(go_buildtags_minitems, Equals(1),
+                        'Expected "go-buildtags" "minitems" to be 1, but '
+                        'it was {}'.format(go_buildtags_minitems))
 
         self.assertTrue(go_buildtags['uniqueItems'])
 
@@ -198,10 +198,10 @@ class GoPluginTestCase(tests.TestCase):
                         '"items"')
 
         go_buildtags_items_type = go_buildtags_items['type']
-        self.assertEqual(go_buildtags_items_type, 'string',
-                         'Expected "go-buildtags" "item" "type" to be '
-                         '"string", but it was "{}"'
-                         .format(go_packages_items_type))
+        self.assertThat(go_buildtags_items_type, Equals('string'),
+                        'Expected "go-buildtags" "item" "type" to be '
+                        '"string", but it was "{}"'
+                        .format(go_packages_items_type))
 
         # Check required properties
         self.assertNotIn('required', schema)
@@ -478,12 +478,12 @@ class GoPluginTestCase(tests.TestCase):
         os.makedirs(os.path.join(plugin.project.stage_dir, 'usr', 'lib'))
         plugin.pull()
 
-        self.assertEqual(1, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(1))
         for call_args in self.run_mock.call_args_list:
             env = call_args[1]['env']
             self.assertTrue(
                 'GOPATH' in env, 'Expected environment to include GOPATH')
-            self.assertEqual(env['GOPATH'], plugin._gopath)
+            self.assertThat(env['GOPATH'], Equals(plugin._gopath))
 
             self.assertTrue(
                 'CGO_LDFLAGS' in env,

--- a/snapcraft/tests/plugins/test_godeps.py
+++ b/snapcraft/tests/plugins/test_godeps.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
 import os
 
 from unittest import mock
-from testtools.matchers import HasLength
+from testtools.matchers import Equals, HasLength
 
 import snapcraft
 from snapcraft.plugins import godeps
@@ -66,15 +66,17 @@ class GodepsPluginTestCase(tests.TestCase):
                     expected))
 
         godeps_file_type = godeps_file['type']
-        self.assertEqual(godeps_file_type, 'string',
-                         'Expected "godeps-file" "type" to be "string", but '
-                         'it was "{}"'.format(godeps_file_type))
+        self.assertThat(
+            godeps_file_type, Equals('string'),
+            'Expected "godeps-file" "type" to be "string", but '
+            'it was "{}"'.format(godeps_file_type))
 
         godeps_file_default = godeps_file['default']
-        self.assertEqual(godeps_file_default, 'dependencies.tsv',
-                         'Expected "godeps-file" "default" to be '
-                         '"dependencies.tsv", but it was "{}"'.format(
-                             godeps_file_default))
+        self.assertThat(
+            godeps_file_default, Equals('dependencies.tsv'),
+            'Expected "godeps-file" "default" to be '
+            '"dependencies.tsv", but it was "{}"'.format(
+                godeps_file_default))
 
         # Check go-importpath
         go_importpath = properties['go-importpath']
@@ -85,9 +87,10 @@ class GodepsPluginTestCase(tests.TestCase):
                     expected))
 
         go_importpath_type = go_importpath['type']
-        self.assertEqual(go_importpath_type, 'string',
-                         'Expected "go-importpath" "type" to be "string", but '
-                         'it was "{}"'.format(go_importpath_type))
+        self.assertThat(
+            go_importpath_type, Equals('string'),
+            'Expected "go-importpath" "type" to be "string", but '
+            'it was "{}"'.format(go_importpath_type))
 
         # go-importpath should be required
         self.assertTrue('go-importpath' in schema['required'],
@@ -102,14 +105,14 @@ class GodepsPluginTestCase(tests.TestCase):
                     expected))
 
         go_packages_type = go_packages['type']
-        self.assertEqual(go_packages_type, 'array',
-                         'Expected "go-packages" "type" to be "array", but '
-                         'it was "{}"'.format(go_packages_type))
+        self.assertThat(go_packages_type, Equals('array'),
+                        'Expected "go-packages" "type" to be "array", but '
+                        'it was "{}"'.format(go_packages_type))
 
         go_packages_default = go_packages['default']
-        self.assertEqual(go_packages_default, [],
-                         'Expected "go-packages" "default" to be "[]", but '
-                         'it was "{}"'.format(go_packages_default))
+        self.assertThat(go_packages_default, Equals([]),
+                        'Expected "go-packages" "default" to be "[]", but '
+                        'it was "{}"'.format(go_packages_default))
 
     def test_get_pull_properties(self):
         expected_pull_properties = ['godeps-file', 'go-importpath']
@@ -142,12 +145,12 @@ class GodepsPluginTestCase(tests.TestCase):
         os.makedirs(os.path.join(plugin.project.stage_dir, 'usr', 'lib'))
         plugin.pull()
 
-        self.assertEqual(2, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(2))
         for call_args in self.run_mock.call_args_list:
             env = call_args[1]['env']
             self.assertTrue(
                 'GOPATH' in env, 'Expected environment to include GOPATH')
-            self.assertEqual(env['GOPATH'], plugin._gopath)
+            self.assertThat(env['GOPATH'], Equals(plugin._gopath))
 
             self.assertTrue(
                 'PATH' in env, 'Expected environment to include PATH')
@@ -178,7 +181,7 @@ class GodepsPluginTestCase(tests.TestCase):
 
         plugin.pull()
 
-        self.assertEqual(2, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(2))
         self.run_mock.assert_has_calls([
             mock.call(['go', 'get', 'github.com/rogpeppe/godeps'],
                       cwd=plugin._gopath_src, env=mock.ANY),
@@ -195,7 +198,7 @@ class GodepsPluginTestCase(tests.TestCase):
         sourcedir = os.path.join(
             plugin._gopath_src, 'github.com', 'foo', 'bar')
         self.assertTrue(os.path.islink(sourcedir))
-        self.assertEqual(plugin.sourcedir, os.readlink(sourcedir))
+        self.assertThat(os.readlink(sourcedir), Equals(plugin.sourcedir))
 
     def test_clean_pull(self):
         plugin = godeps.GodepsPlugin(
@@ -228,7 +231,7 @@ class GodepsPluginTestCase(tests.TestCase):
         open(os.path.join(plugin._gopath_bin, 'godeps'), 'w').close()
         plugin.build()
 
-        self.assertEqual(1, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(1))
         self.run_mock.assert_has_calls([
             mock.call(
                 ['go', 'install', './github.com/foo/bar/...'],
@@ -264,7 +267,7 @@ class GodepsPluginTestCase(tests.TestCase):
         open(os.path.join(plugin._gopath_bin, 'godeps'), 'w').close()
         plugin.build()
 
-        self.assertEqual(1, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(1))
         self.run_mock.assert_has_calls([
             mock.call(
                 ['go', 'install', 'github.com/foo/bar/cmd/my-command'],

--- a/snapcraft/tests/plugins/test_gradle.py
+++ b/snapcraft/tests/plugins/test_gradle.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -18,7 +18,7 @@ import os
 from unittest import mock
 
 import fixtures
-from testtools.matchers import HasLength
+from testtools.matchers import Equals, HasLength
 
 import snapcraft
 from snapcraft import tests
@@ -57,16 +57,16 @@ class GradlePluginTestCase(BaseGradlePluginTestCase):
         self.assertTrue(
             'type' in gradle_options,
             'Expected "type" to be included in "gradle-options"')
-        self.assertEqual(gradle_options['type'], 'array',
-                         'Expected "gradle-options" "type" to be "array", but '
-                         'it was "{}"'.format(gradle_options['type']))
+        self.assertThat(gradle_options['type'], Equals('array'),
+                        'Expected "gradle-options" "type" to be "array", but '
+                        'it was "{}"'.format(gradle_options['type']))
 
         self.assertTrue(
             'minitems' in gradle_options,
             'Expected "minitems" to be included in "gradle-options"')
-        self.assertEqual(gradle_options['minitems'], 1,
-                         'Expected "gradle-options" "minitems" to be 1, but '
-                         'it was "{}"'.format(gradle_options['minitems']))
+        self.assertThat(gradle_options['minitems'], Equals(1),
+                        'Expected "gradle-options" "minitems" to be 1, but '
+                        'it was "{}"'.format(gradle_options['minitems']))
 
         self.assertTrue(
             'uniqueItems' in gradle_options,
@@ -79,9 +79,9 @@ class GradlePluginTestCase(BaseGradlePluginTestCase):
         self.assertTrue(
             'type' in output_dir,
             'Expected "type" to be included in "gradle-options"')
-        self.assertEqual(output_dir['type'], 'string',
-                         'Expected "gradle-options" "type" to be "string", '
-                         'but it was "{}"'.format(output_dir['type']))
+        self.assertThat(output_dir['type'], Equals('string'),
+                        'Expected "gradle-options" "type" to be "string", '
+                        'but it was "{}"'.format(output_dir['type']))
 
     def test_get_build_properties(self):
         expected_build_properties = ['gradle-options', 'gradle-output-dir']

--- a/snapcraft/tests/plugins/test_gulp.py
+++ b/snapcraft/tests/plugins/test_gulp.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -20,7 +20,7 @@ from os import path
 from unittest import mock
 
 import fixtures
-from testtools.matchers import HasLength
+from testtools.matchers import Equals, HasLength
 
 import snapcraft
 from snapcraft.plugins import gulp, nodejs
@@ -121,8 +121,8 @@ class GulpPluginTestCase(tests.TestCase):
             errors.SnapcraftEnvironmentError,
             gulp.GulpPlugin, 'test-part', Options(), self.project_options)
 
-        self.assertEqual(raised.__str__(),
-                         'architecture not supported (fantasy-arch)')
+        self.assertThat(raised.__str__(),
+                        Equals('architecture not supported (fantasy-arch)'))
 
     def test_schema(self):
         schema = gulp.GulpPlugin.schema()
@@ -136,16 +136,16 @@ class GulpPluginTestCase(tests.TestCase):
         self.assertTrue(
             'type' in gulp_tasks,
             'Expected "type" to be included in "gulp-tasks"')
-        self.assertEqual(gulp_tasks['type'], 'array',
-                         'Expected "gulp-tasks" "type" to be "array", but '
-                         'it was "{}"'.format(gulp_tasks['type']))
+        self.assertThat(gulp_tasks['type'], Equals('array'),
+                        'Expected "gulp-tasks" "type" to be "array", but '
+                        'it was "{}"'.format(gulp_tasks['type']))
 
         self.assertTrue(
             'minitems' in gulp_tasks,
             'Expected "minitems" to be included in "gulp-tasks"')
-        self.assertEqual(gulp_tasks['minitems'], 1,
-                         'Expected "gulp-tasks" "minitems" to be 1, but '
-                         'it was "{}"'.format(gulp_tasks['minitems']))
+        self.assertThat(gulp_tasks['minitems'], Equals(1),
+                        'Expected "gulp-tasks" "minitems" to be 1, but '
+                        'it was "{}"'.format(gulp_tasks['minitems']))
 
         self.assertTrue(
             'uniqueItems' in gulp_tasks,
@@ -158,10 +158,10 @@ class GulpPluginTestCase(tests.TestCase):
                         'Expected "node-engine" to be included in '
                         'properties')
         node_engine_type = properties['node-engine']['type']
-        self.assertEqual(node_engine_type, 'string',
-                         'Expected "node_engine" "type" to be '
-                         '"string", but it was "{}"'
-                         .format(node_engine_type))
+        self.assertThat(node_engine_type, Equals('string'),
+                        'Expected "node_engine" "type" to be '
+                        '"string", but it was "{}"'
+                        .format(node_engine_type))
 
     def test_get_build_properties(self):
         expected_build_properties = ['gulp-tasks']

--- a/snapcraft/tests/plugins/test_kbuild.py
+++ b/snapcraft/tests/plugins/test_kbuild.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -19,7 +19,7 @@ import os
 from unittest import mock
 
 import fixtures
-from testtools.matchers import HasLength
+from testtools.matchers import Equals, HasLength
 
 import snapcraft
 from snapcraft import tests
@@ -46,19 +46,21 @@ class KBuildPluginTestCase(tests.TestCase):
         schema = kbuild.KBuildPlugin.schema()
 
         properties = schema['properties']
-        self.assertEqual(properties['kdefconfig']['type'], 'array')
-        self.assertEqual(properties['kdefconfig']['default'], ['defconfig'])
+        self.assertThat(properties['kdefconfig']['type'], Equals('array'))
+        self.assertThat(
+            properties['kdefconfig']['default'], Equals(['defconfig']))
 
-        self.assertEqual(properties['kconfigfile']['type'], 'string')
-        self.assertEqual(properties['kconfigfile']['default'], None)
+        self.assertThat(properties['kconfigfile']['type'], Equals('string'))
+        self.assertThat(properties['kconfigfile']['default'], Equals(None))
 
-        self.assertEqual(properties['kconfigflavour']['type'], 'string')
-        self.assertEqual(properties['kconfigflavour']['default'], None)
+        self.assertThat(properties['kconfigflavour']['type'], Equals('string'))
+        self.assertThat(properties['kconfigflavour']['default'], Equals(None))
 
-        self.assertEqual(properties['kconfigs']['type'], 'array')
-        self.assertEqual(properties['kconfigs']['default'], [])
-        self.assertEqual(properties['kconfigs']['minitems'], 1)
-        self.assertEqual(properties['kconfigs']['items']['type'], 'string')
+        self.assertThat(properties['kconfigs']['type'], Equals('array'))
+        self.assertThat(properties['kconfigs']['default'], Equals([]))
+        self.assertThat(properties['kconfigs']['minitems'], Equals(1))
+        self.assertThat(
+            properties['kconfigs']['items']['type'], Equals('string'))
         self.assertTrue(properties['kconfigs']['uniqueItems'])
 
     def test_get_build_properties(self):
@@ -87,13 +89,13 @@ class KBuildPluginTestCase(tests.TestCase):
 
         plugin.build()
 
-        self.assertEqual(1, check_call_mock.call_count)
+        self.assertThat(check_call_mock.call_count, Equals(1))
         check_call_mock.assert_has_calls([
             mock.call('yes "" | make -j2 oldconfig', shell=True,
                       cwd=plugin.builddir),
         ])
 
-        self.assertEqual(2, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(2))
         run_mock.assert_has_calls([
             mock.call(['make', '-j2']),
             mock.call(['make', '-j2',
@@ -107,7 +109,7 @@ class KBuildPluginTestCase(tests.TestCase):
         with open(config_file) as f:
             config_contents = f.read()
 
-        self.assertEqual(config_contents, 'ACCEPT=y\n')
+        self.assertThat(config_contents, Equals('ACCEPT=y\n'))
 
     @mock.patch('subprocess.check_call')
     @mock.patch.object(kbuild.KBuildPlugin, 'run')
@@ -126,13 +128,13 @@ class KBuildPluginTestCase(tests.TestCase):
 
         plugin.build()
 
-        self.assertEqual(1, check_call_mock.call_count)
+        self.assertThat(check_call_mock.call_count, Equals(1))
         check_call_mock.assert_has_calls([
             mock.call('yes "" | make -j2 V=1 oldconfig', shell=True,
                       cwd=plugin.builddir),
         ])
 
-        self.assertEqual(2, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(2))
         run_mock.assert_has_calls([
             mock.call(['make', '-j2', 'V=1']),
             mock.call(['make', '-j2', 'V=1',
@@ -146,7 +148,7 @@ class KBuildPluginTestCase(tests.TestCase):
         with open(config_file) as f:
             config_contents = f.read()
 
-        self.assertEqual(config_contents, 'ACCEPT=y\n')
+        self.assertThat(config_contents, Equals('ACCEPT=y\n'))
 
     @mock.patch('subprocess.check_call')
     @mock.patch.object(kbuild.KBuildPlugin, 'run')
@@ -168,13 +170,13 @@ class KBuildPluginTestCase(tests.TestCase):
 
         plugin.build()
 
-        self.assertEqual(1, check_call_mock.call_count)
+        self.assertThat(check_call_mock.call_count, Equals(1))
         check_call_mock.assert_has_calls([
             mock.call('yes "" | make -j2 oldconfig', shell=True,
                       cwd=plugin.builddir),
         ])
 
-        self.assertEqual(2, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(2))
         run_mock.assert_has_calls([
             mock.call(['make', '-j2']),
             mock.call(['make', '-j2',
@@ -196,7 +198,7 @@ ACCEPT=y
 SOMETHING=y
 ACCEPT=n
 """
-        self.assertEqual(config_contents, expected_config)
+        self.assertThat(config_contents, Equals(expected_config))
 
     @mock.patch('subprocess.check_call')
     @mock.patch.object(kbuild.KBuildPlugin, 'run')
@@ -225,13 +227,13 @@ ACCEPT=n
 
         plugin.build()
 
-        self.assertEqual(1, check_call_mock.call_count)
+        self.assertThat(check_call_mock.call_count, Equals(1))
         check_call_mock.assert_has_calls([
             mock.call('yes "" | make -j2 oldconfig', shell=True,
                       cwd=plugin.builddir),
         ])
 
-        self.assertEqual(3, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(3))
         run_mock.assert_has_calls([
             mock.call(['make', '-j2']),
             mock.call(['make', '-j2',
@@ -252,7 +254,7 @@ ACCEPT=y
 SOMETHING=y
 ACCEPT=n
 """
-        self.assertEqual(config_contents, expected_config)
+        self.assertThat(config_contents, Equals(expected_config))
 
 
 class KBuildCrossCompilePluginTestCase(tests.TestCase):

--- a/snapcraft/tests/plugins/test_kernel.py
+++ b/snapcraft/tests/plugins/test_kernel.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -90,40 +90,42 @@ class KernelPluginTestCase(tests.TestCase):
         schema = kernel.KernelPlugin.schema()
 
         properties = schema['properties']
-        self.assertEqual(properties['kdefconfig']['type'], 'array')
-        self.assertEqual(properties['kdefconfig']['default'], ['defconfig'])
+        self.assertThat(properties['kdefconfig']['type'], Equals('array'))
+        self.assertThat(
+            properties['kdefconfig']['default'], Equals(['defconfig']))
 
-        self.assertEqual(properties['kconfigfile']['type'], 'string')
-        self.assertEqual(properties['kconfigfile']['default'], None)
+        self.assertThat(properties['kconfigfile']['type'], Equals('string'))
+        self.assertThat(properties['kconfigfile']['default'], Equals(None))
 
-        self.assertEqual(properties['kconfigflavour']['type'], 'string')
-        self.assertEqual(properties['kconfigflavour']['default'], None)
+        self.assertThat(properties['kconfigflavour']['type'], Equals('string'))
+        self.assertThat(properties['kconfigflavour']['default'], Equals(None))
 
         for prop in ['kconfigs', 'kernel-initrd-modules',
                      'kernel-initrd-firmware', 'kernel-device-trees']:
-            self.assertEqual(properties[prop]['type'], 'array')
-            self.assertEqual(properties[prop]['default'], [])
-            self.assertEqual(properties[prop]['minitems'], 1)
-            self.assertEqual(properties[prop]['items']['type'], 'string')
+            self.assertThat(properties[prop]['type'], Equals('array'))
+            self.assertThat(properties[prop]['default'], Equals([]))
+            self.assertThat(properties[prop]['minitems'], Equals(1))
+            self.assertThat(
+                properties[prop]['items']['type'], Equals('string'))
             self.assertTrue(properties[prop]['uniqueItems'])
 
-        self.assertEqual(
+        self.assertThat(
             properties['kernel-image-target']['oneOf'],
-            [{'type': 'string'}, {'type': 'object'}])
-        self.assertEqual(
-            properties['kernel-image-target']['default'], '')
+            Equals([{'type': 'string'}, {'type': 'object'}]))
+        self.assertThat(
+            properties['kernel-image-target']['default'], Equals(''))
 
-        self.assertEqual(
-            properties['kernel-with-firmware']['type'], 'boolean')
-        self.assertEqual(
-            properties['kernel-with-firmware']['default'], True)
+        self.assertThat(
+            properties['kernel-with-firmware']['type'], Equals('boolean'))
+        self.assertThat(
+            properties['kernel-with-firmware']['default'], Equals(True))
 
-        self.assertEqual(
-            properties['kernel-initrd-compression']['type'], 'string')
-        self.assertEqual(
-            properties['kernel-initrd-compression']['default'], 'gz')
-        self.assertEqual(
-            properties['kernel-initrd-compression']['enum'], ['gz'])
+        self.assertThat(
+            properties['kernel-initrd-compression']['type'], Equals('string'))
+        self.assertThat(
+            properties['kernel-initrd-compression']['default'], Equals('gz'))
+        self.assertThat(
+            properties['kernel-initrd-compression']['enum'], Equals(['gz']))
 
     def test_get_build_properties(self):
         expected_build_properties = [
@@ -141,7 +143,7 @@ class KernelPluginTestCase(tests.TestCase):
             self.assertIn(property, resulting_build_properties)
 
     def _assert_generic_check_call(self, builddir, installdir, os_snap_path):
-        self.assertEqual(4, self.check_call_mock.call_count)
+        self.assertThat(self.check_call_mock.call_count, Equals(4))
         self.check_call_mock.assert_has_calls([
             mock.call('yes "" | make -j2 oldconfig', shell=True,
                       cwd=builddir),
@@ -283,8 +285,9 @@ class KernelPluginTestCase(tests.TestCase):
             RuntimeError,
             plugin._unpack_generic_initrd)
 
-        self.assertEqual("initrd file type is unsupported: 'application/foo'",
-                         str(raised))
+        self.assertThat(
+            str(raised),
+            Equals("initrd file type is unsupported: 'application/foo'"))
 
     def test_pack_initrd_modules(self):
         self.options.kernel_initrd_modules = [
@@ -371,7 +374,7 @@ class KernelPluginTestCase(tests.TestCase):
         self._assert_generic_check_call(plugin.builddir, plugin.installdir,
                                         plugin.os_snap)
 
-        self.assertEqual(2, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(2))
         self.run_mock.assert_has_calls([
             mock.call(['make', '-j2', 'bzImage', 'modules']),
             mock.call(['make', '-j2',
@@ -389,7 +392,7 @@ class KernelPluginTestCase(tests.TestCase):
         with open(config_file) as f:
             config_contents = f.read()
 
-        self.assertEqual(config_contents, 'ACCEPT=y\n')
+        self.assertThat(config_contents, Equals('ACCEPT=y\n'))
         self._assert_common_assets(plugin.installdir)
 
     @mock.patch.object(
@@ -411,7 +414,7 @@ class KernelPluginTestCase(tests.TestCase):
 
         plugin.build()
 
-        self.assertEqual(4, self.check_call_mock.call_count)
+        self.assertThat(self.check_call_mock.call_count, Equals(4))
         self.check_call_mock.assert_has_calls([
             mock.call('yes "" | make -j2 V=1 oldconfig', shell=True,
                       cwd=plugin.builddir),
@@ -430,7 +433,7 @@ class KernelPluginTestCase(tests.TestCase):
                       shell=True)
         ])
 
-        self.assertEqual(2, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(2))
         self.run_mock.assert_has_calls([
             mock.call(['make', '-j2', 'V=1', 'bzImage', 'modules']),
             mock.call(['make', '-j2', 'V=1',
@@ -448,7 +451,7 @@ class KernelPluginTestCase(tests.TestCase):
         with open(config_file) as f:
             config_contents = f.read()
 
-        self.assertEqual(config_contents, 'ACCEPT=y\n')
+        self.assertThat(config_contents, Equals('ACCEPT=y\n'))
         self._assert_common_assets(plugin.installdir)
 
     @mock.patch.object(
@@ -525,7 +528,7 @@ class KernelPluginTestCase(tests.TestCase):
         self._assert_generic_check_call(plugin.builddir, plugin.installdir,
                                         plugin.os_snap)
 
-        self.assertEqual(2, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(2))
         self.run_mock.assert_has_calls([
             mock.call(['make', '-j2', 'bzImage', 'modules']),
             mock.call(['make', '-j2',
@@ -551,7 +554,7 @@ ACCEPT=y
 SOMETHING=y
 ACCEPT=n
 """
-        self.assertEqual(config_contents, expected_config)
+        self.assertThat(config_contents, Equals(expected_config))
         self._assert_common_assets(plugin.installdir)
 
     @mock.patch.object(
@@ -585,7 +588,7 @@ ACCEPT=n
         self._assert_generic_check_call(plugin.builddir, plugin.installdir,
                                         plugin.os_snap)
 
-        self.assertEqual(3, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(3))
         self.run_mock.assert_has_calls([
             mock.call(['make', '-j1', 'defconfig']),
             mock.call(['make', '-j2', 'bzImage', 'modules']),
@@ -611,7 +614,7 @@ ACCEPT=y
 SOMETHING=y
 ACCEPT=n
 """
-        self.assertEqual(config_contents, expected_config)
+        self.assertThat(config_contents, Equals(expected_config))
         self._assert_common_assets(plugin.installdir)
 
     @mock.patch.object(
@@ -641,7 +644,7 @@ ACCEPT=n
         self._assert_generic_check_call(plugin.builddir, plugin.installdir,
                                         plugin.os_snap)
 
-        self.assertEqual(3, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(3))
         self.run_mock.assert_has_calls([
             mock.call(['make', '-j1', 'defconfig', 'defconfig2']),
             mock.call(['make', '-j2', 'bzImage', 'modules']),
@@ -677,7 +680,7 @@ ACCEPT=n
         self._assert_generic_check_call(plugin.builddir, plugin.installdir,
                                         plugin.os_snap)
 
-        self.assertEqual(2, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(2))
         self.run_mock.assert_has_calls([
             mock.call([
                 'make', '-j2', 'bzImage', 'modules', 'fake-dtb.dtb']),
@@ -696,7 +699,7 @@ ACCEPT=n
         with open(config_file) as f:
             config_contents = f.read()
 
-        self.assertEqual(config_contents, 'ACCEPT=y\n')
+        self.assertThat(config_contents, Equals('ACCEPT=y\n'))
         self._assert_common_assets(plugin.installdir)
         self.assertTrue(os.path.exists(os.path.join(
             plugin.installdir, 'dtbs', 'fake-dtb.dtb')))
@@ -715,8 +718,9 @@ ACCEPT=n
 
         raised = self.assertRaises(RuntimeError, plugin.build)
 
-        self.assertEqual(
-            "No match for dtb 'fake-dtb.dtb' was found", str(raised))
+        self.assertThat(
+            str(raised),
+            Equals("No match for dtb 'fake-dtb.dtb' was found"))
 
     @mock.patch.object(
         snapcraft._options.ProjectOptions,
@@ -759,7 +763,7 @@ ACCEPT=n
         self._assert_generic_check_call(plugin.builddir, plugin.installdir,
                                         plugin.os_snap)
 
-        self.assertEqual(2, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(2))
         self.run_mock.assert_has_calls([
             mock.call([
                 'make', '-j2', 'bzImage', 'modules']),
@@ -772,7 +776,7 @@ ACCEPT=n
                            plugin.installdir, 'lib', 'firmware'))])
         ])
 
-        self.assertEqual(1, self.run_output_mock.call_count)
+        self.assertThat(self.run_output_mock.call_count, Equals(1))
         self.run_output_mock.assert_has_calls([
             mock.call([
                 'modprobe', '-n', '--show-depends', '-d',
@@ -784,7 +788,7 @@ ACCEPT=n
         with open(config_file) as f:
             config_contents = f.read()
 
-        self.assertEqual(config_contents, 'ACCEPT=y\n')
+        self.assertThat(config_contents, Equals('ACCEPT=y\n'))
         self._assert_common_assets(plugin.installdir)
 
     @mock.patch.object(
@@ -817,7 +821,7 @@ ACCEPT=n
         self._assert_generic_check_call(plugin.builddir, plugin.installdir,
                                         plugin.os_snap)
 
-        self.assertEqual(2, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(2))
         self.run_mock.assert_has_calls([
             mock.call([
                 'make', '-j2', 'bzImage', 'modules']),
@@ -836,7 +840,7 @@ ACCEPT=n
         with open(config_file) as f:
             config_contents = f.read()
 
-        self.assertEqual(config_contents, 'ACCEPT=y\n')
+        self.assertThat(config_contents, Equals('ACCEPT=y\n'))
         self._assert_common_assets(plugin.installdir)
         self.assertTrue(os.path.exists(os.path.join(
             plugin.installdir, 'firmware', 'fake-fw-dir')))
@@ -861,7 +865,7 @@ ACCEPT=n
         self._assert_generic_check_call(plugin.builddir, plugin.installdir,
                                         plugin.os_snap)
 
-        self.assertEqual(2, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(2))
         self.run_mock.assert_has_calls([
             mock.call([
                 'make', '-j2', 'bzImage', 'modules']),
@@ -915,7 +919,7 @@ ACCEPT=n
         self._assert_generic_check_call(plugin.builddir, plugin.installdir,
                                         plugin.os_snap)
 
-        self.assertEqual(2, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(2))
         self.run_mock.assert_has_calls([
             mock.call(['make', '-j2', 'bzImage', 'modules']),
             mock.call(['make', '-j2',
@@ -953,12 +957,13 @@ ACCEPT=n
 
         raised = self.assertRaises(ValueError, plugin.build)
 
-        self.assertEqual(
-            'kernel build did not output a vmlinux binary in top level dir, '
-            'expected {!r}'.format(os.path.join(
-                plugin.builddir, 'arch', self.project_options.kernel_arch,
-                'boot', 'bzImage')),
-            str(raised))
+        self.assertThat(
+            str(raised),
+            Equals('kernel build did not output a vmlinux binary in top level '
+                   'dir, expected {!r}'.format(os.path.join(
+                       plugin.builddir, 'arch',
+                       self.project_options.kernel_arch,
+                       'boot', 'bzImage'))))
 
     def test_build_with_missing_kernel_release_fails(self):
         self.options.kconfigfile = 'config'
@@ -975,10 +980,11 @@ ACCEPT=n
 
         raised = self.assertRaises(ValueError, plugin.build)
 
-        self.assertEqual(
-            'No kernel release version info found at {!r}'.format(os.path.join(
-                plugin.builddir, 'include', 'config', 'kernel.release')),
-            str(raised))
+        self.assertThat(
+            str(raised),
+            Equals('No kernel release version info found at {!r}'.format(
+                os.path.join(
+                    plugin.builddir, 'include', 'config', 'kernel.release'))))
 
     def test_build_with_missing_system_map_fails(self):
         self.options.kconfigfile = 'config'
@@ -994,9 +1000,10 @@ ACCEPT=n
 
         raised = self.assertRaises(ValueError, plugin.build)
 
-        self.assertEqual(
-            'kernel build did not output a System.map in top level dir',
-            str(raised))
+        self.assertThat(
+            str(raised),
+            Equals(
+                'kernel build did not output a System.map in top level dir'))
 
     def test_enable_cross_compilation(self):
         project_options = snapcraft.ProjectOptions(target_deb_arch='arm64')
@@ -1004,11 +1011,13 @@ ACCEPT=n
                                      project_options)
         plugin.enable_cross_compilation()
 
-        self.assertEqual(
+        self.assertThat(
             plugin.make_cmd,
-            ['make', '-j2', 'ARCH=arm64', 'CROSS_COMPILE=aarch64-linux-gnu-',
-             'PATH={}:/usr/{}/bin'.format(os.environ.copy().get('PATH', ''),
-                                          'aarch64-linux-gnu')])
+            Equals([
+                'make', '-j2', 'ARCH=arm64',
+                'CROSS_COMPILE=aarch64-linux-gnu-',
+                'PATH={}:/usr/{}/bin'.format(os.environ.copy().get('PATH', ''),
+                                             'aarch64-linux-gnu')]))
 
     def test_override_cross_compile(self):
         project_options = snapcraft.ProjectOptions(target_deb_arch='arm64')
@@ -1018,11 +1027,13 @@ ACCEPT=n
                                                      'foo-bar-toolchain-'))
         plugin.enable_cross_compilation()
 
-        self.assertEqual(
+        self.assertThat(
             plugin.make_cmd,
-            ['make', '-j2', 'ARCH=arm64', 'CROSS_COMPILE=foo-bar-toolchain-',
-             'PATH={}:/usr/{}/bin'.format(os.environ.copy().get('PATH', ''),
-                                          'aarch64-linux-gnu')])
+            Equals([
+                'make', '-j2', 'ARCH=arm64',
+                'CROSS_COMPILE=foo-bar-toolchain-',
+                'PATH={}:/usr/{}/bin'.format(os.environ.copy().get('PATH', ''),
+                                             'aarch64-linux-gnu')]))
 
     def test_kernel_image_target_as_map(self):
         self.options.kernel_image_target = {'arm64': 'Image'}
@@ -1030,7 +1041,8 @@ ACCEPT=n
         plugin = kernel.KernelPlugin('test-part', self.options,
                                      project_options)
 
-        self.assertEqual(plugin.make_targets, ['Image', 'modules', 'dtbs'])
+        self.assertThat(
+            plugin.make_targets, Equals(['Image', 'modules', 'dtbs']))
 
     def test_kernel_image_target_as_string(self):
         self.options.kernel_image_target = 'Image'
@@ -1038,7 +1050,8 @@ ACCEPT=n
         plugin = kernel.KernelPlugin('test-part', self.options,
                                      project_options)
 
-        self.assertEqual(plugin.make_targets, ['Image', 'modules', 'dtbs'])
+        self.assertThat(
+            plugin.make_targets, Equals(['Image', 'modules', 'dtbs']))
 
     def test_kernel_image_target_non_existent(self):
         class Options:
@@ -1055,7 +1068,8 @@ ACCEPT=n
         plugin = kernel.KernelPlugin('test-part', self.options,
                                      project_options)
 
-        self.assertEqual(plugin.make_targets, ['bzImage', 'modules', 'dtbs'])
+        self.assertThat(
+            plugin.make_targets, Equals(['bzImage', 'modules', 'dtbs']))
 
     @mock.patch.object(storeapi.StoreClient, 'download')
     def test_pull(self, download_mock):

--- a/snapcraft/tests/plugins/test_make.py
+++ b/snapcraft/tests/plugins/test_make.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
 import os
 
 from unittest import mock
-from testtools.matchers import HasLength
+from testtools.matchers import Equals, HasLength
 
 import snapcraft
 from snapcraft import tests
@@ -58,17 +58,17 @@ class MakePluginTestCase(tests.TestCase):
                         'Expected "type" to be included in "makefile"')
 
         makefile_type = makefile['type']
-        self.assertEqual(makefile_type, 'string',
-                         'Expected "makefile" "type" to be "string", but it '
-                         'was "{}"'.format(makefile_type))
+        self.assertThat(makefile_type, Equals('string'),
+                        'Expected "makefile" "type" to be "string", but it '
+                        'was "{}"'.format(makefile_type))
 
         make_parameters = properties['make-parameters']
         self.assertTrue('type' in make_parameters,
                         'Expected "type" to be included in "make-parameters"')
 
         make_parameters_type = make_parameters['type']
-        self.assertEqual(
-            make_parameters_type, 'array',
+        self.assertThat(
+            make_parameters_type, Equals('array'),
             'Expected "make-parameters" "type" to be "array", but it '
             'was "{}"'.format(make_parameters_type))
 
@@ -77,14 +77,14 @@ class MakePluginTestCase(tests.TestCase):
                         'Expected "type" to be included in "make-install-var"')
 
         make_install_var_type = make_install_var['type']
-        self.assertEqual(
-            make_install_var_type, 'string',
+        self.assertThat(
+            make_install_var_type, Equals('string'),
             'Expected "make-install-var" "type" to be "string", but it '
             'was "{}"'.format(make_install_var_type))
 
         make_install_var_default = make_install_var['default']
-        self.assertEqual(
-            make_install_var_default, 'DESTDIR',
+        self.assertThat(
+            make_install_var_default, Equals('DESTDIR'),
             'Expected "make-install-var" "default" to be "DESTDIR", but it '
             'was "{}"'.format(make_install_var_default))
 
@@ -107,7 +107,7 @@ class MakePluginTestCase(tests.TestCase):
 
         plugin.build()
 
-        self.assertEqual(2, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(2))
         run_mock.assert_has_calls([
             mock.call(['make', '-j2'], env=None),
             mock.call(['make', 'install',
@@ -123,7 +123,7 @@ class MakePluginTestCase(tests.TestCase):
 
         plugin.build()
 
-        self.assertEqual(2, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(2))
         run_mock.assert_has_calls([
             mock.call(['make', '-j1'], env=None),
             mock.call(['make', 'install',
@@ -139,7 +139,7 @@ class MakePluginTestCase(tests.TestCase):
 
         plugin.build()
 
-        self.assertEqual(2, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(2))
         run_mock.assert_has_calls([
             mock.call(['make', '-f', 'makefile.linux', '-j2'], env=None),
             mock.call(['make', '-f', 'makefile.linux', 'install',
@@ -155,7 +155,7 @@ class MakePluginTestCase(tests.TestCase):
 
         plugin.build()
 
-        self.assertEqual(2, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(2))
         run_mock.assert_has_calls([
             mock.call(['make', '-j2'], env=None),
             mock.call(['make', 'install',
@@ -171,7 +171,7 @@ class MakePluginTestCase(tests.TestCase):
 
         plugin.build()
 
-        self.assertEqual(2, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(2))
         run_mock.assert_has_calls([
             mock.call(['make', '-j2'], env=None),
             mock.call(['make', 'install'], env=None)
@@ -190,17 +190,17 @@ class MakePluginTestCase(tests.TestCase):
 
         plugin.build()
 
-        self.assertEqual(1, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(1))
         run_mock.assert_has_calls([
             mock.call(['make', '-j2'], env=None),
         ])
-        self.assertEqual(1, link_or_copy_mock.call_count)
+        self.assertThat(link_or_copy_mock.call_count, Equals(1))
         link_or_copy_mock.assert_has_calls([
             mock.call(
                 os.path.join(plugin.builddir, 'file_artifact'),
                 os.path.join(plugin.installdir, 'file_artifact'),
             )])
-        self.assertEqual(1, link_or_copy_tree_mock.call_count)
+        self.assertThat(link_or_copy_tree_mock.call_count, Equals(1))
         link_or_copy_tree_mock.assert_has_calls([
             mock.call(
                 os.path.join(plugin.builddir, 'dir_artifact'),
@@ -216,7 +216,7 @@ class MakePluginTestCase(tests.TestCase):
         env = {'foo': 'bar'}
         plugin.make(env=env)
 
-        self.assertEqual(2, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(2))
         run_mock.assert_has_calls([
             mock.call(['make', '-j2'], env=env),
             mock.call(['make', 'install',

--- a/snapcraft/tests/plugins/test_maven.py
+++ b/snapcraft/tests/plugins/test_maven.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -20,7 +20,7 @@ from unittest import mock
 from xml.etree import ElementTree
 
 import fixtures
-from testtools.matchers import HasLength
+from testtools.matchers import Equals, HasLength
 
 import snapcraft
 from snapcraft import tests
@@ -67,9 +67,9 @@ class MavenPluginTestCase(tests.TestCase):
     def assertSettingsEqual(self, expected, observed):
         print(repr(self._canonicalize_settings(expected)))
         print(repr(self._canonicalize_settings(observed)))
-        self.assertEqual(
-            self._canonicalize_settings(expected),
-            self._canonicalize_settings(observed))
+        self.assertThat(
+            self._canonicalize_settings(observed),
+            Equals(self._canonicalize_settings(expected)))
 
     def test_schema(self):
         schema = maven.MavenPlugin.schema()
@@ -84,16 +84,16 @@ class MavenPluginTestCase(tests.TestCase):
         self.assertTrue(
             'type' in maven_options,
             'Expected "type" to be included in "maven-options"')
-        self.assertEqual(maven_options['type'], 'array',
-                         'Expected "maven-options" "type" to be "array", but '
-                         'it was "{}"'.format(maven_options['type']))
+        self.assertThat(maven_options['type'], Equals('array'),
+                        'Expected "maven-options" "type" to be "array", but '
+                        'it was "{}"'.format(maven_options['type']))
 
         self.assertTrue(
             'minitems' in maven_options,
             'Expected "minitems" to be included in "maven-options"')
-        self.assertEqual(maven_options['minitems'], 1,
-                         'Expected "maven-options" "minitems" to be 1, but '
-                         'it was "{}"'.format(maven_options['minitems']))
+        self.assertThat(maven_options['minitems'], Equals(1),
+                        'Expected "maven-options" "minitems" to be 1, but '
+                        'it was "{}"'.format(maven_options['minitems']))
 
         self.assertTrue(
             'uniqueItems' in maven_options,
@@ -107,16 +107,16 @@ class MavenPluginTestCase(tests.TestCase):
         self.assertTrue(
             'type' in maven_targets,
             'Expected "type" to be included in "maven-targets"')
-        self.assertEqual(maven_targets['type'], 'array',
-                         'Expected "maven-targets" "type" to be "array", but '
-                         'it was "{}"'.format(maven_targets['type']))
+        self.assertThat(maven_targets['type'], Equals('array'),
+                        'Expected "maven-targets" "type" to be "array", but '
+                        'it was "{}"'.format(maven_targets['type']))
 
         self.assertTrue(
             'minitems' in maven_targets,
             'Expected "minitems" to be included in "maven-targets"')
-        self.assertEqual(maven_targets['minitems'], 1,
-                         'Expected "maven-targets" "minitems" to be 1, but '
-                         'it was "{}"'.format(maven_targets['minitems']))
+        self.assertThat(maven_targets['minitems'], Equals(1),
+                        'Expected "maven-targets" "minitems" to be 1, but '
+                        'it was "{}"'.format(maven_targets['minitems']))
 
         self.assertTrue(
             'uniqueItems' in maven_targets,

--- a/snapcraft/tests/plugins/test_meson.py
+++ b/snapcraft/tests/plugins/test_meson.py
@@ -17,7 +17,7 @@
 import os
 
 from unittest import mock
-from testtools.matchers import HasLength
+from testtools.matchers import Equals, HasLength
 
 import snapcraft
 from snapcraft import tests
@@ -52,16 +52,16 @@ class MesonPluginTestCase(tests.TestCase):
         self.assertTrue(
             'type' in meson_parameters,
             'Expected "type" to be included in "meson-parameters"')
-        self.assertEqual(meson_parameters['type'], 'array',
-                         'Expected "meson-parameters" "type" to be "array", '
-                         'but it was "{}"'.format(meson_parameters['type']))
+        self.assertThat(meson_parameters['type'], Equals('array'),
+                        'Expected "meson-parameters" "type" to be "array", '
+                        'but it was "{}"'.format(meson_parameters['type']))
 
         self.assertTrue(
             'minitems' in meson_parameters,
             'Expected "minitems" to be included in "meson-parameters"')
-        self.assertEqual(meson_parameters['minitems'], 1,
-                         'Expected "meson-parameters" "minitems" to be 1, but '
-                         'it was "{}"'.format(meson_parameters['minitems']))
+        self.assertThat(meson_parameters['minitems'], Equals(1),
+                        'Expected "meson-parameters" "minitems" to be 1, but '
+                        'it was "{}"'.format(meson_parameters['minitems']))
 
         self.assertTrue(
             'uniqueItems' in meson_parameters,
@@ -91,7 +91,7 @@ class MesonPluginTestCase(tests.TestCase):
         env = os.environ.copy()
         env['DESTDIR'] = plugin.installdir
 
-        self.assertEqual(3, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(3))
         run_mock.assert_has_calls([
             mock.call(['meson', plugin.snapbuildname]),
             mock.call(['ninja'], cwd=plugin.mesonbuilddir),
@@ -110,7 +110,7 @@ class MesonPluginTestCase(tests.TestCase):
         env = os.environ.copy()
         env['DESTDIR'] = plugin.installdir
 
-        self.assertEqual(3, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(3))
         run_mock.assert_has_calls([
             mock.call(['meson', '--strip', plugin.snapbuildname]),
             mock.call(['ninja'], cwd=plugin.mesonbuilddir),

--- a/snapcraft/tests/plugins/test_nil.py
+++ b/snapcraft/tests/plugins/test_nil.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015, 2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from testtools.matchers import Equals
+
 from snapcraft.plugins.nil import NilPlugin
 from snapcraft.tests import TestCase
 
@@ -21,8 +23,9 @@ from snapcraft.tests import TestCase
 class TestNilPlugin(TestCase):
     def test_schema(self):
         schema = NilPlugin.schema()
-        self.assertEqual('http://json-schema.org/draft-04/schema#',
-                         schema['$schema'])
-        self.assertEqual('object', schema['type'])
+        self.assertThat(
+            schema['$schema'],
+            Equals('http://json-schema.org/draft-04/schema#'))
+        self.assertThat(schema['type'], Equals('object'))
         self.assertFalse(schema['additionalProperties'])
         self.assertFalse(schema['properties'])

--- a/snapcraft/tests/plugins/test_nodejs.py
+++ b/snapcraft/tests/plugins/test_nodejs.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015, 2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
 import os
 
 from unittest import mock
-from testtools.matchers import DirExists, HasLength
+from testtools.matchers import DirExists, Equals, HasLength
 
 import snapcraft
 from snapcraft.plugins import nodejs
@@ -246,8 +246,8 @@ class NodePluginTestCase(NodePluginBaseTestCase):
             'test-part', Options(),
             self.project_options)
 
-        self.assertEqual(raised.__str__(),
-                         'architecture not supported (fantasy-arch)')
+        self.assertThat(raised.__str__(),
+                        Equals('architecture not supported (fantasy-arch)'))
 
     def test_get_build_properties(self):
         expected_build_properties = ['node-packages', 'npm-run']
@@ -377,7 +377,7 @@ class NodeReleaseTestCase(tests.TestCase):
         architecture_mock.return_value = self.architecture
         project = snapcraft.ProjectOptions()
         node_url = nodejs.get_nodejs_release(self.engine, project.deb_arch)
-        self.assertEqual(node_url, self.expected_url)
+        self.assertThat(node_url, Equals(self.expected_url))
 
 
 class NodePluginSchemaTestCase(tests.TestCase):
@@ -393,16 +393,16 @@ class NodePluginSchemaTestCase(tests.TestCase):
         self.assertTrue(
             'type' in node_packages,
             'Expected "type" to be included in "node-packages"')
-        self.assertEqual(node_packages['type'], 'array',
-                         'Expected "node-packages" "type" to be "array", but '
-                         'it was "{}"'.format(node_packages['type']))
+        self.assertThat(node_packages['type'], Equals('array'),
+                        'Expected "node-packages" "type" to be "array", but '
+                        'it was "{}"'.format(node_packages['type']))
 
         self.assertTrue(
             'minitems' in node_packages,
             'Expected "minitems" to be included in "node-packages"')
-        self.assertEqual(node_packages['minitems'], 1,
-                         'Expected "node-packages" "minitems" to be 1, but '
-                         'it was "{}"'.format(node_packages['minitems']))
+        self.assertThat(node_packages['minitems'], Equals(1),
+                        'Expected "node-packages" "minitems" to be 1, but '
+                        'it was "{}"'.format(node_packages['minitems']))
 
         self.assertTrue('node-package-manager' in properties,
                         'Expected "node-package-manager" to be included in '
@@ -412,17 +412,17 @@ class NodePluginSchemaTestCase(tests.TestCase):
         self.assertTrue(
             'type' in node_package_manager,
             'Expected "type" to be included in "node-package-manager"')
-        self.assertEqual(node_package_manager['type'], 'string',
-                         'Expected "node-package-manager" "type" to be '
-                         '"string", but it was '
-                         '"{}"'.format(node_package_manager['type']))
+        self.assertThat(node_package_manager['type'], Equals('string'),
+                        'Expected "node-package-manager" "type" to be '
+                        '"string", but it was '
+                        '"{}"'.format(node_package_manager['type']))
         self.assertTrue(
             'default' in node_package_manager,
             'Expected "default" to be included in "node-package-manager"')
-        self.assertEqual(node_package_manager['default'], 'npm',
-                         'Expected "node-package-manager" "default" to be '
-                         '"npm", but it was '
-                         '"{}"'.format(node_package_manager['type']))
+        self.assertThat(node_package_manager['default'], Equals('npm'),
+                        'Expected "node-package-manager" "default" to be '
+                        '"npm", but it was '
+                        '"{}"'.format(node_package_manager['type']))
 
         self.assertTrue(
             'uniqueItems' in node_packages,
@@ -440,16 +440,16 @@ class NodePluginSchemaTestCase(tests.TestCase):
         self.assertTrue(
             'type' in npm_run,
             'Expected "type" to be included in "npm-run"')
-        self.assertEqual(npm_run['type'], 'array',
-                         'Expected "npm-run" "type" to be "array", but '
-                         'it was "{}"'.format(npm_run['type']))
+        self.assertThat(npm_run['type'], Equals('array'),
+                        'Expected "npm-run" "type" to be "array", but '
+                        'it was "{}"'.format(npm_run['type']))
 
         self.assertTrue(
             'minitems' in npm_run,
             'Expected "minitems" to be included in "npm-run"')
-        self.assertEqual(npm_run['minitems'], 1,
-                         'Expected "npm-run" "minitems" to be 1, but '
-                         'it was "{}"'.format(npm_run['minitems']))
+        self.assertThat(npm_run['minitems'], Equals(1),
+                        'Expected "npm-run" "minitems" to be 1, but '
+                        'it was "{}"'.format(npm_run['minitems']))
 
         self.assertTrue(
             'uniqueItems' in npm_run,
@@ -462,7 +462,7 @@ class NodePluginSchemaTestCase(tests.TestCase):
                         'Expected "node-engine" to be included in '
                         'properties')
         node_engine_type = properties['node-engine']['type']
-        self.assertEqual(node_engine_type, 'string',
-                         'Expected "node_engine" "type" to be '
-                         '"string", but it was "{}"'
-                         .format(node_engine_type))
+        self.assertThat(node_engine_type, Equals('string'),
+                        'Expected "node_engine" "type" to be '
+                        '"string", but it was "{}"'
+                        .format(node_engine_type))

--- a/snapcraft/tests/plugins/test_plainbox_provider.py
+++ b/snapcraft/tests/plugins/test_plainbox_provider.py
@@ -15,8 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-
 from unittest import mock
+
+from testtools.matchers import Equals
 
 import snapcraft
 from snapcraft import tests
@@ -92,7 +93,7 @@ class PythonPluginTestCase(tests.TestCase):
         for file_info in files:
             with open(os.path.join(plugin.installdir,
                                    file_info['path']), 'r') as f:
-                self.assertEqual(f.read(), file_info['expected'])
+                self.assertThat(f.read(), Equals(file_info['expected']))
 
     def test_build_with_proivder_stage_dir(self):
         self.useFixture(tests.fixture_setup.CleanEnvironment())
@@ -152,7 +153,7 @@ class PythonPluginTestCase(tests.TestCase):
         for file_info in files:
             with open(os.path.join(plugin.installdir,
                                    file_info['path']), 'r') as f:
-                self.assertEqual(f.read(), file_info['expected'])
+                self.assertThat(f.read(), Equals(file_info['expected']))
 
     def test_fileset_ignores(self):
         plugin = plainbox_provider.PlainboxProviderPlugin(

--- a/snapcraft/tests/plugins/test_python.py
+++ b/snapcraft/tests/plugins/test_python.py
@@ -391,7 +391,7 @@ class PythonPluginTestCase(BasePythonPluginTestCase):
         for file_info in files:
             with open(os.path.join(plugin.installdir,
                                    file_info['path']), 'r') as f:
-                self.assertEqual(f.read(), file_info['expected'])
+                self.assertThat(f.read(), Equals(file_info['expected']))
 
     @mock.patch.object(
         python.PythonPlugin, 'run_output', side_effect=fake_empty_pip_list)

--- a/snapcraft/tests/plugins/test_python2.py
+++ b/snapcraft/tests/plugins/test_python2.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2016 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from unittest import mock
+
+from testtools.matchers import Equals
 
 import snapcraft
 from snapcraft import tests
@@ -43,4 +45,4 @@ class Python2PluginTestCase(tests.TestCase):
     def test_check_version(self):
         plugin = python2.Python2Plugin('test-part', self.options,
                                        self.project_options)
-        self.assertEqual(plugin.options.python_version, 'python2')
+        self.assertThat(plugin.options.python_version, Equals('python2'))

--- a/snapcraft/tests/plugins/test_python3.py
+++ b/snapcraft/tests/plugins/test_python3.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2016 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from unittest import mock
+
+from testtools.matchers import Equals
 
 import snapcraft
 from snapcraft import tests
@@ -43,4 +45,4 @@ class Python3PluginTestCase(tests.TestCase):
     def test_check_version(self):
         plugin = python3.Python3Plugin('test-part', self.options,
                                        self.project_options)
-        self.assertEqual(plugin.options.python_version, 'python3')
+        self.assertThat(plugin.options.python_version, Equals('python3'))

--- a/snapcraft/tests/plugins/test_qmake.py
+++ b/snapcraft/tests/plugins/test_qmake.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
 import os
 
 from unittest import mock
-from testtools.matchers import HasLength
+from testtools.matchers import Equals, HasLength
 
 import snapcraft
 from snapcraft.plugins import qmake
@@ -64,21 +64,24 @@ class QMakeTestCase(tests.TestCase):
                             .format(item))
 
         options_type = options['type']
-        self.assertEqual(options_type, 'array',
-                         'Expected "options" "type" to be "array", but it '
-                         'was "{}"'.format(options_type))
+        self.assertThat(
+            options_type, Equals('array'),
+            'Expected "options" "type" to be "array", but it '
+            'was "{}"'.format(options_type))
 
         options_minitems = options['minitems']
-        self.assertEqual(options_minitems, 1,
-                         'Expected "options" "minitems" to be 1, but '
-                         'it was {}'.format(options_minitems))
+        self.assertThat(
+            options_minitems, Equals(1),
+            'Expected "options" "minitems" to be 1, but '
+            'it was {}'.format(options_minitems))
 
         self.assertTrue(options['uniqueItems'])
 
         options_default = options['default']
-        self.assertEqual(options_default, [],
-                         'Expected "options" "default" to be [], but '
-                         'it was {}'.format(options_default))
+        self.assertThat(
+            options_default, Equals([]),
+            'Expected "options" "default" to be [], but '
+            'it was {}'.format(options_default))
 
         options_items = options['items']
         self.assertTrue('type' in options_items,
@@ -86,10 +89,11 @@ class QMakeTestCase(tests.TestCase):
                         '"items"')
 
         options_items_type = options_items['type']
-        self.assertEqual(options_items_type, 'string',
-                         'Expected "options" "items" "type" to be '
-                         '"string", but it was "{}"'
-                         .format(options_items_type))
+        self.assertThat(
+            options_items_type, Equals('string'),
+            'Expected "options" "items" "type" to be '
+            '"string", but it was "{}"'
+            .format(options_items_type))
 
         # Check qt-version property
         qt_version = properties['qt-version']
@@ -98,12 +102,13 @@ class QMakeTestCase(tests.TestCase):
 
         qt_version_enum = qt_version['enum']
         # Using sets for order independence in the comparison
-        self.assertEqual(set(['qt4', 'qt5']), set(qt_version_enum))
+        self.assertThat(set(qt_version_enum), Equals(set(['qt4', 'qt5'])))
 
         qt_version_default = qt_version['default']
-        self.assertEqual(qt_version_default, 'qt5',
-                         'Expected "qt_version" "default" to be "qt5", but '
-                         'it was {}'.format(qt_version_default))
+        self.assertThat(
+            qt_version_default, Equals('qt5'),
+            'Expected "qt_version" "default" to be "qt5", but '
+            'it was {}'.format(qt_version_default))
 
         self.assertTrue('build-properties' in schema,
                         'Expected schema to include "build-properties"')
@@ -119,21 +124,24 @@ class QMakeTestCase(tests.TestCase):
                             .format(item))
 
         project_files_type = project_files['type']
-        self.assertEqual(project_files_type, 'array',
-                         'Expected "project_files" "type" to be "array", but '
-                         'it was "{}"'.format(project_files_type))
+        self.assertThat(
+            project_files_type, Equals('array'),
+            'Expected "project_files" "type" to be "array", but '
+            'it was "{}"'.format(project_files_type))
 
         project_files_minitems = project_files['minitems']
-        self.assertEqual(project_files_minitems, 1,
-                         'Expected "project_files" "minitems" to be 1, but '
-                         'it was {}'.format(project_files_minitems))
+        self.assertThat(
+            project_files_minitems, Equals(1),
+            'Expected "project_files" "minitems" to be 1, but '
+            'it was {}'.format(project_files_minitems))
 
         self.assertTrue(project_files['uniqueItems'])
 
         project_files_default = project_files['default']
-        self.assertEqual(project_files_default, [],
-                         'Expected "project_files" "default" to be [], but '
-                         'it was {}'.format(project_files_default))
+        self.assertThat(
+            project_files_default, Equals([]),
+            'Expected "project_files" "default" to be [], but '
+            'it was {}'.format(project_files_default))
 
         project_files_items = project_files['items']
         self.assertTrue('type' in project_files_items,
@@ -141,10 +149,11 @@ class QMakeTestCase(tests.TestCase):
                         '"items"')
 
         project_files_items_type = project_files_items['type']
-        self.assertEqual(project_files_items_type, 'string',
-                         'Expected "project_files" "items" "type" to be '
-                         '"string", but it was "{}"'
-                         .format(project_files_items_type))
+        self.assertThat(
+            project_files_items_type, Equals('string'),
+            'Expected "project_files" "items" "type" to be '
+            '"string", but it was "{}"'
+            .format(project_files_items_type))
 
     def test_get_build_properties(self):
         expected_build_properties = ['options', 'project-files']
@@ -173,8 +182,8 @@ class QMakeTestCase(tests.TestCase):
             qmake.QmakePlugin,
             'test-part', self.options, self.project_options)
 
-        self.assertEqual(str(raised),
-                         "Unsupported Qt version: 'qt3'")
+        self.assertThat(str(raised),
+                        Equals("Unsupported Qt version: 'qt3'"))
 
     def test_build_referencing_sourcedir_if_no_subdir(self):
         plugin = qmake.QmakePlugin('test-part', self.options,
@@ -312,7 +321,7 @@ class QMakeTestCase(tests.TestCase):
         self.assert_expected_environment({'QT_SELECT': 'qt5'})
 
     def assert_expected_environment(self, expected):
-        self.assertEqual(3, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(3))
         for call_args in self.run_mock.call_args_list:
             environment = call_args[1]['env']
             for variable, value in expected.items():
@@ -321,6 +330,6 @@ class QMakeTestCase(tests.TestCase):
                     'Expected variable {!r} to be in environment'.format(
                         variable))
 
-                self.assertEqual(environment[variable], value,
-                                 'Expected ${}={}, but it was {}'.format(
-                                     variable, value, environment[variable]))
+                self.assertThat(environment[variable], Equals(value),
+                                'Expected ${}={}, but it was {}'.format(
+                                    variable, value, environment[variable]))

--- a/snapcraft/tests/plugins/test_rust.py
+++ b/snapcraft/tests/plugins/test_rust.py
@@ -1,3 +1,5 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
 # Copyright (C) 2016-2017 Marius Gripsgard (mariogrip@ubuntu.com)
 #
 # This program is free software: you can redistribute it and/or modify
@@ -15,7 +17,7 @@
 import os
 
 from unittest import mock
-from testtools.matchers import DirExists, FileExists, Not
+from testtools.matchers import DirExists, Equals, FileExists, Not
 
 import snapcraft
 from snapcraft import tests
@@ -71,11 +73,11 @@ class RustPluginCrossCompileTestCase(tests.TestCase):
         os.makedirs(plugin.sourcedir)
 
         plugin.enable_cross_compilation()
-        self.assertEqual(self.target, plugin._target)
+        self.assertThat(plugin._target, Equals(self.target))
 
         plugin.pull()
         mock_download.assert_called_once_with()
-        self.assertEqual(2, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(2))
         self.run_mock.assert_has_calls([
             mock.call(
                 [plugin._rustup,
@@ -95,7 +97,7 @@ class RustPluginCrossCompileTestCase(tests.TestCase):
         self.assertThat(os.path.join(plugin._cargo_dir, 'config'),
                         FileExists())
 
-        self.assertEqual(3, self.run_mock.call_count)
+        self.assertThat(self.run_mock.call_count, Equals(3))
         self.run_mock.assert_has_calls([
             mock.call(
                 [plugin._cargo, 'install',
@@ -148,18 +150,18 @@ class RustPluginTestCase(tests.TestCase):
                         'Expected "type" to be included in "rust-channel"')
 
         rust_channel_type = rust_channel['type']
-        self.assertEqual(rust_channel_type, 'string',
-                         'Expected "rust-channel" "type" to be "string", '
-                         'but it was "{}"'.format(rust_channel_type))
+        self.assertThat(rust_channel_type, Equals('string'),
+                        'Expected "rust-channel" "type" to be "string", '
+                        'but it was "{}"'.format(rust_channel_type))
 
         rust_revision = properties['rust-revision']
         self.assertTrue('type' in rust_revision,
                         'Expected "type" to be included in "rust-revision"')
 
         rust_revision_type = rust_revision['type']
-        self.assertEqual(rust_revision_type, 'string',
-                         'Expected "rust-revision" "type" to be "string", '
-                         'but it was "{}"'.format(rust_revision_type))
+        self.assertThat(rust_revision_type, Equals('string'),
+                        'Expected "rust-revision" "type" to be "string", '
+                        'but it was "{}"'.format(rust_revision_type))
 
     @mock.patch.object(rust.RustPlugin, 'run')
     def test_build(self, run_mock):
@@ -169,7 +171,7 @@ class RustPluginTestCase(tests.TestCase):
 
         plugin.build()
 
-        self.assertEqual(1, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(1))
         run_mock.assert_has_calls([
             mock.call(
                 [plugin._cargo, 'install',
@@ -188,7 +190,7 @@ class RustPluginTestCase(tests.TestCase):
 
         plugin.build()
 
-        self.assertEqual(1, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(1))
         run_mock.assert_has_calls([
             mock.call(
                 [plugin._cargo, 'install',
@@ -210,7 +212,7 @@ class RustPluginTestCase(tests.TestCase):
 
         plugin.pull()
 
-        self.assertEqual(2, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(2))
 
         rustdir = os.path.join(plugin.partdir, 'rust')
         run_mock.assert_has_calls([mock.call([
@@ -231,7 +233,7 @@ class RustPluginTestCase(tests.TestCase):
 
         plugin.pull()
 
-        self.assertEqual(2, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(2))
 
         rustdir = os.path.join(plugin.partdir, 'rust')
         run_mock.assert_has_calls([mock.call([
@@ -253,7 +255,7 @@ class RustPluginTestCase(tests.TestCase):
 
         plugin.pull()
 
-        self.assertEqual(2, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(2))
 
         rustdir = os.path.join(plugin.partdir, 'rust')
         run_mock.assert_has_calls([mock.call([

--- a/snapcraft/tests/plugins/test_scons.py
+++ b/snapcraft/tests/plugins/test_scons.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
 import os
 
 from unittest import mock
-from testtools.matchers import HasLength
+from testtools.matchers import Equals, HasLength
 
 import snapcraft
 from snapcraft import tests
@@ -52,16 +52,16 @@ class SconsPluginTestCase(tests.TestCase):
         self.assertTrue(
             'type' in scons_options,
             'Expected "type" to be included in "scons-options"')
-        self.assertEqual(scons_options['type'], 'array',
-                         'Expected "scons-options" "type" to be "array", but '
-                         'it was "{}"'.format(scons_options['type']))
+        self.assertThat(scons_options['type'], Equals('array'),
+                        'Expected "scons-options" "type" to be "array", but '
+                        'it was "{}"'.format(scons_options['type']))
 
         self.assertTrue(
             'minitems' in scons_options,
             'Expected "minitems" to be included in "scons-options"')
-        self.assertEqual(scons_options['minitems'], 1,
-                         'Expected "scons-options" "minitems" to be 1, but '
-                         'it was "{}"'.format(scons_options['minitems']))
+        self.assertThat(scons_options['minitems'], Equals(1),
+                        'Expected "scons-options" "minitems" to be 1, but '
+                        'it was "{}"'.format(scons_options['minitems']))
 
         self.assertTrue(
             'uniqueItems' in scons_options,
@@ -95,7 +95,7 @@ class SconsPluginTestCase(tests.TestCase):
         env = os.environ.copy()
         env['DESTDIR'] = plugin.installdir
 
-        self.assertEqual(2, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(2))
         run_mock.assert_has_calls([
             mock.call(['scons', '--debug=explain']),
             mock.call(['scons', 'install', '--debug=explain'], env=env)

--- a/snapcraft/tests/plugins/test_tar_content.py
+++ b/snapcraft/tests/plugins/test_tar_content.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os.path
+
+from testtools.matchers import Equals
 
 import snapcraft
 from snapcraft.plugins.tar_content import TarContentPlugin
@@ -47,8 +49,8 @@ class TestTarContentPlugin(TestCase):
             'tar_content', Options(),
             self.project_options)
 
-        self.assertEqual(raised.__str__(),
-                         "path '/destdir1' must be relative")
+        self.assertThat(raised.__str__(),
+                        Equals("path '/destdir1' must be relative"))
 
     def test_install_destination_dir_exists(self):
         class Options:

--- a/snapcraft/tests/plugins/test_waf.py
+++ b/snapcraft/tests/plugins/test_waf.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
 import os
 
 from unittest import mock
-from testtools.matchers import HasLength
+from testtools.matchers import Equals, HasLength
 
 import snapcraft
 from snapcraft import tests
@@ -54,21 +54,21 @@ class WafPluginTestCase(tests.TestCase):
                             .format(item))
 
         configflags_type = configflags['type']
-        self.assertEqual(configflags_type, 'array',
-                         'Expected "configflags" "type" to be "array", but it '
-                         'was "{}"'.format(configflags_type))
+        self.assertThat(configflags_type, Equals('array'),
+                        'Expected "configflags" "type" to be "array", but it '
+                        'was "{}"'.format(configflags_type))
 
         configflags_minitems = configflags['minitems']
-        self.assertEqual(configflags_minitems, 1,
-                         'Expected "configflags" "minitems" to be 1, but '
-                         'it was {}'.format(configflags_minitems))
+        self.assertThat(configflags_minitems, Equals(1),
+                        'Expected "configflags" "minitems" to be 1, but '
+                        'it was {}'.format(configflags_minitems))
 
         self.assertTrue(configflags['uniqueItems'])
 
         configflags_default = configflags['default']
-        self.assertEqual(configflags_default, [],
-                         'Expected "configflags" "default" to be [], but '
-                         'it was {}'.format(configflags_default))
+        self.assertThat(configflags_default, Equals([]),
+                        'Expected "configflags" "default" to be [], but '
+                        'it was {}'.format(configflags_default))
 
         configflags_items = configflags['items']
         self.assertTrue('type' in configflags_items,
@@ -76,10 +76,10 @@ class WafPluginTestCase(tests.TestCase):
                         '"items"')
 
         configflags_items_type = configflags_items['type']
-        self.assertEqual(configflags_items_type, 'string',
-                         'Expected "configflags" "items" "type" to be '
-                         '"string", but it was "{}"'
-                         .format(configflags_items_type))
+        self.assertThat(configflags_items_type, Equals('string'),
+                        'Expected "configflags" "items" "type" to be '
+                        '"string", but it was "{}"'
+                        .format(configflags_items_type))
 
         self.assertTrue('build-properties' in schema,
                         'Expected schema to include "build-properties"')
@@ -112,7 +112,7 @@ class WafPluginTestCase(tests.TestCase):
         """Test building via waf and check for known calls and destdir"""
         plugin = self.waf_build()
 
-        self.assertEqual(4, run_mock.call_count)
+        self.assertThat(run_mock.call_count, Equals(4))
         run_mock.assert_has_calls([
             mock.call(['./waf', 'distclean']),
             mock.call(['./waf', 'configure']),

--- a/snapcraft/tests/repo/test_base.py
+++ b/snapcraft/tests/repo/test_base.py
@@ -18,7 +18,7 @@ import os
 import stat
 from textwrap import dedent
 
-from testtools.matchers import FileContains
+from testtools.matchers import Equals, FileContains
 
 from snapcraft.internal import errors
 from snapcraft.internal.repo import check_for_command
@@ -165,7 +165,7 @@ class FixShebangTestCase(RepoBaseTestCase):
         BaseRepo('root').normalize('root')
 
         with open(self.file_path, 'r') as fd:
-            self.assertEqual(fd.read(), self.expected)
+            self.assertThat(fd.read(), Equals(self.expected))
 
 
 class FixPkgConfigTestCase(RepoBaseTestCase):
@@ -242,7 +242,7 @@ class FixSymlinksTestCase(RepoBaseTestCase):
 
         BaseRepo(self.tempdir).normalize(self.tempdir)
 
-        self.assertEqual(os.readlink(self.dst), self.src)
+        self.assertThat(os.readlink(self.dst), Equals(self.src))
 
 
 class FixSUIDTestCase(RepoBaseTestCase):
@@ -266,5 +266,5 @@ class FixSUIDTestCase(RepoBaseTestCase):
 
         BaseRepo(self.tempdir).normalize(self.tempdir)
 
-        self.assertEqual(
-            stat.S_IMODE(os.stat(file).st_mode), self.expected_mod)
+        self.assertThat(
+            stat.S_IMODE(os.stat(file).st_mode), Equals(self.expected_mod))

--- a/snapcraft/tests/repo/test_deb.py
+++ b/snapcraft/tests/repo/test_deb.py
@@ -20,6 +20,7 @@ from unittest.mock import ANY, call, patch, MagicMock
 
 from testtools.matchers import (
     Contains,
+    Equals,
     FileExists,
 )
 
@@ -51,18 +52,18 @@ class UbuntuTestCase(RepoBaseTestCase):
 
     def test_get_pkg_name_parts_name_only(self):
         name, version = repo.get_pkg_name_parts('hello')
-        self.assertEqual('hello', name)
-        self.assertEqual(None, version)
+        self.assertThat(name, Equals('hello'))
+        self.assertThat(version, Equals(None))
 
     def test_get_pkg_name_parts_all(self):
         name, version = repo.get_pkg_name_parts('hello:i386=2.10-1')
-        self.assertEqual('hello:i386', name)
-        self.assertEqual('2.10-1', version)
+        self.assertThat(name, Equals('hello:i386'))
+        self.assertThat(version, Equals('2.10-1'))
 
     def test_get_pkg_name_parts_no_arch(self):
         name, version = repo.get_pkg_name_parts('hello=2.10-1')
-        self.assertEqual('hello', name)
-        self.assertEqual('2.10-1', version)
+        self.assertThat(name, Equals('hello'))
+        self.assertThat(version, Equals('2.10-1'))
 
     @patch('snapcraft.internal.repo._deb.apt.apt_pkg')
     def test_get_package(self, mock_apt_pkg):
@@ -160,7 +161,7 @@ deb http://security.ubuntu.com/ubuntu xenial-security main restricted
 deb http://security.ubuntu.com/ubuntu xenial-security universe
 deb http://security.ubuntu.com/ubuntu xenial-security multiverse
 '''
-        self.assertEqual(sources_list, expected_sources_list)
+        self.assertThat(sources_list, Equals(expected_sources_list))
 
     def test_no_geoip_uses_default_archive(self):
         sources_list = repo._deb._format_sources_list(
@@ -178,7 +179,7 @@ deb http://security.ubuntu.com/ubuntu xenial-security universe
 deb http://security.ubuntu.com/ubuntu xenial-security multiverse
 '''
 
-        self.assertEqual(sources_list, expected_sources_list)
+        self.assertThat(sources_list, Equals(expected_sources_list))
 
     @patch('snapcraft.internal.repo._deb._get_geoip_country_code_prefix')
     def test_sources_amd64_vivid(self, mock_cc):
@@ -200,7 +201,7 @@ deb http://security.ubuntu.com/ubuntu vivid-security main restricted
 deb http://security.ubuntu.com/ubuntu vivid-security universe
 deb http://security.ubuntu.com/ubuntu vivid-security multiverse
 '''
-        self.assertEqual(sources_list, expected_sources_list)
+        self.assertThat(sources_list, Equals(expected_sources_list))
 
     @patch('snapcraft.repo._deb._get_geoip_country_code_prefix')
     def test_sources_armhf_trusty(self, mock_cc):
@@ -218,7 +219,7 @@ deb http://ports.ubuntu.com/ubuntu-ports trusty-security main restricted
 deb http://ports.ubuntu.com/ubuntu-ports trusty-security universe
 deb http://ports.ubuntu.com/ubuntu-ports trusty-security multiverse
 '''
-        self.assertEqual(sources_list, expected_sources_list)
+        self.assertThat(sources_list, Equals(expected_sources_list))
         self.assertFalse(mock_cc.called)
 
 

--- a/snapcraft/tests/sources/test_7z.py
+++ b/snapcraft/tests/sources/test_7z.py
@@ -13,8 +13,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 import shutil
+
+from testtools.matchers import Equals
 
 from snapcraft.internal import sources
 from snapcraft import tests
@@ -39,7 +42,7 @@ class Test7z(tests.TestCase):
         seven_zip_source = sources.SevenZip(self.test_7z_file_path, dest_dir)
         seven_zip_source.pull()
 
-        self.assertEqual(set(os.listdir(dest_dir)), self._7z_test_files)
+        self.assertThat(set(os.listdir(dest_dir)), Equals(self._7z_test_files))
 
     def test_extract_and_keep_7zfile(self):
         dest_dir = 'src'

--- a/snapcraft/tests/sources/test_base.py
+++ b/snapcraft/tests/sources/test_base.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2016 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -16,6 +16,8 @@
 
 import os
 from unittest import mock
+
+from testtools.matchers import Equals
 
 from snapcraft.internal.sources import _base
 from snapcraft import tests
@@ -62,8 +64,8 @@ class TestFileBase(tests.TestCase):
 
         file_src.pull()
 
-        self.assertEqual(file_src.file, os.path.join(
-                file_src.source_dir, os.path.basename(file_src.source)))
+        self.assertThat(file_src.file, Equals(os.path.join(
+                file_src.source_dir, os.path.basename(file_src.source))))
 
     @mock.patch(
         'snapcraft.internal.sources._base.download_requests_stream')
@@ -99,6 +101,8 @@ class TestFileBase(tests.TestCase):
 
         file_src.pull()
 
-        self.assertEqual(mock_urlretrieve.call_count, 1)
-        self.assertEqual(mock_urlretrieve.call_args[0][0], file_src.source)
-        self.assertEqual(mock_urlretrieve.call_args[0][1], file_src.file)
+        self.assertThat(mock_urlretrieve.call_count, Equals(1))
+        self.assertThat(
+            mock_urlretrieve.call_args[0][0], Equals(file_src.source))
+        self.assertThat(
+            mock_urlretrieve.call_args[0][1], Equals(file_src.file))

--- a/snapcraft/tests/sources/test_bazaar.py
+++ b/snapcraft/tests/sources/test_bazaar.py
@@ -17,6 +17,8 @@
 import os
 from unittest import mock
 
+from testtools.matchers import Equals
+
 from snapcraft.internal import sources
 from snapcraft import tests
 from snapcraft.tests import fixture_setup
@@ -90,7 +92,7 @@ class TestBazaar(tests.sources.SourceTestCase):
             'lp:mysource', 'source_dir', source_branch='branch')
 
         expected_message = 'can\'t specify a source-branch for a bzr source'
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_init_with_source_depth_raises_exception(self):
         raised = self.assertRaises(
@@ -100,7 +102,7 @@ class TestBazaar(tests.sources.SourceTestCase):
 
         expected_message = (
             'can\'t specify source-depth for a bzr source')
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_init_with_source_tag_and_commit_raises_exception(self):
         raised = self.assertRaises(
@@ -112,7 +114,7 @@ class TestBazaar(tests.sources.SourceTestCase):
         expected_message = (
             'can\'t specify both source-tag and source-commit for '
             'a bzr source')
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_source_checksum_raises_exception(self):
         raised = self.assertRaises(
@@ -123,7 +125,7 @@ class TestBazaar(tests.sources.SourceTestCase):
 
         expected_message = (
             "can't specify a source-checksum for a bzr source")
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_has_source_handler_entry(self):
         self.assertTrue(sources._source_handler['bzr'] is sources.Bazaar)
@@ -146,8 +148,8 @@ class BazaarDetailsTestCase(tests.TestCase):
         self.source_details = self.bzr._get_source_details()
 
     def test_bzr_details_commit(self):
-        self.assertEqual(
-            self.bzr_repo.commit, self.source_details['source-commit'])
+        self.assertThat(
+            self.source_details['source-commit'], Equals(self.bzr_repo.commit))
 
     def test_bzr_details_tag(self):
         self.bzr = sources.Bazaar(self.working_tree, self.source_dir,
@@ -155,4 +157,5 @@ class BazaarDetailsTestCase(tests.TestCase):
         self.bzr.pull()
 
         self.source_details = self.bzr._get_source_details()
-        self.assertEqual('feature-tag', self.source_details['source-tag'])
+        self.assertThat(
+            self.source_details['source-tag'], Equals('feature-tag'))

--- a/snapcraft/tests/sources/test_checksum.py
+++ b/snapcraft/tests/sources/test_checksum.py
@@ -14,14 +14,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from snapcraft import tests
-from snapcraft.internal.sources import errors
-from snapcraft.internal.sources._checksum import verify_checksum
-
 import os
 import hashlib
 import zipfile
 import sys
+
+from testtools.matchers import Equals
+
+from snapcraft import tests
+from snapcraft.internal.sources import errors
+from snapcraft.internal.sources._checksum import verify_checksum
+
 
 if sys.version_info < (3, 6):
     import sha3  # noqa
@@ -78,5 +81,5 @@ class TestChecksum(tests.TestCase):
                                    'md5/' + incorrect_checksum,
                                    'src/test.zip')
 
-        self.assertEqual(raised.expected, incorrect_checksum)
-        self.assertEqual(raised.calculated, calculated_checksum)
+        self.assertThat(raised.expected, Equals(incorrect_checksum))
+        self.assertThat(raised.calculated, Equals(calculated_checksum))

--- a/snapcraft/tests/sources/test_deb.py
+++ b/snapcraft/tests/sources/test_deb.py
@@ -18,8 +18,9 @@ import os
 import sys
 from unittest import mock
 
-from snapcraft.internal import sources
+from testtools.matchers import Equals
 
+from snapcraft.internal import sources
 from snapcraft import tests
 
 
@@ -60,7 +61,7 @@ class TestDeb(tests.FakeFileHTTPServerBasedTestCase):
             os.path.join(deb_source.source_dir, deb_file_name))
 
         with open(deb_download, 'r') as deb_file:
-            self.assertEqual('Test fake file', deb_file.read())
+            self.assertThat(deb_file.read(), Equals('Test fake file'))
 
     def test_has_source_handler_entry_on_linux(self):
         if sys.platform == 'linux':

--- a/snapcraft/tests/sources/test_git.py
+++ b/snapcraft/tests/sources/test_git.py
@@ -160,7 +160,7 @@ class TestGit(SourceTestCase):
 
         expected_message = \
             'can\'t specify both source-tag and source-branch for a git source'
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_init_with_source_branch_and_commit_raises_exception(self):
         raised = self.assertRaises(
@@ -173,7 +173,7 @@ class TestGit(SourceTestCase):
         expected_message = \
             'can\'t specify both source-branch and source-commit for ' \
             'a git source'
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_init_with_source_tag_and_commit_raises_exception(self):
         raised = self.assertRaises(
@@ -186,7 +186,7 @@ class TestGit(SourceTestCase):
         expected_message = \
             'can\'t specify both source-tag and source-commit for ' \
             'a git source'
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_source_checksum_raises_exception(self):
         raised = self.assertRaises(
@@ -197,7 +197,7 @@ class TestGit(SourceTestCase):
 
         expected_message = (
             "can't specify a source-checksum for a git source")
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_has_source_handler_entry(self):
         self.assertTrue(sources._source_handler['git'] is sources.Git)
@@ -234,7 +234,7 @@ class GitBaseTestCase(tests.TestCase):
         body = None
         with open(path) as fp:
             body = fp.read()
-        self.assertEqual(body, expected)
+        self.assertThat(body, Equals(expected))
 
 
 class TestGitConflicts(GitBaseTestCase):
@@ -277,7 +277,7 @@ class TestGitConflicts(GitBaseTestCase):
         with open(os.path.join(working_tree, 'fake')) as fp:
             body = fp.read()
 
-        self.assertEqual(body, 'fake 2')
+        self.assertThat(body, Equals('fake 2'))
 
     def test_git_submodules(self):
         """Test that updates to submodules are pulled"""
@@ -395,8 +395,8 @@ class GitDetailsTestCase(GitBaseTestCase):
         self.source_details = self.git._get_source_details()
 
     def test_git_details_commit(self):
-        self.assertEqual(
-            self.expected_commit, self.source_details['source-commit'])
+        self.assertThat(
+            self.source_details['source-commit'], Equals(self.expected_commit))
 
     def test_git_details_branch(self):
         shutil.rmtree(self.source_dir)
@@ -405,8 +405,8 @@ class GitDetailsTestCase(GitBaseTestCase):
         self.git.pull()
 
         self.source_details = self.git._get_source_details()
-        self.assertEqual(
-            self.expected_branch, self.source_details['source-branch'])
+        self.assertThat(
+            self.source_details['source-branch'], Equals(self.expected_branch))
 
     def test_git_details_tag(self):
         self.git = sources.Git(self.working_tree, self.source_dir, silent=True,
@@ -414,7 +414,8 @@ class GitDetailsTestCase(GitBaseTestCase):
         self.git.pull()
 
         self.source_details = self.git._get_source_details()
-        self.assertEqual(self.expected_tag, self.source_details['source-tag'])
+        self.assertThat(
+            self.source_details['source-tag'], Equals(self.expected_tag))
 
 
 class GitGenerateVersionBaseTestCase(tests.TestCase):

--- a/snapcraft/tests/sources/test_local.py
+++ b/snapcraft/tests/sources/test_local.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2016 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -19,6 +19,7 @@ import os
 from unittest import mock
 from testtools.matchers import (
     DirExists,
+    Equals,
     FileExists
 )
 
@@ -41,8 +42,8 @@ class TestLocal(tests.TestCase):
         local = sources.Local('.', 'destination')
         local.pull()
 
-        self.assertEqual(
-            snapcraft_files_before_pull, common.SNAPCRAFT_FILES)
+        self.assertThat(
+            snapcraft_files_before_pull, Equals(common.SNAPCRAFT_FILES))
 
     def test_pull_with_existing_empty_source_dir_creates_hardlinks(self):
         os.makedirs(os.path.join('src', 'dir'))

--- a/snapcraft/tests/sources/test_mercurial.py
+++ b/snapcraft/tests/sources/test_mercurial.py
@@ -18,8 +18,9 @@ import os
 import shutil
 from unittest import mock
 
-from snapcraft.internal import sources
+from testtools.matchers import Equals
 
+from snapcraft.internal import sources
 from snapcraft import tests
 from snapcraft.tests.subprocess_utils import (
     call,
@@ -119,7 +120,7 @@ class TestMercurial(tests.sources.SourceTestCase):
         expected_message = (
             'can\'t specify both source-tag and source-branch for a mercurial '
             'source')
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_init_with_source_commit_and_tag_raises_exception(self):
         raised = self.assertRaises(
@@ -131,7 +132,7 @@ class TestMercurial(tests.sources.SourceTestCase):
         expected_message = (
             'can\'t specify both source-tag and source-commit for a mercurial '
             'source')
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_init_with_source_commit_and_branch_raises_exception(self):
         raised = self.assertRaises(
@@ -143,7 +144,7 @@ class TestMercurial(tests.sources.SourceTestCase):
         expected_message = (
             'can\'t specify both source-branch and source-commit for '
             'a mercurial source')
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_init_with_source_depth_raises_exception(self):
         raised = self.assertRaises(
@@ -153,7 +154,7 @@ class TestMercurial(tests.sources.SourceTestCase):
 
         expected_message = (
             'can\'t specify source-depth for a mercurial source')
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_source_checksum_raises_exception(self):
         raised = self.assertRaises(
@@ -164,7 +165,7 @@ class TestMercurial(tests.sources.SourceTestCase):
 
         expected_message = (
             "can't specify a source-checksum for a mercurial source")
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_has_source_handler_entry(self):
         self.assertTrue(sources._source_handler['mercurial'] is
@@ -198,7 +199,7 @@ class MercurialBaseTestCase(tests.TestCase):
         body = None
         with open(path) as fp:
             body = fp.read()
-        self.assertEqual(body, expected)
+        self.assertThat(body, Equals(expected))
 
 
 class MercurialDetailsTestCase(MercurialBaseTestCase):
@@ -230,8 +231,8 @@ class MercurialDetailsTestCase(MercurialBaseTestCase):
         self.source_details = self.hg._get_source_details()
 
     def test_hg_details_commit(self):
-        self.assertEqual(
-            self.expected_commit, self.source_details['source-commit'])
+        self.assertThat(
+            self.source_details['source-commit'], Equals(self.expected_commit))
 
     def test_hg_details_branch(self):
         self.clean_dir(self.source_dir)
@@ -240,8 +241,8 @@ class MercurialDetailsTestCase(MercurialBaseTestCase):
         self.hg.pull()
 
         self.source_details = self.hg._get_source_details()
-        self.assertEqual(
-            self.expected_branch, self.source_details['source-branch'])
+        self.assertThat(
+            self.source_details['source-branch'], Equals(self.expected_branch))
 
     def test_hg_details_tag(self):
         self.clean_dir(self.source_dir)
@@ -250,4 +251,5 @@ class MercurialDetailsTestCase(MercurialBaseTestCase):
         self.hg.pull()
 
         self.source_details = self.hg._get_source_details()
-        self.assertEqual(self.expected_tag, self.source_details['source-tag'])
+        self.assertThat(
+            self.source_details['source-tag'], Equals(self.expected_tag))

--- a/snapcraft/tests/sources/test_rpm.py
+++ b/snapcraft/tests/sources/test_rpm.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2016 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -18,6 +18,8 @@ import os
 import libarchive
 import shutil
 import sys
+
+from testtools.matchers import Equals
 
 from snapcraft.internal import sources
 from snapcraft import tests
@@ -40,7 +42,7 @@ class TestRpm(tests.TestCase):
         rpm_source = sources.Rpm(rpm_file_path, dest_dir)
         rpm_source.pull()
 
-        self.assertEqual(os.listdir(dest_dir), ['test.txt'])
+        self.assertThat(os.listdir(dest_dir), Equals(['test.txt']))
 
     def test_extract_and_keep_rpmfile(self):
         rpm_file_name = 'test.rpm'

--- a/snapcraft/tests/sources/test_sources.py
+++ b/snapcraft/tests/sources/test_sources.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2016 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+
+from testtools.matchers import Equals
 
 from snapcraft.internal import sources
 from snapcraft import tests
@@ -42,8 +44,8 @@ class TestUri(tests.TestCase):
     ]
 
     def test_get_source_typefrom_uri(self):
-        self.assertEqual(sources._get_source_type_from_uri(self.source),
-                         self.result)
+        self.assertThat(sources._get_source_type_from_uri(self.source),
+                        Equals(self.result))
 
 
 class SourceWithBranchTestCase(tests.TestCase):
@@ -105,10 +107,10 @@ class SourceWithBranchTestCase(tests.TestCase):
             source_tag=self.source_tag,
             source_commit=self.source_commit)
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'can\'t specify a {} for a {} source'.format(
-                self.error, self.source_type))
+            Equals('can\'t specify a {} for a {} source'.format(
+                self.error, self.source_type)))
 
 
 class SourceWithBranchAndTagTestCase(tests.TestCase):
@@ -137,10 +139,10 @@ class SourceWithBranchAndTagTestCase(tests.TestCase):
             source_branch=self.source_branch,
             source_tag=self.source_tag)
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'can\'t specify both source-tag and source-branch for a {} '
-            'source'.format(self.source_type))
+            Equals('can\'t specify both source-tag and source-branch for a {} '
+                   'source'.format(self.source_type)))
 
 
 class GetSourceTestClass(tests.TestCase):

--- a/snapcraft/tests/sources/test_subversion.py
+++ b/snapcraft/tests/sources/test_subversion.py
@@ -18,8 +18,9 @@ import os
 import shutil
 from unittest import mock
 
-from snapcraft.internal import sources
+from testtools.matchers import Equals
 
+from snapcraft.internal import sources
 from snapcraft import tests
 from snapcraft.tests.subprocess_utils import call
 
@@ -77,7 +78,7 @@ class TestSubversion(tests.sources.SourceTestCase):
             'svn://mysource', 'source_dir', source_tag='tag')
         expected_message = (
             "Can't specify source-tag for a Subversion source")
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_init_with_source_branch_raises_exception(self):
         raised = self.assertRaises(
@@ -86,7 +87,7 @@ class TestSubversion(tests.sources.SourceTestCase):
             'svn://mysource', 'source_dir', source_branch='branch')
         expected_message = (
             "Can't specify source-branch for a Subversion source")
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_init_with_source_branch_and_tag_raises_exception(self):
         raised = self.assertRaises(
@@ -98,7 +99,7 @@ class TestSubversion(tests.sources.SourceTestCase):
         expected_message = (
             "Can't specify source-tag OR source-branch for a Subversion "
             "source")
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_init_with_source_depth_raises_exception(self):
         raised = self.assertRaises(
@@ -108,7 +109,7 @@ class TestSubversion(tests.sources.SourceTestCase):
 
         expected_message = (
             'can\'t specify source-depth for a Subversion source')
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_source_checksum_raises_exception(self):
         raised = self.assertRaises(
@@ -119,7 +120,7 @@ class TestSubversion(tests.sources.SourceTestCase):
 
         expected_message = (
             "can't specify a source-checksum for a Subversion source")
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_has_source_handler_entry(self):
         self.assertTrue(sources._source_handler['subversion'] is
@@ -174,5 +175,5 @@ class SubversionDetailsTestCase(SubversionBaseTestCase):
         self.source_details = self.svn._get_source_details()
 
     def test_svn_details_commit(self):
-        self.assertEqual(
-            self.expected_commit, self.source_details['source-commit'])
+        self.assertThat(
+            self.source_details['source-commit'], Equals(self.expected_commit))

--- a/snapcraft/tests/sources/test_tar.py
+++ b/snapcraft/tests/sources/test_tar.py
@@ -22,7 +22,6 @@ from unittest import mock
 import requests
 from testtools.matchers import Equals
 
-from snapcraft.internal import sources
 from snapcraft import tests
 from snapcraft.internal import sources
 

--- a/snapcraft/tests/sources/test_tar.py
+++ b/snapcraft/tests/sources/test_tar.py
@@ -20,7 +20,9 @@ import fixtures
 from unittest import mock
 
 import requests
+from testtools.matchers import Equals
 
+from snapcraft.internal import sources
 from snapcraft import tests
 from snapcraft.internal import sources
 
@@ -51,7 +53,7 @@ class TestTar(tests.FakeFileHTTPServerBasedTestCase):
         source_file = os.path.join(dest_dir, tar_file_name)
         mock_prov.assert_called_once_with(dest_dir, src=source_file)
         with open(os.path.join(dest_dir, tar_file_name), 'r') as tar_file:
-            self.assertEqual('Test fake file', tar_file.read())
+            self.assertThat(tar_file.read(), Equals('Test fake file'))
 
     @mock.patch('snapcraft.sources.Tar.provision')
     def test_pull_twice_downloads_once(self, mock_prov):
@@ -69,7 +71,7 @@ class TestTar(tests.FakeFileHTTPServerBasedTestCase):
             'requests.get',
                 new=mock.Mock(wraps=requests.get)) as download_spy:
             tar_source.pull()
-            self.assertEqual(download_spy.call_count, 0)
+            self.assertThat(download_spy.call_count, Equals(0))
 
     def test_strip_common_prefix(self):
         # Create tar file for testing
@@ -99,10 +101,9 @@ class TestTar(tests.FakeFileHTTPServerBasedTestCase):
 
         def check_for_symlink(tarinfo):
             self.assertTrue(tarinfo.issym())
-            self.assertEqual(file_to_link, tarinfo.name)
-            self.assertEqual(file_to_tar, os.path.normpath(
-                os.path.join(
-                    os.path.dirname(file_to_tar), tarinfo.linkname)))
+            self.assertThat(file_to_link, Equals(tarinfo.name))
+            self.assertThat(file_to_tar, Equals(os.path.normpath(
+                os.path.join(os.path.dirname(file_to_tar), tarinfo.linkname))))
             return tarinfo
 
         tar = tarfile.open(os.path.join('src', 'test.tar'), 'w')
@@ -131,8 +132,8 @@ class TestTar(tests.FakeFileHTTPServerBasedTestCase):
         def check_for_hardlink(tarinfo):
             self.assertTrue(tarinfo.islnk())
             self.assertFalse(tarinfo.issym())
-            self.assertEqual(file_to_link, tarinfo.name)
-            self.assertEqual(file_to_tar, tarinfo.linkname)
+            self.assertThat(file_to_link, Equals(tarinfo.name))
+            self.assertThat(file_to_tar, Equals(tarinfo.linkname))
             return tarinfo
 
         tar = tarfile.open(os.path.join('src', 'test.tar'), 'w')

--- a/snapcraft/tests/sources/test_zip.py
+++ b/snapcraft/tests/sources/test_zip.py
@@ -17,8 +17,9 @@
 import os
 from unittest import mock
 
-from snapcraft.internal import sources
+from testtools.matchers import Equals
 
+from snapcraft.internal import sources
 from snapcraft import tests
 
 
@@ -53,7 +54,7 @@ class TestZip(tests.FakeFileHTTPServerBasedTestCase):
         mock_zip.assert_called_once_with(zip_download)
 
         with open(zip_download, 'r') as zip_file:
-            self.assertEqual('Test fake file', zip_file.read())
+            self.assertThat(zip_file.read(), Equals('Test fake file'))
 
     def test_has_source_handler_entry(self):
         self.assertTrue(sources._source_handler['zip'] is sources.Zip)

--- a/snapcraft/tests/states/test_build.py
+++ b/snapcraft/tests/states/test_build.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import yaml
+
+from testtools.matchers import Equals
 
 import snapcraft.internal
 from snapcraft import tests
@@ -41,7 +43,7 @@ class BuildStateTestCase(BuildStateBaseTestCase):
 
     def test_yaml_conversion(self):
         state_from_yaml = yaml.load(yaml.dump(self.state))
-        self.assertEqual(self.state, state_from_yaml)
+        self.assertThat(state_from_yaml, Equals(self.state))
 
     def test_comparison(self):
         other = snapcraft.internal.states.BuildState(
@@ -59,21 +61,22 @@ class BuildStateTestCase(BuildStateBaseTestCase):
         })
 
         properties = self.state.properties_of_interest(self.part_properties)
-        self.assertEqual(6, len(properties))
-        self.assertEqual('bar', properties['foo'])
-        self.assertEqual('test-after', properties['after'])
-        self.assertEqual(
-            ['test-build-attribute'], properties['build-attributes'])
-        self.assertEqual('test-build-packages', properties['build-packages'])
-        self.assertEqual('test-disable-parallel',
-                         properties['disable-parallel'])
-        self.assertEqual({'baz': 'qux'}, properties['organize'])
+        self.assertThat(len(properties), Equals(6))
+        self.assertThat(properties['foo'], Equals('bar'))
+        self.assertThat(properties['after'], Equals('test-after'))
+        self.assertThat(
+            properties['build-attributes'], Equals(['test-build-attribute']))
+        self.assertThat(
+            properties['build-packages'], Equals('test-build-packages'))
+        self.assertThat(
+            properties['disable-parallel'], Equals('test-disable-parallel'))
+        self.assertThat(properties['organize'], Equals({'baz': 'qux'}))
 
     def test_project_options_of_interest(self):
         options = self.state.project_options_of_interest(self.project)
 
-        self.assertEqual(1, len(options))
-        self.assertEqual('amd64', options['deb_arch'])
+        self.assertThat(len(options), Equals(1))
+        self.assertThat(options['deb_arch'], Equals('amd64'))
 
 
 class BuildStateNotEqualTestCase(BuildStateBaseTestCase):

--- a/snapcraft/tests/states/test_prime.py
+++ b/snapcraft/tests/states/test_prime.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import yaml
+
+from testtools.matchers import Equals
 
 import snapcraft.internal
 from snapcraft import tests
@@ -42,7 +44,7 @@ class PrimeStateTestCase(PrimeStateBaseTestCase):
 
     def test_yaml_conversion(self):
         state_from_yaml = yaml.load(yaml.dump(self.state))
-        self.assertEqual(self.state, state_from_yaml)
+        self.assertThat(state_from_yaml, Equals(self.state))
 
     def test_comparison(self):
         other = snapcraft.internal.states.PrimeState(
@@ -53,8 +55,8 @@ class PrimeStateTestCase(PrimeStateBaseTestCase):
 
     def test_properties_of_interest(self):
         properties = self.state.properties_of_interest(self.part_properties)
-        self.assertEqual(1, len(properties))
-        self.assertEqual(['qux'], properties['prime'])
+        self.assertThat(len(properties), Equals(1))
+        self.assertThat(properties['prime'], Equals(['qux']))
 
     def test_project_options_of_interest(self):
         self.assertFalse(self.state.project_options_of_interest(self.project))

--- a/snapcraft/tests/states/test_pull.py
+++ b/snapcraft/tests/states/test_pull.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import yaml
+
+from testtools.matchers import Equals
 
 import snapcraft.internal
 from snapcraft import tests
@@ -40,7 +42,7 @@ class PullStateTestCase(PullStateBaseTestCase):
 
     def test_yaml_conversion(self):
         state_from_yaml = yaml.load(yaml.dump(self.state))
-        self.assertEqual(self.state, state_from_yaml)
+        self.assertThat(state_from_yaml, Equals(self.state))
 
     def test_comparison(self):
         other = snapcraft.internal.states.PullState(
@@ -62,23 +64,28 @@ class PullStateTestCase(PullStateBaseTestCase):
         })
 
         properties = self.state.properties_of_interest(self.part_properties)
-        self.assertEqual(10, len(properties))
-        self.assertEqual('bar', properties['foo'])
-        self.assertEqual('test-plugin', properties['plugin'])
-        self.assertEqual(['test-stage-package'], properties['stage-packages'])
-        self.assertEqual('test-source', properties['source'])
-        self.assertEqual('test-source-commit', properties['source-commit'])
-        self.assertEqual('test-source-depth', properties['source-depth'])
-        self.assertEqual('test-source-tag', properties['source-tag'])
-        self.assertEqual('test-source-type', properties['source-type'])
-        self.assertEqual('test-source-branch', properties['source-branch'])
-        self.assertEqual('test-source-subdir', properties['source-subdir'])
+        self.assertThat(len(properties), Equals(10))
+        self.assertThat(properties['foo'], Equals('bar'))
+        self.assertThat(properties['plugin'], Equals('test-plugin'))
+        self.assertThat(
+            properties['stage-packages'], Equals(['test-stage-package']))
+        self.assertThat(properties['source'], Equals('test-source'))
+        self.assertThat(
+            properties['source-commit'], Equals('test-source-commit'))
+        self.assertThat(
+            properties['source-depth'], Equals('test-source-depth'))
+        self.assertThat(properties['source-tag'], Equals('test-source-tag'))
+        self.assertThat(properties['source-type'], Equals('test-source-type'))
+        self.assertThat(
+            properties['source-branch'], Equals('test-source-branch'))
+        self.assertThat(
+            properties['source-subdir'], Equals('test-source-subdir'))
 
     def test_project_options_of_interest(self):
         options = self.state.project_options_of_interest(self.project)
 
-        self.assertEqual(1, len(options))
-        self.assertEqual('amd64', options['deb_arch'])
+        self.assertThat(len(options), Equals(1))
+        self.assertThat(options['deb_arch'], Equals('amd64'))
 
 
 class PullStateNotEqualTestCase(PullStateBaseTestCase):

--- a/snapcraft/tests/states/test_stage.py
+++ b/snapcraft/tests/states/test_stage.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import yaml
+
+from testtools.matchers import Equals
 
 import snapcraft.internal
 from snapcraft import tests
@@ -40,7 +42,7 @@ class StateStageTestCase(StageStateBaseTestCase):
 
     def test_yaml_conversion(self):
         state_from_yaml = yaml.load(yaml.dump(self.state))
-        self.assertEqual(self.state, state_from_yaml)
+        self.assertThat(state_from_yaml, Equals(self.state))
 
     def test_comparison(self):
         other = snapcraft.internal.states.StageState(
@@ -50,9 +52,9 @@ class StateStageTestCase(StageStateBaseTestCase):
 
     def test_properties_of_interest(self):
         properties = self.state.properties_of_interest(self.part_properties)
-        self.assertEqual(2, len(properties))
-        self.assertEqual(['baz'], properties['stage'])
-        self.assertEqual({'qux': 'quux'}, properties['filesets'])
+        self.assertThat(len(properties), Equals(2))
+        self.assertThat(properties['stage'], Equals(['baz']))
+        self.assertThat(properties['filesets'], Equals({'qux': 'quux'}))
 
     def test_project_options_of_interest(self):
         self.assertFalse(self.state.project_options_of_interest(self.project))

--- a/snapcraft/tests/states/test_state.py
+++ b/snapcraft/tests/states/test_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016, 2017 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -13,6 +13,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from testtools.matchers import Equals
 
 from snapcraft.internal.states._state import PartState
 from snapcraft import tests
@@ -60,9 +62,9 @@ class StateTestCase(tests.TestCase):
     def test_diff_properties_of_interest(self):
         differing_properties = self.state.diff_properties_of_interest(
             self.new)
-        self.assertEqual(differing_properties, {'foo'})
+        self.assertThat(differing_properties, Equals({'foo'}))
 
     def test_diff_project_options_of_interest(self):
         differing_properties = self.state.diff_project_options_of_interest(
             _TestProject(self.new))
-        self.assertEqual(differing_properties, {'foo'})
+        self.assertThat(differing_properties, Equals({'foo'}))

--- a/snapcraft/tests/store/test_edit_collaborators.py
+++ b/snapcraft/tests/store/test_edit_collaborators.py
@@ -17,11 +17,9 @@
 from unittest import mock
 
 import fixtures
+from testtools.matchers import Equals
 
-from snapcraft import tests
-
-
-from snapcraft import _store
+from snapcraft import tests, _store
 
 
 class EditCollaboratorsTestCase(tests.TestCase):
@@ -62,8 +60,9 @@ class EditCollaboratorsTestCase(tests.TestCase):
         written = ''
         for call in mock_open().write.call_args_list:
             written += str(call.call_list()[0][0][0])
-        self.assertEqual(expected_written, written)
-        self.assertEqual(developers_for_assertion, developers_from_assertion)
+        self.assertThat(written, Equals(expected_written))
+        self.assertThat(
+            developers_for_assertion, Equals(developers_from_assertion))
 
     def test_edit_collaborators_must_return_new_developers(self):
         developers_from_assertion = [
@@ -90,7 +89,7 @@ class EditCollaboratorsTestCase(tests.TestCase):
             'since': '2016-02-10T08:35:00.000000Z',
             'until': '2019-02-10T08:35:00.000000Z',
         }]
-        self.assertEqual(developers_for_assertion, expected_developers)
+        self.assertThat(developers_for_assertion, Equals(expected_developers))
 
 
 class EditCollaboratorsOpenEditorTestCase(tests.TestCase):

--- a/snapcraft/tests/store/test_store_client.py
+++ b/snapcraft/tests/store/test_store_client.py
@@ -22,7 +22,7 @@ from unittest import mock
 
 import fixtures
 import pymacaroons
-from testtools.matchers import Contains
+from testtools.matchers import Contains, Equals
 
 from snapcraft import (
     config,
@@ -143,10 +143,10 @@ class DownloadTestCase(StoreTestCase):
             errors.SnapNotFoundError,
             self.client.download,
             'unexisting-snap', 'test-channel', 'dummy', 'test-arch')
-        self.assertEqual(
-            "Snap 'unexisting-snap' for 'test-arch' cannot be found in "
-            "the 'test-channel' channel.",
-            str(e))
+        self.assertThat(
+            str(e),
+            Equals("Snap 'unexisting-snap' for 'test-arch' cannot be found in "
+                   "the 'test-channel' channel."))
 
     def test_download_snap(self):
         self.fake_logger = fixtures.FakeLogger(level=logging.INFO)
@@ -166,10 +166,11 @@ class DownloadTestCase(StoreTestCase):
             'test-snap-branded-store', 'test-channel', 'dummy')
 
         arch = ProjectOptions().deb_arch
-        self.assertEqual(
-            "Snap 'test-snap-branded-store' for '{}' cannot be found in "
-            "the 'test-channel' channel.".format(arch),
-            str(err))
+        self.assertThat(
+            str(err),
+            Equals(
+                "Snap 'test-snap-branded-store' for '{}' cannot be found in "
+                "the 'test-channel' channel.".format(arch)))
 
     def test_download_from_branded_store_requires_store(self):
         self.client.login('dummy', 'test correct password')
@@ -179,10 +180,11 @@ class DownloadTestCase(StoreTestCase):
             'test-snap-branded-store', 'test-channel', 'dummy')
 
         arch = ProjectOptions().deb_arch
-        self.assertEqual(
-            "Snap 'test-snap-branded-store' for '{}' cannot be found in "
-            "the 'test-channel' channel.".format(arch),
-            str(err))
+        self.assertThat(
+            str(err),
+            Equals(
+                "Snap 'test-snap-branded-store' for '{}' cannot be found in "
+                "the 'test-channel' channel.".format(arch)))
 
     def test_download_from_branded_store(self):
         # Downloading from a branded-store requires login (authorization)
@@ -261,19 +263,20 @@ class PushSnapBuildTestCase(StoreTestCase):
         raised = self.assertRaises(
             errors.StoreSnapBuildError,
             self.client.push_snap_build, 'snap-id', 'test-not-implemented')
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'Could not assert build: The snap-build assertions are '
-            'currently disabled.')
+            Equals('Could not assert build: The snap-build assertions are '
+                   'currently disabled.'))
 
     def test_push_snap_build_invalid_data(self):
         self.client.login('dummy', 'test correct password')
         raised = self.assertRaises(
             errors.StoreSnapBuildError,
             self.client.push_snap_build, 'snap-id', 'test-invalid-data')
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'Could not assert build: The snap-build assertion is not valid.')
+            Equals('Could not assert build: The snap-build assertion is not '
+                   'valid.'))
 
     def test_push_snap_build_unexpected_data(self):
         # The endpoint in SCA would never return plain/text, however anything
@@ -282,9 +285,9 @@ class PushSnapBuildTestCase(StoreTestCase):
         raised = self.assertRaises(
             errors.StoreSnapBuildError,
             self.client.push_snap_build, 'snap-id', 'test-unexpected-data')
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'Could not assert build: 500 Internal Server Error')
+            Equals('Could not assert build: 500 Internal Server Error'))
 
     def test_push_snap_build_successfully(self):
         self.client.login('dummy', 'test correct password')
@@ -301,110 +304,114 @@ class GetAccountInformationTestCase(StoreTestCase):
 
     def test_get_account_information_successfully(self):
         self.client.login('dummy', 'test correct password')
-        self.assertEqual({
-            'account_id': 'abcd',
-            'account_keys': [],
-            'snaps': {
-                '16': {
-                    'basic': {
-                        'snap-id': 'snap-id',
-                        'status': 'Approved',
-                        'private': False,
-                        'price': None,
-                        'since': '2016-12-12T01:01:01Z',
-                    },
-                    'ubuntu-core': {
-                        'snap-id': 'good',
-                        'status': 'Approved',
-                        'private': False,
-                        'price': None,
-                        'since': '2016-12-12T01:01:01Z',
-                    },
-                    'core-no-dev': {
-                        'snap-id': 'no-dev',
-                        'status': 'Approved',
-                        'private': False,
-                        'price': None,
-                        'since': '2016-12-12T01:01:01Z',
-                    },
-                    'badrequest': {
-                        'snap-id': 'badrequest',
-                        'status': 'Approved',
-                        'private': False,
-                        'price': None,
-                        'since': '2016-12-12T01:01:01Z',
-                    },
-                    'test-snap-with-dev': {
-                        'price': None,
-                        'private': False,
-                        'since': '2016-12-12T01:01:01Z',
-                        'snap-id': 'test-snap-id-with-dev',
-                        'status': 'Approved'
-                    },
-                    'test-snap-with-no-validations': {
-                        'price': None,
-                        'private': False,
-                        'since': '2016-12-12T01:01:01Z',
-                        'snap-id': 'test-snap-id-with-no-validations',
-                        'status': 'Approved'
-                    },
+        self.assertThat(
+            self.client.get_account_information(),
+            Equals({
+                'account_id': 'abcd',
+                'account_keys': [],
+                'snaps': {
+                    '16': {
+                        'basic': {
+                            'snap-id': 'snap-id',
+                            'status': 'Approved',
+                            'private': False,
+                            'price': None,
+                            'since': '2016-12-12T01:01:01Z',
+                        },
+                        'ubuntu-core': {
+                            'snap-id': 'good',
+                            'status': 'Approved',
+                            'private': False,
+                            'price': None,
+                            'since': '2016-12-12T01:01:01Z',
+                        },
+                        'core-no-dev': {
+                            'snap-id': 'no-dev',
+                            'status': 'Approved',
+                            'private': False,
+                            'price': None,
+                            'since': '2016-12-12T01:01:01Z',
+                        },
+                        'badrequest': {
+                            'snap-id': 'badrequest',
+                            'status': 'Approved',
+                            'private': False,
+                            'price': None,
+                            'since': '2016-12-12T01:01:01Z',
+                        },
+                        'test-snap-with-dev': {
+                            'price': None,
+                            'private': False,
+                            'since': '2016-12-12T01:01:01Z',
+                            'snap-id': 'test-snap-id-with-dev',
+                            'status': 'Approved'
+                        },
+                        'test-snap-with-no-validations': {
+                            'price': None,
+                            'private': False,
+                            'since': '2016-12-12T01:01:01Z',
+                            'snap-id': 'test-snap-id-with-no-validations',
+                            'status': 'Approved'
+                        },
+                    }
                 }
-            }
-        }, self.client.get_account_information())
+            }))
 
     def test_get_account_information_refreshes_macaroon(self):
         self.client.login('dummy', 'test correct password')
         self.fake_store.needs_refresh = True
-        self.assertEqual({
-            'account_id': 'abcd',
-            'account_keys': [],
-            'snaps': {
-                '16': {
-                    'basic': {
-                        'snap-id': 'snap-id',
-                        'status': 'Approved',
-                        'private': False,
-                        'price': None,
-                        'since': '2016-12-12T01:01:01Z',
-                    },
-                    'ubuntu-core': {
-                        'snap-id': 'good',
-                        'status': 'Approved',
-                        'private': False,
-                        'price': None,
-                        'since': '2016-12-12T01:01:01Z',
-                    },
-                    'core-no-dev': {
-                        'snap-id': 'no-dev',
-                        'status': 'Approved',
-                        'private': False,
-                        'price': None,
-                        'since': '2016-12-12T01:01:01Z',
-                    },
-                    'badrequest': {
-                        'snap-id': 'badrequest',
-                        'status': 'Approved',
-                        'private': False,
-                        'price': None,
-                        'since': '2016-12-12T01:01:01Z',
-                    },
-                    'test-snap-with-dev': {
-                        'price': None,
-                        'private': False,
-                        'since': '2016-12-12T01:01:01Z',
-                        'snap-id': 'test-snap-id-with-dev',
-                        'status': 'Approved'
-                    },
-                    'test-snap-with-no-validations': {
-                        'price': None,
-                        'private': False,
-                        'since': '2016-12-12T01:01:01Z',
-                        'snap-id': 'test-snap-id-with-no-validations',
-                        'status': 'Approved'
-                    },
+        self.assertThat(
+            self.client.get_account_information(),
+            Equals({
+                'account_id': 'abcd',
+                'account_keys': [],
+                'snaps': {
+                    '16': {
+                        'basic': {
+                            'snap-id': 'snap-id',
+                            'status': 'Approved',
+                            'private': False,
+                            'price': None,
+                            'since': '2016-12-12T01:01:01Z',
+                        },
+                        'ubuntu-core': {
+                            'snap-id': 'good',
+                            'status': 'Approved',
+                            'private': False,
+                            'price': None,
+                            'since': '2016-12-12T01:01:01Z',
+                        },
+                        'core-no-dev': {
+                            'snap-id': 'no-dev',
+                            'status': 'Approved',
+                            'private': False,
+                            'price': None,
+                            'since': '2016-12-12T01:01:01Z',
+                        },
+                        'badrequest': {
+                            'snap-id': 'badrequest',
+                            'status': 'Approved',
+                            'private': False,
+                            'price': None,
+                            'since': '2016-12-12T01:01:01Z',
+                        },
+                        'test-snap-with-dev': {
+                            'price': None,
+                            'private': False,
+                            'since': '2016-12-12T01:01:01Z',
+                            'snap-id': 'test-snap-id-with-dev',
+                            'status': 'Approved'
+                        },
+                        'test-snap-with-no-validations': {
+                            'price': None,
+                            'private': False,
+                            'since': '2016-12-12T01:01:01Z',
+                            'snap-id': 'test-snap-id-with-no-validations',
+                            'status': 'Approved'
+                        },
+                    }
                 }
-            }
-        }, self.client.get_account_information())
+            }))
         self.assertFalse(self.fake_store.needs_refresh)
 
 
@@ -439,19 +446,19 @@ class RegisterKeyTestCase(StoreTestCase):
         raised = self.assertRaises(
             errors.StoreKeyRegistrationError,
             self.client.register_key, 'test-not-implemented')
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'Key registration failed: 501 Not Implemented')
+            Equals('Key registration failed: 501 Not Implemented'))
 
     def test_invalid_data(self):
         self.client.login('dummy', 'test correct password')
         raised = self.assertRaises(
             errors.StoreKeyRegistrationError,
             self.client.register_key, 'test-invalid-data')
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'Key registration failed: '
-            'The account-key-request assertion is not valid.')
+            Equals('Key registration failed: '
+                   'The account-key-request assertion is not valid.'))
 
 
 class RegisterTestCase(StoreTestCase):
@@ -482,46 +489,47 @@ class RegisterTestCase(StoreTestCase):
         raised = self.assertRaises(
             errors.StoreRegistrationError,
             self.client.register, 'test-already-registered-snap-name')
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            "The name 'test-already-registered-snap-name' is already taken."
-            "\n\n"
-            "We can if needed rename snaps to ensure they match the "
-            "expectations of most users. If you are the publisher most users "
-            "expect for 'test-already-registered-snap-name' then claim the "
-            "name at 'https://myapps.com/register-name/'")
+            Equals(
+                "The name 'test-already-registered-snap-name' is already "
+                "taken.\n\n"
+                "We can if needed rename snaps to ensure they match the "
+                "expectations of most users. If you are the publisher most "
+                "users expect for 'test-already-registered-snap-name' then "
+                "claim the name at 'https://myapps.com/register-name/'"))
 
     def test_register_a_reserved_name(self):
         self.client.login('dummy', 'test correct password')
         raised = self.assertRaises(
             errors.StoreRegistrationError,
             self.client.register, 'test-reserved-snap-name')
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            "The name 'test-reserved-snap-name' is reserved."
-            "\n\n"
-            "If you are the publisher most users expect for "
-            "'test-reserved-snap-name' then please claim the "
-            "name at 'https://myapps.com/register-name/'")
+            Equals("The name 'test-reserved-snap-name' is reserved."
+                   "\n\n"
+                   "If you are the publisher most users expect for "
+                   "'test-reserved-snap-name' then please claim the "
+                   "name at 'https://myapps.com/register-name/'"))
 
     def test_register_already_owned_name(self):
         self.client.login('dummy', 'test correct password')
         raised = self.assertRaises(
             errors.StoreRegistrationError,
             self.client.register, 'test-already-owned-snap-name')
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            "You already own the name 'test-already-owned-snap-name'.")
+            Equals("You already own the name 'test-already-owned-snap-name'."))
 
     def test_registering_too_fast_in_a_row(self):
         self.client.login('dummy', 'test correct password')
         raised = self.assertRaises(
             errors.StoreRegistrationError,
             self.client.register, 'test-too-fast')
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'You must wait 177 seconds before trying to register your '
-            'next snap.')
+            Equals('You must wait 177 seconds before trying to register your '
+                   'next snap.'))
 
     def test_registering_name_too_long(self):
         self.client.login('dummy', 'test correct password')
@@ -532,7 +540,7 @@ class RegisterTestCase(StoreTestCase):
         expected = (
             'The name {} should not be longer than 40 characters.'
             .format(name))
-        self.assertEqual(str(raised), expected)
+        self.assertThat(str(raised), Equals(expected))
 
     def test_registering_name_invalid(self):
         self.client.login('dummy', 'test correct password')
@@ -543,14 +551,14 @@ class RegisterTestCase(StoreTestCase):
         expected = (
             'The name {!r} is not valid. It can only contain dashes, numbers '
             'and lowercase ascii letters.'.format(name))
-        self.assertEqual(str(raised), expected)
+        self.assertThat(str(raised), Equals(expected))
 
     def test_unhandled_registration_error_path(self):
         self.client.login('dummy', 'test correct password')
         raised = self.assertRaises(
             errors.StoreRegistrationError,
             self.client.register, 'snap-name-no-clear-error')
-        self.assertEqual(str(raised), 'Registration failed.')
+        self.assertThat(str(raised), Equals('Registration failed.'))
 
 
 class ValidationsTestCase(StoreTestCase):
@@ -600,7 +608,7 @@ class ValidationsTestCase(StoreTestCase):
             "required": True,
         }]
         result = self.client.get_assertion('good', 'validations')
-        self.assertEqual(result, expected)
+        self.assertThat(result, Equals(expected))
 
     def test_get_bad_response(self):
         self.client.login('dummy', 'test correct password')
@@ -610,7 +618,7 @@ class ValidationsTestCase(StoreTestCase):
             self.client.get_assertion, 'bad', 'validations')
 
         expected = ("Received error 200: 'Invalid response from the server'")
-        self.assertEqual(str(err), expected)
+        self.assertThat(str(err), Equals(expected))
         self.assertIn(
             'Invalid response from the server', self.fake_logger.output)
 
@@ -631,7 +639,7 @@ class ValidationsTestCase(StoreTestCase):
         result = self.client.push_assertion('good', assertion, 'validations')
 
         expected = {'assertion': '{"foo": "bar"}'}
-        self.assertEqual(result, expected)
+        self.assertThat(result, Equals(expected))
 
     def test_push_bad_response(self):
         self.client.login('dummy', 'test correct password')
@@ -642,7 +650,7 @@ class ValidationsTestCase(StoreTestCase):
             self.client.push_assertion, 'bad', assertion, 'validations')
 
         expected = ("Received error 200: 'Invalid response from the server'")
-        self.assertEqual(str(err), expected)
+        self.assertThat(str(err), Equals(expected))
         self.assertIn(
             'Invalid response from the server', self.fake_logger.output)
 
@@ -655,7 +663,7 @@ class ValidationsTestCase(StoreTestCase):
             self.client.push_assertion, 'err', assertion, 'validations')
 
         expected = ("Received error 501: 'error'")
-        self.assertEqual(str(err), expected)
+        self.assertThat(str(err), Equals(expected))
 
 
 class UploadTestCase(StoreTestCase):
@@ -692,7 +700,7 @@ class UploadTestCase(StoreTestCase):
             'can_release': True,
             'processed': True
         }
-        self.assertEqual(result, expected_result)
+        self.assertThat(result, Equals(expected_result))
 
         # This should not raise
         tracker.raise_for_code()
@@ -709,7 +717,7 @@ class UploadTestCase(StoreTestCase):
             'can_release': True,
             'processed': True
         }
-        self.assertEqual(result, expected_result)
+        self.assertThat(result, Equals(expected_result))
 
         # This should not raise
         tracker.raise_for_code()
@@ -726,11 +734,11 @@ class UploadTestCase(StoreTestCase):
             errors.StoreUploadError,
             self.client.upload, 'test-snap', self.snap_path)
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'There was an error uploading the package.\n'
-            'Reason: \'Internal Server Error\'\n'
-            'Text: \'Broken\'')
+            Equals('There was an error uploading the package.\n'
+                   'Reason: \'Internal Server Error\'\n'
+                   'Text: \'Broken\''))
 
     def test_upload_snap_requires_review(self):
         self.client.login('dummy', 'test correct password')
@@ -744,7 +752,7 @@ class UploadTestCase(StoreTestCase):
             'can_release': False,
             'processed': True
         }
-        self.assertEqual(result, expected_result)
+        self.assertThat(result, Equals(expected_result))
 
         self.assertRaises(
             errors.StoreReviewError,
@@ -765,26 +773,28 @@ class UploadTestCase(StoreTestCase):
                 {'message': 'Duplicate snap already uploaded'},
             ]
         }
-        self.assertEqual(expected_result, result)
+        self.assertThat(result, Equals(expected_result))
 
         raised = self.assertRaises(
             errors.StoreReviewError,
             tracker.raise_for_code)
 
-        self.assertEqual(
-            'The store was unable to accept this snap.\n'
-            '  - Duplicate snap already uploaded', str(raised))
+        self.assertThat(
+            str(raised),
+            Equals('The store was unable to accept this snap.\n'
+                   '  - Duplicate snap already uploaded'))
 
     def test_push_unregistered_snap(self):
         self.client.login('dummy', 'test correct password')
         raised = self.assertRaises(
             errors.StorePushError,
             self.client.upload, 'test-snap-unregistered', self.snap_path)
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'You are not the publisher or allowed to push revisions for this '
-            'snap. To become the publisher, run `snapcraft register '
-            'test-snap-unregistered` and try to push again.')
+            Equals(
+                'You are not the publisher or allowed to push revisions for '
+                'this snap. To become the publisher, run `snapcraft register '
+                'test-snap-unregistered` and try to push again.'))
 
     def test_upload_with_invalid_credentials_raises_exception(self):
         conf = config.Config()
@@ -815,7 +825,7 @@ class ReleaseTestCase(StoreTestCase):
                 {'channel': 'edge', 'info': 'tracking'}
             ]
         }
-        self.assertEqual(channel_map, expected_channel_map)
+        self.assertThat(channel_map, Equals(expected_channel_map))
 
     def test_release_refreshes_macaroon(self):
         self.client.login('dummy', 'test correct password')
@@ -831,7 +841,7 @@ class ReleaseTestCase(StoreTestCase):
                 {'channel': 'edge', 'info': 'tracking'}
             ]
         }
-        self.assertEqual(channel_map, expected_channel_map)
+        self.assertThat(channel_map, Equals(expected_channel_map))
         self.assertFalse(self.fake_store.needs_refresh)
 
     def test_release_snap_to_invalid_channel(self):
@@ -840,9 +850,9 @@ class ReleaseTestCase(StoreTestCase):
             errors.StoreReleaseError,
             self.client.release, 'test-snap', '19', ['alpha'])
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'Not a valid channel: alpha')
+            Equals('Not a valid channel: alpha'))
 
     def test_release_unregistered_snap(self):
         self.client.login('dummy', 'test correct password')
@@ -850,11 +860,11 @@ class ReleaseTestCase(StoreTestCase):
             errors.StoreReleaseError,
             self.client.release, 'test-snap-unregistered', '19', ['alpha'])
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'Sorry, try `snapcraft register test-snap-unregistered` '
-            'before trying to release or choose an existing '
-            'revision.')
+            Equals('Sorry, try `snapcraft register test-snap-unregistered` '
+                   'before trying to release or choose an existing '
+                   'revision.'))
 
     def test_release_with_invalid_credentials_raises_exception(self):
         conf = config.Config()
@@ -888,10 +898,10 @@ class CloseChannelsTestCase(StoreTestCase):
         raised = self.assertRaises(
             errors.StoreChannelClosingError,
             self.client.close_channels, 'snap-id', ['invalid'])
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            "Could not close channel: The 'channels' field content "
-            "is not valid.")
+            Equals("Could not close channel: The 'channels' field content "
+                   "is not valid."))
 
     def test_close_unexpected_data(self):
         # The endpoint in SCA would never return plain/text, however anything
@@ -900,9 +910,9 @@ class CloseChannelsTestCase(StoreTestCase):
         raised = self.assertRaises(
             errors.StoreChannelClosingError,
             self.client.close_channels, 'snap-id', ['unexpected'])
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'Could not close channel: 500 Internal Server Error')
+            Equals('Could not close channel: 500 Internal Server Error'))
 
     def test_close_broken_store_plain(self):
         # If the contract is broken by the Store, users will be have additional
@@ -911,28 +921,32 @@ class CloseChannelsTestCase(StoreTestCase):
         raised = self.assertRaises(
             errors.StoreChannelClosingError,
             self.client.close_channels, 'snap-id', ['broken-plain'])
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'Could not close channel: 200 OK')
-        self.assertEqual([
-            'Invalid response from the server on channel closing:',
-            '200 OK',
-            'b\'plain data\'',
-            ], self.fake_logger.output.splitlines()[-3:])
+            Equals('Could not close channel: 200 OK'))
+        self.assertThat(
+            self.fake_logger.output.splitlines()[-3:],
+            Equals([
+                'Invalid response from the server on channel closing:',
+                '200 OK',
+                'b\'plain data\'',
+            ]))
 
     def test_close_broken_store_json(self):
         self.client.login('dummy', 'test correct password')
         raised = self.assertRaises(
             errors.StoreChannelClosingError,
             self.client.close_channels, 'snap-id', ['broken-json'])
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'Could not close channel: 200 OK')
-        self.assertEqual([
-            'Invalid response from the server on channel closing:',
-            '200 OK',
-            'b\'{"closed_channels": ["broken-json"]}\'',
-            ], self.fake_logger.output.splitlines()[-3:])
+            Equals('Could not close channel: 200 OK'))
+        self.assertThat(
+            self.fake_logger.output.splitlines()[-3:],
+            Equals([
+                'Invalid response from the server on channel closing:',
+                '200 OK',
+                'b\'{"closed_channels": ["broken-json"]}\'',
+            ]))
 
     def test_close_successfully(self):
         # Successfully closing a channels returns 'closed_channels'
@@ -940,19 +954,21 @@ class CloseChannelsTestCase(StoreTestCase):
         self.client.login('dummy', 'test correct password')
         closed_channels, channel_map_tree = self.client.close_channels(
             'snap-id', ['beta'])
-        self.assertEqual(['beta'], closed_channels)
-        self.assertEqual({
-            'latest': {
-                '16': {
-                    'amd64': [
-                        {'channel': 'stable', 'info': 'none'},
-                        {'channel': 'candidate', 'info': 'none'},
-                        {'channel': 'beta', 'info': 'specific',
-                         'revision': 42, 'version': '1.1'},
-                        {'channel': 'edge', 'info': 'tracking'}]
+        self.assertThat(closed_channels, Equals(['beta']))
+        self.assertThat(
+            channel_map_tree,
+            Equals({
+                'latest': {
+                    '16': {
+                        'amd64': [
+                            {'channel': 'stable', 'info': 'none'},
+                            {'channel': 'candidate', 'info': 'none'},
+                            {'channel': 'beta', 'info': 'specific',
+                             'revision': 42, 'version': '1.1'},
+                            {'channel': 'edge', 'info': 'tracking'}]
+                    }
                 }
-            }
-        }, channel_map_tree)
+            }))
 
 
 class MacaroonsTestCase(tests.TestCase):
@@ -1004,52 +1020,54 @@ class GetSnapRevisionsTestCase(StoreTestCase):
 
     def test_get_snap_revisions_successfully(self):
         self.client.login('dummy', 'test correct password')
-        self.assertEqual(self.expected,
-                         self.client.get_snap_revisions('basic'))
+        self.assertThat(
+            self.client.get_snap_revisions('basic'),
+            Equals(self.expected))
 
     def test_get_snap_revisions_filter_by_series(self):
         self.client.login('dummy', 'test correct password')
-        self.assertEqual(
-            self.expected,
-            self.client.get_snap_revisions('basic', series='16'))
+        self.assertThat(
+            self.client.get_snap_revisions('basic', series='16'),
+            Equals(self.expected))
 
     def test_get_snap_revisions_filter_by_arch(self):
         self.client.login('dummy', 'test correct password')
-        self.assertEqual(
-            [rev for rev in self.expected if rev['arch'] == 'amd64'],
-            self.client.get_snap_revisions('basic', arch='amd64'))
+        self.assertThat(
+            self.client.get_snap_revisions('basic', arch='amd64'),
+            Equals([rev for rev in self.expected if rev['arch'] == 'amd64']))
 
     def test_get_snap_revisions_filter_by_series_and_filter(self):
         self.client.login('dummy', 'test correct password')
-        self.assertEqual(
-            [rev for rev in self.expected
-             if '16' in rev['series'] and rev['arch'] == 'amd64'],
+        self.assertThat(
             self.client.get_snap_revisions(
-                'basic', series='16', arch='amd64'))
+                'basic', series='16', arch='amd64'),
+            Equals([rev for rev in self.expected
+                    if '16' in rev['series'] and rev['arch'] == 'amd64']))
 
     def test_get_snap_revisions_filter_by_unknown_series(self):
         self.client.login('dummy', 'test correct password')
         e = self.assertRaises(
             storeapi.errors.SnapNotFoundError,
             self.client.get_snap_revisions, 'basic', series='12')
-        self.assertEqual(
-            "Snap 'basic' was not found in '12' series.",
-            str(e))
+        self.assertThat(
+            str(e),
+            Equals("Snap 'basic' was not found in '12' series."))
 
     def test_get_snap_revisions_filter_by_unknown_arch(self):
         self.client.login('dummy', 'test correct password')
         e = self.assertRaises(
             storeapi.errors.SnapNotFoundError,
             self.client.get_snap_revisions, 'basic', arch='somearch')
-        self.assertEqual(
-            "Snap 'basic' for 'somearch' was not found in '16' series.",
-            str(e))
+        self.assertThat(
+            str(e),
+            Equals(
+                "Snap 'basic' for 'somearch' was not found in '16' series."))
 
     def test_get_snap_revisions_refreshes_macaroon(self):
         self.client.login('dummy', 'test correct password')
         self.fake_store.needs_refresh = True
-        self.assertEqual(self.expected,
-                         self.client.get_snap_revisions('basic'))
+        self.assertThat(
+            self.client.get_snap_revisions('basic'), Equals(self.expected))
         self.assertFalse(self.fake_store.needs_refresh)
 
     @mock.patch.object(storeapi.StoreClient, 'get_account_information')
@@ -1069,10 +1087,11 @@ class GetSnapRevisionsTestCase(StoreTestCase):
         e = self.assertRaises(
             storeapi.errors.StoreSnapRevisionsError,
             self.client.get_snap_revisions, 'basic')
-        self.assertEqual(
-            "Error fetching revisions of snap id 'my_snap_id' for 'any arch' "
-            "in '16' series: 500 Server error.",
-            str(e))
+        self.assertThat(
+            str(e),
+            Equals(
+                "Error fetching revisions of snap id 'my_snap_id' for "
+                "'any arch' in '16' series: 500 Server error."))
 
 
 class GetSnapStatusTestCase(StoreTestCase):
@@ -1129,63 +1148,70 @@ class GetSnapStatusTestCase(StoreTestCase):
 
     def test_get_snap_status_successfully(self):
         self.client.login('dummy', 'test correct password')
-        self.assertEqual(self.expected, self.client.get_snap_status('basic'))
+        self.assertThat(
+            self.client.get_snap_status('basic'),
+            Equals(self.expected))
 
     def test_get_snap_status_filter_by_series(self):
         self.client.login('dummy', 'test correct password')
-        self.assertEqual(
-            self.expected,
-            self.client.get_snap_status('basic', series='16'))
+        self.assertThat(
+            self.client.get_snap_status('basic', series='16'),
+            Equals(self.expected))
 
     def test_get_snap_status_filter_by_arch(self):
         self.client.login('dummy', 'test correct password')
         exp_arch = self.expected['channel_map_tree']['latest']['16']['amd64']
-        self.assertEqual(
-            {'channel_map_tree': {
-                'latest': {
-                    '16': {
-                        'amd64': exp_arch
+        self.assertThat(
+            self.client.get_snap_status('basic', arch='amd64'),
+            Equals(
+                {'channel_map_tree': {
+                    'latest': {
+                        '16': {
+                            'amd64': exp_arch
+                        }
                     }
-                }
-            }},
-            self.client.get_snap_status('basic', arch='amd64'))
+                }}))
 
     def test_get_snap_status_filter_by_series_and_filter(self):
         self.client.login('dummy', 'test correct password')
         exp_arch = self.expected['channel_map_tree']['latest']['16']['amd64']
-        self.assertEqual(
-            {'channel_map_tree': {
-                'latest': {
-                    '16': {
-                        'amd64': exp_arch
-                    }
-                }
-            }},
+        self.assertThat(
             self.client.get_snap_status(
-                'basic', series='16', arch='amd64'))
+                'basic', series='16', arch='amd64'),
+            Equals(
+                {'channel_map_tree': {
+                    'latest': {
+                        '16': {
+                            'amd64': exp_arch
+                        }
+                    }
+                }}))
 
     def test_get_snap_status_filter_by_unknown_series(self):
         self.client.login('dummy', 'test correct password')
         e = self.assertRaises(
             storeapi.errors.SnapNotFoundError,
             self.client.get_snap_status, 'basic', series='12')
-        self.assertEqual(
-            "Snap 'basic' was not found in '12' series.",
-            str(e))
+        self.assertThat(
+            str(e),
+            Equals("Snap 'basic' was not found in '12' series."))
 
     def test_get_snap_status_filter_by_unknown_arch(self):
         self.client.login('dummy', 'test correct password')
         e = self.assertRaises(
             storeapi.errors.SnapNotFoundError,
             self.client.get_snap_status, 'basic', arch='somearch')
-        self.assertEqual(
-            "Snap 'basic' for 'somearch' was not found in '16' series.",
-            str(e))
+        self.assertThat(
+            str(e),
+            Equals(
+                "Snap 'basic' for 'somearch' was not found in '16' series."))
 
     def test_get_snap_status_refreshes_macaroon(self):
         self.client.login('dummy', 'test correct password')
         self.fake_store.needs_refresh = True
-        self.assertEqual(self.expected, self.client.get_snap_status('basic'))
+        self.assertThat(
+            self.client.get_snap_status('basic'),
+            Equals(self.expected))
         self.assertFalse(self.fake_store.needs_refresh)
 
     @mock.patch.object(storeapi.StoreClient, 'get_account_information')
@@ -1202,10 +1228,11 @@ class GetSnapStatusTestCase(StoreTestCase):
         e = self.assertRaises(
             storeapi.errors.StoreSnapStatusError,
             self.client.get_snap_status, 'basic')
-        self.assertEqual(
-            "Error fetching status of snap id 'my_snap_id' for 'any arch' "
-            "in '16' series: 500 Server error.",
-            str(e))
+        self.assertThat(
+            str(e),
+            Equals(
+                "Error fetching status of snap id 'my_snap_id' for 'any arch' "
+                "in '16' series: 500 Server error."))
 
 
 class SignDeveloperAgreementTestCase(StoreTestCase):
@@ -1220,9 +1247,11 @@ class SignDeveloperAgreementTestCase(StoreTestCase):
                 "accepted_tos_date": "2010-10-10"
                 }
             }
-        self.assertEqual(
+        self.assertThat(
             response,
-            self.client.sign_developer_agreement(latest_tos_accepted=True))
+            Equals(
+                self.client.sign_developer_agreement(
+                    latest_tos_accepted=True)))
 
     def test_sign_dev_agreement_exception(self):
         self.client.login('dummy', 'test correct password')
@@ -1241,8 +1270,8 @@ class SignDeveloperAgreementTestCase(StoreTestCase):
             errors.DeveloperAgreementSignError,
             self.client.sign_developer_agreement,
             latest_tos_accepted=True)
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            'There was an error while signing developer agreement.\n'
-            'Reason: \'Internal Server Error\'\n'
-            'Text: \'Broken\'')
+            Equals('There was an error while signing developer agreement.\n'
+                   'Reason: \'Internal Server Error\'\n'
+                   'Text: \'Broken\''))

--- a/snapcraft/tests/test_common.py
+++ b/snapcraft/tests/test_common.py
@@ -16,6 +16,8 @@
 
 import os
 
+from testtools.matchers import Equals
+
 from snapcraft.internal import (
     common,
     errors
@@ -28,12 +30,12 @@ class CommonTestCase(tests.TestCase):
     def test_set_plugindir(self):
         plugindir = os.path.join(self.path, 'testplugin')
         common.set_plugindir(plugindir)
-        self.assertEqual(plugindir, common.get_plugindir())
+        self.assertThat(plugindir, Equals(common.get_plugindir()))
 
     def test_set_tourdir(self):
         tourdir = os.path.join(self.path, 'testtour')
         common.set_tourdir(tourdir)
-        self.assertEqual(tourdir, common.get_tourdir())
+        self.assertThat(tourdir, Equals(common.get_tourdir()))
 
     def test_isurl(self):
         self.assertTrue(common.isurl('git://'))
@@ -50,27 +52,27 @@ class CommonMigratedTestCase(tests.TestCase):
             errors.PluginOutdatedError,
             common.get_parallel_build_count)
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            "This plugin is outdated: use 'parallel_build_count'")
+            Equals("This plugin is outdated: use 'parallel_build_count'"))
 
     def test_deb_arch_migration_message(self):
         raised = self.assertRaises(
             errors.PluginOutdatedError,
             common.get_arch)
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            "This plugin is outdated: use 'project.deb_arch'")
+            Equals("This plugin is outdated: use 'project.deb_arch'"))
 
     def test_arch_triplet_migration_message(self):
         raised = self.assertRaises(
             errors.PluginOutdatedError,
             common.get_arch_triplet)
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            "This plugin is outdated: use 'project.arch_triplet'")
+            Equals("This plugin is outdated: use 'project.arch_triplet'"))
 
 
 class FormatInColumnsTestCase(tests.TestCase):
@@ -85,33 +87,37 @@ class FormatInColumnsTestCase(tests.TestCase):
                     'nodejs   python3  tar-content',
                     'autotools  cmake   go    kbuild  make    nil    '
                     'python2  scons  ']
-        self.assertEquals(expected,
-                          common.format_output_in_columns(self.elements_list))
+        self.assertThat(
+            common.format_output_in_columns(self.elements_list),
+            Equals(expected))
 
     def test_format_output_in_columns_narrow(self):
         """Format output on 3 lines, with narrow max-width and space sep"""
         expected = ['ant        cmake  jdk     make   nodejs   scons      ',
                     'autotools  copy   kbuild  maven  python2  tar-content',
                     'catkin     go     kernel  nil    python3']
-        self.assertEquals(expected,
-                          common.format_output_in_columns(self.elements_list,
-                                                          max_width=60))
+        self.assertThat(
+            common.format_output_in_columns(self.elements_list,
+                                            max_width=60),
+            Equals(expected))
 
     def test_format_output_in_columns_large(self):
         """Format output on one big line, with default space sep"""
         expected = ['ant  autotools  catkin  cmake  copy  go  jdk  kbuild  '
                     'kernel  make  maven  nil  nodejs  python2  python3  '
                     'scons  tar-content']
-        self.assertEquals(expected,
-                          common.format_output_in_columns(self.elements_list,
-                                                          max_width=990))
+        self.assertThat(
+            common.format_output_in_columns(self.elements_list,
+                                            max_width=990),
+            Equals(expected))
 
     def test_format_output_in_columns_one_space(self):
         """Format output with one space sep"""
         expected = ['ant       cmake jdk    make  nodejs  scons      ',
                     'autotools copy  kbuild maven python2 tar-content',
                     'catkin    go    kernel nil   python3']
-        self.assertEquals(expected,
-                          common.format_output_in_columns(self.elements_list,
-                                                          max_width=60,
-                                                          num_col_spaces=1))
+        self.assertThat(
+            common.format_output_in_columns(self.elements_list,
+                                            max_width=60,
+                                            num_col_spaces=1),
+            Equals(expected))

--- a/snapcraft/tests/test_config.py
+++ b/snapcraft/tests/test_config.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -16,6 +16,8 @@
 
 import fixtures
 import os
+
+from testtools.matchers import Equals
 
 from snapcraft import (
     config,
@@ -33,7 +35,7 @@ class TestConfig(tests.TestCase):
 
     def test_non_existing_file_succeeds(self):
         conf = config.Config()
-        self.assertEqual([], conf.parser.sections())
+        self.assertThat(conf.parser.sections(), Equals([]))
         self.assertTrue(conf.is_empty())
 
     def test_existing_file(self):
@@ -42,39 +44,39 @@ class TestConfig(tests.TestCase):
         existing_conf.save()
         # Check we find and use the existing conf
         conf = config.Config()
-        self.assertEqual('bar', conf.get('foo'))
+        self.assertThat(conf.get('foo'), Equals('bar'))
         self.assertFalse(conf.is_empty())
 
     def test_irrelevant_sections_are_ignored(self):
         create_config_from_string('''[example.com]\nfoo=bar''')
         conf = config.Config()
-        self.assertEqual(None, conf.get('foo'))
+        self.assertThat(conf.get('foo'), Equals(None))
 
     def test_section_from_url(self):
         create_config_from_string('''[example.com]\nfoo=bar''')
         self.useFixture(fixtures.EnvironmentVariable(
             'UBUNTU_SSO_API_ROOT_URL', 'http://example.com/api/v2'))
         conf = config.Config()
-        self.assertEqual('bar', conf.get('foo'))
+        self.assertThat(conf.get('foo'), Equals('bar'))
 
     def test_save_one_option(self):
         conf = config.Config()
         conf.set('bar', 'baz')
         conf.save()
         new_conf = config.Config()
-        self.assertEqual('baz', new_conf.get('bar'))
+        self.assertThat(new_conf.get('bar'), Equals('baz'))
 
     def test_clear_preserver_other_sections(self):
         create_config_from_string('''[keep_me]\nfoo=bar\n''')
         conf = config.Config()
         conf.set('bar', 'baz')
-        self.assertEqual('baz', conf.get('bar'))
+        self.assertThat(conf.get('bar'), Equals('baz'))
         conf.clear()
         conf.save()
         new_conf = config.Config()
-        self.assertEqual(None, new_conf.get('bar'))
+        self.assertThat(new_conf.get('bar'), Equals(None))
         # Picking behind the curtains
-        self.assertEqual('bar', new_conf.parser.get('keep_me', 'foo'))
+        self.assertThat(new_conf.parser.get('keep_me', 'foo'), Equals('bar'))
         self.assertTrue(conf.is_empty())
 
 
@@ -88,7 +90,7 @@ class TestOptions(tests.TestCase):
 
     def test_string(self):
         conf = self.create_config(foo='bar')
-        self.assertEqual('bar', conf.get('foo'))
+        self.assertThat(conf.get('foo'), Equals('bar'))
 
 
 def create_local_config_from_string(content):
@@ -108,13 +110,13 @@ class TestLocalConfig(tests.TestCase):
     def test_local_config_is_considered(self):
         create_local_config_from_string('''[example.com]\nfoo=bar''')
         conf = config.Config()
-        self.assertEqual('bar', conf.get('foo'))
+        self.assertThat(conf.get('foo'), Equals('bar'))
 
     def test_local_config_is_preferred(self):
         create_config_from_string('''[example.com]\nfoo=baz''')
         create_local_config_from_string('''[example.com]\nfoo=bar''')
         conf = config.Config()
-        self.assertEqual('bar', conf.get('foo'))
+        self.assertThat(conf.get('foo'), Equals('bar'))
 
     def test_local_config_is_static(self):
         create_local_config_from_string('''[example.com]\nfoo=bar''')
@@ -122,4 +124,4 @@ class TestLocalConfig(tests.TestCase):
         conf.set('foo', 'baz')
         conf.save()
         new_conf = config.Config()
-        self.assertEqual('bar', new_conf.get('foo'))
+        self.assertThat(new_conf.get('foo'), Equals('bar'))

--- a/snapcraft/tests/test_deltas.py
+++ b/snapcraft/tests/test_deltas.py
@@ -1,6 +1,6 @@
 # -*- mode:python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -50,15 +50,15 @@ class BaseDeltaGenerationTestCase(TestCase):
 
         unique_file_name = tmp_delta.find_unique_file_name(
             tmp_delta.source_path)
-        self.assertEqual(
-            unique_file_name, tmp_delta.source_path + '-0'
+        self.assertThat(
+            unique_file_name, m.Equals(tmp_delta.source_path + '-0')
         )
         with open(unique_file_name, 'wb') as f:
             f.write(b'tmp file.')
 
-        self.assertEqual(
+        self.assertThat(
             tmp_delta.find_unique_file_name(tmp_delta.source_path),
-            tmp_delta.source_path + '-1'
+            m.Equals(tmp_delta.source_path + '-1')
         )
 
     def test_not_set_delta_property_correctly(self):
@@ -75,7 +75,7 @@ class BaseDeltaGenerationTestCase(TestCase):
                                       delta_format=None,
                                       delta_tool_path='/usr/bin/xdelta3')
         expected = 'delta_format must be set in subclass!'
-        self.assertEqual(str(exception), expected)
+        self.assertThat(str(exception), m.Equals(expected))
 
         self.assertThat(
             lambda: deltas.BaseDeltasGenerator(
@@ -91,7 +91,7 @@ class BaseDeltaGenerationTestCase(TestCase):
                                       delta_format='xdelta3',
                                       delta_tool_path=None)
         expected = 'delta_tool_path must be set in subclass!'
-        self.assertEqual(str(exception), expected)
+        self.assertThat(str(exception), m.Equals(expected))
 
         self.assertThat(
             lambda: deltas.BaseDeltasGenerator(
@@ -109,7 +109,7 @@ class BaseDeltaGenerationTestCase(TestCase):
                                       delta_tool_path=self.delta_tool_path)
         expected = """delta_format must be a option in ['xdelta3'].
 for now delta_format='invalid-delta-format'"""
-        self.assertEqual(str(exception), expected)
+        self.assertThat(str(exception), m.Equals(expected))
 
     def test_file_existence_failed(self):
         class Tmpdelta(deltas.BaseDeltasGenerator):

--- a/snapcraft/tests/test_deltas_xdelta3.py
+++ b/snapcraft/tests/test_deltas_xdelta3.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -95,7 +95,7 @@ class XDelta3TestCase(TestCase):
                                       source_path=self.source_file,
                                       target_path=self.target_file)
         expected = 'delta_tool_path must be set in subclass!'
-        self.assertEqual(str(exception), expected)
+        self.assertThat(str(exception), m.Equals(expected))
 
     def test_xdelta3(self):
         self.generate_snap_pair()
@@ -106,7 +106,7 @@ class XDelta3TestCase(TestCase):
         self.assertThat(path, m.FileExists())
         expect_path = '{}.{}'.format(base_delta.target_path,
                                      base_delta.delta_file_extname)
-        self.assertEqual(expect_path, path)
+        self.assertThat(path, m.Equals(expect_path))
 
     def test_xdelta3_with_progress_indicator(self):
         self.generate_snap_pair()
@@ -128,7 +128,7 @@ class XDelta3TestCase(TestCase):
         self.assertThat(path, m.FileExists())
         expect_path = '{}.{}'.format(base_delta.target_path,
                                      base_delta.delta_file_extname)
-        self.assertEqual(expect_path, path)
+        self.assertThat(path, m.Equals(expect_path))
 
     def test_xdelta3_with_custom_output_dir(self):
         self.generate_snap_pair()
@@ -143,7 +143,7 @@ class XDelta3TestCase(TestCase):
 
         expect_path = os.path.join(existed_output_dir, delta_filename)
         self.assertThat(path, m.FileExists())
-        self.assertEqual(expect_path, path)
+        self.assertThat(path, m.Equals(expect_path))
 
         none_existed_output_dir = self.useFixture(
             fixtures.TempDir()).path + '/whatever/'
@@ -151,7 +151,7 @@ class XDelta3TestCase(TestCase):
 
         expect_path = os.path.join(none_existed_output_dir, delta_filename)
         self.assertThat(path, m.FileExists())
-        self.assertEqual(expect_path, path)
+        self.assertThat(path, m.Equals(expect_path))
 
     def test_xdelta3_logs(self):
         self.generate_snap_pair()

--- a/snapcraft/tests/test_file_utils.py
+++ b/snapcraft/tests/test_file_utils.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2016 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -20,6 +20,7 @@ import subprocess
 from unittest import mock
 
 import fixtures
+from testtools.matchers import Equals
 
 from snapcraft import file_utils
 from snapcraft import tests
@@ -62,7 +63,7 @@ class ReplaceInFileTestCase(tests.TestCase):
                                    r'#!/usr/bin/env python')
 
         with open(self.file_path, 'r') as f:
-            self.assertEqual(f.read(), self.expected)
+            self.assertThat(f.read(), Equals(self.expected))
 
     def test_replace_in_file_with_permission_error(self):
         os.makedirs('bin')
@@ -83,7 +84,7 @@ class ReplaceInFileTestCase(tests.TestCase):
                                        r'#!/usr/bin/env python')
 
         with open(file_info['path'], 'r') as f:
-            self.assertEqual(f.read(), file_info['expected'])
+            self.assertThat(f.read(), Equals(file_info['expected']))
 
 
 class TestLinkOrCopyTree(tests.TestCase):
@@ -102,7 +103,7 @@ class TestLinkOrCopyTree(tests.TestCase):
             NotADirectoryError,
             file_utils.link_or_copy_tree, '1', 'qux')
 
-        self.assertEqual(str(raised), "'1' is not a directory")
+        self.assertThat(str(raised), Equals("'1' is not a directory"))
 
     def test_link_file_into_directory(self):
         os.mkdir('qux')
@@ -110,7 +111,7 @@ class TestLinkOrCopyTree(tests.TestCase):
             NotADirectoryError,
             file_utils.link_or_copy_tree, '1', 'qux')
 
-        self.assertEqual(str(raised), "'1' is not a directory")
+        self.assertThat(str(raised), Equals("'1' is not a directory"))
 
     def test_link_directory_to_directory(self):
         file_utils.link_or_copy_tree('foo', 'qux')
@@ -124,9 +125,10 @@ class TestLinkOrCopyTree(tests.TestCase):
             NotADirectoryError,
             file_utils.link_or_copy_tree, 'foo', 'qux')
 
-        self.assertEqual(
+        self.assertThat(
             str(raised),
-            "Cannot overwrite non-directory 'qux' with directory 'foo'")
+            Equals(
+                "Cannot overwrite non-directory 'qux' with directory 'foo'"))
 
     def test_link_subtree(self):
         file_utils.link_or_copy_tree('foo/bar', 'qux')
@@ -240,7 +242,7 @@ class RequiresCommandSuccessTestCase(tests.TestCase):
             file_utils.requires_command_success('foo').__enter__)
 
         self.assertIsInstance(raised, SnapcraftError)
-        self.assertEqual("'foo' not found.", str(raised))
+        self.assertThat(str(raised), Equals("'foo' not found."))
 
     @mock.patch('subprocess.check_call')
     def test_requires_command_success_error(self, mock_check_call):
@@ -252,14 +254,15 @@ class RequiresCommandSuccessTestCase(tests.TestCase):
             file_utils.requires_command_success('foo').__enter__)
 
         self.assertIsInstance(raised, SnapcraftError)
-        self.assertEqual("'foo' failed.", str(raised))
+        self.assertThat(str(raised), Equals("'foo' failed."))
 
     def test_requires_command_success_broken(self):
         raised = self.assertRaises(
             TypeError,
             file_utils.requires_command_success(1).__enter__)
 
-        self.assertEqual('command must be a string.', str(raised))
+        self.assertThat(
+            str(raised), Equals('command must be a string.'))
 
     @mock.patch('subprocess.check_call')
     def test_requires_command_success_custom_error(self, mock_check_call):
@@ -274,7 +277,7 @@ class RequiresCommandSuccessTestCase(tests.TestCase):
                 'foo', not_found_fmt='uhm? {cmd_list!r} -> {command}'
             ).__enter__)
 
-        self.assertEqual("uhm? ['foo'] -> foo", str(raised))
+        self.assertThat(str(raised), Equals("uhm? ['foo'] -> foo"))
 
         raised = self.assertRaises(
             RequiredCommandFailure,
@@ -282,7 +285,7 @@ class RequiresCommandSuccessTestCase(tests.TestCase):
                 'foo', failure_fmt='failed {cmd_list!r} -> {command}'
             ).__enter__)
 
-        self.assertEqual("failed ['foo'] -> foo", str(raised))
+        self.assertThat(str(raised), Equals("failed ['foo'] -> foo"))
 
 
 class RequiresPathExistsTestCase(tests.TestCase):
@@ -301,8 +304,8 @@ class RequiresPathExistsTestCase(tests.TestCase):
             file_utils.requires_path_exists('foo').__enter__)
 
         self.assertIsInstance(raised, SnapcraftError)
-        self.assertEqual(
-            "Required path does not exist: 'foo'", str(raised))
+        self.assertThat(
+            str(raised), Equals("Required path does not exist: 'foo'"))
 
     def test_requires_path_exists_custom_error(self):
         raised = self.assertRaises(
@@ -311,4 +314,4 @@ class RequiresPathExistsTestCase(tests.TestCase):
                 'foo', error_fmt='what? {path!r}'
             ).__enter__)
 
-        self.assertEqual("what? 'foo'", str(raised))
+        self.assertThat(str(raised), Equals("what? 'foo'"))

--- a/snapcraft/tests/test_fixture_setup.py
+++ b/snapcraft/tests/test_fixture_setup.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -18,6 +18,8 @@ import http.client
 import http.server
 import json
 import urllib.parse
+
+from testtools.matchers import Equals
 
 from snapcraft import tests
 from snapcraft.tests import fixture_setup
@@ -70,4 +72,4 @@ class FakeServerRunningTestCase(tests.TestCase):
         self.addCleanup(self.assert_server_not_running)
         self.start_fake_server()
         status = self.do_request('GET', '/')
-        self.assertEqual(status, 200)
+        self.assertThat(status, Equals(200))

--- a/snapcraft/tests/test_formatting_utils.py
+++ b/snapcraft/tests/test_formatting_utils.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2016 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from testtools.matchers import Equals
+
 from snapcraft import formatting_utils
 from snapcraft import tests
 
@@ -23,30 +25,30 @@ class HumanizeListTestCases(tests.TestCase):
     def test_no_items(self):
         items = []
         output = formatting_utils.humanize_list(items, 'and')
-        self.assertEqual(output, '')
+        self.assertThat(output, Equals(''))
 
     def test_one_item(self):
         items = ['foo']
         output = formatting_utils.humanize_list(items, 'and')
-        self.assertEqual(output, "'foo'")
+        self.assertThat(output, Equals("'foo'"))
 
     def test_two_items(self):
         items = ['foo', 'bar']
         output = formatting_utils.humanize_list(items, 'and')
-        self.assertEqual(output, "'bar' and 'foo'",
-                         "Expected 'bar' before 'foo' due to sorting")
+        self.assertThat(output, Equals("'bar' and 'foo'"),
+                        "Expected 'bar' before 'foo' due to sorting")
 
     def test_three_items(self):
         items = ['foo', 'bar', 'baz']
         output = formatting_utils.humanize_list(items, 'and')
-        self.assertEqual(output, "'bar', 'baz', and 'foo'")
+        self.assertThat(output, Equals("'bar', 'baz', and 'foo'"))
 
     def test_four_items(self):
         items = ['foo', 'bar', 'baz', 'qux']
         output = formatting_utils.humanize_list(items, 'and')
-        self.assertEqual(output, "'bar', 'baz', 'foo', and 'qux'")
+        self.assertThat(output, Equals("'bar', 'baz', 'foo', and 'qux'"))
 
     def test_another_conjunction(self):
         items = ['foo', 'bar', 'baz', 'qux']
         output = formatting_utils.humanize_list(items, 'or')
-        self.assertEqual(output, "'bar', 'baz', 'foo', or 'qux'")
+        self.assertThat(output, Equals("'bar', 'baz', 'foo', or 'qux'"))

--- a/snapcraft/tests/test_indicators.py
+++ b/snapcraft/tests/test_indicators.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -18,10 +18,12 @@ import fixtures
 import os
 import progressbar
 import requests
+from unittest.mock import patch
+
+from testtools.matchers import Equals
 
 from snapcraft import tests
 from snapcraft.internal import indicators
-from unittest.mock import patch
 
 
 class DumbTerminalTests(tests.TestCase):
@@ -59,24 +61,24 @@ class ProgressBarInitializationTests(tests.TestCase):
     def test_init_progress_bar_with_length(self, mock_is_dumb_terminal):
         mock_is_dumb_terminal.return_value = self.dumb
         pb = indicators._init_progress_bar(10, "destination", "message")
-        self.assertEqual(pb.maxval, 10)
+        self.assertThat(pb.maxval, Equals(10))
         self.assertTrue("message" in pb.widgets)
         pb_widgets_types = [type(w) for w in pb.widgets]
         self.assertTrue(type(progressbar.Percentage()) in pb_widgets_types)
-        self.assertEqual(
-            type(progressbar.Bar()) in pb_widgets_types, not self.dumb)
+        self.assertThat(
+            type(progressbar.Bar()) in pb_widgets_types, Equals(not self.dumb))
 
     @patch('snapcraft.internal.indicators.is_dumb_terminal')
     def test_init_progress_bar_with_unknown_length(
             self, mock_is_dumb_terminal):
         mock_is_dumb_terminal.return_value = self.dumb
         pb = indicators._init_progress_bar(0, "destination", "message")
-        self.assertEqual(pb.maxval, progressbar.UnknownLength)
+        self.assertThat(pb.maxval, Equals(progressbar.UnknownLength))
         self.assertTrue("message" in pb.widgets)
         pb_widgets_types = [type(w) for w in pb.widgets]
-        self.assertEqual(
+        self.assertThat(
             type(progressbar.AnimatedMarker()) in pb_widgets_types,
-            not self.dumb)
+            Equals(not self.dumb))
 
 
 class IndicatorsDownloadTests(tests.FakeFileHTTPServerBasedTestCase):

--- a/snapcraft/tests/test_libraries.py
+++ b/snapcraft/tests/test_libraries.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016, 2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -20,6 +20,7 @@ import os
 import subprocess
 import tempfile
 
+from testtools.matchers import Equals
 from unittest import mock
 
 from snapcraft.internal import libraries
@@ -43,9 +44,10 @@ class TestLdLibraryPathParser(tests.TestCase):
 /colon:/separated,/comma\t/tab /space # This is another comment
 /baz""")
 
-        self.assertEqual(['/foo/bar', '/colon', '/separated', '/comma',
-                          '/tab', '/space', '/baz'],
-                         libraries._extract_ld_library_paths(file_path))
+        self.assertThat(
+            libraries._extract_ld_library_paths(file_path),
+            Equals(['/foo/bar', '/colon', '/separated', '/comma',
+                    '/tab', '/space', '/baz']))
 
 
 class TestGetLibraries(tests.TestCase):
@@ -81,7 +83,7 @@ class TestGetLibraries(tests.TestCase):
 
     def test_get_libraries(self):
         libs = libraries.get_dependencies('foo')
-        self.assertEqual(libs, ['/lib/foo.so.1', '/usr/lib/bar.so.2'])
+        self.assertThat(libs, Equals(['/lib/foo.so.1', '/usr/lib/bar.so.2']))
 
     def test_get_libraries_excludes_slash_snap(self):
         lines = [
@@ -93,22 +95,22 @@ class TestGetLibraries(tests.TestCase):
         self.run_output_mock.return_value = '\t' + '\n\t'.join(lines) + '\n'
 
         libs = libraries.get_dependencies('foo')
-        self.assertEqual(libs, ['/lib/foo.so.1', '/usr/lib/bar.so.2'])
+        self.assertThat(libs, Equals(['/lib/foo.so.1', '/usr/lib/bar.so.2']))
 
     def test_get_libraries_filtered_by_system_libraries(self):
         self.get_system_libs_mock.return_value = frozenset(['foo.so.1'])
 
         libs = libraries.get_dependencies('foo')
-        self.assertEqual(libs, ['/usr/lib/bar.so.2'])
+        self.assertThat(libs, Equals(['/usr/lib/bar.so.2']))
 
     def test_get_libraries_ldd_failure_logs_warning(self):
         self.run_output_mock.side_effect = subprocess.CalledProcessError(
             1, 'foo', b'bar')
 
-        self.assertEqual(libraries.get_dependencies('foo'), [])
-        self.assertEqual(
-            "Unable to determine library dependencies for 'foo'\n",
-            self.fake_logger.output)
+        self.assertThat(libraries.get_dependencies('foo'), Equals([]))
+        self.assertThat(
+            self.fake_logger.output,
+            Equals("Unable to determine library dependencies for 'foo'\n"))
 
 
 class TestSystemLibsOnNewRelease(tests.TestCase):
@@ -133,4 +135,4 @@ class TestSystemLibsOnNewRelease(tests.TestCase):
         self.run_output_mock.return_value = '\t' + '\n\t'.join(lines) + '\n'
 
     def test_fail_gracefully_if_system_libs_not_found(self):
-        self.assertEqual(libraries.get_dependencies('foo'), [])
+        self.assertThat(libraries.get_dependencies('foo'), Equals([]))

--- a/snapcraft/tests/test_lifecycle.py
+++ b/snapcraft/tests/test_lifecycle.py
@@ -26,6 +26,7 @@ import fixtures
 from testtools.matchers import (
     Contains,
     DirExists,
+    Equals,
     FileContains,
     FileExists,
     MatchesRegex,
@@ -83,7 +84,8 @@ class ExecutionTestCase(BaseLifecycleTestCase):
         part = Part()
         new_part = lifecycle._replace_in_part(part)
 
-        self.assertEqual(part.code.installdir, new_part.code.options.source)
+        self.assertThat(
+            new_part.code.options.source, Equals(part.code.installdir))
 
     def test_exception_when_dependency_is_required(self):
         self.make_snapcraft_yaml("""parts:
@@ -101,10 +103,10 @@ class ExecutionTestCase(BaseLifecycleTestCase):
             'pull', self.project_options,
             part_names=['part2'])
 
-        self.assertEqual(
+        self.assertThat(
             raised.__str__(),
-            "Requested 'pull' of 'part2' but there are unsatisfied "
-            "prerequisites: 'part1'")
+            Equals("Requested 'pull' of 'part2' but there are unsatisfied "
+                   "prerequisites: 'part1'"))
 
     def test_no_exception_when_dependency_is_required_but_already_staged(self):
         self.make_snapcraft_yaml("""parts:
@@ -125,14 +127,14 @@ class ExecutionTestCase(BaseLifecycleTestCase):
             lifecycle.execute('pull', self.project_options,
                               part_names=['part2'])
 
-        self.assertEqual(
-            'Skipping pull part1 (already ran)\n'
-            'Skipping build part1 (already ran)\n'
-            'Skipping stage part1 (already ran)\n'
-            'Skipping prime part1 (already ran)\n'
-            'Preparing to pull part2 \n'
-            'Pulling part2 \n',
-            self.fake_logger.output)
+        self.assertThat(
+            self.fake_logger.output,
+            Equals('Skipping pull part1 (already ran)\n'
+                   'Skipping build part1 (already ran)\n'
+                   'Skipping stage part1 (already ran)\n'
+                   'Skipping prime part1 (already ran)\n'
+                   'Preparing to pull part2 \n'
+                   'Pulling part2 \n'))
 
     def test_dependency_recursed_correctly(self):
         self.make_snapcraft_yaml("""parts:
@@ -156,24 +158,25 @@ class ExecutionTestCase(BaseLifecycleTestCase):
             'arch': [self.project_options.deb_arch],
             'type': ''
         }
-        self.assertEqual(snap_info, expected_snap_info)
+        self.assertThat(snap_info, Equals(expected_snap_info))
 
-        self.assertEqual(
-            'Preparing to pull part1 \n'
-            'Pulling part1 \n'
-            '\'part2\' has prerequisites that need to be staged: part1\n'
-            'Preparing to build part1 \n'
-            'Building part1 \n'
-            'Staging part1 \n'
-            'Preparing to pull part2 \n'
-            'Pulling part2 \n'
-            '\'part3\' has prerequisites that need to be staged: part2\n'
-            'Preparing to build part2 \n'
-            'Building part2 \n'
-            'Staging part2 \n'
-            'Preparing to pull part3 \n'
-            'Pulling part3 \n',
-            self.fake_logger.output)
+        self.assertThat(
+            self.fake_logger.output, Equals(
+                'Preparing to pull part1 \n'
+                'Pulling part1 \n'
+                '\'part2\' has prerequisites that need to be staged: part1\n'
+                'Preparing to build part1 \n'
+                'Building part1 \n'
+                'Staging part1 \n'
+                'Preparing to pull part2 \n'
+                'Pulling part2 \n'
+                '\'part3\' has prerequisites that need to be staged: part2\n'
+                'Preparing to build part2 \n'
+                'Building part2 \n'
+                'Staging part2 \n'
+                'Preparing to pull part3 \n'
+                'Pulling part3 \n',
+            ))
 
     def test_os_type_returned_by_lifecycle(self):
         self.make_snapcraft_yaml("""parts:
@@ -193,7 +196,7 @@ class ExecutionTestCase(BaseLifecycleTestCase):
             'arch': [self.project_options.deb_arch],
             'type': 'os'
         }
-        self.assertEqual(snap_info, expected_snap_info)
+        self.assertThat(snap_info, Equals(expected_snap_info))
 
     def test_dirty_prime_reprimes_single_part(self):
         self.make_snapcraft_yaml("""parts:
@@ -225,24 +228,24 @@ class ExecutionTestCase(BaseLifecycleTestCase):
         part1_output = [line.strip() for line in output if 'part1' in line]
         part2_output = [line.strip() for line in output if 'part2' in line]
 
-        self.assertEqual(
-            [
+        self.assertThat(
+            part2_output,
+            Equals([
                 'Skipping pull part2 (already ran)',
                 'Skipping build part2 (already ran)',
                 'Skipping stage part2 (already ran)',
                 'Skipping prime part2 (already ran)',
-            ],
-            part2_output)
+            ]))
 
-        self.assertEqual(
-            [
+        self.assertThat(
+            part1_output,
+            Equals([
                 'Skipping pull part1 (already ran)',
                 'Skipping build part1 (already ran)',
                 'Skipping stage part1 (already ran)',
                 'Cleaning priming area for part1 (out of date)',
                 'Priming part1',
-            ],
-            part1_output)
+            ]))
 
     def test_dirty_prime_reprimes_multiple_part(self):
         self.make_snapcraft_yaml("""parts:
@@ -274,25 +277,25 @@ class ExecutionTestCase(BaseLifecycleTestCase):
         part1_output = [line.strip() for line in output if 'part1' in line]
         part2_output = [line.strip() for line in output if 'part2' in line]
 
-        self.assertEqual(
-            [
+        self.assertThat(
+            part2_output,
+            Equals([
                 'Skipping pull part2 (already ran)',
                 'Skipping build part2 (already ran)',
                 'Skipping stage part2 (already ran)',
                 'Cleaning priming area for part2 (out of date)',
                 'Priming part2',
-            ],
-            part2_output)
+            ]))
 
-        self.assertEqual(
-            [
+        self.assertThat(
+            part1_output,
+            Equals([
                 'Skipping pull part1 (already ran)',
                 'Skipping build part1 (already ran)',
                 'Skipping stage part1 (already ran)',
                 'Cleaning priming area for part1 (out of date)',
                 'Priming part1',
-            ],
-            part1_output)
+            ]))
 
     def test_dirty_stage_restages_single_part(self):
         self.make_snapcraft_yaml("""parts:
@@ -324,24 +327,24 @@ class ExecutionTestCase(BaseLifecycleTestCase):
         part1_output = [line.strip() for line in output if 'part1' in line]
         part2_output = [line.strip() for line in output if 'part2' in line]
 
-        self.assertEqual(
-            [
+        self.assertThat(
+            part2_output,
+            Equals([
                 'Skipping pull part2 (already ran)',
                 'Skipping build part2 (already ran)',
                 'Skipping stage part2 (already ran)',
-            ],
-            part2_output)
+            ]))
 
-        self.assertEqual(
-            [
+        self.assertThat(
+            part1_output,
+            Equals([
                 'Skipping pull part1 (already ran)',
                 'Skipping build part1 (already ran)',
                 'Skipping cleaning priming area for part1 (out of date) '
                 '(already clean)',
                 'Cleaning staging area for part1 (out of date)',
                 'Staging part1',
-            ],
-            part1_output)
+            ]))
 
     def test_dirty_stage_restages_multiple_parts(self):
         self.make_snapcraft_yaml("""parts:
@@ -373,27 +376,27 @@ class ExecutionTestCase(BaseLifecycleTestCase):
         part1_output = [line.strip() for line in output if 'part1' in line]
         part2_output = [line.strip() for line in output if 'part2' in line]
 
-        self.assertEqual(
-            [
+        self.assertThat(
+            part2_output,
+            Equals([
                 'Skipping pull part2 (already ran)',
                 'Skipping build part2 (already ran)',
                 'Skipping cleaning priming area for part2 (out of date) '
                 '(already clean)',
                 'Cleaning staging area for part2 (out of date)',
                 'Staging part2',
-            ],
-            part2_output)
+            ]))
 
-        self.assertEqual(
-            [
+        self.assertThat(
+            part1_output,
+            Equals([
                 'Skipping pull part1 (already ran)',
                 'Skipping build part1 (already ran)',
                 'Skipping cleaning priming area for part1 (out of date) '
                 '(already clean)',
                 'Cleaning staging area for part1 (out of date)',
                 'Staging part1',
-            ],
-            part1_output)
+            ]))
 
     def test_dirty_stage_part_with_built_dependent_raises(self):
         self.make_snapcraft_yaml("""parts:
@@ -430,17 +433,18 @@ class ExecutionTestCase(BaseLifecycleTestCase):
 
         output = self.fake_logger.output.split('\n')
         part1_output = [line.strip() for line in output if 'part1' in line]
-        self.assertEqual(
-            [
+        self.assertThat(
+            part1_output,
+            Equals([
                 'Skipping pull part1 (already ran)',
                 'Skipping build part1 (already ran)',
-            ],
-            part1_output)
+            ]))
 
-        self.assertEqual(
-            "The 'stage' step for 'part1' needs to be run again, but 'part2' "
-            "depends upon it. Please clean the build step of 'part2' first.",
-            str(raised))
+        self.assertThat(
+            str(raised), Equals(
+                "The 'stage' step for 'part1' needs to be run again, but "
+                "'part2' depends upon it. Please clean the build step of "
+                "'part2' first."))
 
     def test_dirty_stage_part_with_unbuilt_dependent(self):
         self.make_snapcraft_yaml("""parts:
@@ -470,18 +474,18 @@ class ExecutionTestCase(BaseLifecycleTestCase):
             lifecycle.execute('stage', self.project_options,
                               part_names=['part1'])
 
-        self.assertEqual(
-            'Skipping pull part1 (already ran)\n'
-            'Skipping build part1 (already ran)\n'
-            'Skipping cleaning priming area for part1 (out of date) '
-            '(already clean)\n'
-            'Cleaning staging area for part1 (out of date)\n'
-            'Skipping cleaning priming area for part2 (out of date) '
-            '(already clean)\n'
-            'Skipping cleaning staging area for part2 (out of date) '
-            '(already clean)\n'
-            'Staging part1 \n',
-            self.fake_logger.output)
+        self.assertThat(
+            self.fake_logger.output, Equals(
+                'Skipping pull part1 (already ran)\n'
+                'Skipping build part1 (already ran)\n'
+                'Skipping cleaning priming area for part1 (out of date) '
+                '(already clean)\n'
+                'Cleaning staging area for part1 (out of date)\n'
+                'Skipping cleaning priming area for part2 (out of date) '
+                '(already clean)\n'
+                'Skipping cleaning staging area for part2 (out of date) '
+                '(already clean)\n'
+                'Staging part1 \n'))
 
     def test_dirty_stage_reprimes(self):
         self.make_snapcraft_yaml("""parts:
@@ -507,14 +511,14 @@ class ExecutionTestCase(BaseLifecycleTestCase):
                                _fake_dirty_report):
             lifecycle.execute('prime', self.project_options)
 
-        self.assertEqual(
-            'Skipping pull part1 (already ran)\n'
-            'Skipping build part1 (already ran)\n'
-            'Cleaning priming area for part1 (out of date)\n'
-            'Cleaning staging area for part1 (out of date)\n'
-            'Staging part1 \n'
-            'Priming part1 \n',
-            self.fake_logger.output)
+        self.assertThat(
+            self.fake_logger.output, Equals(
+                'Skipping pull part1 (already ran)\n'
+                'Skipping build part1 (already ran)\n'
+                'Cleaning priming area for part1 (out of date)\n'
+                'Cleaning staging area for part1 (out of date)\n'
+                'Staging part1 \n'
+                'Priming part1 \n'))
 
     def test_dirty_build_raises(self):
         self.make_snapcraft_yaml("""parts:
@@ -542,16 +546,16 @@ class ExecutionTestCase(BaseLifecycleTestCase):
                 lifecycle.execute,
                 'build', self.project_options)
 
-        self.assertEqual(
-            'Skipping pull part1 (already ran)\n',
-            self.fake_logger.output)
+        self.assertThat(
+            self.fake_logger.output,
+            Equals('Skipping pull part1 (already ran)\n'))
 
-        self.assertEqual(
-            "The 'build' step of 'part1' is out of date:\n"
-            "The 'bar' and 'foo' part properties appear to have changed.\n"
-            "In order to continue, please clean that part's 'build' step "
-            "by running: snapcraft clean part1 -s build\n",
-            str(raised))
+        self.assertThat(
+            str(raised), Equals(
+                "The 'build' step of 'part1' is out of date:\n"
+                "The 'bar' and 'foo' part properties appear to have changed.\n"
+                "In order to continue, please clean that part's 'build' step "
+                "by running: snapcraft clean part1 -s build\n"))
 
     def test_dirty_pull_raises(self):
         self.make_snapcraft_yaml("""parts:
@@ -579,14 +583,14 @@ class ExecutionTestCase(BaseLifecycleTestCase):
                 lifecycle.execute,
                 'pull', self.project_options)
 
-        self.assertEqual('', self.fake_logger.output)
+        self.assertThat(self.fake_logger.output, Equals(''))
 
-        self.assertEqual(
-            "The 'pull' step of 'part1' is out of date:\n"
-            "The 'bar' and 'foo' project options appear to have changed.\n"
-            "In order to continue, please clean that part's 'pull' step "
-            "by running: snapcraft clean part1 -s pull\n",
-            str(raised))
+        self.assertThat(
+            str(raised), Equals(
+                "The 'pull' step of 'part1' is out of date:\n"
+                "The 'bar' and 'foo' project options appear to have changed.\n"
+                "In order to continue, please clean that part's 'pull' step "
+                "by running: snapcraft clean part1 -s pull\n"))
 
     @mock.patch.object(snapcraft.BasePlugin, 'enable_cross_compilation')
     @mock.patch('snapcraft.repo.Repo.install_build_packages')
@@ -615,15 +619,16 @@ class ExecutionTestCase(BaseLifecycleTestCase):
             'pull', snapcraft.ProjectOptions(
                 target_deb_arch='armhf'))
 
-        self.assertEqual("Setting target machine to 'armhf'\n",
-                         self.fake_logger.output)
+        self.assertThat(
+            self.fake_logger.output,
+            Equals("Setting target machine to 'armhf'\n"))
 
-        self.assertEqual(
-            "The 'pull' step of 'part1' is out of date:\n"
-            "The 'deb_arch' project option appears to have changed.\n"
-            "In order to continue, please clean that part's 'pull' step "
-            "by running: snapcraft clean part1 -s pull\n",
-            str(raised))
+        self.assertThat(
+            str(raised), Equals(
+                "The 'pull' step of 'part1' is out of date:\n"
+                "The 'deb_arch' project option appears to have changed.\n"
+                "In order to continue, please clean that part's 'pull' step "
+                "by running: snapcraft clean part1 -s pull\n"))
 
     def test_prime_excludes_internal_snapcraft_dir(self):
         self.make_snapcraft_yaml("""parts:

--- a/snapcraft/tests/test_log.py
+++ b/snapcraft/tests/test_log.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -16,9 +16,10 @@
 
 import logging
 
+from testtools.matchers import Equals
+
 from snapcraft.internal import log
 from snapcraft import tests
-
 from snapcraft.tests import fixture_setup
 
 
@@ -48,9 +49,8 @@ class LogTestCase(tests.TestCase):
                         '{}Test warning\033[0m\n').format(
             self.info_color, self.warning_color)
 
-        self.assertEqual(expected_out,
-                         self.fake_terminal.getvalue())
-        self.assertEqual('', self.fake_terminal.getvalue(stderr=True))
+        self.assertThat(self.fake_terminal.getvalue(), Equals(expected_out))
+        self.assertThat(self.fake_terminal.getvalue(stderr=True), Equals(''))
 
     def test_configure_must_send_errors_to_stderr(self):
         logger_name = self.id()
@@ -66,9 +66,10 @@ class LogTestCase(tests.TestCase):
                         '{}Test critical\033[0m\n').format(
             self.error_color, self.critical_color)
 
-        self.assertEqual(expected_err,
-                         self.fake_terminal.getvalue(stderr=True))
-        self.assertEqual('', self.fake_terminal.getvalue())
+        self.assertThat(
+            self.fake_terminal.getvalue(stderr=True),
+            Equals(expected_err))
+        self.assertThat(self.fake_terminal.getvalue(), Equals(''))
 
     def test_configure_must_log_info_and_higher(self):
         logger_name = self.id()
@@ -88,9 +89,9 @@ class LogTestCase(tests.TestCase):
                         '{}Test critical\033[0m\n').format(
             self.error_color, self.critical_color)
 
-        self.assertEqual(expected_out, self.fake_terminal.getvalue())
-        self.assertEqual(expected_err,
-                         self.fake_terminal.getvalue(stderr=True))
+        self.assertThat(self.fake_terminal.getvalue(), Equals(expected_out))
+        self.assertThat(
+            self.fake_terminal.getvalue(stderr=True), Equals(expected_err))
 
     def test_configure_must_support_debug(self):
         logger_name = self.id()
@@ -111,9 +112,9 @@ class LogTestCase(tests.TestCase):
                         '{}Test critical\033[0m\n').format(
             self.error_color, self.critical_color)
 
-        self.assertEqual(expected_out, self.fake_terminal.getvalue())
-        self.assertEqual(expected_err,
-                         self.fake_terminal.getvalue(stderr=True))
+        self.assertThat(self.fake_terminal.getvalue(), Equals(expected_out))
+        self.assertThat(
+            self.fake_terminal.getvalue(stderr=True), Equals(expected_err))
 
     def test_configure_must_support_no_tty(self):
         self.fake_terminal = fixture_setup.FakeTerminal(isatty=False)
@@ -134,6 +135,6 @@ class LogTestCase(tests.TestCase):
         expected_err = ('Test error\n'
                         'Test critical\n')
 
-        self.assertEqual(expected_out, self.fake_terminal.getvalue())
-        self.assertEqual(expected_err,
-                         self.fake_terminal.getvalue(stderr=True))
+        self.assertThat(self.fake_terminal.getvalue(), Equals(expected_out))
+        self.assertThat(
+            self.fake_terminal.getvalue(stderr=True), Equals(expected_err))

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -24,7 +24,7 @@ from unittest.mock import (
 
 import fixtures
 from testtools import ExpectedException
-from testtools.matchers import Contains
+from testtools.matchers import Contains, Equals
 
 from snapcraft import tests
 from snapcraft import ProjectOptions
@@ -132,7 +132,7 @@ class LXDTestCase(tests.TestCase):
             lxd.Cleanbuilder(output='snap.snap', source='project.tar',
                              metadata=metadata,
                              project_options=ProjectOptions()).execute)
-        self.assertEquals(fake_lxd.status, None)
+        self.assertThat(fake_lxd.status, Equals(None))
         # lxc launch should fail and no further commands should come after that
         self.assertThat(str(raised), Contains("Command '['lxc', 'launch'"))
 

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -97,7 +97,7 @@ class CreateTestCase(CreateBaseTestCase):
                     'name': 'my-package',
                     'version': '1.0'}
 
-        self.assertEqual(y, expected, expected)
+        self.assertThat(y, Equals(expected))
 
     def test_create_meta_with_epoch(self):
         self.config_data['epoch'] = '1*'
@@ -106,7 +106,7 @@ class CreateTestCase(CreateBaseTestCase):
         self.assertTrue(
             'epoch' in y,
             'Expected "epoch" property to be copied into snap.yaml')
-        self.assertEqual(y['epoch'], '1*')
+        self.assertThat(y['epoch'], Equals('1*'))
 
     def test_create_meta_with_assumes(self):
         self.config_data['assumes'] = ['feature1', 'feature2']
@@ -115,7 +115,7 @@ class CreateTestCase(CreateBaseTestCase):
         self.assertTrue(
             'assumes' in y,
             'Expected "assumes" property to be copied into snap.yaml')
-        self.assertEqual(y['assumes'], ['feature1', 'feature2'])
+        self.assertThat(y['assumes'], Equals(['feature1', 'feature2']))
 
     def test_create_gadget_meta_with_gadget_yaml(self):
         gadget_yaml = 'stub entry: stub value'
@@ -346,8 +346,9 @@ class CreateTestCase(CreateBaseTestCase):
         contents.read(desktop_file)
         section = 'Desktop Entry'
         self.assertTrue(section in contents)
-        self.assertEqual(contents[section].get('Exec'), 'my-package.app1 %U')
-        self.assertEqual(contents[section].get('Icon'), 'app1.png')
+        self.assertThat(
+            contents[section].get('Exec'), Equals('my-package.app1 %U'))
+        self.assertThat(contents[section].get('Icon'), Equals('app1.png'))
 
         desktop_file = os.path.join(self.meta_dir, 'gui', 'app2.desktop')
         self.assertThat(desktop_file, FileExists())
@@ -355,9 +356,10 @@ class CreateTestCase(CreateBaseTestCase):
         contents.read(desktop_file)
         section = 'Desktop Entry'
         self.assertTrue(section in contents)
-        self.assertEqual(contents[section].get('Exec'), 'my-package.app2 %U')
-        self.assertEqual(contents[section].get('Icon'),
-                         '${SNAP}/usr/share/app2.png')
+        self.assertThat(
+            contents[section].get('Exec'), Equals('my-package.app2 %U'))
+        self.assertThat(contents[section].get('Icon'),
+                        Equals('${SNAP}/usr/share/app2.png'))
 
         desktop_file = os.path.join(self.meta_dir, 'gui', 'my-package.desktop')
         self.assertThat(desktop_file, FileExists())
@@ -365,7 +367,7 @@ class CreateTestCase(CreateBaseTestCase):
         contents.read(desktop_file)
         section = 'Desktop Entry'
         self.assertTrue(section in contents)
-        self.assertEqual(contents[section].get('Exec'), 'my-package %U')
+        self.assertThat(contents[section].get('Exec'), Equals('my-package %U'))
 
         snap_yaml = os.path.join('prime', 'meta', 'snap.yaml')
         self.assertThat(snap_yaml, Not(FileContains('desktop: app1.desktop')))
@@ -520,7 +522,7 @@ class CreateWithConfinementTestCase(CreateBaseTestCase):
         self.assertTrue(
             'confinement' in y,
             'Expected "confinement" property to be in snap.yaml')
-        self.assertEqual(y['confinement'], self.confinement)
+        self.assertThat(y['confinement'], Equals(self.confinement))
 
 
 class EnsureFilePathsTestCase(CreateBaseTestCase):
@@ -575,7 +577,7 @@ class CreateWithGradeTestCase(CreateBaseTestCase):
         self.assertTrue(
             'grade' in y,
             'Expected "grade" property to be in snap.yaml')
-        self.assertEqual(y['grade'], self.grade)
+        self.assertThat(y['grade'], Equals(self.grade))
 
 
 # TODO this needs more tests.
@@ -628,7 +630,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
             relative_exe_path, basename='new-name')
         wrapper_path = os.path.join(self.prime_dir, relative_wrapper_path)
 
-        self.assertEqual(relative_wrapper_path, 'new-name.wrapper')
+        self.assertThat(relative_wrapper_path, Equals('new-name.wrapper'))
 
         expected = ('#!/bin/sh\n'
                     'PATH=$SNAP/usr/bin:$SNAP/bin\n\n'
@@ -711,7 +713,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         self.assertThat(wrapper_path, FileContains(expected))
 
         with open(path, 'rb') as exe:
-            self.assertEqual(exe_contents, exe.read())
+            self.assertThat(exe.read(), Equals(exe_contents))
 
     @patch('snapcraft.internal.common.run_output')
     def test_exe_is_in_path(self, run_mock):
@@ -733,10 +735,11 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         raised = self.assertRaises(
             errors.InvalidAppCommandError,
             self.packager._wrap_apps, apps)
-        self.assertEqual(
-            "The specified command 'command-does-not-exist' defined in the "
-            "app 'app1' does not exist or is not executable",
-            str(raised))
+        self.assertThat(
+            str(raised),
+            Equals(
+                "The specified command 'command-does-not-exist' defined in "
+                "the app 'app1' does not exist or is not executable"))
 
     def test_command_is_not_executable(self):
         common.env = ['PATH={}/bin:$PATH'.format(self.prime_dir)]
@@ -749,10 +752,10 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         raised = self.assertRaises(
             errors.InvalidAppCommandError,
             self.packager._wrap_apps, apps)
-        self.assertEqual(
-            "The specified command 'command-not-executable' defined in the "
-            "app 'app1' does not exist or is not executable",
-            str(raised))
+        self.assertThat(
+            str(raised),
+            Equals("The specified command 'command-not-executable' defined in "
+                   "the app 'app1' does not exist or is not executable"))
 
     def test_command_found(self):
         common.env = ['PATH={}/bin:$PATH'.format(self.prime_dir)]
@@ -764,8 +767,8 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
 
         wrapped_apps = self.packager._wrap_apps(apps)
 
-        self.assertEqual(wrapped_apps,
-                         {'app1': {'command': 'command-app1.wrapper'}})
+        self.assertThat(wrapped_apps,
+                        Equals({'app1': {'command': 'command-app1.wrapper'}}))
 
 
 def _create_file(path, *, content='', executable=False):

--- a/snapcraft/tests/test_options.py
+++ b/snapcraft/tests/test_options.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -15,7 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from unittest import mock
+
 import testtools
+from testtools.matchers import Equals
 
 import snapcraft
 from snapcraft.internal.errors import SnapcraftEnvironmentError
@@ -100,9 +102,12 @@ class NativeOptionsTestCase(tests.TestCase):
         mock_platform_machine.return_value = self.machine
         mock_platform_architecture.return_value = self.architecture
         options = snapcraft.ProjectOptions()
-        self.assertEqual(options.arch_triplet, self.expected_arch_triplet)
-        self.assertEqual(options.deb_arch, self.expected_deb_arch)
-        self.assertEqual(options.kernel_arch, self.expected_kernel_arch)
+        self.assertThat(
+            options.arch_triplet, Equals(self.expected_arch_triplet))
+        self.assertThat(
+            options.deb_arch, Equals(self.expected_deb_arch))
+        self.assertThat(
+            options.kernel_arch, Equals(self.expected_kernel_arch))
 
     @mock.patch('platform.architecture')
     @mock.patch('platform.machine')
@@ -116,10 +121,10 @@ class NativeOptionsTestCase(tests.TestCase):
 
         if self.architecture[0] == '32bit' and \
            self.machine in userspace_conversions:
-            self.assertEqual(
-                platform_arch, userspace_conversions[self.machine])
+            self.assertThat(
+                platform_arch, Equals(userspace_conversions[self.machine]))
         else:
-            self.assertEqual(platform_arch, self.machine)
+            self.assertThat(platform_arch, Equals(self.machine))
 
 
 class OptionsTestCase(tests.TestCase):

--- a/snapcraft/tests/test_parser.py
+++ b/snapcraft/tests/test_parser.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016, 2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -23,6 +23,7 @@ import fixtures
 import tempfile
 import yaml
 from collections import OrderedDict
+from testtools.matchers import Equals
 
 import snapcraft                           # noqa, initialize yaml
 from snapcraft.internal import errors
@@ -59,7 +60,7 @@ def _get_part_list_count(path=PARTS_FILE):
 
 class TestParserBaseDir(TestCase):
     def test__get_base_dir(self):
-        self.assertEqual(parser.BASE_DIR, parser._get_base_dir())
+        self.assertThat(parser._get_base_dir(), Equals(parser.BASE_DIR))
 
 
 class TestParser(TestCase):
@@ -111,7 +112,7 @@ test:
         doc = yaml.load(test_yaml)
 
         self.assertTrue(isinstance(doc, OrderedDict))
-        self.assertEqual(doc['test']['property'], 'value')
+        self.assertThat(doc['test']['property'], Equals('value'))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_main_nested_parts_valid(self, mock_get_origin_data):
@@ -147,7 +148,7 @@ description: example
 parts: [main, part1, part2]
 """)
         main(['--debug', '--index', TEST_OUTPUT_PATH])
-        self.assertEqual(3, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(3))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_main_nested_parts_invalid(self, mock_get_origin_data):
@@ -183,7 +184,7 @@ description: example
 parts: [main, part1]
 """)
         main(['--debug', '--index', TEST_OUTPUT_PATH])
-        self.assertEqual(0, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(0))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_wiki_code_tags(self, mock_get_origin_data):
@@ -206,7 +207,7 @@ parts: [main]
             }
         }
         main(['--debug', '--index', TEST_OUTPUT_PATH])
-        self.assertEqual(1, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(1))
 
     @mock.patch('snapcraft.internal.parser._get_base_dir')
     @mock.patch('snapcraft.internal.parser._get_origin_data')
@@ -250,9 +251,9 @@ parts: [main]
         ])
 
         mock_handler = mock_source_handler.return_value
-        self.assertEqual(mock_handler.source_branch, 'stable-branch')
-        self.assertEqual(mock_handler.source_commit, 123)
-        self.assertEqual(mock_handler.source_tag, 'source-tag')
+        self.assertThat(mock_handler.source_branch, Equals('stable-branch'))
+        self.assertThat(mock_handler.source_commit, Equals(123))
+        self.assertThat(mock_handler.source_tag, Equals('source-tag'))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_main_valid_variable_substition(self, mock_get_origin_data):
@@ -277,11 +278,11 @@ parts: [main]
             }
         }
         retval = main(['--debug', '--index', TEST_OUTPUT_PATH])
-        self.assertEqual(1, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(1))
         part = _get_part('main')
-        self.assertEqual(part['source'], 'lp:something/r0.1')
+        self.assertThat(part['source'], Equals('lp:something/r0.1'))
         self.assertIn('something/file1', part['files'])
-        self.assertEqual(0, retval)
+        self.assertThat(retval, Equals(0))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_main_valid(self, mock_get_origin_data):
@@ -302,20 +303,20 @@ parts: [main]
             }
         }
         retval = main(['--debug', '--index', TEST_OUTPUT_PATH])
-        self.assertEqual(1, _get_part_list_count())
-        self.assertEqual(0, retval)
+        self.assertThat(_get_part_list_count(), Equals(1))
+        self.assertThat(retval, Equals(0))
 
     def test_404_index(self):
         retval = main(['--debug', '--index', 'https://fake.example.com'])
         self.assertIn('Unable to access index: ', self.fake_logger.output)
-        self.assertEqual(1, retval)
+        self.assertThat(retval, Equals(1))
 
     def test_invalid_yaml(self):
         _create_example_output(':')
         retval = main(['--debug', '--index', TEST_OUTPUT_PATH])
         self.assertIn('Bad wiki entry, possibly malformed YAML for entry: ',
                       self.fake_logger.output)
-        self.assertEqual(1, retval)
+        self.assertThat(retval, Equals(1))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_main_slash_warning(self, mock_get_origin_data):
@@ -339,7 +340,7 @@ parts: [main/a]
             }
         }
         main(['--debug', '--index', TEST_OUTPUT_PATH])
-        self.assertEqual(1, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(1))
 
         m = 'DEPRECATED: Found a "/" in the name of the {!r} part'.format(
             'main/a')
@@ -349,7 +350,7 @@ parts: [main/a]
     def test_main_valid_with_empty_index(self):
         _create_example_output('')
         main(['--debug', '--index', TEST_OUTPUT_PATH])
-        self.assertEqual(0, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(0))
 
     @mock.patch('urllib.request.urlopen')
     def test_main_valid_with_default_index(self, mock_urlopen):
@@ -358,7 +359,7 @@ parts: [main/a]
                 return b''
         mock_urlopen.return_value = FakeResponse()
         main(['--debug'])
-        self.assertEqual(0, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(0))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_main_invalid(self, mock_get_origin_data):
@@ -380,7 +381,7 @@ parts: [main, part1]
             }
         }
         main(['--debug', '--index', TEST_OUTPUT_PATH])
-        self.assertEqual(0, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(0))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_single_part_origin(self, mock_get_origin_data):
@@ -403,7 +404,7 @@ parts: [main]
         }
         main(['--debug', '--index', TEST_OUTPUT_PATH])
 
-        self.assertEqual(1, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(1))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_multiple_part_origin(self, mock_get_origin_data):
@@ -432,7 +433,7 @@ parts: ['main', 'subpart']
         }
         main(['--debug', '--index', TEST_OUTPUT_PATH])
 
-        self.assertEqual(2, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(2))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_output_parameter(self, mock_get_origin_data):
@@ -458,7 +459,7 @@ parts: [main]
 
         main(['--debug', '--index', TEST_OUTPUT_PATH, '--output', filename])
 
-        self.assertEqual(1, _get_part_list_count(filename))
+        self.assertThat(_get_part_list_count(filename), Equals(1))
         self.assertTrue(os.path.exists(filename))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
@@ -482,10 +483,10 @@ parts: [main]
         }
         main(['--debug', '--index', TEST_OUTPUT_PATH])
 
-        self.assertEqual(1, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(1))
         part = _get_part('main')
         self.assertNotEqual('.', part['source'])
-        self.assertEqual(5, len(part.keys()))
+        self.assertThat(len(part.keys()), Equals(5))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_source_with_local_subdir_part_origin(self, mock_get_origin_data):
@@ -508,11 +509,11 @@ parts: [main]
         }
         main(['--debug', '--index', TEST_OUTPUT_PATH])
 
-        self.assertEqual(1, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(1))
         part = _get_part('main')
         self.assertNotEqual('local', part['source'])
-        self.assertEqual('local', part['source-subdir'])
-        self.assertEqual(6, len(part.keys()))
+        self.assertThat(part['source-subdir'], Equals('local'))
+        self.assertThat(len(part.keys()), Equals(6))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_source_with_local_source_subdir_part_origin(
@@ -537,11 +538,11 @@ parts: [main]
         }
         main(['--debug', '--index', TEST_OUTPUT_PATH])
 
-        self.assertEqual(1, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(1))
         part = _get_part('main')
         self.assertNotEqual('.', part['source'])
-        self.assertEqual('local', part['source-subdir'])
-        self.assertEqual(6, len(part.keys()))
+        self.assertThat(part['source-subdir'], Equals('local'))
+        self.assertThat(len(part.keys()), Equals(6))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_n_documents(self, mock_get_origin_data):
@@ -574,7 +575,7 @@ parts: [main2]
         }
         main(['--debug', '--index', TEST_OUTPUT_PATH])
 
-        self.assertEqual(2, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(2))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_maintaner_is_included(self, mock_get_origin_data):
@@ -608,12 +609,14 @@ parts: [main2]
         main(['--debug', '--index', TEST_OUTPUT_PATH])
 
         part = _get_part('main')
-        self.assertEqual('John Doe <john.doe@example.com>', part['maintainer'])
+        self.assertThat(
+            part['maintainer'], Equals('John Doe <john.doe@example.com>'))
 
         part = _get_part('main2')
-        self.assertEqual('Jim Doe <jim.doe@example.com>', part['maintainer'])
+        self.assertThat(
+            part['maintainer'], Equals('Jim Doe <jim.doe@example.com>'))
 
-        self.assertEqual(2, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(2))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_description_is_included(self, mock_get_origin_data):
@@ -647,12 +650,12 @@ parts: [main2]
         main(['--debug', '--index', TEST_OUTPUT_PATH])
 
         part = _get_part('main')
-        self.assertEqual('example main', part['description'])
+        self.assertThat(part['description'], Equals('example main'))
 
         part = _get_part('main2')
-        self.assertEqual('example main2', part['description'])
+        self.assertThat(part['description'], Equals('example main2'))
 
-        self.assertEqual(2, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(2))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_origin_part_without_source(self, mock_get_origin_data):
@@ -672,8 +675,8 @@ parts: [main]
             }
         }
         main(['--debug', '--index', TEST_OUTPUT_PATH])
-        self.assertEqual(1, _get_part_list_count())
-        self.assertEqual(4, len(_get_part('main').keys()))
+        self.assertThat(_get_part_list_count(), Equals(1))
+        self.assertThat(len(_get_part('main').keys()), Equals(4))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_missing_fields(self, mock_get_origin_data):
@@ -698,8 +701,8 @@ parts: [main]
         }
 
         retval = main(['--debug', '--index', TEST_OUTPUT_PATH])
-        self.assertEqual(0, _get_part_list_count())
-        self.assertEqual(2, retval)
+        self.assertThat(_get_part_list_count(), Equals(0))
+        self.assertThat(retval, Equals(2))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_partial_processing_for_malformed_yaml(self, mock_get_origin_data):
@@ -738,7 +741,7 @@ parts: [main2]
             }
         }
         main(['--debug', '--index', TEST_OUTPUT_PATH])
-        self.assertEqual(1, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(1))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_descriptions_get_block_quotes(self, mock_get_origin_data):
@@ -768,7 +771,7 @@ parts: [main]
             data = fp.read()
             self.assertNotIn('description: "', data)
             self.assertIn('description: |', data)
-        self.assertEqual(1, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(1))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_wiki_interactions_with_fake(self, mock_get_origin_data):
@@ -786,7 +789,7 @@ parts: [main]
             }
         }
         main(['--debug', '--index', fixture.fake_parts_wiki_fixture.url])
-        self.assertEqual(1, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(1))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_wiki_interactions_with_fake_with_slashes(
@@ -811,7 +814,7 @@ parts: [main]
         }
         main(['--debug', '--index',
               fixture.fake_parts_wiki_with_slashes_fixture.url])
-        self.assertEqual(2, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(2))
 
         part1 = _get_part('curl/a')
         self.assertTrue(part1)
@@ -837,7 +840,7 @@ parts: [somepart]
 """.format(origin_url=origin_url))
 
         main(['--debug', '--index', TEST_OUTPUT_PATH])
-        self.assertEqual(0, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(0))
 
         self.assertTrue(
             '1 wiki errors found'
@@ -858,7 +861,7 @@ parts: [somepart]
 """.format(origin_url=origin_url))
 
         main(['--index', TEST_OUTPUT_PATH])
-        self.assertEqual(0, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(0))
 
     def test_wiki_with_fake_origin_with_bad_snapcraft_yaml(self):
 
@@ -887,7 +890,7 @@ parts: [somepart]
             fp.write("bad yaml is : bad :yaml:::")
 
         main(['--debug', '--index', TEST_OUTPUT_PATH])
-        self.assertEqual(0, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(0))
 
         self.assertTrue(
             'Invalid wiki entry'
@@ -918,7 +921,7 @@ parts: [somepart]
             fp.write(text)
 
         main(['--debug', '--index', TEST_OUTPUT_PATH])
-        self.assertEqual(1, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(1))
         part = _get_part('somepart')
         self.assertTrue(part)
 
@@ -953,9 +956,9 @@ parts: [main]
         main(['--debug', '--index', TEST_OUTPUT_PATH])
 
         part = _get_part('main')
-        self.assertEqual('example main', part['description'])
+        self.assertThat(part['description'], Equals('example main'))
 
-        self.assertEqual(1, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(1))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_duplicate_entries(self, mock_get_origin_data):
@@ -988,9 +991,9 @@ parts: [main]
         main(['--debug', '--index', TEST_OUTPUT_PATH])
 
         part = _get_part('main')
-        self.assertEqual('example main', part['description'])
+        self.assertThat(part['description'], Equals('example main'))
 
-        self.assertEqual(1, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(1))
 
         self.assertTrue(
             'Duplicate part found in the wiki: main'
@@ -1045,10 +1048,9 @@ parts: [app1]
             'parts': parts,
         }
         main(['--index', TEST_OUTPUT_PATH])
-        self.assertEqual(3, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(3))
 
-        self.assertEqual(parts,
-                         _get_part_list())
+        self.assertThat(parts, Equals(_get_part_list()))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_remote_after_parts(self, mock_get_origin_data):
@@ -1085,7 +1087,7 @@ parts: [parent]
             'parts': parts,
         }
         main(['--index', TEST_OUTPUT_PATH])
-        self.assertEqual(2, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(2))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_part_missing_in_origin(self, mock_get_origin_data):
@@ -1106,8 +1108,8 @@ parts: [not-there]
             }
         }
         retcode = main(['--index', TEST_OUTPUT_PATH])
-        self.assertEqual(0, _get_part_list_count())
-        self.assertEqual(1, retcode)
+        self.assertThat(_get_part_list_count(), Equals(0))
+        self.assertThat(retcode, Equals(1))
 
     @mock.patch('snapcraft.internal.parser._get_origin_data')
     def test_remote_after_parts_unordered(self, mock_get_origin_data):
@@ -1144,7 +1146,7 @@ parts: [child]
             'parts': parts,
         }
         main(['--index', TEST_OUTPUT_PATH])
-        self.assertEqual(2, _get_part_list_count())
+        self.assertThat(_get_part_list_count(), Equals(2))
 
     def test__get_origin_data_both(self):
         with open(os.path.join(self.tempdir_path,
@@ -1176,13 +1178,15 @@ parts: [child]
         origin = 'git@github.com:testuser/testproject.git'
         origin_dir = _encode_origin(origin)
 
-        self.assertEqual('gitgithub.comtestusertestproject.git', origin_dir)
+        self.assertThat(
+            origin_dir, Equals('gitgithub.comtestusertestproject.git'))
 
     def test__encode_origin_lp(self):
         origin = 'lp:~testuser/testproject/testbranch'
         origin_dir = _encode_origin(origin)
 
-        self.assertEqual('lptestusertestprojecttestbranch', origin_dir)
+        self.assertThat(
+            origin_dir, Equals('lptestusertestprojecttestbranch'))
 
 
 class MissingAssetsTestCase(TestCase):
@@ -1231,7 +1235,7 @@ description: example main
 parts: [main2]
 """)
         retval = main(['--debug', '--index', TEST_OUTPUT_PATH])
-        self.assertEqual(2, retval)
+        self.assertThat(retval, Equals(2))
 
         self.assertTrue(
             'One or more required commands are missing, please install'

--- a/snapcraft/tests/test_parts.py
+++ b/snapcraft/tests/test_parts.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2016 Canonical Ltd
+# Copyright (C) 2015-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -18,9 +18,9 @@ import logging
 import os
 import unittest
 import unittest.mock
-from testtools.matchers import Contains
 
 import fixtures
+from testtools.matchers import Contains, Equals
 
 import snapcraft
 from snapcraft.internal import (
@@ -60,7 +60,7 @@ parts:
     stage-packages: [fswebcam]
 """)
         config = project_loader.load_config(None)
-        self.assertEqual(None, config.parts.get_part('not-a-part'))
+        self.assertThat(config.parts.get_part('not-a-part'), Equals(None))
 
     @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
     def test_slash_warning(self, mock_loadPlugin):

--- a/snapcraft/tests/test_project_loader.py
+++ b/snapcraft/tests/test_project_loader.py
@@ -78,8 +78,8 @@ parts:
 
         self.assertTrue('aliases' in c.data['apps']['test'],
                         'Expected "aliases" property to be in snap.yaml')
-        self.assertEqual(
-            c.data['apps']['test']['aliases'], ['test-it', 'testing'])
+        self.assertThat(
+            c.data['apps']['test']['aliases'], Equals(['test-it', 'testing']))
 
     @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
     def test_yaml_aliases_with_duplicates(self, mock_loadPlugin):
@@ -108,10 +108,11 @@ parts:
         raised = self.assertRaises(errors.DuplicateAliasError,
                                    project_loader.Config)
 
-        self.assertEqual(
-            'Multiple parts have the same alias defined: {!r}'.format(
-                'testing'),
-            str(raised))
+        self.assertThat(
+            str(raised),
+            Equals(
+                'Multiple parts have the same alias defined: {!r}'.format(
+                    'testing')))
 
     @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
     def test_yaml_invalid_alias(self, mock_loadPlugin):
@@ -355,9 +356,9 @@ parts:
         self.make_snapcraft_yaml(yaml)
         config = project_loader.Config(project_options)
 
-        self.assertEqual(config.parts.build_tools,
-                         ['gcc-arm-linux-gnueabihf',
-                          'libc6-dev-armhf-cross'])
+        self.assertThat(config.parts.build_tools,
+                        Equals(['gcc-arm-linux-gnueabihf',
+                                'libc6-dev-armhf-cross']))
 
     def test_config_has_no_extra_build_tools_when_not_cross_compiling(self):
         class ProjectOptionsFake(snapcraft.ProjectOptions):
@@ -379,7 +380,7 @@ parts:
         self.make_snapcraft_yaml(yaml)
         config = project_loader.Config(ProjectOptionsFake())
 
-        self.assertEqual(config.parts.build_tools, [])
+        self.assertThat(config.parts.build_tools, Equals([]))
 
     def test_config_loop(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
@@ -406,9 +407,9 @@ parts:
             errors.SnapcraftLogicError,
             project_loader.Config)
 
-        self.assertEqual(
+        self.assertThat(
             raised.message,
-            'circular dependency chain found in parts definition')
+            Equals('circular dependency chain found in parts definition'))
 
     @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
     def test_invalid_yaml_missing_name(self, mock_loadPlugin):
@@ -431,8 +432,8 @@ parts:
             errors.SnapcraftSchemaError,
             project_loader.Config)
 
-        self.assertEqual(raised.message,
-                         "'name' is a required property")
+        self.assertThat(raised.message,
+                        Equals("'name' is a required property"))
 
     def test_get_metadata(self):
         self.make_snapcraft_yaml("""name: test
@@ -450,9 +451,9 @@ parts:
 """)
         config = project_loader.load_config()
         metadata = config.get_metadata()
-        self.assertEqual(metadata['name'], 'test')
-        self.assertEqual(metadata['version'], '1')
-        self.assertEqual(metadata['arch'], ['amd64'])
+        self.assertThat(metadata['name'], Equals('test'))
+        self.assertThat(metadata['version'], Equals('1'))
+        self.assertThat(metadata['arch'], Equals(['amd64']))
 
     def test_version_script(self):
         self.make_snapcraft_yaml("""name: test
@@ -470,7 +471,8 @@ parts:
     stage-packages: [fswebcam]
 """)
         config = project_loader.load_config()
-        self.assertEqual(config.data['version-script'], 'echo 1.0-devel')
+        self.assertThat(
+            config.data['version-script'], Equals('echo 1.0-devel'))
 
     @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
     def test_invalid_yaml_invalid_name_as_number(self, mock_loadPlugin):
@@ -493,9 +495,10 @@ parts:
             errors.SnapcraftSchemaError,
             project_loader.Config)
 
-        self.assertEqual(raised.message,
-                         "The 'name' property does not match the required "
-                         "schema: 1 is not of type 'string'")
+        self.assertThat(
+            raised.message,
+            Equals("The 'name' property does not match the required "
+                   "schema: 1 is not of type 'string'"))
 
     @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
     def test_invalid_yaml_invalid_icon_extension(self, mock_loadPlugin):
@@ -519,8 +522,8 @@ parts:
             errors.SnapcraftSchemaError,
             project_loader.Config)
 
-        self.assertEqual(raised.message,
-                         "'icon' must be either a .png or a .svg")
+        self.assertThat(raised.message,
+                        Equals("'icon' must be either a .png or a .svg"))
 
     @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
     def test_invalid_yaml_missing_icon(self, mock_loadPlugin):
@@ -544,8 +547,8 @@ parts:
             errors.SnapcraftSchemaError,
             project_loader.Config)
 
-        self.assertEqual(raised.message,
-                         "Specified icon 'icon.png' does not exist")
+        self.assertThat(raised.message,
+                        Equals("Specified icon 'icon.png' does not exist"))
 
     @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
     def test_invalid_yaml_invalid_name_chars(self, mock_loadPlugin):
@@ -568,10 +571,10 @@ parts:
             errors.SnapcraftSchemaError,
             project_loader.Config)
 
-        self.assertEqual(
+        self.assertThat(
             raised.message,
-            "The 'name' property does not match the required schema: "
-            "'myapp@me_1.0' does not match '^[a-z0-9][a-z0-9+-]*$'")
+            Equals("The 'name' property does not match the required schema: "
+                   "'myapp@me_1.0' does not match '^[a-z0-9][a-z0-9+-]*$'"))
 
     @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
     def test_invalid_yaml_missing_description(self, mock_loadPlugin):
@@ -593,9 +596,9 @@ parts:
             errors.SnapcraftSchemaError,
             project_loader.Config)
 
-        self.assertEqual(
+        self.assertThat(
             raised.message,
-            "'description' is a required property")
+            Equals("'description' is a required property"))
 
     @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
     def test_yaml_missing_confinement_must_log(self, mock_loadPlugin):
@@ -617,7 +620,7 @@ parts:
         # Verify the default is "strict"
         self.assertTrue('confinement' in c.data,
                         'Expected "confinement" property to be in snap.yaml')
-        self.assertEqual(c.data['confinement'], 'strict')
+        self.assertThat(c.data['confinement'], Equals('strict'))
         self.assertTrue(
             '"confinement" property not specified: defaulting to "strict"'
             in fake_logger.output, 'Missing confinement hint in output')
@@ -643,7 +646,7 @@ parts:
         # Verify the default is "stable"
         self.assertTrue('grade' in c.data,
                         'Expected "grade" property to be in snap.yaml')
-        self.assertEqual(c.data['grade'], 'stable')
+        self.assertThat(c.data['grade'], Equals('stable'))
         self.assertTrue(
             '"grade" property not specified: defaulting to "stable"'
             in fake_logger.output, 'Missing grade hint in output')
@@ -670,10 +673,10 @@ parts:
             errors.SnapcraftSchemaError,
             project_loader.Config)
 
-        self.assertEqual(
+        self.assertThat(
             raised.message,
-            'found character \'\\t\' that cannot start any token '
-            'on line 5 of snap/snapcraft.yaml')
+            Equals('found character \'\\t\' that cannot start any token '
+                   'on line 5 of snap/snapcraft.yaml'))
 
     @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
     def test_yaml_organize_value_none(self, mock_loadPlugin):
@@ -777,8 +780,9 @@ parts:
         config = project_loader.Config()
 
         self.assertFalse(config.parts.get_prereqs('main'))
-        self.assertEqual({'main'},
-                         config.parts.get_prereqs('dependent'))
+        self.assertThat(
+            config.parts.get_prereqs('dependent'),
+            Equals({'main'}))
 
     def test_get_dependents(self):
         self.make_snapcraft_yaml("""name: test
@@ -799,8 +803,9 @@ parts:
         config = project_loader.Config()
 
         self.assertFalse(config.parts.get_dependents('dependent'))
-        self.assertEqual({'dependent'},
-                         config.parts.get_dependents('main'))
+        self.assertThat(
+            config.parts.get_dependents('main'),
+            Equals({'dependent'}))
 
     @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
     def test_replace_snapcraft_variables(self, mock_load_plugin):
@@ -904,10 +909,10 @@ parts:
             errors.SnapcraftSchemaError,
             project_loader.Config)
 
-        self.assertEqual(
+        self.assertThat(
             raised.message,
-            "The 'version' property does not match the required "
-            "schema: '' does not match '^[a-zA-Z0-9.+~-]+$'")
+            Equals("The 'version' property does not match the required "
+                   "schema: '' does not match '^[a-zA-Z0-9.+~-]+$'"))
 
 
 class YamlEncodingsTestCase(YamlBaseTestCase):
@@ -1117,7 +1122,7 @@ parts:
     stage-packages: [fswebcam]
 """.format(self.confinement))
         c = project_loader.Config()
-        self.assertEqual(c.data['confinement'], self.confinement)
+        self.assertThat(c.data['confinement'], Equals(self.confinement))
 
 
 class InvalidConfinementTypesYamlTestCase(YamlBaseTestCase):
@@ -1146,11 +1151,11 @@ parts:
             errors.SnapcraftSchemaError,
             project_loader.Config)
 
-        self.assertEqual(
+        self.assertThat(
             raised.message,
-            "The 'confinement' property does not match the required "
-            "schema: '{}' is not one of ['classic', 'devmode', "
-            "'strict']".format(self.confinement))
+            Equals("The 'confinement' property does not match the required "
+                   "schema: '{}' is not one of ['classic', 'devmode', "
+                   "'strict']".format(self.confinement)))
 
 
 class ValidGradeTypesYamlTestCase(YamlBaseTestCase):
@@ -1176,7 +1181,7 @@ parts:
     stage-packages: [fswebcam]
 """.format(self.grade))
         c = project_loader.Config()
-        self.assertEqual(c.data['grade'], self.grade)
+        self.assertThat(c.data['grade'], Equals(self.grade))
 
 
 class InvalidGradeTypesYamlTestCase(YamlBaseTestCase):
@@ -1205,11 +1210,11 @@ parts:
             errors.SnapcraftSchemaError,
             project_loader.Config)
 
-        self.assertEqual(
+        self.assertThat(
             raised.message,
-            "The 'grade' property does not match the required "
-            "schema: '{}' is not one of ['stable', 'devel']".format(
-                self.grade))
+            Equals("The 'grade' property does not match the required "
+                   "schema: '{}' is not one of ['stable', 'devel']".format(
+                       self.grade)))
 
 
 class ValidEpochsYamlTestCase(YamlBaseTestCase):
@@ -1277,7 +1282,7 @@ parts:
     stage-packages: [fswebcam]
 """.format(self.yaml))
         c = project_loader.Config()
-        self.assertEqual(c.data['epoch'], self.expected)
+        self.assertThat(c.data['epoch'], Equals(self.expected))
 
 
 class InvalidEpochsYamlTestCase(YamlBaseTestCase):
@@ -1345,10 +1350,10 @@ class InitTestCase(tests.TestCase):
         raised = self.assertRaises(errors.SnapcraftEnvironmentError,
                                    project_loader.Config)
 
-        self.assertEqual(
-            "Found a 'snap/snapcraft.yaml' and a 'snapcraft.yaml', please "
-            "remove one.",
-            str(raised))
+        self.assertThat(
+            str(raised), Equals(
+                "Found a 'snap/snapcraft.yaml' and a 'snapcraft.yaml', please "
+                "remove one."))
 
     def test_both_new_and_hidden_yamls_cause_error(self):
         os.mkdir('snap')
@@ -1358,10 +1363,10 @@ class InitTestCase(tests.TestCase):
         raised = self.assertRaises(errors.SnapcraftEnvironmentError,
                                    project_loader.Config)
 
-        self.assertEqual(
-            "Found a 'snap/snapcraft.yaml' and a '.snapcraft.yaml', please "
-            "remove one.",
-            str(raised))
+        self.assertThat(
+            str(raised), Equals(
+                "Found a 'snap/snapcraft.yaml' and a '.snapcraft.yaml', "
+                "please remove one."))
 
     def test_both_visible_and_hidden_yamls_cause_error(self):
         open('snapcraft.yaml', 'w').close()
@@ -1370,10 +1375,10 @@ class InitTestCase(tests.TestCase):
         raised = self.assertRaises(errors.SnapcraftEnvironmentError,
                                    project_loader.Config)
 
-        self.assertEqual(
-            "Found a 'snapcraft.yaml' and a '.snapcraft.yaml', please "
-            'remove one.',
-            str(raised))
+        self.assertThat(
+            str(raised), Equals(
+                "Found a 'snapcraft.yaml' and a '.snapcraft.yaml', please "
+                'remove one.'))
 
     def test_snapcraft_yaml_loads(self):
         self.make_snapcraft_yaml("""name: test
@@ -1767,35 +1772,35 @@ parts:
                 parts_dir=self.parts_dir,
                 stage_dir=self.stage_dir,
                 arch_triplet=self.arch_triplet))
-        self.assertEqual(get_envvar('CFLAGS'), expected_cflags)
-        self.assertEqual(get_envvar('CXXFLAGS'), expected_cflags)
-        self.assertEqual(get_envvar('CPPFLAGS'), expected_cflags)
+        self.assertThat(get_envvar('CFLAGS'), Equals(expected_cflags))
+        self.assertThat(get_envvar('CXXFLAGS'), Equals(expected_cflags))
+        self.assertThat(get_envvar('CPPFLAGS'), Equals(expected_cflags))
 
-        self.assertEqual(
-            get_envvar('LDFLAGS'),
-            '-L/user-provided '
-            '-L{parts_dir}/part2/install/lib -L{stage_dir}/lib '
-            '-L{stage_dir}/usr/lib -L{stage_dir}/lib/{arch_triplet} '
-            '-L{stage_dir}/usr/lib/{arch_triplet}'.format(
-                parts_dir=self.parts_dir,
-                stage_dir=self.stage_dir,
-                arch_triplet=self.arch_triplet))
+        self.assertThat(
+            get_envvar('LDFLAGS'), Equals(
+                '-L/user-provided '
+                '-L{parts_dir}/part2/install/lib -L{stage_dir}/lib '
+                '-L{stage_dir}/usr/lib -L{stage_dir}/lib/{arch_triplet} '
+                '-L{stage_dir}/usr/lib/{arch_triplet}'.format(
+                    parts_dir=self.parts_dir,
+                    stage_dir=self.stage_dir,
+                    arch_triplet=self.arch_triplet)))
 
-        self.assertEqual(
-            get_envvar('LD_LIBRARY_PATH'),
-            '/user-provided:'
-            '{parts_dir}/part2/install/lib:'
-            '{stage_dir}/lib:'
-            '{stage_dir}/usr/lib:'
-            '{stage_dir}/lib/{arch_triplet}:'
-            '{stage_dir}/usr/lib/{arch_triplet}:'
-            '{stage_dir}/lib:'
-            '{stage_dir}/usr/lib:'
-            '{stage_dir}/lib/{arch_triplet}:'
-            '{stage_dir}/usr/lib/{arch_triplet}'.format(
-                parts_dir=self.parts_dir,
-                stage_dir=self.stage_dir,
-                arch_triplet=self.arch_triplet))
+        self.assertThat(
+            get_envvar('LD_LIBRARY_PATH'), Equals(
+                '/user-provided:'
+                '{parts_dir}/part2/install/lib:'
+                '{stage_dir}/lib:'
+                '{stage_dir}/usr/lib:'
+                '{stage_dir}/lib/{arch_triplet}:'
+                '{stage_dir}/usr/lib/{arch_triplet}:'
+                '{stage_dir}/lib:'
+                '{stage_dir}/usr/lib:'
+                '{stage_dir}/lib/{arch_triplet}:'
+                '{stage_dir}/usr/lib/{arch_triplet}'.format(
+                    parts_dir=self.parts_dir,
+                    stage_dir=self.stage_dir,
+                    arch_triplet=self.arch_triplet)))
 
     def test_parts_build_env_contains_parallel_build_count(self):
         self.useFixture(fixture_setup.FakeProjectOptions(
@@ -1854,8 +1859,8 @@ class ValidationTestCase(ValidationBaseTestCase):
             "The 'summary' property does not match the required schema: "
             "'{}' is too long (maximum length is 78)").format(
                 self.data['summary'])
-        self.assertEqual(raised.message, expected_message,
-                         message=self.data)
+        self.assertThat(raised.message, Equals(expected_message),
+                        message=self.data)
 
     def test_apps_required_properties(self):
         self.data['apps'] = {'service1': {}}
@@ -1867,8 +1872,8 @@ class ValidationTestCase(ValidationBaseTestCase):
         expected_message = ("The 'apps/service1' property does not match the "
                             "required schema: 'command' is a required "
                             "property")
-        self.assertEqual(raised.message, expected_message,
-                         message=self.data)
+        self.assertThat(raised.message, Equals(expected_message),
+                        message=self.data)
 
     def test_schema_file_not_found(self):
         mock_the_open = unittest.mock.mock_open()
@@ -1883,7 +1888,7 @@ class ValidationTestCase(ValidationBaseTestCase):
 
         expected_message = ('snapcraft validation file is missing from '
                             'installation path')
-        self.assertEqual(raised.message, expected_message)
+        self.assertThat(raised.message, Equals(expected_message))
 
     def test_icon_missing_is_valid_yaml(self):
         self.mock_path_exists.return_value = False
@@ -1900,8 +1905,8 @@ class ValidationTestCase(ValidationBaseTestCase):
         expected_message = ("The 'parts' property does not match the "
                             "required schema: Additional properties are not "
                             "allowed ('plugins' was unexpected)")
-        self.assertEqual(raised.message, expected_message,
-                         message=self.data)
+        self.assertThat(raised.message, Equals(expected_message),
+                        message=self.data)
 
     def test_valid_app_daemons(self):
         self.data['apps'] = {
@@ -2012,8 +2017,8 @@ class RequiredPropertiesTestCase(ValidationBaseTestCase):
             project_loader.Validator(data).validate)
 
         expected_message = '\'{}\' is a required property'.format(self.key)
-        self.assertEqual(raised.message, expected_message,
-                         message=data)
+        self.assertThat(raised.message, Equals(expected_message),
+                        message=data)
 
 
 class InvalidNamesTestCase(ValidationBaseTestCase):
@@ -2032,8 +2037,8 @@ class InvalidNamesTestCase(ValidationBaseTestCase):
         expected_message = ("The 'name' property does not match the "
                             "required schema: '{}' does not match "
                             "'^[a-z0-9][a-z0-9+-]*$'").format(self.name)
-        self.assertEqual(raised.message, expected_message,
-                         message=data)
+        self.assertThat(raised.message, Equals(expected_message),
+                        message=data)
 
 
 class ValidTypesTestCase(ValidationBaseTestCase):
@@ -2064,8 +2069,8 @@ class InvalidTypesTestCase(ValidationBaseTestCase):
             "The 'type' property does not match the required "
             "schema: '{}' is not one of "
             "['app', 'base', 'gadget', 'kernel', 'os']").format(self.type_)
-        self.assertEqual(raised.message, expected_message,
-                         message=data)
+        self.assertThat(raised.message, Equals(expected_message),
+                        message=data)
 
 
 class ValidRestartConditionsTestCase(ValidationBaseTestCase):
@@ -2102,8 +2107,8 @@ class InvalidAppNamesTestCase(ValidationBaseTestCase):
             "The 'apps' property does not match the required "
             "schema: Additional properties are not allowed ('{}' "
             "was unexpected)").format(self.name)
-        self.assertEqual(raised.message, expected_message,
-                         message=data)
+        self.assertThat(raised.message, Equals(expected_message),
+                        message=data)
 
 
 class TestPluginLoadingProperties(tests.TestCase):
@@ -2152,13 +2157,13 @@ class TestFilesets(tests.TestCase):
         self.properties['stage'] = ['$1']
 
         fs = project_loader._expand_filesets_for('stage', self.properties)
-        self.assertEqual(fs, ['1', '2', '3'])
+        self.assertThat(fs, Equals(['1', '2', '3']))
 
     def test_no_expansion(self):
         self.properties['stage'] = ['1']
 
         fs = project_loader._expand_filesets_for('stage', self.properties)
-        self.assertEqual(fs, ['1'])
+        self.assertThat(fs, Equals(['1']))
 
     def test_invalid_expansion(self):
         self.properties['stage'] = ['$3']
@@ -2200,10 +2205,11 @@ class SnapcraftEnvTestCase(tests.TestCase):
         )
 
         for test_name, subject, expected in replacements:
-            self.assertEqual(project_loader.replace_attr(
+            self.assertThat(project_loader.replace_attr(
                 subject, [('$SNAPCRAFT_PROJECT_NAME', 'project_name'),
                           ('$SNAPCRAFT_PROJECT_VERSION', 'version'),
-                          ('$SNAPCRAFT_STAGE', self.stage_dir)]), expected)
+                          ('$SNAPCRAFT_STAGE', self.stage_dir)]),
+                            Equals(expected))
 
     def test_lists_with_string_replacements(self):
         replacements = (
@@ -2243,10 +2249,11 @@ class SnapcraftEnvTestCase(tests.TestCase):
         )
 
         for test_name, subject, expected in replacements:
-            self.assertEqual(project_loader.replace_attr(
+            self.assertThat(project_loader.replace_attr(
                 subject, [('$SNAPCRAFT_PROJECT_NAME', 'project_name'),
                           ('$SNAPCRAFT_PROJECT_VERSION', 'version'),
-                          ('$SNAPCRAFT_STAGE', self.stage_dir)]), expected)
+                          ('$SNAPCRAFT_STAGE', self.stage_dir)]),
+                            Equals(expected))
 
     def test_tuples_with_string_replacements(self):
         replacements = (
@@ -2286,10 +2293,11 @@ class SnapcraftEnvTestCase(tests.TestCase):
         )
 
         for test_name, subject, expected in replacements:
-            self.assertEqual(project_loader.replace_attr(
+            self.assertThat(project_loader.replace_attr(
                 subject, [('$SNAPCRAFT_PROJECT_NAME', 'project_name'),
                           ('$SNAPCRAFT_PROJECT_VERSION', 'version'),
-                          ('$SNAPCRAFT_STAGE', self.stage_dir)]), expected)
+                          ('$SNAPCRAFT_STAGE', self.stage_dir)]),
+                            Equals(expected))
 
     def test_dict_with_string_replacements(self):
         replacements = (
@@ -2329,10 +2337,11 @@ class SnapcraftEnvTestCase(tests.TestCase):
         )
 
         for test_name, subject, expected in replacements:
-            self.assertEqual(project_loader.replace_attr(
+            self.assertThat(project_loader.replace_attr(
                 subject, [('$SNAPCRAFT_PROJECT_NAME', 'project_name'),
                           ('$SNAPCRAFT_PROJECT_VERSION', 'version'),
-                          ('$SNAPCRAFT_STAGE', self.stage_dir)]), expected)
+                          ('$SNAPCRAFT_STAGE', self.stage_dir)]),
+                            Equals(expected))
 
     def test_string_replacement_with_complex_data(self):
         subject = {
@@ -2363,7 +2372,8 @@ class SnapcraftEnvTestCase(tests.TestCase):
             ],
         }
 
-        self.assertEqual(project_loader.replace_attr(
+        self.assertThat(project_loader.replace_attr(
             subject, [('$SNAPCRAFT_PROJECT_NAME', 'project_name'),
                       ('$SNAPCRAFT_PROJECT_VERSION', 'version'),
-                      ('$SNAPCRAFT_STAGE', self.stage_dir)]), expected)
+                      ('$SNAPCRAFT_STAGE', self.stage_dir)]),
+                        Equals(expected))

--- a/snapcraft/tests/test_target_arch.py
+++ b/snapcraft/tests/test_target_arch.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from testtools.matchers import Equals
+
 import snapcraft
 from snapcraft import tests
 
@@ -58,4 +60,4 @@ class OptionsTestCase(tests.TestCase):
 
     def test_find_machine(self):
         machine = snapcraft._options._find_machine(self.machine)
-        self.assertEqual(machine, self.expected_machine)
+        self.assertThat(machine, Equals(self.expected_machine))

--- a/snaps_tests/__init__.py
+++ b/snaps_tests/__init__.py
@@ -30,6 +30,7 @@ import testtools
 from testtools import content
 from testtools.matchers import (
     Contains,
+    Equals,
     MatchesRegex
 )
 
@@ -228,7 +229,7 @@ class SnapsTestCase(testtools.TestCase):
             self, command, expected_output, cwd=None):
         if not config.get('skip-install', False):
             output = self.run_command_in_snappy_testbed(command, cwd)
-            self.assertEqual(expected_output, output)
+            self.assertThat(output, Equals(expected_output))
 
     def assert_command_in_snappy_testbed_with_regex(
             self, command, expected_regex, flags=0, cwd=None):

--- a/snaps_tests/demos_tests/test_ros.py
+++ b/snaps_tests/demos_tests/test_ros.py
@@ -20,6 +20,8 @@ import subprocess
 from platform import linux_distribution
 from unittest import skipUnless
 
+from testtools.matchers import Equals
+
 import snapcraft
 import snaps_tests
 
@@ -51,7 +53,7 @@ class ROSTestCase(snaps_tests.SnapsTestCase):
         output = subprocess.check_output(
             "sed -n '/env/p;1q' prime/usr/bin/rosversion",
             cwd=os.path.join(self.path, self.snap_content_dir), shell=True)
-        self.assertEqual(output, expected)
+        self.assertThat(output, Equals(expected))
 
         # Regression test for LP: #1660852. Make sure --help actually gets
         # passed to rosaunch instead of being eaten by setup.sh.


### PR DESCRIPTION
assertThat from testtools offers a better error message in casee of failure, and makes it easier to use a consistent order in the actual and expected arguments.