### PR TITLE
storeapi: ensure snap ID is sane before using it

### DIFF
--- a/snapcraft/storeapi/_store_client.py
+++ b/snapcraft/storeapi/_store_client.py
@@ -172,6 +172,9 @@ class StoreClient():
         except KeyError:
             raise errors.SnapNotFoundError(snap_name, series=series, arch=arch)
 
+        if not snap_id:
+            raise errors.NoSnapIdError(snap_name)
+
         response = self._refresh_if_necessary(
             self.sca.snap_revisions, snap_id, series, arch)
 
@@ -189,6 +192,9 @@ class StoreClient():
             snap_id = account_info['snaps'][series][snap_name]['snap-id']
         except KeyError:
             raise errors.SnapNotFoundError(snap_name, series=series, arch=arch)
+
+        if not snap_id:
+            raise errors.NoSnapIdError(snap_name)
 
         response = self._refresh_if_necessary(
             self.sca.snap_status, snap_id, series, arch)
@@ -296,6 +302,9 @@ class StoreClient():
         except KeyError:
             raise errors.SnapNotFoundError(snap_name, series=series)
 
+        if not snap_id:
+            raise errors.NoSnapIdError(snap_name)
+
         return self._refresh_if_necessary(
             self.sca.push_metadata, snap_id, snap_name, metadata, force)
 
@@ -307,6 +316,9 @@ class StoreClient():
             snap_id = account_info['snaps'][series][snap_name]['snap-id']
         except KeyError:
             raise errors.SnapNotFoundError(snap_name, series=series)
+
+        if not snap_id:
+            raise errors.NoSnapIdError(snap_name)
 
         return self._refresh_if_necessary(
             self.sca.push_binary_metadata, snap_id, snap_name, metadata,

--- a/snapcraft/storeapi/_store_client.py
+++ b/snapcraft/storeapi/_store_client.py
@@ -172,7 +172,7 @@ class StoreClient():
         except KeyError:
             raise errors.SnapNotFoundError(snap_name, series=series, arch=arch)
 
-        if not snap_id:
+        if snap_id is None:
             raise errors.NoSnapIdError(snap_name)
 
         response = self._refresh_if_necessary(
@@ -193,7 +193,7 @@ class StoreClient():
         except KeyError:
             raise errors.SnapNotFoundError(snap_name, series=series, arch=arch)
 
-        if not snap_id:
+        if snap_id is None:
             raise errors.NoSnapIdError(snap_name)
 
         response = self._refresh_if_necessary(
@@ -227,7 +227,7 @@ class StoreClient():
             logger.info('Already downloaded {} at {}'.format(
                 name, download_path))
             return
-        logger.info('Downloading {}'.format(name, download_path))
+        logger.info('Downloading {}'.format(name))
 
         # we only resume when redirected to our CDN since we use internap's
         # special sauce.
@@ -302,7 +302,7 @@ class StoreClient():
         except KeyError:
             raise errors.SnapNotFoundError(snap_name, series=series)
 
-        if not snap_id:
+        if snap_id is None:
             raise errors.NoSnapIdError(snap_name)
 
         return self._refresh_if_necessary(
@@ -317,7 +317,7 @@ class StoreClient():
         except KeyError:
             raise errors.SnapNotFoundError(snap_name, series=series)
 
-        if not snap_id:
+        if snap_id is None:
             raise errors.NoSnapIdError(snap_name)
 
         return self._refresh_if_necessary(

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -27,6 +27,7 @@ from snapcraft import formatting_utils
 logger = logging.getLogger(__name__)
 
 _STORE_STATUS_URL = 'https://status.snapcraft.io/'
+_FORUM_URL = 'https://forum.snapcraft.io/'
 
 
 class StoreError(SnapcraftError):
@@ -103,6 +104,17 @@ class SnapNotFoundError(StoreError):
             self.fmt = self.__FMT_SERIES
 
         super().__init__(name=name, channel=channel, arch=arch, series=series)
+
+
+class NoSnapIdError(StoreError):
+
+    fmt = (
+        'Unable to get snap ID for snap {snap_name!r}: The store returned '
+        'data, but included no ID. This is an error in the store, please open '
+        'a new topic on the forum: {forum_url}')
+
+    def __init__(self, snap_name):
+        super().__init__(snap_name=snap_name, forum_url=_FORUM_URL)
 
 
 class SHAMismatchError(StoreError):

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -27,7 +27,7 @@ from snapcraft import formatting_utils
 logger = logging.getLogger(__name__)
 
 _STORE_STATUS_URL = 'https://status.snapcraft.io/'
-_FORUM_URL = 'https://forum.snapcraft.io/'
+_FORUM_URL = 'https://forum.snapcraft.io/c/store'
 
 
 class StoreError(SnapcraftError):
@@ -109,9 +109,9 @@ class SnapNotFoundError(StoreError):
 class NoSnapIdError(StoreError):
 
     fmt = (
-        'Unable to get snap ID for snap {snap_name!r}: The store returned '
-        'data, but included no ID. This is an error in the store, please open '
-        'a new topic on the forum: {forum_url}')
+        'Failed to get snap ID for snap {snap_name!r}. This is an error in '
+        "the store, please open a new topic in the 'store' category in the "
+        'forum: {forum_url}')
 
     def __init__(self, snap_name):
         super().__init__(snap_name=snap_name, forum_url=_FORUM_URL)

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -868,6 +868,9 @@ class FakeStoreAPIServer(base.BaseFakeServer):
             'no-revoked': {'snap-id': 'no-revoked', 'status': 'Approved',
                            'private': False, 'price': None,
                            'since': '2016-12-12T01:01:01Z'},
+            'no-id': {'snap-id': None, 'status': 'Approved',
+                      'private': False, 'price': None,
+                      'since': '2016-12-12T01:01:01Z'},
             }
         snaps.update({
             name: {'snap-id': snap_data['snap_id'], 'status': 'Approved',

--- a/tests/integration/store/test_store_status.py
+++ b/tests/integration/store/test_store_status.py
@@ -79,6 +79,19 @@ class StatusTestCase(integration.StoreTestCase):
             '                 edge       1.0-i386   3'))
         self.assertThat(output, Contains(expected))
 
+    def test_status_no_id(self):
+        if not self.is_store_fake():
+            self.skipTest('This test only works in the fake store')
+
+        self.addCleanup(self.logout)
+        self.login()
+
+        error = self.assertRaises(
+            subprocess.CalledProcessError, self.run_snapcraft,
+            ['status', 'no-id'])
+        self.assertThat(error.output, Contains(
+            "Unable to get snap ID for snap 'no-id'"))
+
     def test_status_staging_store(self):
         if not self.is_store_staging():
             self.skipTest('This test only works in the staging store')

--- a/tests/integration/store/test_store_status.py
+++ b/tests/integration/store/test_store_status.py
@@ -90,7 +90,7 @@ class StatusTestCase(integration.StoreTestCase):
             subprocess.CalledProcessError, self.run_snapcraft,
             ['status', 'no-id'])
         self.assertThat(error.output, Contains(
-            "Unable to get snap ID for snap 'no-id'"))
+            "Failed to get snap ID for snap 'no-id'"))
 
     def test_status_staging_store(self):
         if not self.is_store_staging():

--- a/tests/unit/store/test_store_client.py
+++ b/tests/unit/store/test_store_client.py
@@ -411,6 +411,13 @@ class GetAccountInformationTestCase(StoreTestCase):
                             'snap-id': 'test-snap-id-with-no-validations',
                             'status': 'Approved'
                         },
