### PR TITLE
build_providers: new build provider using multipass

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ packages = [
     'snapcraft.integrations',
     'snapcraft.internal',
     'snapcraft.internal.cache',
+    'snapcraft.internal.build_providers',
+    'snapcraft.internal.build_providers._multipass',
     'snapcraft.internal.deltas',
     'snapcraft.internal.lifecycle',
     'snapcraft.internal.lxd',

--- a/snapcraft/cli/env.py
+++ b/snapcraft/cli/env.py
@@ -42,9 +42,12 @@ class BuilderEnvironmentConfig:
     results in an error.
     """
 
-    def __init__(self, *, additional_providers: List[str]=None) -> None:
+    def __init__(self, *, default='host',
+                 additional_providers: List[str]=None) -> None:
         """Instantiate a BuildEnvironmentConfig.
 
+        :param str default: the default provider to use among the list of valid
+                            ones.
         :param str additional_providers: Additional providers allowed in the
                                          environment.
         """
@@ -76,7 +79,7 @@ class BuilderEnvironmentConfig:
         if use_lxd:
             build_provider = 'lxd'
         elif not build_provider:
-            build_provider = 'host'
+            build_provider = default
         elif build_provider not in valid_providers:
             raise errors.SnapcraftEnvironmentError(
                 'SNAPCRAFT_BUILD_ENVIRONMENT must be one of: {}.'.format(

--- a/snapcraft/cli/env.py
+++ b/snapcraft/cli/env.py
@@ -15,9 +15,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 from distutils import util
+from typing import List
 
 from . import echo
 from snapcraft.internal import errors
+from snapcraft.formatting_utils import humanize_list
 
 
 class BuilderEnvironmentConfig:
@@ -31,6 +33,7 @@ class BuilderEnvironmentConfig:
 
     - host: the host will drive the build.
     - lxd: the host will setup a container to drive the build.
+    - multipass: a vm driven by multipass will be created to drive the build.
 
     Use of the lxd value is equivalent to setting the now deprecated
     SNAPCRAFT_CONTAINER_BUILDS environment variable to a value that
@@ -39,7 +42,16 @@ class BuilderEnvironmentConfig:
     results in an error.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, additional_providers: List[str]=None) -> None:
+        """Instantiate a BuildEnvironmentConfig.
+
+        :param str additional_providers: Additional providers allowed in the
+                                         environment.
+        """
+        valid_providers = ['host', 'lxd']
+        if additional_providers is not None:
+            valid_providers.extend(additional_providers)
+
         use_lxd = None
         container_builds = os.environ.get('SNAPCRAFT_CONTAINER_BUILDS')
         if container_builds:
@@ -64,12 +76,12 @@ class BuilderEnvironmentConfig:
         if use_lxd:
             build_provider = 'lxd'
         elif not build_provider:
-            echo.warning('Using the host as the build environment.')
             build_provider = 'host'
-        # TODO add multipass
-        elif build_provider not in ['host', 'lxd']:
+        elif build_provider not in valid_providers:
             raise errors.SnapcraftEnvironmentError(
-                'SNAPCRAFT_BUILD_ENVIRONMENT must be one of: host or lxd.')
+                'SNAPCRAFT_BUILD_ENVIRONMENT must be one of: {}.'.format(
+                    humanize_list(items=valid_providers, conjunction='or')))
 
         self.provider = build_provider
         self.is_host = build_provider == 'host'
+        self.is_lxd = build_provider == 'lxd'

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -200,7 +200,6 @@ def cleanbuild(remote, debug, **kwargs):
     \b
     Examples:
         snapcraft cleanbuild
-        snapcraft cleanbuild --use-multipass
 
     The cleanbuild command requires a properly setup lxd environment that
     can connect to external networks. Refer to the "Ubuntu Desktop and

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -195,12 +195,12 @@ def clean(parts, step, **kwargs):
 @click.option('--debug', is_flag=True,
               help='Shells into the environment if the build fails.')
 def cleanbuild(remote, debug, **kwargs):
-    """Create a snap using a clean environment managed by lxd.
+    """Create a snap using a clean environment managed by a build provider.
 
     \b
     Examples:
         snapcraft cleanbuild
-        snapcraft cleanbuild --output
+        snapcraft cleanbuild --use-multipass
 
     The cleanbuild command requires a properly setup lxd environment that
     can connect to external networks. Refer to the "Ubuntu Desktop and
@@ -211,8 +211,18 @@ def cleanbuild(remote, debug, **kwargs):
     If using a remote, a prior setup is required which is described on:
     https://linuxcontainers.org/lxd/getting-started-cli/#multiple-hosts
     """
+    build_environment = env.BuilderEnvironmentConfig(
+        additional_providers=['multipass'])
+    # cleanbuild is a special snow flake, while all the other commands
+    # would work with the host as the build_provider it makes little
+    # sense in this scenario, so change it back to the default of lxd.
+    if build_environment.is_host:
+        build_environment.provider = 'lxd'
     project_options = get_project_options(**kwargs, debug=debug)
-    lifecycle.cleanbuild(project_options, remote)
+    lifecycle.cleanbuild(project=project_options,
+                         echoer=echo,
+                         remote=remote,
+                         build_environment=build_environment)
 
 
 if __name__ == '__main__':

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -211,13 +211,11 @@ def cleanbuild(remote, debug, **kwargs):
     If using a remote, a prior setup is required which is described on:
     https://linuxcontainers.org/lxd/getting-started-cli/#multiple-hosts
     """
-    build_environment = env.BuilderEnvironmentConfig(
-        additional_providers=['multipass'])
     # cleanbuild is a special snow flake, while all the other commands
     # would work with the host as the build_provider it makes little
-    # sense in this scenario, so change it back to the default of lxd.
-    if build_environment.is_host:
-        build_environment.provider = 'lxd'
+    # sense in this scenario.
+    build_environment = env.BuilderEnvironmentConfig(
+        default='lxd', additional_providers=['multipass'])
     project_options = get_project_options(**kwargs, debug=debug)
     lifecycle.cleanbuild(project=project_options,
                          echoer=echo,

--- a/snapcraft/internal/build_providers/__init__.py
+++ b/snapcraft/internal/build_providers/__init__.py
@@ -14,5 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from ._project import Project                          # noqa F401
-from ._project_info import ProjectInfo                 # noqa F401
+from . import errors                    # noqa: F401
+from ._factory import get_provider_for  # noqa: F401
+from ._multipass import Multipass       # noqa: F401

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -65,7 +65,11 @@ class Provider():
 
     @abc.abstractmethod
     def destroy(self):
-        """Provider steps needed to ensure the instance is destroyed."""
+        """Provider steps needed to ensure the instance is destroyed.
+        
+        This method should be safe to call multiple times and do nothing
+        if the instance to destroy is already destroyed.
+        """
 
     @abc.abstractmethod
     def provision_project(self, tarball: str) -> None:

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -1,0 +1,48 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import shlex
+
+import petname
+
+
+# This class is a mix of a parent and a mixin.
+class BaseProvider:
+
+    def __init__(self, *, project, executor, echoer) -> None:
+        self.project = project
+        self.echoer = echoer
+        self.instance_name = petname.Generate(2, '-')
+        self.project_dir = shlex.quote(project.info.name)
+        self._exec = executor
+
+        if project.info.version:
+            self.snap_filename = '{}_{}_{}.snap'.format(
+                project.info.name, project.info.version, project.deb_arch)
+        else:
+            self.snap_filename = '{}_{}.snap'.format(
+                project.info.name, project.deb_arch)
+
+    def launch_instance(self, method, **kwargs):
+        self.echoer.info('Creating a build environment named {!r}'.format(
+            self.instance_name))
+        method(instance_name=self.instance_name, **kwargs)
+
+    def setup_snapcraft(self):
+        self.echoer.info('Setting up snapcraft in {!r}'.format(
+            self.instance_name))
+        install_cmd = ['sudo', 'snap', 'install', 'snapcraft', '--classic']
+        self._exec(command=install_cmd, instance_name=self.instance_name)

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -25,6 +25,8 @@ class BaseProvider:
     def __init__(self, *, project, executor, echoer) -> None:
         self.project = project
         self.echoer = echoer
+        # Once https://github.com/CanonicalLtd/multipass/issues/220 is
+        # closed we can prepend snapcraft- again.
         self.instance_name = petname.Generate(2, '-')
         self.project_dir = shlex.quote(project.info.name)
         self._exec = executor

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -16,7 +16,7 @@
 
 import abc
 import shlex
-from typing import Callable
+from typing import List
 
 import petname
 
@@ -45,28 +45,22 @@ class Provider():
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.destroy()
 
-    @property
     @abc.abstractmethod
-    def run(self) -> Callable[[str], None]:
-        """Return a callable to run commands on the the instance.
-
-        :returns: a callable which takes one argument, a list, with the
-                  command to run.
-        """
-
-    @property
-    @abc.abstractmethod
-    def launch(self) -> Callable[[], None]:
-        """Return a callable that can be used to launch an instance."""
+    def _run(self, command: List) -> None:
+        """Run a command on the instance."""
 
     @abc.abstractmethod
-    def create(self):
+    def _launch(self):
+        """Launch the instance."""
+
+    @abc.abstractmethod
+    def create(self) -> None:
         """Provider steps needed to create a fully functioning environemnt."""
 
     @abc.abstractmethod
-    def destroy(self):
+    def destroy(self) -> None:
         """Provider steps needed to ensure the instance is destroyed.
-        
+
         This method should be safe to call multiple times and do nothing
         if the instance to destroy is already destroyed.
         """
@@ -83,15 +77,18 @@ class Provider():
     def retrieve_snap(self) -> str:
         """
         Provider steps needed to retrieve the built snap from the instance.
+
+        :returns: the filename of the retrieved snap.
+        :rtype: str
         """
 
-    def launch_instance(self):
+    def launch_instance(self) -> None:
         self.echoer.info('Creating a build environment named {!r}'.format(
             self.instance_name))
-        self.launch()
+        self._launch()
 
-    def setup_snapcraft(self):
+    def setup_snapcraft(self) -> None:
         self.echoer.info('Setting up snapcraft in {!r}'.format(
             self.instance_name))
         install_cmd = ['sudo', 'snap', 'install', 'snapcraft', '--classic']
-        self.run(install_cmd)
+        self._run(install_cmd)

--- a/snapcraft/internal/build_providers/_factory.py
+++ b/snapcraft/internal/build_providers/_factory.py
@@ -14,13 +14,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, Type
+from typing import TYPE_CHECKING
 
 from . import errors
 from ._multipass import Multipass
 
+if TYPE_CHECKING:
+    from typing import Type                   # noqa: F401
 
-def get_provider_for(provider_name: str) -> Union[Type[Multipass]]:
+    from ._base_provider import Provider  # noqa: F401
+
+
+def get_provider_for(provider_name: str) -> 'Type[Provider]':
     """Returns a Type that can build with provider_name."""
     if provider_name == 'multipass':
         return Multipass

--- a/snapcraft/internal/build_providers/_factory.py
+++ b/snapcraft/internal/build_providers/_factory.py
@@ -25,4 +25,4 @@ def get_provider_for(provider_name: str) -> Union[Type[Multipass]]:
     if provider_name == 'multipass':
         return Multipass
     else:
-        raise errors.ProviderNotSupported(provider=provider_name)
+        raise errors.ProviderNotSupportedError(provider=provider_name)

--- a/snapcraft/internal/build_providers/_factory.py
+++ b/snapcraft/internal/build_providers/_factory.py
@@ -14,5 +14,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from ._project import Project                          # noqa F401
-from ._project_info import ProjectInfo                 # noqa F401
+from typing import Union, Type
+
+from . import errors
+from ._multipass import Multipass
+
+
+def get_provider_for(provider_name: str) -> Union[Type[Multipass]]:
+    """Returns a Type that can build with provider_name."""
+    if provider_name == 'multipass':
+        return Multipass
+    else:
+        raise errors.ProviderNotSupported(provider=provider_name)

--- a/snapcraft/internal/build_providers/_multipass/__init__.py
+++ b/snapcraft/internal/build_providers/_multipass/__init__.py
@@ -14,5 +14,5 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from ._project import Project                          # noqa F401
-from ._project_info import ProjectInfo                 # noqa F401
+from ._multipass import Multipass                 # noqa: F401
+from ._multipass_command import MultipassCommand  # noqa: F401

--- a/snapcraft/internal/build_providers/_multipass/_instance_info.py
+++ b/snapcraft/internal/build_providers/_multipass/_instance_info.py
@@ -23,9 +23,8 @@ from snapcraft.internal.build_providers import errors
 class InstanceInfo:
 
     @classmethod
-    def new_instance_info_from_json(cls: Type['InstanceInfo'], *,
-                                    instance_name: str,
-                                    json_info: str) -> 'InstanceInfo':
+    def from_json(cls: Type['InstanceInfo'], *, instance_name: str,
+                  json_info: str) -> 'InstanceInfo':
         """Create an InstanceInfo from json_info retrieved from multipass.
 
         :param str instance_name: the name of the instance.

--- a/snapcraft/internal/build_providers/_multipass/_instance_info.py
+++ b/snapcraft/internal/build_providers/_multipass/_instance_info.py
@@ -1,0 +1,81 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+from typing import TypeVar, Type
+
+from snapcraft.internal.build_providers import errors
+
+T = TypeVar('T', bound='InstanceInfo')
+
+
+class InstanceInfo:
+
+    @classmethod
+    def new_instance_info_from_json(cls: Type[T], *, instance_name: str,
+                                    json_info: str) -> T:
+        """Create an InstanceInfo from json_info retrieved from multipass.
+
+        :param str instance_name: the name of the instance.
+        :param str json_info: a json formatted string with the structure
+                              that would follow the output of a json formatted
+                              multipass info command.
+        :returns: an InstanceInfo.
+        :rtype: InstanceInfo
+        :raises snapcraft.internal.build_providers.ProviderInfoDataKeyError:
+            if the instance name cannot be found in the given json or if a
+            required key is missing from that data structure for the instance.
+        """
+        try:
+            json_data = json.loads(json_info)
+        except json.decoder.JSONDecodeError as decode_error:
+            raise errors.ProviderBadDataError(
+                provider_name='multipass',
+                data=json_info) from decode_error
+        try:
+            instance_info = json_data['info'][instance_name]
+        except KeyError as missing_key:
+            raise errors.ProviderInfoDataKeyError(
+                provider_name='multipass',
+                key_info=str(missing_key),
+                data=json_data) from missing_key
+        try:
+            return cls(name=instance_name,
+                       state=instance_info['state'],
+                       image_release=instance_info['image_release'])
+        except KeyError as missing_key:
+            raise errors.ProviderInfoDataKeyError(
+                provider_name='multipass',
+                key_info=str(missing_key),
+                data=instance_info) from missing_key
+
+    def __init__(self, *, name: str, state: str, image_release: str) -> None:
+        """Initialize an InstanceInfo.
+
+        :param str name: the instance name.
+        :param str state: the state of the instance which can be any one of
+                          RUNNING, STOPPED, DELETED.
+        :param str image_release: the Operating System release string for the
+                                  image.
+        """
+        # We do not check for validity of state given that new states could
+        # be introduced.
+        self.name = name
+        self.state = state
+        self.image_release = image_release
+
+    def is_stopped(self):
+        return self.state == 'STOPPED'

--- a/snapcraft/internal/build_providers/_multipass/_instance_info.py
+++ b/snapcraft/internal/build_providers/_multipass/_instance_info.py
@@ -50,7 +50,7 @@ class InstanceInfo:
         except KeyError as missing_key:
             raise errors.ProviderInfoDataKeyError(
                 provider_name='multipass',
-                key_info=str(missing_key),
+                missing_key=str(missing_key),
                 data=json_data) from missing_key
         try:
             return cls(name=instance_name,
@@ -59,7 +59,7 @@ class InstanceInfo:
         except KeyError as missing_key:
             raise errors.ProviderInfoDataKeyError(
                 provider_name='multipass',
-                key_info=str(missing_key),
+                missing_key=str(missing_key),
                 data=instance_info) from missing_key
 
     def __init__(self, *, name: str, state: str, image_release: str) -> None:

--- a/snapcraft/internal/build_providers/_multipass/_instance_info.py
+++ b/snapcraft/internal/build_providers/_multipass/_instance_info.py
@@ -15,18 +15,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
-from typing import TypeVar, Type
+from typing import Type
 
 from snapcraft.internal.build_providers import errors
-
-T = TypeVar('T', bound='InstanceInfo')
 
 
 class InstanceInfo:
 
     @classmethod
-    def new_instance_info_from_json(cls: Type[T], *, instance_name: str,
-                                    json_info: str) -> T:
+    def new_instance_info_from_json(cls: Type['InstanceInfo'], *,
+                                    instance_name: str,
+                                    json_info: str) -> 'InstanceInfo':
         """Create an InstanceInfo from json_info retrieved from multipass.
 
         :param str instance_name: the name of the instance.

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -102,6 +102,5 @@ class Multipass(BaseProvider):
     def _get_instance_info(self):
         instance_info_raw = self._multipass_cmd.info(
             instance_name=self.instance_name, output_format='json')
-        return InstanceInfo.new_instance_info_from_json(
-            instance_name=self.instance_name,
-            json_info=instance_info_raw.decode())
+        return InstanceInfo.from_json(instance_name=self.instance_name,
+                                      json_info=instance_info_raw.decode())

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -23,7 +23,7 @@ from ._multipass_command import MultipassCommand
 
 
 class Multipass(BaseProvider):
-    """A multipass provider for snapcraft execute its lifecycle."""
+    """A multipass provider for snapcraft to execute its lifecycle."""
 
     def __init__(self, *, project, echoer) -> None:
         self._multipass_cmd = MultipassCommand()

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -1,0 +1,103 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import shlex
+from contextlib import contextmanager
+from typing import Generator
+
+from .. import errors
+from .._base_provider import BaseProvider
+from ._instance_info import InstanceInfo
+from ._multipass_command import MultipassCommand
+
+
+class Multipass(BaseProvider):
+    """A multipass provider for snapcraft execute its lifecycle."""
+
+    def __init__(self, *, project, echoer) -> None:
+        self._multipass_cmd = MultipassCommand()
+        super().__init__(project=project, echoer=echoer,
+                         executor=self._multipass_cmd.execute)
+
+    @contextmanager
+    def new_instance(self, keep=True) -> Generator:
+        """Create the multipass instance."""
+        try:
+            self.launch_instance(self._multipass_cmd.launch, image='16.04')
+            self.setup_snapcraft()
+            yield self
+        finally:
+            try:
+                self._try_stop_and_delete(keep=keep)
+            except errors.ProviderStopError as stop_error:
+                self.echoer.warning('Could not stop {!r}: {}.'.format(
+                    self.instance_name, stop_error))
+            except errors.ProviderDeleteError as delete_error:
+                self.echoer.warning('Could not stop {!r}: {}.'.format(
+                    self.instance_name, delete_error))
+
+    def _try_stop_and_delete(self, *, keep: bool) -> None:
+        try:
+            instance_info = self._get_instance_info()
+        except errors.ProviderInfoError as info_error:
+            # An error here means this instance may not exist
+            return
+
+        if instance_info.is_stopped():
+            return
+        self._multipass_cmd.stop(instance_name=self.instance_name)
+        if not keep:
+            self._multipass_cmd.delete(instance_name=self.instance_name)
+
+    def provision_project(self, tarball: str) -> None:
+        """Provision the multipass instance with the project to work with."""
+        # Step 0, sanitize the input
+        tarball = shlex.quote(tarball)
+
+        # First create a working directory
+        self._multipass_cmd.execute(command=['mkdir', self.project_dir],
+                                    instance_name=self.instance_name)
+
+        # Then copy the tarball over
+        destination = '{}:{}'.format(self.instance_name, tarball)
+        self._multipass_cmd.copy_files(source=tarball, destination=destination)
+
+        # Finally extract it into project_dir.
+        extract_cmd = ['tar', '-xvf', tarball, '-C', self.project_dir]
+        self._multipass_cmd.execute(command=extract_cmd,
+                                    instance_name=self.instance_name)
+
+    def build_project(self) -> None:
+        # Use the full path as /snap/bin is not in PATH.
+        snapcraft_cmd = 'cd {}; /snap/bin/snapcraft snap --output {}'.format(
+            self.project_dir, self.snap_filename)
+        self._multipass_cmd.execute(command=['sh', '-c', snapcraft_cmd],
+                                    instance_name=self.instance_name)
+
+    def retrieve_snap(self) -> str:
+        source = '{}:{}/{}'.format(self.instance_name,
+                                   self.project_dir,
+                                   self.snap_filename)
+        self._multipass_cmd.copy_files(source=source,
+                                       destination=self.snap_filename)
+        return self.snap_filename
+
+    def _get_instance_info(self):
+        instance_info_raw = self._multipass_cmd.info(
+            instance_name=self.instance_name, output_format='json')
+        return InstanceInfo.new_instance_info_from_json(
+            instance_name=self.instance_name,
+            json_info=instance_info_raw.decode())

--- a/snapcraft/internal/build_providers/_multipass/_multipass_command.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass_command.py
@@ -1,0 +1,147 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import signal
+import shutil
+import subprocess
+from typing import List
+
+from snapcraft.internal.build_providers import errors
+
+
+logger = logging.getLogger(__name__)
+
+
+def _run(command: List) -> None:
+    logger.debug('Running {}'.format(' '.join(command)))
+    subprocess.check_call(command)
+
+
+def _run_output(command: List) -> bytes:
+    logger.debug('Running {}'.format(' '.join(command)))
+    return subprocess.check_output(command)
+
+
+def _ignore_signal(sig, stack):
+    # We only do this for SIGUSR1 as it is the one we mostly
+    # care about.
+    if sig == signal.SIGUSR1:
+        sig = 'SIGUSR1'
+    logger.debug('Ignoring {!r}: {!r}'.format(sig, dir(stack)))
+
+
+class MultipassCommand:
+    """An object representation of common multipass cli commands."""
+
+    provider_name = 'multipass'
+
+    def __init__(self) -> None:
+        """Initialize a MultipassCommand instance.
+
+        :raises errors.ProviderCommandNotFound:
+            if the multipass command is not found.
+        """
+        provider_cmd = 'multipass'
+        if not shutil.which(provider_cmd):
+            raise errors.ProviderCommandNotFound(command=provider_cmd)
+        self.provider_cmd = provider_cmd
+        # Workaround for https://github.com/CanonicalLtd/multipass/issues/221
+        signal.signal(signal.SIGUSR1, _ignore_signal)
+
+    def launch(self, *, instance_name: str, image: str,
+               remote: str=None) -> None:
+        """Passthrough for running multipass launch.
+
+        :param str instance_name: the name the launched instance will have.
+        :param str image: the image to create the instance with.
+        :param str remote: the remote server to retrieve the image from.
+        """
+        if remote is not None:
+            image = '{}:{}'.format(remote, image)
+        cmd = [self.provider_cmd, 'launch', image, '--name', instance_name]
+        try:
+            _run(cmd)
+        except subprocess.CalledProcessError as process_error:
+            raise errors.ProviderLaunchError(
+                provider_name=self.provider_name) from process_error
+
+    def stop(self, *, instance_name: str) -> None:
+        """Passthrough for running multipass stop.
+
+        :param str instance_name: the name of the instance to stop.
+        """
+        cmd = [self.provider_cmd, 'stop', instance_name]
+        try:
+            _run(cmd)
+        except subprocess.CalledProcessError as process_error:
+            raise errors.ProviderStopError(
+                provider_name=self.provider_name) from process_error
+
+    def delete(self, *, instance_name: str, purge=True) -> None:
+        """Passthrough for running multipass delete.
+
+        :param str instance_name: the name of the instance to delete.
+        :param bool purge: if true, purge the instance's image after deleting.
+        """
+        cmd = [self.provider_cmd, 'delete', instance_name]
+        if purge:
+            cmd.append('--purge')
+        try:
+            _run(cmd)
+        except subprocess.CalledProcessError as process_error:
+            raise errors.ProviderDeleteError(
+                provider_name=self.provider_name) from process_error
+
+    def execute(self, *, command: List[str], instance_name: str) -> None:
+        """Passthrough for running multipass exec.
+
+        :param list command: the command to exectute on the instance.
+        :param str instance_name: the name of the instance to execute command.
+        """
+        cmd = [self.provider_cmd, 'exec', instance_name, '--'] + command
+        try:
+            _run(cmd)
+        except subprocess.CalledProcessError as process_error:
+            raise errors.ProviderExecError(
+                provider_name=self.provider_name,
+                command=command) from process_error
+
+    def copy_files(self, *, source: str, destination: str):
+        """Passthrough for running multipass copy-files.
+
+        :param str source: the source file to copy, using syntax expected
+                           by multipass.
+        :param str destination: the destination of the copied file, using
+                                syntax expected by multipass.
+        """
+        cmd = [self.provider_cmd, 'copy-files', source, destination]
+        try:
+            _run(cmd)
+        except subprocess.CalledProcessError as process_error:
+            raise errors.ProviderFileCopyError(
+                provider_name=self.provider_name) from process_error
+
+    def info(self, *, instance_name: str, output_format: str=None) -> bytes:
+        """Passthrough for running multipass info."""
+        cmd = [self.provider_cmd, 'info', instance_name]
+        if output_format is not None:
+            cmd.extend(['--format', output_format])
+        try:
+            return _run_output(cmd)
+        except subprocess.CalledProcessError as process_error:
+            raise errors.ProviderInfoError(
+                provider_name=self.provider_name) from process_error

--- a/snapcraft/internal/build_providers/_multipass/_multipass_command.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass_command.py
@@ -124,7 +124,7 @@ class MultipassCommand:
                 command=command,
                 exit_code=process_error.returncode) from process_error
 
-    def copy_files(self, *, source: str, destination: str):
+    def copy_files(self, *, source: str, destination: str) -> None:
         """Passthrough for running multipass copy-files.
 
         :param str source: the source file to copy, using syntax expected

--- a/snapcraft/internal/build_providers/_multipass/_multipass_command.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass_command.py
@@ -77,7 +77,8 @@ class MultipassCommand:
             _run(cmd)
         except subprocess.CalledProcessError as process_error:
             raise errors.ProviderLaunchError(
-                provider_name=self.provider_name) from process_error
+                provider_name=self.provider_name,
+                exit_code=process_error.returncode) from process_error
 
     def stop(self, *, instance_name: str) -> None:
         """Passthrough for running multipass stop.
@@ -89,7 +90,8 @@ class MultipassCommand:
             _run(cmd)
         except subprocess.CalledProcessError as process_error:
             raise errors.ProviderStopError(
-                provider_name=self.provider_name) from process_error
+                provider_name=self.provider_name,
+                exit_code=process_error.returncode) from process_error
 
     def delete(self, *, instance_name: str, purge=True) -> None:
         """Passthrough for running multipass delete.
@@ -104,7 +106,8 @@ class MultipassCommand:
             _run(cmd)
         except subprocess.CalledProcessError as process_error:
             raise errors.ProviderDeleteError(
-                provider_name=self.provider_name) from process_error
+                provider_name=self.provider_name,
+                exit_code=process_error.returncode) from process_error
 
     def execute(self, *, command: List[str], instance_name: str) -> None:
         """Passthrough for running multipass exec.
@@ -118,7 +121,8 @@ class MultipassCommand:
         except subprocess.CalledProcessError as process_error:
             raise errors.ProviderExecError(
                 provider_name=self.provider_name,
-                command=command) from process_error
+                command=command,
+                exit_code=process_error.returncode) from process_error
 
     def copy_files(self, *, source: str, destination: str):
         """Passthrough for running multipass copy-files.
