### PR TITLE
tests: fix broken rust test snap

### DIFF
--- a/snapcraft/tests/integration/snaps/rust-with-revision/Cargo.toml
+++ b/snapcraft/tests/integration/snaps/rust-with-revision/Cargo.toml
@@ -4,6 +4,5 @@ version = "0.1.0"
 authors = ["Marius Gripsgard <mariogrip@ubuntu.com>"]
 
 [dependencies]
-log = "*"
 rustc_version = "= 0.1.2"
 rustc_version_runtime = "0.1.0"

--- a/snapcraft/tests/integration/snaps/rust-with-revision/src/main.rs
+++ b/snapcraft/tests/integration/snaps/rust-with-revision/src/main.rs
@@ -1,4 +1,3 @@
-extern crate log;
 extern crate rustc_version_runtime;
 
 use rustc_version_runtime::version;


### PR DESCRIPTION
The test snap rust-with-revisons had an unnecessary dependency
on the `log` crate which was unversioned. The latest version of
`log` breaks with the rust revision this snap is fixed to.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
