### PR TITLE
many: set rpath for elf files for classic

### DIFF
--- a/demos/opencv/snap/snapcraft.yaml
+++ b/demos/opencv/snap/snapcraft.yaml
@@ -2,7 +2,7 @@ name: opencv-example
 version: 1.0
 summary: Use OpenCV and OpenGL
 description: A simple OpenCV example
-confinement: strict
+confinement: classic
 
 build-packages: [gcc, g++, libc6-dev, libopencv-dev]
 
@@ -14,3 +14,4 @@ parts:
   example:
     plugin: cmake
     source: src
+    stage-packages: [libopencv-core2.4v5]

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -105,7 +105,7 @@ class Patcher:
         self._base_rpaths = base_rpaths
 
         # If we are running from the snap we want to use the patchelf
-        # bundled there as it would have the capabilty of working
+        # bundled there as it would have the capability of working
         # anywhere given the fixed ld it would have.
         # If not found, resort to whatever is on the system brought
         # in by packaging dependencies.
@@ -136,6 +136,7 @@ class Patcher:
 
     def _patch_rpath(self, elf_file: ElfFile) -> None:
         rpath = self._get_rpath(elf_file)
+        print(elf_file.path, rpath)
         # Parameters:
         # --force-rpath: use RPATH instead of RUNPATH.
         # --shrink-rpath: will remove unneeded entries, with the
@@ -165,7 +166,10 @@ class Patcher:
         origin_paths = ':'.join((r for r in set(rpaths) if r))
         base_rpaths = ':'.join(self._base_rpaths)
 
-        return '{}:{}'.format(origin_paths, base_rpaths)
+        if origin_paths:
+            return '{}:{}'.format(origin_paths, base_rpaths)
+        else:
+            return base_rpaths
 
 
 def determine_ld_library_path(root: str) -> List[str]:
@@ -177,7 +181,7 @@ def determine_ld_library_path(root: str) -> List[str]:
 
     :param root str: the root directory to search for specific ld.so.conf
                      entries.
