### PR TITLE
cli: add provides command

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -189,6 +189,41 @@ class SnapcraftPartMissingError(SnapcraftError):
     )
 
 
+class NoSuchFileError(SnapcraftError):
+
+    fmt = (
+        'Failed to find part that provided path: {path!r} does not '
+        'exist.\n'
+        'Check the file path and try again.'
+    )
+
+    def __init__(self, path):
+        super().__init__(path=path)
+
+
+class ProvidesInvalidFilePathError(SnapcraftError):
+
+    fmt = (
+        'Failed to find part that provides path: {path!r} is not in the '
+        'staging or priming area.\n'
+        'Ensure the path is in the staging or priming area and try again.'
+    )
+
+    def __init__(self, path):
+        super().__init__(path=path)
+
+
+class UntrackedFileError(SnapcraftError):
+
+    fmt = (
+        'No known parts provided {path!r}. It may have been provided '
+        'by a scriptlet.'
+    )
+
+    def __init__(self, path):
+        super().__init__(path=path)
+
+
 class RemotePartsError(SnapcraftError):
     pass
 

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -23,7 +23,7 @@ import os
 import shutil
 import sys
 from glob import glob, iglob
-from typing import Dict, Set, Sequence  # noqa: F401
+from typing import cast, Dict, Set, Sequence  # noqa: F401
 
 import yaml
 
@@ -121,23 +121,29 @@ class PluginHandler:
 
     def get_pull_state(self) -> states.PullState:
         if not self._pull_state:
-            self._pull_state = states.get_state(self.plugin.statedir, 'pull')
+            self._pull_state = cast(states.PullState, self.get_state('pull'))
         return self._pull_state
 
     def get_build_state(self) -> states.BuildState:
         if not self._build_state:
-            self._build_state = states.get_state(self.plugin.statedir, 'build')
+            self._build_state = cast(
+                states.BuildState, self.get_state('build'))
         return self._build_state
 
     def get_stage_state(self) -> states.StageState:
         if not self._stage_state:
-            self._stage_state = states.get_state(self.plugin.statedir, 'stage')
+            self._stage_state = cast(
+                states.StageState, self.get_state('stage'))
         return self._stage_state
 
     def get_prime_state(self) -> states.PrimeState:
         if not self._prime_state:
-            self._prime_state = states.get_state(self.plugin.statedir, 'prime')
+            self._prime_state = cast(
+                states.PrimeState, self.get_state('prime'))
         return self._prime_state
+
+    def get_state(self, step) -> states.PartState:
+        return states.get_state(self.plugin.statedir, step)
 
     def _get_source_handler(self, properties):
         """Returns a source_handler for the source in properties."""

--- a/snapcraft/internal/states/__init__.py
+++ b/snapcraft/internal/states/__init__.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from snapcraft.internal.states._state import PartState  # noqa
 from snapcraft.internal.states._build_state import BuildState  # noqa
 from snapcraft.internal.states._global_state import GlobalState  # noqa
 from snapcraft.internal.states._prime_state import PrimeState  # noqa

--- a/tests/unit/commands/test_provides.py
+++ b/tests/unit/commands/test_provides.py
@@ -1,0 +1,114 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import re
+import textwrap
+
+from testtools.matchers import Equals, MatchesRegex
+import snapcraft.internal.errors
+
+from . import CommandBaseTestCase
+
+
+class ProvidesCommandTestCase(CommandBaseTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.make_snapcraft_yaml(textwrap.dedent("""\
+            name: my-snap-name
+            version: '0.1'
+            summary: summary
+            description: description
+
+            grade: devel
+            confinement: devmode
+
+            parts:
+              part1:
+                plugin: dump
+                override-pull: |
+                  mkdir dir
+                  touch dir/file1
+
+              part2:
+                plugin: dump
+                override-pull: |
+                  mkdir dir
+                  touch dir/file2
+
+              part3:
+                plugin: nil
+                override-stage: |
+                  touch file3
+            """))
+
+        self.run_command(['prime'])
+
+    def test_provides(self):
+        for part_number in ('1', '2'):
+            part = 'part{}'.format(part_number)
+            file_name = 'file{}'.format(part_number)
+            result = self.run_command(
+                    ['provides', os.path.join('stage', 'dir', file_name)])
+            self.expectThat(result.output, Equals(
+                'This path was provided by the following part:\n{}\n'.format(
+                    part)))
+
+            result = self.run_command(
+                    ['provides', os.path.join(
+                        self.prime_dir, 'dir', file_name)])
+            self.expectThat(result.output, Equals(
+                'This path was provided by the following part:\n{}\n'.format(
+                    part)))
+
+        result = self.run_command(
+            ['provides', os.path.join('prime', 'dir')])
+
+        # Using MatchesRegex since the order is non-deterministic
+        self.expectThat(result.output, MatchesRegex(
+            '.*provided by the following parts.*part1', re.DOTALL))
+        self.expectThat(result.output, MatchesRegex(
+            '.*provided by the following parts.*part2', re.DOTALL))
+
+    def test_provides_file_outside_stage_or_prime(self):
+        file_path = os.path.join(
+                self.parts_dir, 'part1', 'src', 'dir', 'file1')
+        raised = self.assertRaises(
+            snapcraft.internal.errors.ProvidesInvalidFilePathError,
+            self.run_command, ['provides', file_path])
+
+        self.assertThat(
+            raised.path, Equals(file_path))
+
+    def test_provides_untracked_file(self):
+        file_path = os.path.join('stage', 'file3')
+        raised = self.assertRaises(
+            snapcraft.internal.errors.UntrackedFileError,
+            self.run_command, ['provides', file_path])
+
+        self.assertThat(
+            raised.path, Equals(file_path))
+
+    def test_provides_no_such_file(self):
+        file_path = os.path.join('stage', 'foo')
+        raised = self.assertRaises(
+            snapcraft.internal.errors.NoSuchFileError,
+            self.run_command, ['provides', file_path])
+
+        self.assertThat(
+            raised.path, Equals(file_path))

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -422,6 +422,39 @@ class ErrorFormattingTestCase(unit.TestCase):
                 'https://status.snapcraft.io/'
             )
         }),
+        ('NoSuchFileError', {
+            'exception': errors.NoSuchFileError,
+            'kwargs': {
+                'path': 'test-path'
+            },
+            'expected_message': (
+                "Failed to find part that provided path: 'test-path' does not "
+                'exist.\n'
+                'Check the file path and try again.'
+            )
+        }),
+        ('ProvidesInvalidFilePathError', {
+            'exception': errors.ProvidesInvalidFilePathError,
+            'kwargs': {
+                'path': 'test-path'
+            },
+            'expected_message': (
+                "Failed to find part that provides path: 'test-path' is not "
+                'in the staging or priming area.\n'
+                'Ensure the path is in the staging or priming area and try '
+                'again.'
+            )
+        }),
+        ('UntrackedFileError', {
+            'exception': errors.UntrackedFileError,
+            'kwargs': {
+                'path': 'test-path'
+            },
+            'expected_message': (
+                "No known parts provided 'test-path'. It may have been "
+                'provided by a scriptlet.'
+            )
+        }),
     )
 
     def test_error_formatting(self):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Once the snapcraft CLI merges files from multiple parts into the staging and priming areas, it's easy to lose track of which part provided which file. This PR resolves [LP: #1759700](https://bugs.launchpad.net/snapcraft/+bug/1759700) by adding a new `snapcraft provides` command meant to serve exactly that purpose.

    $ snapcraft provides <path>

`<path>` must be in either the staging or priming area, and can be a file or a directory.