### PR TITLE
autotools: cross-compile using --host instead of env

### DIFF
--- a/integration_tests/plugins/test_autotools_plugin.py
+++ b/integration_tests/plugins/test_autotools_plugin.py
@@ -29,8 +29,8 @@ class AutotoolsPluginTestCase(integration_tests.TestCase):
         self.run_snapcraft('stage', 'autotools-hello')
 
         binary_output = self.get_output_ignoring_non_zero_exit(
-            os.path.join(self.stage_dir, 'bin', 'test'))
-        self.assertThat(binary_output, Equals('Hello world\n'))
+            os.path.join(self.stage_dir, 'bin', 'hello'))
+        self.assertThat(binary_output, Equals('Hello, world!\n'))
 
     def test_cross_compiling(self):
         if snapcraft.ProjectOptions().deb_arch != 'amd64':
@@ -39,5 +39,5 @@ class AutotoolsPluginTestCase(integration_tests.TestCase):
         self.run_snapcraft(['build', '--target-arch=arm64'],
                            'autotools-hello')
         binary = os.path.join(self.parts_dir, 'make-project', 'install', 'bin',
-                              'test')
+                              'hello')
         self.assertThat(binary, HasArchitecture('aarch64'))

--- a/integration_tests/snapd/test_autotools_snap.py
+++ b/integration_tests/snapd/test_autotools_snap.py
@@ -31,4 +31,4 @@ class AutotoolsTestCase(integration_tests.SnapdIntegrationTestCase):
             self.assertThat(
                 subprocess.check_output(
                     ['autotools-hello'], universal_newlines=True),
-                Equals("Hello world\n"))
+                Equals('Hello, world!\n'))

--- a/integration_tests/snaps/autotools-hello/Makefile.am
+++ b/integration_tests/snaps/autotools-hello/Makefile.am
@@ -1,2 +1,0 @@
-bin_PROGRAMS = test
-test_SOURCES = test.c

--- a/integration_tests/snaps/autotools-hello/configure.ac
+++ b/integration_tests/snaps/autotools-hello/configure.ac
@@ -1,8 +1,0 @@
-AC_INIT([test], [0.1], [snapcraft@lists.snapcraft.io])
-AM_INIT_AUTOMAKE([-Wall -Werror foreign])
-AC_PROG_CC
-AC_CONFIG_HEADERS([config.h])
-AC_CONFIG_FILES([
- Makefile
-])
-AC_OUTPUT

--- a/integration_tests/snaps/autotools-hello/snapcraft.yaml
+++ b/integration_tests/snaps/autotools-hello/snapcraft.yaml
@@ -9,11 +9,11 @@ confinement: strict
 
 apps:
   autotools-hello:
-    command: test
+    command: hello
 
 build-packages: [gcc]
 
 parts:
   make-project:
     plugin: autotools
-    source: .
+    source: http://ftp.gnu.org/gnu/hello/hello-2.10.tar.gz

--- a/integration_tests/snaps/autotools-hello/test.c
+++ b/integration_tests/snaps/autotools-hello/test.c
@@ -1,6 +1,0 @@
-#include <stdio.h>
-
-int main (void)
-{
-  printf("Hello world\n");
-}

--- a/snapcraft/plugins/autotools.py
+++ b/snapcraft/plugins/autotools.py
@@ -89,15 +89,6 @@ class AutotoolsPlugin(make.MakePlugin):
             raise RuntimeError('Unsupported installation method: "{}"'.format(
                 options.install_via))
 
-    def env(self, root):
-        env = super().env(root)
-        if self.project.is_cross_compiling:
-            env.extend([
-                'CC={}-gcc'.format(self.project.arch_triplet),
-                'CXX={}-g++'.format(self.project.arch_triplet),
-            ])
-        return env
-
     def enable_cross_compilation(self):
         pass
 
@@ -129,7 +120,8 @@ class AutotoolsPlugin(make.MakePlugin):
         else:
             configure_command.append('--prefix=' + self.installdir)
         if self.project.is_cross_compiling:
-            configure_command.append('--host={}'.format(self.project.deb_arch))
+            configure_command.append('--host={}'.format(
+                self.project.arch_triplet))
 
         self.run(configure_command + self.options.configflags)
         self.make()


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Take a look at the `configure` output for our autotools cross-compile integration test (I'm doing this by hand, running `snapcraft --target-arch=armhf`):

```
[...]
./configure --prefix= --host=armhf
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for armhf-strip... no
checking for strip... strip
[...]
```

Note that it's using the build system's `strip`, not the cross-toolchain's `strip`. What is `armhf-strip` anyway? Nothing, I tell you! We're setting --host to the deb arch instead of the triplet.

Currently the autotools plugin uses the CC and CXX environment variables to force autotools to cross-compile. However, autotools will do this on its own if one sets the --host parameter correctly, and will actually do a better job (e.g. use the cross-toolchain's strip as well).

Remove the environment variables, and set the --host to the target triplet if cross-compiling. More info on how to cross-compile using autotools (including details on --host) can be found [here](https://www.gnu.org/software/automake/manual/html_node/Cross_002dCompilation.html).