### PR TITLE
project: export the arch triplet into the environment

### DIFF
--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -231,6 +231,8 @@ class PartsConfig:
                 self._project_options.arch_triplet,
                 core_dynamic_linker=core_dynamic_linker)
             env.append('SNAPCRAFT_PART_INSTALL="{}"'.format(part.installdir))
+            env.append('SNAPCRAFT_ARCH_TRIPLET="{}"'.format(
+                self._project_options.arch_triplet))
             env.append('SNAPCRAFT_PARALLEL_BUILD_COUNT={}'.format(
                        self._project_options.parallel_build_count))
         else:

--- a/snapcraft/tests/integration/__init__.py
+++ b/snapcraft/tests/integration/__init__.py
@@ -108,7 +108,10 @@ class TestCase(testtools.TestCase):
         self.stage_dir = 'stage'
         self.prime_dir = 'prime'
 
-        self.deb_arch = _ProjectOptions().deb_arch
+        project = _ProjectOptions()
+        self.deb_arch = project.deb_arch
+        self.arch_triplet = project.arch_triplet
+
         release = OsRelease()
         self.distro_series = release.version_codename()
 

--- a/snapcraft/tests/integration/general/test_scriptlets.py
+++ b/snapcraft/tests/integration/general/test_scriptlets.py
@@ -58,3 +58,6 @@ class ScriptletTestCase(integration.TestCase):
         self.assertThat(echoed_file_path, FileExists())
         self.assertThat(echoed_file_path,
                         FileContains('config-key=config-value\n'))
+        arch_triplet_file = os.path.join(installdir, 'lib',
+                                         self.arch_triplet, 'lib.so')
+        self.assertThat(arch_triplet_file, FileExists())

--- a/snapcraft/tests/integration/snaps/scriptlet-install/snapcraft.yaml
+++ b/snapcraft/tests/integration/snaps/scriptlet-install/snapcraft.yaml
@@ -13,3 +13,5 @@ parts:
     install: |
       touch $SNAPCRAFT_PART_INSTALL/build-done
       echo config-key=config-value > $SNAPCRAFT_PART_INSTALL/config.ini
+      mkdir -p $SNAPCRAFT_PART_INSTALL/lib/$SNAPCRAFT_ARCH_TRIPLET
+      touch $SNAPCRAFT_PART_INSTALL/lib/$SNAPCRAFT_ARCH_TRIPLET/lib.so


### PR DESCRIPTION
It is exported as SNAPCRAFT_ARCH_TRIPLET and usable by
the scripting functionality in snapcraft.

Fixes: #1752

Signed-off-by: Ubuntu <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
