### PR TITLE
tests: fork skip into snaps_tests

### DIFF
--- a/snaps_tests/demos_tests/test_rosinstall.py
+++ b/snaps_tests/demos_tests/test_rosinstall.py
@@ -16,11 +16,10 @@
 
 import re
 
-from snapcraft.tests import skip
-import snaps_tests
+from snaps_tests import SnapsTestCase, skip
 
 
-class RosinstallTestCase(snaps_tests.SnapsTestCase):
+class RosinstallTestCase(SnapsTestCase):
 
     snap_content_dir = 'rosinstall'
 

--- a/snaps_tests/demos_tests/test_shared_ros.py
+++ b/snaps_tests/demos_tests/test_shared_ros.py
@@ -18,11 +18,10 @@ import os
 import re
 import subprocess
 
-from snapcraft.tests import skip
-import snaps_tests
+from snaps_tests import SnapsTestCase, skip
 
 
-class SharedROSTestCase(snaps_tests.SnapsTestCase):
+class SharedROSTestCase(SnapsTestCase):
 
     snap_content_dir = 'shared-ros'
 

--- a/snaps_tests/skip.py
+++ b/snaps_tests/skip.py
@@ -1,0 +1,39 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015-2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import contextlib
+import functools
+
+from unittest import skipUnless
+
+from snapcraft.internal import errors, os_release
+
+
+# TODO: remove this duplicated functionality once __init__ for
+#       the testing packages are cleaned up. (LP: #1729593)
+def skip_unless_codename(codename, message):
+    def _wrap(func):
+        release = os_release.OsRelease()
+        actual_codename = None
+        with contextlib.suppress(errors.OsReleaseCodenameError):
+            actual_codename = release.version_codename()
+
+        @functools.wraps(func)
+        @skipUnless(actual_codename == codename, message)
+        def _skip_test(*args, **kwargs):
+            func(*args, **kwargs)
+        return _skip_test
+    return _wrap


### PR DESCRIPTION
This is to avoid the overly broad imports done in
snapcraft.tests which break autopackage tests.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
