### PR TITLE
pluginhandler: warn about migrated system libraries

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -459,16 +459,26 @@ class PluginHandler:
 
         dependency_paths = part_dependency_paths | staged_dependency_paths
 
-        if not self._build_attributes.no_system_libraries():
+        if not self._build_attributes.no_system_libraries() and system:
             system_dependency_paths = {os.path.dirname(d) for d in system}
             dependency_paths.update(system_dependency_paths)
 
-            if system:
-                # Lots of dependencies are linked with a symlink, so we need to
-                # make sure we follow those symlinks when we migrate the
-                # dependencies.
-                _migrate_files(system, system_dependency_paths, '/',
-                               self.primedir, follow_symlinks=True)
+            logger.warning(
+                'The following files from the build host will migrate to the '
+                'snap to\nstatisfy library dependencies:\n\n{}\n'
+                'This behavior is problematic, these dependent libraries '
+                'should be provided\nthrough stage-packages entries or other '
+                'parts.\n'
+                'You can disable this behavior in the part by setting:'
+                '\n    <part-name>:'
+                '\n        build-attributes: [no-system-libraries]'.format(
+                    ''.join([' - /{}\n'.format(p) for p in system])))
+
+            # Lots of dependencies are linked with a symlink, so we need to
+            # make sure we follow those symlinks when we migrate the
+            # dependencies.
+            _migrate_files(system, system_dependency_paths, '/',
+                           self.primedir, follow_symlinks=True)
 
         self.mark_prime_done(snap_files, snap_dirs, dependency_paths)
 


### PR DESCRIPTION
System libraries from the host where a snap build takes
place are brought into the priming area without
feedback to the user.

Since snapcraft is allowed to build on many systems,
even those where a proper base filesystem does
not exist, we need to warn users when such an
event occurs.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
