### PR TITLE
many: ensure classic confined binaries use the correct interpreter

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -4,7 +4,7 @@
 
 First install a few dependencies:
 
-    sudo apt install gcc g++ make python3-dev python3-venv libffi-dev libsodium-dev libapt-pkg-dev libarchive13 squashfs-tools
+    sudo apt install gcc g++ make python3-dev python3-venv libffi-dev libsodium-dev libapt-pkg-dev libarchive13 squashfs-tools patchelf
 
 Create and activate a new virtual environment:
 

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Build-Depends: bash-completion,
                dh-python,
                git,
                mercurial,
+               patchelf,
                pkg-config,
                python3 (>= 3.4),
                python3-apt,
@@ -46,7 +47,8 @@ Standards-Version: 3.9.8
 
 Package: snapcraft
 Architecture: all
-Depends: python3-apt,
+Depends: patchelf,
+         python3-apt,
          python3-debian,
          python3-click,
          python3-jsonschema,

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,6 +52,12 @@ parts:
         LIBSODIUM=$(readlink -n $TRIPLET_PATH/libsodium.so.18)
         ln -s $LIBSODIUM $TRIPLET_PATH/libsodium.so
     after: [python, apt]
+  patchelf:
+    source: https://launchpad.net/ubuntu/+archive/primary/+files/patchelf_0.9.orig.tar.gz
+    source-checksum: sha256/f2aa40a6148cb3b0ca807a1bf836b081793e55ec9e5540a5356d800132be7e0a
+    plugin: autotools
+    stage:
+        - bin/patchelf
   python:
     source: https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tar.xz
     plugin: autotools

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -75,7 +75,7 @@ class Patcher:
     def patch(self, *, elf_file: ElfFile) -> None:
         """Patch elf_file with the Patcher instance configuration.
 
-        patch will to the right thing with regards to the different type
+        patch will to the right thing with regards to the different types
         of elf files.
 
         :param str elf_file: path to the elf_file to patch.

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -20,7 +20,7 @@ import logging
 import os
 import subprocess
 import sys
-from typing import Dict, List, Set, Sequence, FrozenSet
+from typing import FrozenSet, List, Set, Sequence
 
 import magic
 
@@ -33,6 +33,72 @@ from snapcraft.internal import (
 
 
 logger = logging.getLogger(__name__)
+
+
+class ElfFile:
+    """ElfFile represents and elf file on a path and its attributes."""
+
+    def __init__(self, *, path: str, is_executable: bool) -> None:
+        """Initialize an ElfFile instance.
+
+        :param str path: path to an elf_file within a snapcraft project.
+        :param bool is_executable: True if the elf_file is an executable,
+                                   meaning that it has in .interp entry
+                                   in its headers.
+        """
+        self.path = path
+        self.is_executable = is_executable
+
+
+class Patcher:
+    """Patcher holds the necessary logic to patch elf files."""
+
+    def __init__(self, *, dynamic_linker: str) -> None:
+        """Create a Patcher instance.
+
+        :param str dynamic_linker: the path to the dynamic linker to set the
+                                   elf file to.
+        """
+        self._dynamic_linker = dynamic_linker
+
+        # If we are running from the snap we want to use the patchelf
+        # bundled there as it would have the capabilty of working
+        # anywhere given the fixed ld it would have.
+        # If not found, resort to whatever is on the system brought
+        # in by packaging dependencies.
+        if common.is_snap():
+            snap_dir = os.getenv('SNAP')
+            self._patchelf = os.path.join(snap_dir, 'bin', 'patchelf')
+        else:
+            self._patchelf = 'patchelf'
+
+    def patch(self, *, elf_file: ElfFile) -> None:
+        """Patch elf_file with the Patcher instance configuration.
+
+        patch will to the right thing with regards to the different type
+        of elf files.
+
+        :param str elf_file: path to the elf_file to patch.
+        :param dict elf_properties:
+            properties of the elf file. The property list is as follows:
+                * executable: boolean stating if elf_file is executable.
+        :raises snapcraft.internal.errors.PatcherError:
+            raised when the elf_file cannot be patched.
+        """
+        # When setting rpath for libraries is implemented, we will do more
+        # here.
+        if not elf_file.is_executable:
+            return
+        try:
+            subprocess.check_call([self._patchelf,
+                                   '--set-interpreter',  self._dynamic_linker,
+                                   elf_file.path])
+        # There is no need to catch FileNotFoundError as patchelf should be
+        # bundled with snapcraft which means its lack of existence is a
+        # "packager" error.
+        except subprocess.CalledProcessError as call_error:
+            raise errors.PatcherError(elf_file=elf_file.path,
+                                      message=str(call_error))
 
 
 def determine_ld_library_path(root: str) -> List[str]:
@@ -136,19 +202,18 @@ def get_dependencies(elf: str) -> Set[str]:
 
 
 def get_elf_files(root: str,
-                  file_list: Sequence[str]) -> Dict[str, Dict[str, str]]:
+                  file_list: Sequence[str]) -> FrozenSet[ElfFile]:
     """Return a frozenset of elf files from file_list prepended with root.
 
     :param str root: the root directory from where the file_list is generated.
     :param file_list: a list of file in root.
