### PR TITLE
many: simplify plugin loading

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -191,3 +191,25 @@ class RequiredPathDoesNotExist(SnapcraftError):
 class SnapcraftPathEntryError(SnapcraftError):
 
     fmt = 'The path {value!r} set for {key!r} in {app!r} does not exist.'
+
+
+class InvalidPullPropertiesError(SnapcraftError):
+
+    fmt = (
+        'Invalid pull properties specified by {plugin_name!r} plugin: '
+        '{properties}'
+    )
+
+    def __init__(self, plugin_name, properties):
+        super().__init__(plugin_name=plugin_name, properties=properties)
+
+
+class InvalidBuildPropertiesError(SnapcraftError):
+
+    fmt = (
+        'Invalid build properties specified by {plugin_name!r} plugin: '
+        '{properties}'
+    )
+
+    def __init__(self, plugin_name, properties):
+        super().__init__(plugin_name=plugin_name, properties=properties)

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -167,11 +167,11 @@ def _setup_core(deb_arch):
 
 
 def _replace_in_part(part):
-    for key, value in part.code.options.__dict__.items():
+    for key, value in part.plugin.options.__dict__.items():
         value = replace_attr(value, [
-            ('$SNAPCRAFT_PART_INSTALL', part.code.installdir),
+            ('$SNAPCRAFT_PART_INSTALL', part.plugin.installdir),
         ])
-        setattr(part.code.options, key, value)
+        setattr(part.plugin.options, key, value)
 
     return part
 

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -17,14 +17,12 @@
 import contextlib
 import copy
 import filecmp
-import importlib
 import logging
 import os
 import shutil
 import sys
 from glob import glob, iglob
 
-import jsonschema
 import yaml
 
 import snapcraft
@@ -37,13 +35,14 @@ from snapcraft.internal import (
     sources,
     states,
 )
-from snapcraft.internal.project_loader.errors import YamlValidationError
 from ._scriptlets import ScriptRunner
 from ._build_attributes import BuildAttributes
 from ._stage_package_handler import StagePackageHandler
 
 if sys.platform == 'linux':
     import magic
+
+from ._plugin_loader import load_plugin  # noqa
 
 logger = logging.getLogger(__name__)
 
@@ -58,28 +57,21 @@ class PluginHandler:
 
     @property
     def name(self):
-        return self._name
+        return self.plugin.name
 
     @property
     def installdir(self):
-        return self.code.installdir
+        return self.plugin.installdir
 
-    def __init__(self, *, plugin_name, part_name,
-                 part_properties, project_options, part_schema,
-                 definitions_schema):
+    def __init__(self, *, plugin, part_properties, project_options,
+                 part_schema, definitions_schema):
         self.valid = False
-        self.code = None
+        self.plugin = plugin
         self.config = {}
-        self._name = part_name
         self._part_properties = _expand_part_properties(
             part_properties, part_schema)
         self.stage_packages = []
 
-        # Some legacy parts can have a '/' in them to separate the main project
-        # part with the subparts. This is rather unfortunate as it affects the
-        # the layout of parts inside the parts directory causing collisions
-        # between the main project part and its subparts.
-        part_name = part_name.replace('/', '\N{BIG SOLIDUS}')
         self._project_options = project_options
         self.deps = []
 
@@ -87,9 +79,9 @@ class PluginHandler:
         self.primedir = project_options.prime_dir
 
         parts_dir = project_options.parts_dir
-        self.ubuntudir = os.path.join(parts_dir, part_name, 'ubuntu')
-        self.statedir = os.path.join(parts_dir, part_name, 'state')
-        self.sourcedir = os.path.join(parts_dir, part_name, 'src')
+        self.ubuntudir = os.path.join(parts_dir, self.name, 'ubuntu')
+        self.statedir = os.path.join(parts_dir, self.name, 'state')
+        self.sourcedir = os.path.join(parts_dir, self.name, 'src')
 
         # We don't need to set the source_handler on systems where we do not
         # build
@@ -104,78 +96,11 @@ class PluginHandler:
 
         self._migrate_state_file()
 
-        try:
-            self._load_code(
-                plugin_name, self._part_properties, part_schema,
-                definitions_schema)
-        except jsonschema.ValidationError as e:
-            error = YamlValidationError.from_validation_error(e)
-            raise errors.PluginError(
-                'properties failed to load for {}: {}'.format(
-                    part_name, error.message))
-
-        stage_packages = getattr(self.code, 'stage_packages', [])
-        sources = getattr(self.code, 'PLUGIN_STAGE_SOURCES', None)
+        stage_packages = getattr(plugin, 'stage_packages', [])
+        sources = getattr(self.plugin, 'PLUGIN_STAGE_SOURCES', None)
         self._stage_package_handler = StagePackageHandler(
             stage_packages, self.ubuntudir,
             sources=sources, project_options=self._project_options)
