### PR TITLE
lxd: refresh remote container

### DIFF
--- a/snapcraft/cli/containers.py
+++ b/snapcraft/cli/containers.py
@@ -54,5 +54,6 @@ def refresh(debug, **kwargs):
     project_options = get_project_options(**kwargs, debug=debug)
     config = snapcraft.internal.load_config(project_options)
     lxd.Project(project_options=project_options,
+                remote=container_config.remote,
                 output=None, source=os.path.curdir,
                 metadata=config.get_metadata()).refresh()


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
With SNAPCRAFT_CONTAINER_BUILDS=foo running snapcraft refresh will actually look for a local container, and refresh that instead of the container on foo.