### PR TITLE
meta: make sure adapter does not propagate

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -503,7 +503,7 @@ class _SnapPackaging:
             if os.path.splitext(f)[1] == '.desktop':
                 os.remove(os.path.join(gui_dir, f))
         for app in apps:
-            adapter = apps[app].get('adapter', '')
+            adapter = apps[app].pop('adapter', '')
             if adapter != 'none':
                 self._wrap_app(app, apps[app])
             self._generate_desktop_file(app, apps[app])

--- a/tests/integration/general/test_snap.py
+++ b/tests/integration/general/test_snap.py
@@ -80,10 +80,34 @@ class SnapTestCase(integration.TestCase):
                          'command-binary-wrapper-none.wrapper.wrapper'),
             Not(FileExists()))
 
+        # LP: #1750658
+        self.assertThat(
+            os.path.join(self.prime_dir, 'meta', 'snap.yaml'),
+            FileContains(dedent("""\
+                name: assemble
+                version: 1.0
+                summary: one line summary
+                description: a longer description
+                architectures:
+                - amd64
+                confinement: strict
+                grade: stable
+                apps:
+                  assemble-bin:
+                    command: command-assemble-bin.wrapper
+                  assemble-service:
+                    command: command-assemble-service.wrapper
+                    daemon: simple
+                    stop-command: stop-command-assemble-service.wrapper
+                  binary-wrapper-none:
+                    command: subdir/binary3
+                  binary2:
+                    command: command-binary2.wrapper
+            """)))
+
     def test_snap_default(self):
         self.copy_project_to_cwd('assemble')
         self.run_snapcraft([])
-
         snap_file_path = 'assemble_1.0_{}.snap'.format(self.deb_arch)
         self.assertThat(snap_file_path, FileExists())
 


### PR DESCRIPTION
adapter is a snapcraft.yaml only property and should not make it into
snap.yaml

LP: #1750658
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
