### PR TITLE
many: account for python shebang args in rewrite

### DIFF
--- a/integration_tests/snaps/catkin-with-python-part/snap/snapcraft.yaml
+++ b/integration_tests/snaps/catkin-with-python-part/snap/snapcraft.yaml
@@ -26,11 +26,6 @@ parts:
     # the most problems.
     after: [python-part]
 
-
-    # FIXME: This filter should not be necessary, but the Catkin plugin isn't
-    # propery fixing shebangs. Remove this filter when it is.
     stage:
-    - -usr/bin/2to3-2.7
-    - -usr/bin/pydoc2.7
-    - -usr/lib/python2.7
-    - -usr/share/python
+      # The python part includes a sitecustomize that we don't want to clobber
+      - -usr/lib/python2.7/sitecustomize.py

--- a/snapcraft/internal/mangling.py
+++ b/snapcraft/internal/mangling.py
@@ -1,0 +1,48 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+
+from snapcraft import file_utils
+
+
+def rewrite_python_shebangs(root_dir):
+    """Recursively change #!/usr/bin/pythonX shebangs to #!/usr/bin/env pythonX
+
+    :param str root_dir: Directory that will be crawled for shebangs.
+    """
+
+    file_pattern = re.compile(r'')
+    argless_shebang_pattern = re.compile(
+        r'\A#!.*(python\S*)$', re.MULTILINE)
+    shebang_pattern_with_args = re.compile(
+        r'\A#!.*(python\S*)[ \t\f\v]+(\S+)$', re.MULTILINE)
+
+    file_utils.replace_in_file(
+        root_dir, file_pattern, argless_shebang_pattern, r'#!/usr/bin/env \1')
+
+    # The above rewrite will barf if the shebang includes any args to python.
+    # For example, if the shebang was `#!/usr/bin/python3 -Es`, just replacing
+    # that with `#!/usr/bin/env python3 -Es` isn't going to work as `env`
+    # doesn't support arguments like that.
+    #
+    # The solution is to replace the shebang with one pointing to /bin/sh, and
+    # then exec the original shebang with included arguments. This requires
+    # some quoting hacks to ensure the file can be interpreted by both sh as
+    # well as python, but it's better than shipping our own `env`.
+    file_utils.replace_in_file(
+        root_dir, file_pattern, shebang_pattern_with_args,
+        r"""#!/bin/sh\n''''exec \1 \2 -- "$0" "$@" # '''""")

--- a/snapcraft/internal/repo/_base.py
+++ b/snapcraft/internal/repo/_base.py
@@ -24,6 +24,7 @@ import shutil
 import stat
 
 from snapcraft import file_utils
