### PR TITLE
pluginhandler: special case go patchelf failures for classic confinement

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -371,9 +371,10 @@ def _retry_patch(f):
             # should eventually be removed once patchelf catches up.
             try:
                 elf_file_path = kwargs['elf_file_path']
-                logger.info('Failed to update {!r}. Retrying after stripping '
-                            'the .note.go.buildid from the elf file.'.format(
-                                elf_file_path))
+                logger.warning(
+                    'Failed to update {!r}. Retrying after stripping '
+                    'the .note.go.buildid from the elf file.'.format(
+                        elf_file_path))
                 subprocess.check_call([
                     'strip', '--remove-section', '.note.go.buildid',
                     elf_file_path])

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -532,11 +532,9 @@ class PluginHandler:
 
         if self._build_attributes.no_patchelf():
             logger.warning(
-                'The primed files for part {!r} files are not going to be '
-                'verified for correctness nor patched to work correctly '
-                'in the environment if required as '
-                '`build-attributes: [no-patchelf]` is set for the '
-                'part.'.format(self.name))
+                'The primed files for part {!r} will not be verified for '
+                'correctness or patched: build-attributes: [no-patchelf] '
+                'is set.'.format(self.name))
         else:
             part_patcher = PartPatcher(
                 elf_files=elf_files,

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -22,7 +22,7 @@ import os
 import shutil
 import sys
 from glob import glob, iglob
-from typing import Dict, Set  # noqa
+from typing import Dict, Set  # noqa: F401
 
 import yaml
 
@@ -35,6 +35,7 @@ from ._build_attributes import BuildAttributes
 from ._metadata_extraction import extract_metadata
 from ._plugin_loader import load_plugin  # noqa
 from ._scriptlets import ScriptRunner
+from ._patchelf import PartPatcher
 
 logger = logging.getLogger(__name__)
 
@@ -505,7 +506,7 @@ class PluginHandler:
 
         self.mark_cleaned('stage')
 
-    def prime(self, force=False) -> None:  # noqa: C901
+    def prime(self, force=False) -> None:
         self.makedirs()
         self.notify_part_progress('Priming')
         snap_files, snap_dirs = self.migratable_fileset_for('prime')
@@ -529,79 +530,26 @@ class PluginHandler:
         if not self._build_attributes.keep_execstack():
             clear_execstack(elf_files=elf_files)
 
-        # TODO revisit if we need to support variations and permutations
-        #  of this
-        staged_patchelf_path = os.path.join(self.stagedir, 'bin', 'patchelf')
-        if not os.path.exists(staged_patchelf_path):
-            staged_patchelf_path = None
-
-        # If libc6 is staged, to avoid symbol mixups we will resort to
-        # glibc mangling.
-        libc6_staged = 'libc6' in self._part_properties.get(
-            'stage-packages', [])
-        is_classic = self._confinement == 'classic'
-
-        # classic confined snaps built on anything but a host supporting the
-        # the target base will require glibc mangling.
-        classic_mangling_needed = (
-            is_classic and
-            not self._project_options.is_host_compatible_with_base(self._base))
-
-        # We need to verify now that the GLIBC version would be compatible
-        # with that of the base.
-        # TODO we do not require the base to be installed when building,
-        #      it would only be required for classic, but not for glibc
-        #      mismatch checks.
-        linker_incompat = dict()  # type: Dict[str, str]
-        try:
-            linker = os.path.basename(
-                self._project_options.get_core_dynamic_linker(self._base))
-            for elf_file in elf_files:
-                if not elf_file.is_linker_compatible(linker=linker):
-                    linker_incompat[elf_file.path] = \
-                        elf_file.get_required_glibc()
-            if linker_incompat:
-                formatted_items = ['- {} (requires GLIBC {})'.format(k, v)
-                                   for k, v in linker_incompat.items()]
-                logger.warning(
-                    'The GLIBC version of the targeted core is {}. A newer '
-                    'libc will be required for the following files:'
-                    '\n{}'.format(linker, '\n'.join(formatted_items)))
-        except errors.SnapcraftMissingLinkerInBaseError as base_error:
-            if is_classic or classic_mangling_needed:
-                raise base_error
-
-        dynamic_linker = None
-        if linker_incompat or libc6_staged or classic_mangling_needed:
-            if not libc6_staged:
-                raise errors.StagePackageMissingError(package='libc6')
-            dynamic_linker = elf.find_linker(
-                root_path=self.primedir,
-                snap_base_path=self._snap_base_path)
-        elif is_classic:
-            dynamic_linker = self._project_options.get_core_dynamic_linker(
-                self._base, expand=False)
-
-        if dynamic_linker and not self._build_attributes.no_patchelf():
+        if self._build_attributes.no_patchelf():
             logger.warning(
-                'Files in this part are going to be patched to execute '
-                'correctly on diverse environments.\n'
-                'To disable this behavior set '
-                '`build-attributes: [no-patchelf]` for the part.')
-            elf_patcher = elf.Patcher(
-                dynamic_linker=dynamic_linker,
-                root_path=self.primedir,
-                preferred_patchelf_path=staged_patchelf_path)
-            files_to_patch = elf.get_elf_files_to_patch(elf_files)
-            for elf_file in files_to_patch:
-                elf_patcher.patch(elf_file=elf_file)
-        elif dynamic_linker and self._build_attributes.no_patchelf():
-            logger.warning(
-                'The following files are not going to be patched to work '
-                'correctly in the environment as '
+                'The primed files for part {!r} files are not going to be '
+                'verified for correctness nor patched to work correctly '
+                'in the environment if required as '
                 '`build-attributes: [no-patchelf]` is set for the '
-                'part:\n{}'.format(
-                    ''.join(['- {}\n'.format(e.path) for e in elf_files])))
+                'part.'.format(self.name))
+        else:
+            part_patcher = PartPatcher(
+                elf_files=elf_files,
+                plugin=self.plugin,
+                project=self._project_options,
+                confinement=self._confinement,
+                core_base=self._base,
+                snap_base_path=self._snap_base_path,
+                stagedir=self.stagedir,
+                primedir=self.primedir,
+                stage_packages=self._part_properties.get(
+                    'stage-packages', []))
+            part_patcher.patch()
 
         self.mark_prime_done(snap_files, snap_dirs, dependency_paths)
 

