### PR TITLE
python plugin: always record constraints and requirements contents

### DIFF
--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -354,12 +354,12 @@ class PythonPlugin(snapcraft.BasePlugin):
             installed_pipy_packages = self._run_pip(setup_file)
         # We record the requirements and constraints files only if they are
         # remote. If they are local, they are already tracked with the source.
-        if self.options.requirements and isurl(self.options.requirements):
+        if self.options.requirements:
             self._manifest['requirements-contents'] = (
-                self._get_remote_file_contents(self.options.requirements))
-        if self.options.constraints and isurl(self.options.constraints):
+                self._get_file_contents(self.options.requirements))
+        if self.options.constraints:
             self._manifest['constraints-contents'] = (
-                self._get_remote_file_contents(self.options.constraints))
+                self._get_file_contents(self.options.constraints))
         self._manifest['python-packages'] = [
             '{}={}'.format(name, installed_pipy_packages[name])
             for name in installed_pipy_packages
@@ -374,8 +374,13 @@ class PythonPlugin(snapcraft.BasePlugin):
 
         self._setup_sitecustomize()
 
-    def _get_remote_file_contents(self, path):
-        return requests.get(path).text
+    def _get_file_contents(self, path):
+        if isurl(path):
+            return requests.get(path).text
+        else:
+            file_path = os.path.join(self.sourcedir, path)
+            with open(file_path) as _file:
+                return _file.read()
 
     def _setup_sitecustomize(self):
         # This avoids needing to leak PYTHONUSERBASE

--- a/snapcraft/tests/plugins/test_python.py
+++ b/snapcraft/tests/plugins/test_python.py
@@ -548,23 +548,36 @@ class PythonPluginTestCase(BasePythonPluginTestCase):
         plugin = python.PythonPlugin('test-part', self.options,
                                      self.project_options)
         setup_directories(plugin, self.options.python_version)
+        requirements_path = os.path.join(plugin.sourcedir, 'requirements.txt')
+        with open(requirements_path, 'w') as requirements_file:
+            requirements_file.write('testpackage1==1.0\n')
+            requirements_file.write('testpackage2==1.2')
 
         plugin.build()
 
-        self.assertNotIn('requirements-contents', plugin.get_manifest())
+        self.assertThat(
+            plugin.get_manifest()['requirements-contents'],
+            Equals('testpackage1==1.0\ntestpackage2==1.2'))
 
     @mock.patch.object(
         python.PythonPlugin, 'run_output', side_effect=fake_empty_pip_list)
     @mock.patch.object(python.PythonPlugin, 'run')
     def test_get_manifest_with_local_constraints(self, _, mock_run_output):
         self.options.constraints = 'constraints.txt'
+
         plugin = python.PythonPlugin('test-part', self.options,
                                      self.project_options)
         setup_directories(plugin, self.options.python_version)
+        constraints_path = os.path.join(plugin.sourcedir, 'constraints.txt')
+        with open(constraints_path, 'w') as constraints_file:
+            constraints_file.write('testpackage1==1.0\n')
+            constraints_file.write('testpackage2==1.2')
 
         plugin.build()
 
-        self.assertNotIn('constraints-contents', plugin.get_manifest())
+        self.assertThat(
+            plugin.get_manifest()['constraints-contents'],
+            Equals('testpackage1==1.0\ntestpackage2==1.2'))
 
 
 class PythonPluginWithURLTestCase(


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
Sergio suggested an existential question about the usefulness of recording these files if they are already tracked in the source. I made a naive implementation of ignoring the file if it's not from a remote server, but this brings more questions about when we should and when we shouldn't record the contents. If you have an opinion, please comment on the forum:

https://forum.snapcraft.io/t/record-build-details-of-python-snaps/1640/4

For now, I'm just recording it always.