### PR TITLE
repo: silence deb caching when fetching packages

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -381,17 +381,19 @@ class Ubuntu(BaseRepo):
         destfile = os.path.join(self._cache.packages_dir, base)
         if apt.package._file_is_same(destfile, package_candidate.size,
                                      package_candidate._records.md5_hash):
-            logging.debug('Ignoring already existing file: {}'.format(destfile))
+            logging.debug('Ignoring already existing file: {}'.format(
+                destfile))
             return os.path.abspath(destfile)
-        acq = apt_pkg.Acquire(progress)
-        acqfile = apt_pkg.AcquireFile(
+        acq = apt.apt_pkg.Acquire(self.progress)
+        acqfile = apt.apt_pkg.AcquireFile(
             acq, package_candidate.uri, package_candidate._records.md5_hash,
             package_candidate.size, base, destfile=destfile)
         acq.run()
 
         if acqfile.status != acqfile.STAT_DONE:
-            raise FetchError("The item %r could not be fetched: %s" %
-                             (acqfile.destfile, acqfile.error_text))
+            raise apt.apt_pkgFetchError(
+                "The item %r could not be fetched: %s" %
+                (acqfile.destfile, acqfile.error_text))
 
     def unpack(self, unpackdir):
         pkgs_abs_path = glob.glob(os.path.join(self._downloaddir, '*.deb'))

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -384,7 +384,7 @@ class Ubuntu(BaseRepo):
             logging.debug('Ignoring already existing file: {}'.format(
                 destfile))
             return os.path.abspath(destfile)
-        acq = apt.apt_pkg.Acquire(self.progress)
+        acq = apt.apt_pkg.Acquire(self._apt.progress)
         acqfile = apt.apt_pkg.AcquireFile(
             acq, package_candidate.uri, package_candidate._records.md5_hash,
             package_candidate.size, base, destfile=destfile)

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -362,8 +362,7 @@ class Ubuntu(BaseRepo):
         pkg_list = []
         for package in apt_cache.get_changes():
             pkg_list.append(str(package.candidate))
-            source = package.candidate.fetch_binary(
-                self._cache.packages_dir, progress=self._apt.progress)
+            source = self._fetch_binary(package.candidate)
             destination = os.path.join(
                 self._downloaddir, os.path.basename(source))
             with contextlib.suppress(FileNotFoundError):
@@ -371,6 +370,28 @@ class Ubuntu(BaseRepo):
             file_utils.link_or_copy(source, destination)
 
         return pkg_list
+
+    def _fetch_binary(self, package_candidate):
+        # This is a workaround for the overly verbose python-apt we use.
+        # There is an unreleased patch which once released could replace
+        # this code https://salsa.debian.org/apt-team/python-apt/commit/d122f9142df614dbb5f7644112280140dc155ecc  # noqa
+        # What follows is almost a tit for tat implementation of upstream's
+        # fetch_binary logic.
+        base = os.path.basename(package_candidate._records.filename)
+        destfile = os.path.join(self._cache.packages_dir, base)
+        if apt.package._file_is_same(destfile, package_candidate.size,
+                                     package_candidate._records.md5_hash):
+            logging.debug('Ignoring already existing file: {}'.format(destfile))
+            return os.path.abspath(destfile)
+        acq = apt_pkg.Acquire(progress)
+        acqfile = apt_pkg.AcquireFile(
+            acq, package_candidate.uri, package_candidate._records.md5_hash,
+            package_candidate.size, base, destfile=destfile)
+        acq.run()
+
+        if acqfile.status != acqfile.STAT_DONE:
+            raise FetchError("The item %r could not be fetched: %s" %
+                             (acqfile.destfile, acqfile.error_text))
 
     def unpack(self, unpackdir):
         pkgs_abs_path = glob.glob(os.path.join(self._downloaddir, '*.deb'))

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -178,6 +178,8 @@ class _AptCache:
                 "The item %r could not be fetched: %s" %
                 (acqfile.destfile, acqfile.error_text))
 
