### PR TITLE
meta: implement pass-through of properties to snap.yaml

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -183,6 +183,9 @@ properties:
         - type: string
           minLength: 1
         - type: number
+  pass-through:
+    type: object
+    description: properties to be passed into snap.yaml as-is
   apps:
     type: object
     additionalProperties: false
@@ -296,6 +299,9 @@ properties:
                         usage: "socket path, a string"
                   socket-mode:
                     type: integer
+          pass-through:
+            type: object
+            description: properties to be passed into snap.yaml as-is
   hooks:
     type: object
     additionalProperties: false

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -320,6 +320,9 @@ properties:
             uniqueItems: true
             items:
               type: string
+          passthrough:
+            type: object
+            description: properties to be passed into snap.yaml as-is
   parts:
     type: object
     minProperties: 1

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -183,7 +183,7 @@ properties:
         - type: string
           minLength: 1
         - type: number
-  pass-through:
+  passthrough:
     type: object
     description: properties to be passed into snap.yaml as-is
   apps:
@@ -299,7 +299,7 @@ properties:
                         usage: "socket path, a string"
                   socket-mode:
                     type: integer
-          pass-through:
+          passthrough:
             type: object
             description: properties to be passed into snap.yaml as-is
   hooks:

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -240,7 +240,8 @@ class _Executor:
             common.env = self.config.snap_env()
             meta.create_snap_packaging(
                 self.config.data, self.config.parts, self.project_options,
-                self.config.snapcraft_yaml_path)
+                self.config.snapcraft_yaml_path,
+                self.config.original_snapcraft_yaml)
 
     def _handle_dirty(self, part, step, dirty_report):
         if step not in constants.STEPS_TO_AUTOMATICALLY_CLEAN_IF_DIRTY:

--- a/snapcraft/internal/meta/_errors.py
+++ b/snapcraft/internal/meta/_errors.py
@@ -60,3 +60,15 @@ class AdoptedPartNotParsingInfo(SnapMetaGenerationError):
 
     def __init__(self, part: str) -> None:
         super().__init__(part=part)
+
+
+class AmbiguousPassThroughKeyError(SnapMetaGenerationError):
+
+    fmt = (
+        "Failed to pass-through keys to snap metadata: "
+        "{key!r} is specified as both a regular key and in pass-through. "
+        "Remove one of the keys."
+    )
+
+    def __init__(self, key: str) -> None:
+        super().__init__(key=key)

--- a/snapcraft/internal/meta/_errors.py
+++ b/snapcraft/internal/meta/_errors.py
@@ -16,6 +16,7 @@
 
 from snapcraft import formatting_utils
 from snapcraft.internal import errors
+from typing import Set
 
 
 class CommandError(errors.SnapcraftError):
@@ -66,9 +67,11 @@ class AmbiguousPassthroughKeyError(SnapMetaGenerationError):
 
     fmt = (
         "Failed to propagate keys to snap metadata: "
-        "{key!r} is specified as both a regular key and in pass-through. "
-        "Remove one of the keys."
+        "The following keys are specified as both regular keys and in "
+        "passthrough:\n"
+        '{keys}\n\n'
+        "Remove duplicate keys."
     )
 
-    def __init__(self, key: str) -> None:
-        super().__init__(key=key)
+    def __init__(self, keys: Set[str]) -> None:
+        super().__init__(keys=', '.join(keys))

--- a/snapcraft/internal/meta/_errors.py
+++ b/snapcraft/internal/meta/_errors.py
@@ -62,10 +62,10 @@ class AdoptedPartNotParsingInfo(SnapMetaGenerationError):
         super().__init__(part=part)
 
 
-class AmbiguousPassThroughKeyError(SnapMetaGenerationError):
+class AmbiguousPassthroughKeyError(SnapMetaGenerationError):
 
     fmt = (
-        "Failed to pass-through keys to snap metadata: "
+        "Failed to propagate keys to snap metadata: "
         "{key!r} is specified as both a regular key and in pass-through. "
         "Remove one of the keys."
     )

