### PR TITLE
sources: don't clean target for FileBase sources

### DIFF
--- a/snapcraft/internal/sources/_base.py
+++ b/snapcraft/internal/sources/_base.py
@@ -64,8 +64,9 @@ class FileBase(Base):
         if self.source_checksum:
             verify_checksum(self.source_checksum, source_file)
 
-        # We finally provision
-        self.provision(self.source_dir, src=source_file)
+        # We finally provision, but we don't clean the target so override-pull
+        # can actually have meaning when using these sources.
+        self.provision(self.source_dir, src=source_file, clean_target=False)
 
     def download(self):
         # First check if we already have the source file cached.

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -39,7 +39,7 @@ class TestFileBase(unit.TestCase):
 
         mock_download.assert_called_once_with()
         file_src.provision.assert_called_once_with(
-            file_src.source_dir, src='dir')
+            file_src.source_dir, src='dir', clean_target=False)
 
     @mock.patch('shutil.copy2')
     def test_pull_copy(self, mock_shutil_copy2):
@@ -50,7 +50,7 @@ class TestFileBase(unit.TestCase):
         mock_shutil_copy2.assert_called_once_with(
             file_src.source, expected)
         file_src.provision.assert_called_once_with(
-            file_src.source_dir, src=expected)
+            file_src.source_dir, src=expected, clean_target=False)
 
     @mock.patch('snapcraft.internal.sources._base.requests')
     @mock.patch(

--- a/tests/unit/sources/test_rpm.py
+++ b/tests/unit/sources/test_rpm.py
@@ -17,6 +17,7 @@
 import os
 import sys
 
+from unittest import mock
 from testtools.matchers import FileExists
 
 from snapcraft.internal import sources
@@ -41,6 +42,15 @@ class TestRpm(unit.TestCase):
 
         self.assertThat(os.path.join(self.dest_dir, 'bin', 'hello'),
                         FileExists())
+
+    @mock.patch.object(sources.Rpm, 'provision')
+    def test_pull_rpm_must_not_clean_targets(self, mock_provision):
+        rpm_source = sources.Rpm(self.rpm_file_path, self.dest_dir)
+        rpm_source.pull()
+
+        mock_provision.assert_called_once_with(
+            self.dest_dir, clean_target=False, src=os.path.join(
+                self.dest_dir, 'small-0.1-1.noarch.rpm'))
 
     def test_has_source_handler_entry_on_linux(self):
         if sys.platform == 'linux':

--- a/tests/unit/sources/test_tar.py
+++ b/tests/unit/sources/test_tar.py
@@ -50,7 +50,8 @@ class TestTar(unit.FakeFileHTTPServerBasedTestCase):
         tar_source.pull()
 
         source_file = os.path.join(dest_dir, tar_file_name)
-        mock_prov.assert_called_once_with(dest_dir, src=source_file)
+        mock_prov.assert_called_once_with(
+            dest_dir, src=source_file, clean_target=False)
         with open(os.path.join(dest_dir, tar_file_name), 'r') as tar_file:
             self.assertThat(tar_file.read(), Equals('Test fake file'))
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

The source directory is already removed by the pluginhandler, having the sources do it is redundant and prevents `override-pull` from being useful when using those sources. This PR fixes [LP: #1767753](https://bugs.launchpad.net/snapcraft/+bug/1767753) by changing the `Tar`, `Zip`, and `Rpm` sources to no longer clean the target directory before extracting.