### PR TITLE
tests: update the store failure tests

### DIFF
--- a/debian/tests/integrationtests
+++ b/debian/tests/integrationtests
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/autopkgtest
 
 su ubuntu -c "SNAPCRAFT_FROM_INSTALLED=1 TEST_STORE=fake python3 -m unittest discover -b -v -s integration_tests"

--- a/debian/tests/snapstests
+++ b/debian/tests/snapstests
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/autopkgtest
 
 snapd_config_dir=/etc/systemd/system/snapd.service.d

--- a/integration_tests/store/test_store_gated.py
+++ b/integration_tests/store/test_store_gated.py
@@ -40,7 +40,7 @@ class GatedTestCase(integration_tests.StoreTestCase):
             self.gated(
                 'ubuntu-core',
                 expected_output='Have you run "snapcraft login'),
-            Equals(1))
+            Equals(2))
 
     def test_gated_unknown_snap_failure(self):
         self.addCleanup(self.logout)
@@ -49,7 +49,7 @@ class GatedTestCase(integration_tests.StoreTestCase):
             self.gated(
                 'unknown',
                 expected_output="Snap 'unknown' was not found"),
-            Equals(1))
+            Equals(2))
 
     def test_gated_no_validations(self):
         self.addCleanup(self.logout)

--- a/integration_tests/store/test_store_validate.py
+++ b/integration_tests/store/test_store_validate.py
@@ -50,7 +50,7 @@ class ValidateTestCase(integration_tests.StoreTestCase):
         self.assertThat(
             self.validate('unknown', ["ubuntu-core=3", "test-snap=4"],
                           expected_error="Snap 'unknown' was not found."),
-            Equals(1))
+            Equals(2))
 
     def test_validate_bad_argument(self):
         self.addCleanup(self.logout)
@@ -58,10 +58,10 @@ class ValidateTestCase(integration_tests.StoreTestCase):
         self.assertThat(
             self.validate('ubuntu-core', ["ubuntu-core=foo"],
                           expected_error='format must be name=revision'),
-            Equals(1))
+            Equals(2))
 
     def test_validate_no_login_failure(self):
         self.assertThat(
             self.validate('ubuntu-core', ["ubuntu-core=3", "test-snap=4"],
                           expected_error='Have you run "snapcraft login"'),
-            Equals(1))
+            Equals(2))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
There is a good bunch of things going on here.

First, the autopkgtests scripts are run without -e, so only the last error is reported.
Then, through a set of changes, when there is an exception that causes snapcraft to exit the return code is 2 ( https://github.com/snapcore/snapcraft/blob/67089e05002c5fcbfed0d64ac1b3f69363102e3a/snapcraft/internal/errors.py#L35 ).
Finally, this only happens when the integration tests are run against the fake servers. Otherwise, the tests are skipped. Now this is confusing, because the pull requests from forks should run against the fakes, and should have caught this. However, the tests are being skipped, which means that TEST_STORE env var is not set to `fake`. Probably, we are not passing the right var to the container, but I will take care of that tomorrow.

I'm sorry about this list of wrongs.