### PR TITLE
repo: catch error due to broken build packages

### DIFF
--- a/snapcraft/internal/repo/_base.py
+++ b/snapcraft/internal/repo/_base.py
@@ -22,6 +22,7 @@ import os
 import re
 import shutil
 import stat
+from typing import List
 
 from snapcraft import file_utils
 from snapcraft.internal import mangling
@@ -92,13 +93,28 @@ class BaseRepo:
         raise errors.NoNativeBackendError()
 
     @classmethod
-    def install_build_packages(cls, package_names):
+    def install_build_packages(cls, package_names: List[str]) -> List[str]:
         """Install packages on the host required to build.
+
+        This method needs to be implemented by using the appropriate method
+        to install packages on the system. If possible they should be marked
+        as automatically installed to allow for easy removal.
+        The method should return a list of the actually installed packages
+        in the form "package=version".
+
+        If one of the packages cannot be found
+        snapcraft.repo.errors.BuildPackageNotFoundError should be raised.
+        If dependencies for a package cannot be resolved
+        snapcraft.repo.errors.PackageBrokenError should be raised.
+        If installing a package on the host failed
+        snapcraft.repo.errors.BuildPackagesNotInstalledError should be raised.
 
         :param package_names: a list of package names to install.
         :type package_names: a list of strings.
-        :raises snapcraft.repo.errors.BuildPackageNotFoundError:
-            if one of the package_names cannot be installed.
+        :return: a list with the packages installed and their versions.
+        :rtype: list of strings.
+        :raises snapcraft.repo.errors.NoNativeBackendError:
+            if the method is not implemented in the subclass.
         """
         raise errors.NoNativeBackendError()
 

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -46,6 +46,14 @@ class BuildPackageNotFoundError(RepoError):
         super().__init__(package=package)
 
 
+class BuildPackagesNotInstalledError(RepoError):
+
+    fmt = "Could not install all requested build packages: {packages}"
+
+    def __init__(self, *, packages: List[str]) -> None:
+        super().__init__(packages=' '.join(packages))
+
+
 class PackageBrokenError(RepoError):
 
     fmt = "The package {package} has unmet dependencies: {deps}"

--- a/tests/fixture_setup.py
+++ b/tests/fixture_setup.py
@@ -954,7 +954,7 @@ class FakeAptCachePackage():
         if version is not None:
             self.versions.update({version: self})
 
-    def mark_install(self):
+    def mark_install(self, *, auto_fix=True):
         if not self.installed:
             if len(self.dependencies):
                 return

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -336,3 +336,14 @@ class BuildPackagesTestCase(unit.TestCase):
             errors.PackageBrokenError,
             repo.Ubuntu.install_build_packages,
             ['package-not-installable'])
+
+    @patch('subprocess.check_call')
+    def test_broken_package_apt_install(self, mock_check_call):
+        mock_check_call.side_effect = CalledProcessError(100, 'apt-get')
+        self.fake_apt_cache.add_packages(('package-not-installable',))
+        raised = self.assertRaises(
+            errors.BuildPackagesNotInstalledError,
+            repo.Ubuntu.install_build_packages,
+            ['package-not-installable'])
+        self.assertThat(raised.packages,
+                        Equals('package-not-installable'))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This PR modifies `repo._deb` to handle failure to `sudo apt-get install` new packages as [reported in the forum](https://forum.snapcraft.io/t/unable-to-correct-problems-you-have-held-broken-packages/4584). Typically this occurs when packages have conflicting dependencies. Currently Snapcraft just bails out with a stack trace in this case.

The Python Apt bindings have a heuristic that's similar to what `apt-get` does but exposes less information. So if it fails to resolve conflicts in `apt.Package.mark_install` we get a `SystemError` with not enough details to produce a sensible error message. By specifying `auto_fix=False` we can always fall-through to `apt-get` which will show a verbose error message so just referring to the packages we couldn't install is still clear enough even if we don't know which one(s) specifically failed. For this case I'm introducing a new `BuildPackagesNotInstalledError`.

The following new tests are being added:

 - tests.unit.repo.test_deb.test_broken_package_apt_install
 - To verify that `apt-get install` failing with a `CalledProcessError` is handled.

I locally ran the tests:
 - `./runtests.sh tests/unit` with unrelated failures in [tests.unit.test_lifecycle.CoreSetupTestCase.test_core_setup_if_docker_env](https://bugs.launchpad.net/snapcraft/+bug/1752576), `tests.unit.test_mangling.TestClearExecstack.test_execstack_clears` and `tests.unit.test_elf`.
 - `./runtests.sh tests/integration` with one unrelated failure in [tests.integration.general.test_parser.TestParserWikis](https://bugs.launchpad.net/snapcraft/+bug/1752580)
 - `./runtests.sh static`: Everything passed

Manual test steps:
 - cd tests/integration/snaps/basic
 - Add this line to `snap/snapcraft.yaml`:
   `build-packages: [cpp-arm-linux-gnueabihf, gcc-5-arm-linux-gnueabihf, gcc-arm-linux-gnueabihf, gcc-multilib]`
 - snapcraft
 - Observe that you get an error that looks like this:
    `The following packages have unmet dependencies:`
    `  gcc-5-arm-linux-gnueabihf : Conflicts: gcc-multilib but 4:5.3.1-1ubuntu1 is to be installed`
    ` gcc-multilib : Conflicts: gcc-5-arm-linux-gnueabihf`
    `                Conflicts: gcc-5-arm-linux-gnueabihf:i386`
   `Could not install all requested build packages: gcc-5-arm-linux-gnueabihf gcc-arm-linux-gnueabihf gcc-multilib`