-    :returns: a frozentset of strings representing paths of valid elf files
-              found in root from file_list.
+    :returns: a frozentset of ElfFile objects.
     """
     ms = magic.open(magic.NONE)
     if ms.load() != 0:
         raise RuntimeError('Cannot load magic header detection')
 
-    elf_files = dict()  # type: Dict[str, Dict[str, str]]
+    elf_files = set()  # type: Set[ElfFile]
 
     fs_encoding = sys.getfilesystemencoding()
 
@@ -171,57 +236,6 @@ def get_elf_files(root: str,
         file_m = ms.file(path_b)
         if file_m.startswith('ELF') and 'dynamically linked' in file_m:
             is_executable = 'interpreter' in file_m
-            elf_files[path] = dict(executable=is_executable)
+            elf_files.add(ElfFile(path=path, is_executable=is_executable))
 
-    return elf_files
-
-
-class Patcher:
-    """Patcher holds the necessary logic to patch elf files."""
-
-    def __init__(self, *, dynamic_linker: str) -> None:
-        """Create a Patcher instance.
-
-        :param str dynamic_linker: the path to the dynamic linker to set the
-                                   elf file to.
-        """
-        self._dynamic_linker = dynamic_linker
-
-        # If we are running from the snap we want to use the patchelf
-        # bundled there as it would have the capabilty of working
-        # anywhere given the fixed ld it would have.
-        # If not found, resort to whatever is on the system brought
-        # in by packaging dependencies.
-        if common.is_snap():
-            snap_dir = os.getenv('SNAP')
-            self._patchelf = os.path.join(snap_dir, 'bin', 'patchelf')
-        else:
-            self._patchelf = 'patchelf'
-
-    def patch(self, *, elf_file: str, elf_properties: Dict[str, str]) -> None:
-        """Patch elf_file with the Patcher instance configuration.
-
-        patch will to the right thing with regards to the different type
-        of elf files.
-
-        :param str elf_file: path to the elf_file to patch.
-        :param dict elf_properties:
-            properties of the elf file. The property list is as follows:
-                * executable: boolean stating if elf_file is executable.
-        :raises snapcraft.internal.errors.PatcherError:
-            raised when the elf_file cannot be patched.
-        """
-        # When setting rpath for libraries is implemented, we will do more
-        # here.
-        if not elf_properties['executable']:
-            return
-        try:
-            subprocess.check_call([self._patchelf,
-                                   '--set-interpreter',  self._dynamic_linker,
-                                   elf_file])
-        # There is no need to catch FileNotFoundError as patchelf should be
-        # bundled with snapcraft which means its lack of existence is a
-        # "packager" error.
-        except subprocess.CalledProcessError as call_error:
-            raise errors.PatcherError(elf_file=elf_file,
-                                      message=str(call_error))
+    return frozenset(elf_files)

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -68,9 +68,9 @@ class Patcher:
         # in by packaging dependencies.
         if common.is_snap():
             snap_dir = os.getenv('SNAP')
-            self._patchelf = os.path.join(snap_dir, 'bin', 'patchelf')
+            self._patchelf_cmd = os.path.join(snap_dir, 'bin', 'patchelf')
         else:
-            self._patchelf = 'patchelf'
+            self._patchelf_cmd = 'patchelf'
 
     def patch(self, *, elf_file: ElfFile) -> None:
         """Patch elf_file with the Patcher instance configuration.
