### PR TITLE
repo: friendly, helpful error for unsupported distros

### DIFF
--- a/snapcraft/internal/repo/_base.py
+++ b/snapcraft/internal/repo/_base.py
@@ -24,6 +24,7 @@ import shutil
 import stat
 
 from snapcraft import file_utils
+from . import errors
 
 _BIN_PATHS = (
     'bin',
@@ -64,7 +65,7 @@ class BaseRepo:
                   directories.
         :rtype: set.
         """
-        raise NotImplemented()
+        raise errors.NoNativeBackendError()
 
     @classmethod
     def get_packages_for_source_type(cls, source_type):
@@ -87,7 +88,7 @@ class BaseRepo:
         :returns: a set of packages that need to be installed on the host.
         :rtype: set of strings.
         """
-        raise NotImplementedError()
+        raise errors.NoNativeBackendError()
 
     @classmethod
     def install_build_packages(cls, package_names):
@@ -98,7 +99,7 @@ class BaseRepo:
         :raises snapcraft.repo.errors.BuildPackageNotFoundError:
             if one of the package_names cannot be installed.
         """
-        raise NotImplementedError()
+        raise errors.NoNativeBackendError()
 
     @classmethod
     def build_package_is_valid(cls, package_name):
@@ -107,7 +108,7 @@ class BaseRepo:
         :param package_name: a package name to check.
         :type package_name: str
         """
-        raise NotImplementedError()
+        raise errors.NoNativeBackendError()
 
     @classmethod
     def is_package_installed(cls, package_name):
@@ -117,7 +118,7 @@ class BaseRepo:
         :returns: True if package_name is installed if not False.
         :rtype: boolean
         """
-        raise NotImplementedError()
+        raise errors.NoNativeBackendError()
 
     @classmethod
     def get_installed_packages(cls):
@@ -125,7 +126,7 @@ class BaseRepo:
 
         :rtype: list of strings with the form package=version.
         """
-        raise NotImplementedError()
+        raise errors.NoNativeBackendError()
 
     def __init__(self, rootdir, *args, **kwargs):
         """Initialize a repository handler.
@@ -150,7 +151,7 @@ class BaseRepo:
         :raises snapcraft.repo.errors.PackageNotFoundError:
             when a package in package_names is not found.
         """
-        raise NotImplemented()
+        raise errors.NoNativeBackendError()
 
     def unpack(self, unpackdir):
         """Unpack obtained packages into unpackdir.
@@ -163,7 +164,7 @@ class BaseRepo:
 
         :param str unpackdir: target directory to unpack packages to.
         """
-        raise NotImplemented()
+        raise errors.NoNativeBackendError()
 
     def normalize(self, unpackdir):
         """Normalize artifacts in unpackdir.

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -23,6 +23,15 @@ class RepoError(errors.SnapcraftError):
     pass
 
 
+class NoNativeBackendError(RepoError):
+
+    fmt = ("Native builds aren't supported on {distro}. "
+           "You can however use 'snapcraft cleanbuild' with a container.")
+
+    def __init__(self):
+        super().__init__(distro=get_os_release_info()['NAME'])
+
+
 class BuildPackageNotFoundError(RepoError):
 
     fmt = "Could not find a required package in 'build-packages': {package}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----
On distros with no native backend, such as Fedora or Archlinux, currently you get an unhelpful "NotImplementedError" with a stacktrace. Instead Snapcraft could be suggesting the user to build in a container.
@Conan-Kudo I can't request a review from you for some reason... but this is what we talked about, so I'd like your eyes on this (even if we'll have the RPM backend soon).