### PR TITLE
python plugin: find setup.py when source-subdir is used

### DIFF
--- a/snapcraft/plugins/_python/_pip.py
+++ b/snapcraft/plugins/_python/_pip.py
@@ -24,6 +24,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+from typing import List, Set
 
 import snapcraft
 from snapcraft import file_utils
@@ -38,8 +39,10 @@ from . import errors
 logger = logging.getLogger(__name__)
 
 
-def _process_common_args(*, packages, constraints,
-                         requirements, process_dependency_links):
+def _process_common_args(*, packages: List[str],
+                         constraints: Set[str],
+                         requirements: Set[str],
+                         process_dependency_links: bool) -> List[str]:
     args = []
     if constraints:
         for constraint in constraints:

--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -220,8 +220,13 @@ class PythonPlugin(snapcraft.BasePlugin):
     def _get_setup_py_dir(self):
         setup_py_dir = None
         setup_py = 'setup.py'
-        if os.listdir(self.sourcedir):
-            setup_py = os.path.join(self.sourcedir, 'setup.py')
+        if self.options.source_subdir:
+            sourcedir = os.path.join(self.sourcedir,
+                                     self.options.source_subdir)
+        else:
+            sourcedir = self.sourcedir
+        if os.listdir(sourcedir):
+            setup_py = os.path.join(sourcedir, 'setup.py')
         if os.path.exists(setup_py):
             setup_py_dir = os.path.dirname(setup_py)
 

--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -220,9 +220,13 @@ class PythonPlugin(snapcraft.BasePlugin):
     def _find_file(self, *, filename: str) -> str:
         # source-subdir defaults to ''
         for basepath in [self.builddir, self.sourcedir]:
-            filepath = os.path.join(basepath,
-                                    self.options.source_subdir,
-                                    filename)
+            if basepath == self.sourcedir:
+                # This is overwritten in the base plugin
+                # TODO add consistency
+                source_subdir = self.options.source_subdir
+            else:
+                source_subdir = ''
+            filepath = os.path.join(basepath, source_subdir, filename)
             if os.path.exists(filepath):
                 return filepath
 

--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -73,6 +73,20 @@ class UnsupportedPythonVersionError(snapcraft.internal.errors.SnapcraftError):
     fmt = 'Unsupported python version: {python_version!r}'
 
 
+class SnapcraftPluginPythonFileMissing(
+        snapcraft.internal.errors.SnapcraftError):
+
+    fmt = (
+        'Failed to find the referred {plugin_property} file at the given '
+        'path: {plugin_property_value!r}.\n'
+        'Check the property and ensure the file exists.'
+    )
+
+    def __init__(self, *, plugin_property, plugin_property_value):
+        super().__init__(plugin_property=plugin_property,
+                         plugin_property_value=plugin_property_value)
+
+
 class PythonPlugin(snapcraft.BasePlugin):
 
     @classmethod
@@ -246,11 +260,13 @@ class PythonPlugin(snapcraft.BasePlugin):
             if isurl(self.options.constraints):
                 constraints = {self.options.constraints}
             else:
-                constraints = {self._find_file(
-                    filename=self.options.constraints)}
-                if not constraints:
-                    # TODO snapcraft owned message
-                    raise FileNotFoundError(self.options.constraints)
+                constraints_file = self._find_file(
+                    filename=self.options.constraints)
+                if not constraints_file:
+                    raise SnapcraftPluginPythonFileMissing(
+                        plugin_property='constraints',
+                        plugin_property_value=self.options.constraints)
+                constraints = {constraints_file}
         return constraints
 
     def _get_requirements(self):
@@ -259,11 +275,13 @@ class PythonPlugin(snapcraft.BasePlugin):
             if isurl(self.options.requirements):
                 requirements = {self.options.requirements}
             else:
-                requirements = {self._find_file(
-                    filename=self.options.requirements)}
-                if not requirements:
-                    # TODO snapcraft owned message
-                    raise FileNotFoundError(self.options.requirements)
+                requirements_file = self._find_file(
+                    filename=self.options.requirements)
+                if not requirements_file:
+                    raise SnapcraftPluginPythonFileMissing(
+                        plugin_property='requirements',
+                        plugin_property_value=self.options.requirements)
+                requirements = {requirements_file}
 
         return requirements
 

--- a/tests/integration/plugins_python/test_python_plugin.py
+++ b/tests/integration/plugins_python/test_python_plugin.py
@@ -218,3 +218,10 @@ class PythonPluginTestCase(integration.TestCase):
         # Regression test for https://bugs.launchpad.net/snapcraft/+bug/1663739
         self.run_snapcraft('stage', 'python-with-two-parts')
         # If there is a conflict, stage will raise an exception.
+
+    def test_use_of_source_subdir_picks_up_setup_py(self):
+        # Regression test for LP: #1752481
+        self.run_snapcraft('stage', 'python-with-source-subdir')
+
+        self.assertThat(os.path.join(self.stage_dir, 'bin', 'hello'),
+                        FileExists())

