### PR TITLE
tests: in autopkgtests, use a tempdir in home, not in the tmpfs

### DIFF
--- a/debian/tests/integrationtests
+++ b/debian/tests/integrationtests
@@ -14,6 +14,7 @@ if [ -z "$SNAPCRAFT_SLOW_TESTS" ]; then
     SNAPCRAFT_SLOW_TESTS=1
 fi
 
+mkdir --parents /home/ubuntu/autopkgtest_tmp --mode 777
 for suite in $suites; do
-    su ubuntu -c "SNAPCRAFT_FROM_INSTALLED=1 TEST_STORE=fake ADT_TEST=1 PATH=/snap/bin:$PATH python3 -m unittest discover -b -v -s ${suite}"
+    su ubuntu -c "SNAPCRAFT_FROM_INSTALLED=1 TEST_STORE=fake ADT_TEST=1 PATH=/snap/bin:$PATH TMPDIR=\$HOME/autopkgtest_tmp python3 -m unittest discover -b -v -s ${suite}"
 done

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -52,6 +52,11 @@ from snapcraft.tests.subprocess_utils import (
 
 class TempCWD(fixtures.TempDir):
 
+    def __init__(self, rootdir=None):
+        if rootdir is None and 'TMPDIR' in os.environ:
+            rootdir = os.environ.get('TMPDIR')
+        super().__init__(rootdir)
+
     def setUp(self):
         """Create a temporary directory an cd into it for the test duration."""
         super().setUp()

--- a/snapcraft/tests/test_fixture_setup.py
+++ b/snapcraft/tests/test_fixture_setup.py
@@ -17,12 +17,28 @@
 import http.client
 import http.server
 import json
+import os
+import tempfile
 import urllib.parse
 
+import fixtures
 from testtools.matchers import Equals
 
 from snapcraft import tests
 from snapcraft.tests import fixture_setup
+
+
+class TempCWDTestCase(tests.TestCase):
+
+    def test_with_TEMPDIR_env_var(self):
+        with tempfile.TemporaryDirectory() as test_tmp_dir:
+            with fixtures.EnvironmentVariable('TMPDIR', test_tmp_dir):
+                temp_cwd_fixture = fixture_setup.TempCWD()
+                self.useFixture(temp_cwd_fixture)
+
+        self.assertThat(
+            os.path.dirname(temp_cwd_fixture.path),
+            Equals(test_tmp_dir))
 
 
 class TestFakeServer(http.server.HTTPServer):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