-    :returns: a list of strings of library paths where releavant libraries
+    :returns: a list of strings of library paths where relevant libraries
               can be found within root.
     """
     # If more ld.so.conf files need to be supported, add them here.

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -139,7 +139,7 @@ class Patcher:
         # Parameters:
         # --force-rpath: use RPATH instead of RUNPATH.
         # --shrink-rpath: will remove unneeded entries, with the
-        #                 side effect of prefering host libraries
+        #                 side effect of preferring host libraries
         #                 so we simply do not use it.
         # --set-rpath: set the RPATH to the colon separated argument.
         self._run_patchelf(['--force-rpath',

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -136,8 +136,14 @@ class Patcher:
 
     def _patch_rpath(self, elf_file: ElfFile) -> None:
         rpath = self._get_rpath(elf_file)
-        print(elf_file.path, 'rpath: ', rpath)
-        self._run_patchelf(['--force-rpath', '--set-rpath', rpath],
+        # Parameters:
+        # --force-rpath: use RPATH instead of RUNPATH.
+        # --shrink-rpath: will remove unneeded entries, with the
+        #                 side effect of prefering host libraries
+        #                 so we simply do not use it.
+        # --set-rpath: set the RPATH to the colon separated argument.
+        self._run_patchelf(['--force-rpath',
+                            '--set-rpath', rpath],
                            elf_file.path)
 
     def _run_patchelf(self, args: List[str], elf_file_path: str) -> None:

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -442,9 +442,9 @@ class PluginHandler:
         _migrate_files(snap_files, snap_dirs, self.stagedir, self.primedir)
 
         elf_files = elf.get_elf_files(self.primedir, snap_files)
-        dependencies = set()
+        all_dependencies = set()
         for elf_file in elf_files:
-            dependencies.update(elf.get_dependencies(elf_file.path))
+            all_dependencies.update(elf_file.load_dependencies())
 
         # Split the necessary dependencies into their corresponding location.
         # We'll both migrate and track the system dependencies, but we'll only
@@ -452,7 +452,7 @@ class PluginHandler:
         # already been primed by other means, and migrating them again could
         # potentially override the `stage` or `snap` filtering.
         (in_part, staged, primed, system) = _split_dependencies(
-            dependencies, self.installdir, self.stagedir, self.primedir)
+            all_dependencies, self.installdir, self.stagedir, self.primedir)
 
         part_dependency_paths = {os.path.dirname(d) for d in in_part}
         staged_dependency_paths = {os.path.dirname(d) for d in staged}
@@ -470,9 +470,36 @@ class PluginHandler:
                 _migrate_files(system, system_dependency_paths, '/',
                                self.primedir, follow_symlinks=True)
 
+        # TODO: base snap support
+        core_path = common.get_core_path()
+
+        def library_pather(library_path: str, elf_file_path: str) -> str:
+            # If the path is is in the core snap, use the absolute path,
+            # if the path is primed, use $ORIGIN, and last if the dependency
+            # is not anywhere return an empty string.
+            #
+            # Once we move away from the system library grabbing logic
+            # we can move to a smarter library capturing mechanism.
+            library_path = library_path.replace(self.installdir, self.primedir)
+            if library_path.startswith(core_path):
+                return library_path
+            elif (library_path.startswith(self.primedir) and
+                  os.path.exists(self.primedir)):
+                rel_library_path = os.path.relpath(library_path, elf_file_path)
+                rel_library_path_dir = os.path.dirname(rel_library_path)
+                # return the dirname, with the first .. replace with $ORIGIN
+                return rel_library_path_dir.replace('..', '$ORIGIN', 1)
+            else:
+                return ''
+
         if self._confinement == 'classic':
+            core_rpaths = common.get_library_paths(
+                core_path, self._project_options.arch_triplet,
+                existing_only=False)
             dynamic_linker = self._project_options.get_core_dynamic_linker()
-            elf_patcher = elf.Patcher(dynamic_linker=dynamic_linker)
+            elf_patcher = elf.Patcher(dynamic_linker=dynamic_linker,
+                                      library_path_func=library_pather,
+                                      base_rpaths=core_rpaths)
             for elf_file in elf_files:
                 elf_patcher.patch(elf_file=elf_file)
 

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -473,7 +473,7 @@ class PluginHandler:
         # TODO: base snap support
         core_path = common.get_core_path()
 
-        def library_pather(library_path: str, elf_file_path: str) -> str:
+        def mangle_library_path(library_path: str, elf_file_path: str) -> str:
             # If the path is is in the core snap, use the absolute path,
             # if the path is primed, use $ORIGIN, and last if the dependency
             # is not anywhere return an empty string.
@@ -482,9 +482,9 @@ class PluginHandler:
             # we can move to a smarter library capturing mechanism.
             library_path = library_path.replace(self.installdir, self.primedir)
             if library_path.startswith(core_path):
-                return library_path
+                return os.path.dirname(library_path)
             elif (library_path.startswith(self.primedir) and
-                  os.path.exists(self.primedir)):
+                  os.path.exists(library_path)):
                 rel_library_path = os.path.relpath(library_path, elf_file_path)
                 rel_library_path_dir = os.path.dirname(rel_library_path)
                 # return the dirname, with the first .. replace with $ORIGIN
@@ -498,7 +498,7 @@ class PluginHandler:
                 existing_only=False)
             dynamic_linker = self._project_options.get_core_dynamic_linker()
             elf_patcher = elf.Patcher(dynamic_linker=dynamic_linker,
-                                      library_path_func=library_pather,
+                                      library_path_func=mangle_library_path,
                                       base_rpaths=core_rpaths)
             for elf_file in elf_files:
                 elf_patcher.patch(elf_file=elf_file)

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -162,16 +162,13 @@ class Config:
 
     def stage_env(self):
         stage_dir = self._project_options.stage_dir
-        core_dynamic_linker = self._project_options.get_core_dynamic_linker()
         env = []
 
         env += runtime_env(stage_dir, self._project_options.arch_triplet)
         env += build_env_for_stage(
             stage_dir,
             self.data['name'],
-            self.data['confinement'],
-            self._project_options.arch_triplet,
-            core_dynamic_linker=core_dynamic_linker)
+            self._project_options.arch_triplet)
         for part in self.parts.all_parts:
             env += part.env(stage_dir)
 

--- a/snapcraft/internal/project_loader/_env.py
+++ b/snapcraft/internal/project_loader/_env.py
@@ -13,12 +13,21 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-import os
-
-import snapcraft
 from snapcraft import formatting_utils
 from snapcraft.internal import common, elf
+
+
+def env_for_classic(arch_triplet):
+    """Set the required environment variables for a classic confined build."""
+    env = []
+
+    core_path = common.get_core_path()
+    paths = common.get_library_paths(core_path, arch_triplet,
+                                     existing_only=False)
+    env.append(formatting_utils.format_path_variable(
+        'LD_LIBRARY_PATH', paths, prepend='', separator=':'))
+
+    return env
 
 
 def runtime_env(root, arch_triplet):
@@ -35,21 +44,17 @@ def runtime_env(root, arch_triplet):
 
     # Add the default LD_LIBRARY_PATH
     paths = common.get_library_paths(root, arch_triplet)
+    # Add more specific LD_LIBRARY_PATH from staged packages if necessary
+    paths += elf.determine_ld_library_path(root)
+
     if paths:
         env.append(formatting_utils.format_path_variable(
             'LD_LIBRARY_PATH', paths, prepend='', separator=':'))
 
-    # Add more specific LD_LIBRARY_PATH from staged packages if necessary
-    ld_library_paths = elf.determine_ld_library_path(root)
-    if ld_library_paths:
-        env.append('LD_LIBRARY_PATH="' + ':'.join(ld_library_paths) +
-                   ':$LD_LIBRARY_PATH"')
-
     return env
 
 
-def build_env(root, snap_name, confinement, arch_triplet,
-              core_dynamic_linker=None):
+def build_env(root, snap_name, arch_triplet):
     """Set the environment variables required for building.
 
     This is required for the current parts installdir due to stage-packages
