### PR TITLE
many: introduce variables for part src and build

### DIFF
--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -24,15 +24,14 @@ import yaml
 import snapcraft
 from snapcraft.internal import (
     common,
+    errors,
     meta,
     pluginhandler,
     project_loader,
     repo,
     states,
 )
-from snapcraft.internal import errors
 from snapcraft.internal.cache import SnapCache
-from snapcraft.internal.project_loader import replace_attr
 from . import constants
 
 
@@ -137,9 +136,10 @@ def _should_get_core(confinement: str) -> bool:
 
 def _replace_in_part(part):
     for key, value in part.plugin.options.__dict__.items():
-        value = replace_attr(value, [
-            ('$SNAPCRAFT_PART_INSTALL', part.plugin.installdir),
-        ])
+        replacements = project_loader.environment_to_replacements(
+            project_loader.snapcraft_part_environment(part))
+
+        value = project_loader.replace_attr(value, replacements)
         setattr(part.plugin.options, key, value)
 
     return part

--- a/snapcraft/internal/parser.py
+++ b/snapcraft/internal/parser.py
@@ -123,10 +123,10 @@ def _process_entry_parts(entry_parts, parts, origin, maintainer, description,
                 'DEPRECATED: Found a "/" in the name of the {!r} part'.format(
                     part_name))
         source_part = parts.get(part_name)
-        replacements = [
-            ('$SNAPCRAFT_PROJECT_NAME', origin_name),
-            ('$SNAPCRAFT_PROJECT_VERSION', origin_version),
-        ]
+        replacements = project_loader.environment_to_replacements({
+            'SNAPCRAFT_PROJECT_NAME': origin_name,
+            'SNAPCRAFT_PROJECT_VERSION': origin_version,
+        })
 
         source_part = project_loader.replace_attr(source_part, replacements)
 

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -53,18 +53,6 @@ class PluginHandler:
     def name(self):
         return self.plugin.name
 
-    @property
-    def sourcedir(self):
-        return self.plugin.sourcedir
-
-    @property
-    def builddir(self):
-        return self.plugin.builddir
-
-    @property
-    def installdir(self):
-        return self.plugin.installdir
-
     def __init__(self, *, plugin, part_properties, project_options,
                  part_schema, definitions_schema, stage_packages_repo,
                  grammar_processor, snap_base_path, base, confinement,
@@ -339,8 +327,8 @@ class PluginHandler:
         stage_packages = self._grammar_processor.get_stage_packages()
         if stage_packages:
             logger.debug('Unpacking stage-packages to {!r}'.format(
-                self.installdir))
-            self._stage_packages_repo.unpack(self.installdir)
+                self.plugin.installdir))
+            self._stage_packages_repo.unpack(self.plugin.installdir)
 
     def prepare_pull(self, force=False):
         self.makedirs()
@@ -522,8 +510,8 @@ class PluginHandler:
         if os.path.exists(self.plugin.build_basedir):
             shutil.rmtree(self.plugin.build_basedir)
 
-        if os.path.exists(self.installdir):
-            shutil.rmtree(self.installdir)
+        if os.path.exists(self.plugin.installdir):
+            shutil.rmtree(self.plugin.installdir)
 
         self.plugin.clean_build()
         self.mark_cleaned('build')
@@ -717,7 +705,8 @@ class PluginHandler:
         # already been primed by other means, and migrating them again could
         # potentially override the `stage` or `snap` filtering.
         (in_part, staged, primed, system) = _split_dependencies(
-            all_dependencies, self.installdir, self.stagedir, self.primedir)
+            all_dependencies, self.plugin.installdir, self.stagedir,
+            self.primedir)
         part_dependency_paths = {os.path.dirname(d) for d in in_part}
         staged_dependency_paths = {os.path.dirname(d) for d in staged}
         dependency_paths = part_dependency_paths | staged_dependency_paths
@@ -1078,7 +1067,7 @@ def check_for_collisions(parts):
             common = part_files & parts_files[other_part_name]['files']
             conflict_files = []
             for f in common:
-                this = os.path.join(part.installdir, f)
+                this = os.path.join(part.plugin.installdir, f)
                 other = os.path.join(
                     parts_files[other_part_name]['installdir'],
                     f)
