### PR TITLE
many: remove support for remote lxd per project containers

### DIFF
--- a/snapcraft/cli/_command_group.py
+++ b/snapcraft/cli/_command_group.py
@@ -62,6 +62,6 @@ class SnapcraftGroup(click.Group):
         # from the store.
         commands.pop(commands.index('edit-collaborators'))
         build_environment = env.BuilderEnvironmentConfig()
-        if build_environment.provider == 'host':
+        if build_environment.is_host:
             commands.pop(commands.index('refresh'))
         return commands

--- a/snapcraft/cli/_command_group.py
+++ b/snapcraft/cli/_command_group.py
@@ -61,7 +61,7 @@ class SnapcraftGroup(click.Group):
         # Let's keep edit-collaborators hidden until we get the green light
         # from the store.
         commands.pop(commands.index('edit-collaborators'))
-        container_config = env.get_container_config()
-        if not container_config.use_container:
+        build_environment = env.BuilderEnvironmentConfig()
+        if build_environment.provider == 'host':
             commands.pop(commands.index('refresh'))
         return commands

--- a/snapcraft/cli/containers.py
+++ b/snapcraft/cli/containers.py
@@ -41,11 +41,11 @@ def refresh(debug, **kwargs):
     as needed as well as refreshing snaps.
     """
 
-    container_config = env.get_container_config()
-    if not container_config.use_container:
+    build_environment = env.BuilderEnvironmentConfig()
+    if build_environment.is_host:
         raise errors.SnapcraftEnvironmentError(
             "The 'refresh' command only applies to LXD containers but "
-            "SNAPCRAFT_CONTAINER_BUILDS is not set or 0.\n"
+            "SNAPCRAFT_BUILD_ENVIRONMENT is not set or set to host.\n"
             "Maybe you meant to update the parts cache instead? "
             "You can do that with the following command:\n\n"
             "snapcraft update")
@@ -53,6 +53,5 @@ def refresh(debug, **kwargs):
     project_options = get_project_options(**kwargs, debug=debug)
     config = project_loader.load_config(project_options)
     lxd.Project(project_options=project_options,
-                remote=container_config.remote,
                 output=None, source=os.path.curdir,
                 metadata=config.get_metadata()).refresh()

--- a/snapcraft/cli/env.py
+++ b/snapcraft/cli/env.py
@@ -34,8 +34,8 @@ class BuilderEnvironmentConfig:
                 use_lxd = util.strtobool(container_builds)
             except ValueError:
                 raise errors.SnapcraftEnvironmentError(
-                    'The experimental feature of using lxd remotes other '
-                    'that cleanbuild has been dropped.')
+                    'The experimental feature of using non-local LXD remotes '
+                    'with SNAPCRAFT_CONTAINER_BUILDS has been dropped.')
 
         build_provider = os.environ.get('SNAPCRAFT_BUILD_ENVIRONMENT')
         if use_lxd:

--- a/snapcraft/cli/env.py
+++ b/snapcraft/cli/env.py
@@ -44,7 +44,7 @@ class BuilderEnvironmentConfig:
             echo.warning('Using the host as the build environment.')
             build_provider = 'host'
         # TODO add multipass
-        elif build_provider not in ['host', 'multipass', 'lxd']:
+        elif build_provider not in ['host', 'lxd']:
             raise errors.SnapcraftEnvironmentError(
                 'SNAPCRAFT_BUILD_ENVIRONMENT must be one of: host or lxd.')
 

--- a/snapcraft/cli/env.py
+++ b/snapcraft/cli/env.py
@@ -33,7 +33,8 @@ class BuilderEnvironmentConfig:
     - lxd: the host will setup a container to drive the build.
 
     Use of the lxd value is equivalent to setting the now deprecated
-    SNAPCRAFT_CONTAINER_BUILDS environment variable to a value of True.
+    SNAPCRAFT_CONTAINER_BUILDS environment variable to a value that
+    would evaluate to True.
     Setting this variable to a value that resolves to a non boolean
     results in an error.
     """

--- a/snapcraft/cli/env.py
+++ b/snapcraft/cli/env.py
@@ -58,7 +58,8 @@ class BuilderEnvironmentConfig:
             raise errors.SnapcraftEnvironmentError(
                 'SNAPCRAFT_BUILD_ENVIRONMENT and SNAPCRAFT_CONTAINER_BUILDS '
                 'cannot be used together.\n'
-                'Unset one of them from the environment and try again.')
+                'Given that SNAPCRAFT_BUILD_ENVIRONMENT is deprecated, '
+                'unset that variable from the environment and try again.')
 
         if use_lxd:
             build_provider = 'lxd'

--- a/snapcraft/cli/env.py
+++ b/snapcraft/cli/env.py
@@ -38,6 +38,12 @@ class BuilderEnvironmentConfig:
                     'with SNAPCRAFT_CONTAINER_BUILDS has been dropped.')
 
         build_provider = os.environ.get('SNAPCRAFT_BUILD_ENVIRONMENT')