+from snapcraft.internal import mangling
 from . import errors
 
 _BIN_PATHS = (
@@ -238,9 +239,7 @@ class BaseRepo:
         paths = [p for p in _BIN_PATHS
                  if os.path.exists(os.path.join(unpackdir, p))]
         for p in [os.path.join(unpackdir, p) for p in paths]:
-            file_utils.replace_in_file(p, re.compile(r''),
-                                       re.compile(r'#!.*python\n'),
-                                       r'#!/usr/bin/env python\n')
+            mangling.rewrite_python_shebangs(p)
 
 
 class DummyRepo(BaseRepo):

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -79,7 +79,10 @@ from snapcraft import (
     formatting_utils,
     repo,
 )
-from snapcraft.internal import errors
+from snapcraft.internal import (
+    errors,
+    mangling,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -658,9 +661,7 @@ deb http://${{security}}.ubuntu.com/${{suffix}} {0}-security main universe
 
     def _use_in_snap_python(self):
         # Fix all shebangs to use the in-snap python.
-        file_utils.replace_in_file(self.rosdir, re.compile(r''),
-                                   re.compile(r'^#!.*python'),
-                                   r'#!/usr/bin/env python')
+        mangling.rewrite_python_shebangs(self.installdir)
 
         # Also replace the python usage in 10.ros.sh to use the in-snap python.
         ros10_file = os.path.join(self.rosdir,

--- a/snapcraft/plugins/plainbox_provider.py
+++ b/snapcraft/plugins/plainbox_provider.py
@@ -30,10 +30,9 @@ For more information check the 'plugins' topic for the former and the
 """
 
 import os
-import re
 
 import snapcraft
-from snapcraft import file_utils
+from snapcraft.internal import mangling
 
 
 class PlainboxProviderPlugin(snapcraft.BasePlugin):
@@ -63,10 +62,7 @@ class PlainboxProviderPlugin(snapcraft.BasePlugin):
             '--prefix=/providers/{}'.format(self.name),
             '--root={}'.format(self.installdir)])
 
-        # Fix all shebangs to use the in-snap python.
-        file_utils.replace_in_file(self.installdir, re.compile(r''),
-                                   re.compile(r'^#!.*python'),
-                                   r'#!/usr/bin/env python')
+        mangling.rewrite_python_shebangs(self.installdir)
 
     def snap_fileset(self):
         fileset = super().snap_fileset()

--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -55,7 +55,6 @@ be preferred instead and no interpreter would be brought in through
 import collections
 import json
 import os
-import re
 import shutil
 import stat
 import subprocess
@@ -70,6 +69,7 @@ import requests
 import snapcraft
 from snapcraft import file_utils
 from snapcraft.common import isurl
+from snapcraft.internal import mangling
 
 
 _SITECUSTOMIZE_TEMPLATE = dedent("""\
@@ -368,9 +368,7 @@ class PythonPlugin(snapcraft.BasePlugin):
         self._fix_permissions()
 
         # Fix all shebangs to use the in-snap python.
-        file_utils.replace_in_file(self.installdir, re.compile(r''),
-                                   re.compile(r'^#!.*python'),
-                                   r'#!/usr/bin/env python')
+        mangling.rewrite_python_shebangs(self.installdir)
 
         self._setup_sitecustomize()
 

--- a/snapcraft/tests/repo/test_base.py
+++ b/snapcraft/tests/repo/test_base.py
@@ -132,8 +132,8 @@ class FixShebangTestCase(RepoBaseTestCase):
         }),
         ('python3 bin dir', {
             'file_path': os.path.join('root', 'bin', 'd'),
-            'content': '#!/usr/bin/python3\nraise Exception()',
-            'expected': '#!/usr/bin/python3\nraise Exception()',
+            'content': '#!/usr/bin/python3\nimport this',
+            'expected': '#!/usr/bin/env python3\nimport this',
         }),
         ('sbin dir', {
             'file_path': os.path.join('root', 'sbin', 'b'),

--- a/snapcraft/tests/test_mangling.py
+++ b/snapcraft/tests/test_mangling.py
@@ -1,0 +1,109 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import textwrap
+
+from testtools.matchers import FileContains
+
+from snapcraft.internal import mangling
+
+from snapcraft import tests
+
+
+def _create_file(filename, contents):
+    os.makedirs('test-dir', exist_ok=True)
+    file_path = os.path.join('test-dir', filename)
+    with open(file_path, 'w') as f:
+        f.write(contents)
+
+    return file_path
+
+
+class ManglingPythonShebangTestCase(tests.TestCase):
+
+    def test_python(self):
+        file_path = _create_file('file', textwrap.dedent("""\
+            #! /usr/bin/python2.7
+
+            # Larger file
+        """))
+        mangling.rewrite_python_shebangs(os.path.dirname(file_path))
+        self.assertThat(file_path, FileContains(textwrap.dedent("""\
+            #!/usr/bin/env python2.7
+
+            # Larger file
+        """)))
+
+    def test_python3(self):
+        file_path = _create_file('file', '#!/usr/bin/python3')
+        mangling.rewrite_python_shebangs(os.path.dirname(file_path))
+        self.assertThat(file_path, FileContains('#!/usr/bin/env python3'))
+
+    def test_python_args(self):
+        file_path1 = _create_file('file1', '#!/usr/bin/python')
+        file_path2 = _create_file('file2', textwrap.dedent("""\
+            #! /usr/bin/python -E
+
+            # Larger file
+        """))
+        mangling.rewrite_python_shebangs(os.path.dirname(file_path1))
+        self.assertThat(file_path1, FileContains('#!/usr/bin/env python'))
+        self.assertThat(file_path2, FileContains(
+            textwrap.dedent("""\
+                #!/bin/sh
+                ''''exec python -E -- "$0" "$@" # '''
+
+                # Larger file
+            """)))
+
+    def test_python3_args(self):
+        file_path1 = _create_file('file1', '#!/usr/bin/python3')
+        file_path2 = _create_file('file2', '#!/usr/bin/python3 -E')
+        mangling.rewrite_python_shebangs(os.path.dirname(file_path1))
+        self.assertThat(file_path1, FileContains('#!/usr/bin/env python3'))
+        self.assertThat(file_path2, FileContains(
+            textwrap.dedent("""\
+                #!/bin/sh
+                ''''exec python3 -E -- "$0" "$@" # '''""")))
+
+    def test_python_mixed_args(self):
+        file_path1 = _create_file('file1', '#!/usr/bin/python')
+        # Ensure extra spaces are chopped off
+        file_path2 = _create_file('file2', '#!/usr/bin/python3       -Es')
+        mangling.rewrite_python_shebangs(os.path.dirname(file_path1))
+        self.assertThat(file_path1, FileContains('#!/usr/bin/env python'))
+        self.assertThat(file_path2, FileContains(
+            textwrap.dedent("""\
+                #!/bin/sh
+                ''''exec python3 -Es -- "$0" "$@" # '''""")))
+
+    def test_following_docstring_no_rewrite(self):
+        file_path = _create_file('file', textwrap.dedent("""\
+            #!/usr/bin/env python3.5
+
+            '''
+            This is a test
+            =======================
+        """))
+        mangling.rewrite_python_shebangs(os.path.dirname(file_path))
+        self.assertThat(file_path, FileContains(textwrap.dedent("""\
+            #!/usr/bin/env python3.5
+
+            '''
+            This is a test
+            =======================
+        """)))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently Snapcraft rewrites absolute Python shebangs to point into the snap by using `/usr/bin/env`. However, `/usr/bin/env` doesn't handle shebang args, whereas Python itself does.

This PR fixes LP: [#1730472](https://bugs.launchpad.net/snapcraft/+bug/1730472) by accounting for the possibility of shebang args in rewrite, and making sure that all components that rewrite the Python shebang use the same code path to do so. As a side effect of this last step, this PR also fixes LP: [#1673451](https://bugs.launchpad.net/snapcraft/+bug/1673451).