### PR TITLE
debian/control: Add patchelf to Depends:

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -46,7 +46,8 @@ Standards-Version: 3.9.8
 
 Package: snapcraft
 Architecture: all
-Depends: python3-apt,
+Depends: patchelf,
+         python3-apt,
          python3-debian,
          python3-click,
          python3-jsonschema,


### PR DESCRIPTION
- [y] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [y] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [y] If this is a bugfix. https://bugs.launchpad.net/snapcraft/+bug/1742707
- [n] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [y] Have you successfully run `./runtests.sh static`?
- [y] Have you successfully run `./runtests.sh unit`?

-----
Since snapcraft 2.38 `patchelf` is required but it is not listed in `Depends:` or `Recommends:` This pull request fixes that.