### PR TITLE
remote_parts: Use hashed folder based on parts URI

### DIFF
--- a/snapcraft/internal/remote_parts.py
+++ b/snapcraft/internal/remote_parts.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import difflib
+import hashlib
 import logging
 import os
 import sys
@@ -85,7 +86,11 @@ def get_remote_parts():
 class _Base:
 
     def __init__(self):
-        self.parts_dir = os.path.join(BaseDirectory.xdg_data_home, 'snapcraft')
+        self._parts_uri = os.environ.get('SNAPCRAFT_PARTS_URI', PARTS_URI)
+        self.parts_dir = os.path.join(
+            BaseDirectory.xdg_data_home, 'snapcraft',
+            hashlib.sha384(self._parts_uri.encode(
+               sys.getfilesystemencoding())).hexdigest())
         os.makedirs(self.parts_dir, exist_ok=True)
         self.parts_yaml = os.path.join(self.parts_dir, 'parts.yaml')
 
@@ -95,7 +100,6 @@ class _Update(_Base):
     def __init__(self):
         super().__init__()
         self._headers_yaml = os.path.join(self.parts_dir, 'headers.yaml')
-        self._parts_uri = os.environ.get('SNAPCRAFT_PARTS_URI', PARTS_URI)
 
     def execute(self):
         headers = self._load_headers()

--- a/snapcraft/tests/fake_servers/__init__.py
+++ b/snapcraft/tests/fake_servers/__init__.py
@@ -103,6 +103,15 @@ class FakePartsRequestHandler(BaseHTTPRequestHandler):
                     ('maintainer', 'none'),
                 ))),
             ))
+            if 'CUSTOM_PARTS' in os.environ:
+                response = OrderedDict((
+                    ('curl-custom', OrderedDict((
+                        ('plugin', 'autotools'),
+                        ('source', 'http://curl.org'),
+                        ('description', 'custom curl part'),
+                        ('maintainer', 'none'),
+                    ))),
+                ))
         self.send_header('Content-Type', 'text/plain')
         if 'NO_CONTENT_LENGTH' not in os.environ:
             self.send_header('Content-Length', '1000')

--- a/snapcraft/tests/fake_servers/__init__.py
+++ b/snapcraft/tests/fake_servers/__init__.py
@@ -75,6 +75,16 @@ class FakePartsRequestHandler(BaseHTTPRequestHandler):
         if ims_date is not None and ims_date >= self._parts_date:
             self.send_response(304)
             response = {}
+        elif 'CUSTOM_PARTS' in os.environ:
+            self.send_response(200)
+            response = OrderedDict((
+                ('curl-custom', OrderedDict((
+                    ('plugin', 'autotools'),
+                    ('source', 'http://curl.org'),
+                    ('description', 'custom curl part'),
+                    ('maintainer', 'none'),
+                ))),
+            ))
         else:
             self.send_response(200)
             response = OrderedDict((
@@ -103,15 +113,6 @@ class FakePartsRequestHandler(BaseHTTPRequestHandler):
                     ('maintainer', 'none'),
                 ))),
             ))
-            if 'CUSTOM_PARTS' in os.environ:
-                response = OrderedDict((
-                    ('curl-custom', OrderedDict((
-                        ('plugin', 'autotools'),
-                        ('source', 'http://curl.org'),
-                        ('description', 'custom curl part'),
-                        ('maintainer', 'none'),
-                    ))),
-                ))
         self.send_header('Content-Type', 'text/plain')
         if 'NO_CONTENT_LENGTH' not in os.environ:
             self.send_header('Content-Length', '1000')

--- a/snapcraft/tests/integration/general/test_parts.py
+++ b/snapcraft/tests/integration/general/test_parts.py
@@ -14,7 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import hashlib
 import os
+import sys
 
 import yaml
 from testtools.matchers import Contains, Equals
@@ -24,10 +26,17 @@ from snapcraft.tests import integration
 
 class PartsTestCase(integration.TestCase):
 
+    def _parts_dir(self):
+        parts_uri = 'https://parts.snapcraft.io/v1/parts.yaml'
+        return os.path.join(
+            'data', 'snapcraft',
+            hashlib.sha384(parts_uri.encode(
+                sys.getfilesystemencoding())).hexdigest())
+
     def setUp(self):
         super().setUp()
 
-        self.parts_dir = os.path.join('data', 'snapcraft')
+        self.parts_dir = self._parts_dir()
         self.parts_yaml = os.path.join(self.parts_dir, 'parts.yaml')
         self.headers_yaml = os.path.join(self.parts_dir, 'headers.yaml')
 

--- a/snapcraft/tests/unit/commands/test_update.py
+++ b/snapcraft/tests/unit/commands/test_update.py
@@ -17,6 +17,8 @@ import os
 from collections import OrderedDict
 
 import fixtures
+import hashlib
+import sys
 import yaml
 from testtools.matchers import Contains, Equals, FileExists
 from xdg import BaseDirectory
@@ -48,11 +50,41 @@ class UpdateCommandTestCase(CommandBaseTestCase, unit.TestWithFakeRemoteParts):
                 plugin: nil
         """)
 
+    def _parts_dir(self):
+        parts_uri = os.environ.get('SNAPCRAFT_PARTS_URI')
+        return os.path.join(
+            BaseDirectory.xdg_data_home, 'snapcraft',
+            hashlib.sha384(parts_uri.encode(
+                sys.getfilesystemencoding())).hexdigest())
+
     def setUp(self):
         super().setUp()
-        self.parts_dir = os.path.join(BaseDirectory.xdg_data_home, 'snapcraft')
+        self.parts_dir = self._parts_dir()
         self.parts_yaml = os.path.join(self.parts_dir, 'parts.yaml')
         self.headers_yaml = os.path.join(self.parts_dir, 'headers.yaml')
+
+    def test_changed_parts_uri(self):
+        result = self.run_command(['update'])
+        self.assertThat(result.exit_code, Equals(0))
+
+        self.useFixture(fixture_setup.FakeParts())
+        self.useFixture(fixtures.EnvironmentVariable('CUSTOM_PARTS', '1'))
+        self.parts_dir = self._parts_dir()
+        self.parts_yaml = os.path.join(self.parts_dir, 'parts.yaml')
+        result = self.run_command(['update'])
+        self.assertThat(result.exit_code, Equals(0))
+
+        expected_parts = OrderedDict()
+        expected_parts['curl-custom'] = p = OrderedDict()
+        p['plugin'] = 'autotools'
+        p['source'] = 'http://curl.org'
+        p['description'] = 'custom curl part'
+        p['maintainer'] = 'none'
+
+        with open(self.parts_yaml) as parts_file:
+            parts = yaml.load(parts_file)
+
+        self.assertThat(parts, Equals(expected_parts))
 
     def test_update(self):
         result = self.run_command(['update'])


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Fixes: #1816
  