### PR TITLE
project_loader: support architectures for CI

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -99,12 +99,31 @@ properties:
           "{.instance!r} is not a valid snap name. Snap names cannot have two
           hyphens in a row."
   architectures:
+    description: architectures on which to build, and on which the resulting snap runs
     type: array
-    description: architectures to override with
     minItems: 1
     uniqueItems: true
+    format: architectures
     items:
-      - type: string
+      anyOf:
+        - type: string
+        - type: object
+          additionalProperties: false
+          required:
+            - build-on
+          properties:
+            build-on:
+              anyOf:
+                - type: string
+                - type: array
+                  minItems: 1
+                  uniqueItems: true
+            run-on:
+              anyOf:
+                - type: string
+                - type: array
+                  minItems: 1
+                  uniqueItems: true
   version:
     # python's defaul yaml loading code loads 1.0 as an int
     # type: string

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -407,18 +407,18 @@ def _expand_filesets_for(step, properties):
 
 class _Architecture:
     def __init__(self, *, build_on, run_on=None):
-        self.build_on = build_on
         if isinstance(build_on, str):
             self.build_on = [build_on]
-
-        self.run_on = run_on
-        if isinstance(run_on, str):
-            self.run_on = [run_on]
+        else:
+            self.build_on = build_on
 
         # If there is no run_on, it defaults to the value of build_on
         if not run_on:
             self.run_on = self.build_on
