### PR TITLE
lxd: Change "Terminating" message to debug level

### DIFF
--- a/snapcraft/internal/lxd/_project.py
+++ b/snapcraft/internal/lxd/_project.py
@@ -156,7 +156,7 @@ class Project(Containerbuild):
 
     def _finish(self):
         for process in self._processes:
-            logger.info('Terminating {}'.format(process.args))
+            logger.debug('Terminating {}'.format(process.args))
             process.terminate()
 
     def refresh(self):

--- a/snapcraft/tests/unit/test_lxd.py
+++ b/snapcraft/tests/unit/test_lxd.py
@@ -606,6 +606,19 @@ class ProjectTestCase(ContainerbuildTestCase):
                 ContainerConnectionError,
                 self.make_containerbuild().execute)))
 
+    def test_debug_messages(self):
+        class TestFormatter(logging.Formatter):
+            def format(self, record):
+                message = super().format(record)
+                return '[{}]{}'.format(record.levelname, message)
+
+        self.fake_logger = fixtures.FakeLogger(
+            format='%(message)s', formatter=TestFormatter, level=logging.DEBUG)
+        self.useFixture(self.fake_logger)
+
+        self.make_containerbuild().execute()
+        self.assertIn('[DEBUG]Terminating', self.fake_logger.output)
+
 
 class LocalProjectTestCase(ContainerbuildTestCase):
 

--- a/snapcraft/tests/unit/test_lxd.py
+++ b/snapcraft/tests/unit/test_lxd.py
@@ -617,7 +617,8 @@ class ProjectTestCase(ContainerbuildTestCase):
         self.useFixture(self.fake_logger)
 
         self.make_containerbuild().execute()
-        self.assertIn('[DEBUG]Terminating', self.fake_logger.output)
+        self.assertThat(self.fake_logger.output,
+                        Contains('[DEBUG]Terminating'))
 
 
 class LocalProjectTestCase(ContainerbuildTestCase):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
As discussed briefly in a hangout with @sergiusens the "Terminating..." message should be a debug message. We don't currently have unit tests for unexpected messages so I'm not touching the tests (@elopio please correct me if I'm wrong on this one).