### PR TITLE
 tests: use a fake pip, instead of mocking everything

### DIFF
--- a/snapcraft/tests/fixture_setup/__init__.py
+++ b/snapcraft/tests/fixture_setup/__init__.py
@@ -39,6 +39,7 @@ from snapcraft.tests.fake_servers import (
     search,
     upload
 )
+from snapcraft.tests.fixture_setup.fake_pip import FakePip  # NOQA
 from snapcraft.tests.subprocess_utils import (
     call,
     call_with_output,

--- a/snapcraft/tests/fixture_setup/fake_pip.py
+++ b/snapcraft/tests/fixture_setup/fake_pip.py
@@ -1,0 +1,146 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import os
+import subprocess
+from unittest import mock
+
+import fixtures
+
+
+class FakePip(fixtures.Fixture):
+
+    def __init__(self):
+        super().__init__()
+        self.download = {
+            'disable_pip_version_check': False,
+            'dest': None,
+            'requirements': [],
+            'constraints': [],
+            'packages': []
+        }
+        self.install = {
+            'disable_pip_version_check': False,
+            'user': False,
+            'no_compile': False,
+            'no_index': False,
+            'find_links': False,
+            'ignore_installed': False,
+            'installed': []
+        }
+        self.local_setup_file = False
+
+    def setUp(self):
+        super().setUp()
+
+        original_call = subprocess.call
+        original_check_output = subprocess.check_output
+
+        def side_effect_call(cmd, *args, **kwargs):
+            return side_effect(original_call, cmd, *args, **kwargs)
+
+        def side_effect_check_output(cmd, *args, **kwargs):
+            return side_effect(original_check_output, cmd, *args, **kwargs)
+
+        def side_effect(original, cmd, *args, **kwargs):
+            if self._is_pip_command(cmd):
+                return self._fake_pip_command(cmd, *args, **kwargs)
+            else:
+                return original(cmd, *args, **kwargs)
+
+        call_patcher = mock.patch(
+            'subprocess.call', side_effect=side_effect_call)
+        self.mock_call = call_patcher.start()
+        self.addCleanup(call_patcher.stop)
+
+        check_output_patcher = mock.patch(
+            'subprocess.check_output', side_effect=side_effect_check_output)
+        check_output_patcher.start()
+        self.addCleanup(check_output_patcher.stop)
+
+    def get_downloaded(self):
+        return (self.download['constraints'] +
+                self.download['requirements'] +
+                self.download['packages'])
+
+    def _is_pip_command(self, cmd):
+        for index, arg in enumerate(cmd):
+            if arg.endswith('/usr/bin/python3'):
+                if cmd[index + 1] == '-m' and cmd[index + 2] == 'pip':
+                    return True
+
+        return False
+
+    def _fake_pip_command(self, cmd, *args, **kwargs):
+        if 'download' in cmd:
+            return self._download(
+                *cmd[cmd.index('download') + 1:], **kwargs)
+        elif 'install' in cmd:
+            return self._install(
+                *cmd[cmd.index('install') + 1:], **kwargs)
+        elif 'list' in cmd:
+            return json.dumps([
+                {'version': 'dummy', 'name': package}
+                for package in self._list()]).encode('utf-8')
+
+    def _download(self, *args, **kwargs):
+        args = list(args)
+        if '--disable-pip-version-check' in args:
+            self.download['disable_pip_version_check'] = True
+            args.remove('--disable-pip-version-check')
+        if '--dest' in args:
+            index = args.index('--dest')
+            self.download['dest'] = args[index + 1]
+            args.remove(args[index])
+            args.remove(args[index])
+        if '--constraint' in args:
+            index = args.index('--constraint')
+            with open(args[index + 1]) as constraint:
+                self.download['constraints'] = constraint.read().splitlines()
+            args.remove(args[index])
+            args.remove(args[index])
+        if '--requirement' in args:
+            index = args.index('--requirement')
+            with open(args[index + 1]) as requirement:
+                self.download['requirements'] = requirement.read().splitlines()
+            args.remove(args[index])
+            args.remove(args[index])
+        if args[0] == '.':
+            if not os.path.exists(os.path.join(kwargs['cwd'], 'setup.py')):
+                raise subprocess.CalledProcessError(returncode=1, cmd='dummy')
+            args.remove('.')
+            self.local_setup_file = True
+        self.download['packages'] = args
+
+    def _install(self, *args, **kwargs):
+        args = list(args)
+        for flag in [
+                '--user', '--no-compile', '--disable-pip-version-check',
+                '--no-index', '--ignore-installed']:
+            if flag in args:
+                self.install[flag.lstrip('-').replace('-', '_')] = True
+                args.remove(flag)
+        if '--find-links' in args:
+            index = args.index('--find-links')
+            # TODO test find-links
+            args.remove(args[index])
+            args.remove(args[index])
+        self.install['installed'] = args
+
+    def _list(self):
+        # TODO
+        return []

--- a/snapcraft/tests/fixture_setup/fake_pip.py
+++ b/snapcraft/tests/fixture_setup/fake_pip.py
@@ -72,7 +72,7 @@ class FakePip(fixtures.Fixture):
         check_output_patcher.start()
         self.addCleanup(check_output_patcher.stop)
 
-    def get_downloaded(self):
+    def get_downloaded_packages(self):
         return (self.download['constraints'] +
                 self.download['requirements'] +
                 self.download['packages'])

--- a/snapcraft/tests/plugins/test_python.py
+++ b/snapcraft/tests/plugins/test_python.py
@@ -149,7 +149,7 @@ class FakePip(fixtures.Fixture):
                 self.download['constraints'] = constraint.read().splitlines()
             args.remove(args[index])
             args.remove(args[index])
-        if args[0] == '--requirement':
+        if '--requirement' in args:
             index = args.index('--requirement')
             with open(args[index + 1]) as requirement:
                 self.download['requirements'] = requirement.read().splitlines()

--- a/snapcraft/tests/plugins/test_python.py
+++ b/snapcraft/tests/plugins/test_python.py
@@ -122,9 +122,8 @@ class PythonPluginPullTestCase(BasePythonPluginTestCase):
 
         with fixture_setup.FakePip() as fake_pip:
             plugin.pull()
-            self.assertThat(fake_pip.download['constraints'], Equals([]))
-            self.assertThat(fake_pip.download['requirements'], Equals([]))
-            self.assertThat(fake_pip.download['downloaded'], Equals([]))
+
+        self.assertThat(fake_pip.get_downloaded(), Equals([]))
 
     def test_pull_with_constraints(self):
         self.options.constraints = 'constraints.txt'
@@ -138,9 +137,10 @@ class PythonPluginPullTestCase(BasePythonPluginTestCase):
 
         with fixture_setup.FakePip() as fake_pip:
             plugin.pull()
-            self.assertThat(
-                fake_pip.download['constraints'],
-                Equals(['testpackage1', 'testpackage2']))
+
+        self.assertThat(
+            fake_pip.get_downloaded(),
+            Equals(['testpackage1', 'testpackage2']))
 
     def test_pull_with_requirements(self):
         self.options.requirements = 'requirements.txt'
@@ -154,9 +154,10 @@ class PythonPluginPullTestCase(BasePythonPluginTestCase):
 
         with fixture_setup.FakePip() as fake_pip:
             plugin.pull()
-            self.assertThat(
-                fake_pip.download['requirements'],
-                Equals(['testpackage1', 'testpackage2']))
+
+        self.assertThat(
+            fake_pip.get_downloaded(),
+            Equals(['testpackage1', 'testpackage2']))
 
     def test_pull_with_python_packages(self):
         self.options.python_packages = ['testpackage1', 'testpackage2']
@@ -167,9 +168,10 @@ class PythonPluginPullTestCase(BasePythonPluginTestCase):
 
         with fixture_setup.FakePip() as fake_pip:
             plugin.pull()
-            self.assertThat(
-                fake_pip.download['downloaded'],
-                Equals(['testpackage1', 'testpackage2']))
+
+        self.assertThat(
+            fake_pip.get_downloaded(),
+            Equals(['testpackage1', 'testpackage2']))
 
 
 class PythonPluginTestCase(BasePythonPluginWithMockTestCase):

--- a/snapcraft/tests/plugins/test_python.py
+++ b/snapcraft/tests/plugins/test_python.py
@@ -21,7 +21,7 @@ from glob import glob
 from unittest import mock
 
 import fixtures
-from testtools.matchers import Contains, Equals, FileContains, HasLength, Not
+from testtools.matchers import Equals, FileContains, HasLength
 
 import snapcraft
 from snapcraft import tests
@@ -102,11 +102,8 @@ class PythonPluginPullTestCase(BasePythonPluginTestCase):
             plugin, self.options.python_version, setup_file=False)
         with fixture_setup.FakePip() as fake_pip:
             plugin.pull()
