### PR TITLE
storeapi: handle 5xx error codes for all store endpoints

### DIFF
--- a/snapcraft/storeapi/_client.py
+++ b/snapcraft/storeapi/_client.py
@@ -71,7 +71,7 @@ class Client():
         # Handle 5XX responses generically right here, so the callers don't
         # need to worry about it.
         if response.status_code >= 500:
-            raise errors.StoreInternalError(response)
+            raise errors.StoreServerError(response)
 
         return response
 

--- a/snapcraft/storeapi/_client.py
+++ b/snapcraft/storeapi/_client.py
@@ -68,6 +68,11 @@ class Client():
         except (ConnectionError, RetryError) as e:
             raise errors.StoreNetworkError(e) from e
 
+        # Handle 5XX responses generically right here, so the callers don't
+        # need to worry about it.
+        if response.status_code >= 500:
+            raise errors.StoreInternalError(response)
+
         return response
 
     def get(self, url, **kwargs):

--- a/snapcraft/storeapi/_store_client.py
+++ b/snapcraft/storeapi/_store_client.py
@@ -221,7 +221,7 @@ class StoreClient():
             logger.info('Already downloaded {} at {}'.format(
                 name, download_path))
             return
-        logger.info('Downloading {}'.format(name, download_path))
+        logger.info('Downloading {}'.format(name))
 
         # we only resume when redirected to our CDN since we use internap's
         # special sauce.

--- a/snapcraft/storeapi/_upload.py
+++ b/snapcraft/storeapi/_upload.py
@@ -67,11 +67,6 @@ def upload_files(binary_filename, updown_client):
 
         # Make sure progress bar shows 100% complete
         progress_bar.finish()
-
-    except Exception as err:
-        raise RuntimeError(
-            'An unexpected error was found while uploading '
-            'files: {!r}.'.format(err))
     finally:
         # Close the open file
         binary_file.close()

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -375,11 +375,12 @@ class StoreServerError(StoreError):
     fmt = '{what}: {error_text} (code {error_code}).\n{action}'
 
     def __init__(self, response):
-        what = 'The store encountered a server error'
-        error_text = responses[response.status_code].lower()
+        what = ('The Snap Store encountered an error while processing your '
+                'request')
         error_code = response.status_code
-        action = ('The status of the store and associated services can be '
-                  'checked at {}'.format(_STORE_STATUS_URL))
+        error_text = responses[error_code].lower()
+        action = ('The operational status of the Snap Store can be checked at '
+                  '{}'.format(_STORE_STATUS_URL))
 
         super().__init__(
             response=response, what=what, error_text=error_text,

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -1043,7 +1043,7 @@ class FakeStoreAPIServer(base.BaseFakeServer):
             response_code = 200
         elif snap_id == 'err':
             payload = json.dumps({
-                'error_list': [{'message': 'error'}]
+                'error_list': [{'code': 'test-code', 'message': 'test-error'}]
             }).encode()
             response_code = 503
         content_type = 'application/json'
@@ -1093,7 +1093,7 @@ class FakeStoreAPIServer(base.BaseFakeServer):
             response_code = 200
         elif snap_id == 'err':
             payload = json.dumps({
-                'error_list': [{'message': 'error'}]
+                'error_list': [{'code': 'test-code', 'message': 'test-error'}]
             }).encode()
             response_code = 501
         elif snap_id == 'bad':

--- a/tests/integration/store/test_store_release.py
+++ b/tests/integration/store/test_store_release.py
@@ -130,6 +130,6 @@ class ReleaseTestCase(integration.StoreTestCase):
             subprocess.CalledProcessError,
             self.run_snapcraft, ['release', name, '1', 'bad-channel'])
         self.assertThat(error.output, Contains(
-            'store encountered an internal error. The status of the store and '
-            'associated services can be checked at '
-            'https://status.snapcraft.io/'))
+            'store encountered a server error: internal server error (code '
+            '500).\nThe status of the store and associated services can be '
+            'checked at https://status.snapcraft.io/'))

--- a/tests/integration/store/test_store_release.py
+++ b/tests/integration/store/test_store_release.py
@@ -57,7 +57,7 @@ class ReleaseTestCase(integration.StoreTestCase):
             os.path.join(snap_file_path), FileExists())
 
         output = self.run_snapcraft(['upload', snap_file_path])
-        expected = r'.*Ready to release!.*'.format(name)
+        expected = r'.*Ready to release!.*'
         self.assertThat(output, MatchesRegex(expected, flags=re.DOTALL))
 
         # Release it
@@ -88,7 +88,7 @@ class ReleaseTestCase(integration.StoreTestCase):
             os.path.join(snap_file_path), FileExists())
 
         output = self.run_snapcraft(['push', snap_file_path])
