### PR TITLE
setuptools: conditional Debian-specific deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,12 +9,11 @@ PyYAML==3.11
 pyxdg==0.25
 requests==2.9.1
 requests_unixsocket==0.1.5
-https://launchpad.net/ubuntu/+archive/primary/+files/python-apt_1.1.0~beta1build1.tar.xz; sys_platform == 'linux'
 https://launchpad.net/python-distutils-extra/trunk/2.39/+download/python-distutils-extra-2.39.tar.gz
 requests-toolbelt==0.6.0
 responses==0.5.1
 petname==1.12
-pymacaroons==0.9.2; sys_platform != 'win32'
+pymacaroons>=0.9.2<=0.9.3; sys_platform != 'win32'
 pymacaroons==0.10.0; sys_platform == 'win32'
 pymacaroons-pynacl==0.9.3
 pysha3==1.0b1; python_version < '3.6'

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,9 @@ if sys.platform == 'win32':
 else:
     from setuptools import setup
 
+    debian_requires = []
+    if 'ID_LIKE=debian' in open('/etc/os-release').read():
+        debian_requires.append('python-apt==0.0.0')
     setup(
         name=name,
         version=version,
@@ -146,6 +149,11 @@ else:
             'pyxdg',
             'requests',
             'libarchive-c',
+            *debian_requires,
+        ],
+        dependency_links=[
+            ('https://launchpad.net/ubuntu/+archive/primary/+files/'
+             'python-apt_1.1.0~beta1build1.tar.xz')
         ],
         test_suite='snapcraft.tests',
     )


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
Currently requirements.txt assumes "linux" equals Ubuntu/Debian, making it impossible to install it on eg. Fedora.
@Conan-Kudo Please review