### PR TITLE
lifecycle: use the -no-fragments mksquashfs option

### DIFF
--- a/snapcraft/internal/lifecycle/_packer.py
+++ b/snapcraft/internal/lifecycle/_packer.py
@@ -65,7 +65,8 @@ def pack(directory, output=None):
 
     # These options need to match the review tools:
     # http://bazaar.launchpad.net/~click-reviewers/click-reviewers-tools/trunk/view/head:/clickreviews/common.py#L38
-    mksquashfs_args = ['-noappend', '-comp', 'xz', '-no-xattrs']
+    mksquashfs_args = ['-noappend', '-comp', 'xz', '-no-xattrs',
+                       '-no-fragments']
     if snap['type'] != 'os':
         mksquashfs_args.append('-all-root')
 

--- a/snapcraft/tests/unit/commands/test_pack.py
+++ b/snapcraft/tests/unit/commands/test_pack.py
@@ -63,7 +63,8 @@ class PackCommandTestCase(PackCommandBaseTestCase):
 
         self.popen_spy.assert_called_once_with([
             'mksquashfs', 'mysnap', 'my_snap_99_multi.snap',
-            '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'],
+            '-noappend', '-comp', 'xz', '-no-xattrs', '-no-fragments',
+            '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
         self.assertThat('my_snap_99_multi.snap', FileExists())
@@ -83,7 +84,8 @@ class PackCommandTestCase(PackCommandBaseTestCase):
 
         self.popen_spy.assert_called_once_with([
             'mksquashfs', 'mysnap', 'my_snap_99_all.snap',
-            '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'],
+            '-noappend', '-comp', 'xz', '-no-xattrs', '-no-fragments',
+            '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
         self.assertThat('my_snap_99_all.snap', FileExists())
@@ -105,7 +107,7 @@ class PackCommandTestCase(PackCommandBaseTestCase):
 
         self.popen_spy.assert_called_once_with([
             'mksquashfs', 'mysnap', 'my_snap_99_multi.snap',
-            '-noappend', '-comp', 'xz', '-no-xattrs'],
+            '-noappend', '-comp', 'xz', '-no-xattrs', '-no-fragments'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
         self.assertThat('my_snap_99_multi.snap', FileExists())

--- a/snapcraft/tests/unit/commands/test_snap.py
+++ b/snapcraft/tests/unit/commands/test_snap.py
@@ -88,7 +88,8 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
 
         self.popen_spy.assert_called_once_with([
             'mksquashfs', self.prime_dir, 'snap-test_1.0_amd64.snap',
-            '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'],
+            '-noappend', '-comp', 'xz', '-no-xattrs', '-no-fragments',
+            '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
     def test_snap_fails_with_bad_type(self):
@@ -113,7 +114,8 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
 
         self.popen_spy.assert_called_once_with([
             'mksquashfs', self.prime_dir, 'snap-test_1.0_amd64.snap',
-            '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'],
+            '-noappend', '-comp', 'xz', '-no-xattrs', '-no-fragments',
+            '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
     @mock.patch('snapcraft.internal.lxd.Containerbuild._container_run')
@@ -198,7 +200,8 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
 
         self.popen_spy.assert_called_once_with([
             'mksquashfs', self.prime_dir, 'snap-test_1.0_amd64.snap',
-            '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'],
+            '-noappend', '-comp', 'xz', '-no-xattrs', '-no-fragments',
+            '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
         self.assertThat('snap-test_1.0_amd64.snap', FileExists())
@@ -214,7 +217,7 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
 
         self.popen_spy.assert_called_once_with([
             'mksquashfs', self.prime_dir, 'snap-test_1.0_amd64.snap',
-            '-noappend', '-comp', 'xz', '-no-xattrs'],
+            '-noappend', '-comp', 'xz', '-no-xattrs', '-no-fragments'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
         self.assertThat('snap-test_1.0_amd64.snap', FileExists())
@@ -244,7 +247,8 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
 
         self.popen_spy.assert_called_once_with([
             'mksquashfs', self.prime_dir, 'snap-test_1.0_amd64.snap',
-            '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'],
+            '-noappend', '-comp', 'xz', '-no-xattrs', '-no-fragments',
+            '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
         self.assertThat('snap-test_1.0_amd64.snap', FileExists())
@@ -269,7 +273,8 @@ architectures: [amd64, armhf]
 
         self.popen_spy.assert_called_once_with([
             'mksquashfs', 'mysnap', 'my_snap_99_multi.snap',
-            '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'],
+            '-noappend', '-comp', 'xz', '-no-xattrs', '-no-fragments',
+            '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
         self.assertThat('my_snap_99_multi.snap', FileExists())
@@ -293,7 +298,8 @@ version: 99
 
         self.popen_spy.assert_called_once_with([
             'mksquashfs', 'mysnap', 'my_snap_99_all.snap',
-            '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'],
+            '-noappend', '-comp', 'xz', '-no-xattrs', '-no-fragments',
+            '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
         self.assertThat('my_snap_99_all.snap', FileExists())
@@ -320,7 +326,7 @@ type: os
 
         self.popen_spy.assert_called_once_with([
             'mksquashfs', 'mysnap', 'my_snap_99_multi.snap',
-            '-noappend', '-comp', 'xz', '-no-xattrs'],
+            '-noappend', '-comp', 'xz', '-no-xattrs', '-no-fragments'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
         self.assertThat('my_snap_99_multi.snap', FileExists())
@@ -346,7 +352,8 @@ type: os
 
         self.popen_spy.assert_called_once_with([
             'mksquashfs', self.prime_dir, 'mysnap.snap',
-            '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'],
+            '-noappend', '-comp', 'xz', '-no-xattrs', '-no-fragments',
+            '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
         self.assertThat('mysnap.snap', FileExists())
@@ -617,5 +624,6 @@ class SnapCommandAsDefaultTestCase(SnapCommandBaseTestCase):
 
         self.popen_spy.assert_called_once_with([
             'mksquashfs', self.prime_dir, 'snap-test_1.0_amd64.snap',
-            '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'],
+            '-noappend', '-comp', 'xz', '-no-xattrs', '-no-fragments',
+            '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)


### PR DESCRIPTION
Use of the Squashfs fragments feature results in unpredictable snap
composition due to how fragments are gathered and compressed using a
separate thread in mksquashfs. Disable fragments entirely so that the
review tools can perform validation of snaps.

https://forum.snapcraft.io/t/proposal-to-disable-squashfs-fragments-in-snaps/3103
LP: #1576763

Signed-off-by: Tyler Hicks <tyhicks@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
