### PR TITLE
kbuild plugin: if the parts build dir already contains a .config file, use it as the base config

### DIFF
--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -182,6 +182,10 @@ class KBuildPlugin(BasePlugin):
         return os.path.join(self.builddir, '.config')
 
     def do_base_config(self, config_path):
+        # if the parts build dir already contains a .config file,
+        # use it
+        if os.path.isfile(config_path):
+            return
         # if kconfigfile is provided use that
         # elif kconfigflavour is provided, assemble the ubuntu.flavour config
         # otherwise use defconfig to seed the base config


### PR DESCRIPTION

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
https://bugs.launchpad.net/snapcraft/+bug/1722494
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

If the part build dir comes bundled with a .config file, reuse it as the actual base config