### PR TITLE
storeapi: add docstrings to _client

### DIFF
--- a/snapcraft/storeapi/_client.py
+++ b/snapcraft/storeapi/_client.py
@@ -16,6 +16,12 @@ class Client():
     """
 
     def __init__(self, conf, root_url):
+        """Set up Client object
+
+        :param config conf: Configuration details for the client
+        :param str root_url: Root url for all requests to base on.
+        :type config: snapcraft.config
+        """
         self.conf = conf
         self.root_url = root_url
         self.session = requests.Session()
@@ -31,7 +37,16 @@ class Client():
         }
 
     def request(self, method, url, params=None, headers=None, **kwargs):
-        """Overriding base class to handle the root url."""
+        """Send a request to url relative to the root url.
+
+        :param str method: Method used for the request.
+        :param str url: url to send the request to, which will be appended with
+                        the root url first.
+        :param list params: Query parameters to be sent along with the request.
+        :param list headers: Headers to be sent along with the request.
+
+        :return Response of the request.
+        """
         # Note that url may be absolute in which case 'root_url' is ignored by
         # urljoin.
 
@@ -51,10 +66,34 @@ class Client():
         return response
 
     def get(self, url, **kwargs):
+        """Perform a GET request with the given arguments.
+
+        The arguments are the same as for the request function,
+        namely params and headers.
+
+        :param str url: url to send the request.
+        :return Response of the request.
+        """
         return self.request('GET', url, **kwargs)
 
     def post(self, url, **kwargs):
+        """Perform a POST request with the given arguments.
+
+        The arguments are the same as for the request function,
+        namely params and headers.
+
+        :param str url: url to send the request.
+        :return Response of the request.
+        """
         return self.request('POST', url, **kwargs)
 
     def put(self, url, **kwargs):
+        """Perform a PUT request with the given arguments.
+
+        The arguments are the same as for the request function,
+        namely params and headers.
+
+        :param str url: url to send the request.
+        :return Response of the request.
+        """
         return self.request('PUT', url, **kwargs)

--- a/snapcraft/storeapi/_client.py
+++ b/snapcraft/storeapi/_client.py
@@ -16,11 +16,11 @@ class Client():
     """
 
     def __init__(self, conf, root_url):
-        """Set up Client object
+        """Initialize Client object
 
         :param config conf: Configuration details for the client
-        :param str root_url: Root url for all requests to base on.
-        :type config: snapcraft.config
+        :param str root_url: Root url for all requests.
+        :type config: snapcraft.config.Config
         """
         self.conf = conf
         self.root_url = root_url
@@ -40,8 +40,7 @@ class Client():
         """Send a request to url relative to the root url.
 
         :param str method: Method used for the request.
-        :param str url: url to send the request to, which will be appended with
-                        the root url first.
+        :param str url: Appended with the root url first.
         :param list params: Query parameters to be sent along with the request.
         :param list headers: Headers to be sent along with the request.
 


### PR DESCRIPTION
Add reST docstrings to _client

I'm not sure what to do for kwargs, so I've left them out for now.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
