### PR TITLE
elf: strip the .note.go.buildid to make room for patching elf

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,6 @@ Build-Depends: bash-completion,
                dh-python,
                git,
                mercurial,
-               patchelf,
                pkg-config,
                python3 (>= 3.4),
                python3-apt,
@@ -47,8 +46,7 @@ Standards-Version: 3.9.8
 
 Package: snapcraft
 Architecture: all
-Depends: patchelf,
-         python3-apt,
+Depends: python3-apt,
          python3-debian,
          python3-click,
          python3-jsonschema,

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,8 +53,9 @@ parts:
         ln -s $LIBSODIUM $TRIPLET_PATH/libsodium.so
     after: [python, apt]
   patchelf:
-    source: https://launchpad.net/ubuntu/+archive/primary/+files/patchelf_0.9.orig.tar.gz
-    source-checksum: sha256/f2aa40a6148cb3b0ca807a1bf836b081793e55ec9e5540a5356d800132be7e0a
+    source: https://github.com/NixOS/patchelf
+    source-type: git
+    source-commit: 29c085fd9d3fc972f75b3961905d6b4ecce7eb2b
     plugin: autotools
     stage:
         - bin/patchelf

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -40,6 +40,7 @@ _schemadir = _DEFAULT_SCHEMADIR
 _DEFAULT_LIBRARIESDIR = os.path.join(sys.prefix, 'share', 'snapcraft',
                                      'libraries')
 _librariesdir = _DEFAULT_LIBRARIESDIR
+_DOCKERENV_FILE = '/.dockerenv'
 
 MAX_CHARACTERS_WRAP = 120
 
@@ -104,6 +105,10 @@ def is_snap() -> bool:
     logger.debug('snapcraft is running as a snap {!r}, '
                  'SNAP_NAME set to {!r}'.format(is_snap, snap_name))
     return is_snap
+
+
+def is_docker_instance() -> bool:
+    return os.path.exists(_DOCKERENV_FILE)
 
 
 def set_plugindir(plugindir):

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -139,10 +139,6 @@ class Patcher:
         else:
             self._patchelf_cmd = 'patchelf'
 
-        logger.debug('snapcraft from snap: {!r}; '
-                     'so patchelf set to {!r}'.format(common.is_snap(),
-                                                      self._patchelf_cmd))
-
     def patch(self, *, elf_file: ElfFile) -> None:
         """Patch elf_file with the Patcher instance configuration.
 

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -156,7 +156,8 @@ class Patcher:
         """
         if elf_file.is_executable:
             self._patch_interpreter(elf_file)
