### PR TITLE
lxd: unset SNAP to work-around LXD deb thinking it's a snap

### DIFF
--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -75,6 +75,8 @@ class Containerbuild:
         self._lxd_common_dir = os.path.expanduser(
             os.path.join('~', 'snap', 'lxd', 'common'))
         os.makedirs(self._lxd_common_dir, exist_ok=True)
+        # Work-around for https://github.com/lxc/lxd/issues/4183
+        os.environ['SNAP'] = ''
 
     @contextmanager
     def _container_running(self):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
Work-around for [LP: #1746612](https://bugs.launchpad.net/snapcraft/+bug/1746612)

Manual test steps:
    1. Have LXD v2.21 deb installeed
    2. `$ snapcraft cleanbuild`
    3. Observe that the build succeeds