### PR TITLE
lxd: better surfacing of errors

### DIFF
--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -18,7 +18,7 @@ import sys
 import traceback
 
 from . import echo
-import snapcraft.internal.errors
+from snapcraft.internal import errors
 
 
 def exception_handler(exception_type, exception, exception_traceback, *,
@@ -40,16 +40,18 @@ def exception_handler(exception_type, exception, exception_traceback, *,
     """
 
     exit_code = 1
-    is_snapcraft_error = issubclass(
-        exception_type, snapcraft.internal.errors.SnapcraftError)
+    is_snapcraft_error = issubclass(exception_type, errors.SnapcraftError)
 
     if debug or not is_snapcraft_error:
         traceback.print_exception(
             exception_type, exception, exception_traceback)
 
+    should_print_error = not debug and (
+        exception_type != errors.ContainerSnapcraftCmdError)
+
     if is_snapcraft_error:
         exit_code = exception.get_exit_code()
-        if not debug:
+        if should_print_error:
             echo.error(str(exception))
 
     sys.exit(exit_code)

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -118,6 +118,28 @@ class ContainerConnectionError(ContainerError):
            'https://linuxcontainers.org/lxd/getting-started-cli.')
 
 
+class ContainerRunError(SnapcraftError):
+
+    fmt = (
+        'The following command failed to run: '
+        '{command!r} exited with {exit_code}\n'
+    )
+
+    def __init__(self, *, command, exit_code):
+        super().__init__(command=' '.join(command), exit_code=exit_code)
+
+
+class ContainerSnapcraftCmdError(ContainerRunError):
+
+    fmt = (
+        'Snapcraft command failed in the container: '
+        '{command!r} exited with {exit_code}\n'
+    )
+
+    def __init__(self, *, command, exit_code):
+        super().__init__(command=' '.join(command), exit_code=exit_code)
+
+
 class SnapdError(SnapcraftError):
     fmt = '{message}'
 

--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -153,7 +153,7 @@ class Containerbuild:
 
     def _container_run(self, cmd, cwd=None, **kwargs):
         sh = ''
-        original_cmd = cmd
+        original_cmd = cmd.copy()
         # Automatically wait on lock files before running commands
         if cmd[0] == 'apt-get':
             lock_file = '/var/lib/dpkg/lock'


### PR DESCRIPTION
We do not want to print the same error twice, so the caller should
produce a silent error with a proper exit code as the message
related to the error would be displayed by the callee.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
I do wish ContainerRunError would be more generalized and that these Container* exceptions live inside the lxd package, but oh well, this fixes the problem today.