### PR TITLE
Don't fail over empty or faulty lines

### DIFF
--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -265,10 +265,11 @@ def get_pkg_config_paths(root, arch_triplet):
     return [p for p in paths if os.path.exists(p)]
 
 
-def get_os_release_info():
-    with open("/etc/os-release") as os_release_file:
+def get_os_release_info(os_release_file='/etc/os-release'):
+    with open(os_release_file) as os_release_file:
         os_release_dict = {}
         for line in os_release_file:
-            key, value = line.rstrip().split('=')
-            os_release_dict[key] = value.strip('"')
+            entry = line.rstrip().split('=')
+            if len(entry) == 2:
+                os_release_dict[entry[0]] = entry[1].strip('"')
     return os_release_dict

--- a/snapcraft/tests/test_common.py
+++ b/snapcraft/tests/test_common.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+from textwrap import dedent
 
 from testtools.matchers import Equals
 
@@ -116,3 +117,36 @@ class FormatInColumnsTestCase(tests.TestCase):
                                             max_width=60,
                                             num_col_spaces=1),
             Equals(expected))
+
+
+class OSReleaseTestCase(tests.TestCase):
+
+    def test_os_release_with_blank_lines(self):
+        with open('os-release', 'w') as release_file:
+            print(dedent("""\
+                NAME="Arch Linux"
+
+                PRETTY_NAME="Arch Linux"
+                ID=arch
+                ID_LIKE=archlinux
+                ANSI_COLOR="0;36"
+                HOME_URL="https://www.archlinux.org/"
+                SUPPORT_URL="https://bbs.archlinux.org/"
+                BUG_REPORT_URL="https://bugs.archlinux.org/"
+
+            """), file=release_file)
+
+        release_info = common.get_os_release_info(os_release_file='os-release')
+
+        expected_release_info = dict(
+            NAME='Arch Linux',
+            PRETTY_NAME='Arch Linux',
+            ID='arch',
+            ID_LIKE='archlinux',
+            ANSI_COLOR='0;36',
+            HOME_URL='https://www.archlinux.org/',
+            SUPPORT_URL='https://bbs.archlinux.org/',
+            BUG_REPORT_URL='https://bugs.archlinux.org/',
+        )
+
+        self.assertThat(release_info, Equals(expected_release_info))


### PR DESCRIPTION
If we're not going to be able to unpack it, ignore the line.

This is what it looks like on Arch Linux. Note the empty line in the end:
```
$ cat /etc/os-release 
NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=arch
ID_LIKE=archlinux
ANSI_COLOR="0;36"
HOME_URL="https://www.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://bugs.archlinux.org/"

$ 
```
-----
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`? < some tests fail but they also failed before as well


