### PR TITLE
lxd: Use user in container when mounting remote via sshfs

### DIFF
--- a/manual-tests.md
+++ b/manual-tests.md
@@ -67,6 +67,18 @@
    build folders as well as the container `snapcraft-<project>` is gone.
 
 
+# Test containerized building with LXD on a remote host
+
+1. Setup LXD on a remote host as described on
+   https://linuxcontainers.org/lxd/getting-started-cli/
+2. Add your remote locally via `lxc remote add <remote>`
+2. Select a project <project> to build.
+3. Run `SNAPCRAFT_CONTAINER_BUILDS=<remote> snapcraft -d` and observe that
+   the debug message `Setting up user <user> in container` shows up.
+4. Run `SNAPCRAFT_CONTAINER_BUILDS=<remote> snapcraft clean` and observe that
+   build folders as well as the container `snapcraft-<project>` is gone.
+
+
 # Test cross-compilation with Go
 
 1. Go to integration_tests/snaps/go-hello.

--- a/snapcraft/internal/lxd/_cleanbuilder.py
+++ b/snapcraft/internal/lxd/_cleanbuilder.py
@@ -42,7 +42,6 @@ class Cleanbuilder(Containerbuild):
         except subprocess.CalledProcessError as e:
             raise ContainerConnectionError('Failed to setup container')
         self._configure_container()
-        self._setup_user()
         self._wait_for_network()
         self._container_run(['apt-get', 'update'])
         # Because of https://bugs.launchpad.net/snappy/+bug/1628289

--- a/snapcraft/internal/lxd/_cleanbuilder.py
+++ b/snapcraft/internal/lxd/_cleanbuilder.py
@@ -42,6 +42,7 @@ class Cleanbuilder(Containerbuild):
         except subprocess.CalledProcessError as e:
             raise ContainerConnectionError('Failed to setup container')
         self._configure_container()
+        self._setup_user()
         self._wait_for_network()
         self._container_run(['apt-get', 'update'])
         # Because of https://bugs.launchpad.net/snappy/+bug/1628289

--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -179,9 +179,10 @@ class Containerbuild:
                 command += ['--target-arch', self._project_options.target_arch]
             if args:
                 command += args
-            self._container_run(command, cwd=self._project_folder, user=True)
+            self._container_run(command, cwd=self._project_folder,
+                                user=self._user)
 
-    def _container_run(self, cmd: List[str], cwd=None, user=False, **kwargs):
+    def _container_run(self, cmd: List[str], cwd=None, user='root', **kwargs):
         sh = ''
         original_cmd = cmd.copy()
         # Automatically wait on lock files before running commands
@@ -196,8 +197,8 @@ class Containerbuild:
         if sh:
             cmd = ['sh', '-c', '{}{}'.format(sh,
                    ' '.join(pipes.quote(arg) for arg in cmd))]
