### PR TITLE
many: dedup environment entries

### DIFF
--- a/snapcraft/internal/pluginhandler/_runner.py
+++ b/snapcraft/internal/pluginhandler/_runner.py
@@ -116,6 +116,20 @@ class Runner:
                 'override-prime', self._override_prime_scriptlet,
                 self._primedir)
 
+    def _get_env(self):
+        env = ''
+        if common.is_snap():
+            # Since the snap is classic, $SNAP/bin is not on the $PATH.
+            # Let's set an alias to make sure it's found (but only if it
+            # exists).
+            snapcraftctl_path = os.path.join(
+                os.getenv('SNAP'), 'bin', 'snapcraftctl')
+            if os.path.exists(snapcraftctl_path):
+                env += 'alias snapcraftctl="$SNAP/bin/snapcraftctl"\n'
+        env += common.assemble_env()
+
+        return env
+
     def _run_scriptlet(self, scriptlet_name: str, scriptlet: str,
                        workdir: str) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -124,17 +138,6 @@ class Runner:
             feedback_fifo = _NonBlockingRWFifo(
                 os.path.join(tempdir, 'call_feedback'))
 
-            env = ''
-            if common.is_snap():
-                # Since the snap is classic, $SNAP/bin is not on the $PATH.
-                # Let's set an alias to make sure it's found (but only if it
-                # exists).
-                snapcraftctl_path = os.path.join(
-                    os.getenv('SNAP'), 'bin', 'snapcraftctl')
-                if os.path.exists(snapcraftctl_path):
-                    env += 'alias snapcraftctl="$SNAP/bin/snapcraftctl"\n'
-            env += common.assemble_env()
-
             # snapcraftctl only works consistently if it's using the exact same
             # interpreter as that used by snapcraft itself, thus the definition
             # of SNAPCRAFT_INTERPRETER.
@@ -142,14 +145,20 @@ class Runner:
                 export SNAPCRAFTCTL_CALL_FIFO={call_fifo}
                 export SNAPCRAFTCTL_FEEDBACK_FIFO={feedback_fifo}
                 export SNAPCRAFT_INTERPRETER={interpreter}
-                {env}
                 {scriptlet}""").format(
                     interpreter=sys.executable, call_fifo=call_fifo.path,
-                    feedback_fifo=feedback_fifo.path, env=env,
-                    scriptlet=scriptlet)
+                    feedback_fifo=feedback_fifo.path, scriptlet=scriptlet)
 
-            process = subprocess.Popen(
-                ['/bin/sh', '-e', '-c', script], cwd=workdir)
+            # We write to a file as the script may be to long and hit the
+            # argument list limit.
+            run_script = os.path.join(tempdir, 'run_script')
+            with open(run_script, 'w+') as script_file:
+                print('set -e', file=script_file)
+                print(self._get_env(), file=script_file)
+                print(script, file=script_file)
+
+            process = subprocess.Popen(['/bin/sh', script_file.name],
+                                       cwd=workdir)
 
             status = None
             try:

--- a/snapcraft/internal/pluginhandler/_runner.py
+++ b/snapcraft/internal/pluginhandler/_runner.py
@@ -138,11 +138,10 @@ class Runner:
                     feedback_fifo=feedback_fifo.path, scriptlet=scriptlet,
                     env=_get_env())
 
-            # We write to a file as the script may be to long and hit the
-            # argument list limit.
-            run_script = os.path.join(tempdir, 'run_script')
-            with open(run_script, 'w+') as script_file:
+            with tempfile.TemporaryFile(mode='w+') as script_file:
                 print(script, file=script_file)
+                script_file.flush()
+                script_file.seek(0)
 
                 process = subprocess.Popen(['/bin/sh'], stdin=script_file,
                                            cwd=workdir)

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -254,4 +254,13 @@ class PartsConfig:
             env += dep_part.env(stagedir)
             env += self.build_env_for_part(dep_part, root_part=False)
 
-        return env
+        # LP: #1767625
+        # Remove duplicates from using the same plugin in dependent parts.
+        seen = dict()
+        deduped_env = list()
+        for e in env:
+            if e not in seen:
+                deduped_env.append(e)
+                seen[e] = e
+
+        return deduped_env

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
 from os import path
+from typing import List
+from typing import Set  # noqa: F401
 
 import snapcraft
 from snapcraft.internal import deprecations, elf, pluginhandler, repo
@@ -212,10 +214,10 @@ class PartsConfig:
 
         return part
 
-    def build_env_for_part(self, part, root_part=True):
+    def build_env_for_part(self, part, root_part=True) -> List[str]:
         """Return a build env of all the part's dependencies."""
 
-        env = []
+        env = []  # type: List[str]
         stagedir = self._project_options.stage_dir
         is_host_compat = self._project_options.is_host_compatible_with_base(
             self._base)
@@ -256,11 +258,11 @@ class PartsConfig:
 
         # LP: #1767625
         # Remove duplicates from using the same plugin in dependent parts.
-        seen = dict()
-        deduped_env = list()
+        seen = set()  # type: Set[str]
+        deduped_env = list()  # type: List[str]
         for e in env:
             if e not in seen:
                 deduped_env.append(e)
-                seen[e] = e
+                seen.add(e)
 
         return deduped_env


### PR DESCRIPTION
Deduplicate the environment entries when generating it for a specific part.
Also wrap the override script into an actual file to reduce the possibility
of an argument list error occurring.

LP: #1767625
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----
