### PR TITLE
catkin plugin: don't assume catkin is in underlay

### DIFF
--- a/demos/shared-ros/Makefile
+++ b/demos/shared-ros/Makefile
@@ -1,0 +1,16 @@
+all: ros-app/*.snap
+
+ros-base/*.snap:
+	cd ros-base && snapcraft
+
+ros-app/ros-base.tar.bz2: ros-base/*.snap
+	tar czf ros-app/ros-base.tar.bz2 -C ros-base stage/
+
+ros-app/*.snap: ros-app/ros-base.tar.bz2
+	cd ros-app && snapcraft
+
+.PHONY: clean
+clean:
+	cd ros-base && snapcraft clean
+	cd ros-app && snapcraft clean
+	rm -f ros-app/*.tar.bz2 ros-app/*.snap ros-base/*.snap

--- a/demos/shared-ros/README.md
+++ b/demos/shared-ros/README.md
@@ -14,6 +14,8 @@ This demo is actually made up of two snaps:
 
 ## Build procedure
 
+See the Makefile for explicit steps, but the general idea is:
+
 1. Build ros-base snap.
 2. Tar ros-base staging area: `tar czf ros-base.tar.bz2 stage/`
 3. Copy that tarball into ros-app (as required by its `ros-base` part).

--- a/integration_tests/snaps/catkin-shared-ros/consumer/snap/snapcraft.yaml
+++ b/integration_tests/snaps/catkin-shared-ros/consumer/snap/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: catkin-shared-ros-consumer
+version: '0.1'
+summary: Test building a consumer for a shared part.
+description: |
+  The shared part doesn't contain Catkin, so this makes sure the Catkin
+  used within the Catkin plugin is properly isolated.
+
+grade: devel
+confinement: strict
+
+parts:
+  underlay:
+    plugin: dump
+    source: underlay.tar.bz2
+    prime: [-*]
+
+  # Create the overlay, the consumer that uses the stuff shared from the
+  # producer.
+  overlay:
+    plugin: catkin
+    rosdistro: kinetic
+    include-roscore: false
+    catkin-packages: [overlay_package]
+    underlay:
+      build-path: $SNAPCRAFT_STAGE/opt/ros/kinetic
+      run-path: $SNAP/opt/ros/kinetic
+    after: [underlay]

--- a/integration_tests/snaps/catkin-shared-ros/consumer/src/overlay_package/CMakeLists.txt
+++ b/integration_tests/snaps/catkin-shared-ros/consumer/src/overlay_package/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(overlay_package)
+
+find_package(catkin REQUIRED)
+
+catkin_package()

--- a/integration_tests/snaps/catkin-shared-ros/consumer/src/overlay_package/package.xml
+++ b/integration_tests/snaps/catkin-shared-ros/consumer/src/overlay_package/package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<package>
+  <name>overlay_package</name>
+  <version>0.0.0</version>
+  <description>A description</description>
+  <maintainer email="me@example.com">me</maintainer>
+  <license>GPLv3</license>
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>underlay_package</build_depend>
+  <run_depend>underlay_package</run_depend>
+</package>

--- a/integration_tests/snaps/catkin-shared-ros/producer/snap/snapcraft.yaml
+++ b/integration_tests/snaps/catkin-shared-ros/producer/snap/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: catkin-shared-ros-producer
+version: '0.1'
+summary: Producer for sharing ROS
+description: |
+  Of particular note, the shared bits do not include Catkin
+
+grade: devel
+confinement: strict
+
+parts:
+  # Create the underlay, the stuff shared from the producer.
+  underlay:
+    plugin: catkin
+    rosdistro: kinetic
+    include-roscore: false
+    catkin-packages: [underlay_package]
+
+    # Strip out everything except that single dependency. Of particular
+    # importance: the underlay does not include Catkin.
+    stage:
+      - opt/ros/kinetic/.catkin
+      - opt/ros/kinetic/env.sh
+      - opt/ros/kinetic/setup.bash
+      - opt/ros/kinetic/setup.sh
+      - opt/ros/kinetic/_setup_util.py
+      - opt/ros/kinetic/lib/pkgconfig/underlay_package.pc
+      - opt/ros/kinetic/share/underlay_package/

--- a/integration_tests/snaps/catkin-shared-ros/producer/src/underlay_package/CMakeLists.txt
+++ b/integration_tests/snaps/catkin-shared-ros/producer/src/underlay_package/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(underlay_package)
+
+find_package(catkin REQUIRED)
+
+catkin_package()

--- a/integration_tests/snaps/catkin-shared-ros/producer/src/underlay_package/package.xml
+++ b/integration_tests/snaps/catkin-shared-ros/producer/src/underlay_package/package.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<package>
+  <name>underlay_package</name>
+  <version>0.0.0</version>
+  <description>A description</description>
+  <maintainer email="me@example.com">me</maintainer>
+  <license>GPLv3</license>
+  <buildtool_depend>catkin</buildtool_depend>
+</package>

--- a/integration_tests/test_catkin_shared_ros.py
+++ b/integration_tests/test_catkin_shared_ros.py
@@ -1,0 +1,46 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import subprocess
+import tempfile
+
+import integration_tests
+
+
+class CatkinSharedRosTestCase(integration_tests.TestCase):
+
+    def test_shared_ros_builds_without_catkin_in_underlay(self):
+        # Build the producer until we have a good staging area
+        self.copy_project_to_cwd(os.path.join('catkin-shared-ros', 'producer'))
+        self.run_snapcraft('stage')
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            underlay_tarball = os.path.join(tmpdir, 'underlay.tar.bz2')
+
+            # Now tar up the producer's staging area to be used in the consumer
+            subprocess.check_call(['tar', 'czf', underlay_tarball, 'stage/'])
+
+            # Blow away the entire producer project
+            self.run_snapcraft('clean')
+            subprocess.check_call(['rm', '-rf', '*'])
+
+            # Copy the tarball back into cwd
+            os.rename(underlay_tarball, 'underlay.tar.bz2')
+
+        # Now copy in and build the consumer. This should not throw exceptions.
+        self.copy_project_to_cwd(os.path.join('catkin-shared-ros', 'consumer'))
+        self.run_snapcraft('build')

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -914,9 +914,14 @@ class _Catkin:
                 formatting_utils.format_path_variable(
                     'PATH', bin_paths, prepend='', separator=':')))
 
-            lines.append('export _CATKIN_SETUP_DIR={}'.format(self._workspace))
-            lines.append('source {}'.format(os.path.join(
-                self._workspace, 'setup.sh')))
+            # Source our own workspace so we have all of Catkin's dependencies,
+            # then source the workspace we're actually supposed to be crawling.
+            lines.append('_CATKIN_SETUP_DIR={} source {}'.format(
+                ros_path, os.path.join(ros_path, 'setup.sh')))
+            lines.append('_CATKIN_SETUP_DIR={} source {} --extend'.format(
+                self._workspace,
+                os.path.join(self._workspace, 'setup.sh')))
+
             lines.append('exec "$@"')
             f.write('\n'.join(lines))
             f.flush()


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently the Catkin plugin pulls its own Catkin off to the side in order to search for dependencies in the underlay, but then doesn't use it in isolation, using Catkin components out of the underlay. This breaks if the underlay doesn't actually include Catkin, and makes no sense considering that Catkin is already pulled off to the side. This PR fixes LP: [#1696014](https://bugs.launchpad.net/snapcraft/+bug/1696014) by using that version completely.