### PR TITLE
ci: correctly run from snap

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -111,9 +111,13 @@ The snaps tests script has more complex arguments. For an explanation of them, r
 
     python3 -m snaps_tests -h
 
-The integration and snaps suites can be run using the snapcraft source from the repository, or using the snapacraft command installed in the system. By default, they will use the source code, so you can modify your clone of the repository and verify that your changes are correct. If instead you want to verify that the snapcraft version installed in your system is correct, run them with the environment variable `SNAPCRAFT_FROM_INSTALLED` set, like this:
+The integration and snaps suites can be run using the snapcraft source from the repository, or using the snapacraft command installed in the system. By default, they will use the source code, so you can modify your clone of the repository and verify that your changes are correct. If instead you want to verify that the snapcraft version installed in your system is correct, run them with the environment variable `SNAPCRAFT_FROM_DEB` or `SNAPCRAFT_FROM_SNAP` set, like this:
 
-    SNAPCRAFT_FROM_INSTALLED=1 ./runtests.sh snapcraft/tests/integration
+    SNAPCRAFT_FROM_DEB=1 ./runtests.sh snapcraft/tests/integration
+
+or
+
+    SNAPCRAFT_FROM_SNAP=1 ./runtests.sh snapcraft/tests/integration
 
 The store tests by default will start fake servers that are configured to reply like the real store does. But you can run them also against the staging and production store servers. To do that, you will need to set the `TEST_STORE` environment variable to either `staging` or `production`, and you also have to pass credentials for a valid user in that store with the environment variable `TEST_USER_EMAIL` and `TEST_USER_PASSWORD`, like this:
 

--- a/debian/tests/snapstests
+++ b/debian/tests/snapstests
@@ -9,4 +9,4 @@ mkdir -p $snapd_config_dir
 echo "[Service]\nEnvironment='http_proxy=$http_proxy'\nEnvironment='https_proxy=$https_proxy'\nEnvironment='ftp_proxy=$http_proxy'\nEnvironment='no_proxy=$no_proxy'\n" | tee $snapd_config_dir/snapd.env.conf > /dev/null
 systemctl daemon-reload
 
-su ubuntu -c "SNAPCRAFT_FROM_INSTALLED=1 python3 -m snaps_tests --ip localhost"
+su ubuntu -c "SNAPCRAFT_FROM_DEB=1 python3 -m snaps_tests --ip localhost"

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -98,8 +98,12 @@ def format_snap_name(snap):
     return '{name}_{version}_{arch}.snap'.format(**snap)
 
 
-def is_snap():
-    return os.environ.get('SNAP_NAME') == 'snapcraft'
+def is_snap() -> bool:
+    snap_name = os.environ.get('SNAP_NAME', '')
+    is_snap = snap_name == 'snapcraft'
+    logger.debug('snapcraft is running as a snap {!r}, '
+                 'SNAP_NAME set to {!r}'.format(is_snap, snap_name))
+    return is_snap
 
 
 def set_plugindir(plugindir):

--- a/snapcraft/tests/integration/__init__.py
+++ b/snapcraft/tests/integration/__init__.py
@@ -63,6 +63,11 @@ class TestCase(testtools.TestCase):
             self.snapcraft_parser_command = os.path.join(
                 os.getcwd(), 'bin', 'snapcraft-parser')
 
+        if os.getenv('SNAPCRAFT_FROM_SNAP', False):
+            self.patchelf_command = '/snap/snapcraft/current/bin/patchelf'
+        else:
+            self.patchelf_command = 'patchelf'
+
         self.snaps_dir = os.path.join(os.path.dirname(__file__), 'snaps')
         temp_cwd_fixture = fixture_setup.TempCWD()
         self.useFixture(temp_cwd_fixture)

--- a/snapcraft/tests/integration/__init__.py
+++ b/snapcraft/tests/integration/__init__.py
@@ -140,6 +140,7 @@ class TestCase(testtools.TestCase):
                 stderr=subprocess.STDOUT, universal_newlines=True,
                 env=env)
         except subprocess.CalledProcessError as e:
