### PR TITLE
errors: add ability to send stack traces to sentry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pymacaroons==0.9.2; sys_platform != 'win32'
 pymacaroons==0.10.0; sys_platform == 'win32'
 pymacaroons-pynacl==0.9.3
 pysha3==1.0b1; python_version < '3.6'
+raven==6.5.0
 simplejson==3.8.2
 tabulate==0.7.5
 python-debian==0.1.28


### PR DESCRIPTION
Adds the ability to send reports, asking for confirmation before doing
so.

Closes: #1918

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