+        if build_provider and use_lxd:
+            raise errors.SnapcraftEnvironmentError(
+                'SNAPCRAFT_BUILD_ENVIRONMENT and SNAPCRAFT_CONTAINER_BUILDS '
+                'cannot be used together.\n'
+                'Unset one of them from the environment and try again.')
+
         if use_lxd:
             build_provider = 'lxd'
         elif not build_provider:

--- a/snapcraft/cli/env.py
+++ b/snapcraft/cli/env.py
@@ -21,7 +21,22 @@ from snapcraft.internal import errors
 
 
 class BuilderEnvironmentConfig:
-    """Handle the chosen build provider."""
+    """Handle the chosen build provider.
+
+    To determine the build environment, SNAPCRAFT_BUILD_ENVIRONMENT is
+    retrieved from the environment and used to determine the build
+    provider. If it is not set, a value of `host` is assumed.
+
+    Valid values are:
+
+    - host: the host will drive the build.
+    - lxd: the host will setup a container to drive the build.
+
+    Use of the lxd value is equivalent to setting the now deprecated
+    SNAPCRAFT_CONTAINER_BUILDS environment variable to a value of True.
+    Setting this variable to a value that resolves to a non boolean
+    results in an error.
+    """
 
     def __init__(self) -> None:
         use_lxd = None

--- a/snapcraft/cli/parts.py
+++ b/snapcraft/cli/parts.py
@@ -31,10 +31,10 @@ def partscli(ctx):
 def update(ctx, **kwargs):
     """Updates the parts listing from the cloud."""
     # Update in the container so that it will use the parts at build time
-    container_config = env.get_container_config()
-    if container_config.use_container:
+    build_environment = env.BuilderEnvironmentConfig()
+    if not build_environment.is_host:
         project_options = get_project_options(**kwargs)
-        lifecycle.containerbuild('update', project_options, container_config)
+        lifecycle.containerbuild('update', project_options)
 
     # Parts can be defined and searched from any folder on the host, so
     # regardless of using containers we always update these as well

--- a/snapcraft/internal/lifecycle/_containers.py
+++ b/snapcraft/internal/lifecycle/_containers.py
@@ -38,18 +38,10 @@ def _create_tar_filter(tar_filename):
     return _tar_filter
 
 
-def containerbuild(step, project_options, container_config,
-                   output=None, args=[]):
+def containerbuild(step, project_options, output=None, args=[]):
     config = project_loader.load_config(project_options)
-    if container_config.remote:
-        logger.info('Using LXD remote {!r} from SNAPCRAFT_CONTAINER_BUILDS'
-                    .format(container_config.remote))
-    else:
-        logger.info('Using default LXD remote because '
-                    'SNAPCRAFT_CONTAINER_BUILDS is set to 1')
     lxd.Project(output=output, source=os.path.curdir,
                 project_options=project_options,
-                remote=container_config.remote,
                 metadata=config.get_metadata()).execute(step, args)
 
 

--- a/snapcraft/internal/lxd/_project.py
+++ b/snapcraft/internal/lxd/_project.py
@@ -18,17 +18,10 @@
 import logging
 import os
 import subprocess
-import time
 from typing import List
 
 from ._containerbuild import Containerbuild
-
-from snapcraft.internal.errors import (
-        ContainerConnectionError,
-        ContainerRunError,
-        SnapcraftEnvironmentError,
-)
-from snapcraft.internal import lifecycle
+from snapcraft.internal import errors, lifecycle
 from snapcraft.cli import echo
 
 logger = logging.getLogger(__name__)
@@ -37,11 +30,11 @@ logger = logging.getLogger(__name__)
 class Project(Containerbuild):
 
     def __init__(self, *, output, source, project_options,
-                 metadata, remote=None):
+                 metadata):
         super().__init__(output=output, source=source,
                          project_options=project_options,
                          metadata=metadata, container_name=metadata['name'],
-                         remote=remote)
+                         remote='local')
         self._processes = []
 
     def _ensure_container(self):
@@ -51,7 +44,8 @@ class Project(Containerbuild):
                 subprocess.check_call([
                     'lxc', 'init', self._image, self._container_name])
             except subprocess.CalledProcessError as e:
-                raise ContainerConnectionError('Failed to setup container')
+                raise errors.ContainerConnectionError(
+                    'Failed to setup container')
         if self._get_container_status()['status'] == 'Stopped':
             self._configure_container()
             try:
@@ -66,7 +60,7 @@ class Project(Containerbuild):
                             '\nNote: Add the line to both files, do not '
                             'remove any existing lines.'
                             '\nRestart lxd after making this change.')
-                raise ContainerConnectionError(msg)
+                raise errors.ContainerConnectionError(msg)
         self._wait_for_network()
         if new_container:
             self._container_run(['apt-get', 'update'])
@@ -77,13 +71,11 @@ class Project(Containerbuild):
 
     def _configure_container(self):
         super()._configure_container()
