### PR TITLE
project_loader: recursively process after of remote parts

### DIFF
--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -24,6 +24,7 @@ import re
 import jsonschema
 import yaml
 import yaml.reader
+from typing import Any, Dict
 from typing import Set  # noqa: F401
 
 
@@ -354,15 +355,23 @@ class Config:
             else:
                 new_parts[part_name] = parts[part_name].copy()
 
-            after_parts = parts[part_name].get('after', [])
-            after_remote_parts = [p for p in after_parts if p not in parts]
-
-            for after_part in after_remote_parts:
-                properties = self._remote_parts.get_part(after_part)
-                new_parts[after_part] = properties
+            self._process_remote_after_parts(
+                new_parts, parts, new_parts[part_name])
 
         snapcraft_yaml['parts'] = new_parts
         return snapcraft_yaml
+
+    def _process_remote_after_parts(
+            self, new_parts: Dict[str, Any], parts: Dict[str, Any],
+            part: Dict[str, Any]) -> None:
+        after_parts = part.get('after', [])
+        after_remote_parts = [p for p in after_parts if p not in parts]
+
+        for after_part in after_remote_parts:
+            properties = self._remote_parts.get_part(after_part)
+            new_parts[after_part] = properties
+            # Process the newly added part which may have 'after' as well.
+            self._process_remote_after_parts(new_parts, parts, properties)
 
 
 def _snapcraft_yaml_load(yaml_file):

--- a/tests/fake_servers/__init__.py
+++ b/tests/fake_servers/__init__.py
@@ -112,6 +112,23 @@ class FakePartsRequestHandler(BaseHTTPRequestHandler):
                     ('description', 'this is a multiline description\n' * 3),
                     ('maintainer', 'none'),
                 ))),
+                ('alsa', OrderedDict((
+                    ('plugin', 'nil'),
+                    ('description', 'this part depends on a part with after'),
+                    ('maintainer', 'none'),
+                    ('after', ['alsa-plugins']),
+                ))),
+                ('alsa-plugins', OrderedDict((
+                    ('plugin', 'nil'),
+                    ('description', 'this part depends on a part'),
+                    ('maintainer', 'none'),
+                    ('after', ['alsa-lib']),
+                ))),
+                ('alsa-lib', OrderedDict((
+                    ('plugin', 'nil'),
+                    ('description', 'this part is used by alsa-plugins'),
+                    ('maintainer', 'none'),
+                ))),
             ))
         self.send_header('Content-Type', 'text/plain')
         if 'NO_CONTENT_LENGTH' not in os.environ:

