### PR TITLE
repo: handle invalid snaps

### DIFF
--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -85,7 +85,8 @@ class SnapUnavailableError(RepoError):
 
     fmt = ('Failed to install or refresh a snap: {snap_name!r} does not exist '
            'or is not available on the desired channel {snap_channel!r}. '
-           'Verify that the snap is available.')
+           'Use `snap info {snap_name}` to get a list of channels the '
+           'snap is available on.')
 
     def __init__(self, *, snap_name: str, snap_channel: str) -> None:
         super().__init__(snap_name=snap_name, snap_channel=snap_channel)

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -81,6 +81,16 @@ class UnpackError(RepoError):
         super().__init__(package=package)
 
 
+class SnapUnavailableError(RepoError):
+
+    fmt = ('Failed to install or refresh a snap: {snap_name!r} does not exist '
+           'or is not available on the desired channel {snap_channel!r}. '
+           'Verify that the snap is available.')
+
+    def __init__(self, *, snap_name: str, snap_channel: str) -> None:
+        super().__init__(snap_name=snap_name, snap_channel=snap_channel)
+
+
 class SnapInstallError(RepoError):
 
     fmt = ('Error while installing snap {snap_name!r} from channel '

--- a/snapcraft/internal/repo/snaps.py
+++ b/snapcraft/internal/repo/snaps.py
@@ -138,6 +138,9 @@ class SnapPackage:
         try:
             return store_channels[self.channel]['confinement'] == 'classic'
         except KeyError:
+            # We have seen some KeyError issues when running tests that are
+            # hard to debug as they only occur there, logging in debug mode
+            # will help uncover the root cause if it happens again.
             logger.debug('Current store channels are {!r} and the store'
                          'payload is {!r}'.format(store_channels,
                                                   self._store_snap_info))

--- a/snapcraft/internal/repo/snaps.py
+++ b/snapcraft/internal/repo/snaps.py
@@ -195,7 +195,7 @@ def install_snaps(snaps_list):
     snaps_installed = []
     for snap in snaps_list:
         snap_pkg = SnapPackage(snap)
-        if not snap_pkg.in_store:
+        if not snap_pkg.is_valid():
             raise errors.SnapUnavailableError(snap_name=snap_pkg.name,
                                               snap_channel=snap_pkg.channel)
 

--- a/snapcraft/internal/repo/snaps.py
+++ b/snapcraft/internal/repo/snaps.py
@@ -94,6 +94,9 @@ class SnapPackage:
     def get_store_snap_info(self):
         """Returns a store payload for the snap."""
         if self._is_in_store is None:
+            # Some environments timeout often, like the armv7 testing
+            # infrastructure. Given that constraint, we add some retry
+            # logic.
             retry_count = 5
             while retry_count > 0:
                 try:

--- a/snapcraft/tests/fake_servers/snapd.py
+++ b/snapcraft/tests/fake_servers/snapd.py
@@ -25,6 +25,7 @@ class FakeSnapdRequestHandler(fake_servers.BaseHTTPRequestHandler):
     snaps_result = []  # type: List[Dict[str, Any]]
     snap_details_func = None
     find_result = []  # type: List[Dict[str, Any]]
+    find_exit_code = 200  # type: int
     _private_data = {'new_fake_snap_installed': False}
 
     def do_GET(self):
@@ -39,7 +40,7 @@ class FakeSnapdRequestHandler(fake_servers.BaseHTTPRequestHandler):
             self.wfile.write(parsed_url.path.encode())
 
     def _handle_snaps(self):
-        status_code = 200
+        status_code = self.find_exit_code
         params = self.snaps_result
         self.send_response(status_code)
         self.send_header('Content-Type', 'text/application+json')

--- a/snapcraft/tests/integration/general/test_build_snaps.py
+++ b/snapcraft/tests/integration/general/test_build_snaps.py
@@ -70,6 +70,8 @@ class BuildSnapsErrorsTestCase(integration.TestCase):
         self.assertThat(exception.returncode, Equals(2))
         self.assertThat(exception.output, Contains(
             "'inexistent'"))
+        self.assertFalse(snapcraft.repo.snaps.SnapPackage.is_snap_installed(
+            'inexistent'))
 
     def test_snap_exists_but_not_on_channel(self):
         # If the snap tested here does not exist, then BuildSnapsTestCase
@@ -81,7 +83,7 @@ class BuildSnapsErrorsTestCase(integration.TestCase):
         snapcraft_yaml.update_part(
             'test-part-with-build-snap', {
                 'plugin': 'nil',
-                'build-snaps': ['u1test-snap-with-tracks/test-track-1/beta']
+                'build-snaps': ['u1test-snap-with-tracks/not-exists/candidate']
             })
         self.useFixture(snapcraft_yaml)
 
@@ -92,3 +94,6 @@ class BuildSnapsErrorsTestCase(integration.TestCase):
         self.assertThat(exception.returncode, Equals(2))
         self.assertThat(exception.output, Contains(
             "'u1test-snap-with-tracks'"))
+
+        self.assertFalse(snapcraft.repo.snaps.SnapPackage.is_snap_installed(
+            'u1test-snap-with-tracks'))

--- a/snapcraft/tests/integration/general/test_build_snaps.py
+++ b/snapcraft/tests/integration/general/test_build_snaps.py
@@ -70,3 +70,25 @@ class BuildSnapsErrorsTestCase(integration.TestCase):
         self.assertThat(exception.returncode, Equals(2))
         self.assertThat(exception.output, Contains(
             "'inexistent'"))
+
+    def test_snap_exists_but_not_on_channel(self):
+        # If the snap tested here does not exist, then BuildSnapsTestCase
+        # will fail.
+        if os.environ.get('ADT_TEST') and self.deb_arch == 'armhf':
+            self.expectFailure('The autopkgtest armhf runners cannot '
+                               'install snaps')
+        snapcraft_yaml = fixture_setup.SnapcraftYaml(self.path)
+        snapcraft_yaml.update_part(
+            'test-part-with-build-snap', {
+                'plugin': 'nil',
+                'build-snaps': ['u1test-snap-with-tracks/test-track-1/beta']
+            })
+        self.useFixture(snapcraft_yaml)
+
+        exception = self.assertRaises(
+            subprocess.CalledProcessError,
+            self.run_snapcraft, ['build'])
+
+        self.assertThat(exception.returncode, Equals(2))
+        self.assertThat(exception.output, Contains(
+            "'u1test-snap-with-tracks'"))

--- a/snapcraft/tests/unit/repo/test_snaps.py
+++ b/snapcraft/tests/unit/repo/test_snaps.py
@@ -248,6 +248,12 @@ class SnapPackageIsValidTest(SnapPackageBaseTestCase):
                 'fake-snap': {'channels': {
                     'strict/stable': {'confinement': 'strict'}}}}],
             expected=True)),
