### PR TITLE
internal: skip -all-root for base snaps

### DIFF
--- a/snapcraft/internal/lifecycle/_packer.py
+++ b/snapcraft/internal/lifecycle/_packer.py
@@ -79,7 +79,7 @@ def _run_mksquashfs(mksquashfs_command, *, directory, snap_name, snap_type,
     # http://bazaar.launchpad.net/~click-reviewers/click-reviewers-tools/trunk/view/head:/clickreviews/common.py#L38
     mksquashfs_args = ['-noappend', '-comp', 'xz', '-no-xattrs',
                        '-no-fragments']
-    if snap_type != 'os':
+    if snap_type not in ('os', 'base'):
         mksquashfs_args.append('-all-root')
 
     complete_command = [

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -279,6 +279,22 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
 
         self.assertThat('snap-test_1.0_amd64.snap', FileExists())
 
+    def test_snap_type_base_does_not_use_all_root(self):
+        self.make_snapcraft_yaml(snap_type='base')
+
+        result = self.run_command(['snap'])
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(result.output,
+                        Contains('\nSnapped snap-test_1.0_amd64.snap\n'))
+
+        self.popen_spy.assert_called_once_with([
+            'mksquashfs', self.prime_dir, 'snap-test_1.0_amd64.snap',
+            '-noappend', '-comp', 'xz', '-no-xattrs', '-no-fragments'],
+            stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
+
+        self.assertThat('snap-test_1.0_amd64.snap', FileExists())
+
     def test_snap_defaults_with_parts_in_prime(self):
         fake_logger = fixtures.FakeLogger(level=logging.INFO)
         self.useFixture(fake_logger)


### PR DESCRIPTION
When base snaps become bootable we will need to ensure that they
do not squash all uids on the snap into "root". This fixes core18 builds that
change some files like etc/shadow from root:shadow to root:root.