### PR TITLE
elf: better handling for newer libc6

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -459,7 +459,7 @@ class StagePackageMissingError(SnapcraftError):
     fmt = (
         '{package!r} is required as a `stage-packages` entry for this part to '
         'work properly.\n'
-        'Add {package!r} as a stage-packages entry for this part.'
+        'Add {package!r} as a `stage-packages` entry for this part.'
     )
 
     def __init__(self, *, package):

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -454,6 +454,18 @@ class PatcherNewerPatchelfError(PatcherError):
                          patchelf_version=patchelf_version)
 
 
+class StagePackageMissingError(SnapcraftError):
+
+    fmt = (
+        '{package!r} is required as a `stage-packages` entry for this part to '
+        'work properly.\n'
+        'Add {package!r} as a stage-packages entry for this part.'
+    )
+
+    def __init__(self, *, package):
+        super().__init__(package=package)
+
+
 class MetadataExtractionError(SnapcraftError):
     pass
 

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -457,9 +457,9 @@ class PatcherNewerPatchelfError(PatcherError):
 class StagePackageMissingError(SnapcraftError):
 
     fmt = (
-        '{package!r} is required as a `stage-packages` entry for this part to '
-        'work properly.\n'
-        'Add {package!r} as a `stage-packages` entry for this part.'
+        '{package!r} is required inside the snap for this part to work '
+        'properly.\n'
+        'Add it as a `stage-packages` entry for this part.'
     )
 
     def __init__(self, *, package):

