### PR TITLE
options: fix core-dynamic-linker on ppc64el/s390x

### DIFF
--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -63,7 +63,7 @@ _ARCH_TRANSLATIONS = {
         'cross-build-packages': ['gcc-powerpc64le-linux-gnu',
                                  'libc6-dev-ppc64el-cross'],
         'triplet': 'powerpc64le-linux-gnu',
-        'core-dynamic-linker': '/lib64/ld64.so.2',
+        'core-dynamic-linker': 'lib64/ld64.so.2',
     },
     'ppc': {
         'kernel': 'powerpc',
@@ -89,7 +89,7 @@ _ARCH_TRANSLATIONS = {
         'cross-build-packages': ['gcc-s390x-linux-gnu',
                                  'libc6-dev-s390x-cross'],
         'triplet': 's390x-linux-gnu',
-        'core-dynamic-linker': '/lib/ld64.so.1',
+        'core-dynamic-linker': 'lib/ld64.so.1',
     }
 }
 

--- a/snapcraft/tests/project_loader/test_config.py
+++ b/snapcraft/tests/project_loader/test_config.py
@@ -1626,6 +1626,7 @@ parts:
             'snapcraft._options.ProjectOptions.get_core_dynamic_linker')
         mock_core_dynamic_linker = patcher.start()
         mock_core_dynamic_linker.return_value = dynamic_linker
+        self.addCleanup(patcher.stop)
 
         self.make_snapcraft_yaml("""name: test
 version: "1"

--- a/snapcraft/tests/test_options.py
+++ b/snapcraft/tests/test_options.py
@@ -14,12 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os.path
 from unittest import mock
 
 import testtools
 from testtools.matchers import Equals
 
 import snapcraft
+from snapcraft.internal import common
 from snapcraft.internal.errors import SnapcraftEnvironmentError
 from snapcraft import tests
 
@@ -32,67 +34,78 @@ class NativeOptionsTestCase(tests.TestCase):
             architecture=('64bit', 'ELF'),
             expected_arch_triplet='x86_64-linux-gnu',
             expected_deb_arch='amd64',
-            expected_kernel_arch='x86')),
+            expected_kernel_arch='x86',
+            expected_core_dynamic_linker='lib64/ld-linux-x86-64.so.2')),
         ('amd64-kernel-i686-userspace', dict(
             machine='x86_64',
             architecture=('32bit', 'ELF'),
             expected_arch_triplet='i386-linux-gnu',
             expected_deb_arch='i386',
-            expected_kernel_arch='x86')),
+            expected_kernel_arch='x86',
+            expected_core_dynamic_linker='lib/ld-linux.so.2')),
         ('i686', dict(
             machine='i686',
             architecture=('32bit', 'ELF'),
             expected_arch_triplet='i386-linux-gnu',
             expected_deb_arch='i386',
-            expected_kernel_arch='x86')),
+            expected_kernel_arch='x86',
+            expected_core_dynamic_linker='lib/ld-linux.so.2')),
         ('armv7l', dict(
             machine='armv7l',
             architecture=('32bit', 'ELF'),
             expected_arch_triplet='arm-linux-gnueabihf',
             expected_deb_arch='armhf',
-            expected_kernel_arch='arm')),
+            expected_kernel_arch='arm',
+            expected_core_dynamic_linker='lib/ld-linux-armhf.so.3')),
         ('aarch64', dict(
             machine='aarch64',
             architecture=('64bit', 'ELF'),
             expected_arch_triplet='aarch64-linux-gnu',
             expected_deb_arch='arm64',
-            expected_kernel_arch='arm64')),
+            expected_kernel_arch='arm64',
+            expected_core_dynamic_linker='lib/ld-linux-aarch64.so.1')),
         ('aarch64-kernel-armv7l-userspace', dict(
             machine='aarch64',
             architecture=('32bit', 'ELF'),
             expected_arch_triplet='arm-linux-gnueabihf',
             expected_deb_arch='armhf',
-            expected_kernel_arch='arm')),
+            expected_kernel_arch='arm',
+            expected_core_dynamic_linker='lib/ld-linux-armhf.so.3')),
         ('armv8l-kernel-armv7l-userspace', dict(
             machine='armv8l',
             architecture=('32bit', 'ELF'),
             expected_arch_triplet='arm-linux-gnueabihf',
             expected_deb_arch='armhf',
-            expected_kernel_arch='arm')),
+            expected_kernel_arch='arm',
+            expected_core_dynamic_linker='lib/ld-linux-armhf.so.3')),
         ('ppc', dict(
             machine='ppc',
             architecture=('32bit', 'ELF'),
             expected_arch_triplet='powerpc-linux-gnu',
             expected_deb_arch='powerpc',
-            expected_kernel_arch='powerpc')),
+            expected_kernel_arch='powerpc',
+            expected_core_dynamic_linker='lib/ld-linux.so.2')),
         ('ppc64le', dict(
             machine='ppc64le',
             architecture=('64bit', 'ELF'),
             expected_arch_triplet='powerpc64le-linux-gnu',
             expected_deb_arch='ppc64el',
-            expected_kernel_arch='powerpc')),
+            expected_kernel_arch='powerpc',
+            expected_core_dynamic_linker='lib64/ld64.so.2')),
         ('ppc64le-kernel-ppc-userspace', dict(
             machine='ppc64le',
             architecture=('32bit', 'ELF'),
             expected_arch_triplet='powerpc-linux-gnu',
             expected_deb_arch='powerpc',
-            expected_kernel_arch='powerpc')),
+            expected_kernel_arch='powerpc',
+            expected_core_dynamic_linker='lib/ld-linux.so.2')),
         ('s390x', dict(
             machine='s390x',
             architecture=('64bit', 'ELF'),
             expected_arch_triplet='s390x-linux-gnu',
             expected_deb_arch='s390x',
-            expected_kernel_arch='s390'))
+            expected_kernel_arch='s390',
+            expected_core_dynamic_linker='lib/ld64.so.1'))
     ]
 
     @mock.patch('platform.architecture')
@@ -108,6 +121,20 @@ class NativeOptionsTestCase(tests.TestCase):
             options.deb_arch, Equals(self.expected_deb_arch))
         self.assertThat(
             options.kernel_arch, Equals(self.expected_kernel_arch))
+
+        # The core dynamic linker is correct.  Guard against stray absolute
+        # paths, as they cause os.path.join to discard the previous
+        # argument.
+        self.assertFalse(os.path.isabs(self.expected_core_dynamic_linker))
+        with mock.patch('os.path.lexists') as mock_lexists:
+            mock_lexists.return_value = True
+            with mock.patch('os.path.islink') as mock_islink:
+                mock_islink.return_value = False
+                self.assertThat(
+                    options.get_core_dynamic_linker(),
+                    Equals(os.path.join(
+                        common.get_core_path(),
+                        self.expected_core_dynamic_linker)))
 
     @mock.patch('platform.architecture')
     @mock.patch('platform.machine')


### PR DESCRIPTION
ppc64el and s390x had leading slashes on their settings for
`core-dynamic-linker`.  In some cases this caused snapcraft to
incorrectly believe that the core snap was not installed, as the target
of the symlink on the host system couldn't be resolved within the core
snap.

LP: #1722521