### PR TITLE
python: bring back support for older versions of pip

### DIFF
--- a/snapcraft/plugins/_python/_pip.py
+++ b/snapcraft/plugins/_python/_pip.py
@@ -386,6 +386,8 @@ class Pip:
             for line in output.splitlines():
                 line = line.split()
                 m = version_regex.search(line[1])
+                if not m:
+                    raise errors.PipListInvalidLegacyFormatError(output)
                 json_output.append({'name': line[0], 'version': m.group(1)})
         except json.decoder.JSONDecodeError as e:
             raise errors.PipListInvalidJsonError(output) from e

--- a/snapcraft/plugins/_python/_pip.py
+++ b/snapcraft/plugins/_python/_pip.py
@@ -369,20 +369,17 @@ class Pip:
         :return: Dict of installed python packages and their versions
         :rtype: dict
         """
-        command = ['list', '--format=json']
+        command = ['list']
         if user:
             command.append('--user')
 
         packages = collections.OrderedDict()
         try:
-            output = self._run_output(command)
+            output = self._run_output(command + ['--format=json'])
             json_output = json.loads(
                     output, object_pairs_hook=collections.OrderedDict)
         except subprocess.CalledProcessError:
             # --format requires a newer pip, so fall back to legacy output
-            command = ['list']
-            if user:
-                command.append('--user')
             output = self._run_output(command)
             json_output = []  # type: List[Dict[str, str]]
             version_regex = re.compile('\((.+)\)')

--- a/snapcraft/plugins/_python/errors.py
+++ b/snapcraft/plugins/_python/errors.py
@@ -49,6 +49,18 @@ class MissingSitePyError(PythonPluginError):
         super().__init__(site_py_glob=site_py_glob)
 
 
+class PipListInvalidLegacyFormatError(PythonPluginError):
+
+    fmt = (
+        "Failed to parse Python package list: "
+        "The returned output is not in the expected format:\n"
+        "{output}"
+    )
+
+    def __init__(self, output):
+        super().__init__(output=output)
+
+
 class PipListInvalidJsonError(PythonPluginError):
 
     fmt = "Pip packages output isn't valid json: {json!r}"

--- a/tests/integration/plugins_python/test_python_plugin.py
+++ b/tests/integration/plugins_python/test_python_plugin.py
@@ -26,10 +26,21 @@ from testtools.matchers import (
     FileExists
 )
 
-from tests import integration
+from tests import integration, fixture_setup
 
 
 class PythonPluginTestCase(integration.TestCase):
+
+    def test_use_staged_pip(self):
+        snapcraft_yaml = fixture_setup.SnapcraftYaml(self.path)
+        snapcraft_yaml.update_part('test-part', {
+            'plugin': 'python',
+            'source': '.',
+            'stage-packages': ['python3-pip']
+        })
+        self.useFixture(snapcraft_yaml)
+
+        self.run_snapcraft('pull')
 
     def test_pull_with_pip_requirements_file(self):
         self.run_snapcraft('build', 'pip-requirements-file')

--- a/tests/unit/plugins/python/test_errors.py
+++ b/tests/unit/plugins/python/test_errors.py
@@ -1,0 +1,40 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from testtools.matchers import Equals
+
+
+from snapcraft.plugins._python import errors
+from tests import unit
+
+
+class ErrorFormattingTestCase(unit.TestCase):
+
+    scenarios = (
+        ('PipListInvalidLegacyFormatError', {
+            'exception': errors.PipListInvalidLegacyFormatError,
+            'kwargs': {'output': 'test-output'},
+            'expected_message': (
+                "Failed to parse Python package list: "
+                "The returned output is not in the expected format:\n"
+                "test-output"
+                )}),
+    )
+
+    def test_error_formatting(self):
+        self.assertThat(
+            str(self.exception(**self.kwargs)),
+            Equals(self.expected_message))

--- a/tests/unit/plugins/python/test_pip.py
+++ b/tests/unit/plugins/python/test_pip.py
@@ -713,7 +713,7 @@ class PipListTestCase(PipCommandBaseTestCase):
         self.mock_run.return_value = '[{"name": "foo", "version": "1.0"}]'
         self.assertThat(self.pip.list(user=True), Equals({'foo': '1.0'}))
         self.mock_run.assert_called_once_with(
-            ['list', '--format=json', '--user'], runner=mock.ANY)
+            ['list', '--user', '--format=json'], runner=mock.ANY)
 
     def test_missing_name(self):
         self.mock_run.return_value = '[{"version": "1.0"}]'
@@ -741,7 +741,6 @@ class PipListTestCase(PipCommandBaseTestCase):
             subprocess.CalledProcessError(2, 'pip', 'no such option'),
             'foo (1.0)',
         ]
-        self.mock_run.return_value = '[{"name": "foo", "version": "1.0"}]'
         self.assertThat(self.pip.list(), Equals({'foo': '1.0'}))
         self.mock_run.assert_has_calls([
             mock.call(['list', '--format=json'], runner=mock.ANY),

--- a/tests/unit/plugins/python/test_pip.py
+++ b/tests/unit/plugins/python/test_pip.py
@@ -736,6 +736,18 @@ class PipListTestCase(PipCommandBaseTestCase):
         self.assertThat(
             str(raised), Contains("Pip packages output isn't valid json"))
 
+    def test_no_json_format(self):
+        self.mock_run.side_effect = [
+            subprocess.CalledProcessError(2, 'pip', 'no such option'),
+            'foo (1.0)',
+        ]
+        self.mock_run.return_value = '[{"name": "foo", "version": "1.0"}]'
+        self.assertThat(self.pip.list(), Equals({'foo': '1.0'}))
+        self.mock_run.assert_has_calls([
+            mock.call(['list', '--format=json'], runner=mock.ANY),
+            mock.call(['list'], runner=mock.ANY),
+        ])
+
 
 class _CheckPythonhomeEnv():
     def __init__(self, test, expected_pythonhome):

--- a/tests/unit/plugins/python/test_pip.py
+++ b/tests/unit/plugins/python/test_pip.py
@@ -747,6 +747,15 @@ class PipListTestCase(PipCommandBaseTestCase):
             mock.call(['list'], runner=mock.ANY),
         ])
 
+    def test_no_json_format_invalid_result(self):
+        self.mock_run.side_effect = [
+            subprocess.CalledProcessError(2, 'pip', 'no such option'),
+            'foo 1.0',
+        ]
+        raised = self.assertRaises(errors.PipListInvalidLegacyFormatError,
+                                   self.pip.list)
+        self.assertThat(raised.output, Equals('foo 1.0'))
+
 
 class _CheckPythonhomeEnv():
     def __init__(self, test, expected_pythonhome):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This PR brings back support for older versions of pip, most notably 8.1.1 which is in Xenial, that don't support `pip list --format=json`. Ease of parsing is why we dropped that support previously. And we support pulling in pip from stage-packages so that should include Xenial and not require resorting to PyPI, which is what Snapcraft does with pip, setuptools and wheel when they're not available.

Note that no effort is made to hide the error message as per what we do in other places.

The following new test is being added:

 - tests.unit.plugins.python.test_pip.PipListTestCase.test_no_json_format
 - To verify that we fallback to the legacy format if pip returns an error and list the packages from that successfully.

I locally ran the tests:
 - `./runtests.sh tests/unit` with unrelated failures in [tests.unit.test_lifecycle.CoreSetupTestCase.test_core_setup_if_docker_env](https://bugs.launchpad.net/snapcraft/+bug/1752576), `tests.unit.test_mangling.TestClearExecstack.test_execstack_clears` and `tests.unit.test_elf`.
 - `./runtests.sh tests/integration` with one unrelated failure in [tests.integration.general.test_parser.TestParserWikis](https://bugs.launchpad.net/snapcraft/+bug/1752580)
 - `./runtests.sh static`: Everything passed

Manual test steps:
 - cd tests/integration/snaps/python-hello
 - Update `snapcraft.yaml` by adding this snippet to "python-part":
   stage-packages:
    - python3-pip
    - python3-wheel
    - python3-setuptools
 - snapcraft
 - Observe that the build proceeds without an error and notice the error message "no such option: --format=json" being logged.