### PR TITLE
elf: use surrogate escape when decoding readelf output

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -115,7 +115,7 @@ class ElfFile:
         readelf_path = file_utils.get_tool_path('readelf')
         output = subprocess.check_output([
             readelf_path, '--wide', '--program-headers', '--dyn-syms', path])
-        readelf_lines = output.decode().split('\n')
+        readelf_lines = output.decode(errors='surrogateescape').split('\n')
         # Regex inspired by the regexes in lintian to match entries similar to
         # the following sample output
         # Program Headers:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
Fixes [LP:1746639](https://bugs.launchpad.net/snapcraft/+bug/1746639)