### PR TITLE
kernel plugin: don't assume /lib/firmware is present if !kernel-with-firmware

### DIFF
--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -475,6 +475,8 @@ class KernelPlugin(kbuild.KBuildPlugin):
         # but snapd expects modules/ and firmware/
         shutil.move(
             os.path.join(self.installdir, 'lib', 'modules'), self.installdir)
-        shutil.move(
-            os.path.join(self.installdir, 'lib', 'firmware'), self.installdir)
+        if self.options.kernel_with_firmware:
+            shutil.move(
+                os.path.join(self.installdir, 'lib', 'firmware'),
+                self.installdir)
         os.rmdir(os.path.join(self.installdir, 'lib'))

--- a/snapcraft/tests/plugins/test_kernel.py
+++ b/snapcraft/tests/plugins/test_kernel.py
@@ -169,7 +169,8 @@ class KernelPluginTestCase(tests.TestCase):
 
     def _simulate_build(
             self, sourcedir, builddir, installdir, do_dtbs=False,
-            do_release=True, do_kernel=True, do_system_map=True):
+            do_release=True, do_kernel=True, do_system_map=True,
+            do_firmware=True):
         os.makedirs(sourcedir)
         kernel_version = '4.4.2'
 
@@ -188,10 +189,11 @@ class KernelPluginTestCase(tests.TestCase):
             modules_dep_path = os.path.join(
                 installdir, 'lib', 'modules', kernel_version, 'modules.dep')
             modules_dep_bin_path = '{}.bin'.format(modules_dep_path)
-            fw_bin_path = os.path.join(
-                installdir, 'lib', 'firmware', 'fake-fw.bin')
-            os.makedirs(os.path.join(
-                installdir, 'lib', 'firmware', 'fake-fw-dir'))
+            if do_firmware:
+                fw_bin_path = os.path.join(
+                    installdir, 'lib', 'firmware', 'fake-fw.bin')
+                os.makedirs(os.path.join(
+                    installdir, 'lib', 'firmware', 'fake-fw-dir'))
             dtb_path = os.path.join(build_arch_path, 'dts', 'fake-dtb.dtb')
 
             os.makedirs(os.path.dirname(release_path))
@@ -201,14 +203,15 @@ class KernelPluginTestCase(tests.TestCase):
                 else:
                     f.write('\n')
 
-            files = [initrd_path, modules_dep_path, modules_dep_bin_path,
-                     fw_bin_path]
+            files = [initrd_path, modules_dep_path, modules_dep_bin_path]
             if do_kernel:
                 files.append(kernel_path)
             if do_system_map:
                 files.append(system_map_path)
             if do_dtbs:
                 files.append(dtb_path)
+            if do_firmware:
+                files.append(fw_bin_path)
 
             for f in files:
                 os.makedirs(os.path.dirname(f), exist_ok=True)
@@ -858,7 +861,8 @@ ACCEPT=n
                                      self.project_options)
 
         self._simulate_build(
-            plugin.sourcedir, plugin.builddir, plugin.installdir, do_dtbs=True)
+            plugin.sourcedir, plugin.builddir, plugin.installdir, do_dtbs=True,
+            do_firmware=False)
 
         plugin.build()
 


### PR DESCRIPTION
This is an hot-fix candidate: in case of 'kernel-with-firmware: false', don't assume /lib/firmware is present, and avoid referencing it later on.

snapcraft.yaml:
...
kernel-with-firmware: false

Traceback (most recent call last):
  File "/usr/lib/python3.5/shutil.py", line 538, in move
    os.rename(src, real_dst)
FileNotFoundError: [Errno 2] No such file or directory: '/home/flag/canonical/linux/snap/parts/kernel/install/lib/firmware' -> '/home/flag/canonical/lin
ux/snap/parts/kernel/install/firmware'

During handling of the above exception, another exception occurred:

Traceback (most recent call last): [4/9271]
  File "/home/flag/canonical/snapcraft/bin/snapcraft", line 36, in <module>
    obj=dict(project=snapcraft.ProjectOptions()))
  File "/usr/lib/python3/dist-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1037, in invoke
    return Command.invoke(self, ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3/dist-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/flag/canonical/snapcraft/snapcraft/cli/__init__.py", line 124, in run
    ctx.forward(lifecyclecli.commands['snap'])
  File "/usr/lib/python3/dist-packages/click/core.py", line 552, in forward
    return self.invoke(cmd, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/flag/canonical/snapcraft/snapcraft/cli/lifecycle.py", line 140, in snap
    project_options, directory=directory, output=output)
  File "/home/flag/canonical/snapcraft/snapcraft/internal/lifecycle/_packer.py", line 45, in snap
    execute('prime', project_options)
  File "/home/flag/canonical/snapcraft/snapcraft/internal/lifecycle/_runner.py", line 80, in execute
    _Executor(config, project_options).run(step, part_names)
  File "/home/flag/canonical/snapcraft/snapcraft/internal/lifecycle/_runner.py", line 175, in run
    self._run_step(step, part, part_names)
  File "/home/flag/canonical/snapcraft/snapcraft/internal/lifecycle/_runner.py", line 212, in _run_step
    getattr(part, step)()
  File "/home/flag/canonical/snapcraft/snapcraft/internal/pluginhandler/__init__.py", line 330, in build
    self.plugin.build()
  File "/home/flag/canonical/snapcraft/snapcraft/plugins/kbuild.py", line 258, in build
    self.do_install()
  File "/home/flag/canonical/snapcraft/snapcraft/plugins/kernel.py", line 479, in do_install
    os.path.join(self.installdir, 'lib', 'firmware'), self.installdir)
  File "/usr/lib/python3.5/shutil.py", line 552, in move
    copy_function(src, real_dst)
  File "/usr/lib/python3.5/shutil.py", line 251, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.5/shutil.py", line 114, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/home/flag/canonical/linux/snap/parts/kernel/install/lib/firmware'

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>

https://bugs.launchpad.net/snapcraft/+bug/1733564

-----
