### PR TITLE
packaging: simplify snapcraft.yaml

### DIFF
--- a/patches/ctypes_init.diff
+++ b/patches/ctypes_init.diff
@@ -1,20 +1,34 @@
-409a410,420
-> 
-> _ARCH_TRIPLET = {
->     'arm64': 'aarch64-linux-gnu',
->     'i386': 'i386-linux-gnu',
->     'ppc64el': 'powerpc64le-linux-gnu',
->     'powerpc': 'powerpc-linux-gnu',
->     'amd64': 'x86_64-linux-gnu',
->     's390x': 's390x-linux-gnu',
-> }
-> 
-> 
-421a433,439
->         if _os.getenv('SNAP_NAME', '') == 'snapcraft':
->             _name = _os.path.join(
->                         _os.getenv('SNAP'), 'usr', 'lib',
->                         _ARCH_TRIPLET.get(_os.getenv('SNAP_ARCH')),
->                         name)
->             if _os.path.exists(_name):
->                 name = _name
+--- __init__.py.orig	2018-04-10 15:40:17.061623054 -0300
++++ __init__.py	2018-04-10 15:41:40.150948367 -0300
+@@ -407,6 +407,17 @@
+         _func_flags_ = _FUNCFLAG_STDCALL
+         _func_restype_ = HRESULT
+ 
++
++_ARCH_TRIPLET = {
++    'arm64': 'aarch64-linux-gnu',
++    'i386': 'i386-linux-gnu',
++    'ppc64el': 'powerpc64le-linux-gnu',
++    'powerpc': 'powerpc-linux-gnu',
++    'amd64': 'x86_64-linux-gnu',
++    's390x': 's390x-linux-gnu',
++}
++
++
+ class LibraryLoader(object):
+     def __init__(self, dlltype):
+         self._dlltype = dlltype
+@@ -419,6 +430,13 @@
+         return dll
+ 
+     def __getitem__(self, name):
++        if _os.getenv('SNAP_NAME', '') == 'snapcraft':
++            _name = _os.path.join(
++                        _os.getenv('SNAP'), 'usr', 'lib',
++                        _ARCH_TRIPLET.get(_os.getenv('SNAP_ARCH')),
++                        name)
++            if _os.path.exists(_name):
++                name = _name
+         return getattr(self, name)
+ 
+     def LoadLibrary(self, name):

