### PR TITLE
lxd: let lxd choose the architecture

### DIFF
--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -542,10 +542,8 @@ class FakeLXD(fixtures.Fixture):
         if args[0] == ['lxc', 'remote', 'get-default']:
             return 'local'.encode('utf-8')
         elif args[0][:2] == ['lxc', 'info']:
-            return '''
-                environment:
-                  kernel_architecture: {}
-                '''.format(self.kernel_arch).encode('utf-8')
+            return 'Architecture: {}'.format(
+                self.kernel_arch).encode('utf-8')
         elif args[0][:3] == ['lxc', 'list', '--format=json']:
             if self.status and args[0][3] == self.name:
                 return string.Template('''

--- a/snapcraft/tests/unit/commands/test_snap.py
+++ b/snapcraft/tests/unit/commands/test_snap.py
@@ -460,7 +460,7 @@ class SnapCommandWithContainerBuildTestCase(SnapCommandBaseTestCase):
         container_name = 'local:snapcraft-snap-test'
         project_folder = '/root/build_snap-test'
         fake_lxd.check_call_mock.assert_has_calls([
-            call(['lxc', 'init', 'ubuntu:xenial/amd64', container_name]),
+            call(['lxc', 'init', 'ubuntu:xenial', container_name]),
             call(['lxc', 'config', 'set', container_name,
                   'environment.SNAPCRAFT_SETUP_CORE', '1']),
             call(['lxc', 'config', 'set', container_name,


### PR DESCRIPTION
lxd implements exactly the same logic as snapcraft does to choose an
architecture when one is not specified, so remove snapcraft's copy.

It is still necessary to record the architecture of the created
container to detect whether snaps can just be copied across, but this
is now done after the container is started, which will still be correct
when/if support for building on a non-default image is merged.