### PR TITLE
cli: improve the help command

### DIFF
--- a/snapcraft/cli/echo.py
+++ b/snapcraft/cli/echo.py
@@ -20,6 +20,18 @@ click.echo adding the corresponding color codes for each level.
 """
 import click
 
+from snapcraft.internal import common
+
+
+def wrapped(msg: str) -> None:
+    """Output msg wrapped to the terminal width to stdout.
+
+    The maximum wrapping is determined by
+    snapcraft.internal.common.MAX_CHARACTERS_WRAP
+    """
+    click.echo(click.formatting.wrap_text(
+        msg, width=common.MAX_CHARACTERS_WRAP, preserve_paragraphs=True))
+
 
 def info(msg: str) -> None:
     """Output msg as informative to stdout.

--- a/snapcraft/cli/help.py
+++ b/snapcraft/cli/help.py
@@ -20,6 +20,7 @@ from textwrap import dedent
 import click
 
 import snapcraft
+from . import echo
 from snapcraft.internal import sources
 
 
@@ -61,7 +62,7 @@ def help_command(ctx, topic, devel):
         click.echo(ctx.parent.get_help())
         click.echo(dedent("""\
 
-            To get additional help, run:
+            For more help, use:
                 snapcraft help topics
                 snapcraft help <topic>
                 snapcraft help <plugin-name>
@@ -75,16 +76,20 @@ def help_command(ctx, topic, devel):
         try:
             _module_help(topic, devel)
         except ImportError:
-            click.echo(dedent("""\
-    The argument to help is not a plugin name nor topic, to see the
-    available topics run:
+            # 10 is the limit which determines ellipsis is needed
+            if len(topic) > 10:
+                topic = '{}...'.format(topic[:10])
+            echo.wrapped(dedent("""\
+    There is no help topic or plugin {!r}. Try:
+
+    For topics:
 
         snapcraft help topics
 
-    to see the available plugins run:
+    For valid plugins:
 
         snapcraft list-plugins
-    """))
+    """).format(topic))
             sys.exit(1)
 
 

--- a/snapcraft/cli/help.py
+++ b/snapcraft/cli/help.py
@@ -61,7 +61,7 @@ def help_command(ctx, topic, devel):
         click.echo(ctx.parent.get_help())
         click.echo(dedent("""\
 
-            You can obtain more help by running
+            To get additional help, run:
                 snapcraft help topics
                 snapcraft help <topic>
                 snapcraft help <plugin-name>

--- a/snapcraft/cli/help.py
+++ b/snapcraft/cli/help.py
@@ -15,12 +15,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import importlib
 import sys
+from textwrap import dedent
 
 import click
 
 import snapcraft
 from snapcraft.internal import sources
-from . import echo
 
 
 _TOPICS = {
@@ -36,10 +36,11 @@ def helpcli():
 
 
 @helpcli.command('help')
-@click.argument('topic', metavar='<topic>')
+@click.argument('topic', metavar='<topic>', required=False)
 @click.option('--devel', is_flag=True,
               help='Show more details for snapcraft developers')
-def help_command(topic, devel):
+@click.pass_context
+def help_command(ctx, topic, devel):
     """Obtain help for a certain plugin or topic.
 
     The <topic> can either be a plugin name or one of:
@@ -56,7 +57,16 @@ def help_command(topic, devel):
         snapcraft help sources
         snapcraft help go
     """
-    if topic == 'topics':
+    if not topic:
+        click.echo(ctx.parent.get_help())
+        click.echo(dedent("""\
+
+            You can obtain more help by running
+                snapcraft help topics
+                snapcraft help <topic>
+                snapcraft help <plugin-name>
+        """))
+    elif topic == 'topics':
         for key in _TOPICS:
             click.echo(key)
     elif topic in _TOPICS:
@@ -65,8 +75,16 @@ def help_command(topic, devel):
         try:
             _module_help(topic, devel)
         except ImportError:
-            echo.error('The plugin does not exist. Run `snapcraft '
-                       'list-plugins` to see the available plugins.')
+            click.echo(dedent("""\
+    The argument to help is not a plugin name nor topic, to see the
+    available topics run:
+
+        snapcraft help topics
+
+    to see the available plugins run:
+
+        snapcraft list-plugins
+    """))
             sys.exit(1)
 
 

--- a/snapcraft/tests/unit/commands/test_help.py
+++ b/snapcraft/tests/unit/commands/test_help.py
@@ -19,7 +19,7 @@ import pydoc
 from unittest import mock
 
 import fixtures
-from testtools.matchers import Equals, StartsWith
+from testtools.matchers import Contains, Equals, StartsWith
 
 from snapcraft.cli.help import _TOPICS
 
@@ -46,10 +46,8 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
         result = self.run_command(['help', 'does-not-exist'])
 
         self.assertThat(result.exit_code, Equals(1))
-        self.assertThat(
-            'The plugin does not exist. Run `snapcraft '
-            'list-plugins` to see the available plugins.\n',
-            Equals(result.output))
+        self.assertThat(result.output, Contains(
+            'The argument to help is not a plugin name nor topic'))
 
     def test_print_module_help_when_no_help_for_valid_plugin(self):
         result = self.run_command(['help', 'jdk'])
@@ -99,6 +97,14 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
         self.assertThat(output, Equals(expected),
                         'The help message does not start with {!r} but with '
                         '{!r} instead'.format(expected, output))
+
+    def test_print_generic_help_by_default(self):
+        result = self.run_command(['help'])
+
+        self.assertThat(result.output, Contains(
+            'Snapcraft is a delightful packaging tool.'))
+        self.assertThat(result.output, Contains(
+            'You can obtain more help by running'))
 
     def test_no_unicode_in_help_strings(self):
         helps = ['topics']

--- a/snapcraft/tests/unit/commands/test_help.py
+++ b/snapcraft/tests/unit/commands/test_help.py
@@ -104,7 +104,7 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
         self.assertThat(result.output, Contains(
             'Snapcraft is a delightful packaging tool.'))
         self.assertThat(result.output, Contains(
-            'You can obtain more help by running'))
+            'To get additional help'))
 
     def test_no_unicode_in_help_strings(self):
         helps = ['topics']

--- a/snapcraft/tests/unit/commands/test_help.py
+++ b/snapcraft/tests/unit/commands/test_help.py
@@ -47,7 +47,17 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
 
         self.assertThat(result.exit_code, Equals(1))
         self.assertThat(result.output, Contains(
-            'The argument to help is not a plugin name nor topic'))
+            'There is no help topic or plugin'))
+
+    def test_topic_and_plugin_adds_ellipsis_for_long_arg(self):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        result = self.run_command(['help', '1234567890123'])
+
+        self.assertThat(result.exit_code, Equals(1))
+        self.assertThat(result.output, Contains(
+            '1234567890...'))
 
     def test_print_module_help_when_no_help_for_valid_plugin(self):
         result = self.run_command(['help', 'jdk'])
@@ -104,7 +114,7 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
         self.assertThat(result.output, Contains(
             'Snapcraft is a delightful packaging tool.'))
         self.assertThat(result.output, Contains(
-            'To get additional help'))
+            'For more help'))
 
     def test_no_unicode_in_help_strings(self):
         helps = ['topics']


### PR DESCRIPTION
Give it parity with --help but also extend it so topics and plugin help is
not completely hidden.

LP: #1698116

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
