### PR TITLE
schema: remove underscore from version pattern

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -94,10 +94,10 @@ properties:
     validation-failure:
       "{.instance!r} is not a valid snap version. Snap versions consist of
       upper- and lower-case alphanumeric characters, as well as periods,
-      colons, plus signs, tildes, hyphens, and underscores. They cannot begin
-      with a period, colon, plus sign, tilde, hyphen, or underscore. They
-      cannot end with a period, colon, hyphen, or underscore."
-    pattern: "^[a-zA-Z0-9](?:[a-zA-Z0-9:.+~_-]*[a-zA-Z0-9+~])?$"
+      colons, plus signs, tildes, and hyphens. They cannot begin with a period,
+      colon, plus sign, tilde, or hyphen. They cannot end with a period, colon,
+      or hyphen."
+    pattern: "^[a-zA-Z0-9](?:[a-zA-Z0-9:.+~-]*[a-zA-Z0-9+~])?$"
     maxLength: 32
   version-script:
     type: string

--- a/snapcraft/tests/unit/project_loader/test_config.py
+++ b/snapcraft/tests/unit/project_loader/test_config.py
@@ -861,7 +861,7 @@ parts:
 class ValidVersionTestCase(YamlBaseTestCase):
     scenarios = [
         (version, dict(version=version)) for
-        version in ['buttered-popcorn', '1.2.3', 'v12.4:1:2~', 'HeLlo']
+        version in ['buttered-popcorn', '1.2.3', 'v12.4:1:2~', 'HeLlo', 'v+']
     ]
 
     def test_valid_version(self):
@@ -887,7 +887,7 @@ class InvalidVersionTestCase(YamlBaseTestCase):
         (version, dict(version=version)) for
         version in [
             '*', '', ':v', '.v', '+v', '~v', '_v', '-v', 'v:', 'v.', 'v_',
-            'v-',
+            'v-', 'underscores_are_bad',
         ]
     ]
 
@@ -912,14 +912,13 @@ class InvalidVersionTestCase(YamlBaseTestCase):
 
         self.assertThat(
             raised.message,
-            Equals(
-                "The 'version' property does not match the required schema: "
-                "{!r} is not a valid snap version. Snap versions consist of "
-                "upper- and lower-case alphanumeric characters, as well as "
-                "periods, colons, plus signs, tildes, hyphens, and "
-                "underscores. They cannot begin with a period, colon, plus "
-                "sign, tilde, hyphen, or underscore. They cannot end with a "
-                "period, colon, hyphen, or underscore.".format(self.version)))
+            Equals("The 'version' property does not match the required "
+                   "schema: {!r} is not a valid snap version. Snap versions "
+                   "consist of upper- and lower-case alphanumeric characters, "
+                   "as well as periods, colons, plus signs, tildes, and "
+                   "hyphens. They cannot begin with a period, colon, plus "
+                   "sign, tilde, or hyphen. They cannot end with a period, "
+                   "colon, or hyphen.".format(self.version)))
 
 
 class YamlEncodingsTestCase(YamlBaseTestCase):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

An update from https://forum.snapcraft.io/t/3974, underscores should not be allowed in the version.