### PR TITLE
meta: stop creating empty snap directory in prime

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -376,8 +376,12 @@ class _SnapPackaging:
         # First migrate the snap directory. It will overwrite any conflicting
         # files.
         for root, directories, files in os.walk('snap'):
-            if '.snapcraft' in directories:
+            with contextlib.suppress(ValueError):
                 directories.remove('.snapcraft')
+            with contextlib.suppress(ValueError):
+                # The snapcraft.yaml is migrated later
+                files.remove('snapcraft.yaml')
+
             for directory in directories:
                 source = os.path.join(root, directory)
                 destination = os.path.join(self._prime_dir, source)

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -26,6 +26,7 @@ import testtools
 import yaml
 from testtools.matchers import (
     Contains,
+    DirExists,
     Equals,
     FileContains,
     FileExists,
@@ -1000,6 +1001,17 @@ class WriteSnapDirectoryTestCase(CreateBaseTestCase):
         # no wrapper is generated (i.e. that hook is copied to both locations).
         self.assertThat(
             os.path.join(self.hooks_dir, 'test-hook'), FileContains(''))
+
+    def test_nothing_to_write(self):
+        # Setup a snap directory containing just a snapcraft.yaml, nothing else
+        _create_file(os.path.join(self.snap_dir, 'snapcraft.yaml'))
+
+        # Now generate the metadata, and verify that no snap directory was
+        # created
+        self.generate_meta_yaml()
+        self.assertThat(
+            os.path.join(self.prime_dir, 'snap'), Not(DirExists()),
+            'Expected snap directory to NOT be created')
 
     def test_snap_hooks_overwrite_part_hooks(self):
         # Setup a prime/snap directory containing a hook.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

The snapcraft CLI currently has manifest generation hidden behind a feature flag. However, it's not quite all the way hidden, as an empty `snap` directory is still created in the priming area. This isn't particularly useful, so this PR fixes [LP: #1660890](https://bugs.launchpad.net/snapcraft/+bug/1660890) by no longer doing that.