### PR TITLE
schema: sync patterns with snapd

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -37,7 +37,11 @@ properties:
   name:
     type: string
     description: name of the snap package
-    pattern: "^[a-z0-9][a-z0-9+-]*$"
+    validation-failure:
+      "{.instance!r} is not a valid snap name. Snap names consist of lower-case
+      alphanumeric characters and hyphens. They cannot be all numbers. They
+      also cannot start or end with a hyphen."
+    pattern: "^(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9])*$"
   architectures:
     type: array
     description: architectures to override with
@@ -49,6 +53,10 @@ properties:
     # python's defaul yaml loading code loads 1.0 as an int
     # type: string
     description: package version
+    validation-failure:
+      "{.instance!r} is not a valid snap version. Snap versions consist of
+      upper- and lower-case alphanumeric characters, as well as periods, plus
+      signs, tildes, and hyphens."
     pattern: "^[a-zA-Z0-9.+~-]+$"
     maxLength: 32
   version-script:
@@ -122,7 +130,8 @@ properties:
     additionalProperties: false
     validation-failure:
             "{!r} is not a valid app name. App names consist of upper- and
-            lower-case alphanumeric characters and hyphens."
+            lower-case alphanumeric characters and hyphens. They cannot start
+            or end with a hyphen."
     patternProperties:
       "^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$":
         type: object
@@ -206,10 +215,11 @@ properties:
     type: object
     additionalProperties: false
     validation-failure:
-        "{!r} is not a valid hook name. Hook names consist of upper- and
-        lower-case alphanumeric characters and hyphens."
+        "{!r} is not a valid hook name. Hook names consist of lower-case
+        alphanumeric characters and hyphens. They cannot start or end with a
+        hyphen."
     patternProperties:
-      "^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$":
+      "^[a-z](?:-?[a-z0-9])*$":
         type: object
         additionalProperties: false
         properties:

--- a/snapcraft/tests/project_loader/test_config.py
+++ b/snapcraft/tests/project_loader/test_config.py
@@ -429,7 +429,10 @@ parts:
         self.assertThat(
             raised.message,
             Equals("The 'name' property does not match the required "
-                   "schema: 1 is not of type 'string'"))
+                   "schema: 1 is not a valid snap name. Snap names "
+                   "consist of lower-case alphanumeric characters and "
+                   "hyphens. They cannot be all numbers. They also cannot "
+                   "start or end with a hyphen."))
 
     def test_invalid_yaml_invalid_icon_extension(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
@@ -502,7 +505,10 @@ parts:
         self.assertThat(
             raised.message,
             Equals("The 'name' property does not match the required schema: "
-                   "'myapp@me_1.0' does not match '^[a-z0-9][a-z0-9+-]*$'"))
+                   "'myapp@me_1.0' is not a valid snap name. Snap names "
+                   "consist of lower-case alphanumeric characters and "
+                   "hyphens. They cannot be all numbers. They also cannot "
+                   "start or end with a hyphen."))
 
     def test_invalid_yaml_missing_description(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
@@ -829,7 +835,35 @@ parts:
         self.assertThat(
             raised.message,
             Equals("The 'version' property does not match the required "
-                   "schema: '' does not match '^[a-zA-Z0-9.+~-]+$'"))
+                   "schema: '' is not a valid snap version. Snap versions "
+                   "consist of upper- and lower-case alphanumeric characters, "
+                   "as well as periods, plus signs, tildes, and hyphens."))
+
+    def test_invalid_yaml_invalid_version(self):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        self.make_snapcraft_yaml(dedent("""
+            name: test
+            version: '*'
+            summary: test
+            description: test
+            confinement: strict
+            grade: stable
+            parts:
+              part1:
+                plugin: nil
+        """))
+        raised = self.assertRaises(
+            errors.YamlValidationError,
+            _config.Config)
+
+        self.assertThat(
+            raised.message,
+            Equals("The 'version' property does not match the required "
+                   "schema: '*' is not a valid snap version. Snap versions "
+                   "consist of upper- and lower-case alphanumeric characters, "
+                   "as well as periods, plus signs, tildes, and hyphens."))
 
     def test_invalid_yaml_version_too_long(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
@@ -1130,7 +1164,7 @@ class InvalidHookNamesYamlTestCase(YamlBaseTestCase):
         name in [
             '', '-', '--', 'a--a', 'a-', 'a ', ' a', 'a a', '日本語', '한글',
             'ру́сский язы́к', 'ໄຂ່​ອີ​ສ​ເຕີ້', ':a', 'a:', 'a:a', '_a', 'a_',
-            'a_a',
+            'a_a', 'Hi',
         ]
     ]
 
