### PR TITLE
tests: add more unit tests for formatting_utils

### DIFF
--- a/snapcraft/tests/unit/test_formatting_utils.py
+++ b/snapcraft/tests/unit/test_formatting_utils.py
@@ -52,3 +52,32 @@ class HumanizeListTestCases(unit.TestCase):
         items = ['foo', 'bar', 'baz', 'qux']
         output = formatting_utils.humanize_list(items, 'or')
         self.assertThat(output, Equals("'bar', 'baz', 'foo', or 'qux'"))
+
+
+class FormatPathVariableTestCases(unit.TestCase):
+
+    def test_no_paths(self):
+        self.assertRaises(ValueError,
+                          formatting_utils.format_path_variable,
+                          'PATH', None, '/usr', ';')
+
+    def test_one_path(self):
+        paths = ['/bin']
+        output = formatting_utils.format_path_variable('PATH', paths,
+                                                       '/usr', ';')
+        self.assertThat(output,
+                        Equals('PATH="$PATH;/usr/bin"'))
+
+    def test_two_paths(self):
+        paths = ['/bin', '/sbin']
+        output = formatting_utils.format_path_variable('PATH', paths,
+                                                       '/usr', ';')
+        self.assertThat(output,
+                        Equals('PATH="$PATH;/usr/bin;/usr/sbin"'))
+
+    def test_two_paths_other_paremeters(self):
+        paths = ['/usr/bin', '/usr/sbin']
+        output = formatting_utils.format_path_variable('PATH', paths,
+                                                       '', ',')
+        self.assertThat(output,
+                        Equals('PATH="$PATH,/usr/bin,/usr/sbin"'))

--- a/snapcraft/tests/unit/test_formatting_utils.py
+++ b/snapcraft/tests/unit/test_formatting_utils.py
@@ -59,21 +59,21 @@ class FormatPathVariableTestCases(unit.TestCase):
     def test_no_paths(self):
         self.assertRaises(ValueError,
                           formatting_utils.format_path_variable,
-                          'PATH', None, '/usr', ';')
+                          'PATH', None, '/usr', ':')
 
     def test_one_path(self):
         paths = ['/bin']
         output = formatting_utils.format_path_variable('PATH', paths,
-                                                       '/usr', ';')
+                                                       '/usr', ':')
         self.assertThat(output,
-                        Equals('PATH="$PATH;/usr/bin"'))
+                        Equals('PATH="$PATH:/usr/bin"'))
 
     def test_two_paths(self):
         paths = ['/bin', '/sbin']
         output = formatting_utils.format_path_variable('PATH', paths,
-                                                       '/usr', ';')
+                                                       '/usr', ':')
         self.assertThat(output,
-                        Equals('PATH="$PATH;/usr/bin;/usr/sbin"'))
+                        Equals('PATH="$PATH:/usr/bin:/usr/sbin"'))
 
     def test_two_paths_other_paremeters(self):
         paths = ['/usr/bin', '/usr/sbin']


### PR DESCRIPTION
Add unit tests for the "format_path_variable" function in "formatting_utils" module.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Add unit tests which cover format_path_variable function (in formatting_utils module).