### PR TITLE
kbuild: pick up CROSS_COMPILE only if it's not empty

### DIFF
--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -125,7 +125,7 @@ class KBuildPlugin(BasePlugin):
     def enable_cross_compilation(self):
         self.make_cmd.append('ARCH={}'.format(
             self.project.kernel_arch))
-        if 'CROSS_COMPILE' in os.environ:
+        if os.environ['CROSS_COMPILE']:
             toolchain = os.environ['CROSS_COMPILE']
         else:
             toolchain = self.project.cross_compiler_prefix

--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -125,7 +125,7 @@ class KBuildPlugin(BasePlugin):
     def enable_cross_compilation(self):
         self.make_cmd.append('ARCH={}'.format(
             self.project.kernel_arch))
-        if os.environ['CROSS_COMPILE']:
+        if os.environ.get('CROSS_COMPILE'):
             toolchain = os.environ['CROSS_COMPILE']
         else:
             toolchain = self.project.cross_compiler_prefix

--- a/snapcraft/tests/unit/plugins/test_kernel.py
+++ b/snapcraft/tests/unit/plugins/test_kernel.py
@@ -1002,6 +1002,22 @@ ACCEPT=n
                 'PATH={}:/usr/{}/bin'.format(os.environ.copy().get('PATH', ''),
                                              'aarch64-linux-gnu')]))
 
+    def test_override_cross_compile_empty(self):
+        project_options = snapcraft.ProjectOptions(target_deb_arch='arm64')
+        plugin = kernel.KernelPlugin('test-part', self.options,
+                                     project_options)
+        self.useFixture(fixtures.EnvironmentVariable('CROSS_COMPILE',
+                                                     ''))
+        plugin.enable_cross_compilation()
+
+        self.assertThat(
+            plugin.make_cmd,
+            Equals([
+                'make', '-j2', 'ARCH=arm64',
+                'CROSS_COMPILE=aarch64-linux-gnu-',
+                'PATH={}:/usr/{}/bin'.format(os.environ.copy().get('PATH', ''),
+                                             'aarch64-linux-gnu')]))
+
     def test_kernel_image_target_as_map(self):
         self.options.kernel_image_target = {'arm64': 'Image'}
         project_options = snapcraft.ProjectOptions(target_deb_arch='arm64')


### PR DESCRIPTION
If snapcraft gets invoked by kbuild during a cross-compile session, there's a nasty corner case when the variable CROSS_COMPILE could be defined but effectively be empty, resulting in a FTBFS.

This for example happens when, cross compiling, you setup only the ARCH variable but forget the CROSS_COMPILE variable, kbuild won't complain and it will pass down the pair as it is: one containing the correct ARCH value, the other completely empty.

$ echo $ARCH
arm
$ unset CROSS_COMPILE
$ echo $CROSS_COMPILE

$ make snap-pkg
scripts/kconfig/conf --silentoldconfig Kconfig
  CHK include/config/kernel.release
  UPD include/config/kernel.release
rm -rf ./snap
mkdir ./snap
make clean
  TAR kernel-4.15.0_rc8_next_20180116.tar.gz
sed "s@KERNELRELEASE@4.15.0-rc8-next-20180116@; \
        s@SRCTREE@/home/flag/canonical/linux/kernel-4.15.0_rc8_next_20180116.tar.gz@" \
        ./scripts/package/snapcraft.template > \
        ./snap/snapcraft.yaml
cd ./snap && \
snapcraft --target-arch=arm
Setting target machine to 'arm'
Cross compiling kernel target 'arm'
Preparing to pull kernel
Pulling kernel
Downloading core
Downloading 'os.snap'[============================================================================================================================] 100%
Successfully downloaded core at /home/flag/canonical/linux/snap/parts/kernel/src/os.snap
Preparing to build kernel
Building kernel
  HOSTCC scripts/basic/fixdep
  HOSTCC scripts/kconfig/conf.o
  LEX scripts/kconfig/zconf.lex.c
  YACC scripts/kconfig/zconf.tab.c
  HOSTCC scripts/kconfig/zconf.tab.o
  HOSTLD scripts/kconfig/conf
