### PR TITLE
catkin plugin: support rosdep pip dependencies

### DIFF
--- a/integration_tests/snapd/test_catkin_snap.py
+++ b/integration_tests/snapd/test_catkin_snap.py
@@ -1,0 +1,37 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+
+from testtools.matchers import Contains
+
+import integration_tests
+from snapcraft.tests import fixture_setup
+
+
+class CatkinTestCase(integration_tests.SnapdIntegrationTestCase):
+
+    def test_catkin_pip_support(self):
+        with fixture_setup.WithoutSnapInstalled('ros-pip-example'):
+            self.run_snapcraft(project_dir='ros-pip')
+            self.install_snap()
+
+            # If pip support didn't work properly, the import should fail.
+            self.assertThat(
+                subprocess.check_output(
+                    ['ros-pip-example.launch-project'],
+                    universal_newlines=True, stderr=subprocess.STDOUT),
+                Contains("Local timezone:"))

--- a/integration_tests/snaps/ros-pip/snap/snapcraft.yaml
+++ b/integration_tests/snaps/ros-pip/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: ros-pip-example
+version: 1.0
+summary: ROS Example using pip dependencies
+description: Contains a simple pip test and a .launch file.
+confinement: strict
+grade: devel
+
+apps:
+  launch-project:
+    command: roslaunch timezone_test test.launch
+    plugs: [network-bind]
+
+parts:
+  ros-project:
+    plugin: catkin
+    source: .
+    rosdistro: kinetic
+    catkin-packages:
+      - timezone_test
+    include-roscore: true

