### PR TITLE
libraries: exclude the full set of libc6

### DIFF
--- a/snapcraft/internal/libraries.py
+++ b/snapcraft/internal/libraries.py
@@ -20,7 +20,7 @@ import logging
 import os
 import subprocess
 
-from snapcraft.internal import common
+from snapcraft.internal import common, repo
 
 
 logger = logging.getLogger(__name__)
@@ -73,9 +73,10 @@ def _get_system_libs():
         lib_path = None
 
     if not lib_path or not os.path.exists(lib_path):
-        logger.debug('No libraries to exclude from this release')
-        # Always exclude libc.so.6
-        return frozenset(['libc.so.6'])
+        logger.debug('Only excluding libc libraries from the release')
+        libc6_libs = [os.path.basename(l)
+                      for l in repo.Repo.get_package_libraries('libc6')]
+        return frozenset(libc6_libs)
 
     with open(lib_path) as fn:
         _libraries = frozenset(fn.read().split())

--- a/snapcraft/tests/test_libraries.py
+++ b/snapcraft/tests/test_libraries.py
@@ -169,6 +169,8 @@ class TestSystemLibsOnReleasesWithNoVersionId(tests.TestCase):
                                         "https://bugs.gentoo.org/"}
         self.addCleanup(patcher.stop)
 
-    def test_fail_gracefully_if_no_version_id_found(self):
+    @mock.patch('snapcraft.internal.libraries.repo.Repo.get_package_libraries',
+                return_value=['/usr/lib/libc.so.6', '/lib/libpthreads.so.6'])
+    def test_fail_gracefully_if_no_version_id_found(self, mock_package_libs):
         self.assertThat(libraries._get_system_libs(),
-                        Equals(frozenset(['libc.so.6'])))
+                        Equals(frozenset(['libc.so.6', 'libpthreads.so.6'])))


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