-
+        elif isinstance(run_on, str):
+            self.run_on = [run_on]
+        else:
+            self.run_on = run_on
 
 def _get_architecture_list(architectures, current_arch):
     if not architectures:

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -234,7 +234,7 @@ class Config:
                                  snapcraft_yaml=self.snapcraft_yaml_path)
 
         self.data['architectures'] = _process_architectures(
-            self.data.get('architectures'), self._project_options)
+            self.data.get('architectures'), self._project_options.deb_arch)
 
     def get_metadata(self):
         return {'name': self.data['name'],
@@ -440,8 +440,7 @@ def _get_architecture_list(architectures, current_arch):
     return architecture_list
 
 
-def _process_architectures(architectures, project):
-    current_arch = project.deb_arch
+def _process_architectures(architectures, current_arch):
     architecture_list = _get_architecture_list(architectures, current_arch)
 
     for architecture in architecture_list:

--- a/snapcraft/internal/project_loader/errors.py
+++ b/snapcraft/internal/project_loader/errors.py
@@ -136,7 +136,11 @@ def _determine_cause(error):
             key = contextual_error.schema_path.popleft()
             if key not in contextual_messages:
                 contextual_messages[key] = []
-            contextual_messages[key].append(contextual_error.message)
+            message = contextual_error.message
+            if message:
+                # Sure it starts lower-case (not all messages do)
+                contextual_messages[key].append(
+                    message[0].lower() + message[1:])
 
         oneOf_messages = []  # type: List[str]
         for key, value in contextual_messages.items():

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -214,6 +214,7 @@ class TestCase(testtools.TestCase):
                        summary='Simple test snap',
                        description='Something something',
                        grade=None,
+                       architectures=None,
                        parts=dedent('''\
                            my-part:
                              plugin: nil
@@ -234,6 +235,8 @@ class TestCase(testtools.TestCase):
             snapcraft_yaml['adopt-info'] = adopt_info
         if grade:
             snapcraft_yaml['grade'] = grade
+        if architectures:
+            snapcraft_yaml['architectures'] = architectures
 
         with open('snapcraft.yaml', 'w') as f:
             yaml.dump(snapcraft_yaml, f, default_flow_style=False)

--- a/tests/integration/general/test_architectures.py
+++ b/tests/integration/general/test_architectures.py
@@ -1,0 +1,59 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import yaml
+
+from testtools.matchers import Equals
+
+from tests import integration
+
+
+class ArchitecturesTestCase(integration.TestCase):
+
+    def test_simple_architecture(self):
+        self.construct_yaml(architectures=[self.deb_arch])
+
+        self.run_snapcraft('prime')
+
+        with open(os.path.join('prime', 'meta', 'snap.yaml')) as f:
+            y = yaml.load(f)
+
+        self.assertThat(y['architectures'], Equals([self.deb_arch]))
+
+    def test_build_and_run_on_architecture(self):
+        self.construct_yaml(architectures=[
+            {'build-on': [self.deb_arch], 'run-on': [self.deb_arch]},
+        ])
+
+        self.run_snapcraft('prime')
+
+        with open(os.path.join('prime', 'meta', 'snap.yaml')) as f:
+            y = yaml.load(f)
+
+        self.assertThat(y['architectures'], Equals([self.deb_arch]))
+
+    def test_default_architecture(self):
+        self.construct_yaml(architectures=[
+            {'build-on': ['other-arch']},
+        ])
+
+        self.run_snapcraft('prime')
+
+        with open(os.path.join('prime', 'meta', 'snap.yaml')) as f:
+            y = yaml.load(f)
+
+        self.assertThat(y['architectures'], Equals([self.deb_arch]))

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -43,7 +43,9 @@ class SnapCommandBaseTestCase(CommandBaseTestCase):
         version: 1.0
         summary: test snapping
         description: if snap is successful a snap package will be available
-        architectures: ['amd64']
+        architectures:
+          - build-on: all
+            run-on: 'amd64'
         type: {}
         confinement: strict
         grade: stable

--- a/tests/unit/project_loader/test_config.py
+++ b/tests/unit/project_loader/test_config.py
@@ -2702,32 +2702,34 @@ class InvalidArchitecturesTestCase(ValidationBaseTestCase):
                 {'build-on': ['amd64'], 'run-on': ['all']},
                 {'build-on': ['i396'], 'run-on': ['i386']},
             ],
-            'message': "one of the items has 'all' in 'run-on', which only "
-                       "makes sense if it's the only item, and there are 2",
+            'message': "one of the items has 'all' in 'run-on', but there are "
+                       "2 items: upon release they will conflict. 'all' "
+                       "should only be used if there is a single item",
         }),
         ('build on all and more objects', {
             'architectures': [
                 {'build-on': ['all']},
                 {'build-on': ['i396']},
             ],
-            'message': "one of the items has 'all' in 'build-on', which only "
-                       "makes sense if it's the only item, and there are 2",
+            'message': "one of the items has 'all' in 'build-on', but there "
+                       "are 2 items: snapcraft doesn't know which one to use. "
+                       "'all' should only be used if there is a single item",
         }),
         ('multiple builds run on same arch', {
             'architectures': [
                 {'build-on': ['amd64'], 'run-on': ['amd64']},
                 {'build-on': ['i396'], 'run-on': ['amd64', 'i386']},
             ],
-            'message': "multiple items will build snaps that claim they run "
-                       "on 'amd64'",
+            'message': "multiple items will build snaps that claim to run on "
+                       "'amd64'",
         }),
         ('multiple builds run on same arch with implicit run-on', {
             'architectures': [
                 {'build-on': ['amd64']},
                 {'build-on': ['i396'], 'run-on': ['amd64', 'i386']},
             ],
-            'message': "multiple items will build snaps that claim they run "
-                       "on 'amd64'",
+            'message': "multiple items will build snaps that claim to run on "
+                       "'amd64'",
         }),
         ('mixing forms', {
             'architectures': [
@@ -2741,15 +2743,18 @@ class InvalidArchitecturesTestCase(ValidationBaseTestCase):
                 {'build-on': ['all'], 'run-on': ['amd64']},
                 {'build-on': ['all'], 'run-on': ['i386']},
             ],
-            'message': "one of the items has 'all' in 'build-on', which only "
-                       "makes sense if it's the only item, and there are 2",
+            'message': "one of the items has 'all' in 'build-on', but there "
+                       "are 2 items: snapcraft doesn't know which one to use. "
+                       "'all' should only be used if there is a single item",
         }),
         ('build on overlap', {
             'architectures': [
                 {'build-on': ['amd64', 'i386'], 'run-on': ['i386']},
                 {'build-on': ['amd64'], 'run-on': ['amd64']},
             ],
-            'message': "ambiguous run-ons when building on 'amd64'",
+            'message': "'amd64' is present in the 'build-on' of multiple "
+                       "items, which means snapcraft doesn't know which "
+                       "'run-on' to use when building on that architecture",
         }),
     ]
 

--- a/tests/unit/project_loader/test_config.py
+++ b/tests/unit/project_loader/test_config.py
@@ -515,7 +515,9 @@ parts:
 version: "1"
 summary: test
 description: nothing
-architectures: ['amd64']
+architectures:
+  - build-on: all
+    run-on: amd64
 confinement: strict
 grade: stable
 
@@ -1574,6 +1576,130 @@ parts:
             "followed by an optional asterisk\)")
 
 
+class ValidArchitecturesYamlTestCase(YamlBaseTestCase):
+
+    yaml_scenarios = [
+        ('none', {
+            'expected_amd64': ['amd64'],
+            'expected_i386': ['i386'],
+            'expected_armhf': ['armhf'],
+            'yaml': None,
+        }),
+        ('single string list', {
+            'expected_amd64': ['amd64'],
+            'expected_i386': ['i386'],
+            'expected_armhf': ['armhf'],
+            'yaml': '[amd64]',
+        }),
+        ('multiple string list', {
+            'expected_amd64': ['amd64', 'i386'],
+            'expected_i386': ['amd64', 'i386'],
+            'expected_armhf': ['armhf'],
+            'yaml': '[amd64, i386]',
+        }),
+        ('single object list', {
+            'expected_amd64': ['amd64'],
+            'expected_i386': ['i386'],
+            'expected_armhf': ['armhf'],
+            'yaml': dedent("""
+                - build-on: [amd64]
+                  run-on: [amd64]
+            """),
+        }),
+        ('multiple object list', {
+            'expected_amd64': ['amd64'],
+            'expected_i386': ['i386'],
+            'expected_armhf': ['armhf', 'arm64'],
+            'yaml': dedent("""
+                - build-on: [amd64]
+                  run-on: [amd64]
+                - build-on: [i386]
+                  run-on: [i386]
+                - build-on: [armhf]
+                  run-on: [armhf, arm64]
+            """),
+        }),
+        ('omit run-on', {
+            'expected_amd64': ['amd64'],
+            'expected_i386': ['i386'],
+            'expected_armhf': ['armhf'],
+            'yaml': dedent("""
+                - build-on: [amd64]
+            """),
+        }),
+        ('single build-on string, no list', {
+            'expected_amd64': ['amd64'],
+            'expected_i386': ['i386'],
+            'expected_armhf': ['armhf'],
+            'yaml': dedent("""
+                - build-on: amd64
+            """),
+        }),
+        ('build- and run-on string, no lists', {
+            'expected_amd64': ['amd64'],
+            'expected_i386': ['amd64'],
+            'expected_armhf': ['armhf'],
+            'yaml': dedent("""
+                - build-on: i386
+                  run-on: amd64
+            """),
+        }),
+        ('build on all', {
+            'expected_amd64': ['amd64'],
+            'expected_i386': ['amd64'],
+            'expected_armhf': ['amd64'],
+            'yaml': dedent("""
+                - build-on: [all]
+                  run-on: [amd64]
+            """),
+        }),
+        ('run on all', {
+            'expected_amd64': ['all'],
+            'expected_i386': ['i386'],
+            'expected_armhf': ['armhf'],
+            'yaml': dedent("""
+                - build-on: [amd64]
+                  run-on: [all]
+            """),
+        }),
+    ]
+
+    arch_scenarios = [
+        ('amd64', {'arch': 'amd64'}),
+        ('i386', {'arch': 'i386'}),
+        ('armhf', {'arch': 'armhf'}),
+    ]
+
+    scenarios = multiply_scenarios(yaml_scenarios, arch_scenarios)
+
+    def test_architectures(self):
+        snippet = ''
+        if self.yaml:
+            snippet = 'architectures: {}'.format(self.yaml)
+        self.make_snapcraft_yaml(dedent("""\
+            name: test
+            version: "1"
+            summary: test
+            description: test
+            {}
+            parts:
+              my-part:
+                plugin: nil
+        """).format(snippet))
+
+        # with open(os.path.join('snap', 'snapcraft.yaml'), 'r') as f:
+        #     raise RuntimeError(f.read())
+
+        try:
+            c = _config.Config(
+                snapcraft.project.Project(target_deb_arch=self.arch))
+
+            expected = getattr(self, 'expected_{}'.format(self.arch))
+            self.assertThat(c.data['architectures'], Equals(expected))
+        except errors.YamlValidationError as e:
+            self.fail('Expected YAML to be valid, got an error: {}'.format(e))
+
+
 class InitTestCase(unit.TestCase):
 
     def test_config_raises_on_missing_snapcraft_yaml(self):
@@ -2542,6 +2668,103 @@ class InvalidPartNamesTestCase(ValidationBaseTestCase):
             "name.").format(self.name)
         self.assertThat(raised.message, Equals(expected_message),
                         message=data)
+
+
+class InvalidArchitecturesTestCase(ValidationBaseTestCase):
+
+    scenarios = [
+        ('single string', {
+            'architectures': 'amd64',
+            'message': "'amd64' is not of type 'array'",
+        }),
+        ('unknown object properties', {
+            'architectures': [{'builds-on': ['amd64'], 'runs-on': ['amd64']}],
+            'message': "'build-on' is a required property and additional "
+                       "properties are not allowed",
+        }),
+        ('omit build-on', {
+            'architectures': [{'run-on': ['amd64']}],
+            'message': "'build-on' is a required property",
+        }),
+        ('build on all and others', {
+            'architectures': [{'build-on': ['amd64', 'all']}],
+            'message': "'all' can only be used within 'build-on' by itself, "
+                       "not with other architectures",
+        }),
+        ('run on all and others', {
+            'architectures': [
+                {'build-on': ['amd64'], 'run-on': ['amd64', 'all']}],
+            'message': "'all' can only be used within 'run-on' by itself, "
+                       "not with other architectures",
+        }),
+        ('run on all and more objects', {
+            'architectures': [
+                {'build-on': ['amd64'], 'run-on': ['all']},
+                {'build-on': ['i396'], 'run-on': ['i386']},
+            ],
+            'message': "one of the items has 'all' in 'run-on', which only "
+                       "makes sense if it's the only item, and there are 2",
+        }),
+        ('build on all and more objects', {
+            'architectures': [
+                {'build-on': ['all']},
+                {'build-on': ['i396']},
+            ],
+            'message': "one of the items has 'all' in 'build-on', which only "
+                       "makes sense if it's the only item, and there are 2",
+        }),
+        ('multiple builds run on same arch', {
+            'architectures': [
+                {'build-on': ['amd64'], 'run-on': ['amd64']},
+                {'build-on': ['i396'], 'run-on': ['amd64', 'i386']},
+            ],
+            'message': "multiple items will build snaps that claim they run "
+                       "on 'amd64'",
+        }),
+        ('multiple builds run on same arch with implicit run-on', {
+            'architectures': [
+                {'build-on': ['amd64']},
+                {'build-on': ['i396'], 'run-on': ['amd64', 'i386']},
+            ],
+            'message': "multiple items will build snaps that claim they run "
+                       "on 'amd64'",
+        }),
+        ('mixing forms', {
+            'architectures': [
+                'amd64',
+                {'build-on': ['i386'], 'run-on': ['amd64', 'i386']},
+            ],
+            'message': 'every item must either be a string or an object',
+        }),
+        ('build on all run on specific', {
+            'architectures': [
+                {'build-on': ['all'], 'run-on': ['amd64']},
+                {'build-on': ['all'], 'run-on': ['i386']},
+            ],
+            'message': "one of the items has 'all' in 'build-on', which only "
+                       "makes sense if it's the only item, and there are 2",
+        }),
+        ('build on overlap', {
+            'architectures': [
+                {'build-on': ['amd64', 'i386'], 'run-on': ['i386']},
+                {'build-on': ['amd64'], 'run-on': ['amd64']},
+            ],
+            'message': "ambiguous run-ons when building on 'amd64'",
+        }),
+    ]
+
+    def test_invalid_architectures(self):
+        data = self.data.copy()
+        data['architectures'] = self.architectures
+
+        raised = self.assertRaises(
+            errors.YamlValidationError,
+            project_loader.Validator(data).validate)
+
+        self.assertThat(
+            raised.message, MatchesRegex(
+                "The 'architectures.*?' property does not match the required "
+                "schema: {}".format(self.message)), message=data)
 
 
 class TestPluginLoadingProperties(unit.TestCase):

--- a/tests/unit/project_loader/test_config.py
+++ b/tests/unit/project_loader/test_config.py
@@ -1665,9 +1665,9 @@ class ValidArchitecturesYamlTestCase(YamlBaseTestCase):
     ]
 
     arch_scenarios = [
-        ('amd64', {'arch': 'amd64'}),
-        ('i386', {'arch': 'i386'}),
-        ('armhf', {'arch': 'armhf'}),
+        ('amd64', {'deb_arch': 'amd64'}),
+        ('i386', {'deb_arch': 'i386'}),
+        ('armhf', {'deb_arch': 'armhf'}),
     ]
 
     scenarios = multiply_scenarios(yaml_scenarios, arch_scenarios)
@@ -1687,14 +1687,11 @@ class ValidArchitecturesYamlTestCase(YamlBaseTestCase):
                 plugin: nil
         """).format(snippet))
 
-        # with open(os.path.join('snap', 'snapcraft.yaml'), 'r') as f:
-        #     raise RuntimeError(f.read())
-
         try:
             c = _config.Config(
-                snapcraft.project.Project(target_deb_arch=self.arch))
+                snapcraft.project.Project(target_deb_arch=self.deb_arch))
 
-            expected = getattr(self, 'expected_{}'.format(self.arch))
+            expected = getattr(self, 'expected_{}'.format(self.deb_arch))
             self.assertThat(c.data['architectures'], Equals(expected))
         except errors.YamlValidationError as e:
             self.fail('Expected YAML to be valid, got an error: {}'.format(e))

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -50,7 +50,7 @@ class CreateBaseTestCase(unit.TestCase):
         super().setUp()
 
         self.config_data = {
-            'architectures': ['amd64'],
+            'architectures': [{'build-on': 'all', 'run-on': 'amd64'}],
             'name': 'my-package',
             'version': '1.0',
             'description': 'my description',
@@ -112,6 +112,22 @@ class CreateTestCase(CreateBaseTestCase):
         y = self.generate_meta_yaml()
 
         expected = {'architectures': ['amd64'],
+                    'confinement': 'devmode',
+                    'grade': 'stable',
+                    'description': 'my description',
+                    'environment': {'GLOBAL': 'y'},
+                    'summary': 'my summary',
+                    'name': 'my-package',
+                    'version': '1.0'}
+
+        self.assertThat(y, Equals(expected))
+
+    def test_create_meta_default_architecture(self):
+        del self.config_data['architectures']
+
+        y = self.generate_meta_yaml()
+
+        expected = {'architectures': [self.project_options.deb_arch],
                     'confinement': 'devmode',
                     'grade': 'stable',
                     'description': 'my description',


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

This PR resolves #1685 by changing the `architectures` keyword according to the new CI-friendly proposal [here](https://forum.snapcraft.io/t/4675). This adds support for new syntax to that keyword:

    architectures:
      - build-on: [<build arch 1>, <build arch 2>]
        run-on: [<run arch 1>, <run arch 2>]

Please see the proposal for more details.