### PR TITLE
lifecycle: do not include source tarballs from previous runs

### DIFF
--- a/snapcraft/internal/lifecycle/_containers.py
+++ b/snapcraft/internal/lifecycle/_containers.py
@@ -32,6 +32,8 @@ def _create_tar_filter(tar_filename):
             return None
         elif fn.endswith('.snap'):
             return None
+        elif fn.endswith('_source.tar.bz2'):
+            return None
         return tarinfo
     return _tar_filter
 

--- a/snapcraft/tests/unit/commands/test_cleanbuild.py
+++ b/snapcraft/tests/unit/commands/test_cleanbuild.py
@@ -78,6 +78,7 @@ class CleanBuildCommandTestCase(CleanBuildCommandBaseTestCase):
             os.path.join(self.prime_dir, 'binary'),
             'snap-test.snap',
             'snap-test_1.0_source.tar.bz2',
+            'snap-test_0.9_source.tar.bz2',
         ]
         for d in dirs:
             os.makedirs(d)


### PR DESCRIPTION
Playing with the version number made me realize my source tarballs were getting bigger and bigger... fixing.