--- a/patches/ctypes_init.diff
+++ b/patches/ctypes_init.diff
@@ -1,4 +1,4 @@
-406a407,417
+409a410,420
 > 
 > _ARCH_TRIPLET = {
 >     'arm64': 'aarch64-linux-gnu',

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,8 +20,7 @@ parts:
     source: patches
     plugin: dump
     prime:
-        - -ctypes_init.diff
-        - -pyyaml-support-high-codepoints.diff
+        - -*.diff
   bash-completion:
     source: debian
     plugin: dump
@@ -36,99 +35,67 @@ parts:
         - libffi-dev
         - libsodium-dev
         - liblzma-dev
+        - patch
     stage-packages:
         - binutils
         - execstack
+        - gpgv
         - libffi6
         - libsodium18
+        - patchelf
         - squashfs-tools
         - xdelta3
-    prime:
-        - '*'
-        - '**/*.pyc'
     install: |
         TRIPLET_PATH="$SNAPCRAFT_PART_INSTALL/usr/lib/$(gcc -print-multiarch)"
         LIBSODIUM=$(readlink -n $TRIPLET_PATH/libsodium.so.18)
         ln -s $LIBSODIUM $TRIPLET_PATH/libsodium.so
-        patch -d $SNAPCRAFT_PART_INSTALL/lib/python3.6/site-packages -p1 < $SNAPCRAFT_STAGE/pyyaml-support-high-codepoints.diff
-    after: [python, apt]
-  patchelf:
-    source: https://launchpad.net/ubuntu/+archive/primary/+files/patchelf_0.9.orig.tar.gz
-    source-checksum: sha384/88c97bfc417db32b61991b974055801b904e5a50b362a178a745e92c3d3479463a4470528aee1561139052ee95107ba5
-    plugin: autotools
-    stage:
-        - bin/patchelf
-  python:
-    source: https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tar.xz
-    plugin: autotools
-    configflags: [--prefix=/usr]
-    build-packages: [libssl-dev, patch]
-    prime:
-        - -usr/include
-    install: |
-        patch $SNAPCRAFT_PART_INSTALL/usr/lib/python3.6/ctypes/__init__.py $SNAPCRAFT_STAGE/ctypes_init.diff
-    after: [patches]
+        patch -d $SNAPCRAFT_PART_INSTALL/lib/python3.5/site-packages -p1 < $SNAPCRAFT_STAGE/pyyaml-support-high-codepoints.diff
+        patch $SNAPCRAFT_PART_INSTALL/usr/lib/python3.5/ctypes/__init__.py $SNAPCRAFT_STAGE/ctypes_init.diff
+    after: [patches, apt]
   apt:
-    source: https://github.com/Debian/apt
-    source-type: git
-    source-tag: 1.2.19
-    source-depth: 1
-    plugin: autotools
-    prepare: |
-        make startup
-    build: |
-        mkdir apt-build
-        cd apt-build
-        ../configure
-        make
-    install: |
-        cd apt-build
-        install -d $SNAPCRAFT_PART_INSTALL/apt
-        cp -r bin/methods/* $SNAPCRAFT_PART_INSTALL/apt/
-        cp -r bin/methods/* $SNAPCRAFT_PART_INSTALL/apt/
-        install bin/apt-key $SNAPCRAFT_PART_INSTALL/apt/
-        install bin/apt-mark $SNAPCRAFT_PART_INSTALL/apt/
-        install bin/apt-internal-solver $SNAPCRAFT_PART_INSTALL/apt/
-        install bin/apt-helper $SNAPCRAFT_PART_INSTALL/apt/
-        install -d $SNAPCRAFT_PART_INSTALL/usr/lib
-        install bin/libapt-inst.so.2.0.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
-        install bin/libapt-pkg.so $SNAPCRAFT_PART_INSTALL/usr/lib/
-        install bin/libapt-pkg-5.0-0.symver $SNAPCRAFT_PART_INSTALL/usr/lib/
-        install bin/libapt-private.so $SNAPCRAFT_PART_INSTALL/usr/lib/
-        install bin/libapt-private-0.0-0.symver $SNAPCRAFT_PART_INSTALL/usr/lib/
-        install bin/libapt-private.so.0.0.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
-        install bin/libapt-inst.so.2.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
-        install bin/libapt-inst.so $SNAPCRAFT_PART_INSTALL/usr/lib/
-        install bin/libapt-pkg.so.5.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
-        install bin/libapt-inst-2.0-0.symver $SNAPCRAFT_PART_INSTALL/usr/lib/
-        install bin/libapt-pkg.so.5.0.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
-        install bin/libapt-private.so.0.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
-        install -d $SNAPCRAFT_PART_INSTALL/usr/include
-        cp -r include/* $SNAPCRAFT_PART_INSTALL/usr/include/
-    prime:
-        - -usr/include
-    build-packages:
-        - gettext
-        - libbz2-dev
-        - libcurl4-gnutls-dev
-        - libdb-dev
-        - liblz4-dev
-        - liblzma-dev
-        - zlib1g-dev
-    after: [python]
-  gpg:
-      source: https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.21.tar.bz2
+      source: https://github.com/Debian/apt
+      source-type: git
+      source-tag: 1.2.19
+      source-depth: 1
       plugin: autotools
-      configflags:
-        - --enable-minimal
-        - --disable-makeinfo
-        - --disable-ldap
-        - --disable-finger
-        - --disable-nls
       prepare: |
-        # This is fragile but we use a fixed tag
-        sed -i.bak -e 's/\(^ *g10 keyserver\) po doc ${checks}$/\1 ${checks}/' Makefile.am
-      build-packages:
-        - texinfo
+          make startup
+      build: |
+          mkdir apt-build
+          cd apt-build
+          ../configure
+          make
+      install: |
+          cd apt-build
+          install -d $SNAPCRAFT_PART_INSTALL/apt
+          cp -r bin/methods/* $SNAPCRAFT_PART_INSTALL/apt/
+          cp -r bin/methods/* $SNAPCRAFT_PART_INSTALL/apt/
+          install bin/apt-key $SNAPCRAFT_PART_INSTALL/apt/
+          install bin/apt-mark $SNAPCRAFT_PART_INSTALL/apt/
+          install bin/apt-internal-solver $SNAPCRAFT_PART_INSTALL/apt/
+          install bin/apt-helper $SNAPCRAFT_PART_INSTALL/apt/
+          install -d $SNAPCRAFT_PART_INSTALL/usr/lib
+          install bin/libapt-inst.so.2.0.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
+          install bin/libapt-pkg.so $SNAPCRAFT_PART_INSTALL/usr/lib/
+          install bin/libapt-pkg-5.0-0.symver $SNAPCRAFT_PART_INSTALL/usr/lib/
+          install bin/libapt-private.so $SNAPCRAFT_PART_INSTALL/usr/lib/
+          install bin/libapt-private-0.0-0.symver $SNAPCRAFT_PART_INSTALL/usr/lib/
+          install bin/libapt-private.so.0.0.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
+          install bin/libapt-inst.so.2.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
+          install bin/libapt-inst.so $SNAPCRAFT_PART_INSTALL/usr/lib/
+          install bin/libapt-pkg.so.5.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
+          install bin/libapt-inst-2.0-0.symver $SNAPCRAFT_PART_INSTALL/usr/lib/
+          install bin/libapt-pkg.so.5.0.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
+          install bin/libapt-private.so.0.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
+          install -d $SNAPCRAFT_PART_INSTALL/usr/include
+          cp -r include/* $SNAPCRAFT_PART_INSTALL/usr/include/
       prime:
-        - bin/gpgv
+          - -usr/include
+      build-packages:
+          - gettext
+          - libbz2-dev
+          - libcurl4-gnutls-dev
+          - libdb-dev
+          - liblz4-dev
+          - liblzma-dev
+          - zlib1g-dev

--- a/snaps_tests/__init__.py
+++ b/snaps_tests/__init__.py
@@ -115,7 +115,7 @@ class SnapsTestCase(testtools.TestCase):
         self.patchelf_command = 'patchelf'
         if os.getenv('SNAPCRAFT_FROM_SNAP', False):
             self.snapcraft_command = '/snap/bin/snapcraft'
-            self.patchelf_command = '/snap/snapcraft/current/bin/patchelf'
+            self.patchelf_command = '/snap/snapcraft/current/usr/bin/patchelf'
         elif os.getenv('SNAPCRAFT_FROM_DEB', False):
             self.snapcraft_command = '/usr/bin/snapcraft'
         elif os.getenv('VIRTUAL_ENV'):

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -72,7 +72,7 @@ class TestCase(testtools.TestCase):
                 'as described in HACKING.md.')
 
         if os.getenv('SNAPCRAFT_FROM_SNAP', False):
-            self.patchelf_command = '/snap/snapcraft/current/bin/patchelf'
+            self.patchelf_command = '/snap/snapcraft/current/usr/bin/patchelf'
             self.execstack_command = (
                 '/snap/snapcraft/current/usr/sbin/execstack')
         else:


### PR DESCRIPTION
Now that 2.40 has been released, we can get rid of compiling our own
python and any other component needed to run correctly in a classic
confined snap.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
