### PR TITLE
tests: use a common cache for the integration tests

### DIFF
--- a/tests/fixture_setup.py
+++ b/tests/fixture_setup.py
@@ -1122,26 +1122,6 @@ class FakeSnapd(fixtures.Fixture):
         thread.join()
 
 
-class SharedCache(fixtures.Fixture):
-
-    def __init__(self, name) -> None:
-        super().__init__()
-        self.name = name
-
-    def setUp(self) -> None:
-        super().setUp()
-        shared_cache_dir = os.path.join(
-            tempfile.gettempdir(), 'snapcraft_test_cache_{}'.format(self.name))
-        os.makedirs(shared_cache_dir, exist_ok=True)
-        self.useFixture(fixtures.EnvironmentVariable(
-            'XDG_CACHE_HOME', shared_cache_dir))
-        patcher = mock.patch(
-            'xdg.BaseDirectory.xdg_cache_home',
-            new=os.path.join(shared_cache_dir))
-        patcher.start()
-        self.addCleanup(patcher.stop)
-
-
 def _fake_elffile_extract(self, path):
     arch = ('ELFCLASS64', 'ELFDATA2LSB', 'EM_X86_64')
     name = os.path.basename(path)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -87,8 +87,6 @@ class TestCase(testtools.TestCase):
         self.useFixture(fixtures.EnvironmentVariable(
             'XDG_CONFIG_HOME', os.path.join(self.path, '.config')))
         self.useFixture(fixtures.EnvironmentVariable(
-            'XDG_CACHE_HOME', os.path.join(self.path, '.cache')))
-        self.useFixture(fixtures.EnvironmentVariable(
             'XDG_DATA_HOME', os.path.join(self.path, 'data')))
         self.useFixture(fixtures.EnvironmentVariable('TERM', 'dumb'))
 
@@ -104,11 +102,6 @@ class TestCase(testtools.TestCase):
         patcher = mock.patch(
             'xdg.BaseDirectory.xdg_data_home',
             new=os.path.join(self.path, 'data'))
-        patcher.start()
-        self.addCleanup(patcher.stop)
-        patcher = mock.patch(
-            'xdg.BaseDirectory.xdg_cache_home',
-            new=os.path.join(self.path, '.cache'))
         patcher.start()
         self.addCleanup(patcher.stop)
 

--- a/tests/integration/plugins_catkin/test_catkin.py
+++ b/tests/integration/plugins_catkin/test_catkin.py
@@ -18,24 +18,12 @@ import os
 import subprocess
 import tempfile
 
-from testtools.matchers import (
-    FileContains,
-    FileExists,
-)
+from testtools.matchers import FileContains, FileExists
 
-from tests import (
-    fixture_setup,
-    integration,
-    skip
-)
+from tests import integration, skip
 
 
 class CatkinTestCase(integration.TestCase):
-
-    def setUp(self):
-        super().setUp()
-        # share the cache in all tests.
-        self.useFixture(fixture_setup.SharedCache('ros'))
 
     @skip.skip_unless_codename('xenial', 'ROS Kinetic only targets Xenial')
     def test_shared_ros_builds_without_catkin_in_underlay(self):

--- a/tests/integration/snapd/test_catkin_snap.py
+++ b/tests/integration/snapd/test_catkin_snap.py
@@ -35,11 +35,6 @@ class CatkinTestCase(integration.SnapdIntegrationTestCase):
 
     slow_test = True
 
-    def setUp(self):
-        super().setUp()
-        # share the cache in all tests.
-        self.useFixture(fixture_setup.SharedCache('ros'))
-
     @skip.skip_unless_codename('xenial', 'ROS Kinetic only targets Xenial')
     def test_install_and_execution(self):
         self.useFixture(fixture_setup.WithoutSnapInstalled('ros-example'))

--- a/tests/integration/snapd/test_catkin_tools_snap.py
+++ b/tests/integration/snapd/test_catkin_tools_snap.py
@@ -19,21 +19,12 @@ import subprocess
 
 from testtools.matchers import MatchesRegex
 
-from tests import (
-    fixture_setup,
-    integration,
-    skip,
-)
+from tests import fixture_setup, integration, skip
 
 
 class CatkinToolsTestCase(integration.SnapdIntegrationTestCase):
 
     slow_test = True
-
-    def setUp(self) -> None:
-        super().setUp()
-        # Share the cache in all ROS-based tests
-        self.useFixture(fixture_setup.SharedCache('ros'))
 
     @skip.skip_unless_codename('xenial', 'ROS Kinetic only targets Xenial')
     def test_install_and_execution(self) -> None:


### PR DESCRIPTION
Our integration tests are might slow and we make things worse by removing
any caching we have which consequentally removes an integration point
from our tests.

If a test needs to test the caching specifically, it can set the
required variables to do so.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