-        expected = r'.*Ready to release!.*'.format(name)
+        expected = r'.*Ready to release!.*'
         self.assertThat(output, MatchesRegex(expected, flags=re.DOTALL))
 
         # Attempt to release it
@@ -122,7 +122,7 @@ class ReleaseTestCase(integration.StoreTestCase):
             os.path.join(snap_file_path), FileExists())
 
         output = self.run_snapcraft(['push', snap_file_path])
-        expected = r'.*Ready to release!.*'.format(name)
+        expected = r'.*Ready to release!.*'
         self.assertThat(output, MatchesRegex(expected, flags=re.DOTALL))
 
         # Attempt to release it
@@ -130,6 +130,6 @@ class ReleaseTestCase(integration.StoreTestCase):
             subprocess.CalledProcessError,
             self.run_snapcraft, ['release', name, '1', 'bad-channel'])
         self.assertThat(error.output, Contains(
-            'store encountered an internal error. The status of store and '
-            'associated services can be checked at:\n'
+            'store encountered an internal error. The status of the store and '
+            'associated services can be checked at '
             'https://status.snapcraft.io/'))

--- a/tests/integration/store/test_store_release.py
+++ b/tests/integration/store/test_store_release.py
@@ -130,6 +130,6 @@ class ReleaseTestCase(integration.StoreTestCase):
             subprocess.CalledProcessError,
             self.run_snapcraft, ['release', name, '1', 'bad-channel'])
         self.assertThat(error.output, Contains(
-            'store encountered a server error: internal server error (code '
-            '500).\nThe status of the store and associated services can be '
-            'checked at https://status.snapcraft.io/'))
+            'Snap Store encountered an error while processing your request: '
+            'internal server error (code 500).\nThe operational status of the '
+            'Snap Store can be checked at https://status.snapcraft.io/'))

--- a/tests/unit/store/test_store_client.py
+++ b/tests/unit/store/test_store_client.py
@@ -305,10 +305,9 @@ class PushSnapBuildTestCase(StoreTestCase):
         # will get a descriptive error message.
         self.client.login('dummy', 'test correct password')
         raised = self.assertRaises(
-            errors.StoreInternalError,
+            errors.StoreServerError,
             self.client.push_snap_build, 'snap-id', 'test-not-implemented')
-        self.assertThat(raised.why, Contains(
-            'The snap-build assertions are currently disabled'))
+        self.assertThat(raised.error_code, Equals(501))
 
     def test_push_snap_build_invalid_data(self):
         self.client.login('dummy', 'test correct password')
@@ -325,9 +324,9 @@ class PushSnapBuildTestCase(StoreTestCase):
         # might happen in the internet, so we are a little defensive.
         self.client.login('dummy', 'test correct password')
         raised = self.assertRaises(
-            errors.StoreInternalError,
+            errors.StoreServerError,
             self.client.push_snap_build, 'snap-id', 'test-unexpected-data')
-        self.assertFalse(raised.why)
+        self.assertThat(raised.error_code, Equals(500))
 
     def test_push_snap_build_successfully(self):
         self.client.login('dummy', 'test correct password')
@@ -512,9 +511,9 @@ class RegisterKeyTestCase(StoreTestCase):
         # will get a 501 Not Implemented response.
         self.client.login('dummy', 'test correct password')
         raised = self.assertRaises(
-            errors.StoreInternalError,
+            errors.StoreServerError,
             self.client.register_key, 'test-not-implemented')
-        self.assertFalse(raised.why)
+        self.assertThat(raised.error_code, Equals(501))
 
     def test_invalid_data(self):
         self.client.login('dummy', 'test correct password')
@@ -728,9 +727,9 @@ class ValidationsTestCase(StoreTestCase):
         assertion = json.dumps({'foo': 'bar'}).encode('utf-8')
 
         err = self.assertRaises(
-            errors.StoreInternalError,
+            errors.StoreServerError,
             self.client.push_assertion, 'err', assertion, 'validations')
-        self.assertThat(err.why, Contains('test-error'))
+        self.assertThat(err.error_code, Equals(501))
 
 
 class UploadTestCase(StoreTestCase):
@@ -801,9 +800,9 @@ class UploadTestCase(StoreTestCase):
         self.client.login('dummy', 'test correct password')
 
         raised = self.assertRaises(
-            errors.StoreInternalError,
+            errors.StoreServerError,
             self.client.upload, 'test-snap', self.snap_path)
-        self.assertFalse(raised.why)
+        self.assertThat(raised.error_code, Equals(500))
 
     def test_upload_snap_requires_review(self):
         self.client.login('dummy', 'test correct password')
