### PR TITLE
project_loader: support grammar on architectures

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -43,12 +43,8 @@ properties:
       also cannot start or end with a hyphen."
     pattern: "^(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9])*$"
   architectures:
-    type: array
-    description: architectures to override with
-    minItems: 1
-    uniqueItems: true
-    items:
-      - type: string
+    $ref: "#/definitions/grammar-array"
+    description: architectures on which to build and run
   version:
     # python's defaul yaml loading code loads 1.0 as an int
     # type: string

--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -20,7 +20,7 @@ import os
 import platform
 import sys
 
-# These are used my a mypy 'type:' comment below, and nowhere else. As a
+# These are used by a mypy 'type:' comment below, and nowhere else. As a
 # result, flake8 doesn't think they're used. Thus noqa.
 from typing import Dict, List, Union  # noqa
 

--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -20,6 +20,10 @@ import os
 import platform
 import sys
 
+# These are used my a mypy 'type:' comment below, and nowhere else. As a
+# result, flake8 doesn't think they're used. Thus noqa.
+from typing import Dict, List, Union  # noqa
+
 from snapcraft.internal import common
 from snapcraft.internal.deprecations import handle_deprecation_notice
 from snapcraft.internal.errors import SnapcraftEnvironmentError
@@ -91,7 +95,7 @@ _ARCH_TRANSLATIONS = {
         'triplet': 's390x-linux-gnu',
         'core-dynamic-linker': 'lib/ld64.so.1',
     }