@@ -133,7 +137,8 @@ class MultipassCommand:
             _run(cmd)
         except subprocess.CalledProcessError as process_error:
             raise errors.ProviderFileCopyError(
-                provider_name=self.provider_name) from process_error
+                provider_name=self.provider_name,
+                exit_code=process_error.returncode) from process_error
 
     def info(self, *, instance_name: str, output_format: str=None) -> bytes:
         """Passthrough for running multipass info."""
@@ -144,4 +149,5 @@ class MultipassCommand:
             return _run_output(cmd)
         except subprocess.CalledProcessError as process_error:
             raise errors.ProviderInfoError(
-                provider_name=self.provider_name) from process_error
+                provider_name=self.provider_name,
+                exit_code=process_error.returncode) from process_error

--- a/snapcraft/internal/build_providers/errors.py
+++ b/snapcraft/internal/build_providers/errors.py
@@ -35,8 +35,8 @@ class ProviderNotSupportedError(_SnapcraftError):
 class ProviderCommandNotFound(_SnapcraftError):
 
     fmt = (
-        'The {command!r} command is necessary to be able to build in this '
-        'environment.\n'
+        '{command!r} command not found: this command is necessary to build in '
+        'this environment.\n'
         'Install {command!r} or if already installed, ensure it is '
         'on the system PATH, and try again.'
     )