-        if self._remote == 'local':
-            # Map host user to root (0) inside container
-            subprocess.check_call([
-                'lxc', 'config', 'set', self._container_name,
-                'raw.idmap',
-                'both {} {}'.format(os.getenv('SUDO_UID', os.getuid()),
-                                    0)])
+        # Map host user to root (0) inside container
+        subprocess.check_call([
+            'lxc', 'config', 'set', self._container_name,
+            'raw.idmap',
+            'both {} {}'.format(os.getenv('SUDO_UID', os.getuid()), 0)])
         # Remove existing device (to ensure we update old containers)
         devices = self._get_container_status()['devices']
         if self._project_folder in devices:
@@ -97,11 +89,6 @@ class Project(Containerbuild):
                 ])
 
     def _setup_project(self):
-        if self._remote != 'local':
-            self._setup_user()
-            logger.info('Mounting {} into container'.format(self._source))
-            return self._remote_mount(self._project_folder, self._source)
-
         devices = self._get_container_status()['devices']
         if self._project_folder not in devices:
             logger.info('Mounting {} into container'.format(self._source))
@@ -109,77 +96,6 @@ class Project(Containerbuild):
                 'lxc', 'config', 'device', 'add', self._container_name,
                 self._project_folder, 'disk', 'source={}'.format(self._source),
                 'path={}'.format(self._project_folder)])
-
-    def _remote_mount(self, destination, source):
-        # Pipes for sshfs and sftp-server to communicate
-        stdin1, stdout1 = os.pipe()
-        stdin2, stdout2 = os.pipe()
-        # XXX: This needs to be extended once we support other distros
-        try:
-            self._background_process_run(['/usr/lib/sftp-server'],
-                                         stdin=stdin1, stdout=stdout2)
-        except FileNotFoundError:
-            raise SnapcraftEnvironmentError(
-                'You must have openssh-sftp-server installed to use a LXD '
-                'remote on a different host.\n'
-                )
-        except subprocess.CalledProcessError:
-            raise SnapcraftEnvironmentError(
-                'sftp-server seems to be installed but could not be run.\n'
-                )
-
-        # Use sshfs in slave mode to reverse mount the destination
-        self._container_run(['apt-get', 'install', '-y', 'sshfs'])
-        self._container_run(['mkdir', '-p', destination], user=self._user)
-        self._background_process_run([
-            'lxc', 'exec', self._container_name, '--',
-            'sudo', '-H', '-u', self._user,
-            'sshfs', '-o', 'slave', '-o', 'nonempty',
-            ':{}'.format(source), destination],
-            stdin=stdin2, stdout=stdout1)
-
-        # It may take a second or two for sshfs to come up
-        retry_count = 5
-        while retry_count:
-            time.sleep(1)
-            if subprocess.check_output([
-                    'lxc', 'exec', self._container_name, '--',
-                    'sudo', '-H', '-u', self._user,
-                    'ls', self._project_folder]):
-                return
-            retry_count -= 1
-        raise ContainerConnectionError(
-            'The project folder could not be mounted.\n'
-            'Fuse must be enabled on the LXD host.\n'
-            'You can run the following command to enable it:\n'
-            'echo Y | sudo tee /sys/module/fuse/parameters/userns_mounts')
-
-    def _setup_user(self):
-        # If we run as root or sudo we don't need a user in the container
-        if os.geteuid() == 0:
-            return
-        # Setup user mirroring host user with sudo access
-        self._user = os.environ['USER']
-        self._project_folder = '/home/{}/build_{}'.format(
-            self._user, self._metadata['name'])
-        logger.debug('Setting up user {!r} in container'.format(self._user))
-        try:
-            self._container_run([
-                'useradd', self._user, '--create-home'])
-        except ContainerRunError as e:
-            # Exit code 9 'username already in use' is safe to ignore
-            if e.exit_code != 9:
-                raise e
-        self._container_run([
-            'usermod', self._user, '-o',
-            '-u', str(os.getuid()), '-G', 'sudo'])
-        self._container_run([
-            'chown', '{}:{}'.format(self._user, self._user),
-            '/home/{}'.format(self._user)])
-        subprocess.check_output([
-            'lxc', 'exec', self._container_name, '--',
-            'tee', '-a', '/etc/sudoers'],
-            input='{} ALL=(ALL) NOPASSWD: ALL\n'.format(self._user).encode())
 
     def _background_process_run(self, cmd, **kwargs):
         self._processes += [subprocess.Popen(cmd, **kwargs)]

--- a/tests/integration/lifecycle/test_clean_pull_step.py
+++ b/tests/integration/lifecycle/test_clean_pull_step.py
@@ -16,12 +16,7 @@
 
 import os
 
-from testtools.matchers import (
-    DirExists,
-    Equals,
-    FileExists,
-    Not
-)
+from testtools.matchers import Contains, DirExists, FileExists, Not
 
 from tests import integration
 
@@ -113,12 +108,11 @@ class CleanPullStepPrimedTestCase(integration.TestCase):
 
         # Assert that the priming and staging areas were removed wholesale, not
         # a part at a time (since we didn't specify any parts).
