### PR TITLE
cli: show helpful message for 'snapcraft list-keys' with no keys

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -241,14 +241,18 @@ def list_keys():
     enabled_keys = {
         account_key['public-key-sha3-384']
         for account_key in account_info['account_keys']}
-    tabulated_keys = tabulate(
-        [('*' if key['sha3-384'] in enabled_keys else '-',
-          key['name'], key['sha3-384'],
-          '' if key['sha3-384'] in enabled_keys else '(not registered)')
-         for key in keys],
-        headers=["", "Name", "SHA3-384 fingerprint", ""],
-        tablefmt="plain")
-    print(tabulated_keys)
+    if enabled_keys:
+        tabulated_keys = tabulate(
+            [('*' if key['sha3-384'] in enabled_keys else '-',
+              key['name'], key['sha3-384'],
+              '' if key['sha3-384'] in enabled_keys else '(not registered)')
+             for key in keys],
+            headers=["", "Name", "SHA3-384 fingerprint", ""],
+            tablefmt="plain")
+        print(tabulated_keys)
+    else:
+        print('No keys have been registered.'
+              ' See \'snapcraft register-key --help\' to register a key.')
 
 
 def create_key(name):

--- a/snapcraft/tests/unit/commands/test_list_keys.py
+++ b/snapcraft/tests/unit/commands/test_list_keys.py
@@ -85,3 +85,23 @@ class ListKeysCommandTestCase(CommandBaseTestCase):
             """).format(
                 default_sha3_384=get_sample_key('default')['sha3-384'],
                 another_sha3_384=get_sample_key('another')['sha3-384'])))
+
+    @mock.patch.object(storeapi.SCAClient, 'get_account_information')
+    @mock.patch('subprocess.check_output')
+    @mock.patch('snapcraft.internal.repo.Repo.is_package_installed')
+    def test_list_keys_without_registered(self, mock_installed,
+                                          mock_check_output,
+                                          mock_get_account_information):
+        mock_installed.return_value = True
+        mock_check_output.side_effect = mock_snap_output
+        mock_get_account_information.return_value = {
+            'account_id': 'abcd',
+            'account_keys': [],
+        }
+
+        result = self.run_command([self.command_name])
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(result.output, Contains(
+            "No keys have been registered. "
+            "See \'snapcraft register-key --help\' to register a key."))


### PR DESCRIPTION
Tell user to see 'register-key --help' if there is no key registered. Before this fix, an empty table was printed. (which is ugly and redundant)

LP: [#1720210](https://bugs.launchpad.net/snapcraft/+bug/1720210)

- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [X] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Hi! I could check that the changed message is printed with my account w/o registering key, and after I registered one, the ordinary table showed up. However, I'm not sure how to write a test for it. Or is it simple enough that there's no test needed? I'm doing this as a GCI task to fix a bitesize bug of snapcraft, and not that familiar with these stuff ;( If there's something I didn't do correctly with the flow, do not hesitate to teach me. Many thanks!