### PR TITLE
project_loader: improve the logic to install patchelf as a build tool

### DIFF
--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -264,10 +264,10 @@ def _patchelf_install_required(project_options) -> bool:
 
     is_snap = common.is_snap()
     is_environment = os.getenv('SNAPCRAFT_NO_PATCHELF')
-    is_arch_armhf = project_options.deb_arch == 'armhf'
+    is_arch_missing_xenial = project_options.deb_arch in ('armhf', 's390x')
 
     return not (is_snap or is_environment or
-                (is_arch_armhf and is_xenial))
+                (is_arch_missing_xenial and is_xenial))
 
 
 def _snapcraft_yaml_load(yaml_file):

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2017 Canonical Ltd
+# Copyright (C) 2015-2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import contextlib
 import codecs
 import logging
 import os
@@ -26,7 +27,8 @@ import yaml.reader
 
 
 import snapcraft
-from snapcraft.internal import common, deprecations, remote_parts, states
+from snapcraft.internal import (common, deprecations, remote_parts, states,
+                                os_release)
 from ._schema import Validator
 from ._parts_config import PartsConfig
 from ._env import (
@@ -115,8 +117,7 @@ class Config:
         self.build_tools = grammar_processor.get_build_packages()
         self.build_tools |= set(project_options.additional_build_packages)
 
-        if not (common.is_snap() or os.getenv('SNAPCRAFT_NO_PATCHELF')
-                or project_options.deb_arch == 'armhf'):
+        if _patchelf_install_required(project_options):
             self.build_tools.add('patchelf')
 
         self.parts = PartsConfig(parts=self.data,
@@ -253,6 +254,20 @@ class Config:
 
         snapcraft_yaml['parts'] = new_parts
         return snapcraft_yaml
+
+
+def _patchelf_install_required(project_options) -> bool:
+    is_xenial = False
+    with contextlib.suppress(os_release.errors.OsReleaseCodenameError):
+        release_codename = os_release.OsRelease().version_codename()
+        is_xenial = release_codename == 'xenial'
+
+    is_snap = common.is_snap()
+    is_environment = os.getenv('SNAPCRAFT_NO_PATCHELF')
+    is_arch_armhf = project_options.deb_arch == 'armhf'
+
+    return not (is_snap or is_environment or
+                (is_arch_armhf and is_xenial))
 
 
 def _snapcraft_yaml_load(yaml_file):


### PR DESCRIPTION
patchelf is a broken build on xenial/armhf and xenial/s390x so we do not add it as a build tool.
Users of the snapcraft deb will need to provide it in a part or use the build-snap.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
Integrating changes in #1943 one step at a time