### PR TITLE
tests: fix the skip of snapd integration tests in armhf

### DIFF
--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -599,9 +599,9 @@ class StoreTestCase(TestCase):
 class SnapdIntegrationTestCase(TestCase):
 
     def setUp(self):
+        super().setUp()
         if os.environ.get('ADT_TEST') and self.deb_arch == 'armhf':
             self.skipTest("The autopkgtest armhf runners can't install snaps")
-        super().setUp()
 
     def install_snap(self):
         try:

--- a/integration_tests/test_asset_recording.py
+++ b/integration_tests/test_asset_recording.py
@@ -89,6 +89,10 @@ class ManifestRecordingTestCase(AssetRecordingBaseTestCase):
             Contains(expected_package))
 
     def test_prime_records_installed_snaps(self):
+        if os.environ.get('ADT_TEST') and self.deb_arch == 'armhf':
+            self.skipTest("The autopkgtest armhf runners can't install snaps")
+
+        subprocess.check_call(['sudo', 'snap', 'install', 'core'])
         self.run_snapcraft('prime', project_dir='basic')
 
         recorded_yaml_path = os.path.join(
@@ -137,6 +141,9 @@ class ManifestRecordingTestCase(AssetRecordingBaseTestCase):
             Equals([snapcraft.ProjectOptions().deb_arch]))
 
     def test_prime_records_build_snaps(self):
+        if os.environ.get('ADT_TEST') and self.deb_arch == 'armhf':
+            self.skipTest("The autopkgtest armhf runners can't install snaps")
+
         self.useFixture(fixture_setup.WithoutSnapInstalled('hello'))
         snapcraft_yaml = fixture_setup.SnapcraftYaml(self.path)
         snapcraft_yaml.update_part('test-part', {

--- a/integration_tests/test_build_snaps.py
+++ b/integration_tests/test_build_snaps.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+
 import testscenarios
 
 import integration_tests
@@ -30,6 +32,8 @@ class BuildSnapsTestCase(
          {'snap': 'u1test-snap-with-tracks/test-track-1/beta'}))
 
     def test_build_snap(self):
+        if os.environ.get('ADT_TEST') and self.deb_arch == 'armhf':
+            self.skipTest("The autopkgtest armhf runners can't install snaps")
         self.useFixture(fixture_setup.WithoutSnapInstalled(self.snap))
         snapcraft_yaml = fixture_setup.SnapcraftYaml(self.path)
         snapcraft_yaml.update_part(


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
A little mistake here on my side: `self.deb_arch` is only available after calling the parent `setUp`. Sorry about that.