### PR TITLE
Sentry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pymacaroons==0.9.2; sys_platform != 'win32'
 pymacaroons==0.10.0; sys_platform == 'win32'
 pymacaroons-pynacl==0.9.3
 pysha3==1.0b1; python_version < '3.6'
+raven==6.5.0
 simplejson==3.8.2
 tabulate==0.7.5
 python-debian==0.1.28

--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -28,10 +28,8 @@ try:
 except ImportError:
     RavenClient = None
 
-_SEND_TO_SENTRY = (
-    'Sorry, Snapcraft had an internal error.\n'
-    'To help us improve, would you like to send error data?'
-)
+_MSG_INTERNAL_ERROR = 'Sorry, Snapcraft had an internal error.'
+_MSG_SEND_TO_SENTRY = 'To help us improve, would you like to send error data?'
 
 
 def exception_handler(exception_type, exception, exception_traceback, *,
@@ -55,12 +53,14 @@ def exception_handler(exception_type, exception, exception_traceback, *,
     exit_code = 1
     is_snapcraft_error = issubclass(exception_type, errors.SnapcraftError)
 
-    if debug or not is_snapcraft_error:
+    if debug:
         traceback.print_exception(
             exception_type, exception, exception_traceback)
 
-    if not is_snapcraft_error and RavenClient is not None:
-        _submit_trace(exception)
+    if not is_snapcraft_error:
+        echo.error('Sorry, Snapcraft had an internal error.')
+        if RavenClient is not None:
+            _submit_trace(exception)
 
     should_print_error = not debug and (
         exception_type != errors.ContainerSnapcraftCmdError)
@@ -78,7 +78,7 @@ def _submit_trace(exception):
         'https://b0fef3e0ced2443c92143ae0d038b0a4:'
         'b7c67d7fa4ee46caae12b29a80594c54@sentry.io/277754',
         transport=RequestsHTTPTransport)
-    if click.confirm(_SEND_TO_SENTRY):
+    if click.confirm(_MSG_SEND_TO_SENTRY):
         try:
             raise exception
         except Exception:

--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -60,7 +60,7 @@ def exception_handler(exception_type, exception, exception_traceback, *,
 
     if not is_snapcraft_error:
         echo.error('Sorry, Snapcraft had an internal error.')
-        if RavenClient is not None and _is_environment_ok():
+        if _is_send_error_data():
             _submit_trace(exception)
 
     should_print_error = not debug and (
@@ -74,9 +74,10 @@ def exception_handler(exception_type, exception, exception_traceback, *,
     sys.exit(exit_code)
 
 
-def _is_environment_ok():
-    send_data = os.environ.get('SNAPCRAFT_SEND_ERROR_DATA', 'y')
-    return send_data == 'y'
+def _is_send_error_data():
+    is_raven_client = RavenClient is not None
+    is_env_send_data = os.environ.get('SNAPCRAFT_SEND_ERROR_DATA', 'y') == 'y'
+    return is_env_send_data and is_raven_client
 
 
 def _submit_trace(exception):

--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import sys
 import traceback
 
@@ -59,7 +60,7 @@ def exception_handler(exception_type, exception, exception_traceback, *,
 
     if not is_snapcraft_error:
         echo.error('Sorry, Snapcraft had an internal error.')
-        if RavenClient is not None:
+        if RavenClient is not None and _is_environment_ok():
             _submit_trace(exception)
 
     should_print_error = not debug and (
@@ -71,6 +72,11 @@ def exception_handler(exception_type, exception, exception_traceback, *,
             echo.error(str(exception))
 
     sys.exit(exit_code)
+
+
+def _is_environment_ok():
+    send_data = os.environ.get('SNAPCRAFT_SEND_ERROR_DATA', 'y')
+    return send_data == 'y'
 
 
 def _submit_trace(exception):

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -92,6 +92,10 @@ class TestCase(testtools.TestCase):
             'XDG_DATA_HOME', os.path.join(self.path, 'data')))
         self.useFixture(fixtures.EnvironmentVariable('TERM', 'dumb'))
 
+        # Do not send crash reports
+        self.useFixture(fixtures.EnvironmentVariable(
+            'SNAPCRAFT_SEND_ERROR_DATA', 'n'))
+
         patcher = mock.patch(
             'xdg.BaseDirectory.xdg_config_home',
             new=os.path.join(self.path, '.config'))


### PR DESCRIPTION
Adds the ability to send reports, asking for confirmation before doing
so. This feature is only enabled for the deb as raven is not provided in
xenial and most of the user base will be using the snap.

Closes: #1918

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Hae you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
