### PR TITLE
integration tests: snap tests shouldn't be arch-specific

### DIFF
--- a/tests/integration/general/test_snap.py
+++ b/tests/integration/general/test_snap.py
@@ -84,7 +84,7 @@ class SnapTestCase(integration.TestCase):
                 summary: one line summary
                 description: a longer description
                 architectures:
-                - amd64
+                - {}
                 confinement: strict
                 grade: stable
                 apps:
@@ -98,7 +98,7 @@ class SnapTestCase(integration.TestCase):
                     command: subdir/binary3
                   binary2:
                     command: command-binary2.wrapper
-            """)))
+            """).format(self.deb_arch)))
 
     def test_snap_default(self):
         self.copy_project_to_cwd('assemble')


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?