### PR TITLE
meta: parse LAUNCHPAD_BUILD_INFO for inclusion in the manifest

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -429,6 +429,14 @@ class InvalidContainerImageInfoError(SnapcraftError):
         super().__init__(image_info=image_info)
 
 
+class InvalidLaunchpadBuildInfoError(SnapcraftError):
+
+    fmt = 'Error parsing the Launchpad build info: {build_info}'
+
+    def __init__(self, build_info):
+        super().__init__(build_info=build_info)
+
+
 class PatcherError(SnapcraftError):
     pass
 

--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -115,7 +115,8 @@ class Containerbuild:
             'lxc', 'config', 'set', self._container_name,
             'environment.SNAPCRAFT_SETUP_CORE', '1'])
         for snapcraft_env_var in (
-                'SNAPCRAFT_PARTS_URI', 'SNAPCRAFT_BUILD_INFO'):
+                'SNAPCRAFT_PARTS_URI', 'SNAPCRAFT_BUILD_INFO',
+                'LAUNCHPAD_BUILD_INFO'):
             if os.getenv(snapcraft_env_var):
                 subprocess.check_call([
                     'lxc', 'config', 'set', self._container_name,

--- a/snapcraft/internal/meta/_manifest.py
+++ b/snapcraft/internal/meta/_manifest.py
@@ -33,6 +33,14 @@ def annotate_snapcraft(data, parts_dir: str):
             raise errors.InvalidContainerImageInfoError(
                 image_info) from exception
         data['image-info'] = image_info_dict
+    build_info = os.environ.get('LAUNCHPAD_BUILD_INFO')
+    if build_info:
+        try:
+            build_info_dict = json.loads(build_info)
+        except json.decoder.JSONDecodeError as exception:
+            raise errors.InvalidLaunchpadBuildInfoError(
+                build_info) from exception
+        data['build-info'] = build_info_dict
     for field in ('build-packages', 'build-snaps'):
         data[field] = get_global_state().assets.get(field, [])
     for part in data['parts']:

--- a/tests/unit/test_lxd.py
+++ b/tests/unit/test_lxd.py
@@ -183,6 +183,17 @@ class ContainerbuildTestCase(LXDTestCase):
                   'test_build_info_value']),
         ])
 
+    def test_launchpad_build_info_set(self):
+        self.useFixture(
+            fixtures.EnvironmentVariable(
+                'LAUNCHPAD_BUILD_INFO', 'test_build_info_value'))
+        self.make_containerbuild().execute()
+        self.fake_lxd.check_call_mock.assert_has_calls([
+            call(['lxc', 'config', 'set', self.fake_lxd.name,
+                  'environment.LAUNCHPAD_BUILD_INFO',
+                  'test_build_info_value']),
+        ])
+
     def test_wait_for_network_loops(self):
         self.fake_lxd.check_call_mock.side_effect = CalledProcessError(
             -1, ['my-cmd'])


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This PR implements support for the `LAUNCHPAD_BUILD_INFO` variable which, if set in addition to setting `SNAPCRAFT_BUILD_INFO` to enable generation of `manifest.yaml`, records the JSON specified in that variable in the *manifest* under a new `build-info` keyword. The exact values aren't filtered but taken as-is - InvalidLaunchpadBuildInfoError is raised if the parsing fails.
`LAUNCHPAD_BUILD_INFO` will also be propagated to LXD containers as-is and the Snapcraft within the container will parse it (if generation of the manifest is also enabled).
This variable is going to be set by [buildd](https://launchpad.net/launchpad-buildd).

The following new tests are being added:

 - tests.unit.test_lifecycle.RecordManifestTestCase.test_prime_with_launchpad_build_info_records_manifest
 - To verify that the manifest contains the parsed JSON under `build-info`.
 - tests.unit.test_lifecycle.RecordManifestTestCase.test_prime_with_invalid_launchpad_build_info_raises_exception
 - To verify that invalid JSON raises an error.
 - tests.unit.test_lxd.test_launchpad_build_info_set
 - To verify that `LAUNCHPAD_BUILD_INFO` is propagated to containers.

I localled ran the tests:
 - `./runtests.sh tests/unit` with one unrelated failure in [tests.unit.test_lifecycle.CoreSetupTestCase.test_core_setup_if_docker_env](https://bugs.launchpad.net/snapcraft/+bug/1752576)
 - `./runtests.sh tests/integration` with one unrelated failure in [tests.integration.general.test_parser.TestParserWikis](https://bugs.launchpad.net/snapcraft/+bug/1752580)
 - `./runtests.sh tests/static`: Everything passed

Manual test steps:
 - cd tests/integration/snaps/basic
 - LAUNCHPAD_BUILD_INFO='{"build-url":"test-build-url"}' SNAPCRAFT_BUILD_INFO=1 snapcraft
 - grep -C 1 build-info prime/snap/manifest.yaml 
   grade: stable
   build-info:
     build-url: test-build-url
 - Observe the manifest containing build-info with build-url.
 - snapcraft clean
 - LAUNCHPAD_BUILD_INFO=not-json SNAPCRAFT_BUILD_INFO=1 snapcraft
 - Observe the error message "Error parsing the Launchpad build info: not-json".