### PR TITLE
lifecycle: always prime dependencies

### DIFF
--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -197,12 +197,9 @@ class _Executor:
         common.reset_env()
         prereqs = self.parts_config.get_prereqs(part.name)
 
-        # Dependencies need to be primed to have paths to.
-        if step == 'prime':
-            required_step = 'prime'
-        # Or staged to be built with.
-        else:
-            required_step = 'stage'
+        # We need to prime dependencies so that paths are always found for
+        # them.
+        required_step = 'prime'
 
         step_prereqs = {p for p in prereqs
                         if required_step not in self._steps_run[p]}

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -178,16 +178,18 @@ class ExecutionTestCase(BaseLifecycleTestCase):
             self.fake_logger.output, Equals(
                 'Preparing to pull part1 \n'
                 'Pulling part1 \n'
-                '\'part2\' has prerequisites that need to be staged: part1\n'
+                '\'part2\' has prerequisites that need to be primed: part1\n'
                 'Preparing to build part1 \n'
                 'Building part1 \n'
                 'Staging part1 \n'
+                'Priming part1 \n'
                 'Preparing to pull part2 \n'
                 'Pulling part2 \n'
-                '\'part3\' has prerequisites that need to be staged: part2\n'
+                '\'part3\' has prerequisites that need to be primed: part2\n'
                 'Preparing to build part2 \n'
                 'Building part2 \n'
                 'Staging part2 \n'
+                'Priming part2 \n'
                 'Preparing to pull part3 \n'
                 'Pulling part3 \n',
             ))
@@ -434,8 +436,8 @@ class ExecutionTestCase(BaseLifecycleTestCase):
                     after: [part1]
                 """))
 
-        # Stage dependency
-        lifecycle.execute('stage', self.project_options, part_names=['part1'])
+        # Prime dependency
+        lifecycle.execute('prime', self.project_options, part_names=['part1'])
         # Build dependent
         lifecycle.execute('build', self.project_options, part_names=['part2'])
 


### PR DESCRIPTION
This ensures consistency across build variations of classic,
libc6 patching and strict.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