--- a/snapcraft/internal/meta/_errors.py
+++ b/snapcraft/internal/meta/_errors.py
@@ -16,7 +16,7 @@
 
 from snapcraft import formatting_utils
 from snapcraft.internal import errors
-from typing import Set
+from typing import List
 
 
 class CommandError(errors.SnapcraftError):
@@ -66,12 +66,11 @@ class AdoptedPartNotParsingInfo(SnapMetaGenerationError):
 class AmbiguousPassthroughKeyError(SnapMetaGenerationError):
 
     fmt = (
-        "Failed to propagate keys to snap metadata: "
-        "The following keys are specified as both regular keys and in "
-        "passthrough:\n"
-        '{keys}\n\n'
+        "Failed to generate snap metadata: "
+        "The following keys are specified in their regular location "
+        "as well as in passthrough: {keys}. "
         "Remove duplicate keys."
     )
 
-    def __init__(self, keys: Set[str]) -> None:
-        super().__init__(keys=', '.join(keys))
+    def __init__(self, keys: List[str]) -> None:
+        super().__init__(keys=formatting_utils.humanize_list(keys, 'and'))

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -399,27 +399,12 @@ class _SnapPackaging:
             if key_name in self._config_data:
                 snap_yaml[key_name] = self._config_data[key_name]
 
-        passthrough_applied = False
-
         if 'apps' in self._config_data:
             _verify_app_paths(basedir='prime', apps=self._config_data['apps'])
             snap_yaml['apps'] = self._wrap_apps(self._config_data['apps'])
             self._render_socket_modes(snap_yaml['apps'])
-            for app_name, app in snap_yaml['apps'].items():
-                if self._apply_passthrough(
-                        app_name, app, app.pop('passthrough', {}),
-                        self._original_snapcraft_yaml['apps'][app_name]):
-                    passthrough_applied = True
 
-        if self._apply_passthrough('snapcraft.yaml', snap_yaml,
-                                   self._config_data.get('passthrough', {}),
-                                   self._original_snapcraft_yaml):
-            passthrough_applied = True
-
-        if passthrough_applied:
-            logger.warn('Passthrough is being used to propagate experimental '
-                        'properties to snap.yaml that have not been '
-                        'validated. The snap cannot be released to the store.')
+        self._process_passthrough_properties(snap_yaml)
 
         return snap_yaml
 
@@ -542,16 +527,39 @@ class _SnapPackaging:
                 if mode is not None:
                     socket['socket-mode'] = OctInt(mode)
 
