### PR TITLE
apt repo: allow insecure repos

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -66,6 +66,13 @@ class _AptCache:
         # Do not install recommends
         apt.apt_pkg.config.set('Apt::Install-Recommends', 'False')
 
+        # Don't verify repository keys. FIXME: We should have a way to simply
+        # ack keys for extra repositories. We're only setting this here because
+        # in Xenial it defaulted to True, but in Zesty that has changed to
+        # False, and we want consistent behavior. This is, however, not a
+        # long-term solution.
+        apt.apt_pkg.config.set('Acquire::AllowInsecureRepositories', 'True')
+
         # Methods and solvers dir for when in the SNAP
         if common.is_snap():
             snap_dir = os.getenv('SNAP')

--- a/snapcraft/tests/repo/test_deb.py
+++ b/snapcraft/tests/repo/test_deb.py
@@ -76,6 +76,7 @@ class UbuntuTestCase(RepoBaseTestCase):
 
         mock_apt_pkg.assert_has_calls([
             call.config.set('Apt::Install-Recommends', 'False'),
+            call.config.set('Acquire::AllowInsecureRepositories', 'True'),
             call.config.find_file('Dir::Etc::Trusted'),
             call.config.set('Dir::Etc::Trusted', ANY),
             call.config.find_file('Dir::Etc::TrustedParts'),
@@ -115,6 +116,7 @@ class UbuntuTestCase(RepoBaseTestCase):
 
         mock_apt_pkg.assert_has_calls([
             call.config.set('Apt::Install-Recommends', 'False'),
+            call.config.set('Acquire::AllowInsecureRepositories', 'True'),
             call.config.find_file('Dir::Etc::Trusted'),
             call.config.set('Dir::Etc::Trusted', ANY),
             call.config.find_file('Dir::Etc::TrustedParts'),


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

In Xenial this was the default behavior, which explains why Snapcraft works. However, in Zesty this behavior changed, causing breakage when using external repositories (e.g. ROS). Instead of relying on defaults, ensure the behavior is consistent across releases.

This is not a long-term fix. We should add a way to ack repository keys.