### PR TITLE
errors: add ability to send stack traces to sentry

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Build-Depends: bash-completion,
                cpio,
                debhelper (>= 9),
                dh-python,
+               execstack,
                git,
                mercurial,
                p7zip-full,
@@ -48,7 +49,7 @@ Standards-Version: 3.9.8
 
 Package: snapcraft
 Architecture: all
-Depends: binutils,
+Depends: execstack,
          python3-apt,
          python3-debian,
          python3-click,

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pymacaroons==0.9.2; sys_platform != 'win32'
 pymacaroons==0.10.0; sys_platform == 'win32'
 pymacaroons-pynacl==0.9.3
 pysha3==1.0b1; python_version < '3.6'
+raven==6.5.0
 simplejson==3.8.2
 tabulate==0.7.5
 python-debian==0.1.28

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -73,13 +73,31 @@ properties:
     type: string
     description: name of the part that provides source files that will be parsed to extract snap metadata information
   name:
-    type: string
     description: name of the snap package
-    validation-failure:
-      "{.instance!r} is not a valid snap name. Snap names consist of lower-case
-      alphanumeric characters and hyphens. They cannot be all numbers. They
-      also cannot start or end with a hyphen."
-    pattern: "^(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9])*$"
+    allOf:
+      - type: string
+        # this failure message avoids printing repr of the thing, as it could be huge
+        validation-failure: "snap names need to be strings."
+        # string, but too long, is caught by this
+        maxLength: 40
+      - pattern: "^[a-z0-9-]*[a-z][a-z0-9-]*$"
+        validation-failure:
+          "{.instance!r} is not a valid snap name. Snap names can only use ASCII
+          lowercase letters, numbers, and hyphens, and must have at least one
+          letter."
+      - pattern: "^[^-]"
+        validation-failure:
+          "{.instance!r} is not a valid snap name. Snap names cannot start with
+          a hyphen."
+      - pattern: "[^-]$"
+        validation-failure:
+          "{.instance!r} is not a valid snap name. Snap names cannot end with a
+          hyphen."
+      - not:
+          pattern: "--"
+        validation-failure:
+          "{.instance!r} is not a valid snap name. Snap names cannot have two
+          hyphens in a row."
   architectures:
     type: array
     description: architectures to override with

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,7 +35,7 @@ parts:
         - libsodium-dev
         - liblzma-dev
     stage-packages:
-        - binutils
+        - execstack
         - libffi6
         - libsodium18
         - squashfs-tools

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,7 @@ confinement: classic
 apps:
   snapcraft:
     command: bin/snapcraft
+    completer: snapcraft-completion
 
 parts:
   ctypes:

--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -28,10 +28,8 @@ try:
 except ImportError:
     RavenClient = None
 
