### PR TITLE
repo: do not pull in libc6-dev by default for stage-packages

### DIFF
--- a/snapcraft/internal/repo/manifest.txt
+++ b/snapcraft/internal/repo/manifest.txt
@@ -39,6 +39,7 @@ libblkid1
 libbz2-1.0
 libc-bin
 libc6
+libc6-dev
 libcap2
 libcap2-bin
 libcomerr2


### PR DESCRIPTION
Cut the chain at libc6-dev for stage-packages if any other
stage-packages entry has it as a dependency.

LP: #1554015

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