@@ -1096,7 +1085,7 @@ def check_for_collisions(parts):
 
         # And add our files to the list
         parts_files[part.name] = {'files': part_files,
-                                  'installdir': part.installdir}
+                                  'installdir': part.plugin.installdir}
 
 
 def _get_includes(fileset):

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -54,6 +54,14 @@ class PluginHandler:
         return self.plugin.name
 
     @property
+    def sourcedir(self):
+        return self.plugin.sourcedir
+
+    @property
+    def builddir(self):
+        return self.plugin.builddir
+
+    @property
     def installdir(self):
         return self.plugin.installdir
 

--- a/snapcraft/internal/project_loader/__init__.py
+++ b/snapcraft/internal/project_loader/__init__.py
@@ -15,7 +15,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+from typing import cast, Dict, List, Union
 
+from ._env import (  # noqa
+    environment_to_replacements,
+    snapcraft_global_environment,
+    snapcraft_part_environment,
+)
 from ._schema import Validator  # noqa
 from ._parts_config import PartsConfig  # noqa
 
@@ -25,16 +31,18 @@ def load_config(project_options=None):
     return Config(project_options)
 
 
-def replace_attr(attr, replacements):
+def replace_attr(
+        attr: Union[List[str], Dict[str, str], str],
+        replacements: Dict[str, str]) -> Union[List[str], Dict[str, str], str]:
     if isinstance(attr, str):
-        for replacement in replacements:
-            attr = attr.replace(replacement[0], str(replacement[1]))
+        for replacement, value in replacements.items():
+            attr = attr.replace(replacement, str(value))
         return attr
     elif isinstance(attr, list) or isinstance(attr, tuple):
