### PR TITLE
many: allow building in containers with no version in project

### DIFF
--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -86,7 +86,18 @@ def get_core_path(base):
     return os.path.join(os.path.sep, 'snap', base, 'current')
 
 
-def format_snap_name(snap):
+def format_snap_name(snap, *, allow_empty_version: bool=False) -> str:
+    """Return a filename representing the snap depending on snap attributes.
+
+    :param dict snap: a dictionary of keys containing name, version and arch.
+    :param bool allow_empty_version: if set a filename without a version is
+                                     allowed.
+    """
+    if allow_empty_version and snap.get('version') is None:
+        template = '{name}_{arch}.snap'
+    else:
+        template = '{name}_{version}_{arch}.snap'
+
     if 'arch' not in snap:
         snap['arch'] = snap.get('architectures', None)
     if not snap['arch']:
@@ -96,7 +107,7 @@ def format_snap_name(snap):
     else:
         snap['arch'] = 'multi'
 
-    return '{name}_{version}_{arch}.snap'.format(**snap)
+    return template.format(**snap)
 
 
 def is_snap() -> bool:

--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -66,10 +66,11 @@ _STORE_KEY = (
 
 class Containerbuild:
 
-    def __init__(self, *, output, source, project_options,
-                 metadata, container_name, remote=None):
-        if not output:
-            output = common.format_snap_name(metadata)
+    def __init__(self, *, source, project_options, metadata,
+                 container_name, output=None, remote=None):
+        if output is None:
+            output = common.format_snap_name(
+                metadata, allow_empty_version=True)
         self._snap_output = output
         self._source = os.path.realpath(source)
         self._project_options = project_options

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -238,7 +238,7 @@ class Config:
 
     def get_metadata(self):
         return {'name': self.data['name'],
-                'version': self.data['version'],
+                'version': self.data.get('version', None),
                 'arch': self.data['architectures']}
 
     def _ensure_no_duplicate_app_aliases(self):

--- a/tests/unit/project_loader/test_config.py
+++ b/tests/unit/project_loader/test_config.py
@@ -24,7 +24,8 @@ import unittest.mock
 from textwrap import dedent
 
 import fixtures
-from testtools.matchers import Contains, Equals, MatchesRegex, Not, StartsWith
+from testtools.matchers import (Contains, Equals, Is, MatchesRegex, Not,
+                                StartsWith)
 from testscenarios.scenarios import multiply_scenarios
 
 import snapcraft
@@ -530,6 +531,29 @@ parts:
         metadata = config.get_metadata()
         self.assertThat(metadata['name'], Equals('test'))
         self.assertThat(metadata['version'], Equals('1'))
+        self.assertThat(metadata['arch'], Equals(['amd64']))
+
+    def test_get_metadata_version_adopted(self):
+        self.make_snapcraft_yaml(dedent("""\
+            name: test
+            summary: test
+            description: nothing
+            architectures:
+              - build-on: all
+                run-on: amd64
+            confinement: strict
+            grade: stable
+            adopt-info: part1
+
+            parts:
+              part1:
+                plugin: go
+                stage-packages: [fswebcam]
+            """))
+        config = project_loader.load_config()
+        metadata = config.get_metadata()
+        self.assertThat(metadata['name'], Equals('test'))
+        self.assertThat(metadata['version'], Is(None))
         self.assertThat(metadata['arch'], Equals(['amd64']))
 
     def test_version_script(self):

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -116,3 +116,45 @@ class FormatInColumnsTestCase(unit.TestCase):
                                             max_width=60,
                                             num_col_spaces=1),
             Equals(expected))
+
+
+class FormatSnapFileNameTest(unit.TestCase):
+
+    scenarios = [
+        ('all info', dict(snap=dict(name='name', version='version',
+                                    architectures=['amd64']),
+                          expected='name_version_amd64.snap')),
+        ('missing version', dict(snap=dict(name='name',
+                                 architectures=['amd64']),
+                                 allow_empty_version=True,
+                                 expected='name_amd64.snap')),
+        ('no arch', dict(snap=dict(name='name', version='version'),
+                         expected='name_version_all.snap')),
+        ('multi', dict(snap=dict(name='name', version='version',
+                                 architectures=['amd64', 'i386']),
+                       expected='name_version_multi.snap')),
+        ('pack', dict(snap=dict(name='name', version='version',
+                                arch=['amd64']),
+                      expected='name_version_amd64.snap')),
+        ('pack multi', dict(snap=dict(name='name', version='version',
+                                      arch=['amd64', 'i386']),
+                            expected='name_version_multi.snap')),
+    ]
+
+    def test_filename(self):
+        if hasattr(self, 'allow_empty_version'):
+            snap_name = common.format_snap_name(
+                self.snap, allow_empty_version=self.allow_empty_version)
+        else:
+            snap_name = common.format_snap_name(self.snap)
+
+        self.assertThat(snap_name, Equals(self.expected))
+
+
+class FormatSnapFileNameErrorTest(unit.TestCase):
+
+    def test_version_missing_and_not_allowed_is_error(self):
+        # This is to not experience unexpected results given the
+        # fact that version is not allowed.
+        snap = dict(name='name')
+        self.assertRaises(KeyError, common.format_snap_name, snap)

--- a/tests/unit/test_lxd.py
+++ b/tests/unit/test_lxd.py
@@ -663,3 +663,23 @@ class FailedImageInfoTestCase(LXDBaseTestCase):
 
         self.make_containerbuild().execute()
         self.assertEqual(self.fake_logger.output, self.expected_warn)
+
+
+class SnapOutputTestCase(unit.TestCase):
+
+    scenarios = [
+        ('all info', dict(snap=dict(name='name', version='version',
+                                    architectures=['amd64']),
+                          expected='name_version_amd64.snap')),
+        ('missing version', dict(snap=dict(name='name',
+                                 architectures=['amd64']),
+                                 expected='name_amd64.snap')),
+    ]
+
+    def test_output_set_correctly(self):
+        project = ProjectOptions()
+        instance = lxd.Containerbuild(project_options=project,
+                                      source='tarball.tgz',
+                                      metadata=self.snap,
+                                      container_name='name')
+        self.assertThat(instance._snap_output, Equals(self.expected))


### PR DESCRIPTION
Support building in containers now that version can be retrieved
with `adopt-info`.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----
