### PR TITLE
tests: move refresh to unit folder

### DIFF
--- a/snapcraft/tests/unit/commands/test_refresh.py
+++ b/snapcraft/tests/unit/commands/test_refresh.py
@@ -22,7 +22,7 @@ from unittest import mock
 from unittest.mock import call
 
 from testtools.matchers import Equals
-from snapcraft.tests import TestWithFakeRemoteParts
+from snapcraft.tests.unit import TestWithFakeRemoteParts
 from snapcraft.tests import fixture_setup
 from . import CommandBaseTestCase
 from snapcraft.internal.errors import SnapcraftEnvironmentError


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
Somehow the refresh test ended up in a folder that's not part of the new structure so it wouldn't run as part of the regular test runs, which allowed #1769 to pass when it shouldn't have.