### PR TITLE
Fix Store integration tests with updated snap name registration error messages (take 2)

### DIFF
--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -597,14 +597,19 @@ class FakeStoreAPIServer(base.BaseFakeServer):
 
     def _register_name_invalid(self, snap_name):
         # Emulates the current Store behaviour and never combines errors.
-        # It's either using invalid chars or too long, never both.
         if len(snap_name) > 40:
-            msg = ('The name {} should not be longer than 40 characters.'
-                   .format(snap_name))
+            msg = ("The name '{}' is not valid: it should be no longer than"
+                   " 40 characters.").format(snap_name)
+        elif snap_name.startswith('-') or snap_name.endswith('-'):
+            msg = ("The name '{}' is not valid: it should not start"
+                   " nor end with a hyphen.").format(snap_name)
+        elif '--' in snap_name:
+            msg = ("The name '{}' is not valid: it should not have"
+                   " two hyphens in a row.").format(snap_name)
         else:
-            msg = (
-                'The name {!r} is not valid. It can only contain dashes, '
-                'numbers and lowercase ascii letters.'.format(snap_name))
+            msg = ("The name '{}' is not valid: it should only have"
+                   " ASCII lowercase letters, numbers, and hyphens,"
+                   " and must have at least one letter.").format(snap_name)
 
         payload = json.dumps({
             'error_list': [

--- a/tests/integration/store/test_store_register.py
+++ b/tests/integration/store/test_store_register.py
@@ -83,8 +83,9 @@ class RegisterTestCase(integration.StoreTestCase):
             integration.RegisterError, self.register, name)
 
         self.assertThat(str(error), Contains(
-            'The name {!r} is not valid. It can only contain dashes, numbers '
-            'and lowercase ascii letters.'.format(name)))
+            'The name {!r} is not valid: it should only have ASCII lowercase '
+            'letters, numbers, and hyphens, and must have at least '
+            'one letter.'.format(name)))
 
     def test_registration_of_too_long_name(self):
         self.login()
@@ -93,8 +94,8 @@ class RegisterTestCase(integration.StoreTestCase):
             integration.RegisterError, self.register, name)
 
         self.assertThat(str(error), Contains(
-            'The name {} should not be longer than 40 characters.'
-            .format(name)))
+            'The name {!r} is not valid: it should be no longer than 40 '
+            'characters.'.format(name)))
 
     def test_registrations_in_a_row_fail_if_too_fast(self):
         # This test has a potential to fail if working off a slow

--- a/tests/unit/store/test_store_client.py
+++ b/tests/unit/store/test_store_client.py
@@ -612,8 +612,8 @@ class RegisterTestCase(StoreTestCase):
             errors.StoreRegistrationError,
             self.client.register, name)
         expected = (
-            'The name {} should not be longer than 40 characters.'
-            .format(name))
+            "The name '{}' is not valid: it should be no longer than 40"
+            " characters.".format(name))
         self.assertThat(str(raised), Equals(expected))
 
     def test_registering_name_invalid(self):
@@ -623,8 +623,9 @@ class RegisterTestCase(StoreTestCase):
             errors.StoreRegistrationError,
             self.client.register, name)
         expected = (
-            'The name {!r} is not valid. It can only contain dashes, numbers '
-            'and lowercase ascii letters.'.format(name))
+            "The name '{}' is not valid: it should only have"
+            " ASCII lowercase letters, numbers, and hyphens,"
+            " and must have at least one letter.".format(name))
         self.assertThat(str(raised), Equals(expected))
 
     def test_unhandled_registration_error_path(self):


### PR DESCRIPTION
This starts from @maxiberta's #1963 and fixes a couple more strings.

Here goes nothing.