### PR TITLE
tests: dotnet only works on 16.04

### DIFF
--- a/integration_tests/snapd/test_dotnet_snap.py
+++ b/integration_tests/snapd/test_dotnet_snap.py
@@ -19,11 +19,12 @@ import subprocess
 from testtools.matchers import Equals
 
 import integration_tests
-from snapcraft.tests import fixture_setup
+from snapcraft.tests import fixture_setup, skip
 
 
 class DotnetTestCase(integration_tests.SnapdIntegrationTestCase):
 
+    @skip.skip_unless_codename('xenial', 'the dotnet plugin targets Xenial')
     def test_install_and_execution(self):
         if self.deb_arch != 'amd64':
             self.skipTest('The dotnet plugin only supports amd64, for now')


### PR DESCRIPTION
The dotnet plugin as is today only works on 16.04, once the
snap is consumable from the plugin we can remove this
restriction.

LP: #1732065

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