-        if user:
-            cmd = ['sudo', '-H', '-E', '-u', self._user] + cmd
+        if user != 'root':
+            cmd = ['sudo', '-H', '-E', '-u', user] + cmd
         try:
             subprocess.check_call([
                 'lxc', 'exec', self._container_name, '--'] + cmd,

--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -197,7 +197,7 @@ class Containerbuild:
             cmd = ['sh', '-c', '{}{}'.format(sh,
                    ' '.join(pipes.quote(arg) for arg in cmd))]
         if user:
-            cmd = ['sudo', '-H', '-u', self._user] + cmd
+            cmd = ['sudo', '-H', '-E', '-u', self._user] + cmd
         try:
             subprocess.check_call([
                 'lxc', 'exec', self._container_name, '--'] + cmd,

--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -63,15 +63,8 @@ class Containerbuild:
         self._source = os.path.realpath(source)
         self._project_options = project_options
         self._metadata = metadata
-        if os.geteuid() > 0:
-            self._user = os.environ['USER']
-            self._home = '/home/{}'.format(self._user)
-        else:
-            self._user = 'root'
-            self._home = '/{}'.format(self._user)
-        # os.sep needs to be `/` and on Windows it will be set to `\`
-        self._project_folder = '{}/build_{}'.format(self._home,
-                                                    metadata['name'])
+        self._user = 'root'
+        self._project_folder = '/root/build_{}'.format(metadata['name'])
 
         if not remote:
             remote = _get_default_remote()
@@ -142,26 +135,6 @@ class Containerbuild:
                 break
         else:
             raise ContainerError("Could not find architecture for container")
-
-    def _setup_user(self):
-        # Setup user mirroring host user with sudo access
-        try:
-            self._container_run([
-                'useradd', self._user, '--create-home'])
-        except ContainerRunError as e:
-            # username already in use
-            if e.exit_code != 9:
-                raise e
-        self._container_run([
-            'usermod', self._user, '-o',
-            '-u', str(os.getuid()), '-G', 'sudo'])
-        self._container_run([
-            'chown', '{}:0'.format(os.getuid(), 0),
-            self._home.format(self._user)])
-        subprocess.check_output([
-            'lxc', 'exec', self._container_name, '--',
-            'tee', '-a', '/etc/sudoers'],
-            input='{} ALL=(ALL) NOPASSWD: ALL\n'.format(self._user).encode())
 
     def _set_image_info_env_var(self):
         FAILURE_WARNING_FORMAT = (

--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -179,9 +179,9 @@ class Containerbuild:
                 command += ['--target-arch', self._project_options.target_arch]
             if args:
                 command += args
-            self._container_run(command, cwd=self._project_folder)
+            self._container_run(command, cwd=self._project_folder, user=True)
 
-    def _container_run(self, cmd, cwd=None, **kwargs):
+    def _container_run(self, cmd: List[str], cwd=None, user=False, **kwargs):
         sh = ''
         original_cmd = cmd.copy()
         # Automatically wait on lock files before running commands
@@ -196,8 +196,7 @@ class Containerbuild:
         if sh:
             cmd = ['sh', '-c', '{}{}'.format(sh,
                    ' '.join(pipes.quote(arg) for arg in cmd))]
-        # Run commands where file ownership matters as user
-        if os.geteuid() > 0 and (cwd or cmd[0] == 'mkdir'):
+        if user:
             cmd = ['sudo', '-H', '-u', self._user] + cmd
         try:
             subprocess.check_call([

--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -292,7 +292,6 @@ class Containerbuild:
             ], tmp_dir)
 
         container_filename = os.path.join(os.sep, 'run', filename)
-        os.chmod(filepath, 0o777)
         self._push_file(filepath, container_filename)
         self._install_snap(container_filename,
                            is_dangerous=rev.startswith('x'),
@@ -355,7 +354,6 @@ class Containerbuild:
                 f.write(subprocess.check_output(['snap', 'known', *assertion]))
                 f.write(b'\n')
         container_filename = os.path.join(os.path.sep, 'run', filename)
-        os.chmod(filepath, 0o777)
         self._push_file(filepath, container_filename)
         logger.info('Adding assertion {}'.format(filename))
         self._container_run(['snap', 'ack', container_filename])

--- a/snapcraft/internal/lxd/_project.py
+++ b/snapcraft/internal/lxd/_project.py
@@ -166,7 +166,7 @@ class Project(Containerbuild):
             self._container_run([
                 'useradd', self._user, '--create-home'])
         except ContainerRunError as e:
-            # username already in use
+            # Exit code 9 'username already in use' is safe to ignore
             if e.exit_code != 9:
                 raise e
         self._container_run([

--- a/snapcraft/internal/lxd/_project.py
+++ b/snapcraft/internal/lxd/_project.py
@@ -173,7 +173,7 @@ class Project(Containerbuild):
             'usermod', self._user, '-o',
             '-u', str(os.getuid()), '-G', 'sudo'])
         self._container_run([
-            'chown', '{}:0'.format(os.getuid(), 0),
+            'chown', '{}:{}'.format(self._user, self._user),
             '/home/{}'.format(self._user)])
         subprocess.check_output([
             'lxc', 'exec', self._container_name, '--',

--- a/snapcraft/internal/lxd/_project.py
+++ b/snapcraft/internal/lxd/_project.py
@@ -130,7 +130,7 @@ class Project(Containerbuild):
 
         # Use sshfs in slave mode to reverse mount the destination
         self._container_run(['apt-get', 'install', '-y', 'sshfs'])
-        self._container_run(['mkdir', '-p', destination], user=True)
+        self._container_run(['mkdir', '-p', destination], user=self._user)
         self._background_process_run([
             'lxc', 'exec', self._container_name, '--',
             'sudo', '-H', '-u', self._user,
@@ -155,6 +155,7 @@ class Project(Containerbuild):
             'echo Y | sudo tee /sys/module/fuse/parameters/userns_mounts')
 
     def _setup_user(self):
+        # If we run as root or sudo we don't need a user in the container
         if os.geteuid() == 0:
             return
         # Setup user mirroring host user with sudo access

--- a/snapcraft/internal/lxd/_project.py
+++ b/snapcraft/internal/lxd/_project.py
@@ -130,7 +130,7 @@ class Project(Containerbuild):
 
         # Use sshfs in slave mode to reverse mount the destination
         self._container_run(['apt-get', 'install', '-y', 'sshfs'])
-        self._container_run(['mkdir', '-p', destination])
+        self._container_run(['mkdir', '-p', destination], user=True)
         self._background_process_run([
             'lxc', 'exec', self._container_name, '--',
             'sudo', '-H', '-u', self._user,

--- a/snapcraft/internal/lxd/_project.py
+++ b/snapcraft/internal/lxd/_project.py
@@ -98,8 +98,7 @@ class Project(Containerbuild):
 
     def _setup_project(self):
         if not self._container_name.startswith('local:'):
-            if os.geteuid() > 0:
-                self._setup_user()
+            self._setup_user()
             logger.info('Mounting {} into container'.format(self._source))
             return self._remote_mount(self._project_folder, self._source)
 
@@ -156,6 +155,8 @@ class Project(Containerbuild):
             'echo Y | sudo tee /sys/module/fuse/parameters/userns_mounts')
 
     def _setup_user(self):
+        if os.geteuid() == 0:
+            return
         # Setup user mirroring host user with sudo access
         self._user = os.environ['USER']
         self._project_folder = '/home/{}/build_{}'.format(

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -504,10 +504,6 @@ class FakeFilesystem(fixtures.Fixture):
         self.open_mock.side_effect = self.open_side_effect()
         self.addCleanup(patcher.stop)
 
-        patcher = mock.patch('os.chmod')
-        self.chmod_mock = patcher.start()
-        self.addCleanup(patcher.stop)
-
         patcher = mock.patch('shutil.copyfile')
         self.copyfile_mock = patcher.start()
         self.addCleanup(patcher.stop)

--- a/snapcraft/tests/fixture_setup.py
+++ b/snapcraft/tests/fixture_setup.py
@@ -504,6 +504,10 @@ class FakeFilesystem(fixtures.Fixture):
         self.open_mock.side_effect = self.open_side_effect()
         self.addCleanup(patcher.stop)
 
+        patcher = mock.patch('os.chmod')
+        self.chmod_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
         patcher = mock.patch('shutil.copyfile')
         self.copyfile_mock = patcher.start()
         self.addCleanup(patcher.stop)
@@ -640,6 +644,8 @@ class FakeLXD(fixtures.Fixture):
     def _lxc_exec(self, args):
         if self.status and args[0][2] == self.name:
             cmd = args[0][4]
+            if cmd == 'sudo':
+                cmd = args[0][8]
             if cmd == 'ls':
                 return ' '.join(self.files).encode('utf-8')
             elif cmd == 'readlink':

--- a/snapcraft/tests/unit/commands/test_snap.py
+++ b/snapcraft/tests/unit/commands/test_snap.py
@@ -494,7 +494,8 @@ class SnapCommandWithContainerBuildTestCase(SnapCommandBaseTestCase):
             call(['apt-get', 'update']),
             call(['apt-get', 'install', 'squashfuse', '-y']),
             call(['snapcraft', 'snap', '--output',
-                  'snap-test_1.0_amd64.snap'], cwd=project_folder, user=True),
+                  'snap-test_1.0_amd64.snap'],
+                 cwd=project_folder, user='root'),
         ])
 
     @mock.patch('snapcraft.internal.lxd.Containerbuild._container_run')
@@ -531,7 +532,7 @@ class SnapCommandWithContainerBuildTestCase(SnapCommandBaseTestCase):
                   ', timeout=5)']),
             call(['snapcraft', 'snap', '--output',
                   'snap-test_1.0_amd64.snap'],
-                 cwd=project_folder, user=True),
+                 cwd=project_folder, user='root'),
         ])
 
     @mock.patch('os.getuid')