@@ -90,7 +90,7 @@ class Patcher:
         if not elf_file.is_executable:
             return
         try:
-            subprocess.check_call([self._patchelf,
+            subprocess.check_call([self._patchelf_cmd,
                                    '--set-interpreter',  self._dynamic_linker,
                                    elf_file.path])
         # There is no need to catch FileNotFoundError as patchelf should be

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -75,13 +75,10 @@ class Patcher:
     def patch(self, *, elf_file: ElfFile) -> None:
         """Patch elf_file with the Patcher instance configuration.
 
-        patch will to the right thing with regards to the different types
-        of elf files.
+        If the ELF is executable, patch it to use the configured linker.
 
-        :param str elf_file: path to the elf_file to patch.
-        :param dict elf_properties:
-            properties of the elf file. The property list is as follows:
-                * executable: boolean stating if elf_file is executable.
+        :param ElfFile elf: a data object representing an elf file and its
+                            relevant attributes.
         :raises snapcraft.internal.errors.PatcherError:
             raised when the elf_file cannot be patched.
         """

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -355,3 +355,13 @@ class InvalidContainerImageInfoError(SnapcraftError):
 
     def __init__(self, image_info):
         super().__init__(image_info=image_info)
+
+
+class PatcherError(SnapcraftError):
+
+    fmt = (
+        '{elf_file!r} cannot be patched to function properly as a classic '
+        'snap: {message}')
+
+    def __init__(self, *, elf_file, message):
+        super().__init__(elf_file=elf_file, message=message)

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -209,7 +209,9 @@ class _Executor:
 
         part = _replace_in_part(part)
 
-        getattr(part, step)()
+        is_classic = self.config.data['confinement'] == 'classic'  # type: bool
+
+        getattr(part, step)(is_classic=is_classic)
 
     def _create_meta(self, step, part_names):
         if step == 'prime' and part_names == self.config.part_names:

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -209,9 +209,7 @@ class _Executor:
 
         part = _replace_in_part(part)
 
-        is_classic = self.config.data['confinement'] == 'classic'  # type: bool
-
-        getattr(part, step)(is_classic=is_classic)
+        getattr(part, step)()
 
     def _create_meta(self, step, part_names):
         if step == 'prime' and part_names == self.config.part_names:

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -444,7 +444,7 @@ class PluginHandler:
         elf_files = elf.get_elf_files(self.primedir, snap_files)
         dependencies = set()
         for elf_file in elf_files:
-            dependencies.update(elf.get_dependencies(elf_file))
+            dependencies.update(elf.get_dependencies(elf_file.path))
 
         # Split the necessary dependencies into their corresponding location.
         # We'll both migrate and track the system dependencies, but we'll only
@@ -474,9 +474,7 @@ class PluginHandler:
             dynamic_linker = self._project_options.get_core_dynamic_linker()
             elf_patcher = elf.Patcher(dynamic_linker=dynamic_linker)
             for elf_file in elf_files:
-                elf_file_path = os.path.join(self.primedir, elf_file)
-                elf_patcher.patch(elf_file=elf_file_path,
-                                  elf_properties=elf_files[elf_file])
+                elf_patcher.patch(elf_file=elf_file)
 
         self.mark_prime_done(snap_files, snap_dirs, dependency_paths)
 

--- a/snapcraft/internal/project_loader/_env.py
+++ b/snapcraft/internal/project_loader/_env.py
@@ -83,8 +83,7 @@ def build_env(root, snap_name, confinement, arch_triplet,
                    # Building tools to continue the build becomes problematic
                    # with nodefaultlib.
                    # '-Wl,-z,nodefaultlib '
-                   '-Wl,--dynamic-linker={0} '
-                   '-Wl,-rpath,{1}"'.format(core_dynamic_linker, rpaths))
+                   '-Wl,-rpath,{}"'.format(rpaths))
 
     paths = common.get_library_paths(root, arch_triplet)
     if paths:

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -191,7 +191,8 @@ class PartsConfig:
             part_schema=self._validator.part_schema,
             definitions_schema=self._validator.definitions_schema,
             stage_packages_repo=stage_packages_repo,
-            grammar_processor=grammar_processor)
+            grammar_processor=grammar_processor,
+            confinement=self._confinement)
 
         self.build_snaps |= grammar_processor.get_build_snaps()
         self.build_tools |= grammar_processor.get_build_packages()

