### PR TITLE
errros: add a specific error when running commands from plugins

### DIFF
--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -205,7 +205,7 @@ class BasePlugin:
         except CalledProcessError as process_error:
             raise errors.SnapcraftPluginCommandError(
                 command=cmd, part_name=self.name,
-                exit_code=process_error.returncode)
+                exit_code=process_error.returncode) from process_error
 
     def run_output(self, cmd, cwd=None, **kwargs):
         if not cwd:
@@ -216,4 +216,4 @@ class BasePlugin:
         except CalledProcessError as process_error:
             raise errors.SnapcraftPluginCommandError(
                 command=cmd, part_name=self.name,
-                exit_code=process_error.returncode)
+                exit_code=process_error.returncode) from process_error

--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -202,12 +202,18 @@ class BasePlugin:
         os.makedirs(cwd, exist_ok=True)
         try:
             return common.run(cmd, cwd=cwd, **kwargs)
-        except CalledProcessError:
+        except CalledProcessError as process_error:
             raise errors.SnapcraftPluginCommandError(
-                command=cmd, part_name=self.name)
+                command=cmd, part_name=self.name,
+                exit_code=process_error.returncode)
 
     def run_output(self, cmd, cwd=None, **kwargs):
         if not cwd:
             cwd = self.builddir
         os.makedirs(cwd, exist_ok=True)
-        return common.run_output(cmd, cwd=cwd, **kwargs)
+        try:
+            return common.run_output(cmd, cwd=cwd, **kwargs)
+        except CalledProcessError as process_error:
+            raise errors.SnapcraftPluginCommandError(
+                command=cmd, part_name=self.name,
+                exit_code=process_error.returncode)

--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -17,8 +17,9 @@
 import contextlib
 import logging
 import os
+from subprocess import CalledProcessError
 
-from snapcraft.internal import common
+from snapcraft.internal import common, errors
 
 
 logger = logging.getLogger(__name__)
@@ -199,7 +200,11 @@ class BasePlugin:
             cwd = self.builddir
         print(' '.join(cmd))
         os.makedirs(cwd, exist_ok=True)
-        return common.run(cmd, cwd=cwd, **kwargs)
+        try:
+            return common.run(cmd, cwd=cwd, **kwargs)
+        except CalledProcessError:
+            raise errors.SnapcraftPluginCommandError(
+                command=cmd, part_name=self.name)
 
     def run_output(self, cmd, cwd=None, **kwargs):
         if not cwd:

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -538,8 +538,8 @@ class SnapcraftPluginCommandError(SnapcraftError):
     """Command executed by a plugin fails."""
 
     fmt = (
-        'The command {command!r} run for the {part_name!r} part has failed.\n'
-        'Exited with exit code {exit_code}.\n'
+        'Failed to run {command!r} for {part_name!r}: '
+        'Exited with code {exit_code}.\n'
         'Verify that the part is using the correct parameters and try again.'
     )
 

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -534,7 +534,7 @@ class InvalidExtractorValueError(MetadataExtractionError):
 
 
 class SnapcraftPluginCommandError(SnapcraftError):
