### PR TITLE
catkin plugin: only append PYTHONPATH if set

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -18,7 +18,7 @@
 set -e
 
 export PATH=$(pwd)/bin:$PATH
-export PYTHONPATH=$(pwd):$PYTHONPATH
+export PYTHONPATH=$(pwd)${PYTHONPATH:+:$PYTHONPATH}
 
 parseargs(){
     if [[ "$#" -eq 0 ]] || [[ "$1" == "all" ]]; then

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -286,7 +286,12 @@ deb http://${{security}}.ubuntu.com/${{suffix}} {0}-security main universe
             # The ROS packaging system tools (e.g. rospkg, etc.) don't go
             # into the ROS install path (/opt/ros/$distro), so we need the
             # PYTHONPATH to include the dist-packages in /usr/lib as well.
-            env.append('PYTHONPATH={0}:$PYTHONPATH'.format(
+            #
+            # Note: Empty segments in PYTHONPATH are interpreted as `.`, thus
+            # adding the current working directory to the PYTHONPATH. That is
+            # not desired in this situation, so take proper precautions when
+            # expanding PYTHONPATH: only add it if it's not empty.
+            env.append('PYTHONPATH={}${{PYTHONPATH:+:$PYTHONPATH}}'.format(
                 common.get_python2_path(root)))
         except errors.SnapcraftEnvironmentError as e:
             logger.debug(e)


### PR DESCRIPTION
This PR fixes LP: [#1714333](https://bugs.launchpad.net/snapcraft/+bug/1714333) by only including the original PYTHONPATH if it's actually set. Otherwise, Python interprets empty PYTHONPATH segments as the current working directory, which in the case of the Catkin plugin is not desired.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?