### PR TITLE
storeapi: handle errors even for >400 responses

### DIFF
--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import contextlib
 from simplejson.scanner import JSONDecodeError
 from typing import List  # noqa
 
@@ -91,12 +92,12 @@ class SHAMismatchError(StoreError):
 
 class StoreAuthenticationError(StoreError):
 
-    fmt = 'Authentication error: {message}.'
+    fmt = 'Authentication error: {message}'
 
     def __init__(self, message, response=None):
         # Unfortunately the store doesn't give us a consistent error response,
         # so we'll check the ones of which we're aware.
-        if response:
+        with contextlib.suppress(AttributeError, JSONDecodeError):
             response_json = response.json()
             extra_error_message = ''
             if 'error_message' in response_json:

--- a/snapcraft/tests/fake_servers/api.py
+++ b/snapcraft/tests/fake_servers/api.py
@@ -211,6 +211,22 @@ class FakeStoreAPIServer(base.BaseFakeServer):
     # POST
 
     def acl(self, request):
+        content_type = 'application/json'
+
+        if 'packages' in request.json_body:
+            packages = request.json_body['packages']
+            unregistered_package = {
+                'name': 'unregistered-snap-name',
+                'series': '16',
+            }
+            if unregistered_package in packages:
+                return response.Response(
+                    json.dumps({
+                        'error_message': "Snap not found for the given snap "
+                                         "name: 'unregistered-snap-name' and "
+                                         "series: '16'",
+                    }).encode(), 404, [('Content-Type', content_type)])
+
         permission = request.path.split('/')[-1]
         logger.debug(
             'Handling ACL request for {}'.format(permission))
@@ -225,7 +241,6 @@ class FakeStoreAPIServer(base.BaseFakeServer):
             ])
         payload = json.dumps({'macaroon': macaroon.serialize()}).encode()
         response_code = 200
-        content_type = 'application/json'
         return response.Response(
             payload, response_code, [('Content-Type', content_type)])
 

--- a/snapcraft/tests/integration/__init__.py
+++ b/snapcraft/tests/integration/__init__.py
@@ -516,7 +516,7 @@ class StoreTestCase(TestCase):
         else:
             process.expect_exact(
                 'Cannot continue without logging in successfully: '
-                'Authentication error: Failed to get unbound discharge.')
+                'Authentication error: Failed to get unbound discharge')
         process.expect(pexpect.EOF)
         process.close()
         return process.exitstatus

--- a/snapcraft/tests/unit/store/test_store_client.py
+++ b/snapcraft/tests/unit/store/test_store_client.py
@@ -160,6 +160,18 @@ class LoginTestCase(StoreTestCase):
 
         self.assertTrue(config.Config().is_empty())
 
+    def test_failed_login_with_unregistered_snap(self):
+        raised = self.assertRaises(
+            errors.StoreAuthenticationError,
+            self.client.login,
+            'dummy email',
+            'test correct password',
+            packages=[{'name': 'unregistered-snap-name', 'series': '16'}])
+
+        self.assertThat(str(raised), Contains('not found'))
+
+        self.assertTrue(config.Config().is_empty())
+
 
 class DownloadTestCase(StoreTestCase):
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

This PR resolves LP: [#1736963](https://bugs.launchpad.net/snapcraft/+bug/1736963) by showing proper error messages even for responses with error return codes.

The requests lib's Response object overwrites __bool__ to return false if the response code indicates a failure. As a result, if we want to see if a response is actually `None` as must compare directly to `None`. Or just make a call and catch a missing attribute which is what we do here.