+        ('valid but invalid channel', dict(
+            snap='fake-snap/non-existent/edge',
+            find_result=[{
+                'fake-snap': {'channels': {
+                    'strict/stable': {'confinement': 'strict'}}}}],
+            expected=False)),
         ('invalid', dict(
             snap='missing-snap',
             find_result=[],
@@ -386,6 +392,14 @@ class SnapPackageLifecycleTest(SnapPackageBaseTestCase):
         self.fake_snapd.find_code = 404
         self.assertRaises(errors.SnapUnavailableError,
                           snaps.install_snaps, ['fake-snap'])
+
+    def test_install_snaps_non_existent_channel(self):
+        self.fake_snapd.find_result = [{
+            'fake-snap': {'channels': {
+                'classic/stable': {'confinement': 'classic'}}}}]
+
+        self.assertRaises(errors.SnapUnavailableError,
+                          snaps.install_snaps, ['fake-snap/non-existent/edge'])
 
     def test_install_multiple_snaps(self):
         self.fake_snapd.find_result = [{

--- a/snapcraft/tests/unit/repo/test_snaps.py
+++ b/snapcraft/tests/unit/repo/test_snaps.py
@@ -380,7 +380,12 @@ class SnapPackageLifecycleTest(SnapPackageBaseTestCase):
         installed_snaps = snaps.install_snaps(['fake-snap'])
         self.assertThat(
             installed_snaps,
-            Equals(['fake-snap=test-fake-snap-revision']))
+            Equals(['fake-snap=test-fake-snap-revision']))        
+
+    def test_install_snaps_non_existent_snap(self):
+        self.fake_snapd.find_code = 404
+        self.assertRaises(errors.SnapUnavailableError,
+                          snaps.install_snaps, ['fake-snap'])
 
     def test_install_multiple_snaps(self):
         self.fake_snapd.find_result = [{

--- a/snapcraft/tests/unit/repo/test_snaps.py
+++ b/snapcraft/tests/unit/repo/test_snaps.py
@@ -380,7 +380,7 @@ class SnapPackageLifecycleTest(SnapPackageBaseTestCase):
         installed_snaps = snaps.install_snaps(['fake-snap'])
         self.assertThat(
             installed_snaps,
-            Equals(['fake-snap=test-fake-snap-revision']))        
+            Equals(['fake-snap=test-fake-snap-revision']))
 
     def test_install_snaps_non_existent_snap(self):
         self.fake_snapd.find_code = 404


### PR DESCRIPTION
Handle invalid snaps listed under `build-snaps`, provide a nice error. Also add retries to the information fetching logic to be able to have easier debugging information when the network goes wrong.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