-        output = output.strip().split('\n')
-        self.expectThat(output, Equals([
-            'Cleaning up priming area',
-            'Cleaning up staging area',
-            'Cleaning up parts directory'
-        ]))
+        output = output.strip()
+        self.expectThat(output, Contains(
+            'Cleaning up priming area\n'
+            'Cleaning up staging area\n'
+            'Cleaning up parts directory'))
 
         # Now try to prime again
         self.run_snapcraft('prime')

--- a/tests/unit/commands/test_clean.py
+++ b/tests/unit/commands/test_clean.py
@@ -105,7 +105,6 @@ class ContainerizedCleanCommandTestCase(CleanCommandBaseTestCase):
 
     scenarios = [
         ('local', dict(snapcraft_container_builds='1', remote='local')),
-        ('remote', dict(snapcraft_container_builds='foo', remote='foo')),
     ]
 
     def test_clean_containerized_noop(self):

--- a/tests/unit/commands/test_refresh.py
+++ b/tests/unit/commands/test_refresh.py
@@ -62,7 +62,6 @@ class RefreshCommandTestCase(RefreshCommandBaseTestCase):
 
     scenarios = [
          ('local', dict(snapcraft_container_builds='1', remote='local')),
-         ('remote', dict(snapcraft_container_builds='foo', remote='foo')),
     ]
 
     @mock.patch('snapcraft.internal.lxd.Containerbuild._container_run')
@@ -73,7 +72,7 @@ class RefreshCommandTestCase(RefreshCommandBaseTestCase):
         fake_filesystem = fixture_setup.FakeFilesystem()
         self.useFixture(fake_filesystem)
         self.useFixture(fixtures.EnvironmentVariable(
-            'SNAPCRAFT_CONTAINER_BUILDS', self.snapcraft_container_builds))
+            'SNAPCRAFT_BUILD_ENVIRONMENT', 'lxd'))
         self.make_snapcraft_yaml()
 
         self.run_command(['refresh'])
@@ -83,8 +82,7 @@ class RefreshCommandTestCase(RefreshCommandBaseTestCase):
             call(['apt-get', 'upgrade', '-y']),
             call(['snap', 'refresh']),
         ])
-        self.assertThat(fake_lxd.name,
-                        Equals('{}:snapcraft-snap-test'.format(self.remote)))
+        self.assertThat(fake_lxd.name, Equals('local:snapcraft-snap-test'))
 
 
 class RefreshCommandErrorsTestCase(RefreshCommandBaseTestCase):

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -201,6 +201,22 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
             'The experimental feature of using non-local LXD remotes '
             'with SNAPCRAFT_CONTAINER_BUILDS has been dropped.'))
 
+    def test_use_of_both_build_env_affecting_vars_fails(self):
+        self.useFixture(fixtures.EnvironmentVariable(
+            'SNAPCRAFT_CONTAINER_BUILDS', 'on'))
+        self.useFixture(fixtures.EnvironmentVariable(
+            'SNAPCRAFT_BUILD_ENVIRONMENT', 'host'))
+        self.make_snapcraft_yaml()
+
+        raised = self.assertRaises(
+            snapcraft.internal.errors.SnapcraftEnvironmentError,
+            self.run_command, ['snap'])
+
+        self.assertThat(str(raised), Contains(
+            'SNAPCRAFT_BUILD_ENVIRONMENT and SNAPCRAFT_CONTAINER_BUILDS '
+            'cannot be used together.\n'
+            'Unset one of them from the environment and try again.'))
+
     def test_snap_type_os_does_not_use_all_root(self):
         self.make_snapcraft_yaml(snap_type='os')
 

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -200,7 +200,8 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
         self.assertThat(str(raised), Contains(
             'SNAPCRAFT_BUILD_ENVIRONMENT and SNAPCRAFT_CONTAINER_BUILDS '
             'cannot be used together.\n'
-            'Unset one of them from the environment and try again.'))
+            'Given that SNAPCRAFT_BUILD_ENVIRONMENT is deprecated, '
+            'unset that variable from the environment and try again.'))
 
     def test_snap_type_os_does_not_use_all_root(self):
         self.make_snapcraft_yaml(snap_type='os')

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -173,24 +173,9 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
             '-all-root'],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
 
-    @mock.patch('snapcraft.internal.lxd.Containerbuild._container_run')
-    @mock.patch('os.pipe')
-    @mock.patch('os.geteuid')
-    def test_snap_containerized_remote_fails(
-            self, mock_geteuid, mock_pipe, mock_container_run):
-        mock_container_run.side_effect = lambda cmd, **kwargs: cmd
-        mock_pipe.return_value = (9, 9)
-        mock_geteuid.return_value = 1234
-        fake_lxd = fixture_setup.FakeLXD()
-        self.useFixture(fake_lxd)
-        fake_filesystem = fixture_setup.FakeFilesystem()
-        self.useFixture(fake_filesystem)
-        fake_logger = fixtures.FakeLogger(level=logging.INFO)
-        self.useFixture(fake_logger)
+    def test_snap_containerized_remote_fails(self):
         self.useFixture(fixtures.EnvironmentVariable(
             'SNAPCRAFT_CONTAINER_BUILDS', 'myremote'))
