### PR TITLE
many: add snapcraftctl set-grade

### DIFF
--- a/snapcraft/cli/snapcraftctl/_runner.py
+++ b/snapcraft/cli/snapcraftctl/_runner.py
@@ -75,6 +75,13 @@ def set_version(version):
     _call_function('set-version', {'version': version})
 
 
+@run.command('set-grade')
+@click.argument('grade')
+def set_grade(grade):
+    """Set the grade of the snap"""
+    _call_function('set-grade', {'grade': grade})
+
+
 def _call_function(function_name, args=None):
     if not args:
         args = {}

--- a/snapcraft/extractors/_metadata.py
+++ b/snapcraft/extractors/_metadata.py
@@ -25,7 +25,7 @@ class ExtractedMetadata(yaml.YAMLObject):
 
     def __init__(
             self, *, common_id: str='', summary: str='', description: str='',
-            version: str='', icon: str='',
+            version: str='', grade: str='', icon: str='',
             desktop_file_paths: List[str]=None) -> None:
         """Create a new ExtractedMetadata instance.
 
@@ -33,6 +33,8 @@ class ExtractedMetadata(yaml.YAMLObject):
             formats
         :param str summary: Extracted summary
         :param str description: Extracted description
+        :param str version: Extracted version
+        :param str grade: Extracted grade
         :param str icon: Extracted icon
         :param list desktop_file_paths: Extracted desktop file paths
         """  # noqa
@@ -47,6 +49,8 @@ class ExtractedMetadata(yaml.YAMLObject):
             self._data['description'] = description
         if version:
             self._data['version'] = version
+        if grade:
+            self._data['grade'] = grade
         if icon:
             self._data['icon'] = icon
         if desktop_file_paths:
@@ -97,6 +101,15 @@ class ExtractedMetadata(yaml.YAMLObject):
         """
         version = self._data.get('version')
         return str(version) if version else None
+
+    def get_grade(self) -> str:
+        """Return extracted grade.
+
+        :returns: Extracted grade
+        :rtype: str
+        """
+        grade = self._data.get('grade')
+        return str(grade) if grade else None
 
     def get_icon(self) -> str:
         """Return extracted icon.

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -586,14 +586,14 @@ class ScriptletDuplicateDataError(ScriptletBaseError):
             humanized_keys=formatting_utils.humanize_list(keys, 'and'))
 
 
-class ScriptletDuplicateVersionError(ScriptletBaseError):
+class ScriptletDuplicateFieldError(ScriptletBaseError):
     fmt = (
-        'Unable to set version: '
+        'Unable to set {field}: '
         'it was already set in the {step!r} step.'
     )
 
-    def __init__(self, step: str) -> None:
-        super().__init__(step=step)
+    def __init__(self, field: str, step: str) -> None:
+        super().__init__(field=field, step=step)
 
 
 class SnapcraftctlError(ScriptletBaseError):

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -73,7 +73,7 @@ def execute(step, project_options, part_names=None):
         state_file.write(yaml.dump(
             states.GlobalState(installed_packages, installed_snaps)))
 
-    if _should_get_core(config.data['confinement']):
+    if _should_get_core(config.data.get('confinement')):
         _setup_core(project_options.deb_arch,
                     config.data.get('base', 'core'))
 
