### PR TITLE
python plugin: do not invoke wheel install if empty

### DIFF
--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -327,7 +327,8 @@ class PythonPlugin(snapcraft.BasePlugin):
             constraints=constraints, requirements=requirements,
             process_dependency_links=self.options.process_dependency_links)
 
-        self._install_wheels(wheels)
+        if wheels:
+            self._install_wheels(wheels)
 
         if setup_py_dir is not None:
             setup_py_path = os.path.join(setup_py_dir, 'setup.py')


### PR DESCRIPTION
If there are no wheels to install then do not even attempt to install.

This behavior is recently changing due to pip 10 being released.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
