### PR TITLE
tests: remove _options dependency from integration suite

### DIFF
--- a/tests/integration/general/test_hardlink_src_old_tree.py
+++ b/tests/integration/general/test_hardlink_src_old_tree.py
@@ -22,7 +22,6 @@ from testtools.matchers import (
     Not
 )
 
-from snapcraft import _options
 from tests import integration
 
 
@@ -30,13 +29,11 @@ class HardlinkSrcOldTreeTestCase(integration.TestCase):
 
     def test_build_old_tree_still_filters(self):
         self.copy_project_to_cwd('old-part-src')
-        platform_architecture = _options._get_platform_architecture()
-        arch = _options._ARCH_TRANSLATIONS[platform_architecture]['deb']
         with fileinput.FileInput(
                 os.path.join(self.parts_dir, 'part-name', 'state', 'pull'),
                 inplace=True) as pull_state:
             for line in pull_state:
-                print(line.replace('$arch', arch), end='')
+                print(line.replace('$arch', self.deb_arch), end='')
 
         self.run_snapcraft('build')
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
Closes #1953