### PR TITLE
ci: cache core and lxd to avoid redownloading

### DIFF
--- a/tools/travis/run_tests.sh
+++ b/tools/travis/run_tests.sh
@@ -39,7 +39,7 @@ elif [[ "$test" = "tests/integration"* || "$test" = "tests.integration"* ]]; the
     # snap install core exits with this error message:
     # - Setup snap "core" (2462) security profiles (cannot reload udev rules: exit status 2
     # but the installation succeeds, so we just ingore it.
-    dependencies="apt install -y bzr git libnacl-dev libsodium-dev libffi-dev libapt-pkg-dev mercurial python3-pip subversion sudo snapd && python3 -m pip install -r requirements-devel.txt -r requirements.txt && (snap install core || echo 'ignored error') && ${SNAPCRAFT_INSTALL_COMMAND:-sudo snap install snaps-cache/snapcraft-pr$TRAVIS_PULL_REQUEST.snap --dangerous --classic}"
+    dependencies="apt install -y bzr git libnacl-dev libsodium-dev libffi-dev libapt-pkg-dev mercurial python3-pip subversion sudo snapd && python3 -m pip install -r requirements-devel.txt -r requirements.txt && snap ack snaps-cache/core_*.assert && (snap install snaps-cache/core_*.snap || echo 'ignored error') && ${SNAPCRAFT_INSTALL_COMMAND:-sudo snap install snaps-cache/snapcraft-pr$TRAVIS_PULL_REQUEST.snap --dangerous --classic}"
 else
     echo "Unknown test suite: $test"
     exit 1

--- a/tools/travis/setup_lxd.sh
+++ b/tools/travis/setup_lxd.sh
@@ -28,14 +28,21 @@ done
 apt-get install --yes snapd
 apt-get remove --yes lxd lxd-client
 
-# Use edge because the feature to copy links to the container has not yet been
-# released to stable:
-# https://github.com/lxc/lxd/commit/004e7c361e1d914795d3ba7582654622e32ff193
+if [ ! -f $TRAVIS_BUILD_DIR/snaps-cache/downloaded ]; then
+    mkdir -p "$TRAVIS_BUILD_DIR/snaps-cache"
+    pushd "$TRAVIS_BUILD_DIR/snaps-cache"
+    snap download core
+    snap download lxd
+    touch downloaded
+    popd
+fi  
 # snap install core exits with this error message:
 # - Setup snap "core" (3604) security profiles (cannot reload udev rules: exit status 2)
 # but the installation succeeds, so we just ingore it.
-snap install core || echo 'ignored error'
-snap install lxd
+snap ack $TRAVIS_BUILD_DIR/snaps-cache/core_*.assert
+snap install $TRAVIS_BUILD_DIR/snaps-cache/core_*.snap || echo 'ignored error'
+snap ack $TRAVIS_BUILD_DIR/snaps-cache/lxd_*.assert
+snap install $TRAVIS_BUILD_DIR/snaps-cache/lxd_*.snap
 # Wait while LXD first generates its keys. In a low entropy environment this
 # can take a while.
 


### PR DESCRIPTION
Download core and lxd once and cache them in snaps-cache for reuse.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