@@ -596,7 +597,7 @@ class SnapCommandWithContainerBuildTestCase(SnapCommandBaseTestCase):
                     ', timeout=5)']),
               call(['snapcraft', 'snap', '--output',
                     'snap-test_1.0_amd64.snap'],
-                   cwd=project_folder, user=True),
+                   cwd=project_folder, user='root'),
         ])
         # Ensure there's no unexpected calls eg. two network checks
         self.assertThat(mock_container_run.call_count, Equals(2))

--- a/snapcraft/tests/unit/commands/test_snap.py
+++ b/snapcraft/tests/unit/commands/test_snap.py
@@ -494,7 +494,7 @@ class SnapCommandWithContainerBuildTestCase(SnapCommandBaseTestCase):
             call(['apt-get', 'update']),
             call(['apt-get', 'install', 'squashfuse', '-y']),
             call(['snapcraft', 'snap', '--output',
-                  'snap-test_1.0_amd64.snap'], cwd=project_folder),
+                  'snap-test_1.0_amd64.snap'], cwd=project_folder, user=True),
         ])
 
     @mock.patch('snapcraft.internal.lxd.Containerbuild._container_run')
@@ -531,7 +531,7 @@ class SnapCommandWithContainerBuildTestCase(SnapCommandBaseTestCase):
                   ', timeout=5)']),
             call(['snapcraft', 'snap', '--output',
                   'snap-test_1.0_amd64.snap'],
-                 cwd=project_folder),
+                 cwd=project_folder, user=True),
         ])
 
     @mock.patch('os.getuid')