+            self.addDetail('command', content.text(self.snapcraft_command))
             self.addDetail('output', content.text_content(e.output))
             raise
 

--- a/snapcraft/tests/integration/__init__.py
+++ b/snapcraft/tests/integration/__init__.py
@@ -52,9 +52,11 @@ class TestCase(testtools.TestCase):
 
     def setUp(self):
         super().setUp()
-        if os.getenv('SNAPCRAFT_FROM_INSTALLED', False):
-            self.snapcraft_command = 'snapcraft'
-            self.snapcraft_parser_command = 'snapcraft-parser'
+        if os.getenv('SNAPCRAFT_FROM_SNAP', False):
+            self.snapcraft_command = '/snap/bin/snapcraft'
+        elif os.getenv('SNAPCRAFT_FROM_DEB', False):
+            self.snapcraft_command = '/usr/bin/snapcraft'
+            self.snapcraft_parser_command = '/usr/bin/snapcraft-parser'
         else:
             self.snapcraft_command = os.path.join(
                 os.getcwd(), 'bin', 'snapcraft')

--- a/snapcraft/tests/integration/__init__.py
+++ b/snapcraft/tests/integration/__init__.py
@@ -140,7 +140,8 @@ class TestCase(testtools.TestCase):
                 stderr=subprocess.STDOUT, universal_newlines=True,
                 env=env)
         except subprocess.CalledProcessError as e:
-            self.addDetail('command', content.text(self.snapcraft_command))
+            self.addDetail('command', content.text_content(
+                self.snapcraft_command))
             self.addDetail('output', content.text_content(e.output))
             raise
 

--- a/snapcraft/tests/integration/containers/test_cleanbuild.py
+++ b/snapcraft/tests/integration/containers/test_cleanbuild.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+import os
 import subprocess
 
 from testtools.matchers import FileExists
@@ -38,6 +38,10 @@ class CleanbuildTestCase(integration.TestCase):
             raise subprocess.CalledProcessError(return_code, command)
 
     def test_cleanbuild(self):
+        if os.getenv('SNAPCRAFT_FROM_SNAP', False):
+            self.skipTest('container build tests when running from a snap are '
+                          'currently broken LP: #1738210')
+
         self.run_snapcraft_cleanbuild('basic')
 
         snap_file_path = 'basic_0.1_all.snap'

--- a/snapcraft/tests/integration/containers/test_container_builds.py
+++ b/snapcraft/tests/integration/containers/test_container_builds.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+import os
 import subprocess
 
 import fixtures
@@ -26,6 +26,9 @@ class ContainerBuildsTestCase(integration.TestCase):
 
     def setUp(self):
         super().setUp()
+        if os.getenv('SNAPCRAFT_FROM_SNAP', False):
+            self.skipTest('container build tests when running from a snap are '
+                          'currently broken LP: #1738210')
         self.useFixture(
             fixtures.EnvironmentVariable('SNAPCRAFT_CONTAINER_BUILDS', '1'))
 

--- a/snapcraft/tests/integration/general/test_parser.py
+++ b/snapcraft/tests/integration/general/test_parser.py
@@ -33,6 +33,8 @@ class ParserTestCase(integration.TestCase):
 
     def setUp(self):
         super().setUp()
+        if os.getenv('SNAPCRAFT_FROM_SNAP', False):
+            self.skipTest('The snapcraft-parser is not provided by the snap')
         self.useFixture(fixtures.EnvironmentVariable('TMPDIR', self.path))
 
     def call_parser(self, wiki_path, expect_valid, expect_output=True):
@@ -71,7 +73,7 @@ class TestParserWikis(testscenarios.WithScenarios, ParserTestCase):
 
         # Since we're running in a temporary directory use
         # the original source tree version of snapcraft-parser
-        if not os.getenv('SNAPCRAFT_FROM_INSTALLED', False):
+        if not os.getenv('SNAPCRAFT_FROM_DEB', False):
             self.snapcraft_parser_command = os.path.join(
                 os.path.dirname(__file__), '..', '..', '..', '..',
                 'bin', 'snapcraft-parser')

