### PR TITLE
catkin plugin: extract Wstool into its own module

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -25,7 +25,7 @@ class SnapcraftError(Exception):
     """
     fmt = 'Daughter classes should redefine this'
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         for key, value in kwargs.items():
             setattr(self, key, value)
 

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -315,7 +315,7 @@ class Ubuntu(BaseRepo):
                             package.name, package.installed.version))
         return installed_packages
 
-    def __init__(self, rootdir, sources=None, project_options=None):
+    def __init__(self, rootdir, sources=None, project_options=None) -> None:
         super().__init__(rootdir)
         self._downloaddir = os.path.join(rootdir, 'download')
 
@@ -333,7 +333,7 @@ class Ubuntu(BaseRepo):
         with self._apt.archive(self._cache.base_dir) as apt_cache:
             return package_name in apt_cache
 
-    def get(self, package_names):
+    def get(self, package_names) -> None:
         with self._apt.archive(self._cache.base_dir) as apt_cache:
             self._mark_install(apt_cache, package_names)
             self._filter_base_packages(apt_cache, package_names)
@@ -399,7 +399,7 @@ class Ubuntu(BaseRepo):
 
         return pkg_list
 
-    def unpack(self, unpackdir):
+    def unpack(self, unpackdir) -> None:
         pkgs_abs_path = glob.glob(os.path.join(self._downloaddir, '*.deb'))
         for pkg in pkgs_abs_path:
             sources.Deb(None, None).provision(

--- a/snapcraft/plugins/_ros/__init__.py
+++ b/snapcraft/plugins/_ros/__init__.py
@@ -16,3 +16,4 @@
 
 from snapcraft.plugins._ros import rosdep  # noqa
 from snapcraft.plugins._ros import ros2  # noqa
+from snapcraft.plugins._ros import wstool  # noqa

--- a/snapcraft/plugins/_ros/wstool.py
+++ b/snapcraft/plugins/_ros/wstool.py
@@ -1,0 +1,119 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015-2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import logging
+import subprocess
+import sys
+from typing import List
+
+import snapcraft
+from snapcraft.internal import (
+    errors,
+    repo
+)
+
+logger = logging.getLogger(__name__)
+
+
+class WstoolError(errors.SnapcraftError):
+    pass
+
+
+class WorkspaceInitializationError(WstoolError):
+    fmt = 'Error initializing workspace: {message}'
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message=message)
+
+
+class RosinstallMergeError(WstoolError):
+    fmt = 'Error merging rosinstall file {path!r} into workspace: {message}'
+
+    def __init__(self, path: str, message: str) -> None:
+        super().__init__(path=path, message=message)
+
+
+class WorkspaceUpdateError(WstoolError):
+    fmt = 'Error updating workspace: {message}'
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message=message)
+
+
+class Wstool:
+    def __init__(self, ros_package_path: str, wstool_path: str,
+                 ubuntu_sources: str,
+                 project: snapcraft.ProjectOptions) -> None:
+        self._ros_package_path = ros_package_path
+        self._ubuntu_sources = ubuntu_sources
+        self._wstool_path = wstool_path
+        self._wstool_install_path = os.path.join(wstool_path, 'install')
+        self._project = project
+
+    def setup(self) -> None:
+        os.makedirs(self._wstool_install_path, exist_ok=True)
+
+        # wstool isn't a dependency of the project, so we'll unpack it
+        # somewhere else, and use it from there.
+        logger.info('Preparing to fetch wstool...')
+        ubuntu = repo.Ubuntu(self._wstool_path, sources=self._ubuntu_sources,
+                             project_options=self._project)
+        logger.info('Fetching wstool...')
+        ubuntu.get(['python-wstool'])
+
+        logger.info('Installing wstool...')
+        ubuntu.unpack(self._wstool_install_path)
+
+        logger.info('Initializing workspace (if necessary)...')
+        try:
+            self._run(['init', self._ros_package_path, '-j{}'.format(
+                self._project.parallel_build_count)])
+        except subprocess.CalledProcessError as e:
+            output = e.output.decode(sys.getfilesystemencoding()).strip()
+            if 'already is a workspace' not in output:
+                stderr = e.stderr.decode(sys.getfilesystemencoding()).strip()
+                raise WorkspaceInitializationError(stderr)
+
+    def merge(self, rosinstall_file: str) -> str:
+        try:
+            return self._run(
+                ['merge', rosinstall_file, '--confirm-all', '-t{}'.format(
+                    self._ros_package_path)]).strip()
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr.decode(sys.getfilesystemencoding()).strip()
+            raise RosinstallMergeError(rosinstall_file, stderr)
+
+    def update(self) -> str:
+        try:
+            return self._run(
+                ['update', '-j{}'.format(self._project.parallel_build_count),
+                 '-t{}'.format(self._ros_package_path)])
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr.decode(sys.getfilesystemencoding()).strip()
+            raise WorkspaceUpdateError(stderr)
+
+    def _run(self, arguments: List[str]) -> str:
+        env = os.environ.copy()
+
+        env['PATH'] += ':' + os.path.join(self._wstool_install_path, 'usr',
+                                          'bin')
+        env['PYTHONPATH'] = os.path.join(self._wstool_install_path, 'usr',
+                                         'lib', 'python2.7', 'dist-packages')
+
+        return subprocess.check_output(
+            ['wstool'] + arguments, stderr=subprocess.PIPE, env=env).decode(
+                sys.getfilesystemencoding()).strip()

--- a/tests/unit/plugins/ros/test_wstool.py
+++ b/tests/unit/plugins/ros/test_wstool.py
@@ -1,0 +1,161 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015-2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import subprocess
+
+from unittest import mock
+from testtools.matchers import Equals
+
+from snapcraft.plugins._ros import wstool
+
+import snapcraft
+from tests import unit
+
+
+class WstoolTestCase(unit.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.project = snapcraft.ProjectOptions()
+        self.wstool = wstool.Wstool(
+            'package_path', 'wstool_path', 'sources', self.project)
+
+        patcher = mock.patch('snapcraft.repo.Ubuntu')
+        self.ubuntu_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch('subprocess.check_output')
+        self.check_output_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_setup(self):
+        # Return something other than a Mock to ease later assertions
+        self.check_output_mock.return_value = b''
+
+        self.wstool.setup()
+
+        # Verify that only wstool was installed (no other .debs)
+        self.assertThat(self.ubuntu_mock.call_count, Equals(1))
+        self.assertThat(
+            self.ubuntu_mock.return_value.get.call_count, Equals(1))
+        self.assertThat(
+            self.ubuntu_mock.return_value.unpack.call_count, Equals(1))
+        self.ubuntu_mock.assert_has_calls([
+            mock.call(self.wstool._wstool_path, sources='sources',
+                      project_options=self.project),
+            mock.call().get(['python-wstool']),
+            mock.call().unpack(self.wstool._wstool_install_path)])
+
+        # Verify that wstool was initialized
+        self.check_output_mock.assert_called_once_with(
+            ['wstool', 'init', 'package_path', '-j2'], env=mock.ANY,
+            stderr=subprocess.PIPE)
+
+    def test_setup_can_run_multiple_times(self):
+        self.wstool.setup()
+
+        # Make sure running setup() again doesn't have problems with the old
+        # environment. An exception will be raised if setup can't be called
+        # twice.
+        self.wstool.setup()
+
+    def test_setup_initialization_rosinstall_already_exists(self):
+        """Test that an existing .rosinstall file is not an error."""
+
+        def run(args, **kwargs):
+            if args[0:2] == ['wstool', 'init']:
+                raise subprocess.CalledProcessError(
+                    1, 'foo',
+                    b'Error: There already is a workspace config file '
+                    b'.rosinstall at ".". Use wstool install/modify.')
+
+        self.check_output_mock.side_effect = run
+
+        self.wstool.setup()
+
+    def test_setup_initialization_failure(self):
+        def run(args, **kwargs):
+            if args[0:2] == ['wstool', 'init']:
+                raise subprocess.CalledProcessError(1, 'foo', b'bar', b'baz')
+
+        self.check_output_mock.side_effect = run
+
+        raised = self.assertRaises(
+            wstool.WorkspaceInitializationError, self.wstool.setup)
+
+        self.assertThat(str(raised),
+                        Equals('Error initializing workspace: baz'))
+
+    def test_merge(self):
+        self.wstool.merge('rosinstall-file')
+
+        self.check_output_mock.assert_called_with(
+            ['wstool', 'merge', 'rosinstall-file', '--confirm-all',
+             '-tpackage_path'],
+            stderr=subprocess.PIPE, env=mock.ANY)
+
+    def test_merge_failure(self):
+        def run(args, **kwargs):
+            if args[0:2] == ['wstool', 'merge']:
+                raise subprocess.CalledProcessError(1, 'foo', b'bar', b'baz')
+
+        self.check_output_mock.side_effect = run
+
+        raised = self.assertRaises(
+            wstool.RosinstallMergeError, self.wstool.merge, 'rosinstall-file')
+
+        self.assertThat(
+            str(raised), Equals(
+                "Error merging rosinstall file 'rosinstall-file' into "
+                'workspace: baz'))
+
+    def test_update(self):
+        self.wstool.update()
+
+        self.check_output_mock.assert_called_with(
+            ['wstool', 'update', '-j2', '-tpackage_path'], env=mock.ANY,
+            stderr=subprocess.PIPE)
+
+    def test_update_failure(self):
+        def run(args, **kwargs):
+            if args[0:2] == ['wstool', 'update']:
+                raise subprocess.CalledProcessError(1, 'foo', b'bar', b'baz')
+
+        self.check_output_mock.side_effect = run
+
+        raised = self.assertRaises(
+            wstool.WorkspaceUpdateError, self.wstool.update)
+
+        self.assertThat(
+            str(raised), Equals(
+                'Error updating workspace: baz'))
+
+    def test_run(self):
+        wstool = self.wstool
+        wstool._run(['init'])
+
+        class check_env():
+            def __eq__(self, env):
+                return (
+                    env['PATH'] == os.environ['PATH'] + ':' + os.path.join(
+                        wstool._wstool_install_path, 'usr', 'bin') and
+                    env['PYTHONPATH'] == os.path.join(
+                        wstool._wstool_install_path, 'usr', 'lib',
+                        'python2.7', 'dist-packages'))
+
+        self.check_output_mock.assert_called_with(
+            mock.ANY, env=check_env(), stderr=subprocess.PIPE)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently Wstool is a class within the Catkin plugin. However, in order to support recursively parsing rosinstall files (#1714), Wstool needs to undergo some changes. In order to ease that work, extract Wstool into its own module.

Note that I added some basic error handling here, but no other changes have been made.