### PR TITLE
metadata: add infrastructure for extracting metadata from parts

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -63,6 +63,9 @@ properties:
   build-packages:
     $ref: "#/definitions/grammar-array"
     description: top level build packages.
+  adopt-info:
+    type: string
+    description: name of the part that provides source files that will be parsed to extract snap metadata information
   name:
     type: string
     description: name of the snap package
@@ -390,6 +393,13 @@ properties:
           prepare:
             type: string
             default: ''
+          parse-info:
+            type: array
+            minitems: 1
+            uniqueItems: true
+            items:
+              type: string
+            default: []
   plugs:
     type: object
   slots:
@@ -397,9 +407,16 @@ properties:
 required:
   - name
   - version
-  - summary
-  - description
   - parts
+
+# Either summary/description is required, or adopt-info is required to specify
+# the part from which this metadata will be retrieved.
+anyOf:
+  - required:
+    - summary
+    - description
+  - required:
+    - adopt-info
 dependencies:
   license-agreement: ["license"]
   license-version: ["license"]

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ url = 'https://github.com/snapcore/snapcraft'
 packages = [
     'snapcraft',
     'snapcraft.cli',
+    'snapcraft.extractors',
     'snapcraft.integrations',
     'snapcraft.internal',
     'snapcraft.internal.cache',

--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -423,6 +423,7 @@ from snapcraft._store import (                      # noqa
     validate,
 )
 from snapcraft import common                        # noqa
+from snapcraft import extractors                    # noqa
 from snapcraft import plugins                       # noqa
 from snapcraft import sources                       # noqa
 from snapcraft import file_utils                    # noqa

--- a/snapcraft/cli/containers.py
+++ b/snapcraft/cli/containers.py
@@ -17,8 +17,7 @@
 import click
 import os
 
-import snapcraft
-from snapcraft.internal import errors, lxd
+from snapcraft.internal import errors, lxd, project_loader
 from ._options import get_project_options
 from . import env
 
@@ -52,7 +51,7 @@ def refresh(debug, **kwargs):
             "snapcraft update")
 
     project_options = get_project_options(**kwargs, debug=debug)