@@ -1160,8 +1194,8 @@ parts:
         self.assertRegex(
             raised.message,
             "The 'hooks' property does not match the required schema: .* is "
-            'not a valid hook name. Hook names consist of upper- and '
-            'lower-case alphanumeric characters and hyphens')
+            'not a valid hook name. Hook names consist of lower-case '
+            'alphanumeric characters and hyphens')
 
 
 class ValidConfinmentTypesYamlTestCase(YamlBaseTestCase):
@@ -2075,7 +2109,10 @@ class RequiredPropertiesTestCase(ValidationBaseTestCase):
 class InvalidNamesTestCase(ValidationBaseTestCase):
 
     scenarios = [(name, dict(name=name)) for
-                 name in ['package@awesome', 'something.another', '_hideme']]
+                 name in [
+                    'package@awesome', 'something.another', '_hideme', '-no',
+                    'a:a', '123'
+    ]]
 
     def test_invalid_names(self):
         data = self.data.copy()
@@ -2085,9 +2122,11 @@ class InvalidNamesTestCase(ValidationBaseTestCase):
             errors.YamlValidationError,
             project_loader.Validator(data).validate)
 
-        expected_message = ("The 'name' property does not match the "
-                            "required schema: '{}' does not match "
-                            "'^[a-z0-9][a-z0-9+-]*$'").format(self.name)
+        expected_message = (
+            "The 'name' property does not match the required schema: '{}' is "
+            "not a valid snap name. Snap names consist of lower-case "
+            "alphanumeric characters and hyphens. They cannot be all numbers. "
+            "They also cannot start or end with a hyphen.").format(self.name)
         self.assertThat(raised.message, Equals(expected_message),
                         message=data)
 
@@ -2157,7 +2196,8 @@ class InvalidAppNamesTestCase(ValidationBaseTestCase):
         expected_message = (
             "The 'apps' property does not match the required schema: {!r} is "
             "not a valid app name. App names consist of upper- and lower-case "
-            "alphanumeric characters and hyphens.").format(self.name)
+            "alphanumeric characters and hyphens. They cannot start or end "
+            "with a hyphen.").format(self.name)
         self.assertThat(raised.message, Equals(expected_message),
                         message=data)
 
@@ -2165,7 +2205,7 @@ class InvalidAppNamesTestCase(ValidationBaseTestCase):
 class InvalidHookNamesTestCase(ValidationBaseTestCase):
 
     scenarios = [(name, dict(name=name)) for
-                 name in ['qwe#rty', 'qwe_rty', 'que rty', 'que  rty']]
+                 name in ['qwe#rty', 'qwe_rty', 'que rty', 'que  rty', 'Hi']]
 
     def test_invalid_app_names(self):
         data = self.data.copy()
@@ -2177,8 +2217,9 @@ class InvalidHookNamesTestCase(ValidationBaseTestCase):
 
         expected_message = (
             "The 'hooks' property does not match the required schema: {!r} is "
-            "not a valid hook name. Hook names consist of upper- and "
-            "lower-case alphanumeric characters and hyphens.").format(
+            "not a valid hook name. Hook names consist of lower-case "
+            "alphanumeric characters and hyphens. They cannot start or end "
+            "with a hyphen.").format(
                 self.name)
         self.assertThat(raised.message, Equals(expected_message),
                         message=data)
@@ -2190,7 +2231,7 @@ class InvalidPartNamesTestCase(ValidationBaseTestCase):
                  name in [
                     'plugins', 'qwe#rty', 'qwe_rty', 'que rty', 'que  rty']]
 
-    def test_invalid_app_names(self):
+    def test_invalid_part_names(self):
         data = self.data.copy()
         data['parts'] = {self.name: {'plugin': 'nil'}}
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

The snap name and hook name patterns got out of sync. This PR fixes LP: [#1693798](https://bugs.launchpad.net/snapcraft/+bug/1693798) by getting them back in sync. It also updates the jsonschema error handling to be more readable.