-        self.useFixture(
-            fixtures.EnvironmentVariable('USER', 'user'))
         self.make_snapcraft_yaml()
 
         raised = self.assertRaises(

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -198,8 +198,8 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
             self.run_command, ['snap'])
 
         self.assertThat(str(raised), Contains(
-            'The experimental feature of using lxd remotes other that '
-            'cleanbuild has been dropped'))
+            'The experimental feature of using non-local LXD remotes '
+            'with SNAPCRAFT_CONTAINER_BUILDS has been dropped.'))
 
     def test_snap_type_os_does_not_use_all_root(self):
         self.make_snapcraft_yaml(snap_type='os')

--- a/tests/unit/commands/test_update.py
+++ b/tests/unit/commands/test_update.py
@@ -150,8 +150,6 @@ class UpdateCommandTestCase(CommandBaseTestCase, unit.TestWithFakeRemoteParts):
         result = self.run_command(['update'])
         self.assertThat(result.exit_code, Equals(0))
 
-        self.assertThat(result.output, Equals(''))
-
     def test_update_with_no_content_length_is_supported(self):
         self.useFixture(fixtures.EnvironmentVariable('NO_CONTENT_LENGTH', '1'))
         result = self.run_command(['update'])

--- a/tests/unit/test_lxd.py
+++ b/tests/unit/test_lxd.py
@@ -32,16 +32,8 @@ from testtools.matchers import Contains, Equals
 from snapcraft import ProjectOptions
 from snapcraft.project._project_options import _get_deb_arch
 from snapcraft.internal import lxd
-from snapcraft.internal.errors import (
-    ContainerConnectionError,
-    InvalidContainerImageInfoError,
-    SnapdError,
-    SnapcraftEnvironmentError,
-)
-from tests import (
-    fixture_setup,
-    unit
-)
+from snapcraft.internal import errors
+from tests import fixture_setup, unit
 
 
 class LXDBaseTestCase(unit.TestCase):
@@ -151,7 +143,7 @@ class CleanbuilderTestCase(LXDTestCase):
         self.fake_lxd.check_call_mock.side_effect = call_effect
 
         raised = self.assertRaises(
-            ContainerConnectionError,
+            errors.ContainerConnectionError,
             self.make_containerbuild().execute)
         self.assertThat(self.fake_lxd.status, Equals(None))
         # lxc launch should fail and no further commands should come after that
@@ -206,7 +198,7 @@ class ContainerbuildTestCase(LXDTestCase):
         self.useFixture(
             fixtures.EnvironmentVariable(
                 'SNAPCRAFT_IMAGE_INFO', test_image_info))
