### PR TITLE
node plugin: record installed node packages in manifest

### DIFF
--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -40,10 +40,15 @@ Additionally, this plugin uses the following plugin-specific keywords:
       The language package manager to use to drive installation
       of node packages. Can be either `npm` (default) or `yarn`.
 """
+
+import collections
 import contextlib
+import json
 import logging
 import os
 import shutil
+import subprocess
+import sys
 
 import snapcraft
 from snapcraft import sources
@@ -126,6 +131,7 @@ class NodePlugin(snapcraft.BasePlugin):
             logger.warning(
                 'EXPERIMENTAL: use of yarn to manage packages is experimental')
             self._yarn_tar = sources.Tar(_YARN_URL, self._npm_dir)
+        self._manifest = collections.OrderedDict()
 
     def pull(self):
         super().pull()
@@ -149,13 +155,17 @@ class NodePlugin(snapcraft.BasePlugin):
     def build(self):
         super().build()
         if self.options.node_package_manager == 'npm':
-            self._npm_install(rootdir=self.builddir)
+            installed_node_packages = self._npm_install(rootdir=self.builddir)
             # Copy the content of the symlink to the build directory
             # LP: #1702661
             modules_dir = os.path.join(self.installdir, 'lib', 'node_modules')
             _copy_symlinked_content(modules_dir)
         else:
-            self._yarn_install(rootdir=self.builddir)
+            installed_node_packages = self._yarn_install(rootdir=self.builddir)
+        self._manifest['node-packages'] = [
+            '{}={}'.format(name, installed_node_packages[name])
+            for name in installed_node_packages
+        ]
 
     def _npm_install(self, rootdir):
         self._nodejs_tar.provision(
@@ -168,6 +178,7 @@ class NodePlugin(snapcraft.BasePlugin):
             self.run(npm_install + ['--global'], cwd=rootdir)
         for target in self.options.npm_run:
             self.run(['npm', 'run', target], cwd=rootdir)
+        return self._get_installed_node_packages('npm', self.installdir)
 
     def _yarn_install(self, rootdir):
         self._nodejs_tar.provision(
@@ -208,6 +219,33 @@ class NodePlugin(snapcraft.BasePlugin):
         for target in self.options.npm_run:
             self.run(yarn_cmd + ['run', target], cwd=rootdir,
                      env=self._build_environment(rootdir))
+        return self._get_installed_node_packages('npm', self.installdir)
+
+    def _get_installed_node_packages(self, package_manager, cwd):
+        try:
+            output = self.run_output(
+                [package_manager, 'ls', '--global', '--json'], cwd=cwd)
+        except subprocess.CalledProcessError as error:
+            # XXX When dependencies have missing dependencies, an error like
+            # this is printed to stderr:
+            # npm ERR! peer dep missing: glob@*, required by glob-promise@3.1.0
+            # retcode is not 0, which raises an exception.
+            output = error.output.decode(sys.getfilesystemencoding()).strip()
+        packages = collections.OrderedDict()
+        dependencies = json.loads(
+            output, object_pairs_hook=collections.OrderedDict)['dependencies']
+        while dependencies:
+            key, value = dependencies.popitem(last=False)
+            # XXX Just as above, dependencies without version are the ones
+            # missing.
+            if 'version' in value:
+                packages[key] = value['version']
+            if 'dependencies' in value:
+                dependencies.update(value['dependencies'])
+        return packages
+
+    def get_manifest(self):
+        return self._manifest
 
     def _build_environment(self, rootdir):
         env = os.environ.copy()

--- a/snapcraft/tests/plugins/test_nodejs.py
+++ b/snapcraft/tests/plugins/test_nodejs.py
@@ -14,9 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import collections
 import os
 
 from unittest import mock
+from testscenarios.scenarios import multiply_scenarios
 from testtools.matchers import DirExists, Equals, HasLength
 
 import snapcraft
@@ -37,6 +39,11 @@ class NodePluginBaseTestCase(tests.TestCase):
         patcher = mock.patch('snapcraft.internal.common.run')
         self.run_mock = patcher.start()
         self.addCleanup(patcher.stop)
+
+        patcher = mock.patch('snapcraft.internal.common.run_output')
+        self.run_output_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.run_output_mock.return_value = '{"dependencies": []}'
 
         patcher = mock.patch('snapcraft.sources.Tar')
         self.tar_mock = patcher.start()
@@ -344,6 +351,50 @@ class NodePluginTestCase(NodePluginBaseTestCase):
         plugin.clean_pull()
 
         self.assertFalse(os.path.exists(plugin._npm_dir))
+
+
+class NodePluginManifestTestCase(NodePluginBaseTestCase):
+
+    scenarios = multiply_scenarios(
+        [
+            ('simple', dict(ls_output=(
+                '{"dependencies": {'
+                '   "testpackage1": {"version": "1.0"},'
+                '   "testpackage2": {"version": "1.2"}}}'))),
+            ('nested', dict(ls_output=(
+                '{"dependencies": {'
+                '   "testpackage1": {'
+                '      "version": "1.0",'
+                '      "dependencies": {'
+                '        "testpackage2": {"version": "1.2"}}}}}'))),
+            ('missing', dict(ls_output=(
+                '{"dependencies": {'
+                '   "testpackage1": {"version": "1.0"},'
+                '   "testpackage2": {"version": "1.2"},'
+                '   "missing": {"noversion": "dummy"}}}')))],
+        [('npm', dict(package_manager='npm')),
+         ('yarn', dict(package_manager='yarn'))])
+
+    def test_get_manifest_with_node_packages(self):
+        self.run_output_mock.return_value = self.ls_output
+
+        class Options:
+            source = '.'
+            node_packages = []
+            node_engine = '4'
+            npm_run = []
+            node_package_manager = self.package_manager
+        plugin = nodejs.NodePlugin('test-part', Options(),
+                                   self.project_options)
+        os.makedirs(plugin.sourcedir)
+
+        plugin.build()
+
+        self.assertThat(
+            plugin.get_manifest(), Equals(
+                collections.OrderedDict(
+                    {'node-packages':
+                     ['testpackage1=1.0', 'testpackage2=1.2']})))
 
 
 class NodePluginNpmWorkaroundsTestCase(NodePluginBaseTestCase):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This is part of #1453.