@@ -62,28 +67,6 @@ def build_env(root, snap_name, confinement, arch_triplet,
         for envvar in ['CPPFLAGS', 'CFLAGS', 'CXXFLAGS']:
             env.append(formatting_utils.format_path_variable(
                 envvar, paths, prepend='-I', separator=' '))
-
-    if confinement == 'classic':
-        if not core_dynamic_linker:
-            raise snapcraft.internal.errors.SnapcraftEnvironmentError(
-                'classic confinement requires the core snap to be installed. '
-                'Install it by running `snap install core`.')
-
-        core_path = common.get_core_path()
-        core_rpaths = common.get_library_paths(core_path, arch_triplet,
-                                               existing_only=False)
-        snap_path = os.path.join('/snap', snap_name, 'current')
-        snap_rpaths = common.get_library_paths(snap_path, arch_triplet,
-                                               existing_only=False)
-
-        # snap_rpaths before core_rpaths to prefer libraries from the snap.
-        rpaths = formatting_utils.combine_paths(
-            snap_rpaths + core_rpaths, prepend='', separator=':')
-        env.append('LDFLAGS="$LDFLAGS '
-                   # Building tools to continue the build becomes problematic
-                   # with nodefaultlib.
-                   # '-Wl,-z,nodefaultlib '
-                   '-Wl,-rpath,{}"'.format(rpaths))
 
     paths = common.get_library_paths(root, arch_triplet)
     if paths:
@@ -98,10 +81,8 @@ def build_env(root, snap_name, confinement, arch_triplet,
     return env
 
 
-def build_env_for_stage(stagedir, snap_name, confinement,
-                        arch_triplet, core_dynamic_linker=None):
-    env = build_env(stagedir, snap_name, confinement,
-                    arch_triplet, core_dynamic_linker)
+def build_env_for_stage(stagedir, snap_name, arch_triplet):
+    env = build_env(stagedir, snap_name, arch_triplet)
     env.append('PERL5LIB="{0}/usr/share/perl5/"'.format(stagedir))
 
     return env

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -23,6 +23,7 @@ from snapcraft.internal import (
     repo
 )
 from ._env import (
+    env_for_classic,
     build_env,
     build_env_for_stage,
     runtime_env,
@@ -209,7 +210,6 @@ class PartsConfig:
 
         env = []
         stagedir = self._project_options.stage_dir
-        core_dynamic_linker = self._project_options.get_core_dynamic_linker()
 
         if root_part:
             # this has to come before any {}/usr/bin
@@ -221,15 +221,13 @@ class PartsConfig:
             env += build_env(
                 part.installdir,
                 self._snap_name,
-                self._confinement,
-                self._project_options.arch_triplet,
-                core_dynamic_linker=core_dynamic_linker)
+                self._project_options.arch_triplet)
             env += build_env_for_stage(
                 stagedir,
                 self._snap_name,
-                self._confinement,
-                self._project_options.arch_triplet,
-                core_dynamic_linker=core_dynamic_linker)
+                self._project_options.arch_triplet)
+            if self._confinement == 'classic':
+                env += env_for_classic(self._project_options.arch_triplet)
             env.append('SNAPCRAFT_PART_INSTALL="{}"'.format(part.installdir))
             env.append('SNAPCRAFT_ARCH_TRIPLET="{}"'.format(
                 self._project_options.arch_triplet))

--- a/snapcraft/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/snapcraft/tests/unit/pluginhandler/test_pluginhandler.py
@@ -1136,11 +1136,14 @@ class StateTestCase(StateBaseTestCase):
             '{}/lib1/installed'.format(self.handler.installdir),
             '{}/lib2/staged'.format(self.handler.stagedir),
         }
