### PR TITLE
cli: support exporting login to stdout

### DIFF
--- a/snapcraft/config.py
+++ b/snapcraft/config.py
@@ -14,15 +14,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import base64
 import configparser
+import io
 import logging
 import os
+import sys
 import urllib.parse
 from typing import TextIO
 
 from xdg import BaseDirectory
 
-from snapcraft.storeapi import constants
+from snapcraft.storeapi import (
+    constants,
+    errors,
+)
 
 LOCAL_CONFIG_FILENAME = '.snapcraft/snapcraft.cfg'
 
@@ -71,8 +77,9 @@ class Config(object):
         return True
 
     def load(self, *, config_fd: TextIO = None) -> None:
+        config = ''
         if config_fd:
-            self.parser.read_file(config_fd)
+            config = config_fd.read()
         else:
             # Local configurations (per project) are supposed to be static.
             # That's why it's only checked for 'loading' and never written to.
@@ -92,19 +99,50 @@ class Config(object):
                 file_path = BaseDirectory.load_first_config(
                     'snapcraft', 'snapcraft.cfg')
             if file_path and os.path.exists(file_path):
-                self.parser.read(file_path)
+                with open(file_path, 'r') as f:
+                    config = f.read()
+
+        if config:
+            _load_potentially_base64_config(self.parser, config)
 
     @staticmethod
     def save_path() -> str:
         return os.path.join(BaseDirectory.save_config_path('snapcraft'),
                             'snapcraft.cfg')
 
-    def save(self, *, config_fd: TextIO = None) -> None:
-        if config_fd:
-            self.parser.write(config_fd)
-        else:
-            with open(self.save_path(), 'w') as f:
-                self.parser.write(f)
+    def save(self, *, config_fd: TextIO=None, encode: bool=False) -> None:
+        with io.StringIO() as config_buffer:
+            self.parser.write(config_buffer)
+            config = config_buffer.getvalue()
+            if encode:
+                # Encode config using base64
+                config = base64.b64encode(
+                    config.encode(sys.getfilesystemencoding())).decode(
+                        sys.getfilesystemencoding())
+
+            if config_fd:
+                config_fd.write(config)
+            else:
+                with open(self.save_path(), 'w') as f:
+                    f.write(config)
 
     def clear(self) -> None:
         self.parser.remove_section(self._section_name())
+
+
+def _load_potentially_base64_config(parser, config):
+    try:
+        parser.read_string(config)
+    except configparser.Error as e:
+        # The config may be base64-encoded, try decoding it
+        try:
+            config = base64.b64decode(config).decode(
+                sys.getfilesystemencoding())
+        except base64.binascii.Error:  # type: ignore
+            # It wasn't base64, so use the original error
+            raise errors.InvalidLoginConfig(e) from e
+
+        try:
+            parser.read_string(config)
+        except configparser.Error as e:
+            raise errors.InvalidLoginConfig(e) from e

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -624,3 +624,11 @@ class SignBuildAssertionError(StoreError):
 
     def __init__(self, snap_name):
         super().__init__(snap_name=snap_name)
+
+
+class InvalidLoginConfig(StoreError):
+
+    fmt = 'Invalid login config: {error}'
+
+    def __init__(self, error):
+        super().__init__(error=error)

--- a/tests/unit/commands/test_export_login.py
+++ b/tests/unit/commands/test_export_login.py
@@ -83,6 +83,49 @@ class ExportLoginCommandTestCase(CommandBaseTestCase):
                        'get_account_information')
     @mock.patch.object(storeapi.StoreClient, 'login')
     @mock.patch.object(storeapi.StoreClient, 'acl')
+    def test_successful_export_stdout(
+            self, mock_acl, mock_login, mock_get_account_information):
+        self.mock_input.return_value = 'user@example.com'
+        mock_acl.return_value = {
+            'snap_ids': None,
+            'channels': None,
+            'permissions': None,
+            'expires': '2018-02-01T00:00:00',
+        }
+
+        result = self.run_command(['export-login', '-'])
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(result.output, Contains(
+            storeapi.constants.TWO_FACTOR_WARNING))
+        self.assertThat(
+            result.output, Contains('Exported login starts on next line'))
+        self.assertThat(
+            result.output, Contains(
+                'Login successfully exported and printed above'))
+        self.assertThat(
+            result.output, MatchesRegex(
+                r'.*snaps:.*?No restriction', re.DOTALL))
+        self.assertThat(
+            result.output, MatchesRegex(
+                r'.*channels:.*?No restriction', re.DOTALL))
+        self.assertThat(
+            result.output, MatchesRegex(
+                r'.*permissions:.*?No restriction', re.DOTALL))
+        self.assertThat(
+            result.output, MatchesRegex(
+                r'.*expires:.*?2018-02-01T00:00:00', re.DOTALL))
+
+        self.mock_input.assert_called_once_with('Email: ')
+        mock_login.assert_called_once_with(
+            'user@example.com', mock.ANY, acls=None, packages=None,
+            channels=None, expires=None, save=False, config_fd=None)
+        mock_acl.assert_called_once_with()
+
+    @mock.patch.object(storeapi._sca_client.SCAClient,
+                       'get_account_information')
+    @mock.patch.object(storeapi.StoreClient, 'login')
+    @mock.patch.object(storeapi.StoreClient, 'acl')
     def test_successful_export_expires(
             self, mock_acl, mock_login, mock_get_account_information):
         self.mock_input.return_value = 'user@example.com'


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
And instead of simply printing the ini file, base64-encode it so it can be more easily handled. This is intended to fit the use-case of sticking the exported login straight into the environment of a CI system instead of needing to encrypt a file.