### PR TITLE
integration tests: skip shared ROS test on non-xenial

### DIFF
--- a/integration_tests/test_catkin_shared_ros.py
+++ b/integration_tests/test_catkin_shared_ros.py
@@ -20,9 +20,12 @@ import tempfile
 
 import integration_tests
 
+from snapcraft.tests import skip
+
 
 class CatkinSharedRosTestCase(integration_tests.TestCase):
 
+    @skip.skip_unless_codename('xenial', 'ROS Kinetic only targets Xenial')
     def test_shared_ros_builds_without_catkin_in_underlay(self):
         # Build the producer until we have a good staging area
         self.copy_project_to_cwd(os.path.join('catkin-shared-ros', 'producer'))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?