### PR TITLE
Update test_rpm.py

### DIFF
--- a/snapcraft/tests/unit/sources/test_rpm.py
+++ b/snapcraft/tests/unit/sources/test_rpm.py
@@ -42,6 +42,10 @@ class TestRpm(unit.TestCase):
         rpm_source = sources.Rpm(rpm_file_path, dest_dir)
         rpm_source.pull()
 
+        
+        rpm_source2 = sources.Rpm(rpm_file_path, dest_dir,2)
+        rpm_source2.pull()
+    
         self.assertThat(os.listdir(dest_dir), Equals(['test.txt']))
 
     def test_extract_and_keep_rpmfile(self):


### PR DESCRIPTION
I have added an additional test for rpm to trigger the error by setting the third parameter source_tag to 2 instead of leaving it to none.

I have added these two lines of code at line 46
  rpm_source2 = sources.Rpm(rpm_file_path, dest_dir,2)
  rpm_source2.pull()

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