-        self._patch_rpath(elf_file)
+        if elf_file.dependencies:
+            self._patch_rpath(elf_file)
 
     def _patch_interpreter(self, elf_file: ElfFile) -> None:
         self._run_patchelf(args=['--set-interpreter',  self._dynamic_linker],

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -138,6 +138,8 @@ class Patcher:
             self._patchelf_cmd = os.path.join(snap_dir, 'bin', 'patchelf')
         else:
             self._patchelf_cmd = 'patchelf'
+        logger.debug('Setting the patchelf command to {!r}'.format(
+            self._patchelf_cmd))
 
     def patch(self, *, elf_file: ElfFile) -> None:
         """Patch elf_file with the Patcher instance configuration.

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -18,7 +18,6 @@ import re
 import glob
 import logging
 import os
-import shutil
 import subprocess
 import sys
 from functools import wraps
@@ -139,8 +138,10 @@ class Patcher:
             self._patchelf_cmd = os.path.join(snap_dir, 'bin', 'patchelf')
         else:
             self._patchelf_cmd = 'patchelf'
-        logger.debug('Setting the patchelf command to {!r}'.format(
-            shutil.which(self._patchelf_cmd)))
+
+        logger.debug('snapcraft from snap: {!r}; '
+                     'so patchelf set to {!r}'.format(common.is_snap(),
+                                                      self._patchelf_cmd))
 
     def patch(self, *, elf_file: ElfFile) -> None:
         """Patch elf_file with the Patcher instance configuration.

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -20,6 +20,7 @@ import logging
 import os
 import subprocess
 import sys
+from functools import wraps
 from typing import FrozenSet, List, Set, Sequence
 
 import magic
@@ -82,6 +83,31 @@ class ElfFile:
         return libs
 
 
+def _retry_patch(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except errors.PatcherError as patch_error:
+            # This is needed for patchelf to properly work with
+            # go binaries (LP: #1736861).
+            # We do this here instead of the go plugin for two reasons, the
+            # first being that we do not want to blindly remove the section,
+            # only doing it when necessary, and the second, this logic
+            # should eventually be removed once patchelf catches up.
+            try:
+                elf_file_path = kwargs['elf_file_path']
+                subprocess.check_call([
+                    'strip', '--remove-section', '.note.go.buildid',
+                    elf_file_path])
+            except subprocess.CalledProcessError:
+                logger.warning('Could not properly strip .note.go.buildid '
+                               'from {!r}.'.format(elf_file_path))
+                raise patch_error
+            return f(*args, **kwargs)
+    return wrapper
+
+
 class Patcher:
     """Patcher holds the necessary logic to patch elf files."""
 
@@ -130,8 +156,8 @@ class Patcher:
             self._patch_rpath(elf_file)
 
     def _patch_interpreter(self, elf_file: ElfFile) -> None:
-        self._run_patchelf(['--set-interpreter',  self._dynamic_linker],
-                           elf_file.path)
+        self._run_patchelf(args=['--set-interpreter',  self._dynamic_linker],
+                           elf_file_path=elf_file.path)
 
     def _patch_rpath(self, elf_file: ElfFile) -> None:
         rpath = self._get_rpath(elf_file)
@@ -141,11 +167,12 @@ class Patcher:
         #                 side effect of preferring host libraries
         #                 so we simply do not use it.
         # --set-rpath: set the RPATH to the colon separated argument.
-        self._run_patchelf(['--force-rpath',
-                            '--set-rpath', rpath],
-                           elf_file.path)
+        self._run_patchelf(args=['--force-rpath',
+                                 '--set-rpath', rpath],
+                           elf_file_path=elf_file.path)
 
-    def _run_patchelf(self, args: List[str], elf_file_path: str) -> None:
+    @_retry_patch
+    def _run_patchelf(self, *, args: List[str], elf_file_path: str) -> None:
         try:
             subprocess.check_call([self._patchelf_cmd] + args +
                                   [elf_file_path])

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -133,9 +133,14 @@ class Patcher:
         # anywhere given the fixed ld it would have.
         # If not found, resort to whatever is on the system brought
         # in by packaging dependencies.
+        # The docker conditional will work if the docker image has the
+        # snaps unpacked in the corresponding locations.
         if common.is_snap():
             snap_dir = os.getenv('SNAP')
             self._patchelf_cmd = os.path.join(snap_dir, 'bin', 'patchelf')
+        elif (common.is_docker_instance() and
+              os.path.exists('/snap/snapcraft/current/bin/patchelf')):
+            self._patchelf_cmd = '/snap/snapcraft/current/bin/patchelf'
         else:
             self._patchelf_cmd = 'patchelf'
 

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -18,6 +18,7 @@ import re
 import glob
 import logging
 import os
+import shutil
 import subprocess
 import sys
 from functools import wraps
@@ -139,7 +140,7 @@ class Patcher:
         else:
             self._patchelf_cmd = 'patchelf'
         logger.debug('Setting the patchelf command to {!r}'.format(
-            self._patchelf_cmd))
+            shutil.which(self._patchelf_cmd)))
 
     def patch(self, *, elf_file: ElfFile) -> None:
         """Patch elf_file with the Patcher instance configuration.
@@ -154,8 +155,7 @@ class Patcher:
         """
         if elf_file.is_executable:
             self._patch_interpreter(elf_file)
