### PR TITLE
lxd: ContainerConnectionError on failed launch/ start

### DIFF
--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -111,6 +111,8 @@ class Containerbuild:
         try:
             self._ensure_container()
             yield
+        except subprocess.CalledProcessError as e:
+            raise ContainerConnectionError('Failed to setup container')
         finally:
             status = self._get_container_status()
             if status and status['status'] == 'Running':


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
Currently if LXD fails to launch one still ends up with a backtrace w/o the --debug switch, eg.:

    Creating snapcraft-nontechnically-bilinear-viviana
    error: Failed container creation:
     - https://cloud-images.ubuntu.com/releases: No storage pool found. Please create a new storage pool.

This should show an error referring to LXD docs as well.