### PR TITLE
ci: name the travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,56 +14,105 @@ jobs:
     # Tests, only when not triggered by the daily cron.
     - stage: static
       if: type != cron
-      script: sudo ./tools/travis/run_tests.sh static
+      script: sudo ./tools/travis/run_tests.sh $TEST
+      env:
+          - TEST=static
     - if: type != cron
       script: sudo ./tools/travis/run_codespell.sh
+      env:
+          - TEST=codespell
     - stage: unit
       if: type != cron
-      script: sudo ./tools/travis/run_tests.sh snapcraft/tests/unit
+      script: sudo ./tools/travis/run_tests.sh $TEST
+      env:
+          - TEST=snapcraft/tests/unit
     - if: type != cron
-      script: SNAPCRAFT_TEST_MOCK_MACHINE=armv7l sudo ./tools/travis/run_tests.sh snapcraft/tests/unit
+      script: sudo ./tools/travis/run_tests.sh $TEST
+      env:
+          - TEST=snapcraft/tests/unit
+          - SNAPCRAFT_TEST_MOCK_MACHINE=armv7l
     - stage: snap
       if: type != cron
       script: sudo ./tools/travis/build_snapcraft_snap.sh
+      env:
+          - TEST=snapcraft-snap
     - stage: integration
       if: type != cron
-      script: sudo ./tools/travis/run_tests.sh snapcraft/tests/integration/general
+      script: sudo ./tools/travis/run_tests.sh $TEST
+      env:
+          - TEST=snapcraft/tests/integration/general
     - if: type != cron
-      script: sudo ./tools/travis/run_tests.sh snapcraft/tests/integration/plugins
+      script: sudo ./tools/travis/run_tests.sh $TEST
+      env:
+          - TEST=snapcraft/tests/integration/plugins
     - if: type != cron
-      script: sudo ./tools/travis/run_tests.sh snapcraft.tests.integration.plugins.catkin
+      script: sudo ./tools/travis/run_tests.sh $TEST
+      env:
+          - TEST=snapcraft.tests.integration.plugins.catkin
     - if: type != cron
-      script: sudo ./tools/travis/run_tests.sh snapcraft/tests/integration/store
+      script: sudo ./tools/travis/run_tests.sh $TEST
+      env:
+          - TEST=snapcraft/tests/integration/store
     - if: type != cron
-      script: sudo ./tools/travis/run_tests.sh snapcraft/tests/integration/containers
+      script: sudo ./tools/travis/run_tests.sh $TEST
+      env:
+          - TEST=snapcraft/tests/integration/containers
     - if: type != cron
-      script: sudo ./tools/travis/run_tests.sh snapcraft/tests/integration/snapd
+      script: sudo ./tools/travis/run_tests.sh $TEST
+      env:
+          - TEST=snapcraft/tests/integration/snapd
     # CLA check, only in pull requests, not coming from the bot.
     - if: type = pull_request AND sender != snappy-m-o
       script: ./tools/travis/run_cla_check.sh
+      env:
+          - TEST=cla-check
     # Trigger nightly tests, only in cron.
     - stage: nightly
       if: type = cron
-      script: ./runtests.sh spread
+      script: ./runtests.sh $TEST
+      env:
+          - TEST=spread
     - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-general
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial $TEST
+      env:
+          - TEST=integrationtests-general
     - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-store
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial $TEST
+      env:
+          - TEST=integrationtests-store
     - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-plugins
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial $TEST
+      env:
+          - TEST=integrationtests-plugins
     - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-plugins-catkin
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial $TEST
+      env:
+          - TEST=integrationtests-plugins-catkin
     - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-snapd
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial $TEST
+      env:
+          - TEST=integrationtests-snapd
     - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-general
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic $TEST
+      env:
+          - TEST=integrationtests-general
     - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-store
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic $TEST
+      env:
+          - TEST=integrationtests-store
     - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-plugins
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic $TEST
+      env:
+          - TEST=integrationtests-plugins
     - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-plugins-catkin
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic $TEST
+      env:
+          - TEST=integrationtests-plugins-catkin
     - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-snapd
+      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic $TEST
+      env:
+          - TEST=integrationtests-snapd
     - if: type = cron
       script: ./tools/travis/run_ppa_autopkgtests.sh
+      env:
+          - TEST=ppa-adt

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: bash
 
 cache:
   directories:
-    - $TRAVIS_BUILD_DIR/snaps-cache
+    - $HOME/snaps-cache
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ jobs:
     - if: type != cron
       script: sudo ./tools/travis/run_tests.sh $TEST
       env:
-          - TEST=snapcraft/tests/unit
-          - SNAPCRAFT_TEST_MOCK_MACHINE=armv7l
+          - TEST=snapcraft/tests/unit SNAPCRAFT_TEST_MOCK_MACHINE=armv7l
     - stage: snap
       if: type != cron
       script: sudo ./tools/travis/build_snapcraft_snap.sh

--- a/tools/travis/build_snapcraft_snap.sh
+++ b/tools/travis/build_snapcraft_snap.sh
@@ -33,6 +33,6 @@ $lxc file push --recursive $project_path snap-builder/root/
 $lxc exec snap-builder -- sh -c "snap install snapcraft --candidate --classic"
 $lxc exec snap-builder -- sh -c "cd snapcraft && /snap/bin/snapcraft snap --output snapcraft-pr$TRAVIS_PULL_REQUEST.snap"
 # Pull the snap from the container to save it into the cache.
-mkdir -p "$TRAVIS_BUILD_DIR/snaps-cache"
-$lxc file pull "snap-builder/root/snapcraft/snapcraft-pr$TRAVIS_PULL_REQUEST.snap" "$TRAVIS_BUILD_DIR/snaps-cache/"
+mkdir -p "$HOME/snaps-cache"
+$lxc file pull "snap-builder/root/snapcraft/snapcraft-pr$TRAVIS_PULL_REQUEST.snap" "$HOME/snaps-cache/"
 $lxc stop snap-builder

--- a/tools/travis/run_tests.sh
+++ b/tools/travis/run_tests.sh
@@ -37,7 +37,7 @@ elif [[ "$test" = "snapcraft/tests/integration"* || "$test" = "snapcraft.tests.i
     # snap install core exits with this error message:
     # - Setup snap "core" (2462) security profiles (cannot reload udev rules: exit status 2
     # but the installation succeeds, so we just ingore it.
-    dependencies="apt install -y bzr curl git libnacl-dev libsodium-dev libffi-dev libapt-pkg-dev libarchive-dev mercurial python3-pip subversion squashfs-tools sudo snapd xdelta3 patchelf && python3 -m pip install -r requirements-devel.txt -r requirements.txt && (snap install core || echo 'ignored error') && sudo snap install snaps-cache/snapcraft-pr$TRAVIS_PULL_REQUEST.snap --dangerous --classic"
+    dependencies="apt install -y bzr curl git libnacl-dev libsodium-dev libffi-dev libapt-pkg-dev libarchive-dev mercurial python3-pip subversion squashfs-tools sudo snapd xdelta3 patchelf && python3 -m pip install -r requirements-devel.txt -r requirements.txt && (snap install core || echo 'ignored error') && sudo snap install $HOME/snaps-cache/snapcraft-pr$TRAVIS_PULL_REQUEST.snap --dangerous --classic"
 else
     echo "Unknown test suite: $test"
     exit 1


### PR DESCRIPTION
It is really hard to have a general view of what is failing
in the eagle eye view offered by travis when using stages and
parallel jobs inside.

We introduce use of the TEST travis defined environment variable
as a mechanism to view what is being run in each job.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
