### PR TITLE
docker: don't rely on snapcraft-classic

### DIFF
--- a/docker/snap-beta.Dockerfile
+++ b/docker/snap-beta.Dockerfile
@@ -8,7 +8,10 @@ RUN apt-get update && \
   mkdir -p /snap/core && unsquashfs -d /snap/core/current core.snap && rm core.snap && \
   curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=beta' | jq '.download_url' -r) --output snapcraft.snap && \
   mkdir -p /snap/snapcraft && unsquashfs -d /snap/snapcraft/current snapcraft.snap && rm snapcraft.snap && \
-  mkdir -p /snap/bin && ln -s /snap/snapcraft/current/bin/snapcraft-classic /snap/bin/snapcraft && \
+  mkdir -p /snap/bin && \
+  echo "#!/bin/sh" > /snap/bin/snapcraft && \
+  echo 'exec $SNAP/usr/bin/python3 $SNAP/bin/snapcraft "$@"' >> /snap/bin/snapcraft && \
+  chmod a+x /snap/bin/snapcraft && \
   apt remove --yes --purge curl jq squashfs-tools && \
   apt-get autoclean --yes && \
   apt-get clean --yes

--- a/docker/snap-edge.Dockerfile
+++ b/docker/snap-edge.Dockerfile
@@ -8,7 +8,10 @@ RUN apt-get update && \
   mkdir -p /snap/core && unsquashfs -d /snap/core/current core.snap && rm core.snap && \
   curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=edge' | jq '.download_url' -r) --output snapcraft.snap && \
   mkdir -p /snap/snapcraft && unsquashfs -d /snap/snapcraft/current snapcraft.snap && rm snapcraft.snap && \
-  mkdir -p /snap/bin && ln -s /snap/snapcraft/current/bin/snapcraft-classic /snap/bin/snapcraft && \
+  mkdir -p /snap/bin && \
+  echo "#!/bin/sh" > /snap/bin/snapcraft && \
+  echo 'exec $SNAP/usr/bin/python3 $SNAP/bin/snapcraft "$@"' >> /snap/bin/snapcraft && \
+  chmod a+x /snap/bin/snapcraft && \
   apt remove --yes --purge curl jq squashfs-tools && \
   apt-get autoclean --yes && \
   apt-get clean --yes


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

The Dockerfiles currently create a symlink from `/snap/bin/snapcraft` to `/snap/snapcraft/current/bin/snapcraft-classic`. However, `snapcraft-classic` no longer exists. We can't just symlink to `snapcraft` either, or Python isn't found.

Instead of creating a symlink, write a simple script to run the Python (and Snapcraft) out of the snap.