### PR TITLE
errors: introduce ContainerError

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -71,7 +71,9 @@ class ContainerError(SnapcraftError):
 
 
 class ContainerConnectionError(ContainerError):
-    fmt = '{message}'
+    fmt = ('{message}\n'
+           'Refer to the documentation at '
+           'https://linuxcontainers.org/lxd/getting-started-cli.')
 
 
 class SnapdError(SnapcraftError):

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -63,8 +63,22 @@ class SnapcraftEnvironmentError(SnapcraftError):
         super().__init__(message=message)
 
 
-class ContainerError(SnapcraftEnvironmentError):
+class ContainerError(SnapcraftError):
     fmt = '{message}'
+
+    def __init__(self, message):
+        super().__init__(message=message)
+
+
+class ContainerConnectionError(ContainerError):
+    fmt = '{message}'
+
+
+class SnapdError(SnapcraftError):
+    fmt = '{message}'
+
+    def __init__(self, message):
+        super().__init__(message=message)
 
 
 class PrimeFileConflictError(SnapcraftError):

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -63,6 +63,10 @@ class SnapcraftEnvironmentError(SnapcraftError):
         super().__init__(message=message)
 
 
+class ContainerError(SnapcraftEnvironmentError):
+    fmt = '{message}'
+
+
 class PrimeFileConflictError(SnapcraftError):
 
     fmt = (

--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -31,7 +31,6 @@ import petname
 import yaml
 
 from snapcraft.internal.errors import (
-        SnapcraftEnvironmentError,
         ContainerConnectionError,
         SnapdError,
 )
@@ -351,23 +350,17 @@ def _get_default_remote():
 
     :returns: default lxd remote.
     :rtype: string.
-    :raises snapcraft.internal.errors.SnapcraftEnvironmentError:
-        raised if the lxc call fails.
     :raises snapcraft.internal.errors.ContainerConnectionError:
-        raised if the call to lxc returns an error.
+        raised if the lxc call fails.
     """
     try:
         default_remote = check_output(['lxc', 'remote', 'get-default'])
     except FileNotFoundError:
-        raise SnapcraftEnvironmentError(
-            'You must have LXD installed in order to use cleanbuild.\n'
-            'Refer to the documentation at '
-            'https://linuxcontainers.org/lxd/getting-started-cli.')
+        raise ContainerConnectionError(
+            'You must have LXD installed in order to use cleanbuild.')
     except CalledProcessError:
         raise ContainerConnectionError(
-            'Something seems to be wrong with your installation of LXD.\n'
-            'Refer to the documentation at '
-            'https://linuxcontainers.org/lxd/getting-started-cli.')
+            'Something seems to be wrong with your installation of LXD.')
     return default_remote.decode(sys.getfilesystemencoding()).strip()
 
 
@@ -387,6 +380,4 @@ def _verify_remote(remote):
             'There are either no permissions or the remote {!r} '
             'does not exist.\n'
             'Verify the existing remotes by running `lxc remote list`\n'
-            'To setup a new remote, follow the instructions at\n'
-            'https://linuxcontainers.org/lxd/getting-started-cli/'
-            '#multiple-hosts'.format(remote)) from e
+            .format(remote)) from e

--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -30,7 +30,11 @@ import requests_unixsocket
 import petname
 import yaml
 
-from snapcraft.internal.errors import ContainerError
+from snapcraft.internal.errors import (
+        SnapcraftEnvironmentError,
+        ContainerConnectionError,
+        SnapdError,
+)
 from snapcraft.internal import common
 from snapcraft._options import _get_deb_arch
 
@@ -69,7 +73,7 @@ class Containerbuild:
             kernel = server_environment['kernelarchitecture']
         deb_arch = _get_deb_arch(kernel)
         if not deb_arch:
-            raise ContainerError(
+            raise ContainerConnectionError(
                 'Unrecognized server architecture {}'.format(kernel))
         self._host_arch = deb_arch
         self._image = 'ubuntu:xenial/{}'.format(deb_arch)
@@ -194,10 +198,10 @@ class Containerbuild:
         try:
             json = session.request('GET', api).json()
         except requests.exceptions.ConnectionError as e:
-            raise ContainerError(
+            raise SnapdError(
                 'Error connecting to {}'.format(api)) from e
         if json['type'] == 'error':
-            raise ContainerError(
+            raise SnapdError(
                 'Error querying {!r} snap: {}'.format(
                     name, json['result']['message']))
         id = json['result']['id']
@@ -347,18 +351,20 @@ def _get_default_remote():
 
     :returns: default lxd remote.
     :rtype: string.
-    :raises snapcraft.internal.errors.ContainerError:
+    :raises snapcraft.internal.errors.SnapcraftEnvironmentError:
         raised if the lxc call fails.
+    :raises snapcraft.internal.errors.ContainerConnectionError:
+        raised if the call to lxc returns an error.
     """
     try:
         default_remote = check_output(['lxc', 'remote', 'get-default'])
     except FileNotFoundError:
-        raise ContainerError(
+        raise SnapcraftEnvironmentError(
             'You must have LXD installed in order to use cleanbuild.\n'
             'Refer to the documentation at '
             'https://linuxcontainers.org/lxd/getting-started-cli.')
     except CalledProcessError:
-        raise ContainerError(
+        raise ContainerConnectionError(
             'Something seems to be wrong with your installation of LXD.\n'
             'Refer to the documentation at '
             'https://linuxcontainers.org/lxd/getting-started-cli.')
@@ -369,7 +375,7 @@ def _verify_remote(remote):
     """Verify that the lxd remote exists.
 
     :param str remote: the lxd remote to verify.
-    :raises snapcraft.internal.errors.ContainerError:
+    :raises snapcraft.internal.errors.ContainerConnectionError:
         raised if the lxc call listing the remote fails.
     """
     # There is no easy way to grep the results from `lxc remote list`
@@ -377,7 +383,7 @@ def _verify_remote(remote):
     try:
         check_output(['lxc', 'list', '{}:'.format(remote)])
     except CalledProcessError as e:
-        raise ContainerError(
+        raise ContainerConnectionError(
             'There are either no permissions or the remote {!r} '
             'does not exist.\n'
             'Verify the existing remotes by running `lxc remote list`\n'

--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -30,7 +30,7 @@ import requests_unixsocket
 import petname
 import yaml
 
-from snapcraft.internal.errors import SnapcraftEnvironmentError
+from snapcraft.internal.errors import ContainerError
 from snapcraft.internal import common
 from snapcraft._options import _get_deb_arch
 
@@ -69,7 +69,7 @@ class Containerbuild:
             kernel = server_environment['kernelarchitecture']
         deb_arch = _get_deb_arch(kernel)
         if not deb_arch:
-            raise SnapcraftEnvironmentError(
+            raise ContainerError(
                 'Unrecognized server architecture {}'.format(kernel))
         self._host_arch = deb_arch
         self._image = 'ubuntu:xenial/{}'.format(deb_arch)
@@ -194,10 +194,10 @@ class Containerbuild:
         try:
             json = session.request('GET', api).json()
         except requests.exceptions.ConnectionError as e:
-            raise SnapcraftEnvironmentError(
+            raise ContainerError(
                 'Error connecting to {}'.format(api)) from e
         if json['type'] == 'error':
-            raise SnapcraftEnvironmentError(
+            raise ContainerError(
                 'Error querying {!r} snap: {}'.format(
                     name, json['result']['message']))
         id = json['result']['id']
@@ -347,18 +347,18 @@ def _get_default_remote():
 
     :returns: default lxd remote.
     :rtype: string.
-    :raises snapcraft.internal.errors.SnapcraftEnvironmentError:
+    :raises snapcraft.internal.errors.ContainerError:
         raised if the lxc call fails.
     """
     try:
         default_remote = check_output(['lxc', 'remote', 'get-default'])
     except FileNotFoundError:
-        raise SnapcraftEnvironmentError(
+        raise ContainerError(
             'You must have LXD installed in order to use cleanbuild.\n'
             'Refer to the documentation at '
             'https://linuxcontainers.org/lxd/getting-started-cli.')
     except CalledProcessError:
-        raise SnapcraftEnvironmentError(
+        raise ContainerError(
             'Something seems to be wrong with your installation of LXD.\n'
             'Refer to the documentation at '
             'https://linuxcontainers.org/lxd/getting-started-cli.')
@@ -369,7 +369,7 @@ def _verify_remote(remote):
     """Verify that the lxd remote exists.
 
     :param str remote: the lxd remote to verify.
-    :raises snapcraft.internal.errors.SnapcraftEnvironmentError:
+    :raises snapcraft.internal.errors.ContainerError:
         raised if the lxc call listing the remote fails.
     """
     # There is no easy way to grep the results from `lxc remote list`
@@ -377,7 +377,7 @@ def _verify_remote(remote):
     try:
         check_output(['lxc', 'list', '{}:'.format(remote)])
     except CalledProcessError as e:
-        raise SnapcraftEnvironmentError(
+        raise ContainerError(
             'There are either no permissions or the remote {!r} '
             'does not exist.\n'
             'Verify the existing remotes by running `lxc remote list`\n'

--- a/snapcraft/tests/commands/test_cleanbuild.py
+++ b/snapcraft/tests/commands/test_cleanbuild.py
@@ -140,7 +140,7 @@ class CleanBuildFailuresCommandTestCase(CleanBuildCommandBaseTestCase):
         fake_lxd.check_output_mock.side_effect = FileNotFoundError('lxc')
 
         raised = self.assertRaises(
-            snapcraft.internal.errors.SnapcraftEnvironmentError,
+            snapcraft.internal.errors.ContainerError,
             self.run_command, ['cleanbuild'])
 
         self.assertThat(str(raised), Equals(

--- a/snapcraft/tests/commands/test_cleanbuild.py
+++ b/snapcraft/tests/commands/test_cleanbuild.py
@@ -140,7 +140,7 @@ class CleanBuildFailuresCommandTestCase(CleanBuildCommandBaseTestCase):
         fake_lxd.check_output_mock.side_effect = FileNotFoundError('lxc')
 
         raised = self.assertRaises(
-            snapcraft.internal.errors.ContainerError,
+            snapcraft.internal.errors.SnapcraftEnvironmentError,
             self.run_command, ['cleanbuild'])
 
         self.assertThat(str(raised), Equals(

--- a/snapcraft/tests/commands/test_cleanbuild.py
+++ b/snapcraft/tests/commands/test_cleanbuild.py
@@ -140,7 +140,7 @@ class CleanBuildFailuresCommandTestCase(CleanBuildCommandBaseTestCase):
         fake_lxd.check_output_mock.side_effect = FileNotFoundError('lxc')
 
         raised = self.assertRaises(
-            snapcraft.internal.errors.SnapcraftEnvironmentError,
+            snapcraft.internal.errors.ContainerConnectionError,
             self.run_command, ['cleanbuild'])
 
         self.assertThat(str(raised), Equals(

--- a/snapcraft/tests/commands/test_snap.py
+++ b/snapcraft/tests/commands/test_snap.py
@@ -34,7 +34,7 @@ from testtools.matchers import (
 )
 from . import CommandBaseTestCase
 from snapcraft.tests import fixture_setup
-from snapcraft.internal.errors import ContainerError
+from snapcraft.internal.errors import SnapdError
 
 
 class SnapCommandBaseTestCase(CommandBaseTestCase):
@@ -262,7 +262,7 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
         self.make_snapcraft_yaml()
 
         self.assertIn('Error connecting to ',
-                      str(self.assertRaises(ContainerError,
+                      str(self.assertRaises(SnapdError,
                                             self.run_command, ['snap'])))
         # Temporary folder should remain in case of failure
         mock_rmtree.assert_not_called()
@@ -286,7 +286,7 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
         self.make_snapcraft_yaml()
 
         self.assertIn('Error querying \'core\' snap: not found',
-                      str(self.assertRaises(ContainerError,
+                      str(self.assertRaises(SnapdError,
                                             self.run_command, ['snap'])))
         # Temporary folder should remain in case of failure
         mock_rmtree.assert_not_called()

--- a/snapcraft/tests/commands/test_snap.py
+++ b/snapcraft/tests/commands/test_snap.py
@@ -34,7 +34,7 @@ from testtools.matchers import (
 )
 from . import CommandBaseTestCase
 from snapcraft.tests import fixture_setup
-from snapcraft.internal.errors import SnapcraftEnvironmentError
+from snapcraft.internal.errors import ContainerError
 
 
 class SnapCommandBaseTestCase(CommandBaseTestCase):
@@ -262,7 +262,7 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
         self.make_snapcraft_yaml()
 
         self.assertIn('Error connecting to ',
-                      str(self.assertRaises(SnapcraftEnvironmentError,
+                      str(self.assertRaises(ContainerError,
                                             self.run_command, ['snap'])))
         # Temporary folder should remain in case of failure
         mock_rmtree.assert_not_called()
@@ -286,7 +286,7 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
         self.make_snapcraft_yaml()
 
         self.assertIn('Error querying \'core\' snap: not found',
-                      str(self.assertRaises(SnapcraftEnvironmentError,
+                      str(self.assertRaises(ContainerError,
                                             self.run_command, ['snap'])))
         # Temporary folder should remain in case of failure
         mock_rmtree.assert_not_called()

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -29,6 +29,7 @@ from testtools.matchers import Contains, Equals
 from snapcraft import tests
 from snapcraft import ProjectOptions
 from snapcraft.internal import lxd
+from snapcraft.internal.errors import ContainerError
 
 
 class LXDTestCase(tests.TestCase):
@@ -188,7 +189,7 @@ class LXDTestCase(tests.TestCase):
         project_options = ProjectOptions(debug=False)
         metadata = {'name': 'project'}
         with ExpectedException(
-                lxd.SnapcraftEnvironmentError,
+                ContainerError,
                 'You must have LXD installed in order to use cleanbuild.\n'
                 'Refer to the documentation at '
                 'https://linuxcontainers.org/lxd/getting-started-cli.'):
@@ -205,7 +206,7 @@ class LXDTestCase(tests.TestCase):
 
         project_options = ProjectOptions(debug=False)
         metadata = {'name': 'project'}
-        with ExpectedException(lxd.SnapcraftEnvironmentError,
+        with ExpectedException(ContainerError,
                                'There are either.*my-remote.*'):
             lxd.Cleanbuilder(output='snap.snap', source='project.tar',
                              metadata=metadata,

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -29,7 +29,10 @@ from testtools.matchers import Contains, Equals
 from snapcraft import tests
 from snapcraft import ProjectOptions
 from snapcraft.internal import lxd
-from snapcraft.internal.errors import ContainerError
+from snapcraft.internal.errors import (
+    ContainerConnectionError,
+    SnapcraftEnvironmentError,
+)
 
 
 class LXDTestCase(tests.TestCase):
@@ -189,7 +192,7 @@ class LXDTestCase(tests.TestCase):
         project_options = ProjectOptions(debug=False)
         metadata = {'name': 'project'}
         with ExpectedException(
-                ContainerError,
+                SnapcraftEnvironmentError,
                 'You must have LXD installed in order to use cleanbuild.\n'
                 'Refer to the documentation at '
                 'https://linuxcontainers.org/lxd/getting-started-cli.'):
@@ -206,7 +209,7 @@ class LXDTestCase(tests.TestCase):
 
         project_options = ProjectOptions(debug=False)
         metadata = {'name': 'project'}
-        with ExpectedException(ContainerError,
+        with ExpectedException(ContainerConnectionError,
                                'There are either.*my-remote.*'):
             lxd.Cleanbuilder(output='snap.snap', source='project.tar',
                              metadata=metadata,

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -31,7 +31,6 @@ from snapcraft import ProjectOptions
 from snapcraft.internal import lxd
 from snapcraft.internal.errors import (
     ContainerConnectionError,
-    SnapcraftEnvironmentError,
 )
 
 
@@ -192,7 +191,7 @@ class LXDTestCase(tests.TestCase):
         project_options = ProjectOptions(debug=False)
         metadata = {'name': 'project'}
         with ExpectedException(
-                SnapcraftEnvironmentError,
+                ContainerConnectionError,
                 'You must have LXD installed in order to use cleanbuild.\n'
                 'Refer to the documentation at '
                 'https://linuxcontainers.org/lxd/getting-started-cli.'):


### PR DESCRIPTION
As suggested during the review of #1302 container-related errors should use their own error class.