### PR TITLE
elf: avoid duplicating rpath entries

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -504,8 +504,10 @@ class Patcher:
                     rel_library_path_dir = os.path.dirname(rel_library_path)
                     # return the dirname, with the first .. replace
                     # with $ORIGIN
-                    origin_rpaths.append(rel_library_path_dir.replace(
-                        '..', '$ORIGIN', 1))
+                    origin_rpath = rel_library_path_dir.replace(
+                        '..', '$ORIGIN', 1)
+                    if origin_rpath not in origin_rpaths:
+                        origin_rpaths.append(origin_rpath)
 
         if existing_rpaths:
             # Only keep those that mention origin and are not already in our


### PR DESCRIPTION
One path is enough for '$ORIGIN' based rpaths.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

On `bionic`:
```
(snapcraft) ubuntu@snapcraft-bionic-dev:~/source/snapcraft$ SNAPCRAFT_TEST_KEEP_DATA_PATH=/home/ubuntu/test python3 -m unittest -v -b run tests.integration.general.test_elf.OriginRPATHTestCase
run (unittest.loader._FailedTest) ... ok
test_origin (tests.integration.general.test_elf.OriginRPATHTestCase)
tests.integration.general.test_elf.OriginRPATHTestCase.test_origin ... ok

----------------------------------------------------------------------
Ran 2 tests in 161.552s

OK
```

On `xenial`:
```
(snapcraft) ubuntu@snapcraft-xenial-dev:~/source/snapcraft$ SNAPCRAFT_TEST_KEEP_DATA_PATH=/home/ubuntu/test python3 -m unittest -v -b run tests.integration.general.test_elf.OriginRPATHTestCase
run (unittest.loader._FailedTest) ... ok
test_origin (tests.integration.general.test_elf.OriginRPATHTestCase)
tests.integration.general.test_elf.OriginRPATHTestCase.test_origin ... ok

----------------------------------------------------------------------
Ran 2 tests in 163.682s

OK
```

And without the fix we see something like
```
$ readelf -d prime/usr/bin/python3

Dynamic section at offset 0x270 contains 31 entries:
  Tag        Type                         Name/Value
 0x000000000000000f (RPATH)              Library rpath: [$ORIGIN/../../lib/x86_64-linux-gnu:$ORIGIN/../../lib/x86_64-linux-gnu:$ORIGIN/../../lib/x86_64-linux-gnu:$ORIGIN/../../lib/x86_64-linux-gnu:$ORIGIN/../../lib/x86_64-linux-gnu:$ORIGIN/../../lib/x86_64-linux-gnu:/snap/core/current/lib/x86_64-linux-gnu]
...
```

Instead of
```
$ readelf -d prime/usr/bin/python3

Dynamic section at offset 0x270 contains 31 entries:
  Tag        Type                         Name/Value
 0x000000000000000f (RPATH)              Library rpath: [$ORIGIN/../../lib/x86_64-linux-gnu:/snap/core/current/lib/x86_64-linux-gnu]
...
```