### PR TITLE
elf: remove dead code

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -606,10 +606,6 @@ def _get_system_libs() -> FrozenSet[str]:
     return _libraries
 
 
-def _is_dynamically_linked_elf(file_m: str) -> bool:
-    return file_m.startswith('ELF') and 'dynamically linked' in file_m
-
-
 def get_elf_files(root: str,
                   file_list: Sequence[str]) -> FrozenSet[ElfFile]:
     """Return a frozenset of elf files from file_list prepended with root.


### PR DESCRIPTION
The logic migrated to the ElfFile class which does not use the string
returned from magic.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
