### PR TITLE
many: add snapcraftctl set-version

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -561,15 +561,15 @@ properties:
     type: object
 required:
   - name
-  - version
   - parts
 
-# Either summary/description is required, or adopt-info is required to specify
-# the part from which this metadata will be retrieved.
+# Either summary/description/version is required, or adopt-info is required to
+# specify the part from which this metadata will be retrieved.
 anyOf:
   - required:
     - summary
     - description
+    - version
   - required:
     - adopt-info
 dependencies:

--- a/snapcraft/extractors/_metadata.py
+++ b/snapcraft/extractors/_metadata.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import yaml
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Set, Union
 
 
 class ExtractedMetadata(yaml.YAMLObject):
@@ -24,8 +24,8 @@ class ExtractedMetadata(yaml.YAMLObject):
     yaml_tag = u'!ExtractedMetadata'
 
     def __init__(
-            self, *, common_id: str='', summary: str='',
-            description: str='', icon: str='',
+            self, *, common_id: str='', summary: str='', description: str='',
+            version: str='', icon: str='',
             desktop_file_paths: List[str]=None) -> None:
         """Create a new ExtractedMetadata instance.
 
@@ -45,6 +45,8 @@ class ExtractedMetadata(yaml.YAMLObject):
             self._data['summary'] = summary
         if description:
             self._data['description'] = description
+        if version:
+            self._data['version'] = version
         if icon:
             self._data['icon'] = icon
         if desktop_file_paths:
@@ -87,6 +89,15 @@ class ExtractedMetadata(yaml.YAMLObject):
         description = self._data.get('description')
         return str(description) if description else None
 
+    def get_version(self) -> str:
+        """Return extracted version.
+
+        :returns: Extracted version
+        :rtype: str
+        """
+        version = self._data.get('version')
+        return str(version) if version else None
+
     def get_icon(self) -> str:
         """Return extracted icon.
 
