### PR TITLE
tests: run daily autopkgtest in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,25 @@ jobs:
     # CLA check, only in pull requests, not comming from the bot.
     - if: type = pull_request AND sender != snappy-m-o
       script: ./tools/travis/run_cla_check.sh
-    # Trigger edge tests, only in the daily cron.
-    - stage: edge
+    # Trigger nightly tests, only in cron.
+    - stage: nightly
       if: type = cron
       script: ./runtests.sh spread
-    # Trigger beta tests, only in the daily cron.
-    - stage: beta
-      if: type = cron
+    - if: type = cron
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-general
+    - if: type = cron
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-store
+    - if: type = cron
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-plugins
+    - if: type = cron
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-snapd
+    - if: type = cron
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-general
+    - if: type = cron
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-store
+    - if: type = cron
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-plugins
+    - if: type = cron
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-snapd
+    - if: type = cron
       script: ./tools/travis/make_beta_pr.sh

--- a/tools/travis/run_autopkgtests.sh
+++ b/tools/travis/run_autopkgtests.sh
@@ -36,12 +36,14 @@ project_path="$(readlink -f "$script_path/../..")"
 "$script_path/setup_lxd.sh"
 "$script_path/run_lxd_container.sh" test-runner
 $lxc file push --recursive $project_path test-runner/root/
-# Workaround for
-# - Setup snap "core" (2462) security profiles (cannot reload udev rules: exit status 2
 $lxc exec test-runner -- sh -c "apt remove --yes lxd lxd-client"
+# Ignore the core install error as a workaround for
+# - Setup snap "core" (2462) security profiles (cannot reload udev rules: exit status 2
 $lxc exec test-runner -- sh -c "snap install core" || echo "ignored error"
 $lxc exec test-runner -- sh -c "cd snapcraft && ./tools/travis/setup_lxd.sh"
 $lxc exec test-runner -- sh -c "apt install --yes autopkgtest"
+# Ignore the core install error as a workaround for
+# - Setup snap "core" (2462) security profiles (cannot reload udev rules: exit status 2
 $lxc exec test-runner -- sh -c "cd snapcraft && adt-run --testname $test snapcraft --setup-commands $script_path/setup_autopkgtests_ppa.sh -U --setup-commands \"apt install squashfuse && (snap install core || echo 'ignored error')\" --- lxd $distro
 
 $lxc stop test-runner

--- a/tools/travis/run_autopkgtests.sh
+++ b/tools/travis/run_autopkgtests.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Run snapcraft autopkgtests.
+# Arguments:
+#   suite: The test suite to run.
+
+set -ev
+
+if [ "$#" -ne 2 ] ; then
+    echo "Usage: "$0" <distro> <test>"
+    exit 1
+fi
+
+distro="$1"
+test="$2"
+
+lxc="/snap/bin/lxc"
+
+script_path="$(dirname "$0")"
+project_path="$(readlink -f "$script_path/../..")"
+
+"$script_path/setup_lxd.sh"
+"$script_path/run_lxd_container.sh" test-runner
+$lxc file push --recursive $project_path test-runner/root/
+# Workaround for
+# - Setup snap "core" (2462) security profiles (cannot reload udev rules: exit status 2
+$lxc exec test-runner -- sh -c "apt remove --yes lxd lxd-client"
+$lxc exec test-runner -- sh -c "snap install core" || echo "ignored error"
+$lxc exec test-runner -- sh -c "cd snapcraft && ./tools/travis/setup_lxd.sh"
+$lxc exec test-runner -- sh -c "apt install --yes autopkgtest"
+$lxc exec test-runner -- sh -c "cd snapcraft && adt-run --testname $test snapcraft --setup-commands $script_path/setup_autopkgtests_ppa.sh -U --setup-commands \"apt install squashfuse && (snap install core || echo 'ignored error')\" --- lxd $distro
+
+$lxc stop test-runner

--- a/tools/travis/setup_autopkgtests_ppa.sh
+++ b/tools/travis/setup_autopkgtests_ppa.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+apt-key adv --keyserver keyserver.ubuntu.com --recv-key 78E1918602959B9C59103100F1831DDAFC42E99D
+set -x; REL=$(sed -rn "/^(deb|deb-src) .*(ubuntu.com|ftpmaster)/ { s/^[^ ]+ +(\[.*\] *)?[^ ]* +([^ -]+) +.*$/\\2/p; q }" /etc/apt/sources.list)
+echo "deb http://ppa.launchpad.net/snappy-dev/snapcraft-daily/ubuntu $REL main\ndeb-src http://ppa.launchpad.net/snappy-dev/snapcraft-daily/ubuntu $REL main" > /etc/apt/sources.list.d/autopkgtest-snapcraft.list


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
WIP: this makes sense only to be run on the daily. But, I need first to check if travis gets green results. I will update the .travis.yml after that.