-        self.assertRaises(InvalidContainerImageInfoError,
+        self.assertRaises(errors.InvalidContainerImageInfoError,
                           self.make_containerbuild().execute)
 
     def test_wait_for_network_loops(self):
@@ -215,7 +207,7 @@ class ContainerbuildTestCase(LXDTestCase):
 
         builder = self.make_containerbuild()
 
-        self.assertRaises(ContainerConnectionError,
+        self.assertRaises(errors.ContainerConnectionError,
                           builder._wait_for_network)
 
     def test_failed_build_with_debug(self):
@@ -255,7 +247,7 @@ class ContainerbuildTestCase(LXDTestCase):
         self.fake_lxd.check_output_mock.side_effect = FileNotFoundError('lxc')
 
         with ExpectedException(
-                ContainerConnectionError,
+                errors.ContainerConnectionError,
                 'You must have LXD installed in order to use cleanbuild.\n'
                 'Refer to the documentation at '
                 'https://linuxcontainers.org/lxd/getting-started-cli.'):
@@ -266,7 +258,7 @@ class ContainerbuildTestCase(LXDTestCase):
         self.fake_lxd.check_output_mock.side_effect = CalledProcessError(
             255, ['lxd', 'list', self.remote])
 
-        with ExpectedException(ContainerConnectionError,
+        with ExpectedException(errors.ContainerConnectionError,
                                'There are either.*{}.*'.format(self.remote)):
             self.make_containerbuild().execute()
 
@@ -336,9 +328,9 @@ class ContainerbuildTestCase(LXDTestCase):
         self.useFixture(fake_snapd)
 
         builder = self.make_containerbuild()
-        self.assertIn('Error connecting to',
-                      str(self.assertRaises(SnapdError,
-                                            builder.execute)))
+
+        raised = self.assertRaises(errors.SnapdError, builder.execute)
+        self.assertThat(str(raised), Contains('Error connecting to'))
 
     @patch('snapcraft.internal.common.is_snap')
     def test_inject_snap_api_error(self,
@@ -350,9 +342,11 @@ class ContainerbuildTestCase(LXDTestCase):
         self.useFixture(fake_snapd)
 
         builder = self.make_containerbuild()
-        self.assertIn('Error querying \'core\' snap: not found',
-                      str(self.assertRaises(SnapdError,
-                                            builder.execute)))
+
+        raised = self.assertRaises(errors.SnapdError, builder.execute)
+        self.assertThat(
+            str(raised),
+            Contains('Error querying \'core\' snap: not found'))
 
     @patch('snapcraft.internal.lxd.Containerbuild._container_run')
     @patch('snapcraft.internal.common.is_snap')
@@ -536,216 +530,7 @@ class ContainerbuildTestCase(LXDTestCase):
         ])
 
 
-class ProjectTestCase(ContainerbuildTestCase):
-
-    scenarios = [
-          ('remote/root', dict(remote='myremote', target_arch=None, euid=0,
-                               server='x86_64', user='root', home='/root')),
-          ('remote/user', dict(remote='myremote', target_arch=None, euid=1234,
-                               server='x86_64', user='me', home='/home/me')),
-          ('cross/user', dict(remote='myremote', target_arch='armhf',
-                              cross=True, euid=1234,
-                              server='x86_64', user='me', home='/home/me')),
-    ]
-
-    def setUp(self):
-        super().setUp()
-        patcher = patch('os.geteuid')
-        mock_geteuid = patcher.start()
-        mock_geteuid.return_value = self.euid
-        self.addCleanup(patcher.stop)
-        self.useFixture(
-            fixtures.EnvironmentVariable('USER', self.user))
-
-    def make_containerbuild(self):
-        return lxd.Project(output='snap.snap', source='project.tar',
-                           metadata={'name': 'project'},
-                           project_options=self.project_options,
-                           remote=self.remote)
-
-    @patch('snapcraft.internal.lxd.Containerbuild._container_run')
-    @patch('snapcraft.internal.common.is_snap')
-    def test_inject_snap_existing_container(self,
-                                            mock_is_snap,
-                                            mock_container_run):
-        mock_is_snap.return_value = True
-
-        fake_snapd = fixture_setup.FakeSnapd()
-        self.useFixture(fake_snapd)
-        fake_snapd.snaps_result = [
-            {'name': 'core',
-             'confinement': 'strict',
-             'id': '2kkitQurgOkL3foImG4wDwn9CIANuHlt',
-             'channel': 'stable',
-             'revision': '123'},
-            {'name': 'snapcraft',
-             'confinement': 'classic',
-             'id': '3lljuRvshPlM4gpJnH5xExo0DJBOvImu',
-             'channel': 'edge',
-             'revision': '345'},
-        ]
-        # Container was created before, and isn't running
-        self.fake_lxd.name = 'myremote:snapcraft-project'
-        self.fake_lxd.status = 'Stopped'
-
-        self.make_containerbuild().execute()
-
-        if hasattr(self, 'cross') and self.cross:
-            mock_container_run.assert_has_calls([
-                call(['snap', 'install', 'core', '--channel', 'stable']),
-                call(['snap', 'refresh', 'core', '--channel', 'stable']),
-                call(['snap', 'install', 'snapcraft', '--channel', 'edge',
-                      '--classic']),
-                call(['snap', 'refresh', 'snapcraft', '--channel', 'edge',
-                      '--classic']),
-            ])
-        else:
-            mock_container_run.assert_has_calls([
-                call(['snap', 'ack', '/run/core_123.assert']),
-                call(['snap', 'install', '/run/core_123.snap']),
-                call(['snap', 'ack', '/run/snapcraft_345.assert']),
-                call(['snap', 'install', '/run/snapcraft_345.snap',
-                      '--classic']),
-            ])
-
-    def test_command_with_sudo(self):
-        self.make_containerbuild().execute()
-        project_folder = '{}/build_project'.format(self.home)
-        args = ''
-        if self.target_arch:
-            args += ' --target-arch {}'.format(self.target_arch)
-        sudo = []
-        if self.user != 'root':
-            sudo = ['sudo', '-H', '-E', '-u', self.user]
-        self.fake_lxd.check_call_mock.assert_has_calls([
-            call(['lxc', 'exec', self.fake_lxd.name, '--'] + sudo
-                 + ['mkdir', '-p', project_folder]),
-            call(['lxc', 'exec', self.fake_lxd.name, '--'] + sudo
-                 + ['sh', '-c', 'cd {}; snapcraft snap --output snap.snap{}'.
-                    format(project_folder, args)]),
-        ])
-
-    @patch('os.getuid')
-    @patch('snapcraft.internal.lxd.Containerbuild._container_run')
-    def test_user_setup(self, mock_container_run, mock_getuid):
-        mock_container_run.side_effect = lambda cmd, **kwargs: cmd
-        mock_getuid.return_value = 1234
-
-        self.make_containerbuild().execute()
-
-        if self.euid > 0:
-            mock_container_run.assert_has_calls([
-                call(['useradd', self.user, '--create-home']),
-                call(['usermod', self.user, '-o', '-u', '1234', '-G', 'sudo']),
-                call(['chown', 'me:me', self.home]),
-            ])
-            self.fake_lxd.check_output_mock.assert_has_calls([
-                call(['lxc', 'exec', self.fake_lxd.name, '--',
-                      'tee', '-a', '/etc/sudoers'],
-                     input='{} ALL=(ALL) NOPASSWD: ALL\n'.format(
-                         self.user).encode()),
-                call(['lxc', 'exec', self.fake_lxd.name, '--',
-                      'sudo', '-H', '-u', 'me', 'ls',
-                      '{}/build_project'.format(self.home)]),
-            ])
-
-    def test_init_failed(self):
-        def call_effect(*args, **kwargs):
-            if args[0][:2] == ['lxc', 'init']:
-                raise CalledProcessError(returncode=255, cmd=args[0])
-            return self.fake_lxd.check_output_side_effect()(*args, **kwargs)
-
-        self.fake_lxd.check_call_mock.side_effect = call_effect
-
-        raised = self.assertRaises(ContainerConnectionError,
-                                   self.make_containerbuild().execute)
-        self.assertThat(self.fake_lxd.status, Equals(None))
-        # lxc launch should fail and no further commands should come after that
-        self.assertThat(str(raised), Contains('Failed to setup container'))
-
-    def test_start_failed(self):
-        def call_effect(*args, **kwargs):
-            if args[0][:2] == ['lxc', 'start']:
-                raise CalledProcessError(returncode=255, cmd=args[0])
-            return self.fake_lxd.check_output_side_effect()(*args, **kwargs)
-
-        self.fake_lxd.check_call_mock.side_effect = call_effect
-
-        raised = self.assertRaises(ContainerConnectionError,
-                                   self.make_containerbuild().execute)
-        self.assertThat(self.fake_lxd.status, Equals('Stopped'))
-        # lxc launch should fail and no further commands should come after that
-        self.assertThat(str(raised),
-                        Contains('The container could not be started'))
-
-    @patch('snapcraft.internal.lxd.Containerbuild._container_run')
-    def test_ftp_not_installed(self, mock_container_run):
-        mock_container_run.side_effect = lambda cmd, **kwargs: cmd
-
-        def call_effect(*args, **kwargs):
-            if args[0][:1] == ['/usr/lib/sftp-server']:
-                raise FileNotFoundError(
-                    2, 'No such file or directory')
-
-        self.fake_lxd.popen_mock.side_effect = call_effect
-
-        self.assertIn(
-            'You must have openssh-sftp-server installed to use a LXD '
-            'remote on a different host.\n',
-            str(self.assertRaises(
-                SnapcraftEnvironmentError,
-                self.make_containerbuild().execute)))
-
-    @patch('snapcraft.internal.lxd.Containerbuild._container_run')
-    def test_ftp_error(self, mock_container_run):
-        mock_container_run.side_effect = lambda cmd, **kwargs: cmd
-
-        def call_effect(*args, **kwargs):
-            if args[0][:1] == ['/usr/lib/sftp-server']:
-                raise CalledProcessError(
-                    returncode=255, cmd=args[0])
-
-        self.fake_lxd.popen_mock.side_effect = call_effect
-
-        self.assertIn(
-            'sftp-server seems to be installed but could not be run.\n',
-            str(self.assertRaises(
-                SnapcraftEnvironmentError,
-                self.make_containerbuild().execute)))
-
-    @patch('snapcraft.internal.lxd.Containerbuild._container_run')
-    def test_sshfs_failed(self, mock_container_run):
-        mock_container_run.side_effect = lambda cmd, **kwargs: cmd
-
-        def call_effect(*args, **kwargs):
-            if args[0][:2] == ['lxc', 'exec'] and 'ls' in args[0]:
-                return ''.encode('utf-8')
-            return self.fake_lxd.check_output_side_effect()(*args, **kwargs)
-
-        self.fake_lxd.check_output_mock.side_effect = call_effect
-
-        self.assertIn(
-            'The project folder could not be mounted.\n',
-            str(self.assertRaises(
-                ContainerConnectionError,
-                self.make_containerbuild().execute)))
-
-    def test_debug_messages(self):
-        class TestFormatter(logging.Formatter):
-            def format(self, record):
-                message = super().format(record)
-                return '[{}]{}'.format(record.levelname, message)
-
-        self.fake_logger = fixtures.FakeLogger(
-            format='%(message)s', formatter=TestFormatter, level=logging.DEBUG)
-        self.useFixture(self.fake_logger)
-
-        self.make_containerbuild().execute()
-        self.assertThat(self.fake_logger.output,
-                        Contains('[DEBUG]Terminating'))
-
-
-class LocalProjectTestCase(ContainerbuildTestCase):
+class LocalProjectTestCase(LXDTestCase):
 
     scenarios = [
         ('local', dict(remote='local', target_arch=None, server='x86_64')),
@@ -754,8 +539,7 @@ class LocalProjectTestCase(ContainerbuildTestCase):
     def make_containerbuild(self):
         return lxd.Project(output='snap.snap', source='project.tar',
                            metadata={'name': 'project'},
-                           project_options=self.project_options,
-                           remote=self.remote)
+                           project_options=self.project_options)
 
     @patch('snapcraft.internal.lxd.Containerbuild._container_run')
     def test_start_failed(self, mock_container_run):
@@ -770,12 +554,13 @@ class LocalProjectTestCase(ContainerbuildTestCase):
         d = self.fake_lxd.check_call_mock.side_effect
         self.fake_lxd.check_call_mock.side_effect = call_effect
 
-        self.assertIn(
+        raised = self.assertRaises(
+                errors.ContainerConnectionError,
+                self.make_containerbuild().execute)
+        self.assertThat(str(raised), Contains(
             'The container could not be started.\n'
-            'The files /etc/subuid and /etc/subgid need to contain this line ',
-            str(self.assertRaises(
-                ContainerConnectionError,
-                self.make_containerbuild().execute)))
+            'The files /etc/subuid and /etc/subgid need to contain this line'))
+
         # Should not attempt to stop a container that wasn't started
         self.assertNotIn(call(['lxc', 'stop', '-f', self.fake_lxd.name]),
                          self.fake_lxd.check_call_mock.call_args_list)
@@ -807,8 +592,7 @@ class FailedImageInfoTestCase(LXDBaseTestCase):
     def make_containerbuild(self):
         return lxd.Project(output='snap.snap', source='project.tar',
                            metadata={'name': 'project'},
-                           project_options=self.project_options,
-                           remote=self.remote)
+                           project_options=self.project_options)
 
     def test_failed_image_info_just_warns(self):
         self.fake_logger = fixtures.FakeLogger(level=logging.WARN)

--- a/tests/unit/test_lxd.py
+++ b/tests/unit/test_lxd.py
@@ -262,6 +262,50 @@ class ContainerbuildTestCase(LXDTestCase):
                                'There are either.*{}.*'.format(self.remote)):
             self.make_containerbuild().execute()
 
