### PR TITLE
meta: ensure main keys are ordered in snap.yaml

### DIFF
--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import copy
+import collections
 import contextlib
 import configparser
 import logging
@@ -46,22 +47,23 @@ logger = logging.getLogger(__name__)
 
 _MANDATORY_PACKAGE_KEYS = [
     'name',
-    'description',
+    'version',
     'summary',
+    'description',
 ]
 
 _OPTIONAL_PACKAGE_KEYS = [
-    'architectures',
-    'assumes',
-    'base',
-    'environment',
     'type',
+    'base',
+    'architectures',
+    'confinement',
+    'grade',
+    'assumes',
     'plugs',
     'slots',
-    'confinement',
     'epoch',
-    'grade',
     'hooks',
+    'environment',
 ]
 
 
@@ -258,11 +260,12 @@ class _SnapPackaging:
 
         Keys that are in _OPTIONAL_PACKAGE_KEYS are ignored if not there.
         """
-        snap_yaml = {}
+        snap_yaml = collections.OrderedDict()
 
         for key_name in _MANDATORY_PACKAGE_KEYS:
             snap_yaml[key_name] = self._config_data[key_name]
 
+        # Reparse the version, the order should stick.
         snap_yaml['version'] = self._get_version(
             self._config_data['version'],
             self._config_data.get('version-script'))


### PR DESCRIPTION
The current snap.yaml is unordered to the point it looks ugly, by using an ordered dict we ensure the resulting snap.yaml is ordered for human viewing.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This is just a first step to achieve beautiful results. There used to be a bug for this, I guess it was incorrectly fixed released.