### PR TITLE
elf: make patchelf a dependency

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -4,7 +4,7 @@
 
 First install a few dependencies:
 
-    sudo apt install gcc g++ make python3-dev python3-venv libffi-dev libsodium-dev libapt-pkg-dev libarchive13 squashfs-tools
+    sudo apt install gcc g++ make python3-dev python3-venv libffi-dev libsodium-dev libapt-pkg-dev libarchive13 squashfs-tools patchelf
 
 Create and activate a new virtual environment:
 

--- a/debian/control
+++ b/debian/control
@@ -45,7 +45,8 @@ Standards-Version: 3.9.8
 
 Package: snapcraft
 Architecture: all
-Depends: python3-apt,
+Depends: patchelf,
+         python3-apt,
          python3-debian,
          python3-click,
          python3-jsonschema,

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -113,10 +113,6 @@ class Config:
         self.build_tools = grammar_processor.get_build_packages()
         self.build_tools |= set(project_options.additional_build_packages)
 
-        # Always install patchelf given that we will potentially need it to
-        # support snaps building on a newer base than that of the runtime.
-        self.build_tools.add('patchelf')
-
         self.parts = PartsConfig(parts=self.data,
                                  project_options=self._project_options,
                                  validator=self._validator,

--- a/snapcraft/tests/integration/general/test_asset_recording.py
+++ b/snapcraft/tests/integration/general/test_asset_recording.py
@@ -183,8 +183,7 @@ class ManifestRecordingBuildPackagesTestCase(
 
         """
         expected_packages = [
-            'haskell-doc', 'haskell98-tutorial', 'patchelf',
-            'haskell98-report']
+            'haskell-doc', 'haskell98-tutorial', 'haskell98-report']
         self.addCleanup(
             subprocess.call,
             ['sudo', 'apt', 'remove', '-y'] + expected_packages)

--- a/snapcraft/tests/unit/project_loader/test_config.py
+++ b/snapcraft/tests/unit/project_loader/test_config.py
@@ -339,8 +339,7 @@ parts:
         self.make_snapcraft_yaml(yaml)
         config = _config.Config(ProjectOptionsFake())
 
-        self.assertThat(config.parts.build_tools,
-                        Equals(set(['patchelf'])))
+        self.assertThat(config.parts.build_tools, Equals(set()))
 
     def test_invalid_yaml_missing_name(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)


### PR DESCRIPTION
Making it a build_tools entry in the project_loader was the wrong
call, we do not for example do the same for xdelta3. We should
instead be handling it through the delivery mechanisms in place,
such that it is in debian/control for the deb and bundled in the
snapcraft snap when running from there.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