+    @patch('snapcraft.internal.lxd.Containerbuild._container_run')
+    @patch('snapcraft.internal.common.is_snap')
+    def test_inject_snap_existing_container(
+            self, mock_is_snap, mock_container_run):
+        mock_is_snap.return_value = True
+
+        fake_snapd = fixture_setup.FakeSnapd()
+        self.useFixture(fake_snapd)
+        fake_snapd.snaps_result = [
+            {'name': 'core',
+             'confinement': 'strict',
+             'id': '2kkitQurgOkL3foImG4wDwn9CIANuHlt',
+             'channel': 'stable',
+             'revision': '123'},
+            {'name': 'snapcraft',
+             'confinement': 'classic',
+             'id': '3lljuRvshPlM4gpJnH5xExo0DJBOvImu',
+             'channel': 'edge',
+             'revision': '345'},
+        ]
+        # Container was created before, and isn't running
+        self.fake_lxd.name = 'myremote:snapcraft-project'
+        self.fake_lxd.status = 'Stopped'
+
+        self.make_containerbuild().execute()
+
+        if hasattr(self, 'cross') and self.cross:
+            mock_container_run.assert_has_calls([
+                call(['snap', 'install', 'core', '--channel', 'stable']),
+                call(['snap', 'refresh', 'core', '--channel', 'stable']),
+                call(['snap', 'install', 'snapcraft', '--channel', 'edge',
+                      '--classic']),
+                call(['snap', 'refresh', 'snapcraft', '--channel', 'edge',
+                      '--classic']),
+            ])
+        else:
+            mock_container_run.assert_has_calls([
+                call(['snap', 'ack', '/run/core_123.assert']),
+                call(['snap', 'install', '/run/core_123.snap']),
+                call(['snap', 'ack', '/run/snapcraft_345.assert']),
+                call(['snap', 'install', '/run/snapcraft_345.snap',
+                      '--classic']),
+            ])
+
     @patch('snapcraft.internal.common.is_snap')
     def test_parallel_invocation(self, mock_is_snap):
         mock_is_snap.side_effect = lambda: False
