### PR TITLE
python plugin: install python-distutils when run on bionic

### DIFF
--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -63,7 +63,7 @@ import requests
 
 import snapcraft
 from snapcraft.common import isurl
-from snapcraft.internal import mangling
+from snapcraft.internal import mangling, os_release
 from snapcraft.internal.errors import SnapcraftPluginCommandError
 from snapcraft.plugins import _python
 
@@ -150,10 +150,20 @@ class PythonPlugin(snapcraft.BasePlugin):
 
     @property
     def plugin_stage_packages(self):
-        if self.options.python_version == 'python3':
-            return ['python3']
-        elif self.options.python_version == 'python2':
-            return ['python']
+        release_codename = os_release.OsRelease().version_codename()
+        if self.options.python_version == 'python2':
+            python_base = 'python'
+        elif self.options.python_version == 'python3':
+            python_base = 'python3'
+        else:
+            return
+
+        stage_packages = [python_base]
+        if release_codename == 'bionic':
+            # In bionic, pip started requiring python-distutils to be
+            # installed.
+            stage_packages.append('{}-distutils'.format(python_base))
+        return stage_packages
 
     # ignore mypy error: Read-only property cannot override read-write property
     @property  # type: ignore

--- a/tests/unit/plugins/test_python.py
+++ b/tests/unit/plugins/test_python.py
@@ -374,7 +374,9 @@ class PythonPluginTestCase(BasePythonPluginTestCase):
 
         plugin = python.PythonPlugin('test-part', self.options,
                                      self.project_options)
-        self.assertEqual(['python'], plugin.plugin_stage_packages)
+        self.assertThat(
+            plugin.plugin_stage_packages,
+            Equals(['python']))
 
     def test_plugin_stage_packages_python3_xenial(self):
         self.options.python_version = 'python3'
@@ -383,7 +385,9 @@ class PythonPluginTestCase(BasePythonPluginTestCase):
 
         plugin = python.PythonPlugin('test-part', self.options,
                                      self.project_options)
-        self.assertEqual(['python3'], plugin.plugin_stage_packages)
+        self.assertThat(
+            plugin.plugin_stage_packages,
+            Equals(['python3']))
 
     def test_plugin_stage_packages_python2_bionic(self):
         self.options.python_version = 'python2'
@@ -392,8 +396,9 @@ class PythonPluginTestCase(BasePythonPluginTestCase):
 
         plugin = python.PythonPlugin('test-part', self.options,
                                      self.project_options)
-        self.assertEqual(
-            ['python', 'python-distutils'], plugin.plugin_stage_packages)
+        self.assertThat(
+            plugin.plugin_stage_packages,
+            Equals(['python', 'python-distutils']))
 
     def test_plugin_stage_packages_python3_bionic(self):
         self.options.python_version = 'python3'
@@ -402,8 +407,9 @@ class PythonPluginTestCase(BasePythonPluginTestCase):
 
         plugin = python.PythonPlugin('test-part', self.options,
                                      self.project_options)
-        self.assertEqual(
-            ['python3', 'python3-distutils'], plugin.plugin_stage_packages)
+        self.assertThat(
+            plugin.plugin_stage_packages,
+            Equals(['python3', 'python3-distutils']))
 
 
 class FileMissingPythonPluginTest(BasePythonPluginTestCase):

--- a/tests/unit/plugins/test_python.py
+++ b/tests/unit/plugins/test_python.py
@@ -79,6 +79,10 @@ class BasePythonPluginTestCase(unit.TestCase):
         self.mock_setup_tools = patcher.start()
         self.addCleanup(patcher.stop)
 
+        patcher = mock.patch('snapcraft.internal.os_release.OsRelease')
+        self.mock_os_release = patcher.start()
+        self.addCleanup(patcher.stop)
+
 
 class PythonPluginTestCase(BasePythonPluginTestCase):
 
@@ -362,6 +366,44 @@ class PythonPluginTestCase(BasePythonPluginTestCase):
         self.assertThat(
             plugin.get_manifest()['constraints-contents'],
             Equals('testpackage1==1.0\ntestpackage2==1.2'))
+
+    def test_plugin_stage_packages_python2_xenial(self):
+        self.options.python_version = 'python2'
+        self.mock_os_release.return_value.version_codename.return_value = (
+            'xenial')
+
+        plugin = python.PythonPlugin('test-part', self.options,
+                                     self.project_options)
+        self.assertEqual(['python'], plugin.plugin_stage_packages)
+
+    def test_plugin_stage_packages_python3_xenial(self):
+        self.options.python_version = 'python3'
+        self.mock_os_release.return_value.version_codename.return_value = (
+            'xenial')
+
+        plugin = python.PythonPlugin('test-part', self.options,
+                                     self.project_options)
+        self.assertEqual(['python3'], plugin.plugin_stage_packages)
+
+    def test_plugin_stage_packages_python2_bionic(self):
+        self.options.python_version = 'python2'
+        self.mock_os_release.return_value.version_codename.return_value = (
+            'bionic')
+
+        plugin = python.PythonPlugin('test-part', self.options,
+                                     self.project_options)
+        self.assertEqual(
+            ['python', 'python-distutils'], plugin.plugin_stage_packages)
+
+    def test_plugin_stage_packages_python3_bionic(self):
+        self.options.python_version = 'python3'
+        self.mock_os_release.return_value.version_codename.return_value = (
+            'bionic')
+
+        plugin = python.PythonPlugin('test-part', self.options,
+                                     self.project_options)
+        self.assertEqual(
+            ['python3', 'python3-distutils'], plugin.plugin_stage_packages)
 
 
 class FileMissingPythonPluginTest(BasePythonPluginTestCase):


### PR DESCRIPTION
The Python packages in bionic changed slightly, so that
distutils/sysconfig.py (which pip needs) is now in a separate package.

This fixes https://bugs.launchpad.net/snapcraft/+bug/1762456