### PR TITLE
elf: remove all un-primed libs from soname cache

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -65,10 +65,14 @@ class SonameCache:
         """Initialize a cache for sonames"""
         self._soname_paths = dict()  # type: Dict[str, str]
 
-    def reset(self):
-        """Reset the cache values that are empty."""
-        self._soname_paths = {k: v for (k, v) in self._soname_paths.items()
-                              if v is not None}
+    def reset_except_root(self, root):
+        """Reset the cache values that aren't contained within root."""
+        new_soname_paths = {}  # type: Dict[str, str]
+        for key, value in self._soname_paths.items():
+            if value is not None and value.startswith(root):
+                new_soname_paths[key] = value
+
+        self._soname_paths = new_soname_paths
 
 
 class NeededLibrary:

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -515,9 +515,8 @@ class PluginHandler:
         # TODO: base snap support
         core_path = common.get_core_path()
 
-        # Reset to take into account new data inside prime provided by other
-        # parts.
-        self._soname_cache.reset()
+        # Clear the cache of all libs that aren't already in the primedir
+        self._soname_cache.reset_except_root(self.primedir)
         for elf_file in elf_files:
             all_dependencies.update(
                 elf_file.load_dependencies(root_path=self.primedir,

--- a/tests/unit/test_elf.py
+++ b/tests/unit/test_elf.py
@@ -458,14 +458,17 @@ class TestSonameCache(unit.TestCase):
         self.soname_cache['soname.so'] = '/fake/path/soname.so'
         self.assertTrue('soname.so' in self.soname_cache)
 
-    def test_add_many_remove_empty_entries(self):
+    def test_reset_except_root(self):
         self.soname_cache['soname.so'] = '/fake/path/soname.so'
+        self.soname_cache['soname2.so'] = '/keep/me/soname2.so'
         self.soname_cache['notfound.so'] = None
 
         self.assertTrue('soname.so' in self.soname_cache)
+        self.assertTrue('soname2.so' in self.soname_cache)
         self.assertTrue('notfound.so' in self.soname_cache)
 
-        self.soname_cache.reset()
+        self.soname_cache.reset_except_root('/keep/me')
 
-        self.assertTrue('soname.so' in self.soname_cache)
+        self.assertFalse('soname.so' in self.soname_cache)
         self.assertFalse('notfound.so' in self.soname_cache)
+        self.assertTrue('soname2.so' in self.soname_cache)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Snapcraft currently resets the cache for each part, but the cache's concept of "resetting" is only to remove libs that weren't found. Caching library lookups between parts causes issues in snaps where multiple parts rely on the same lib, but they come from different places (e.g. git-ubuntu).

This PR makes more progress on LP: [#1752481](https://bugs.launchpad.net/ubuntu/+source/snapcraft/+bug/1752481) by emptying the cache of all libs not already primed. This may slow things down a little, but will further isolate each part, preventing these kinds of issues.