### PR TITLE
lxd: wait for on-going refreshes to finish

### DIFF
--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -257,7 +257,8 @@ class Containerbuild:
                 # Wait for any on-going refreshes to finish.
                 # If there are no changes an error will be returned.
                 with contextlib.suppress(ContainerRunError):
-                    self._container_run(['snap', 'watch', '--last=refresh'])
+                    self._container_run([
+                        'snap', 'watch', '--last=auto-refresh'])
                 self._inject_snap('core', tmp_dir)
                 self._inject_snap('snapcraft', tmp_dir)
         elif new_container:

--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -25,6 +25,7 @@ import requests_unixsocket
 import shutil
 import sys
 import tempfile
+import contextlib
 from contextlib import contextmanager
 import subprocess
 import time
@@ -253,6 +254,10 @@ class Containerbuild:
         if common.is_snap():
             with tempfile.TemporaryDirectory(
                     prefix='snapcraft', dir=self._lxd_common_dir) as tmp_dir:
+                # Wait for any on-going refreshes to finish.
+                # If there are no changes an error will be returned.
+                with contextlib.suppress(ContainerRunError):
+                    self._container_run(['snap', 'watch', '--last=refresh'])
                 self._inject_snap('core', tmp_dir)
                 self._inject_snap('snapcraft', tmp_dir)
         elif new_container:

--- a/tests/unit/test_lxd.py
+++ b/tests/unit/test_lxd.py
@@ -313,7 +313,7 @@ class ContainerbuildTestCase(LXDTestCase):
         mock_is_snap.return_value = True
 
         def call_effect(*args, **kwargs):
-            if args[0][-3:] == ['snap', 'watch', '--last=refresh']:
+            if args[0][-3:] == ['snap', 'watch', '--last=auto-refresh']:
                 raise CalledProcessError(returncode=1, cmd=args[0])
             return self.fake_lxd.check_output_side_effect()(*args, **kwargs)
 
@@ -497,7 +497,7 @@ class ContainerbuildTestCase(LXDTestCase):
         ])
         mock_container_run.assert_has_calls([
             call(['apt-get', 'install', 'squashfuse', '-y']),
-            call(['snap', 'watch', '--last=refresh']),
+            call(['snap', 'watch', '--last=auto-refresh']),
             call(['snap', 'ack', '/run/core_123.assert']),
             call(['snap', 'install', '/run/core_123.snap']),
             call(['snap', 'ack', '/run/snapcraft_345.assert']),
@@ -621,7 +621,7 @@ class ContainerbuildTestCase(LXDTestCase):
         ])
         mock_container_run.assert_has_calls([
             call(['apt-get', 'install', 'squashfuse', '-y']),
-            call(['snap', 'watch', '--last=refresh']),
+            call(['snap', 'watch', '--last=auto-refresh']),
             call(['snap', 'ack', '/run/snapcraft_123.assert']),
             call(['snap', 'install', '/run/snapcraft_123.snap', '--classic']),
         ])

--- a/tests/unit/test_lxd.py
+++ b/tests/unit/test_lxd.py
@@ -306,6 +306,57 @@ class ContainerbuildTestCase(LXDTestCase):
                       '--classic']),
             ])
 
