### PR TITLE
sources: get svn revision with --show-item flag

### DIFF
--- a/snapcraft/internal/sources/_subversion.py
+++ b/snapcraft/internal/sources/_subversion.py
@@ -80,14 +80,12 @@ class Subversion(Base):
         source = self.source
         commit = self.source_commit
 
-        if not commit:  # retrieve the commit id
-            lines = subprocess.check_output(['svn', 'info', self.source_dir]
-                                            ).decode('utf-8').split('\n')
-            prefix = 'Last Changed Rev: '
-            for line in lines:
-                if line.startswith(prefix):
-                    commit = line.replace(prefix, '')
-                    break
+        if not commit:
+            commit = subprocess.check_output(
+                ['svn', 'info',
+                 '--show-item', 'last-changed-revision',
+                 '--no-newline',
+                 self.source_dir]).decode('utf-8').strip()
 
         return {
             'source-commit': commit,


### PR DESCRIPTION
Currently, svn last changed revision is extracted from `svn info`
text output. The same information can be retrieved directly from
the command

`svn info --show-item last-changed-revision`

without the need to parse text.

Adding also the flag `--no-newline` to avoid the need to strip
newline character from the output.

Since there is not need to parse text anymore, this also remove
the dependency from the current locale and then
fixes https://bugs.launchpad.net/snapcraft/+bug/1724674

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