-        return [replace_attr(i, replacements)
+        return [cast(str, replace_attr(i, replacements))
                 for i in attr]
     elif isinstance(attr, dict):
-        return {k: replace_attr(attr[k], replacements)
+        return {k: cast(str, replace_attr(attr[k], replacements))
                 for k in attr}
 
     return attr

--- a/snapcraft/internal/project_loader/_env.py
+++ b/snapcraft/internal/project_loader/_env.py
@@ -121,9 +121,9 @@ def snapcraft_global_environment(project: project.Project) -> Dict[str, str]:
 def snapcraft_part_environment(
         part: pluginhandler.PluginHandler) -> Dict[str, str]:
     return {
-        'SNAPCRAFT_PART_SRC': part.sourcedir,
-        'SNAPCRAFT_PART_BUILD': part.builddir,
-        'SNAPCRAFT_PART_INSTALL': part.installdir,
+        'SNAPCRAFT_PART_SRC': part.plugin.sourcedir,
+        'SNAPCRAFT_PART_BUILD': part.plugin.builddir,
+        'SNAPCRAFT_PART_INSTALL': part.plugin.installdir,
     }
 
 

--- a/snapcraft/internal/project_loader/_env.py
+++ b/snapcraft/internal/project_loader/_env.py
@@ -13,10 +13,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from snapcraft import formatting_utils
-from snapcraft.internal import common, elf
+from snapcraft import formatting_utils, project
+from snapcraft.internal import common, elf, pluginhandler
 
-from typing import List
+from typing import Dict, List
 
 
 def env_for_classic(base: str, arch_triplet: str) -> List[str]:
@@ -89,3 +89,49 @@ def build_env_for_stage(stagedir: str, snap_name: str,
     env.append('PERL5LIB="{0}/usr/share/perl5/"'.format(stagedir))
 
     return env
+
+
+def snapcraft_global_environment(project: project.Project) -> Dict[str, str]:
+    if project.info.name:
+        name = project.info.name
+    else:
+        name = ''
+
+    if project.info.version:
+        version = project.info.version
+    else:
+        version = ''
+
+    if project.info.grade:
+        grade = project.info.grade
+    else:
+        grade = ''
+
+    return {
+        'SNAPCRAFT_ARCH_TRIPLET': project.arch_triplet,
+        'SNAPCRAFT_PARALLEL_BUILD_COUNT': project.parallel_build_count,
+        'SNAPCRAFT_PROJECT_NAME': name,
+        'SNAPCRAFT_PROJECT_VERSION': version,
+        'SNAPCRAFT_PROJECT_GRADE': grade,
+        'SNAPCRAFT_STAGE': project.stage_dir,
+        'SNAPCRAFT_PRIME': project.prime_dir,
+    }
+
+
+def snapcraft_part_environment(
+        part: pluginhandler.PluginHandler) -> Dict[str, str]:
+    return {
+        'SNAPCRAFT_PART_SRC': part.sourcedir,
+        'SNAPCRAFT_PART_BUILD': part.builddir,
+        'SNAPCRAFT_PART_INSTALL': part.installdir,
+    }
+
+
+def environment_to_replacements(environment: Dict[str, str]) -> Dict[str, str]:
+    replacements = {}  # type: Dict[str, str]
+    for variable, value in environment.items():
+        # Support both $VAR and ${VAR} syntax
+        replacements['${}'.format(variable)] = value
+        replacements['${{{}}}'.format(variable)] = value
+
+    return replacements

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -228,13 +228,13 @@ class PartsConfig:
 
         if root_part:
             # this has to come before any {}/usr/bin
-            env += part.env(part.installdir)
+            env += part.env(part.plugin.installdir)
             env += runtime_env(
-                part.installdir, self._project_options.arch_triplet)
+                part.plugin.installdir, self._project_options.arch_triplet)
             env += runtime_env(
                 stagedir, self._project_options.arch_triplet)
             env += build_env(
-                part.installdir,
+                part.plugin.installdir,
                 self._snap_name,
                 self._project_options.arch_triplet)
             env += build_env_for_stage(

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -13,6 +13,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections import ChainMap
 import logging
 from os import path
 from typing import List
@@ -25,6 +27,8 @@ from ._env import (
     build_env,
     build_env_for_stage,
     runtime_env,
+    snapcraft_global_environment,
+    snapcraft_part_environment
 )
 from . import (
     errors,
@@ -242,11 +246,11 @@ class PartsConfig:
             if (self._confinement == 'classic' and is_host_compat):
                 env += env_for_classic(self._base,
                                        self._project_options.arch_triplet)
-            env.append('SNAPCRAFT_PART_INSTALL="{}"'.format(part.installdir))
-            env.append('SNAPCRAFT_ARCH_TRIPLET="{}"'.format(
-                self._project_options.arch_triplet))
-            env.append('SNAPCRAFT_PARALLEL_BUILD_COUNT={}'.format(
-                       self._project_options.parallel_build_count))
+
+            global_env = snapcraft_global_environment(self._project_options)
+            part_env = snapcraft_part_environment(part)
+            for variable, value in ChainMap(part_env, global_env).items():
+                env.append('{}="{}"'.format(variable, value))
         else:
             env += part.env(stagedir)
             env += runtime_env(

--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -26,3 +26,4 @@ class ProjectInfo:
         self.summary = data.get('summary')
         self.description = data.get('description')
         self.confinement = data.get('confinement')
+        self.grade = data.get('grade')

--- a/tests/integration/general/test_environment.py
+++ b/tests/integration/general/test_environment.py
@@ -55,13 +55,21 @@ class EnvironmentTestCase(integration.TestCase):
         self.run_snapcraft('stage', 'stage_env')
 
     def test_stage_cmake_plugin_with_replace(self):
-        """Replace SNAPCRAFT_PART_INSTALL in the part's attributes"""
+        """Replace SNAPCRAFT_PART_* in the part's attributes"""
         self.run_snapcraft('stage', 'cmake-with-env-var')
 
         binary_output = subprocess.check_output([
             os.path.join(self.stage_dir, 'bin', 'cmake-with-env-var')])
-        path = os.path.join(
+        sourcedir = os.path.join(
+            self.path, self.parts_dir, 'cmake-project', 'src')
+        builddir = os.path.join(
+            self.path, self.parts_dir, 'cmake-project', 'build')
+        installdir = os.path.join(
             self.path, self.parts_dir, 'cmake-project', 'install')
         self.assertThat(
             binary_output.decode('utf-8'),
-            Equals("When I was built I was installed to {}\n".format(path)))
+            Equals(
+                'I was built with:\n'
+                'PART_SRC: {}\n'
+                'PART_BUILD: {}\n'
+                'PART_INSTALL: {}\n'.format(sourcedir, builddir, installdir)))

--- a/tests/integration/snaps/cmake-with-env-var/CMakeLists.txt
+++ b/tests/integration/snaps/cmake-with-env-var/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 project(cmake-with-env-var C)
+add_definitions(-DPART_SRC=${PART_SRC})
+add_definitions(-DPART_BUILD=${PART_BUILD})
 add_definitions(-DPART_INSTALL=${PART_INSTALL})
 add_executable(cmake-with-env-var test.c)
 install(TARGETS cmake-with-env-var RUNTIME DESTINATION bin)

--- a/tests/integration/snaps/cmake-with-env-var/snapcraft.yaml
+++ b/tests/integration/snaps/cmake-with-env-var/snapcraft.yaml
@@ -11,5 +11,8 @@ build-packages: [gcc, libc6-dev]
 parts:
   cmake-project:
     plugin: cmake
-    configflags: ['-DPART_INSTALL="$SNAPCRAFT_PART_INSTALL"']
+    configflags:
+      - '-DPART_SRC="$SNAPCRAFT_PART_SRC"'
+      - '-DPART_BUILD="$SNAPCRAFT_PART_BUILD"'
+      - '-DPART_INSTALL="$SNAPCRAFT_PART_INSTALL"'
     source: .

--- a/tests/integration/snaps/cmake-with-env-var/test.c
+++ b/tests/integration/snaps/cmake-with-env-var/test.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
 
 int main() {
-    printf("When I was built I was installed to %s\n", PART_INSTALL);
+    printf("I was built with:\nPART_SRC: %s\nPART_BUILD: %s\nPART_INSTALL: %s\n", PART_SRC, PART_BUILD, PART_INSTALL);
 }

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -1460,7 +1460,7 @@ class StateTestCase(StateBaseTestCase):
                                            mock_get_symbols):
         mock_load_dependencies.return_value = {
             '/foo/bar/baz',
-            '{}/lib1/installed'.format(self.handler.installdir),
+            '{}/lib1/installed'.format(self.handler.plugin.installdir),
             '{}/lib2/staged'.format(self.handler.stagedir),
         }
         self.get_elf_files_mock.return_value = frozenset([
@@ -1530,7 +1530,7 @@ class StateTestCase(StateBaseTestCase):
         # dependency.
         mock_load_dependencies.return_value = set([
             '/foo/bar/baz',
-            '{}/lib1/installed'.format(self.handler.installdir),
+            '{}/lib1/installed'.format(self.handler.plugin.installdir),
             '{}/lib2/staged'.format(self.handler.stagedir),
         ])
 
@@ -2361,39 +2361,39 @@ class CollisionTestCase(unit.TestCase):
 
         part1 = self.load_part('part1')
         part1.plugin.installdir = tmpdir + '/install1'
-        os.makedirs(part1.installdir + '/a')
-        open(part1.installdir + '/a/1', mode='w').close()
-        with open(part1.installdir + '/file.pc', mode='w') as f:
-            f.write('prefix={}\n'.format(part1.installdir))
+        os.makedirs(part1.plugin.installdir + '/a')
+        open(part1.plugin.installdir + '/a/1', mode='w').close()
+        with open(part1.plugin.installdir + '/file.pc', mode='w') as f:
+            f.write('prefix={}\n'.format(part1.plugin.installdir))
             f.write('Name: File\n')
 
         part2 = self.load_part('part2')
         part2.plugin.installdir = tmpdir + '/install2'
-        os.makedirs(part2.installdir + '/a')
-        with open(part2.installdir + '/1', mode='w') as f:
+        os.makedirs(part2.plugin.installdir + '/a')
+        with open(part2.plugin.installdir + '/1', mode='w') as f:
             f.write('1')
-        open(part2.installdir + '/2', mode='w').close()
-        with open(part2.installdir + '/a/2', mode='w') as f:
+        open(part2.plugin.installdir + '/2', mode='w').close()
+        with open(part2.plugin.installdir + '/a/2', mode='w') as f:
             f.write('a/2')
-        with open(part2.installdir + '/file.pc', mode='w') as f:
-            f.write('prefix={}\n'.format(part2.installdir))
+        with open(part2.plugin.installdir + '/file.pc', mode='w') as f:
+            f.write('prefix={}\n'.format(part2.plugin.installdir))
             f.write('Name: File\n')
 
         part3 = self.load_part('part3')
         part3.plugin.installdir = tmpdir + '/install3'
-        os.makedirs(part3.installdir + '/a')
-        os.makedirs(part3.installdir + '/b')
-        with open(part3.installdir + '/1', mode='w') as f:
+        os.makedirs(part3.plugin.installdir + '/a')
+        os.makedirs(part3.plugin.installdir + '/b')
+        with open(part3.plugin.installdir + '/1', mode='w') as f:
             f.write('2')
-        with open(part2.installdir + '/2', mode='w') as f:
+        with open(part2.plugin.installdir + '/2', mode='w') as f:
             f.write('1')
-        open(part3.installdir + '/a/2', mode='w').close()
+        open(part3.plugin.installdir + '/a/2', mode='w').close()
 
         part4 = self.load_part('part4')
         part4.plugin.installdir = tmpdir + '/install4'
-        os.makedirs(part4.installdir)
-        with open(part4.installdir + '/file.pc', mode='w') as f:
-            f.write('prefix={}\n'.format(part4.installdir))
+        os.makedirs(part4.plugin.installdir)
+        with open(part4.plugin.installdir + '/file.pc', mode='w') as f:
+            f.write('prefix={}\n'.format(part4.plugin.installdir))
             f.write('Name: ConflictFile\n')
 
         self.part1 = part1
@@ -2430,8 +2430,9 @@ class CollisionTestCase(unit.TestCase):
             'part_built', part_properties={'stage': ['collision']})
         part_built.plugin.installdir = 'part_built_install'
         # a part built has the stage file in the installdir.
-        os.makedirs(part_built.installdir)
-        open(os.path.join(part_built.installdir, 'collision'), 'w').close()
+        os.makedirs(part_built.plugin.installdir)
+        open(os.path.join(
+            part_built.plugin.installdir, 'collision'), 'w').close()
         part_not_built = self.load_part(
             'part_not_built', part_properties={'stage': ['collision']})
         part_not_built.plugin.installdir = 'part_not_built_install'

--- a/tests/unit/project_loader/test_config.py
+++ b/tests/unit/project_loader/test_config.py
@@ -2034,8 +2034,15 @@ parts:
              '{0}/stage/bin:$PATH"').format(self.path),
             'PERL5LIB="{0}/stage/usr/share/perl5/"'.format(self.path),
             'SNAPCRAFT_ARCH_TRIPLET="{}"'.format(self.arch_triplet),
-            'SNAPCRAFT_PARALLEL_BUILD_COUNT=2',
+            'SNAPCRAFT_PARALLEL_BUILD_COUNT="2"',
+            'SNAPCRAFT_PART_BUILD="{}/parts/main/build"'.format(self.path),
             'SNAPCRAFT_PART_INSTALL="{}/parts/main/install"'.format(self.path),
+            'SNAPCRAFT_PART_SRC="{}/parts/main/src"'.format(self.path),
+            'SNAPCRAFT_PRIME="{}/prime"'.format(self.path),
+            'SNAPCRAFT_PROJECT_GRADE="stable"',
+            'SNAPCRAFT_PROJECT_NAME="test"',
+            'SNAPCRAFT_PROJECT_VERSION="1"',
+            'SNAPCRAFT_STAGE="{}/stage"'.format(self.path),
         ]))
 
     def test_config_stage_environment_confinement_classic(self):
@@ -2292,7 +2299,7 @@ parts:
         part1 = [part for part in
                  config.parts.all_parts if part.name == 'part1'][0]
         env = config.parts.build_env_for_part(part1)
-        self.assertIn('SNAPCRAFT_PARALLEL_BUILD_COUNT=fortytwo', env)
+        self.assertIn('SNAPCRAFT_PARALLEL_BUILD_COUNT="fortytwo"', env)
 
 
 class ValidationBaseTestCase(unit.TestCase):
@@ -3023,10 +3030,11 @@ class SnapcraftEnvTestCase(unit.TestCase):
 
         for test_name, subject, expected in replacements:
             self.assertThat(project_loader.replace_attr(
-                subject, [('$SNAPCRAFT_PROJECT_NAME', 'project_name'),
-                          ('$SNAPCRAFT_PROJECT_VERSION', 'version'),
-                          ('$SNAPCRAFT_STAGE', self.stage_dir)]),
-                            Equals(expected))
+                subject, {
+                    '$SNAPCRAFT_PROJECT_NAME': 'project_name',
+                    '$SNAPCRAFT_PROJECT_VERSION': 'version',
+                    '$SNAPCRAFT_STAGE': self.stage_dir,
+                }), Equals(expected))
 
     def test_lists_with_string_replacements(self):
         replacements = (
@@ -3067,10 +3075,11 @@ class SnapcraftEnvTestCase(unit.TestCase):
 
         for test_name, subject, expected in replacements:
             self.assertThat(project_loader.replace_attr(
-                subject, [('$SNAPCRAFT_PROJECT_NAME', 'project_name'),
-                          ('$SNAPCRAFT_PROJECT_VERSION', 'version'),
-                          ('$SNAPCRAFT_STAGE', self.stage_dir)]),
-                            Equals(expected))
+                subject, {
+                    '$SNAPCRAFT_PROJECT_NAME': 'project_name',
+                    '$SNAPCRAFT_PROJECT_VERSION': 'version',
+                    '$SNAPCRAFT_STAGE': self.stage_dir,
+                }), Equals(expected))
 
     def test_tuples_with_string_replacements(self):
         replacements = (
@@ -3111,10 +3120,11 @@ class SnapcraftEnvTestCase(unit.TestCase):
 
         for test_name, subject, expected in replacements:
             self.assertThat(project_loader.replace_attr(
-                subject, [('$SNAPCRAFT_PROJECT_NAME', 'project_name'),
-                          ('$SNAPCRAFT_PROJECT_VERSION', 'version'),
-                          ('$SNAPCRAFT_STAGE', self.stage_dir)]),
-                            Equals(expected))
+                subject, {
+                    '$SNAPCRAFT_PROJECT_NAME': 'project_name',
+                    '$SNAPCRAFT_PROJECT_VERSION': 'version',
+                    '$SNAPCRAFT_STAGE': self.stage_dir,
+                }), Equals(expected))
 
     def test_dict_with_string_replacements(self):
         replacements = (
@@ -3155,10 +3165,11 @@ class SnapcraftEnvTestCase(unit.TestCase):
 
         for test_name, subject, expected in replacements:
             self.assertThat(project_loader.replace_attr(
-                subject, [('$SNAPCRAFT_PROJECT_NAME', 'project_name'),
-                          ('$SNAPCRAFT_PROJECT_VERSION', 'version'),
-                          ('$SNAPCRAFT_STAGE', self.stage_dir)]),
-                            Equals(expected))
+                subject, {
+                    '$SNAPCRAFT_PROJECT_NAME': 'project_name',
+                    '$SNAPCRAFT_PROJECT_VERSION': 'version',
+                    '$SNAPCRAFT_STAGE': self.stage_dir,
+                }), Equals(expected))
 
     def test_string_replacement_with_complex_data(self):
         subject = {
@@ -3190,7 +3201,8 @@ class SnapcraftEnvTestCase(unit.TestCase):
         }
 
         self.assertThat(project_loader.replace_attr(
-            subject, [('$SNAPCRAFT_PROJECT_NAME', 'project_name'),
-                      ('$SNAPCRAFT_PROJECT_VERSION', 'version'),
-                      ('$SNAPCRAFT_STAGE', self.stage_dir)]),
-                        Equals(expected))
+            subject, {
+                '$SNAPCRAFT_PROJECT_NAME': 'project_name',
+                '$SNAPCRAFT_PROJECT_VERSION': 'version',
+                '$SNAPCRAFT_STAGE': self.stage_dir,
+            }), Equals(expected))

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -75,7 +75,7 @@ class BaseLifecycleTestCase(unit.TestCase):
 
 class ExecutionTestCase(BaseLifecycleTestCase):
 
