### PR TITLE
elf: only set rpaths to libs of the same arch

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -72,6 +72,16 @@ class SonameCache:
         return self._soname_paths[key]
 
     def __setitem__(self, key, item):
+        # Initial API error checks
+        if not isinstance(key, tuple):
+            raise EnvironmentError('The key for SonameCache has to be a '
+                                   '(arch, soname) tuple.')
+        if not isinstance(key[0], tuple) or len(key[0]) != 3:
+            raise EnvironmentError('The first element of the key needs to of '
+                                   'type ElfArchitectureTuple.')
+        if not isinstance(key[1], str):
+            raise EnvironmentError('The second element of the key needs to be '
+                                   'of type str representing the soname.')
         self._soname_paths[key] = item
 
     def __contains__(self, key):

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -123,7 +123,8 @@ class Library:
         else:
             self.system_lib = False
 
-        if path.startswith(core_base_path):
+        # self.path has the correct resulting path.
+        if self.path.startswith(core_base_path):
             self.in_base_snap = True
         else:
             self.in_base_snap = False
@@ -134,7 +135,7 @@ def _crawl_for_path(*, soname: str, root_path: str, core_base_path: str,
                     soname_cache: SonameCache) -> str:
     # Speed things up and return what was already found once.
     if (arch, soname) in soname_cache:
-        return soname_cache[soname]
+        return soname_cache[arch, soname]
 
     logger.debug('Crawling to find soname {!r}'.format(soname))
     for path in (root_path, core_base_path):
@@ -153,7 +154,7 @@ def _crawl_for_path(*, soname: str, root_path: str, core_base_path: str,
                             return file_path
 
     # If not found we cache it too
-    soname_cache[soname] = None
+    soname_cache[arch, soname] = None
     return None
 
 

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -90,7 +90,9 @@ class Library:
     """Represents the SONAME and path to the library."""
 
     def __init__(self, *, soname: str, path: str, root_path: str,
-                 core_base_path: str, arch: str, soname_cache: SonameCache) -> None:
+                 core_base_path: str,
+                 arch: Tuple[str, str, str],
+                 soname_cache: SonameCache) -> None:
         self.soname = soname
 
         # We need to always look for the soname inside root first,
@@ -123,8 +125,9 @@ class Library:
             self.in_base_snap = False
 
 
-def _crawl_for_path(*, soname: str, root_path: str,
-                    core_base_path: str, arch: str, soname_cache: SonameCache) -> str:
+def _crawl_for_path(*, soname: str, root_path: str, core_base_path: str,
+                    arch: Tuple[str, str, str],
+                    soname_cache: SonameCache) -> str:
     # Speed things up and return what was already found once.
     if soname in soname_cache:
         return soname_cache[soname]
@@ -187,7 +190,7 @@ class ElfFile:
 
     def _extract(self, path):  # noqa: C901
         # type: (str) -> Tuple[Tuple[str, str, str], str, str, Dict[str, NeededLibrary], bool]  # noqa: E501
-        arch = str()
+        arch = None  # type: Tuple[str, str, str]
         interp = str()
         soname = str()
         libs = dict()

--- a/tests/fixture_setup.py
+++ b/tests/fixture_setup.py
@@ -1159,6 +1159,8 @@ def _fake_elffile_extract(self, path):
         return arch, '', 'libc.so.6', {}, False
     elif name == 'libssl.so.1.0.0':
         return arch, '', 'libssl.so.1.0.0', {}, False
+    else:
+        return arch, '', '', {}, False
 
 
 class FakeElf(fixtures.Fixture):


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----

This PR is a spike RFC. Tests will fail. This has been tested, and works, but performance will take a hit. I'll be working on the tests (and rebasing onto #1959) tomorrow, but want to get it up tonight so you guys can verify the approach.

Currently Snapcraft looks for libs by soname, and gets tripped up if it finds multiple sonames that match (i.e. it takes the first one). This happens in the case of libc coming from the core snap, which includes both amd64's and i386's libc, and it takes i386's libc by default.

Fix this issue by matching architecture in addition to soname.