### PR TITLE
lxd: merge existing image info contents

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -438,9 +438,12 @@ class OsReleaseCodenameError(SnapcraftError):
 
 class InvalidContainerImageInfoError(SnapcraftError):
 
-    fmt = 'Error parsing the container image info: {image_info}'
+    fmt = (
+        'Failed to parse container image info: '
+        'SNAPCRAFT_IMAGE_INFO is not a valid JSON string: {image_info}'
+    )
 
-    def __init__(self, image_info):
+    def __init__(self, image_info: str) -> None:
         super().__init__(image_info=image_info)
 
 

--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -38,6 +38,7 @@ from snapcraft.internal.errors import (
         ContainerError,
         ContainerRunError,
         ContainerSnapcraftCmdError,
+        InvalidContainerImageInfoError,
         SnapdError,
 )
 from snapcraft.project._project_options import _get_deb_arch
@@ -167,6 +168,15 @@ class Containerbuild:
         for field in ('fingerprint', 'architecture', 'created_at'):
             if field in image_info[0]:
                 edited_image_info[field] = image_info[0][field]
+
+        # Pick up existing image info if set
+        image_info_str = os.environ.get('SNAPCRAFT_IMAGE_INFO')
+        if image_info_str:
+            try:
+                edited_image_info.update(json.loads(image_info_str))
+            except json.decoder.JSONDecodeError as e:
+                raise InvalidContainerImageInfoError(image_info_str) from e
+
         # Pass the image info to the container so it can be used when recording
         # information about the build environment.
         subprocess.check_call([

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -301,7 +301,9 @@ class ErrorFormattingTestCase(unit.TestCase):
             'exception': errors.InvalidContainerImageInfoError,
             'kwargs': {'image_info': 'test-image-info'},
             'expected_message': (
-                'Error parsing the container image info: test-image-info')}),
+                'Failed to parse container image info: '
+                'SNAPCRAFT_IMAGE_INFO is not a valid JSON string: '
+                'test-image-info')}),
         # meta errors.
         ('AdoptedPartMissingError', {
             'exception': meta_errors.AdoptedPartMissingError,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This PR implements support for merging the contents of `SNAPCRAFT_IMAGE_INFO` set when building in a container with the information gathered from LXD in the container. The result of it will go into `manifest.yaml` if `SNAPCRAFT_BUILD_INFO` is set (as usual). The exact values aren't filtered but taken as-is - InvalidLaunchpadBuildInfoError is raised if the parsing fails.
This variable is going to be set by [buildd](https://launchpad.net/launchpad-buildd).
Note on compatibility: Older Snapcraft versions already pick up `SNAPCRAFT_IMAGE_INFO`, the main take away here is that builds in containers will merge the provided JSON with what's taken from the container.

The following new tests are being added:

 - tests.unit.test_lifecycle.RecordManifestTestCase.test_prime_with_launchpad_build_info_records_manifest
 - tests.unit.test_lxd.ContainerbuildTestCase.test_image_info_merged
 - To verify the contents of SNAPCRAFT_IMAGE_INFO will be merged with the values populated from the LXD container.
 - tests.unit.test_lxd.ContainerbuildTestCase.test_image_info_invalid
 - To verify that invalid JSON raises an error.
 - tests.unit.test_lxd.test_launchpad_build_info_set

I locally ran the tests:
 - `./runtests.sh tests/unit` unrelated failures in [tests.unit.test_lifecycle.CoreSetupTestCase.test_core_setup_if_docker_env](https://bugs.launchpad.net/snapcraft/+bug/1752576) and `tests.unit.test_elf`.
 - `./runtests.sh tests/integration` with one unrelated failure in [tests.integration.general.test_parser.TestParserWikis](https://bugs.launchpad.net/snapcraft/+bug/1752580).
 - `./runtests.sh tests/static`: Everything passed

Manual test steps:
 - Build and install a Snapcraft snap from this branch.
 - cd tests/integration/snaps/basic
 - SNAPCRAFT_IMAGE_INFO='{"build_url":"test-build-url"}' SNAPCRAFT_BUILD_INFO=1 snapcraft
 - grep -C 1 build_url prime/snap/manifest.yaml
   image-info:
  build_url: test-build-url
build-packages: []
 - Observe the manifest containing build-info with build-url.
 - snapcraft clean
 - SNAPCRAFT_IMAGE_INFO=not-json SNAPCRAFT_BUILD_INFO=1 snapcraft
 - Observe the error message "Failed to parse container image info: SNAPCRAFT_IMAGE_INFO is not a valid JSON string: not-json".
 - snapcraft clean
 - SNAPCRAFT_CONTAINER_BUILDS=1 SNAPCRAFT_IMAGE_INFO='{"build_url":"test-build-url"}' SNAPCRAFT_BUILD_INFO=1 snapcraft
 - grep -C 1 build_url prime/snap/manifest.yaml
  architecture: x86_64
  build_url: test-build-url
  created_at: '2018-03-23T00:00:00Z'
 - Note: The architecture may be wrong because of [LP: #1760857](https://bugs.launchpad.net/snapcraft/+bug/1760857).