### PR TITLE
ci: switch to stable lxd and unconfined containers

### DIFF
--- a/tools/travis/run_lxd_container.sh
+++ b/tools/travis/run_lxd_container.sh
@@ -32,8 +32,7 @@ name="$1"
 lxc="/snap/bin/lxc"
 
 echo "Starting the LXD container."
-# FIXME switch back to unprovileged once LP: #1709536 is fixed
-$lxc launch --ephemeral --config security.privileged=true --config security.nesting=true ubuntu:xenial "$name"
+$lxc launch --ephemeral --config security.nesting=true ubuntu:xenial "$name"
 # This is likely needed to wait for systemd in the container to start and get
 # an IP, configure DNS. First boot is always a bit slow because cloud-init
 # needs to run too.

--- a/tools/travis/setup_lxd.sh
+++ b/tools/travis/setup_lxd.sh
@@ -35,7 +35,7 @@ apt-get remove --yes lxd lxd-client
 # - Setup snap "core" (3604) security profiles (cannot reload udev rules: exit status 2)
 # but the installation succeeds, so we just ingore it.
 snap install core || echo 'ignored error'
-snap install lxd --edge
+snap install lxd
 # Wait while LXD first generates its keys. In a low entropy environment this
 # can take a while.
 


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
