### PR TITLE
lxd: catch CalledProcessError in _container_run

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -118,6 +118,17 @@ class ContainerConnectionError(ContainerError):
            'https://linuxcontainers.org/lxd/getting-started-cli.')
 
 
+class ContainerRunError(SnapcraftError):
+
+    fmt = (
+        'Command failed in the container: '
+        '{command!r} exited with {exit_code}\n'
+    )
+
+    def __init__(self, *, command, exit_code):
+        super().__init__(command=' '.join(command), exit_code=exit_code)
+
+
 class SnapdError(SnapcraftError):
     fmt = '{message}'
 

--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -32,6 +32,7 @@ from urllib import parse
 
 from snapcraft.internal import common
 from snapcraft.internal.errors import (
+        ContainerRunError,
         ContainerConnectionError,
         SnapdError,
 )
@@ -138,7 +139,7 @@ class Containerbuild:
                 command += args
             try:
                 self._container_run(command, cwd=self._project_folder)
-            except subprocess.CalledProcessError as e:
+            except ContainerRunError as e:
                 if self._project_options.debug:
                     logger.info('Debug mode enabled, dropping into a shell')
                     self._container_run(['bash', '-i'])
@@ -163,9 +164,12 @@ class Containerbuild:
         if sh:
             cmd = ['sh', '-c', '{}{}'.format(sh,
                    ' '.join(pipes.quote(arg) for arg in cmd))]
-        subprocess.check_call([
-            'lxc', 'exec', self._container_name, '--'] + cmd,
-            **kwargs)
+        try:
+            subprocess.check_call([
+                'lxc', 'exec', self._container_name, '--'] + cmd,
+                **kwargs)
+        except subprocess.CalledProcessError as e:
+            raise ContainerRunError(command=cmd, exit_code=e.returncode)
 
     def _wait_for_network(self):
         logger.info('Waiting for a network connection...')
@@ -176,7 +180,7 @@ class Containerbuild:
             try:
                 self._container_run(['python3', '-c', _NETWORK_PROBE_COMMAND])
                 not_connected = False
-            except subprocess.CalledProcessError as e:
+            except ContainerRunError as e:
                 retry_count -= 1
                 if retry_count == 0:
                     raise e


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
Show a nice, clean error if a command fails in the container.