### PR TITLE
pluginhandler: warn the inclusion of libraries from the host

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -474,6 +474,15 @@ class PluginHandler:
                 # dependencies.
                 _migrate_files(system, system_dependency_paths, '/',
                                self.primedir, follow_symlinks=True)
+                formatted_system = '\n'.join(sorted(system))
+                logger.warning(
+                    'Files from the build host were migrated into the snap to '
+                    'satisfy dependencies that would otherwise not be met. '
+                    'This feature will be removed in a future release. If '
+                    'these libraries are needed in the final snap, ensure '
+                    'that the following are either satisfied by a '
+                    'stage-packages entry or through a part:\n{}'.format(
+                        formatted_system))
 
         if self._confinement == 'classic':
             dynamic_linker = self._project_options.get_core_dynamic_linker()


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
