### PR TITLE
tests: run tests on Trusty on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ services: [docker]
 language: python
 python:
  - "3.6"
+install:
+ - echo 'No installing of dependencies here'
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,11 +58,11 @@ jobs:
     # Trusty
     - stage: integration-trusty
       if: type != cron
-      script: sudo ./tools/travis/run_tests.sh tests/integration/general native
+      script: sudo -E ./tools/travis/run_tests.sh tests/integration/general native
     - if: type != cron
-      script: sudo ./tools/travis/run_tests.sh tests/integration/store native
+      script: sudo -E ./tools/travis/run_tests.sh tests/integration/store native
     - if: type != cron
-      script: sudo ./tools/travis/run_tests.sh tests/integration/plugins_catkin native
+      script: sudo -E ./tools/travis/run_tests.sh tests/integration/plugins_catkin native
     # Trigger nightly tests, only in cron.
     - stage: nightly
     # Run spread tests for the snapcraft snap in edge.

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ dist: trusty
 
 services: [docker]
 
-language: bash
+language: python
+python:
+ - "3.6"
 
 cache:
   directories:
@@ -51,6 +53,14 @@ jobs:
     # CLA check, only in pull requests, not coming from the bot.
     - if: type = pull_request AND sender != snappy-m-o
       script: ./tools/travis/run_cla_check.sh
+    # Trusty
+    - stage: integration-trusty
+      if: type != cron
+      script: sudo ./tools/travis/run_tests.sh tests/integration/general native
+    - if: type != cron
+      script: sudo ./tools/travis/run_tests.sh tests/integration/store native
+    - if: type != cron
+      script: sudo ./tools/travis/run_tests.sh tests/integration/plugins_catkin native
     # Trigger nightly tests, only in cron.
     - stage: nightly
     # Run spread tests for the snapcraft snap in edge.

--- a/tools/travis/run_tests.sh
+++ b/tools/travis/run_tests.sh
@@ -28,6 +28,8 @@ fi
 test="$1"
 image="${2:-ubuntu:xenial}"
 
+PATH="$VIRTUAL_ENV/bin:$PATH"
+
 if [ "$test" = "static" ]; then
     dependencies="apt install -y python3-pip && python3 -m pip install -r requirements-devel.txt"
 elif [ "$test" = "tests/unit" ]; then
@@ -49,7 +51,7 @@ project_path="$(readlink -f "$script_path/../..")"
 
 if [ "$image" = "native" ]; then
     if grep 14.04 /etc/os-release; then
-        sed -i 's/apt_1.1.0~beta1build1/apt_0.9.3.5ubuntu2/' requirements.txt
+        # libsodium-dev
         sudo add-apt-repository -y ppa:chris-lea/libsodium
         sudo apt update
     fi

--- a/tools/travis/run_tests.sh
+++ b/tools/travis/run_tests.sh
@@ -53,7 +53,11 @@ if [ "$image" = "native" ]; then
     if grep 14.04 /etc/os-release; then
         # libsodium-dev
         sudo add-apt-repository -y ppa:chris-lea/libsodium
-        sudo apt update
+        sudo apt-get update
+        # FIXME: Work-around for
+        # mksquashfs: error while loading shared libraries: liblz4.so.1
+        # This can be removed once 2.40.1 is out
+        sudo apt-get install liblz4-1
     fi
     run(){ sh -c "SNAPCRAFT_FROM_SNAP=1 $1"; }
 elif [ "$image" = "ubuntu:xenial" ]; then


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This PR adds a stage to Travis for running `tests/integration/general`, `tests/integration/store` and `tests.integration.plugins_catkin` on **Trusty** natively - due to [LP: #1628289](https://bugs.launchpad.net/snappy/+bug/1628289/comments/18) we can't use a Trusty container.
The script `tools/travis/run_tests.sh` gains a new optional **image** argument which can currently be `ubuntu:xenial` (the default) or `native` to run the tests on the host.

**Note on testing**: As follows I did some sanity checks. This PR is using Travis to pull in Python 3.6, so tests won't run properly out of the box on Trusty.

I locally tested the scripts like so, on a Trusty VM and Xenial:
 - `sudo -H ./tools/travis/run_tests.sh tests/unit ubuntu:xenial`
 - `sudo -H ./tools/travis/run_tests.sh tests/unit native`

Manual test steps:
 - `sudo -H ./tools/travis/run_tests.sh tests/unit ubuntu:trusty`
 - Observe `Invalid image: ubuntu:trusty`
 - `sudo -H ./tools/travis/run_tests.sh tests/unit ubuntu:xenial`
 - `sudo -H ./tools/travis/run_tests.sh tests/unit`
 - `sudo -H ./tools/travis/run_tests.sh tests/unit native`

**Note:** Run these commands before each attempt at running the non-native tests if you're not running from a new machine. Stop any other containers that you may have running, otherwise removing the network device will fail - errors `not found` and `The device doesn't exist` are safe to ignore.
 - `lxc delete --force test-runner; lxc network delete testbr0; lxc profile device remove default eth0`