### PR TITLE
unit tests: reset log level after test

### DIFF
--- a/snapcraft/tests/__init__.py
+++ b/snapcraft/tests/__init__.py
@@ -27,7 +27,10 @@ import testscenarios
 import testtools
 
 import snapcraft
-from snapcraft.internal import common
+from snapcraft.internal import (
+    common,
+    log,
+)
 from snapcraft.tests import fake_servers, fixture_setup
 from snapcraft.internal.project_loader import grammar_processing
 
@@ -147,6 +150,9 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
             self.mock_machine = patcher.start()
             self.mock_machine.return_value = machine
             self.addCleanup(patcher.stop)
+
+        # Ensure logging is set back to the default
+        self.addCleanup(log.configure)
 
     def make_snapcraft_yaml(self, content, encoding='utf-8'):
         with contextlib.suppress(FileExistsError):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Several tests (the command tests, parser tests, etc.) call the main executables with `--debug`, which changes the Snapcraft log level. However, when running the entire suite together, that level tends to stick, and can make later tests (that depend on debug mode NOT being enabled) fail. I hit this pretty much every time trying to run adt locally.

Reset the log level to the default after each test.