### PR TITLE
tests: fix the TEST_STORE environment variable 

### DIFF
--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -366,6 +366,12 @@ class StoreTestCase(TestCase):
         self.test_store = fixture_setup.TestStore()
         self.useFixture(self.test_store)
 
+    def is_store_fake(self):
+        return (os.getenv('TEST_STORE') or 'fake') == 'fake'
+
+    def is_store_staging(self):
+        return os.getenv('TEST_STORE') == 'staging'
+
     def login(self, email=None, password=None, expect_success=True):
         email = email or self.test_store.user_email
         password = password or self.test_store.user_password

--- a/integration_tests/store/test_store_gated.py
+++ b/integration_tests/store/test_store_gated.py
@@ -14,8 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-
 from testtools.matchers import Equals
 
 import integration_tests
@@ -24,10 +22,10 @@ import integration_tests
 class GatedTestCase(integration_tests.StoreTestCase):
 
     def setUp(self):
-        if os.getenv('TEST_STORE', 'fake') != 'fake':
+        super().setUp()
+        if not self.is_store_fake():
             self.skipTest('Right combination of snaps and IDs is not '
                           'available in real stores.')
-        super().setUp()
 
     def test_gated_success(self):
         self.addCleanup(self.logout)

--- a/integration_tests/store/test_store_register.py
+++ b/integration_tests/store/test_store_register.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import os
+
 import re
 
 from testtools.matchers import Contains, MatchesRegex
@@ -50,7 +50,7 @@ class RegisterTestCase(integration_tests.StoreTestCase):
     def test_registration_of_already_owned_name(self):
         self.login()
         self.addCleanup(self.logout)
-        if os.getenv('TEST_STORE', 'fake') != 'fake':
+        if not self.is_store_fake():
             snap_name = self.get_unique_name()
             self.register(snap_name)
         else:

--- a/integration_tests/store/test_store_register_key.py
+++ b/integration_tests/store/test_store_register_key.py
@@ -34,7 +34,7 @@ class RegisterKeyTestCase(integration_tests.StoreTestCase):
             'SNAP_GNUPG_HOME', temp_keys_dir))
 
     def test_successful_key_registration(self):
-        if os.getenv('TEST_STORE', 'fake') != 'fake':
+        if not self.is_store_fake():
             # https://bugs.launchpad.net/bugs/1621441
             self.skipTest(
                 'Cannot register test keys against staging/production until '

--- a/integration_tests/store/test_store_revisions.py
+++ b/integration_tests/store/test_store_revisions.py
@@ -14,10 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import re
 import subprocess
-import unittest
 
 from testtools.matchers import Contains, Equals, FileExists, MatchesRegex
 
@@ -64,9 +62,10 @@ class RevisionsTestCase(integration_tests.StoreTestCase):
             "Snap 'mysnap' for 'i386' was not found in '16' series.",
             str(error.output))
 
-    @unittest.skipUnless(
-        os.getenv('TEST_STORE', 'fake') == 'fake', 'Skip fake store.')
     def test_revisions_fake_store(self):
+        if not self.is_store_fake():
+            self.skipTest('This test only works in the fake store')
+
         self.addCleanup(self.logout)
         self.login()
 
@@ -78,9 +77,10 @@ class RevisionsTestCase(integration_tests.StoreTestCase):
         ))
         self.assertThat(output, Contains(expected))
 
-    @unittest.skipUnless(
-        os.getenv('TEST_STORE', 'fake') == 'fake', 'Skip fake store.')
     def test_list_revisions_fake_store(self):
+        if not self.is_store_fake():
+            self.skipTest('This test only works in the fake store')
+
         self.addCleanup(self.logout)
         self.login()
 
@@ -92,9 +92,10 @@ class RevisionsTestCase(integration_tests.StoreTestCase):
         ))
         self.assertThat(output, Contains(expected))
 
-    @unittest.skipUnless(
-        os.getenv('TEST_STORE', 'fake') == 'fake', 'Skip fake store.')
     def test_history_fake_store(self):
+        if not self.is_store_fake():
+            self.skipTest('This test only works in the fake store')
+
         self.addCleanup(self.logout)
         self.login()
 
@@ -110,9 +111,10 @@ class RevisionsTestCase(integration_tests.StoreTestCase):
             "DEPRECATED: The 'history' command has "
             "been replaced by 'list-revisions'."))
 
-    @unittest.skipUnless(
-        os.getenv('TEST_STORE', 'fake') == 'staging', 'Skip staging store.')
     def test_revisions_staging_store(self):
+        if not self.is_store_staging():
+            self.skipTest('This test only works in the staging store')
+
         self.addCleanup(self.logout)
         self.login()
 

--- a/integration_tests/store/test_store_sign_build.py
+++ b/integration_tests/store/test_store_sign_build.py
@@ -82,7 +82,7 @@ class SignBuildTestCase(integration_tests.StoreTestCase):
         self.assertThat(self.snap_build_path, Not(FileExists()))
 
     def test_successful_sign_build_push(self):
-        if os.getenv('TEST_STORE', 'fake') != 'fake':
+        if not self.is_store_fake():
             # https://bugs.launchpad.net/bugs/1621441
             self.skipTest(
                 'Cannot push signed assertion against staging/production '

--- a/integration_tests/store/test_store_status.py
+++ b/integration_tests/store/test_store_status.py
@@ -14,9 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import subprocess
-import unittest
 
 from testtools.matchers import Equals, Contains, FileExists
 
@@ -63,9 +61,10 @@ class StatusTestCase(integration_tests.StoreTestCase):
             "Snap 'mysnap' for 'i386' was not found in '16' series.",
             str(error.output))
 
-    @unittest.skipUnless(
-        os.getenv('TEST_STORE', 'fake') == 'fake', 'Skip fake store.')
     def test_status_fake_store(self):
+        if not self.is_store_fake():
+            self.skipTest('This test only works in the fake store')
+
         self.addCleanup(self.logout)
         self.login()
 
@@ -80,9 +79,10 @@ class StatusTestCase(integration_tests.StoreTestCase):
             '                 edge       1.0-i386   3'))
         self.assertThat(output, Contains(expected))
 
-    @unittest.skipUnless(
-        os.getenv('TEST_STORE', 'fake') == 'staging', 'Skip staging store.')
     def test_status_staging_store(self):
+        if not self.is_store_staging():
+            self.skipTest('This test only works in the staging store')
+
         self.addCleanup(self.logout)
         self.login()
 

--- a/integration_tests/store/test_store_validate.py
+++ b/integration_tests/store/test_store_validate.py
@@ -26,10 +26,11 @@ import integration_tests
 class ValidateTestCase(integration_tests.StoreTestCase):
 
     def setUp(self):
-        if os.getenv('TEST_STORE', 'fake') != 'fake':
+        super().setUp()
+        if not self.is_store_fake():
             self.skipTest('Right combination of snaps and IDs is not '
                           'available in real stores.')
-        super().setUp()
+
         keys_dir = os.path.join(os.path.dirname(__file__), 'keys')
         temp_keys_dir = os.path.join(self.path, '.snap', 'gnupg')
         shutil.copytree(keys_dir, temp_keys_dir)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
The environment variable is passed to the containers as ''. The setup of integration tests takes care of translating that to 'fake', but some tests are calling the skip before the setup, so weird things happen.

This is a patch for now. The right solution is to not skip any tests, which is almost always doable.