-    def test__replace_in_parts(self):
+    def test_replace_in_parts(self):
         class Options:
             def __init__(self):
                 self.source = '$SNAPCRAFT_PART_INSTALL'
@@ -88,6 +88,9 @@ class ExecutionTestCase(BaseLifecycleTestCase):
         class Part:
             def __init__(self):
                 self.plugin = Plugin()
+                self.sourcedir = '/tmp'
+                self.builddir = '/tmp'
+                self.installdir = '/tmp'
 
         part = Part()
         new_part = _replace_in_part(part)

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -83,14 +83,13 @@ class ExecutionTestCase(BaseLifecycleTestCase):
         class Plugin:
             def __init__(self):
                 self.options = Options()
+                self.sourcedir = '/tmp'
+                self.builddir = '/tmp'
                 self.installdir = '/tmp'
 
         class Part:
             def __init__(self):
                 self.plugin = Plugin()
-                self.sourcedir = '/tmp'
-                self.builddir = '/tmp'
-                self.installdir = '/tmp'
 
         part = Part()
         new_part = _replace_in_part(part)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

This PR resolves [LP: #1763028](https://bugs.launchpad.net/snapcraft/+bug/1763028) by adding new environment variables (and replacements) for part src and build directories. It also refactors the `SNAPCRAFT_*` environment handling to happen in one place instead of multiple.