### PR TITLE
project_loader: support grammar on build-packages

### DIFF
--- a/integration_tests/snaps/build-package-grammar-fail/snapcraft.yaml
+++ b/integration_tests/snaps/build-package-grammar-fail/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: build-package-grammar-fail
+version: '0.1'
+summary: Test build package grammar failures
+description: Make sure the build package grammar handles `else fail` as expected
+grade: devel
+confinement: strict
+
+parts:
+  my-part:
+    plugin: nil
+    build-packages:
+      - on other-arch:
+        - foo
+      - else fail

--- a/integration_tests/snaps/build-package-grammar-global/snapcraft.yaml
+++ b/integration_tests/snaps/build-package-grammar-global/snapcraft.yaml
@@ -1,0 +1,16 @@
+name: build-package-grammar-global
+version: '0.1'
+summary: Test global build package grammar on statement else
+description: Verify that the on statement moves to else on other architectures
+grade: devel
+confinement: strict
+
+build-packages:
+  - on other-arch:
+    - foo
+  - else:
+    - hello
+
+parts:
+  my-part:
+    plugin: nil

--- a/integration_tests/snaps/build-package-grammar-on-else/snapcraft.yaml
+++ b/integration_tests/snaps/build-package-grammar-on-else/snapcraft.yaml
@@ -1,0 +1,15 @@
+name: build-package-grammar-on-else
+version: '0.1'
+summary: Test build package grammar on statement else
+description: Verify that the on statement moves to else on other architectures
+grade: devel
+confinement: strict
+
+parts:
+  my-part:
+    plugin: nil
+    build-packages:
+      - on other-arch:
+        - foo
+      - else:
+        - hello

--- a/integration_tests/snaps/build-package-grammar-on/snapcraft.yaml
+++ b/integration_tests/snaps/build-package-grammar-on/snapcraft.yaml
@@ -1,0 +1,13 @@
+name: build-package-grammar-on
+version: '0.1'
+summary: Test build package grammar on statement
+description: Verify that the on statement skips other architecture branches
+grade: devel
+confinement: strict
+
+parts:
+  my-part:
+    plugin: nil
+    build-packages:
+      - on other-arch:
+        - hello

--- a/integration_tests/snaps/build-package-grammar-try-else/snapcraft.yaml
+++ b/integration_tests/snaps/build-package-grammar-try-else/snapcraft.yaml
@@ -1,0 +1,15 @@
+name: build-package-grammar-try-else
+version: '0.1'
+summary: Test build package grammar try statement else
+description: Verify that the try statement moves to the else if invalid
+grade: devel
+confinement: strict
+
+parts:
+  my-part:
+    plugin: nil
+    build-packages:
+      - try:
+        - invalid-package
+      - else:
+        - hello

--- a/integration_tests/snaps/build-package-grammar-try-skip/snapcraft.yaml
+++ b/integration_tests/snaps/build-package-grammar-try-skip/snapcraft.yaml
@@ -1,0 +1,13 @@
+name: build-package-grammar-try
+version: '0.1'
+summary: Test build package grammar try statement
+description: Verify that the try statement results in an optional build package
+grade: devel
+confinement: strict
+
+parts:
+  my-part:
+    plugin: nil
+    build-packages:
+      - try:
+        - invalid-package

--- a/integration_tests/snaps/build-package-grammar-try/snapcraft.yaml
+++ b/integration_tests/snaps/build-package-grammar-try/snapcraft.yaml
@@ -1,0 +1,13 @@
+name: build-package-grammar-try
+version: '0.1'
+summary: Test build package grammar try statement
+description: Verify that the try statement results in an optional build package
+grade: devel
+confinement: strict
+
+parts:
+  my-part:
+    plugin: nil
+    build-packages:
+      - try:
+        - hello

--- a/integration_tests/snaps/build-package-grammar/snapcraft.yaml
+++ b/integration_tests/snaps/build-package-grammar/snapcraft.yaml
@@ -1,0 +1,12 @@
+name: build-package-grammar
+version: '0.1'
+summary: Test the build package grammar
+description: Simple, standalone build-package
+grade: devel
+confinement: strict
+
+parts:
+  my-part:
+    plugin: nil
+    build-packages:
+      - hello