+        stub_magic = ('ELF 64-bit LSB executable, x86-64, version 1 (SYSV), '
+                      'dynamically linked, interpreter '
+                      '/lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32')
         self.get_elf_files_mock.return_value = frozenset([
             elf.ElfFile(path=os.path.join(self.handler.primedir, 'bin', '1'),
-                        is_executable=True),
+                        magic=stub_magic),
             elf.ElfFile(path=os.path.join(self.handler.primedir, 'bin', '2'),
-                        is_executable=True),
+                        magic=stub_magic),
         ])
         self.assertThat(self.handler.last_step(), Equals(None))
 
@@ -1193,10 +1196,13 @@ class StateTestCase(StateBaseTestCase):
             'build-attributes': ['no-system-libraries']
         })
 
+        stub_magic = ('ELF 64-bit LSB executable, x86-64, version 1 (SYSV), '
+                      'dynamically linked, interpreter '
+                      '/lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32')
         self.get_elf_files_mock.return_value = frozenset([
             elf.ElfFile(
                 path=os.path.join(self.handler.primedir, 'bin', 'file'),
-                is_executable=True)])
+                magic=stub_magic)])
         # Pretend we found a system dependency, as well as a part and stage
         # dependency.
         mock_load_dependencies.return_value = set([
@@ -1239,8 +1245,11 @@ class StateTestCase(StateBaseTestCase):
     @patch('snapcraft.internal.pluginhandler._migrate_files')
     def test_prime_state_with_shadowed_dependencies(self, mock_migrate_files,
                                                     mock_load_dependencies):
+        stub_magic = ('ELF 64-bit LSB executable, x86-64, version 1 (SYSV), '
+                      'dynamically linked, interpreter '
+                      '/lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32')
         self.get_elf_files_mock.return_value = frozenset([
-            elf.ElfFile(path='bin/1', is_executable=True)])
+            elf.ElfFile(path='bin/1', magic=stub_magic)])
         self.assertThat(self.handler.last_step(), Equals(None))
 
         bindir = os.path.join(self.handler.plugin.installdir, 'bin')

--- a/snapcraft/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/snapcraft/tests/unit/pluginhandler/test_pluginhandler.py
@@ -1127,11 +1127,11 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(type(state.project_options) is OrderedDict)
         self.assertThat(len(state.project_options), Equals(0))
 
-    @patch('snapcraft.internal.elf.get_dependencies')
+    @patch('snapcraft.internal.elf.ElfFile.load_dependencies')
     @patch('snapcraft.internal.pluginhandler._migrate_files')
     def test_prime_state_with_dependencies(self, mock_migrate_files,
-                                           mock_get_dependencies):
-        mock_get_dependencies.return_value = {
+                                           mock_load_dependencies):
+        mock_load_dependencies.return_value = {
             '/foo/bar/baz',
             '{}/lib1/installed'.format(self.handler.installdir),
             '{}/lib2/staged'.format(self.handler.stagedir),
@@ -1184,10 +1184,10 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(type(state.project_options) is OrderedDict)
         self.assertThat(len(state.project_options), Equals(0))
 
-    @patch('snapcraft.internal.elf.get_dependencies')
+    @patch('snapcraft.internal.elf.ElfFile.load_dependencies')
     @patch('snapcraft.internal.pluginhandler._migrate_files')
     def test_prime_state_disable_ldd_crawl(self, mock_migrate_files,
-                                           mock_get_dependencies):
+                                           mock_load_dependencies):
         # Disable system library migration (i.e. ldd crawling).
         self.handler = self.load_part('test_part', part_properties={
             'build-attributes': ['no-system-libraries']
@@ -1199,7 +1199,7 @@ class StateTestCase(StateBaseTestCase):
                 is_executable=True)])
         # Pretend we found a system dependency, as well as a part and stage
         # dependency.
