### PR TITLE
demos: use realpath in command entry for java-hello-world

### DIFF
--- a/demos/java-hello-world/snap/snapcraft.yaml
+++ b/demos/java-hello-world/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ grade: stable
 
 apps:
  hello:
-    command: usr/lib/jvm/default-java/bin/java oata.HelloWorld
+    command: usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java oata.HelloWorld
     adapter: none
     environment:
        JAVA_HOME: $SNAP/usr/lib/jvm/default-java


### PR DESCRIPTION
snapd's new checks do not allow for relative symlinks as the main entry
point in a command so use the realpath to the existing path instead.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
