### PR TITLE
elf: do not strip rpaths that contain $ORIGIN

### DIFF
--- a/snapcraft/tests/integration/general/test_prime.py
+++ b/snapcraft/tests/integration/general/test_prime.py
@@ -27,6 +27,7 @@ from testtools.matchers import (
     FileExists,
     MatchesRegex,
     Not,
+    StartsWith,
 )
 
 import snapcraft
@@ -78,6 +79,37 @@ class PrimeTestCase(integration.TestCase):
             self.patchelf_command, '--print-interpreter',
             staged_bin_path]).decode()
         self.assertThat(staged_interpreter, MatchesRegex(r'^/lib.*'))
+
+    def test_classic_confinement_with_existing_rpath(self):
+        if os.environ.get('ADT_TEST') and self.deb_arch == 'armhf':
+            self.skipTest("The autopkgtest armhf runners can't install snaps")
+        project_dir = 'classic-build-existing-rpath'
+
+        # The first run should fail as the environment variable is not
+        # set but we can only test this on clean systems.
+        if not os.path.exists(os.path.join(
+                os.path.sep, 'snap', 'core', 'current')):
+            try:
+                self.run_snapcraft(['prime'], project_dir)
+            except subprocess.CalledProcessError:
+                pass
+            else:
+                self.fail(
+                    'This should fail as SNAPCRAFT_SETUP_CORE is not set')
+
+        # Now we set the required environment variable
+        self.useFixture(fixtures.EnvironmentVariable(
+                'SNAPCRAFT_SETUP_CORE', '1'))
+
+        self.run_snapcraft(['prime'], project_dir)
+
+        bin_path = os.path.join(self.prime_dir, 'bin', 'hello-classic')
+        self.assertThat(bin_path, FileExists())
+
+        rpath = subprocess.check_output([
+            self.patchelf_command, '--print-rpath', bin_path]).decode().strip()
+        expected_rpath = '$ORIGIN/../fake-lib:/snap/core/current/'
+        self.assertThat(rpath, StartsWith(expected_rpath))
 
     def test_prime_includes_stage_fileset(self):
         self.run_snapcraft('prime', 'prime-from-stage')

--- a/snapcraft/tests/integration/snaps/classic-build-existing-rpath/Makefile
+++ b/snapcraft/tests/integration/snaps/classic-build-existing-rpath/Makefile
@@ -1,0 +1,10 @@
+# -*- Mode: Makefile; indent-tabs-mode:t; tab-width: 4 -*-
+.PHONY: all
+
+all: hello-classic
+
+install: hello-classic
+	install -d $(DESTDIR)/bin
+	install $^ $(DESTDIR)/bin/
+
+hello-classic: hello-classic.c

--- a/snapcraft/tests/integration/snaps/classic-build-existing-rpath/hello-classic.c
+++ b/snapcraft/tests/integration/snaps/classic-build-existing-rpath/hello-classic.c
@@ -1,0 +1,4 @@
+#include <stdio.h>
+int main() {
+    printf("Hello world\n");
+}

--- a/snapcraft/tests/integration/snaps/classic-build-existing-rpath/snap/snapcraft.yaml
+++ b/snapcraft/tests/integration/snaps/classic-build-existing-rpath/snap/snapcraft.yaml
@@ -1,0 +1,16 @@
+name: classic-build-with-rpath
+version: '0.1'
+summary: Build a classic confined snap
+description: |
+  Build a classic confined snap, mostly used to test the provisioning
+  of `core` inside a snap.
+
+grade: devel
+confinement: classic
+
+parts:
+  hello:
+    plugin: make
+    build-packages: [patchelf]
+    install: |
+      patchelf --force-rpath --set-rpath "\$ORIGIN/../fake-lib" $SNAPCRAFT_PART_INSTALL/bin/hello-classic


### PR DESCRIPTION
This is enabled to support users setting up rpaths for their
projects for paths that snapcraft would not find otherwise.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
