### PR TITLE
repo: add elementary to deb distros

### DIFF
--- a/snapcraft/internal/repo/_platform.py
+++ b/snapcraft/internal/repo/_platform.py
@@ -24,6 +24,7 @@ _DEB_BASED_PLATFORM = [
     'ubuntu',
     'debian',
     'elementary OS',
+    'elementary',
     'neon',
 ]
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Elementary fixed their `/etc/os-release` file, but we don't support the fixed version (just "elementary", no spaces and no "OS"). This PR fixes LP: [#1719336](https://bugs.launchpad.net/snapcraft/+bug/1719336) by adding that support.