### PR TITLE
snapcraft.yaml: don't re-use build dir

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,12 +68,12 @@ parts:
     prepare: |
         make startup
     build: |
-        mkdir build
-        cd build
+        mkdir apt-build
+        cd apt-build
         ../configure
         make
     install: |
-        cd build
+        cd apt-build
         install -d $SNAPCRAFT_PART_INSTALL/apt
         cp -r bin/methods/* $SNAPCRAFT_PART_INSTALL/apt/
         cp -r bin/methods/* $SNAPCRAFT_PART_INSTALL/apt/


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Creating the snapcraft snap works fine as long as one is using the snap or the deb to build. However, for reasons unknown to me, when running from source, the `make startup` of the `apt` part creates a directory named `build` that clashes with the `build` scriptlet that also tries to create a directory named `build`. I'm still not sure why this only happens when building from source, but an easy fix is to simply create a different directory in the `build` scriptlet.