### PR TITLE
dirs: set plugin, schema, and library dir for snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ demos/*/parts/
 demos/*/prime/
 demos/*/stage/
 demos/**/*.snap
+snap/.snapcraft/
 tests/unit/parts/
 tests/unit/snap/
 tests/unit/stage/

--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -456,8 +456,3 @@ def str_presenter(dumper, data):
 yaml.add_representer(str, str_presenter)
 yaml.add_representer(OrderedDict, dict_representer)
 yaml.add_constructor(_mapping_tag, dict_constructor)
-
-from snapcraft.internal import common as _common # noqa
-if _common.is_snap():
-    snap = _os.environ.get('SNAP')
-    _common.set_schemadir(_os.path.join(snap, 'share', 'snapcraft', 'schema'))

--- a/snapcraft/internal/dirs.py
+++ b/snapcraft/internal/dirs.py
@@ -24,8 +24,20 @@ def setup_dirs():
     """
     from snapcraft.internal import common
     topdir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
-    # only change the default if we are running from a checkout
+    # Only change the default if we are running from a checkout or from the
+    # snap.
     if os.path.exists(os.path.join(topdir, 'setup.py')):
         common.set_plugindir(os.path.join(topdir, 'snapcraft', 'plugins'))
         common.set_schemadir(os.path.join(topdir, 'schema'))
         common.set_librariesdir(os.path.join(topdir, 'libraries'))
+
+    # The default paths are relative to sys.prefix, which works well for
+    # Snapcraft as a deb or in a venv. However, the Python plugin installs
+    # packages into $SNAP/ as a prefix, while Python itself is contained in
+    # $SNAP/usr/. As a result, using sys.prefix (which is '/usr') to find these
+    # files won't work in the snap.
+    elif common.is_snap():
+        parent_dir = os.path.join(os.environ.get('SNAP'), 'share', 'snapcraft')
+        common.set_plugindir(os.path.join(parent_dir, 'plugins'))
+        common.set_schemadir(os.path.join(parent_dir, 'schema'))
+        common.set_librariesdir(os.path.join(parent_dir, 'libraries'))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

The default plugin, schema, and library dir are relative to `sys.prefix`, which works nicely for Snapcraft as a deb or in a venv. However, Snapcraft's Python plugin installs packages in `$SNAP/` as a prefix, while Python itself is contained in `$SNAP/usr/`. As a result, using `sys.prefix` (which is `/usr`) to find these files when Snapcraft is a snap ends up looking in the wrong place.

Treat running Snapcraft as a snap as a special case, similar to how running from git is supported, and set the directories appropriately.

It's worth pointing out: when making this change, I realized nothing uses `common.get_plugindir()`. The fact that it points to an invalid place (as it always does, even in a deb or venv) doesn't have any side-effects. This PR sets it anyway for consistency, but we should consider getting rid of it.