### PR TITLE
elf: better debug messages

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -217,7 +217,8 @@ class ElfFile:
         linker_version = m.group('linker_version')
         r = parse_version(version_required) <= parse_version(linker_version)
         logger.debug('Checking if linker {!r} will work with '
-                     'GLIBC_{}: {!r}'.format(linker, version_required, r))
+                     'GLIBC_{} required by {!r}: {!r}'.format(
+                         linker, version_required, self.path, r))
         return r
 
     def get_required_glibc(self) -> str:
@@ -531,10 +532,10 @@ def _get_system_libs() -> FrozenSet[str]:
         logger.debug('Only excluding libc libraries from the release')
         libc6_libs = [os.path.basename(l)
                       for l in repo.Repo.get_package_libraries('libc6')]
-        return frozenset(libc6_libs)
-
-    with open(lib_path) as fn:
-        _libraries = frozenset(fn.read().split())
+        _libraries = frozenset(libc6_libs)
+    else:
+        with open(lib_path) as fn:
+            _libraries = frozenset(fn.read().split())
 
     return _libraries
 


### PR DESCRIPTION
Some debug messages needed polishing, like the linker check.
Others, like the check for exclusions of libraries, needed
polish to not repeat itself over and over again when
running off of a non supported base. This comes with a
side effect of reducing the amount of calls necessary
for the check where the debug message is displayed.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