--- a/snapcraft/internal/build_providers/errors.py
+++ b/snapcraft/internal/build_providers/errors.py
@@ -45,83 +45,83 @@ class ProviderCommandNotFound(_SnapcraftError):
         super().__init__(command=command)
 
 
-class ProviderLaunchError(_SnapcraftError):
+class _GenericProviderError(_SnapcraftError):
 
     fmt = (
-        'An error occurred when trying to launch the instance with '
-        '{provider_name!r}.'
+        'An error occurred when trying to {action} the instance with '
+        '{provider_name!r}: returned exit code {exit_code!r}.\n'
+        'Ensure that {provider_name!r} is setup correctly and try again.'
     )
 
-    def __init__(self, *, provider_name: str) -> None:
-        super().__init__(provider_name=provider_name)
+
+class ProviderLaunchError(_GenericProviderError):
+
+    def __init__(self, *, provider_name: str, exit_code: int) -> None:
+        super().__init__(action='launch', provider_name=provider_name,
+                         exit_code=exit_code)
 
 
-class ProviderStopError(_SnapcraftError):
+class ProviderStopError(_GenericProviderError):
 
-    fmt = (
-        'An error occurred when trying to stop the instance with '
-        '{provider_name!r}.'
-    )
-
-    def __init__(self, *, provider_name: str) -> None:
-        super().__init__(provider_name=provider_name)
+    def __init__(self, *, provider_name: str, exit_code: int) -> None:
+        super().__init__(action='stop', provider_name=provider_name,
+                         exit_code=exit_code)
 
 
-class ProviderDeleteError(_SnapcraftError):
+class ProviderDeleteError(_GenericProviderError):
 