-}
+}  # type: Dict[str, Dict[str, Union[str, List[str]]]]
 
 
 _32BIT_USERSPACE_ARCHITECTURE = {
@@ -282,3 +286,26 @@ def _find_machine(deb_arch):
 
     raise SnapcraftEnvironmentError(
         'Cannot set machine from deb_arch {!r}'.format(deb_arch))
+
+
+def deb_arch_is_supported(deb_arch) -> bool:
+    """Check for support of a specific architecture.
+
+    :param str deb_arch: Debian architecture to check (e.g. amd64).
+    :return: Whether or not architecture is supported by Snapcraft.
+    :rtype: bool
+
+    Supported architecture example:
+    >>> deb_arch_is_supported('amd64')
+    True
+
+    Unsupported architecture example:
+    >>> deb_arch_is_supported('invalid-arch')
+    False
+    """
+
+    for machine in _ARCH_TRANSLATIONS:
+        if _ARCH_TRANSLATIONS[machine].get('deb', '') == deb_arch:
+            return True
+
+    return False

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -117,15 +117,18 @@ class Config:
         self.build_tools = grammar_processor.get_build_packages()
         self.build_tools |= set(project_options.additional_build_packages)
 
+        self.data['architectures'] = list(
+            grammar_processor.get_architectures())
+
+        if not self.data['architectures']:
+            self.data['architectures'] = [self._project_options.deb_arch]
+
         self.parts = PartsConfig(parts=self.data,
                                  project_options=self._project_options,
                                  validator=self._validator,
                                  build_snaps=self.build_snaps,
                                  build_tools=self.build_tools,
                                  snapcraft_yaml=self.snapcraft_yaml_path)
-
-        if 'architectures' not in self.data:
-            self.data['architectures'] = [self._project_options.deb_arch]
 
     def get_metadata(self):
         return {'name': self.data['name'],

--- a/snapcraft/internal/project_loader/grammar_processing/_global_grammar_processor.py
+++ b/snapcraft/internal/project_loader/grammar_processing/_global_grammar_processor.py
@@ -14,6 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Set
+
+import snapcraft
 from snapcraft.internal import repo
 from snapcraft.internal.project_loader import grammar
 
@@ -29,18 +32,38 @@ class GlobalGrammarProcessor:
     ...    project_options=snapcraft.ProjectOptions())
     >>> processor.get_build_packages()
     {'hello'}
+
+    Architectures example:
+    >>> import snapcraft
+    >>> from snapcraft import repo
+    >>> processor = GlobalGrammarProcessor(
+    ...    properties={'architectures': [{'try': ['armhf']}]},
+    ...    project_options=snapcraft.ProjectOptions())
+    >>> processor.get_architectures()
+    {'armhf'}
     """
 
-    def __init__(self, *, properties, project_options):
+    def __init__(self, *, properties, project_options) -> None:
         self._project_options = project_options
 
         self._build_package_grammar = properties.get('build-packages', [])
-        self.__build_packages = set()
+        self.__build_packages = set()  # type: Set[str]
 
-    def get_build_packages(self):
+        self._architectures_grammar = properties.get('architectures', [])
+        self.__architectures = set()  # type: Set[str]
+
+    def get_build_packages(self) -> Set[str]:
         if not self.__build_packages:
             self.__build_packages = grammar.process_grammar(
                 self._build_package_grammar, self._project_options,
                 repo.Repo.build_package_is_valid)
 
         return self.__build_packages
+
+    def get_architectures(self) -> Set[str]:
+        if not self.__architectures:
+            self.__architectures = grammar.process_grammar(
+                self._architectures_grammar, self._project_options,
+                snapcraft._options.deb_arch_is_supported)
+
+        return self.__architectures

--- a/snapcraft/tests/integration/general/test_architectures_grammar.py
+++ b/snapcraft/tests/integration/general/test_architectures_grammar.py
@@ -1,0 +1,96 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import subprocess
+import yaml
+from typing import List
+
+import snapcraft
+
+from snapcraft.tests import integration
+from testtools.matchers import Contains, Equals, HasLength
+
+
+def _snap_architectures() -> List[str]:
+    with open(os.path.join('prime', 'meta', 'snap.yaml'), 'r') as f:
+        return yaml.load(f)['architectures']
+
+
+class ArchitecturesGrammarTestCase(integration.TestCase):
+
+    def test_simple(self):
+        """Test that grammar handles standalone architectures."""
+
+        self.run_snapcraft(['prime'], 'multiarch')
+
+        architectures = _snap_architectures()
+        self.assertThat(architectures, HasLength(2))
+        self.assertThat(architectures, Contains('armhf'))
+        self.assertThat(architectures, Contains('amd64'))
+
+    def test_try(self):
+        """Test that 'try' uses valid architectures."""
+
+        self.run_snapcraft(['prime'], 'architectures-grammar-try')
+
+        self.assertThat(_snap_architectures(), Equals(['armhf']))
+
+    def test_try_skipped(self):
+        """Test that 'try' skips invalid architectures."""
+
+        self.run_snapcraft(['prime'], 'architectures-grammar-try-skip')
+
+        # This means that the resulting snap should have an arch equal to the
+        # host
+        self.assertThat(
+            _snap_architectures(),
+            Equals([snapcraft.ProjectOptions().deb_arch]))
+
+    def test_try_else(self):
+        """Test that 'try' moves to the 'else' branch if body is invalid"""
+
+        self.run_snapcraft(['prime'], 'architectures-grammar-try-else')
+
+        self.assertThat(_snap_architectures(), Equals(['armhf']))
+
+    def test_on_other_arch(self):
+        """Test that 'on' does nothing when running on another arch."""
+
+        self.run_snapcraft(['prime'], 'architectures-grammar-on')
+
+        # This means that the resulting snap should have an arch equal to the
+        # host
+        self.assertThat(
+            _snap_architectures(),
+            Equals([snapcraft.ProjectOptions().deb_arch]))
+
+    def test_on_other_arch_else(self):
+        """Test that 'on' moves to the 'else' branch if on other arch."""
+
+        self.run_snapcraft(['prime'], 'architectures-grammar-on-else')
+
+        self.assertThat(_snap_architectures(), Equals(['armhf']))
+
+    def test_on_other_arch_else_fail(self):
+        """Test that 'on' fails with an error if it hits an 'else fail'."""
+
+        exception = self.assertRaises(
+            subprocess.CalledProcessError, self.run_snapcraft,
+            ['prime'], 'architectures-grammar-fail')
+
+        self.assertThat(exception.output, Contains(
+            "Unable to satisfy 'on other-arch', failure forced"))

--- a/snapcraft/tests/integration/snaps/architectures-grammar-fail/snapcraft.yaml
+++ b/snapcraft/tests/integration/snaps/architectures-grammar-fail/snapcraft.yaml
@@ -1,0 +1,15 @@
+name: architectures-grammar-fail
+version: '0.1'
+summary: Test architectures grammar failures
+description: Make sure the architectures grammar handles `else fail` as expected
+grade: devel
+confinement: strict
+
+architectures:
+  - on other-arch:
+    - armhf
+  - else fail
+
+parts:
+  my-part:
+    plugin: nil

--- a/snapcraft/tests/integration/snaps/architectures-grammar-on-else/snapcraft.yaml
+++ b/snapcraft/tests/integration/snaps/architectures-grammar-on-else/snapcraft.yaml
@@ -1,0 +1,16 @@
+name: architectures-grammar-on-else
+version: '0.1'
+summary: Test architectures grammar on statement else
+description: Verify that the on statement moves to else on other architectures
+grade: devel
+confinement: strict
+
+architectures:
+  - on other-arch:
+    - arm64
+  - else:
+    - armhf
+
+parts:
+  my-part:
+    plugin: nil

--- a/snapcraft/tests/integration/snaps/architectures-grammar-on/snapcraft.yaml
+++ b/snapcraft/tests/integration/snaps/architectures-grammar-on/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: architectures-grammar-on
+version: '0.1'
+summary: Test architectures grammar on statement
+description: Verify that the on statement skips other architecture branches
+grade: devel
+confinement: strict
+
+architectures:
+  - on other-arch:
+    - armhf
+
+parts:
+  my-part:
+    plugin: nil

--- a/snapcraft/tests/integration/snaps/architectures-grammar-try-else/snapcraft.yaml
+++ b/snapcraft/tests/integration/snaps/architectures-grammar-try-else/snapcraft.yaml
@@ -1,0 +1,16 @@
+name: architectures-grammar-try-else
+version: '0.1'
+summary: Test architectures grammar try statement else
+description: Verify that the try statement moves to the else if invalid
+grade: devel
+confinement: strict
+
+architectures:
+  - try:
+    - invalid-arch
+  - else:
+    - armhf
+
+parts:
+  my-part:
+    plugin: nil

--- a/snapcraft/tests/integration/snaps/architectures-grammar-try-skip/snapcraft.yaml
+++ b/snapcraft/tests/integration/snaps/architectures-grammar-try-skip/snapcraft.yaml
@@ -1,0 +1,13 @@
+name: architectures-grammar-try-skip
+version: '0.1'
+summary: Test build package grammar try statement
+description: Verify that the try statement skips unsupported architectures
+grade: devel
+confinement: strict
+
+architectures:
+  - try: [invalid-arch]
+
+parts:
+  my-part:
+    plugin: nil

--- a/snapcraft/tests/integration/snaps/architectures-grammar-try/snapcraft.yaml
+++ b/snapcraft/tests/integration/snaps/architectures-grammar-try/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: architectures-grammar-try
+version: '0.1'
+summary: Test architectures grammar try statement
+description: |
+  Verify that the try statement results in an optional architecture spec
+grade: devel
+confinement: strict
+
+architectures:
+  - try: [armhf]
+
+parts:
+  my-part:
+    plugin: nil

--- a/snapcraft/tests/unit/test_lifecycle.py
+++ b/snapcraft/tests/unit/test_lifecycle.py
@@ -831,6 +831,9 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             'SNAPCRAFT_BUILD_INFO', '1'))
         self.make_snapcraft_yaml(
             textwrap.dedent("""\
+                architectures:
+                  - try: [i386, invalid-arch]
+                  - else: [armhf]
                 parts:
                   test-part:
                     plugin: nil
@@ -844,6 +847,8 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             description: test
             confinement: strict
             grade: stable
+            architectures:
+            - armhf
             parts:
               test-part:
                 build-packages: []
@@ -854,11 +859,9 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
                 stage: []
                 stage-packages: []
                 uname: Linux test uname 4.10 x86_64
-            architectures:
-            - {}
             build-packages: []
             build-snaps: []
-            """.format(self.project_options.deb_arch))
+            """)
         self.assertThat(
             os.path.join('prime', 'snap', 'manifest.yaml'),
             FileContains(expected))