-    def _apply_passthrough(self, location: str, section: Dict[str, Any],
+    def _process_passthrough_properties(
+            self, snap_yaml: Dict[str, Any]) -> None:
+        passthrough_applied = False
+
+        for section in ['apps', 'hooks']:
+            if section in self._config_data:
+                for name, value in snap_yaml[section].items():
+                    if self._apply_passthrough(
+                            value, value.pop('passthrough', {}),
+                            self._original_snapcraft_yaml[section][name]):
+                        passthrough_applied = True
+
+        if self._apply_passthrough(snap_yaml,
+                                   self._config_data.get('passthrough', {}),
+                                   self._original_snapcraft_yaml):
+            passthrough_applied = True
+
+        if passthrough_applied:
+            logger.warn("The 'passthrough' property is being used to "
+                        "propagate experimental properties to snap.yaml "
+                        "that have not been validated. The snap cannot be "
+                        "released to the store.")
+
+    def _apply_passthrough(self, section: Dict[str, Any],
                            passthrough: Dict[str, Any],
                            original: Dict[str, Any]) -> bool:
         # Any value already in the original dictionary must
         # not be specified in passthrough at the same time.
-        duplicates = set(original.keys() & passthrough.keys())
+        duplicates = list(original.keys() & passthrough.keys())
         if duplicates:
             raise meta_errors.AmbiguousPassthroughKeyError(duplicates)
         section.update(passthrough)
-        return passthrough is not {}
+        return bool(passthrough)
 
 
 def _find_bin(binary, basedir):

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -404,13 +404,13 @@ class _SnapPackaging:
             snap_yaml['apps'] = self._wrap_apps(self._config_data['apps'])
             self._render_socket_modes(snap_yaml['apps'])
             for app_name, app in snap_yaml['apps'].items():
-                self._apply_pass_through(
-                    app_name, app, app.pop('pass-through', {}),
+                self._apply_passthrough(
+                    app_name, app, app.pop('passthrough', {}),
                     self._original_snapcraft_yaml['apps'][app_name])
 
-        self._apply_pass_through('snapcraft.yaml', snap_yaml,
-                                 self._config_data.get('pass-through', {}),
-                                 self._original_snapcraft_yaml)
+        self._apply_passthrough('snapcraft.yaml', snap_yaml,
+                                self._config_data.get('passthrough', {}),
+                                self._original_snapcraft_yaml)
 
         return snap_yaml
 
@@ -533,18 +533,18 @@ class _SnapPackaging:
                 if mode is not None:
                     socket['socket-mode'] = OctInt(mode)
 
-    def _apply_pass_through(self, location: str, this: Dict[str, Any],
-                            pass_through: Dict[str, Any],
-                            original: Dict[str, Any]) -> None:
-        # Look for properties defined in pass-through and add them to the
+    def _apply_passthrough(self, location: str, section: Dict[str, Any],
+                           passthrough: Dict[str, Any],
+                           original: Dict[str, Any]) -> None:
+        # Look for properties defined in passthrough and add them to the
         # given dictionary. Any value already in the original dictionary must
-        # not be specified in pass-through at the same time.
-        for key in pass_through:
+        # not be specified in passthrough at the same time.
+        for key in passthrough:
             if key in original:
-                raise meta_errors.AmbiguousPassThroughKeyError(key)
-            this[key] = pass_through[key]
-        if pass_through:
-            logger.warn('Pass-through is being used to add experimental '
+                raise meta_errors.AmbiguousPassthroughKeyError(key)
+            section[key] = passthrough[key]
+        if passthrough:
+            logger.warn('Passthrough is being used to add experimental '
                         'properties to {!r} that have not been '
                         'validated. The snap cannot be released to the store.'
                         .format(location))

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -96,6 +96,7 @@ class Config:
 
         self.snapcraft_yaml_path = get_snapcraft_yaml()
         snapcraft_yaml = _snapcraft_yaml_load(self.snapcraft_yaml_path)
+        self.original_snapcraft_yaml = snapcraft_yaml.copy()
 
         self._validator = Validator(snapcraft_yaml)
         self._validator.validate()

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -327,11 +327,11 @@ class ErrorFormattingTestCase(unit.TestCase):
                 "Missing required key(s) in snapcraft.yaml: "
                 "'test-key1' and 'test-key2'. Either specify the missing "
                 "key(s), or use 'adopt-info' to get them from a part.")}),
-        ('AmbiguousPassThroughKeyError', {
-            'exception': meta_errors.AmbiguousPassThroughKeyError,
+        ('AmbiguousPassthroughKeyError', {
+            'exception': meta_errors.AmbiguousPassthroughKeyError,
             'kwargs': {'key': 'key'},
             'expected_message': (
-                "Failed to pass-through keys to snap metadata: "
+                "Failed to propagate keys to snap metadata: "
                 "'key' is specified as both a regular key and in "
                 "pass-through. Remove one of the keys."),
         }),

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -329,11 +329,13 @@ class ErrorFormattingTestCase(unit.TestCase):
                 "key(s), or use 'adopt-info' to get them from a part.")}),
         ('AmbiguousPassthroughKeyError', {
             'exception': meta_errors.AmbiguousPassthroughKeyError,
-            'kwargs': {'key': 'key'},
+            'kwargs': {'keys': ['key1', 'key2']},
             'expected_message': (
                 "Failed to propagate keys to snap metadata: "
-                "'key' is specified as both a regular key and in "
-                "pass-through. Remove one of the keys."),
+                "The following keys are specified as both regular keys and in "
+                "passthrough:\n"
+                "key1, key2\n\n"
+                "Remove duplicate keys."),
         }),
         ('MissingMetadataFileError', {
             'exception': errors.MissingMetadataFileError,

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -327,6 +327,14 @@ class ErrorFormattingTestCase(unit.TestCase):
                 "Missing required key(s) in snapcraft.yaml: "
                 "'test-key1' and 'test-key2'. Either specify the missing "
                 "key(s), or use 'adopt-info' to get them from a part.")}),
