### PR TITLE
snapcraft.yaml: use gcc to determine tuple

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,7 +46,7 @@ parts:
         - '*'
         - '**/*.pyc'
     install: |
-        TRIPLET_PATH=$(ls -d $SNAPCRAFT_PART_INSTALL/usr/lib/$(uname -p)-*)
+        TRIPLET_PATH="$SNAPCRAFT_PART_INSTALL/usr/lib/$(gcc -print-multiarch)"
         LIBARCHIVE=$(readlink -n $TRIPLET_PATH/libarchive.so.13)
         ln -s $LIBARCHIVE $TRIPLET_PATH/libarchive.so
         LIBSODIUM=$(readlink -n $TRIPLET_PATH/libsodium.so.18)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently, when building the Snapcraft snap, we try to create the libsodium.so symlink by manually constructing the arch tuple using `uname`. However, this does not work correctly in all cases, for example i686.

This PR fixes LP: [#1733922](https://bugs.launchpad.net/snapcraft/+bug/1733922) by using `gcc -print-multiarch` instead. It's exactly what we need, and it's already a `build-package`.

Please test this PR by simply smoke-testing this snap on i386 (even an i386 LXD container would work):

    $ sudo snap install snapcraft --channel=stable/pr-1764 --classic