### PR TITLE
tests: conditionally add python3-distutils

### DIFF
--- a/tests/integration/plugins_python/test_python_plugin.py
+++ b/tests/integration/plugins_python/test_python_plugin.py
@@ -26,17 +26,21 @@ from testtools.matchers import (
     FileExists
 )
 
-from tests import integration, fixture_setup
+from tests import integration, fixture_setup, os_release
 
 
 class PythonPluginTestCase(integration.TestCase):
 
     def test_use_staged_pip(self):
         snapcraft_yaml = fixture_setup.SnapcraftYaml(self.path)
+        stage_packages = ['python3-pip']
+        # bionic (and potentially future releases) require python3-distutils.
+        if os_release.get_version_codename() not in ('xenial', 'artful'):
+            stage_packages.append('python3-distutils')
         snapcraft_yaml.update_part('test-part', {
             'plugin': 'python',
             'source': '.',
-            'stage-packages': ['python3-pip']
+            'stage-packages': stage_packages
         })
         self.useFixture(snapcraft_yaml)
 


### PR DESCRIPTION
The test to verify pip from stage-packages is used has the issue on
bionic that it requires python3-distutils but it is not a direct
dependency.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----
