### PR TITLE
travis: run snapd tests only if not cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
     - if: type != cron
       script: sudo ./tools/travis/run_tests.sh store
     - if: type != cron
-    - script: sudo ./tools/travis/run_tests.sh snapd
+      script: sudo ./tools/travis/run_tests.sh snapd
     # CLA check, only in pull requests, not comming from the bot.
     - if: type = pull_request AND sender != snappy-m-o
       script: ./tools/travis/run_cla_check.sh


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Otherwise the `if` turns into its own job that does nothing, and the snapd tests run all the time. Look at that 10 second job there:

![image](https://user-images.githubusercontent.com/946674/31233536-bc4f6956-a9a1-11e7-96b2-8cc7ffad4aa8.png)