-        mock_get_dependencies.return_value = set([
+        mock_load_dependencies.return_value = set([
             '/foo/bar/baz',
             '{}/lib1/installed'.format(self.handler.installdir),
             '{}/lib2/staged'.format(self.handler.stagedir),
@@ -1234,11 +1234,11 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue('lib1' in state.dependency_paths)
         self.assertTrue('lib2' in state.dependency_paths)
 
-    @patch('snapcraft.internal.elf.get_dependencies',
+    @patch('snapcraft.internal.elf.ElfFile.load_dependencies',
            return_value=set(['/foo/bar/baz']))
     @patch('snapcraft.internal.pluginhandler._migrate_files')
     def test_prime_state_with_shadowed_dependencies(self, mock_migrate_files,
-                                                    mock_get_dependencies):
+                                                    mock_load_dependencies):
         self.get_elf_files_mock.return_value = frozenset([
             elf.ElfFile(path='bin/1', is_executable=True)])
         self.assertThat(self.handler.last_step(), Equals(None))

--- a/snapcraft/tests/unit/project_loader/test_config.py
+++ b/snapcraft/tests/unit/project_loader/test_config.py
@@ -1699,13 +1699,6 @@ parts:
                                 item))
 
     def test_config_stage_environment_confinement_classic(self):
-        dynamic_linker = '/snap/core/current/lib/ld.so'
-        patcher = unittest.mock.patch(
-            'snapcraft._options.ProjectOptions.get_core_dynamic_linker')
-        mock_core_dynamic_linker = patcher.start()
-        mock_core_dynamic_linker.return_value = dynamic_linker
-        self.addCleanup(patcher.stop)
-
         self.make_snapcraft_yaml("""name: test
 version: "1"
 summary: test
@@ -1718,19 +1711,12 @@ parts:
     plugin: nil
 """)
         config = _config.Config()
-        environment = config.stage_env()
+        part = config.parts.get_part('part1')
+        environment = config.parts.build_env_for_part(part, root_part=True)
         self.assertIn(
-            'LDFLAGS="$LDFLAGS '
-            '-Wl,-rpath,'
-            '/snap/test/current/lib:'
-            '/snap/test/current/usr/lib:'
-            '/snap/test/current/lib/{arch_triplet}:'
-            '/snap/test/current/usr/lib/{arch_triplet}:'
-            '/snap/core/current/lib:'
-            '/snap/core/current/usr/lib:'
-            '/snap/core/current/lib/{arch_triplet}:'
-            '/snap/core/current/usr/lib/{arch_triplet}"'.format(
-                arch_triplet=self.arch_triplet),
+            'LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/snap/core/current/lib:'
+            '/snap/core/current/usr/lib:/snap/core/current/lib/{0}:'
+            '/snap/core/current/usr/lib/{0}"'.format(self.arch_triplet),
             environment)
 
     def test_config_stage_environment(self):

--- a/snapcraft/tests/unit/test_elf.py
+++ b/snapcraft/tests/unit/test_elf.py
@@ -83,7 +83,7 @@ class TestGetLibraries(unit.TestCase):
         self.useFixture(self.fake_logger)
 
     def test_get_libraries(self):
-        libs = elf.get_dependencies('foo')
+        libs = elf.ElfFile(path='foo').load_dependencies()
         self.assertThat(libs, Equals(frozenset(
             ['/lib/foo.so.1', '/usr/lib/bar.so.2'])))
 
@@ -96,21 +96,22 @@ class TestGetLibraries(unit.TestCase):
         ]
         self.run_output_mock.return_value = '\t' + '\n\t'.join(lines) + '\n'
 
-        libs = elf.get_dependencies('foo')
+        libs = elf.ElfFile(path='foo').load_dependencies()
         self.assertThat(libs, Equals(
             frozenset(['/lib/foo.so.1', '/usr/lib/bar.so.2'])))
 
     def test_get_libraries_filtered_by_system_libraries(self):
         self.get_system_libs_mock.return_value = frozenset(['foo.so.1'])
 
-        libs = elf.get_dependencies('foo')
+        libs = elf.ElfFile(path='foo').load_dependencies()
         self.assertThat(libs, Equals(frozenset(['/usr/lib/bar.so.2'])))
 
     def test_get_libraries_ldd_failure_logs_warning(self):
         self.run_output_mock.side_effect = subprocess.CalledProcessError(
             1, 'foo', b'bar')
 
-        self.assertThat(elf.get_dependencies('foo'), Equals(set()))
+        self.assertThat(elf.ElfFile(path='foo').load_dependencies(),
+                        Equals(set()))
         self.assertThat(
             self.fake_logger.output,
             Equals("Unable to determine library dependencies for 'foo'\n"))
@@ -157,7 +158,8 @@ class TestSystemLibsOnNewRelease(unit.TestCase):
         self.run_output_mock.return_value = '\t' + '\n\t'.join(lines) + '\n'
 
     def test_fail_gracefully_if_system_libs_not_found(self):
-        self.assertThat(elf.get_dependencies('foo'), Equals(frozenset()))
+        self.assertThat(elf.ElfFile(path='foo').load_dependencies(),
+                        Equals(frozenset()))
 
 
 class TestSystemLibsOnReleasesWithNoVersionId(unit.TestCase):

--- a/snapcraft/tests/unit/test_elf.py
+++ b/snapcraft/tests/unit/test_elf.py
@@ -82,8 +82,14 @@ class TestGetLibraries(unit.TestCase):
         self.fake_logger = fixtures.FakeLogger(level=logging.WARNING)
         self.useFixture(self.fake_logger)
 
+        self.stub_magic = ('ELF 64-bit LSB executable, x86-64, '
+                           'version 1 (SYSV),dynamically linked, '
+                           'interpreter /lib64/ld-linux-x86-64.so.2, '
+                           'for GNU/Linux 2.6.32')
+
     def test_get_libraries(self):
-        libs = elf.ElfFile(path='foo').load_dependencies()
+        libs = elf.ElfFile(path='foo',
+                           magic=self.stub_magic).load_dependencies()
         self.assertThat(libs, Equals(frozenset(
             ['/lib/foo.so.1', '/usr/lib/bar.so.2'])))
 
@@ -96,22 +102,25 @@ class TestGetLibraries(unit.TestCase):
         ]
         self.run_output_mock.return_value = '\t' + '\n\t'.join(lines) + '\n'
 
