### PR TITLE
Make the pip filtering in the Python plugin more fine-grained

### DIFF
--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -324,7 +324,11 @@ class PythonPlugin(snapcraft.BasePlugin):
 
     def snap_fileset(self):
         fileset = super().snap_fileset()
-        fileset.append('-bin/pip*')
+        fileset.append('-bin/pip')
+        fileset.append('-bin/pip2')
+        fileset.append('-bin/pip3')
+        fileset.append('-bin/pip2.7')
+        fileset.append('-bin/pip3.*')
         fileset.append('-bin/easy_install*')
         fileset.append('-bin/wheel')
         # Holds all the .pyc files. It is a major cause of inter part

--- a/snapcraft/tests/unit/plugins/test_python.py
+++ b/snapcraft/tests/unit/plugins/test_python.py
@@ -265,7 +265,11 @@ class PythonPluginTestCase(BasePythonPluginTestCase):
         plugin = python.PythonPlugin('test-part', self.options,
                                      self.project_options)
         expected_fileset = [
-            '-bin/pip*',
+            '-bin/pip',
+            '-bin/pip2',
+            '-bin/pip3',
+            '-bin/pip2.7',
+            '-bin/pip3.*',
             '-bin/easy_install*',
             '-bin/wheel',
             '-**/__pycache__',


### PR DESCRIPTION
This allows Python scripts that begin with "pip" but aren't actually pip
(such as pip2pi and friends) to be included in snaps using the Python
part.

LP: #1734213

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