--- a/snapcraft/internal/mangling.py
+++ b/snapcraft/internal/mangling.py
@@ -129,7 +129,7 @@ def handle_glibc_mismatch(*, elf_files: FrozenSet[elf.ElfFile],
 
     # Before doing anything else, verify there's a dynamic linker we can use.
     dynamic_linker_path = os.path.join(
-        snap_base_path, dynamic_linker[1:])
+        snap_base_path, dynamic_linker[len(root_path)+1:])
 
     elf_patcher = elf.Patcher(dynamic_linker=dynamic_linker_path,
                               root_path=root_path,

--- a/snapcraft/internal/mangling.py
+++ b/snapcraft/internal/mangling.py
@@ -76,6 +76,8 @@ def handle_glibc_mismatch(*, elf_files: FrozenSet[elf.ElfFile],
     """Copy over libc6 libraries from the host and patch necessary elf files.
 
     If no newer glibc version is detected in elf_files, this function returns.
+    The dynamic linker and related libraries to libc6 are expected to be found
+    in root_path.
 
     :param snapcraft.internal.elf.ElfFile elf_files:
         set of candidate elf files to patch if a newer libc6 is required.
@@ -112,11 +114,7 @@ def handle_glibc_mismatch(*, elf_files: FrozenSet[elf.ElfFile],
                    'files and the linker version (2.23) used in the '
                    'base. These are the GLIBC versions required by '
                    'the primed files that do not match and will be '
-                   'patched:\n {}\n'
-                   'For this to work, `libc6` will need to be explicitly '
-                   'added to `stage-packages` for this part. These files '
-                   'will be patched to use it.'.format(
-                       '\n'.join(formatted_list)))
+                   'patched:\n {}\n'.format('\n'.join(formatted_list)))
     # We assume the current system will satisfy the GLIBC requirement,
     # get the current libc6 libraries (which includes the linker)
     libc6_libraries_list = repo.Repo.get_package_libraries('libc6')

--- a/snapcraft/internal/mangling.py
+++ b/snapcraft/internal/mangling.py
@@ -127,7 +127,10 @@ def handle_glibc_mismatch(*, elf_files: FrozenSet[elf.ElfFile],
 
     dynamic_linker = _get_dynamic_linker(libc6_libraries_paths)
 
-    # Before doing anything else, verify there's a dynamic linker we can use.
+    # Get the path to the "would be" dynamic linker when this snap is
+    # installed. Strip the root_path from the retrieved dynamic_linker
+    # variables + the leading `/` so that os.path.join can perform the
+    # proper join with snap_base_path.
     dynamic_linker_path = os.path.join(
         snap_base_path, dynamic_linker[len(root_path)+1:])
 

--- a/snapcraft/internal/mangling.py
+++ b/snapcraft/internal/mangling.py
@@ -114,7 +114,7 @@ def handle_glibc_mismatch(*, elf_files: FrozenSet[elf.ElfFile],
                    'files and the linker version (2.23) used in the '
                    'base. These are the GLIBC versions required by '
                    'the primed files that do not match and will be '
-                   'patched:\n {}\n'.format('\n'.join(formatted_list)))
+                   'patched:\n{}\n'.format('\n'.join(formatted_list)))
     # We assume the current system will satisfy the GLIBC requirement,
     # get the current libc6 libraries (which includes the linker)
     libc6_libraries_list = repo.Repo.get_package_libraries('libc6')

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -564,6 +564,9 @@ class PluginHandler:
         linker_compatible = (e.is_linker_compatible(linker='ld-2.23.so')
                              for e in elf_files)
         if not all((x for x in linker_compatible)):
+            if 'libc6' not in self.stage_packages:
+                raise errors.StagePackageMissingError(package='libc6')
+
             handle_glibc_mismatch(elf_files=elf_files,
                                   root_path=self.primedir,
                                   snap_base_path=self._snap_base_path,

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -564,7 +564,7 @@ class PluginHandler:
         linker_compatible = (e.is_linker_compatible(linker='ld-2.23.so')
                              for e in elf_files)
         if not all((x for x in linker_compatible)):
-            if 'libc6' not in self.stage_packages:
+            if 'libc6' not in self._part_properties.get('stage-packages', []):
                 raise errors.StagePackageMissingError(package='libc6')
 
             handle_glibc_mismatch(elf_files=elf_files,

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -24,12 +24,7 @@ import jsonschema
 import yaml
 
 import snapcraft
-from snapcraft.internal import (
-    common,
-    deprecations,
-    remote_parts,
-    states,
-)
+from snapcraft.internal import deprecations, remote_parts, states
 from ._schema import Validator
 from ._parts_config import PartsConfig
 from ._env import (
@@ -118,9 +113,9 @@ class Config:
         self.build_tools = grammar_processor.get_build_packages()
         self.build_tools |= set(project_options.additional_build_packages)
 
-        # Install patchelf to enable patching in classic
-        if self.data['confinement'] == 'classic' and not common.is_snap():
-            self.build_tools.add('patchelf')
+        # Always install patchelf given that we will potentially need it to
+        # support snaps building on a newer base than that of the runtime.
+        self.build_tools.add('patchelf')
 
         self.parts = PartsConfig(parts=self.data,
                                  project_options=self._project_options,

--- a/snapcraft/tests/integration/general/test_asset_recording.py
+++ b/snapcraft/tests/integration/general/test_asset_recording.py
@@ -183,7 +183,8 @@ class ManifestRecordingBuildPackagesTestCase(
 
         """
         expected_packages = [
-            'haskell-doc', 'haskell98-tutorial', 'haskell98-report']
+            'haskell-doc', 'haskell98-tutorial', 'patchelf',
+            'haskell98-report']
         self.addCleanup(
             subprocess.call,
             ['sudo', 'apt', 'remove', '-y'] + expected_packages)

--- a/snapcraft/tests/unit/project_loader/test_config.py
+++ b/snapcraft/tests/unit/project_loader/test_config.py
@@ -315,8 +315,9 @@ parts:
         config = _config.Config(project_options)
 
         self.assertThat(config.parts.build_tools,
-                        Equals({'gcc-arm-linux-gnueabihf',
-                                'libc6-dev-armhf-cross'}))
+                        Contains('gcc-arm-linux-gnueabihf')),
+        self.assertThat(config.parts.build_tools,
+                        Contains('libc6-dev-armhf-cross')),
 
     def test_config_has_no_extra_build_tools_when_not_cross_compiling(self):
         class ProjectOptionsFake(snapcraft.ProjectOptions):
@@ -338,7 +339,8 @@ parts:
         self.make_snapcraft_yaml(yaml)
         config = _config.Config(ProjectOptionsFake())
 
-        self.assertThat(config.parts.build_tools, Equals(set()))
+        self.assertThat(config.parts.build_tools,
+                        Equals(set(['patchelf'])))
 
     def test_invalid_yaml_missing_name(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)

--- a/snapcraft/tests/unit/test_errors.py
+++ b/snapcraft/tests/unit/test_errors.py
@@ -357,6 +357,15 @@ class ErrorFormattingTestCase(unit.TestCase):
                 "'test/path' cannot be patched to function properly in a "
                 'classic confined snap: patchelf failed with exit code -1'
             )}),
+        ('StagePackageMissingError', {
+            'exception': errors.StagePackageMissingError,
+            'kwargs': {'package': 'libc6'},
+            'expected_message': (
+                "'libc6' is required as a `stage-packages` entry for this "
+                "part to work properly.\nAdd 'libc6' as a `stage-packages` "
+                "entry for this part."
+            )
+        }),
     )
 
     def test_error_formatting(self):

