### PR TITLE
repo: Use os-release(5) to detect supported Linux distributions

### DIFF
--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -16,7 +16,6 @@
 
 import fileinput
 import os
-import platform
 import re
 import shutil
 import subprocess
@@ -35,6 +34,7 @@ from unittest import mock
 from testtools import content
 from testtools.matchers import MatchesRegex
 from snapcraft import ProjectOptions as _ProjectOptions
+from snapcraft.internal.common import get_os_release_info
 from snapcraft.tests import (
     fixture_setup,
     subprocess_utils
@@ -107,7 +107,7 @@ class TestCase(testtools.TestCase):
         self.prime_dir = 'prime'
 
         self.deb_arch = _ProjectOptions().deb_arch
-        self.distro_series = platform.linux_distribution()[2]
+        self.distro_series = get_os_release_info()['VERSION_CODENAME']
 
     def run_snapcraft(
             self, command, project_dir=None, debug=True,

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -263,3 +263,12 @@ def get_pkg_config_paths(root, arch_triplet):
     ]
 
     return [p for p in paths if os.path.exists(p)]
+
+
+def get_os_release_info():
+    with open("/etc/os-release") as os_release_file:
+        os_release_dict = {}
+        for line in os_release_file:
+            key, value = line.rstrip().split('=')
+            os_release_dict[key] = value.strip('"')
+    return os_release_dict

--- a/snapcraft/internal/libraries.py
+++ b/snapcraft/internal/libraries.py
@@ -18,7 +18,6 @@ import re
 import glob
 import logging
 import os
-import platform
 import subprocess
 
 from snapcraft.internal import common
@@ -67,7 +66,7 @@ def _get_system_libs():
     if _libraries:
         return _libraries
 
-    release = platform.linux_distribution()[1]
+    release = common.get_os_release_info()['VERSION_ID']
     lib_path = os.path.join(common.get_librariesdir(), release)
 
     if not os.path.exists(lib_path):

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -19,7 +19,6 @@ import glob
 import hashlib
 import logging
 import os
-import platform
 import shutil
 import stat
 import string
@@ -147,7 +146,7 @@ class _AptCache:
 
     def _collected_sources_list(self):
         if self._use_geoip or self._sources_list:
-            release = platform.linux_distribution()[2]
+            release = common.get_os_release_info()['VERSION_CODENAME']
             return _format_sources_list(
                 self._sources_list, deb_arch=self._deb_arch,
                 use_geoip=self._use_geoip, release=release)

--- a/snapcraft/internal/repo/_platform.py
+++ b/snapcraft/internal/repo/_platform.py
@@ -15,28 +15,27 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from platform import linux_distribution as _linux_distribution
+
+from snapcraft.internal.common import get_os_release_info
 
 logger = logging.getLogger(__name__)
+
 _DEB_BASED_PLATFORM = [
-    'Ubuntu',
-    'Debian',
-    'elementary',
-    # Not sure what was going on when this was added.
-    '"elementary"',
+    'ubuntu',
     'debian',
+    'elementary OS',
     'neon',
 ]
 
 
 def _is_deb_based(distro=None):
     if not distro:
-        distro = _linux_distribution()[0]
+        distro = get_os_release_info()['ID']
     return distro in _DEB_BASED_PLATFORM
 
 
 def _get_repo_for_platform():
-    distro = _linux_distribution()[0]
+    distro = get_os_release_info()['ID']
     if _is_deb_based(distro):
         from ._deb import Ubuntu
         return Ubuntu

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from platform import linux_distribution as _linux_distribution
+from snapcraft.internal.common import get_os_release_info
 from ._platform import _is_deb_based
 from snapcraft.internal import errors
 
@@ -38,7 +38,7 @@ class PackageNotFoundError(RepoError):
         message = 'The package {!r} was not found.'.format(
             self.package_name)
         # If the package was multiarch, try to help.
-        distro = _linux_distribution()[0]
+        distro = get_os_release_info()['ID']
         if _is_deb_based(distro) and ':' in self.package_name:
             (name, arch) = self.package_name.split(':', 2)
             if arch:

--- a/snapcraft/tests/test_libraries.py
+++ b/snapcraft/tests/test_libraries.py
@@ -118,9 +118,19 @@ class TestSystemLibsOnNewRelease(tests.TestCase):
     def setUp(self):
         super().setUp()
 
-        patcher = mock.patch('platform.linux_distribution')
+        patcher = mock.patch('snapcraft.internal.common.get_os_release_info')
         distro_mock = patcher.start()
-        distro_mock.return_value = ('Ubuntu', '16.05', 'xenial')
+        distro_mock.return_value = {'VERSION_CODENAME': 'xenial',
+                                    'HOME_URL': 'http://www.ubuntu.com/',
+                                    'BUG_REPORT_URL':
+                                        'http://bugs.launchpad.net/ubuntu/',
+                                    'VERSION_ID': '16.04',
+                                    'UBUNTU_CODENAME': 'xenial',
+                                    'ID': 'ubuntu', 'NAME': 'Ubuntu',
+                                    'ID_LIKE': 'debian',
+                                    'PRETTY_NAME': 'Ubuntu 16.04.3 LTS',
+                                    'VERSION': '16.04.3 LTS (Xenial Xerus)',
+                                    'SUPPORT_URL': 'http://help.ubuntu.com/'}
         self.addCleanup(patcher.stop)
 
         patcher = mock.patch('snapcraft.internal.common.run_output')

--- a/snaps_tests/demos_tests/test_ros.py
+++ b/snaps_tests/demos_tests/test_ros.py
@@ -17,12 +17,12 @@
 import os
 import re
 import subprocess
-from platform import linux_distribution
 from unittest import skipUnless
 
 from testtools.matchers import Equals
 
 import snapcraft
+from snapcraft.internal.common import get_os_release_info
 import snaps_tests
 
 
@@ -30,7 +30,7 @@ class ROSTestCase(snaps_tests.SnapsTestCase):
 
     snap_content_dir = 'ros'
 
-    @skipUnless(linux_distribution()[2] == 'xenial',
+    @skipUnless(get_os_release_info()['VERSION_CODENAME'] == 'xenial',
                 'This test fails on yakkety LP: #1614476')
     def test_ros(self):
         try:

--- a/snaps_tests/demos_tests/test_rosinstall.py
+++ b/snaps_tests/demos_tests/test_rosinstall.py
@@ -15,8 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from platform import linux_distribution
 from unittest import skipUnless
+
+from snapcraft.internal.common import get_os_release_info
 
 import snaps_tests
 
@@ -25,7 +26,7 @@ class RosinstallTestCase(snaps_tests.SnapsTestCase):
 
     snap_content_dir = 'rosinstall'
 
-    @skipUnless(linux_distribution()[2] == 'xenial',
+    @skipUnless(get_os_release_info()['VERSION_CODENAME'] == 'xenial',
                 'This test fails on yakkety LP: #1614476')
     def test_rosinstall(self):
         snap_path = self.build_snap(self.snap_content_dir, timeout=1800)

--- a/snaps_tests/demos_tests/test_shared_ros.py
+++ b/snaps_tests/demos_tests/test_shared_ros.py
@@ -19,15 +19,16 @@ import snaps_tests
 import os
 import re
 import subprocess
-from platform import linux_distribution
 from unittest import skipUnless
+
+from snapcraft.internal.common import get_os_release_info
 
 
 class SharedROSTestCase(snaps_tests.SnapsTestCase):
 
     snap_content_dir = 'shared-ros'
 
-    @skipUnless(linux_distribution()[2] == 'xenial',
+    @skipUnless(get_os_release_info()['VERSION_CODENAME'] == 'xenial',
                 'This test fails on yakkety LP: #1614476')
     def test_shared_ros(self):
         ros_base_path = os.path.join(self.snap_content_dir, 'ros-base')


### PR DESCRIPTION
All supported Linux distributions provide an `/etc/os-release` file that contains the necessary information for determining supported repository modules to use.

Thus, we can rely on it instead of the deprecated `linux_distribution` method from the `platform` module that will be removed in Python 3.7.

This will also make it much easier to extend to support RPM-based Linux distributions.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?