### PR TITLE
cross compile: enable cross compilation of i386 kernel on x86-64 hosts

### DIFF
--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -53,6 +53,7 @@ _ARCH_TRANSLATIONS = {
         'kernel': 'x86',
         'deb': 'i386',
         'uts_machine': 'i686',
+        'cross-compiler-prefix': '',
         'triplet': 'i386-linux-gnu',
     },
     'ppc64le': {


### PR DESCRIPTION
Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>

- [x ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
https://bugs.launchpad.net/snapcraft/+bug/1563363
- [ x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ x] Have you successfully run `./runtests.sh static`?
- [ x] Have you successfully run `./runtests.sh unit`?

-----