@@ -241,7 +241,8 @@ class _Executor:
             meta.create_snap_packaging(
                 self.config.data, self.config.parts, self.project_options,
                 self.config.snapcraft_yaml_path,
-                self.config.original_snapcraft_yaml)
+                self.config.original_snapcraft_yaml,
+                self.config.validator.schema)
 
     def _handle_dirty(self, part, step, dirty_report):
         if step not in constants.STEPS_TO_AUTOMATICALLY_CLEAN_IF_DIRTY:

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -88,7 +88,8 @@ def create_snap_packaging(
         parts_config: project_loader.PartsConfig,
         project_options: Project,
         snapcraft_yaml_path: str,
-        original_snapcraft_yaml: Dict[str, Any]) -> str:
+        original_snapcraft_yaml: Dict[str, Any],
+        snapcraft_schema: Dict[str, Any]) -> str:
     """Create snap.yaml and related assets in meta.
 
     Create the meta directory and provision it with snap.yaml in the snap dir
@@ -101,6 +102,14 @@ def create_snap_packaging(
 
     # Update config_data using metadata extracted from the project
     _update_yaml_with_extracted_metadata(config_data, parts_config)
+
+    # Now that we've updated config_data with random stuff extracted from
+    # parts, re-validate it to ensure the it still conform with the schema.
+    validator = project_loader.Validator(config_data)
+    validator.validate(source='properties')
+
+    _update_yaml_with_defaults(config_data, snapcraft_schema)
+    _ensure_required_keywords(config_data)
 
     packaging = _SnapPackaging(
         config_data, project_options,
@@ -151,15 +160,6 @@ def _update_yaml_with_extracted_metadata(
                 raise meta_errors.AdoptedPartNotParsingInfo(part_name)
 
         _adopt_info(config_data, metadata)
-
-    # Verify that all mandatory keys have been satisfied
-    missing_keys = []  # type: List[str]
-    for key in _MANDATORY_PACKAGE_KEYS:
-        if key not in config_data:
-            missing_keys.append(key)
-
-    if missing_keys:
-        raise meta_errors.MissingSnapcraftYamlKeysError(keys=missing_keys)
 
 
 def _adopt_info(
@@ -263,6 +263,30 @@ def _desktop_file_exists(app_name: str) -> bool:
             return True
     else:
         return False
+
+
+def _update_yaml_with_defaults(config_data, schema):
+    # Verify that all optional keys have their defaults (taken from the schema)
+    # applied
+    for key in _OPTIONAL_PACKAGE_KEYS:
+        if key not in config_data:
+            with contextlib.suppress(KeyError):
+                default = schema[key]['default']
+                config_data[key] = default
+                logger.warn(
+                    '{!r} property not specified: defaulting to {!r}'.format(
+                        key, default))
+
+
+def _ensure_required_keywords(config_data):
+    # Verify that all mandatory keys have been satisfied
+    missing_keys = []  # type: List[str]
+    for key in _MANDATORY_PACKAGE_KEYS:
+        if key not in config_data:
+            missing_keys.append(key)
+
+    if missing_keys:
+        raise meta_errors.MissingSnapcraftYamlKeysError(keys=missing_keys)
 
 
 class _SnapPackaging:

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -114,6 +114,7 @@ class PluginHandler:
                 'stage': self._do_stage,
                 'prime': self._do_prime,
                 'set-version': self._set_version,
+                'set-grade': self._set_grade,
             })
 
         self._migrate_state_file()
@@ -163,7 +164,14 @@ class PluginHandler:
             self._set_scriptlet_metadata(
                 snapcraft.extractors.ExtractedMetadata(version=version))
         except errors.ScriptletDuplicateDataError as e:
-            raise errors.ScriptletDuplicateVersionError(e.other_step)
+            raise errors.ScriptletDuplicateFieldError('version', e.other_step)
+
+    def _set_grade(self, *, grade):
+        try:
+            self._set_scriptlet_metadata(
+                snapcraft.extractors.ExtractedMetadata(grade=grade))
+        except errors.ScriptletDuplicateDataError as e:
+            raise errors.ScriptletDuplicateFieldError('grade', e.other_step)
 
     def _set_scriptlet_metadata(
             self, metadata: snapcraft.extractors.ExtractedMetadata):

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -38,7 +38,7 @@ class PartsConfig:
                  build_snaps, build_tools, snapcraft_yaml):
         self._snap_name = parts['name']
         self._base = parts.get('base', 'core')
-        self._confinement = parts['confinement']
+        self._confinement = parts.get('confinement')
         self._soname_cache = elf.SonameCache()
         self._parts_data = parts.get('parts', {})
         self._snap_type = parts.get('type', 'app')

--- a/snapcraft/internal/project_loader/_schema.py
+++ b/snapcraft/internal/project_loader/_schema.py
@@ -61,11 +61,12 @@ class Validator:
             raise errors.YamlValidationError(
                 'snapcraft validation file is missing from installation path')
 
-    def validate(self):
+    def validate(self, *, source=None):
         format_check = jsonschema.FormatChecker()
         try:
             jsonschema.validate(
                 self._snapcraft, self._schema, format_checker=format_check)
         except jsonschema.ValidationError as e:
             from snapcraft.internal.project_loader import errors
-            raise errors.YamlValidationError.from_validation_error(e)
+            raise errors.YamlValidationError.from_validation_error(
+                e, source=source)

--- a/snapcraft/internal/project_loader/errors.py
+++ b/snapcraft/internal/project_loader/errors.py
@@ -58,10 +58,10 @@ class MissingSnapcraftYamlError(ProjectLoaderError):
 
 class YamlValidationError(ProjectLoaderError):
 
-    fmt = 'Issues while validating {snapcraft_yaml}: {message}'
+    fmt = 'Issues while validating {source}: {message}'
 
     @classmethod
-    def from_validation_error(cls, error):
+    def from_validation_error(cls, error, *, source='snapcraft.yaml'):
         """Take a jsonschema.ValidationError and create a SnapcraftSchemaError.
 
         The validation errors coming from jsonschema are a nightmare. This
