### PR TITLE
Import run so bin/snapcraft can work

### DIFF
--- a/snapcraft/cli/__init__.py
+++ b/snapcraft/cli/__init__.py
@@ -14,5 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import snapcraft.internal.dirs
+from ._runner import run       # noqa
 
 snapcraft.internal.dirs.setup_dirs()


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This is fixing the following error that prevents integration tests from running against a git source tree:

    ERROR: test_stage_7z (snapcraft.tests.integration.general.test_7z_source.SevenZipTestCase)
    snapcraft.tests.integration.general.test_7z_source.SevenZipTestCase.test_stage_7z
    ----------------------------------------------------------------------
    testtools.testresult.real._StringException: command: {{{/home/cris/bau/snapcraft/bin/snapcraft}}}
    output: {{{
    Traceback (most recent call last):
      File "/home/rumo/dev/snapcraft/bin/snapcraft", line 35, in <module>
        snapcraft.cli.run(prog_name='snapcraft',
    AttributeError: module 'snapcraft.cli' has no attribute 'run'
    }}}
  