### PR TITLE
project_loader: aliases are deprecated

### DIFF
--- a/snapcraft/internal/deprecations.py
+++ b/snapcraft/internal/deprecations.py
@@ -29,6 +29,8 @@ _DEPRECATION_MESSAGES = {
     'dn2': "Custom plugins should now be placed in 'snap/plugins'.",
     'dn3': "Assets in 'setup/gui' should now be placed in 'snap/gui'.",
     'dn4': "The 'history' command has been replaced by 'list-revisions'.",
+    'dn5': "Aliases are now handled by the store, and shouldn't be declared "
+           "in the snap.",
 }
 
 _DEPRECATION_URL_FMT = 'http://snapcraft.io/docs/deprecation-notices/{id}'

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -25,6 +25,7 @@ import yaml
 
 import snapcraft
 from snapcraft.internal import (
+    deprecations,
     remote_parts,
     states,
 )
@@ -136,6 +137,10 @@ class Config:
         aliases = []
         for app_name, app in self.data.get('apps', {}).items():
             aliases.extend(app.get('aliases', []))
+
+        # The aliases property is actually deprecated:
+        if aliases:
+            deprecations.handle_deprecation_notice('dn5')
         seen = set()
         duplicates = set()
         for alias in aliases:

--- a/snapcraft/tests/project_loader/test_config.py
+++ b/snapcraft/tests/project_loader/test_config.py
@@ -69,6 +69,8 @@ class YamlTestCase(YamlBaseTestCase):
         self.addCleanup(patcher.stop)
 
     def test_yaml_aliases(self,):
+        fake_logger = fixtures.FakeLogger(level=logging.WARNING)
+        self.useFixture(fake_logger)
 
         self.make_snapcraft_yaml("""name: test
 version: "1"
@@ -93,6 +95,13 @@ parts:
                         'Expected "aliases" property to be in snap.yaml')
         self.assertThat(
             c.data['apps']['test']['aliases'], Equals(['test-it', 'testing']))
+
+        # Verify that aliases are properly deprecated
+        self.assertThat(fake_logger.output, Contains(
+            "Aliases are now handled by the store, and shouldn't be declared "
+            'in the snap.'))
+        self.assertThat(fake_logger.output, Contains(
+            "See http://snapcraft.io/docs/deprecation-notices/dn5"))
 
     def test_yaml_aliases_with_duplicates(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Aliases have become a store-only property, not something to be specified within the snap. As such, we need to point that fact out so developers know how to get aliases working. More details in [this forum post](https://forum.snapcraft.io/t/improving-the-aliases-implementation/18).

Also note the [deprecation notice PR](https://github.com/CanonicalLtd/snappy-docs/pull/97).