-        libs = elf.ElfFile(path='foo').load_dependencies()
+        libs = elf.ElfFile(path='foo',
+                           magic=self.stub_magic).load_dependencies()
         self.assertThat(libs, Equals(
             frozenset(['/lib/foo.so.1', '/usr/lib/bar.so.2'])))
 
     def test_get_libraries_filtered_by_system_libraries(self):
         self.get_system_libs_mock.return_value = frozenset(['foo.so.1'])
 
-        libs = elf.ElfFile(path='foo').load_dependencies()
+        libs = elf.ElfFile(path='foo',
+                           magic=self.stub_magic).load_dependencies()
         self.assertThat(libs, Equals(frozenset(['/usr/lib/bar.so.2'])))
 
     def test_get_libraries_ldd_failure_logs_warning(self):
         self.run_output_mock.side_effect = subprocess.CalledProcessError(
             1, 'foo', b'bar')
 
-        self.assertThat(elf.ElfFile(path='foo').load_dependencies(),
-                        Equals(set()))
+        dependencies = elf.ElfFile(
+            path='foo', magic=self.stub_magic).load_dependencies()
+        self.assertThat(dependencies, Equals(set()))
         self.assertThat(
             self.fake_logger.output,
             Equals("Unable to determine library dependencies for 'foo'\n"))
@@ -158,8 +167,12 @@ class TestSystemLibsOnNewRelease(unit.TestCase):
         self.run_output_mock.return_value = '\t' + '\n\t'.join(lines) + '\n'
 
     def test_fail_gracefully_if_system_libs_not_found(self):