-    config = snapcraft.internal.load_config(project_options)
+    config = project_loader.load_config(project_options)
     lxd.Project(project_options=project_options,
                 remote=container_config.remote,
                 output=None, source=os.path.curdir,

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -17,8 +17,7 @@
 import click
 import os
 
-import snapcraft
-from snapcraft.internal import deprecations, lifecycle, lxd
+from snapcraft.internal import deprecations, lifecycle, lxd, project_loader
 from ._options import add_build_options, get_project_options
 from . import echo
 from . import env
@@ -178,7 +177,7 @@ def clean(parts, step, **kwargs):
     project_options = get_project_options(**kwargs)
     container_config = env.get_container_config()
     if container_config.use_container:
-        config = snapcraft.internal.load_config(project_options)
+        config = project_loader.load_config(project_options)
         lxd.Project(project_options=project_options,
                     remote=container_config.remote,
                     output=None, source=os.path.curdir,

--- a/snapcraft/extractors/__init__.py
+++ b/snapcraft/extractors/__init__.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,6 +14,5 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from snapcraft.internal import cache             # noqa
-from snapcraft.internal import deltas            # noqa
-from snapcraft.internal import states            # noqa
+from ._metadata import ExtractedMetadata  # noqa
+from ._errors import UnhandledFileError  # noqa

--- a/snapcraft/extractors/_errors.py
+++ b/snapcraft/extractors/_errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2017 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,6 +14,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from snapcraft.internal import cache             # noqa
-from snapcraft.internal import deltas            # noqa
-from snapcraft.internal import states            # noqa
+from snapcraft.internal.errors import MetadataExtractionError
+
+
+class UnhandledFileError(MetadataExtractionError):
+
+    fmt = (
+        "Failed to extract metadata from {file_path!r}: "
+        "This file is not handled by {extractor_name!r}."
+    )
+
+    def __init__(self, file_path: str, extractor_name: str) -> None:
+        super().__init__(file_path=file_path, extractor_name=extractor_name)

--- a/snapcraft/extractors/_metadata.py
+++ b/snapcraft/extractors/_metadata.py
@@ -1,0 +1,78 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import yaml
+from typing import Any, Dict
+
+
+class ExtractedMetadata(yaml.YAMLObject):
+    """Collection of metadata extracted from a part."""
+
+    yaml_tag = u'!ExtractedMetadata'
+
+    def __init__(self, *, summary='', description='') -> None:
+        """Create a new ExtractedMetadata instance.
+
+        :param str summary: Extracted summary
+        :param str description: Extracted description
+        """
+
+        self._data = {}  # type: Dict[str, str]
+
+        if summary:
+            self._data['summary'] = summary
+        if description:
+            self._data['description'] = description
+
+    def update(self, other: 'ExtractedMetadata') -> None:
+        """Update this metadata with other metadata.
+
+        Note that the other metadata will take precedence, and may overwrite
+        data contained here.
+
+        :param ExtractedMetadata other: Metadata from which to update
+        """
+        self._data.update(other.to_dict())
+
+    def get_summary(self) -> str:
+        """Return extracted summary.
+
+        :returns: Extracted summary
+        :rtype: str
+        """
+        return self._data.get('summary')
+
+    def get_description(self) -> str:
+        """Return extracted description.
+
+        :returns: Extracted description
+        :rtype: str
+        """
+        return self._data.get('description')
+
+    def to_dict(self) -> Dict[str, str]:
+        """Return all extracted metadata.
+
+        :returns: All extracted metadata in dict form.
+        :rtype: dict
+        """
+        return self._data.copy()
+
+    def __eq__(self, other: Any) -> bool:
+        if type(other) is type(self):
+            return self._data == other._data
+
+        return False

--- a/snapcraft/formatting_utils.py
+++ b/snapcraft/formatting_utils.py
@@ -48,18 +48,20 @@ def format_path_variable(envvar: str, paths: List[str],
             paths, prepend, separator))
 
 
-def humanize_list(items: List[str], conjunction: str) -> str:
+def humanize_list(items: List[str], conjunction: str,
+                  item_format: str = '{!r}') -> str:
     """Format a list into a human-readable string.
 
     :param list items: List to humanize.
     :param str conjunction: The conjunction used to join the final element to
                             the rest of the list (e.g. 'and').
+    :param str item_format: Format string to use per item.
     """
 
     if len(items) == 0:
         return ''
 
-    quoted_items = ['{!r}'.format(item) for item in sorted(items)]
+    quoted_items = [item_format.format(item) for item in sorted(items)]
     if len(items) == 1:
         return quoted_items[0]
 

--- a/snapcraft/integrations/travis.py
+++ b/snapcraft/integrations/travis.py
@@ -75,7 +75,7 @@ from snapcraft.file_utils import (
     requires_command_success,
     requires_path_exists,
 )
-from snapcraft.internal import load_config
+from snapcraft.internal import project_loader
 from snapcraft._store import login
 from snapcraft.config import LOCAL_CONFIG_FILENAME
 
@@ -177,7 +177,7 @@ def requires_travis_preconditions():
 @requires_travis_preconditions()
 def refresh():
     series = storeapi.constants.DEFAULT_SERIES
-    project_config = load_config()
+    project_config = project_loader.load_config()
     snap_name = project_config.data['name']
     logger.info(
         'Refreshing credentials to push and release "{}" snaps '
@@ -195,7 +195,7 @@ def refresh():
 @requires_travis_preconditions()
 def enable():
     series = storeapi.constants.DEFAULT_SERIES
-    project_config = load_config()
+    project_config = project_loader.load_config()
     snap_name = project_config.data['name']
     logger.info(
         'Enabling Travis testbeds to push and release {!r} snaps '

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -422,3 +422,41 @@ class PatcherError(SnapcraftError):
 
     def __init__(self, *, elf_file, message):
         super().__init__(elf_file=elf_file, message=message)
+
+
+class MetadataExtractionError(SnapcraftError):
+    pass
+
+
+class MissingMetadataFileError(MetadataExtractionError):
+
+    fmt = (
+        "Failed to generate snap metadata: "
+        "Part {part_name!r} has a 'parse-info' referring to metadata file "
+        "{path!r}, which does not exist.")
+
+    def __init__(self, part_name: str, path: str) -> None:
+        super().__init__(part_name=part_name, path=path)
+
+
+class UnhandledMetadataFileTypeError(MetadataExtractionError):
+
+    fmt = (
+        "Failed to extract metadata from {path!r}: "
+        "This type of file is not supported for supplying metadata."
+    )
+
+    def __init__(self, path: str) -> None:
+        super().__init__(path=path)
+
+
+class InvalidExtractorValueError(MetadataExtractionError):
+
+    fmt = (
+        "Failed to extract metadata from {path!r}: "
+        "Extractor {extractor_name!r} didn't return ExtractedMetadata as "
+        "expected."
+    )
+
+    def __init__(self, path: str, extractor_name: str) -> None:
+        super().__init__(path=path, extractor_name=extractor_name)

--- a/snapcraft/internal/lifecycle/_clean.py
+++ b/snapcraft/internal/lifecycle/_clean.py
@@ -19,7 +19,7 @@ import os
 import shutil
 
 from snapcraft import formatting_utils
-from snapcraft.internal import common, load_config
+from snapcraft.internal import common, project_loader
 from . import constants
 
 
@@ -174,7 +174,7 @@ def clean(project_options, parts, step=None):
         _cleanup_common_directories_for_step(step, project_options)
         return
 
-    config = load_config()
+    config = project_loader.load_config()
 
     if not parts and (step == 'stage' or step == 'prime'):
         # If we've been asked to clean stage or prime without being given

--- a/snapcraft/internal/lifecycle/_containers.py
+++ b/snapcraft/internal/lifecycle/_containers.py
@@ -17,7 +17,7 @@ import logging
 import os
 import tarfile
 
-from snapcraft.internal import errors, load_config, lxd
+from snapcraft.internal import errors, lxd, project_loader
 
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ def _create_tar_filter(tar_filename):
 
 def containerbuild(step, project_options, container_config,
                    output=None, args=[]):
-    config = load_config(project_options)
+    config = project_loader.load_config(project_options)
     if container_config.remote:
         logger.info('Using LXD remote {!r} from SNAPCRAFT_CONTAINER_BUILDS'
                     .format(container_config.remote))
@@ -57,7 +57,7 @@ def cleanbuild(project_options, remote=''):
     if remote and not lxd._remote_is_valid(remote):
         raise errors.InvalidContainerRemoteError(remote)
 
-    config = load_config(project_options)
+    config = project_loader.load_config(project_options)
     tar_filename = '{}_{}_source.tar.bz2'.format(
         config.data['name'], config.data['version'])
 

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -22,11 +22,11 @@ from tempfile import TemporaryDirectory
 import yaml
 
 import snapcraft
-import snapcraft.internal
 from snapcraft.internal import (
     common,
     meta,
     pluginhandler,
+    project_loader,
     repo,
     states
 )
@@ -58,7 +58,7 @@ def execute(step, project_options, part_names=None):
                           over.
     :returns: A dict with the snap name, version, type and architectures.
     """
-    config = snapcraft.internal.load_config(project_options)
+    config = project_loader.load_config(project_options)
     installed_packages = repo.Repo.install_build_packages(
         config.build_tools)
     if installed_packages is None:
@@ -224,7 +224,7 @@ class _Executor:
         if step == 'prime' and part_names == self.config.part_names:
             common.env = self.config.snap_env()
             meta.create_snap_packaging(
-                self.config.data, self.project_options,
+                self.config.data, self.config.parts, self.project_options,
                 self.config.snapcraft_yaml_path)
 
     def _handle_dirty(self, part, step, dirty_report):

--- a/snapcraft/internal/meta/_errors.py
+++ b/snapcraft/internal/meta/_errors.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from snapcraft import formatting_utils
 from snapcraft.internal import errors
 
 
@@ -21,3 +22,41 @@ class CommandError(errors.SnapcraftError):
 
     def __init__(self, message: str) -> None:
         self.fmt = message
+
+
+class SnapMetaGenerationError(errors.SnapcraftError):
+    pass
+
+
+class MissingSnapcraftYamlKeysError(SnapMetaGenerationError):
+
+    fmt = (
+        'Failed to generate snap metadata: '
+        'Missing required key(s) in snapcraft.yaml: {keys}. '
+        "Either specify the missing key(s), or use 'adopt-info' to get them "
+        'from a part.')
+
+    def __init__(self, keys: list) -> None:
+        super().__init__(keys=formatting_utils.humanize_list(keys, 'and'))
+
+
+class AdoptedPartMissingError(SnapMetaGenerationError):
+
+    fmt = (
+        "Failed to generate snap metadata: "
+        "'adopt-info' refers to a part named {part!r}, but it is not defined "
+        "in the 'snapcraft.yaml' file.")
+
+    def __init__(self, part: str) -> None:
+        super().__init__(part=part)
+
+
+class AdoptedPartNotParsingInfo(SnapMetaGenerationError):
+
+    fmt = (
+        "Failed to generate snap metadata: "
+        "'adopt-info' refers to part {part!r}, but that part is lacking the "
+        "'parse-info' property.")
+
+    def __init__(self, part: str) -> None:
+        super().__init__(part=part)

--- a/snapcraft/internal/pluginhandler/_metadata_extraction.py
+++ b/snapcraft/internal/pluginhandler/_metadata_extraction.py
@@ -1,0 +1,62 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import importlib
+import logging
+import os
+import pkgutil
+
+from snapcraft import extractors
+from snapcraft.internal.errors import (
+    InvalidExtractorValueError,
+    MissingMetadataFileError,
+    UnhandledMetadataFileTypeError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def extract_metadata(part_name: str,
+                     file_path: str) -> extractors.ExtractedMetadata:
+    if not os.path.exists(file_path):
+        raise MissingMetadataFileError(part_name, file_path)
+
+    # Iterate through each extractor module, calling the 'extract' function
+    # from it. If it raises an 'UnhandledFileError' move onto the next.
+    for _, module_name, _ in pkgutil.iter_modules(
+            extractors.__path__):  # type: ignore
+        # We only care about non-private modules in here
+        if not module_name.startswith('_'):
+            module = importlib.import_module(
+                'snapcraft.extractors.{}'.format(module_name))
+
+            try:
+                # mypy is confused since we dynamically loaded the module. It
+                # doesn't think it has an 'extract' function. Ignore.
+                metadata = module.extract(file_path)  # type: ignore
+                if not isinstance(metadata, extractors.ExtractedMetadata):
+                    raise InvalidExtractorValueError(file_path, module_name)
+
+                return metadata
+            except extractors.UnhandledFileError:
+                pass  # Try the next extractor
+            except AttributeError:
+                logger.warn(
+                    "Extractor {!r} doesn't include the 'extract' function. "
+                    'Skipping...'.format(module_name))
+
+    # If we get here, no extractor was able to handle the file
+    raise UnhandledMetadataFileTypeError(file_path)

--- a/snapcraft/internal/project_loader/__init__.py
+++ b/snapcraft/internal/project_loader/__init__.py
@@ -17,6 +17,7 @@
 import os
 
 from ._schema import Validator  # noqa
+from ._parts_config import PartsConfig  # noqa
 
 
 def load_config(project_options=None):

--- a/snapcraft/internal/states/_build_state.py
+++ b/snapcraft/internal/states/_build_state.py
@@ -16,6 +16,7 @@
 
 import yaml
 
+from snapcraft import extractors
 from snapcraft.internal.states._state import PartState
 
 
@@ -30,13 +31,13 @@ yaml.add_constructor(u'!BuildState', _build_state_constructor)
 def _schema_properties():
     return {
         'after',
+        'build',
         'build-attributes',
         'build-packages',
         'disable-parallel',
+        'install',
         'organize',
         'prepare',
-        'build',
-        'install',
     }
 
 
@@ -45,7 +46,8 @@ class BuildState(PartState):
 
     def __init__(
             self, property_names, part_properties=None, project=None,
-            plugin_assets=None, machine_assets=None):
+            plugin_assets=None, machine_assets=None, metadata=None,
+            metadata_files=None):
         # Save this off before calling super() since we'll need it
         # FIXME: for 3.x the name `schema_properties` is leaking
         #        implementation details from a higher layer.
@@ -56,6 +58,17 @@ class BuildState(PartState):
             self.assets = {}
         if machine_assets:
             self.assets.update(machine_assets)
+
+        if not metadata:
+            metadata = extractors.ExtractedMetadata()
+
+        if not metadata_files:
+            metadata_files = []
+
+        self.extracted_metadata = {
+            'metadata': metadata,
+            'files': metadata_files
+        }
 
         super().__init__(part_properties, project)
 

--- a/snapcraft/internal/states/_pull_state.py
+++ b/snapcraft/internal/states/_pull_state.py
@@ -16,6 +16,7 @@
 
 import yaml
 
+import snapcraft.extractors
 from snapcraft.internal.states._state import PartState
 
 
@@ -29,15 +30,16 @@ yaml.add_constructor(u'!PullState', _pull_state_constructor)
 
 def _schema_properties():
     return {
+        'parse-info',
         'plugin',
-        'stage-packages',
         'source',
         'source-commit',
         'source-depth',
         'source-tag',
         'source-type',
         'source-branch',
-        'source-subdir'
+        'source-subdir',
+        'stage-packages',
     }
 
 
@@ -46,7 +48,7 @@ class PullState(PartState):
 
     def __init__(self, property_names, part_properties=None, project=None,
                  stage_packages=None, build_snaps=None, build_packages=None,
-                 source_details=None):
+                 source_details=None, metadata=None, metadata_files=None):
         # Save this off before calling super() since we'll need it
         # FIXME: for 3.x the name `schema_properties` is leaking
         #        implementation details from a higher layer.
@@ -56,6 +58,17 @@ class PullState(PartState):
             'build-snaps': build_snaps,
             'build-packages': build_packages,
             'source-details': source_details,
+        }
+
+        if not metadata:
+            metadata = snapcraft.extractors.ExtractedMetadata()
+
+        if not metadata_files:
+            metadata_files = []
+
+        self.extracted_metadata = {
+            'metadata': metadata,
+            'files': metadata_files
         }
 
         super().__init__(part_properties, project)

--- a/snapcraft/internal/states/_state.py
+++ b/snapcraft/internal/states/_state.py
@@ -101,5 +101,5 @@ def get_state(state_dir, step):
     return state
 
 
-def get_step_state_file(state_dir, step):
+def get_step_state_file(state_dir: str, step: str) -> str:
     return os.path.join(state_dir, step)

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -19,6 +19,7 @@ import contextlib
 import copy
 import io
 import os
+import pkgutil
 import socketserver
 import string
 import subprocess
@@ -31,6 +32,7 @@ from functools import partial
 from types import ModuleType
 from unittest import mock
 from subprocess import CalledProcessError
+from typing import Callable
 
 import fixtures
 import xdg
@@ -430,6 +432,41 @@ class FakePlugin(fixtures.Fixture):
         self.addCleanup(self._remove_module)
 
     def _remove_module(self):
+        del sys.modules[self._import_name]
+
+
+class FakeMetadataExtractor(fixtures.Fixture):
+    """Dynamically generate a new module containing the provided extractor"""
+
+    def __init__(self, extractor_name: str,
+                 extractor: Callable[
+                    [str], snapcraft.extractors.ExtractedMetadata],
+                 exported_name='extract') -> None:
+        super().__init__()
+        self._extractor_name = extractor_name
+        self._exported_name = exported_name
+        self._import_name = 'snapcraft.extractors.{}'.format(extractor_name)
+        self._extractor = extractor
+
+    def _setUp(self) -> None:
+        extractor_module = ModuleType(self._import_name)
+        setattr(extractor_module, self._exported_name, self._extractor)
+        sys.modules[self._import_name] = extractor_module
+        self.addCleanup(self._remove_module)
+
+        real_iter_modules = pkgutil.iter_modules
+
+        def _fake_iter_modules(path):
+            if path == snapcraft.extractors.__path__:
+                yield None, self._extractor_name, False
+            else:
+                yield real_iter_modules(path)
+
+        patcher = mock.patch('pkgutil.iter_modules', new=_fake_iter_modules)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _remove_module(self) -> None:
         del sys.modules[self._import_name]
 
 
@@ -955,10 +992,12 @@ class SnapcraftYaml(fixtures.Fixture):
         self.data = {
             'name': name,
             'version': version,
-            'summary': summary,
-            'description': description,
             'parts': {}
         }
+        if summary is not None:
+            self.data['summary'] = summary
+        if description is not None:
+            self.data['description'] = description
 
     def update_part(self, name, data):
         part = {name: data}

--- a/snapcraft/tests/integration/snaps/old-part-src/parts/part-name/state/pull
+++ b/snapcraft/tests/integration/snaps/old-part-src/parts/part-name/state/pull
@@ -1,6 +1,7 @@
 !PullState
 project_options: {deb_arch: $arch}
 properties:
+  parse-info: []
   plugin: copy
   source: .
   source-branch: ''

--- a/snapcraft/tests/unit/extractors/test_metadata.py
+++ b/snapcraft/tests/unit/extractors/test_metadata.py
@@ -1,0 +1,79 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from testtools.matchers import Equals, Not
+
+from snapcraft.extractors._metadata import ExtractedMetadata
+from snapcraft.tests import unit
+
+
+class ExtractedMetadataTestCase(unit.TestCase):
+
+    def test_init(self):
+        metadata = ExtractedMetadata(summary='summary')
+
+        self.assertThat(metadata.get_summary(), Equals('summary'))
+        self.assertThat(metadata.get_description(), Equals(None))
+
+    def test_update_merge(self):
+        metadata = ExtractedMetadata(summary='summary')
+        metadata2 = ExtractedMetadata(description='description')
+        metadata.update(metadata2)
+
+        self.assertThat(metadata.get_summary(), Equals('summary'))
+        self.assertThat(metadata.get_description(), Equals('description'))
+
+    def test_update_overwrite(self):
+        metadata = ExtractedMetadata(
+            summary='summary', description='description')
+        metadata2 = ExtractedMetadata(description='new description')
+        metadata.update(metadata2)
+
+        self.assertThat(metadata.get_summary(), Equals('summary'))
+        self.assertThat(metadata.get_description(), Equals('new description'))
+
+    def test_eq(self):
+        metadata1 = ExtractedMetadata(summary='summary')
+        metadata2 = ExtractedMetadata(summary='summary')
+        self.assertThat(metadata1, Equals(metadata2))
+
+    def test_empty_eq(self):
+        self.assertThat(ExtractedMetadata(), Equals(ExtractedMetadata()))
+
+    def test_not_eq(self):
+        metadata1 = ExtractedMetadata(summary='summary')
+        metadata2 = ExtractedMetadata(description='description')
+        self.assertThat(metadata1, Not(Equals(metadata2)))
+
+    def test_to_dict_partial(self):
+        metadata = ExtractedMetadata(summary='summary')
+        self.assertThat(metadata.to_dict(), Equals({'summary': 'summary'}))
+
+    def test_to_dict_complete(self):
+        metadata = ExtractedMetadata(
+            summary='summary', description='description')
+        self.assertThat(metadata.to_dict(), Equals({
+            'summary': 'summary',
+            'description': 'description',
+        }))
+
+    def test_to_dict_is_a_copy(self):
+        metadata = ExtractedMetadata(summary='summary')
+        metadata_dict = metadata.to_dict()
+        metadata_dict['summary'] = 'edited summary'
+
+        # Ensure the metadata cannot be edited with its dict
+        self.assertThat(metadata.get_summary(), Equals('summary'))

--- a/snapcraft/tests/unit/pluginhandler/test_metadata_extraction.py
+++ b/snapcraft/tests/unit/pluginhandler/test_metadata_extraction.py
@@ -1,0 +1,107 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import fixtures
+import logging
+from testtools.matchers import (
+    Contains,
+    Equals,
+)
+
+from snapcraft.internal import errors
+from snapcraft import extractors
+from snapcraft.internal.pluginhandler import extract_metadata
+
+from snapcraft.tests import (
+    fixture_setup,
+    unit,
+)
+
+
+class MetadataExtractionTestCase(unit.TestCase):
+
+    def test_handled_file(self):
+        open('test-metadata-file', 'w').close()
+
+        def _fake_extractor(file_path):
+            return extractors.ExtractedMetadata(
+                summary='test summary',
+                description='test description')
+
+        self.useFixture(fixture_setup.FakeMetadataExtractor(
+            'fake', _fake_extractor))
+
+        metadata = extract_metadata('test-part', 'test-metadata-file')
+        self.assertThat(metadata.get_summary(), Equals('test summary'))
+        self.assertThat(metadata.get_description(), Equals('test description'))
+
+    def test_unhandled_file(self):
+        open('unhandled-file', 'w').close()
+
+        def _fake_extractor(file_path):
+            raise extractors.UnhandledFileError(file_path, 'fake')
+
+        self.useFixture(fixture_setup.FakeMetadataExtractor(
+            'fake', _fake_extractor))
+
+        raised = self.assertRaises(
+            errors.UnhandledMetadataFileTypeError, extract_metadata,
+            'test-part', 'unhandled-file')
+
+        self.assertThat(raised.path, Equals('unhandled-file'))
+
+    def test_extractor_missing_extract_function(self):
+        fake_logger = fixtures.FakeLogger(level=logging.WARN)
+        self.useFixture(fake_logger)
+
+        open('unhandled-file', 'w').close()
+
+        def _fake_extractor(file_path):
+            raise extractors.UnhandledFileError(file_path, 'fake')
+
+        self.useFixture(fixture_setup.FakeMetadataExtractor(
+            'fake', _fake_extractor, 'not_extract'))
+
+        raised = self.assertRaises(
+            errors.UnhandledMetadataFileTypeError, extract_metadata,
+            'test-part', 'unhandled-file')
+
+        self.assertThat(raised.path, Equals('unhandled-file'))
+        self.assertThat(fake_logger.output, Contains(
+            "'fake' doesn't include the 'extract' function"))
+
+    def test_extractor_returning_invalid_things(self):
+        open('unhandled-file', 'w').close()
+
+        def _fake_extractor(file_path):
+            return "I'm not metadata!"
+
+        self.useFixture(fixture_setup.FakeMetadataExtractor(
+            'fake', _fake_extractor))
+
+        raised = self.assertRaises(
+            errors.InvalidExtractorValueError, extract_metadata,
+            'test-part', 'unhandled-file')
+
+        self.assertThat(raised.path, Equals('unhandled-file'))
+        self.assertThat(raised.extractor_name, Equals('fake'))
+
+    def test_missing_file(self):
+        raised = self.assertRaises(
+            errors.MissingMetadataFileError, extract_metadata,
+            'test-part', 'non-existent')
+
+        self.assertThat(raised.path, Equals('non-existent'))

--- a/snapcraft/tests/unit/states/test_pull.py
+++ b/snapcraft/tests/unit/states/test_pull.py
@@ -53,6 +53,7 @@ class PullStateTestCase(PullStateBaseTestCase):
     def test_properties_of_interest(self):
         self.part_properties.update({
             'plugin': 'test-plugin',
+            'parse-info': 'test-parse-info',
             'stage-packages': ['test-stage-package'],
             'source': 'test-source',
             'source-commit': 'test-source-commit',
@@ -64,9 +65,10 @@ class PullStateTestCase(PullStateBaseTestCase):
         })
 
         properties = self.state.properties_of_interest(self.part_properties)
-        self.assertThat(len(properties), Equals(10))
+        self.assertThat(len(properties), Equals(11))
         self.assertThat(properties['foo'], Equals('bar'))
         self.assertThat(properties['plugin'], Equals('test-plugin'))
+        self.assertThat(properties['parse-info'], Equals('test-parse-info'))
         self.assertThat(
             properties['stage-packages'], Equals(['test-stage-package']))
         self.assertThat(properties['source'], Equals('test-source'))

--- a/snapcraft/tests/unit/test_errors.py
+++ b/snapcraft/tests/unit/test_errors.py
@@ -17,6 +17,7 @@
 from testtools.matchers import Equals
 
 from snapcraft.internal import errors
+from snapcraft.internal.meta import _errors as meta_errors
 from snapcraft.tests import unit
 
 
@@ -286,7 +287,51 @@ class ErrorFormattingTestCase(unit.TestCase):
             'exception': errors.InvalidContainerImageInfoError,
             'kwargs': {'image_info': 'test-image-info'},
             'expected_message': (
-                'Error parsing the container image info: test-image-info')})
+                'Error parsing the container image info: test-image-info')}),
+        # meta errors.
+        ('AdoptedPartMissingError', {
+            'exception': meta_errors.AdoptedPartMissingError,
+            'kwargs': {'part': 'test-part'},
+            'expected_message': (
+                "Failed to generate snap metadata: "
+                "'adopt-info' refers to a part named 'test-part', but it is "
+                "not defined in the 'snapcraft.yaml' file.")}),
+        ('AdoptedPartNotParsingInfo', {
+            'exception': meta_errors.AdoptedPartNotParsingInfo,
+            'kwargs': {'part': 'test-part'},
+            'expected_message': (
+                "Failed to generate snap metadata: "
+                "'adopt-info' refers to part 'test-part', but that part is "
+                "lacking the 'parse-info' property.")}),
+        ('MissingSnapcraftYamlKeysError', {
+            'exception': meta_errors.MissingSnapcraftYamlKeysError,
+            'kwargs': {'keys': ['test-key1', 'test-key2']},
+            'expected_message': (
+                "Failed to generate snap metadata: "
+                "Missing required key(s) in snapcraft.yaml: "
+                "'test-key1' and 'test-key2'. Either specify the missing "
+                "key(s), or use 'adopt-info' to get them from a part.")}),
+        ('MissingMetadataFileError', {
+            'exception': errors.MissingMetadataFileError,
+            'kwargs': {'part_name': 'test-part', 'path': 'test/path'},
+            'expected_message': (
+                "Failed to generate snap metadata: "
+                "Part 'test-part' has a 'parse-info' referring to metadata "
+                "file 'test/path', which does not exist.")}),
+        ('UnhandledMetadataFileTypeError', {
+            'exception': errors.UnhandledMetadataFileTypeError,
+            'kwargs': {'path': 'test/path'},
+            'expected_message': (
+                "Failed to extract metadata from 'test/path': "
+                "This type of file is not supported for supplying "
+                "metadata.")}),
+        ('InvalidExtractorValueError', {
+            'exception': errors.InvalidExtractorValueError,
+            'kwargs': {'path': 'test/path', 'extractor_name': 'extractor'},
+            'expected_message': (
+                "Failed to extract metadata from 'test/path': "
+                "Extractor 'extractor' didn't return ExtractedMetadata as "
+                "expected.")}),
     )
 
     def test_error_formatting(self):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

This PR resolves #1693 by adding the underlying infrastructure necessary to extract metadata from parts. No actual metadata extraction is done here (e.g. Appstream). That will come in follow-up PRs, and will be as simple as adding a new module to `snapcraft.extractors` with an `extract` function.