### PR TITLE
cli: use C.UTF-8 if locale not set

### DIFF
--- a/snapcraft/cli/__main__.py
+++ b/snapcraft/cli/__main__.py
@@ -14,6 +14,30 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import codecs
+import locale
+import os
+import subprocess
+
 from ._runner import run
+from .echo import warning
+
+# If the locale ends up being ascii, Click will barf. Let's try to prevent that
+# here by using C.UTF-8 as a last-resort fallback. This mostly happens in CI,
+# using LXD or Docker. This is the same logic used by Click to error out.
+if (codecs.lookup(locale.getpreferredencoding()).name == 'ascii' and
+        os.name == 'posix'):
+    output = subprocess.check_output(['locale', '-a']).decode(
+        'ascii', 'replace')
+
+    for line in output.splitlines():
+        this_locale = line.strip()
+        if this_locale.lower() in ('c.utf8', 'c.utf-8'):
+            warning(
+                'Locale not set! Snapcraft will temporarily use C.UTF-8')
+            os.environ['LC_ALL'] = 'C.UTF-8'
+            os.environ['LANG'] = 'C.UTF-8'
+            break
 
 run(prog_name='snapcraft')

--- a/snapcraft/tests/integration/general/test_init.py
+++ b/snapcraft/tests/integration/general/test_init.py
@@ -1,0 +1,28 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import fixtures
+from snapcraft.tests import integration
+
+
+class InitTestCase(integration.TestCase):
+
+    def test_init_without_locale(self):
+        self.useFixture(fixtures.EnvironmentVariable('LC_ALL'))
+        self.useFixture(fixtures.EnvironmentVariable('LANG'))
+
+        # This should not throw exceptions
+        self.run_snapcraft(['init'])


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

When running Snapcraft in a specific way (e.g. Docker, LXD) it's possible to have a situation where no locale is set. This happens mostly in CI systems. Click raises a `RuntimeError` in this situation, which is a pretty terrible user experience.

This PR fixes LP: [#1746100](https://bugs.launchpad.net/snapcraft/+bug/1746100) by using C.UTF-8 by default if it's is available This will allow Snapcraft to run on these systems without creating more work for our users.