### PR TITLE
lxd: delete container only if parts is empty

### DIFF
--- a/snapcraft/internal/lxd/_project.py
+++ b/snapcraft/internal/lxd/_project.py
@@ -19,6 +19,7 @@ import logging
 import os
 import subprocess
 import time
+from typing import List
 
 from ._containerbuild import Containerbuild
 
@@ -158,13 +159,14 @@ class Project(Containerbuild):
             self._container_run(['apt-get', 'upgrade', '-y'])
             self._container_run(['snap', 'refresh'])
 
-    def clean(self, parts, step):
+    def clean(self, parts: List[str], step: str):
         # clean with no parts deletes the container
         if not step:
-            if self._get_container_status():
-                print('Deleting {}'.format(self._container_name))
-                subprocess.check_call([
-                    'lxc', 'delete', '-f', self._container_name])
+            if not parts:
+                if self._get_container_status():
+                    print('Deleting {}'.format(self._container_name))
+                    subprocess.check_call([
+                        'lxc', 'delete', '-f', self._container_name])
             step = 'pull'
         # clean normally, without involving the container
         if step == 'strip':

--- a/snapcraft/tests/unit/commands/test_clean.py
+++ b/snapcraft/tests/unit/commands/test_clean.py
@@ -166,6 +166,7 @@ class ContainerizedCleanCommandTestCase(CleanCommandTestCase):
     def test_clean_containerized_with_part(self):
         fake_lxd = fixture_setup.FakeLXD()
         fake_lxd.name = 'local:snapcraft-clean-test'
+        fake_lxd.status = 'Stopped'
         self.useFixture(fake_lxd)
         self.useFixture(fixtures.EnvironmentVariable(
             'SNAPCRAFT_CONTAINER_BUILDS', self.snapcraft_container_builds))
@@ -175,8 +176,7 @@ class ContainerizedCleanCommandTestCase(CleanCommandTestCase):
 
         self.assertThat(result.exit_code, Equals(0))
         # clean with parts should NOT delete the container
-        self.assertNotEqual(fake_lxd.check_call_mock.call_args,
-                            call(['lxc', 'delete', '-f', fake_lxd.name]))
+        fake_lxd.check_call_mock.assert_not_called()
 
 
 class CleanCommandPartsTestCase(CleanCommandTestCase):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
Steps to manually test this:
* export SNAPCRAFT_CONTAINER_BUILDS=helga
* cd snapcraft/tests/integration/snaps/go-hello/
* lxc list helga: | grep go-hello
* Observe no container exists
* snapcraft pull
* lxc list helga: | grep go-hello
* Observe container exists
* snapcraft clean -s pull go-hello
* lxc list helga: | grep go-hello
* Observe container exists
* snapcraft clean go-hello
* Observe container still exists, artifacts were cleaned
* snapcraft clean
* lxc list helga: | grep go-hello
* Observe container was deleted, message "Deleting helga:snapcraft-go-hello"
* Repeat "snapcraft clean", "snapcraft clean go-hello", "snapcraft clean -s pull go-hello"
* Observe no error occurred with already deleted container

Fixes [bug 1734145](https://bugs.launchpad.net/snapcraft/+bug/1734145)