### PR TITLE
recording: don't log the command when image info fails

### DIFF
--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -146,11 +146,16 @@ class Containerbuild:
             'Failed to get container image info: {}\n'
             'It will not be recorded in manifest.')
         try:
+            image_info_command = [
+                'lxc', 'image', 'list', '--format=json', self._image]
             image_info = json.loads(subprocess.check_output(
-                ['lxc', 'image', 'list',
-                 '--format=json', self._image]).decode())
+                image_info_command).decode())
         except subprocess.CalledProcessError as e:
-            message = '{}, output: {}'.format(str(e), e.output)
+            message = ('`{command}` returned with exit code {returncode}, '
+                       'output: {output}'.format(
+                           command=' '.join(image_info_command),
+                           returncode=e.returncode,
+                           output=e.output))
             logger.warning(FAILURE_WARNING_FORMAT.format(message))
             return
         except json.decoder.JSONDecodeError as e:

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -635,8 +635,9 @@ class FailedImageInfoTestCase(LXDBaseTestCase):
             exception=CalledProcessError,
             kwargs=dict(cmd='testcmd', returncode=1, output='test output'),
             expected_warn=(
-                "Failed to get container image info: Command 'testcmd' "
-                "returned non-zero exit status 1, output: test output\n"
+                "Failed to get container image info: "
+                "`lxc image list --format=json ubuntu:xenial/amd64` "
+                "returned with exit code 1, output: test output\n"
                 "It will not be recorded in manifest.\n"))),
         ('JSONDecodeError', dict(
             exception=json.decoder.JSONDecodeError,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
In here I'm removing the part that we don't control from the message, and at the same time making it look a little nicer for the issue that Christian pointed out in the original branch.