### PR TITLE
repo: catch error updating the package cache

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -122,8 +122,11 @@ class _AptCache:
                 "Cannot find 'dpkg' command needed to support multiarch")
 
         apt_cache = apt.Cache(rootdir=cache_dir, memonly=True)
-        apt_cache.update(fetch_progress=self.progress,
-                         sources_list=sources_list_file)
+        try:
+            apt_cache.update(fetch_progress=self.progress,
+                             sources_list=sources_list_file)
+        except apt.cache.FetchFailedException:
+            raise errors.CacheUpdateFailedError()
 
         return apt_cache
 

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -19,6 +19,7 @@ import glob
 import hashlib
 import logging
 import os
+import re
 import shutil
 import stat
 import string
@@ -54,6 +55,8 @@ deb http://${security}.ubuntu.com/${suffix} ${release}-security multiverse
 '''
 _GEOIP_SERVER = "http://geoip.ubuntu.com/lookup"
 _library_list = dict()  # type: Dict[str, Set[str]]
+_HASHSUM_MISMATCH_PATTERN = re.compile(
+    r'(E:Failed to fetch copy.+Hash Sum mismatch)+')
 
 
 class _AptCache:
@@ -121,13 +124,28 @@ class _AptCache:
             logger.warning(
                 "Cannot find 'dpkg' command needed to support multiarch")
 
+        return self._create_cache(cache_dir, sources_list_file)
+
+    def _create_cache(self, cache_dir: str,
+                      sources_list_file: str) -> apt.Cache:
         apt_cache = apt.Cache(rootdir=cache_dir, memonly=True)
         try:
             apt_cache.update(fetch_progress=self.progress,
                              sources_list=sources_list_file)
-        except apt.cache.FetchFailedException:
-            raise errors.CacheUpdateFailedError()
-
+        except apt.cache.FetchFailedException as e:
+            # In case of a hashsum mismatch, clear the index and try again.
+            # Re-raise the error if that failed.
+            if re.match(_HASHSUM_MISMATCH_PATTERN, str(e)):
+                try:
+                    index = apt.apt_pkg.config.find_dir('Dir::State::Lists')
+                    shutil.rmtree(index)
+                    apt_cache = apt.Cache(rootdir=cache_dir, memonly=True)
+                    apt_cache.update(fetch_progress=self.progress,
+                                     sources_list=sources_list_file)
+                except apt.cache.FetchFailedException as retry:
+                    raise errors.CacheUpdateFailedError(str(retry))
+            else:
+                raise errors.CacheUpdateFailedError(str(e))
         return apt_cache
 
     @contextlib.contextmanager

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -56,7 +56,7 @@ deb http://${security}.ubuntu.com/${suffix} ${release}-security multiverse
 _GEOIP_SERVER = "http://geoip.ubuntu.com/lookup"
 _library_list = dict()  # type: Dict[str, Set[str]]
 _HASHSUM_MISMATCH_PATTERN = re.compile(
-    r'(E:Failed to fetch copy.+Hash Sum mismatch)+')
+    r'(E:Failed to fetch.+Hash Sum mismatch)+')
 
 
 class _AptCache:

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -42,12 +42,16 @@ class CacheUpdateFailedError(RepoError):
 
     fmt = (
         "Failed to update the package cache: "
-        "Some files could not be downloaded. "
+        "Some files could not be downloaded:{errors}"
         "Check that the sources on your host are configured correctly."
     )
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, errors: str) -> None:
+        if errors:
+            errors = '\n\n{}\n\n'.format(errors.replace(', ', '\n'))
+        else:
+            errors = ' '
+        super().__init__(errors=errors)
 
 
 class BuildPackageNotFoundError(RepoError):

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -38,6 +38,18 @@ class NoNativeBackendError(RepoError):
         super().__init__(distro=distro)
 
 
+class CacheUpdateFailedError(RepoError):
+
+    fmt = (
+        "Failed to update the package cache: "
+        "Some files could not be downloaded. "
+        "Check that the sources on your host are configured correctly."
+    )
+
+    def __init__(self):
+        super().__init__()
+
+
 class BuildPackageNotFoundError(RepoError):
 
     fmt = "Could not find a required package in 'build-packages': {package}"

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import apt
 import os
 from subprocess import CalledProcessError
 from unittest.mock import ANY, call, patch, MagicMock
@@ -51,6 +52,16 @@ class UbuntuTestCase(RepoBaseTestCase):
         self.mock_package.candidate.fetch_binary.side_effect = _fetch_binary
         self.mock_cache.return_value.get_changes.return_value = [
             self.mock_package]
+
+    def test_cache_update_failed(self):
+        self.mock_cache().update.side_effect = apt.cache.FetchFailedException()
+        project_options = snapcraft.ProjectOptions(
+            use_geoip=False)
+        ubuntu = repo.Ubuntu(self.tempdir, project_options=project_options)
+        self.assertRaises(
+            errors.CacheUpdateFailedError,
+            ubuntu.get,
+            ['fake-package'])
 
     def test_get_pkg_name_parts_name_only(self):
         name, version = repo.get_pkg_name_parts('hello')

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -20,6 +20,7 @@ from testtools.matchers import Equals
 
 from snapcraft.internal import errors
 from snapcraft.internal.meta import _errors as meta_errors
+from snapcraft.internal.repo import errors as repo_errors
 from tests import unit
 
 
@@ -427,6 +428,15 @@ class ErrorFormattingTestCase(unit.TestCase):
                 "Exited with code 2.\n"
                 "Verify that the part is using the correct parameters and try "
                 "again."
+            )
+        }),
+        ('CacheUpdateFailedError', {
+            'exception': repo_errors.CacheUpdateFailedError,
+            'kwargs': {},
+            'expected_message': (
+                "Failed to update the package cache: "
+                "Some files could not be downloaded. "
+                "Check that the sources on your host are configured correctly."
             )
         }),
     )

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -432,10 +432,19 @@ class ErrorFormattingTestCase(unit.TestCase):
         }),
         ('CacheUpdateFailedError', {
             'exception': repo_errors.CacheUpdateFailedError,
-            'kwargs': {},
+            'kwargs': {'errors': ''},
             'expected_message': (
                 "Failed to update the package cache: "
-                "Some files could not be downloaded. "
+                "Some files could not be downloaded: "
+                "Check that the sources on your host are configured correctly."
+            )
+        }),
+        ('CacheUpdateFailedError', {
+            'exception': repo_errors.CacheUpdateFailedError,
+            'kwargs': {'errors': 'foo, bar'},
+            'expected_message': (
+                "Failed to update the package cache: "
+                "Some files could not be downloaded:\n\nfoo\nbar\n\n"
                 "Check that the sources on your host are configured correctly."
             )
         }),


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This PR handles errors when updating the package cache, such as a hash mismatch or unresolved hostnames. The apt API doesn't distinguish these, so unfortunately we can't be very specific here but need to rely on the output we get before the error is raised.
If the error is a hashsum mismatch, the index will be cleared and Snapcraft will continue.

Fixes: #2029 #2030 
Fixes: [LP: #1747715](https://bugs.launchpad.net/snapcraft/+bug/1747715)

The following tests are added/ modified:

 - tests.unit.test_errors
 - To verify CacheUpdateFailedError
 - tests.unit.repo.test_deb.UbuntuTestCase.test_cache_update_failed
 - To verify that an `apt.cache.FetchFailedException` is handled as a proper error.
 - tests.unit.repo.test_deb.UbuntuTestCase.test_cache_hashsum_mismatch
 - To verify that a hashsum error will be caught and proceed after clearing the index.

I locally ran the tests:
 - `./runtests.sh tests/unit` with unrelated failures in [tests.unit.test_lifecycle.CoreSetupTestCase.test_core_setup_if_docker_env](https://bugs.launchpad.net/snapcraft/+bug/1752576), `tests.unit.test_mangling.TestClearExecstack.test_execstack_clears` and `tests.unit.test_elf`.
 - `./runtests.sh tests/integration` with one unrelated failure in [tests.integration.general.test_parser.TestParserWikis](https://bugs.launchpad.net/snapcraft/+bug/1752580)
 - `./runtests.sh static`: Everything passed

Manual test steps:
 - cd tests/integration/snaps/go-hello
 - Add a stage package:
   stages-packages: [appstream]
 - Modify `/etc/apt/sources.list` so that it can't update successfully, such as by adding an invalid URL.
 - snapcraft
 - Observe the error "Failed to update the package cache: Some files could not be downloaded. Check that the sources on your host are configured correctly.".