### PR TITLE
tests: update metadata store integration test, no previous push required

### DIFF
--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -681,17 +681,6 @@ class FakeStoreAPIServer(base.BaseFakeServer):
 
     def snap_metadata(self, request):
         logger.debug('Handling metadata request')
-        snap_id = request.matchdict['snap_id']
-
-        # check if snap was previously pushed
-        if snap_id not in self.pushed_snaps:
-            err = {'error_list': [
-                {'message': 'Snap not found', 'code': 'not-found'}]}
-            payload = json.dumps(err).encode('utf8')
-            response_code = 404
-            content_type = 'application/json'
-            return response.Response(
-                payload, response_code, [('Content-Type', content_type)])
 
         if 'invalid' in request.json_body:
             err = {'error_list': [{

--- a/tests/integration/store/test_store_push_metadata.py
+++ b/tests/integration/store/test_store_push_metadata.py
@@ -64,7 +64,7 @@ class PushMetadataTestCase(integration.StoreTestCase):
         expected = "The metadata has been pushed"
         self.assertThat(output, Contains(expected))
 
-    def test_need_push_first(self):
+    def test_no_push_needed_first(self):
         self.addCleanup(self.logout)
         self.login()
 
@@ -72,9 +72,9 @@ class PushMetadataTestCase(integration.StoreTestCase):
         name, snap_file_path = self._build_snap()
         self.register(name)
 
-        # Push the metadata withouth pusing the binary first
-        error = self.assertRaises(
-            subprocess.CalledProcessError,
-            self.run_snapcraft, ['push-metadata', snap_file_path])
-        expected = "Sorry, updating the information on the store has failed"
-        self.assertThat(str(error.output), Contains(expected))
+        # Now push the metadata
+        output = self.run_snapcraft(['push-metadata', snap_file_path])
+        expected = "Pushing metadata to the Store (force=False)"
+        self.assertThat(output, Contains(expected))
+        expected = "The metadata has been pushed"
+        self.assertThat(output, Contains(expected))


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [X] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [X] Have you successfully run `./runtests.sh static`?
- [X] Have you successfully run `./runtests.sh unit`?

-----

We have implemented some changes in the store initializing the snap package on snap name approval, allowing to update the snap metadata (through web UI or snapcraft) without needing to push any revision.