@@ -955,7 +954,7 @@ class ReleaseTestCase(StoreTestCase):
     def test_release_snap_to_bad_channel(self):
         self.client.login('dummy', 'test correct password')
         self.assertRaises(
-            errors.StoreInternalError,
+            errors.StoreServerError,
             self.client.release, 'test-snap', '19', ['bad-channel'])
 
     def test_release_unregistered_snap(self):
@@ -1024,9 +1023,9 @@ class CloseChannelsTestCase(StoreTestCase):
         # might happen in the internet, so we are a little defensive.
         self.client.login('dummy', 'test correct password')
         raised = self.assertRaises(
-            errors.StoreInternalError,
+            errors.StoreServerError,
             self.client.close_channels, 'snap-id', ['unexpected'])
-        self.assertFalse(raised.why)
+        self.assertThat(raised.error_code, Equals(500))
 
     def test_close_broken_store_plain(self):
         # If the contract is broken by the Store, users will be have additional
@@ -1395,10 +1394,10 @@ class SignDeveloperAgreementTestCase(StoreTestCase):
         self.useFixture(fixtures.EnvironmentVariable('STORE_DOWN', '1'))
         self.client.login('dummy', 'test correct password')
         raised = self.assertRaises(
-            errors.StoreInternalError,
+            errors.StoreServerError,
             self.client.sign_developer_agreement,
             latest_tos_accepted=True)
-        self.assertFalse(raised.why)
+        self.assertThat(raised.error_code, Equals(500))
 
 
 class PushMetadataTestCase(StoreTestCase):

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -445,9 +445,10 @@ class ErrorFormattingTestCase(unit.TestCase):
                 'response': _fake_error_response(500)
             },
             'expected_message': (
-                'The store encountered a server error: internal server error '
-                '(code 500).\nThe status of the store and associated services '
-                'can be checked at https://status.snapcraft.io/'
+                'The Snap Store encountered an error while processing your '
+                'request: internal server error (code 500).\nThe operational '
+                'status of the Snap Store can be checked at '
+                'https://status.snapcraft.io/'
             )
         }),
         ('StoreServerError 501', {
@@ -456,9 +457,10 @@ class ErrorFormattingTestCase(unit.TestCase):
                 'response': _fake_error_response(501)
             },
             'expected_message': (
-                'The store encountered a server error: not implemented '
-                '(code 501).\nThe status of the store and associated services '
-                'can be checked at https://status.snapcraft.io/'
+                'The Snap Store encountered an error while processing your '
+                'request: not implemented (code 501).\nThe operational '
+                'status of the Snap Store can be checked at '
+                'https://status.snapcraft.io/'
             )
         }),
     )

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -27,17 +27,9 @@ from snapcraft.storeapi import errors as store_errors
 from tests import unit
 
 
-def _fake_error_response(*, error_list):
+def _fake_error_response(status_code):
     response = mock.Mock()
-
-    if error_list:
-        # Create a fake error response corresponding to this format:
-        # https://dashboard.snapcraft.io/docs/api/snap.html#format
-        response.json.return_value = {'error_list': [
-            {'code': 'test-error-code', 'message': 'this is a test error'}
-        ]}
-    else:
-        response.json.return_value = {}
+    response.status_code = status_code
     return response
 
 
@@ -437,26 +429,26 @@ class ErrorFormattingTestCase(unit.TestCase):
                 'https://status.snapcraft.io/'
             )
         }),
-        ('StoreInternalError no error list', {
-            'exception': store_errors.StoreInternalError,
+        ('StoreServerError 500', {
+            'exception': store_errors.StoreServerError,
             'kwargs': {
-                'response': _fake_error_response(error_list=False)
+                'response': _fake_error_response(500)
             },
             'expected_message': (
-                'The store encountered an internal error. The status of the '
-                'store and associated services can be checked at '
-                'https://status.snapcraft.io/'
+                'The store encountered a server error: internal server error '
+                '(code 500).\nThe status of the store and associated services '
+                'can be checked at https://status.snapcraft.io/'
             )
         }),
-        ('StoreInternalError with error list', {
-            'exception': store_errors.StoreInternalError,
+        ('StoreServerError 501', {
+            'exception': store_errors.StoreServerError,
             'kwargs': {
-                'response': _fake_error_response(error_list=True)
+                'response': _fake_error_response(501)
             },
             'expected_message': (
-                'The store encountered an internal error: this is a test '
-                'error\nThe status of the store and associated services can '
-                'be checked at https://status.snapcraft.io/'
+                'The store encountered a server error: not implemented '
+                '(code 501).\nThe status of the store and associated services '
+                'can be checked at https://status.snapcraft.io/'
             )
         }),
     )


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently, the snapcraft CLI handles a 500 response when releasing a snap. This PR fixes [LP: #1768370](https://bugs.launchpad.net/snapcraft/+bug/1768370) by making this more robust, and nicely handling 5xx codes for all endpoints.