### PR TITLE
tests: don't hit internet in ros2 units

### DIFF
--- a/snapcraft/tests/plugins/ros/test_ros2.py
+++ b/snapcraft/tests/plugins/ros/test_ros2.py
@@ -46,8 +46,12 @@ class Ros2TestCase(tests.TestCase):
         self.check_call_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
-    def test_pull(self):
+    @mock.patch('snapcraft.sources.Script')
+    def test_pull(self, mock_script):
         self.bootstrapper.pull()
+
+        # Assert that the ros2 repos file was pulled down
+        mock_script.return_value.download.assert_called_once_with()
 
         # Verify that python3-vcstool is installed
         self.ubuntu_mock.assert_has_calls([


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

This causes the PPA tests to fail, and shouldn't be happening in general anyway.