### PR TITLE
elf: warn if primed files will not work with the base's linker

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -24,6 +24,7 @@ from functools import lru_cache, wraps
 from typing import FrozenSet, List, Set, Sequence
 
 import magic
+from pkg_resources import parse_version
 
 from snapcraft.internal import (
     common,
@@ -34,6 +35,18 @@ from snapcraft.internal import (
 
 
 logger = logging.getLogger(__name__)
+
+
+class Symbol:
+    """Represents a symbol within an ELF file."""
+
+    def __init__(self, *, name: str, version: str, section: str) -> None:
+        self.name = name
+        self.version = version
+        self.section = section
+
+    def is_undefined(self) -> bool:
+        return self.section == 'UND'
 
 
 class Library:
@@ -91,6 +104,65 @@ class ElfFile:
         self.path = path
         self.is_executable = 'interpreter' in magic
         self.dependencies = set()  # type: Set[Library]
+        self.symbols = self._get_symbols(path)  # type: List[Symbol]
+
+    def _get_symbols(self, path) -> List[Symbol]:
+        symbols = list()  # type: List[Symbol]
+        symbols_section = subprocess.check_output([
+            'readelf', '--wide', '--dyn-syms', path]).decode()
+        # Regex inspired by the regex in lintian to match entries similar to
+        # number '1' from the following sample output
+        #
+        # Symbol table '.dynsym' contains 2281 entries:
+        #   Num:    Value          Size Type    Bind   Vis      Ndx Name
+        #     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND
+        #     1: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND endgrent@GLIBC_2.2.5 (2)  # noqa
+        symbol_match = (r'\s*\d+:\s*[0-9a-f]+\s*\d+\s*\S+\s*\S+\s*\S+\s*'
+                        r'(?P<section>\S+)\s*(?P<symbol>\S+).*\Z')
+        regex = re.compile(symbol_match)
+        for line in symbols_section.split('\n'):
+            m = regex.search(line)
+            if m:
+                section = m.group('section')
+                try:
+                    name, version = m.group('symbol').split('@')
+                except ValueError:
+                    name = m.group('symbol')
+                    version = ''
+                symbols.append(Symbol(name=name, version=version,
+                                      section=section))
+        return symbols
+
+    def is_linker_compatible(self, *, linker: str) -> bool:
+        """Determines if linker will work given the required glibc version.
+
+        The linker passed needs to be of the format <root>/ld-<X>.<Y>.so.
+        """
+        version_required = self.get_required_glibc()
+        m = re.search(r'ld-(?P<linker_version>[\d.]+).so$',
+                      os.path.basename(linker))
+        if not m:
+            # This is a programmatic error, we don't want to be friendly
+            # about this.
+            raise EnvironmentError('{!r} is incorrect.')
+        linker_version = m.group('linker_version')
+        r = parse_version(version_required) <= parse_version(linker_version)
+        logger.debug('Checking if linker {!r} will work with '
+                     'GLIBC_{}: {!r}'.format(linker, version_required, r))
+        return r
+
+    def get_required_glibc(self) -> str:
+        """Returns the required glibc version for this ELF file."""
+        version_required = ''
+        for symbol in self.symbols:
+            if symbol.section != 'UND':
+                continue
+            if not symbol.version.startswith('GLIBC_'):
+                continue
+            version = symbol.version[6:]
+            if parse_version(version) > parse_version(version_required):
+                version_required = version
+        return version_required
 
     def load_dependencies(self, root_path: str,
                           core_base_path: str) -> Set[str]:
@@ -195,7 +267,7 @@ class Patcher:
         """Patch elf_file with the Patcher instance configuration.
 
         If the ELF is executable, patch it to use the configured linker.
-        If the ELF has dependencies, set an rpath to them.
+        If the ELF has dependencies (DT_NEEDED), set an rpath to them.
 
         :param ElfFile elf: a data object representing an elf file and its
                             relevant attributes.

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -117,8 +117,8 @@ class ElfFile:
         #   Num:    Value          Size Type    Bind   Vis      Ndx Name
         #     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND
         #     1: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND endgrent@GLIBC_2.2.5 (2)  # noqa
-        symbol_match = (r'\s*\d+:\s*[0-9a-f]+\s*\d+\s*\S+\s*\S+\s*\S+\s*'
-                        r'(?P<section>\S+)\s*(?P<symbol>\S+).*\Z')
+        symbol_match = (r'^\s+\d+:\s+[0-9a-f]+\s+\d+\s+\S+\s+\S+\s+\S+\s+'
+                        r'(?P<section>\S+)\s+(?P<symbol>\S+).*\Z')
         regex = re.compile(symbol_match)
         for line in symbols_section.split('\n'):
             m = regex.search(line)

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -156,6 +156,9 @@ class ElfFile:
 
     def get_required_glibc(self) -> str:
         """Returns the required glibc version for this ELF file."""
+        with contextlib.suppress(AttributeError):
+            return self._required_glibc  # type: ignore
+
         version_required = ''
         for symbol in self.symbols:
             if not symbol.is_undefined():
@@ -165,6 +168,8 @@ class ElfFile:
             version = symbol.version[6:]
             if parse_version(version) > parse_version(version_required):
                 version_required = version
+
+        self._required_glibc = version_required
         return version_required
 
     def load_dependencies(self, root_path: str,

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -145,7 +145,9 @@ class ElfFile:
         if not m:
             # This is a programmatic error, we don't want to be friendly
             # about this.
-            raise EnvironmentError('{!r} is incorrect.')
+            raise EnvironmentError('The format for the linker should be of the'
+                                   'form <root>/ld-<X>.<Y>.so. {!r} does not '
+                                   'match that format.'.format(linker))
         linker_version = m.group('linker_version')
         r = parse_version(version_required) <= parse_version(linker_version)
         logger.debug('Checking if linker {!r} will work with '

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -124,10 +124,11 @@ class ElfFile:
             m = regex.search(line)
             if m:
                 section = m.group('section')
+                symbol = m.group('symbol')
                 try:
-                    name, version = m.group('symbol').split('@')
+                    name, version = symbol.split('@')
                 except ValueError:
-                    name = m.group('symbol')
+                    name = symbol
                     version = ''
                 symbols.append(Symbol(name=name, version=version,
                                       section=section))

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016-2017 Canonical Ltd
+# Copyright (C) 2016-2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -155,7 +155,7 @@ class ElfFile:
         """Returns the required glibc version for this ELF file."""
         version_required = ''
         for symbol in self.symbols:
-            if symbol.section != 'UND':
+            if not symbol.is_undefined():
                 continue
             if not symbol.version.startswith('GLIBC_'):
                 continue

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2017 Canonical Ltd
+# Copyright (C) 2015-2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -536,6 +536,20 @@ class PluginHandler:
 
         dependency_paths = part_dependency_paths | staged_dependency_paths
 
+        # We need to verify now that the GLIBC version would be compatible
+        # with that of the base.
+        # TODO the linker version depends on the chosen base, but that
+        # base may not be installed so we cannot depend on
+        # get_core_dynamic_linker to resolve the final path for which
+        # we resort to our only working base 16, ld-2.23.so.
+        linker_compatible = (e.is_linker_compatible(linker='ld-2.23.so')
+                             for e in elf_files)
+        if not all((x for x in linker_compatible)):
+            logger.warning('The primed files will not work with the current '
+                           'base given the GLIBC missmatch of the primed '
+                           'files and the linker version used in the base.')
+            # TODO implement GH Issue #1668
+
         if not self._build_attributes.no_system_libraries():
             system_dependency_paths = {os.path.dirname(d) for d in system}
             dependency_paths.update(system_dependency_paths)

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -545,9 +545,14 @@ class PluginHandler:
         linker_compatible = (e.is_linker_compatible(linker='ld-2.23.so')
                              for e in elf_files)
         if not all((x for x in linker_compatible)):
+            files = ('- {} -> GLIBC {}'.format(e.path, e.get_required_glibc())
+                     for e in elf_files if e.get_required_glibc())
             logger.warning('The primed files will not work with the current '
-                           'base given the GLIBC missmatch of the primed '
-                           'files and the linker version used in the base.')
+                           'base given the GLIBC mismatch of the primed '
+                           'files and the linker version (2.23) used in the '
+                           'base. These are the GLIBC versions required by '
+                           'the primed files that do not match:\n {}\n'.format(
+                               '\n'.join(files)))
             # TODO implement GH Issue #1668
 
         if not self._build_attributes.no_system_libraries():

--- a/snapcraft/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/snapcraft/tests/unit/pluginhandler/test_pluginhandler.py
@@ -1227,10 +1227,13 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(type(state.project_options) is OrderedDict)
         self.assertThat(len(state.project_options), Equals(0))
 
+    @patch('snapcraft.internal.elf.ElfFile._get_symbols',
+           return_value=list())
     @patch('snapcraft.internal.elf.ElfFile.load_dependencies')
     @patch('snapcraft.internal.pluginhandler._migrate_files')
     def test_prime_state_with_dependencies(self, mock_migrate_files,
-                                           mock_load_dependencies):
+                                           mock_load_dependencies,
+                                           mock_get_symbols):
         mock_load_dependencies.return_value = {
             '/foo/bar/baz',
             '{}/lib1/installed'.format(self.handler.installdir),
@@ -1287,10 +1290,13 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(type(state.project_options) is OrderedDict)
         self.assertThat(len(state.project_options), Equals(0))
 
+    @patch('snapcraft.internal.elf.ElfFile._get_symbols',
+           return_value=list())
     @patch('snapcraft.internal.elf.ElfFile.load_dependencies')
     @patch('snapcraft.internal.pluginhandler._migrate_files')
     def test_prime_state_disable_ldd_crawl(self, mock_migrate_files,
-                                           mock_load_dependencies):
+                                           mock_load_dependencies,
+                                           mock_get_symbols):
         # Disable system library migration (i.e. ldd crawling).
         self.handler = self.load_part('test_part', part_properties={
             'build-attributes': ['no-system-libraries']
@@ -1340,11 +1346,14 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue('lib1' in state.dependency_paths)
         self.assertTrue('lib2' in state.dependency_paths)
 
+    @patch('snapcraft.internal.elf.ElfFile._get_symbols',
+           return_value=list())
     @patch('snapcraft.internal.elf.ElfFile.load_dependencies',
            return_value=set(['/foo/bar/baz']))
     @patch('snapcraft.internal.pluginhandler._migrate_files')
     def test_prime_state_with_shadowed_dependencies(self, mock_migrate_files,
-                                                    mock_load_dependencies):
+                                                    mock_load_dependencies,
+                                                    mock_get_symbols):
         stub_magic = ('ELF 64-bit LSB executable, x86-64, version 1 (SYSV), '
                       'dynamically linked, interpreter '
                       '/lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32')

--- a/snapcraft/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/snapcraft/tests/unit/pluginhandler/test_pluginhandler.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2017 Canonical Ltd
+# Copyright (C) 2015-2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/snapcraft/tests/unit/test_elf.py
+++ b/snapcraft/tests/unit/test_elf.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016, 2017 Canonical Ltd
+# Copyright (C) 2016-2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as


### PR DESCRIPTION
Parse all the primed files and make sure it will work with
the version of the linker provided by the supporting base.

Closes: #1667

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