--- a/snapcraft/tests/unit/test_errors.py
+++ b/snapcraft/tests/unit/test_errors.py
@@ -361,8 +361,8 @@ class ErrorFormattingTestCase(unit.TestCase):
             'exception': errors.StagePackageMissingError,
             'kwargs': {'package': 'libc6'},
             'expected_message': (
-                "'libc6' is required as a `stage-packages` entry for this "
-                "part to work properly.\nAdd 'libc6' as a `stage-packages` "
+                "'libc6' is required inside the snap for this "
+                "part to work properly.\nAdd it as a `stage-packages` "
                 "entry for this part."
             )
         }),

--- a/snapcraft/tests/unit/test_lifecycle.py
+++ b/snapcraft/tests/unit/test_lifecycle.py
@@ -820,6 +820,9 @@ class RecordManifestBaseTestCase(BaseLifecycleTestCase):
 
         self.fake_apt_cache = fixture_setup.FakeAptCache()
         self.useFixture(self.fake_apt_cache)
+        self.fake_apt_cache.add_package(
+            fixture_setup.FakeAptCachePackage(
+                'patchelf', '0.9', installed=True))
 
         self.fake_snapd = fixture_setup.FakeSnapd()
         self.useFixture(self.fake_snapd)
@@ -849,7 +852,8 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             parts:
               test-part:
                 build-packages: []
-                installed-packages: []
+                installed-packages:
+                - patchelf=0.9
                 installed-snaps: []
                 plugin: nil
                 prime: []
@@ -893,7 +897,8 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             parts:
               test-part:
                 build-packages: []
-                installed-packages: []
+                installed-packages:
+                - patchelf=0.9
                 installed-snaps:
                 - test-snap-1=test-snap-1-revision
                 - test-snap-2=test-snap-2-revision
@@ -939,6 +944,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
               test-part:
                 build-packages: []
                 installed-packages:
+                - patchelf=0.9
                 - test-package1=test-version1
                 - test-package2=test-version2
                 installed-snaps: []
@@ -984,7 +990,8 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             parts:
               test-part:
                 build-packages: []
-                installed-packages: []
+                installed-packages:
+                - patchelf=0.9
                 installed-snaps: []
                 plugin: nil
                 prime: []
@@ -1034,7 +1041,8 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             parts:
               test-part:
                 build-packages: []
-                installed-packages: []
+                installed-packages:
+                - patchelf=0.9
                 installed-snaps: []
                 plugin: nil
                 prime: []
@@ -1078,7 +1086,8 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             parts:
               test-part:
                 build-packages: []
-                installed-packages: []
+                installed-packages:
+                - patchelf=0.9
                 installed-snaps: []
                 plugin: nil
                 prime: []
@@ -1129,7 +1138,8 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
               test-part:
                 build-packages:
                 - test-package:any
-                installed-packages: []
+                installed-packages:
+                - patchelf=0.9
                 installed-snaps: []
                 plugin: nil
                 prime: []
@@ -1176,7 +1186,8 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
               test-part:
                 build-packages:
                 - test-virtual-package
-                installed-packages: []
+                installed-packages:
+                - patchelf=0.9
                 installed-snaps: []
                 plugin: nil
                 prime: []
@@ -1217,7 +1228,8 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             parts:
               test-part:
                 build-packages: []
-                installed-packages: []
+                installed-packages:
+                - patchelf=0.9
                 installed-snaps: []
                 plugin: nil
                 prime: []
@@ -1261,7 +1273,8 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             parts:
               test-part:
                 build-packages: []
-                installed-packages: []
+                installed-packages:
+                - patchelf=0.9
                 installed-snaps: []
                 plugin: nil
                 prime: []
@@ -1327,7 +1340,8 @@ class RecordManifestWithDeprecatedSnapKeywordTestCase(
             parts:
               test-part:
                 build-packages: []
-                installed-packages: []
+                installed-packages:
+                - patchelf=0.9
                 installed-snaps: []
                 plugin: nil
                 prime:

--- a/snapcraft/tests/unit/test_mangling.py
+++ b/snapcraft/tests/unit/test_mangling.py
@@ -165,8 +165,6 @@ class HandleGlibcTestCase(unit.TestCase):
             snap_base_path='/snap/snap-name/current')
 
         self.get_packages_mock.assert_called_once_with('libc6')
-        self.assertThat(os.path.join(self.path, 'snap', 'libc6', 'ld-2.26.so'),
-                        FileExists())
         # Only fake_elf1 requires a newer libc6
         self.patch_mock.assert_called_once_with(
             elf_file=self.fake_elf['fake_elf-2.26'])


### PR DESCRIPTION
Require that the snapcraft.yaml explicitly state it needs libc6 so that it is recorded and an explicit action from the developer.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
