### PR TITLE
Fixed StoreReleaseError format for BAD REQUEST error

### DIFF
--- a/snapcraft/tests/fake_servers/api.py
+++ b/snapcraft/tests/fake_servers/api.py
@@ -442,6 +442,15 @@ class FakeStoreAPIServer(base.BaseFakeServer):
                     }
                 }
             }).encode()
+        elif 'notanumber' in revision:
+            response_code = 400
+            payload = json.dumps({
+                'success': False,
+                'error_list': [{
+                    'code': 'invalid-field',
+                    'message': "The 'revision' field must be an integer"}],
+                'errors': {'revision': ['This field must be an integer.']}}
+            ).encode()
         else:
             raise NotImplementedError(
                 'Cannot handle release request for {!r}'.format(name))

--- a/snapcraft/tests/store/test_store_client.py
+++ b/snapcraft/tests/store/test_store_client.py
@@ -902,6 +902,18 @@ class ReleaseTestCase(StoreTestCase):
             errors.InvalidCredentialsError,
             self.client.release, 'test-snap', '10', ['beta'])
 
+    def test_release_with_invalid_revision(self):
+        self.client.login('dummy', 'test correct password')
+        raised = self.assertRaises(
+            errors.StoreReleaseError,
+            self.client.release,
+            'test-snap-invalid-data', 'notanumber', ['beta'])
+
+        self.assertThat(
+            str(raised),
+            Equals(
+                'invalid-field: The \'revision\' field must be an integer\n'))
+
 
 class CloseChannelsTestCase(StoreTestCase):
 


### PR DESCRIPTION
Currently, when releasing a snap with invalid data (e.g. revision),
the error string is not formatted for a user, e.g.

    {'revision': ['This field must be an integer.']}

With this commit, the error is formatted as follows:

    "invalid-field: The 'revision' field must be an integer"

Moreover:
- added test case in test_store_client.py: ReleaseTestCase.test_release_with_invalid_revision
- added new conditional branch in fake_servers/api.py:snap_release method to support the test above.
- reworked StoreReleaseError class to wrap the code that formats
    different errors in dedicated methods.

Fixes LP 1604815

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
