### PR TITLE
plugins: extract pip from python plugin

### DIFF
--- a/snapcraft/plugins/_python/__init__.py
+++ b/snapcraft/plugins/_python/__init__.py
@@ -14,5 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from ._pip import Pip  # noqa
 from ._python_finder import get_python_command  # noqa
 from ._sitecustomize import generate_sitecustomize  # noqa

--- a/snapcraft/plugins/_python/_pip.py
+++ b/snapcraft/plugins/_python/_pip.py
@@ -1,0 +1,349 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016-2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import collections
+import contextlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import snapcraft
+from snapcraft import file_utils
+from ._python_finder import (
+    get_python_command,
+    get_python_headers,
+    get_python_home,
+)
+from . import errors
+
+logger = logging.getLogger(__name__)
+
+
+def _process_common_args(*, packages, constraints,
+                         requirements, process_dependency_links):
+    args = []
+    if constraints:
+        for constraint in constraints:
+            args.extend(['--constraint', constraint])
+
+    if requirements:
+        for requirement in requirements:
+            args.extend(['--requirement', requirement])
+
+    if process_dependency_links:
+        args.append('--process-dependency-links')
+
+    if packages:
+        args.extend(packages)
+
+    return args
+
+
+class Pip:
+    """Wrapper for pip abstracting the args necessary for use in a part.
+
+    This class takes care of fetching pip, setuptools, and wheel, and then
+    simply shells out to pip with the magical arguments necessary to install
+    packages into a part.
+
+    Of particular importance: packages must be downloaded (via download())
+    before they can be installed or have wheels built.
+    """
+
+    def __init__(self, *, python_major_version, part_dir, install_dir,
+                 stage_dir):
+        """Initialize pip.
+
+        Check to see if pip has already been installed. If not, fetch pip,
+        setuptools, and wheel, and install them so they can be used.
+
+        :param str python_major_version: The python major version to find (2 or
+                                         3)
+        :param str part_dir: Path to the part's working area
+        :param str install_dir: Path to the part's install area
+        :param str stage_dir: Path to the staging area
+
+        :raises MissingPythonCommandError: If no python could be found in the
+                                           staging or part's install area.
+        """
+        self._python_major_version = python_major_version
+        self._part_dir = part_dir
+        self._install_dir = install_dir
+        self._stage_dir = stage_dir
+
+        self._python_package_dir = os.path.join(
+            self._part_dir, 'python-packages')
+        os.makedirs(self._python_package_dir, exist_ok=True)
+
+        self._python_command = get_python_command(
+            self._python_major_version, stage_dir=self._stage_dir,
+            install_dir=self._install_dir)
+        self._python_home = get_python_home(
+            self._python_major_version, stage_dir=self._stage_dir,
+            install_dir=self._install_dir)
+
+        self._setup()
+
+    def _setup(self):
+        # Check to see if we have our own pip, yet. If not, we need to use the
+        # pip on the host (installed via build-packages) to grab our own.
+        if not self._is_pip_installed():
+            logger.info('Fetching pip, setuptools, and wheel...')
+
+            real_python_home = self._python_home
+
+            # Make sure we're using pip from the host. Wrapping this operation
+            # in a try/finally to make sure we revert away from the host's
+            # python at the end.
+            try:
+                self._python_home = os.path.join(os.path.sep, 'usr')
+
+                # Using the host's pip, install our own pip and other tools we
+                # need.
+                self.download({'pip', 'setuptools', 'wheel'})
+                self.install(
+                    {'pip', 'setuptools', 'wheel'}, ignore_installed=True)
+            finally:
+                # Now that we have our own pip, reset the python home
+                self._python_home = real_python_home
+
+    def _is_pip_installed(self):
+        try:
+            # We're expecting an error here at least once complaining about
+            # pip not being installed. In order to verify that the error is the
+            # one we think it is, we need to process the stderr. So we'll
+            # redirect it to stdout. If it's not the error we expect, something
+            # is wrong, so re-raise it.
+            self._run([], stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            output = e.output.decode(sys.getfilesystemencoding()).strip()
+            if 'no module named pip' in output.lower():
+                return False
+            else:
+                raise e
+
+        return True
+
+    def download(self, packages, *, setup_py_dir=None, constraints=None,
+                 requirements=None, process_dependency_links=False):
+        """Download packages into cache, but do not install them.
+
+        :param iterable packages: Packages to download from index.
+        :param str setup_py_dir: Directory containing setup.py.
+        :param iterable constraints: Collection of paths to constraints files.
+        :param iterable requirements: Collection of paths to requirements
+                                      files.
+        :param boolean process_dependency_links: Enable the processing of
+                                                 dependency links.
+        """
+        args = _process_common_args(
+            process_dependency_links=process_dependency_links,
+            packages=packages, constraints=constraints,
+            requirements=requirements)
+
+        cwd = None
+        if setup_py_dir:
+            args.append('.')
+            cwd = setup_py_dir
+
+        if not args:
+            return  # No operation was requested
+
+        # Using pip with a few special parameters:
+        #
+        # --disable-pip-version-check: Don't whine if pip is out-of-date with
+        #                              the version on pypi.
+        # --dest: Download packages into the directory we've set aside for it.
+        self._run(['download', '--disable-pip-version-check', '--dest',
+                   self._python_package_dir] + args, cwd=cwd)
+
+    def install(self, packages, *, setup_py_dir=None, constraints=None,
+                requirements=None, process_dependency_links=False,
+                upgrade=False, install_deps=True, ignore_installed=False):
+        """Install packages from cache.
+
+        The packages should have already been downloaded via `download()`.
+
+        :param iterable packages: Packages to install from cache.
+        :param str setup_py_dir: Directory containing setup.py.
+        :param iterable constraints: Collection of paths to constraints files.
+        :param iterable requirements: Collection of paths to requirements
+                                      files.
+        :param boolean process_dependency_links: Enable the processing of
+                                                 dependency links.
+        :param boolean upgrade: Recursively upgrade packages.
+        :param boolean install_deps: Install package dependencies.
+        :param boolean ignore_installed: Reinstall packages if they're already
+                                         installed
+        """
+        args = _process_common_args(
+            process_dependency_links=process_dependency_links,
+            packages=packages, constraints=constraints,
+            requirements=requirements)
+
+        if upgrade:
+            args.append('--upgrade')
+
+        if not install_deps:
+            args.append('--no-deps')
+
+        if ignore_installed:
+            args.append('--ignore-installed')
+
+        cwd = None
+        if setup_py_dir:
+            args.append('.')
+            cwd = setup_py_dir
+
+        if not args:
+            return  # No operation was requested
+
+        # Using pip with a few special parameters:
+        #
+        # --user: Install packages to PYTHONUSERBASE, which we've pointed to
+        #         the installdir.
+        # --no-compile: Don't compile .pyc files. FIXME: This is legacy, and
+        #               should be removed once this refactor has been
+        #               validated.
+        # --no-index: Don't hit pypi, assume the packages are already
+        #             downloaded (i.e. by using `self.download()`)
+        # --find-links: Provide the directory into which the packages should
+        #               have already been fetched
+        self._run(['install', '--user', '--no-compile', '--no-index',
+                   '--find-links', self._python_package_dir] + args, cwd=cwd)
+
+    def wheel(self, packages, *, setup_py_dir=None, constraints=None,
+              requirements=None, process_dependency_links=False):
+        """Build wheels of packages in the cache.
+
+        The packages should have already been downloaded via `download()`.
+
+        :param iterable packages: Packages in cache for which to build wheels.
+        :param str setup_py_dir: Directory containing setup.py.
+        :param iterable constraints: Collection of paths to constraints files.
+        :param iterable requirements: Collection of paths to requirements
+                                      files.
+        :param boolean process_dependency_links: Enable the processing of
+                                                 dependency links.
+
+        :return: List of paths to each wheel that was built.
+        :rtype: list
+        """
+        args = _process_common_args(
+            process_dependency_links=process_dependency_links,
+            packages=packages, constraints=constraints,
+            requirements=requirements)
+
+        cwd = None
+        if setup_py_dir:
+            args.append('.')
+            cwd = setup_py_dir
+
+        if not args:
+            return  # No operation was requested
+
+        wheels = []
+        with tempfile.TemporaryDirectory() as temp_dir:
+
+            # Using pip with a few special parameters:
+            #
+            # --no-index: Don't hit pypi, assume the packages are already
+            #             downloaded (i.e. by using `self.download()`)
+            # --find-links: Provide the directory into which the packages
+            #               should have already been fetched
+            # --wheel-dir: Build wheels into a temporary working area rather
+            #              rather than cwd. We'll copy them over. FIXME: We can
+            #              probably get away just building them in the package
+            #              dir. Try that once this refactor has been validated.
+            self._run(['wheel', '--no-index', '--find-links',
+                       self._python_package_dir, '--wheel-dir',
+                       temp_dir] + args, cwd=cwd)
+            wheels = os.listdir(temp_dir)
+            for wheel in wheels:
+                file_utils.link_or_copy(
+                    os.path.join(temp_dir, wheel),
+                    os.path.join(self._python_package_dir, wheel))
+
+        return [os.path.join(self._python_package_dir, wheel)
+                for wheel in wheels]
+
+    def list(self):
+        """Determine which packages have been installed.
+
+        :return: Dict of installed python packages and their versions
+        :rtype: dict
+        """
+        output = self._run(['list', '--format=json'])
+        packages = collections.OrderedDict()
+        try:
+            json_output = json.loads(
+                    output, object_pairs_hook=collections.OrderedDict)
+        except json.decoder.JSONDecodeError as e:
+            raise errors.PipListInvalidJsonError(output) from e
+
+        for package in json_output:
+            if 'name' not in package:
+                raise errors.PipListMissingFieldError('name', output)
+            if 'version' not in package:
+                raise errors.PipListMissingFieldError('version', output)
+            packages[package['name']] = package['version']
+        return packages
+
+    def clean_packages(self):
+        """Remove the package cache."""
+        with contextlib.suppress(FileNotFoundError):
+            shutil.rmtree(self._python_package_dir)
+
+    def env(self):
+        """The environment used by pip.
+
+        This function is only useful if you happen to need to call into pip's
+        environment without using the API otherwise made available here (e.g.
+        calling the setup.py directly instead of with pip).
+
+        :return: Dict of the environment necessary to use the pip contained
+                 here.
+        :rtype: dict
+        """
+        env = os.environ.copy()
+        env['PYTHONUSERBASE'] = self._install_dir
+        env['PYTHONHOME'] = self._python_home
+
+        env['PATH'] = '{}:{}'.format(
+            os.path.join(self._install_dir, 'usr', 'bin'),
+            os.path.expandvars('$PATH'))
+
+        headers = get_python_headers(
+            self._python_major_version, stage_dir=self._stage_dir)
+        if headers:
+            current_cppflags = env.get('CPPFLAGS', '')
+            env['CPPFLAGS'] = '-I{}'.format(headers)
+            if current_cppflags:
+                env['CPPFLAGS'] = '{} {}'.format(
+                    env['CPPFLAGS'], current_cppflags)
+
+        return env
+
+    def _run(self, args, **kwargs):
+        env = self.env()
+
+        return snapcraft.internal.common.run_output(
+            [self._python_command, '-m', 'pip'] + list(args), env=env,
+            **kwargs)

--- a/snapcraft/plugins/_python/_python_finder.py
+++ b/snapcraft/plugins/_python/_python_finder.py
@@ -76,3 +76,28 @@ def get_python_headers(python_major_version, *, stage_dir):
         return host_python[0]
     else:
         return ''
+
+
+def get_python_home(python_major_version, *, stage_dir, install_dir):
+    """Find the correct PYTHONHOME, preferring staged over the part.
+
+    We prefer the staged python as opposed to the in-part python in order to
+    support one part that supplies python, with another part built `after` it
+    wanting to use its python.
+
+    :param str python_major_version: The python major version to find (2 or 3)
+    :param str stage_dir: Path to the staging area
+    :param str install_dir: Path to the part's install area
+
+    :return: Path to the PYTHONHOME that was found
+    :rtype: str
+
+    :raises MissingPythonCommandError: If no python could be found in the
+                                       staging or part's install area.
+    """
+    python_command = get_python_command(
+        python_major_version, stage_dir=stage_dir, install_dir=install_dir)
+    if python_command.startswith(stage_dir):
+        return os.path.join(stage_dir, 'usr')
+    else:
+        return os.path.join(install_dir, 'usr')

--- a/snapcraft/plugins/_python/errors.py
+++ b/snapcraft/plugins/_python/errors.py
@@ -47,3 +47,19 @@ class MissingSitePyError(PythonPluginError):
 
     def __init__(self, site_py_glob):
         super().__init__(site_py_glob=site_py_glob)
+
+
+class PipListInvalidJsonError(PythonPluginError):
+
+    fmt = "Pip packages output isn't valid json: {json!r}"
+
+    def __init__(self, json):
+        super().__init__(json=json)
+
+
+class PipListMissingFieldError(PythonPluginError):
+
+    fmt = 'Pip packages json missing {field!r} field: {json!r}'
+
+    def __init__(self, field, json):
+        super().__init__(field=field, json=json)

--- a/snapcraft/tests/plugins/python/__init__.py
+++ b/snapcraft/tests/plugins/python/__init__.py
@@ -1,0 +1,29 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+import snapcraft
+
+
+class PythonBaseTestCase(snapcraft.tests.TestCase):
+
+    def _create_python_binary(self, base_dir):
+        python_command_path = os.path.join(
+            base_dir, 'usr', 'bin', 'pythontest')
+        os.makedirs(os.path.dirname(python_command_path), exist_ok=True)
+        open(python_command_path, 'w').close()
+        return python_command_path

--- a/snapcraft/tests/plugins/python/test_pip.py
+++ b/snapcraft/tests/plugins/python/test_pip.py
@@ -1,0 +1,595 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import subprocess
+
+import fixtures
+from unittest import mock
+
+from testtools.matchers import (
+    Contains,
+    Equals,
+    HasLength,
+)
+
+from snapcraft.plugins._python import (
+    _pip,
+    errors,
+)
+
+from . import PythonBaseTestCase
+
+
+class PipRunTestCase(PythonBaseTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        patcher = mock.patch('snapcraft.internal.common.run_output')
+        self.mock_run_output = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _assert_expected_enviroment(self, expected_python, headers_path):
+        _pip.Pip(
+            python_major_version='test',
+            part_dir='part_dir',
+            install_dir='install_dir',
+            stage_dir='stage_dir')
+
+        class check_env():
+            def __init__(self, test):
+                self.test = test
+
+            def __eq__(self, env):
+                self.test.assertThat(env, Contains('PYTHONUSERBASE'))
+                self.test.assertThat(
+                    env['PYTHONUSERBASE'], Equals('install_dir'))
+
+                self.test.assertThat(env, Contains('PYTHONHOME'))
+                if expected_python.startswith('install_dir'):
+                    self.test.assertThat(
+                        env['PYTHONHOME'], Equals(os.path.join(
+                            'install_dir', 'usr')))
+                else:
+                    self.test.assertThat(
+                        env['PYTHONHOME'], Equals(os.path.join(
+                            'stage_dir', 'usr')))
+
+                self.test.assertThat(env, Contains('PATH'))
+                self.test.assertThat(
+                    env['PATH'], Contains(os.path.join(
+                        'install_dir', 'usr', 'bin')))
+
+                if headers_path:
+                    self.test.assertThat(env, Contains('CPPFLAGS'))
+                    self.test.assertThat(
+                        env['CPPFLAGS'], Contains('-I{}'.format(headers_path)))
+
+                return True
+
+        self.mock_run_output.assert_called_once_with(
+            [expected_python, '-m', 'pip'], env=check_env(self),
+            stderr=subprocess.STDOUT)
+
+    def test_environment_part_python_without_headers(self):
+        expected_python = self._create_python_binary('install_dir')
+        self._assert_expected_enviroment(expected_python, None)
+
+    def test_environment_part_python_with_staged_headers(self):
+        expected_python = self._create_python_binary('install_dir')
+        # First, create staged headers
+        staged_headers = os.path.join(
+            'stage_dir', 'usr', 'include', 'pythontest')
+        os.makedirs(staged_headers)
+        self._assert_expected_enviroment(expected_python, staged_headers)
+
+    @mock.patch('glob.glob')
+    def test_environment_part_python_with_host_headers(self, mock_glob):
+        host_headers = os.path.join(os.sep, 'usr', 'include', 'pythontest')
+
+        # Fake out glob so it looks like the headers are installed on the host
+        def _fake_glob(pattern):
+            if pattern.startswith(os.sep):
+                return [host_headers]
+            return []
+        mock_glob.side_effect = _fake_glob
+
+        expected_python = self._create_python_binary('install_dir')
+        self._assert_expected_enviroment(expected_python, host_headers)
+
+    def test_environment_staged_python_without_headers(self):
+        expected_python = self._create_python_binary('stage_dir')
+        self._assert_expected_enviroment(expected_python, None)
+
+    def test_environment_staged_python_with_staged_headers(self):
+        # First, create staged headers
+        staged_headers = os.path.join(
+            'stage_dir', 'usr', 'include', 'pythontest')
+        os.makedirs(staged_headers)
+
+        # Also create staged python
+        expected_python = self._create_python_binary('stage_dir')
+
+        self._assert_expected_enviroment(expected_python, staged_headers)
+
+    @mock.patch('glob.glob')
+    def test_environment_staged_python_with_host_headers(self, mock_glob):
+        host_headers = os.path.join(os.sep, 'usr', 'include', 'pythontest')
+
+        # Fake out glob so it looks like the headers are installed on the host
+        def _fake_glob(pattern):
+            if pattern.startswith(os.sep):
+                return [host_headers]
+            return []
+        mock_glob.side_effect = _fake_glob
+
+        expected_python = self._create_python_binary('stage_dir')
+        self._assert_expected_enviroment(expected_python, host_headers)
+
+    def test_with_extra_cppflags(self):
+        """Verify that existing CPPFLAGS are preserved"""
+
+        expected_python = self._create_python_binary('install_dir')
+
+        self.useFixture(fixtures.EnvironmentVariable(
+                        'CPPFLAGS', '-I/opt/include'))
+        _pip.Pip(
+            python_major_version='test',
+            part_dir='part_dir',
+            install_dir='install_dir',
+            stage_dir='stage_dir')
+
+        class check_env():
+            def __init__(self, test):
+                self.test = test
+
+            def __eq__(self, env):
+                self.test.assertThat(env, Contains('CPPFLAGS'))
+                self.test.assertThat(
+                    env['CPPFLAGS'], Contains('-I/opt/include'))
+
+                return True
+
+        self.mock_run_output.assert_has_calls([
+            mock.call([expected_python, '-m', 'pip'], env=check_env(self),
+                      stderr=subprocess.STDOUT)])
+
+
+class InitTestCase(PipRunTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.command = [self._create_python_binary('install_dir'), '-m', 'pip']
+
+    def test_init_with_pip_installed(self):
+        """Test that no attempt is made to reinstall pip"""
+
+        # Since _run doesn't raise an exception indicating pip isn't installed,
+        # it must be installed.
+
+        # Verify that no attempt is made to reinstall pip
+        _pip.Pip(
+            python_major_version='test',
+            part_dir='part_dir',
+            install_dir='install_dir',
+            stage_dir='stage_dir')
+
+        self.mock_run_output.assert_called_once_with(
+            self.command, stderr=subprocess.STDOUT, env=mock.ANY)
+
+    def test_init_without_pip_installed(self):
+        """Test that the system pip is used to install our own pip"""
+
+        # Raise an exception indicating that pip isn't installed
+        def fake_run(command, **kwargs):
+            if command == self.command:
+                raise subprocess.CalledProcessError(
+                    1, 'foo', b'no module named pip')
+        self.mock_run_output.side_effect = fake_run
+
+        # Verify that pip is then installed
+        _pip.Pip(
+            python_major_version='test',
+            part_dir='part_dir',
+            install_dir='install_dir',
+            stage_dir='stage_dir')
+
+        part_pythonhome = os.path.join('install_dir', 'usr')
+        host_pythonhome = os.path.join(os.path.sep, 'usr')
+
+        # What we're asserting here:
+        # 1. That we test for the installed pip
+        # 2. That we then download pip (and associated tools) using host pip
+        # 3. That we then install pip (and associated tools) using host pip
+        self.assertThat(self.mock_run_output.mock_calls, HasLength(3))
+        self.mock_run_output.assert_has_calls([
+            mock.call(
+                self.command, env=_CheckPythonhomeEnv(self, part_pythonhome),
+                stderr=subprocess.STDOUT),
+            mock.call(
+                _CheckCommand(
+                    self, 'download', ['pip', 'setuptools', 'wheel'], []),
+                env=_CheckPythonhomeEnv(self, host_pythonhome), cwd=None),
+            mock.call(
+                _CheckCommand(
+                    self, 'install', ['pip', 'setuptools', 'wheel'],
+                    ['--ignore-installed']),
+                env=_CheckPythonhomeEnv(self, host_pythonhome), cwd=None),
+        ])
+
+    def test_init_unexpected_error(self):
+        """Test that pip initialization doesn't eat legit errors"""
+
+        # Raises an exception indicating something bad happened
+        self.mock_run_output.side_effect = subprocess.CalledProcessError(
+            1, 'foo', b'no good, very bad')
+
+        # Verify that pip lets that exception through
+        self.assertRaises(
+            subprocess.CalledProcessError, _pip.Pip,
+            python_major_version='test', part_dir='part_dir',
+            install_dir='install_dir', stage_dir='stage_dir')
+
+
+class PipTestCase(PythonBaseTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        patcher = mock.patch.object(_pip.Pip, '_run')
+        self.mock_run = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self._create_python_binary('install_dir')
+
+    def test_clean_packages(self):
+        pip = _pip.Pip(
+            python_major_version='test',
+            part_dir='part_dir',
+            install_dir='install_dir',
+            stage_dir='stage_dir')
+
+        packages_dir = os.path.join('part_dir', 'python-packages')
+        self.assertTrue(os.path.exists(packages_dir))
+
+        # Now verify that asking pip to clean removes its packages
+        pip.clean_packages()
+        self.assertFalse(os.path.exists(packages_dir))
+
+
+class PipCommandTestCase(PipTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.pip = _pip.Pip(
+            python_major_version='test',
+            part_dir='part_dir',
+            install_dir='install_dir',
+            stage_dir='stage_dir')
+
+        # We don't care about anything init did to the mock here: reset it
+        self.mock_run.reset_mock()
+
+
+class PipDownloadTestCase(PipCommandTestCase):
+
+    scenarios = [
+        ('packages', {
+            'packages': ['foo', 'bar'],
+            'kwargs': {},
+            'expected_args': ['foo', 'bar'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('setup_py_dir', {
+            'packages': [],
+            'kwargs': {'setup_py_dir': 'test_setup_py_dir'},
+            'expected_args': ['.'],
+            'expected_kwargs': {'cwd': 'test_setup_py_dir'},
+        }),
+        ('single constraint', {
+            'packages': [],
+            'kwargs': {'constraints': ['constraint']},
+            'expected_args': ['--constraint', 'constraint'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('multiple constraints', {
+            'packages': [],
+            'kwargs': {'constraints': ['constraint1', 'constraint2']},
+            'expected_args': [
+                '--constraint', 'constraint1', '--constraint', 'constraint2'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('single requirement', {
+            'packages': [],
+            'kwargs': {'requirements': ['requirement']},
+            'expected_args': ['--requirement', 'requirement'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('multiple requirements', {
+            'packages': [],
+            'kwargs': {'requirements': ['requirement1', 'requirement2']},
+            'expected_args': [
+                '--requirement', 'requirement1', '--requirement',
+                'requirement2'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('process dependency links', {
+            'packages': [],
+            'kwargs': {'process_dependency_links': True},
+            'expected_args': ['--process-dependency-links'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('packages and setup_py_dir', {
+            'packages': ['foo', 'bar'],
+            'kwargs': {'setup_py_dir': 'test_setup_py_dir'},
+            'expected_args': ['foo', 'bar', '.'],
+            'expected_kwargs': {'cwd': 'test_setup_py_dir'},
+        }),
+    ]
+
+    def _assert_mock_run_with(self, *args, **kwargs):
+        common_args = [
+            'download', '--disable-pip-version-check', '--dest', mock.ANY]
+        common_args.extend(*args)
+        self.mock_run.assert_called_once_with(
+            common_args, **kwargs)
+
+    def test_without_packages_or_kwargs_should_noop(self):
+        self.pip.download([])
+        self.mock_run.assert_not_called()
+
+    def test_with_packages_and_kwargs(self):
+        self.pip.download(self.packages, **self.kwargs)
+        self._assert_mock_run_with(self.expected_args, **self.expected_kwargs)
+
+
+class PipInstallTestCase(PipCommandTestCase):
+
+    scenarios = [
+        ('packages', {
+            'packages': ['foo', 'bar'],
+            'kwargs': {},
+            'expected_args': ['foo', 'bar'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('setup_py_dir', {
+            'packages': [],
+            'kwargs': {'setup_py_dir': 'test_setup_py_dir'},
+            'expected_args': ['.'],
+            'expected_kwargs': {'cwd': 'test_setup_py_dir'},
+        }),
+        ('single constraint', {
+            'packages': [],
+            'kwargs': {'constraints': ['constraint']},
+            'expected_args': ['--constraint', 'constraint'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('multiple constraints', {
+            'packages': [],
+            'kwargs': {'constraints': ['constraint1', 'constraint2']},
+            'expected_args': [
+                '--constraint', 'constraint1', '--constraint', 'constraint2'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('single requirement', {
+            'packages': [],
+            'kwargs': {'requirements': ['requirement']},
+            'expected_args': ['--requirement', 'requirement'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('multiple requirements', {
+            'packages': [],
+            'kwargs': {'requirements': ['requirement1', 'requirement2']},
+            'expected_args': [
+                '--requirement', 'requirement1', '--requirement',
+                'requirement2'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('process dependency links', {
+            'packages': [],
+            'kwargs': {'process_dependency_links': True},
+            'expected_args': ['--process-dependency-links'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('upgrade', {
+            'packages': [],
+            'kwargs': {'upgrade': True},
+            'expected_args': ['--upgrade'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('install_deps', {
+            'packages': [],
+            'kwargs': {'install_deps': False},
+            'expected_args': ['--no-deps'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('ignore_installed', {
+            'packages': [],
+            'kwargs': {'ignore_installed': True},
+            'expected_args': ['--ignore-installed'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('packages and setup_py_dir', {
+            'packages': ['foo', 'bar'],
+            'kwargs': {'setup_py_dir': 'test_setup_py_dir'},
+            'expected_args': ['foo', 'bar', '.'],
+            'expected_kwargs': {'cwd': 'test_setup_py_dir'},
+        }),
+    ]
+
+    def _assert_mock_run_with(self, *args, **kwargs):
+        common_args = [
+            'install', '--user', '--no-compile', '--no-index', '--find-links',
+            mock.ANY]
+        common_args.extend(*args)
+        self.mock_run.assert_called_once_with(
+            common_args, **kwargs)
+
+    def test_without_packages_or_kwargs_should_noop(self):
+        self.pip.install([])
+        self.mock_run.assert_not_called()
+
+    def test_with_packages_and_kwargs(self):
+        self.pip.install(self.packages, **self.kwargs)
+        self._assert_mock_run_with(self.expected_args, **self.expected_kwargs)
+
+
+class PipWheelTestCase(PipCommandTestCase):
+
+    scenarios = [
+        ('packages', {
+            'packages': ['foo', 'bar'],
+            'kwargs': {},
+            'expected_args': ['foo', 'bar'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('setup_py_dir', {
+            'packages': [],
+            'kwargs': {'setup_py_dir': 'test_setup_py_dir'},
+            'expected_args': ['.'],
+            'expected_kwargs': {'cwd': 'test_setup_py_dir'},
+        }),
+        ('single constraint', {
+            'packages': [],
+            'kwargs': {'constraints': ['constraint']},
+            'expected_args': ['--constraint', 'constraint'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('multiple constraints', {
+            'packages': [],
+            'kwargs': {'constraints': ['constraint1', 'constraint2']},
+            'expected_args': [
+                '--constraint', 'constraint1', '--constraint', 'constraint2'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('single requirement', {
+            'packages': [],
+            'kwargs': {'requirements': ['requirement']},
+            'expected_args': ['--requirement', 'requirement'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('multiple requirements', {
+            'packages': [],
+            'kwargs': {'requirements': ['requirement1', 'requirement2']},
+            'expected_args': [
+                '--requirement', 'requirement1', '--requirement',
+                'requirement2'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('process dependency links', {
+            'packages': [],
+            'kwargs': {'process_dependency_links': True},
+            'expected_args': ['--process-dependency-links'],
+            'expected_kwargs': {'cwd': None},
+        }),
+        ('packages and setup_py_dir', {
+            'packages': ['foo', 'bar'],
+            'kwargs': {'setup_py_dir': 'test_setup_py_dir'},
+            'expected_args': ['foo', 'bar', '.'],
+            'expected_kwargs': {'cwd': 'test_setup_py_dir'},
+        }),
+    ]
+
+    def _assert_mock_run_with(self, *args, **kwargs):
+        common_args = [
+            'wheel', '--no-index', '--find-links', mock.ANY, '--wheel-dir',
+            mock.ANY]
+        common_args.extend(*args)
+        self.mock_run.assert_called_once_with(
+            common_args, **kwargs)
+
+    def test_without_packages_or_kwargs_should_noop(self):
+        self.pip.wheel([])
+        self.mock_run.assert_not_called()
+
+    def test_with_packages_and_kwargs(self):
+        self.pip.wheel(self.packages, **self.kwargs)
+        self._assert_mock_run_with(self.expected_args, **self.expected_kwargs)
+
+
+class PipListTestCase(PipCommandTestCase):
+
+    def test_none(self):
+        self.mock_run.return_value = '{}'
+        self.assertFalse(self.pip.list())
+        self.mock_run.assert_called_once_with(['list', '--format=json'])
+
+    def test_package(self):
+        self.mock_run.return_value = '[{"name": "foo", "version": "1.0"}]'
+        self.assertThat(self.pip.list(), Equals({'foo': '1.0'}))
+        self.mock_run.assert_called_once_with(['list', '--format=json'])
+
+    def test_missing_name(self):
+        self.mock_run.return_value = '[{"version": "1.0"}]'
+        raised = self.assertRaises(
+            errors.PipListMissingFieldError, self.pip.list)
+        self.assertThat(
+            str(raised), Contains("Pip packages json missing 'name' field"))
+
+    def test_missing_version(self):
+        self.mock_run.return_value = '[{"name": "foo"}]'
+        raised = self.assertRaises(
+            errors.PipListMissingFieldError, self.pip.list)
+        self.assertThat(
+            str(raised), Contains("Pip packages json missing 'version' field"))
+
+    def test_invalid_json(self):
+        self.mock_run.return_value = '[{]'
+        raised = self.assertRaises(
+            errors.PipListInvalidJsonError, self.pip.list)
+        self.assertThat(
+            str(raised), Contains("Pip packages output isn't valid json"))
+
+
+class _CheckPythonhomeEnv():
+    def __init__(self, test, expected_pythonhome):
+        self.test = test
+        self.expected_pythonhome = expected_pythonhome
+
+    def __eq__(self, env):
+        # Verify that we're using the installed pip
+        self.test.assertThat(env, Contains('PYTHONHOME'))
+        self.test.assertThat(
+            env['PYTHONHOME'], Equals(self.expected_pythonhome))
+
+        return True
+
+
+class _CheckCommand():
+    def __init__(self, test, command, packages, flags):
+        self.test = test
+        self.command = command
+        self.packages = packages
+        self.flags = flags
+
+    def __eq__(self, command):
+        # Not worrying about the command arguments here, those are
+        # tested elsewhere. Just want to test that the right command
+        # is called with the right packages.
+        self.test.assertTrue(command)
+        self.test.assertThat(
+            command[len(self.test.command)], Equals(self.command))
+
+        for package in self.packages:
+            self.test.assertThat(command, Contains(package))
+
+        for flag in self.flags:
+            self.test.assertThat(command, Contains(flag))
+
+        return True

--- a/snapcraft/tests/plugins/python/test_sitecustomize.py
+++ b/snapcraft/tests/plugins/python/test_sitecustomize.py
@@ -23,16 +23,7 @@ from testtools.matchers import (
 
 from snapcraft.plugins import _python
 
-from snapcraft import (
-    tests
-)
-
-
-def _create_python_binary(base_dir):
-    python_command_path = os.path.join(
-        base_dir, 'usr', 'bin', 'pythontest')
-    os.makedirs(os.path.dirname(python_command_path))
-    open(python_command_path, 'w').close()
+from . import PythonBaseTestCase
 
 
 def _create_site_py(base_dir):
@@ -48,14 +39,14 @@ def _create_user_site_packages(base_dir):
     os.makedirs(user_site_dir)
 
 
-class SiteCustomizeTestCase(tests.TestCase):
+class SiteCustomizeTestCase(PythonBaseTestCase):
 
     def test_generate_sitecustomize_staged(self):
         stage_dir = 'stage_dir'
         install_dir = 'install_dir'
 
         # Create the python binary in the staging area
-        _create_python_binary(stage_dir)
+        self._create_python_binary(stage_dir)
 
         # Create a site.py in both staging and install areas
         _create_site_py(stage_dir)
@@ -94,7 +85,7 @@ class SiteCustomizeTestCase(tests.TestCase):
         install_dir = 'install_dir'
 
         # Create the python binary in the installed area
-        _create_python_binary(install_dir)
+        self._create_python_binary(install_dir)
 
         # Create a site.py in both staging and install areas
         _create_site_py(stage_dir)
@@ -133,7 +124,7 @@ class SiteCustomizeTestCase(tests.TestCase):
         install_dir = 'install_dir'
 
         # Create the python binary in the installed area
-        _create_python_binary(install_dir)
+        self._create_python_binary(install_dir)
 
         # Create a site.py in both staging and install areas
         _create_site_py(stage_dir)
@@ -152,7 +143,7 @@ class SiteCustomizeTestCase(tests.TestCase):
         install_dir = 'install_dir'
 
         # Create the python binary in the staging area
-        _create_python_binary(stage_dir)
+        self._create_python_binary(stage_dir)
 
         # Create a site.py, but only in install area (not staging area)
         _create_site_py(install_dir)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

At long last, making more progress on LP: [#1683036](https://bugs.launchpad.net/snapcraft/+bug/1683036) and #1444, here is the final bit of extraction necessary from the Python plugin: the Pip wrapper itself.

Note that unlike the other PRs, this is a bit of a refactor. The previous pip wrapper was a very private implementation detail of the Python plugin, and didn't need much of an API. This PR introduces a bit more of an API to it in the hopes of making it a little easier to use in other plugins. It also makes it easier to test.

This PR doesn't modify the Python plugin in any way just yet (that's the next PR).