--- a/snapcraft/tests/integration/general/test_prime.py
+++ b/snapcraft/tests/integration/general/test_prime.py
@@ -18,6 +18,7 @@ import os
 import subprocess
 from textwrap import dedent
 
+import fixtures
 import testscenarios
 from testtools.matchers import (
     Contains,
@@ -36,6 +37,33 @@ class PrimeTestCase(integration.TestCase):
     def setUp(self):
         super().setUp()
         self.deb_arch = snapcraft.ProjectOptions().deb_arch
+
+    def test_classic_confinement(self):
+        project_dir = 'classic-build'
+
+        # The first run should fail as the environment variable is not
+        # set but we can only test this on clean systems.
+        if not os.path.exists(os.path.join(
+                os.path.sep, 'snap', 'core', 'current')):
+            try:
+                self.run_snapcraft(['prime'], project_dir)
+            except subprocess.CalledProcessError:
+                pass
+            else:
+                self.fail(
+                    'This should fail as SNAPCRAFT_SETUP_CORE is not set')
+
+        # Now we set the required environment variable
+        self.useFixture(fixtures.EnvironmentVariable(
+                'SNAPCRAFT_SETUP_CORE', '1'))
+
+        self.run_snapcraft(['prime'], project_dir)
+        bin_path = os.path.join(self.prime_dir, 'bin', 'hello-classic')
+        self.assertThat(bin_path, FileExists())
+
+        interpreter = subprocess.check_output([
+            'patchelf', '--print-interpreter', bin_path]).decode()
+        self.assertThat(interpreter, Contains('/snap/core/current'))
 
     def test_prime_includes_stage_fileset(self):
         self.run_snapcraft('prime', 'prime-from-stage')

--- a/snapcraft/tests/integration/general/test_prime.py
+++ b/snapcraft/tests/integration/general/test_prime.py
@@ -64,7 +64,7 @@ class PrimeTestCase(integration.TestCase):
 
         interpreter = subprocess.check_output([
             'patchelf', '--print-interpreter', bin_path]).decode()
-        expected_interpreter = r'^{}.*'.format(self.startswith)
+        expected_interpreter = r'^/snap/core/current/.*'
         self.assertThat(interpreter, MatchesRegex(expected_interpreter))
 
     def test_prime_includes_stage_fileset(self):

--- a/snapcraft/tests/integration/general/test_prime.py
+++ b/snapcraft/tests/integration/general/test_prime.py
@@ -25,6 +25,7 @@ from testtools.matchers import (
     Equals,
     FileContains,
     FileExists,
+    MatchesRegex,
     Not,
 )
 
@@ -63,7 +64,8 @@ class PrimeTestCase(integration.TestCase):
 
         interpreter = subprocess.check_output([
             'patchelf', '--print-interpreter', bin_path]).decode()
-        self.assertThat(interpreter, Contains('/snap/core/current'))
+        expected_interpreter = r'^{}.*'.format(self.startswith)
+        self.assertThat(interpreter, MatchesRegex(expected_interpreter))
 
     def test_prime_includes_stage_fileset(self):
         self.run_snapcraft('prime', 'prime-from-stage')

--- a/snapcraft/tests/integration/general/test_stage.py
+++ b/snapcraft/tests/integration/general/test_stage.py
@@ -105,8 +105,12 @@ class StageTestCase(integration.TestCase):
                 'SNAPCRAFT_SETUP_CORE', '1'))
 
         self.run_snapcraft(['stage'], project_dir)
