### PR TITLE
dotnet plugin: add dotnet command to path and enable developer scenario for  snap

### DIFF
--- a/snapcraft/plugins/dotnet.py
+++ b/snapcraft/plugins/dotnet.py
@@ -140,3 +140,9 @@ class DotNetPlugin(snapcraft.BasePlugin):
             if fnmatch.fnmatch(file, '*.??proj'):
                 return os.path.splitext(file)[0]
                 break
+
+    def env(self, root):
+        if root == self.installdir:
+            return ['PATH={}:$PATH'.format(self._dotnet_sdk_dir)]
+        else:
+            return []

--- a/snapcraft/plugins/dotnet.py
+++ b/snapcraft/plugins/dotnet.py
@@ -142,6 +142,7 @@ class DotNetPlugin(snapcraft.BasePlugin):
                 break
 
     def env(self, root):
+        # Update the PATH only during the Build and Install step
         if root == self.installdir:
             return ['PATH={}:$PATH'.format(self._dotnet_sdk_dir)]
         else:

--- a/tests/unit/plugins/test_dotnet.py
+++ b/tests/unit/plugins/test_dotnet.py
@@ -95,6 +95,12 @@ class DotNetProjectBaseTestCase(unit.TestCase):
 
 class DotNetProjectTestCase(DotNetProjectBaseTestCase):
 
+    def test_sdk_in_path(self):
+        plugin = dotnet.DotNetPlugin(
+            'test-part', self.options, self.project)
+        self.assertThat(plugin.env(plugin.installdir), Contains(
+            'PATH={}:$PATH'.format(plugin._dotnet_sdk_dir)))
+
     def test_init_with_non_amd64_architecture(self):
         with mock.patch(
                 'snapcraft.ProjectOptions.deb_arch',

--- a/tests/unit/plugins/test_dotnet.py
+++ b/tests/unit/plugins/test_dotnet.py
@@ -100,6 +100,9 @@ class DotNetProjectTestCase(DotNetProjectBaseTestCase):
             'test-part', self.options, self.project)
         self.assertThat(plugin.env(plugin.installdir), Contains(
             'PATH={}:$PATH'.format(plugin._dotnet_sdk_dir)))
+        # Be sure that the PATH doesn't leak into the final snap
+        self.assertThat(plugin.env(self.project.stage_dir), Equals([]))
+        self.assertThat(plugin.env(self.project.prime_dir), Equals([]))
 
     def test_init_with_non_amd64_architecture(self):
         with mock.patch(


### PR DESCRIPTION
Add dotnet command to path and enable developer scenario for  snap ild via application yaml

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
