### PR TITLE
python plugin: properly handle distutils on bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ jobs:
     - if: type != cron
       script: sudo ./tools/travis/run_tests.sh tests.integration.plugins_python
     - if: type != cron
+      script: LXD_IMAGE="ubuntu-daily:bionic" sudo ./tools/travis/run_tests.sh tests.integration.plugins_python
+    - if: type != cron
       script: sudo ./tools/travis/run_tests.sh tests.integration.plugins_catkin
     - if: type != cron
       script: sudo ./tools/travis/run_tests.sh tests/integration/store

--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -159,9 +159,9 @@ class PythonPlugin(snapcraft.BasePlugin):
             return
 
         stage_packages = [python_base]
-        if release_codename == 'bionic':
-            # In bionic, pip started requiring python-distutils to be
-            # installed.
+        # In bionic, python3's pip started requiring python-distutils
+        # to be installed.
+        if python_base == 'python3' and release_codename == 'bionic':
             stage_packages.append('{}-distutils'.format(python_base))
         return stage_packages
 

--- a/tests/unit/plugins/test_python.py
+++ b/tests/unit/plugins/test_python.py
@@ -399,7 +399,7 @@ class PythonPluginTestCase(BasePythonPluginTestCase):
                                      self.project_options)
         self.assertThat(
             plugin.plugin_stage_packages,
-            Equals(['python', 'python-distutils']))
+            Equals(['python']))
 
     def test_plugin_stage_packages_python3_bionic(self):
         self.options.python_version = 'python3'


### PR DESCRIPTION
distutils has been split out into its own package for python3 but
not for python2.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