-        self.assertThat(os.path.join(self.stage_dir, 'bin', 'hello-classic'),
-                        FileExists())
+        bin_path = os.path.join(self.stage_dir, 'bin', 'hello-classic')
+        self.assertThat(bin_path, FileExists())
+
+        interpreter = subprocess.check_output([
+            'patchelf', '--print-interpreter', bin_path]).decode()
+        self.assertThat(interpreter, Not(Contains('/snap/core/current')))
 
     def test_staging_libc_links(self):
         project_dir = 'staging_links_to_libc'

--- a/snapcraft/tests/integration/general/test_stage.py
+++ b/snapcraft/tests/integration/general/test_stage.py
@@ -108,6 +108,7 @@ class StageTestCase(integration.TestCase):
         bin_path = os.path.join(self.stage_dir, 'bin', 'hello-classic')
         self.assertThat(bin_path, FileExists())
 
+        # ld-linux will not be set until everything is primed.
         interpreter = subprocess.check_output([
             'patchelf', '--print-interpreter', bin_path]).decode()
         self.assertThat(interpreter, Not(Contains('/snap/core/current')))

--- a/snapcraft/tests/integration/plugins/test_rust_plugin.py
+++ b/snapcraft/tests/integration/plugins/test_rust_plugin.py
@@ -129,8 +129,7 @@ class RustPluginConfinementTestCase(testscenarios.WithScenarios,
 
         self.run_snapcraft('prime')
 
-        bin_path = os.path.join(self.parts_dir, 'rust-hello', 'install',
-                                'bin', 'rust-hello')
+        bin_path = os.path.join('prime', 'bin', 'rust-hello')
 
         interpreter = subprocess.check_output([
             'patchelf', '--print-interpreter', bin_path]).decode()

--- a/snapcraft/tests/integration/plugins/test_rust_plugin.py
+++ b/snapcraft/tests/integration/plugins/test_rust_plugin.py
@@ -134,6 +134,5 @@ class RustPluginConfinementTestCase(testscenarios.WithScenarios,
 
         interpreter = subprocess.check_output([
             'patchelf', '--print-interpreter', bin_path]).decode()
-
         expected_interpreter = r'^{}.*'.format(self.startswith)
         self.assertThat(interpreter, MatchesRegex(expected_interpreter))

--- a/snapcraft/tests/unit/__init__.py
+++ b/snapcraft/tests/unit/__init__.py
@@ -167,7 +167,8 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
                                 step, part_name))
 
     def load_part(self, part_name, plugin_name=None, part_properties=None,
-                  project_options=None, stage_packages_repo=None):
+                  project_options=None, stage_packages_repo=None,
+                  confinement='strict'):
         if not plugin_name:
             plugin_name = 'nil'
         properties = {'plugin': plugin_name}
@@ -202,7 +203,8 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
             part_schema=schema,
             definitions_schema=definitions_schema,
             grammar_processor=grammar_processor,
-            stage_packages_repo=stage_packages_repo)
+            stage_packages_repo=stage_packages_repo,
+            confinement=confinement)
 
 
 class TestWithFakeRemoteParts(TestCase):

--- a/snapcraft/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/snapcraft/tests/unit/pluginhandler/test_pluginhandler.py
@@ -33,6 +33,7 @@ import snapcraft
 from . import mocks
 from snapcraft.internal import (
     common,
+    elf,
     errors,
     lifecycle,
     pluginhandler,
@@ -1136,8 +1137,10 @@ class StateTestCase(StateBaseTestCase):
             '{}/lib2/staged'.format(self.handler.stagedir),
         }
         self.get_elf_files_mock.return_value = frozenset([
-            os.path.join(self.handler.primedir, 'bin', '1'),
-            os.path.join(self.handler.primedir, 'bin', '2'),
+            elf.ElfFile(path=os.path.join(self.handler.primedir, 'bin', '1'),
+                        is_executable=True),
+            elf.ElfFile(path=os.path.join(self.handler.primedir, 'bin', '2'),
+                        is_executable=True),
         ])
         self.assertThat(self.handler.last_step(), Equals(None))
 
