### PR TITLE
tests: update the snap name already registered for store tests

### DIFF
--- a/snapcraft/tests/integration/store/test_store_register.py
+++ b/snapcraft/tests/integration/store/test_store_register.py
@@ -38,13 +38,13 @@ class RegisterTestCase(integration.StoreTestCase):
         # The snap name is already registered.
         error = self.assertRaises(
             integration.RegisterError,
-            self.register, 'test-already-registered-snap-name')
+            self.register, 'test-snap-name-already-registered')
         self.assertThat(str(error), Contains(
-            "The name 'test-already-registered-snap-name' is already taken."))
+            "The name 'test-snap-name-already-registered' is already taken."))
         self.assertThat(str(error), Contains(
             'We can if needed rename snaps to ensure they match the '
             'expectations of most users. If you are the publisher most '
-            'users expect for \'test-already-registered-snap-name\' then '
+            'users expect for \'test-snap-name-already-registered\' then '
             'claim the name at'))
 
     def test_registration_of_already_owned_name(self):


### PR DESCRIPTION
The previous snap name we were using for this test was revoked at some point.
The store is now returning a different message for revoked snaps, so we needed
to refresh this sceneario with a new name registered by someone else, but not
revoked.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
