### PR TITLE
extractors: support for setup.py

### DIFF
--- a/snapcraft/extractors/_errors.py
+++ b/snapcraft/extractors/_errors.py
@@ -36,3 +36,26 @@ class AppstreamFileParseError(MetadataExtractionError):
 
     def __init__(self, path: str) -> None:
         super().__init__(path=path)
+
+
+class SetupPyFileParseError(MetadataExtractionError):
+
+    fmt = (
+        "Failed to extract metadata from {path!r}: "
+        "the logic in setup.py is currently not handled."
+    )
+
+    def __init__(self, path: str) -> None:
+        super().__init__(path=path)
+
+
+class SetupPyImportError(MetadataExtractionError):
+
+    fmt = (
+        "Failed to extract metadata from {path!r}: "
+        "some packages or modules used could not be imported: "
+        "{error}"
+    )
+
+    def __init__(self, path: str, error: str) -> None:
+        super().__init__(path=path, error=error)

--- a/snapcraft/extractors/_metadata.py
+++ b/snapcraft/extractors/_metadata.py
@@ -132,6 +132,9 @@ class ExtractedMetadata(yaml.YAMLObject):
         """
         return set(self._data.keys() & other.to_dict().keys())
 
+    def __str__(self) -> str:
+        return str(self._data)
+
     def __eq__(self, other: Any) -> bool:
         if type(other) is type(self):
             return self._data == other._data

--- a/snapcraft/extractors/setuppy.py
+++ b/snapcraft/extractors/setuppy.py
@@ -16,7 +16,7 @@
 
 import os
 import importlib.util
-from typing import Dict
+from typing import Dict  # noqa: F401
 from unittest.mock import patch
 
 from ._metadata import ExtractedMetadata
@@ -31,6 +31,7 @@ def extract(path: str) -> ExtractedMetadata:
     setuppy = importlib.util.module_from_spec(spec)
 
     params = dict()  # type: Dict[str, str]
+
     def _fake_setup(*args, **kwargs):
         nonlocal params
         params = kwargs
@@ -39,7 +40,6 @@ def extract(path: str) -> ExtractedMetadata:
         setup_mock.side_effect = _fake_setup
         spec.loader.exec_module(setuppy)
 
-    # mypy is confused by the use of global
     version = params.get('version')
     description = params.get('description')
 

--- a/snapcraft/extractors/setuppy.py
+++ b/snapcraft/extractors/setuppy.py
@@ -1,0 +1,46 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import importlib.util
+from typing import Dict
+from unittest.mock import patch
+
+from ._metadata import ExtractedMetadata
+from snapcraft.extractors import _errors
+
+
+def extract(path: str) -> ExtractedMetadata:
+    if os.path.basename(path) != 'setup.py':
+        raise _errors.UnhandledFileError(path, 'setup.py')
+
+    spec = importlib.util.spec_from_file_location('setuppy', path)
+    setuppy = importlib.util.module_from_spec(spec)
+
+    params = dict()  # type: Dict[str, str]
+    def _fake_setup(*args, **kwargs):
+        nonlocal params
+        params = kwargs
+
+    with patch('setuptools.setup') as setup_mock:
+        setup_mock.side_effect = _fake_setup
+        spec.loader.exec_module(setuppy)
+
+    # mypy is confused by the use of global
+    version = params.get('version')
+    description = params.get('description')
+
+    return ExtractedMetadata(version=version, description=description)

--- a/tests/fixture_setup.py
+++ b/tests/fixture_setup.py
@@ -1025,11 +1025,12 @@ class SnapcraftYaml(fixtures.Fixture):
         self.path = path
         self.data = {
             'name': name,
-            'version': version,
             'confinement': confinement,
             'parts': {},
             'apps': {}
         }
+        if version is not None:
+            self.data['version'] = version
         if summary is not None:
             self.data['summary'] = summary
         if description is not None:

--- a/tests/integration/general/test_metadata_setuppy.py
+++ b/tests/integration/general/test_metadata_setuppy.py
@@ -1,0 +1,110 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import shutil
+import yaml
+from textwrap import dedent
+
+from testtools.matchers import Equals, FileExists
+
+import tests
+from tests import (
+    fixture_setup,
+    integration
+)
+
+
+class SetupPyMetadataTestCase(integration.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        with open('setup.py', 'w') as setup_file:
+            print(dedent("""\
+                from setuptools import setup
+
+                setup(
+                    name='hello-world',
+                    version='test-setuppy-version',
+                    description='test-setuppy-description',
+                    author='Canonical LTD',
+                    author_email='snapcraft@lists.snapcraft.io',
+                    scripts=['hello']
+                )
+                """), file=setup_file)
+
+    def test_metadata_extracted_from_setuppy(self):
+        snapcraft_yaml = fixture_setup.SnapcraftYaml(
+            self.path, version=None, description=None)
+        snapcraft_yaml.data['adopt-info'] = 'test-part'
+        snapcraft_yaml.update_part(
+            'test-part', {
+                'plugin': 'nil',
+                'parse-info': ['setup.py']})
+        self.useFixture(snapcraft_yaml)
+
+        self.run_snapcraft('prime')
+        snap_yaml_path = os.path.join('prime', 'meta', 'snap.yaml')
+        with open(snap_yaml_path) as snap_yaml_file:
+            snap_yaml = yaml.load(snap_yaml_file)
+
+        self.assertThat(snap_yaml['version'],
+                        Equals('test-setuppy-version'))
+        self.assertThat(snap_yaml['description'],
+                        Equals('test-setuppy-description'))
+
+    def test_all_metadata_from_yaml(self):
+        snapcraft_yaml = fixture_setup.SnapcraftYaml(
+            self.path, version='test-yaml-version',
+            description='test-yaml-description')
+        snapcraft_yaml.data['adopt-info'] = 'test-part'
+        snapcraft_yaml.update_part(
+            'test-part', {
+                'plugin': 'dump',
+                'parse-info': ['setup.py']})
+        self.useFixture(snapcraft_yaml)
+
+        self.run_snapcraft('prime')
+        snap_yaml_path = os.path.join('prime', 'meta', 'snap.yaml')
+        with open(snap_yaml_path) as snap_yaml_file:
+            snap_yaml = yaml.load(snap_yaml_file)
+
+        self.assertThat(snap_yaml['version'],
+                        Equals('test-yaml-version'))
+        self.assertThat(snap_yaml['description'],
+                        Equals('test-yaml-description'))
+
+    def test_version_metadata_from_yaml_description_collected(self):
+        snapcraft_yaml = fixture_setup.SnapcraftYaml(
+            self.path, version='test-yaml-version',
+            description=None)
+        snapcraft_yaml.data['adopt-info'] = 'test-part'
+        snapcraft_yaml.update_part(
+            'test-part', {
+                'plugin': 'dump',
+                'parse-info': ['setup.py']})
+        self.useFixture(snapcraft_yaml)
+
+        self.run_snapcraft('prime')
+        snap_yaml_path = os.path.join('prime', 'meta', 'snap.yaml')
+        with open(snap_yaml_path) as snap_yaml_file:
+            snap_yaml = yaml.load(snap_yaml_file)
+
+        self.assertThat(snap_yaml['version'],
+                        Equals('test-yaml-version'))
+        self.assertThat(snap_yaml['description'],
+                        Equals('test-setuppy-description'))

--- a/tests/integration/general/test_metadata_setuppy.py
+++ b/tests/integration/general/test_metadata_setuppy.py
@@ -15,17 +15,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import shutil
 import yaml
 from textwrap import dedent
 
-from testtools.matchers import Equals, FileExists
+from testtools.matchers import Equals
 
-import tests
-from tests import (
-    fixture_setup,
-    integration
-)
+from tests import integration, fixture_setup
 
 
 class SetupPyMetadataTestCase(integration.TestCase):

--- a/tests/unit/extractors/test_setuppy.py
+++ b/tests/unit/extractors/test_setuppy.py
@@ -14,12 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 from textwrap import dedent
 
 from snapcraft.extractors import setuppy, ExtractedMetadata
 
-import testscenarios
 from testtools.matchers import Equals
 
 from snapcraft.extractors import _errors
@@ -32,10 +30,10 @@ class SetupPyTestCase(unit.TestCase):
         ('description', dict(params=dict(
             version=None,
             description='test-description'))),
-         ('version', dict(params=dict(
+        ('version', dict(params=dict(
             version='test-version',
             description=None))),
-         ('key and version', dict(params=dict(
+        ('key and version', dict(params=dict(
             description='test-description',
             version='test-version')))
     ]

--- a/tests/unit/extractors/test_setuppy.py
+++ b/tests/unit/extractors/test_setuppy.py
@@ -1,0 +1,77 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from textwrap import dedent
+
+from snapcraft.extractors import setuppy, ExtractedMetadata
+
+import testscenarios
+from testtools.matchers import Equals
+
+from snapcraft.extractors import _errors
+from tests import unit
+
+
+class SetupPyTestCase(unit.TestCase):
+
+    scenarios = [
+        ('description', dict(params=dict(
+            version=None,
+            description='test-description'))),
+         ('version', dict(params=dict(
+            version='test-version',
+            description=None))),
+         ('key and version', dict(params=dict(
+            description='test-description',
+            version='test-version')))
+    ]
+
+    def setUp(self):
+        super().setUp()
+
+        params = ['    {}="{}",'.format(k, v)
+                  for k, v in self.params.items() if v]
+
+        with open('setup.py', 'w') as setup_file:
+            print(dedent("""\
+                import setuptools
+
+                setuptools.setup(
+                    name='hello-world',
+                {}
+                    author='Canonical LTD',
+                    author_email='snapcraft@lists.snapcraft.io',
+                    scripts=['hello']
+                )
+            """).format('\n'.join(params)), file=setup_file)
+
+    def test_info_extraction(self):
+        expected = ExtractedMetadata(**self.params)
+        actual = setuppy.extract('setup.py')
+        self.assertThat(str(actual), Equals(str(expected)))
+        self.assertThat(actual, Equals(expected))
+
+
+class SetupPyUnhandledFileTestCase(unit.TestCase):
+
+    def test_unhandled_file_test_case(self):
+        raised = self.assertRaises(
+            _errors.UnhandledFileError, setuppy.extract,
+            'unhandled-file')
+
+        self.assertThat(raised.path, Equals('unhandled-file'))
+        self.assertThat(raised.extractor_name, Equals('setup.py'))


### PR DESCRIPTION
Add support for loading setup.py and retrieving version and
description information from it.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
