### PR TITLE
snap: actually plug the completer in.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,7 @@ confinement: classic
 apps:
   snapcraft:
     command: bin/snapcraft
+    completer: snapcraft-completion
 
 parts:
   ctypes:


### PR DESCRIPTION
snapcraft ships with a lovely tab completer, but it's not plugged in!
This fixes that. Reported as [lp:1751391](https://bugs.launchpad.net/snapcraft/+bug/1751391).

-----
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----
The tests are failing for me on master, and they continue to fail in the same way with my change. 