### PR TITLE
tests: use the common base handler on the fake snapd server

### DIFF
--- a/snapcraft/tests/fake_servers/snapd.py
+++ b/snapcraft/tests/fake_servers/snapd.py
@@ -13,7 +13,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 import json
 from urllib import parse
 

--- a/snapcraft/tests/fake_servers/snapd.py
+++ b/snapcraft/tests/fake_servers/snapd.py
@@ -13,12 +13,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import json
-from http.server import BaseHTTPRequestHandler
 from urllib import parse
 
+from snapcraft.tests import fake_servers
 
-class FakeSnapdRequestHandler(BaseHTTPRequestHandler):
+
+class FakeSnapdRequestHandler(fake_servers.BaseHTTPRequestHandler):
 
     snaps_result = []
     snap_details_func = None


### PR DESCRIPTION
Our base handler makes sure that the server doesn't print debug messages to stdout. This messages can leak into other tests that are checking stdout.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
