### PR TITLE
nodejs plugin: expose hidden bin path when using yarn

### DIFF
--- a/integration_tests/plugins/test_nodejs_plugin.py
+++ b/integration_tests/plugins/test_nodejs_plugin.py
@@ -60,3 +60,9 @@ class NodeJSPluginTestCase(testscenarios.WithScenarios,
                         FileExists())
         self.assertThat(os.path.join(part_builddir, 'command-two-run'),
                         FileExists())
+
+        # Ensure the bin entry makes it to bin in the part's install directory
+        part_installdir = os.path.join(
+            self.parts_dir, 'nodejs-part', 'install')
+        print_binary_path = os.path.join(part_installdir, 'bin', 'node-print')
+        self.assertThat(print_binary_path, FileExists())


### PR DESCRIPTION
Expose the path for `yarn run` to find the correct binaries
given that it is now not exposed to the bin directory in the
part's install directory.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