@@ -596,7 +596,7 @@ class SnapCommandWithContainerBuildTestCase(SnapCommandBaseTestCase):
                     ', timeout=5)']),
               call(['snapcraft', 'snap', '--output',
                     'snap-test_1.0_amd64.snap'],
-                   cwd=project_folder),
+                   cwd=project_folder, user=True),
         ])
         # Ensure there's no unexpected calls eg. two network checks
         self.assertThat(mock_container_run.call_count, Equals(2))

--- a/snapcraft/tests/unit/commands/test_snap.py
+++ b/snapcraft/tests/unit/commands/test_snap.py
@@ -120,11 +120,14 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
 
     @mock.patch('snapcraft.internal.lxd.Containerbuild._container_run')
     @mock.patch('os.pipe')
+    @mock.patch('os.geteuid')
     def test_snap_containerized_remote(self,
+                                       mock_geteuid,
                                        mock_pipe,
                                        mock_container_run):
         mock_container_run.side_effect = lambda cmd, **kwargs: cmd
         mock_pipe.return_value = (9, 9)
+        mock_geteuid.return_value = 1234
         fake_lxd = fixture_setup.FakeLXD()
         self.useFixture(fake_lxd)
         fake_filesystem = fixture_setup.FakeFilesystem()

--- a/snapcraft/tests/unit/commands/test_update.py
+++ b/snapcraft/tests/unit/commands/test_update.py
@@ -149,5 +149,5 @@ class UpdateCommandTestCase(CommandBaseTestCase, unit.TestWithFakeRemoteParts):
 
         project_folder = '/root/build_snap-test'
         mock_container_run.assert_has_calls([
-            call(['snapcraft', 'update'], cwd=project_folder),
+            call(['snapcraft', 'update'], cwd=project_folder, user='root'),
         ])

--- a/snapcraft/tests/unit/test_lxd.py
+++ b/snapcraft/tests/unit/test_lxd.py
@@ -549,7 +549,7 @@ class ProjectTestCase(ContainerbuildTestCase):
             mock_container_run.assert_has_calls([
                 call(['useradd', self.user, '--create-home']),
                 call(['usermod', self.user, '-o', '-u', '1234', '-G', 'sudo']),
-                call(['chown', '1234:0', self.home]),
+                call(['chown', 'me:me', self.home]),
             ])
             self.fake_lxd.check_output_mock.assert_has_calls([
                 call(['lxc', 'exec', self.fake_lxd.name, '--',

--- a/snapcraft/tests/unit/test_lxd.py
+++ b/snapcraft/tests/unit/test_lxd.py
@@ -131,7 +131,7 @@ class CleanbuilderTestCase(LXDTestCase):
             call(['tar', 'xvf', 'project.tar'],
                  cwd=project_folder),
             call(['snapcraft', 'snap', '--output', 'snap.snap', *args],
-                 cwd=project_folder),
+                 cwd=project_folder, user=True),
         ])
         # Ensure there's no unexpected calls eg. two network checks
         self.assertThat(mock_container_run.call_count, Equals(6))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
Based on the proof of concept #1484 I'm proposing setting up a user in the LXD container specifically when sshfs is used to mount the project folder into a remote instance of LXD to [ensure correct file ownership](https://bugs.launchpad.net/snapcraft/+bug/1741082).

Fixes: [LP: #1741082](https://bugs.launchpad.net/snapcraft/+bug/1741082 )