@@ -85,10 +85,10 @@ class YamlValidationError(ProjectLoaderError):
         else:
             messages.append(error.message)
 
-        return cls(' '.join(messages))
+        return cls(' '.join(messages), source)
 
-    def __init__(self, message, snapcraft_yaml='snapcraft.yaml'):
-        super().__init__(message=message, snapcraft_yaml=snapcraft_yaml)
+    def __init__(self, message, source='snapcraft.yaml'):
+        super().__init__(message=message, source=source)
 
 
 class SnapcraftLogicError(ProjectLoaderError):

--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -25,4 +25,4 @@ class ProjectInfo:
         self.version = data.get('version')
         self.summary = data.get('summary')
         self.description = data.get('description')
-        self.confinement = data['confinement']
+        self.confinement = data.get('confinement')

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -209,6 +209,7 @@ class TestCase(testtools.TestCase):
     def construct_yaml(self, name='test', version='0.1',
                        summary='Simple test snap',
                        description='Something something',
+                       grade=None,
                        parts=dedent('''\
                            my-part:
                              plugin: nil
@@ -227,6 +228,8 @@ class TestCase(testtools.TestCase):
             snapcraft_yaml['version'] = version
         if adopt_info:
             snapcraft_yaml['adopt-info'] = adopt_info
+        if grade:
+            snapcraft_yaml['grade'] = grade
 
         with open('snapcraft.yaml', 'w') as f:
             yaml.dump(snapcraft_yaml, f, default_flow_style=False)

--- a/tests/integration/general/test_snapcraftctl_set_grade.py
+++ b/tests/integration/general/test_snapcraftctl_set_grade.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 3 as
+# it under the terms of the GNU General Public License grade 3 as
 # published by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful,
@@ -24,14 +24,14 @@ from testtools.matchers import Equals, Contains
 from tests import integration
 
 
-class SnapcraftctlSetVersionTestCase(integration.TestCase):
+class SnapcraftctlSetGradeTestCase(integration.TestCase):
 
-    def test_set_version(self):
+    def test_set_grade(self):
         self.construct_yaml(
-            version=None, adopt_info='my-part', parts=textwrap.dedent("""\
+            grade=None, adopt_info='my-part', parts=textwrap.dedent("""\
                 my-part:
                   plugin: nil
-                  override-pull: snapcraftctl set-version override-version
+                  override-pull: snapcraftctl set-grade override-grade
                 """))
 
         self.run_snapcraft('prime')
@@ -39,15 +39,15 @@ class SnapcraftctlSetVersionTestCase(integration.TestCase):
         with open(os.path.join('prime', 'meta', 'snap.yaml')) as f:
             y = yaml.load(f)
 
-        self.assertThat(y['version'], Equals('override-version'))
+        self.assertThat(y['grade'], Equals('override-grade'))
 
-    def test_set_version_no_overwrite(self):
+    def test_set_grade_no_overwrite(self):
         self.construct_yaml(
-            version='test-version', adopt_info='my-part',
+            grade='devel', adopt_info='my-part',
             parts=textwrap.dedent("""\
                 my-part:
                   plugin: nil
-                  override-pull: snapcraftctl set-version override-version
+                  override-pull: snapcraftctl set-grade override-grade
                 """))
 
         self.run_snapcraft('prime')
@@ -55,22 +55,22 @@ class SnapcraftctlSetVersionTestCase(integration.TestCase):
         with open(os.path.join('prime', 'meta', 'snap.yaml')) as f:
             y = yaml.load(f)
 
-        self.assertThat(y['version'], Equals('test-version'))
+        self.assertThat(y['grade'], Equals('devel'))
 
-    def test_set_version_twice_errors(self):
+    def test_set_grade_twice_errors(self):
         self.construct_yaml(
-            version=None, adopt_info='my-part', parts=textwrap.dedent("""\
+            grade=None, adopt_info='my-part', parts=textwrap.dedent("""\
                 my-part:
                   plugin: nil
-                  override-pull: snapcraftctl set-version override-version
-                  override-prime: snapcraftctl set-version no-this-version
+                  override-pull: snapcraftctl set-grade override-grade
+                  override-prime: snapcraftctl set-grade no-this-grade
                 """))
 
         raised = self.assertRaises(
             subprocess.CalledProcessError, self.run_snapcraft, 'prime')
         self.assertThat(
             raised.output, Contains(
-                "Unable to set version: it was already set in the 'pull' "
+                "Unable to set grade: it was already set in the 'pull' "
                 "step"))
         self.assertThat(
             raised.output, Contains("Failed to run 'override-prime'"))

--- a/tests/unit/commands/snapcraftctl/test_set_grade.py
+++ b/tests/unit/commands/snapcraftctl/test_set_grade.py
@@ -1,0 +1,67 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+
+from testtools.matchers import (
+    Contains,
+    Equals,
+    FileExists,
+)
+
+from snapcraft.internal import errors
+
+from . import CommandBaseTestCase, CommandBaseNoFifoTestCase
+
+
+class SetGradeCommandTestCase(CommandBaseTestCase):
+
+    def test_set_grade(self):
+        self.run_command(['set-grade', 'test-grade'])
+        self.assertThat(self.call_fifo, FileExists())
+
+        with open(self.call_fifo, 'r') as f:
+            data = json.loads(f.read())
+
+        self.assertThat(data, Contains('function'))
+        self.assertThat(data, Contains('args'))
+
+        self.assertThat(data['function'], Equals('set-grade'))
+        self.assertThat(data['args'], Equals({'grade': 'test-grade'}))
+
+    def test_set_grade_error(self):
+        # If there is a string in the feedback, it should be considered an
+        # error
+        with open(self.feedback_fifo, 'w') as f:
+            f.write('this is an error\n')
+
+        raised = self.assertRaises(
+            errors.SnapcraftctlError, self.run_command,
+            ['set-grade', 'test-grade'])
+
+        self.assertThat(str(raised), Equals('this is an error'))
+
+
+class SetGradeCommandWithoutFifoTestCase(CommandBaseNoFifoTestCase):
+
+    def test_set_grade_without_fifo(self):
+        raised = self.assertRaises(
+            errors.SnapcraftEnvironmentError, self.run_command,
+            ['set-grade', 'test-grade'])
+
+        self.assertThat(str(raised), Contains(
+            'environment variable must be defined. Note that this utility is '
+            'only designed for use within a snapcraft.yaml'))

--- a/tests/unit/commands/snapcraftctl/test_set_version.py
+++ b/tests/unit/commands/snapcraftctl/test_set_version.py
@@ -1,0 +1,67 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+
+from testtools.matchers import (
+    Contains,
+    Equals,
+    FileExists,
+)
+
+from snapcraft.internal import errors
+
+from . import CommandBaseTestCase, CommandBaseNoFifoTestCase
+
+
+class SetVersionCommandTestCase(CommandBaseTestCase):
+
+    def test_set_version(self):
+        self.run_command(['set-version', 'test-version'])
+        self.assertThat(self.call_fifo, FileExists())
+
+        with open(self.call_fifo, 'r') as f:
+            data = json.loads(f.read())
+
+        self.assertThat(data, Contains('function'))
+        self.assertThat(data, Contains('args'))
+
+        self.assertThat(data['function'], Equals('set-version'))
+        self.assertThat(data['args'], Equals({'version': 'test-version'}))
+
+    def test_set_version_error(self):
+        # If there is a string in the feedback, it should be considered an
+        # error
+        with open(self.feedback_fifo, 'w') as f:
+            f.write('this is an error\n')
+
+        raised = self.assertRaises(
+            errors.SnapcraftctlError, self.run_command,
+            ['set-version', 'test-version'])
+
+        self.assertThat(str(raised), Equals('this is an error'))
+
+
+class SetVersionCommandWithoutFifoTestCase(CommandBaseNoFifoTestCase):
+
+    def test_set_version_without_fifo(self):
+        raised = self.assertRaises(
+            errors.SnapcraftEnvironmentError, self.run_command,
+            ['set-version', 'test-version'])
+
+        self.assertThat(str(raised), Contains(
+            'environment variable must be defined. Note that this utility is '
+            'only designed for use within a snapcraft.yaml'))

--- a/tests/unit/extractors/test_metadata.py
+++ b/tests/unit/extractors/test_metadata.py
@@ -91,3 +91,34 @@ class ExtractedMetadataTestCase(unit.TestCase):
 
         # Ensure the metadata cannot be edited with its dict
         self.assertThat(metadata.get_summary(), Equals('summary'))
+
+
+class ExtractedMetadataGettersTestCase(unit.TestCase):
+
+    scenarios = [
+        ('common_id', {'property': 'common_id', 'value': 'test-value'}),
+        ('summary', {'property': 'summary', 'value': 'test-value'}),
+        ('description', {'property': 'description', 'value': 'test-value'}),
+        ('version', {'property': 'version', 'value': 'test-value'}),
+        ('grade', {'property': 'grade', 'value': 'test-value'}),
+        ('icon', {'property': 'icon', 'value': 'test-value'}),
+        ('desktop_file_paths', {
+            'property': 'desktop_file_paths', 'value': ['test-value']}),
+    ]
+
+    properties = ('common_id', 'summary', 'description', 'version', 'grade',
+                  'icon', 'desktop_file_paths')
+
+    def test_getters(self):
+        metadata = ExtractedMetadata(**{self.property: self.value})
+        for prop in self.properties:
+            gotten = getattr(metadata, 'get_{}'.format(prop))()
+            if prop == self.property:
+                self.assertThat(
+                    gotten, Equals(self.value),
+                    'Expected {!r} getter to return {}'.format(
+                        prop, self.value))
+            else:
+                self.assertThat(
+                    gotten, Equals(None),
+                    'Expected {!r} getter to return None'.format(prop))

--- a/tests/unit/project_loader/test_config.py
+++ b/tests/unit/project_loader/test_config.py
@@ -721,55 +721,6 @@ parts:
                    " only use ASCII lowercase letters, numbers, and hyphens,"
                    " and must have at least one letter."))
 
-    def test_yaml_missing_confinement_must_log(self):
-        fake_logger = fixtures.FakeLogger(level=logging.WARNING)
-        self.useFixture(fake_logger)
-
-        self.make_snapcraft_yaml("""name: test
-version: "1"
-summary: test
-description: nothing
-
-parts:
-  part1:
-    plugin: go
-    stage-packages: [fswebcam]
-""")
-        c = _config.Config()
-
-        # Verify the default is "strict"
-        self.assertTrue('confinement' in c.data,
-                        'Expected "confinement" property to be in snap.yaml')
-        self.assertThat(c.data['confinement'], Equals('strict'))
-        self.assertTrue(
-            '"confinement" property not specified: defaulting to "strict"'
-            in fake_logger.output, 'Missing confinement hint in output')
-
-    def test_yaml_missing_grade_must_log(self):
-        fake_logger = fixtures.FakeLogger(level=logging.WARNING)
-        self.useFixture(fake_logger)
-
-        self.make_snapcraft_yaml("""name: test
-version: "1"
-summary: test
-description: nothing
-confinement: strict
-
-parts:
-  part1:
-    plugin: go
-    stage-packages: [fswebcam]
-""")
-        c = _config.Config()
-
-        # Verify the default is "stable"
-        self.assertTrue('grade' in c.data,
-                        'Expected "grade" property to be in snap.yaml')
-        self.assertThat(c.data['grade'], Equals('stable'))
-        self.assertTrue(
-            '"grade" property not specified: defaulting to "stable"'
-            in fake_logger.output, 'Missing grade hint in output')
-
     def test_tab_in_yaml(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
         self.useFixture(fake_logger)

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import configparser
+import contextlib
 import logging
 import os
 from unittest.mock import patch
@@ -96,7 +97,7 @@ class CreateBaseTestCase(unit.TestCase):
 
         _snap_packaging.create_snap_packaging(
             self.config.data, self.config.parts, self.project_options, 'dummy',
-            self.config.original_snapcraft_yaml)
+            self.config.original_snapcraft_yaml, self.config.validator.schema)
 
         self.assertTrue(
             os.path.exists(self.snap_yaml), 'snap.yaml was not created')
@@ -152,7 +153,7 @@ class CreateTestCase(CreateBaseTestCase):
 
         _snap_packaging.create_snap_packaging(
             self.config_data, config.parts, self.project_options, 'dummy',
-            config.original_snapcraft_yaml)
+            config.original_snapcraft_yaml, config.validator.schema)
 
         expected_gadget = os.path.join(self.meta_dir, 'gadget.yaml')
         self.assertTrue(os.path.exists(expected_gadget))
@@ -175,7 +176,8 @@ class CreateTestCase(CreateBaseTestCase):
             config.parts,
             self.project_options,
             'dummy',
-            config.original_snapcraft_yaml
+            config.original_snapcraft_yaml,
+            config.validator.schema
         )
 
     def test_create_meta_with_declared_icon(self):
@@ -267,12 +269,12 @@ class CreateTestCase(CreateBaseTestCase):
 
         _snap_packaging.create_snap_packaging(
             self.config_data, config.parts, self.project_options, 'dummy',
-            config.original_snapcraft_yaml)
+            config.original_snapcraft_yaml, config.validator.schema)
 
         # Running again should be good
         _snap_packaging.create_snap_packaging(
             self.config_data, config.parts, self.project_options, 'dummy',
-            config.original_snapcraft_yaml)
+            config.original_snapcraft_yaml, config.validator.schema)
 
     def test_create_meta_with_icon_in_setup(self):
         gui_path = os.path.join('setup', 'gui')
@@ -788,65 +790,136 @@ class MetadataFromSourceWithDesktopFileTestCase(
 
 class ScriptletsMetadataTestCase(CreateMetadataFromSourceBaseTestCase):
 
+    scenarios = [
+        ('set-version', {
+            'keyword': 'version',
+            'original': 'original-version',
+            'value': 'test-version',
+            'setter': 'set-version'}),
+        ('set-grade', {
+            'keyword': 'grade',
+            'original': 'stable',
+            'value': 'devel',
+            'setter': 'set-grade'}),
+    ]
+
     def test_scriptlets_satisfy_required_property(self):
-        del self.config_data['version']
+        with contextlib.suppress(KeyError):
+            del self.config_data[self.keyword]
+
         del self.config_data['parts']['test-part']['parse-info']
         self.config_data['parts']['test-part']['override-prime'] = (
-            'snapcraftctl set-version override-version')
+            'snapcraftctl {} {}'.format(self.setter, self.value))
 
         generated = self.generate_meta_yaml(build=True)
 
-        self.assertThat(generated['version'], Equals('override-version'))
+        self.assertThat(generated[self.keyword], Equals(self.value))
 
     def test_scriptlets_no_overwrite_existing_property(self):
+        self.config_data[self.keyword] = self.original
         fake_logger = fixtures.FakeLogger(level=logging.WARNING)
         self.useFixture(fake_logger)
 
         del self.config_data['parts']['test-part']['parse-info']
         self.config_data['parts']['test-part']['override-prime'] = (
-            'snapcraftctl set-version override-version')
+            'snapcraftctl {} {}'.format(self.setter, self.value))
 
         generated = self.generate_meta_yaml(build=True)
 
-        self.assertThat(generated['version'], Equals('test-version'))
+        self.assertThat(generated[self.keyword], Equals(self.original))
 
         # Since the specified version took precedence over the scriptlet-set
         # version, verify that we warned
         self.assertThat(fake_logger.output, Contains(
-            "The 'version' property is specified in adopted info as well as "
-            "the YAML: taking the property from the YAML"))
+            "The {!r} property is specified in adopted info as well as "
+            "the YAML: taking the property from the YAML".format(
+                self.keyword)))
 
     def test_scriptlets_overwrite_extracted_metadata(self):
-        del self.config_data['version']
+        with contextlib.suppress(KeyError):
+            del self.config_data[self.keyword]
 
         self.config_data['parts']['test-part']['override-build'] = (
-            'snapcraftctl build && snapcraftctl set-version override-version')
+            'snapcraftctl build && snapcraftctl {} {}'.format(
+                self.setter, self.value))
 
         def _fake_extractor(file_path):
-            return extractors.ExtractedMetadata(version='extracted-version')
+            return extractors.ExtractedMetadata(
+                **{self.keyword: 'extracted-value'})
 
         self.useFixture(fixture_setup.FakeMetadataExtractor(
             'fake', _fake_extractor))
 
         generated = self.generate_meta_yaml(build=True)
 
-        self.assertThat(generated['version'], Equals('override-version'))
+        self.assertThat(generated[self.keyword], Equals(self.value))
 
     def test_scriptlets_overwrite_extracted_metadata_regardless_of_order(self):
-        del self.config_data['version']
+        with contextlib.suppress(KeyError):
+            del self.config_data[self.keyword]
 
         self.config_data['parts']['test-part']['override-pull'] = (
-            'snapcraftctl set-version override-version && snapcraftctl pull')
+            'snapcraftctl {} {} && snapcraftctl pull'.format(
+                self.setter, self.value))
 
         def _fake_extractor(file_path):
-            return extractors.ExtractedMetadata(version='extracted-version')
+            return extractors.ExtractedMetadata(
+                **{self.keyword: 'extracted-value'})
 
         self.useFixture(fixture_setup.FakeMetadataExtractor(
             'fake', _fake_extractor))
 
         generated = self.generate_meta_yaml(build=True)
 
-        self.assertThat(generated['version'], Equals('override-version'))
+        self.assertThat(generated[self.keyword], Equals(self.value))
+
+
+class InvalidMetadataTestCase(CreateMetadataFromSourceBaseTestCase):
+
+    scenarios = [
+        ('version', {
+            'keyword': 'version',
+            'setter': 'set-version',
+            'value': '.invalid-'}),
+        ('grade', {
+            'keyword': 'grade',
+            'setter': 'set-grade',
+            'value': 'invalid'}),
+    ]
+
+    def test_invalid_scriptlet_metadata(self):
+        with contextlib.suppress(KeyError):
+            del self.config_data[self.keyword]
+
+        del self.config_data['parts']['test-part']['parse-info']
+
+        self.config_data['parts']['test-part']['override-prime'] = (
+            'snapcraftctl {} {}'.format(self.setter, self.value))
+
+        raised = self.assertRaises(
+            project_loader.errors.YamlValidationError, self.generate_meta_yaml,
+            build=True)
+        self.assertThat(str(raised), Contains(
+            'Issues while validating properties: The {!r} property does not '
+            'match the required schema'.format(self.keyword)))
+
+    def test_invalid_extracted_metadata(self):
+        with contextlib.suppress(KeyError):
+            del self.config_data[self.keyword]
+
+        def _fake_extractor(file_path):
+            return extractors.ExtractedMetadata(
+                **{self.keyword: self.value})
+
+        self.useFixture(fixture_setup.FakeMetadataExtractor(
+            'fake', _fake_extractor))
+
+        raised = self.assertRaises(
+            project_loader.errors.YamlValidationError, self.generate_meta_yaml,
+            build=True)
+        self.assertThat(str(raised), Contains(
+            'Issues while validating properties: The {!r} property does not '
+            'match the required schema'.format(self.keyword)))
 
 
 class WriteSnapDirectoryTestCase(CreateBaseTestCase):
@@ -950,16 +1023,31 @@ class GenerateHookWrappersTestCase(CreateBaseTestCase):
 class CreateWithConfinementTestCase(CreateBaseTestCase):
 
     scenarios = [(confinement, dict(confinement=confinement)) for
-                 confinement in ['strict', 'devmode', 'classic']]
+                 confinement in ['', 'strict', 'devmode', 'classic']]
 
     def test_create_meta_with_confinement(self):
-        self.config_data['confinement'] = self.confinement
+        fake_logger = fixtures.FakeLogger(level=logging.INFO)
+        self.useFixture(fake_logger)
+
+        if self.confinement:
+            self.config_data['confinement'] = self.confinement
+        else:
+            del self.config_data['confinement']
 
         y = self.generate_meta_yaml()
         self.assertTrue(
             'confinement' in y,
             'Expected "confinement" property to be in snap.yaml')
-        self.assertThat(y['confinement'], Equals(self.confinement))
+
+        if self.confinement:
+            self.assertThat(y['confinement'], Equals(self.confinement))
+        else:
+            # Ensure confinement defaults to strict if not specified. Also
+            # verify that a warning is printed
+            self.assertThat(y['confinement'], Equals('strict'))
+            self.assertThat(fake_logger.output, Contains(
+                "'confinement' property not specified: defaulting to "
+                "'strict'"))
 
 
 class EnsureFilePathsTestCase(CreateBaseTestCase):
@@ -1015,16 +1103,28 @@ class EnsureFilePathsTestCaseFails(CreateBaseTestCase):
 class CreateWithGradeTestCase(CreateBaseTestCase):
 
     scenarios = [(grade, dict(grade=grade)) for
-                 grade in ['stable', 'devel']]
+                 grade in ['', 'stable', 'devel']]
 
     def test_create_meta_with_grade(self):
-        self.config_data['grade'] = self.grade
+        fake_logger = fixtures.FakeLogger(level=logging.INFO)
+        self.useFixture(fake_logger)
+
+        if self.grade:
+            self.config_data['grade'] = self.grade
 
         y = self.generate_meta_yaml()
         self.assertTrue(
             'grade' in y,
             'Expected "grade" property to be in snap.yaml')
-        self.assertThat(y['grade'], Equals(self.grade))
+
+        if self.grade:
+            self.assertThat(y['grade'], Equals(self.grade))
+        else:
+            # Ensure that grade always defaults to stable, even if not
+            # specified. Also verify that a warning is printed
+            self.assertThat(y['grade'], Equals('stable'))
+            self.assertThat(fake_logger.output, Contains(
+                "'grade' property not specified: defaulting to 'stable'"))
 
 
 # TODO this needs more tests.


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----

This PR resolves #2064 by adding the ability to set the snap grade from a scriptlet using `snapcraftctl set-grade <grade>`.

It also begins validating final YAML before generating the `snap.yaml`, catching both extracted and scriptlet metadata (such as grade) that doesn't match the schema.