### PR TITLE
recording: do not crash when snapd is not installed

### DIFF
--- a/snapcraft/internal/repo/snaps.py
+++ b/snapcraft/internal/repo/snaps.py
@@ -198,7 +198,10 @@ def get_installed_snaps():
 
     :return: a list of "name=revision" for the snaps installed.
     """
-    local_snaps = _get_local_snaps()
+    try:
+        local_snaps = _get_local_snaps()
+    except exceptions.ConnectionError as e:
+        local_snaps = []
     return ['{}={}'.format(snap['name'], snap['revision']) for
             snap in local_snaps]
 

--- a/snapcraft/tests/repo/test_snaps.py
+++ b/snapcraft/tests/repo/test_snaps.py
@@ -426,3 +426,18 @@ class InstalledSnapsTestCase(SnapPackageBaseTestCase):
             installed_snaps,
             Equals(['test-snap-1=test-snap-1-revision',
                     'test-snap-2=test-snap-2-revision']))
+
+
+class SnapdNotInstalledTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        socket_path_patcher = mock.patch(
+            'snapcraft.internal.repo.snaps.get_snapd_socket_path_template')
+        mock_socket_path = socket_path_patcher.start()
+        mock_socket_path.return_value = 'http+unix://nonexisting'
+        self.addCleanup(socket_path_patcher.stop)
+
+    def test_get_installed_snaps(self):
+        installed_snaps = snaps.get_installed_snaps()
+        self.assertThat(installed_snaps, Equals([]))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
