### PR TITLE
tests: allow to overwrite the snapcraft install command

### DIFF
--- a/tools/travis/run_tests.sh
+++ b/tools/travis/run_tests.sh
@@ -39,7 +39,7 @@ elif [[ "$test" = "snapcraft/tests/integration"* || "$test" = "snapcraft.tests.i
     # snap install core exits with this error message:
     # - Setup snap "core" (2462) security profiles (cannot reload udev rules: exit status 2
     # but the installation succeeds, so we just ingore it.
-    dependencies="apt install -y bzr git libnacl-dev libsodium-dev libffi-dev libapt-pkg-dev libarchive-dev mercurial python3-pip subversion sudo snapd && python3 -m pip install -r requirements-devel.txt -r requirements.txt && (snap install core || echo 'ignored error') && sudo snap install snaps-cache/snapcraft-pr$TRAVIS_PULL_REQUEST.snap --dangerous --classic"
+    dependencies="apt install -y bzr git libnacl-dev libsodium-dev libffi-dev libapt-pkg-dev libarchive-dev mercurial python3-pip subversion sudo snapd && python3 -m pip install -r requirements-devel.txt -r requirements.txt && (snap install core || echo 'ignored error') && ${SNAPCRAFT_INSTALL_COMMAND:-sudo snap install snaps-cache/snapcraft-pr$TRAVIS_PULL_REQUEST.snap --dangerous --classic}"
 else
     echo "Unknown test suite: $test"
     exit 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
The snap store team wants to run only one stage. They can define their stage and the script to run through the api. However, in here we have a dependency on a previous stage, so it wouldn't be possible to call `sudo ./tools/travis/run_tests.sh snapcraft/tests/integration/store` independently.
Their tests don't need to build the snapcraft snap from source, so we could just install snapcraft from edge.
I am adding here an optional env var SNAPCRAFT_INSTALL_COMMAND, that the store team can send on their API request set to `sudo snap install snapcraft --edge --classic`.
