### PR TITLE
repo: automatically prune unneeded stage-packages

### DIFF
--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -831,6 +831,17 @@ class RecordManifestBaseTestCase(BaseLifecycleTestCase):
         check_output_patcher.start()
         self.addCleanup(check_output_patcher.stop)
 
+        original_check_call = subprocess.check_call
+
+        def _fake_dpkg_deb(command, *args, **kwargs):
+            if 'dpkg-deb' not in command:
+                return original_check_call(command, *args, **kwargs)
+
+        check_call_patcher = mock.patch(
+            'subprocess.check_call', side_effect=_fake_dpkg_deb)
+        check_call_patcher.start()
+        self.addCleanup(check_call_patcher.stop)
+
         self.fake_apt_cache = fixture_setup.FakeAptCache()
         self.useFixture(self.fake_apt_cache)
         self.fake_apt_cache.add_package(


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

The apt cache doesn't do any hand-holding when it comes to alternative dependencies. As a result, it's possible for the snapcraft CLI to get into the following situation:

- A depends on B OR C
- B depends on D
- C conflicts with B
- A and C are `stage-packages`

If A is handled first, apt defaults to the first alternate (which is sensible), and marks both A and B (and, by extension, D) to be installed. Then C is handled, which automatically unmarks B, but doesn't do anything to D. As a result, A, C, and D are installed into the snap, even though D is no longer required.

Fix this by crawling the set of changes in the cache and taking care of anything that can be automatically removed.