-_SEND_TO_SENTRY = (
-    'Sorry, Snapcraft had an internal error.\n'
-    'To help us improve, would you like to send error data?'
-)
+_MSG_INTERNAL_ERROR = 'Sorry, Snapcraft had an internal error.'
+_MSG_SEND_TO_SENTRY = 'To help us improve, would you like to send error data?'
 
 
 def exception_handler(exception_type, exception, exception_traceback, *,
@@ -55,12 +53,14 @@ def exception_handler(exception_type, exception, exception_traceback, *,
     exit_code = 1
     is_snapcraft_error = issubclass(exception_type, errors.SnapcraftError)
 
-    if debug or not is_snapcraft_error:
+    if debug:
         traceback.print_exception(
             exception_type, exception, exception_traceback)
 
-    if not is_snapcraft_error and RavenClient is not None:
-        _submit_trace(exception)
+    if not is_snapcraft_error:
+        echo.error('Sorry, Snapcraft had an internal error.')
+        if RavenClient is not None:
+            _submit_trace(exception)
 
     should_print_error = not debug and (
         exception_type != errors.ContainerSnapcraftCmdError)
@@ -78,7 +78,7 @@ def _submit_trace(exception):
         'https://b0fef3e0ced2443c92143ae0d038b0a4:'
         'b7c67d7fa4ee46caae12b29a80594c54@sentry.io/277754',
         transport=RequestsHTTPTransport)
-    if click.confirm(_SEND_TO_SENTRY):
+    if click.confirm(_MSG_SEND_TO_SENTRY):
         try:
             raise exception
         except Exception:

--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -60,7 +60,7 @@ def exception_handler(exception_type, exception, exception_traceback, *,
 
     if not is_snapcraft_error:
         echo.error('Sorry, Snapcraft had an internal error.')
-        if RavenClient is not None and _is_environment_ok():
+        if _is_send_error_data():
             _submit_trace(exception)
 
     should_print_error = not debug and (
@@ -74,9 +74,10 @@ def exception_handler(exception_type, exception, exception_traceback, *,
     sys.exit(exit_code)
 
 
-def _is_environment_ok():
-    send_data = os.environ.get('SNAPCRAFT_SEND_ERROR_DATA', 'y')
-    return send_data == 'y'
+def _is_send_error_data():
+    is_raven_client = RavenClient is not None
+    is_env_send_data = os.environ.get('SNAPCRAFT_SEND_ERROR_DATA', 'y') == 'y'
+    return is_env_send_data and is_raven_client
 
 
 def _submit_trace(exception):

--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import sys
 import traceback
 
@@ -59,7 +60,7 @@ def exception_handler(exception_type, exception, exception_traceback, *,
 
     if not is_snapcraft_error:
         echo.error('Sorry, Snapcraft had an internal error.')
-        if RavenClient is not None:
+        if RavenClient is not None and _is_environment_ok():
             _submit_trace(exception)
 
     should_print_error = not debug and (
@@ -71,6 +72,11 @@ def exception_handler(exception_type, exception, exception_traceback, *,
             echo.error(str(exception))
 
     sys.exit(exit_code)
+
+
+def _is_environment_ok():
+    send_data = os.environ.get('SNAPCRAFT_SEND_ERROR_DATA', 'y')
+    return send_data == 'y'
 
 
 def _submit_trace(exception):

--- a/snapcraft/cli/_runner.py
+++ b/snapcraft/cli/_runner.py
@@ -29,6 +29,7 @@ from .lifecycle import lifecyclecli
 from .store import storecli
 from .parts import partscli
 from .help import helpcli
+from .version import versioncli, SNAPCRAFT_VERSION_TEMPLATE
 from .ci import cicli
 from ._command_group import SnapcraftGroup
 from ._options import add_build_options
@@ -44,11 +45,13 @@ command_groups = [
     helpcli,
     lifecyclecli,
     partscli,
+    versioncli,
 ]
 
 
 @click.group(cls=SnapcraftGroup, invoke_without_command=True)
-@click.version_option(version=snapcraft.__version__)
+@click.version_option(message=SNAPCRAFT_VERSION_TEMPLATE,  # type: ignore
+                      version=snapcraft.__version__)
 @click.pass_context
 @add_build_options(hidden=True)
 @click.option('--debug', '-d', is_flag=True)

--- a/snapcraft/cli/version.py
+++ b/snapcraft/cli/version.py
@@ -13,21 +13,26 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from testtools.matchers import Equals
 
-from . import CommandBaseTestCase
+import click
+
+import snapcraft
+
+SNAPCRAFT_VERSION_TEMPLATE = 'snapcraft, version %(version)s'
 
 
-class VersionCommandTestCase(CommandBaseTestCase):
-    def test_has_version(self):
-        result = self.run_command(['--version'])
-        self.assertThat(result.exit_code, Equals(0))
+@click.group()
+def versioncli():
+    """Version commands"""
+    pass
 
-    def test_has_version_without_hyphens(self):
-        result = self.run_command(['version'])
-        self.assertThat(result.exit_code, Equals(0))
 
-    def test_method_return_same_value(self):
-        result1 = self.run_command(['version'])
-        result2 = self.run_command(['--version'])
-        self.assertEqual(result1.output, result2.output)
+@versioncli.command('version')
+def version():
+    """Obtain snapcraft's version number.
+
+    Examples:
+        snapcraft version
+        snapcraft --version
+    """
+    click.echo(SNAPCRAFT_VERSION_TEMPLATE % {'version': snapcraft.__version__})

--- a/snapcraft/extractors/_metadata.py
+++ b/snapcraft/extractors/_metadata.py
@@ -26,14 +26,13 @@ class ExtractedMetadata(yaml.YAMLObject):
     def __init__(
             self, *, summary: str='',
             description: str='', icon: str='',
-            desktop_file_ids: List[str]=None) -> None:
+            desktop_file_paths: List[str]=None) -> None:
         """Create a new ExtractedMetadata instance.
 
         :param str summary: Extracted summary
         :param str description: Extracted description
         :param str icon: Extracted icon
-        :param dict desktop_file_ids: Extracted desktop file ids, as defined in
-            https://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#desktop-file-id
+        :param list desktop_file_paths: Extracted desktop file paths
         """  # noqa
 
         self._data = {}  # type: Dict[str, Union[str, List[str]]]
@@ -44,8 +43,8 @@ class ExtractedMetadata(yaml.YAMLObject):
             self._data['description'] = description
         if icon:
             self._data['icon'] = icon
-        if desktop_file_ids:
-            self._data['desktop_file_ids'] = desktop_file_ids
+        if desktop_file_paths:
+            self._data['desktop_file_paths'] = desktop_file_paths
 
     def update(self, other: 'ExtractedMetadata') -> None:
         """Update this metadata with other metadata.
@@ -84,14 +83,14 @@ class ExtractedMetadata(yaml.YAMLObject):
         icon = self._data.get('icon')
         return str(icon) if icon else None
 
-    def get_desktop_file_ids(self) -> List[str]:
-        """Return extracted desktop files ids.
+    def get_desktop_file_paths(self) -> List[str]:
+        """Return extracted desktop files paths.
 
-        :returns: Extracted desktop files ids
+        :returns: Extracted desktop files paths
         :rtype: list
         """
-        desktop_file_ids = self._data.get('desktop_file_ids')
-        return list(desktop_file_ids) if desktop_file_ids else None
+        desktop_file_paths = self._data.get('desktop_file_paths')
+        return list(desktop_file_paths) if desktop_file_paths else None
 
     def to_dict(self) -> Dict[str, Union[str, List[str]]]:
         """Return all extracted metadata.

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -159,12 +159,19 @@ class ElfFile:
         """
         self.path = path
         self.dependencies = set()  # type: Set[Library]
-        self.interp, self.soname, self.needed = self._extract(path)
+        elf_data = self._extract(path)
+        self.interp = elf_data[0]
+        self.soname = elf_data[1]
+        self.needed = elf_data[2]
+        self.execstack_set = elf_data[3]
 
-    def _extract(self, path) -> Tuple[str, str, Dict[str, NeededLibrary]]:
+    def _extract(self, path):  # noqa: C901
+        # type: (str) -> Tuple[str, str, Dict[str, NeededLibrary], bool]
         interp = str()
         soname = str()
         libs = dict()
+        execstack_set = False
+
         with open(path, 'rb') as fp:
             elf = elftools.elf.elffile.ELFFile(fp)
 
@@ -198,7 +205,16 @@ class ElfFile:
                     lib = libs[library_name]
                     for version in versions:
                         lib.add_version(_ensure_str(version.name))
-        return interp, soname, libs
+
+            for segment in elf.iter_segments():
+                if segment['p_type'] == 'PT_GNU_STACK':
+                    # p_flags holds the bit mask for this segment.
+                    # See `man 5 elf`.
+                    mode = segment['p_flags']
+                    if mode & elftools.elf.constants.P_FLAGS.PF_X:
+                        execstack_set = True
+
+        return interp, soname, libs, execstack_set
 
     def is_linker_compatible(self, *, linker: str) -> bool:
         """Determines if linker will work given the required glibc version.

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -217,7 +217,8 @@ class ElfFile:
         linker_version = m.group('linker_version')
         r = parse_version(version_required) <= parse_version(linker_version)
         logger.debug('Checking if linker {!r} will work with '
-                     'GLIBC_{}: {!r}'.format(linker, version_required, r))
+                     'GLIBC_{} required by {!r}: {!r}'.format(
+                         linker, version_required, self.path, r))
         return r
 
     def get_required_glibc(self) -> str:
@@ -531,10 +532,10 @@ def _get_system_libs() -> FrozenSet[str]:
         logger.debug('Only excluding libc libraries from the release')
         libc6_libs = [os.path.basename(l)
                       for l in repo.Repo.get_package_libraries('libc6')]
-        return frozenset(libc6_libs)
-
-    with open(lib_path) as fn:
-        _libraries = frozenset(fn.read().split())
+        _libraries = frozenset(libc6_libs)
+    else:
+        with open(lib_path) as fn:
+            _libraries = frozenset(fn.read().split())
 
     return _libraries
 

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -503,7 +503,7 @@ class _SnapPackaging:
             if os.path.splitext(f)[1] == '.desktop':
                 os.remove(os.path.join(gui_dir, f))
         for app in apps:
-            adapter = apps[app].get('adapter', '')
+            adapter = apps[app].pop('adapter', '')
             if adapter != 'none':
                 self._wrap_app(app, apps[app])
             self._generate_desktop_file(app, apps[app])

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -148,27 +148,23 @@ def _adopt_info(
         extracted_metadata: _metadata.ExtractedMetadata):
     metadata_dict = extracted_metadata.to_dict()
     for key, value in metadata_dict.items():
-        # desktop_file_ids are a special case that will be handled
+        # desktop_file_paths are a special case that will be handled
         # after all the top level snapcraft.yaml keys.
-        if key != 'desktop_file_ids' and key not in config_data:
+        if key != 'desktop_file_paths' and key not in config_data:
             if key == 'icon':
                 if _icon_file_exists() or not os.path.exists(
                         str(value)):
                     # Do not overwrite the icon file.
                     continue
             config_data[key] = value
-    if 'desktop_file_ids' in metadata_dict:
-        for desktop_file_id in metadata_dict['desktop_file_ids']:
-            app_name = _get_app_name_from_desktop_file_id(
-                config_data, desktop_file_id)
+    if 'desktop_file_paths' in metadata_dict:
+        for desktop_file_path in metadata_dict['desktop_file_paths']:
+            app_name = _get_app_name_from_desktop_file_path(
+                config_data, desktop_file_path)
             if app_name and not _desktop_file_exists(app_name):
-                for xdg_data_dir in ('usr/local/share', 'usr/share'):
-                    desktop_file_path = os.path.join(
-                        xdg_data_dir, 'applications',
-                        desktop_file_id.replace('-', '/'))
-                    if os.path.exists(desktop_file_path):
-                        config_data['apps'][app_name]['desktop'] = (
-                            desktop_file_path)
+                if os.path.exists(desktop_file_path):
+                    config_data['apps'][app_name]['desktop'] = (
+                        desktop_file_path)
 
 
 def _icon_file_exists() -> bool:
@@ -190,31 +186,32 @@ def _icon_file_exists() -> bool:
         return False
 
 
-def _get_app_name_from_desktop_file_id(
-        config_data: Dict[str, Any], desktop_file_id: str) -> str:
-    """Get the snap app name from a desktop file ID.
+def _get_app_name_from_desktop_file_path(
+        config_data: Dict[str, Any], desktop_file_path: str) -> str:
+    """Get the snap app name from a desktop file path.
 
-    Desktop file IDs are defined in
-    https://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#desktop-file-id
-
-    XXX We try to find a match between desktop file id and snap app name.
+    XXX We try to find a match between desktop file path and snap app name.
     This will be much nicer once snapcraft supports appstream IDs:
     https://forum.snapcraft.io/t/support-for-appstream-id/2327
     --elopio - 20180108
 
-    :params desktop_file_id: The identifier of the desktop file.
+    :params desktop_file_path: The path to the desktop file.
     :returns: The name of the snap app that corresponds to the desktop file.
 
-    """  # noqa
-    desktop_file_id_parts = desktop_file_id.split('.')
-    if desktop_file_id_parts[-1] == 'desktop':
-        desktop_file_id_parts = desktop_file_id_parts[:-1]
-    app_id = desktop_file_id_parts[-1]
-    if ('apps' in config_data and
-            app_id in config_data['apps'].keys()):
-        return app_id
-    else:
-        return None
+    """
+    if 'applications' in desktop_file_path:
+        desktop_file_id = desktop_file_path[
+            desktop_file_path.find('applications') +
+            len('applications') + 1:
+        ].replace('/', '-')
+        desktop_file_id_parts = desktop_file_id.split('.')
+        if desktop_file_id_parts[-1] == 'desktop':
+            desktop_file_id_parts = desktop_file_id_parts[:-1]
+            app_id = desktop_file_id_parts[-1]
+            if ('apps' in config_data and
+                    app_id in config_data['apps'].keys()):
+                return app_id
+    return None
 
 
 def _desktop_file_exists(app_name: str) -> bool:

--- a/snapcraft/internal/pluginhandler/_build_attributes.py
+++ b/snapcraft/internal/pluginhandler/_build_attributes.py
@@ -22,3 +22,6 @@ class BuildAttributes:
 
     def no_system_libraries(self):
         return 'no-system-libraries' in self._attributes
+
+    def keep_execstack(self):
+        return 'keep-execstack' in self._attributes

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -154,6 +154,32 @@ class _AptCache:
 
         return _get_local_sources_list()
 
+    def fetch_binary(self, *, package_candidate, destination: str) -> None:
+        # This is a workaround for the overly verbose python-apt we use.
+        # There is an unreleased patch which once released could replace
+        # this code https://salsa.debian.org/apt-team/python-apt/commit/d122f9142df614dbb5f7644112280140dc155ecc  # noqa
+        # What follows is almost a tit for tat implementation of upstream's
+        # fetch_binary logic.
+        base = os.path.basename(package_candidate._records.filename)
+        destfile = os.path.join(destination, base)
+        if apt.package._file_is_same(destfile, package_candidate.size,
+                                     package_candidate._records.md5_hash):
+            logging.debug('Ignoring already existing file: {}'.format(
+                destfile))
+            return os.path.abspath(destfile)
+        acq = apt.apt_pkg.Acquire(self.progress)
+        acqfile = apt.apt_pkg.AcquireFile(
+            acq, package_candidate.uri, package_candidate._records.md5_hash,
+            package_candidate.size, base, destfile=destfile)
+        acq.run()
+
+        if acqfile.status != acqfile.STAT_DONE:
+            raise apt.package.FetchError(
+                "The item %r could not be fetched: %s" %
+                (acqfile.destfile, acqfile.error_text))
+
+        return os.path.abspath(destfile)
+
 
 class Ubuntu(BaseRepo):
 
@@ -362,8 +388,9 @@ class Ubuntu(BaseRepo):
         pkg_list = []
         for package in apt_cache.get_changes():
             pkg_list.append(str(package.candidate))
-            source = package.candidate.fetch_binary(
-                self._cache.packages_dir, progress=self._apt.progress)
+            source = self._apt.fetch_binary(
+                package_candidate=package.candidate,
+                destination=self._cache.packages_dir)
             destination = os.path.join(
                 self._downloaddir, os.path.basename(source))
             with contextlib.suppress(FileNotFoundError):

--- a/tests/bin/elf/execstack
+++ b/tests/bin/elf/execstack
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+def main():
+    basename = os.path.basename(sys.argv[-1])
+    exit_code = 0
+    if basename == 'fake_elf-with-bad-execstack':
+        exit_code = 1
+    elif basename == 'fake_elf-with-execstack':
+        open('{}.execstack'.format(sys.argv[-1]), 'w').close()
+    sys.exit(exit_code)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/fixture_setup.py
+++ b/tests/fixture_setup.py
@@ -874,6 +874,16 @@ class FakeAptCache(fixtures.Fixture):
         for package, version in self.packages:
             self.add_package(FakeAptCachePackage(package, version))
 
+        def fetch_binary(package_candidate, destination):
+            path = os.path.join(self.path, package_candidate.name)
+            open(path, 'w').close()
+            return path
+
+        patcher = mock.patch('snapcraft.repo._deb._AptCache.fetch_binary')
+        mock_fetch_binary = patcher.start()
+        mock_fetch_binary.side_effect = fetch_binary
+        self.addCleanup(patcher.stop)
+
         # Add all the packages in the manifest.
         with open(os.path.abspath(
                 os.path.join(
@@ -939,11 +949,6 @@ class FakeAptCachePackage():
 
     def mark_keep(self):
         pass
-
-    def fetch_binary(self, dir_, progress):
-        path = os.path.join(self.temp_dir, self.name)
-        open(path, 'w').close()
-        return path
 
     def get_dependencies(self, _):
         return []

--- a/tests/fixture_setup.py
+++ b/tests/fixture_setup.py
@@ -1116,23 +1116,31 @@ def _fake_elffile_extract(self, path):
         glibc = elf.NeededLibrary(name='libc.so.6')
         glibc.add_version('GLIBC_2.2.5')
         glibc.add_version('GLIBC_2.26')
-        return '/lib64/ld-linux-x86-64.so.2', '', {glibc.name: glibc}
+        return '/lib64/ld-linux-x86-64.so.2', '', {glibc.name: glibc}, False
     elif name == 'fake_elf-2.23':
         glibc = elf.NeededLibrary(name='libc.so.6')
         glibc.add_version('GLIBC_2.2.5')
         glibc.add_version('GLIBC_2.23')
-        return '/lib64/ld-linux-x86-64.so.2', '', {glibc.name: glibc}
+        return '/lib64/ld-linux-x86-64.so.2', '', {glibc.name: glibc}, False
     elif name == 'fake_elf-1.1':
         glibc = elf.NeededLibrary(name='libc.so.6')
         glibc.add_version('GLIBC_1.1')
         glibc.add_version('GLIBC_0.1')
-        return '/lib64/ld-linux-x86-64.so.2', '', {glibc.name: glibc}
+        return '/lib64/ld-linux-x86-64.so.2', '', {glibc.name: glibc}, False
     elif name == 'fake_elf-static':
-        return '', '', {}
+        return '', '', {}, False
     elif name == 'fake_elf-shared-object':
         openssl = elf.NeededLibrary(name='libssl.so.1.0.0')
         openssl.add_version('OPENSSL_1.0.0')
-        return '', 'libfake_elf.so.0', {openssl.name: openssl}
+        return '', 'libfake_elf.so.0', {openssl.name: openssl}, False
+    elif name == 'fake_elf-with-execstack':
+        glibc = elf.NeededLibrary(name='libc.so.6')
+        glibc.add_version('GLIBC_2.23')
+        return '/lib64/ld-linux-x86-64.so.2', '', {glibc.name: glibc}, True
+    elif name == 'fake_elf-with-bad-execstack':
+        glibc = elf.NeededLibrary(name='libc.so.6')
+        glibc.add_version('GLIBC_2.23')
+        return '/lib64/ld-linux-x86-64.so.2', '', {glibc.name: glibc}, True
 
 
 class FakeElf(fixtures.Fixture):
@@ -1161,7 +1169,7 @@ class FakeElf(fixtures.Fixture):
         self.useFixture(fixtures.EnvironmentVariable('PATH', new_path))
 
         # Copy strip
-        for f in ['strip']:
+        for f in ['strip', 'execstack']:
             shutil.copy(os.path.join(binaries_path, f),
                         os.path.join(new_binaries_path, f))
             os.chmod(os.path.join(new_binaries_path, f), 0o755)
@@ -1204,6 +1212,11 @@ class FakeElf(fixtures.Fixture):
                 path=os.path.join(self.root_path, 'fake_elf-bad-patchelf')),
             'fake_elf-with-core-libs': elf.ElfFile(
                 path=os.path.join(self.root_path, 'fake_elf-with-core-libs')),
+            'fake_elf-with-execstack': elf.ElfFile(
+                path=os.path.join(self.root_path, 'fake_elf-with-execstack')),
+            'fake_elf-with-bad-execstack': elf.ElfFile(
+                path=os.path.join(self.root_path,
+                                  'fake_elf-with-bad-execstack')),
         }
 
         for elf_file in self._elf_files.values():

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -92,6 +92,10 @@ class TestCase(testtools.TestCase):
             'XDG_DATA_HOME', os.path.join(self.path, 'data')))
         self.useFixture(fixtures.EnvironmentVariable('TERM', 'dumb'))
 
+        # Do not send crash reports
+        self.useFixture(fixtures.EnvironmentVariable(
+            'SNAPCRAFT_SEND_ERROR_DATA', 'n'))
+
         patcher = mock.patch(
             'xdg.BaseDirectory.xdg_config_home',
             new=os.path.join(self.path, '.config'))

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -73,8 +73,11 @@ class TestCase(testtools.TestCase):
 
         if os.getenv('SNAPCRAFT_FROM_SNAP', False):
             self.patchelf_command = '/snap/snapcraft/current/bin/patchelf'
+            self.execstack_command = (
+                '/snap/snapcraft/current/usr/sbin/execstack')
         else:
             self.patchelf_command = 'patchelf'
+            self.execstack_command = 'execstack'
 
         self.snaps_dir = os.path.join(os.path.dirname(__file__), 'snaps')
         temp_cwd_fixture = fixture_setup.TempCWD()

--- a/tests/integration/general/test_prime.py
+++ b/tests/integration/general/test_prime.py
@@ -168,6 +168,24 @@ class PrimeTestCase(integration.TestCase):
         self.assertThat(
             self._prime_invalid_part(True), Contains("Traceback"))
 
+    def test_clear_execstack(self):
+        self.run_snapcraft('prime', 'execstack')
+
+        stage_bin_path = os.path.join('stage', 'bin', 'test')
+        stage_bin_query = subprocess.check_output([
+            self.execstack_command, '--query',
+            stage_bin_path]).decode().strip()
+        # 'X' means the executable stack is required. See `man 8 execstack`.
+        self.assertThat(stage_bin_query, Equals('X {}'.format(stage_bin_path)))
+
+        prime_bin_path = os.path.join('prime', 'bin', 'test')
+        prime_bin_query = subprocess.check_output([
+            self.execstack_command, '--query',
+            prime_bin_path]).decode().strip()
+        # '-' means the executable stack is not required.
+        # See `man 8 execstack`.
+        self.assertThat(prime_bin_query, Equals('- {}'.format(prime_bin_path)))
+
 
 class PrimedAssetsTestCase(testscenarios.WithScenarios,
                            integration.TestCase):

--- a/tests/integration/general/test_snap.py
+++ b/tests/integration/general/test_snap.py
@@ -80,10 +80,34 @@ class SnapTestCase(integration.TestCase):
                          'command-binary-wrapper-none.wrapper.wrapper'),
             Not(FileExists()))
 
+        # LP: #1750658
+        self.assertThat(
+            os.path.join(self.prime_dir, 'meta', 'snap.yaml'),
+            FileContains(dedent("""\
+                name: assemble
+                version: 1.0
+                summary: one line summary
+                description: a longer description
+                architectures:
+                - amd64
+                confinement: strict
+                grade: stable
+                apps:
+                  assemble-bin:
+                    command: command-assemble-bin.wrapper
+                  assemble-service:
+                    command: command-assemble-service.wrapper
+                    daemon: simple
+                    stop-command: stop-command-assemble-service.wrapper
+                  binary-wrapper-none:
+                    command: subdir/binary3
+                  binary2:
+                    command: command-binary2.wrapper
+            """)))
+
     def test_snap_default(self):
         self.copy_project_to_cwd('assemble')
         self.run_snapcraft([])
-
         snap_file_path = 'assemble_1.0_{}.snap'.format(self.deb_arch)
         self.assertThat(snap_file_path, FileExists())
 

--- a/tests/integration/snaps/execstack/Makefile
+++ b/tests/integration/snaps/execstack/Makefile
@@ -1,0 +1,10 @@
+# -*- Mode: Makefile; indent-tabs-mode:t; tab-width: 4 -*-
+
+all:
+	gcc -o test test.c
+
+install:
+	execstack --set-execstack test
+	install -d $(DESTDIR)/bin
+	install test $(DESTDIR)/bin/
+	

--- a/tests/integration/snaps/execstack/snapcraft.yaml
+++ b/tests/integration/snaps/execstack/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: execstack
+version: 0.1
+summary: execstat test
+description: |
+  Create a binary with the execstat bit set, which should be cleared
+  when priming
+confinement: strict
+
+build-packages: [gcc, libc6-dev, execstack]
+
+apps:
+  make-hello:
+    command: test
+
+parts:
+  make-project:
+    plugin: make
+    source: .

--- a/tests/integration/snaps/execstack/test.c
+++ b/tests/integration/snaps/execstack/test.c
@@ -1,0 +1,4 @@
+#include <stdio.h>
+int main() {
+    printf("Hello world\n");
+}

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -857,7 +857,8 @@ class StateTestCase(StateBaseTestCase):
                 summary='test summary',
                 description='test description',
                 icon='/test/path',
-                desktop_file_ids=['com.example.test-app.desktop']
+                desktop_file_paths=[
+                    'usr/share/applications/com.example.test/app.desktop']
             )
 
         self.useFixture(fixture_setup.FakeMetadataExtractor(
@@ -892,8 +893,8 @@ class StateTestCase(StateBaseTestCase):
         self.assertThat(metadata.get_description(), Equals('test description'))
         self.assertThat(metadata.get_icon(), Equals('/test/path'))
         self.assertThat(
-            metadata.get_desktop_file_ids(),
-            Equals(['com.example.test-app.desktop']))
+            metadata.get_desktop_file_paths(),
+            Equals(['usr/share/applications/com.example.test/app.desktop']))
         files = state.extracted_metadata['files']
         self.assertThat(files, Equals(['metadata-file']))
 
@@ -963,7 +964,8 @@ class StateTestCase(StateBaseTestCase):
                 summary='test summary',
                 description='test description',
                 icon='/test/path',
-                desktop_file_ids=['com.example.test-app.desktop'])
+                desktop_file_paths=[
+                    'usr/share/applications/com.example.test/app.desktop'])
 
         self.useFixture(fixture_setup.FakeMetadataExtractor(
             'fake', _fake_extractor))
@@ -995,8 +997,8 @@ class StateTestCase(StateBaseTestCase):
         self.assertThat(metadata.get_description(), Equals('test description'))
         self.assertThat(metadata.get_icon(), Equals('/test/path'))
         self.assertThat(
-            metadata.get_desktop_file_ids(),
-            Equals(['com.example.test-app.desktop']))
+            metadata.get_desktop_file_paths(),
+            Equals(['usr/share/applications/com.example.test/app.desktop']))
         files = state.extracted_metadata['files']
         self.assertThat(files, Equals(['metadata-file']))
 

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -1243,7 +1243,7 @@ class StateTestCase(StateBaseTestCase):
         self.assertThat(len(state.project_options), Equals(0))
 
     @patch('snapcraft.internal.elf.ElfFile._extract',
-           return_value=('EXEC', '', dict()))
+           return_value=('EXEC', '', dict(), False))
     @patch('snapcraft.internal.elf.ElfFile.load_dependencies')
     @patch('snapcraft.internal.pluginhandler._migrate_files')
     def test_prime_state_with_dependencies(self, mock_migrate_files,
@@ -1301,7 +1301,7 @@ class StateTestCase(StateBaseTestCase):
         self.assertThat(len(state.project_options), Equals(0))
 
     @patch('snapcraft.internal.elf.ElfFile._extract',
-           return_value=('EXEC', '', dict()))
+           return_value=('EXEC', '', dict(), False))
     @patch('snapcraft.internal.elf.ElfFile.load_dependencies')
     @patch('snapcraft.internal.pluginhandler._migrate_files')
     def test_prime_state_disable_ldd_crawl(self, mock_migrate_files,
@@ -1353,7 +1353,7 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue('lib2' in state.dependency_paths)
 
     @patch('snapcraft.internal.elf.ElfFile._extract',
-           return_value=('EXEC', '', dict()))
+           return_value=('EXEC', '', dict(), False))
     @patch('snapcraft.internal.elf.ElfFile.load_dependencies',
            return_value=set(['/foo/bar/baz']))
     @patch('snapcraft.internal.pluginhandler._migrate_files')

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -67,8 +67,12 @@ class UbuntuTestCase(RepoBaseTestCase):
         self.assertThat(name, Equals('hello'))
         self.assertThat(version, Equals('2.10-1'))
 
+    @patch('snapcraft.internal.repo._deb._AptCache.fetch_binary')
     @patch('snapcraft.internal.repo._deb.apt.apt_pkg')
-    def test_get_package(self, mock_apt_pkg):
+    def test_get_package(self, mock_apt_pkg, mock_fetch_binary):
+        fake_package_path = os.path.join(self.path, 'fake-package.deb')
+        open(fake_package_path, 'w').close()
+        mock_fetch_binary.return_value = fake_package_path
         self.mock_cache().is_virtual_package.return_value = False
 
         project_options = snapcraft.ProjectOptions(
@@ -96,18 +100,18 @@ class UbuntuTestCase(RepoBaseTestCase):
             self.mock_cache.return_value.__getitem__.call_args_list,
             Contains(call('fake-package')))
 
-        self.mock_package.assert_has_calls([
-            call.candidate.fetch_binary(ANY, progress=ANY)
-        ])
-
         # Verify that the package was actually fetched and copied into the
         # requested location.
         self.assertThat(
             os.path.join(self.tempdir, 'download', 'fake-package.deb'),
             FileExists())
 
-    @patch('snapcraft.repo._deb.apt.apt_pkg')
-    def test_get_multiarch_package(self, mock_apt_pkg):
+    @patch('snapcraft.internal.repo._deb._AptCache.fetch_binary')
+    @patch('snapcraft.internal.repo._deb.apt.apt_pkg')
+    def test_get_multiarch_package(self, mock_apt_pkg, mock_fetch_binary):
+        fake_package_path = os.path.join(self.path, 'fake-package.deb')
+        open(fake_package_path, 'w').close()
+        mock_fetch_binary.return_value = fake_package_path
         self.mock_cache().is_virtual_package.return_value = False
 
         project_options = snapcraft.ProjectOptions(
@@ -133,10 +137,6 @@ class UbuntuTestCase(RepoBaseTestCase):
         self.assertThat(
             self.mock_cache.return_value.__getitem__.call_args_list,
             Contains(call('fake-package:arch')))
-
-        self.mock_package.assert_has_calls([
-            call.candidate.fetch_binary(ANY, progress=ANY)
-        ])
 
         # Verify that the package was actually fetched and copied into the
         # requested location.

--- a/tests/unit/test_elf.py
+++ b/tests/unit/test_elf.py
@@ -281,6 +281,18 @@ class TestGetElfFiles(TestElfBase):
                                       {'fake_elf-static'})
         self.assertThat(elf_files, Equals(set()))
 
+    def test_elf_with_execstack(self):
+        elf_files = elf.get_elf_files(self.fake_elf.root_path,
+                                      {'fake_elf-with-execstack'})
+        elf_file = set(elf_files).pop()
+        self.assertThat(elf_file.execstack_set, Equals(True))
+
+    def test_elf_without_execstack(self):
+        elf_files = elf.get_elf_files(self.fake_elf.root_path,
+                                      {'fake_elf-2.23'})
+        elf_file = set(elf_files).pop()
+        self.assertThat(elf_file.execstack_set, Equals(False))
+
     def test_non_elf_files(self):
         with open(os.path.join(
                 self.fake_elf.root_path, 'non-elf'), 'wb') as f:

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -627,7 +627,8 @@ class MetadataFromSourceWithDesktopFileTestCase(
 
         def _fake_extractor(file_path):
             return extractors.ExtractedMetadata(
-                desktop_file_ids=['com.example.test-app.desktop'])
+                desktop_file_paths=[
+                    'usr/share/applications/com.example.test/app.desktop'])
 
         self.useFixture(fixture_setup.FakeMetadataExtractor(
             'fake', _fake_extractor))


### PR DESCRIPTION
Adds the ability to send reports, asking for confirmation before doing
so. This feature is only enabled for the deb as raven is not provided in
`xenial` and most of the user base will be using the snap.

Closes: #1918

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
