### PR TITLE
elf: clear the current runpath before setting the rpath

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -384,13 +384,17 @@ class Patcher:
         if elf_file.interp:
             patchelf_args.extend(['--set-interpreter',  self._dynamic_linker])
         if elf_file.dependencies:
+            rpath = self._get_rpath(elf_file)
+            # Due to https://github.com/NixOS/patchelf/issues/94 we need
+            # to first clear the current rpath
+            self._run_patchelf(patchelf_args=['--remove-rpath'],
+                               elf_file_path=elf_file.path)
             # Parameters:
             # --force-rpath: use RPATH instead of RUNPATH.
             # --shrink-rpath: will remove unneeded entries, with the
             #                 side effect of preferring host libraries
             #                 so we simply do not use it.
             # --set-rpath: set the RPATH to the colon separated argument.
-            rpath = self._get_rpath(elf_file)
             patchelf_args.extend(['--force-rpath', '--set-rpath', rpath])
 
         # no patchelf_args means there is nothing to do.


### PR DESCRIPTION
Given https://github.com/NixOS/patchelf/issues/94 we may find ourselves
in a situation where given an elf file with an existing RUNPATH, a
proper RPATH may not be set.

Resolve #2071

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