-    """Command excecuted by a plugin fails."""
+    """Command executed by a plugin fails."""
 
     fmt = (
         'The command {command!r} run for the {part_name!r} part has failed.\n'

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from typing import List, Union
 
 from snapcraft import formatting_utils
 
@@ -538,10 +539,13 @@ class SnapcraftPluginCommandError(SnapcraftError):
 
     fmt = (
         'The command {command!r} run for the {part_name!r} part has failed.\n'
+        'Exited with exit code {exit_code}.\n'
         'Verify that the part is using the correct parameters and try again.'
     )
 
-    def __init__(self, *, command, part_name):
+    def __init__(self, *, command: Union[List, str], part_name: str,
+                 exit_code: int) -> None:
         if isinstance(command, list):
             command = ' '.join(command)
-        super().__init__(command=command, part_name=part_name)
+        super().__init__(command=command, part_name=part_name,
+                         exit_code=exit_code)

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -531,3 +531,17 @@ class InvalidExtractorValueError(MetadataExtractionError):
 
     def __init__(self, path: str, extractor_name: str) -> None:
         super().__init__(path=path, extractor_name=extractor_name)
+
+
+class SnapcraftPluginCommandError(SnapcraftError):
+    """Command excecuted by a plugin fails."""
+
+    fmt = (
+        'The command {command!r} run for the {part_name!r} part has failed.\n'
+        'Verify that the part is using the correct parameters and try again.'
+    )
+
+    def __init__(self, *, command, part_name):
+        if isinstance(command, list):
+            command = ' '.join(command)
+        super().__init__(command=command, part_name=part_name)

--- a/snapcraft/plugins/_python/_pip.py
+++ b/snapcraft/plugins/_python/_pip.py
@@ -29,7 +29,6 @@ from typing import List, Set
 import snapcraft
 from snapcraft import file_utils
 from snapcraft.internal import mangling
-from snapcraft.internal.errors import SnapcraftPluginCommandError
 from ._python_finder import (
     get_python_command,
     get_python_headers,
@@ -197,8 +196,7 @@ class Pip:
             # Using _run_output here so stdout doesn't get printed to the
             # terminal.
             self._run_output([], stderr=subprocess.STDOUT)
-        except (subprocess.CalledProcessError,
-                SnapcraftPluginCommandError) as e:
+        except subprocess.CalledProcessError as e:
             output = e.output.decode(sys.getfilesystemencoding()).strip()
             if 'no module named pip' in output.lower():
                 return False

--- a/snapcraft/plugins/_python/_pip.py
+++ b/snapcraft/plugins/_python/_pip.py
@@ -29,6 +29,7 @@ from typing import List, Set
 import snapcraft
 from snapcraft import file_utils
 from snapcraft.internal import mangling
+from snapcraft.internal.errors import SnapcraftPluginCommandError
 from ._python_finder import (
     get_python_command,
     get_python_headers,
@@ -196,7 +197,8 @@ class Pip:
             # Using _run_output here so stdout doesn't get printed to the
             # terminal.
             self._run_output([], stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError as e:
+        except (subprocess.CalledProcessError,
+                SnapcraftPluginCommandError) as e:
             output = e.output.decode(sys.getfilesystemencoding()).strip()
             if 'no module named pip' in output.lower():
                 return False

--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -57,7 +57,6 @@ import contextlib
 import os
 import re
 from shutil import which
-import subprocess
 from textwrap import dedent
 
 import requests
@@ -328,8 +327,7 @@ class PythonPlugin(snapcraft.BasePlugin):
                 # There is also a chance that this setup.py is distutils based
                 # in which case we will rely on the `pip install .` ran before
                 #  this.
-                with contextlib.suppress(subprocess.CalledProcessError,
-                                         SnapcraftPluginCommandError):
+                with contextlib.suppress(SnapcraftPluginCommandError):
                     self._setup_tools_install(setup_py_path)
 
         return self._pip.list()

--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -65,6 +65,7 @@ import requests
 import snapcraft
 from snapcraft.common import isurl
 from snapcraft.internal import mangling
+from snapcraft.internal.errors import SnapcraftPluginCommandError
 from snapcraft.plugins import _python
 
 
@@ -327,7 +328,8 @@ class PythonPlugin(snapcraft.BasePlugin):
                 # There is also a chance that this setup.py is distutils based
                 # in which case we will rely on the `pip install .` ran before
                 #  this.
-                with contextlib.suppress(subprocess.CalledProcessError):
+                with contextlib.suppress(subprocess.CalledProcessError,
+                                         SnapcraftPluginCommandError):
                     self._setup_tools_install(setup_py_path)
 
         return self._pip.list()

--- a/tests/integration/general/test_after.py
+++ b/tests/integration/general/test_after.py
@@ -78,7 +78,7 @@ class AfterTestCase(integration.TestCase):
             subprocess.CalledProcessError,
             self.run_snapcraft, 'build')
 
-        self.assertThat(exception.returncode, Equals(1))
+        self.assertThat(exception.returncode, Equals(2))
 
     def test_pull_with_tree_of_dependencies(self):
         self.run_snapcraft(

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -390,6 +390,32 @@ class ErrorFormattingTestCase(unit.TestCase):
                 'occurred.\nPlease try again.'
             )
         }),
+        ('SnapcraftPluginCommandError string command', {
+            'exception': errors.SnapcraftPluginCommandError,
+            'kwargs': {
+                'command': 'make install',
+                'part_name': 'make_test',
+            },
+            'expected_message': (
+                "The command 'make install' run for the 'make_test' part has "
+                "failed.\n"
+                "Verify that the part is using the correct parameters and try "
+                "again."
+            )
+        }),
+        ('SnapcraftPluginCommandError list command', {
+            'exception': errors.SnapcraftPluginCommandError,
+            'kwargs': {
+                'command': ['make', 'install'],
+                'part_name': 'make_test',
+            },
+            'expected_message': (
+                "The command 'make install' run for the 'make_test' part has "
+                "failed.\n"
+                "Verify that the part is using the correct parameters and try "
+                "again."
+            )
+        })
     )
 
     def test_error_formatting(self):

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -394,11 +394,13 @@ class ErrorFormattingTestCase(unit.TestCase):
             'exception': errors.SnapcraftPluginCommandError,
             'kwargs': {
                 'command': 'make install',
+                'exit_code': -1,
                 'part_name': 'make_test',
             },
             'expected_message': (
                 "The command 'make install' run for the 'make_test' part has "
                 "failed.\n"
+                'Exited with exit code -1.\n'
                 "Verify that the part is using the correct parameters and try "
                 "again."
             )
@@ -407,11 +409,13 @@ class ErrorFormattingTestCase(unit.TestCase):
             'exception': errors.SnapcraftPluginCommandError,
             'kwargs': {
                 'command': ['make', 'install'],
+                'exit_code': 2,
                 'part_name': 'make_test',
             },
             'expected_message': (
                 "The command 'make install' run for the 'make_test' part has "
                 "failed.\n"
+                'Exited with exit code 2.\n'
                 "Verify that the part is using the correct parameters and try "
                 "again."
             )

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -398,9 +398,8 @@ class ErrorFormattingTestCase(unit.TestCase):
                 'part_name': 'make_test',
             },
             'expected_message': (
-                "The command 'make install' run for the 'make_test' part has "
-                "failed.\n"
-                'Exited with exit code -1.\n'
+                "Failed to run 'make install' for 'make_test': "
+                "Exited with code -1.\n"
                 "Verify that the part is using the correct parameters and try "
                 "again."
             )
@@ -413,9 +412,8 @@ class ErrorFormattingTestCase(unit.TestCase):
                 'part_name': 'make_test',
             },
             'expected_message': (
-                "The command 'make install' run for the 'make_test' part has "
-                "failed.\n"
-                'Exited with exit code 2.\n'
+                "Failed to run 'make install' for 'make_test': "
+                "Exited with code 2.\n"
                 "Verify that the part is using the correct parameters and try "
                 "again."
             )


### PR DESCRIPTION
When a plugin fails a horrible traceback is printed because there is no
SnapcraftError class handling the situation.

LP: #1753965
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
