### PR TITLE
plugins: extract sitecustomize logic from python

### DIFF
--- a/snapcraft/plugins/_python/__init__.py
+++ b/snapcraft/plugins/_python/__init__.py
@@ -15,3 +15,4 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from ._python_finder import get_python_command  # noqa
+from ._sitecustomize import generate_sitecustomize  # noqa

--- a/snapcraft/plugins/_python/_sitecustomize.py
+++ b/snapcraft/plugins/_python/_sitecustomize.py
@@ -1,0 +1,100 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import contextlib
+import glob
+import os
+from textwrap import dedent
+
+from ._python_finder import get_python_command
+from . import errors
+
+_SITECUSTOMIZE_TEMPLATE = dedent("""\
+    import site
+    import os
+
+    snap_dir = os.getenv("SNAP")
+    snapcraft_stage_dir = os.getenv("SNAPCRAFT_STAGE")
+    snapcraft_part_install = os.getenv("SNAPCRAFT_PART_INSTALL")
+
+    for d in (snap_dir, snapcraft_stage_dir, snapcraft_part_install):
+        if d:
+            site_dir = os.path.join(d, "{site_dir}")
+            site.addsitedir(site_dir)
+
+    if snap_dir:
+        site.ENABLE_USER_SITE = False""")
+
+
+def _get_user_site_dir(python_major_version, *, install_dir):
+    path_glob = os.path.join(
+        install_dir, 'lib', 'python{}*'.format(python_major_version),
+        'site-packages')
+    user_site_dirs = glob.glob(path_glob)
+    if not user_site_dirs:
+        raise errors.MissingUserSitePackagesError(path_glob)
+
+    return user_site_dirs[0][len(install_dir)+1:]
+
+
+def _get_sitecustomize_path(python_major_version, *, stage_dir, install_dir):
+    # Use the part's install_dir unless there's a python in the staging area
+    base_dir = install_dir
+    with contextlib.suppress(errors.MissingPythonCommandError):
+        python_command = get_python_command(
+            python_major_version, stage_dir=stage_dir, install_dir=install_dir)
+        if python_command.startswith(stage_dir):
+            base_dir = stage_dir
+
+    site_py_glob = os.path.join(
+        base_dir, 'usr', 'lib', 'python{}*'.format(python_major_version),
+        'site.py')
+    python_sites = glob.glob(site_py_glob)
+    if not python_sites:
+        raise errors.MissingSitePyError(site_py_glob)
+
+    python_site_dir = os.path.dirname(python_sites[0])
+
+    return os.path.join(
+        install_dir, python_site_dir[len(base_dir)+1:], 'sitecustomize.py')
+
+
+def generate_sitecustomize(python_major_version, *, stage_dir, install_dir):
+    """Generate a sitecustomize.py to look in staging, part install, and snap.
+
+    This is done by checking the values of the environment variables $SNAP,
+    $SNAPCRAFT_STAGE, and $SNAPCRAFT_PART_INSTALL. As a result, the same
+    sitecustomize.py works to find packages at both build- and run-time.
+
+    :param str python_major_version: The python major version to use (2 or 3)
+    :param str stage_dir: Path to the staging area
+    :param str install_dir: Path to the part's install area
+
+    :raises MissingUserSitePackagesError: If no user site packages are found in
+                                          install_dir/lib/pythonX*
+    :raises MissingSitePyError: If no site.py can be found in either the
+                                staging area or the part install area.
+    """
+    sitecustomize_path = _get_sitecustomize_path(
+        python_major_version, stage_dir=stage_dir, install_dir=install_dir)
+    os.makedirs(os.path.dirname(sitecustomize_path), exist_ok=True)
+
+    # Create our sitecustomize. Python from the archives already has one
+    # which is distro-specific and not needed here, so we truncate it if it's
+    # already there.
+    with open(sitecustomize_path, 'w') as f:
+        f.write(_SITECUSTOMIZE_TEMPLATE.format(site_dir=_get_user_site_dir(
+            python_major_version, install_dir=install_dir)))

--- a/snapcraft/plugins/_python/errors.py
+++ b/snapcraft/plugins/_python/errors.py
@@ -31,3 +31,19 @@ class MissingPythonCommandError(PythonPluginError):
             python_version=python_version,
             search_paths=snapcraft.formatting_utils.combine_paths(
                 search_paths, '', ':'))
+
+
+class MissingUserSitePackagesError(PythonPluginError):
+
+    fmt = 'Unable to find user site packages: {site_dir_glob}'
+
+    def __init__(self, site_dir_glob):
+        super().__init__(site_dir_glob=site_dir_glob)
+
+
+class MissingSitePyError(PythonPluginError):
+
+    fmt = 'Unable to find site.py: {site_py_glob}'
+
+    def __init__(self, site_py_glob):
+        super().__init__(site_py_glob=site_py_glob)