-            # XXX Just a safeguard to make sure that the mock doesn't get out
-            # of sync.
-            self.assertThat(
-                fake_pip.mock_call.mock_calls[2][1][0],
-                Not(Contains('.')))
+
+        self.assertFalse(fake_pip.local_setup_file)
 
     def test_with_setup_file(self):
         self.options.python_packages = ['dummy']
@@ -115,11 +112,8 @@ class PythonPluginPullTestCase(BasePythonPluginTestCase):
         setup_directories(plugin, self.options.python_version, setup_file=True)
         with fixture_setup.FakePip() as fake_pip:
             plugin.pull()
-            # XXX Just a safeguard to make sure that the mock doesn't get out
-            # of sync.
-            self.assertThat(
-                fake_pip.mock_call.mock_calls[2][1][0][-2],
-                Equals('.'))
+
+        self.assertTrue(fake_pip.local_setup_file)
 
     def test_pull_with_nothing(self):
         plugin = python.PythonPlugin('test-part', self.options,

--- a/snapcraft/tests/plugins/test_python.py
+++ b/snapcraft/tests/plugins/test_python.py
@@ -123,7 +123,7 @@ class PythonPluginPullTestCase(BasePythonPluginTestCase):
         with fixture_setup.FakePip() as fake_pip:
             plugin.pull()
 
-        self.assertThat(fake_pip.get_downloaded(), Equals([]))
+        self.assertThat(fake_pip.get_downloaded_packages(), Equals([]))
 
     def test_pull_with_constraints(self):
         self.options.constraints = 'constraints.txt'
@@ -139,7 +139,7 @@ class PythonPluginPullTestCase(BasePythonPluginTestCase):
             plugin.pull()
 
         self.assertThat(
-            fake_pip.get_downloaded(),
+            fake_pip.get_downloaded_packages(),
             Equals(['testpackage1', 'testpackage2']))
 
     def test_pull_with_requirements(self):
@@ -156,7 +156,7 @@ class PythonPluginPullTestCase(BasePythonPluginTestCase):
             plugin.pull()
 
         self.assertThat(
-            fake_pip.get_downloaded(),
+            fake_pip.get_downloaded_packages(),
             Equals(['testpackage1', 'testpackage2']))
 
     def test_pull_with_python_packages(self):
@@ -170,7 +170,7 @@ class PythonPluginPullTestCase(BasePythonPluginTestCase):
             plugin.pull()
 
         self.assertThat(
-            fake_pip.get_downloaded(),
+            fake_pip.get_downloaded_packages(),
             Equals(['testpackage1', 'testpackage2']))
 
 


### PR DESCRIPTION
I think we are using too many mocks for subprocess. If we just mock every call to subprocess, the tests become less clear, and they don't really cover everything that might be happening.
This is challenging, because things are order dependent. So I've been experimenting with mocks and fakes.

The idea is that we will mock only the specific command that we are testing, letting everything else continue calling the real thing. We replace the command with a fake implementation that will record some values in memory when required, and return the same things that the real would return. In addition, we keep a mock where we can assert the order of the calls.

Before going any further, I would like to put this for discussion. This approach also has drawbacks, but I would like to implement it with all our plugins and with LXD/LXC.