### PR TITLE
extractors: replace desktop file ids with paths

### DIFF
--- a/snapcraft/extractors/_metadata.py
+++ b/snapcraft/extractors/_metadata.py
@@ -26,14 +26,13 @@ class ExtractedMetadata(yaml.YAMLObject):
     def __init__(
             self, *, summary: str='',
             description: str='', icon: str='',
-            desktop_file_ids: List[str]=None) -> None:
+            desktop_file_paths: List[str]=None) -> None:
         """Create a new ExtractedMetadata instance.
 
         :param str summary: Extracted summary
         :param str description: Extracted description
         :param str icon: Extracted icon
-        :param dict desktop_file_ids: Extracted desktop file ids, as defined in
-            https://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#desktop-file-id
+        :param list desktop_file_paths: Extracted desktop file paths
         """  # noqa
 
         self._data = {}  # type: Dict[str, Union[str, List[str]]]
@@ -44,8 +43,8 @@ class ExtractedMetadata(yaml.YAMLObject):
             self._data['description'] = description
         if icon:
             self._data['icon'] = icon
-        if desktop_file_ids:
-            self._data['desktop_file_ids'] = desktop_file_ids
+        if desktop_file_paths:
+            self._data['desktop_file_paths'] = desktop_file_paths
 
     def update(self, other: 'ExtractedMetadata') -> None:
         """Update this metadata with other metadata.
@@ -84,14 +83,14 @@ class ExtractedMetadata(yaml.YAMLObject):
         icon = self._data.get('icon')
         return str(icon) if icon else None
 
-    def get_desktop_file_ids(self) -> List[str]:
-        """Return extracted desktop files ids.
+    def get_desktop_file_paths(self) -> List[str]:
+        """Return extracted desktop files paths.
 
-        :returns: Extracted desktop files ids
+        :returns: Extracted desktop files paths
         :rtype: list
         """
-        desktop_file_ids = self._data.get('desktop_file_ids')
-        return list(desktop_file_ids) if desktop_file_ids else None
+        desktop_file_paths = self._data.get('desktop_file_paths')
+        return list(desktop_file_paths) if desktop_file_paths else None
 
     def to_dict(self) -> Dict[str, Union[str, List[str]]]:
         """Return all extracted metadata.

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -199,19 +199,19 @@ def _get_app_name_from_desktop_file_path(
     :returns: The name of the snap app that corresponds to the desktop file.
 
     """
-    desktop_file_id = desktop_file_path[
-        desktop_file_path.find('applications') +
-        len('applications') + 1:
-    ].replace('/', '-')
-    desktop_file_id_parts = desktop_file_id.split('.')
-    if desktop_file_id_parts[-1] == 'desktop':
-        desktop_file_id_parts = desktop_file_id_parts[:-1]
-    app_id = desktop_file_id_parts[-1]
-    if ('apps' in config_data and
-            app_id in config_data['apps'].keys()):
-        return app_id
-    else:
-        return None
+    if 'applications' in desktop_file_path:
+        desktop_file_id = desktop_file_path[
+            desktop_file_path.find('applications') +
+            len('applications') + 1:
+        ].replace('/', '-')
+        desktop_file_id_parts = desktop_file_id.split('.')
+        if desktop_file_id_parts[-1] == 'desktop':
+            desktop_file_id_parts = desktop_file_id_parts[:-1]
+            app_id = desktop_file_id_parts[-1]
+            if ('apps' in config_data and
+                    app_id in config_data['apps'].keys()):
+                return app_id
+    return None
 
 
 def _desktop_file_exists(app_name: str) -> bool:

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -857,7 +857,8 @@ class StateTestCase(StateBaseTestCase):
                 summary='test summary',
                 description='test description',
                 icon='/test/path',
-                desktop_file_ids=['com.example.test-app.desktop']
+                desktop_file_paths=[
+                    'usr/share/applications/com.example.test/app.desktop']
             )
 
         self.useFixture(fixture_setup.FakeMetadataExtractor(
@@ -892,8 +893,8 @@ class StateTestCase(StateBaseTestCase):
         self.assertThat(metadata.get_description(), Equals('test description'))
         self.assertThat(metadata.get_icon(), Equals('/test/path'))
         self.assertThat(
-            metadata.get_desktop_file_ids(),
-            Equals(['com.example.test-app.desktop']))
+            metadata.get_desktop_file_paths(),
+            Equals(['usr/share/applications/com.example.test/app.desktop']))
         files = state.extracted_metadata['files']
         self.assertThat(files, Equals(['metadata-file']))
 
@@ -963,7 +964,8 @@ class StateTestCase(StateBaseTestCase):
                 summary='test summary',
                 description='test description',
                 icon='/test/path',
-                desktop_file_ids=['com.example.test-app.desktop'])
+                desktop_file_paths=[
+                    'usr/share/applications/com.example.test/app.desktop'])
 
         self.useFixture(fixture_setup.FakeMetadataExtractor(
             'fake', _fake_extractor))
@@ -995,8 +997,8 @@ class StateTestCase(StateBaseTestCase):
         self.assertThat(metadata.get_description(), Equals('test description'))
         self.assertThat(metadata.get_icon(), Equals('/test/path'))
         self.assertThat(
-            metadata.get_desktop_file_ids(),
-            Equals(['com.example.test-app.desktop']))
+            metadata.get_desktop_file_paths(),
+            Equals(['usr/share/applications/com.example.test/app.desktop']))
         files = state.extracted_metadata['files']
         self.assertThat(files, Equals(['metadata-file']))
 

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -627,7 +627,8 @@ class MetadataFromSourceWithDesktopFileTestCase(
 
         def _fake_extractor(file_path):
             return extractors.ExtractedMetadata(
-                desktop_file_ids=['com.example.test-app.desktop'])
+                desktop_file_paths=[
+                    'usr/share/applications/com.example.test/app.desktop'])
 
         self.useFixture(fixture_setup.FakeMetadataExtractor(
             'fake', _fake_extractor))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
@kyrofa and I discussed about moving the task of translating from desktop file id to desktop file path to the appstream extractor. This opens the door to save in the metadata the contents of the file, instead of the path. But we haven't yet decided if that next step would be good.