### PR TITLE
lxd: instructions for /etc/sub{u,g}id after failed start

### DIFF
--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -130,7 +130,8 @@ class Containerbuild:
             self._ensure_container()
             yield
         finally:
-            if self._get_container_status():
+            status = self._get_container_status()
+            if status and status['status'] == 'Running':
                 # Stopping takes a while and lxc doesn't print anything.
                 print('Stopping {}'.format(self._container_name))
                 check_call(['lxc', 'stop', '-f', self._container_name])

--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -327,8 +327,19 @@ class Project(Containerbuild):
                     'lxc', 'config', 'device', 'add', self._container_name,
                     'fuse', 'unix-char', 'path=/dev/fuse'
                     ])
-            check_call([
-                'lxc', 'start', self._container_name])
+            try:
+                check_call([
+                    'lxc', 'start', self._container_name])
+            except CalledProcessError:
+                msg = 'The container could not be started.'
+                if self._container_name.startswith('local:'):
+                    msg += ('\nThe files /etc/subuid and /etc/subgid need to '
+                            'contain this line for mounting the local folder:'
+                            '\n    root:1000:1'
+                            '\nNote: Add the line to both files, do not '
+                            'remove any existing lines.'
+                            '\nRestart lxd after making this change.')
+                raise ContainerConnectionError(msg)
 
     def _setup_project(self):
         self._ensure_mount(self._project_folder, self._source)

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -468,3 +468,6 @@ class LocalProjectTestCase(LXDTestCase):
             str(self.assertRaises(
                 ContainerConnectionError,
                 self.make_project().execute)))
+        # Should not attempt to stop a container that wasn't started
+        self.assertNotIn(call(['lxc', 'stop', '-f', self.fake_lxd.name]),
+                         self.fake_lxd.check_call_mock.call_args_list)

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -366,6 +366,25 @@ class ProjectTestCase(LXDTestCase):
                            remote=self.remote)
 
     @patch('snapcraft.internal.lxd.Containerbuild._container_run')
+    def test_start_failed(self, mock_container_run):
+        mock_container_run.side_effect = lambda cmd, **kwargs: cmd
+
+        def call_effect(*args, **kwargs):
+            if args[0][:2] == ['lxc', 'start']:
+                raise CalledProcessError(
+                    returncode=255, cmd=args[0])
+            return d(*args, **kwargs)
+
+        d = self.fake_lxd.check_call_mock.side_effect
+        self.fake_lxd.check_call_mock.side_effect = call_effect
+
+        self.assertIn(
+            'The container could not be started.\n',
+            str(self.assertRaises(
+                ContainerConnectionError,
+                self.make_project().execute)))
+
+    @patch('snapcraft.internal.lxd.Containerbuild._container_run')
     def test_ftp_not_installed(self, mock_container_run):
         mock_container_run.side_effect = lambda cmd, **kwargs: cmd
 
@@ -413,6 +432,39 @@ class ProjectTestCase(LXDTestCase):
 
         self.assertIn(
             'The project folder could not be mounted.\n',
+            str(self.assertRaises(
+                ContainerConnectionError,
+                self.make_project().execute)))
+
+
+class LocalProjectTestCase(LXDTestCase):
+
+    scenarios = [
+        ('local', dict(remote='local', target_arch=None, server='x86_64')),
+    ]
+
+    def make_project(self):
+        return lxd.Project(output='snap.snap', source='project.tar',
+                           metadata={'name': 'project'},
+                           project_options=self.project_options,
+                           remote=self.remote)
+
+    @patch('snapcraft.internal.lxd.Containerbuild._container_run')
+    def test_start_failed(self, mock_container_run):
+        mock_container_run.side_effect = lambda cmd, **kwargs: cmd
+
+        def call_effect(*args, **kwargs):
+            if args[0][:2] == ['lxc', 'start']:
+                raise CalledProcessError(
+                    returncode=255, cmd=args[0])
+            return d(*args, **kwargs)
+
+        d = self.fake_lxd.check_call_mock.side_effect
+        self.fake_lxd.check_call_mock.side_effect = call_effect
+
+        self.assertIn(
+            'The container could not be started.\n'
+            'The files /etc/subuid and /etc/subgid need to contain this line ',
             str(self.assertRaises(
                 ContainerConnectionError,
                 self.make_project().execute)))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
If a persistent container fails to start it may be because id mapping isn't setup on the host. Snapcraft needs to try and be helpful with how it can be corrected.

Fixes [bug 1716738](https://bugs.launchpad.net/snapcraft/+bug/1716738)