--- a/tests/integration/snaps/python-with-source-subdir/snap/snapcraft.yaml
+++ b/tests/integration/snaps/python-with-source-subdir/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: python-hello-with-source-subdir
+version: '0.1'
+summary: A simple hello world in python
+description: |
+  This is a basic python snap. It just hosts a hello world.
+  If you want to add other functionalities to this snap, please don't.
+  Make a new one.
+  This snapcraft project specifically tests that source-subdirs are
+  properly handled.
+confinement: strict
+
+apps:
+  python-hello:
+    command: hello
+
+parts:
+  python-part:
+    source: .
+    source-subdir: source-subdir
+    plugin: python

--- a/tests/integration/snaps/python-with-source-subdir/source-subdir/hello
+++ b/tests/integration/snaps/python-with-source-subdir/source-subdir/hello
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+print('Hello world!')

--- a/tests/integration/snaps/python-with-source-subdir/source-subdir/setup.py
+++ b/tests/integration/snaps/python-with-source-subdir/source-subdir/setup.py
@@ -1,0 +1,11 @@
+import setuptools
+
+
+setuptools.setup(
+    name='hello-world',
+    version='0.0.1',
+    author='Canonical LTD',
+    author_email='snapcraft@lists.snapcraft.io',
+    description='A simple hello world in python',
+    scripts=['hello']
+)

--- a/tests/unit/plugins/test_python.py
+++ b/tests/unit/plugins/test_python.py
@@ -364,6 +364,26 @@ class PythonPluginTestCase(BasePythonPluginTestCase):
             Equals('testpackage1==1.0\ntestpackage2==1.2'))
 
 
+class FileMissingPythonPluginTest(BasePythonPluginTestCase):
+
+    scenarios = (
+        ('constraints', dict(property='constraints',
+                             file_path='constraints.txt')),
+        ('requirements', dict(property='requirements',
+                              file_path='requirements.txt'))
+    )
+
+    def test_constraints_file_missing(self):
+        setattr(self.options, self.property, self.file_path)
+
+        plugin = python.PythonPlugin('test-part', self.options,
+                                     self.project_options)
+        setup_directories(plugin, self.options.python_version)
+
+        self.assertRaises(python.SnapcraftPluginPythonFileMissing,
+                          plugin.pull)
+
+
 class PythonPluginWithURLTestCase(
         BasePythonPluginTestCase, unit.FakeFileHTTPServerBasedTestCase):
 

--- a/tests/unit/plugins/test_python.py
+++ b/tests/unit/plugins/test_python.py
@@ -60,6 +60,7 @@ class BasePythonPluginTestCase(unit.TestCase):
 
         class Options:
             source = '.'
+            source_subdir = ''
             requirements = ''
             constraints = ''
             python_version = 'python3'
@@ -148,9 +149,10 @@ class PythonPluginTestCase(BasePythonPluginTestCase):
                                      self.project_options)
         setup_directories(plugin, self.options.python_version)
 
-        plugin.pull()
-
         requirements_path = os.path.join(plugin.sourcedir, 'requirements.txt')
+        open(requirements_path, 'w').close()
+
+        plugin.pull()
 
         pip_download = self.mock_pip.return_value.download
         pip_download.assert_called_once_with(
@@ -169,9 +171,10 @@ class PythonPluginTestCase(BasePythonPluginTestCase):
                                      self.project_options)
         setup_directories(plugin, self.options.python_version)
 
-        plugin.pull()
-
         constraints_path = os.path.join(plugin.sourcedir, 'constraints.txt')
+        open(constraints_path, 'w').close()
+
+        plugin.pull()
 
         pip_download = self.mock_pip.return_value.download
         pip_download.assert_called_once_with(
@@ -202,16 +205,18 @@ class PythonPluginTestCase(BasePythonPluginTestCase):
             path = os.path.join(plugin.sourcedir, file_name)
             open(path, 'w').close()
 
+        requirements_path = os.path.join(plugin.builddir, 'requirements.txt')
+        constraints_path = os.path.join(plugin.builddir, 'constraints.txt')
+
         def build_side_effect():
             open(os.path.join(plugin.builddir, 'setup.py'), 'w').close()
             os.mkdir(os.path.join(plugin.builddir, 'dist'))
             open(os.path.join(
                 plugin.builddir, 'dist', 'package.tar'), 'w').close()
+            open(requirements_path, 'w').close()
+            open(constraints_path, 'w').close()
 
         mock_base_build.side_effect = build_side_effect
-
-        requirements_path = os.path.join(plugin.sourcedir, 'requirements.txt')
-        constraints_path = os.path.join(plugin.sourcedir, 'constraints.txt')
 
         pip_wheel = self.mock_pip.return_value.wheel
         pip_wheel.return_value = ['foo', 'bar']
@@ -225,7 +230,7 @@ class PythonPluginTestCase(BasePythonPluginTestCase):
         pip_wheel.assert_called_once_with(
             ['test', 'packages'], constraints={constraints_path},
             process_dependency_links=False, requirements={requirements_path},
-            setup_py_dir=plugin.sourcedir)
+            setup_py_dir=plugin.builddir)
 
         pip_install = self.mock_pip.return_value.install
         pip_install.assert_called_once_with(


### PR DESCRIPTION
LP: #1752481

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
