### PR TITLE
pluginhandler: organize correcly for targets with leading /

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -831,7 +831,9 @@ def _migrate_files(snap_files, snap_dirs, srcdir, dstdir, missing_ok=False,
 def _organize_filesets(fileset, base_dir):
     for key in sorted(fileset, key=lambda x: ['*' in x, x]):
         src = os.path.join(base_dir, key)
-        dst = os.path.join(base_dir, fileset[key])
+        # Remove the leading slash if there so os.path.join
+        # actually joins
+        dst = os.path.join(base_dir, fileset[key].lstrip('/'))
 
         sources = iglob(src, recursive=True)
 

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -556,6 +556,12 @@ class OrganizeTestCase(unit.TestCase):
                 (['bar', 'basefoo', 'foo'], 'bin'),
             ]
         )),
+        ('leading_slash_in_value', dict(
+            setup_dirs=[],
+            setup_files=['foo'],
+            organize_set={'foo': '/bar'},
+            expected=[(['bar'], '')],
+        )),
         ('overwrite_existing_file', dict(
             setup_dirs=[],
             setup_files=['foo', 'bar'],


### PR DESCRIPTION
Strip the leading / that can be part of a value for the organize keyword
so that os.path.join can correctly join the destination directory for the
organized file.

Closes: #1974
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