@@ -1191,7 +1194,9 @@ class StateTestCase(StateBaseTestCase):
         })
 
         self.get_elf_files_mock.return_value = frozenset([
-            os.path.join(self.handler.primedir, 'bin', 'file')])
+            elf.ElfFile(
+                path=os.path.join(self.handler.primedir, 'bin', 'file'),
+                is_executable=True)])
         # Pretend we found a system dependency, as well as a part and stage
         # dependency.
         mock_get_dependencies.return_value = set([
@@ -1234,8 +1239,8 @@ class StateTestCase(StateBaseTestCase):
     @patch('snapcraft.internal.pluginhandler._migrate_files')
     def test_prime_state_with_shadowed_dependencies(self, mock_migrate_files,
                                                     mock_get_dependencies):
-        self.get_elf_files_mock.return_value = frozenset(['bin/1'])
-
+        self.get_elf_files_mock.return_value = frozenset([
+            elf.ElfFile(path='bin/1', is_executable=True)])
         self.assertThat(self.handler.last_step(), Equals(None))
 
         bindir = os.path.join(self.handler.plugin.installdir, 'bin')

--- a/snapcraft/tests/unit/project_loader/test_config.py
+++ b/snapcraft/tests/unit/project_loader/test_config.py
@@ -1721,7 +1721,6 @@ parts:
         environment = config.stage_env()
         self.assertIn(
             'LDFLAGS="$LDFLAGS '
-            '-Wl,--dynamic-linker={core_dynamic_linker} '
             '-Wl,-rpath,'
             '/snap/test/current/lib:'
             '/snap/test/current/usr/lib:'
@@ -1731,7 +1730,6 @@ parts:
             '/snap/core/current/usr/lib:'
             '/snap/core/current/lib/{arch_triplet}:'
             '/snap/core/current/usr/lib/{arch_triplet}"'.format(
-                core_dynamic_linker=dynamic_linker,
                 arch_triplet=self.arch_triplet),
             environment)
 

--- a/tools/travis/run_tests.sh
+++ b/tools/travis/run_tests.sh
@@ -37,7 +37,7 @@ elif [[ "$test" = "snapcraft/tests/integration"* ]]; then
     # snap install core exits with this error message:
     # - Setup snap "core" (2462) security profiles (cannot reload udev rules: exit status 2
     # but the installation succeeds, so we just ingore it.
-    dependencies="apt install -y bzr curl git libnacl-dev libsodium-dev libffi-dev libapt-pkg-dev libarchive-dev mercurial python3-pip subversion squashfs-tools sudo snapd xdelta3 && python3 -m pip install -r requirements-devel.txt -r requirements.txt && (snap install core || echo 'ignored error') && sudo snap install snaps-cache/snapcraft-pr$TRAVIS_PULL_REQUEST.snap --dangerous --classic"
+    dependencies="apt install -y bzr curl git libnacl-dev libsodium-dev libffi-dev libapt-pkg-dev libarchive-dev mercurial python3-pip subversion squashfs-tools sudo snapd xdelta3 patchelf && python3 -m pip install -r requirements-devel.txt -r requirements.txt && (snap install core || echo 'ignored error') && sudo snap install snaps-cache/snapcraft-pr$TRAVIS_PULL_REQUEST.snap --dangerous --classic"
 else
     echo "Unknown test suite: $test"
     exit 1


### PR DESCRIPTION
During the prime step, the pluginhandler collects all elf files,
as a postprocessing step, the elf files that contain an .interp
section in the elf headers are set to use the linker loader
from core.

Fixes: #1662

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
I have built a snap (but still sets the LD_FLAG) which can be obtained by `snap install snapcraft --classic --channel edge/patchelf`