### PR TITLE
lxd: specify arch in lxc image list command

### DIFF
--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -148,8 +148,12 @@ class Containerbuild:
             'Failed to get container image info: {}\n'
             'It will not be recorded in manifest.')
         try:
+            # This command takes the same image name as used to create a new
+            # container. But we must always use the form distro:series/arch
+            # here so that we get only the image we're actually using!
             image_info_command = [
-                'lxc', 'image', 'list', '--format=json', self._image]
+                'lxc', 'image', 'list', '--format=json',
+                '{}/{}'.format(self._image, self._get_container_arch())]
             image_info = json.loads(subprocess.check_output(
                 image_info_command).decode())
         except subprocess.CalledProcessError as e:

--- a/tests/unit/test_lxd.py
+++ b/tests/unit/test_lxd.py
@@ -30,6 +30,7 @@ from testtools import ExpectedException
 from testtools.matchers import Contains, Equals
 
 from snapcraft import ProjectOptions
+from snapcraft.project._project_options import _get_deb_arch
 from snapcraft.internal import lxd
 from snapcraft.internal.errors import (
     ContainerConnectionError,
@@ -134,6 +135,10 @@ class CleanbuilderTestCase(LXDTestCase):
                   '{}{}/snap.snap'.format(container_name, project_folder),
                   'snap.snap']),
             call(['lxc', 'stop', '-f', container_name]),
+        ])
+        self.fake_lxd.check_output_mock.assert_has_calls([
+            call(['lxc', 'image', 'list', '--format=json',
+                  'ubuntu:xenial/{}'.format(_get_deb_arch(self.server))]),
         ])
 
     def test_failed_container_never_created(self):
@@ -764,7 +769,7 @@ class FailedImageInfoTestCase(LXDBaseTestCase):
             kwargs=dict(cmd='testcmd', returncode=1, output='test output'),
             expected_warn=(
                 "Failed to get container image info: "
-                "`lxc image list --format=json ubuntu:xenial` "
+                "`lxc image list --format=json ubuntu:xenial/amd64` "
                 "returned with exit code 1, output: test output\n"
                 "It will not be recorded in manifest.\n"))),
         ('JSONDecodeError', dict(


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This PR fixes getting the correct values for the LXD image for `SNAPCRAFT_IMAGE_INFO` (which is added to the manifest if `SNAPCRAFT_BUILD_INFO` is set). This regressed when the image used to create containers stopped containing the architecture as `ubuntu:xenial` rather than `ubuntu:xenial/$ARCH', which is still passed to `lxc image list`. So in the end we got all matching images in an unordered list. The fix is to specify the architecture explicitly.

Fixes: [LP: #1760857](https://bugs.launchpad.net/snapcraft/+bug/1760857)

The following new tests are being modified:

 - tests.unit.test_lxd.CleanbuilderTestCase.test_cleanbuild
 - To verify that the image info is obtained for the right architecture.
 - tests.unit.test_lxd.FailedImageInfoTestCase.test_failed_image_info_just_warns
 - To verify the exact command appearing in the error message.

I locally ran the tests:
 - `./runtests.sh tests/unit` unrelated failures in [tests.unit.test_lifecycle.CoreSetupTestCase.test_core_setup_if_docker_env](https://bugs.launchpad.net/snapcraft/+bug/1752576) and `tests.unit.test_elf`.
 - `./runtests.sh tests/integration` with one unrelated failure in [tests.integration.general.test_parser.TestParserWikis](https://bugs.launchpad.net/snapcraft/+bug/1752580).
 - `./runtests.sh tests/static`: Everything passed

Manual test steps:
 - **With the snap built from this branch**
 - Build and install a Snapcraft snap from this branch.
 - cd tests/integration/snaps/basic
 - SNAPCRAFT_BUILD_INFO=1 snapcraft
 - grep architecture prime/snap/manifest.yaml
   architecture: x86_64
 - Observe the manifest containing the right architecture.
 - Repeat this step a few times to ensure the value is the same.