--- a/tests/unit/commands/test_search.py
+++ b/tests/unit/commands/test_search.py
@@ -40,6 +40,9 @@ class SearchCommandTestCase(CommandBaseTestCase, TestWithFakeRemoteParts):
         self.assertThat(result.exit_code, Equals(0))
         self.assertThat(result.output, Contains(dedent("""\
             PART NAME            DESCRIPTION
+            alsa                 this part depends on a part with after
+            alsa-lib             this part is used by alsa-plugins
+            alsa-plugins         this part depends on a part
             curl                 test entry for curl
             long-described-part  this is a repetitive description this is a repetitive de...
             multiline-part       this is a multiline description

--- a/tests/unit/commands/test_update.py
+++ b/tests/unit/commands/test_update.py
@@ -118,6 +118,23 @@ class UpdateCommandTestCase(CommandBaseTestCase, unit.TestWithFakeRemoteParts):
         p['description'] = 'this is a multiline description\n' * 3
         p['maintainer'] = 'none'
 
+        expected_parts['alsa'] = p = OrderedDict()
+        p['plugin'] = 'nil'
+        p['description'] = 'this part depends on a part with after'
+        p['maintainer'] = 'none'
+        p['after'] = ['alsa-plugins']
+
+        expected_parts['alsa-plugins'] = p = OrderedDict()
+        p['plugin'] = 'nil'
+        p['description'] = 'this part depends on a part'
+        p['maintainer'] = 'none'
+        p['after'] = ['alsa-lib']
+
+        expected_parts['alsa-lib'] = p = OrderedDict()
+        p['plugin'] = 'nil'
+        p['description'] = 'this part is used by alsa-plugins'
+        p['maintainer'] = 'none'
+
         expected_headers = {
             'If-Modified-Since': 'Thu, 07 Jul 2016 10:00:20 GMT',
         }

--- a/tests/unit/project_loader/test_config.py
+++ b/tests/unit/project_loader/test_config.py
@@ -397,6 +397,61 @@ parts:
         remote_parts.update()
         _config.Config()
 
+    def test_remote_part_with_after(self):
+        """Test to verify we can load remote parts which pull in other remote
+           parts using "after".
+        """
+        self.useFixture(fixture_setup.FakeParts())
+        self.make_snapcraft_yaml("""name: test
+version: "1"
+summary: test
+description: test
+confinement: strict
+grade: stable
+
+parts:
+  part1:
+    plugin: nil
+    after: [alsa]
+""")
+        remote_parts.update()
+        config = _config.Config()
+
+        self.assertThat(config.parts.after_requests, Equals({
+            'alsa-plugins': ['alsa-lib'],
+            'alsa': ['alsa-plugins'],
+            'part1': ['alsa']}))
+
+    def test_remote_part_with_after_local_override(self):
+        """Test to verify we can override remote parts with "after".
+        """
+        self.useFixture(fixture_setup.FakeParts())
+        self.make_snapcraft_yaml("""name: test
+version: "1"
+summary: test
+description: test
+confinement: strict
+grade: stable
+
+parts:
+  part1:
+    plugin: nil
+    after: [alsa]
+
+  alsa-plugins:
+    after: [alsa-extras]
+
+  alsa-extras:
+    plugin: nil
+""")
+        remote_parts.update()
+        config = _config.Config()
+
+        self.assertThat(config.parts.after_requests, Equals({
+            'alsa-plugins': ['alsa-extras'],
+            'alsa': ['alsa-plugins'],
+            'part1': ['alsa']}))
+
     def test_config_composes_with_a_non_existent_remote_part(self):
         self.useFixture(fixture_setup.FakeParts())
         self.make_snapcraft_yaml("""name: test


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
This PR makes processing of remote parts recursive so that any part from an origin can use "after" to pull in another part, which in turn may use "after" and so on.

Fixes: #2027 
Fixes: [LP: #1750866](https://bugs.launchpad.net/snapcraft/+bug/1750866)

The following test is being added:

 - tests.unit.project_loader.test_config.YamlTestCase.test_remote_part_with_after
 - To verify that remote parts can have parts using after that in turn use after.

I locally ran the tests:
 - `./runtests.sh tests/unit` with unrelated failures in [tests.unit.test_lifecycle.CoreSetupTestCase.test_core_setup_if_docker_env](https://bugs.launchpad.net/snapcraft/+bug/1752576), `tests.unit.test_mangling.TestClearExecstack.test_execstack_clears` and `tests.unit.test_elf`.
 - `./runtests.sh tests/integration` with one unrelated failure in [tests.integration.general.test_parser.TestParserWikis](https://bugs.launchpad.net/snapcraft/+bug/1752580)
 - `./runtests.sh static`: Everything passed

Manual test steps:
 - cd tests/integration/snaps/basic
 - Note: The "alsa" remote part currently avoids the use of "after" but there's an "alsa-chain-test" part that can be used to exercise the improved behavior.
 - Update `snapcraft.yaml` by adding `after: [alsa-chain-test]` to "dummy-part".
 - snapcraft
 - Observe that the build completes without an error. For comparison, current master would fail with a message `KeyError: 'alsa'` or `KeyError: 'alsa-lib-chain-test'` depending on how parts happen to be evaluated.