### PR TITLE
tests: skip classic confined tests on armhf

### DIFF
--- a/snapcraft/tests/integration/general/test_build_snaps.py
+++ b/snapcraft/tests/integration/general/test_build_snaps.py
@@ -53,8 +53,7 @@ class BuildSnapsErrorsTestCase(integration.TestCase):
 
     def test_inexistent_build_snap(self):
         if os.environ.get('ADT_TEST') and self.deb_arch == 'armhf':
-            self.expectFailure('The autopkgtest armhf runners cannot '
-                               'install snaps')
+            self.skipTest("The autopkgtest armhf runners can't install snaps")
         snapcraft_yaml = fixture_setup.SnapcraftYaml(self.path)
         snapcraft_yaml.update_part(
             'test-part-with-build-snap', {
@@ -77,8 +76,7 @@ class BuildSnapsErrorsTestCase(integration.TestCase):
         # If the snap tested here does not exist, then BuildSnapsTestCase
         # will fail.
         if os.environ.get('ADT_TEST') and self.deb_arch == 'armhf':
-            self.expectFailure('The autopkgtest armhf runners cannot '
-                               'install snaps')
+            self.skipTest("The autopkgtest armhf runners can't install snaps")
         snapcraft_yaml = fixture_setup.SnapcraftYaml(self.path)
         snapcraft_yaml.update_part(
             'test-part-with-build-snap', {

--- a/snapcraft/tests/integration/general/test_prime.py
+++ b/snapcraft/tests/integration/general/test_prime.py
@@ -40,6 +40,8 @@ class PrimeTestCase(integration.TestCase):
         self.deb_arch = snapcraft.ProjectOptions().deb_arch
 
     def test_classic_confinement(self):
+        if os.environ.get('ADT_TEST') and self.deb_arch == 'armhf':
+            self.skipTest("The autopkgtest armhf runners can't install snaps")
         project_dir = 'classic-build'
 
         # The first run should fail as the environment variable is not

--- a/snapcraft/tests/integration/general/test_stage.py
+++ b/snapcraft/tests/integration/general/test_stage.py
@@ -88,6 +88,8 @@ class StageTestCase(integration.TestCase):
         self.assertThat(exception.output, Contains(expected_help))
 
     def test_classic_confinement(self):
+        if os.environ.get('ADT_TEST') and self.deb_arch == 'armhf':
+            self.skipTest("The autopkgtest armhf runners can't install snaps")
         project_dir = 'classic-build'
 
         # The first run should fail as the environment variable is not

--- a/snapcraft/tests/integration/plugins/test_go_plugin.py
+++ b/snapcraft/tests/integration/plugins/test_go_plugin.py
@@ -39,6 +39,9 @@ class GoPluginTestCase(integration.TestCase):
 
     def test_classic_with_conflicting_build_id(self):
         # TODO find a faster test to verify LP: #1736861
+        if os.environ.get('ADT_TEST') and self.deb_arch == 'armhf':
+            self.skipTest("The autopkgtest armhf runners can't install snaps")
+
         self.run_snapcraft('prime', 'go-gotty')
 
         bin_path = os.path.join(self.prime_dir, 'bin', 'gotty')

--- a/snapcraft/tests/integration/plugins/test_rust_plugin.py
+++ b/snapcraft/tests/integration/plugins/test_rust_plugin.py
@@ -122,6 +122,8 @@ class RustPluginConfinementTestCase(testscenarios.WithScenarios,
             yaml.dump(snapcraft_yaml, f)
 
     def test_prime(self):
+        if os.environ.get('ADT_TEST') and self.deb_arch == 'armhf':
+            self.skipTest("The autopkgtest armhf runners can't install snaps")
         self.useFixture(fixtures.EnvironmentVariable(
                 'SNAPCRAFT_SETUP_CORE', '1'))
         self.copy_project_to_cwd('rust-hello')

--- a/snaps_tests/__init__.py
+++ b/snaps_tests/__init__.py
@@ -93,8 +93,6 @@ def _get_latest_ssh_private_key():
 
 class SnapsTestCase(testtools.TestCase):
 
-    snap_content_dir = ''
-
     def __init__(self, *args, **kwargs):
         # match base snap src path on current
         relative_path = os.path.relpath(

--- a/snaps_tests/__init__.py
+++ b/snaps_tests/__init__.py
@@ -93,7 +93,7 @@ def _get_latest_ssh_private_key():
 
 class SnapsTestCase(testtools.TestCase):
 
-    snap_content_dir = None
+    snap_content_dir = ''
 
     def __init__(self, *args, **kwargs):
         # match base snap src path on current

--- a/snaps_tests/demos_tests/test_opencv.py
+++ b/snaps_tests/demos_tests/test_opencv.py
@@ -30,6 +30,9 @@ class OpenCVTestCase(snaps_tests.SnapsTestCase):
     @skip.skip_unless_codename('xenial',
                                'declared stage-packages only in xenial')
     def test_opencv(self):
+        if os.environ.get('ADT_TEST') and self.deb_arch == 'armhf':
+            self.skipTest("The autopkgtest armhf runners can't install snaps")
+
         snap_path = self.build_snap(self.snap_content_dir)
 
         bin_path = os.path.join(os.path.dirname(snap_path),


### PR DESCRIPTION
We recently added a requirement to the snapcraft deb to install patchelf
from the snapstore which disabled a couple of tests.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
