### PR TITLE
lxd: suppress traceback when lxc launch / init fails

### DIFF
--- a/snapcraft/internal/lxd/_cleanbuilder.py
+++ b/snapcraft/internal/lxd/_cleanbuilder.py
@@ -21,7 +21,7 @@ import petname
 import subprocess
 
 from ._containerbuild import Containerbuild
-from snapcraft.internal.errors import ContainerError
+from snapcraft.internal.errors import ContainerConnectionError
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class Cleanbuilder(Containerbuild):
             subprocess.check_call([
                 'lxc', 'launch', '-e', self._image, self._container_name])
         except subprocess.CalledProcessError as e:
-            raise ContainerError(e)
+            raise ContainerConnectionError('Failed to setup container')
         self._configure_container()
         self._wait_for_network()
         self._container_run(['apt-get', 'update'])

--- a/snapcraft/internal/lxd/_cleanbuilder.py
+++ b/snapcraft/internal/lxd/_cleanbuilder.py
@@ -21,6 +21,7 @@ import petname
 import subprocess
 
 from ._containerbuild import Containerbuild
+from snapcraft.internal.errors import ContainerError
 
 logger = logging.getLogger(__name__)
 
@@ -35,8 +36,11 @@ class Cleanbuilder(Containerbuild):
                          container_name=container_name, remote=remote)
 
     def _ensure_container(self):
-        subprocess.check_call([
-            'lxc', 'launch', '-e', self._image, self._container_name])
+        try:
+            subprocess.check_call([
+                'lxc', 'launch', '-e', self._image, self._container_name])
+        except subprocess.CalledProcessError as e:
+            raise ContainerError(e)
         self._configure_container()
         self._wait_for_network()
         self._container_run(['apt-get', 'update'])

--- a/snapcraft/internal/lxd/_project.py
+++ b/snapcraft/internal/lxd/_project.py
@@ -25,6 +25,7 @@ from ._containerbuild import Containerbuild
 
 from snapcraft.internal.errors import (
         ContainerConnectionError,
+        ContainerError,
         SnapcraftEnvironmentError,
 )
 from snapcraft.internal import lifecycle
@@ -46,8 +47,11 @@ class Project(Containerbuild):
     def _ensure_container(self):
         new_container = not self._get_container_status()
         if new_container:
-            subprocess.check_call([
-                'lxc', 'init', self._image, self._container_name])
+            try:
+                subprocess.check_call([
+                    'lxc', 'init', self._image, self._container_name])
+            except subprocess.CalledProcessError as e:
+                raise ContainerError(e)
         if self._get_container_status()['status'] == 'Stopped':
             self._configure_container()
             try:

--- a/snapcraft/internal/lxd/_project.py
+++ b/snapcraft/internal/lxd/_project.py
@@ -25,7 +25,6 @@ from ._containerbuild import Containerbuild
 
 from snapcraft.internal.errors import (
         ContainerConnectionError,
-        ContainerError,
         SnapcraftEnvironmentError,
 )
 from snapcraft.internal import lifecycle
@@ -51,7 +50,7 @@ class Project(Containerbuild):
                 subprocess.check_call([
                     'lxc', 'init', self._image, self._container_name])
             except subprocess.CalledProcessError as e:
-                raise ContainerError(e)
+                raise ContainerConnectionError('Failed to setup container')
         if self._get_container_status()['status'] == 'Stopped':
             self._configure_container()
             try:

--- a/snapcraft/tests/unit/test_lxd.py
+++ b/snapcraft/tests/unit/test_lxd.py
@@ -31,6 +31,7 @@ from testtools.matchers import Contains, Equals
 from snapcraft import ProjectOptions
 from snapcraft.internal import lxd
 from snapcraft.internal.errors import (
+    ContainerError,
     ContainerConnectionError,
     ContainerRunError,
     SnapdError,
@@ -150,7 +151,7 @@ class CleanbuilderTestCase(LXDTestCase):
         self.fake_lxd.check_call_mock.side_effect = call_effect
 
         raised = self.assertRaises(
-            CalledProcessError,
+            ContainerError,
             self.make_containerbuild().execute)
         self.assertThat(self.fake_lxd.status, Equals(None))
         # lxc launch should fail and no further commands should come after that

--- a/snapcraft/tests/unit/test_lxd.py
+++ b/snapcraft/tests/unit/test_lxd.py
@@ -523,21 +523,34 @@ class ProjectTestCase(ContainerbuildTestCase):
                            project_options=self.project_options,
                            remote=self.remote)
 
-    @patch('snapcraft.internal.lxd.Containerbuild._container_run')
-    def test_start_failed(self, mock_container_run):
-        mock_container_run.side_effect = lambda cmd, **kwargs: cmd
-
+    def test_init_failed(self):
         def call_effect(*args, **kwargs):
-            if args[0][:2] == ['lxc', 'start']:
-                raise CalledProcessError(
-                    returncode=255, cmd=args[0])
-            return d(*args, **kwargs)
+            if args[0][:2] == ['lxc', 'init']:
+                raise CalledProcessError(returncode=255, cmd=args[0])
+            return self.fake_lxd.check_output_side_effect()(*args, **kwargs)
 
-        d = self.fake_lxd.check_call_mock.side_effect
         self.fake_lxd.check_call_mock.side_effect = call_effect
 
-        self.assertRaises(ContainerConnectionError,
-                          self.make_containerbuild().execute)
+        raised = self.assertRaises(ContainerConnectionError,
+                                   self.make_containerbuild().execute)
+        self.assertThat(self.fake_lxd.status, Equals(None))
+        # lxc launch should fail and no further commands should come after that
+        self.assertThat(str(raised), Contains('Failed to setup container'))
+
+    def test_start_failed(self):
+        def call_effect(*args, **kwargs):
+            if args[0][:2] == ['lxc', 'start']:
+                raise CalledProcessError(returncode=255, cmd=args[0])
+            return self.fake_lxd.check_output_side_effect()(*args, **kwargs)
+
+        self.fake_lxd.check_call_mock.side_effect = call_effect
+
+        raised = self.assertRaises(ContainerConnectionError,
+                                   self.make_containerbuild().execute)
+        self.assertThat(self.fake_lxd.status, Equals('Stopped'))
+        # lxc launch should fail and no further commands should come after that
+        self.assertThat(str(raised),
+                        Contains('The container could not be started'))
 
     @patch('snapcraft.internal.lxd.Containerbuild._container_run')
     def test_ftp_not_installed(self, mock_container_run):

--- a/snapcraft/tests/unit/test_lxd.py
+++ b/snapcraft/tests/unit/test_lxd.py
@@ -31,7 +31,6 @@ from testtools.matchers import Contains, Equals
 from snapcraft import ProjectOptions
 from snapcraft.internal import lxd
 from snapcraft.internal.errors import (
-    ContainerError,
     ContainerConnectionError,
     ContainerRunError,
     SnapdError,
@@ -151,11 +150,11 @@ class CleanbuilderTestCase(LXDTestCase):
         self.fake_lxd.check_call_mock.side_effect = call_effect
 
         raised = self.assertRaises(
-            ContainerError,
+            ContainerConnectionError,
             self.make_containerbuild().execute)
         self.assertThat(self.fake_lxd.status, Equals(None))
         # lxc launch should fail and no further commands should come after that
-        self.assertThat(str(raised), Contains("Command '['lxc', 'launch'"))
+        self.assertThat(str(raised), Contains('Failed to setup container'))
 
 
 class ContainerbuildTestCase(LXDTestCase):


### PR DESCRIPTION
lxc itself prints a useful enough error message when this happens.