### PR TITLE
cli: exported login should only be readable by owner

### DIFF
--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
+import functools
 import stat
 import sys
 from textwrap import dedent
@@ -337,10 +338,12 @@ def export_login(login_file: str, snaps: str, channels: str, acls: str,
                            save=False):
         sys.exit(1)
 
-    with open(login_file, 'w') as f:
+    # This is sensitive-- it should only be accessible by the owner
+    private_open = functools.partial(os.open, mode=0o600)
+    with open(login_file, 'w', opener=private_open) as f:
         store.conf.save(config_fd=f)
 
-    # This is sensitive-- make sure it's only readable by the owner
+    # Now that the file has been written, we can just make it owner-readable
     os.chmod(login_file, stat.S_IRUSR)
 
     print()

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -340,7 +340,9 @@ def export_login(login_file: str, snaps: str, channels: str, acls: str,
 
     # This is sensitive-- it should only be accessible by the owner
     private_open = functools.partial(os.open, mode=0o600)
-    with open(login_file, 'w', opener=private_open) as f:
+
+    # mypy doesn't have the opener arg in its stub. Ignore its warning
+    with open(login_file, 'w', opener=private_open) as f:  # type: ignore
         store.conf.save(config_fd=f)
 
     # Now that the file has been written, we can just make it owner-readable

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -14,9 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
+import stat
 import sys
 from textwrap import dedent
-from typing import TextIO
 
 # Using mypy 'type:' comment below, but flake8 thinks these aren't used
 from typing import Dict, List, Union  # noqa
@@ -282,7 +282,8 @@ def list_registered():
 
 
 @storecli.command('export-login')
-@click.argument('login_file', metavar='FILE', type=click.File('w'))
+@click.argument('login_file', metavar='FILE',
+                type=click.Path(dir_okay=False, writable=True))
 @click.option('--snaps', metavar='<snaps>',
               help='Comma-separated list of snaps to limit access')
 @click.option('--channels', metavar='<channels>',
@@ -291,7 +292,7 @@ def list_registered():
               help='Comma-separated list of ACLs to limit access')
 @click.option('--expires', metavar='<expiration date>',
               help='Date/time (in ISO 8601) when this exported login expires')
-def export_login(login_file: TextIO, snaps: str, channels: str, acls: str,
+def export_login(login_file: str, snaps: str, channels: str, acls: str,
                  expires: str):
     """Save login configuration for a store account in FILE.
 
@@ -336,14 +337,18 @@ def export_login(login_file: TextIO, snaps: str, channels: str, acls: str,
                            save=False):
         sys.exit(1)
 
-    store.conf.save(config_fd=login_file)
+    with open(login_file, 'w') as f:
+        store.conf.save(config_fd=f)
+
+    # This is sensitive-- make sure it's only readable by the owner
+    os.chmod(login_file, stat.S_IRUSR)
 
     print()
     echo.info(dedent("""\
         Login successfully exported to {0!r}. This file can now be used with
         'snapcraft login --with {0}' to log in to this account with no password
         and have these capabilities:\n""".format(
-            login_file.name)))
+            login_file)))
     echo.info(_human_readable_acls(store))
     echo.warning(
         'This exported login is not encrypted. Do not commit it to version '

--- a/snapcraft/tests/integration/store/test_store_export_login.py
+++ b/snapcraft/tests/integration/store/test_store_export_login.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from testtools.matchers import HasPermissions
 from snapcraft.tests import integration
 
 
@@ -21,6 +22,9 @@ class ExportLoginTestCase(integration.StoreTestCase):
 
     def test_successful_export(self):
         self.export_login('exported', expect_success=True)
+
+        # Verify that the exported login is only readable by the owner
+        self.assertThat('exported', HasPermissions('0400'))
 
     def test_failed_export(self):
         self.export_login(


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

When one uses click.File as an argument type, Click just saves it world-readable, and there doesn't seem to be a way to change it.

Use click.Path instead, and open the file ourselves. Then ensure that only the owner can read it once finished.