### PR TITLE
store: support pushing snap with no architectures

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from contextlib import contextmanager
+import contextlib
 import getpass
 import hashlib
 import json
@@ -65,7 +65,7 @@ def _get_data_from_snap_file(snap_path):
     return snap_yaml
 
 
-@contextmanager
+@contextlib.contextmanager
 def _get_icon_from_snap_file(snap_path):
     icon_file = None
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -198,7 +198,7 @@ def login(*, store: storeapi.StoreClient = None,
     return True
 
 
-@contextmanager
+@contextlib.contextmanager
 def _requires_login():
     try:
         yield
@@ -478,9 +478,12 @@ def push(snap_filename, release_channels=None):
         store.push_precheck(snap_name)
 
     snap_cache = cache.SnapCache(project_name=snap_name)
-    arch = snap_yaml['architectures'][0]
-    source_snap = snap_cache.get(deb_arch=arch)
+    arch = 'all'
 
+    with contextlib.suppress(KeyError):
+        arch = snap_yaml['architectures'][0]
+
+    source_snap = snap_cache.get(deb_arch=arch)
     sha3_384_available = hasattr(hashlib, 'sha3_384')
 
     if sha3_384_available and source_snap:

--- a/snapcraft/internal/cache/_snap.py
+++ b/snapcraft/internal/cache/_snap.py
@@ -52,7 +52,10 @@ class SnapCache(SnapcraftProjectCache):
             ) as yaml_file:
                 snap_yaml = yaml.load(yaml_file)
         # XXX: add multiarch support later
-        return snap_yaml['architectures'][0]
+        try:
+            return snap_yaml['architectures'][0]
+        except KeyError:
+            return 'all'
 
     def _get_snap_cache_path(self, snap_filename):
         snap_hash = file_utils.calculate_sha3_384(snap_filename)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

In response to https://forum.snapcraft.io/t/snapcraft-push-error-keyerror-architectures/4056 . snapd (and the store) interpret this as `architectures: [all]`. Snapcraft isn't the only tool that creates snaps, and needs to stop assuming an optional field is present when pushing.