### PR TITLE
tests: remove plainbox part from plugin tests

### DIFF
--- a/snapcraft/tests/integration/snaps/plainbox-provider-with-deps/snapcraft.yaml
+++ b/snapcraft/tests/integration/snaps/plainbox-provider-with-deps/snapcraft.yaml
@@ -7,20 +7,27 @@ description: |
 confinement: strict
 
 parts:
-    plainbox-local:
-        plugin: python3
-        python-packages:
-            - plainbox
-            - requests-oauthlib
+    checkbox-ng-dev:
+        plugin: python
+        source: git://git.launchpad.net/checkbox-ng
+        source-type: git
+        stage-packages:
+            - libc6
         build-packages:
             - libxml2-dev
             - libxslt1-dev
             - zlib1g-dev
             - build-essential
+        python-packages:
+            - requests-oauthlib
+            - XlsxWriter
+            - Jinja2
+            - guacamole
+            - padme
     parent-plainbox-provider:
         plugin: plainbox-provider
         source: ./2017.com.example_parent
-        after: [plainbox-local]
+        after: [checkbox-ng-dev]
     child-plainbox-provider:
         plugin: plainbox-provider
         source: ./2017.com.example_child

--- a/snapcraft/tests/integration/snaps/plainbox-provider/snapcraft.yaml
+++ b/snapcraft/tests/integration/snaps/plainbox-provider/snapcraft.yaml
@@ -7,8 +7,10 @@ description: |
 confinement: strict
 
 parts:
-    plainbox-dev:
+    checkbox-ng-dev:
         plugin: python
+        source: git://git.launchpad.net/checkbox-ng
+        source-type: git
         build-packages:
             - libxml2-dev
             - libxslt1-dev
@@ -20,25 +22,11 @@ parts:
             - Jinja2
             - guacamole
             - padme
-        source: git://git.launchpad.net/plainbox
-        source-type: git
     checkbox-support-dev:
         plugin: python
         source: git://git.launchpad.net/checkbox-support
         source-type: git
-    checkbox-ng-dev:
-        plugin: python
-        source: git://git.launchpad.net/checkbox-ng
-        source-type: git
-        stage:
-            - bin/checkbox*
-            - lib/*/*/checkbox_ng*/*
-            - lib/*/*/checkbox_ng*/*/*
-        snap:
-            - bin/checkbox*
-            - lib/*/*/checkbox_ng*/*
-            - lib/*/*/checkbox_ng*/*/*
     simple-plainbox-provider:
         plugin: plainbox-provider
         source: ./2016.com.example_simple
-        after: [plainbox-dev, checkbox-support-dev, checkbox-ng-dev]
+        after: [checkbox-ng-dev, checkbox-support-dev]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Fixes for current failures of integration tests introduced by changes in external plainbox library.

The plainbox library is being merged in to the checkbox
application. The plainbox part should therefore no
longer be needed in snaps.