### PR TITLE
tests: add /snap/bin to PATH in autopkgtests

### DIFF
--- a/debian/tests/integrationtests
+++ b/debian/tests/integrationtests
@@ -7,4 +7,4 @@ echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/autopkgtest
 su ubuntu -c "SNAPCRAFT_FROM_INSTALLED=1 TEST_STORE=fake ADT_TEST=1 python3 -m unittest discover -b -v -s integration_tests"
 su ubuntu -c "SNAPCRAFT_FROM_INSTALLED=1 TEST_STORE=fake ADT_TEST=1 python3 -m unittest discover -b -v -s integration_tests/store"
 su ubuntu -c "SNAPCRAFT_FROM_INSTALLED=1 TEST_STORE=fake ADT_TEST=1 python3 -m unittest discover -b -v -s integration_tests/plugins"
-su ubuntu -c "SNAPCRAFT_FROM_INSTALLED=1 TEST_STORE=fake ADT_TEST=1 python3 -m unittest discover -b -v -s integration_tests/snapd"
+su ubuntu -c "SNAPCRAFT_FROM_INSTALLED=1 TEST_STORE=fake ADT_TEST=1 PATH=/snap/bin:$PATH python3 -m unittest discover -b -v -s integration_tests/snapd"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
Requires #1595.