-    fmt = (
-        'An error occurred when trying to delete the instance with '
-        '{provider_name!r}.'
-    )
-
-    def __init__(self, *, provider_name: str) -> None:
-        super().__init__(provider_name=provider_name)
+    def __init__(self, *, provider_name: str, exit_code: int) -> None:
+        super().__init__(action='delete', provider_name=provider_name,
+                         exit_code=exit_code)
 
 
 class ProviderExecError(_SnapcraftError):
 
     fmt = (
         'An error occurred when trying to execute {command_string!r} with '
-        '{provider_name!r}.'
+        '{provider_name!r}: returned exit code {exit_code!r}.'
     )
 
-    def __init__(self, *, provider_name: str, command: Sequence[str]) -> None:
+    def __init__(self, *, provider_name: str, command: Sequence[str],
+                 exit_code: int) -> None:
         command_string = ' '.join(shlex.quote(i) for i in command)
         super().__init__(provider_name=provider_name, command=command,
-                         command_string=command_string)
+                         command_string=command_string,
+                         exit_code=exit_code)
 
 
 class ProviderFileCopyError(_SnapcraftError):
 
     fmt = (
-        'An error occurred when trying to copy files using {provider_name!r}.'
+        'An error occurred when trying to copy files using {provider_name!r}: '
+        'returned exit code {exit_code!r}.'
     )
 
-    def __init__(self, *, provider_name: str) -> None:
-        super().__init__(provider_name=provider_name)
+    def __init__(self, *, provider_name: str, exit_code: int) -> None:
+        super().__init__(provider_name=provider_name, exit_code=exit_code)
 
 
 class ProviderInfoError(_SnapcraftError):
 
     fmt = (
         'An error occurred when using {provider_name!r} to '
-        'query the status of the instance.'
+        'query the status of the instance: returned exit code {exit_code!r}.'
     )
 
-    def __init__(self, *, provider_name: str) -> None:
-        super().__init__(provider_name=provider_name)
+    def __init__(self, *, provider_name: str, exit_code: int) -> None:
+        super().__init__(provider_name=provider_name, exit_code=exit_code)
 
 
 class ProviderInfoDataKeyError(_SnapcraftError):
 
     fmt = (
         'The data returned by {provider_name!r} was not expected. '
-        'It is missing some key data {key_info!r} in {data!r}.'
+        'It is missing a required key {missing_key!r} in {data!r}.'
     )
 
