### PR TITLE
Remove dangling symlink from JDK plugin (LP Bug #1617296)

### DIFF
--- a/snapcraft/plugins/gradle.py
+++ b/snapcraft/plugins/gradle.py
@@ -74,7 +74,6 @@ class GradlePlugin(snapcraft.plugins.jdk.JdkPlugin):
         filename = os.path.join(os.getcwd(), 'gradlew')
         if not os.path.isfile(filename):
             self.build_packages.append('gradle')
-        self.build_packages.append('ca-certificates-java')
 
     @classmethod
     def get_build_properties(cls):

--- a/snapcraft/plugins/jdk.py
+++ b/snapcraft/plugins/jdk.py
@@ -21,6 +21,7 @@ class JdkPlugin(snapcraft.BasePlugin):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
+        self.build_packages.append('ca-certificates-java')
         self.stage_packages.append('default-jdk')
 
     def env(self, root):


### PR DESCRIPTION
Using the JDK plugin results a dangling symlink error

package contains external symlinks:
usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts

This pull request adds 'ca-certificates-java' package to the build stage. So at the build part it will just take needed file from symlink and that's it.
LP Bug #1617296

Previous bull requests about this bug:
https://github.com/snapcore/snapcraft/pull/761 (cc @gnouy)