### PR TITLE
catkin plugin: replace python calls in all profile.d scripts

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -701,16 +701,15 @@ class CatkinPlugin(snapcraft.BasePlugin):
         # Fix all shebangs to use the in-snap python.
         mangling.rewrite_python_shebangs(self.installdir)
 
-        # Also replace the python usage in 10.ros.sh to use the in-snap python.
-        ros10_file = os.path.join(self.rosdir,
-                                  'etc/catkin/profile.d/10.ros.sh')
-        if os.path.isfile(ros10_file):
-            with open(ros10_file, 'r+') as f:
-                pattern = re.compile(r'/usr/bin/python')
-                replaced = pattern.sub(r'python', f.read())
-                f.seek(0)
-                f.truncate()
-                f.write(replaced)
+        # Also replace all the /usr/bin/python calls in etc/catkin/profile.d/
+        # files with the in-snap python
+        profile_d_path = os.path.join(
+            self.rosdir, 'etc', 'catkin', 'profile.d')
+        file_utils.replace_in_file(
+            profile_d_path,
+            re.compile(r''),
+            re.compile(r'/usr/bin/python'),
+            r'python')
 
     def _build_catkin_packages(self):
         # Nothing to do if no packages were specified

--- a/tests/unit/plugins/test_catkin.py
+++ b/tests/unit/plugins/test_catkin.py
@@ -645,6 +645,27 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
                             'The absolute path to python was not replaced as '
                             'expected')
 
+    def test_use_in_snap_python_rewrites_1_ros_package_path_sh(self):
+        plugin = catkin.CatkinPlugin('test-part', self.properties,
+                                     self.project_options)
+        os.makedirs(os.path.join(plugin.rosdir, 'etc', 'catkin', 'profile.d'))
+
+        ros_profile = os.path.join(plugin.rosdir, 'etc', 'catkin', 'profile.d',
+                                   '1.ros_package_path.sh')
+
+        # Place 1.ros_package_path.sh with an absolute path to python
+        with open(ros_profile, 'w') as f:
+            f.write('/usr/bin/python foo')
+
+        plugin._use_in_snap_python()
+
+        # Verify that the absolute path in 1.ros_package_path.sh was rewritten
+        # correctly
+        with open(ros_profile, 'r') as f:
+            self.assertThat(f.read(), Equals('python foo'),
+                            'The absolute path to python was not replaced as '
+                            'expected')
+
     def _verify_run_environment(self, plugin):
         python_path = os.path.join(
             plugin.installdir, 'usr', 'lib', 'python2.7', 'dist-packages')


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently, Snapcraft replaces a Python call in `etc/catkin/profile.d/10.ros.sh` that uses an absolute path (that doesn't exist in the core snap) to use just the `python` command instead, thereby ensuring the one from the snap is used. However, a recent ROS Kinetic update switched up the profile.d files, using absolute paths to Python elsewhere, breaking all newly-built ROS Kinetic snaps on Ubuntu Core.

Fix this by taking broader approach, checking _every_ file in `etc/catkin/profile.d/` for absolute Python paths and replacing each if found. Note that this should fix the Catkin Tools plugin as well.

Refer to https://forum.snapcraft.io/t/4518 for more information.

Please test this PR using the `edge/pr-2007-catkin-kinetic-fix` channel:

    sudo snap install snapcraft --channel=edge/pr-2007-catkin-kinetic-fix

Or if you already have it installed:

    sudo snap refresh snapcraft --channel=edge/pr-2007-catkin-kinetic-fix