### PR TITLE
cli: pass remote from container_config to clean method

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -180,6 +180,7 @@ def clean(parts, step, **kwargs):
     if container_config.use_container:
         config = snapcraft.internal.load_config(project_options)
         lxd.Project(project_options=project_options,
+                    remote=container_config.remote,
                     output=None, source=os.path.curdir,
                     metadata=config.get_metadata()).clean(parts, step)
     else:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
With `SNAPCRAFT_CONTAINER_BUILDS=foo` running `snapcraft clean` will actually look for a local container, and clean that instead of the container on `foo` or do nothing.