### PR TITLE
many: implement vendoring support

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -77,6 +77,11 @@ properties:
       - type: string
         validation-failure:
           "{.instance!r} is not a valid hostname."
+        # This format accepts hosts of the form foo or example.com valid.
+        # We don't allow wildcards like .foo or *.example.com because that
+        # would include unwanted resources as for example in the case of
+        # *.launchpad.net which includes ppa.launchpad.net as opposed to being
+        # explicit with [launchpad.net, git.launchpad.net] instead.
         format: hostname
   build-packages:
     $ref: "#/definitions/grammar-array"

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -66,6 +66,18 @@ definitions:
 title: snapcraft schema
 type: object
 properties:
+  vendoring:
+    type: array
+    validation-failure:
+      "a list of valid host names needs to be provided."
+    description: external sources available to resolve dependencies
+    minItems: 1
+    uniqueItems: true
+    items:
+      - type: string
+        validation-failure:
+          "{.instance!r} is not a valid hostname."
+        format: hostname
   build-packages:
     $ref: "#/definitions/grammar-array"
     description: top level build packages.

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -41,6 +41,7 @@ _DEFAULT_LIBRARIESDIR = os.path.join(sys.prefix, 'share', 'snapcraft',
                                      'libraries')
 _librariesdir = _DEFAULT_LIBRARIESDIR
 _DOCKERENV_FILE = '/.dockerenv'
+_LXD_HOST_SOCKET = '/dev/lxd/sock'
 
 MAX_CHARACTERS_WRAP = 120
 
@@ -109,6 +110,10 @@ def is_snap() -> bool:
 
 def is_docker_instance() -> bool:
     return os.path.exists(_DOCKERENV_FILE)
+
+
+def is_lxd_container() -> bool:
+    return os.path.exists(_LXD_HOST_SOCKET)
 
 
 def set_plugindir(plugindir):

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -59,6 +59,8 @@ def execute(step, project_options, part_names=None):
     :returns: A dict with the snap name, version, type and architectures.
     """
     config = project_loader.load_config(project_options)
+    if project_options.info.vendoring:
+        logger.warning('Vendoring should be used with a LXD container')
     installed_packages = repo.Repo.install_build_packages(
         config.build_tools)
     if installed_packages is None:

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -60,7 +60,12 @@ def execute(step, project_options, part_names=None):
     """
     config = project_loader.load_config(project_options)
     if project_options.info.vendoring:
-        logger.warning('Vendoring should be used with a LXD container')
+        logger.warning(
+            'Vendoring is set to {} but it will not be enforced. '
+            'Snapcraft must build inside a LXD container to setup a proxy '
+            'that limits access to external resources to the specified '
+            'hosts. The build will proceed without restrictions.'.format(
+                ', '.join(project_options.info.vendoring)))
     installed_packages = repo.Repo.install_build_packages(
         config.build_tools)
     if installed_packages is None:

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -59,7 +59,7 @@ def execute(step, project_options, part_names=None):
     :returns: A dict with the snap name, version, type and architectures.
     """
     config = project_loader.load_config(project_options)
-    if project_options.info.vendoring:
+    if project_options.info.vendoring and not common.is_lxd_container():
         logger.warning(
             'This snap uses vendoring but it cannot be enforced without '
             'using cleanbuild. Proceeding without restriction.'.format(

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -61,10 +61,8 @@ def execute(step, project_options, part_names=None):
     config = project_loader.load_config(project_options)
     if project_options.info.vendoring:
         logger.warning(
-            'Vendoring is set to {} but it will not be enforced. '
-            'Snapcraft must build inside a LXD container to setup a proxy '
-            'that limits access to external resources to the specified '
-            'hosts. The build will proceed without restrictions.'.format(
+            'This snap uses vendoring but it cannot be enforced without '
+            'using cleanbuild. Proceeding without restriction.'.format(
                 ', '.join(project_options.info.vendoring)))
     installed_packages = repo.Repo.install_build_packages(
         config.build_tools)

--- a/snapcraft/internal/lxd/_cleanbuilder.py
+++ b/snapcraft/internal/lxd/_cleanbuilder.py
@@ -41,17 +41,7 @@ class Cleanbuilder(Containerbuild):
                 'lxc', 'launch', '-e', self._image, self._container_name])
         except subprocess.CalledProcessError as e:
             raise ContainerConnectionError('Failed to setup container')
-        self._configure_container()
-        self._wait_for_network()
-        self._container_run(['apt-get', 'update'])
-        # Because of https://bugs.launchpad.net/snappy/+bug/1628289
-        # Needed to run snapcraft as a snap and build-snaps
-        self._container_run(['apt-get', 'install', 'squashfuse', '-y'])
-        if self._remote != 'local':
-            # For remote mounts we will need sshfs.
-            self._container_run(['apt-get', 'install', 'sshfs', '-y'])
-        self._inject_snapcraft(new_container=True)
-        self._setup_vendoring()
+        self._configure_container(new_container=True)
 
     def _setup_project(self):
         logger.info('Setting up container with project assets')

--- a/snapcraft/internal/lxd/_cleanbuilder.py
+++ b/snapcraft/internal/lxd/_cleanbuilder.py
@@ -47,7 +47,11 @@ class Cleanbuilder(Containerbuild):
         # Because of https://bugs.launchpad.net/snappy/+bug/1628289
         # Needed to run snapcraft as a snap and build-snaps
         self._container_run(['apt-get', 'install', 'squashfuse', '-y'])
+        if self._remote != 'local':
+            # For remote mounts we will need sshfs.
+            self._container_run(['apt-get', 'install', 'sshfs', '-y'])
         self._inject_snapcraft(new_container=True)
+        self._setup_vendoring()
 
     def _setup_project(self):
         logger.info('Setting up container with project assets')

--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -256,8 +256,9 @@ class Containerbuild:
         vendoring = self._project_options.info.vendoring
         if vendoring:
             logger.info(
-                'Vendoring is set to {}. Access to external resources not '
-                'specified here will be denied during the build.'
+                'This snap uses vendoring. In order to enforce it, network '
+                'access to resources not on the following list will be denied:'
+                '\n\n{}'
                 .format(', '.join(vendoring)))
             # Configure a proxy that blocks access to any hosts which are not
             # specified by vendoring in snapcraft.yaml.
@@ -273,8 +274,12 @@ class Containerbuild:
                 http_access allow localhost whitelist Safe_ports
                 http_access deny all
                 """.format(port=port))
-            # Prepend the whitelist here because the deny must come last
+            # Prepend the whitelist here because the deny must come last.
             for host in vendoring:
+                # The schema enforces hosts of the form foo or example.com
+                # so we always have explicit domain names and no wildcards
+                # with a leading period like .spam.eggs will be used.
+                # See also: https://wiki.squid-cache.org/SquidFaq/SquidAcl
                 rules = 'acl whitelist dstdomain {}\n'.format(host) + rules
             subprocess.check_output([
                 'lxc', 'exec', self._container_name, '--',

--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -250,7 +250,6 @@ class Containerbuild:
                         'No network connection in the container.\n'
                         'If using a proxy, check its configuration.')
         logger.info('Network connection established')
-        self._setup_vendoring()
 
     def _setup_vendoring(self):
         vendoring = self._project_options.info.vendoring

--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -255,7 +255,10 @@ class Containerbuild:
     def _setup_vendoring(self):
         vendoring = self._project_options.info.vendoring
         if vendoring:
-            logger.info('Vendoring snap to {}'.format(', '.join(vendoring)))
+            logger.info(
+                'Vendoring is set to {}. Access to external resources not '
+                'specified here will be denied during the build.'
+                .format(', '.join(vendoring)))
             # Configure a proxy that blocks access to any hosts which are not
             # specified by vendoring in snapcraft.yaml.
             # The rules below mean:
@@ -264,12 +267,12 @@ class Containerbuild:
             # Deny everything else.
             self._container_run(['apt-get', 'install', 'squid', '-y'])
             port = 3129
-            rules = dedent('''
+            rules = dedent("""
                 http_port {port!s}
                 acl Safe_ports port 80 443 9418
                 http_access allow localhost whitelist Safe_ports
                 http_access deny all
-                '''.format(port=port))
+                """.format(port=port))
             # Prepend the whitelist here because the deny must come last
             for host in vendoring:
                 rules = 'acl whitelist dstdomain {}\n'.format(host) + rules

--- a/snapcraft/internal/lxd/_project.py
+++ b/snapcraft/internal/lxd/_project.py
@@ -53,7 +53,7 @@ class Project(Containerbuild):
             except subprocess.CalledProcessError as e:
                 raise ContainerConnectionError('Failed to setup container')
         if self._get_container_status()['status'] == 'Stopped':
-            self._configure_container()
+            self._configure_devices()
             try:
                 subprocess.check_call([
                     'lxc', 'start', self._container_name])
@@ -67,20 +67,9 @@ class Project(Containerbuild):
                             'remove any existing lines.'
                             '\nRestart lxd after making this change.')
                 raise ContainerConnectionError(msg)
-        self._wait_for_network()
-        if new_container:
-            self._container_run(['apt-get', 'update'])
-            # Because of https://bugs.launchpad.net/snappy/+bug/1628289
-            # Needed to run snapcraft as a snap and build-snaps
-            self._container_run(['apt-get', 'install', 'squashfuse', '-y'])
-        if self._remote != 'local':
-            # For remote mounts we will need sshfs.
-            self._container_run(['apt-get', 'install', 'sshfs', '-y'])
-        self._inject_snapcraft(new_container=new_container)
-        self._setup_vendoring()
+        self._configure_container(new_container=new_container)
 
-    def _configure_container(self):
-        super()._configure_container()
+    def _configure_devices(self):
         if self._remote == 'local':
             # Map host user to root (0) inside container
             subprocess.check_call([

--- a/snapcraft/internal/lxd/_project.py
+++ b/snapcraft/internal/lxd/_project.py
@@ -73,7 +73,11 @@ class Project(Containerbuild):
             # Because of https://bugs.launchpad.net/snappy/+bug/1628289
             # Needed to run snapcraft as a snap and build-snaps
             self._container_run(['apt-get', 'install', 'squashfuse', '-y'])
+        if self._remote != 'local':
+            # For remote mounts we will need sshfs.
+            self._container_run(['apt-get', 'install', 'sshfs', '-y'])
         self._inject_snapcraft(new_container=new_container)
+        self._setup_vendoring()
 
     def _configure_container(self):
         super()._configure_container()
@@ -129,7 +133,6 @@ class Project(Containerbuild):
                 )
 
         # Use sshfs in slave mode to reverse mount the destination
-        self._container_run(['apt-get', 'install', '-y', 'sshfs'])
         self._container_run(['mkdir', '-p', destination], user=self._user)
         self._background_process_run([
             'lxc', 'exec', self._container_name, '--',

--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -26,3 +26,4 @@ class ProjectInfo:
         self.summary = data.get('summary')
         self.description = data.get('description')
         self.confinement = data['confinement']
+        self.vendoring = data.get('vendoring', [])

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -527,6 +527,10 @@ class SnapCommandWithContainerBuildTestCase(SnapCommandBaseTestCase):
             call(['lxc', 'config', 'set', container_name,
                   'environment.LC_ALL', 'C.UTF-8']),
             call(['lxc', 'config', 'set', container_name,
+                  'environment.http_proxy', '']),
+            call(['lxc', 'config', 'set', container_name,
+                  'environment.https_proxy', '']),
+            call(['lxc', 'config', 'set', container_name,
                   'environment.SNAPCRAFT_IMAGE_INFO',
                   '{"fingerprint": "test-fingerprint", '
                   '"architecture": "test-architecture", '
@@ -625,6 +629,10 @@ class SnapCommandWithContainerBuildTestCase(SnapCommandBaseTestCase):
                   'environment.SNAPCRAFT_SETUP_CORE', '1']),
             call(['lxc', 'config', 'set', container_name,
                   'environment.LC_ALL', 'C.UTF-8']),
+            call(['lxc', 'config', 'set', container_name,
+                  'environment.http_proxy', '']),
+            call(['lxc', 'config', 'set', container_name,
+                  'environment.https_proxy', '']),
             call(['lxc', 'config', 'set', container_name,
                   'environment.SNAPCRAFT_IMAGE_INFO',
                   '{"fingerprint": "test-fingerprint", '

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -523,6 +523,12 @@ class SnapCommandWithContainerBuildTestCase(SnapCommandBaseTestCase):
         fake_lxd.check_call_mock.assert_has_calls([
             call(['lxc', 'init', 'ubuntu:xenial', container_name]),
             call(['lxc', 'config', 'set', container_name,
+                  'raw.idmap', 'both {} {}'.format(
+                    self.expected_idmap, '0')]),
+            call(['lxc', 'config', 'device', 'add', container_name,
+                  'fuse', 'unix-char', 'path=/dev/fuse']),
+            call(['lxc', 'start', container_name]),
+            call(['lxc', 'config', 'set', container_name,
                   'environment.SNAPCRAFT_SETUP_CORE', '1']),
             call(['lxc', 'config', 'set', container_name,
                   'environment.LC_ALL', 'C.UTF-8']),
@@ -535,12 +541,6 @@ class SnapCommandWithContainerBuildTestCase(SnapCommandBaseTestCase):
                   '{"fingerprint": "test-fingerprint", '
                   '"architecture": "test-architecture", '
                   '"created_at": "test-created-at"}']),
-            call(['lxc', 'config', 'set', container_name,
-                  'raw.idmap', 'both {} {}'.format(
-                    self.expected_idmap, '0')]),
-            call(['lxc', 'config', 'device', 'add', container_name,
-                  'fuse', 'unix-char', 'path=/dev/fuse']),
-            call(['lxc', 'start', container_name]),
             call(['lxc', 'config', 'device', 'add', container_name,
                   project_folder, 'disk', 'source={}'.format(source),
                   'path={}'.format(project_folder)]),
@@ -626,6 +626,14 @@ class SnapCommandWithContainerBuildTestCase(SnapCommandBaseTestCase):
         project_folder = '/root/build_snap-test'
         fake_lxd.check_call_mock.assert_has_calls([
             call(['lxc', 'config', 'set', container_name,
+                  'raw.idmap', 'both {} {}'.format(
+                    self.expected_idmap, 0)]),
+            call(['lxc', 'config', 'device', 'remove', container_name,
+                  project_folder]),
+            call(['lxc', 'config', 'device', 'add', container_name,
+                  'fuse', 'unix-char', 'path=/dev/fuse']),
+            call(['lxc', 'start', container_name]),
+            call(['lxc', 'config', 'set', container_name,
                   'environment.SNAPCRAFT_SETUP_CORE', '1']),
             call(['lxc', 'config', 'set', container_name,
                   'environment.LC_ALL', 'C.UTF-8']),
@@ -638,14 +646,6 @@ class SnapCommandWithContainerBuildTestCase(SnapCommandBaseTestCase):
                   '{"fingerprint": "test-fingerprint", '
                   '"architecture": "test-architecture", '
                   '"created_at": "test-created-at"}']),
-            call(['lxc', 'config', 'set', container_name,
-                  'raw.idmap', 'both {} {}'.format(
-                    self.expected_idmap, 0)]),
-            call(['lxc', 'config', 'device', 'remove', container_name,
-                  project_folder]),
-            call(['lxc', 'config', 'device', 'add', container_name,
-                  'fuse', 'unix-char', 'path=/dev/fuse']),
-            call(['lxc', 'start', container_name]),
             call(['lxc', 'stop', '-f', container_name]),
         ])
         mock_container_run.assert_has_calls([

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -203,7 +203,7 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
 
         project_folder = '/home/user/build_snap-test'
         mock_container_run.assert_has_calls([
-            call(['apt-get', 'install', '-y', 'sshfs']),
+            call(['apt-get', 'install', 'sshfs', '-y']),
         ])
         fake_lxd.popen_mock.assert_has_calls([
             call(['/usr/lib/sftp-server'],

--- a/tests/unit/test_lxd.py
+++ b/tests/unit/test_lxd.py
@@ -132,7 +132,16 @@ class CleanbuilderTestCase(LXDTestCase):
         mock_container_run.assert_has_calls([
             call(['python3', '-c', ANY]),
             call(['apt-get', 'update']),
-            call(['apt-get', 'install', 'squashfuse', '-y']),
+        ])
+
+        packages = ['squashfuse', 'sshfs']
+        if self.remote == 'local':
+            packages.remove('sshfs')
+        mock_container_run.assert_has_calls([
+            call(['apt-get', 'install', pkg, '-y']) for pkg in packages
+        ])
+
+        mock_container_run.assert_has_calls([
             call(['mkdir', project_folder]),
             call(['tar', 'xvf', 'project.tar'],
                  cwd=project_folder),
@@ -140,7 +149,8 @@ class CleanbuilderTestCase(LXDTestCase):
                  cwd=project_folder, user='root'),
         ])
         # Ensure there's no unexpected calls eg. two network checks
-        self.assertThat(mock_container_run.call_count, Equals(6))
+        self.assertThat(mock_container_run.call_count,
+                        Equals(5 + len(packages)))
         self.fake_lxd.check_call_mock.assert_has_calls([
             call(['lxc', 'file', 'pull',
                   '{}{}/snap.snap'.format(container_name, project_folder),
@@ -331,9 +341,11 @@ class ContainerbuildTestCase(LXDTestCase):
         builder = self.make_containerbuild()
         builder.execute()
 
+        packages = ['squashfuse', 'sshfs', 'snapcraft']
+        if self.remote == 'local':
+            packages.remove('sshfs')
         mock_container_run.assert_has_calls([
-            call(['apt-get', 'install', 'squashfuse', '-y']),
-            call(['apt-get', 'install', 'snapcraft', '-y']),
+            call(['apt-get', 'install', pkg, '-y']) for pkg in packages
         ])
 
     @patch('snapcraft.internal.common.is_snap')
@@ -421,8 +433,15 @@ class ContainerbuildTestCase(LXDTestCase):
                   os.path.join(tmp_dir, 'snapcraft_345.snap'),
                   '{}/run/snapcraft_345.snap'.format(self.fake_lxd.name)]),
         ])
+
+        packages = ['squashfuse', 'sshfs']
+        if self.remote == 'local':
+            packages.remove('sshfs')
         mock_container_run.assert_has_calls([
-            call(['apt-get', 'install', 'squashfuse', '-y']),
+            call(['apt-get', 'install', pkg, '-y']) for pkg in packages
+        ])
+
+        mock_container_run.assert_has_calls([
             call(['snap', 'ack', '/run/core_123.assert']),
             call(['snap', 'install', '/run/core_123.snap']),
             call(['snap', 'ack', '/run/snapcraft_345.assert']),
@@ -544,8 +563,15 @@ class ContainerbuildTestCase(LXDTestCase):
                   os.path.join(tmp_dir, 'snapcraft_123.snap'),
                   '{}/run/snapcraft_123.snap'.format(self.fake_lxd.name)]),
         ])
+
+        packages = ['squashfuse', 'sshfs']
+        if self.remote == 'local':
+            packages.remove('sshfs')
         mock_container_run.assert_has_calls([
-            call(['apt-get', 'install', 'squashfuse', '-y']),
+            call(['apt-get', 'install', pkg, '-y']) for pkg in packages
+        ])
+
+        mock_container_run.assert_has_calls([
             call(['snap', 'ack', '/run/snapcraft_123.assert']),
             call(['snap', 'install', '/run/snapcraft_123.snap', '--classic']),
         ])

--- a/tests/unit/test_lxd.py
+++ b/tests/unit/test_lxd.py
@@ -815,9 +815,9 @@ class VendoringTestCase(LXDBaseTestCase):
             'git.launchpad.net', 'archive.ubuntu.com']
         self.make_containerbuild().execute()
         self.assertIn(
-            'Vendoring is set to git.launchpad.net, archive.ubuntu.com. '
-            'Access to external resources not specified here will be denied '
-            'during the build.\n',
+            'This snap uses vendoring. In order to enforce it, network '
+            'access to resources not on the following list will be denied:\n\n'
+            'git.launchpad.net, archive.ubuntu.com\n',
             self.fake_logger.output)
         self.fake_lxd.check_call_mock.assert_has_calls([
             call(['lxc', 'config', 'set', self.fake_lxd.name,

--- a/tests/unit/test_lxd.py
+++ b/tests/unit/test_lxd.py
@@ -815,7 +815,9 @@ class VendoringTestCase(LXDBaseTestCase):
             'git.launchpad.net', 'archive.ubuntu.com']
         self.make_containerbuild().execute()
         self.assertIn(
-            'Vendoring snap to git.launchpad.net, archive.ubuntu.com\n',
+            'Vendoring is set to git.launchpad.net, archive.ubuntu.com. '
+            'Access to external resources not specified here will be denied '
+            'during the build.\n',
             self.fake_logger.output)
         self.fake_lxd.check_call_mock.assert_has_calls([
             call(['lxc', 'config', 'set', self.fake_lxd.name,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This PR introduces a new **vendoring** keyword to `snapcraft.yaml` which accepts a list of host names [as outlined in this proposal](https://forum.snapcraft.io/t/proposal-vendoring-hosts-in-snapcraft-yaml/4739). This is exposed in the API via `ProjectInfo.vendoring`.

Note: This PR requires #1995.

The following new tests are affected:

 - tests.unit.project_loader.test_config.ProjectInfoTestCase
 - To verify that `vendoring` is accessible via the API.
 - tests.unit.project_loader.test_config.ProjectTestCase
 - To verify `ProjectInfo` exposes `vendoring` from the YAML
 - tests.unit.project_loader.test_config.InvalidVendoringTestCase
 - To verify that only valid hosts are accepted as specified in the schema.
 - tests.unit.test_lxd.VendoringTestCase
 - To verify that a squid proxy is installed and configured in a container.

I locally ran the tests:
 - `./runtests.sh tests/unit` with unrelated failures in [tests.unit.test_lifecycle.CoreSetupTestCase.test_core_setup_if_docker_env](https://bugs.launchpad.net/snapcraft/+bug/1752576), `tests.unit.test_mangling.TestClearExecstack.test_execstack_clears` and `tests.unit.test_elf`.
 - `./runtests.sh tests/integration` with one unrelated failure in [tests.integration.general.test_parser.TestParserWikis](https://bugs.launchpad.net/snapcraft/+bug/1752580)
 - `./runtests.sh static`: Everything passed

Manual test steps **with the snap built from this branch**:
 - git clone https://git.launchpad.net/subiquity
 - cd subiquity
 - snapcraft cleanbuild
 - Observe that the build succeeds normally.
 - Update `snapcraft.yaml` by adding this snippet:
       vendoring: [archive.ubuntu.com, security.ubuntu.com]
 - snapcraft cleanbuild
 - Observe that the build fails with a proxy error.
 - Update `snapcraft.yaml` to this:
       vendoring: [api.snapcraft.io, archive.ubuntu.com, security.ubuntu.com, 068ed04f23.site.internapcdn.net, github.com, pypi.python.org]
 - Observe that the build succeeds.