### PR TITLE
docker: add the architecture

### DIFF
--- a/docker/beta.Dockerfile
+++ b/docker/beta.Dockerfile
@@ -14,7 +14,4 @@ RUN apt-get update && \
 
 COPY bin/snapcraft-wrapper /snap/bin/snapcraft
 
-
-ENV SNAP=/snap/snapcraft/current
-ENV SNAP_NAME=snapcraft
 ENV PATH=/snap/bin:$PATH

--- a/docker/bin/snapcraft-wrapper
+++ b/docker/bin/snapcraft-wrapper
@@ -1,3 +1,7 @@
 #!/bin/sh
-export SNAP_VERSION="$(awk '/^version:/{print $2}' '/snap/snapcraft/current/meta/snap.yaml')"
+export SNAP=/snap/snapcraft/current
+export SNAP_NAME="$(awk '/^name:/{print $2}' $SNAP/meta/snap.yaml)"
+export SNAP_VERSION="$(awk '/^version:/{print $2}' $SNAP/meta/snap.yaml)"
+export SNAP_ARCH=amd64
+
 exec $SNAP/usr/bin/python3 $SNAP/bin/snapcraft "$@"

--- a/docker/candidate.Dockerfile
+++ b/docker/candidate.Dockerfile
@@ -14,7 +14,4 @@ RUN apt-get update && \
 
 COPY bin/snapcraft-wrapper /snap/bin/snapcraft
 
-
-ENV SNAP=/snap/snapcraft/current
-ENV SNAP_NAME=snapcraft
 ENV PATH=/snap/bin:$PATH

--- a/docker/edge.Dockerfile
+++ b/docker/edge.Dockerfile
@@ -14,7 +14,4 @@ RUN apt-get update && \
 
 COPY bin/snapcraft-wrapper /snap/bin/snapcraft
 
-
-ENV SNAP=/snap/snapcraft/current
-ENV SNAP_NAME=snapcraft
 ENV PATH=/snap/bin:$PATH


### PR DESCRIPTION
Setup the correct SNAP_ARCH for our docker images, also blow up in a more
obvious way if it is missing.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