+        return os.path.abspath(destfile)
+
 
 class Ubuntu(BaseRepo):
 

--- a/tests/fixture_setup.py
+++ b/tests/fixture_setup.py
@@ -874,6 +874,16 @@ class FakeAptCache(fixtures.Fixture):
         for package, version in self.packages:
             self.add_package(FakeAptCachePackage(package, version))
 
+        def fetch_binary(package_candidate, destination):
+            path = os.path.join(self.path, package_candidate.name)
+            open(path, 'w').close()
+            return path
+
+        patcher = mock.patch('snapcraft.repo._deb._AptCache.fetch_binary')
+        mock_fetch_binary = patcher.start()
+        mock_fetch_binary.side_effect = fetch_binary
+        self.addCleanup(patcher.stop)
+
         # Add all the packages in the manifest.
         with open(os.path.abspath(
                 os.path.join(
@@ -939,11 +949,6 @@ class FakeAptCachePackage():
 
     def mark_keep(self):
         pass
-
-    def fetch_binary(self, dir_, progress):
-        path = os.path.join(self.temp_dir, self.name)
-        open(path, 'w').close()
-        return path
 
     def get_dependencies(self, _):
         return []

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -67,8 +67,12 @@ class UbuntuTestCase(RepoBaseTestCase):
         self.assertThat(name, Equals('hello'))
         self.assertThat(version, Equals('2.10-1'))
 
+    @patch('snapcraft.internal.repo._deb._AptCache.fetch_binary')
     @patch('snapcraft.internal.repo._deb.apt.apt_pkg')
-    def test_get_package(self, mock_apt_pkg):
+    def test_get_package(self, mock_apt_pkg, mock_fetch_binary):
+        fake_package_path = os.path.join(self.path, 'fake-package.deb')
+        open(fake_package_path, 'w').close()
+        mock_fetch_binary.return_value = fake_package_path
         self.mock_cache().is_virtual_package.return_value = False
 
         project_options = snapcraft.ProjectOptions(
@@ -96,18 +100,18 @@ class UbuntuTestCase(RepoBaseTestCase):
             self.mock_cache.return_value.__getitem__.call_args_list,
             Contains(call('fake-package')))
 
-        self.mock_package.assert_has_calls([
-            call.candidate.fetch_binary(ANY, progress=ANY)
-        ])
-
         # Verify that the package was actually fetched and copied into the
         # requested location.
         self.assertThat(
             os.path.join(self.tempdir, 'download', 'fake-package.deb'),
             FileExists())
 
-    @patch('snapcraft.repo._deb.apt.apt_pkg')
-    def test_get_multiarch_package(self, mock_apt_pkg):
+    @patch('snapcraft.internal.repo._deb._AptCache.fetch_binary')
+    @patch('snapcraft.internal.repo._deb.apt.apt_pkg')
+    def test_get_multiarch_package(self, mock_apt_pkg, mock_fetch_binary):
+        fake_package_path = os.path.join(self.path, 'fake-package.deb')
+        open(fake_package_path, 'w').close()
+        mock_fetch_binary.return_value = fake_package_path
         self.mock_cache().is_virtual_package.return_value = False
 
         project_options = snapcraft.ProjectOptions(
@@ -133,10 +137,6 @@ class UbuntuTestCase(RepoBaseTestCase):
         self.assertThat(
             self.mock_cache.return_value.__getitem__.call_args_list,
             Contains(call('fake-package:arch')))
-
-        self.mock_package.assert_has_calls([
-            call.candidate.fetch_binary(ANY, progress=ANY)
-        ])
 
         # Verify that the package was actually fetched and copied into the
         # requested location.


### PR DESCRIPTION
Fetching packages is overly verbose. While there is an
upstream fix for this, it hasn't been yet released.

Reimplement fetch_binary locally without the noise
mimicking upstream as much as possible.

LP: #1663365

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
