### PR TITLE
cli: humanize push message

### DIFF
--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -17,7 +17,6 @@ import os
 import sys
 from textwrap import dedent
 from typing import TextIO
-from snapcraft.formatting_utils import humanize_list
 
 # Using mypy 'type:' comment below, but flake8 thinks these aren't used
 from typing import Dict, List, Union  # noqa
@@ -25,7 +24,7 @@ from typing import Dict, List, Union  # noqa
 import click
 
 import snapcraft
-from snapcraft import storeapi
+from snapcraft import storeapi, formatting_utils
 from snapcraft.storeapi.constants import DEFAULT_SERIES
 from . import echo
 
@@ -140,8 +139,8 @@ def push(snap_file, release):
     if release:
         channel_list = release.split(',')
         click.echo(
-            'After pushing, an attempt to release to {} '
-            'will be made'.format(humanize_list(channel_list, 'and')))
+            'After pushing, an attempt will be made to release to {}'
+            ''.format(formatting_utils.humanize_list(channel_list, 'and')))
 
     snapcraft.push(snap_file, channel_list)
 

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -17,6 +17,7 @@ import os
 import sys
 from textwrap import dedent
 from typing import TextIO
+from snapcraft.formatting_utils import humanize_list
 
 # Using mypy 'type:' comment below, but flake8 thinks these aren't used
 from typing import Dict, List, Union  # noqa
@@ -140,7 +141,7 @@ def push(snap_file, release):
         channel_list = release.split(',')
         click.echo(
             'After pushing, an attempt to release to {} '
-            'will be made'.format(channel_list))
+            'will be made'.format(humanize_list(channel_list, 'and')))
 
     snapcraft.push(snap_file, channel_list)
 

--- a/snapcraft/tests/unit/commands/test_push.py
+++ b/snapcraft/tests/unit/commands/test_push.py
@@ -298,8 +298,8 @@ class PushCommandTestCase(PushCommandBaseTestCase):
                                        'edge,beta,candidate'])
 
         self.assertThat(result.output, Contains(
-            "After pushing, an attempt to release to 'beta',"
-            " 'candidate', and 'edge' will be made"))
+            "After pushing, an attempt will be made to release to "
+            "'beta', 'candidate', and 'edge'"))
 
 
 class PushCommandDeltasTestCase(PushCommandBaseTestCase):

--- a/snapcraft/tests/unit/commands/test_push.py
+++ b/snapcraft/tests/unit/commands/test_push.py
@@ -278,15 +278,15 @@ class PushCommandTestCase(PushCommandBaseTestCase):
                 'latest': {
                     '16': {
                         'amd64':
-                            [
-                                {'channel': 'stable', 'info': 'none'},
-                                {'revision': 9, 'channel': 'candidate',
-                                 'version': '0', 'info': 'specific'},
-                                {'revision': 9, 'channel': 'beta', 'version': '0',
-                                 'info': 'specific'},
-                                {'revision': 9, 'channel': 'edge', 'version': '0',
-                                 'info': 'specific'},
-                            ]
+                        [
+                            {'channel': 'stable', 'info': 'none'},
+                            {'revision': 9, 'channel': 'candidate',
+                             'version': '0', 'info': 'specific'},
+                            {'revision': 9, 'channel': 'beta', 'version': '0',
+                             'info': 'specific'},
+                            {'revision': 9, 'channel': 'edge', 'version': '0',
+                             'info': 'specific'},
+                        ]
                     }
                 }
             }
@@ -296,8 +296,10 @@ class PushCommandTestCase(PushCommandBaseTestCase):
                         'StatusTracker') as mock_tracker:
             result = self.run_command(['push', self.snap_file, '--release',
                                        'edge,beta,candidate'])
+
         self.assertThat(result.output, Contains(
-            "After pushing, an attempt to release to 'beta', 'candidate', and 'edge' will be made"))
+            "After pushing, an attempt to release to 'beta',"
+            " 'candidate', and 'edge' will be made"))
 
 
 class PushCommandDeltasTestCase(PushCommandBaseTestCase):


### PR DESCRIPTION
I improved a message displayed after pushing a snap. The humanize_list function from formatting_utils is used to make the list of channels more readable. The unit test was added, to check that the message is displayed correctly.

Fixes https://bugs.launchpad.net/snapcraft/+bug/1735476
I'm a Google Code-in participant.