### PR TITLE
Make sure we don't try to include an empty set

### DIFF
--- a/snapcraft/internal/repo/_base.py
+++ b/snapcraft/internal/repo/_base.py
@@ -245,7 +245,7 @@ class BaseRepo:
 class DummyRepo(BaseRepo):
 
     def get_packages_for_source_type(*args, **kwargs):
-        pass
+        return set()
 
 
 def _try_copy_local(path, target):

--- a/snapcraft/tests/project_loader/test_parts.py
+++ b/snapcraft/tests/project_loader/test_parts.py
@@ -18,6 +18,7 @@ import logging
 import os
 import unittest
 import unittest.mock
+from textwrap import dedent
 
 import fixtures
 from testtools.matchers import Contains, Equals
@@ -111,3 +112,29 @@ parts:
 
         self.assertThat(fake_logger.output,
                         Contains(deprecations._deprecation_message('dn1')))
+
+
+class PartsWithDummyRepoTestCase(tests.TestCase):
+
+    @unittest.mock.patch(
+        'snapcraft.internal.project_loader._parts_config.repo.Repo',
+        wraps=snapcraft.internal.repo._base.DummyRepo)
+    def test_load_with_dummy_repo(self, os_release_mock):
+        self.make_snapcraft_yaml(dedent("""\
+            name: test
+            version: "1"
+            summary: test
+            description: test
+            confinement: strict
+
+            parts:
+              part1:
+                source: https://github.com/snapcore/snapcraft.git
+                plugin: python
+                stage-packages: [fswebcam]
+                snap: [foo]
+        """))
+
+        # Ensure the dummy repo returns an empty set for required
+        # build tools.
+        project_loader.load_config()


### PR DESCRIPTION
This happens when snapcraft loads the configuration in cleanbuild to
retrieve the name and some other metadata. It's too early to resolve the
parts and they are null outside of the container.

-----
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`? < some tests fail but they also failed before as well


