### PR TITLE
integration tests: skip catkin test on non-xenial

### DIFF
--- a/integration_tests/snapd/test_catkin_snap.py
+++ b/integration_tests/snapd/test_catkin_snap.py
@@ -15,15 +15,19 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import subprocess
+from unittest import skipUnless
 
 from testtools.matchers import Contains
 
 import integration_tests
 from snapcraft.tests import fixture_setup
+from snapcraft.internal.common import get_os_release_info
 
 
 class CatkinTestCase(integration_tests.SnapdIntegrationTestCase):
 
+    @skipUnless(get_os_release_info()['VERSION_CODENAME'] == 'xenial',
+                'ROS Kinetic targets xenial, nothing later')
     def test_catkin_pip_support(self):
         with fixture_setup.WithoutSnapInstalled('ros-pip-example'):
             self.run_snapcraft(project_dir='ros-pip')

--- a/integration_tests/snapd/test_catkin_snap.py
+++ b/integration_tests/snapd/test_catkin_snap.py
@@ -26,8 +26,8 @@ from snapcraft.internal.common import get_os_release_info
 
 class CatkinTestCase(integration_tests.SnapdIntegrationTestCase):
 
-    @skipUnless(get_os_release_info()['VERSION_CODENAME'] == 'xenial',
-                'ROS Kinetic targets xenial, nothing later')
+    @skipUnless(get_os_release_info().get('VERSION_CODENAME') == 'xenial',
+                'ROS Kinetic only targets Ubuntu Xenial')
     def test_catkin_pip_support(self):
         with fixture_setup.WithoutSnapInstalled('ros-pip-example'):
             self.run_snapcraft(project_dir='ros-pip')


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

The Catkin test uses ROS Kinetic, which targets Ubuntu releases no later than Xenial. So don't expect them to work there. This also gets us around the fact that we have no way for handling third-party repository keys just yet.