### PR TITLE
nodejs plugin: lazy load the required tarballs

### DIFF
--- a/tests/unit/plugins/test_nodejs.py
+++ b/tests/unit/plugins/test_nodejs.py
@@ -107,9 +107,9 @@ class NodePluginTestCase(NodePluginBaseTestCase):
         else:
             expected_tar_calls = [
                 mock.call(self.nodejs_url, plugin._npm_dir),
+                mock.call().download(),
                 mock.call('https://yarnpkg.com/latest.tar.gz',
                           plugin._npm_dir),
-                mock.call().download(),
                 mock.call().download(),
                 mock.call().provision(plugin.installdir, clean_target=False,
                                       keep_tarball=True),
@@ -161,10 +161,10 @@ class NodePluginTestCase(NodePluginBaseTestCase):
             ]
             expected_tar_calls = [
                 mock.call(self.nodejs_url, plugin._npm_dir),
-                mock.call('https://yarnpkg.com/latest.tar.gz',
-                          plugin._npm_dir),
                 mock.call().provision(plugin.installdir, clean_target=False,
                                       keep_tarball=True),
+                mock.call('https://yarnpkg.com/latest.tar.gz',
+                          plugin._npm_dir),
                 mock.call().provision(plugin._npm_dir,
                                       clean_target=False, keep_tarball=True),
             ]
@@ -216,10 +216,10 @@ class NodePluginTestCase(NodePluginBaseTestCase):
             ]
             expected_tar_calls = [
                 mock.call(self.nodejs_url, plugin._npm_dir),
-                mock.call('https://yarnpkg.com/latest.tar.gz',
-                          plugin._npm_dir),
                 mock.call().provision(plugin.installdir, clean_target=False,
                                       keep_tarball=True),
+                mock.call('https://yarnpkg.com/latest.tar.gz',
+                          plugin._npm_dir),
                 mock.call().provision(plugin._npm_dir,
                                       clean_target=False, keep_tarball=True),
             ]
@@ -270,9 +270,9 @@ class NodePluginTestCase(NodePluginBaseTestCase):
             ]
             expected_tar_calls = [
                 mock.call(self.nodejs_url, plugin._npm_dir),
+                mock.call().download(),
                 mock.call('https://yarnpkg.com/latest.tar.gz',
                           plugin._npm_dir),
-                mock.call().download(),
                 mock.call().download(),
                 mock.call().provision(plugin.installdir, clean_target=False,
                                       keep_tarball=True),


### PR DESCRIPTION
Fixes SNAPCRAFT-T

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
