### PR TITLE
jhbuild plugin: remove dependency on pkgconf

### DIFF
--- a/snapcraft/plugins/jhbuild.py
+++ b/snapcraft/plugins/jhbuild.py
@@ -88,7 +88,6 @@ BUILD_PACKAGES = {
     'make',
     'ninja-build',
     'pkg-config',
-    'pkgconf',
     'python-dev',
     'python3-dev',
     'subversion',


### PR DESCRIPTION
pkgconf : Breaks: pkg-config (>= 0.29-1) so we cannot install both at the same time:

```
pkgconf : Breaks: pkg-config (>= 0.29-1)
```

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
