### PR TITLE
errors: feature flag error reports

### DIFF
--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import distutils.util
 import os
 import sys
 import traceback

--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -68,8 +68,10 @@ def exception_handler(exception_type, exception, exception_traceback, *,
     exit_code = 1
     is_snapcraft_error = issubclass(exception_type, errors.SnapcraftError)
     is_raven_setup = RavenClient is not None
-    is_sentry_enabled = os.getenv('SNAPCRAFT_ENABLE_SENTRY') is not None
-    is_sentry_flag = os.getenv('SNAPCRAFT_SEND_ERROR_DATA', 'n') == 'y'
+    is_sentry_enabled = distutils.util.strtobool(
+        os.getenv('SNAPCRAFT_ENABLE_SENTRY', 'n')) == 1
+    is_sentry_flag = distutils.util.strtobool(
+        os.getenv('SNAPCRAFT_SEND_ERROR_DATA', 'n')) == 1
 
     if is_sentry_enabled and not is_snapcraft_error:
         click.echo(_MSG_TRACEBACK)

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -17,6 +17,8 @@
 import sys
 from unittest import mock
 
+import fixtures
+
 import snapcraft.internal.errors
 from snapcraft.cli._errors import exception_handler
 from tests import unit
@@ -101,11 +103,21 @@ class ErrorsTestCase(unit.TestCase):
 
         self.assert_exception_traceback_exit_1_with_debug()
 
+    def test_handler_raven_but_no_sentry_feature_flag(self):
+        try:
+            self.call_handler(RuntimeError('not a SnapcraftError'), True)
+        except Exception:
+            self.fail('Exception unexpectedly raised')
+
+        self.assert_exception_traceback_exit_1_with_debug()
+
     @mock.patch('snapcraft.cli._errors.RavenClient')
     @mock.patch('snapcraft.cli._errors.RequestsHTTPTransport')
     @mock.patch('click.confirm', return_value=True)
     def test_handler_traceback_send_traceback_to_sentry(
             self, click_confirm_mock, raven_request_mock, raven_client_mock):
+        self.useFixture(fixtures.EnvironmentVariable(
+            'SNAPCRAFT_ENABLE_SENTRY', ''))
         try:
             self.call_handler(RuntimeError('not a SnapcraftError'), True)
         except Exception:

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -117,7 +117,7 @@ class ErrorsTestCase(unit.TestCase):
     def test_handler_traceback_send_traceback_to_sentry(
             self, click_confirm_mock, raven_request_mock, raven_client_mock):
         self.useFixture(fixtures.EnvironmentVariable(
-            'SNAPCRAFT_ENABLE_SENTRY', ''))
+            'SNAPCRAFT_ENABLE_SENTRY', 'yes'))
         try:
             self.call_handler(RuntimeError('not a SnapcraftError'), True)
         except Exception:


### PR DESCRIPTION
Gate the use of sentry error data with a feature flag

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
