### PR TITLE
lxd: use FakeFilesystem in test_snap_containerized_remote

### DIFF
--- a/snapcraft/tests/commands/test_snap.py
+++ b/snapcraft/tests/commands/test_snap.py
@@ -175,21 +175,16 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
         ])
 
     @mock.patch('snapcraft.internal.lxd.Containerbuild._container_run')
-    @mock.patch('shutil.rmtree')
-    @mock.patch('os.makedirs')
     @mock.patch('os.pipe')
-    @mock.patch('snapcraft.internal.lxd.open')
     def test_snap_containerized_remote(self,
-                                       mock_open,
                                        mock_pipe,
-                                       mock_makedirs,
-                                       mock_rmtree,
                                        mock_container_run):
         mock_container_run.side_effect = lambda cmd, **kwargs: cmd
-        mock_open.return_value = mock.MagicMock(spec=open)
         mock_pipe.return_value = (9, 9)
         fake_lxd = fixture_setup.FakeLXD()
         self.useFixture(fake_lxd)
+        fake_filesystem = fixture_setup.FakeFilesystem()
+        self.useFixture(fake_filesystem)
         fake_logger = fixtures.FakeLogger(level=logging.INFO)
         self.useFixture(fake_logger)
         self.useFixture(fixtures.EnvironmentVariable(


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This fixes the following issue visible in autopkg tests:

`ERROR: test_snap_containerized_remote (snapcraft.tests.commands.test_snap.SnapCommandTestCase)
snapcraft.tests.commands.test_snap.SnapCommandTestCase.test_snap_containerized_remote
[...]
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/autopkgtest.TRPyxT/build.nts/snapcraft/.pybuild/pythonX.Y_3.5/snap/lxd/common/snapcraft_06fb0ou'`

The test is mocking creation of ~/snap/lxd/common without handling `open`. Using `FakeFileSystem` takes care of that.