--- a/snapcraft/tests/plugins/python/test_sitecustomize.py
+++ b/snapcraft/tests/plugins/python/test_sitecustomize.py
@@ -1,0 +1,168 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from testtools.matchers import (
+    Contains,
+    FileContains,
+)
+
+from snapcraft.plugins import _python
+
+from snapcraft import (
+    tests
+)
+
+
+def _create_python_binary(base_dir):
+    python_command_path = os.path.join(
+        base_dir, 'usr', 'bin', 'pythontest')
+    os.makedirs(os.path.dirname(python_command_path))
+    open(python_command_path, 'w').close()
+
+
+def _create_site_py(base_dir):
+    site_py = os.path.join(
+        base_dir, 'usr', 'lib', 'pythontest', 'site.py')
+    os.makedirs(os.path.dirname(site_py))
+    open(site_py, 'w').close()
+
+
+def _create_user_site_packages(base_dir):
+    user_site_dir = os.path.join(
+        base_dir, 'lib', 'pythontest', 'site-packages')
+    os.makedirs(user_site_dir)
+
+
+class SiteCustomizeTestCase(tests.TestCase):
+
+    def test_generate_sitecustomize_staged(self):
+        stage_dir = 'stage_dir'
+        install_dir = 'install_dir'
+
+        # Create the python binary in the staging area
+        _create_python_binary(stage_dir)
+
+        # Create a site.py in both staging and install areas
+        _create_site_py(stage_dir)
+        _create_site_py(install_dir)
+
+        # Create a user site dir in install area
+        _create_user_site_packages(install_dir)
+
+        _python.generate_sitecustomize(
+            'test', stage_dir=stage_dir, install_dir=install_dir)
+
+        expected_sitecustomize = (
+            'import site\n'
+            'import os\n'
+            '\n'
+            'snap_dir = os.getenv("SNAP")\n'
+            'snapcraft_stage_dir = os.getenv("SNAPCRAFT_STAGE")\n'
+            'snapcraft_part_install = os.getenv("SNAPCRAFT_PART_INSTALL")\n'
+            '\n'
+            'for d in (snap_dir, snapcraft_stage_dir, '
+            'snapcraft_part_install):\n'
+            '    if d:\n'
+            '        site_dir = os.path.join(d, '
+            '"lib/pythontest/site-packages")\n'
+            '        site.addsitedir(site_dir)\n'
+            '\n'
+            'if snap_dir:\n'
+            '    site.ENABLE_USER_SITE = False')
+
+        site_path = os.path.join(
+            install_dir, 'usr', 'lib', 'pythontest', 'sitecustomize.py')
+        self.assertThat(site_path, FileContains(expected_sitecustomize))
+
+    def test_generate_sitecustomize_installed(self):
+        stage_dir = 'stage_dir'
+        install_dir = 'install_dir'
+
+        # Create the python binary in the installed area
+        _create_python_binary(install_dir)
+
+        # Create a site.py in both staging and install areas
+        _create_site_py(stage_dir)
+        _create_site_py(install_dir)
+
+        # Create a user site dir in install area
+        _create_user_site_packages(install_dir)
+
+        _python.generate_sitecustomize(
+            'test', stage_dir=stage_dir, install_dir=install_dir)
+
+        expected_sitecustomize = (
+            'import site\n'
+            'import os\n'
+            '\n'
+            'snap_dir = os.getenv("SNAP")\n'
+            'snapcraft_stage_dir = os.getenv("SNAPCRAFT_STAGE")\n'
+            'snapcraft_part_install = os.getenv("SNAPCRAFT_PART_INSTALL")\n'
+            '\n'
+            'for d in (snap_dir, snapcraft_stage_dir, '
+            'snapcraft_part_install):\n'
+            '    if d:\n'
+            '        site_dir = os.path.join(d, '
+            '"lib/pythontest/site-packages")\n'
+            '        site.addsitedir(site_dir)\n'
+            '\n'
+            'if snap_dir:\n'
+            '    site.ENABLE_USER_SITE = False')
+
+        site_path = os.path.join(
+            install_dir, 'usr', 'lib', 'pythontest', 'sitecustomize.py')
+        self.assertThat(site_path, FileContains(expected_sitecustomize))
+
+    def test_generate_sitecustomize_missing_user_site_raises(self):
+        stage_dir = 'stage_dir'
+        install_dir = 'install_dir'
+
+        # Create the python binary in the installed area
+        _create_python_binary(install_dir)
+
+        # Create a site.py in both staging and install areas
+        _create_site_py(stage_dir)
+        _create_site_py(install_dir)
+
+        # Do NOT create a user site dir, and attempt to generate sitecustomize.
+        raised = self.assertRaises(
+            _python.errors.MissingUserSitePackagesError,
+            _python.generate_sitecustomize, 'test', stage_dir=stage_dir,
+            install_dir=install_dir)
+        self.assertThat(
+            str(raised), Contains('Unable to find user site packages'))
+
+    def test_generate_sitecustomize_missing_site_py_raises(self):
+        stage_dir = 'stage_dir'
+        install_dir = 'install_dir'
+
+        # Create the python binary in the staging area
+        _create_python_binary(stage_dir)
+
+        # Create a site.py, but only in install area (not staging area)
+        _create_site_py(install_dir)
+
+        # Create a user site dir in install area
+        _create_user_site_packages(install_dir)
+
+        raised = self.assertRaises(
+            _python.errors.MissingSitePyError,
+            _python.generate_sitecustomize, 'test', stage_dir=stage_dir,
+            install_dir=install_dir)
+        self.assertThat(
+            str(raised), Contains('Unable to find site.py'))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

This PR is the next in a series that extracts pip from the python plugin, thus making progress on LP: [#1683036](https://bugs.launchpad.net/snapcraft/+bug/1683036) and #1444. It makes no changes to the Python plugin just yet, just copies functionality out into a more accessible place. The functionality that was copied here is the `sitecustomize.py` generation.