### PR TITLE
plugins: build-attributes is already in the state

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -204,7 +204,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
     def get_build_properties(cls):
         # Inform Snapcraft of the properties associated with building. If these
         # change in the YAML Snapcraft will consider the build step dirty.
-        return ['build-attributes', 'catkin-cmake-args']
+        return ['catkin-cmake-args']
 
     @property
     def _pip(self):

--- a/snapcraft/plugins/dotnet.py
+++ b/snapcraft/plugins/dotnet.py
@@ -63,18 +63,6 @@ class DotNetPlugin(snapcraft.BasePlugin):
 
         return schema
 
-    @classmethod
-    def get_pull_properties(cls):
-        # Inform Snapcraft of the properties associated with pulling. If these
-        # change in the YAML Snapcraft will consider the build step dirty.
-        return []
-
-    @classmethod
-    def get_build_properties(cls):
-        # Inform Snapcraft of the properties associated with building. If these
-        # change in the YAML Snapcraft will consider the build step dirty.
-        return ['build-attributes']
-
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 

--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -109,8 +109,7 @@ class KBuildPlugin(BasePlugin):
     def get_build_properties(cls):
         # Inform Snapcraft of the properties associated with building. If these
         # change in the YAML Snapcraft will consider the build step dirty.
-        return ['kdefconfig', 'kconfigfile', 'kconfigs', 'kconfigflavour',
-                'build-attributes']
+        return ['kdefconfig', 'kconfigfile', 'kconfigs', 'kconfigflavour']
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)

--- a/snapcraft/tests/plugins/test_catkin.py
+++ b/snapcraft/tests/plugins/test_catkin.py
@@ -299,7 +299,7 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
             self.assertIn(property, actual_pull_properties)
 
     def test_get_build_properties(self):
-        expected_build_properties = ['build-attributes', 'catkin-cmake-args']
+        expected_build_properties = ['catkin-cmake-args']
         actual_build_properties = catkin.CatkinPlugin.get_build_properties()
 
         self.assertThat(actual_build_properties,

--- a/snapcraft/tests/plugins/test_dotnet.py
+++ b/snapcraft/tests/plugins/test_dotnet.py
@@ -55,7 +55,7 @@ class DotNetPluginTestCase(tests.TestCase):
             Equals(expected_pull_properties))
 
     def test_get_build_properties(self):
-        expected_build_properties = ['build-attributes']
+        expected_build_properties = []
         self.assertThat(
             dotnet.DotNetPlugin.get_build_properties(),
             Equals(expected_build_properties))

--- a/snapcraft/tests/plugins/test_kbuild.py
+++ b/snapcraft/tests/plugins/test_kbuild.py
@@ -65,8 +65,7 @@ class KBuildPluginTestCase(tests.TestCase):
 
     def test_get_build_properties(self):
         expected_build_properties = ['kdefconfig', 'kconfigfile',
-                                     'kconfigflavour', 'kconfigs',
-                                     'build-attributes']
+                                     'kconfigflavour', 'kconfigs']
         resulting_build_properties = kbuild.KBuildPlugin.get_build_properties()
 
         self.assertThat(resulting_build_properties,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

The build state tracks `build-attributes` as a build property, which means if it changes, the build step is considered dirty. However, a few plugins have also added `build-attributes` to their build properties, which is redundant.

This PR makes sure the core Snapcraft properties are handled in the state classes, and keep the plugins handling their own schema. While we have tests covering this, you can verify `build-attributes` still makes the `build` step dirty manually with the following:

```
$ snapcraft init
Created snap/snapcraft.yaml.
Edit the file to your liking or run `snapcraft` to get started
$ snapcraft build
Preparing to pull my-part 
Pulling my-part 
Preparing to build my-part 
Building my-part 
$ echo "    build-attributes: [debug]" >> snap/snapcraft.yaml 
$ snapcraft build
Skipping pull my-part (already ran)
The 'build' step of 'my-part' is out of date:
The 'build-attributes' part property appears to have changed.
In order to continue, please clean that part's 'build' step by running:
snapcraft clean my-part -s build
```