### PR TITLE
Add sentences to error when registering name

### DIFF
--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -32,8 +32,8 @@ _MESSAGE_REGISTER_PRIVATE = dedent("""\
     then we suggest you prefix the name with your developer identity,
     As ‘nessita-yoyodyne-www-site-content’.""")
 _MESSAGE_REGISTER_CONFIRM = dedent("""
-    We always want to ensure that users get the software they expect for a
-    particular name.
+    We always want to ensure that users get the software they expect
+     for a particular name.
 
     If needed, we will rename snaps to ensure that a particular name
     reflects the software most widely expected by our community.

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -33,7 +33,7 @@ _MESSAGE_REGISTER_PRIVATE = dedent("""\
     As ‘nessita-yoyodyne-www-site-content’.""")
 _MESSAGE_REGISTER_CONFIRM = dedent("""
     We always want to ensure that users get the software they expect
-     for a particular name.
+    for a particular name.
 
     If needed, we will rename snaps to ensure that a particular name
     reflects the software most widely expected by our community.

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -32,8 +32,8 @@ _MESSAGE_REGISTER_PRIVATE = dedent("""\
     then we suggest you prefix the name with your developer identity,
     As ‘nessita-yoyodyne-www-site-content’.""")
 _MESSAGE_REGISTER_CONFIRM = dedent("""
-    We always want to ensure that users get the software they expect
-    for a particular name.
+    On behalf of the snapcraft store, we always want to ensure that
+    users get the software they expect for a particular name.
 
     If needed, we will rename snaps to ensure that a particular name
     reflects the software most widely expected by our community.

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -32,8 +32,8 @@ _MESSAGE_REGISTER_PRIVATE = dedent("""\
     then we suggest you prefix the name with your developer identity,
     As ‘nessita-yoyodyne-www-site-content’.""")
 _MESSAGE_REGISTER_CONFIRM = dedent("""
-    On behalf of the snapcraft store, we always want to ensure that
-    users get the software they expect for a particular name.
+    We always want to ensure that users get the software they expect for a
+    particular name.
 
     If needed, we will rename snaps to ensure that a particular name
     reflects the software most widely expected by our community.

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -177,7 +177,10 @@ class StoreRegistrationError(StoreError):
     __FMT_RESERVED = (
         'The name {snap_name!r} is reserved.\n\n'
         'If you are the publisher most users expect for '
-        '{snap_name!r} then please claim the name at {register_name_url!r}')
+        '{snap_name!r} then please claim the name at {register_name_url!r}\n\n'
+        'Please register a name that people will associate with you. '
+        'We can rename your snap later if needed.\n\n'
+        'You can push your own versions of firefox, as firefox@nessita.')
 
     __FMT_RETRY_WAIT = (
         'You must wait {retry_after} seconds before trying to register '

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -178,8 +178,8 @@ class StoreRegistrationError(StoreError):
         'The name {snap_name!r} is reserved.\n\n'
         'If you are the publisher most users expect for '
         '{snap_name!r} then please claim the name at {register_name_url!r}\n\n'
-        'Please register a name that people will associate with you. '
-        'We can rename your snap later if needed.')
+        'Otherwise, please register a name that people will associate with '
+        'you. We can rename your snap later if needed.')
 
     __FMT_RETRY_WAIT = (
         'You must wait {retry_after} seconds before trying to register '

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -178,8 +178,7 @@ class StoreRegistrationError(StoreError):
         'The name {snap_name!r} is reserved.\n\n'
         'If you are the publisher most users expect for '
         '{snap_name!r} then please claim the name at {register_name_url!r}\n\n'
-        'Otherwise, please register a name that people will associate with '
-        'you. We can rename your snap later if needed.')
+        'Otherwise, please register another name.')
 
     __FMT_RETRY_WAIT = (
         'You must wait {retry_after} seconds before trying to register '

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -179,8 +179,7 @@ class StoreRegistrationError(StoreError):
         'If you are the publisher most users expect for '
         '{snap_name!r} then please claim the name at {register_name_url!r}\n\n'
         'Please register a name that people will associate with you. '
-        'We can rename your snap later if needed.\n\n'
-        'You can push your own versions of firefox, as firefox@nessita.')
+        'We can rename your snap later if needed.')
 
     __FMT_RETRY_WAIT = (
         'You must wait {retry_after} seconds before trying to register '

--- a/snapcraft/tests/unit/store/test_store_client.py
+++ b/snapcraft/tests/unit/store/test_store_client.py
@@ -542,8 +542,8 @@ class RegisterTestCase(StoreTestCase):
                    "If you are the publisher most users expect for "
                    "'test-reserved-snap-name' then please claim the "
                    "name at 'https://myapps.com/register-name/'\n\n"
-                   "Please register a name that people will associate with you. "
-                   "We can rename your snap later if needed."
+                   "Please register a name that people will associate "
+                   "with you. We can rename your snap later if needed."
                    ))
 
     def test_register_already_owned_name(self):

--- a/snapcraft/tests/unit/store/test_store_client.py
+++ b/snapcraft/tests/unit/store/test_store_client.py
@@ -542,8 +542,9 @@ class RegisterTestCase(StoreTestCase):
                    "If you are the publisher most users expect for "
                    "'test-reserved-snap-name' then please claim the "
                    "name at 'https://myapps.com/register-name/'\n\n"
-                   "Please register a name that people will associate "
-                   "with you. We can rename your snap later if needed."
+                   "Otherwise, please register a name that people will "
+                   "associate with you. "
+                   "We can rename your snap later if needed."
                    ))
 
     def test_register_already_owned_name(self):

--- a/snapcraft/tests/unit/store/test_store_client.py
+++ b/snapcraft/tests/unit/store/test_store_client.py
@@ -541,7 +541,10 @@ class RegisterTestCase(StoreTestCase):
                    "\n\n"
                    "If you are the publisher most users expect for "
                    "'test-reserved-snap-name' then please claim the "
-                   "name at 'https://myapps.com/register-name/'"))
+                   "name at 'https://myapps.com/register-name/'\n\n"
+                   "Please register a name that people will associate with you. "
+                   "We can rename your snap later if needed."
+                   ))
 
     def test_register_already_owned_name(self):
         self.client.login('dummy', 'test correct password')

--- a/snapcraft/tests/unit/store/test_store_client.py
+++ b/snapcraft/tests/unit/store/test_store_client.py
@@ -542,9 +542,7 @@ class RegisterTestCase(StoreTestCase):
                    "If you are the publisher most users expect for "
                    "'test-reserved-snap-name' then please claim the "
                    "name at 'https://myapps.com/register-name/'\n\n"
-                   "Otherwise, please register a name that people will "
-                   "associate with you. "
-                   "We can rename your snap later if needed."
+                   "Otherwise, please register another name."
                    ))
 
     def test_register_already_owned_name(self):


### PR DESCRIPTION
This commit will add 2 more sentences to error when trying to register
a reserved name.

Addresses bug at [LP: 1602791](https://pad.lv/1602791).
