### PR TITLE
jhbuild plugin: fix UnboundLocalError for chmod_path

### DIFF
--- a/snapcraft/plugins/jhbuild.py
+++ b/snapcraft/plugins/jhbuild.py
@@ -284,7 +284,8 @@ class JHBuildPlugin(snapcraft.BasePlugin):
 
         if jhbuild_user != os.getuid():
             chmod_path = os.path.dirname(os.path.dirname(self.partdir))
-            for filename in glob.iglob('%s/**' % chmod_path, recursive=True):
+            for filename in glob.iglob('{path!s}/**'.format(path=chmod_path),
+                                       recursive=True):
                 if not os.path.exists(filename):
                     continue
                 os.chown(filename, jhbuild_user, jhbuild_group)

--- a/snapcraft/plugins/jhbuild.py
+++ b/snapcraft/plugins/jhbuild.py
@@ -284,11 +284,10 @@ class JHBuildPlugin(snapcraft.BasePlugin):
 
         if jhbuild_user != os.getuid():
             chmod_path = os.path.dirname(os.path.dirname(self.partdir))
-
-        for filename in glob.iglob('%s/**' % chmod_path, recursive=True):
-            if not os.path.exists(filename):
-                continue
-            os.chown(filename, jhbuild_user, jhbuild_group)
+            for filename in glob.iglob('%s/**' % chmod_path, recursive=True):
+                if not os.path.exists(filename):
+                    continue
+                os.chown(filename, jhbuild_user, jhbuild_group)
 
         if not os.path.exists(self.jhbuild_program):
             logger.info('Building JHBuild')


### PR DESCRIPTION
Move for-loop into the same scope as the variable `chmod_path`.

fixes: https://bugs.launchpad.net/snapcraft/+bug/1715507

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

Failing test groups:
- snapcraft.tests.sources.test_mercurial.MercurialDetailsTestCase
- snapcraft.tests.test_deltas.BaseDeltaGenerationTestCase
- snapcraft.tests.test_deltas_xdelta3.XDelta3TestCase
- snapcraft.tests.commands.test_push.PushCommandDeltasTestCase

None of those touch the jhbuild plugin so I propose the merge anyway.

-----
