### PR TITLE
tests: add the missing quote on autopkgtest run

### DIFF
--- a/tools/travis/run_autopkgtests.sh
+++ b/tools/travis/run_autopkgtests.sh
@@ -44,6 +44,6 @@ $lxc exec test-runner -- sh -c "cd snapcraft && ./tools/travis/setup_lxd.sh"
 $lxc exec test-runner -- sh -c "apt install --yes autopkgtest"
 # Ignore the core install error as a workaround for
 # - Setup snap "core" (2462) security profiles (cannot reload udev rules: exit status 2
-$lxc exec test-runner -- sh -c "cd snapcraft && adt-run --testname $test snapcraft --setup-commands $script_path/setup_autopkgtests_ppa.sh -U --setup-commands \"apt install squashfuse && (snap install core || echo 'ignored error')\" --- lxd $distro
+$lxc exec test-runner -- sh -c "cd snapcraft && adt-run --testname $test snapcraft --setup-commands $script_path/setup_autopkgtests_ppa.sh -U --setup-commands \"apt install squashfuse && (snap install core || echo 'ignored error')\" --- lxd $distro"
 
 $lxc stop test-runner


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
I must have touched backspace by mistake when I was moving the suite to the nightly, or something, because this worked here: https://travis-ci.org/snapcore/snapcraft/jobs/302748980
I'm sorry.
I added the quote, and now I can run this locally: http://paste.ubuntu.com/26029313/
Hopefully travis will not give us any other surprises.