### PR TITLE
tests: allow to select a suite when running autopkgtests

### DIFF
--- a/debian/tests/integrationtests
+++ b/debian/tests/integrationtests
@@ -4,7 +4,16 @@ set -e
 
 echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/autopkgtest
 
-su ubuntu -c "SNAPCRAFT_FROM_INSTALLED=1 TEST_STORE=fake ADT_TEST=1 python3 -m unittest discover -b -v -s integration_tests"
-su ubuntu -c "SNAPCRAFT_FROM_INSTALLED=1 TEST_STORE=fake ADT_TEST=1 python3 -m unittest discover -b -v -s integration_tests/store"
-su ubuntu -c "SNAPCRAFT_FROM_INSTALLED=1 TEST_STORE=fake ADT_TEST=1 python3 -m unittest discover -b -v -s integration_tests/plugins"
-su ubuntu -c "SNAPCRAFT_FROM_INSTALLED=1 SNAPCRAFT_SLOW_TESTS=1 TEST_STORE=fake ADT_TEST=1 PATH=/snap/bin:$PATH python3 -m unittest discover -b -v -s integration_tests/snapd"
+if [ -z "$SNAPCRAFT_AUTOPKGTEST_SUITES" ]; then
+    suites="integration_tests integration_tests/store integration_tests/plugins integration_tests/snapd"
+else
+    suites=$SNAPCRAFT_AUTOPKGTEST_SUITES
+fi
+
+if [ -z "$SNAPCRAFT_SLOW_TESTS" ]; then
+    SNAPCRAFT_SLOW_TESTS=1
+fi
+
+for suite in $suites; do
+    su ubuntu -c "SNAPCRAFT_FROM_INSTALLED=1 TEST_STORE=fake ADT_TEST=1 PATH=/snap/bin:$PATH python3 -m unittest discover -b -v -s ${suite}"
+done


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This PR needs to be split in two, because I first need this tiny change in the PPA in order to use it in the travis daily. I'll propose the second part once I get this change into the daily PPA.