### PR TITLE
Revert "meta: create XDG_RUNTIME_DIR in wrappers. (#1818)"

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -25,7 +25,6 @@ import shlex
 import shutil
 import stat
 import subprocess
-from textwrap import dedent
 from typing import Any, Dict, List  # noqa
 
 import yaml
@@ -459,11 +458,6 @@ class _SnapPackaging:
                       '$LD_LIBRARY_PATH', file=f)
             if cwd:
                 print('{}'.format(cwd), file=f)
-            # TODO remove this once LP: #1656340 is fixed in snapd.
-            print(dedent("""\
-                # Workaround for LP: #1656340
-                [ -n "$XDG_RUNTIME_DIR" ] && mkdir -p $XDG_RUNTIME_DIR -m 700
-                """), file=f)
             print('exec {} {}'.format(executable, args), file=f)
 
         os.chmod(wrappath, 0o755)

--- a/snapcraft/tests/integration/snaps/assemble/binary1.after
+++ b/snapcraft/tests/integration/snaps/assemble/binary1.after
@@ -1,7 +1,4 @@
 #!/bin/sh
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
-# Workaround for LP: #1656340
-[ -n "$XDG_RUNTIME_DIR" ] && mkdir -p $XDG_RUNTIME_DIR -m 700
-
 exec "$SNAP/binary1" "$@"

--- a/snapcraft/tests/unit/test_meta.py
+++ b/snapcraft/tests/unit/test_meta.py
@@ -17,13 +17,12 @@
 import configparser
 import logging
 import os
-from textwrap import dedent
 from unittest.mock import patch
 
 import fixtures
+import testscenarios
 import testtools
 import yaml
-import testscenarios
 from testtools.matchers import (
     Contains,
     Equals,
@@ -847,16 +846,11 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         relative_wrapper_path = self.packager._wrap_exe(relative_exe_path)
         wrapper_path = os.path.join(self.prime_dir, relative_wrapper_path)
 
-        expected = dedent("""\
-            #!/bin/sh
-            PATH=$SNAP/usr/bin:$SNAP/bin
-
-            export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
-            # Workaround for LP: #1656340
-            [ -n "$XDG_RUNTIME_DIR" ] && mkdir -p $XDG_RUNTIME_DIR -m 700
-
-            exec "$SNAP/test_relexepath" "$@"
-            """)
+        expected = ('#!/bin/sh\n'
+                    'PATH=$SNAP/usr/bin:$SNAP/bin\n\n'
+                    'export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:'
+                    '$LD_LIBRARY_PATH\n'
+                    'exec "$SNAP/test_relexepath" "$@"\n')
 
         self.assertThat(wrapper_path, FileContains(expected))
 
@@ -875,16 +869,11 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
 
         self.assertThat(relative_wrapper_path, Equals('new-name.wrapper'))
 
-        expected = dedent("""\
-            #!/bin/sh
-            PATH=$SNAP/usr/bin:$SNAP/bin
-
-            export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
-            # Workaround for LP: #1656340
-            [ -n "$XDG_RUNTIME_DIR" ] && mkdir -p $XDG_RUNTIME_DIR -m 700
-
-            exec "$SNAP/test_relexepath" "$@"
-            """)
+        expected = ('#!/bin/sh\n'
+                    'PATH=$SNAP/usr/bin:$SNAP/bin\n\n'
+                    'export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:'
+                    '$LD_LIBRARY_PATH\n'
+                    'exec "$SNAP/test_relexepath" "$@"\n')
         self.assertThat(wrapper_path, FileContains(expected))
 
     def test_snap_shebangs_extracted(self):
@@ -909,13 +898,9 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         relative_wrapper_path = self.packager._wrap_exe(relative_exe_path)
         wrapper_path = os.path.join(self.prime_dir, relative_wrapper_path)
 
-        expected = dedent("""\
-            #!/bin/sh
-            # Workaround for LP: #1656340
-            [ -n "$XDG_RUNTIME_DIR" ] && mkdir -p $XDG_RUNTIME_DIR -m 700
-
-            exec "$SNAP/snap_exe" "$SNAP/test_relexepath" "$@"
-            """)
+        expected = (
+            '#!/bin/sh\n'
+            'exec "$SNAP/snap_exe" "$SNAP/test_relexepath" "$@"\n')
         self.assertThat(wrapper_path, FileContains(expected))
 
         # The shebang wasn't changed, since we don't know what the
@@ -937,13 +922,8 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         relative_wrapper_path = self.packager._wrap_exe(relative_exe_path)
         wrapper_path = os.path.join(self.prime_dir, relative_wrapper_path)
 
-        expected = dedent("""\
-            #!/bin/sh
-            # Workaround for LP: #1656340
-            [ -n "$XDG_RUNTIME_DIR" ] && mkdir -p $XDG_RUNTIME_DIR -m 700
-
-            exec "$SNAP/test_relexepath" "$@"
-            """)
+        expected = ('#!/bin/sh\n'
+                    'exec "$SNAP/test_relexepath" "$@"\n')
         self.assertThat(wrapper_path, FileContains(expected))
 
         self.assertThat(os.path.join(self.prime_dir, relative_exe_path),
@@ -965,13 +945,8 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         relative_wrapper_path = self.packager._wrap_exe(relative_exe_path)
         wrapper_path = os.path.join(self.prime_dir, relative_wrapper_path)
 
-        expected = dedent("""\
-            #!/bin/sh
-            # Workaround for LP: #1656340
-            [ -n "$XDG_RUNTIME_DIR" ] && mkdir -p $XDG_RUNTIME_DIR -m 700
-
-            exec "$SNAP/test_relexepath" "$@"
-            """)
+        expected = ('#!/bin/sh\n'
+                    'exec "$SNAP/test_relexepath" "$@"\n')
         self.assertThat(wrapper_path, FileContains(expected))
 
         with open(path, 'rb') as exe:
@@ -985,13 +960,8 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         relative_wrapper_path = self.packager._wrap_exe('app1')
         wrapper_path = os.path.join(self.prime_dir, relative_wrapper_path)
 
-        expected = dedent("""\
-            #!/bin/sh
-            # Workaround for LP: #1656340
-            [ -n "$XDG_RUNTIME_DIR" ] && mkdir -p $XDG_RUNTIME_DIR -m 700
-
-            exec "app1" "$@"
-            """)
+        expected = ('#!/bin/sh\n'
+                    'exec "app1" "$@"\n')
         self.assertThat(wrapper_path, FileContains(expected))
 
     def test_command_does_not_exist(self):


### PR DESCRIPTION
This reverts commit 909f6233a64157c1dbc432f0487610c41d7fd170.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This change enters hook world through the wrappers causing an exception we want to of course avoid.

```
sergiusens@mirkwood:/home/sergiusens$ [ -n "$XDG_RUNTIME_DIR" ] && mkdir -p $XDG_RUNTIME_DIR -m 700
Segmentation fault (core dumped)
```

This is an icky place; long term we need to get rid of exporting `LD_LIBRARY_PATH`