### PR TITLE
Add options to configure applications socket activation

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -249,6 +249,30 @@ properties:
             description: What kind of wrapper to generate for the given command
             enum:
               - none
+          sockets:
+            type: object
+            additionalProperties: false
+            validation-failure:
+              "{!r} is not a valid socket name. Socket names consist of
+              lower-case alphanumeric characters and hyphens."
+            patternProperties:
+              "^[a-z][a-z0-9_-]*$":
+                type: object
+                required:
+                  - listen-stream
+                description: Sockets for automatic service activation
+                additionalProperties: false
+                properties:
+                  listen-stream:
+                    anyOf:
+                      - type: integer
+                        usage: "port number, an integer between 1 and 65535"
+                        minimum: 1
+                        maximum: 65535
+                      - type: string
+                        usage: "socket path, a string"
+                  socket-mode:
+                    type: integer
   hooks:
     type: object
     additionalProperties: false

--- a/snapcraft/tests/unit/test_meta.py
+++ b/snapcraft/tests/unit/test_meta.py
@@ -282,6 +282,22 @@ class CreateTestCase(CreateBaseTestCase):
         self.assertFalse('icon' in y,
                          'icon found in snap.yaml {}'.format(y))
 
+    def test_create_meta_with_sockets(self):
+        os.mkdir(self.prime_dir)
+        _create_file(os.path.join(self.prime_dir, 'app.sh'))
+        sockets = {
+            'sock1': {
+                'listen-stream': 8080,
+            },
+            'sock2': {
+                'listen-stream': '$SNAP_COMMON/sock2',
+                'socket-mode': 0o640}}
+        self.config_data['apps'] = {
+            'app': {'command': 'app.sh',
+                    'sockets':  sockets}}
+        y = self.generate_meta_yaml()
+        self.assertThat(y['apps']['app']['sockets'], Equals(sockets))
+
     def test_version_script(self):
         self.config_data['version-script'] = 'echo 10.1-devel'
 


### PR DESCRIPTION
This adds schema and rendering for the `sockets` entries in `apps`, to configure socket activations for deamons. See https://github.com/snapcore/snapd/pull/3916 for the snapd implementation 