### PR TITLE
python plugin: use extracted pip

### DIFF
--- a/snapcraft/plugins/_python/_sitecustomize.py
+++ b/snapcraft/plugins/_python/_sitecustomize.py
@@ -92,6 +92,20 @@ def generate_sitecustomize(python_major_version, *, stage_dir, install_dir):
         python_major_version, stage_dir=stage_dir, install_dir=install_dir)
     os.makedirs(os.path.dirname(sitecustomize_path), exist_ok=True)
 
+    # There may very well already be a sitecustomize.py already there. If so,
+    # get rid of it. Is may be a symlink to another sitecustomize.py, in which
+    # case, we'll get rid of that one as well.
+    if os.path.islink(sitecustomize_path):
+        target_path = os.path.realpath(sitecustomize_path)
+
+        # Only remove the target if it's contained within the install directory
+        if target_path.startswith(os.path.abspath(install_dir)+os.sep):
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(target_path)
+
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(sitecustomize_path)
+
     # Create our sitecustomize. Python from the archives already has one
     # which is distro-specific and not needed here, so we truncate it if it's
     # already there.

--- a/snapcraft/tests/integration/plugins/test_python_plugin.py
+++ b/snapcraft/tests/integration/plugins/test_python_plugin.py
@@ -202,7 +202,7 @@ class PythonPluginTestCase(integration.TestCase):
         self.run_snapcraft('pull', 'pip-bzr')
         self.assertThat(
             glob(os.path.join(
-                self.parts_dir, 'pip-bzr', 'packages',
+                self.parts_dir, 'pip-bzr', 'python-packages',
                 'curtin-*.zip'))[0],
             FileExists())
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Simplify the Python plugin and its tests by using the independently tested pip that was extracted in previous commits. All functionality should remain the same. Please help me test this PR thoroughly!