### PR TITLE
lifecycle: use in-snap mksquashfs if running from snap

### DIFF
--- a/snapcraft/tests/unit/commands/test_snap.py
+++ b/snapcraft/tests/unit/commands/test_snap.py
@@ -92,6 +92,53 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
             '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
+    @mock.patch('snapcraft.internal.repo.check_for_command')
+    @mock.patch('snapcraft.internal.lifecycle._packer._run_mksquashfs')
+    def test_mksquashfs_from_snap_used_if_using_snap(self, mock_run_mksquashfs,
+                                                     mock_check_command):
+        self.useFixture(fixtures.EnvironmentVariable(
+            'SNAP', '/snap/snapcraft/current'))
+        self.useFixture(fixtures.EnvironmentVariable(
+            'SNAP_NAME', 'snapcraft'))
+
+        self.make_snapcraft_yaml()
+
+        self.run_command(['snap'])
+
+        mksquashfs_path = os.path.join('/snap', 'snapcraft', 'current',
+                                       'usr', 'bin', 'mksquashfs')
+
+        mock_run_mksquashfs.assert_called_once_with(
+            mksquashfs_path, directory=self.prime_dir, snap_name='snap-test',
+            snap_type='app', output_snap_name='snap-test_1.0_amd64.snap')
+
+    @mock.patch('snapcraft.internal.common.is_docker_instance')
+    @mock.patch('snapcraft.internal.repo.check_for_command')
+    @mock.patch('snapcraft.internal.lifecycle._packer._run_mksquashfs')
+    def test_mksquashfs_from_snap_used_if_docker(self, mock_run_mksquashfs,
+                                                 mock_check_command,
+                                                 mock_is_docker):
+        mock_is_docker.return_value = True
+        self.make_snapcraft_yaml()
+
+        original_exists = os.path.exists
+
+        def _fake_exists(path):
+            if path == '/snap/snapcraft/current/usr/bin/mksquashfs':
+                return True
+            else:
+                return original_exists(path)
+
+        with mock.patch('os.path.exists', side_effect=_fake_exists):
+            self.run_command(['snap'])
+
+        mksquashfs_path = os.path.join('/snap', 'snapcraft', 'current',
+                                       'usr', 'bin', 'mksquashfs')
+
+        mock_run_mksquashfs.assert_called_once_with(
+            mksquashfs_path, directory=self.prime_dir, snap_name='snap-test',
+            snap_type='app', output_snap_name='snap-test_1.0_amd64.snap')
+
     def test_snap_fails_with_bad_type(self):
         self.make_snapcraft_yaml(snap_type='bad-type')
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently, Snapcraft just runs `mksquashfs`, relying on the $PATH. However, as a classic snap, Snapcraft sets no PATH. As a result, even when running as a snap, Snapcraft relies on `mksquashfs` being installed on the build system.

Start using the one in the snap in this case.