@@ -532,14 +576,24 @@ class ContainerbuildTestCase(LXDTestCase):
 
 class LocalProjectTestCase(LXDTestCase):
 
-    scenarios = [
-        ('local', dict(remote='local', target_arch=None, server='x86_64')),
-    ]
-
     def make_containerbuild(self):
         return lxd.Project(output='snap.snap', source='project.tar',
                            metadata={'name': 'project'},
                            project_options=self.project_options)
+
+    def test_init_failed(self):
+        def call_effect(*args, **kwargs):
+            if args[0][:2] == ['lxc', 'init']:
+                raise CalledProcessError(returncode=255, cmd=args[0])
+            return self.fake_lxd.check_output_side_effect()(*args, **kwargs)
+
+        self.fake_lxd.check_call_mock.side_effect = call_effect
+
+        raised = self.assertRaises(errors.ContainerConnectionError,
+                                   self.make_containerbuild().execute)
+        self.assertThat(self.fake_lxd.status, Equals(None))
+        # lxc launch should fail and no further commands should come after that
+        self.assertThat(str(raised), Contains('Failed to setup container'))
 
     @patch('snapcraft.internal.lxd.Containerbuild._container_run')
     def test_start_failed(self, mock_container_run):


### PR DESCRIPTION
Remove the support as it has not proved to be the best experience, cleanbuild should be used
instead.

Also future feature proof the environment detection.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
