### PR TITLE
tests: don't use os_release and repo from snapcraft

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -38,7 +38,6 @@ from unittest import mock
 from testtools import content
 from testtools.matchers import MatchesRegex
 
-from snapcraft.internal.os_release import OsRelease
 from tests import (
     fixture_setup,
     subprocess_utils
@@ -134,8 +133,7 @@ class TestCase(testtools.TestCase):
         self.deb_arch = platform.get_deb_arch()
         self.arch_triplet = platform.get_arch_triplet()
 
-        release = OsRelease()
-        self.distro_series = release.version_codename()
+        self.distro_series = platform.get_version_codename()
 
     def run_snapcraft(
             self, command: Union[str, List[str]] = None,

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -40,6 +40,7 @@ from testtools.matchers import MatchesRegex
 
 from tests import (
     fixture_setup,
+    os_release,
     subprocess_utils
 )
 from tests.integration import platform
@@ -133,7 +134,7 @@ class TestCase(testtools.TestCase):
         self.deb_arch = platform.get_deb_arch()
         self.arch_triplet = platform.get_arch_triplet()
 
-        self.distro_series = platform.get_version_codename()
+        self.distro_series = os_release.get_version_codename()
 
     def run_snapcraft(
             self, command: Union[str, List[str]] = None,

--- a/tests/integration/general/test_asset_recording.py
+++ b/tests/integration/general/test_asset_recording.py
@@ -25,7 +25,7 @@ import fixtures
 import testscenarios
 from testtools.matchers import Contains, Equals
 
-from snapcraft.internal.repo import snaps
+from tests.integration import repo
 from tests import (
     integration,
     fixture_setup
@@ -102,8 +102,7 @@ class ManifestRecordingTestCase(AssetRecordingBaseTestCase):
             recorded_yaml = yaml.load(recorded_yaml_file)
 
         expected_package = 'core={}'.format(
-            snaps.SnapPackage(
-                'core').get_local_snap_info()['revision'])
+            repo.get_local_snap_info('core')['revision'])
         self.assertThat(
             recorded_yaml['parts']['dummy-part']['installed-snaps'],
             Contains(expected_package))
@@ -155,8 +154,7 @@ class ManifestRecordingTestCase(AssetRecordingBaseTestCase):
 
         self.run_snapcraft('prime')
 
-        expected_revision = snaps.SnapPackage(
-            'hello').get_local_snap_info()['revision']
+        expected_revision = repo.get_local_snap_info('hello')['revision']
         recorded_yaml_path = os.path.join(
             self.prime_dir, 'snap', 'manifest.yaml')
         with open(recorded_yaml_path) as recorded_yaml_file:

--- a/tests/integration/platform.py
+++ b/tests/integration/platform.py
@@ -14,7 +14,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Dict  # noqa: 401
+import contextlib
 import platform
+
+
+_ID_TO_UBUNTU_CODENAME = {
+    '17.10': 'artful',
+    '17.04': 'zesty',
+    '16.04': 'xenial',
+    '14.04': 'trusty',
+}
 
 
 _32BIT_USERSPACE_ARCHITECTURE = {
@@ -56,6 +66,21 @@ _ARCH_TRANSLATIONS = {
         'triplet': 's390x-linux-gnu',
     }
 }
+
+
+def get_version_codename() -> str:
+    with contextlib.suppress(FileNotFoundError):
+        os_release = {}  # type: Dict[str, str]
+        with open('/etc/os-release') as f:
+            for line in f:
+                entry = line.rstrip().split('=')
+                if len(entry) == 2:
+                    os_release[entry[0]] = entry[1].strip('"')
+        with contextlib.suppress(KeyError):
+            return os_release['VERSION_CODENAME']
+        with contextlib.suppress(KeyError):
+            return _ID_TO_UBUNTU_CODENAME[os_release['VERSION_ID']]
+        return 'unknown'
 
 
 def get_deb_arch():

--- a/tests/integration/platform.py
+++ b/tests/integration/platform.py
@@ -14,17 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Dict  # noqa: 401
-import contextlib
 import platform
-
-
-_ID_TO_UBUNTU_CODENAME = {
-    '17.10': 'artful',
-    '17.04': 'zesty',
-    '16.04': 'xenial',
-    '14.04': 'trusty',
-}
 
 
 _32BIT_USERSPACE_ARCHITECTURE = {
@@ -66,21 +56,6 @@ _ARCH_TRANSLATIONS = {
         'triplet': 's390x-linux-gnu',
     }
 }
-
-
-def get_version_codename() -> str:
-    with contextlib.suppress(FileNotFoundError):
-        os_release = {}  # type: Dict[str, str]
-        with open('/etc/os-release') as f:
-            for line in f:
-                entry = line.rstrip().split('=')
-                if len(entry) == 2:
-                    os_release[entry[0]] = entry[1].strip('"')
-        with contextlib.suppress(KeyError):
-            return os_release['VERSION_CODENAME']
-        with contextlib.suppress(KeyError):
-            return _ID_TO_UBUNTU_CODENAME[os_release['VERSION_ID']]
-        return 'unknown'
 
 
 def get_deb_arch():

--- a/tests/integration/repo.py
+++ b/tests/integration/repo.py
@@ -23,10 +23,14 @@ from requests import exceptions
 
 
 def is_snap_installed(snap):
+    return get_local_snap_info(snap) is not None
+
+
+def get_local_snap_info(snap):
     local_snap_info = None
     with contextlib.suppress(exceptions.HTTPError):
         local_snap_info = _get_local_snap_info(_get_parsed_snap(snap)[0])
-    return local_snap_info is not None
+    return local_snap_info
 
 
 def _get_parsed_snap(snap):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This PR removes uses of `os_release` and `repo` from the `snapcraft` module from the integration tests. Necessary functionality is instead added to the integration-specific `platform` and `repo` modules.

Fixes: #1982 

No tests were added or removed.

I locally ran the tests:
 - `./runtests.sh tests/unit` with unrelated failures in [tests.unit.test_lifecycle.CoreSetupTestCase.test_core_setup_if_docker_env](https://bugs.launchpad.net/snapcraft/+bug/1752576), `tests.unit.test_mangling.TestClearExecstack.test_execstack_clears` and `tests.unit.test_elf`.
 - `./runtests.sh tests/integration` with one unrelated failure in [tests.integration.general.test_parser.TestParserWikis](https://bugs.launchpad.net/snapcraft/+bug/1752580)
 - `./runtests.sh static`: Everything passed