### PR TITLE
store: guide to account creation upon login

### DIFF
--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -383,7 +383,9 @@ class StoreTestCase(TestCase):
         process = pexpect.spawn(self.snapcraft_command, ['login'])
 
         process.expect_exact(
-            'Enter your Ubuntu One SSO credentials.\r\n'
+            'Enter your Ubuntu One e-mail address and password.\r\n'
+            'If you do not have an Ubuntu One account, you can create one at '
+            'https://dashboard.snapcraft.io/openid/login\r\n'
             'Email: ')
         process.sendline(email)
         process.expect_exact('Password: ')
@@ -396,8 +398,7 @@ class StoreTestCase(TestCase):
 
     def logout(self):
         output = self.run_snapcraft('logout')
-        expected = (r'.*Clearing credentials for Ubuntu One SSO.\n'
-                    r'Credentials cleared.\n.*')
+        expected = (r'.*Credentials cleared.\n.*')
         self.assertThat(output, MatchesRegex(expected, flags=re.DOTALL))
 
     def register(self, snap_name, private=False, wait=True):
@@ -434,7 +435,9 @@ class StoreTestCase(TestCase):
             self.snapcraft_command, ['register-key', key_name])
 
         process.expect_exact(
-            'Enter your Ubuntu One SSO credentials.\r\n'
+            'Enter your Ubuntu One e-mail address and password.\r\n'
+            'If you do not have an Ubuntu One account, you can create one at '
+            'https://dashboard.snapcraft.io/openid/login\r\n'
             'Email: ')
         process.sendline(email)
         process.expect_exact('Password: ')

--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -117,7 +117,9 @@ def _check_dev_agreement_and_namespace_statuses(store):
 
 
 def _login(store, packages=None, acls=None, channels=None, save=True):
-    print('Enter your Ubuntu One SSO credentials.')
+    print('Enter your Ubuntu One e-mail address and password.\n'
+          'If you do not have an Ubuntu One account, you can create one at '
+          'https://dashboard.snapcraft.io/openid/login')
     email = input('Email: ')
     password = getpass.getpass('Password: ')
 

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -230,7 +230,11 @@ def list_registered():
 
 @storecli.command()
 def login():
-    """Authenticate session against Ubuntu One SSO."""
+    """Login with your Ubuntu One e-mail address and password.
+
+    If you do not have an Ubuntu One account, you can create one at
+    https://dashboard.snapcraft.io/openid/login
+    """
     if not snapcraft.login():
         sys.exit(1)
 
@@ -238,7 +242,6 @@ def login():
 @storecli.command()
 def logout():
     """Clear session credentials."""
-    echo.info('Clearing credentials for Ubuntu One SSO.')
     store = storeapi.StoreClient()
     store.logout()
     echo.info('Credentials cleared.')

--- a/snapcraft/tests/commands/test_logout.py
+++ b/snapcraft/tests/commands/test_logout.py
@@ -30,6 +30,4 @@ class LogoutCommandTestCase(CommandBaseTestCase):
 
         self.assertThat(result.exit_code, Equals(0))
         self.assertThat(result.output, MatchesRegex(
-            'Clearing credentials for Ubuntu One SSO.\n'
-            '.*'
-            'Credentials cleared.\n', flags=re.DOTALL))
+            '.*Credentials cleared.\n', flags=re.DOTALL))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

As the snapcraft workflow becomes more and more CLI-driven, it may not be clear to developers who start with snapcraft how to create an account.

This PR fixes LP: [#1649356](https://bugs.launchpad.net/snapcraft/+bug/1649356) by adding a note when the user attempts to login.