+                        'no-id': {
+                            'snap-id': None,
+                            'status': 'Approved',
+                            'private': False,
+                            'price': None,
+                            'since': '2016-12-12T01:01:01Z'
+                        },
                     }
                 }
             }))
@@ -480,6 +487,13 @@ class GetAccountInformationTestCase(StoreTestCase):
                             'since': '2016-12-12T01:01:01Z',
                             'snap-id': 'test-snap-id-with-no-validations',
                             'status': 'Approved'
+                        },
+                        'no-id': {
+                            'snap-id': None,
+                            'status': 'Approved',
+                            'private': False,
+                            'price': None,
+                            'since': '2016-12-12T01:01:01Z'
                         },
                     }
                 }
@@ -1342,6 +1356,13 @@ class GetSnapStatusTestCase(StoreTestCase):
             str(e),
             Equals(
                 "Snap 'basic' for 'somearch' was not found in '16' series."))
+
+    def test_get_snap_status_no_id(self):
+        self.client.login('dummy', 'test correct password')
+        e = self.assertRaises(
+            storeapi.errors.NoSnapIdError,
+            self.client.get_snap_status, 'no-id')
+        self.assertThat(e.snap_name, Equals('no-id'))
 
     def test_get_snap_status_refreshes_macaroon(self):
         self.client.login('dummy', 'test correct password')


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

The store had a bug that ended up causing a snap to be registered to a user, but have no ID. The snapcraft CLI didn't handle this well, producing a traceback. This PR fixes [LP: #1763721](https://bugs.launchpad.net/snapcraft/+bug/1763721) by checking the snap ID before using it.