### PR TITLE
tests: add the home plug to the plainbox snap

### DIFF
--- a/integration_tests/snaps/plainbox-simple/snap/snapcraft.yaml
+++ b/integration_tests/snaps/plainbox-simple/snap/snapcraft.yaml
@@ -9,6 +9,8 @@ confinement: strict
 apps:
     plainbox:
         command: bin/plainbox-wrapper
+        # Required because of https://bugs.launchpad.net/snapcraft/+bug/1732076
+        plugs: [home]
 
 parts:
     # The testing framework


### PR DESCRIPTION
On integration tests we set XDG_CACHE_HOME to a temporary directory in TMPDIR.
In autopkgtests we are now setting TMPDIR to $HOME/autopkgtest_tmp.
The plainbox test tries to write to XDG_CACHE_HOME, which used to be somewhere
it could write. Now that it is in home, to properly work the snap requires the
home plug.

LP: #1732076

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
