### PR TITLE
elf: only consider regular files as possible ELF binaries

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -125,7 +125,7 @@ def _crawl_for_path(*, soname: str, root_path: str,
             for file_name in files:
                 if file_name == soname:
                     file_path = os.path.join(root, file_name)
-                    if os.path.exists(file_path) and ElfFile.is_elf(file_path):
+                    if ElfFile.is_elf(file_path):
                         soname_cache[soname] = file_path
                         return file_path
 
@@ -149,6 +149,9 @@ class ElfFile:
 
     @classmethod
     def is_elf(cls, path: str) -> bool:
+        if not os.path.isfile(path):
+            # ELF binaries are regular files
+            return False
         with open(path, 'rb') as bin_file:
             return bin_file.read(4) == b'\x7fELF'
 

--- a/tests/unit/test_elf.py
+++ b/tests/unit/test_elf.py
@@ -314,6 +314,13 @@ class TestGetElfFiles(TestElfBase):
         elf_files = elf.get_elf_files('/dev', {'null'})
         self.assertThat(elf_files, Equals(set()))
 
+    def test_fifo(self):
+        fifo_path = os.path.join(self.fake_elf.root_path, 'fifo')
+        os.mkfifo(fifo_path)
+
+        elf_files = elf.get_elf_files(self.fake_elf.root_path, {'fifo'})
+        self.assertThat(elf_files, Equals(set()))
+
 
 class TestGetRequiredGLIBC(TestElfBase):
 

--- a/tests/unit/test_elf.py
+++ b/tests/unit/test_elf.py
@@ -310,6 +310,10 @@ class TestGetElfFiles(TestElfBase):
 
         self.assertThat(elf_files, Equals(set()))
 
+    def test_device_files(self):
+        elf_files = elf.get_elf_files('/dev', {'null'})
+        self.assertThat(elf_files, Equals(set()))
+
 
 class TestGetRequiredGLIBC(TestElfBase):
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
Only consider regular files (or symlinks to regular files) as possible ELF binaries in `ElfFile.is_elf`.  At present, Snapcraft has trouble building the core snap due to the presence of device files.

LP: #1752766