@@ -875,6 +878,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
 
         self.make_snapcraft_yaml(
             textwrap.dedent("""\
+                architectures: [armhf]
                 parts:
                   test-part:
                     plugin: nil
@@ -888,6 +892,8 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             description: test
             confinement: strict
             grade: stable
+            architectures:
+            - armhf
             parts:
               test-part:
                 build-packages: []
@@ -900,11 +906,9 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
                 stage: []
                 stage-packages: []
                 uname: Linux test uname 4.10 x86_64
-            architectures:
-            - {}
             build-packages: []
             build-snaps: []
-            """.format(self.project_options.deb_arch))
+            """)
         self.assertThat(
             os.path.join('prime', 'snap', 'manifest.yaml'),
             FileContains(expected))

--- a/snapcraft/tests/unit/test_options.py
+++ b/snapcraft/tests/unit/test_options.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import doctest
 import os.path
 from unittest import mock
 
@@ -24,6 +25,11 @@ import snapcraft
 from snapcraft.internal import common
 from snapcraft.internal.errors import SnapcraftEnvironmentError
 from snapcraft.tests import unit
+
+
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(snapcraft._options))
+    return tests
 
 
 class NativeOptionsTestCase(unit.TestCase):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently Snapcraft supports a flat list of architecture overrides in the snapcraft.yaml that look something like this:

    architectures: [amd64, i386]

If this property is specified, Snapcraft passes it on verbatim to the snap.yaml, which then assumes the same generated snap supports both of those architectures (called a "fat" snap).

This PR resolves #1681 by expanding Snapcraft's `architectures` property to support the advanced grammar, which allows the property to be dual-purposed into not only run-time architecture support, but build-time (i.e. specify the architecture on which it should be built, as well as the architectures on which the resulting snap can be run). That looks something like this:

    architectures:
      - on i386: [amd64, i386]
      - on armhf: [arm64, armhf]

The final snap.yaml will still only contain a flat list of architectures.