### PR TITLE
Removed dependency on VERSION_ID in os-release

### DIFF
--- a/snapcraft/internal/libraries.py
+++ b/snapcraft/internal/libraries.py
@@ -66,10 +66,13 @@ def _get_system_libs():
     if _libraries:
         return _libraries
 
-    release = common.get_os_release_info()['VERSION_ID']
-    lib_path = os.path.join(common.get_librariesdir(), release)
+    try:
+        release = common.get_os_release_info()['VERSION_ID']
+        lib_path = os.path.join(common.get_librariesdir(), release)
+    except KeyError:
+        lib_path = None
 
-    if not os.path.exists(lib_path):
+    if not lib_path or not os.path.exists(lib_path):
         logger.debug('No libraries to exclude from this release')
         # Always exclude libc.so.6
         return frozenset(['libc.so.6'])

--- a/snapcraft/tests/test_libraries.py
+++ b/snapcraft/tests/test_libraries.py
@@ -146,3 +146,29 @@ class TestSystemLibsOnNewRelease(tests.TestCase):
 
     def test_fail_gracefully_if_system_libs_not_found(self):
         self.assertThat(libraries.get_dependencies('foo'), Equals([]))
+
+
+class TestSystemLibsOnReleasesWithNoVersionId(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        libraries._libraries = None
+
+        patcher = mock.patch('snapcraft.internal.common.get_os_release_info')
+        distro_mock = patcher.start()
+        distro_mock.return_value = {'NAME': 'Gentoo',
+                                    'ID': 'gentoo',
+                                    'PRETTY_NAME': "Gentoo/Linux",
+                                    'ANSI_COLOR': "1;32",
+                                    'HOME_URL': "http://www.gentoo.org/",
+                                    'SUPPORT_URL':
+                                        "http://www.gentoo.org/main/en/support\
+                                        .xml",
+                                    'BUG_REPORT_URL':
+                                        "https://bugs.gentoo.org/"}
+        self.addCleanup(patcher.stop)
+
+    def test_fail_gracefully_if_no_version_id_found(self):
+        self.assertThat(libraries._get_system_libs(),
+                        Equals(frozenset(['libc.so.6'])))


### PR DESCRIPTION
_get_system_libs depends on VERSION_ID for the name of the file that is
expected to contain the list of shared libraries to exclude from the build.
However, according to os-release(5), VERSION_ID is just optional, so its
absence should not cause failures.

With this commit, the absence of VERSION_ID is considered as the file
with the list of shared libraries to be excluded does not exist.

Fixes https://bugs.launchpad.net/snapcraft/+bug/1722650

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
