### PR TITLE
catkin-tools plugin: use stage-packages

### DIFF
--- a/snapcraft/internal/os_release.py
+++ b/snapcraft/internal/os_release.py
@@ -16,6 +16,10 @@
 
 import contextlib
 
+# This is used in a mypy 'type:' comment below, but nowhere else. Flake8
+# doesn't like that very much, so noqa.
+from typing import Dict  # noqa
+
 from snapcraft.internal import errors
 
 _ID_TO_UBUNTU_CODENAME = {
@@ -29,19 +33,19 @@ _ID_TO_UBUNTU_CODENAME = {
 class OsRelease:
     """A class to intelligently determine the OS on which we're running"""
 
-    def __init__(self, *, os_release_file='/etc/os-release'):
+    def __init__(self, *, os_release_file: str = '/etc/os-release') -> None:
         """Create a new OsRelease instance.
 
         :param str os_release_file: Path to os-release file to be parsed.
         """
         with open(os_release_file) as f:
-            self._os_release = {}
+            self._os_release = {}  # type: Dict[str, str]
             for line in f:
                 entry = line.rstrip().split('=')
                 if len(entry) == 2:
                     self._os_release[entry[0]] = entry[1].strip('"')
 
-    def id(self):
+    def id(self) -> str:
         """Return the OS ID
 
         :raises OsReleaseIdError: If no ID can be determined.
@@ -51,7 +55,7 @@ class OsRelease:
 
         raise errors.OsReleaseIdError()
 
-    def name(self):
+    def name(self) -> str:
         """Return the OS name
 
         :raises OsReleaseNameError: If no name can be determined.
@@ -61,7 +65,7 @@ class OsRelease:
 
         raise errors.OsReleaseNameError()
 
-    def version_id(self):
+    def version_id(self) -> str:
         """Return the OS version ID
 
         :raises OsReleaseVersionIdError: If no version ID can be determined.
@@ -71,7 +75,7 @@ class OsRelease:
 
         raise errors.OsReleaseVersionIdError()
 
-    def version_codename(self):
+    def version_codename(self) -> str:
         """Return the OS version codename
 
         This first tries to use the VERSION_CODENAME. If that's missing, it

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -912,11 +912,11 @@ class WithoutSnapInstalled(fixtures.Fixture):
         set up.
     """
 
-    def __init__(self, snap_name):
+    def __init__(self, snap_name: str) -> None:
         super().__init__()
         self.snap_name = snap_name.split('/')[0]
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         if snapcraft.repo.snaps.SnapPackage.is_snap_installed(self.snap_name):
             raise AssertionError(
@@ -926,7 +926,7 @@ class WithoutSnapInstalled(fixtures.Fixture):
 
         self.addCleanup(self._remove_snap)
 
-    def _remove_snap(self):
+    def _remove_snap(self) -> None:
         try:
             subprocess.check_output(
                 ['sudo', 'snap', 'remove', self.snap_name],
@@ -1034,11 +1034,11 @@ class FakeSnapd(fixtures.Fixture):
 
 class SharedCache(fixtures.Fixture):
 
-    def __init__(self, name):
+    def __init__(self, name) -> None:
         super().__init__()
         self.name = name
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         shared_cache_dir = os.path.join(
             tempfile.gettempdir(), 'snapcraft_test_cache_{}'.format(self.name))

--- a/snapcraft/tests/integration/__init__.py
+++ b/snapcraft/tests/integration/__init__.py
@@ -25,6 +25,7 @@ import time
 import uuid
 import xdg
 from distutils import dir_util
+from typing import Callable, List, Union
 
 import fixtures
 import pexpect
@@ -116,8 +117,10 @@ class TestCase(testtools.TestCase):
         self.distro_series = release.version_codename()
 
     def run_snapcraft(
-            self, command=None, project_dir=None, debug=True,
-            pre_func=lambda: None, env=None):
+            self, command: Union[str, List[str]] = None,
+            project_dir: str = None,
+            debug: bool = True,
+            pre_func: Callable[[], None] = lambda: None, env=None) -> None:
         if project_dir:
             self.copy_project_to_cwd(project_dir)
 
@@ -177,7 +180,7 @@ class TestCase(testtools.TestCase):
             if os.getenv('SNAPCRAFT_APT_AUTOREMOVE_CHECK_FAIL', False):
                 raise
 
-    def copy_project_to_cwd(self, project_dir):
+    def copy_project_to_cwd(self, project_dir: str) -> None:
         # Because cwd already exists, shutil.copytree would raise
         # FileExistsError. Use the lesser known distutils.dir_util.copy_tree
         dir_util.copy_tree(
@@ -606,7 +609,7 @@ class SnapdIntegrationTestCase(TestCase):
 
     slow_test = False
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         if (self.slow_test and
                 not os.environ.get('SNAPCRAFT_SLOW_TESTS', False)):
@@ -614,7 +617,7 @@ class SnapdIntegrationTestCase(TestCase):
         if os.environ.get('ADT_TEST') and self.deb_arch == 'armhf':
             self.skipTest("The autopkgtest armhf runners can't install snaps")
 
-    def install_snap(self):
+    def install_snap(self) -> None:
         try:
             subprocess.check_output(
                 ['sudo', 'snap', 'install',

--- a/snapcraft/tests/integration/snapd/test_catkin_tools_snap.py
+++ b/snapcraft/tests/integration/snapd/test_catkin_tools_snap.py
@@ -1,0 +1,54 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import subprocess
+
+from testtools.matchers import MatchesRegex
+
+from snapcraft.tests import (
+    integration,
+    fixture_setup,
+    skip,
+)
+
+
+class CatkinToolsTestCase(integration.SnapdIntegrationTestCase):
+
+    slow_test = True
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Share the cache in all ROS-based tests
+        self.useFixture(fixture_setup.SharedCache('ros'))
+
+    @skip.skip_unless_codename('xenial', 'ROS Kinetic only targets Xenial')
+    def test_install_and_execution(self) -> None:
+        self.useFixture(
+            fixture_setup.WithoutSnapInstalled('catkin-tools-example'))
+        self.run_snapcraft(project_dir='catkin-tools-talker-listener')
+        self.install_snap()
+
+        # Run the ROS system. By default this will never exit, but the code
+        # supports an `exit-after-receive` parameter that, if true, will cause
+        # the system to shutdown after the listener has successfully received
+        # a message.
+        output = subprocess.check_output(
+            ['catkin-tools-example.launch-project',
+             'exit-after-receive:=true']).decode()
+        self.assertThat(
+            output,
+            MatchesRegex(r'.*I heard Hello world.*', flags=re.DOTALL))

--- a/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/snap/snapcraft.yaml
+++ b/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/snap/snapcraft.yaml
@@ -1,0 +1,16 @@
+name: catkin-tools-example
+version: 1.0
+summary: Catkin Tools Example
+description: Contains talker/listener ROS packages and a .launch file.
+confinement: strict
+
+apps:
+  launch-project:
+    command: roslaunch listener talk_and_listen.launch
+    plugs: [network-bind]
+
+parts:
+  ros-project:
+    plugin: catkin-tools
+    rosdistro: kinetic
+    source: .

--- a/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/src/CMakeLists.txt
+++ b/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/src/CMakeLists.txt
@@ -1,0 +1,47 @@
+# toplevel CMakeLists.txt for a catkin workspace
+# catkin/cmake/toplevel.cmake
+
+cmake_minimum_required(VERSION 2.8.3)
+
+# optionally provide a cmake file in the workspace to override arbitrary stuff
+include(workspace.cmake OPTIONAL)
+
+set(CATKIN_TOPLEVEL TRUE)
+
+# include catkin directly or via find_package()
+if(EXISTS "${CMAKE_SOURCE_DIR}/catkin/cmake/all.cmake" AND EXISTS "${CMAKE_SOURCE_DIR}/catkin/CMakeLists.txt")
+  set(catkin_EXTRAS_DIR "${CMAKE_SOURCE_DIR}/catkin/cmake")
+  # include all.cmake without add_subdirectory to let it operate in same scope
+  include(catkin/cmake/all.cmake NO_POLICY_SCOPE)
+  add_subdirectory(catkin)
+
+else()
+  # use either CMAKE_PREFIX_PATH explicitly passed to CMake as a command line argument
+  # or CMAKE_PREFIX_PATH from the environment
+  if(NOT DEFINED CMAKE_PREFIX_PATH)
+    if(NOT "$ENV{CMAKE_PREFIX_PATH}" STREQUAL "")
+      string(REPLACE ":" ";" CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH})
+    endif()
+  endif()
+
+  # list of catkin workspaces
+  set(catkin_search_path "")
+  foreach(path ${CMAKE_PREFIX_PATH})
+    if(EXISTS "${path}/.CATKIN_WORKSPACE")
+      list(FIND catkin_search_path ${path} _index)
+      if(_index EQUAL -1)
+        list(APPEND catkin_search_path ${path})
+      endif()
+    endif()
+  endforeach()
+
+  # search for catkin in all workspaces
+  set(CATKIN_TOPLEVEL_FIND_PACKAGE TRUE)
+  find_package(catkin REQUIRED
+    NO_POLICY_SCOPE
+    PATHS ${catkin_search_path}
+    NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+  unset(CATKIN_TOPLEVEL_FIND_PACKAGE)
+endif()
+
+catkin_workspace()

--- a/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/src/listener/CMakeLists.txt
+++ b/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/src/listener/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(listener)
+
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+  std_msgs
+)
+
+catkin_package()
+
+install(PROGRAMS
+  scripts/listener_node
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(FILES
+  talk_and_listen.launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/src/listener/package.xml
+++ b/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/src/listener/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<package>
+  <name>listener</name>
+  <version>0.0.0</version>
+  <description>The listener package</description>
+  <maintainer email="me@example.com">me</maintainer>
+  <license>GPLv3</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>std_msgs</run_depend>
+</package>

--- a/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/src/listener/scripts/listener_node
+++ b/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/src/listener/scripts/listener_node
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import rospy
+from std_msgs.msg import String
+
+
+def callback(data):
+    rospy.loginfo('I heard %s', data.data)
+
+    if rospy.get_param('~exit-after-receive', False):
+        rospy.signal_shutdown(
+            'Requested to exit after message received. Exiting now.')
+
+
+def listener():
+    rospy.init_node('listener')
+
+    rospy.Subscriber('babble', String, callback)
+
+    rospy.spin()
+
+if __name__ == '__main__':
+    listener()

--- a/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/src/listener/talk_and_listen.launch
+++ b/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/src/listener/talk_and_listen.launch
@@ -1,0 +1,13 @@
+<launch>
+    <arg name = "exit-after-receive" default = "false"
+          doc = "exit system after listener receives a single message." />
+
+    <node name = "talker" pkg = "talker" type = "talker_node"
+          required = "true" output = "screen" />
+
+    <node name = "listener" pkg = "listener" type = "listener_node"
+          required = "true" output = "screen">
+        <remap from = "babble" to = "chatter" />
+        <param name = "exit-after-receive" value = "$(arg exit-after-receive)" />
+    </node>
+</launch>

--- a/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/src/talker/CMakeLists.txt
+++ b/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/src/talker/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(talker)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  std_msgs
+)
+
+catkin_package()
+
+include_directories(${catkin_INCLUDE_DIRS})
+
+add_executable(talker_node src/talker_node.cpp)
+
+target_link_libraries(talker_node ${catkin_LIBRARIES})
+
+install(TARGETS talker_node
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/src/talker/package.xml
+++ b/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/src/talker/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<package>
+  <name>talker</name>
+  <version>0.0.0</version>
+  <description>The talker package</description>
+  <maintainer email="me@example.com">me</maintainer>
+  <license>GPLv3</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>std_msgs</run_depend>
+</package>

--- a/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/src/talker/src/talker_node.cpp
+++ b/snapcraft/tests/integration/snaps/catkin-tools-talker-listener/src/talker/src/talker_node.cpp
@@ -1,0 +1,35 @@
+#include <sstream>
+
+#include <ros/ros.h>
+#include <std_msgs/String.h>
+
+int main(int argc, char **argv)
+{
+    ros::init(argc, argv, "talker");
+
+    ros::NodeHandle nodeHandle;
+
+    ros::Publisher publisher = nodeHandle.advertise<std_msgs::String>("chatter", 1);
+
+    ros::Rate loopRate(10);
+
+    int count = 0;
+    while (ros::ok())
+    {
+        std_msgs::String message;
+
+        std::stringstream stream;
+        stream << "Hello world " << count++;
+        message.data = stream.str();
+
+        ROS_INFO("%s", message.data.c_str());
+
+        publisher.publish(message);
+
+        ros::spinOnce();
+
+        loopRate.sleep();
+    }
+
+    return 0;
+}

--- a/snapcraft/tests/skip.py
+++ b/snapcraft/tests/skip.py
@@ -16,6 +16,7 @@
 
 import contextlib
 import functools
+from typing import Any, Callable
 
 from unittest import skipUnless
 
@@ -25,8 +26,9 @@ from snapcraft.internal import (
 )
 
 
-def skip_unless_codename(codename, message):
-    def _wrap(func):
+def skip_unless_codename(
+        codename: str, message: str) -> Callable[..., Callable[..., None]]:
+    def _wrap(func: Callable[..., None]) -> Callable[..., None]:
         release = os_release.OsRelease()
         actual_codename = None
         with contextlib.suppress(errors.OsReleaseCodenameError):
@@ -34,7 +36,7 @@ def skip_unless_codename(codename, message):
 
         @functools.wraps(func)
         @skipUnless(actual_codename == codename, message)
-        def _skip_test(*args, **kwargs):
+        def _skip_test(*args: Any, **kwargs: Any) -> None:
             func(*args, **kwargs)
         return _skip_test
     return _wrap

--- a/snapcraft/tests/unit/plugins/test_catkin_tools.py
+++ b/snapcraft/tests/unit/plugins/test_catkin_tools.py
@@ -198,13 +198,17 @@ class PrepareBuildTestCase(CatkinToolsPluginBaseTestCase):
 
         confArgs = bashrun_mock.mock_calls[0][1][0]
         command = ' '.join(confArgs)
-        self.assertThat(command, Contains('catkin clean -y'))
+        self.assertThat(command, Contains('catkin init'))
 
         confArgs = bashrun_mock.mock_calls[1][1][0]
         command = ' '.join(confArgs)
-        self.assertThat(command, Contains('catkin profile add -f default'))
+        self.assertThat(command, Contains('catkin clean -y'))
 
         confArgs = bashrun_mock.mock_calls[2][1][0]
+        command = ' '.join(confArgs)
+        self.assertThat(command, Contains('catkin profile add -f default'))
+
+        confArgs = bashrun_mock.mock_calls[3][1][0]
         self.assertThat(confArgs[0], Equals('catkin'))
         self.assertThat(confArgs[1], Equals('config'))
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently the catkin-tools plugin uses `build-packages` for its build dependency instead of `stage-packages`, which fails on clean systems.

Use `stage-packages` instead. Also, since this would have been caught by an integration test, add one of those as well (to the snapd suite, specifically).