### PR TITLE
states: track override scriptlets

### DIFF
--- a/snapcraft/internal/states/_build_state.py
+++ b/snapcraft/internal/states/_build_state.py
@@ -37,6 +37,7 @@ def _schema_properties():
         'disable-parallel',
         'install',
         'organize',
+        'override-build',
         'prepare',
     }
 

--- a/snapcraft/internal/states/_prime_state.py
+++ b/snapcraft/internal/states/_prime_state.py
@@ -53,7 +53,10 @@ class PrimeState(PartState):
         used to filter out files with a white or blacklist.
         """
 
-        return {'prime': part_properties.get('prime', ['*']) or ['*']}
+        return {
+            'override-prime': part_properties.get('override-prime'),
+            'prime': part_properties.get('prime', ['*']) or ['*'],
+        }
 
     def project_options_of_interest(self, project):
         """Extract the options concerning this step from the project.

--- a/snapcraft/internal/states/_pull_state.py
+++ b/snapcraft/internal/states/_pull_state.py
@@ -30,6 +30,7 @@ yaml.add_constructor(u'!PullState', _pull_state_constructor)
 
 def _schema_properties():
     return {
+        'override-pull',
         'parse-info',
         'plugin',
         'source',

--- a/snapcraft/internal/states/_stage_state.py
+++ b/snapcraft/internal/states/_stage_state.py
@@ -50,8 +50,9 @@ class StageState(PartState):
         """
 
         return {
-            'stage': part_properties.get('stage', ['*']) or ['*'],
             'filesets': part_properties.get('filesets', {}) or {},
+            'override-stage': part_properties.get('override-stage'),
+            'stage': part_properties.get('stage', ['*']) or ['*'],
         }
 
     def project_options_of_interest(self, project):

--- a/tests/integration/snaps/old-part-src/parts/part-name/state/pull
+++ b/tests/integration/snaps/old-part-src/parts/part-name/state/pull
@@ -11,4 +11,5 @@ properties:
   source-tag: ''
   source-type: ''
   stage-packages: []
+  override-pull: 'snapcraftctl pull'
 schema_properties: []

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -885,11 +885,11 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(state, 'Expected pull to save state YAML')
         self.assertTrue(type(state) is states.PullState)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertThat(len(state.properties), Equals(10))
+        self.assertThat(len(state.properties), Equals(11))
         for expected in ['source', 'source-branch', 'source-commit',
                          'source-depth', 'source-subdir', 'source-tag',
                          'source-type', 'plugin', 'stage-packages',
-                         'parse-info']:
+                         'parse-info', 'override-pull']:
             self.assertTrue(expected in state.properties)
         self.assertTrue(type(state.project_options) is OrderedDict)
         self.assertTrue('deb_arch' in state.project_options)
@@ -929,11 +929,11 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(state, 'Expected pull to save state YAML')
         self.assertTrue(type(state) is states.PullState)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertThat(len(state.properties), Equals(10))
+        self.assertThat(len(state.properties), Equals(11))
         for expected in ['source', 'source-branch', 'source-commit',
                          'source-depth', 'source-subdir', 'source-tag',
                          'source-type', 'plugin', 'stage-packages',
-                         'parse-info']:
+                         'parse-info', 'override-pull']:
             self.assertThat(state.properties, Contains(expected))
         self.assertTrue(type(state.project_options) is OrderedDict)
         self.assertThat(state.project_options, Contains('deb_arch'))
@@ -972,14 +972,15 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(state, 'Expected pull to save state YAML')
         self.assertTrue(type(state) is states.PullState)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertThat(len(state.properties), Equals(10))
+        self.assertThat(len(state.properties), Equals(11))
         for expected in ['source', 'source-branch', 'source-commit',
                          'source-depth', 'source-subdir', 'source-tag',
                          'source-type', 'plugin', 'stage-packages',
-                         'parse-info']:
+                         'parse-info', 'override-pull']:
             self.assertThat(state.properties, Contains(expected))
-        self.assertTrue(type(state.project_options) is OrderedDict)
-        self.assertThat(state.project_options, Contains('deb_arch'))
+        self.assertThat(
+            state.properties['override-pull'],
+            Equals('snapcraftctl set-version override-version'))
 
         metadata = state.scriptlet_metadata
         self.assertThat(metadata.get_version(), Equals('override-version'))
@@ -1034,10 +1035,10 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(state, 'Expected build to save state YAML')
         self.assertTrue(type(state) is states.BuildState)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertThat(len(state.properties), Equals(8))
+        self.assertThat(len(state.properties), Equals(9))
         for expected in ['after', 'build-attributes', 'build-packages',
                          'disable-parallel', 'organize', 'prepare', 'build',
-                         'install']:
+                         'install', 'override-build']:
             self.assertTrue(expected in state.properties)
         self.assertTrue(type(state.project_options) is OrderedDict)
         self.assertTrue('deb_arch' in state.project_options)
@@ -1075,10 +1076,10 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(state, 'Expected build to save state YAML')
         self.assertTrue(type(state) is states.BuildState)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertThat(len(state.properties), Equals(8))
+        self.assertThat(len(state.properties), Equals(9))
         for expected in ['after', 'build-attributes', 'build-packages',
                          'disable-parallel', 'organize', 'prepare', 'build',
-                         'install']:
+                         'install', 'override-build']:
             self.assertThat(state.properties, Contains(expected))
         self.assertTrue(type(state.project_options) is OrderedDict)
         self.assertThat(state.project_options, Contains('deb_arch'))
@@ -1116,13 +1117,14 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(state, 'Expected build to save state YAML')
         self.assertTrue(type(state) is states.BuildState)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertThat(len(state.properties), Equals(8))
+        self.assertThat(len(state.properties), Equals(9))
         for expected in ['after', 'build-attributes', 'build-packages',
                          'disable-parallel', 'organize', 'prepare', 'build',
-                         'install']:
+                         'install', 'override-build']:
             self.assertThat(state.properties, Contains(expected))
-        self.assertTrue(type(state.project_options) is OrderedDict)
-        self.assertThat(state.project_options, Contains('deb_arch'))
+        self.assertThat(
+            state.properties['override-build'],
+            Equals('snapcraftctl set-version override-version'))
 
         metadata = state.scriptlet_metadata
         self.assertThat(metadata.get_version(), Equals('override-version'))
@@ -1218,9 +1220,12 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(type(state.files) is set)
         self.assertTrue(type(state.directories) is set)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertThat(len(state.properties), Equals(2))
-        for expected in ['stage', 'filesets']:
+        self.assertThat(len(state.properties), Equals(3))
+        for expected in ['stage', 'filesets', 'override-stage']:
             self.assertThat(state.properties, Contains(expected))
+        self.assertThat(
+            state.properties['override-stage'],
+            Equals('snapcraftctl set-version override-version'))
 
         metadata = state.scriptlet_metadata
         self.assertThat(metadata.get_version(), Equals('override-version'))
@@ -1395,8 +1400,12 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(type(state.directories) is set)
         self.assertTrue(type(state.dependency_paths) is set)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertThat(len(state.properties), Equals(1))
-        self.assertThat(state.properties, Contains('prime'))
+        self.assertThat(len(state.properties), Equals(2))
+        for expected in ['prime', 'override-prime']:
+            self.assertThat(state.properties, Contains(expected))
+        self.assertThat(
+            state.properties['override-prime'],
+            Equals('snapcraftctl set-version override-version'))
 
         metadata = state.scriptlet_metadata
         self.assertThat(metadata.get_version(), Equals('override-version'))

--- a/tests/unit/states/test_build.py
+++ b/tests/unit/states/test_build.py
@@ -58,13 +58,14 @@ class BuildStateTestCase(BuildStateBaseTestCase):
             'build-packages': 'test-build-packages',
             'disable-parallel': 'test-disable-parallel',
             'organize': {'baz': 'qux'},
+            'override-build': 'touch override-build',
             'prepare': 'touch prepare',
             'build': 'touch build',
             'install': 'touch install',
         })
 
         properties = self.state.properties_of_interest(self.part_properties)
-        self.assertThat(len(properties), Equals(9))
+        self.assertThat(len(properties), Equals(10))
         self.assertThat(properties['foo'], Equals('bar'))
         self.assertThat(properties['after'], Equals('test-after'))
         self.assertThat(
@@ -74,6 +75,8 @@ class BuildStateTestCase(BuildStateBaseTestCase):
         self.assertThat(
             properties['disable-parallel'], Equals('test-disable-parallel'))
         self.assertThat(properties['organize'], Equals({'baz': 'qux'}))
+        self.assertThat(
+            properties['override-build'], Equals('touch override-build'))
         self.assertThat(properties['prepare'], Equals('touch prepare'))
         self.assertThat(properties['build'], Equals('touch build'))
         self.assertThat(properties['install'], Equals('touch install'))

--- a/tests/unit/states/test_prime.py
+++ b/tests/unit/states/test_prime.py
@@ -33,7 +33,10 @@ class PrimeStateBaseTestCase(unit.TestCase):
         self.files = {'foo'}
         self.directories = {'bar'}
         self.dependency_paths = {'baz'}
-        self.part_properties = {'prime': ['qux']}
+        self.part_properties = {
+            'override-prime': 'touch override-prime',
+            'prime': ['qux'],
+        }
 
         self.state = snapcraft.internal.states.PrimeState(
             self.files, self.directories, self.dependency_paths,
@@ -55,7 +58,9 @@ class PrimeStateTestCase(PrimeStateBaseTestCase):
 
     def test_properties_of_interest(self):
         properties = self.state.properties_of_interest(self.part_properties)
-        self.assertThat(len(properties), Equals(1))
+        self.assertThat(len(properties), Equals(2))
+        self.assertThat(
+            properties['override-prime'], Equals('touch override-prime'))
         self.assertThat(properties['prime'], Equals(['qux']))
 
     def test_project_options_of_interest(self):

--- a/tests/unit/states/test_pull.py
+++ b/tests/unit/states/test_pull.py
@@ -52,6 +52,7 @@ class PullStateTestCase(PullStateBaseTestCase):
 
     def test_properties_of_interest(self):
         self.part_properties.update({
+            'override-pull': 'touch override-pull',
             'plugin': 'test-plugin',
             'parse-info': 'test-parse-info',
             'stage-packages': ['test-stage-package'],
@@ -65,8 +66,10 @@ class PullStateTestCase(PullStateBaseTestCase):
         })
 
         properties = self.state.properties_of_interest(self.part_properties)
-        self.assertThat(len(properties), Equals(11))
+        self.assertThat(len(properties), Equals(12))
         self.assertThat(properties['foo'], Equals('bar'))
+        self.assertThat(
+            properties['override-pull'], Equals('touch override-pull'))
         self.assertThat(properties['plugin'], Equals('test-plugin'))
         self.assertThat(properties['parse-info'], Equals('test-parse-info'))
         self.assertThat(

--- a/tests/unit/states/test_stage.py
+++ b/tests/unit/states/test_stage.py
@@ -32,7 +32,11 @@ class StageStateBaseTestCase(unit.TestCase):
         self.project = Project()
         self.files = {'foo'}
         self.directories = {'bar'}
-        self.part_properties = {'stage': ['baz'], 'filesets': {'qux': 'quux'}}
+        self.part_properties = {
+            'filesets': {'qux': 'quux'},
+            'override-stage': 'touch override-stage',
+            'stage': ['baz'],
+        }
 
         self.state = snapcraft.internal.states.StageState(
             self.files, self.directories, self.part_properties, self.project)
@@ -52,9 +56,11 @@ class StateStageTestCase(StageStateBaseTestCase):
 
     def test_properties_of_interest(self):
         properties = self.state.properties_of_interest(self.part_properties)
-        self.assertThat(len(properties), Equals(2))
-        self.assertThat(properties['stage'], Equals(['baz']))
+        self.assertThat(len(properties), Equals(3))
         self.assertThat(properties['filesets'], Equals({'qux': 'quux'}))
+        self.assertThat(
+            properties['override-stage'], Equals('touch override-stage'))
+        self.assertThat(properties['stage'], Equals(['baz']))
 
     def test_project_options_of_interest(self):
         self.assertFalse(self.state.project_options_of_interest(self.project))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Otherwise they can change without their corresponding steps being considered dirty.