### PR TITLE
schema: version should have a max length of 32

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -54,6 +54,7 @@ properties:
     # type: string
     description: package version
     pattern: "^[a-zA-Z0-9.+~-]+$"
+    maxLength: 32
   version-script:
     type: string
     description: a script that echoes the version to set.

--- a/snapcraft/tests/project_loader/test_config.py
+++ b/snapcraft/tests/project_loader/test_config.py
@@ -822,6 +822,30 @@ parts:
             Equals("The 'version' property does not match the required "
                    "schema: '' does not match '^[a-zA-Z0-9.+~-]+$'"))
 
+    def test_invalid_yaml_version_too_long(self):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        self.make_snapcraft_yaml("""name: test
+version: 'abcdefghijklmnopqrstuvwxyz1234567' # Max is 32 in the store
+summary: test
+description: test
+confinement: strict
+grade: stable
+parts:
+  part1:
+    plugin: nil
+""")
+        raised = self.assertRaises(
+            errors.YamlValidationError,
+            _config.Config)
+
+        self.assertThat(
+            raised.message,
+            Equals("The 'version' property does not match the required "
+                   "schema: 'abcdefghijklmnopqrstuvwxyz1234567' is too long "
+                   '(maximum length is 32)'))
+
     def test_config_uses_remote_part_from_after(self):
         self.useFixture(fixture_setup.FakeParts())
         self.make_snapcraft_yaml("""name: test


### PR DESCRIPTION
This PR addresses one component of LP: [#1712061](https://bugs.launchpad.net/snapcraft/+bug/1712061) by adding a schema validation for the version's length. This is enforced by the review tools in the store, but now Snapcraft will warn before the user gets to the point of uploading.

Note that this PR should not close LP: [#1712061](https://bugs.launchpad.net/snapcraft/+bug/1712061), as it needs wider discussion.