--- a/integration_tests/test_build_package_grammar.py
+++ b/integration_tests/test_build_package_grammar.py
@@ -1,0 +1,107 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+
+import snapcraft
+
+import integration_tests
+from testtools.matchers import Contains
+
+
+class BuildPackageGrammarTestCase(integration_tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        if self._hello_is_installed():
+            self.fail(
+                'This integration test cannot run if you already have the '
+                "'hello' package installed. Please uninstall it before "
+                'running this test.')
+
+    def tearDown(self):
+        super().tearDown()
+
+        # Remove hello. This is safe since the test fails if hello was already
+        # installed.
+        try:
+            subprocess.check_output(
+                ['sudo', 'apt', 'remove', 'hello', '-y'],
+                stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            self.fail("unable to remove 'hello': {}".format(e.output))
+
+    def _hello_is_installed(self):
+        return snapcraft.repo.Ubuntu.is_package_installed('hello')
+
+    def test_simple(self):
+        """Test that grammar installs standalone build package."""
+
+        self.run_snapcraft(['pull'], 'build-package-grammar')
+
+        self.assertTrue(self._hello_is_installed())
+
+    def test_try(self):
+        """Test that 'try' installs valid build packages."""
+
+        self.run_snapcraft(['pull'], 'build-package-grammar-try')
+
+        self.assertTrue(self._hello_is_installed())
+
+    def test_try_skipped(self):
+        """Test that 'try' skips invalid build packages."""
+
+        self.run_snapcraft(['pull'], 'build-package-grammar-try-skip')
+
+        self.assertFalse(self._hello_is_installed())
+
+    def test_try_else(self):
+        """Test that 'try' moves to the 'else' branch if body is invalid"""
+
+        self.run_snapcraft(['pull'], 'build-package-grammar-try-else')
+
+        self.assertTrue(self._hello_is_installed())
+
+    def test_on_other_arch(self):
+        """Test that 'on' fetches nothing when running on another arch."""
+
+        self.run_snapcraft(['pull'], 'build-package-grammar-on')
+
+        self.assertFalse(self._hello_is_installed())
+
+    def test_on_other_arch_else(self):
+        """Test that 'on' moves to the 'else' branch if on other arch."""
+
+        self.run_snapcraft(['pull'], 'build-package-grammar-on-else')
+
+        self.assertTrue(self._hello_is_installed())
+
+    def test_on_other_arch_else_fail(self):
+        """Test that 'on' fails with an error if it hits an 'else fail'."""
+
+        exception = self.assertRaises(
+            subprocess.CalledProcessError, self.run_snapcraft,
+            ['pull'], 'build-package-grammar-fail')
+
+        self.assertThat(exception.output, Contains(
+            "Unable to satisfy 'on other-arch', failure forced"))
+
+    def test_global_build_package_on_other_arch_else(self):
+        """Test that grammar works in global build packages as well."""
+
+        self.run_snapcraft(['pull'], 'build-package-grammar-global')
+
+        self.assertTrue(self._hello_is_installed())

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -1,7 +1,7 @@
 $schema: http://json-schema.org/draft-04/schema#
 
 definitions:
-  stage-packages:
+  grammar-array:
     type: array
     minitems: 1
     uniqueItems: true
@@ -14,30 +14,26 @@ definitions:
           additionalProperties: false
           patternProperties:
             ^on\s+.+$:
-              $ref: "#/definitions/stage-packages"
+              $ref: "#/definitions/grammar-array"
         - type: object
           usage: "try:"
           additionalProperties: false
           patternProperties:
             ^try$:
-              $ref: "#/definitions/stage-packages"
+              $ref: "#/definitions/grammar-array"
         - type: object
           usage: "else:"
           additionalProperties: false
           patternProperties:
             ^else$:
-              $ref: "#/definitions/stage-packages"
+              $ref: "#/definitions/grammar-array"
 
 title: snapcraft schema
 type: object
 properties:
   build-packages:
-    type: array
+    $ref: "#/definitions/grammar-array"
     description: top level build packages.
-    minItems: 1
-    uniqueItems: true
-    items:
-      - type: string
   name:
     type: string
     description: name of the snap package
@@ -278,15 +274,11 @@ properties:
               type: string
             default: []
           stage-packages:
-            $ref: "#/definitions/stage-packages"
+            $ref: "#/definitions/grammar-array"
             default: [] # For some reason this doesn't work if in the ref
           build-packages:
-            type: array
-            minitems: 1
-            uniqueItems: true
-            items:
-              type: string
-            default: []
+            $ref: "#/definitions/grammar-array"
+            default: [] # For some reason this doesn't work if in the ref
           build-attributes:
             type: array
             minitems: 1

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -506,7 +506,7 @@ class PluginHandler:
 
     def get_primed_dependency_paths(self):
         dependency_paths = set()
-        state = states.get_state(self.plugin.statedir, 'prime')
+        state = states.get_state(self.statedir, 'prime')
         if state:
             for path in state.dependency_paths:
                 dependency_paths.add(

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -506,7 +506,7 @@ class PluginHandler:
 
     def get_primed_dependency_paths(self):
         dependency_paths = set()
-        state = states.get_state(self.statedir, 'prime')
+        state = states.get_state(self.plugin.statedir, 'prime')
         if state:
             for path in state.dependency_paths:
                 dependency_paths.add(

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -192,11 +192,11 @@ class PartsConfig:
             stage_packages_repo=stage_packages_repo,
             grammar_processor=grammar_processor)
 
-        self.build_tools += plugin.build_packages
+        self.build_tools |= grammar_processor.get_build_packages()
+
         if part.source_handler and part.source_handler.command:
-            self.build_tools.append(
-                repo.Repo.get_packages_for_source_type(
-                    part.source_handler.command))
+            self.build_tools |= repo.Repo.get_packages_for_source_type(
+                part.source_handler.command)
         self.all_parts.append(part)
 
         return part

--- a/snapcraft/internal/project_loader/grammar_processing/_global_grammar_processor.py
+++ b/snapcraft/internal/project_loader/grammar_processing/_global_grammar_processor.py
@@ -1,0 +1,46 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from snapcraft.internal import repo
+from snapcraft.internal.project_loader import grammar
+
+
+class GlobalGrammarProcessor:
+    """Process global properties that support grammar.
+
+    Build packages example:
+    >>> import snapcraft
+    >>> from snapcraft import repo
+    >>> processor = GlobalGrammarProcessor(
+    ...    properties={'build-packages': [{'try': ['hello']}]},
+    ...    project_options=snapcraft.ProjectOptions())
+    >>> processor.get_build_packages()
+    {'hello'}
+    """
+
+    def __init__(self, *, properties, project_options):
+        self._project_options = project_options
+
+        self._build_package_grammar = properties.get('build-packages', [])
+        self.__build_packages = set()
+
+    def get_build_packages(self):
+        if not self.__build_packages:
+            self.__build_packages = grammar.process_grammar(
+                self._build_package_grammar, self._project_options,
+                repo.Repo.build_package_is_valid)
+
+        return self.__build_packages

--- a/snapcraft/internal/repo/_base.py
+++ b/snapcraft/internal/repo/_base.py
@@ -84,8 +84,8 @@ class BaseRepo:
         - zip
 
         :param str source_type: a VCS source type to handle.
-        :returns: a list of packages that need to be installed on the host.
-        :rtype: list of strings.
+        :returns: a set of packages that need to be installed on the host.
+        :rtype: set of strings.
         """
         raise NotImplementedError()
 
@@ -97,6 +97,15 @@ class BaseRepo:
         :type package_names: a list of strings.
         :raises snapcraft.repo.errors.BuildPackageNotFoundError:
             if one of the package_names cannot be installed.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def build_package_is_valid(cls, package_name):
+        """Check that a given package is valid on the host.
+
+        :param package_name: a package name to check.
+        :type package_name: str
         """
         raise NotImplementedError()
 

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -171,17 +171,17 @@ class Ubuntu(BaseRepo):
     @classmethod
     def get_packages_for_source_type(cls, source_type):
         if source_type == 'bzr':
-            packages = 'bzr'
+            packages = {'bzr'}
         elif source_type == 'git':
-            packages = 'git'
+            packages = {'git'}
         elif source_type == 'tar':
-            packages = 'tar'
+            packages = {'tar'}
         elif source_type == 'hg' or source_type == 'mercurial':
-            packages = 'mercurial'
+            packages = {'mercurial'}
         elif source_type == 'subversion' or source_type == 'svn':
-            packages = 'subversion'
+            packages = {'subversion'}
         else:
-            packages = []
+            packages = set()
 
         return packages
 
@@ -250,6 +250,11 @@ class Ubuntu(BaseRepo):
             logger.warning(
                 'Impossible to mark packages as auto-installed: {}'
                 .format(e))
+
+    @classmethod
+    def build_package_is_valid(cls, package_name):
+        with apt.Cache() as apt_cache:
+            return package_name in apt_cache
 
     @classmethod
     def is_package_installed(cls, package_name):

--- a/snapcraft/tests/project_loader/grammar_processing/test_global_grammar_processor.py
+++ b/snapcraft/tests/project_loader/grammar_processing/test_global_grammar_processor.py
@@ -14,5 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from ._global_grammar_processor import GlobalGrammarProcessor  # noqa
-from ._part_grammar_processor import PartGrammarProcessor    # noqa
+from snapcraft.internal.project_loader.grammar_processing import (
+    _global_grammar_processor as processor
+)
+
+import doctest
+
+
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(processor))
+    return tests

--- a/snapcraft/tests/project_loader/test_config.py
+++ b/snapcraft/tests/project_loader/test_config.py
@@ -310,8 +310,8 @@ parts:
         config = _config.Config(project_options)
 
         self.assertThat(config.parts.build_tools,
-                        Equals(['gcc-arm-linux-gnueabihf',
-                                'libc6-dev-armhf-cross']))
+                        Equals({'gcc-arm-linux-gnueabihf',
+                                'libc6-dev-armhf-cross'}))
 
     def test_config_has_no_extra_build_tools_when_not_cross_compiling(self):
         class ProjectOptionsFake(snapcraft.ProjectOptions):
@@ -333,7 +333,7 @@ parts:
         self.make_snapcraft_yaml(yaml)
         config = _config.Config(ProjectOptionsFake())
 
-        self.assertThat(config.parts.build_tools, Equals([]))
+        self.assertThat(config.parts.build_tools, Equals(set()))
 
     def test_invalid_yaml_missing_name(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)


### PR DESCRIPTION
Currently Snapcraft only supports grammar-powered stage-packages. This PR makes another good chunk of progress on #1492 by adding support for grammar-powered build-packages as well, both at the part-level and global.

Note that this PR depends upon #1509, but was proposed anyway as I'm leaving for a few days. It also may give the other PR more context.