### PR TITLE
Update default node engine to 6.11.3

### DIFF
--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -58,7 +58,7 @@ from snapcraft.internal import errors
 logger = logging.getLogger(__name__)
 
 _NODEJS_BASE = 'node-v{version}-linux-{arch}'
-_NODEJS_VERSION = '6.10.2'
+_NODEJS_VERSION = '6.11.3'
 _NODEJS_TMPL = 'https://nodejs.org/dist/v{version}/{base}.tar.gz'
 _NODEJS_ARCHES = {
     'i386': 'x86',

--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -58,7 +58,7 @@ from snapcraft.internal import errors
 logger = logging.getLogger(__name__)
 
 _NODEJS_BASE = 'node-v{version}-linux-{arch}'
-_NODEJS_VERSION = '6.11.3'
+_NODEJS_VERSION = '6.11.4'
 _NODEJS_TMPL = 'https://nodejs.org/dist/v{version}/{base}.tar.gz'
 _NODEJS_ARCHES = {
     'i386': 'x86',


### PR DESCRIPTION
Most Node.js projects building v6.x compatible versions are now targetting Node.js 6.11.3. This pull request simply bumps the default `_NODEJS_VERSION` to 6.11.3 in the Snapcraft Node.js plugin.

---
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?
