### PR TITLE
vcs: ignore .vscode project settings 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ target
 parts
 stage
 prime
+.vscode


### PR DESCRIPTION
Visual Studio Code allows you to create project specific settings
which we want to ignore to not accidentally commit into the source
tree.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>