### PR TITLE
grammar: support `to` statement in source

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -17,6 +17,12 @@ definitions:
                 ^on\s+.+$:
                   $ref: "#/definitions/grammar-string"
             - type: object
+              usage: "to <selector>[,<selector>...]:"
+              additionalProperties: false
+              patternProperties:
+                ^to\s+.+$:
+                  $ref: "#/definitions/grammar-string"
+            - type: object
               usage: "try:"
               additionalProperties: false
               patternProperties:

--- a/snapcraft/internal/project_loader/grammar/_on.py
+++ b/snapcraft/internal/project_loader/grammar/_on.py
@@ -32,15 +32,15 @@ class OnStatement:
 
     For example:
     >>> from snapcraft import ProjectOptions
+    >>> from snapcraft.internal.project_loader import grammar
     >>> from unittest import mock
     >>>
     >>> def checker(primitive):
     ...     return True
     >>> options = ProjectOptions()
+    >>> processor = grammar.GrammarProcessor(None, options, checker)
     >>>
-    >>> clause = OnStatement(on='on amd64', body=['foo'],
-    ...                      project_options=options,
-    ...                      checker=checker)
+    >>> clause = OnStatement(on='on amd64', body=['foo'], processor=processor)
     >>> clause.add_else(['bar'])
     >>> with mock.patch('platform.machine') as mock_machine:
     ...     # Pretend this machine is an i686, not amd64
@@ -77,14 +77,7 @@ class OnStatement:
 
         self._else_bodies.append(else_body)
 
-    def process(self):
-        """Process the clause.
-
-        :return: Primitives as determined by evaluating the statement.
-        :rtype: list
-        """
-
-        primitives = set()
+    def check(self):
         # A new ProjectOptions instance defaults to the host architecture
         # whereas self._project_options would yield the target architecture
         host_arch = snapcraft.ProjectOptions().deb_arch
@@ -92,20 +85,31 @@ class OnStatement:
         # The only selector currently supported is the host arch. Since
         # selectors are matched with an AND, not OR, there should only be one
         # selector.
-        if (len(self.selectors) == 1) and (host_arch in self.selectors):
-            primitives = self._processor.process(
-                active_statement=self, grammar=self._body)
-        else:
-            for else_body in self._else_bodies:
-                if not else_body:
-                    # Handle the 'else fail' case.
-                    raise UnsatisfiedStatementError(self)
+        return (len(self.selectors) == 1) and (host_arch in self.selectors)
 
-                primitives = self._processor.process(grammar=else_body)
-                if primitives:
-                    break
+    def process_body(self):
+        """Process the clause.
+
+        :return: Primitives as determined by evaluating the statement.
+        :rtype: list
+        """
+
+        return self._processor.process(grammar=self._body)
+
+    def process_else(self):
+        primitives = set()
+
+        for else_body in self._else_bodies:
+            if not else_body:
+                # Handle the 'else fail' case.
+                raise UnsatisfiedStatementError(self)
+
+            primitives = self._processor.process(grammar=else_body)
+            if primitives:
+                break
 
         return primitives
+
 
     def __eq__(self, other):
         return self.selectors == other.selectors

--- a/snapcraft/internal/project_loader/grammar/_on.py
+++ b/snapcraft/internal/project_loader/grammar/_on.py
@@ -18,7 +18,6 @@ import re
 
 import snapcraft
 