-    def __init__(self, *, provider_name: str, key_info: str,
+    def __init__(self, *, provider_name: str, missing_key: str,
                  data: Dict[str, Any]) -> None:
-        super().__init__(provider_name=provider_name, key_info=key_info,
+        super().__init__(provider_name=provider_name, missing_key=missing_key,
                          data=data)
 
 

--- a/snapcraft/internal/build_providers/errors.py
+++ b/snapcraft/internal/build_providers/errors.py
@@ -21,7 +21,7 @@ from typing import Sequence  # noqa: F401
 from snapcraft.internal.errors import SnapcraftError as _SnapcraftError
 
 
-class ProviderNotSupported(_SnapcraftError):
+class ProviderNotSupportedError(_SnapcraftError):
 
     fmt = (
         'The {provider!r} provider is not supported, please choose a '

--- a/snapcraft/internal/build_providers/errors.py
+++ b/snapcraft/internal/build_providers/errors.py
@@ -1,0 +1,136 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import shlex
+from typing import Any, Dict
+from typing import Sequence  # noqa: F401
+
+from snapcraft.internal.errors import SnapcraftError as _SnapcraftError
+
+
+class ProviderNotSupported(_SnapcraftError):
+
+    fmt = (
+        'The {provider!r} provider is not supported, please choose a '
+        'different one and try again.'
+    )
+
+    def __init__(self, *, provider: str) -> None:
+        super().__init__(provider=provider)
+
+
+class ProviderCommandNotFound(_SnapcraftError):
+
+    fmt = (
+        'The {command!r} command is necessary to be able to build in this '
+        'environment.\n'
+        'Install {command!r} or if already installed, ensure it is '
+        'on the system PATH, and try again.'
+    )
+
+    def __init__(self, *, command: str) -> None:
+        super().__init__(command=command)
+
+
+class ProviderLaunchError(_SnapcraftError):
+
+    fmt = (
+        'An error occurred when trying to launch the instance with '
+        '{provider_name!r}.'
+    )
+
+    def __init__(self, *, provider_name: str) -> None:
+        super().__init__(provider_name=provider_name)
+
+
+class ProviderStopError(_SnapcraftError):
+
+    fmt = (
+        'An error occurred when trying to stop the instance with '
+        '{provider_name!r}.'
+    )
+
+    def __init__(self, *, provider_name: str) -> None:
+        super().__init__(provider_name=provider_name)
+
+
+class ProviderDeleteError(_SnapcraftError):
+
+    fmt = (
+        'An error occurred when trying to delete the instance with '
+        '{provider_name!r}.'
+    )
+
+    def __init__(self, *, provider_name: str) -> None:
+        super().__init__(provider_name=provider_name)
+
+
+class ProviderExecError(_SnapcraftError):
+
+    fmt = (
+        'An error occurred when trying to execute {command_string!r} with '
+        '{provider_name!r}.'
+    )
+
+    def __init__(self, *, provider_name: str, command: Sequence[str]) -> None:
+        command_string = ' '.join(shlex.quote(i) for i in command)
+        super().__init__(provider_name=provider_name, command=command,
+                         command_string=command_string)
+
+
+class ProviderFileCopyError(_SnapcraftError):
+
+    fmt = (
+        'An error occurred when trying to copy files using {provider_name!r}.'
+    )
+
+    def __init__(self, *, provider_name: str) -> None:
+        super().__init__(provider_name=provider_name)
+
+
+class ProviderInfoError(_SnapcraftError):
+
+    fmt = (
+        'An error occurred when using {provider_name!r} to '
+        'query the status of the instance.'
+    )
+
+    def __init__(self, *, provider_name: str) -> None:
+        super().__init__(provider_name=provider_name)
+
+
+class ProviderInfoDataKeyError(_SnapcraftError):
+
+    fmt = (
+        'The data returned by {provider_name!r} was not expected. '
+        'It is missing some key data {key_info!r} in {data!r}.'
+    )
+
+    def __init__(self, *, provider_name: str, key_info: str,
+                 data: Dict[str, Any]) -> None:
+        super().__init__(provider_name=provider_name, key_info=key_info,
+                         data=data)
+
+
+class ProviderBadDataError(_SnapcraftError):
+
+    fmt = (
+        'The data returned by {provider_name!r} was not expected '
+        'or in the wrong format: {data!r}.'
+    )
+
+    def __init__(self, *, provider_name: str, data: str) -> None:
+        super().__init__(provider_name=provider_name, data=data)

--- a/snapcraft/internal/lifecycle/_containers.py
+++ b/snapcraft/internal/lifecycle/_containers.py
@@ -54,8 +54,7 @@ def cleanbuild(*, project, echoer, build_environment, remote='') -> None:
         return
 
     build_provider_class = build_providers.get_provider_for('multipass')
-    build_provider = build_provider_class(project=project, echoer=echoer)
-    with build_provider.new_instance(keep=False) as instance:
+    with build_provider_class(project=project, echoer=echoer) as instance:
         instance.provision_project(tar_filename)
         instance.build_project()
         instance.retrieve_snap()

--- a/snapcraft/project/__init__.py
+++ b/snapcraft/project/__init__.py
@@ -15,4 +15,3 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from ._project import Project                          # noqa F401
-from ._project_info import ProjectInfo                 # noqa F401

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -16,7 +16,8 @@
 
 from unittest import mock
 
-from snapcraft.project import Project, ProjectInfo
+from snapcraft.project import Project
+from snapcraft.project._project_info import ProjectInfo
 
 from tests import unit
 

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -37,4 +37,3 @@ class BaseProviderBaseTest(unit.TestCase):
         self.project.info = ProjectInfo(dict(name='project-name'))
 
         self.echoer_mock = mock.Mock()
-        self.executor_mock = mock.Mock()

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -1,0 +1,39 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import mock
+
+from snapcraft.project import Project, ProjectInfo
+
+from tests import unit
+
+
+class BaseProviderBaseTest(unit.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.instance_name = 'ridicoulus-hours'
+        patcher = mock.patch('petname.Generate',
+                             return_value=self.instance_name)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.project = Project()
+        self.project.info = ProjectInfo(dict(name='project-name'))
+
+        self.echoer_mock = mock.Mock()
+        self.executor_mock = mock.Mock()

--- a/tests/unit/build_providers/multipass/test_instance_info.py
+++ b/tests/unit/build_providers/multipass/test_instance_info.py
@@ -97,7 +97,7 @@ class InstanceInfoFromJSONTest(unit.TestCase):
                                    instance_name='wrong-name',
                                    json_info=self.json_string)
         self.assertThat(raised.provider_name, Equals('multipass'))
-        self.assertThat(raised.key_info, Equals("'wrong-name'"))
+        self.assertThat(raised.missing_key, Equals("'wrong-name'"))
 
     def test_new_instance_from_unmarshalled_json_empty_fails(self):
         raised = self.assertRaises(errors.ProviderBadDataError,

--- a/tests/unit/build_providers/multipass/test_instance_info.py
+++ b/tests/unit/build_providers/multipass/test_instance_info.py
@@ -1,0 +1,108 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from textwrap import dedent
+
+from testtools.matchers import Equals
+
+from snapcraft.internal.build_providers import errors
+from snapcraft.internal.build_providers._multipass._instance_info import InstanceInfo  # noqa: E501
+from tests import unit
+
+
+class InstanceInfoGeneralTest(unit.TestCase):
+
+    def test_initialize(self):
+        instance_info = InstanceInfo(name='instance-name', state='RUNNING',
+                                     image_release='16.04 LTS')
+
+        self.assertThat(instance_info.name, Equals('instance-name'))
+        self.assertThat(instance_info.state, Equals('RUNNING'))
+        self.assertThat(instance_info.image_release, Equals('16.04 LTS'))
+        self.assertThat(instance_info.is_stopped(), Equals(False))
+
+    def test_instance_is_stopped(self):
+        instance_info = InstanceInfo(name='instance-name', state='STOPPED',
+                                     image_release='16.04 LTS')
+
+        self.assertThat(instance_info.is_stopped(), Equals(True))
+
+
+class InstanceInfoFromJSONTest(unit.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.json_string = dedent("""\
+            {
+                "errors": [
+                ],
+                "info": {
+                    "announceable-rodney": {
+                        "disks": {
+                            "sda1": {
+                                "total": "5136297984",
+                                "used": "1076072448"
+                            }
+                        },
+                        "image_hash": "bc990872f070249450fc187d668bf65e2f87ffa3d7cf6e2934cb84b62af368e1",
+                        "image_release": "16.04 LTS",
+                        "ipv4": [
+                            "10.74.70.141"
+                        ],
+                        "load": [
+                            0,
+                            0,
+                            0
+                        ],
+                        "memory": {
+                            "total": 1040318464,
+                            "used": 42754048
+                        },
+                        "mounts": {
+                        },
+                        "release": "Ubuntu 16.04.4 LTS",
+                        "state": "RUNNING"
+                    }
+                }
+            }
+        """)  # noqa: E501
+        self.instance_name = 'announceable-rodney'
+
+    def test_new_instance_from_unmarshalled_json(self):
+        instance_info = InstanceInfo.new_instance_info_from_json(
+            instance_name=self.instance_name,
+            json_info=self.json_string)
+
+        self.assertThat(instance_info.name, Equals(self.instance_name))
+        self.assertThat(instance_info.state, Equals('RUNNING'))
+        self.assertThat(instance_info.image_release, Equals('16.04 LTS'))
+
+    def test_new_instance_from_unmarshalled_json_wrong_instance_fails(self):
+        raised = self.assertRaises(errors.ProviderInfoDataKeyError,
+                                   InstanceInfo.new_instance_info_from_json,
+                                   instance_name='wrong-name',
+                                   json_info=self.json_string)
+        self.assertThat(raised.provider_name, Equals('multipass'))
+        self.assertThat(raised.key_info, Equals("'wrong-name'"))
+
+    def test_new_instance_from_unmarshalled_json_empty_fails(self):
+        raised = self.assertRaises(errors.ProviderBadDataError,
+                                   InstanceInfo.new_instance_info_from_json,
+                                   instance_name=self.instance_name,
+                                   json_info='bad-json')
+        self.assertThat(raised.provider_name, Equals('multipass'))
+        self.assertThat(raised.data, Equals('bad-json'))

--- a/tests/unit/build_providers/multipass/test_instance_info.py
+++ b/tests/unit/build_providers/multipass/test_instance_info.py
@@ -83,7 +83,7 @@ class InstanceInfoFromJSONTest(unit.TestCase):
         self.instance_name = 'announceable-rodney'
 
     def test_new_instance_from_unmarshalled_json(self):
-        instance_info = InstanceInfo.new_instance_info_from_json(
+        instance_info = InstanceInfo.from_json(
             instance_name=self.instance_name,
             json_info=self.json_string)
 
@@ -93,7 +93,7 @@ class InstanceInfoFromJSONTest(unit.TestCase):
 
     def test_new_instance_from_unmarshalled_json_wrong_instance_fails(self):
         raised = self.assertRaises(errors.ProviderInfoDataKeyError,
-                                   InstanceInfo.new_instance_info_from_json,
+                                   InstanceInfo.from_json,
                                    instance_name='wrong-name',
                                    json_info=self.json_string)
         self.assertThat(raised.provider_name, Equals('multipass'))
@@ -101,7 +101,7 @@ class InstanceInfoFromJSONTest(unit.TestCase):
 
     def test_new_instance_from_unmarshalled_json_empty_fails(self):
         raised = self.assertRaises(errors.ProviderBadDataError,
-                                   InstanceInfo.new_instance_info_from_json,
+                                   InstanceInfo.from_json,
                                    instance_name=self.instance_name,
                                    json_info='bad-json')
         self.assertThat(raised.provider_name, Equals('multipass'))

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -181,7 +181,7 @@ class MultipassTest(BaseProviderBaseTest):
     def test_instance_does_not_exist_on_destroy(self):
         # An error is raised if the queried image does not exist
         self.multipass_cmd_mock().info.side_effect = errors.ProviderInfoError(
-            provider_name=self.instance_name)
+            provider_name=self.instance_name, exit_code=2)
 
         multipass = Multipass(project=self.project, echoer=self.echoer_mock)
 

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -1,0 +1,191 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from textwrap import dedent
+from unittest import mock
+
+from tests.unit.build_providers import BaseProviderBaseTest
+from snapcraft.internal.build_providers import errors
+from snapcraft.internal.build_providers._multipass import (
+    Multipass, MultipassCommand)
+
+
+_DEFAULT_INSTANCE_INFO = dedent("""\
+    {
+        "errors": [
+        ],
+        "info": {
+            "ridicoulus-hours": {
+                "disks": {
+                    "sda1": {
+                        "total": "5136297984",
+                        "used": "1076072448"
+                    }
+                },
+                "image_hash": "bc990872f070249450fc187d668bf65e2f87ffa3d7cf6e2934cb84b62af368e1",
+                "image_release": "16.04 LTS",
+                "ipv4": [
+                    "10.74.70.141"
+                ],
+                "load": [
+                    0,
+                    0,
+                    0
+                ],
+                "memory": {
+                    "total": 1040318464,
+                    "used": 42754048
+                },
+                "mounts": {
+                },
+                "release": "Ubuntu 16.04.4 LTS",
+                "state": "RUNNING"
+            }
+        }
+    }
+    """)  # noqa: E501
+
+
+class MultipassTest(BaseProviderBaseTest):
+
+    def setUp(self):
+        super().setUp()
+
+        patcher = mock.patch(
+            'snapcraft.internal.build_providers._multipass.'
+            '_multipass.MultipassCommand',
+            spec=MultipassCommand)
+        self.multipass_cmd_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        # default data returned for info
+        self.multipass_cmd_mock().info.return_value = \
+            _DEFAULT_INSTANCE_INFO.encode()
+
+    def test_instance_with_contextmanager(self):
+        with Multipass(project=self.project,
+                       echoer=self.echoer_mock) as instance:
+            instance.provision_project('source.tar')
+            instance.build_project()
+            instance.retrieve_snap()
+
+        self.multipass_cmd_mock().launch.assert_called_once_with(
+            image='16.04', instance_name=self.instance_name)
+        self.multipass_cmd_mock().execute.assert_has_calls([
+            mock.call(
+                instance_name=self.instance_name,
+                command=['sudo', 'snap', 'install', 'snapcraft',
+                         '--classic']),
+            mock.call(
+                instance_name=self.instance_name,
+                command=['mkdir', 'project-name']),
+            mock.call(
+                instance_name=self.instance_name,
+                command=['tar', '-xvf', 'source.tar', '-C', 'project-name']),
+            mock.call(
+                instance_name=self.instance_name,
+                command=['sh', '-c', 'cd project-name; /snap/bin/snapcraft '
+                         'snap --output project-name_{}.snap'.format(
+                             self.project.deb_arch)]),
+        ])
+        self.multipass_cmd_mock().info.assert_called_once_with(
+            instance_name=self.instance_name, output_format='json')
+
+        self.multipass_cmd_mock().copy_files.assert_has_calls([
+            mock.call(destination='{}:source.tar'.format(self.instance_name),
+                      source='source.tar'),
+            mock.call(destination='project-name_{}.snap'.format(
+                        self.project.deb_arch),
+                      source='{}:project-name/project-name_{}.snap'.format(
+                        self.instance_name, self.project.deb_arch)),
+        ])
+        self.multipass_cmd_mock().stop.assert_called_once_with(
+            instance_name=self.instance_name)
+        self.multipass_cmd_mock().delete.assert_called_once_with(
+            instance_name=self.instance_name)
+
+    def test_provision_project(self):
+        multipass = Multipass(project=self.project, echoer=self.echoer_mock)
+
+        # In the real world, MultipassCommand would return an error when
+        # calling this on an instance that does not exist.
+        multipass.provision_project('source.tar')
+
+        self.multipass_cmd_mock().execute.assert_has_calls([
+            mock.call(
+                instance_name=self.instance_name,
+                command=['mkdir', 'project-name']),
+            mock.call(
+                instance_name=self.instance_name,
+                command=['tar', '-xvf', 'source.tar', '-C', 'project-name']),
+            ])
+        self.multipass_cmd_mock().copy_files.assert_called_once_with(
+            destination='{}:source.tar'.format(self.instance_name),
+            source='source.tar')
+
+        self.multipass_cmd_mock().launch.assert_not_called()
+        self.multipass_cmd_mock().info.assert_not_called()
+        self.multipass_cmd_mock().stop.assert_not_called()
+        self.multipass_cmd_mock().delete.assert_not_called()
+
+    def test_build_project(self):
+        multipass = Multipass(project=self.project, echoer=self.echoer_mock)
+
+        # In the real world, MultipassCommand would return an error when
+        # calling this on an instance that does not exist.
+        multipass.build_project()
+
+        self.multipass_cmd_mock().execute.assert_called_once_with(
+            instance_name=self.instance_name,
+            command=['sh', '-c', 'cd project-name; /snap/bin/snapcraft '
+                     'snap --output project-name_{}.snap'.format(
+                        self.project.deb_arch)])
+
+        self.multipass_cmd_mock().copy_files.assert_not_called()
+        self.multipass_cmd_mock().launch.assert_not_called()
+        self.multipass_cmd_mock().info.assert_not_called()
+        self.multipass_cmd_mock().stop.assert_not_called()
+        self.multipass_cmd_mock().delete.assert_not_called()
+
+    def test_retrieve_snap(self):
+        multipass = Multipass(project=self.project, echoer=self.echoer_mock)
+
+        # In the real world, MultipassCommand would return an error when
+        # calling this on an instance that does not exist.
+        multipass.retrieve_snap()
+
+        self.multipass_cmd_mock().copy_files.assert_called_once_with(
+            destination='project-name_{}.snap'.format(self.project.deb_arch),
+            source='{}:project-name/project-name_{}.snap'.format(
+                self.instance_name, self.project.deb_arch))
+
+        self.multipass_cmd_mock().execute.assert_not_called()
+        self.multipass_cmd_mock().launch.assert_not_called()
+        self.multipass_cmd_mock().info.assert_not_called()
+        self.multipass_cmd_mock().stop.assert_not_called()
+        self.multipass_cmd_mock().delete.assert_not_called()
+
+    def test_instance_does_not_exist_on_destroy(self):
+        # An error is raised if the queried image does not exist
+        self.multipass_cmd_mock().info.side_effect = errors.ProviderInfoError(
+            provider_name=self.instance_name)
+
+        multipass = Multipass(project=self.project, echoer=self.echoer_mock)
+
+        multipass.destroy()
+
+        self.multipass_cmd_mock().stop.assert_not_called()
+        self.multipass_cmd_mock().delete.assert_not_called()

--- a/tests/unit/build_providers/multipass/test_multipass_command.py
+++ b/tests/unit/build_providers/multipass/test_multipass_command.py
@@ -1,0 +1,224 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+from unittest import mock
+
+from testtools.matchers import Equals
+
+from snapcraft.internal.build_providers import errors
+from snapcraft.internal.build_providers._multipass import MultipassCommand
+from tests import unit
+
+
+class MultipassCommandBaseTest(unit.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        patcher = mock.patch('signal.signal')
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch('shutil.which', return_value=['multipass'])
+        self.which_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+
+class MultipassCommandGeneralTest(MultipassCommandBaseTest):
+
+    def test_provider_name(self):
+        self.assertThat(MultipassCommand.provider_name, Equals('multipass'))
+
+    def test_multipass_command_missing_raises(self):
+        self.which_mock.return_value = []
+
+        self.assertRaises(errors.ProviderCommandNotFound,
+                          MultipassCommand)
+
+
+class MultipassCommandPassthroughBaseTest(MultipassCommandBaseTest):
+
+    def setUp(self):
+        super().setUp()
+
+        patcher = mock.patch('subprocess.check_call')
+        self.check_call_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch('subprocess.check_output')
+        self.check_output_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.multipass_command = MultipassCommand()
+        self.instance_name = 'stub-instance'
+
+
+class MultipassCommandLaunchTest(MultipassCommandPassthroughBaseTest):
+
+    def test_launch(self):
+        self.multipass_command.launch(instance_name=self.instance_name,
+                                      image='16.04')
+
+        self.check_call_mock.assert_called_once_with([
+            'multipass', 'launch', '16.04', '--name', self.instance_name
+        ])
+        self.check_output_mock.assert_not_called()
+
+    def test_launch_with_remote(self):
+        self.multipass_command.launch(instance_name=self.instance_name,
+                                      image='18.04', remote='daily')
+
+        self.check_call_mock.assert_called_once_with([
+            'multipass', 'launch', 'daily:18.04', '--name', self.instance_name
+        ])
+        self.check_output_mock.assert_not_called()
+
+    def test_launch_fails(self):
+        # multipass can fail due to several reasons and will display the error
+        # right above this exception message, it looks something like:
+        #
+        #   Creating a build environment named 'nonfilterable-mayola'
+        #   failed to launch: failed to obtain exit status for remote process
+        #   An error occurred when trying to launch the instance with 'multipass'.  # noqa: E501
+        cmd = ['multipass', 'launch', '18.04', '--name', self.instance_name]
+        self.check_call_mock.side_effect = subprocess.CalledProcessError(
+            1, cmd)
+
+        self.assertRaises(errors.ProviderLaunchError,
+                          self.multipass_command.launch,
+                          instance_name=self.instance_name, image='18.04')
+        self.check_call_mock.assert_called_once_with(cmd)
+        self.check_output_mock.assert_not_called()
+
+
+class MultipassCommandStopTest(MultipassCommandPassthroughBaseTest):
+
+    def test_stop(self):
+        self.multipass_command.stop(instance_name=self.instance_name)
+
+        self.check_call_mock.assert_called_once_with([
+            'multipass', 'stop', self.instance_name
+        ])
+        self.check_output_mock.assert_not_called()
+
+    def test_stop_fails(self):
+        # multipass can fail due to several reasons and will display the error
+        # right above this exception message.
+        cmd = ['multipass', 'stop', self.instance_name]
+        self.check_call_mock.side_effect = subprocess.CalledProcessError(
+            1, cmd)
+
+        self.assertRaises(errors.ProviderStopError,
+                          self.multipass_command.stop,
+                          instance_name=self.instance_name)
+        self.check_call_mock.assert_called_once_with(cmd)
+        self.check_output_mock.assert_not_called()
+
+
+class MultipassCommandDeleteTest(MultipassCommandPassthroughBaseTest):
+
+    def test_delete_implicit_purge(self):
+        self.multipass_command.delete(instance_name=self.instance_name)
+
+        self.check_call_mock.assert_called_once_with([
+            'multipass', 'delete', self.instance_name, '--purge'
+        ])
+        self.check_output_mock.assert_not_called()
+
+    def test_delete_no_purge(self):
+        self.multipass_command.delete(instance_name=self.instance_name,
+                                      purge=False)
+
+        self.check_call_mock.assert_called_once_with([
+            'multipass', 'delete', self.instance_name,
+        ])
+        self.check_output_mock.assert_not_called()
+
+    def test_delete_fails(self):
+        # multipass can fail due to several reasons and will display the error
+        # right above this exception message.
+        cmd = ['multipass', 'delete', self.instance_name, '--purge']
+        self.check_call_mock.side_effect = subprocess.CalledProcessError(
+            1, cmd)
+
+        self.assertRaises(errors.ProviderDeleteError,
+                          self.multipass_command.delete,
+                          instance_name=self.instance_name)
+        self.check_call_mock.assert_called_once_with(cmd)
+        self.check_output_mock.assert_not_called()
+
+
+class MultipassCommandCopyFilesTest(MultipassCommandPassthroughBaseTest):
+
+    def test_copy_files(self):
+        source = 'source-file'
+        destination = '{}/destination-file'.format(self.instance_name)
+        self.multipass_command.copy_files(source=source,
+                                          destination=destination)
+
+        self.check_call_mock.assert_called_once_with([
+            'multipass', 'copy-files', source, destination
+        ])
+        self.check_output_mock.assert_not_called()
+
+    def test_copy_files_fails(self):
+        # multipass can fail due to several reasons and will display the error
+        # right above this exception message.
+        source = 'source-file'
+        destination = 'destination-file'
+        cmd = ['multipass', 'copy-files', source, destination]
+        self.check_call_mock.side_effect = subprocess.CalledProcessError(
+            1, cmd)
+
+        self.assertRaises(errors.ProviderFileCopyError,
+                          self.multipass_command.copy_files,
+                          source=source, destination=destination)
+        self.check_call_mock.assert_called_once_with(cmd)
+        self.check_output_mock.assert_not_called()
+
+
+class MultipassCommandInfoTest(MultipassCommandPassthroughBaseTest):
+
+    def test_info(self):
+        self.multipass_command.info(instance_name=self.instance_name)
+
+        self.check_output_mock.assert_called_once_with([
+            'multipass', 'info', self.instance_name,
+        ])
+        self.check_call_mock.assert_not_called()
+
+    def test_info_with_format(self):
+        self.multipass_command.info(instance_name=self.instance_name,
+                                    output_format='json')
+
+        self.check_output_mock.assert_called_once_with([
+            'multipass', 'info', self.instance_name, '--format', 'json'
+        ])
+        self.check_call_mock.assert_not_called()
+
+    def test_info_fails(self):
+        # multipass can fail due to several reasons and will display the error
+        # right above this exception message.
+        cmd = ['multipass', 'info', self.instance_name]
+        self.check_output_mock.side_effect = subprocess.CalledProcessError(
+            1, cmd)
+
+        self.assertRaises(errors.ProviderInfoError,
+                          self.multipass_command.info,
+                          instance_name=self.instance_name)
+        self.check_output_mock.assert_called_once_with(cmd)
+        self.check_call_mock.assert_not_called()

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -1,0 +1,91 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import mock
+
+from testtools.matchers import Equals
+
+from snapcraft.project import Project, ProjectInfo
+from snapcraft.internal.build_providers._base_provider import BaseProvider
+from tests import unit
+
+
+class BaseProviderTest(unit.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.instance_name = 'ridicoulus-hours'
+        patcher = mock.patch('petname.Generate',
+                             return_value=self.instance_name)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.project = Project()
+        self.project.info = ProjectInfo(dict(name='project-name'))
+
+        self.echoer_mock = mock.Mock()
+        self.executor_mock = mock.Mock()
+
+    def test_initialize(self):
+        base_provider = BaseProvider(project=self.project,
+                                     executor=self.executor_mock,
+                                     echoer=self.echoer_mock)
+
+        self.assertThat(base_provider.project, Equals(self.project))
+        self.assertThat(base_provider.instance_name,
+                        Equals(self.instance_name))
+        self.assertThat(base_provider.project_dir, Equals('project-name'))
+        self.assertThat(base_provider.snap_filename, Equals(
+            'project-name_{}.snap'.format(self.project.deb_arch)))
+
+    def test_initialize_snap_filename_with_version(self):
+        self.project.info.version = 'test-version'
+
+        base_provider = BaseProvider(project=self.project,
+                                     executor=self.executor_mock,
+                                     echoer=self.echoer_mock)
+
+        self.assertThat(base_provider.snap_filename, Equals(
+            'project-name_test-version_{}.snap'.format(self.project.deb_arch)))
+
+    def test_launch_instance(self):
+        launch_mock = mock.Mock()
+
+        base_provider = BaseProvider(project=self.project,
+                                     executor=self.executor_mock,
+                                     echoer=self.echoer_mock)
+        base_provider.launch_instance(method=launch_mock,
+                                      command=['multipass', 'launch'])
+
+        launch_mock.assert_called_once_with(command=['multipass', 'launch'],
+                                            instance_name=self.instance_name)
+        self.echoer_mock.info.assert_called_once_with(
+            'Creating a build environment named '
+            '{!r}'.format(self.instance_name))
+
+    def test_setup_snapcraft(self):
+        base_provider = BaseProvider(project=self.project,
+                                     executor=self.executor_mock,
+                                     echoer=self.echoer_mock)
+        base_provider.setup_snapcraft()
+
+        self.executor_mock.assert_called_once_with(
+            command=['sudo', 'snap', 'install', 'snapcraft', '--classic'],
+            instance_name=self.instance_name,
+        )
+        self.echoer_mock.info.assert_called_once_with(
+            'Setting up snapcraft in {!r}'.format(self.instance_name))

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -18,27 +18,11 @@ from unittest import mock
 
 from testtools.matchers import Equals
 
-from snapcraft.project import Project, ProjectInfo
+from . import BaseProviderBaseTest
 from snapcraft.internal.build_providers._base_provider import BaseProvider
-from tests import unit
 
 
-class BaseProviderTest(unit.TestCase):
-
-    def setUp(self):
-        super().setUp()
-
-        self.instance_name = 'ridicoulus-hours'
-        patcher = mock.patch('petname.Generate',
-                             return_value=self.instance_name)
-        patcher.start()
-        self.addCleanup(patcher.stop)
-
-        self.project = Project()
-        self.project.info = ProjectInfo(dict(name='project-name'))
-
-        self.echoer_mock = mock.Mock()
-        self.executor_mock = mock.Mock()
+class BaseProviderTest(BaseProviderBaseTest):
 
     def test_initialize(self):
         base_provider = BaseProvider(project=self.project,

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -30,13 +30,11 @@ class ProviderImpl(Provider):
         self.launch_mock = mock.Mock()
         self.run_mock = mock.Mock()
 
-    @property
-    def run(self):
-        return self.run_mock
+    def _run(self, command):
+        self.run_mock(command)
 
-    @property
-    def launch(self):
-        return self.launch_mock
+    def _launch(self):
+        self.launch_mock()
 
 
 class BaseProviderTest(BaseProviderBaseTest):

--- a/tests/unit/build_providers/test_errors.py
+++ b/tests/unit/build_providers/test_errors.py
@@ -39,51 +39,57 @@ class ErrorFormattingTest(unit.TestCase):
                 "on the system PATH, and try again."))),
         ('ProviderLaunchError', dict(
             exception=errors.ProviderLaunchError,
-            kwargs=dict(provider_name='multipass'),
+            kwargs=dict(provider_name='multipass', exit_code=1),
             expected_message=(
-                "An error occurred when trying to launch the instance with "
-                "'multipass'."))),
+                "An error occurred when trying to launch the instance "
+                "with 'multipass': returned exit code 1.\n"
+                "Ensure that 'multipass' is setup correctly and try "
+                "again."))),
         ('ProviderStopError', dict(
             exception=errors.ProviderStopError,
-            kwargs=dict(provider_name='multipass'),
+            kwargs=dict(provider_name='multipass', exit_code=1),
             expected_message=(
-                "An error occurred when trying to stop the instance with "
-                "'multipass'."))),
+                "An error occurred when trying to stop the instance "
+                "with 'multipass': returned exit code 1.\n"
+                "Ensure that 'multipass' is setup correctly and try "
+                "again."))),
         ('ProviderDeleteError', dict(
             exception=errors.ProviderDeleteError,
-            kwargs=dict(provider_name='multipass'),
+            kwargs=dict(provider_name='multipass', exit_code=1),
             expected_message=(
-                "An error occurred when trying to delete the instance with "
-                "'multipass'."))),
+                "An error occurred when trying to delete the instance "
+                "with 'multipass': returned exit code 1.\n"
+                "Ensure that 'multipass' is setup correctly and try "
+                "again."))),
         ('ProviderExecError', dict(
             exception=errors.ProviderExecError,
             kwargs=dict(provider_name='multipass',
-                        command=['snap', 'install', 'snapcraft', '--classic']),
+                        command=['snap', 'install', 'snapcraft', '--classic'],
+                        exit_code=1),
             expected_message=(
                 "An error occurred when trying to execute "
-                "'snap install snapcraft --classic' with 'multipass'."))),
+                "'snap install snapcraft --classic' with 'multipass': "
+                "returned exit code 1."))),
         ('ProviderFileCopyError', dict(
             exception=errors.ProviderFileCopyError,
-            kwargs=dict(provider_name='multipass'),
+            kwargs=dict(provider_name='multipass', exit_code=1),
             expected_message=(
                 "An error occurred when trying to copy files using "
-                "'multipass'."
-            ))),
+                "'multipass': returned exit code 1."))),
         ('ProviderInfoError', dict(
             exception=errors.ProviderInfoError,
-            kwargs=dict(provider_name='multipass'),
+            kwargs=dict(provider_name='multipass', exit_code=1),
             expected_message=(
                 "An error occurred when using 'multipass' to query the status "
-                "of the instance."
-            ))),
+                "of the instance: returned exit code 1."))),
         ('ProviderInfoDataKeyError', dict(
             exception=errors.ProviderInfoDataKeyError,
             kwargs=dict(provider_name='multipass',
-                        key_info='instance-name',
+                        missing_key='instance-name',
                         data=dict(info=dict(another_instance='data'))),
             expected_message=(
                 "The data returned by 'multipass' was not expected. It is "
-                "missing some key data "
+                "missing a required key "
                 "'instance-name' in {'info': {'another_instance': 'data'}}."
             ))),
         ('ProviderBadDataError', dict(

--- a/tests/unit/build_providers/test_errors.py
+++ b/tests/unit/build_providers/test_errors.py
@@ -23,8 +23,8 @@ from tests import unit
 class ErrorFormattingTest(unit.TestCase):
 
     scenarios = [
-        ('ProviderNotSupported', dict(
-            exception=errors.ProviderNotSupported,
+        ('ProviderNotSupportedError', dict(
+            exception=errors.ProviderNotSupportedError,
             kwargs=dict(provider='docker'),
             expected_message=(
                 "The 'docker' provider is not supported, please choose a "

--- a/tests/unit/build_providers/test_errors.py
+++ b/tests/unit/build_providers/test_errors.py
@@ -33,8 +33,8 @@ class ErrorFormattingTest(unit.TestCase):
             exception=errors.ProviderCommandNotFound,
             kwargs=dict(command='multipass'),
             expected_message=(
-                "The 'multipass' command is necessary to be able to build in "
-                "this environment.\n"
+                "'multipass' command not found: this command is necessary to "
+                "build in this environment.\n"
                 "Install 'multipass' or if already installed, ensure it is "
                 "on the system PATH, and try again."))),
         ('ProviderLaunchError', dict(

--- a/tests/unit/build_providers/test_errors.py
+++ b/tests/unit/build_providers/test_errors.py
@@ -1,0 +1,102 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from testtools.matchers import Equals
+
+from snapcraft.internal.build_providers import errors
+from tests import unit
+
+
+class ErrorFormattingTest(unit.TestCase):
+
+    scenarios = [
+        ('ProviderNotSupported', dict(
+            exception=errors.ProviderNotSupported,
+            kwargs=dict(provider='docker'),
+            expected_message=(
+                "The 'docker' provider is not supported, please choose a "
+                "different one and try again."))),
+        ('ProviderCommandNotFound', dict(
+            exception=errors.ProviderCommandNotFound,
+            kwargs=dict(command='multipass'),
+            expected_message=(
+                "The 'multipass' command is necessary to be able to build in "
+                "this environment.\n"
+                "Install 'multipass' or if already installed, ensure it is "
+                "on the system PATH, and try again."))),
+        ('ProviderLaunchError', dict(
+            exception=errors.ProviderLaunchError,
+            kwargs=dict(provider_name='multipass'),
+            expected_message=(
+                "An error occurred when trying to launch the instance with "
+                "'multipass'."))),
+        ('ProviderStopError', dict(
+            exception=errors.ProviderStopError,
+            kwargs=dict(provider_name='multipass'),
+            expected_message=(
+                "An error occurred when trying to stop the instance with "
+                "'multipass'."))),
+        ('ProviderDeleteError', dict(
+            exception=errors.ProviderDeleteError,
+            kwargs=dict(provider_name='multipass'),
+            expected_message=(
+                "An error occurred when trying to delete the instance with "
+                "'multipass'."))),
+        ('ProviderExecError', dict(
+            exception=errors.ProviderExecError,
+            kwargs=dict(provider_name='multipass',
+                        command=['snap', 'install', 'snapcraft', '--classic']),
+            expected_message=(
+                "An error occurred when trying to execute "
+                "'snap install snapcraft --classic' with 'multipass'."))),
+        ('ProviderFileCopyError', dict(
+            exception=errors.ProviderFileCopyError,
+            kwargs=dict(provider_name='multipass'),
+            expected_message=(
+                "An error occurred when trying to copy files using "
+                "'multipass'."
+            ))),
+        ('ProviderInfoError', dict(
+            exception=errors.ProviderInfoError,
+            kwargs=dict(provider_name='multipass'),
+            expected_message=(
+                "An error occurred when using 'multipass' to query the status "
+                "of the instance."
+            ))),
+        ('ProviderInfoDataKeyError', dict(
+            exception=errors.ProviderInfoDataKeyError,
+            kwargs=dict(provider_name='multipass',
+                        key_info='instance-name',
+                        data=dict(info=dict(another_instance='data'))),
+            expected_message=(
+                "The data returned by 'multipass' was not expected. It is "
+                "missing some key data "
+                "'instance-name' in {'info': {'another_instance': 'data'}}."
+            ))),
+        ('ProviderBadDataError', dict(
+            exception=errors.ProviderBadDataError,
+            kwargs=dict(provider_name='multipass',
+                        data='bad-json'),
+            expected_message=(
+                "The data returned by 'multipass' was not expected or in the "
+                "wrong format: 'bad-json'."
+            ))),
+    ]
+
+    def test_error_formatting(self):
+        self.assertThat(
+            str(self.exception(**self.kwargs)),
+            Equals(self.expected_message))

--- a/tests/unit/commands/test_cleanbuild.py
+++ b/tests/unit/commands/test_cleanbuild.py
@@ -95,7 +95,7 @@ class CleanBuildCommandTestCase(CleanBuildCommandBaseTestCase):
             'Retrieved snap-test_1.0_amd64.snap\n',
             self.fake_logger.output)
 
-        with tarfile.open('snap-test_1.0_source.tar.bz2') as tar:
+        with tarfile.open('snap-test_source.tar.bz2') as tar:
             tar_members = tar.getnames()
 
         for f in self.files_no_tar:


### PR DESCRIPTION
build_providers is a new package to handle different providers snapcraft
can use to create a snap.

In addition to the scaffolding, an implementation to handle
multipass is provided. This is the MVP for multipass integration.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
