### PR TITLE
storeapi: handle 500 error response when releasing snap

### DIFF
--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -15,11 +15,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import contextlib
+import logging
 from simplejson.scanner import JSONDecodeError
 from typing import List  # noqa
 
 from snapcraft.internal.errors import SnapcraftError
 from snapcraft import formatting_utils
+
+
+logger = logging.getLogger(__name__)
 
 
 class StoreError(SnapcraftError):
@@ -28,6 +32,12 @@ class StoreError(SnapcraftError):
     :cvar fmt: A format string that daughter classes override
 
     """
+
+    def __init__(self, **kwargs):
+        with contextlib.suppress(KeyError, AttributeError):
+            logger.debug('Store error response: {}'.format(
+                kwargs['response'].__dict__))
+        super().__init__(**kwargs)
 
 
 class InvalidCredentialsError(StoreError):
@@ -109,7 +119,7 @@ class StoreAuthenticationError(StoreError):
             if extra_error_message:
                 message += ': {}'.format(extra_error_message)
 
-        super().__init__(message=message)
+        super().__init__(response=response, message=message)
 
 
 class StoreTwoFactorAuthenticationRequired(StoreAuthenticationError):
@@ -131,7 +141,8 @@ class DeveloperAgreementSignError(StoreError):
         'Text: {text!r}')
 
     def __init__(self, response):
-        super().__init__(reason=response.reason, text=response.text)
+        super().__init__(
+            response=response, reason=response.reason, text=response.text)
 
 
 class NeedTermsSignedError(StoreError):
@@ -161,7 +172,7 @@ class StoreAccountInformationError(StoreError):
                         'error_list'] if 'extra' in error]
         except JSONDecodeError:
             pass
-        super().__init__(error=error, extra=extra)
+        super().__init__(response=response, error=error, extra=extra)
 
 
 class StoreKeyRegistrationError(StoreError):
@@ -177,7 +188,7 @@ class StoreKeyRegistrationError(StoreError):
                     error['message'] for error in response_json['error_list'])
         except JSONDecodeError:
             pass
-        super().__init__(error=error)
+        super().__init__(response=response, error=error)
 
 
 class StoreRegistrationError(StoreError):
@@ -262,7 +273,8 @@ class StoreUploadError(StoreError):
         'Text: {text!r}')
 
     def __init__(self, response):
-        super().__init__(reason=response.reason, text=response.text)
+        super().__init__(
+            response=response, reason=response.reason, text=response.text)
 
 
 class StorePushError(StoreError):
@@ -288,8 +300,9 @@ class StorePushError(StoreError):
             except AttributeError:
                 response_json['text'] = 'error while pushing'
 
-        super().__init__(snap_name=snap_name, status_code=response.status_code,
-                         **response_json)
+        super().__init__(
+            response=response, snap_name=snap_name,
+            status_code=response.status_code, **response_json)
 
 
 class StoreReviewError(StoreError):
@@ -349,12 +362,13 @@ class StoreReleaseError(StoreError):
             401: self.__fmt_error_401_or_403,
             403: self.__fmt_error_401_or_403,
             404: self.__fmt_error_404,
+            500: self.__fmt_error_500,
         }
 
         fmt_error = self.fmt_errors.get(
             response.status_code, self.__fmt_error_unknown)
 
-        super().__init__(message=fmt_error(response).format(
+        super().__init__(response=response, message=fmt_error(response).format(
             snap_name=snap_name))
 
     def __to_json(self, response):
@@ -395,6 +409,16 @@ class StoreReleaseError(StoreError):
 
     def __fmt_error_404(self, response):
         return self.__FMT_NOT_REGISTERED
+
+    def __fmt_error_500(self, response):
+        response_json = self.__to_json(response)
+        message = ('The store encountered an internal error. Please report a '
+                   'bug if this continues.')
+
+        if 'error_list' in response_json:
+            message = _error_list_to_message(response_json)
+
+        return message
 
     def __fmt_error_unknown(self, response):
         response_json = self.__to_json(response)
@@ -445,8 +469,9 @@ class StoreMetadataError(StoreError):
         elif 'error_list' in response_json:
             response_json['text'] = response_json['error_list'][0]['message']
 
-        super().__init__(snap_name=snap_name, status_code=response.status_code,
-                         **response_json)
+        super().__init__(
+            response=response, snap_name=snap_name,
+            status_code=response.status_code, **response_json)
 
 
 class StoreValidationError(StoreError):
@@ -462,7 +487,7 @@ class StoreValidationError(StoreError):
         except (AttributeError, JSONDecodeError):
             response_json = {'text': message or response}
 
-        super().__init__(status_code=response.status_code,
+        super().__init__(response=response, status_code=response.status_code,
                          **response_json)
 
 
@@ -480,7 +505,7 @@ class StoreSnapBuildError(StoreError):
         except JSONDecodeError:
             pass
 
-        super().__init__(error=error)
+        super().__init__(response=response, error=error)
 
 
 class StoreSnapRevisionsError(StoreError):
@@ -500,7 +525,7 @@ class StoreSnapRevisionsError(StoreError):
             pass
 
         super().__init__(
-            snap_id=snap_id, arch=arch or 'any arch',
+            response=response, snap_id=snap_id, arch=arch or 'any arch',
             series=series or 'any', error=error)
 
 
@@ -531,7 +556,7 @@ class StoreChannelClosingError(StoreError):
             error = '{} {}'.format(
                 response.status_code, response.reason)
 
-        super().__init__(error=error)
+        super().__init__(response=response, error=error)
 
 
 class StoreChannelClosingPermissionError(StoreError):

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -412,8 +412,9 @@ class StoreReleaseError(StoreError):
 
     def __fmt_error_500(self, response):
         response_json = self.__to_json(response)
-        message = ('The store encountered an internal error. Please report a '
-                   'bug if this continues.')
+        message = ('The store encountered an internal error. The status of '
+                   'store and associated services can be checked at:\n'
+                   'https://status.snapcraft.io/')
 
         if 'error_list' in response_json:
             message = _error_list_to_message(response_json)

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -479,6 +479,9 @@ class FakeStoreAPIServer(base.BaseFakeServer):
                 'permission': 'channel',
                 'channels': ['no-permission'],
             }).encode()
+        elif 'bad-channel' in channels:
+            response_code = 500
+            payload = json.dumps({}).encode()
         elif (
                 name == 'test-snap' or
                 name.startswith('test-snapcraft')):

--- a/tests/integration/store/test_store_release.py
+++ b/tests/integration/store/test_store_release.py
@@ -98,3 +98,36 @@ class ReleaseTestCase(integration.StoreTestCase):
         self.assertThat(error.output, Contains(
             "Received 403: Lacking permission to release to channel(s) "
             "'no-permission'"))
+
+    def test_release_internal_error(self):
+        if not self.is_store_fake():
+            self.skipTest("The real store won't return the proper response")
+
+        self.addCleanup(self.logout)
+        self.login()
+
+        # Change to a random name and version.
+        name = self.get_unique_name()
+        version = self.get_unique_version()
+        self.copy_project_to_cwd('basic')
+        self.update_name_and_version(name, version)
+
+        self.run_snapcraft('snap')
+
+        # Register the snap
+        self.register(name)
+        # Upload the snap
+        snap_file_path = '{}_{}_{}.snap'.format(name, version, 'all')
+        self.assertThat(
+            os.path.join(snap_file_path), FileExists())
+
+        output = self.run_snapcraft(['push', snap_file_path])
+        expected = r'.*Ready to release!.*'.format(name)
+        self.assertThat(output, MatchesRegex(expected, flags=re.DOTALL))
+
+        # Attempt to release it
+        error = self.assertRaises(
+            subprocess.CalledProcessError,
+            self.run_snapcraft, ['release', name, '1', 'bad-channel'])
+        self.assertThat(error.output, Contains(
+            "store encountered an internal error. Please report a bug"))

--- a/tests/integration/store/test_store_release.py
+++ b/tests/integration/store/test_store_release.py
@@ -130,4 +130,6 @@ class ReleaseTestCase(integration.StoreTestCase):
             subprocess.CalledProcessError,
             self.run_snapcraft, ['release', name, '1', 'bad-channel'])
         self.assertThat(error.output, Contains(
-            "store encountered an internal error. Please report a bug"))
+            'store encountered an internal error. The status of store and '
+            'associated services can be checked at:\n'
+            'https://status.snapcraft.io/'))

--- a/tests/unit/store/test_store_client.py
+++ b/tests/unit/store/test_store_client.py
@@ -1018,13 +1018,20 @@ class CloseChannelsTestCase(StoreTestCase):
         self.assertThat(
             str(raised),
             Equals('Could not close channel: 200 OK'))
-        self.assertThat(
-            self.fake_logger.output.splitlines()[-3:],
-            Equals([
-                'Invalid response from the server on channel closing:',
-                '200 OK',
-                'b\'plain data\'',
-            ]))
+
+        expected_lines = [
+            'Invalid response from the server on channel closing:',
+            '200 OK',
+            'b\'plain data\'',
+        ]
+
+        actual_lines = []
+        for line in self.fake_logger.output.splitlines():
+            line = line.strip()
+            if line in expected_lines:
+                actual_lines.append(line)
+
+        self.assertThat(actual_lines, Equals(expected_lines))
 
     def test_close_broken_store_json(self):
         self.client.login('dummy', 'test correct password')
@@ -1034,13 +1041,20 @@ class CloseChannelsTestCase(StoreTestCase):
         self.assertThat(
             str(raised),
             Equals('Could not close channel: 200 OK'))
-        self.assertThat(
-            self.fake_logger.output.splitlines()[-3:],
-            Equals([
-                'Invalid response from the server on channel closing:',
-                '200 OK',
-                'b\'{"closed_channels": ["broken-json"]}\'',
-            ]))
+
+        expected_lines = [
+            'Invalid response from the server on channel closing:',
+            '200 OK',
+            'b\'{"closed_channels": ["broken-json"]}\'',
+        ]
+
+        actual_lines = []
+        for line in self.fake_logger.output.splitlines():
+            line = line.strip()
+            if line in expected_lines:
+                actual_lines.append(line)
+
+        self.assertThat(actual_lines, Equals(expected_lines))
 
     def test_close_successfully(self):
         # Successfully closing a channels returns 'closed_channels'


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

This PR fixes LP: [#1750177](https://bugs.launchpad.net/snapstore/+bug/1750177) and #2028 by properly handling the store returning a 500 error formatted as HTML instead of a typical error response. It also starts printing store error responses when in debug mode in order to streamline such fixes in the future.