### PR TITLE
Enhanced fake store to detect that metadata can't be pushed prior to pushing the binary, and fixed the test

### DIFF
--- a/snapcraft/tests/integration/store/test_store_push_metadata.py
+++ b/snapcraft/tests/integration/store/test_store_push_metadata.py
@@ -31,7 +31,7 @@ class PushMetadataTestCase(integration.StoreTestCase):
 
         error = self.assertRaises(
             subprocess.CalledProcessError,
-            self.run_snapcraft, ['push', snap_file_path])
+            self.run_snapcraft, ['push-metadata', snap_file_path])
         self.assertIn('No valid credentials found. Have you run "snapcraft '
                       'login"?', str(error.output))
 
@@ -54,6 +54,9 @@ class PushMetadataTestCase(integration.StoreTestCase):
         # Push the snap
         snap_file_path = '{}_{}_{}.snap'.format(name, version, 'all')
         self.assertThat(os.path.join(snap_file_path), FileExists())
+        output = self.run_snapcraft(['push', snap_file_path])
+
+        # Now push the metadata
         output = self.run_snapcraft(['push-metadata', snap_file_path])
         expected = "Pushing metadata to the Store (force=False)"
         self.assertThat(output, Contains(expected))


### PR DESCRIPTION
This is because the real store needs for the binary of snap to be first pushed before really the metadata can be sent.

This was already understood by snapcraft (the error message when that doesn't happen express the problem correctly) but one integration test was incorrectly built (see [this failure](https://travis-ci.org/snapcore/snapcraft/jobs/308248189)).

So I fixed the fake store to make that bad test fail, and then fixed the test.