### PR TITLE
errors: remove stack data when sending to sentry

### DIFF
--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -106,7 +106,15 @@ def _submit_trace(exception):
     client = RavenClient(
         'https://b0fef3e0ced2443c92143ae0d038b0a4:'
         'b7c67d7fa4ee46caae12b29a80594c54@sentry.io/277754',
-        transport=RequestsHTTPTransport)
+        transport=RequestsHTTPTransport,
+        # Should Raven automatically log frame stacks (including locals)
+        # for all calls as it would for exceptions.
+        auto_log_stacks=True,
+        # Removes all stacktrace context variables. This will cripple the
+        # functionality of Sentry, as you’ll only get raw tracebacks,
+        # but it will ensure no local scoped information is available to the
+        # server.
+        processors=('raven.processors.RemoveStackLocalsProcessor',))
     try:
         raise exception
     except Exception:

--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -109,7 +109,7 @@ def _submit_trace(exception):
         transport=RequestsHTTPTransport,
         # Should Raven automatically log frame stacks (including locals)
         # for all calls as it would for exceptions.
-        auto_log_stacks=True,
+        auto_log_stacks=False,
         # Removes all stacktrace context variables. This will cripple the
         # functionality of Sentry, as you’ll only get raw tracebacks,
         # but it will ensure no local scoped information is available to the

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -113,7 +113,8 @@ class ErrorsTestCase(unit.TestCase):
 
         self.assert_exception_traceback_exit_1_with_debug()
         raven_client_mock.assert_called_once_with(
-            mock.ANY, transport=raven_request_mock)
+            mock.ANY, transport=raven_request_mock, processors=mock.ANY,
+            auto_log_stacks=False)
 
     def test_handler_catches_snapcraft_exceptions_no_debug(self):
         try:


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
