### PR TITLE
sources: enforce default language in subversion info

### DIFF
--- a/snapcraft/internal/sources/_subversion.py
+++ b/snapcraft/internal/sources/_subversion.py
@@ -81,8 +81,11 @@ class Subversion(Base):
         commit = self.source_commit
 
         if not commit:  # retrieve the commit id
-            lines = subprocess.check_output(['svn', 'info', self.source_dir]
-                                            ).decode('utf-8').split('\n')
+            env = os.environ.copy()
+            env['LANG'] = 'C'
+            lines = subprocess.check_output(
+                ['svn', 'info', self.source_dir],
+                env=env).decode('utf-8').split('\n')
             prefix = 'Last Changed Rev: '
             for line in lines:
                 if line.startswith(prefix):


### PR DESCRIPTION
subversion `_get_source_details` expects the output of `svn info` to
contain an english prefix and this will fail in a non-english environment.

Setting the `env` subprocess.check_output argument to have the `LANG`
key set to the default language `C` to ensure english language in
the command output.

Fixes [LP 1724674](https://bugs.launchpad.net/snapcraft/+bug/1724674)

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
