### PR TITLE
pluginhandler: only do elf checking and patching for type app

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -59,7 +59,7 @@ class PluginHandler:
     def __init__(self, *, plugin, part_properties, project_options,
                  part_schema, definitions_schema, stage_packages_repo,
                  grammar_processor, snap_base_path, base, confinement,
-                 soname_cache):
+                 snap_type, soname_cache):
         self.valid = False
         self.plugin = plugin
         self._part_properties = _expand_part_properties(
@@ -70,6 +70,7 @@ class PluginHandler:
         self._snap_base_path = snap_base_path
         self._base = base
         self._confinement = confinement
+        self._snap_type = snap_type
         self._soname_cache = soname_cache
         self._source = grammar_processor.get_source()
         if not self._source:
@@ -530,12 +531,12 @@ class PluginHandler:
         if not self._build_attributes.keep_execstack():
             clear_execstack(elf_files=elf_files)
 
-        if self._build_attributes.no_patchelf():
+        if self._snap_type == 'app' and self._build_attributes.no_patchelf():
             logger.warning(
                 'The primed files for part {!r} will not be verified for '
                 'correctness or patched: build-attributes: [no-patchelf] '
                 'is set.'.format(self.name))
-        else:
+        elif self._snap_type == 'app':
             part_patcher = PartPatcher(
                 elf_files=elf_files,
                 plugin=self.plugin,

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -41,6 +41,7 @@ class PartsConfig:
         self._confinement = parts['confinement']
         self._soname_cache = elf.SonameCache()
         self._parts_data = parts.get('parts', {})
+        self._snap_type = parts.get('type', 'app')
         self._project_options = project_options
         self._validator = validator
         self.build_snaps = build_snaps
@@ -194,6 +195,7 @@ class PartsConfig:
             snap_base_path=path.join('/', 'snap', self._snap_name, 'current'),
             base=self._base,
             confinement=self._confinement,
+            snap_type=self._snap_type,
             soname_cache=self._soname_cache)
 
         self.build_snaps |= grammar_processor.get_build_snaps()

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -169,7 +169,7 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
 
     def load_part(self, part_name, plugin_name=None, part_properties=None,
                   project_options=None, stage_packages_repo=None,
-                  base='core', confinement='strict'):
+                  base='core', confinement='strict', snap_type='app'):
         if not plugin_name:
             plugin_name = 'nil'
         properties = {'plugin': plugin_name}
@@ -208,6 +208,7 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
             snap_base_path='/snap/fake-name/current',
             base=base,
             confinement=confinement,
+            snap_type=snap_type,
             soname_cache=elf.SonameCache())
 
 

--- a/tests/unit/pluginhandler/test_patcher.py
+++ b/tests/unit/pluginhandler/test_patcher.py
@@ -1,0 +1,55 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from unittest import mock
+
+from tests import unit
+
+
+class PrimeTypeExcludesPatchingTestCase(unit.TestCase):
+
+    scenarios = (
+        ('kernel', dict(snap_type='kernel')),
+        ('gadget', dict(snap_type='gadget')),
+        ('base', dict(snap_type='base')),
+        ('os', dict(snap_type='os')),
+    )
+
+    def test_no_patcher_called(self):
+        handler = self.load_part(
+            'test-part', part_properties={'source-subdir': 'src'},
+            snap_type=self.snap_type)
+
+        patcher_class = 'snapcraft.internal.pluginhandler.PartPatcher'
+        with mock.patch(patcher_class) as patcher_mock:
+            handler.prime()
+            patcher_mock.assert_not_called()
+
+
+class PrimeTypeAppDoesPatchingTestCase(unit.TestCase):
+
+    def test_patcher_called(self):
+        handler = self.load_part(
+            'test-part', part_properties={'source-subdir': 'src'},
+            snap_type='app')
+
+        patcher_class = 'snapcraft.internal.pluginhandler.PartPatcher'
+        with mock.patch(patcher_class) as patcher_mock:
+            handler.prime()
+            patcher_mock.assert_called_with(
+                confinement='strict', core_base='core', elf_files=frozenset(),
+                plugin=mock.ANY, primedir=self.prime_dir,
+                project=mock.ANY, snap_base_path='/snap/fake-name/current',
+                stage_packages=[], stagedir=self.stage_dir)


### PR DESCRIPTION
If the snap is not of type app, today, it is not necessary to do
ABI/API checks agains libc6.

LP: #1757094

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
