### PR TITLE
Fix running python plugin on Fedora

### DIFF
--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -64,7 +64,7 @@ import requests
 import snapcraft
 from snapcraft.common import isurl
 from snapcraft.internal import mangling, os_release
-from snapcraft.internal.errors import SnapcraftPluginCommandError
+from snapcraft.internal.errors import OsReleaseCodenameError, SnapcraftPluginCommandError
 from snapcraft.plugins import _python
 
 
@@ -150,7 +150,8 @@ class PythonPlugin(snapcraft.BasePlugin):
 
     @property
     def plugin_stage_packages(self):
-        release_codename = os_release.OsRelease().version_codename()
+        with contextlib.suppress('OsReleaseCodenameError'):
+            release_codename = os_release.OsRelease().version_codename()
         if self.options.python_version == 'python2':
             python_base = 'python'
         elif self.options.python_version == 'python3':


### PR DESCRIPTION
There are no codenames on Fedora

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----
