### PR TITLE
pluginhandler: error out on scriptlet errors

### DIFF
--- a/snapcraft/internal/pluginhandler/_scriptlets.py
+++ b/snapcraft/internal/pluginhandler/_scriptlets.py
@@ -34,7 +34,7 @@ class ScriptRunner:
 
         try:
             with tempfile.NamedTemporaryFile(mode='w+', delete=False) as f:
-                f.write('#!/bin/sh\n')
+                f.write('#!/bin/sh -e\n')
                 f.write(scriptlet)
                 f.flush()
                 scriptlet_path = f.name

--- a/snapcraft/tests/pluginhandler/test_scriptlets.py
+++ b/snapcraft/tests/pluginhandler/test_scriptlets.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+from subprocess import CalledProcessError
+from textwrap import dedent
 
 from testtools.matchers import FileExists
 
@@ -42,3 +44,23 @@ class ScriptletTestCase(tests.TestCase):
         after_build_file_path = os.path.join(handler.plugin.build_basedir,
                                              'after-build')
         self.assertThat(after_build_file_path, FileExists())
+
+    def test_failure_on_last_script_command_results_in_failure(self):
+        script = dedent("""\
+            echo success
+            false  # this should trigger an error
+        """)
+        handler = self.load_part(
+            'test-part', part_properties={'prepare': script})
+
+        self.assertRaises(CalledProcessError, handler.build)
+
+    def test_failure_to_execute_mid_script_results_in_failure(self):
+        script = dedent("""\
+            false  # this should trigger an error
+            echo success
+        """)
+        handler = self.load_part(
+            'test-part', part_properties={'prepare': script})
+
+        self.assertRaises(CalledProcessError, handler.build)


### PR DESCRIPTION
The code only handled an erroring scenario correctly when the last command executed on
a script raised an error.

LP: #1707189
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