-        self.assertThat(elf.ElfFile(path='foo').load_dependencies(),
-                        Equals(frozenset()))
+        stub_magic = ('ELF 64-bit LSB executable, x86-64, version 1 (SYSV), '
+                      'dynamically linked, interpreter '
+                      '/lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32')
+        self.assertThat(
+            elf.ElfFile(path='foo', magic=stub_magic).load_dependencies(),
+            Equals(frozenset()))
 
 
 class TestSystemLibsOnReleasesWithNoVersionId(unit.TestCase):
@@ -335,7 +348,10 @@ class TestPatcher(unit.TestCase):
 
     @mock.patch('subprocess.check_call')
     def test_patch(self, check_call_mock):
-        elf_file = elf.ElfFile(path='/fake-elf', is_executable=True)
+        stub_magic = ('ELF 64-bit LSB executable, x86-64, version 1 (SYSV), '
+                      'dynamically linked, interpreter '
+                      '/lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32')
+        elf_file = elf.ElfFile(path='/fake-elf', magic=stub_magic)
         elf_patcher = elf.Patcher(dynamic_linker='/lib/fake-ld')
         elf_patcher.patch(elf_file=elf_file)
 
@@ -345,7 +361,9 @@ class TestPatcher(unit.TestCase):
 
     @mock.patch('subprocess.check_call')
     def test_patch_does_nothing_if_no_interpreter(self, check_call_mock):
-        elf_file = elf.ElfFile(path='/fake-elf', is_executable=False)
+        stub_magic = ('ELF 64-bit LSB shared object, x86-64, '
+                      'version 1 (SYSV), dynamically linked')
+        elf_file = elf.ElfFile(path='/fake-elf', magic=stub_magic)
         elf_patcher = elf.Patcher(dynamic_linker='/lib/fake-ld')
         elf_patcher.patch(elf_file=elf_file)
 
@@ -357,7 +375,10 @@ class TestPatcherErrors(unit.TestCase):
     @mock.patch('subprocess.check_call',
                 side_effect=subprocess.CalledProcessError(2, ['patchelf']))
     def test_patch_fails_raises_patcherror_exception(self, check_call_mock):
-        elf_file = elf.ElfFile(path='/fake-elf', is_executable=True)
+        stub_magic = ('ELF 64-bit LSB executable, x86-64, version 1 (SYSV), '
+                      'dynamically linked, interpreter '
+                      '/lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32')
+        elf_file = elf.ElfFile(path='/fake-elf', magic=stub_magic)
         elf_patcher = elf.Patcher(dynamic_linker='/lib/fake-ld')
 
         self.assertRaises(errors.PatcherError,

--- a/snaps_tests/__init__.py
+++ b/snaps_tests/__init__.py
@@ -192,7 +192,7 @@ class SnapsTestCase(testtools.TestCase):
             raise
 
     def install_snap(self, snap_local_path, snap_name, version,
-                     devmode=False):
+                     devmode=False, classic=False):
         if not config.get('skip-install', False):
             tmp_in_testbed = self.snappy_testbed.run_command(
                 'mktemp -d').strip()
@@ -207,6 +207,8 @@ class SnapsTestCase(testtools.TestCase):
                    snap_path_in_testbed]
             if devmode:
                 cmd.append('--devmode')
+            if classic:
+                cmd.append('--classic')
             try:
                 self.snappy_testbed.run_command(cmd)
             except subprocess.CalledProcessError as e:

--- a/snaps_tests/demos_tests/test_opencv.py
+++ b/snaps_tests/demos_tests/test_opencv.py
@@ -55,7 +55,7 @@ class OpenCVTestCase(snaps_tests.SnapsTestCase):
             '/prime/bin/../usr/lib/{}/libopencv_core'.format(arch_triplet))
         self.assertThat(ldd, Contains(expected_opencv_path))
 
-        self.install_snap(snap_path, 'opencv-example', '1.0')
+        self.install_snap(snap_path, 'opencv-example', '1.0', classic=True)
         if not snaps_tests.config.get('skip-install', False):
             output = self.run_command_in_snappy_testbed(
                 '/snap/bin/opencv-example.example').splitlines()


### PR DESCRIPTION
When working with classic confinement `LD_LIBRARY_PATH`
cannot be set without consequences on when other assets on the host are
called from the snap.

This sets an rpath for every elf file when confinement is set to classic
and allows for further extending this mechanism to non classic.

When setting rpaths it also makes use of `$ORIGIN` to setup relative paths.

Fixes: #1663
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
