### PR TITLE
plainbox-provider plugin: init PROVIDERPATH

### DIFF
--- a/snapcraft/plugins/plainbox_provider.py
+++ b/snapcraft/plugins/plainbox_provider.py
@@ -46,6 +46,10 @@ class PlainboxProviderPlugin(snapcraft.BasePlugin):
         super().build()
 
         env = os.environ.copy()
+        # Ensure the first provider does not attempt to validate against
+        # providers installed on the build host by initialising PROVIDERPATH
+        # to empty
+        env['PROVIDERPATH'] = ''
         provider_stage_dir = os.path.join(self.project.stage_dir, 'providers')
         if os.path.exists(provider_stage_dir):
             provider_dirs = [os.path.join(provider_stage_dir, provider)

--- a/snapcraft/tests/plugins/test_plainbox_provider.py
+++ b/snapcraft/tests/plugins/test_plainbox_provider.py
@@ -78,9 +78,10 @@ class PythonPluginTestCase(tests.TestCase):
 
         plugin.build()
 
+        env = os.environ.copy()
+        env['PROVIDERPATH'] = ''
         calls = [
-            mock.call(['python3', 'manage.py', 'validate'],
-                      env=os.environ.copy()),
+            mock.call(['python3', 'manage.py', 'validate'], env=env),
             mock.call(['python3', 'manage.py', 'build']),
             mock.call(['python3', 'manage.py', 'i18n']),
             mock.call(['python3', 'manage.py', 'install',


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

[LP: #1722833](https://bugs.launchpad.net/snapcraft/+bug/1722833)

Ensure PROVIDER path is set for all provider validations to
prevent providers found on the build host from effecting the
result