### PR TITLE
snap: remove leaking LD_LIBRARY_PATH

### DIFF
--- a/bin/snapcraft-classic
+++ b/bin/snapcraft-classic
@@ -1,21 +1,5 @@
 #!/bin/sh
 
-case $SNAP_ARCH in
-amd64)
-        TRIPLET="x86_64-linux-gnu"
-        ;;
-armhf)
-        TRIPLET="arm-linux-gnueabihf"
-        ;;
-arm64)
-        TRIPLET="aarch64-linux-gnu"
-        ;;
-*)
-	TRIPLET="$(uname -p)-linux-gnu"
-        ;;
-esac
-
-export LD_LIBRARY_PATH=$SNAP/usr/lib:$SNAP/usr/lib/$TRIPLET
 export MAGIC=$SNAP/usr/share/file/magic.mgc
 
 exec $SNAP/usr/bin/python3 $SNAP/bin/snapcraft "$@"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

This PR fixes LP: #1723208 by removing the LD_LIBRARY_PATH set in the snapcraft-classic wrapper. This leaks into the running environment and causes the snap on other distros to break (e.g. Trusty). It also seems completely unnecessary given the rpaths.