### PR TITLE
package: make use of snapcraftctl snapcraft features

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,7 @@ description: |
     a single toolset, but instead is a collection of tools that enable the
     natural workflow of an upstream to be extended with a simple release step
     into Snappy.
-
+adopt-info: snapcraft
 confinement: classic
 
 apps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,5 @@
 name: snapcraft
+version: git
 summary: easily create snaps
 description: |
     Snapcraft aims to make upstream developers' lives easier and as such is not
@@ -44,9 +45,7 @@ parts:
         - squashfs-tools
         - xdelta3
     override-pull: |
-        version=$(git describe --dirty)
-        [ -n "$(echo $version | grep +git)" ] && grade=devel || grade=stable
-        snapcraftctl set-version "$version"
+        [ -n "$SNAPCRAFT_PROJECT_VERSION" ] && grade=devel || grade=stable
         snapcraftctl set-grade "$grade"
         snapcraftctl pull
     override-build: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,7 +44,7 @@ parts:
         - squashfs-tools
         - xdelta3
     override-pull: |
-        version=$(git-describe --dirty)
+        version=$(git describe --dirty)
         [ -n "$(echo $version | grep +git)" ] && grade=devel || grade=stable
         snapcraftctl set-version "$version"
         snapcraftctl set-grade "$grade"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,8 @@ description: |
     a single toolset, but instead is a collection of tools that enable the
     natural workflow of an upstream to be extended with a simple release step
     into Snappy.
-adopt-info: snapcraft
+
+grade: stable
 confinement: classic
 
 apps:
@@ -44,10 +45,6 @@ parts:
         - patchelf
         - squashfs-tools
         - xdelta3
-    override-pull: |
-        [ -n "$SNAPCRAFT_PROJECT_VERSION" ] && grade=devel || grade=stable
-        snapcraftctl set-grade "$grade"
-        snapcraftctl pull
     override-build: |
         snapcraftctl build
         TRIPLET_PATH="$SNAPCRAFT_PART_INSTALL/usr/lib/$(gcc -print-multiarch)"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,6 +56,10 @@ parts:
         ln -s $LIBSODIUM $TRIPLET_PATH/libsodium.so
         patch -d $SNAPCRAFT_PART_INSTALL/lib/python3.5/site-packages -p1 < $SNAPCRAFT_STAGE/pyyaml-support-high-codepoints.diff
         patch $SNAPCRAFT_PART_INSTALL/usr/lib/python3.5/ctypes/__init__.py $SNAPCRAFT_STAGE/ctypes_init.diff
+    override-prime: |
+        # This is the last step, let's now compile all our pyc files.
+        snapcraftctl prime
+        ./usr/bin/python3 -m compileall .
     after: [patches, apt]
   apt:
       source: https://github.com/Debian/apt

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,4 @@
 name: snapcraft
-version: git
 summary: easily create snaps
 description: |
     Snapcraft aims to make upstream developers' lives easier and as such is not
@@ -7,7 +6,6 @@ description: |
     natural workflow of an upstream to be extended with a simple release step
     into Snappy.
 
-grade: stable
 confinement: classic
 
 apps:
@@ -45,7 +43,14 @@ parts:
         - patchelf
         - squashfs-tools
         - xdelta3
-    install: |
+    override-pull: |
+        version=$(git-describe --dirty)
+        [ -n "$(echo $version | grep +git)" ] && grade=devel || grade=stable
+        snapcraftctl set-version "$version"
+        snapcraftctl set-grade "$grade"
+        snapcraftctl pull
+    override-build: |
+        snapcraftctl build
         TRIPLET_PATH="$SNAPCRAFT_PART_INSTALL/usr/lib/$(gcc -print-multiarch)"
         LIBSODIUM=$(readlink -n $TRIPLET_PATH/libsodium.so.18)
         ln -s $LIBSODIUM $TRIPLET_PATH/libsodium.so
@@ -58,14 +63,12 @@ parts:
       source-tag: 1.2.19
       source-depth: 1
       plugin: autotools
-      prepare: |
+      override-build: |
           make startup
-      build: |
           mkdir apt-build
           cd apt-build
           ../configure
           make
-      install: |
           cd apt-build
           install -d $SNAPCRAFT_PART_INSTALL/apt
           cp -r bin/methods/* $SNAPCRAFT_PART_INSTALL/apt/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,7 +73,6 @@ parts:
           cd apt-build
           ../configure
           make
-          cd apt-build
           install -d $SNAPCRAFT_PART_INSTALL/apt
           cp -r bin/methods/* $SNAPCRAFT_PART_INSTALL/apt/
           cp -r bin/methods/* $SNAPCRAFT_PART_INSTALL/apt/


### PR DESCRIPTION
Use override-pull and override-build instead of their respective prepare, build
and install counterparts.

Also, switch to using `snapcraftctl set-version` instead of
`version: git` leveraging the version value to also
`snapcraftctl set-grade`.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
Fixes [LP: #1758958](https://bugs.launchpad.net/snapcraft/+bug/1758958)