--- a/snapcraft/tests/integration/general/test_prime.py
+++ b/snapcraft/tests/integration/general/test_prime.py
@@ -63,7 +63,7 @@ class PrimeTestCase(integration.TestCase):
         self.assertThat(bin_path, FileExists())
 
         interpreter = subprocess.check_output([
-            'patchelf', '--print-interpreter', bin_path]).decode()
+            self.patchelf_command, '--print-interpreter', bin_path]).decode()
         expected_interpreter = r'^/snap/core/current/.*'
         self.assertThat(interpreter, MatchesRegex(expected_interpreter))
 

--- a/snapcraft/tests/integration/general/test_stage.py
+++ b/snapcraft/tests/integration/general/test_stage.py
@@ -112,7 +112,7 @@ class StageTestCase(integration.TestCase):
 
         # ld-linux will not be set until everything is primed.
         interpreter = subprocess.check_output([
-            'patchelf', '--print-interpreter', bin_path]).decode()
+            self.patchelf_command, '--print-interpreter', bin_path]).decode()
         self.assertThat(interpreter, Not(Contains('/snap/core/current')))
 
     def test_staging_libc_links(self):

--- a/snapcraft/tests/integration/plugins/test_rust_plugin.py
+++ b/snapcraft/tests/integration/plugins/test_rust_plugin.py
@@ -132,6 +132,6 @@ class RustPluginConfinementTestCase(testscenarios.WithScenarios,
         bin_path = os.path.join('prime', 'bin', 'rust-hello')
 
         interpreter = subprocess.check_output([
-            'patchelf', '--print-interpreter', bin_path]).decode()
+            self.patchelf_command, '--print-interpreter', bin_path]).decode()
         expected_interpreter = r'^{}.*'.format(self.startswith)
         self.assertThat(interpreter, MatchesRegex(expected_interpreter))

--- a/snapcraft/tests/unit/commands/test_snap.py
+++ b/snapcraft/tests/unit/commands/test_snap.py
@@ -140,12 +140,8 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
         self.assertThat(result.exit_code, Equals(0))
 
         source = os.path.realpath(os.path.curdir)
-        self.assertIn(
-            "Using LXD remote 'myremote' from SNAPCRAFT_CONTAINER_BUILDS\n"
-            'Waiting for a network connection...\n'
-            'Network connection established\n'
-            'Mounting {} into container\n'.format(source),
-            fake_logger.output)
+        self.assertThat(fake_logger.output, Contains(
+            "Using LXD remote 'myremote' from SNAPCRAFT_CONTAINER_BUILDS"))
 
         project_folder = '/root/build_snap-test'
         mock_container_run.assert_has_calls([

--- a/snaps_tests/__init__.py
+++ b/snaps_tests/__init__.py
@@ -113,8 +113,10 @@ class SnapsTestCase(testtools.TestCase):
                         self.snap_content_dir, filter_))
         logger.info('Testing {}'.format(self.snap_content_dir))
         super().setUp()
-        if os.getenv('SNAPCRAFT_FROM_INSTALLED', False):
-            self.snapcraft_command = 'snapcraft'
+        if os.getenv('SNAPCRAFT_FROM_SNAP', False):
+            self.snapcraft_command = '/snap/bin/snapcraft'
+        elif os.getenv('SNAPCRAFT_FROM_DEB', False):
+            self.snapcraft_command = '/usr/bin/snapcraft'
         else:
             self.snapcraft_command = os.path.join(
                 os.getcwd(), 'bin', 'snapcraft')

--- a/snaps_tests/demos_tests/test_opencv.py
+++ b/snaps_tests/demos_tests/test_opencv.py
@@ -37,7 +37,7 @@ class OpenCVTestCase(snaps_tests.SnapsTestCase):
         self.assertThat(bin_path, FileExists())
 
         interpreter = subprocess.check_output([
-            'patchelf', '--print-interpreter', bin_path]).decode()
+            self.patchelf_command, '--print-interpreter', bin_path]).decode()
         expected_interpreter = r'^/snap/core/current/.*'
         self.assertThat(interpreter, MatchesRegex(expected_interpreter))
 