-
-    def _load_code(self, plugin_name, properties, part_schema,
-                   definitions_schema):
-        module_name = plugin_name.replace('-', '_')
-        module = None
-
-        with contextlib.suppress(ImportError):
-            module = _load_local('x-{}'.format(plugin_name),
-                                 self._project_options.local_plugins_dir)
-            logger.info('Loaded local plugin for %s', plugin_name)
-
-        if not module:
-            with contextlib.suppress(ImportError):
-                module = importlib.import_module(
-                    'snapcraft.plugins.{}'.format(module_name))
-
-        if not module:
-            logger.info('Searching for local plugin for %s', plugin_name)
-            with contextlib.suppress(ImportError):
-                module = _load_local(module_name,
-                                     self._project_options.local_plugins_dir)
-            if not module:
-                raise errors.PluginError(
-                    'unknown plugin: {!r}'.format(plugin_name))
-
-        plugin = _get_plugin(module)
-        if not plugin:
-            raise errors.PluginError(
-                'no plugin found in module {!r}'.format(plugin_name))
-        _validate_pull_and_build_properties(
-            plugin_name, plugin, part_schema, definitions_schema)
-        options = _make_options(
-            part_schema, definitions_schema, properties, plugin.schema())
-        # For backwards compatibility we add the project to the plugin
-        try:
-            self.code = plugin(self.name, options, self._project_options)
-        except TypeError:
-            logger.warning(
-                'DEPRECATED: the plugin used by part {!r} needs to be updated '
-                'to accept project options in its initializer. See '
-                'https://github.com/snapcore/snapcraft/blob/master/docs/'
-                'plugins.md#initializing-a-plugin for more information'.format(
-                    self.name))
-            self.code = plugin(self.name, options)
-            # This is for plugins that don't inherit from BasePlugin
-            if not hasattr(self.code, 'project'):
-                setattr(self.code, 'project', self._project_options)
-            # This is for plugins that inherit from BasePlugin but don't have
-            # project in init.
-            if not self.code.project:
-                self.code.project = self._project_options
-
-        if self._project_options.is_cross_compiling:
-            logger.debug(
-                'Setting {!r} as the compilation target for {!r}'.format(
-                    self._project_options.deb_arch, plugin_name))
-            self.code.enable_cross_compilation()
 
     def _get_source_handler(self, properties):
         """Returns a source_handler for the source in properties."""
@@ -199,8 +124,8 @@ class PluginHandler:
 
     def makedirs(self):
         dirs = [
-            self.code.sourcedir, self.code.builddir, self.code.installdir,
-            self.stagedir, self.primedir, self.statedir
+            self.plugin.sourcedir, self.plugin.builddir,
+            self.plugin.installdir, self.stagedir, self.primedir, self.statedir
         ]
         for d in dirs:
             os.makedirs(d, exist_ok=True)
@@ -322,12 +247,12 @@ class PluginHandler:
         self.notify_part_progress('Pulling')
         if self.source_handler:
             self.source_handler.pull()
-        self.code.pull()
+        self.plugin.pull()
 
         self.mark_pull_done()
 
     def mark_pull_done(self):
-        pull_properties = self.code.get_pull_properties()
+        pull_properties = self.plugin.get_pull_properties()
 
         # Add the annotated list of build packages
         part_build_packages = self._part_properties.get('build-packages', [])
@@ -357,7 +282,7 @@ class PluginHandler:
             else:
                 shutil.rmtree(self.sourcedir)
 
-        self.code.clean_pull()
+        self.plugin.clean_pull()
         self.mark_cleaned('pull')
 
     def prepare_build(self, force=False):
@@ -371,8 +296,8 @@ class PluginHandler:
         self.makedirs()
         self.notify_part_progress('Building')
 
-        if os.path.exists(self.code.build_basedir):
-            shutil.rmtree(self.code.build_basedir)
+        if os.path.exists(self.plugin.build_basedir):
+            shutil.rmtree(self.plugin.build_basedir)
 
         # FIXME: It's not necessary to ignore here anymore since it's now done
         # in the Local source. However, it's left here so that it continues to
@@ -388,24 +313,24 @@ class PluginHandler:
             else:
                 return []
 
