### PR TITLE
demos: avoid use of the wrapper for java-hello-world

### DIFF
--- a/demos/java-hello-world/snap/snapcraft.yaml
+++ b/demos/java-hello-world/snap/snapcraft.yaml
@@ -7,7 +7,12 @@ grade: stable
 
 apps:
  hello:
-   command: usr/lib/jvm/default-java/bin/java oata.HelloWorld
+    command: usr/lib/jvm/default-java/bin/java oata.HelloWorld
+    adapter: none
+    environment:
+       JAVA_HOME: $SNAP/usr/lib/jvm/default-java
+       CLASSPATH: $SNAP/jar/HelloWorld.jar
+       PATH: $SNAP/usr/lib/jvm/default-java/bin:$PATH
 
 parts:
     local:


### PR DESCRIPTION
When building on a host different that the target base, there is no
wrapper created. Make use of `adapter: none` to make this demo a bit
more generic and manually setup the environment.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
Part of #1943 