### PR TITLE
catkin plugin: support building entire workspace

### DIFF
--- a/snapcraft/plugins/_ros/rosdep.py
+++ b/snapcraft/plugins/_ros/rosdep.py
@@ -99,13 +99,31 @@ class Rosdep:
             raise RuntimeError(
                 'Error updating rosdep database:\n{}'.format(output))
 
-    def get_dependencies(self, package_name):
+    def get_dependencies(self, package_name=None):
+        """Obtain dependencies for a given package, or entire workspace.
+
+        :param str package_name: Package name for which dependences will be
+                                 obtained. If not provided, will obtain
+                                 dependencies for the entire workspace.
+        """
+        command = ['keys']
+        if package_name:
+            command.append(package_name)
+        else:
+            # Adding a few flags that will make rosdep search the entire
+            # workspace:
+            #
+            # -a: select all packages in workspace
+            # -i: ignore any resolved keys that are satisfied by other packages
+            #     in the workspace
+            command.append('-a')
+            command.append('-i')
         try:
-            output = self._run(['keys', package_name]).strip()
+            output = self._run(command).strip()
             if output:
-                return output.split('\n')
+                return set(output.split('\n'))
             else:
-                return []
+                return set()
         except subprocess.CalledProcessError:
             raise FileNotFoundError(
                 'Unable to find Catkin package "{}"'.format(package_name))

--- a/snapcraft/tests/integration/snaps/ros-talker-listener/snap/snapcraft.yaml
+++ b/snapcraft/tests/integration/snaps/ros-talker-listener/snap/snapcraft.yaml
@@ -13,7 +13,4 @@ parts:
   ros-project:
     plugin: catkin
     source: .
-    catkin-packages:
-      - talker
-      - listener
-    include-roscore: true
+    rosdistro: indigo

--- a/snapcraft/tests/unit/plugins/ros/test_rosdep.py
+++ b/snapcraft/tests/unit/plugins/ros/test_rosdep.py
@@ -111,7 +111,7 @@ class RosdepTestCase(unit.TestCase):
         self.check_output_mock.return_value = b'foo\nbar\nbaz'
 
         self.assertThat(self.rosdep.get_dependencies('foo'),
-                        Equals(['foo', 'bar', 'baz']))
+                        Equals({'foo', 'bar', 'baz'}))
 
         self.check_output_mock.assert_called_with(['rosdep', 'keys', 'foo'],
                                                   env=mock.ANY)
@@ -119,7 +119,7 @@ class RosdepTestCase(unit.TestCase):
     def test_get_dependencies_no_dependencies(self):
         self.check_output_mock.return_value = b''
 
-        self.assertThat(self.rosdep.get_dependencies('foo'), Equals([]))
+        self.assertThat(self.rosdep.get_dependencies('foo'), Equals(set()))
 
     def test_get_dependencies_invalid_package(self):
         self.check_output_mock.side_effect = subprocess.CalledProcessError(
@@ -131,6 +131,15 @@ class RosdepTestCase(unit.TestCase):
 
         self.assertThat(str(raised),
                         Equals('Unable to find Catkin package "bar"'))
+
+    def test_get_dependencies_entire_workspace(self):
+        self.check_output_mock.return_value = b'foo\nbar\nbaz'
+
+        self.assertThat(self.rosdep.get_dependencies(),
+                        Equals({'foo', 'bar', 'baz'}))
+
+        self.check_output_mock.assert_called_with(
+            ['rosdep', 'keys', '-a', '-i'], env=mock.ANY)
 
     def test_resolve_dependency(self):
         self.check_output_mock.return_value = b'#apt\nmylib-dev'


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently the Catkin plugin requires one to specify each and every Catkin package in the workspace that needs to be built and installed into the snap. This is a hindrance for larger projects, especially as oftentimes the entire workspace is needed.

This PR resolves LP: [#1721168](https://bugs.launchpad.net/snapcraft/+bug/1721168) (and #1713) by making the `catkin-packages` property optional. If it's not specified, simply build the entire workspace. Thus the only API change is making what was previously a required property optional, and assigning meaning to its absence.