### PR TITLE
cross compilation: enable cross compilation of i386 kernel on x86-64 …

### DIFF
--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -162,7 +162,7 @@ class ProjectOptions:
             # to start the build
             if (self.__platform_arch == 'x86_64' and
                     self.__target_machine == 'i686'):
-                return
+                return ''
             return self.__machine_info['cross-compiler-prefix']
         except KeyError:
             raise SnapcraftEnvironmentError(

--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -156,6 +156,13 @@ class ProjectOptions:
     @property
     def cross_compiler_prefix(self):
         try:
+            # cross-compilation of x86 32bit binaries on a x86_64 host is
+            # possible by reusing the native toolchain - let Kbuild figure
+            # it out by itself and pass down an empy cross-compiler-prefix
+            # to start the build
+            if (self.__platform_arch == 'x86_64' and
+                    self.__target_machine == 'i686'):
+                return
             return self.__machine_info['cross-compiler-prefix']
         except KeyError:
             raise SnapcraftEnvironmentError(

--- a/snapcraft/tests/test_options.py
+++ b/snapcraft/tests/test_options.py
@@ -163,3 +163,12 @@ class OptionsTestCase(tests.TestCase):
                 SnapcraftEnvironmentError,
                 "Cross compilation not supported for target arch 'x86_64'"):
             options.cross_compiler_prefix
+
+    @mock.patch('platform.architecture')
+    @mock.patch('platform.machine')
+    def test_cross_compiler_prefix_empty(
+            self, mock_platform_machine, mock_platform_architecture):
+        mock_platform_machine.return_value = 'x86_64'
+        mock_platform_architecture.return_value = ('64bit', 'ELF')
+        options = snapcraft.ProjectOptions(target_deb_arch='i386')
+        self.assertThat(options.cross_compiler_prefix, Equals(None))

--- a/snapcraft/tests/test_options.py
+++ b/snapcraft/tests/test_options.py
@@ -171,4 +171,4 @@ class OptionsTestCase(tests.TestCase):
         mock_platform_machine.return_value = 'x86_64'
         mock_platform_architecture.return_value = ('64bit', 'ELF')
         options = snapcraft.ProjectOptions(target_deb_arch='i386')
-        self.assertThat(options.cross_compiler_prefix, Equals(None))
+        self.assertThat(options.cross_compiler_prefix, Equals(''))


### PR DESCRIPTION
…hosts

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
https://bugs.launchpad.net/snapcraft/+bug/1563363
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
Fixes: [bug 1563363](https://bugs.launchpad.net/snapcraft/+bug/1563363)