-        if elf_file.dependencies:
-            self._patch_rpath(elf_file)
+        self._patch_rpath(elf_file)
 
     def _patch_interpreter(self, elf_file: ElfFile) -> None:
         self._run_patchelf(args=['--set-interpreter',  self._dynamic_linker],

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -37,7 +37,6 @@ from . import constants
 
 
 logger = logging.getLogger(__name__)
-_DOCKERENV_FILE = '/.dockerenv'
 
 
 def execute(step, project_options, part_names=None):
@@ -123,8 +122,7 @@ def _should_get_core(confinement: str) -> bool:
     is_env_var_set = os.environ.get('SNAPCRAFT_SETUP_CORE', False) is not False
     # This is a quirk so that docker users not using the Dockerfile
     # we distribute and create can automatically build classic
-    is_docker_instance = os.path.exists(_DOCKERENV_FILE)  # type: bool
-
+    is_docker_instance = common.is_docker_instance()  # type: bool
     is_classic = (confinement == 'classic')  # type: bool
 
     return is_classic and (is_env_var_set or is_docker_instance)

--- a/snapcraft/tests/integration/plugins/test_go_plugin.py
+++ b/snapcraft/tests/integration/plugins/test_go_plugin.py
@@ -46,7 +46,7 @@ class GoPluginTestCase(integration.TestCase):
         self.assertThat(bin_path, FileExists())
 
         interpreter = subprocess.check_output([
-            'patchelf', '--print-interpreter', bin_path]).decode()
+            self.patchelf_command, '--print-interpreter', bin_path]).decode()
         expected_interpreter = r'^/snap/core/current/.*'
         self.assertThat(interpreter, MatchesRegex(expected_interpreter))
 

--- a/snapcraft/tests/integration/plugins/test_go_plugin.py
+++ b/snapcraft/tests/integration/plugins/test_go_plugin.py
@@ -18,7 +18,8 @@ import os
 import subprocess
 
 import yaml
-from testtools.matchers import Equals, FileContains, FileExists, Not
+from testtools.matchers import (Equals, FileContains, FileExists, MatchesRegex,
+                                Not)
 
 from snapcraft.tests import integration
 import snapcraft
@@ -35,6 +36,19 @@ class GoPluginTestCase(integration.TestCase):
             os.path.join(self.stage_dir, 'bin', os.path.basename(self.path)),
             universal_newlines=True)
         self.assertThat(binary_output, Equals('Hello snapcrafter\n'))
+
+    def test_classic_with_conflicting_build_id(self):
+        # TODO find a faster test to verify LP: #1736861
+        self.run_snapcraft('prime', 'go-gotty')
+
+        bin_path = os.path.join(self.prime_dir, 'bin', 'gotty')
+
+        self.assertThat(bin_path, FileExists())
+
+        interpreter = subprocess.check_output([
+            'patchelf', '--print-interpreter', bin_path]).decode()
+        expected_interpreter = r'^/snap/core/current/.*'
+        self.assertThat(interpreter, MatchesRegex(expected_interpreter))
 
     def test_building_multiple_main_packages(self):
         self.run_snapcraft('stage', 'go-with-multiple-main-packages')

--- a/snapcraft/tests/integration/snaps/go-gotty/snapcraft.yaml
+++ b/snapcraft/tests/integration/snaps/go-gotty/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: gotty
+version: 'v2.0.0-alpha.2'
+summary: Share your terminal as a web application
+description: |
+  GoTTY is a simple command line tool that turns your CLI tools into web
+  applications.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: classic
+
+parts:
+  gotty:
+    source: https://github.com/yudai/gotty
+    source-type: git
+    source-commit: 2c50c432906f1034fa1efec8f7866315f8c81025
+    plugin: go
+    go-importpath: github.com/yudai/gotty
+    after: [go]
+  go:
+    source-tag: go1.9.2

--- a/snapcraft/tests/unit/integrations/test_travis.py
+++ b/snapcraft/tests/unit/integrations/test_travis.py
@@ -16,11 +16,12 @@
 
 import logging
 import subprocess
+from textwrap import dedent
 from unittest import mock
 
 import fixtures
 import yaml
