### PR TITLE
docker: add the environment variable to setup core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,3 +14,4 @@ RUN apt-get update && \
 
 # Required by click.
 ENV LC_ALL C.UTF-8
+ENV SNAPCRAFT_SETUP_CORE 1


### PR DESCRIPTION
The Dockerfile is missing SNAPCRAFT_SETUP_CORE which would enable
straightforward snapcraft builds with classic confinement.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
