### PR TITLE
file_utils: don't let FileNotFoundError escape

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -560,3 +560,13 @@ class SnapcraftInvalidCLIConfigError(SnapcraftError):
         super().__init__(config_file=config_file, error=error)
         # This is to keep mypy happy
         self.config_file = config_file
+
+
+class SnapcraftCopyFileNotFoundError(SnapcraftError):
+    fmt = (
+        'Failed to copy {path!r}: no such file or directory.\n'
+        'Check the path and try again.'
+    )
+
+    def __init__(self, path):
+        super().__init__(path=path)

--- a/snapcraft/plugins/dump.py
+++ b/snapcraft/plugins/dump.py
@@ -28,6 +28,17 @@ such as: `filesets`, `stage`, `snap` and `organize`.
 import os
 
 import snapcraft
+from snapcraft.internal import errors
+
+
+class DumpInvalidSymlinkError(errors.SnapcraftError):
+    fmt = (
+        "Failed to copy {path!r}: it's a symlink pointing outside the snap.\n"
+        'Fix it to be valid when snapped and try again.'
+    )
+
+    def __init__(self, path):
+        super().__init__(path=path)
 
 
 class DumpPlugin(snapcraft.BasePlugin):
@@ -63,7 +74,5 @@ def _link_or_copy(source, destination, boundary):
     try:
         snapcraft.file_utils.link_or_copy(source, destination,
                                           follow_symlinks=follow_symlinks)
-    except FileNotFoundError:
-        raise FileNotFoundError(
-            '{!r} is a broken symlink pointing outside the snap'.format(
-                source))
+    except errors.SnapcraftCopyFileNotFoundError:
+        raise DumpInvalidSymlinkError(source)

--- a/tests/unit/plugins/test_copy.py
+++ b/tests/unit/plugins/test_copy.py
@@ -64,12 +64,9 @@ class TestCopyPlugin(unit.TestCase):
         c = CopyPlugin('copy', self.mock_options, self.project_options)
         c.pull()
 
-        raised = self.assertRaises(FileNotFoundError, c.build)
-
-        self.assertThat(
-            str(raised),
-            Equals("[Errno 2] No such file or directory: '{}/src'".format(
-                c.builddir)))
+        raised = self.assertRaises(
+            errors.SnapcraftCopyFileNotFoundError, c.build)
+        self.assertThat(raised.path, Equals(os.path.join(c.builddir, 'src')))
 
     def test_copy_glob_does_not_match_anything(self):
         # ensure that a bad file causes a warning and fails the build even

--- a/tests/unit/plugins/test_dump.py
+++ b/tests/unit/plugins/test_dump.py
@@ -19,7 +19,7 @@ import os
 from testtools.matchers import Equals
 
 import snapcraft
-from snapcraft.plugins.dump import DumpPlugin
+from snapcraft.plugins.dump import DumpInvalidSymlinkError, DumpPlugin
 from tests import unit
 
 
@@ -213,12 +213,11 @@ class DumpPluginTestCase(unit.TestCase):
 
         plugin.pull()
 
-        raised = self.assertRaises(FileNotFoundError, plugin.build)
+        raised = self.assertRaises(DumpInvalidSymlinkError, plugin.build)
 
         self.assertThat(
-            str(raised),
-            Equals('{!r} is a broken symlink pointing outside the snap'.format(
-                os.path.join(plugin.builddir, 'src', 'bad_relative'))))
+            raised.path, Equals(os.path.join(
+                plugin.builddir, 'src', 'bad_relative')))
 
     def test_dump_enable_cross_compilation(self):
         plugin = DumpPlugin('dump', self.options, self.project_options)

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -422,6 +422,16 @@ class ErrorFormattingTestCase(unit.TestCase):
                 'https://status.snapcraft.io/'
             )
         }),
+        ('SnapcraftCopyFileNotFoundError', {
+            'exception': errors.SnapcraftCopyFileNotFoundError,
+            'kwargs': {
+                'path': 'test-path',
+            },
+            'expected_message': (
+                "Failed to copy 'test-path': no such file or directory.\n"
+                'Check the path and try again.'
+            )
+        }),
     )
 
     def test_error_formatting(self):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently, when `file_utils.link_or_copy` is asked to copy files that don't exist (or symlinks that point to files that don't exist), `FileNotFoundErrors` from the underlying python calls leak through, resulting in a nasty traceback.

This PR fixes [LP: #1765282](https://bugs.launchpad.net/snapcraft/+bug/1765282) by catching `FileNotFoundErrors`, and turning them it into `SnapcraftError`-based exceptions.