### PR TITLE
storeapi: better handle network errors and retries

### DIFF
--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -74,7 +74,7 @@ class StoreNetworkError(StoreError):
             if isinstance(underlying_exception,
                           urllib3.exceptions.MaxRetryError):
                 message = (
-                    'max retries exceeded trying to reach the store\n'
+                    'maximum retries exceeded trying to reach the store.\n'
                     'Check your network connection, and check the store '
                     'status at {}'.format(_STORE_STATUS_URL))
         super().__init__(message=message)

--- a/tests/unit/store/test_client.py
+++ b/tests/unit/store/test_client.py
@@ -1,0 +1,52 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import requests
+from requests import exceptions
+from requests.packages import urllib3
+
+from testtools.matchers import Contains
+from unittest import mock
+
+from snapcraft.storeapi import _client
+from snapcraft.storeapi import errors
+
+from tests import unit
+
+
+class ClientTestCase(unit.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.client = _client.Client('conf', 'root_url')
+
+    @mock.patch.object(requests.Session, 'request')
+    def test_generic_network_error(self, mock_request):
+        mock_request.side_effect = exceptions.ConnectionError('naughty error')
+        raised = self.assertRaises(
+            errors.StoreNetworkError, self.client.request, 'GET',
+            'test-url')
+        self.assertThat(str(raised), Contains('naughty error'))
+
+    @mock.patch.object(requests.Session, 'request')
+    def test_max_retries_error(self, mock_request):
+        mock_request.side_effect = exceptions.ConnectionError(
+            urllib3.exceptions.MaxRetryError(pool='test-pool', url='test-url'))
+        raised = self.assertRaises(
+            errors.StoreNetworkError, self.client.request, 'GET',
+            'test-url')
+        self.assertThat(str(raised), Contains('max retries exceeded'))

--- a/tests/unit/store/test_client.py
+++ b/tests/unit/store/test_client.py
@@ -18,7 +18,6 @@ import requests
 from requests import exceptions
 from requests.packages import urllib3
 
-from testtools.matchers import Contains
 from unittest import mock
 
 from snapcraft.storeapi import _client
@@ -37,16 +36,14 @@ class ClientTestCase(unit.TestCase):
     @mock.patch.object(requests.Session, 'request')
     def test_generic_network_error(self, mock_request):
         mock_request.side_effect = exceptions.ConnectionError('naughty error')
-        raised = self.assertRaises(
+        self.assertRaises(
             errors.StoreNetworkError, self.client.request, 'GET',
             'test-url')
-        self.assertThat(str(raised), Contains('naughty error'))
 
     @mock.patch.object(requests.Session, 'request')
     def test_max_retries_error(self, mock_request):
         mock_request.side_effect = exceptions.ConnectionError(
             urllib3.exceptions.MaxRetryError(pool='test-pool', url='test-url'))
-        raised = self.assertRaises(
+        self.assertRaises(
             errors.StoreNetworkError, self.client.request, 'GET',
             'test-url')
-        self.assertThat(str(raised), Contains('max retries exceeded'))

--- a/tests/unit/store/test_store_client.py
+++ b/tests/unit/store/test_store_client.py
@@ -701,10 +701,10 @@ class ValidationsTestCase(StoreTestCase):
         self.client.login('dummy', 'test correct password')
 
         err = self.assertRaises(
-            errors.StoreRetryError,
+            errors.StoreNetworkError,
             self.client.get_assertion, 'err', 'validations')
 
-        expected = ('too many 503 error responses')
+        expected = ('max retries exceeded')
         self.assertThat(str(err), Contains(expected))
 
     def test_push_success(self):

--- a/tests/unit/store/test_store_client.py
+++ b/tests/unit/store/test_store_client.py
@@ -704,7 +704,7 @@ class ValidationsTestCase(StoreTestCase):
             errors.StoreNetworkError,
             self.client.get_assertion, 'err', 'validations')
 
-        expected = ('max retries exceeded')
+        expected = ('maximum retries exceeded')
         self.assertThat(str(err), Contains(expected))
 
     def test_push_success(self):

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -14,12 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import requests.exceptions
+from requests.packages import urllib3
 from subprocess import CalledProcessError
 
 from testtools.matchers import Equals
 
 from snapcraft.internal import errors
 from snapcraft.internal.meta import _errors as meta_errors
+from snapcraft.storeapi import errors as store_errors
 from tests import unit
 
 
@@ -427,6 +429,29 @@ class ErrorFormattingTestCase(unit.TestCase):
                 "Exited with code 2.\n"
                 "Verify that the part is using the correct parameters and try "
                 "again."
+            )
+        }),
+        ('StoreNetworkError generic error', {
+            'exception': store_errors.StoreNetworkError,
+            'kwargs': {
+                'exception': requests.exceptions.ConnectionError('bad error'),
+            },
+            'expected_message': (
+                'There seems to be a network error: bad error'
+            )
+        }),
+        ('StoreNetworkError max retry error', {
+            'exception': store_errors.StoreNetworkError,
+            'kwargs': {
+                'exception': requests.exceptions.ConnectionError(
+                    urllib3.exceptions.MaxRetryError(
+                        pool='test-pool', url='test-url')),
+            },
+            'expected_message': (
+                'There seems to be a network error: max retries exceeded '
+                'trying to reach the store\n'
+                'Check your network connection, and check the store status at '
+                'https://status.snapcraft.io/'
             )
         }),
     )

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -448,8 +448,8 @@ class ErrorFormattingTestCase(unit.TestCase):
                         pool='test-pool', url='test-url')),
             },
             'expected_message': (
-                'There seems to be a network error: max retries exceeded '
-                'trying to reach the store\n'
+                'There seems to be a network error: maximum retries exceeded '
+                'trying to reach the store.\n'
                 'Check your network connection, and check the store status at '
                 'https://status.snapcraft.io/'
             )


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently Snapcraft prints an ugly warning every time it retries a connection instead of just retrying until the max number has occurred. And then, if after all the retries have happened and no connection has been made, it dumps a traceback.

This PR fixes LP: [#1765671](https://bugs.launchpad.net/snapcraft/+bug/1765671) by fixing both of othese issues: up the log level of urllib to ERROR, and properly handle connection errors resulting from exceeding the maximum number of retries.

In the long run, we should consider doing retries differently-- this stuff leaks right through requests.