+        ('AmbiguousPassThroughKeyError', {
+            'exception': meta_errors.AmbiguousPassThroughKeyError,
+            'kwargs': {'key': 'key'},
+            'expected_message': (
+                "Failed to pass-through keys to snap metadata: "
+                "'key' is specified as both a regular key and in "
+                "pass-through. Remove one of the keys."),
+        }),
         ('MissingMetadataFileError', {
             'exception': errors.MissingMetadataFileError,
             'kwargs': {'part_name': 'test-part', 'path': 'test/path'},

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -331,10 +331,9 @@ class ErrorFormattingTestCase(unit.TestCase):
             'exception': meta_errors.AmbiguousPassthroughKeyError,
             'kwargs': {'keys': ['key1', 'key2']},
             'expected_message': (
-                "Failed to propagate keys to snap metadata: "
-                "The following keys are specified as both regular keys and in "
-                "passthrough:\n"
-                "key1, key2\n\n"
+                "Failed to generate snap metadata: "
+                "The following keys are specified in their regular location "
+                "as well as in passthrough: 'key1' and 'key2'. "
                 "Remove duplicate keys."),
         }),
         ('MissingMetadataFileError', {

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -511,8 +511,8 @@ class PassThroughTestCase(CreateBaseTestCase):
         self.generate_meta_yaml()
         self.assertThat(
             fake_logger.output,
-            Contains("Passthrough is being used to add experimental "
-                     "properties to 'snapcraft.yaml' that have not been "
+            Contains("Passthrough is being used to propagate experimental "
+                     "properties to snap.yaml that have not been "
                      "validated. The snap cannot be released to the store.\n"))
 
     def test_ambiguous_key_fails(self):
@@ -520,7 +520,7 @@ class PassThroughTestCase(CreateBaseTestCase):
         raised = self.assertRaises(
             meta_errors.AmbiguousPassthroughKeyError,
             self.generate_meta_yaml)
-        self.assertThat(raised.key, Equals('confinement'))
+        self.assertThat(raised.keys, Equals('confinement'))
 
     def test_app_add_new_key(self):
         self.config_data['apps'] = {'foo': {
@@ -558,8 +558,8 @@ class PassThroughTestCase(CreateBaseTestCase):
         self.generate_meta_yaml()
         self.assertThat(
             fake_logger.output,
-            Contains("Passthrough is being used to add experimental "
-                     "properties to 'foo' that have not been "
+            Contains("Passthrough is being used to propagate experimental "
+                     "properties to snap.yaml that have not been "
                      "validated. The snap cannot be released to the store.\n"))
 
     def test_app_ambiguous_key_fails(self):
@@ -569,7 +569,22 @@ class PassThroughTestCase(CreateBaseTestCase):
         raised = self.assertRaises(
             meta_errors.AmbiguousPassthroughKeyError,
             self.generate_meta_yaml)
-        self.assertThat(raised.key, Equals('daemon'))
+        self.assertThat(raised.keys, Equals('daemon'))
+
+    def test_warn_once_only(self):
+        fake_logger = fixtures.FakeLogger(level=logging.INFO)
+        self.useFixture(fake_logger)
+
+        self.config_data['passthrough'] = {'foo': 'bar', 'spam': 'eggs'}
+        self.config_data['apps'] = {'foo': {
+            'command': 'echo',
+            'passthrough': {'foo': 'bar', 'spam': 'eggs'}}}
+        self.generate_meta_yaml()
+        self.assertThat(
+            fake_logger.output,
+            Contains("Passthrough is being used to propagate experimental "
+                     "properties to snap.yaml that have not been "
+                     "validated. The snap cannot be released to the store.\n"))
 
 
 class CreateMetadataFromSourceBaseTestCase(CreateBaseTestCase):

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -483,7 +483,7 @@ class CreateTestCase(CreateBaseTestCase):
 class PassThroughTestCase(CreateBaseTestCase):
 
     def test_add_new_key(self):
-        self.config_data['pass-through'] = {'spam': 'eggs'}
+        self.config_data['passthrough'] = {'spam': 'eggs'}
         y = self.generate_meta_yaml()
         self.assertThat(
             y, Contains('spam'),
@@ -493,13 +493,13 @@ class PassThroughTestCase(CreateBaseTestCase):
     def test_override_key_with_different_type(self):
         del self.config_data['architectures']
         # This is normally an array of strings
-        self.config_data['pass-through'] = {'architectures': 'all'}
+        self.config_data['passthrough'] = {'architectures': 'all'}
         y = self.generate_meta_yaml()
         self.assertThat(y['architectures'], Equals('all'))
 
     def test_override_key_with_default(self):
         del self.config_data['confinement']
-        self.config_data['pass-through'] = {'confinement': 'next-generation'}
+        self.config_data['passthrough'] = {'confinement': 'next-generation'}
         y = self.generate_meta_yaml()
         self.assertThat(y['confinement'], Equals('next-generation'))
 
@@ -507,25 +507,25 @@ class PassThroughTestCase(CreateBaseTestCase):
         fake_logger = fixtures.FakeLogger(level=logging.INFO)
         self.useFixture(fake_logger)
 
-        self.config_data['pass-through'] = {'foo': 'bar', 'spam': 'eggs'}
+        self.config_data['passthrough'] = {'foo': 'bar', 'spam': 'eggs'}
         self.generate_meta_yaml()
         self.assertThat(
             fake_logger.output,
-            Contains("Pass-through is being used to add experimental "
+            Contains("Passthrough is being used to add experimental "
                      "properties to 'snapcraft.yaml' that have not been "
                      "validated. The snap cannot be released to the store.\n"))
 
     def test_ambiguous_key_fails(self):
-        self.config_data['pass-through'] = {'confinement': 'next-generation'}
+        self.config_data['passthrough'] = {'confinement': 'next-generation'}
         raised = self.assertRaises(
-            meta_errors.AmbiguousPassThroughKeyError,
+            meta_errors.AmbiguousPassthroughKeyError,
             self.generate_meta_yaml)
         self.assertThat(raised.key, Equals('confinement'))
 
     def test_app_add_new_key(self):
         self.config_data['apps'] = {'foo': {
             'command': 'echo',
-            'pass-through': {'spam': 'eggs'}}}
+            'passthrough': {'spam': 'eggs'}}}
         y = self.generate_meta_yaml()['apps']['foo']
         self.assertThat(
             y, Contains('spam'),
@@ -536,7 +536,7 @@ class PassThroughTestCase(CreateBaseTestCase):
         self.config_data['apps'] = {'foo': {
             'command': 'echo',
             # This is normally an array of strings
-            'pass-through': {'aliases': 'foo'}}}
+            'passthrough': {'aliases': 'foo'}}}
         y = self.generate_meta_yaml()['apps']['foo']
         self.assertThat(
             y, Contains('aliases'),
@@ -554,20 +554,20 @@ class PassThroughTestCase(CreateBaseTestCase):
 
         self.config_data['apps'] = {'foo': {
             'command': 'echo',
-            'pass-through': {'foo': 'bar', 'spam': 'eggs'}}}
+            'passthrough': {'foo': 'bar', 'spam': 'eggs'}}}
         self.generate_meta_yaml()
         self.assertThat(
             fake_logger.output,
-            Contains("Pass-through is being used to add experimental "
+            Contains("Passthrough is being used to add experimental "
                      "properties to 'foo' that have not been "
                      "validated. The snap cannot be released to the store.\n"))
 
     def test_app_ambiguous_key_fails(self):
         self.config_data['apps'] = {'foo': {
             'command': 'echo', 'daemon': 'simple',
-            'pass-through': {'daemon': 'complex'}}}
+            'passthrough': {'daemon': 'complex'}}}
         raised = self.assertRaises(
-            meta_errors.AmbiguousPassThroughKeyError,
+            meta_errors.AmbiguousPassthroughKeyError,
             self.generate_meta_yaml)
         self.assertThat(raised.key, Equals('daemon'))
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This PR introduces a new **pass-through** keyword to `snapcraft.yaml` which comes in two forms, a global and an app-local property [as proposed in the forum](https://forum.snapcraft.io/t/support-for-passthrough-into-snap-yaml/4698). As proposed, the key is just defined as a dictionary (object in the schema) and not validated, but instead applied in `snap_packaging.py` where its use will be logged and ambiguous keys will raise an error. The original snapcraft.yaml is used to validate what values have been specified as opposed to default values filled in by Snapcraft.
Note that, as discussed offline, properties like `name` or `command` are not special-cased and not supported by pass-through due to their being strings processed by Snapcraft.

The following tests are added/ modified:

 - tests.unit.test_errors
 - To verify AmbiguousPassThroughError
 - tests.unit.test_meta.PassThroughTestCase
 - To verify that a) a new key not present in the schema can be added b) an existing key can be overridden c) a key both present in the schema and pass-through raising an error d) defaults can be overridden rather than error out because of the check for amiguity e) a warning being logged for using pass-through. Each of these is tested with the global and the apps form.

