### PR TITLE
states: add scriptlets to build state

### DIFF
--- a/snapcraft/internal/states/_build_state.py
+++ b/snapcraft/internal/states/_build_state.py
@@ -32,7 +32,10 @@ def _schema_properties():
         'build-attributes',
         'build-packages',
         'disable-parallel',
-        'organize'
+        'organize',
+        'prepare',
+        'build',
+        'install',
     }
 
 

--- a/snapcraft/tests/pluginhandler/test_pluginhandler.py
+++ b/snapcraft/tests/pluginhandler/test_pluginhandler.py
@@ -869,9 +869,10 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(state, 'Expected build to save state YAML')
         self.assertTrue(type(state) is states.BuildState)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertThat(len(state.properties), Equals(5))
+        self.assertThat(len(state.properties), Equals(8))
         for expected in ['after', 'build-attributes', 'build-packages',
-                         'disable-parallel', 'organize']:
+                         'disable-parallel', 'organize', 'prepare', 'build',
+                         'install']:
             self.assertTrue(expected in state.properties)
         self.assertTrue(type(state.project_options) is OrderedDict)
         self.assertTrue('deb_arch' in state.project_options)

--- a/snapcraft/tests/states/test_build.py
+++ b/snapcraft/tests/states/test_build.py
@@ -57,11 +57,14 @@ class BuildStateTestCase(BuildStateBaseTestCase):
             'build-attributes': ['test-build-attribute'],
             'build-packages': 'test-build-packages',
             'disable-parallel': 'test-disable-parallel',
-            'organize': {'baz': 'qux'}
+            'organize': {'baz': 'qux'},
+            'prepare': 'touch prepare',
+            'build': 'touch build',
+            'install': 'touch install',
         })
 
         properties = self.state.properties_of_interest(self.part_properties)
-        self.assertThat(len(properties), Equals(6))
+        self.assertThat(len(properties), Equals(9))
         self.assertThat(properties['foo'], Equals('bar'))
         self.assertThat(properties['after'], Equals('test-after'))
         self.assertThat(
@@ -71,6 +74,9 @@ class BuildStateTestCase(BuildStateBaseTestCase):
         self.assertThat(
             properties['disable-parallel'], Equals('test-disable-parallel'))
         self.assertThat(properties['organize'], Equals({'baz': 'qux'}))
+        self.assertThat(properties['prepare'], Equals('touch prepare'))
+        self.assertThat(properties['build'], Equals('touch build'))
+        self.assertThat(properties['install'], Equals('touch install'))
 
     def test_project_options_of_interest(self):
         options = self.state.project_options_of_interest(self.project)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently, if one of the scriptlets (`prepare`, `build`, or `install`) changes, Snapcraft doesn't notice. This PR fixes LP: [#1672407](https://bugs.launchpad.net/snapcraft/+bug/1672407) by adding them to the build state so that if one of more of these scriptlets change, Snapcraft considers the build step dirty.