### PR TITLE
elf: patch everything instead of a subset of elf files

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -606,20 +606,6 @@ def get_elf_files(root: str,
     return frozenset(elf_files)
 
 
-def get_elf_files_to_patch(elf_files):
-    # type: (FrozenSet[ElfFile]) -> FrozenSet[ElfFile]
-    """Return a frozenset of elf files that need patching."""
-    sonames = {(elf.arch, elf.soname): elf for elf in elf_files
-               if elf.soname != ''}
-    referenced_libraries = set()
-    for elf in elf_files:
-        for soname in elf.needed:
-            lib = sonames.get((elf.arch, soname))
-            if lib is not None:
-                referenced_libraries.add(lib)
-    return elf_files - referenced_libraries
-
-
 def _get_dynamic_linker(library_list: List[str]) -> str:
     """Return the dynamic linker from library_list."""
     regex = re.compile(r'(?P<dynamic_linker>ld-[\d.]+.so)$')

--- a/snapcraft/internal/pluginhandler/_patchelf.py
+++ b/snapcraft/internal/pluginhandler/_patchelf.py
@@ -121,8 +121,11 @@ class PartPatcher:
             dynamic_linker=dynamic_linker,
             root_path=self._primedir,
             preferred_patchelf_path=preferred_patchelf_path)
-        files_to_patch = elf.get_elf_files_to_patch(self._elf_files)
-        for elf_file in files_to_patch:
+
+        # Patching all files instead of a subset of them to ensure the
+        # environment is consistent and the chain of dlopens that may
+        # happen remains sane.
+        for elf_file in self._elf_files:
             try:
                 elf_patcher.patch(elf_file=elf_file)
             except errors.PatcherError as patch_error:

--- a/tests/unit/test_elf.py
+++ b/tests/unit/test_elf.py
@@ -337,18 +337,6 @@ class TestGetElfFiles(TestElfBase):
         self.assertThat(elf_files, Equals(set()))
 
 
-class TestGetElfFilesToPatch(TestElfBase):
-
-    def test_get_elf_files_to_patch(self):
-        elf_files = elf.get_elf_files(
-            self.fake_elf.root_path,
-            {'libc.so.6', 'libssl.so.1.0.0', 'fake_elf-shared-object',
-             'fake_elf-2.26'})
-        to_patch = elf.get_elf_files_to_patch(elf_files)
-        self.assertThat({os.path.basename(e.path) for e in to_patch},
-                        Equals({'fake_elf-shared-object', 'fake_elf-2.26'}))
-
-
 class TestGetRequiredGLIBC(TestElfBase):
 
     def setUp(self):


### PR DESCRIPTION
Bring back the behavior of 2.39, this is a half revert of
commit 64f78f762a05122fafe0a4d5defced2965603fb7

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