I locally ran the tests:
 - `./runtests.sh tests/unit` with unrelated failures in [tests.unit.test_lifecycle.CoreSetupTestCase.test_core_setup_if_docker_env](https://bugs.launchpad.net/snapcraft/+bug/1752576), `tests.unit.test_mangling.TestClearExecstack.test_execstack_clears` and `tests.unit.test_elf`.
 - `./runtests.sh tests/integration` with one unrelated failure in [tests.integration.general.test_parser.TestParserWikis](https://bugs.launchpad.net/snapcraft/+bug/1752580)
 - `./runtests.sh static`: Everything passed

Manual test steps:
 - cd tests/integration/snaps/basic
 - Add some pass-through properties:
   pass-through:
     foo: bar
     confinement: next-generation
   apps:
     foo:
       command: echo
       daemon: simple
       pass-through:
         foo: bar
         daemon: complex
 - snapcraft
 - Observe the error "Failed to pass-through keys to snap metadata: 'daemon' is specified as both a regular key and in pass-through. Remove one of the keys.".
 - Fix the error by removing "daemon: simple" from the "foo" app.
 - snapcraft
 - Observe the error "Failed to pass-through keys to snap metadata: 'confinement' is specified as both a regular key and in pass-through. Remove one of the keys.".
 - Fix the error by removing "confinement: classic" from the top.
 - snapcraft
 - Observe that that the build succeeds with two warnings:
   Pass-through is being used to add experimental properties to 'foo' that have not been validated. The snap cannot be released to the store.
   Pass-through is being used to add experimental properties to 'snapcraft.yaml' that have not been validated. The snap cannot be released to the store.
 - grep -C 3 foo prime/meta/snap.yaml
   confinement: next-generation
   grade: stable
   apps:
     foo:
       command: command-foo.wrapper
       daemon: complex
       foo: bar
   foo: bar
 - Observe keys being propagated to snap.yaml without validation.