@@ -113,8 +124,19 @@ class ExtractedMetadata(yaml.YAMLObject):
         """
         return self._data.copy()
 
+    def overlap(self, other: 'ExtractedMetadata') -> Set[str]:
+        """Return all overlapping keys between this and other.
+
+        :returns: All overlapping keys between this and other
+        :rtype: set
+        """
+        return set(self._data.keys() & other.to_dict().keys())
+
     def __eq__(self, other: Any) -> bool:
         if type(other) is type(self):
             return self._data == other._data
 
         return False
+
+    def __len__(self) -> int:
+        return self._data.__len__()

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -570,3 +570,34 @@ class ScriptletRunError(ScriptletBaseError):
 
     def __init__(self, scriptlet_name: str, code: int) -> None:
         super().__init__(scriptlet_name=scriptlet_name, code=code)
+
+
+class ScriptletDuplicateDataError(ScriptletBaseError):
+    fmt = (
+        'Failed to save data from scriptlet into {step!r} state: '
+        'The {humanized_keys} key(s) were already saved in the {other_step!r} '
+        'step.'
+    )
+
+    def __init__(self, step: str, other_step: str, keys: List[str]) -> None:
+        self.keys = keys
+        super().__init__(
+            step=step, other_step=other_step,
+            humanized_keys=formatting_utils.humanize_list(keys, 'and'))
+
+
+class ScriptletDuplicateVersionError(ScriptletBaseError):
+    fmt = (
+        'Unable to set version: '
+        'it was already set in the {step!r} step.'
+    )
+
+    def __init__(self, step: str) -> None:
+        super().__init__(step=step)
+
+
+class SnapcraftctlError(ScriptletBaseError):
+    fmt = '{message}'
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message=message)

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -25,7 +25,7 @@ import shlex
 import shutil
 import stat
 import subprocess
-from typing import Any, Dict, List  # noqa
+from typing import Any, Dict, List, Set  # noqa
 
 import yaml
 
@@ -165,6 +165,21 @@ def _update_yaml_with_extracted_metadata(
 def _adopt_info(
         config_data: Dict[str, Any],
         extracted_metadata: _metadata.ExtractedMetadata):
+    ignored_keys = _adopt_keys(config_data, extracted_metadata)
+    if ignored_keys:
+        logger.warning(
+            'The {keys} {plural_property} {plural_is} specified in adopted '
+            'info as well as the YAML: taking the {plural_property} from the '
+            'YAML'.format(
+                keys=formatting_utils.humanize_list(list(ignored_keys), 'and'),
+                plural_property=formatting_utils.pluralize(
+                    ignored_keys, 'property', 'properties'),
+                plural_is=formatting_utils.pluralize(
+                    ignored_keys, 'is', 'are')))
+
+
+def _adopt_keys(config_data: Dict[str, Any],
+                extracted_metadata: _metadata.ExtractedMetadata) -> Set[str]:
     ignored_keys = set()
     metadata_dict = extracted_metadata.to_dict()
     for key, value in metadata_dict.items():
@@ -193,16 +208,7 @@ def _adopt_info(
                         desktop_file_path)
                     break
 
-    if ignored_keys:
-        logger.warning(
-            'The {keys} {plural_property} {plural_is} specified in adopted '
-            'info as well as the YAML: taking the {plural_property} from the '
-            'YAML'.format(
-                keys=formatting_utils.humanize_list(ignored_keys, 'and'),
-                plural_property=formatting_utils.pluralize(
-                    ignored_keys, 'property', 'properties'),
-                plural_is=formatting_utils.pluralize(
-                    ignored_keys, 'is', 'are')))
+    return ignored_keys
 
 
 def _icon_file_exists() -> bool:

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -125,19 +125,18 @@ def _update_yaml_with_extracted_metadata(
         stage_state = part.get_stage_state()
         prime_state = part.get_prime_state()
 
-        # Get the metadata from the pull step first, allowing metadata set via
-        # override-pull to override.
+        # Get the metadata from the pull step first.
         metadata = pull_state.extracted_metadata['metadata']
-        metadata.update(pull_state.scriptlet_metadata)
 
         # Now update it using the metadata from the build step (i.e. the data
-        # from the build step takes precedence over the pull step), allowing
-        # metadata set via override-build to override.
+        # from the build step takes precedence over the pull step).
         metadata.update(build_state.extracted_metadata['metadata'])
-        metadata.update(build_state.scriptlet_metadata)
 
-        # Now make sure any scriptlet data in later steps are taken into
-        # account (later steps take precedence).
+        # Now make sure any scriptlet data are taken into account. Later steps
+        # take precedence, and scriptlet data (even in earlier steps) take
+        # precedence over extracted data.
+        metadata.update(pull_state.scriptlet_metadata)
+        metadata.update(build_state.scriptlet_metadata)
         metadata.update(stage_state.scriptlet_metadata)
         metadata.update(prime_state.scriptlet_metadata)
 

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -167,11 +167,19 @@ class PluginHandler:
 
     def _set_scriptlet_metadata(
             self, metadata: snapcraft.extractors.ExtractedMetadata):
-        last_step = self.last_step()
         step = self.next_step()
+
+        # First, ensure the metadata set here doesn't conflict with metadata
+        # already set for this step
+        conflicts = metadata.overlap(self._scriptlet_metadata[step])
+        if len(conflicts) > 0:
+            raise errors.ScriptletDuplicateDataError(
+                step, step, list(conflicts))
+
+        last_step = self.last_step()
         if last_step:
-            # Ensure the metadata from this step doesn't conflict with metadata
-            # from any other step. Doing so is an error.
+            # Now ensure the metadata from this step doesn't conflict with
+            # metadata from any other step
             index = common.COMMAND_ORDER.index(last_step)
             for index in reversed(range(0, index+1)):
                 other_step = common.COMMAND_ORDER[index]

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -203,7 +203,8 @@ class Config:
         return [
             'SNAPCRAFT_STAGE="{}"'.format(self._project_options.stage_dir),
             'SNAPCRAFT_PROJECT_NAME="{}"'.format(self.data['name']),
-            'SNAPCRAFT_PROJECT_VERSION={}'.format(self.data['version']),
+            'SNAPCRAFT_PROJECT_VERSION={}'.format(
+                self.data.get('version', '')),
             'SNAPCRAFT_PROJECT_GRADE={}'.format(self.data['grade']),
         ]
 
@@ -216,7 +217,8 @@ class Config:
                 snapcraft_yaml[key],
                 [
                     ('$SNAPCRAFT_PROJECT_NAME', snapcraft_yaml['name']),
-                    ('$SNAPCRAFT_PROJECT_VERSION', snapcraft_yaml['version']),
+                    ('$SNAPCRAFT_PROJECT_VERSION', snapcraft_yaml.get(
+                        'version', '')),
                     ('$SNAPCRAFT_PROJECT_GRADE', snapcraft_yaml['grade']),
                     ('$SNAPCRAFT_STAGE', self._project_options.stage_dir),
                 ])

--- a/snapcraft/internal/states/_build_state.py
+++ b/snapcraft/internal/states/_build_state.py
@@ -16,7 +16,7 @@
 
 import yaml
 
-from snapcraft import extractors
+import snapcraft.extractors
 from snapcraft.internal.states._state import PartState
 
 
@@ -47,7 +47,7 @@ class BuildState(PartState):
     def __init__(
             self, property_names, part_properties=None, project=None,
             plugin_assets=None, machine_assets=None, metadata=None,
-            metadata_files=None):
+            metadata_files=None, scriptlet_metadata=None):
         # Save this off before calling super() since we'll need it
         # FIXME: for 3.x the name `schema_properties` is leaking
         #        implementation details from a higher layer.
@@ -59,8 +59,11 @@ class BuildState(PartState):
         if machine_assets:
             self.assets.update(machine_assets)
 
+        if not scriptlet_metadata:
+            scriptlet_metadata = snapcraft.extractors.ExtractedMetadata()
+
         if not metadata:
-            metadata = extractors.ExtractedMetadata()
+            metadata = snapcraft.extractors.ExtractedMetadata()
 
         if not metadata_files:
             metadata_files = []
@@ -69,6 +72,8 @@ class BuildState(PartState):
             'metadata': metadata,
             'files': metadata_files
         }
+
+        self.scriptlet_metadata = scriptlet_metadata
 
         super().__init__(part_properties, project)
 

--- a/snapcraft/internal/states/_prime_state.py
+++ b/snapcraft/internal/states/_prime_state.py
@@ -16,6 +16,7 @@
 
 import yaml
 
+import snapcraft.extractors
 from snapcraft.internal.states._state import PartState
 
 
@@ -31,12 +32,16 @@ class PrimeState(PartState):
     yaml_tag = u'!PrimeState'
 
     def __init__(self, files, directories, dependency_paths=None,
-                 part_properties=None, project=None):
+                 part_properties=None, project=None, scriptlet_metadata=None):
         super().__init__(part_properties, project)
+
+        if not scriptlet_metadata:
+            scriptlet_metadata = snapcraft.extractors.ExtractedMetadata()
 
         self.files = files
         self.directories = directories
         self.dependency_paths = set()
+        self.scriptlet_metadata = scriptlet_metadata
 
         if dependency_paths:
             self.dependency_paths = dependency_paths

--- a/snapcraft/internal/states/_pull_state.py
+++ b/snapcraft/internal/states/_pull_state.py
@@ -48,7 +48,8 @@ class PullState(PartState):
 
     def __init__(self, property_names, part_properties=None, project=None,
                  stage_packages=None, build_snaps=None, build_packages=None,
-                 source_details=None, metadata=None, metadata_files=None):
+                 source_details=None, metadata=None, metadata_files=None,
+                 scriptlet_metadata=None):
         # Save this off before calling super() since we'll need it
         # FIXME: for 3.x the name `schema_properties` is leaking
         #        implementation details from a higher layer.
@@ -60,6 +61,9 @@ class PullState(PartState):
             'source-details': source_details,
         }
 
+        if not scriptlet_metadata:
+            scriptlet_metadata = snapcraft.extractors.ExtractedMetadata()
+
         if not metadata:
             metadata = snapcraft.extractors.ExtractedMetadata()
 
@@ -70,6 +74,8 @@ class PullState(PartState):
             'metadata': metadata,
             'files': metadata_files
         }
+
+        self.scriptlet_metadata = scriptlet_metadata
 
         super().__init__(part_properties, project)
 

--- a/snapcraft/internal/states/_stage_state.py
+++ b/snapcraft/internal/states/_stage_state.py
@@ -16,6 +16,7 @@
 
 import yaml
 
+import snapcraft.extractors
 from snapcraft.internal.states._state import PartState
 
 
@@ -30,11 +31,16 @@ yaml.add_constructor(u'!StageState', _stage_state_constructor)
 class StageState(PartState):
     yaml_tag = u'!StageState'
 
-    def __init__(self, files, directories, part_properties=None, project=None):
+    def __init__(self, files, directories, part_properties=None, project=None,
+                 scriptlet_metadata=None):
         super().__init__(part_properties, project)
+
+        if not scriptlet_metadata:
+            scriptlet_metadata = snapcraft.extractors.ExtractedMetadata()
 
         self.files = files
         self.directories = directories
+        self.scriptlet_metadata = scriptlet_metadata
 
     def properties_of_interest(self, part_properties):
         """Extract the properties concerning this step from part_properties.

