### PR TITLE
schema: improve invalid app, hook, and part errors

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -120,6 +120,9 @@ properties:
   apps:
     type: object
     additionalProperties: false
+    validation-failure:
+            "{!r} is not a valid app name. App names consist of upper- and
+            lower-case alphanumeric characters and hyphens."
     patternProperties:
       "^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$":
         type: object
@@ -202,6 +205,9 @@ properties:
   hooks:
     type: object
     additionalProperties: false
+    validation-failure:
+        "{!r} is not a valid hook name. Hook names consist of upper- and
+        lower-case alphanumeric characters and hyphens."
     patternProperties:
       "^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$":
         type: object
@@ -217,6 +223,10 @@ properties:
     type: object
     minProperties: 1
     additionalProperties: false
+    validation-failure:
+        "{!r} is not a valid part name. Part names consist of lower-case
+        alphanumeric characters, hyphens, plus signs, and forward slashes. As a
+        special case, 'plugins' is also not a valid part name."
     patternProperties:
       ^(?!plugins$)[a-z0-9][a-z0-9+-\/]*$:
         # Make sure snap/prime are mutually exclusive
@@ -224,7 +234,8 @@ properties:
           - not:
               type: object
               required: [snap, prime]
-              validation-failure: "{.instance} cannot contain both 'snap' and 'prime' keywords."
+              validation-failure:
+                  "{.instance} cannot contain both 'snap' and 'prime' keywords."
         type: object
         minProperties: 1
         properties:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently, when one attempts to use an invalid app, hook, or part name, rather than saying something about it being an invalid name because it didn't match the regex, jsonschema uses the `additionalProperties` validator, which makes the error message extra awful, e.g.:

    Issues while validating snapcraft.yaml: The 'apps' property does not match the required schema: Additional properties are not allowed ('invalid_app_name' was unexpected)

This PR fixes LP: [#1606890](https://bugs.launchpad.net/snapcraft/+bug/1606890) by improving these messages, adding custom in-schema validation errors for them instead of relying on jsonschema.