### PR TITLE
Fix formatting of some store errors

### DIFF
--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -318,13 +318,16 @@ class StoreReviewError(StoreError):
 
     def __init__(self, result):
         self.fmt = self.__messages[result['code']]
+        additional = []
         errors = result.get('errors')
         if errors:
             for error in errors:
                 message = error.get('message')
                 if message:
-                    self.fmt = '{}\n  - {message}'.format(
-                        self.fmt, message=message)
+                    additional.append('  - {message}'.format(message=message))
+        if additional:
+            self.additional = '\n'.join(additional)
+            self.fmt += '\n{additional}'
         self.code = result['code']
         super().__init__()
 
@@ -441,7 +444,8 @@ class StoreMetadataError(StoreError):
             parts.append(
                 "You can repeat the push-metadata command with "
                 "--force to force the local values into the Store")
-            self.fmt = "\n".join(parts)
+            self.parts = "\n".join(parts)
+            self.fmt = '{parts}'
         elif 'error_list' in response_json:
             response_json['text'] = response_json['error_list'][0]['message']
 

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -435,6 +435,8 @@ class FakeStoreAPIServer(base.BaseFakeServer):
                 details_path = 'details/upload-id/review-snap'
             elif name == 'test-duplicate-snap':
                 details_path = 'details/upload-id/duplicate-snap'
+            elif name == 'test-scan-error-with-braces':
+                details_path = 'details/upload-id/scan-error-with-braces'
             else:
                 details_path = 'details/upload-id/good-snap'
             if not request.json_body.get('dry_run', False):
@@ -712,8 +714,12 @@ class FakeStoreAPIServer(base.BaseFakeServer):
                 # POST, return error
                 error_list = []
                 for name, value in request.json_body.items():
+                    if name == 'test-conflict-with-braces':
+                        message = 'value with {braces}'
+                    else:
+                        message = value + '-changed'
                     error_list.append({
-                        'message': value + '-changed',
+                        'message': message,
                         'code': 'conflict',
                         'extra': {'name': name},
                     })
@@ -749,6 +755,9 @@ class FakeStoreAPIServer(base.BaseFakeServer):
                            for e in info])
             conflict = any([e.get('filename', '').endswith('conflict')
                            for e in info])
+            conflict_with_braces = any(
+                [e.get('filename', '').endswith('conflict-with-braces')
+                 for e in info])
             if invalid:
                 err = {'error_list': [{
                     'message': 'Invalid field: icon',
@@ -760,6 +769,15 @@ class FakeStoreAPIServer(base.BaseFakeServer):
                 # POST, return error
                 error_list = [{
                     'message': 'original-icon',
+                    'code': 'conflict',
+                    'extra': {'name': 'icon'},
+                }]
+                payload = json.dumps({'error_list': error_list}).encode('utf8')
+                response_code = 409
+            elif conflict_with_braces and request.method == 'POST':
+                # POST, return error
+                error_list = [{
+                    'message': 'original icon with {braces}',
                     'code': 'conflict',
                     'extra': {'name': 'icon'},
                 }]
@@ -791,6 +809,18 @@ class FakeStoreAPIServer(base.BaseFakeServer):
                 'processed': True,
                 'errors': [
                     {'message': 'Duplicate snap already uploaded'},
+                ]
+            }).encode()
+        elif snap == 'scan-error-with-braces':
+            logger.debug('Handling request for scan error with braces')
+            payload = json.dumps({
+                'code': 'processing_error',
+                'url': '/dev/click-apps/5349/rev/1',
+                'can_release': False,
+                'revision': '1',
+                'processed': True,
+                'errors': [
+                    {'message': 'Error message with {braces}'},
                 ]
             }).encode()
         else:


### PR DESCRIPTION
`SnapcraftError.fmt` is run through `str.format` by
`SnapcraftError.__str__`, so it shouldn't itself be the output of a
`str.format` operation.  If it is, and the output contains `{}` (as for
example if it contains raw JSON output), then `__str__` will raise an
exception.

LP: [#1761488](https://bugs.launchpad.net/bugs/1761488)