### PR TITLE
tests: use a simpler test for bzr and python

### DIFF
--- a/snapcraft/tests/integration/plugins/python/test_python_plugin.py
+++ b/snapcraft/tests/integration/plugins/python/test_python_plugin.py
@@ -203,7 +203,7 @@ class PythonPluginTestCase(integration.TestCase):
         self.assertThat(
             glob(os.path.join(
                 self.parts_dir, 'pip-bzr', 'python-packages',
-                'curtin-*.zip'))[0],
+                'bzrtest-*.zip'))[0],
             FileExists())
 
     def test_build_with_data_files_with_root(self):

--- a/snapcraft/tests/integration/snaps/pip-bzr/snapcraft.yaml
+++ b/snapcraft/tests/integration/snaps/pip-bzr/snapcraft.yaml
@@ -11,4 +11,4 @@ parts:
   pip-bzr:
     plugin: python
     python-packages:
-        - bzr+lp:curtin#egg=curtin
+        - bzr+lp:~snappy-dev/+junk/bzrtest#egg=bzrtest


### PR DESCRIPTION
The python plugin test used lp:curtin which recently moved to bzr.

This moves the test to use a bzr repo the ~snappy-dev team controls which is also much simpler and lightweight.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
