### PR TITLE
tests: run tests on Trusty on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,14 @@ jobs:
     # CLA check, only in pull requests, not coming from the bot.
     - if: type = pull_request AND sender != snappy-m-o
       script: ./tools/travis/run_cla_check.sh
+    # Trusty
+    - stage: integration-trusty
+      if: type != cron
+      script: sudo ./tools/travis/run_tests.sh tests/integration/general native
+    - if: type != cron
+      script: sudo ./tools/travis/run_tests.sh tests/integration/store native
+    - if: type != cron
+      script: sudo ./tools/travis/run_tests.sh tests.integration.plugins_catkin native
     # Trigger nightly tests, only in cron.
     - stage: nightly
     # Run spread tests for the snapcraft snap in edge.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This PR adds a stage to Travis for running `tests/integration/general`, `tests/integration/store` and `tests.integration.plugins_catkin` on **Trusty** natively - due to [LP: #1628289](https://bugs.launchpad.net/snappy/+bug/1628289/comments/18) we can't use a Trusty container.
The script `tools/travis/run_tests.sh` gains a new optional **image** argument which can currently be `ubuntu:xenial` (the default) or `native` to run the tests on the host.

I locally tested the scripts like so:
 - `sudo -H ./tools/travis/run_tests.sh tests/unit ubuntu:xenial`
 - `sudo -H ./tools/travis/run_tests.sh tests/unit native`

Manual test steps:
 - `sudo -H ./tools/travis/run_tests.sh tests/unit ubuntu:trusty`
 - Observe `Invalid image: ubuntu:trusty`
 - `sudo -H ./tools/travis/run_tests.sh tests/unit ubuntu:xenial`
 - `sudo -H ./tools/travis/run_tests.sh tests/unit`
 - `sudo -H ./tools/travis/run_tests.sh tests/unit native`

**Note:** Run these commands before each attempt at running the tests if you're not running from a new machine. Stop any other containers that you may have running, otherwise removing the network device will fail - errors `not found` and `The device doesn't exist` are safe to ignore.
 - `lxc delete --force test-runner; lxc network delete testbr0; lxc profile device remove default eth0`