--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -22,7 +22,7 @@ class ProjectInfo:
 
     def __init__(self, data: Dict[str, Any]) -> None:
         self.name = data['name']
-        self.version = data['version']
+        self.version = data.get('version')
         self.summary = data.get('summary')
         self.description = data.get('description')
         self.confinement = data['confinement']

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -213,15 +213,21 @@ class TestCase(testtools.TestCase):
                            my-part:
                              plugin: nil
                            '''),
-                       build_packages='[]'):
+                       build_packages='[]',
+                       adopt_info=None):
         snapcraft_yaml = {
             'name': name,
-            'version': version,
             'summary': summary,
             'description': description,
             'parts': yaml.load(parts),
             'build-packages': yaml.load(build_packages),
         }
+
+        if version:
+            snapcraft_yaml['version'] = version
+        if adopt_info:
+            snapcraft_yaml['adopt-info'] = adopt_info
+
         with open('snapcraft.yaml', 'w') as f:
             yaml.dump(snapcraft_yaml, f, default_flow_style=False)
 

--- a/tests/integration/general/test_snapcraftctl_set_version.py
+++ b/tests/integration/general/test_snapcraftctl_set_version.py
@@ -1,0 +1,57 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016-2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import textwrap
+import yaml
+
+from testtools.matchers import Equals
+
+from tests import integration
+
+
+class SnapcraftctlSetVersionTestCase(integration.TestCase):
+
+    def test_set_version(self):
+        self.construct_yaml(
+            version=None, adopt_info='my-part', parts=textwrap.dedent("""\
+                my-part:
+                  plugin: nil
+                  override-pull: snapcraftctl set-version override-version
+                """))
+
+        self.run_snapcraft('prime')
+
+        with open(os.path.join('prime', 'meta', 'snap.yaml')) as f:
+            y = yaml.load(f)
+
+        self.assertThat(y['version'], Equals('override-version'))
+
+    def test_set_version_no_overwrite(self):
+        self.construct_yaml(
+            version='test-version', adopt_info='my-part',
+            parts=textwrap.dedent("""\
+                my-part:
+                  plugin: nil
+                  override-pull: snapcraftctl set-version override-version
+                """))
+
+        self.run_snapcraft('prime')
+
+        with open(os.path.join('prime', 'meta', 'snap.yaml')) as f:
+            y = yaml.load(f)
+
+        self.assertThat(y['version'], Equals('test-version'))

--- a/tests/unit/commands/snapcraftctl/test_build.py
+++ b/tests/unit/commands/snapcraftctl/test_build.py
@@ -42,6 +42,17 @@ class BuildCommandTestCase(CommandBaseTestCase):
         self.assertThat(data['function'], Equals('build'))
         self.assertThat(data['args'], Equals({}))
 
+    def test_build_error(self):
+        # If there is a string in the feedback, it should be considered an
+        # error
+        with open(self.feedback_fifo, 'w') as f:
+            f.write('this is an error\n')
+
+        raised = self.assertRaises(
+            errors.SnapcraftctlError, self.run_command, ['build'])
+
+        self.assertThat(str(raised), Equals('this is an error'))
+
 
 class BuildCommandWithoutFifoTestCase(CommandBaseNoFifoTestCase):
 

--- a/tests/unit/extractors/test_metadata.py
+++ b/tests/unit/extractors/test_metadata.py
@@ -45,6 +45,13 @@ class ExtractedMetadataTestCase(unit.TestCase):
         self.assertThat(metadata.get_summary(), Equals('summary'))
         self.assertThat(metadata.get_description(), Equals('new description'))
 
+    def test_overlap(self):
+        metadata = ExtractedMetadata(
+            summary='summary', description='description')
+        metadata2 = ExtractedMetadata(description='new description')
+
+        self.assertThat(metadata.overlap(metadata2), Equals({'description'}))
+
     def test_eq(self):
         metadata1 = ExtractedMetadata(summary='summary')
         metadata2 = ExtractedMetadata(summary='summary')
@@ -57,6 +64,13 @@ class ExtractedMetadataTestCase(unit.TestCase):
         metadata1 = ExtractedMetadata(summary='summary')
         metadata2 = ExtractedMetadata(description='description')
         self.assertThat(metadata1, Not(Equals(metadata2)))
+
+    def test_len(self):
+        metadata = ExtractedMetadata(version='version')
+        self.assertThat(len(metadata), Equals(1))
+
+        metadata = ExtractedMetadata(summary='summary', version='version')
+        self.assertThat(len(metadata), Equals(2))
 
     def test_to_dict_partial(self):
         metadata = ExtractedMetadata(summary='summary')

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -15,10 +15,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from collections import OrderedDict
+import contextlib
 import copy
+import functools
 import os
 import shutil
 import stat
+import subprocess
 import tempfile
 from unittest.mock import (
     call,
@@ -27,7 +30,9 @@ from unittest.mock import (
     patch,
 )
 
+import testtools
 from testtools.matchers import Contains, Equals, FileExists, Not
+from testscenarios.scenarios import multiply_scenarios
 
 import snapcraft
 from . import mocks
@@ -822,6 +827,100 @@ class NextLastStepTestCase(unit.TestCase):
 
         self.assertThat(self.handler.last_step(), Equals('prime'))
         self.assertThat(self.handler.next_step(), Equals(None))
+
+
+class ScriptletSetVersionTestCase(unit.TestCase):
+    def test_set_version_in_pull(self):
+        handler = self.load_part('test_part', part_properties={
+            'override-pull': 'snapcraftctl set-version override-version'
+        })
+
+        handler.pull()
+        metadata = handler.get_pull_state().scriptlet_metadata
+        self.assertThat(metadata.get_version(), Equals('override-version'))
+
+    def test_set_version_in_build(self):
+        handler = self.load_part('test_part', part_properties={
+            'override-build': 'snapcraftctl set-version override-version'
+        })
+
+        handler.pull()
+        handler.build()
+        metadata = handler.get_build_state().scriptlet_metadata
+        self.assertThat(metadata.get_version(), Equals('override-version'))
+        self.assertFalse(handler.get_pull_state().scriptlet_metadata)
+
+    def test_set_version_in_stage(self):
+        handler = self.load_part('test_part', part_properties={
+            'override-stage': 'snapcraftctl set-version override-version'
+        })
+
+        handler.pull()
+        handler.build()
+        handler.stage()
+        metadata = handler.get_stage_state().scriptlet_metadata
+        self.assertThat(metadata.get_version(), Equals('override-version'))
+        self.assertFalse(handler.get_pull_state().scriptlet_metadata)
+        self.assertFalse(handler.get_build_state().scriptlet_metadata)
+
+    def test_set_version_in_prime(self):
+        handler = self.load_part('test_part', part_properties={
+            'override-prime': 'snapcraftctl set-version override-version'
+        })
+
+        handler.pull()
+        handler.build()
+        handler.stage()
+        handler.prime()
+        metadata = handler.get_prime_state().scriptlet_metadata
+        self.assertThat(metadata.get_version(), Equals('override-version'))
+        self.assertFalse(handler.get_pull_state().scriptlet_metadata)
+        self.assertFalse(handler.get_build_state().scriptlet_metadata)
+        self.assertFalse(handler.get_stage_state().scriptlet_metadata)
+
+
+class ScriptletSetVersionErrorTestCase(unit.TestCase):
+
+    scriptlet_scenarios = [
+        ('override-pull', {'override_pull': 'snapcraftctl set-version 1'}),
+        ('override-build', {'override_build': 'snapcraftctl set-version 2'}),
+        ('override-stage', {'override_stage': 'snapcraftctl set-version 3'}),
+        ('override-prime', {'override_prime': 'snapcraftctl set-version 4'}),
+    ]
+
+    scenarios = multiply_scenarios(scriptlet_scenarios, scriptlet_scenarios)
+
+    def test_set_version_multiple_times(self):
+        part_properties = {}
+        with contextlib.suppress(AttributeError):
+            part_properties['override-pull'] = self.override_pull
+        with contextlib.suppress(AttributeError):
+            part_properties['override-build'] = self.override_build
+        with contextlib.suppress(AttributeError):
+            part_properties['override-stage'] = self.override_stage
+        with contextlib.suppress(AttributeError):
+            part_properties['override-prime'] = self.override_prime
+
+        # A few of these test cases result in only one of these scriptlets
+        # being set. In that case, we actually want to double them up (i.e.
+        # call set-version twice in the same scriptlet), which should still be
+        # an error.
+        if len(part_properties) == 1:
+            for key, value in part_properties.items():
+                part_properties[key] += '\n{}'.format(value)
+
+        handler = self.load_part('test_part', part_properties=part_properties)
+
+        with testtools.ExpectedException(errors.ScriptletRunError):
+            silent_popen = functools.partial(
+                subprocess.Popen, stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL)
+
+            with patch('subprocess.Popen', wraps=silent_popen):
+                handler.pull()
+                handler.build()
+                handler.stage()
+                handler.prime()
 
 
 class StateBaseTestCase(unit.TestCase):

--- a/tests/unit/pluginhandler/test_scriptlets.py
+++ b/tests/unit/pluginhandler/test_scriptlets.py
@@ -1,0 +1,146 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import contextlib
+import functools
+import os
+import subprocess
+
+import testtools
+from testtools.matchers import Equals, FileExists
+from testscenarios.scenarios import multiply_scenarios
+from unittest import mock
+
+from snapcraft.internal import errors
+
+from tests import unit
+
+
+class ScriptletSetVersionTestCase(unit.TestCase):
+    def test_set_version_in_pull(self):
+        handler = self.load_part('test_part', part_properties={
+            'override-pull': 'snapcraftctl set-version override-version'
+        })
+
+        handler.pull()
+        metadata = handler.get_pull_state().scriptlet_metadata
+        self.assertThat(metadata.get_version(), Equals('override-version'))
+
+    def test_set_version_in_build(self):
+        handler = self.load_part('test_part', part_properties={
+            'override-build': 'snapcraftctl set-version override-version'
+        })
+
+        handler.pull()
+        handler.build()
+        metadata = handler.get_build_state().scriptlet_metadata
+        self.assertThat(metadata.get_version(), Equals('override-version'))
+        self.assertFalse(handler.get_pull_state().scriptlet_metadata)
+
+    def test_set_version_in_stage(self):
+        handler = self.load_part('test_part', part_properties={
+            'override-stage': 'snapcraftctl set-version override-version'
+        })
+
+        handler.pull()
+        handler.build()
+        handler.stage()
+        metadata = handler.get_stage_state().scriptlet_metadata
+        self.assertThat(metadata.get_version(), Equals('override-version'))
+        self.assertFalse(handler.get_pull_state().scriptlet_metadata)
+        self.assertFalse(handler.get_build_state().scriptlet_metadata)
+
+    def test_set_version_in_prime(self):
+        handler = self.load_part('test_part', part_properties={
+            'override-prime': 'snapcraftctl set-version override-version'
+        })
+
+        handler.pull()
+        handler.build()
+        handler.stage()
+        handler.prime()
+        metadata = handler.get_prime_state().scriptlet_metadata
+        self.assertThat(metadata.get_version(), Equals('override-version'))
+        self.assertFalse(handler.get_pull_state().scriptlet_metadata)
+        self.assertFalse(handler.get_build_state().scriptlet_metadata)
+        self.assertFalse(handler.get_stage_state().scriptlet_metadata)
+
+
+class ScriptletSetVersionErrorTestCase(unit.TestCase):
+
+    scriptlet_scenarios = [
+        ('override-pull', {'override_pull': 'snapcraftctl set-version 1'}),
+        ('override-build', {'override_build': 'snapcraftctl set-version 2'}),
+        ('override-stage', {'override_stage': 'snapcraftctl set-version 3'}),
+        ('override-prime', {'override_prime': 'snapcraftctl set-version 4'}),
+    ]
+
+    scenarios = multiply_scenarios(scriptlet_scenarios, scriptlet_scenarios)
+
+    def test_set_version_multiple_times(self):
+        part_properties = {}
+        with contextlib.suppress(AttributeError):
+            part_properties['override-pull'] = self.override_pull
+        with contextlib.suppress(AttributeError):
+            part_properties['override-build'] = self.override_build
+        with contextlib.suppress(AttributeError):
+            part_properties['override-stage'] = self.override_stage
+        with contextlib.suppress(AttributeError):
+            part_properties['override-prime'] = self.override_prime
+
+        # A few of these test cases result in only one of these scriptlets
+        # being set. In that case, we actually want to double them up (i.e.
+        # call set-version twice in the same scriptlet), which should still be
+        # an error.
+        if len(part_properties) == 1:
+            for key, value in part_properties.items():
+                part_properties[key] += '\n{}'.format(value)
+
+        handler = self.load_part('test_part', part_properties=part_properties)
+
+        with testtools.ExpectedException(errors.ScriptletRunError):
+            silent_popen = functools.partial(
+                subprocess.Popen, stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL)
+
+            with mock.patch('subprocess.Popen', wraps=silent_popen):
+                handler.pull()
+                handler.build()
+                handler.stage()
+                handler.prime()
+
+
+class ScripletTestCase(unit.TestCase):
+
+    def test_run_prepare_scriptlet(self):
+        handler = self.load_part(
+            'test-part', part_properties={'prepare': 'touch prepare'})
+
+        handler.build()
+
+        before_build_file_path = os.path.join(handler.plugin.build_basedir,
+                                              'prepare')
+        self.assertThat(before_build_file_path, FileExists())
+
+    def test_run_install_scriptlet(self):
+        handler = self.load_part(
+            'test-part', part_properties={'install': 'touch install'})
+
+        handler.build()
+
+        after_build_file_path = os.path.join(handler.plugin.build_basedir,
+                                             'install')
+        self.assertThat(after_build_file_path, FileExists())

--- a/tests/unit/project_loader/test_config.py
+++ b/tests/unit/project_loader/test_config.py
@@ -158,6 +158,22 @@ parts:
         project = c._project_options
         self.assertThat(project.info.description, Equals(None))
 
+    def test_project_from_config_without_version(self):
+        self.make_snapcraft_yaml("""name: foo
+summary: bar
+description: baz
+adopt-info: part1
+confinement: strict
+
+parts:
+  part1:
+    plugin: go
+""")
+
+        c = _config.Config()
+        project = c._project_options
+        self.assertThat(project.info.version, Equals(None))
+
     def test_project_passed_to_config(self):
         self.make_snapcraft_yaml("""name: foo
 version: "1"
@@ -2382,7 +2398,7 @@ class DaemonDependencyTestCase(ValidationBaseTestCase):
 class RequiredPropertiesTestCase(ValidationBaseTestCase):
 
     scenarios = [(key, dict(key=key)) for
-                 key in ['name', 'version', 'parts']]
+                 key in ['name', 'parts']]
 
     def test_required_properties(self):
         data = self.data.copy()

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -683,6 +683,22 @@ class ScriptletsMetadataTestCase(CreateMetadataFromSourceBaseTestCase):
 
         self.assertThat(generated['version'], Equals('override-version'))
 
+    def test_scriptlets_overwrite_extracted_metadata_regardless_of_order(self):
+        del self.config_data['version']
+
+        self.config_data['parts']['test-part']['override-pull'] = (
+            'snapcraftctl set-version override-version && snapcraftctl pull')
+
+        def _fake_extractor(file_path):
+            return extractors.ExtractedMetadata(version='extracted-version')
+
+        self.useFixture(fixture_setup.FakeMetadataExtractor(
+            'fake', _fake_extractor))
+
+        generated = self.generate_meta_yaml(build=True)
+
+        self.assertThat(generated['version'], Equals('override-version'))
+
 
 class WriteSnapDirectoryTestCase(CreateBaseTestCase):
 

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -91,6 +91,8 @@ class CreateBaseTestCase(unit.TestCase):
             for part in self.config.parts.all_parts:
                 part.pull()
                 part.build()
+                part.stage()
+                part.prime()
 
         _snap_packaging.create_snap_packaging(
             self.config.data, self.config.parts, self.project_options, 'dummy')
@@ -501,15 +503,14 @@ class CreateMetadataFromSourceBaseTestCase(CreateBaseTestCase):
         open('test-metadata-file', 'w').close()
 
 
-class CreateMetadataFromSourceErrorsTestCase(
-        CreateMetadataFromSourceBaseTestCase):
+class CreateMetadataFromSourceTestCase(CreateMetadataFromSourceBaseTestCase):
 
     def test_create_metadata_with_missing_parse_info(self):
         del self.config_data['summary']
         del self.config_data['parts']['test-part']['parse-info']
         raised = self.assertRaises(
             meta_errors.AdoptedPartNotParsingInfo,
-            self.generate_meta_yaml)
+            self.generate_meta_yaml, build=True)
         self.assertThat(raised.part, Equals('test-part'))
 
     def test_create_metadata_with_wrong_adopt_info(self):
@@ -643,6 +644,44 @@ class MetadataFromSourceWithDesktopFileTestCase(
         expected_desktop = os.path.join(
             self.meta_dir, 'gui', 'test-app.desktop')
         self.assertThat(expected_desktop, FileContains(desktop_content))
+
+
+class ScriptletsMetadataTestCase(CreateMetadataFromSourceBaseTestCase):
+
+    def test_scriptlets_satisfy_required_property(self):
+        del self.config_data['version']
+        del self.config_data['parts']['test-part']['parse-info']
+        self.config_data['parts']['test-part']['override-prime'] = (
+            'snapcraftctl set-version override-version')
+
+        generated = self.generate_meta_yaml(build=True)
+
+        self.assertThat(generated['version'], Equals('override-version'))
+
+    def test_scriptlets_no_overwrite_existing_property(self):
+        del self.config_data['parts']['test-part']['parse-info']
+        self.config_data['parts']['test-part']['override-prime'] = (
+            'snapcraftctl set-version override-version')
+
+        generated = self.generate_meta_yaml(build=True)
+
+        self.assertThat(generated['version'], Equals('test-version'))
+
+    def test_scriptlets_overwrite_extracted_metadata(self):
+        del self.config_data['version']
+
+        self.config_data['parts']['test-part']['override-build'] = (
+            'snapcraftctl build && snapcraftctl set-version override-version')
+
+        def _fake_extractor(file_path):
+            return extractors.ExtractedMetadata(version='extracted-version')
+
+        self.useFixture(fixture_setup.FakeMetadataExtractor(
+            'fake', _fake_extractor))
+
+        generated = self.generate_meta_yaml(build=True)
+
+        self.assertThat(generated['version'], Equals('override-version'))
 
 
 class WriteSnapDirectoryTestCase(CreateBaseTestCase):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

This PR resolves #1676 by adding the ability to set the snap version from a scriptlet using `snapcraftctl set-version <version>`. It also lays down generic infrastructure to make adding future such "setters" easy.