-from testtools.matchers import Equals
+from testtools.matchers import Contains, Equals
 
 from snapcraft import (
     storeapi,
@@ -225,20 +226,14 @@ class TravisSuccessfulTestCase(unit.TestCase):
 
         # Descriptive logging ...
         self.assertThat(
-            self.fake_logger.output.splitlines()[1:],
-            Equals([
-                "Enabling Travis testbeds to push and release 'foo' snaps "
-                "to edge channel in series '16'",
-                'Acquiring specific authorization information ...',
-                'Encrypting authorization for Travis and adjusting project '
-                'to automatically decrypt and use it during "after_success".',
-                'Configuring "deploy" phase to build and release the snap in '
-                'the Store.',
-                'Done. Now you just have to review and commit changes in your '
-                'Travis project (`.travis.yml`).',
-                'Also make sure you add the new '
-                '`.snapcraft/travis_snapcraft.cfg` file.',
-            ]))
+            self.fake_logger.output, Contains(dedent("""\
+                Enabling Travis testbeds to push and release 'foo' snaps to edge channel in series '16'
+                Acquiring specific authorization information ...
+                Encrypting authorization for Travis and adjusting project to automatically decrypt and use it during "after_success".
+                Configuring "deploy" phase to build and release the snap in the Store.
+                Done. Now you just have to review and commit changes in your Travis project (`.travis.yml`).
+                Also make sure you add the new `.snapcraft/travis_snapcraft.cfg` file.
+            """))) # noqa TODO this type of test should not be done
 
     @mock.patch('subprocess.check_output')
     @mock.patch('subprocess.check_call')
@@ -289,13 +284,9 @@ class TravisSuccessfulTestCase(unit.TestCase):
 
         # Descriptive logging ...
         self.assertThat(
-            self.fake_logger.output.splitlines()[1:],
-            Equals([
-                'Refreshing credentials to push and release "foo" snaps to '
-                'edge channel in series 16',
-                'Acquiring specific authorization information ...',
-                'Encrypting authorization for Travis and adjusting project '
-                'to automatically decrypt and use it during "after_success".',
-                'Done. Please commit the changes to '
-                '`.snapcraft/travis_snapcraft.cfg` file.',
-            ]))
+            self.fake_logger.output, Contains(dedent("""\
+                Refreshing credentials to push and release "foo" snaps to edge channel in series 16
+                Acquiring specific authorization information ...
+                Encrypting authorization for Travis and adjusting project to automatically decrypt and use it during "after_success".
+                Done. Please commit the changes to `.snapcraft/travis_snapcraft.cfg` file.
+            """))) # noqa TODO this type of test should not be done

--- a/snapcraft/tests/unit/test_lifecycle.py
+++ b/snapcraft/tests/unit/test_lifecycle.py
@@ -1413,7 +1413,7 @@ class CoreSetupTestCase(unit.TestCase):
             self.project_options.deb_arch, '')
 
     @mock.patch.object(storeapi.StoreClient, 'download')
-    @mock.patch('snapcraft.internal.lifecycle._runner._DOCKERENV_FILE')
+    @mock.patch('snapcraft.internal.common._DOCKERENV_FILE')
     def test_core_setup_if_docker_env(self, dockerenv_fake, download_mock):
         dockerenv_file = os.path.join(self.tempdir, 'dockerenv')
         os.makedirs(self.tempdir)

--- a/snapcraft/tests/unit/test_lifecycle.py
+++ b/snapcraft/tests/unit/test_lifecycle.py
@@ -1385,7 +1385,9 @@ class CoreSetupTestCase(unit.TestCase):
         self.project_options = snapcraft.ProjectOptions()
 
     @mock.patch.object(storeapi.StoreClient, 'download')
-    def test_core_setup_with_env_var(self, download_mock):
+    @mock.patch('snapcraft.internal.repo.snaps.install_snaps',
+                return_value=['patchelf=1'])
+    def test_core_setup_with_env_var(self, install_snaps_mock, download_mock):
         self.useFixture(fixtures.EnvironmentVariable(
             'SNAPCRAFT_SETUP_CORE', '1'))
 
@@ -1452,7 +1454,9 @@ class CoreSetupTestCase(unit.TestCase):
 
         self.assertThat(self.witness_path, Not(FileExists()))
 
-    def test_core_setup_skipped_if_core_exists(self):
+    @mock.patch('snapcraft.internal.repo.snaps.install_snaps',
+                return_value=['patchelf=1'])
+    def test_core_setup_skipped_if_core_exists(self, install_snaps_mock):
         os.makedirs(self.core_path)
         open(os.path.join(self.core_path, 'fake-content'), 'w').close()
 


### PR DESCRIPTION
patchelf does not handle the existence of the .note.go.buildid section
so we strip it from the resulting binary as from the perspective of the
snap it is not needed.

A newer patchelf is also required which handles the math required for
the way the headers are layed out when using golang's go.

LP: #1736861

Signed-off-by: Ubuntu <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
