### PR TITLE
project loader: refactor into package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ packages = [
 	'snapcraft.internal.deltas',
 	'snapcraft.internal.pluginhandler',
 	'snapcraft.internal.pluginhandler.stage_package_grammar',
+	'snapcraft.internal.project_loader',
 	'snapcraft.internal.repo',
 	'snapcraft.internal.sources',
 	'snapcraft.internal.states',

--- a/snapcraft/cli/parts.py
+++ b/snapcraft/cli/parts.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import click
-from snapcraft.internal import parts
+from snapcraft.internal import remote_parts
 
 
 @click.group(context_settings={})
@@ -27,7 +27,7 @@ def partscli(ctx):
 @click.pass_context
 def update(ctx):
     """Updates the parts listing from the cloud."""
-    parts.update()
+    remote_parts.update()
 
 
 @partscli.command()
@@ -41,7 +41,7 @@ def define(ctx, part):
         snapcraft define my-part1
 
     """
-    parts.define(part)
+    remote_parts.define(part)
 
 
 @partscli.command()
@@ -55,4 +55,4 @@ def search(ctx, query):
         snapcraft search go
 
     """
-    parts.search(' '.join(query))
+    remote_parts.search(' '.join(query))

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -14,17 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import contextlib
-
-from snapcraft import formatting_utils
-
-# dict of jsonschema validator -> cause pairs. Wish jsonschema just gave us
-# better messages.
-_VALIDATION_ERROR_CAUSES = {
-    'maxLength': 'maximum length is {validator_value}',
-    'minLength': 'minimum length is {validator_value}',
-}
-
 
 class SnapcraftError(Exception):
     """Base class for all snapcraft exceptions.
@@ -71,17 +60,6 @@ class PrimeFileConflictError(SnapcraftError):
     )
 
 
-class DuplicateAliasError(SnapcraftError):
-
-    fmt = 'Multiple parts have the same alias defined: {aliases!r}'
-
-    def __str__(self):
-        if isinstance(self.aliases, (list, set)):
-            self.aliases = ','.join(self.aliases)
-
-        return super().__str__()
-
-
 class InvalidAppCommandError(SnapcraftError):
 
     fmt = (
@@ -122,14 +100,6 @@ class PartNotInCacheError(SnapcraftError):
     )
 
 
-class SnapcraftLogicError(SnapcraftError):
-
-    fmt = 'Issue detected while analyzing snapcraft.yaml: {message}'
-
-    def __init__(self, message):
-        super().__init__(message=message)
-
-
 class PluginError(SnapcraftError):
 
     fmt = 'Issue while loading part: {message}'
@@ -142,13 +112,6 @@ class PluginNotDefinedError(SnapcraftError):
 
     fmt = ("Issues while validating snapcraft.yaml: the 'plugin' keyword is "
            "missing for the {part_name} part.")
-
-
-class SnapcraftYamlFileError(SnapcraftError):
-
-    fmt = ('Could not find {snapcraft_yaml}. Are you sure you are in the '
-           'right directory?\n'
-           'To start a new project, use `snapcraft init`')
 
 
 class SnapcraftPartConflictError(SnapcraftError):
@@ -228,83 +191,3 @@ class RequiredPathDoesNotExist(SnapcraftError):
 class SnapcraftPathEntryError(SnapcraftError):
 
     fmt = 'The path {value!r} set for {key!r} in {app!r} does not exist.'
-
-
-class SnapcraftSchemaError(SnapcraftError):
-
-    fmt = 'Issues while validating {snapcraft_yaml}: {message}'
-
-    @classmethod
-    def from_validation_error(cls, error):
-        """Take a jsonschema.ValidationError and create a SnapcraftSchemaError.
-
-        The validation errors coming from jsonschema are a nightmare. This
-        class tries to make them a bit more understandable.
-        """
-
-        messages = []
-
-        # error.validator_value may contain a custom validation error message.
-        # If so, use it instead of the garbage message jsonschema gives us.
-        with contextlib.suppress(TypeError, KeyError):
-            messages.append(
-                error.validator_value['validation-failure'].format(error))
-
-        if not messages:
-            messages.append(error.message)
-
-        path = []
-        while error.absolute_path:
-            element = error.absolute_path.popleft()
-            # assume numbers are indices and use 'xxx[123]' notation.
-            if isinstance(element, int):
-                path[-1] = '{}[{}]'.format(path[-1], element)
-            else:
-                path.append(str(element))
-        if path:
-            messages.insert(0, "The '{}' property does not match the "
-                               "required schema:".format('/'.join(path)))
-        cause = error.cause or _determine_cause(error)
-        if cause:
-            messages.append('({})'.format(cause))
-
-        return cls(' '.join(messages))
-
-    def __init__(self, message, snapcraft_yaml='snapcraft.yaml'):
-        super().__init__(message=message, snapcraft_yaml=snapcraft_yaml)
-
-
-def _determine_cause(error):
-    """Attempt to determine a cause from validation error.
-
-    :return: A string representing the cause of the error (it may be empty if
-             no cause can be determined).
-    :rtype: str
-    """
-
-    message = _VALIDATION_ERROR_CAUSES.get(error.validator, '').format(
-        validator_value=error.validator_value)
-
-    if not message and error.validator == 'anyOf':
-        message = _interpret_anyOf(error)
-
-    return message
-
-
-def _interpret_anyOf(error):
-    """Interpret a validation error caused by the anyOf validator.
-
-    Returns:
-        A string containing a (hopefully) helpful validation error message. It
-        may be empty.
-    """
-
-    usages = []
-    try:
-        for validator in error.validator_value:
-            usages.append(validator['usage'])
-    except (TypeError, KeyError):
-        return ''
-
-    return 'must be one of {}'.format(formatting_utils.humanize_list(
-        usages, 'or'))

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -37,6 +37,7 @@ from snapcraft.internal import (
     sources,
     states,
 )
+from snapcraft.internal.project_loader.errors import YamlValidationError
 from ._scriptlets import ScriptRunner
 from ._build_attributes import BuildAttributes
 from ._stage_package_handler import StagePackageHandler
@@ -108,7 +109,7 @@ class PluginHandler:
                 plugin_name, self._part_properties, part_schema,
                 definitions_schema)
         except jsonschema.ValidationError as e:
-            error = errors.SnapcraftSchemaError.from_validation_error(e)
+            error = YamlValidationError.from_validation_error(e)
             raise errors.PluginError(
                 'properties failed to load for {}: {}'.format(
                     part_name, error.message))

--- a/snapcraft/internal/project_loader/__init__.py
+++ b/snapcraft/internal/project_loader/__init__.py
@@ -1,0 +1,64 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from ._schema import Validator  # noqa
+
+
+def load_config(project_options=None):
+    from ._config import Config
+    return Config(project_options)
+
+
+def replace_attr(attr, replacements):
+    if isinstance(attr, str):
+        for replacement in replacements:
+            attr = attr.replace(replacement[0], str(replacement[1]))
+        return attr
+    elif isinstance(attr, list) or isinstance(attr, tuple):
+        return [replace_attr(i, replacements)
+                for i in attr]
+    elif isinstance(attr, dict):
+        return {k: replace_attr(attr[k], replacements)
+                for k in attr}
+
+    return attr
+
+
+def get_snapcraft_yaml(base_dir=None):
+    possible_yamls = [
+        os.path.join('snap', 'snapcraft.yaml'),
+        'snapcraft.yaml',
+        '.snapcraft.yaml',
+    ]
+
+    if base_dir:
+        possible_yamls = [os.path.join(base_dir, x) for x in possible_yamls]
+
+    snapcraft_yamls = [y for y in possible_yamls if os.path.exists(y)]
+
+    import snapcraft.internal.errors
+    from snapcraft.internal.project_loader import errors
+    if not snapcraft_yamls:
+        raise errors.MissingSnapcraftYamlError(
+            snapcraft_yaml='snap/snapcraft.yaml')
+    elif len(snapcraft_yamls) > 1:
+        raise snapcraft.internal.errors.SnapcraftEnvironmentError(
+            'Found a {!r} and a {!r}, please remove one.'.format(
+                snapcraft_yamls[0], snapcraft_yamls[1]))
+
+    return snapcraft_yamls[0]

--- a/snapcraft/internal/project_loader/_env.py
+++ b/snapcraft/internal/project_loader/_env.py
@@ -1,0 +1,111 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+import snapcraft
+from snapcraft import formatting_utils
+from snapcraft.internal import (
+    common,
+    libraries,
+)
+
+
+def runtime_env(root, arch_triplet):
+    """Set the environment variables required for running binaries."""
+    env = []
+
+    env.append('PATH="' + ':'.join([
+        '{0}/usr/sbin',
+        '{0}/usr/bin',
+        '{0}/sbin',
+        '{0}/bin',
+        '$PATH'
+    ]).format(root) + '"')
+
+    # Add the default LD_LIBRARY_PATH
+    paths = common.get_library_paths(root, arch_triplet)
+    if paths:
+        env.append(formatting_utils.format_path_variable(
+            'LD_LIBRARY_PATH', paths, prepend='', separator=':'))
+
+    # Add more specific LD_LIBRARY_PATH from staged packages if necessary
+    ld_library_paths = libraries.determine_ld_library_path(root)
+    if ld_library_paths:
+        env.append('LD_LIBRARY_PATH="' + ':'.join(ld_library_paths) +
+                   ':$LD_LIBRARY_PATH"')
+
+    return env
+
+
+def build_env(root, snap_name, confinement, arch_triplet,
+              core_dynamic_linker=None):
+    """Set the environment variables required for building.
+
+    This is required for the current parts installdir due to stage-packages
+    and also to setup the stagedir.
+    """
+    env = []
+
+    paths = common.get_include_paths(root, arch_triplet)
+    if paths:
+        for envvar in ['CPPFLAGS', 'CFLAGS', 'CXXFLAGS']:
+            env.append(formatting_utils.format_path_variable(
+                envvar, paths, prepend='-I', separator=' '))
+
+    if confinement == 'classic':
+        if not core_dynamic_linker:
+            raise snapcraft.internal.errors.SnapcraftEnvironmentError(
+                'classic confinement requires the core snap to be installed. '
+                'Install it by running `snap install core`.')
+
+        core_path = common.get_core_path()
+        core_rpaths = common.get_library_paths(core_path, arch_triplet,
+                                               existing_only=False)
+        snap_path = os.path.join('/snap', snap_name, 'current')
+        snap_rpaths = common.get_library_paths(snap_path, arch_triplet,
+                                               existing_only=False)
+
+        # snap_rpaths before core_rpaths to prefer libraries from the snap.
+        rpaths = formatting_utils.combine_paths(
+            snap_rpaths + core_rpaths, prepend='', separator=':')
+        env.append('LDFLAGS="$LDFLAGS '
+                   # Building tools to continue the build becomes problematic
+                   # with nodefaultlib.
+                   # '-Wl,-z,nodefaultlib '
+                   '-Wl,--dynamic-linker={0} '
+                   '-Wl,-rpath,{1}"'.format(core_dynamic_linker, rpaths))
+
+    paths = common.get_library_paths(root, arch_triplet)
+    if paths:
+        env.append(formatting_utils.format_path_variable(
+            'LDFLAGS', paths, prepend='-L', separator=' '))
+
+    paths = common.get_pkg_config_paths(root, arch_triplet)
+    if paths:
+        env.append(formatting_utils.format_path_variable(
+            'PKG_CONFIG_PATH', paths, prepend='', separator=':'))
+
+    return env
+
+
+def build_env_for_stage(stagedir, snap_name, confinement,
+                        arch_triplet, core_dynamic_linker=None):
+    env = build_env(stagedir, snap_name, confinement,
+                    arch_triplet, core_dynamic_linker)
+    env.append('PERL5LIB={0}/usr/share/perl5/'.format(stagedir))
+
+    return env

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -14,129 +14,22 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import difflib
 import logging
-import os
-import sys
 
-import requests
-import yaml
-from xdg import BaseDirectory
-
-from snapcraft.internal.indicators import download_requests_stream
-from snapcraft.internal.common import get_terminal_width
+import snapcraft
 from snapcraft.internal import (
-    errors,
     deprecations,
     pluginhandler,
-    project_loader,
     repo
 )
+from ._env import (
+    build_env,
+    build_env_for_stage,
+    runtime_env,
+)
+from . import errors
 
-
-PARTS_URI = 'https://parts.snapcraft.io/v1/parts.yaml'
-_MATCH_RATIO = 0.6
-_HEADER_PART_NAME = 'PART NAME'
-_HEADER_DESCRIPTION = 'DESCRIPTION'
-
-logging.getLogger("urllib3").setLevel(logging.CRITICAL)
 logger = logging.getLogger(__name__)
-
-
-class _Base:
-
-    def __init__(self):
-        self.parts_dir = os.path.join(BaseDirectory.xdg_data_home, 'snapcraft')
-        os.makedirs(self.parts_dir, exist_ok=True)
-        self.parts_yaml = os.path.join(self.parts_dir, 'parts.yaml')
-
-
-class _Update(_Base):
-
-    def __init__(self):
-        super().__init__()
-        self._headers_yaml = os.path.join(self.parts_dir, 'headers.yaml')
-        self._parts_uri = os.environ.get('SNAPCRAFT_PARTS_URI', PARTS_URI)
-
-    def execute(self):
-        headers = self._load_headers()
-        self._request = requests.get(self._parts_uri, stream=True,
-                                     headers=headers)
-
-        if self._request.status_code == 304:
-            logger.info('The parts cache is already up to date.')
-            return
-        self._request.raise_for_status()
-
-        download_requests_stream(self._request, self.parts_yaml,
-                                 'Downloading parts list')
-        self._save_headers()
-
-    def _load_headers(self):
-        if not os.path.exists(self._headers_yaml):
-            return None
-
-        with open(self._headers_yaml) as headers_file:
-            return yaml.load(headers_file)
-
-    def _save_headers(self):
-        headers = {
-            'If-Modified-Since': self._request.headers.get('Last-Modified')}
-
-        with open(self._headers_yaml, 'w') as headers_file:
-            headers_file.write(yaml.dump(headers))
-
-
-class _RemoteParts(_Base):
-
-    def __init__(self):
-        super().__init__()
-
-        if not os.path.exists(self.parts_yaml):
-            update()
-
-        with open(self.parts_yaml) as parts_file:
-            self._parts = yaml.load(parts_file)
-
-    def get_part(self, part_name, full=False):
-        try:
-            remote_part = self._parts[part_name].copy()
-        except KeyError:
-            raise errors.SnapcraftPartMissingError(part_name=part_name)
-        if not full:
-            for key in ['description', 'maintainer']:
-                remote_part.pop(key)
-        return remote_part
-
-    def matches_for(self, part_match, max_len=0):
-        matcher = difflib.SequenceMatcher(isjunk=None, autojunk=False)
-        matcher.set_seq2(part_match)
-
-        matching_parts = {}
-        for part_name in self._parts.keys():
-            matcher.set_seq1(part_name)
-            add_part_name = matcher.ratio() >= _MATCH_RATIO
-
-            if add_part_name or (part_match in part_name):
-                matching_parts[part_name] = self._parts[part_name]
-                if len(part_name) > max_len:
-                    max_len = len(part_name)
-
-        return matching_parts, max_len
-
-    def compose(self, part_name, properties):
-        """Return properties composed with the ones from part name in the wiki.
-        :param str part_name: The name of the part to query from the wiki
-        :param dict properties: The current set of properties
-        :return: Part properties from the wiki composed with the properties
-                 passed as a parameter.
-        :rtype: dict
-        :raises KeyError: if part_name is not found in the wiki.
-        """
-        remote_part = self.get_part(part_name)
-        remote_part.update(properties)
-
-        return remote_part
 
 
 class PartsConfig:
@@ -252,7 +145,7 @@ class PartsConfig:
     def validate(self, part_names):
         for part_name in part_names:
             if part_name not in self._part_names:
-                raise errors.SnapcraftEnvironmentError(
+                raise snapcraft.internal.errors.SnapcraftEnvironmentError(
                     'The part named {!r} is not defined in '
                     '{!r}'.format(part_name, self._snapcraft_yaml))
 
@@ -284,17 +177,17 @@ class PartsConfig:
         if root_part:
             # this has to come before any {}/usr/bin
             env += part.env(part.installdir)
-            env += project_loader._runtime_env(
+            env += runtime_env(
                 part.installdir, self._project_options.arch_triplet)
-            env += project_loader._runtime_env(
+            env += runtime_env(
                 stagedir, self._project_options.arch_triplet)
-            env += project_loader._build_env(
+            env += build_env(
                 part.installdir,
                 self._snap_name,
                 self._confinement,
                 self._project_options.arch_triplet,
                 core_dynamic_linker=core_dynamic_linker)
-            env += project_loader._build_env_for_stage(
+            env += build_env_for_stage(
                 stagedir,
                 self._snap_name,
                 self._confinement,
@@ -305,7 +198,7 @@ class PartsConfig:
                        self._project_options.parallel_build_count))
         else:
             env += part.env(stagedir)
-            env += project_loader._runtime_env(
+            env += runtime_env(
                 stagedir, self._project_options.arch_triplet)
 
         for dep_part in part.deps:
@@ -313,48 +206,3 @@ class PartsConfig:
             env += self.build_env_for_part(dep_part, root_part=False)
 
         return env
-
-
-def update():
-    _Update().execute()
-
-
-def define(part_name):
-    try:
-        remote_part = _RemoteParts().get_part(part_name, full=True)
-    except errors.SnapcraftPartMissingError as e:
-        raise errors.PartNotInCacheError(part_name=part_name) from e
-    print('Maintainer: {!r}'.format(remote_part.pop('maintainer')))
-    print('Description: {}'.format(remote_part.pop('description')))
-    print('')
-    yaml.dump({part_name: remote_part},
-              default_flow_style=False, stream=sys.stdout)
-
-
-def search(part_match):
-    header_len = len(_HEADER_PART_NAME)
-    matches, part_length = _RemoteParts().matches_for(part_match, header_len)
-
-    terminal_width = get_terminal_width(max_width=None)
-    part_length = max(part_length, header_len)
-    # <space> + <space> + <description> + ... = 5
-    description_space = terminal_width - part_length - 5
-
-    if not matches:
-        # apt search does not return error, we probably shouldn't either.
-        logger.info('No matches found, try to run `snapcraft update` to '
-                    'refresh the remote parts cache.')
-        return
-
-    print('{}  {}'.format(
-        _HEADER_PART_NAME.ljust(part_length, ' '), _HEADER_DESCRIPTION))
-    for part_key in sorted(matches.keys()):
-        description = matches[part_key]['description'].split('\n')[0]
-        if len(description) > description_space:
-            description = '{}...'.format(description[0:description_space])
-        print('{}  {}'.format(
-            part_key.ljust(part_length, ' '), description))
-
-
-def get_remote_parts():
-    return _RemoteParts()

--- a/snapcraft/internal/project_loader/_schema.py
+++ b/snapcraft/internal/project_loader/_schema.py
@@ -20,10 +20,7 @@ import os
 import jsonschema
 import yaml
 
-from snapcraft.internal import (
-    common,
-    errors
-)
+from snapcraft.internal import common
 
 
 class Validator:
@@ -60,7 +57,8 @@ class Validator:
             with open(schema_file) as fp:
                 self._schema = yaml.load(fp)
         except FileNotFoundError:
-            raise errors.SnapcraftSchemaError(
+            from snapcraft.internal.project_loader import errors
+            raise errors.YamlValidationError(
                 'snapcraft validation file is missing from installation path')
 
     def validate(self):
@@ -69,4 +67,5 @@ class Validator:
             jsonschema.validate(
                 self._snapcraft, self._schema, format_checker=format_check)
         except jsonschema.ValidationError as e:
-            raise errors.SnapcraftSchemaError.from_validation_error(e)
+            from snapcraft.internal.project_loader import errors
+            raise errors.YamlValidationError.from_validation_error(e)

--- a/snapcraft/internal/project_loader/errors.py
+++ b/snapcraft/internal/project_loader/errors.py
@@ -1,0 +1,143 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import contextlib
+
+import snapcraft.internal.errors
+from snapcraft import formatting_utils
+
+# dict of jsonschema validator -> cause pairs. Wish jsonschema just gave us
+# better messages.
+_VALIDATION_ERROR_CAUSES = {
+    'maxLength': 'maximum length is {validator_value}',
+    'minLength': 'minimum length is {validator_value}',
+}
+
+
+class ProjectLoaderError(snapcraft.internal.errors.SnapcraftError):
+
+    fmt = ''
+
+
+class InvalidEpochError(ProjectLoaderError):
+
+    fmt = 'epochs are positive integers followed by an optional asterisk'
+
+
+class DuplicateAliasError(ProjectLoaderError):
+
+    fmt = 'Multiple parts have the same alias defined: {aliases!r}'
+
+    def __str__(self):
+        if isinstance(self.aliases, (list, set)):
+            self.aliases = ','.join(self.aliases)
+
+        return super().__str__()
+
+
+class MissingSnapcraftYamlError(ProjectLoaderError):
+
+    fmt = ('Could not find {snapcraft_yaml}. Are you sure you are in the '
+           'right directory?\n'
+           'To start a new project, use `snapcraft init`')
+
+
+class YamlValidationError(ProjectLoaderError):
+
+    fmt = 'Issues while validating {snapcraft_yaml}: {message}'
+
+    @classmethod
+    def from_validation_error(cls, error):
+        """Take a jsonschema.ValidationError and create a SnapcraftSchemaError.
+
+        The validation errors coming from jsonschema are a nightmare. This
+        class tries to make them a bit more understandable.
+        """
+
+        messages = []
+
+        # error.validator_value may contain a custom validation error message.
+        # If so, use it instead of the garbage message jsonschema gives us.
+        with contextlib.suppress(TypeError, KeyError):
+            messages.append(
+                error.validator_value['validation-failure'].format(error))
+
+        if not messages:
+            messages.append(error.message)
+
+        path = []
+        while error.absolute_path:
+            element = error.absolute_path.popleft()
+            # assume numbers are indices and use 'xxx[123]' notation.
+            if isinstance(element, int):
+                path[-1] = '{}[{}]'.format(path[-1], element)
+            else:
+                path.append(str(element))
+        if path:
+            messages.insert(0, "The '{}' property does not match the "
+                               "required schema:".format('/'.join(path)))
+        cause = error.cause or _determine_cause(error)
+        if cause:
+            messages.append('({})'.format(cause))
+
+        return cls(' '.join(messages))
+
+    def __init__(self, message, snapcraft_yaml='snapcraft.yaml'):
+        super().__init__(message=message, snapcraft_yaml=snapcraft_yaml)
+
+
+class SnapcraftLogicError(ProjectLoaderError):
+
+    fmt = 'Issue detected while analyzing snapcraft.yaml: {message}'
+
+    def __init__(self, message):
+        super().__init__(message=message)
+
+
+def _determine_cause(error):
+    """Attempt to determine a cause from validation error.
+
+    :return: A string representing the cause of the error (it may be empty if
+             no cause can be determined).
+    :rtype: str
+    """
+
+    message = _VALIDATION_ERROR_CAUSES.get(error.validator, '').format(
+        validator_value=error.validator_value)
+
+    if not message and error.validator == 'anyOf':
+        message = _interpret_anyOf(error)
+
+    return message
+
+
+def _interpret_anyOf(error):
+    """Interpret a validation error caused by the anyOf validator.
+
+    Returns:
+        A string containing a (hopefully) helpful validation error message. It
+        may be empty.
+    """
+
+    usages = []
+    try:
+        for validator in error.validator_value:
+            usages.append(validator['usage'])
+    except (TypeError, KeyError):
+        return ''
+
+    return 'must be one of {}'.format(formatting_utils.humanize_list(
+        usages, 'or'))

--- a/snapcraft/internal/remote_parts.py
+++ b/snapcraft/internal/remote_parts.py
@@ -1,0 +1,178 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016-2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import difflib
+import logging
+import os
+import sys
+
+import requests
+import yaml
+from xdg import BaseDirectory
+
+from snapcraft.internal.indicators import download_requests_stream
+from snapcraft.internal.common import get_terminal_width
+from snapcraft.internal import errors
+
+
+PARTS_URI = 'https://parts.snapcraft.io/v1/parts.yaml'
+_MATCH_RATIO = 0.6
+_HEADER_PART_NAME = 'PART NAME'
+_HEADER_DESCRIPTION = 'DESCRIPTION'
+
+logging.getLogger("urllib3").setLevel(logging.CRITICAL)
+logger = logging.getLogger(__name__)
+
+
+def update():
+    _Update().execute()
+
+
+def define(part_name):
+    try:
+        remote_part = _RemoteParts().get_part(part_name, full=True)
+    except errors.SnapcraftPartMissingError as e:
+        raise errors.PartNotInCacheError(part_name=part_name) from e
+    print('Maintainer: {!r}'.format(remote_part.pop('maintainer')))
+    print('Description: {}'.format(remote_part.pop('description')))
+    print('')
+    yaml.dump({part_name: remote_part},
+              default_flow_style=False, stream=sys.stdout)
+
+
+def search(part_match):
+    header_len = len(_HEADER_PART_NAME)
+    matches, part_length = _RemoteParts().matches_for(part_match, header_len)
+
+    terminal_width = get_terminal_width(max_width=None)
+    part_length = max(part_length, header_len)
+    # <space> + <space> + <description> + ... = 5
+    description_space = terminal_width - part_length - 5
+
+    if not matches:
+        # apt search does not return error, we probably shouldn't either.
+        logger.info('No matches found, try to run `snapcraft update` to '
+                    'refresh the remote parts cache.')
+        return
+
+    print('{}  {}'.format(
+        _HEADER_PART_NAME.ljust(part_length, ' '), _HEADER_DESCRIPTION))
+    for part_key in sorted(matches.keys()):
+        description = matches[part_key]['description'].split('\n')[0]
+        if len(description) > description_space:
+            description = '{}...'.format(description[0:description_space])
+        print('{}  {}'.format(
+            part_key.ljust(part_length, ' '), description))
+
+
+def get_remote_parts():
+    return _RemoteParts()
+
+
+class _Base:
+
+    def __init__(self):
+        self.parts_dir = os.path.join(BaseDirectory.xdg_data_home, 'snapcraft')
+        os.makedirs(self.parts_dir, exist_ok=True)
+        self.parts_yaml = os.path.join(self.parts_dir, 'parts.yaml')
+
+
+class _Update(_Base):
+
+    def __init__(self):
+        super().__init__()
+        self._headers_yaml = os.path.join(self.parts_dir, 'headers.yaml')
+        self._parts_uri = os.environ.get('SNAPCRAFT_PARTS_URI', PARTS_URI)
+
+    def execute(self):
+        headers = self._load_headers()
+        self._request = requests.get(self._parts_uri, stream=True,
+                                     headers=headers)
+
+        if self._request.status_code == 304:
+            logger.info('The parts cache is already up to date.')
+            return
+        self._request.raise_for_status()
+
+        download_requests_stream(self._request, self.parts_yaml,
+                                 'Downloading parts list')
+        self._save_headers()
+
+    def _load_headers(self):
+        if not os.path.exists(self._headers_yaml):
+            return None
+
+        with open(self._headers_yaml) as headers_file:
+            return yaml.load(headers_file)
+
+    def _save_headers(self):
+        headers = {
+            'If-Modified-Since': self._request.headers.get('Last-Modified')}
+
+        with open(self._headers_yaml, 'w') as headers_file:
+            headers_file.write(yaml.dump(headers))
+
+
+class _RemoteParts(_Base):
+
+    def __init__(self):
+        super().__init__()
+
+        if not os.path.exists(self.parts_yaml):
+            update()
+
+        with open(self.parts_yaml) as parts_file:
+            self._parts = yaml.load(parts_file)
+
+    def get_part(self, part_name, full=False):
+        try:
+            remote_part = self._parts[part_name].copy()
+        except KeyError:
+            raise errors.SnapcraftPartMissingError(part_name=part_name)
+        if not full:
+            for key in ['description', 'maintainer']:
+                remote_part.pop(key)
+        return remote_part
+
+    def matches_for(self, part_match, max_len=0):
+        matcher = difflib.SequenceMatcher(isjunk=None, autojunk=False)
+        matcher.set_seq2(part_match)
+
+        matching_parts = {}
+        for part_name in self._parts.keys():
+            matcher.set_seq1(part_name)
+            add_part_name = matcher.ratio() >= _MATCH_RATIO
+
+            if add_part_name or (part_match in part_name):
+                matching_parts[part_name] = self._parts[part_name]
+                if len(part_name) > max_len:
+                    max_len = len(part_name)
+
+        return matching_parts, max_len
+
+    def compose(self, part_name, properties):
+        """Return properties composed with the ones from part name in the wiki.
+        :param str part_name: The name of the part to query from the wiki
+        :param dict properties: The current set of properties
+        :return: Part properties from the wiki composed with the properties
+                 passed as a parameter.
+        :rtype: dict
+        :raises KeyError: if part_name is not found in the wiki.
+        """
+        remote_part = self.get_part(part_name)
+        remote_part.update(properties)
+
+        return remote_part

--- a/snapcraft/tests/commands/test_snap.py
+++ b/snapcraft/tests/commands/test_snap.py
@@ -23,6 +23,7 @@ import requests
 from unittest import mock
 from unittest.mock import call
 import snapcraft.internal.errors
+import snapcraft.internal.project_loader.errors
 
 import fixtures
 from testtools.matchers import (
@@ -96,7 +97,7 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
         self.make_snapcraft_yaml(snap_type='bad-type')
 
         raised = self.assertRaises(
-            snapcraft.internal.errors.SnapcraftSchemaError,
+            snapcraft.internal.project_loader.errors.YamlValidationError,
             self.run_command, ['snap'])
 
         self.assertThat(str(raised), Contains(

--- a/snapcraft/tests/project_loader/test_parts.py
+++ b/snapcraft/tests/project_loader/test_parts.py
@@ -43,11 +43,17 @@ class TestParts(tests.TestCase):
         self.mock_get_yaml.return_value = os.path.join(
             'snap', 'snapcraft.yaml')
         self.addCleanup(patcher.stop)
+
+        patcher = unittest.mock.patch(
+            'snapcraft.internal.project_loader._parts_config.PartsConfig'
+            '.load_plugin')
+        self.mock_plugin_loader = patcher.start()
+        self.addCleanup(patcher.stop)
+
         self.part_schema = project_loader.Validator().part_schema
         self.deb_arch = snapcraft.ProjectOptions().deb_arch
 
-    @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
-    def test_get_parts_none(self, mock_loadPlugin):
+    def test_get_parts_none(self):
         self.make_snapcraft_yaml("""name: test
 version: "1"
 summary: test
@@ -62,8 +68,7 @@ parts:
         config = project_loader.load_config(None)
         self.assertThat(config.parts.get_part('not-a-part'), Equals(None))
 
-    @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
-    def test_slash_warning(self, mock_loadPlugin):
+    def test_slash_warning(self):
         fake_logger = fixtures.FakeLogger(level=logging.WARN)
         self.useFixture(fake_logger)
 
@@ -84,8 +89,7 @@ parts:
             'DEPRECATED: Found a "/" in the name of the {!r} part'.format(
                 'part/1')))
 
-    @unittest.mock.patch('snapcraft.internal.parts.PartsConfig.load_plugin')
-    def test_snap_deprecation(self, mock_loadPlugin):
+    def test_snap_deprecation(self):
         """Test that using the 'snap' keyword results in a warning."""
 
         fake_logger = fixtures.FakeLogger(level=logging.WARN)


### PR DESCRIPTION
This PR makes progress on #1492, paving the way for the grammar to be moved into the project loader instead of pluginhandler. It moves `project_loader` into its own package dedicated to loading the project. IT also moves the `PartsConfig` logic in there as well, but leaves the remote parts logic out. Also, since the schema validator was only ever used from project loader, the schema was moved into the `project_loader` package as well. Finally, it creates a base class for project-loading-related errors, and modified the current errors to inherit from that.