--- a/snapcraft/internal/pluginhandler/_patchelf.py
+++ b/snapcraft/internal/pluginhandler/_patchelf.py
@@ -1,0 +1,149 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016-2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import contextlib
+import logging
+import os
+from typing import FrozenSet, List
+from typing import Dict  # noqa: F401
+
+import snapcraft.plugins
+from snapcraft import ProjectOptions
+from snapcraft.internal import elf
+from snapcraft.internal import errors
+
+
+logger = logging.getLogger(__name__)
+
+
+def _is_go_based_plugin(plugin):
+    # We iterate over the plugins suppressing as they may not be loaded.
+    plugin_exceptions = []
+    with contextlib.suppress(AttributeError):
+        plugin_exceptions.append(snapcraft.plugins.godeps.GodepsPlugin)
+    with contextlib.suppress(AttributeError):
+        plugin_exceptions.append(snapcraft.plugins.go.GoPlugin)
+    return isinstance(plugin, tuple(plugin_exceptions))
+
+
+class PartPatcher:
+
+    def __init__(self, *,
+                 elf_files: FrozenSet[elf.ElfFile],
+                 plugin,
+                 project: ProjectOptions,
+                 confinement: str,     # TODO remove once project has this
+                 core_base: str,       # TODO remove once project has this
+                 snap_base_path: str,  # TODO remove once project has this
+                 stage_packages: List[str],
+                 stagedir: str,
+                 primedir: str) -> None:
+        self._elf_files = elf_files
+        self._is_go_based_plugin = _is_go_based_plugin(plugin)
+        self._project = project
+        self._is_classic = confinement == 'classic'
+        self._is_host_compat_with_base = project.is_host_compatible_with_base(
+            core_base)
+        self._core_base = core_base
+        self._snap_base_path = snap_base_path
+        # If libc6 is staged, to avoid symbol mixups we will resort to
+        # glibc mangling.
+        self._is_libc6_staged = 'libc6' in stage_packages
+        self._stagedir = stagedir
+        self._primedir = primedir
+
+    def _get_glibc_compatibility(self, linker_version: str) -> Dict[str, str]:
+        linker_incompat = dict()  # type: Dict[str, str]
+        for elf_file in self._elf_files:
+            if not elf_file.is_linker_compatible(linker=linker_version):
+                linker_incompat[elf_file.path] = \
+                    elf_file.get_required_glibc()
+        if linker_incompat:
+            formatted_items = ['- {} (requires GLIBC {})'.format(k, v)
+                               for k, v in linker_incompat.items()]
+            logger.warning(
+                'The GLIBC version of the targeted core is {}. A newer '
+                'libc will be required for the following files:'
+                '\n{}'.format(linker_version, '\n'.join(formatted_items)))
+        return linker_incompat
+
+    def _get_preferred_patchelf_path(self):
+        # TODO revisit if we need to support variations and permutations
+        #  of this
+        staged_patchelf_path = os.path.join(self._stagedir, 'bin', 'patchelf')
+        if not os.path.exists(staged_patchelf_path):
+            staged_patchelf_path = None
+        return staged_patchelf_path
+
+    def _patch(self, dynamic_linker: str) -> None:
+        preferred_patchelf_path = self._get_preferred_patchelf_path()
+
+        elf_patcher = elf.Patcher(
+            dynamic_linker=dynamic_linker,
+            root_path=self._primedir,
+            preferred_patchelf_path=preferred_patchelf_path)
+        files_to_patch = elf.get_elf_files_to_patch(self._elf_files)
+        for elf_file in files_to_patch:
+            try:
+                elf_patcher.patch(elf_file=elf_file)
+            except errors.PatcherError as patch_error:
+                logger.warning(
+                    'An attempt to patch {!r} so that it would work '
+                    'correctly in diverse environments was made and failed. '
+                    'To disable this behavior set '
+                    '`build-attributes: [no-patchelf]` for the part.')
+                if not self._is_go_based_plugin:
+                    raise patch_error
+
+    def _verify_compat(self) -> None:
+        linker_version = os.path.basename(
+                self._project.get_core_dynamic_linker(self._core_base))
+        linker_incompat = self._get_glibc_compatibility(linker_version)
+        # Even though we do this in patch, it does not hurt to check again
+        logger.debug('Is the {!r} incompatible: {!r}'.format(linker_version,
+                                                             linker_incompat))
+        if linker_incompat and not self._is_libc6_staged:
+            raise errors.StagePackageMissingError(package='libc6')
+
+    def patch(self) -> None:
+        # Rules for verification
+        #   the host is not compatible with the selected base
+        logger.debug('Host compatible with base: {!r}'.format(
+            self._is_host_compat_with_base))
+        if not self._is_host_compat_with_base:
+            self._verify_compat()
+        # Rules for patching:
+        #   if the confinement is classic
+        #   if libc6 is staged
+        logger.debug('Is classic: {!r}'.format(self._is_classic))
+        logger.debug('Is libc6 in stage-packages: {!r}'.format(
+            self._is_libc6_staged))
+        if not (self._is_classic or self._is_libc6_staged):
+            return
+
+        if self._is_libc6_staged:
+            dynamic_linker = elf.find_linker(
+                root_path=self._primedir,
+                snap_base_path=self._snap_base_path)
+        elif self._is_classic:
+            dynamic_linker = self._project.get_core_dynamic_linker(
+                self._core_base, expand=False)
+        else:
+            # This would be bad
+            pass
+
+        logger.debug('Dynamic linker set to {!r}'.format(dynamic_linker))
+        self._patch(dynamic_linker)

