### PR TITLE
many: optimize retrieval of the linker version

### DIFF
--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -22,6 +22,7 @@ import sys
 from contextlib import suppress
 from typing import List, Set  # noqa: F401
 
+from snapcraft import file_utils
 from snapcraft.internal import common, errors, os_release
 from snapcraft.internal.deprecations import handle_deprecation_notice
 
@@ -115,6 +116,12 @@ _HOST_CODENAME_FOR_BASE = {
 _HOST_COMPATIBILITY = {
     'xenial': ['trusty', 'xenial'],
     'bionic': ['trusty', 'xenial', 'bionic'],
+}
+
+
+_LINKER_VERSION_FOR_BASE = {
+    'core18': '2.27',
+    'core': '2.23',
 }
 
 
@@ -257,6 +264,16 @@ class ProjectOptions:
         compatible_hosts = _HOST_COMPATIBILITY.get(
             build_host_for_base, [])  # type: List[str]
         return codename in compatible_hosts
+
+    # This is private to not make the API public given that base
+    # will be part of the new Project.
+    def _get_linker_version_for_base(self, base: str) -> str:
+        """Returns the linker version for base."""
+        try:
+            return _LINKER_VERSION_FOR_BASE[base]
+        except KeyError:
+            linker_file = os.path.basename(self.get_core_dynamic_linker(base))
+            return file_utils.get_linker_version_from_file(linker_file)
 
     def get_core_dynamic_linker(self, base: str, expand: bool=True) -> str:
         """Returns the dynamic linker used for the targeted core.

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -265,25 +265,13 @@ class ElfFile:
 
         return arch, interp, soname, libs, execstack_set
 
-    def is_linker_compatible(self, *, linker: str) -> bool:
-        """Determines if linker will work given the required glibc version.
-
-        The linker passed needs to be of the format <root>/ld-<X>.<Y>.so.
-        """
+    def is_linker_compatible(self, *, linker_version: str) -> bool:
+        """Determines if linker will work given the required glibc version."""
         version_required = self.get_required_glibc()
-        m = re.search(r'ld-(?P<linker_version>[\d.]+).so$',
-                      os.path.basename(linker))
-        if not m:
-            # This is a programmatic error, we don't want to be friendly
-            # about this.
-            raise EnvironmentError('The format for the linker should be of the'
-                                   'form <root>/ld-<X>.<Y>.so. {!r} does not '
-                                   'match that format.'.format(linker))
-        linker_version = m.group('linker_version')
         r = parse_version(version_required) <= parse_version(linker_version)
         logger.debug('Checking if linker {!r} will work with '
                      'GLIBC_{} required by {!r}: {!r}'.format(
-                         linker, version_required, self.path, r))
+                         linker_version, version_required, self.path, r))
         return r
 
     def get_required_glibc(self) -> str:

--- a/snapcraft/internal/pluginhandler/_patchelf.py
+++ b/snapcraft/internal/pluginhandler/_patchelf.py
@@ -93,7 +93,8 @@ class PartPatcher:
     def _get_glibc_compatibility(self, linker_version: str) -> Dict[str, str]:
         linker_incompat = dict()  # type: Dict[str, str]
         for elf_file in self._elf_files:
-            if not elf_file.is_linker_compatible(linker=linker_version):
+            if not elf_file.is_linker_compatible(
+                    linker_version=linker_version):
                 linker_incompat[elf_file.path] = \
                     elf_file.get_required_glibc()
         if linker_incompat:
@@ -135,12 +136,12 @@ class PartPatcher:
                     raise patch_error
 
     def _verify_compat(self) -> None:
-        linker_version = os.path.basename(
-                self._project.get_core_dynamic_linker(self._core_base))
+        linker_version = self._project._get_linker_version_for_base(
+            self._core_base)
         linker_incompat = self._get_glibc_compatibility(linker_version)
+        logger.debug('List of files incompatible with {!r}: {!r}'.format(
+            linker_version, linker_incompat))
         # Even though we do this in patch, it does not hurt to check again
-        logger.debug('Is the {!r} incompatible: {!r}'.format(linker_version,
-                                                             linker_incompat))
         if linker_incompat and not self._is_libc6_staged:
             raise errors.StagePackageMissingError(package='libc6')
 

--- a/tests/unit/test_elf.py
+++ b/tests/unit/test_elf.py
@@ -360,20 +360,15 @@ class TestGetRequiredGLIBC(TestElfBase):
 
     def test_linker_version_greater_than_required_glibc(self):
         self.assertTrue(
-            self.elf_file.is_linker_compatible(linker='ld-2.26.so'))
+            self.elf_file.is_linker_compatible(linker_version='2.26'))
 
     def test_linker_version_equals_required_glibc(self):
         self.assertTrue(
-            self.elf_file.is_linker_compatible(linker='ld-2.23.so'))
+            self.elf_file.is_linker_compatible(linker_version='2.23'))
 
     def test_linker_version_less_than_required_glibc(self):
         self.assertFalse(
-            self.elf_file.is_linker_compatible(linker='ld-1.2.so'))
-
-    def test_bad_linker_raises_exception(self):
-        self.assertRaises(EnvironmentError,
-                          self.elf_file.is_linker_compatible,
-                          linker='lib64/ld-linux-x86-64.so.2')
+            self.elf_file.is_linker_compatible(linker_version='1.2'))
 
 
 class TestElfFileAttrs(TestElfBase):

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -27,6 +27,7 @@ from snapcraft.internal.errors import (
     RequiredCommandFailure,
     RequiredCommandNotFound,
     RequiredPathDoesNotExist,
+    SnapcraftEnvironmentError,
     SnapcraftError,
 )
 from tests import unit
@@ -315,3 +316,24 @@ class RequiresPathExistsTestCase(unit.TestCase):
             ).__enter__)
 
         self.assertThat(str(raised), Equals("what? 'foo'"))
+
+
+class TestGetLinkerFromFile(unit.TestCase):
+
+    def test_get_linker_version_from_basename(self):
+        self.assertThat(
+            file_utils.get_linker_version_from_file('ld-2.26.so'),
+            Equals('2.26'))
+
+    def test_get_linker_version_from_path(self):
+        self.assertThat(
+            file_utils.get_linker_version_from_file('/lib/x86/ld-2.23.so'),
+            Equals('2.23'))
+
+
+class TestGetLinkerFromFileErrors(unit.TestCase):
+
+    def test_bad_file_formatlinker_raises_exception(self):
+        self.assertRaises(SnapcraftEnvironmentError,
+                          file_utils.get_linker_version_from_file,
+                          linker_file='lib64/ld-linux-x86-64.so.2')

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -208,3 +208,32 @@ class TestHostIsCompatibleWithTargetBase(unit.TestCase):
         self.assertThat(
             snapcraft.ProjectOptions().is_host_compatible_with_base(self.base),
             Equals(self.is_compatible))
+
+
+class TestLinkerVersionForBase(unit.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        patcher = mock.patch(
+            'snapcraft.file_utils.get_linker_version_from_file')
+        self.get_linker_version_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_get_linker_version_for_core(self):
+        self.assertThat(
+            snapcraft.ProjectOptions()._get_linker_version_for_base('core'),
+            Equals('2.23'))
+        self.get_linker_version_mock.assert_not_called()
+
+    def test_get_linker_version_for_core18(self):
+        self.assertThat(
+            snapcraft.ProjectOptions()._get_linker_version_for_base('core18'),
+            Equals('2.27'))
+        self.get_linker_version_mock.assert_not_called()
+
+    def test_get_linker_version_for_random_core(self):
+        self.get_linker_version_mock.return_value = '4.10'
+        self.assertThat(
+            snapcraft.ProjectOptions()._get_linker_version_for_base('random'),
+            Equals('4.10'))
+        self.get_linker_version_mock.assert_called_once_with('ld-2.23.so')


### PR DESCRIPTION
When checking for compatibility when the host is not ideal for the base
the base needs to be installed. In many cases the linker version for
the base is known in advance so retrieving the linker from the core
is not required.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