+    @patch('snapcraft.internal.lxd.Containerbuild._container_run')
+    @patch('snapcraft.internal.common.is_snap')
+    def test_inject_snap_no_refresh_running(
+            self, mock_is_snap, mock_container_run):
+        mock_is_snap.return_value = True
+
+        def call_effect(*args, **kwargs):
+            if args[0][-3:] == ['snap', 'watch', '--last=refresh']:
+                raise CalledProcessError(returncode=1, cmd=args[0])
+            return self.fake_lxd.check_output_side_effect()(*args, **kwargs)
+
+        self.fake_lxd.check_call_mock.side_effect = call_effect
+
+        fake_snapd = fixture_setup.FakeSnapd()
+        self.useFixture(fake_snapd)
+        fake_snapd.snaps_result = [
+            {'name': 'core',
+             'confinement': 'strict',
+             'id': '2kkitQurgOkL3foImG4wDwn9CIANuHlt',
+             'channel': 'stable',
+             'revision': '123'},
+            {'name': 'snapcraft',
+             'confinement': 'classic',
+             'id': '3lljuRvshPlM4gpJnH5xExo0DJBOvImu',
+             'channel': 'edge',
+             'revision': '345'},
+        ]
+        # Container was created before, and isn't running
+        self.fake_lxd.name = 'myremote:snapcraft-project'
+        self.fake_lxd.status = 'Stopped'
+
+        self.make_containerbuild().execute()
+
+        if hasattr(self, 'cross') and self.cross:
+            mock_container_run.assert_has_calls([
+                call(['snap', 'install', 'core', '--channel', 'stable']),
+                call(['snap', 'refresh', 'core', '--channel', 'stable']),
+                call(['snap', 'install', 'snapcraft', '--channel', 'edge',
+                      '--classic']),
+                call(['snap', 'refresh', 'snapcraft', '--channel', 'edge',
+                      '--classic']),
+            ])
+        else:
+            mock_container_run.assert_has_calls([
+                call(['snap', 'ack', '/run/core_123.assert']),
+                call(['snap', 'install', '/run/core_123.snap']),
+                call(['snap', 'ack', '/run/snapcraft_345.assert']),
+                call(['snap', 'install', '/run/snapcraft_345.snap',
+                      '--classic']),
+            ])
+
     @patch('snapcraft.internal.common.is_snap')
     def test_parallel_invocation(self, mock_is_snap):
         mock_is_snap.side_effect = lambda: False
@@ -446,6 +497,7 @@ class ContainerbuildTestCase(LXDTestCase):
         ])
         mock_container_run.assert_has_calls([
             call(['apt-get', 'install', 'squashfuse', '-y']),
+            call(['snap', 'watch', '--last=refresh']),
             call(['snap', 'ack', '/run/core_123.assert']),
             call(['snap', 'install', '/run/core_123.snap']),
             call(['snap', 'ack', '/run/snapcraft_345.assert']),
@@ -569,6 +621,7 @@ class ContainerbuildTestCase(LXDTestCase):
         ])
         mock_container_run.assert_has_calls([
             call(['apt-get', 'install', 'squashfuse', '-y']),
+            call(['snap', 'watch', '--last=refresh']),
             call(['snap', 'ack', '/run/snapcraft_123.assert']),
             call(['snap', 'install', '/run/snapcraft_123.snap', '--classic']),
         ])


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This PR adds a `snap watch` call before injecting (core and snapcraft) snaps into the LXD container to force any on-going refreshes to be done.

Fixes: #2037 
Fixes: [LP: #1722049](https://bugs.launchpad.net/snapcraft/+bug/1722049)

The following tests were updated:

 - tests.unit.test_lxd.test_inject_snap
 - To verify that the `snap watch` call is made first.

I locally ran the tests:
 - `./runtests.sh tests/unit` with unrelated failures in [tests.unit.test_lifecycle.CoreSetupTestCase.test_core_setup_if_docker_env](https://bugs.launchpad.net/snapcraft/+bug/1752576), `tests.unit.test_mangling.TestClearExecstack.test_execstack_clears` and `tests.unit.test_elf`.
 - `./runtests.sh tests/integration` with one unrelated failure in [tests.integration.general.test_parser.TestParserWikis](https://bugs.launchpad.net/snapcraft/+bug/1752580)
 - `./runtests.sh static`: Everything passed

Manual testing:
 - Testing this is a bit tricky because by design it's a race. First prepare a new container *running Snapcraft as a snap from this branch*.
 - SNAPCRAFT_CONTAINER_BUILDS=1 snapcraft pull
 - Run the following commands in tandem repeatedly to see that it won't cause a problem. Pick different channels for CHANNEL below eg. `--edge` or `--beta` to alternate so that refreshes won't be no-ops. Running this twice will confirm that there are indeed changes in progress, making Snapcraft fail without the fix.
 - lxc start snapcraft-basic
 - lxc exec snapcraft-basic -- snap refresh core --edge --no-wait
 - lxc exec snapcraft-basic -- snap refresh core --edge --no-wait
 - SNAPCRAFT_CONTAINER_BUILDS=1 snapcraft pull