@@ -45,7 +45,7 @@ class OpenCVTestCase(snaps_tests.SnapsTestCase):
 
         # test $ORIGIN in action
         rpath = subprocess.check_output([
-            'patchelf', '--print-rpath', bin_path]).decode()
+            self.patchelf_command, '--print-rpath', bin_path]).decode()
         expected_rpath = '$ORIGIN/../usr/lib/{}:'.format(arch_triplet)
         self.assertThat(rpath, Contains(expected_rpath))
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -3,7 +3,7 @@ project: snapcraft
 environment:
   LANG: "$(echo ${LANG:-C.UTF-8})"
   LANGUAGE: "$(echo ${LANGUAGE:-en})"
-  SNAPCRAFT_FROM_INSTALLED: "1"
+  SNAPCRAFT_FROM_SNAP: "1"
 
 backends:
   lxd:

--- a/tools/travis/run_lxd_container.sh
+++ b/tools/travis/run_lxd_container.sh
@@ -53,7 +53,7 @@ $lxc config set "$name" environment.GH_TOKEN "$GH_TOKEN"
 $lxc config set "$name" environment.CODECOV_TOKEN "$CODECOV_TOKEN"
 $lxc config set "$name" environment.SNAPCRAFT_AUTOPKGTEST_COOKIE "$SNAPCRAFT_AUTOPKGTEST_COOKIE"
 $lxc config set "$name" environment.LC_ALL "C.UTF-8"
-$lxc config set "$name" environment.SNAPCRAFT_FROM_INSTALLED "1"
+$lxc config set "$name" environment.SNAPCRAFT_FROM_SNAP "1"
 
 $lxc exec "$name" -- apt update
 

--- a/tools/travis/run_tests.sh
+++ b/tools/travis/run_tests.sh
@@ -34,10 +34,12 @@ if [ "$test" = "static" ]; then
 elif [ "$test" = "snapcraft/tests/unit" ]; then
     dependencies="apt install -y git bzr subversion mercurial libnacl-dev libsodium-dev libffi-dev libapt-pkg-dev libarchive-dev python3-pip squashfs-tools xdelta3 && python3 -m pip install -r requirements-devel.txt -r requirements.txt codecov && apt install -y python3-coverage"
 elif [[ "$test" = "snapcraft/tests/integration"* || "$test" = "snapcraft.tests.integration"* ]]; then
+    # TODO remove the need to install the snapcraft dependencies due to nesting
+    #      the tests in the snapcraft package
     # snap install core exits with this error message:
     # - Setup snap "core" (2462) security profiles (cannot reload udev rules: exit status 2
     # but the installation succeeds, so we just ingore it.
-    dependencies="apt install -y bzr curl git libnacl-dev libsodium-dev libffi-dev libapt-pkg-dev libarchive-dev mercurial python3-pip subversion squashfs-tools sudo snapd xdelta3 patchelf && python3 -m pip install -r requirements-devel.txt -r requirements.txt && (snap install core || echo 'ignored error') && sudo snap install snaps-cache/snapcraft-pr$TRAVIS_PULL_REQUEST.snap --dangerous --classic"
+    dependencies="apt install -y bzr git libnacl-dev libsodium-dev libffi-dev libapt-pkg-dev libarchive-dev mercurial python3-pip subversion sudo snapd && python3 -m pip install -r requirements-devel.txt -r requirements.txt && (snap install core || echo 'ignored error') && sudo snap install snaps-cache/snapcraft-pr$TRAVIS_PULL_REQUEST.snap --dangerous --classic"
 else
     echo "Unknown test suite: $test"
     exit 1


### PR DESCRIPTION
We loosly assume tests are using the snap to run, what is worse is that we setup all the development dependencies together with the runtime ones to hide this fact

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