-        shutil.copytree(self.code.sourcedir, self.code.build_basedir,
+        shutil.copytree(self.plugin.sourcedir, self.plugin.build_basedir,
                         symlinks=True, ignore=ignore)
 
-        script_runner = ScriptRunner(builddir=self.code.build_basedir)
+        script_runner = ScriptRunner(builddir=self.plugin.build_basedir)
 
         script_runner.run(scriptlet=self._part_properties.get('prepare'))
         build_scriptlet = self._part_properties.get('build')
         if build_scriptlet:
             script_runner.run(scriptlet=build_scriptlet)
         else:
-            self.code.build()
+            self.plugin.build()
         script_runner.run(scriptlet=self._part_properties.get('install'))
 
         self.mark_build_done()
 
     def mark_build_done(self):
-        build_properties = self.code.get_build_properties()
-        plugin_manifest = self.code.get_manifest()
+        build_properties = self.plugin.get_build_properties()
+        plugin_manifest = self.plugin.get_manifest()
 
         self.mark_done('build', states.BuildState(
             build_properties, self._part_properties,
@@ -420,17 +345,17 @@ class PluginHandler:
 
         self.notify_part_progress('Cleaning build for', hint)
 
-        if os.path.exists(self.code.build_basedir):
-            shutil.rmtree(self.code.build_basedir)
+        if os.path.exists(self.plugin.build_basedir):
+            shutil.rmtree(self.plugin.build_basedir)
 
         if os.path.exists(self.installdir):
             shutil.rmtree(self.installdir)
 
-        self.code.clean_build()
+        self.plugin.clean_build()
         self.mark_cleaned('build')
 
     def migratable_fileset_for(self, step):
-        plugin_fileset = self.code.snap_fileset()
+        plugin_fileset = self.plugin.snap_fileset()
         fileset = self._get_fileset(step).copy()
         includes = _get_includes(fileset)
         # If we're priming and we don't have an explicit set of files to prime
@@ -442,19 +367,19 @@ class PluginHandler:
 
         fileset.extend(plugin_fileset)
 
-        return _migratable_filesets(fileset, self.code.installdir)
+        return _migratable_filesets(fileset, self.plugin.installdir)
 
     def _get_fileset(self, option, default=None):
         if default is None:
             default = ['*']
 
-        fileset = getattr(self.code.options, option, default)
+        fileset = getattr(self.plugin.options, option, default)
         return fileset if fileset else default
 
     def _organize(self):
         fileset = self._get_fileset('organize', {})
 
-        _organize_filesets(fileset.copy(), self.code.installdir)
+        _organize_filesets(fileset.copy(), self.plugin.installdir)
 
     def stage(self, force=False):
         self.makedirs()
@@ -467,9 +392,10 @@ class PluginHandler:
                 return
             if not file_path.endswith('.pc'):
                 return
-            repo.fix_pkg_config(self.stagedir, file_path, self.code.installdir)
+            repo.fix_pkg_config(
+                self.stagedir, file_path, self.plugin.installdir)
 
-        _migrate_files(snap_files, snap_dirs, self.code.installdir,
+        _migrate_files(snap_files, snap_dirs, self.plugin.installdir,
                        self.stagedir, fixup_func=fixup_func)
         # TODO once `snappy try` is in place we will need to copy
         # dependencies here too
@@ -587,7 +513,7 @@ class PluginHandler:
         return dependency_paths
 
     def env(self, root):
-        return self.code.env(root)
+        return self.plugin.env(root)
 
     def clean(self, project_staged_state=None, project_primed_state=None,
               step=None, hint=''):
@@ -610,14 +536,14 @@ class PluginHandler:
                 raise
 
             logger.info('Cleaning up for part {!r}'.format(self.name))
-            if os.path.exists(self.code.partdir):
-                shutil.rmtree(self.code.partdir)
+            if os.path.exists(self.plugin.partdir):
+                shutil.rmtree(self.plugin.partdir)
 
         # Remove the part directory if it's completely empty (i.e. all steps
         # have been cleaned).
-        if (os.path.exists(self.code.partdir) and
-                not os.listdir(self.code.partdir)):
-            os.rmdir(self.code.partdir)
+        if (os.path.exists(self.plugin.partdir) and
+                not os.listdir(self.plugin.partdir)):
+            os.rmdir(self.plugin.partdir)
 
     def _clean_steps(self, project_staged_state, project_primed_state,
                      step=None, hint=None):
@@ -704,144 +630,6 @@ def _expand_part_properties(part_properties, part_schema):
     properties.update(part_properties)
 
     return properties
-
-
-def _merged_part_and_plugin_schemas(part_schema, definitions_schema,
-                                    plugin_schema):
-    plugin_schema = plugin_schema.copy()
-    if 'properties' not in plugin_schema:
-        plugin_schema['properties'] = {}
-
-    if 'definitions' not in plugin_schema:
-        plugin_schema['definitions'] = {}
-
-    # The part schema takes precedence over the plugin's schema.
-    plugin_schema['properties'].update(part_schema)
-    plugin_schema['definitions'].update(definitions_schema)
-
-    return plugin_schema
-
-
-def _validate_pull_and_build_properties(plugin_name, plugin, part_schema,
-                                        definitions_schema):
-    merged_schema = _merged_part_and_plugin_schemas(
-        part_schema, definitions_schema, plugin.schema())
-    merged_properties = merged_schema['properties']
-
-    # First, validate pull properties
-    invalid_properties = _validate_step_properties(
-        plugin.get_pull_properties(), merged_properties)
-
-    if invalid_properties:
-        raise ValueError(
-            "Invalid pull properties specified by {!r} plugin: {}".format(
-                plugin_name, list(invalid_properties)))
-
-    # Now, validate build properties
-    invalid_properties = _validate_step_properties(
-        plugin.get_build_properties(), merged_properties)
-
-    if invalid_properties:
-        raise ValueError(
-            "Invalid build properties specified by {!r} plugin: {}".format(
-                plugin_name, list(invalid_properties)))
-
-
-def _validate_step_properties(step_properties, schema_properties):
-    invalid_properties = set()
-    for step_property in step_properties:
-        if step_property not in schema_properties:
-            invalid_properties.add(step_property)
-
-    return invalid_properties
-
-
-def _make_options(part_schema, definitions_schema, properties, plugin_schema):
-    # Make copies as these dictionaries are tampered with
-    part_schema = part_schema.copy()
-    properties = properties.copy()
-
-    plugin_schema = _merged_part_and_plugin_schemas(
-        part_schema, definitions_schema, plugin_schema)
-
-    # This is for backwards compatibility for when most of the
-    # schema was overridable by the plugins.
-    if 'required' in plugin_schema and not plugin_schema['required']:
-            del plugin_schema['required']
-    # With the same backwards compatibility in mind we need to remove
-    # the source entry before validation. To those concerned, it has
-    # already been validated.
-    validated_properties = properties.copy()
-    remove_set = [k for k in sources.get_source_defaults().keys()
-                  if k in validated_properties]
-    for key in remove_set:
-        del validated_properties[key]
-
-    jsonschema.validate(validated_properties, plugin_schema)
-
-    options = _populate_options(properties, plugin_schema)
-
-    return options
-
-
-def _populate_options(properties, schema):
-    class Options():
-        pass
-
-    options = Options()
-
-    schema_properties = schema.get('properties', {})
-    for key in schema_properties:
-        attr_name = key.replace('-', '_')
-        default_value = schema_properties[key].get('default')
-        attr_value = properties.get(key, default_value)
-        setattr(options, attr_name, attr_value)
-
-    return options
-
-
-def _get_plugin(module):
-    for attr in vars(module).values():
-        if not isinstance(attr, type):
-            continue
-        if not issubclass(attr, snapcraft.BasePlugin):
-            continue
-        if attr == snapcraft.BasePlugin:
-            continue
-        return attr
-
-
-def _load_local(module_name, local_plugin_dir):
-    sys.path = [local_plugin_dir] + sys.path
-    try:
-        module = importlib.import_module(module_name)
-    finally:
-        sys.path.pop(0)
-
-    return module
-
-
-def load_plugin(part_name, *, plugin_name, part_properties=None,
-                project_options=None, part_schema=None,
-                definitions_schema=None):
-    if part_properties is None:
-        part_properties = {}
-    if part_schema is None:
-        part_schema = {}
-    if definitions_schema is None:
-        definitions_schema = {}
-    if project_options is None:
-        project_options = snapcraft.ProjectOptions()
-    logger.debug('Setting up part {!r} with plugin {!r} and '
-                 'properties {!r}.'.format(part_name,
-                                           plugin_name,
-                                           part_properties))
-    return PluginHandler(plugin_name=plugin_name,
-                         part_name=part_name,
-                         part_properties=part_properties,
-                         project_options=project_options,
-                         part_schema=part_schema,
-                         definitions_schema=definitions_schema)
 
 
 def _migratable_filesets(fileset, srcdir):

--- a/snapcraft/internal/pluginhandler/_plugin_loader.py
+++ b/snapcraft/internal/pluginhandler/_plugin_loader.py
@@ -1,0 +1,217 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import contextlib
+import importlib
+import logging
+import sys
+
+import jsonschema
+
+import snapcraft
+from snapcraft.internal.project_loader.errors import YamlValidationError
+from snapcraft.internal import (
+    errors,
+    sources,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def load_plugin(plugin_name, part_name, project_options, properties,
+                part_schema, definitions_schema):
+    module_name = plugin_name.replace('-', '_')
+    module = _load_module(module_name, plugin_name, project_options)
+    plugin_class = _get_plugin(module)
+    if not plugin_class:
+        raise errors.PluginError(
+            'no plugin found in module {!r}'.format(plugin_name))
+
+    _validate_pull_and_build_properties(
+        plugin_name, plugin_class, part_schema, definitions_schema)
+
+    try:
+        options = _make_options(
+            part_schema, definitions_schema, properties, plugin_class.schema())
+    except jsonschema.ValidationError as e:
+        error = YamlValidationError.from_validation_error(e)
+        raise errors.PluginError(
+            'properties failed to load for {}: {}'.format(
+                part_name, error.message))
+
+    # For backwards compatibility we add the project to the plugin
+    try:
+        plugin = plugin_class(part_name, options, project_options)
+    except TypeError:
+        logger.warning(
+            'DEPRECATED: the plugin used by part {!r} needs to be updated '
+            'to accept project options in its initializer. See '
+            'https://github.com/snapcore/snapcraft/blob/master/docs/'
+            'plugins.md#initializing-a-plugin for more information'.format(
+                part_name))
+        plugin = plugin_class(part_name, options)
+        # This is for plugins that don't inherit from BasePlugin
+        if not hasattr(plugin, 'project'):
+            setattr(plugin, 'project', project_options)
+        # This is for plugins that inherit from BasePlugin but don't have
+        # project in init.
+        if not plugin.project:
+            plugin.project = project_options
+
+    if project_options.is_cross_compiling:
+        logger.debug(
+            'Setting {!r} as the compilation target for {!r}'.format(
+                project_options.deb_arch, plugin_name))
+        plugin.enable_cross_compilation()
+
+    return plugin
+
+
+def _load_module(module_name, plugin_name, project_options):
+    module = None
+    with contextlib.suppress(ImportError):
+        module = _load_local('x-{}'.format(plugin_name),
+                             project_options.local_plugins_dir)
+        logger.info('Loaded local plugin for %s', plugin_name)
+
+    if not module:
+        with contextlib.suppress(ImportError):
+            module = importlib.import_module(
+                'snapcraft.plugins.{}'.format(module_name))
+
+    if not module:
+        logger.info('Searching for local plugin for %s', plugin_name)
+        with contextlib.suppress(ImportError):
+            module = _load_local(module_name,
+                                 project_options.local_plugins_dir)
+        if not module:
+            raise errors.PluginError(
+                'unknown plugin: {!r}'.format(plugin_name))
+
+    return module
+
+
+def _load_local(module_name, local_plugin_dir):
+    sys.path = [local_plugin_dir] + sys.path
+    try:
+        module = importlib.import_module(module_name)
+    finally:
+        sys.path.pop(0)
+
+    return module
+
+
+def _get_plugin(module):
+    for attr in vars(module).values():
+        if not isinstance(attr, type):
+            continue
+        if not issubclass(attr, snapcraft.BasePlugin):
+            continue
+        if attr == snapcraft.BasePlugin:
+            continue
+        return attr
+
+
+def _validate_pull_and_build_properties(plugin_name, plugin, part_schema,
+                                        definitions_schema):
+    merged_schema = _merged_part_and_plugin_schemas(
+        part_schema, definitions_schema, plugin.schema())
+    merged_properties = merged_schema['properties']
+
+    # First, validate pull properties
+    invalid_properties = _validate_step_properties(
+        plugin.get_pull_properties(), merged_properties)
+
+    if invalid_properties:
+        raise errors.InvalidPullPropertiesError(
+            plugin_name, list(invalid_properties))
+
+    # Now, validate build properties
+    invalid_properties = _validate_step_properties(
+        plugin.get_build_properties(), merged_properties)
+
+    if invalid_properties:
+        raise errors.InvalidBuildPropertiesError(
+            plugin_name, list(invalid_properties))
+
+
+def _validate_step_properties(step_properties, schema_properties):
+    invalid_properties = set()
+    for step_property in step_properties:
+        if step_property not in schema_properties:
+            invalid_properties.add(step_property)
+
+    return invalid_properties
+
+
+def _make_options(part_schema, definitions_schema, properties, plugin_schema):
+    # Make copies as these dictionaries are tampered with
+    part_schema = part_schema.copy()
+    properties = properties.copy()
+
+    plugin_schema = _merged_part_and_plugin_schemas(
+        part_schema, definitions_schema, plugin_schema)
+
+    # This is for backwards compatibility for when most of the
+    # schema was overridable by the plugins.
+    if 'required' in plugin_schema and not plugin_schema['required']:
+            del plugin_schema['required']
+    # With the same backwards compatibility in mind we need to remove
+    # the source entry before validation. To those concerned, it has
+    # already been validated.
+    validated_properties = properties.copy()
+    remove_set = [k for k in sources.get_source_defaults().keys()
+                  if k in validated_properties]
+    for key in remove_set:
+        del validated_properties[key]
+
+    jsonschema.validate(validated_properties, plugin_schema)
+
+    options = _populate_options(properties, plugin_schema)
+
+    return options
+
+
+def _merged_part_and_plugin_schemas(part_schema, definitions_schema,
+                                    plugin_schema):
+    plugin_schema = plugin_schema.copy()
+    if 'properties' not in plugin_schema:
+        plugin_schema['properties'] = {}
+
+    if 'definitions' not in plugin_schema:
+        plugin_schema['definitions'] = {}
+
+    # The part schema takes precedence over the plugin's schema.
+    plugin_schema['properties'].update(part_schema)
+    plugin_schema['definitions'].update(definitions_schema)
+
+    return plugin_schema
+
+
+def _populate_options(properties, schema):
+    class Options():
+        pass
+
+    options = Options()
+
+    schema_properties = schema.get('properties', {})
+    for key in schema_properties:
+        attr_name = key.replace('-', '_')
+        default_value = schema_properties[key].get('default')
+        attr_value = properties.get(key, default_value)
+        setattr(options, attr_name, attr_value)
+
+    return options

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -164,19 +164,6 @@ class PartsConfig:
             part_schema=self._validator.part_schema,
             definitions_schema=self._validator.definitions_schema)
 
-        part_schema = {}
-        definitions_schema = {}
-        project_options = snapcraft.ProjectOptions()
-
-        if part_properties is None:
-            part_properties = {}
-        if self._validator.part_schema is not None:
-            part_schema = self._validator.part_schema
-        if self._validator.definitions_schema is not None:
-            definitions_schema = self._validator.definitions_schema
-        if self._project_options is not None:
-            project_options = self._project_options
-
         logger.debug('Setting up part {!r} with plugin {!r} and '
                      'properties {!r}.'.format(part_name,
                                                plugin_name,
@@ -185,9 +172,9 @@ class PartsConfig:
         part = pluginhandler.PluginHandler(
             plugin=plugin,
             part_properties=part_properties,
-            project_options=project_options,
-            part_schema=part_schema,
-            definitions_schema=definitions_schema)
+            project_options=self._project_options,
+            part_schema=self._validator.part_schema,
+            definitions_schema=self._validator.definitions_schema)
 
         self.build_tools += plugin.build_packages
         if part.source_handler and part.source_handler.command:

--- a/snapcraft/tests/commands/test_clean.py
+++ b/snapcraft/tests/commands/test_clean.py
@@ -52,19 +52,33 @@ parts:
         validator = project_loader.Validator()
         for i in range(n):
             part_name = 'clean{}'.format(i)
-            handler = pluginhandler.load_plugin(
-                part_name, plugin_name='nil',
-                part_properties={'plugin': 'nil'},
+
+            properties = {'plugin': 'nil'}
+            project_options = snapcraft.ProjectOptions()
+
+            plugin = pluginhandler.load_plugin(
+                part_name=part_name,
+                plugin_name='nil',
+                properties=properties,
+                project_options=project_options,
                 part_schema=validator.part_schema,
                 definitions_schema=validator.definitions_schema)
+
+            handler = pluginhandler.PluginHandler(
+                plugin=plugin,
+                part_properties=properties,
+                project_options=project_options,
+                part_schema=validator.part_schema,
+                definitions_schema=validator.definitions_schema)
+
             parts.append({
-                'part_dir': handler.code.partdir,
+                'part_dir': handler.plugin.partdir,
             })
 
             if create:
                 handler.makedirs()
                 open(os.path.join(
-                    handler.code.installdir, part_name), 'w').close()
+                    handler.plugin.installdir, part_name), 'w').close()
 
                 handler.mark_done('pull')
                 handler.mark_done('build')

--- a/snapcraft/tests/pluginhandler/mocks.py
+++ b/snapcraft/tests/pluginhandler/mocks.py
@@ -42,8 +42,8 @@ class TestPlugin(snapcraft.BasePlugin):
         return ['test-property']
 
 
-def loadplugin(part_name, plugin_name=None, part_properties=None,
-               project_options=None):
+def load_part(part_name, plugin_name=None, part_properties=None,
+              project_options=None):
     if not plugin_name:
         plugin_name = 'nil'
     properties = {'plugin': plugin_name}
@@ -55,9 +55,16 @@ def loadplugin(part_name, plugin_name=None, part_properties=None,
     validator = project_loader.Validator()
     schema = validator.part_schema
     definitions_schema = validator.definitions_schema
-    return pluginhandler.load_plugin(part_name=part_name,
-                                     plugin_name=plugin_name,
-                                     part_properties=properties,
-                                     project_options=project_options,
-                                     part_schema=schema,
-                                     definitions_schema=definitions_schema)
+    plugin = pluginhandler.load_plugin(part_name=part_name,
+                                       plugin_name=plugin_name,
+                                       properties=properties,
+                                       project_options=project_options,
+                                       part_schema=schema,
+                                       definitions_schema=definitions_schema)
+
+    return pluginhandler.PluginHandler(
+        plugin=plugin,
+        part_properties=properties,
+        project_options=project_options,
+        part_schema=schema,
+        definitions_schema=definitions_schema)

--- a/snapcraft/tests/pluginhandler/test_plugin_loader.py
+++ b/snapcraft/tests/pluginhandler/test_plugin_loader.py
@@ -1,0 +1,224 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import copy
+import logging
+import sys
+from unittest.mock import patch
+
+import fixtures
+from testtools.matchers import Equals
+
+import snapcraft
+from . import mocks
+from snapcraft.internal import errors
+from snapcraft import tests
+from snapcraft.tests import fixture_setup
+
+
+class PluginLoaderTestCase(tests.TestCase):
+
+    def test_unknown_plugin_must_raise_exception(self):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        path = copy.copy(sys.path)
+
+        raised = self.assertRaises(
+            errors.PluginError,
+            mocks.load_part,
+            'fake-part', 'test_unexisting')
+
+        self.assertThat(str(raised), Equals(
+            "Issue while loading part: unknown plugin: 'test_unexisting'"))
+
+        # Make sure that nothing was added to sys.path.
+        self.assertThat(path, Equals(sys.path))
+
+    def test_known_module_but_unknown_plugin_must_raise_exception(self):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        path = copy.copy(sys.path)
+
+        # "_ros" is a valid module within the plugin path, but contains no
+        # plugins.
+        raised = self.assertRaises(
+            errors.PluginError,
+            mocks.load_part,
+            'fake-part', '_ros')
+
+        self.assertThat(str(raised), Equals(
+            "Issue while loading part: no plugin found in module '_ros'"))
+
+        # Make sure that nothing was added to sys.path.
+        self.assertThat(path, Equals(sys.path))
+
+    @patch('importlib.import_module')
+    @patch('snapcraft.internal.pluginhandler._plugin_loader._load_local')
+    @patch('snapcraft.internal.pluginhandler._plugin_loader._get_plugin')
+    def test_non_local_plugins(self, plugin_mock,
+                               local_load_mock, import_mock):
+
+        class TestPlugin(snapcraft.BasePlugin):
+            def __init__(self, name, options, project):
+                super().__init__(name, options, project)
+
+        plugin_mock.return_value = TestPlugin
+        local_load_mock.side_effect = ImportError()
+        mocks.load_part('mock-part', 'mock')
+        import_mock.assert_called_with('snapcraft.plugins.mock')
+        local_load_mock.assert_called_with('x-mock', self.local_plugins_dir)
+
+    def test_plugin_without_project(self):
+        class OldPlugin(snapcraft.BasePlugin):
+
+            @classmethod
+            def schema(cls):
+                schema = super().schema()
+                schema['properties']['fake-property'] = {
+                    'type': 'string',
+                }
+                return schema
+
+            def __init__(self, name, options):
+                super().__init__(name, options)
+
+        self.useFixture(fixture_setup.FakePlugin('oldplugin', OldPlugin))
+        handler = mocks.load_part('fake-part', 'oldplugin',
+                                  {'fake-property': '.'})
+
+        self.assertTrue(handler.plugin.project is not None)
+
+    @patch('importlib.import_module')
+    @patch('snapcraft.internal.pluginhandler._plugin_loader._load_local')
+    @patch('snapcraft.internal.pluginhandler._plugin_loader._get_plugin')
+    def test_plugin_without_project_not_from_base(self, plugin_mock,
+                                                  local_load_mock,
+                                                  import_mock):
+        class NonBaseOldPlugin:
+            @classmethod
+            def schema(cls):
+                return {}
+
+            @classmethod
+            def get_pull_properties(cls):
+                return []
+
+            @classmethod
+            def get_build_properties(cls):
+                return []
+
+            def __init__(self, name, options):
+                self.name = 'old_plugin'
+                pass
+
+        plugin_mock.return_value = NonBaseOldPlugin
+        local_load_mock.side_effect = ImportError()
+        handler = mocks.load_part('fake-part', 'nonbaseoldplugin')
+
+        self.assertTrue(handler.plugin.project is not None)
+
+    def test_plugin_schema_step_hint_pull(self):
+        class Plugin(snapcraft.BasePlugin):
+            @classmethod
+            def schema(cls):
+                schema = super().schema()
+                schema['properties']['foo'] = {
+                    'type': 'string',
+                }
+                schema['pull-properties'] = ['foo']
+
+                return schema
+
+        self.useFixture(fixture_setup.FakePlugin('plugin', Plugin))
+        mocks.load_part('fake-part', 'plugin')
+
+    def test_plugin_schema_step_hint_build(self):
+        class Plugin(snapcraft.BasePlugin):
+            @classmethod
+            def schema(cls):
+                schema = super().schema()
+                schema['properties']['foo'] = {
+                    'type': 'string',
+                }
+                schema['build-properties'] = ['foo']
+
+                return schema
+
+        self.useFixture(fixture_setup.FakePlugin('plugin', Plugin))
+        mocks.load_part('fake-part', 'plugin')
+
+    def test_plugin_schema_step_hint_pull_and_build(self):
+        class Plugin(snapcraft.BasePlugin):
+            @classmethod
+            def schema(cls):
+                schema = super().schema()
+                schema['properties']['foo'] = {
+                    'type': 'string',
+                }
+                schema['pull-properties'] = ['foo']
+                schema['build-properties'] = ['foo']
+
+                return schema
+
+        self.useFixture(fixture_setup.FakePlugin('plugin', Plugin))
+        mocks.load_part('fake-part', 'plugin')
+
+    def test_plugin_schema_invalid_pull_hint(self):
+        class Plugin(snapcraft.BasePlugin):
+            @classmethod
+            def schema(cls):
+                schema = super().schema()
+                schema['properties']['foo'] = {
+                    'type': 'string',
+                }
+                schema['pull-properties'] = ['bar']
+
+                return schema
+
+        self.useFixture(fixture_setup.FakePlugin('plugin', Plugin))
+        raised = self.assertRaises(
+            errors.InvalidPullPropertiesError,
+            mocks.load_part,
+            'fake-part', 'plugin')
+
+        self.assertThat(
+            str(raised),
+            Equals("Invalid pull properties specified by 'plugin' plugin: "
+                   "['bar']"))
+
+    def test_plugin_schema_invalid_build_hint(self):
+        class Plugin(snapcraft.BasePlugin):
+            @classmethod
+            def schema(cls):
+                schema = super().schema()
+                schema['properties']['foo'] = {
+                    'type': 'string',
+                }
+                schema['build-properties'] = ['bar']
+
+                return schema
+
+        self.useFixture(fixture_setup.FakePlugin('plugin', Plugin))
+        raised = self.assertRaises(
+            errors.InvalidBuildPropertiesError,
+            mocks.load_part, 'fake-part', 'plugin')
+
+        self.assertThat(
+            str(raised),
+            Equals("Invalid build properties specified by 'plugin' plugin: "
+                   "['bar']"))

--- a/snapcraft/tests/pluginhandler/test_scriptlets.py
+++ b/snapcraft/tests/pluginhandler/test_scriptlets.py
@@ -25,21 +25,21 @@ from snapcraft import tests
 class ScriptletTestCase(tests.TestCase):
 
     def test_run_prepare_scriptlet(self):
-        handler = mocks.loadplugin(
+        handler = mocks.load_part(
             'test-part', part_properties={'prepare': 'touch before-build'})
 
         handler.build()
 
-        before_build_file_path = os.path.join(handler.code.build_basedir,
+        before_build_file_path = os.path.join(handler.plugin.build_basedir,
                                               'before-build')
         self.assertThat(before_build_file_path, FileExists())
 
     def test_run_install_scriptlet(self):
-        handler = mocks.loadplugin(
+        handler = mocks.load_part(
             'test-part', part_properties={'install': 'touch after-build'})
 
         handler.build()
 
-        after_build_file_path = os.path.join(handler.code.build_basedir,
+        after_build_file_path = os.path.join(handler.plugin.build_basedir,
                                              'after-build')
         self.assertThat(after_build_file_path, FileExists())

--- a/snapcraft/tests/project_loader/test_parts.py
+++ b/snapcraft/tests/project_loader/test_parts.py
@@ -46,7 +46,7 @@ class TestParts(tests.TestCase):
 
         patcher = unittest.mock.patch(
             'snapcraft.internal.project_loader._parts_config.PartsConfig'
-            '.load_plugin')
+            '.load_part')
         self.mock_plugin_loader = patcher.start()
         self.addCleanup(patcher.stop)
 

--- a/snapcraft/tests/test_lifecycle.py
+++ b/snapcraft/tests/test_lifecycle.py
@@ -72,20 +72,20 @@ class ExecutionTestCase(BaseLifecycleTestCase):
             def __init__(self):
                 self.source = '$SNAPCRAFT_PART_INSTALL'
 
-        class Code:
+        class Plugin:
             def __init__(self):
                 self.options = Options()
                 self.installdir = '/tmp'
 
         class Part:
             def __init__(self):
-                self.code = Code()
+                self.plugin = Plugin()
 
         part = Part()
         new_part = lifecycle._replace_in_part(part)
 
         self.assertThat(
-            new_part.code.options.source, Equals(part.code.installdir))
+            new_part.plugin.options.source, Equals(part.plugin.installdir))
 
     def test_exception_when_dependency_is_required(self):
         self.make_snapcraft_yaml("""parts:


### PR DESCRIPTION
Currently, loading a plugin goes through many layers of redirection, which is confusing and causes components to be integrated more tightly than would be ideal. This PR simplifies it by no longer loading plugins within PluginHandler, but rather accepting an already-loaded plugin. That plugin is then loaded in PartsConfig, where it is then handed to the PluginHandler.

Beyond an improved design, this also gives us the ability to extract grammar processing completely from the PluginHandler, which will be done in a follow-up PR.