### PR TITLE
meta: soften warning about using passthrough

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -619,8 +619,7 @@ class _SnapPackaging:
         if passthrough_applied:
             logger.warn("The 'passthrough' property is being used to "
                         "propagate experimental properties to snap.yaml "
-                        "that have not been validated. The snap cannot be "
-                        "released to the store.")
+                        "that have not been validated")
 
     def _apply_passthrough(self, section: Dict[str, Any],
                            passthrough: Dict[str, Any],

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -619,7 +619,7 @@ class _SnapPackaging:
         if passthrough_applied:
             logger.warn("The 'passthrough' property is being used to "
                         "propagate experimental properties to snap.yaml "
-                        "that have not been validated")
+                        "that have not been validated.")
 
     def _apply_passthrough(self, section: Dict[str, Any],
                            passthrough: Dict[str, Any],

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -564,7 +564,7 @@ class PassthroughErrorTestCase(PassthroughBaseTestCase):
             fake_logger.output,
             Equals("The 'passthrough' property is being used to propagate "
                    "experimental properties to snap.yaml that have not been "
-                   "validated. The snap cannot be released to the store.\n"))
+                   "validated\n"))
 
 
 class PassthroughPropagateTestCase(PassthroughBaseTestCase):
@@ -622,7 +622,7 @@ class PassthroughPropagateTestCase(PassthroughBaseTestCase):
             fake_logger.output,
             Contains("The 'passthrough' property is being used to propagate "
                      "experimental properties to snap.yaml that have not been "
-                     "validated. The snap cannot be released to the store.\n"))
+                     "validated\n"))
 
 
 class CreateMetadataFromSourceBaseTestCase(CreateBaseTestCase):

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -564,7 +564,7 @@ class PassthroughErrorTestCase(PassthroughBaseTestCase):
             fake_logger.output,
             Equals("The 'passthrough' property is being used to propagate "
                    "experimental properties to snap.yaml that have not been "
-                   "validated\n"))
+                   "validated.\n"))
 
 
 class PassthroughPropagateTestCase(PassthroughBaseTestCase):
@@ -622,7 +622,7 @@ class PassthroughPropagateTestCase(PassthroughBaseTestCase):
             fake_logger.output,
             Contains("The 'passthrough' property is being used to propagate "
                      "experimental properties to snap.yaml that have not been "
-                     "validated\n"))
+                     "validated.\n"))
 
 
 class CreateMetadataFromSourceBaseTestCase(CreateBaseTestCase):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently Snapcraft warns that a snap using passthrough cannot be released to the store. What it means is that it may be flagged for manual review upon push, but even that isn't necessarily the case, as the store may gain support for the option being passed through. Also, some users are interpreting this warning as a fatal error, i.e. that Snapcraft won't allow release.

Stop mentioning the store in the passthrough warning.