### PR TITLE
Provide stub for when /etc/os-release doesn't exist

### DIFF
--- a/snapcraft/internal/os_release.py
+++ b/snapcraft/internal/os_release.py
@@ -46,8 +46,7 @@ class OsRelease:
                     if len(entry) == 2:
                         self._os_release[entry[0]] = entry[1].strip('"')
         except FileNotFoundError:
-            self._os_release['ID'] = 'unknown'
-            self._os_release['NAME'] = 'unknown'
+            pass
 
     def id(self) -> str:
         """Return the OS ID

--- a/snapcraft/internal/os_release.py
+++ b/snapcraft/internal/os_release.py
@@ -38,15 +38,13 @@ class OsRelease:
 
         :param str os_release_file: Path to os-release file to be parsed.
         """
-        self._os_release = {}  # type: Dict[str, str]
-        try:
+        with contextlib.suppress(FileNotFoundError):
+            self._os_release = {}  # type: Dict[str, str]
             with open(os_release_file) as f:
                 for line in f:
                     entry = line.rstrip().split('=')
                     if len(entry) == 2:
                         self._os_release[entry[0]] = entry[1].strip('"')
-        except FileNotFoundError:
-            pass
 
     def id(self) -> str:
         """Return the OS ID

--- a/snapcraft/internal/os_release.py
+++ b/snapcraft/internal/os_release.py
@@ -38,12 +38,16 @@ class OsRelease:
 
         :param str os_release_file: Path to os-release file to be parsed.
         """
-        with open(os_release_file) as f:
-            self._os_release = {}  # type: Dict[str, str]
-            for line in f:
-                entry = line.rstrip().split('=')
-                if len(entry) == 2:
-                    self._os_release[entry[0]] = entry[1].strip('"')
+        self._os_release = {}  # type: Dict[str, str]
+        try:
+            with open(os_release_file) as f:
+                for line in f:
+                    entry = line.rstrip().split('=')
+                    if len(entry) == 2:
+                        self._os_release[entry[0]] = entry[1].strip('"')
+        except FileNotFoundError:
+            self._os_release['ID'] = 'unknown'
+            self._os_release['NAME'] = 'unknown'
 
     def id(self) -> str:
         """Return the OS ID

--- a/snapcraft/internal/repo/_platform.py
+++ b/snapcraft/internal/repo/_platform.py
@@ -16,6 +16,7 @@
 
 import logging
 
+from snapcraft.internal.errors import OsReleaseIdError
 from snapcraft.internal.os_release import OsRelease
 
 logger = logging.getLogger(__name__)
@@ -31,13 +32,15 @@ _DEB_BASED_PLATFORM = [
 
 def _is_deb_based(distro=None):
     if not distro:
-        distro = OsRelease().id()
+        try:
+            distro = OsRelease().id()
+        except OsReleaseIdError:
+            distro = 'unknown'
     return distro in _DEB_BASED_PLATFORM
 
 
 def _get_repo_for_platform():
-    distro = OsRelease().id()
-    if _is_deb_based(distro):
+    if _is_deb_based():
         from ._deb import Ubuntu
         return Ubuntu
     else:

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -31,7 +31,11 @@ class NoNativeBackendError(RepoError):
            "You can however use 'snapcraft cleanbuild' with a container.")
 
     def __init__(self):
-        super().__init__(distro=OsRelease().name())
+        try:
+            distro = OsRelease().name()
+        except errors.OsReleaseNameError:
+            distro = 'this system'
+        super().__init__(distro=distro)
 
 
 class BuildPackageNotFoundError(RepoError):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
It seems there's a regression with running Snapcraft on MacOS (via PyPI). If no file `/etc/os-release` exists on the system, no commands will work and even the "no native builds" error will break.

    $ snapcraft
    [...]
    FileNotFoundError: [Errno 2] No such file or directory: '/etc/os-release'

This branch presents a possible approach for falling back to defaults. We could as a next step try and fill in versions from other systems here. Call sites won't need to be changed this way.

There's no new tests yet - early feedback would be great.