### PR TITLE
tests: update the meson test to latest meson requirements

### DIFF
--- a/integration_tests/plugins/test_meson_plugin.py
+++ b/integration_tests/plugins/test_meson_plugin.py
@@ -27,5 +27,5 @@ class MesonPluginTestCase(integration_tests.TestCase):
         self.run_snapcraft('stage', 'meson-hello')
 
         binary_output = self.get_output_ignoring_non_zero_exit(
-            os.path.join(self.stage_dir, 'opt', 'bin', 'meson-hello'))
+            os.path.join(self.stage_dir, 'opt', 'bin', 'hello-meson'))
         self.assertThat(binary_output, Equals('Hello world\n'))

--- a/integration_tests/snaps/meson-hello/meson.build
+++ b/integration_tests/snaps/meson-hello/meson.build
@@ -1,2 +1,2 @@
 project('meson-hello', 'c')
-executable('meson-hello', 'main.c', install : true)
+executable('hello-meson', 'main.c', install : true)


### PR DESCRIPTION
The latest meson does not allow targets to be prefixed with
`meson-`.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
