### PR TITLE
tests: remove the duplicate nodejs integration tests

### DIFF
--- a/integration_tests/plugins/test_nodejs_plugin.py
+++ b/integration_tests/plugins/test_nodejs_plugin.py
@@ -26,7 +26,6 @@ class NodeJSPluginTestCase(testscenarios.WithScenarios,
                            integration_tests.TestCase):
 
     scenarios = [
-        ('default', dict(package_manager='')),
         ('npm', dict(package_manager='npm')),
         ('yarn', dict(package_manager='yarn')),
     ]


### PR DESCRIPTION
The integration tests for the default package manager doesn't provide any
useful information. We have a unittest that checks that the default value
is npm.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