-from . import process_grammar
 from .errors import (
     OnStatementSyntaxError,
     UnsatisfiedStatementError,
@@ -50,7 +49,7 @@ class OnStatement:
     {'bar'}
     """
 
-    def __init__(self, *, on, body, project_options, checker):
+    def __init__(self, *, on, body, processor):
         """Create an _OnStatement instance.
 
         :param str on: The 'on <selectors>' part of the clause.
@@ -65,8 +64,7 @@ class OnStatement:
 
         self.selectors = _extract_on_clause_selectors(on)
         self._body = body
-        self._project_options = project_options
-        self._checker = checker
+        self._processor = processor
         self._else_bodies = []
 
     def add_else(self, else_body):
@@ -91,20 +89,19 @@ class OnStatement:
         # whereas self._project_options would yield the target architecture
         host_arch = snapcraft.ProjectOptions().deb_arch
 
-        # The only selector currently supported is the target arch. Since
+        # The only selector currently supported is the host arch. Since
         # selectors are matched with an AND, not OR, there should only be one
         # selector.
         if (len(self.selectors) == 1) and (host_arch in self.selectors):
-            primitives = process_grammar(
-                self._body, self._project_options, self._checker)
+            primitives = self._processor.process(
+                active_statement=self, grammar=self._body)
         else:
             for else_body in self._else_bodies:
                 if not else_body:
                     # Handle the 'else fail' case.
                     raise UnsatisfiedStatementError(self)
 
-                primitives = process_grammar(
-                    else_body, self._project_options, self._checker)
+                primitives = self._processor.process(grammar=else_body)
                 if primitives:
                     break
 

--- a/snapcraft/internal/project_loader/grammar/_try.py
+++ b/snapcraft/internal/project_loader/grammar/_try.py
@@ -14,8 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from . import process_grammar
-
 
 class TryStatement:
     """Process a 'try' statement in the grammar.
@@ -32,7 +30,7 @@ class TryStatement:
     {'valid'}
     """
 
-    def __init__(self, *, body, project_options, checker):
+    def __init__(self, *, body, processor):
         """Create an _OnStatement instance.
 
         :param list body: The body of the 'try' clause.
@@ -45,8 +43,7 @@ class TryStatement:
         """
 
         self._body = body
-        self._project_options = project_options
-        self._checker = checker
+        self._processor = processor
         self._else_bodies = []
 
     def add_else(self, else_body):
@@ -66,8 +63,8 @@ class TryStatement:
         :rtype: list
         """
 
-        primitives = process_grammar(
-            self._body, self._project_options, self._checker)
+        primitives = self._processor.process(
+            active_statement=self, grammar=self._body)
 
         # If some of the primitives in the 'try' were invalid, then we need to
         # process the 'else' clauses.
@@ -82,11 +79,10 @@ class TryStatement:
                 if not else_body:
                     continue
 
-                primitives = process_grammar(
-                    else_body, self._project_options, self._checker)
+                primitives = self._processor.process(grammar=else_body)
 
                 # Stop once an 'else' clause gives us valid primitives
-                if _all_primitives_valid(primitives, self._checker):
+                if _all_primitives_valid(primitives, self._processor.checker):
                     break
 
         return primitives

--- a/snapcraft/internal/project_loader/grammar_processing/_global_grammar_processor.py
+++ b/snapcraft/internal/project_loader/grammar_processing/_global_grammar_processor.py
@@ -17,6 +17,8 @@
 from snapcraft.internal import repo
 from snapcraft.internal.project_loader import grammar
 
+from ._package_transformer import package_transformer
+
 
 class GlobalGrammarProcessor:
     """Process global properties that support grammar.
@@ -39,8 +41,10 @@ class GlobalGrammarProcessor:
 
     def get_build_packages(self):
         if not self.__build_packages:
-            self.__build_packages = grammar.process_grammar(
+            processor = grammar.GrammarProcessor(
                 self._build_package_grammar, self._project_options,
-                repo.Repo.build_package_is_valid)
+                repo.Repo.build_package_is_valid,
+                transformer=package_transformer)
+            self.__build_packages = processor.process()
 
         return self.__build_packages

--- a/snapcraft/internal/project_loader/grammar_processing/_package_transformer.py
+++ b/snapcraft/internal/project_loader/grammar_processing/_package_transformer.py
@@ -18,7 +18,7 @@ from snapcraft.internal.project_loader.grammar import _to
 
 
 def package_transformer(statement, package_name, project_options):
-    if isinstance(statement, _to.ToStatement):
+    if statement and isinstance(statement, _to.ToStatement):
         if ':' not in package_name:
             # deb_arch is target arch or host arch if both are the same
             package_name += ':{}'.format(project_options.deb_arch)

--- a/snapcraft/internal/project_loader/grammar_processing/_package_transformer.py
+++ b/snapcraft/internal/project_loader/grammar_processing/_package_transformer.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017 Canonical Ltd
+# Copyright (C) 2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,4 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from ._processor import GrammarProcessor  # noqa
+from snapcraft.internal.project_loader.grammar import _to
+
+
+def package_transformer(statement, package_name, project_options):
+    if isinstance(statement, _to.ToStatement):
+        if ':' not in package_name:
+            # deb_arch is target arch or host arch if both are the same
+            package_name += ':{}'.format(project_options.deb_arch)
+
+    return package_name

--- a/snapcraft/internal/project_loader/grammar_processing/_part_grammar_processor.py
+++ b/snapcraft/internal/project_loader/grammar_processing/_part_grammar_processor.py
@@ -17,6 +17,8 @@
 from snapcraft.internal.project_loader import grammar
 from snapcraft.internal import repo
 
+from ._package_transformer import package_transformer
+
 
 class PartGrammarProcessor:
     """Process part properties that support grammar.
@@ -89,33 +91,39 @@ class PartGrammarProcessor:
         if not self.__source:
             # The grammar is array-based, even though we only support a single
             # source.
-            source_array = grammar.process_grammar(
+            processor = grammar.GrammarProcessor(
                 self._source_grammar, self._project_options,
                 lambda s: True)
+            source_array = processor.process()
             if len(source_array) > 0:
                 self.__source = source_array.pop()
         return self.__source
 
     def get_build_snaps(self):
         if not self.__build_snaps:
-            self.__build_snaps = grammar.process_grammar(
+            processor = grammar.GrammarProcessor(
                 self._build_snap_grammar, self._project_options,
                 repo.snaps.SnapPackage.is_valid_snap)
+            self.__build_snaps = processor.process()
 
         return self.__build_snaps
 
     def get_build_packages(self):
         if not self.__build_packages:
-            self.__build_packages = grammar.process_grammar(
+            processor = grammar.GrammarProcessor(
                 self._build_package_grammar, self._project_options,
-                self._repo.build_package_is_valid)
+                self._repo.build_package_is_valid,
+                transformer=package_transformer)
+            self.__build_packages = processor.process()
 
         return self.__build_packages
 
     def get_stage_packages(self):
         if not self.__stage_packages:
-            self.__stage_packages = grammar.process_grammar(
+            processor = grammar.GrammarProcessor(
                 self._stage_package_grammar, self._project_options,
-                self._repo.is_valid)
+                self._repo.is_valid,
+                transformer=package_transformer)
+            self.__stage_packages = processor.process()
 
         return self.__stage_packages

--- a/tests/unit/project_loader/grammar/test_on_statement.py
+++ b/tests/unit/project_loader/grammar/test_on_statement.py
@@ -158,10 +158,10 @@ class OnStatementGrammarTestCase(GrammarBaseTestCase):
                                   platform_architecture_mock):
         platform_machine_mock.return_value = self.host_arch
         platform_architecture_mock.return_value = ('64bit', 'ELF')
-        options = snapcraft.ProjectOptions()
+        processor = grammar.GrammarProcessor(
+            None, snapcraft.ProjectOptions(), self.checker)
         statement = on.OnStatement(
-            on=self.on, body=self.body, project_options=options,
-            checker=self.checker)
+            on=self.on, body=self.body, processor=processor)
 
         for else_body in self.else_bodies:
             statement.add_else(else_body)
@@ -217,10 +217,10 @@ class OnStatementInvalidGrammarTestCase(GrammarBaseTestCase):
         with testtools.ExpectedException(
                 grammar.errors.OnStatementSyntaxError,
                 self.expected_exception):
-            options = snapcraft.ProjectOptions()
+            processor = grammar.GrammarProcessor(
+                None, snapcraft.ProjectOptions(), self.checker)
             statement = on.OnStatement(
-                on=self.on, body=self.body, project_options=options,
-                checker=self.checker)
+                on=self.on, body=self.body, processor=processor)
 
             for else_body in self.else_bodies:
                 statement.add_else(else_body)
@@ -237,10 +237,10 @@ class OnStatementElseFail(GrammarBaseTestCase):
         platform_machine_mock.return_value = 'x86_64'
         platform_architecture_mock.return_value = ('64bit', 'ELF')
 
-        options = snapcraft.ProjectOptions()
+        processor = grammar.GrammarProcessor(
+            None, snapcraft.ProjectOptions(), self.checker)
         statement = on.OnStatement(
-            on='on i386', body=['foo'], project_options=options,
-            checker=self.checker)
+            on='on i386', body=['foo'], processor=processor)
 
         statement.add_else(None)
 

--- a/tests/unit/project_loader/grammar/test_to_statement.py
+++ b/tests/unit/project_loader/grammar/test_to_statement.py
@@ -39,14 +39,14 @@ class ToStatementGrammarTestCase(GrammarBaseTestCase):
             'body': ['foo'],
             'else_bodies': [],
             'target_arch': None,
-            'expected_packages': {'foo:amd64'}
+            'expected_packages': {'foo'}
         }),
         ('amd64 to armhf', {
             'to': 'to armhf',
             'body': ['foo'],
             'else_bodies': [],
             'target_arch': 'armhf',
-            'expected_packages': {'foo:armhf'}
+            'expected_packages': {'foo'}
         }),
         ('amd64 to armhf, arch specified', {
             'to': 'to armhf',
@@ -69,7 +69,7 @@ class ToStatementGrammarTestCase(GrammarBaseTestCase):
                 ['bar']
             ],
             'target_arch': 'armhf',
-            'expected_packages': {'foo:armhf'}
+            'expected_packages': {'foo'}
         }),
         ('used else', {
             'to': 'to armhf',
@@ -117,7 +117,7 @@ class ToStatementGrammarTestCase(GrammarBaseTestCase):
             ],
             'else_bodies': [],
             'target_arch': 'armhf',
-            'expected_packages': {'foo:armhf'}
+            'expected_packages': {'foo'}
         }),
         ('nested i386', {
             'to': 'to i386',
@@ -127,7 +127,7 @@ class ToStatementGrammarTestCase(GrammarBaseTestCase):
             ],
             'else_bodies': [],
             'target_arch': 'i386',
-            'expected_packages': {'bar:i386'}
+            'expected_packages': {'bar'}
         }),
         ('nested body ignored else', {
             'to': 'to armhf',
@@ -137,7 +137,7 @@ class ToStatementGrammarTestCase(GrammarBaseTestCase):
             ],
             'else_bodies': [],
             'target_arch': 'armhf',
-            'expected_packages': {'foo:armhf'}
+            'expected_packages': {'foo'}
         }),
         ('nested body used else', {
             'to': 'to i386',
@@ -147,7 +147,7 @@ class ToStatementGrammarTestCase(GrammarBaseTestCase):
             ],
             'else_bodies': [],
             'target_arch': 'i386',
-            'expected_packages': {'bar:i386'}
+            'expected_packages': {'bar'}
         }),
         ('nested else ignored else', {
             'to': 'to i386',
@@ -159,7 +159,7 @@ class ToStatementGrammarTestCase(GrammarBaseTestCase):
                 ],
             ],
             'target_arch': 'armhf',
-            'expected_packages': {'bar:armhf'}
+            'expected_packages': {'bar'}
         }),
         ('nested else used else', {
             'to': 'to armhf',
@@ -181,10 +181,11 @@ class ToStatementGrammarTestCase(GrammarBaseTestCase):
                                   platform_architecture_mock):
         platform_machine_mock.return_value = 'x86_64'
         platform_architecture_mock.return_value = ('64bit', 'ELF')
-        options = snapcraft.ProjectOptions(target_deb_arch=self.target_arch)
+        processor = grammar.GrammarProcessor(
+                None, snapcraft.ProjectOptions(
+                    target_deb_arch=self.target_arch), self.checker)
         statement = to.ToStatement(
-            to=self.to, body=self.body, project_options=options,
-            checker=self.checker)
+            to=self.to, body=self.body, processor=processor)
 
         for else_body in self.else_bodies:
             statement.add_else(else_body)
@@ -246,11 +247,11 @@ class ToStatementInvalidGrammarTestCase(GrammarBaseTestCase):
         with testtools.ExpectedException(
                 grammar.errors.ToStatementSyntaxError,
                 self.expected_exception):
-            options = snapcraft.ProjectOptions(
-                target_deb_arch=self.target_arch)
+            processor = grammar.GrammarProcessor(
+                None, snapcraft.ProjectOptions(
+                    target_deb_arch=self.target_arch), self.checker)
             statement = to.ToStatement(
-                to=self.to, body=self.body, project_options=options,
-                checker=self.checker)
+                to=self.to, body=self.body, processor=processor)
 
             for else_body in self.else_bodies:
                 statement.add_else(else_body)
@@ -266,11 +267,11 @@ class ToStatementElseFail(GrammarBaseTestCase):
                        platform_architecture_mock):
         platform_machine_mock.return_value = 'x86_64'
         platform_architecture_mock.return_value = ('64bit', 'ELF')
-        options = snapcraft.ProjectOptions(
-            target_deb_arch='i386')
+        processor = grammar.GrammarProcessor(
+            None, snapcraft.ProjectOptions(
+                target_deb_arch='i386'), self.checker)
         statement = to.ToStatement(
-            to='to armhf', body=['foo'], project_options=options,
-            checker=self.checker)
+            to='to armhf', body=['foo'], processor=processor)
 
         statement.add_else(None)
 

--- a/tests/unit/project_loader/grammar/test_try_statement.py
+++ b/tests/unit/project_loader/grammar/test_try_statement.py
@@ -18,6 +18,7 @@ import doctest
 from testtools.matchers import Equals
 
 import snapcraft
+from snapcraft.internal.project_loader import grammar
 import snapcraft.internal.project_loader.grammar._try as _try
 
 from . import GrammarBaseTestCase
@@ -115,9 +116,9 @@ class TryStatementGrammarTestCase(GrammarBaseTestCase):
     ]
 
     def test_try_statement_grammar(self):
-        statement = _try.TryStatement(
-            body=self.body, project_options=snapcraft.ProjectOptions(),
-            checker=self.checker)
+        processor = grammar.GrammarProcessor(
+            None, snapcraft.ProjectOptions(), self.checker)
+        statement = _try.TryStatement(body=self.body, processor=processor)
 
         for else_body in self.else_bodies:
             statement.add_else(else_body)


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----

This is an RFC spike. Tests will almost certainly fail, and several need to be added.

This involves the introduction of a transformation function to optionally transform primitives. This is done because package names coming from the `to` statement need to have the architecture appended to them, but URLs/directory names (such as those used in `source`) certainly do not.