### PR TITLE
patches: make the ctypes patch more robust and add armhf arch triplet

### DIFF
--- a/patches/ctypes_init.diff
+++ b/patches/ctypes_init.diff
@@ -15,7 +15,7 @@
 >         if _os.getenv('SNAP_NAME', '') == 'snapcraft':
 >             _name = _os.path.join(
 >                         _os.getenv('SNAP'), 'usr', 'lib',
->                         _ARCH_TRIPLET[_os.getenv('SNAP_ARCH')],
+>                         _ARCH_TRIPLET.get(_os.getenv('SNAP_ARCH')),
 >                         name)
 >             if _os.path.exists(_name):
 >                 name = _name

--- a/patches/ctypes_init.diff
+++ b/patches/ctypes_init.diff
@@ -7,6 +7,7 @@
 >     'powerpc': 'powerpc-linux-gnu',
 >     'amd64': 'x86_64-linux-gnu',
 >     's390x': 's390x-linux-gnu',
+>     'armhf': 'arm-linux-gnueabihf',
 > }
 > 
 > 
@@ -14,7 +15,7 @@
 >         if _os.getenv('SNAP_NAME', '') == 'snapcraft':
 >             _name = _os.path.join(
 >                         _os.getenv('SNAP'), 'usr', 'lib',
->                         _ARCH_TRIPLET.get(_os.getenv('SNAP_ARCH')),
+>                         _ARCH_TRIPLET[_os.getenv('SNAP_ARCH')],
 >                         name)
 >             if _os.path.exists(_name):
 >                 name = _name


### PR DESCRIPTION
Explode appropriately if the environment is incorrect to avoid
going down the line of why it broke later due to a bad environment
being setup.

Also add the correct architecture triplet resolution for when SNAP_ARCH
is armhf.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