--- a/snapcraft/internal/pluginhandler/_patchelf.py
+++ b/snapcraft/internal/pluginhandler/_patchelf.py
@@ -142,8 +142,9 @@ class PartPatcher:
             dynamic_linker = self._project.get_core_dynamic_linker(
                 self._core_base, expand=False)
         else:
-            # This would be bad
-            pass
+            raise errors.SnapcraftEnvironmentError(
+                'An unexpected error has occured while patching. '
+                'Please log an issue against the snapcraft tool.')
 
         logger.debug('Dynamic linker set to {!r}'.format(dynamic_linker))
         self._patch(dynamic_linker)

--- a/snapcraft/internal/pluginhandler/_patchelf.py
+++ b/snapcraft/internal/pluginhandler/_patchelf.py
@@ -104,7 +104,8 @@ class PartPatcher:
                     'An attempt to patch {!r} so that it would work '
                     'correctly in diverse environments was made and failed. '
                     'To disable this behavior set '
-                    '`build-attributes: [no-patchelf]` for the part.')
+                    '`build-attributes: [no-patchelf]` for the part.'.format(
+                        elf_file.path))
                 if not self._is_go_based_plugin:
                     raise patch_error
 

--- a/tests/integration/snaps/go-gotty/snapcraft.yaml
+++ b/tests/integration/snaps/go-gotty/snapcraft.yaml
@@ -14,8 +14,8 @@ parts:
     source-type: git
     source-commit: 2c50c432906f1034fa1efec8f7866315f8c81025
     plugin: go
-    build-snaps: [patchelf/latest/edge]
     go-importpath: github.com/yudai/gotty
     after: [go]
   go:
     source-tag: go1.9.2
+    source-depth: 1


### PR DESCRIPTION
Classic confinement for go with patchelf is still a little problematic
and has never really work from a confinement perspective. So we warn if
patchelf fails to run through.

Clean up the logic after the introduction of bases and the requirement
to explicitly add libc6 to stage-packages in case of non host
compatibilities

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
