### PR TITLE
plugins: extract python finder functions

### DIFF
--- a/snapcraft/plugins/_python/__init__.py
+++ b/snapcraft/plugins/_python/__init__.py
@@ -1,0 +1,17 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ._python_finder import get_python_command  # noqa

--- a/snapcraft/plugins/_python/_python_finder.py
+++ b/snapcraft/plugins/_python/_python_finder.py
@@ -1,0 +1,78 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import glob
+
+from . import errors
+
+
+def get_python_command(python_major_version, *, stage_dir, install_dir):
+    """Find the python command to use, preferring staged over the part.
+
+    We prefer the staged python as opposed to the in-part python in order to
+    support one part that supplies python, with another part built `after` it
+    wanting to use its python.
+
+    :param str python_major_version: The python major version to find (2 or 3)
+    :param str stage_dir: Path to the staging area
+    :param str install_dir: Path to the part's install area
+
+    :return: Path to the python command that was found
+    :rtype: str
+
+    :raises MissingPythonCommandError: If no python could be found in the
+                                       staging or part's install area.
+    """
+    python_command_name = 'python{}'.format(python_major_version)
+    python_command = os.path.join('usr', 'bin', python_command_name)
+    staged_python = os.path.join(stage_dir, python_command)
+    part_python = os.path.join(install_dir, python_command)
+
+    if os.path.exists(staged_python):
+        return staged_python
+    elif os.path.exists(part_python):
+        return part_python
+    else:
+        raise errors.MissingPythonCommandError(
+            python_command_name, [stage_dir, install_dir])
+
+
+def get_python_headers(python_major_version, *, stage_dir):
+    """Find the python headers to use, if any, preferring staged over the host.
+
+    We want to make sure we use the headers from the staging area if available,
+    or we may end up building for an older python version than the one we
+    actually want to use.
+
+    :param str python_major_version: The python version to find (2 or 3)
+    :param str stage_dir: Path to the staging area
+
+    :return: Path to the python headers that were found ('' if none)
+    :rtype: str
+    """
+    python_command_name = 'python{}'.format(python_major_version)
+    base_match = os.path.join('usr', 'include', '{}*'.format(
+        python_command_name))
+    staged_python = glob.glob(os.path.join(stage_dir, base_match))
+    host_python = glob.glob(os.path.join(os.path.sep, base_match))
+
+    if staged_python:
+        return staged_python[0]
+    elif host_python:
+        return host_python[0]
+    else:
+        return ''

--- a/snapcraft/plugins/_python/errors.py
+++ b/snapcraft/plugins/_python/errors.py
@@ -1,0 +1,33 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import snapcraft.internal.errors
+import snapcraft.formatting_utils
+
+
+class PythonPluginError(snapcraft.internal.errors.SnapcraftError):
+    pass
+
+
+class MissingPythonCommandError(PythonPluginError):
+
+    fmt = 'Unable to find {python_version}, searched: {search_paths}'
+
+    def __init__(self, python_version, search_paths):
+        super().__init__(
+            python_version=python_version,
+            search_paths=snapcraft.formatting_utils.combine_paths(
+                search_paths, '', ':'))