--- a/integration_tests/snaps/ros-pip/src/CMakeLists.txt
+++ b/integration_tests/snaps/ros-pip/src/CMakeLists.txt
@@ -1,0 +1,47 @@
+# toplevel CMakeLists.txt for a catkin workspace
+# catkin/cmake/toplevel.cmake
+
+cmake_minimum_required(VERSION 2.8.3)
+
+# optionally provide a cmake file in the workspace to override arbitrary stuff
+include(workspace.cmake OPTIONAL)
+
+set(CATKIN_TOPLEVEL TRUE)
+
+# include catkin directly or via find_package()
+if(EXISTS "${CMAKE_SOURCE_DIR}/catkin/cmake/all.cmake" AND EXISTS "${CMAKE_SOURCE_DIR}/catkin/CMakeLists.txt")
+  set(catkin_EXTRAS_DIR "${CMAKE_SOURCE_DIR}/catkin/cmake")
+  # include all.cmake without add_subdirectory to let it operate in same scope
+  include(catkin/cmake/all.cmake NO_POLICY_SCOPE)
+  add_subdirectory(catkin)
+
+else()
+  # use either CMAKE_PREFIX_PATH explicitly passed to CMake as a command line argument
+  # or CMAKE_PREFIX_PATH from the environment
+  if(NOT DEFINED CMAKE_PREFIX_PATH)
+    if(NOT "$ENV{CMAKE_PREFIX_PATH}" STREQUAL "")
+      string(REPLACE ":" ";" CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH})
+    endif()
+  endif()
+
+  # list of catkin workspaces
+  set(catkin_search_path "")
+  foreach(path ${CMAKE_PREFIX_PATH})
+    if(EXISTS "${path}/.CATKIN_WORKSPACE")
+      list(FIND catkin_search_path ${path} _index)
+      if(_index EQUAL -1)
+        list(APPEND catkin_search_path ${path})
+      endif()
+    endif()
+  endforeach()
+
+  # search for catkin in all workspaces
+  set(CATKIN_TOPLEVEL_FIND_PACKAGE TRUE)
+  find_package(catkin REQUIRED
+    NO_POLICY_SCOPE
+    PATHS ${catkin_search_path}
+    NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+  unset(CATKIN_TOPLEVEL_FIND_PACKAGE)
+endif()
+
+catkin_workspace()

--- a/integration_tests/snaps/ros-pip/src/timezone_test/CMakeLists.txt
+++ b/integration_tests/snaps/ros-pip/src/timezone_test/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(timezone_test)
+
+find_package(catkin REQUIRED COMPONENTS rospy)
+
+catkin_package()
+
+install(PROGRAMS
+  scripts/timezone_test_node
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(FILES
+  test.launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/integration_tests/snaps/ros-pip/src/timezone_test/package.xml
+++ b/integration_tests/snaps/ros-pip/src/timezone_test/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<package>
+  <name>timezone_test</name>
+  <version>0.0.0</version>
+  <description>The timezone_test package</description>
+  <maintainer email="me@example.com">me</maintainer>
+  <license>GPLv3</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>python-tzlocal-pip</build_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>python-tzlocal-pip</run_depend>
+</package>

--- a/integration_tests/snaps/ros-pip/src/timezone_test/scripts/timezone_test_node
+++ b/integration_tests/snaps/ros-pip/src/timezone_test/scripts/timezone_test_node
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+import rospy
+import tzlocal
+
+
+def main():
+    # This line verifies that we can connect to ROS master
+    rospy.init_node('timezone_test')
+
+    # This line verifies that we can use tzlocal, which is a pip dependency
+    print('Local timezone: {}'.format(tzlocal.get_localzone()))
+
+if __name__ == '__main__':
+    main()

--- a/integration_tests/snaps/ros-pip/src/timezone_test/test.launch
+++ b/integration_tests/snaps/ros-pip/src/timezone_test/test.launch
@@ -1,0 +1,4 @@
+<launch>
+    <node name = "timezone_test" pkg = "timezone_test" type = "timezone_test_node"
+          required = "true" output = "screen" />
+</launch>

--- a/snapcraft/plugins/_python/_pip.py
+++ b/snapcraft/plugins/_python/_pip.py
@@ -71,8 +71,7 @@ class Pip:
                  stage_dir):
         """Initialize pip.
 
-        Check to see if pip has already been installed. If not, fetch pip,
-        setuptools, and wheel, and install them so they can be used.
+        You must call setup() before you can actually use pip.
 
         :param str python_major_version: The python major version to find (2 or
                                          3)
@@ -99,9 +98,12 @@ class Pip:
             self._python_major_version, stage_dir=self._stage_dir,
             install_dir=self._install_dir)
 
-        self._setup()
+    def setup(self):
+        """Install pip and dependencies.
 
-    def _setup(self):
+        Check to see if pip has already been installed. If not, fetch pip,
+        setuptools, and wheel, and install them so they can be used.
+        """
         # Check to see if we have our own pip, yet. If not, we need to use the
         # pip on the host (installed via build-packages) to grab our own.
         if not self._is_pip_installed():
@@ -123,6 +125,10 @@ class Pip:
             finally:
                 # Now that we have our own pip, reset the python home
                 self._python_home = real_python_home
+
+    def is_setup(self):
+        """Return true if pip has already been setup."""
+        return self._is_pip_installed()
 
     def _is_pip_installed(self):
         try:

--- a/snapcraft/tests/plugins/python/test_pip.py
+++ b/snapcraft/tests/plugins/python/test_pip.py
@@ -48,7 +48,7 @@ class PipRunTestCase(PythonBaseTestCase):
             python_major_version='test',
             part_dir='part_dir',
             install_dir='install_dir',
-            stage_dir='stage_dir')
+            stage_dir='stage_dir').setup()
 
         class check_env():
             def __init__(self, test):
@@ -151,7 +151,7 @@ class PipRunTestCase(PythonBaseTestCase):
             python_major_version='test',
             part_dir='part_dir',
             install_dir='install_dir',
-            stage_dir='stage_dir')
+            stage_dir='stage_dir').setup()
 
         class check_env():
             def __init__(self, test):
@@ -169,14 +169,14 @@ class PipRunTestCase(PythonBaseTestCase):
                       stderr=subprocess.STDOUT)])
 
 
-class InitTestCase(PipRunTestCase):
+class SetupTestCase(PipRunTestCase):
 
     def setUp(self):
         super().setUp()
 
         self.command = [self._create_python_binary('install_dir'), '-m', 'pip']
 
-    def test_init_with_pip_installed(self):
+    def test_setup_with_pip_installed(self):
         """Test that no attempt is made to reinstall pip"""
 
         # Since _run doesn't raise an exception indicating pip isn't installed,
@@ -187,12 +187,12 @@ class InitTestCase(PipRunTestCase):
             python_major_version='test',
             part_dir='part_dir',
             install_dir='install_dir',
-            stage_dir='stage_dir')
+            stage_dir='stage_dir').setup()
 
         self.mock_run_output.assert_called_once_with(
             self.command, stderr=subprocess.STDOUT, env=mock.ANY)
 
-    def test_init_without_pip_installed(self):
+    def test_setup_without_pip_installed(self):
         """Test that the system pip is used to install our own pip"""
 
         # Raise an exception indicating that pip isn't installed
@@ -207,7 +207,7 @@ class InitTestCase(PipRunTestCase):
             python_major_version='test',
             part_dir='part_dir',
             install_dir='install_dir',
-            stage_dir='stage_dir')
+            stage_dir='stage_dir').setup()
 
         part_pythonhome = os.path.join('install_dir', 'usr')
         host_pythonhome = os.path.join(os.path.sep, 'usr')
@@ -232,18 +232,21 @@ class InitTestCase(PipRunTestCase):
                 env=_CheckPythonhomeEnv(self, host_pythonhome), cwd=None),
         ])
 
-    def test_init_unexpected_error(self):
+    def test_setup_unexpected_error(self):
         """Test that pip initialization doesn't eat legit errors"""
 
         # Raises an exception indicating something bad happened
         self.mock_run_output.side_effect = subprocess.CalledProcessError(
             1, 'foo', b'no good, very bad')
 
+        pip = _pip.Pip(
+            python_major_version='test',
+            part_dir='part_dir',
+            install_dir='install_dir',
+            stage_dir='stage_dir')
+
         # Verify that pip lets that exception through
-        self.assertRaises(
-            subprocess.CalledProcessError, _pip.Pip,
-            python_major_version='test', part_dir='part_dir',
-            install_dir='install_dir', stage_dir='stage_dir')
+        self.assertRaises(subprocess.CalledProcessError, pip.setup)
 
 
 class PipTestCase(PythonBaseTestCase):

--- a/snapcraft/tests/plugins/test_catkin.py
+++ b/snapcraft/tests/plugins/test_catkin.py
@@ -111,7 +111,7 @@ class CatkinPluginBaseTestCase(tests.TestCase):
         patcher = mock.patch('snapcraft.plugins._python.Pip')
         self.pip_mock = patcher.start()
         self.addCleanup(patcher.stop)
-        self.pip_mock.return_value.is_setup.return_value = False
+        self.pip_mock.return_value.list.return_value = {}
 
     def assert_rosdep_setup(self, rosdistro, package_path, rosdep_path,
                             ubuntu_distro, sources):
@@ -1301,7 +1301,7 @@ class FinishBuildTestCase(CatkinPluginBaseTestCase):
     def test_finish_build_python_sitecustomize(self, use_python_mock,
                                                run_output_mock, run_mock,
                                                generate_setup_mock):
-        self.pip_mock.return_value.is_setup.return_value = True
+        self.pip_mock.return_value.list.return_value = {'test-package'}
 
         # Create site.py, indicating that python2 was a stage-package
         site_py_path = os.path.join(


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

The Catkin plugin uses rosdep to resolve dependencies, however, the only type of dependencies it currently supports are apt-based. This PR fixes LP: [#1683036](https://bugs.launchpad.net/snapcraft/+bug/1683036) by adding support for pip-based dependencies.