### PR TITLE
cleanbuild: add a --image option to build in a different image

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -171,8 +171,9 @@ def clean(parts, step, **kwargs):
 @click.option('--remote', metavar='<remote>',
               help='Use a specific lxd remote instead of a local container.')
 @click.option('--image', metavar='<image>', default=None,
-              help=('Build in an instance of this image rather than ubuntu:xenial/$arch. '
-                    'Do not use this unless you know what you are doing.'))
+              help=('Build in an instance of this image rather than '
+                    'ubuntu:xenial/$arch. Do not use this unless you know '
+                    'what you are doing.'))
 @click.option('--debug', is_flag=True,
               help='Shells into the environment if the build fails.')
 def cleanbuild(remote, image, debug, **kwargs):

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -170,9 +170,12 @@ def clean(parts, step, **kwargs):
 @add_build_options()
 @click.option('--remote', metavar='<remote>',
               help='Use a specific lxd remote instead of a local container.')
+@click.option('--image', metavar='<image>', default=None,
+              help=('Build in an instance of this image rather than ubuntu:xenial/$arch. '
+                    'Do not use this unless you know what you are doing.'))
 @click.option('--debug', is_flag=True,
               help='Shells into the environment if the build fails.')
-def cleanbuild(remote, debug, **kwargs):
+def cleanbuild(remote, image, debug, **kwargs):
     """Create a snap using a clean environment managed by lxd.
 
     \b
@@ -190,7 +193,7 @@ def cleanbuild(remote, debug, **kwargs):
     https://linuxcontainers.org/lxd/getting-started-cli/#multiple-hosts
     """
     project_options = get_project_options(**kwargs, debug=debug)
-    lifecycle.cleanbuild(project_options, remote)
+    lifecycle.cleanbuild(project_options, remote, image)
 
 
 if __name__ == '__main__':

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -334,7 +334,8 @@ def cleanbuild(project_options, remote='', image=None):
         t.add(os.path.curdir, filter=_create_tar_filter(tar_filename))
     lxd.Cleanbuilder(source=tar_filename,
                      project_options=project_options,
-                     metadata=config.get_metadata(), remote=remote, image=image).execute()
+                     metadata=config.get_metadata(), remote=remote,
+                     image=image).execute()
 
 
 def _snap_data_from_dir(directory):

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -322,7 +322,7 @@ def containerbuild(step, project_options, container_config,
                 metadata=config.get_metadata()).execute(step, args)
 
 
-def cleanbuild(project_options, remote=''):
+def cleanbuild(project_options, remote='', image=None):
     if remote and not lxd._remote_is_valid(remote):
         raise errors.InvalidContainerRemoteError(remote)
 
@@ -334,7 +334,7 @@ def cleanbuild(project_options, remote=''):
         t.add(os.path.curdir, filter=_create_tar_filter(tar_filename))
     lxd.Cleanbuilder(source=tar_filename,
                      project_options=project_options,
-                     metadata=config.get_metadata(), remote=remote).execute()
+                     metadata=config.get_metadata(), remote=remote, image=image).execute()
 
 
 def _snap_data_from_dir(directory):

--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -53,7 +53,7 @@ _STORE_KEY = (
 class Containerbuild:
 
     def __init__(self, *, output, source, project_options,
-                 metadata, container_name, remote=None):
+                 metadata, container_name, remote=None, image=None):
         if not output:
             output = common.format_snap_name(metadata)
         self._snap_output = output
@@ -72,11 +72,14 @@ class Containerbuild:
             kernel = server_environment['kernel_architecture']
         except KeyError:
             kernel = server_environment['kernelarchitecture']
-        deb_arch = _get_deb_arch(kernel)
-        if not deb_arch:
-            raise ContainerConnectionError(
-                'Unrecognized server architecture {}'.format(kernel))
-        self._image = 'ubuntu:xenial/{}'.format(deb_arch)
+        if image is None:
+            deb_arch = _get_deb_arch(kernel)
+            if not deb_arch:
+                raise ContainerConnectionError(
+                    'Unrecognized server architecture {}'.format(kernel))
+            self._image = 'ubuntu:xenial/{}'.format(deb_arch)
+        else:
+            self._image = image
         # Use a temporary folder the 'lxd' snap can access
         lxd_common_dir = os.path.expanduser(
             os.path.join('~', 'snap', 'lxd', 'common'))
@@ -282,11 +285,11 @@ class Containerbuild:
 class Cleanbuilder(Containerbuild):
 
     def __init__(self, *, output=None, source, project_options,
-                 metadata=None, remote=None):
+                 metadata=None, remote=None, image=None):
         container_name = petname.Generate(3, '-')
         super().__init__(output=output, source=source,
                          project_options=project_options, metadata=metadata,
-                         container_name=container_name, remote=remote)
+                         container_name=container_name, remote=remote, image=image)
 
 
 class Project(Containerbuild):

--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -289,7 +289,8 @@ class Cleanbuilder(Containerbuild):
         container_name = petname.Generate(3, '-')
         super().__init__(output=output, source=source,
                          project_options=project_options, metadata=metadata,
-                         container_name=container_name, remote=remote, image=image)
+                         container_name=container_name, remote=remote,
+                         image=image)
 
 
 class Project(Containerbuild):


### PR DESCRIPTION
For my own nefarious purposes I want to build snaps in an artful lxd which you can't do using cleanbuild today.