--- a/snapcraft/tests/plugins/python/test_python_finder.py
+++ b/snapcraft/tests/plugins/python/test_python_finder.py
@@ -1,0 +1,181 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import re
+
+from unittest import mock
+from testtools.matchers import (
+    Equals,
+    MatchesRegex,
+)
+
+from snapcraft.plugins._python import (
+    errors,
+    _python_finder,
+)
+
+from snapcraft import (
+    tests
+)
+
+
+def _create_python_binary(base_dir):
+    python_command_path = os.path.join(
+        base_dir, 'usr', 'bin', 'pythontest')
+    os.makedirs(os.path.dirname(python_command_path))
+    open(python_command_path, 'w').close()
+
+
+class GetPythonCommandTestCase(tests.TestCase):
+
+    def test_staged(self):
+        """get_python_command should support staged python"""
+
+        stage_dir = 'stage_dir'
+        install_dir = 'install_dir'
+
+        # Create staged binary
+        _create_python_binary(stage_dir)
+
+        python_command = _python_finder.get_python_command(
+            'test', stage_dir=stage_dir, install_dir=install_dir)
+        self.assertThat(
+            python_command, Equals(os.path.join(
+                stage_dir, 'usr', 'bin', 'pythontest')))
+
+    def test_in_part(self):
+        """get_python_command should support in-part python"""
+
+        stage_dir = 'stage_dir'
+        install_dir = 'install_dir'
+
+        # Create installed binary
+        _create_python_binary(install_dir)
+
+        python_command = _python_finder.get_python_command(
+            'test', stage_dir=stage_dir, install_dir=install_dir)
+        self.assertThat(
+            python_command, Equals(os.path.join(
+                install_dir, 'usr', 'bin', 'pythontest')))
+
+    def test_staged_and_in_part(self):
+        """get_python_command should prefer staged python over in-part"""
+
+        stage_dir = 'stage_dir'
+        install_dir = 'install_dir'
+
+        # Create both staged and installed binaries
+        _create_python_binary(stage_dir)
+        _create_python_binary(install_dir)
+
+        python_command = _python_finder.get_python_command(
+            'test', stage_dir=stage_dir, install_dir=install_dir)
+        self.assertThat(
+            python_command, Equals(os.path.join(
+                stage_dir, 'usr', 'bin', 'pythontest')))
+
+    def test_missing_raises(self):
+        """get_python_command should raise if no python can be found"""
+
+        stage_dir = 'stage_dir'
+        install_dir = 'install_dir'
+
+        raised = self.assertRaises(
+            errors.MissingPythonCommandError,
+            _python_finder.get_python_command, 'test', stage_dir=stage_dir,
+            install_dir=install_dir)
+        self.assertThat(str(raised), Equals(
+            'Unable to find pythontest, searched: stage_dir:install_dir'))
+
+
+class GetPythonHeadersTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        patcher = mock.patch('glob.glob')
+        self.mock_glob = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_staged(self):
+        """get_python_headers should support staged headers"""
+
+        stage_dir = 'stage_dir'
+
+        # Fake out glob so it looks like the headers are in the staging area
+        def _fake_glob(pattern):
+            if pattern.startswith(stage_dir):
+                return [
+                    os.path.join(stage_dir, 'usr', 'include', 'pythontest')]
+            return []
+        self.mock_glob.side_effect = _fake_glob
+
+        self.assertThat(
+            _python_finder.get_python_headers('test', stage_dir=stage_dir),
+            Equals(os.path.join(stage_dir, 'usr', 'include', 'pythontest')))
+
+    def test_host(self):
+        """get_python_headers should support the hosts's headers"""
+
+        stage_dir = 'stage_dir'
+
+        # Fake out glob so it looks like the headers are installed on the host
+        def _fake_glob(pattern):
+            if pattern.startswith(os.sep):
+                return [
+                    os.path.join(os.sep, 'usr', 'include', 'pythontest')]
+            return []
+        self.mock_glob.side_effect = _fake_glob
+
+        self.assertThat(
+            _python_finder.get_python_headers('test', stage_dir=stage_dir),
+            MatchesRegex(re.escape(os.path.join(
+                os.sep, 'usr', 'include', 'pythontest'))))
+
+    def test_staged_and_host(self):
+        """get_python_headers should prefer staged headers over host"""
+
+        stage_dir = 'stage_dir'
+
+        # Fake out glob so it looks like the headers are in the staging area
+        # AND on the host
+        def _fake_glob(pattern):
+            if pattern.startswith(stage_dir):
+                return [
+                    os.path.join(stage_dir, 'usr', 'include', 'pythontest')]
+            elif pattern.startswith(os.sep):
+                return [
+                    os.path.join(os.sep, 'usr', 'include', 'pythontest')]
+            return []
+        self.mock_glob.side_effect = _fake_glob
+
+        self.assertThat(
+            _python_finder.get_python_headers('test', stage_dir=stage_dir),
+            Equals(os.path.join(stage_dir, 'usr', 'include', 'pythontest')))
+
+    def test_none(self):
+        """get_python_headers should return an empty string if no headers"""
+
+        stage_dir = 'stage_dir'
+
+        # Fake out glob so it looks like the headers aren't installed anywhere
+        def _fake_glob(pattern):
+            return []
+        self.mock_glob.side_effect = _fake_glob
+
+        self.assertFalse(
+            _python_finder.get_python_headers('test', stage_dir=stage_dir))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

This PR is the first in a series that extracts pip from the python plugin, thus making progress on LP: [#1683036](https://bugs.launchpad.net/snapcraft/+bug/1683036). It makes no changes to the Python plugin just yet, just copies functionality out into a more accessible place.