scripts/kconfig/conf --oldconfig Kconfig
#
# configuration written to .config
#
...
make -j4 ARCH=arm CROSS_COMPILE= PATH=/home/flag/bin:/home/flag/.local/bin:/home/flag/bin:/home/flag/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin
:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/flag/bin:/home/flag/bin/dasm:/opt/wine-devel/bin:/opt/cross/gcc-4.6.3-nolibc/m68k-linux
/bin:/opt/cross/gcc-4.6.3-nolibc/sh4-linux/bin:/home/flag/bin:/home/flag/bin/dasm:/opt/wine-devel/bin:/opt/cross/gcc-4.6.3-nolibc/m68k-linux/bin:/opt/cr
oss/gcc-4.6.3-nolibc/sh4-linux/bin:/usr/arm-linux-gnueabihf/bin zImage modules dtbs
scripts/kconfig/conf --silentoldconfig Kconfig
  CHK include/config/kernel.release
...
Kbuild:21: recipe for target 'kernel/bounds.s' failed
make[3]: *** [kernel/bounds.s] Error 1
Makefile:1093: recipe for target 'prepare0' failed
make[2]: *** [prepare0] Error 2
make[2]: *** Waiting for unfinished jobs....
Makefile:558: recipe for target 'scripts' failed
make[2]: *** [scripts] Error 2
Traceback (most recent call last):
  File "/snap/snapcraft/1031/bin/snapcraft", line 11, in <module>
    load_entry_point('snapcraft==2.38', 'console_scripts', 'snapcraft')()
  File "/snap/snapcraft/1031/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 565, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/snap/snapcraft/1031/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2631, in load_entry_point
    return ep.load()
  File "/snap/snapcraft/1031/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2291, in load
    return self.resolve()
  File "/snap/snapcraft/1031/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2297, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/snapcraft/cli/__main__.py", line 19, in <module>
    run(prog_name='snapcraft')
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/click/core.py", line 1043, in invoke
    return Command.invoke(self, ctx)
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/snapcraft/cli/_runner.py", line 72, in run
    ctx.forward(lifecyclecli.commands['snap'])
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/click/core.py", line 553, in forward
    return self.invoke(cmd, **kwargs)
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/snapcraft/cli/lifecycle.py", line 139, in snap
    project_options, directory=directory, output=output)
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/snapcraft/internal/lifecycle/_packer.py", line 45, in snap
    execute('prime', project_options)
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/snapcraft/internal/lifecycle/_runner.py", line 79, in execute
    _Executor(config, project_options).run(step, part_names)
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/snapcraft/internal/lifecycle/_runner.py", line 184, in run
    self._run_step(step, part, part_names)
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/snapcraft/internal/lifecycle/_runner.py", line 221, in _run_step
    getattr(part, step)()
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/snapcraft/internal/pluginhandler/__init__.py", line 362, in build
    self.plugin.build()
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/snapcraft/plugins/kbuild.py", line 256, in build
    self.do_build()
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/snapcraft/plugins/kbuild.py", line 244, in do_build
    self.run(self.make_cmd + self.make_targets)
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/snapcraft/_baseplugin.py", line 202, in run
    return common.run(cmd, cwd=cwd, **kwargs)
  File "/snap/snapcraft/1031/lib/python3.6/site-packages/snapcraft/internal/common.py", line 64, in run
    subprocess.check_call(['/bin/sh', f.name] + cmd, **kwargs)
  File "/snap/snapcraft/1031/usr/lib/python3.6/subprocess.py", line 291, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/bin/sh', '/tmp/tmphycjmu_g', 'make', '-j4', 'ARCH=arm', 'CROSS_COMPILE=', 'PATH=/home/flag/bin:/home/flag/.local/bin:/home/flag/bin:/home/flag/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/flag/bin:/home/flag/bin/dasm:/opt/wine-devel/bin:/opt/cross/gcc-4.6.3-nolibc/m68k-linux/bin:/opt/cross/gcc-4.6.3-nolibc/sh4-linux/bin:/home/flag/bin:/home/flag/bin/dasm:/opt/wine-devel/bin:/opt/cross/gcc-4.6.3-nolibc/m68k-linux/bin:/opt/cross/gcc-4.6.3-nolibc/sh4-linux/bin:/usr/arm-linux-gnueabihf/bin', 'zImage', 'modules', 'dtbs']' returned non-zero exit status 2.
scripts/package/Makefile:104: recipe for target 'snap-pkg' failed
make[1]: *** [snap-pkg] Error 1
Makefile:1386: recipe for target 'snap-pkg' failed
make: *** [snap-pkg] Error 2

Be more resilient against such failures by only picking up CROSS_COMPILE if it's not empty, otherwise fall back to the default toolchain - the change is trivial.

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>

https://bugs.launchpad.net/snapcraft/+bug/1743591

-----
