### PR TITLE
integration tests: remove ruby version

### DIFF
--- a/integration_tests/snaps/ruby-bundle-install/snapcraft.yaml
+++ b/integration_tests/snaps/ruby-bundle-install/snapcraft.yaml
@@ -9,6 +9,5 @@ parts:
   ruby-bundle-install:
     plugin: ruby
     use-bundler: true
-    ruby-version: "2.3.1"
     stage:
       - bin

--- a/integration_tests/snaps/ruby-gem-install/snapcraft.yaml
+++ b/integration_tests/snaps/ruby-gem-install/snapcraft.yaml
@@ -8,7 +8,6 @@ confinement: strict
 parts:
   ruby-gem-install:
     plugin: ruby
-    ruby-version: "2.3.1"
     gems: ['rack']
     stage:
       - bin


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Make all Ruby integration tests use the default (thus latest) version of Ruby. This is required primarily because older versions of Ruby (such as that used in the tests) fail to build in Artful with GCC7.