### PR TITLE
demo tests: bump catkin timeout by a lot

### DIFF
--- a/snaps_tests/demos_tests/test_rosinstall.py
+++ b/snaps_tests/demos_tests/test_rosinstall.py
@@ -25,7 +25,7 @@ class RosinstallTestCase(SnapsTestCase):
 
     @skip.skip_unless_codename('xenial', 'ROS Kinetic only targets Xenial')
     def test_rosinstall(self):
-        snap_path = self.build_snap(self.snap_content_dir, timeout=1800)
+        snap_path = self.build_snap(self.snap_content_dir, timeout=10000)
 
         self.install_snap(snap_path, 'rosinstall-demo', '1.0')
 

--- a/snaps_tests/demos_tests/test_shared_ros.py
+++ b/snaps_tests/demos_tests/test_shared_ros.py
@@ -30,7 +30,7 @@ class SharedROSTestCase(SnapsTestCase):
         ros_base_path = os.path.join(self.snap_content_dir, 'ros-base')
         ros_app_path = os.path.join(self.snap_content_dir, 'ros-app')
 
-        base_snap_path = self.build_snap(ros_base_path, timeout=1800)
+        base_snap_path = self.build_snap(ros_base_path, timeout=10000)
 
         # Now tar up its staging area to be used to build ros-app
         subprocess.check_call([
@@ -38,7 +38,7 @@ class SharedROSTestCase(SnapsTestCase):
             os.path.dirname(base_snap_path), 'stage'], cwd=self.src_dir)
 
         # Now build ros-app
-        app_snap_path = self.build_snap(ros_app_path, timeout=1800)
+        app_snap_path = self.build_snap(ros_app_path, timeout=10000)
 
         # Install both snaps
         self.install_snap(base_snap_path, 'ros-base', '1.0')


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Seeing several adt timeouts where the Catkin tests are priming or snapping. Increase the timeouts significantly, looks like things are running a little slower than usual. We'll remove them completely soon.