### PR TITLE
delta: properly search for in-snap xdelta3

### DIFF
--- a/snapcraft/internal/deltas/_deltas.py
+++ b/snapcraft/internal/deltas/_deltas.py
@@ -17,6 +17,7 @@
 
 import logging
 import os
+import shutil
 import subprocess
 import time
 
@@ -84,7 +85,9 @@ class BaseDeltasGenerator:
 
     def _check_delta_gen_tool(self):
         """Check if the delta generation tool exists"""
-        if not file_utils.executable_exists(self.delta_tool_path):
+        path_exists = file_utils.executable_exists(self.delta_tool_path)
+        on_system = shutil.which(self.delta_tool_path)
+        if not (path_exists or on_system):
             raise DeltaToolError(delta_tool=self.delta_tool_path)
 
     def _check_delta_size_constraint(self, delta_path):

--- a/snapcraft/internal/deltas/_xdelta3.py
+++ b/snapcraft/internal/deltas/_xdelta3.py
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
-import shutil
 import subprocess
 
-from snapcraft.internal.deltas._deltas import BaseDeltasGenerator
-
+from ._deltas import BaseDeltasGenerator
+from snapcraft import file_utils
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +26,7 @@ class XDelta3Generator(BaseDeltasGenerator):
 
     def __init__(self, *, source_path, target_path):
         delta_format = 'xdelta3'
-        delta_tool_path = shutil.which(delta_format)
+        delta_tool_path = file_utils.get_tool_path('xdelta3')
         super().__init__(source_path=source_path,
                          target_path=target_path,
                          delta_file_extname='xdelta3',

--- a/tests/unit/commands/test_push.py
+++ b/tests/unit/commands/test_push.py
@@ -40,7 +40,7 @@ class PushCommandBaseTestCase(CommandBaseTestCase):
         super().setUp()
 
         patcher = mock.patch('snapcraft.storeapi.StoreClient.push_precheck')
-        patcher.start()
+        self.mock_precheck = patcher.start()
         self.addCleanup(patcher.stop)
 
         self.snap_file = os.path.join(
@@ -159,10 +159,7 @@ class PushCommandTestCase(PushCommandBaseTestCase):
             error_list = [{'code': 'resource-not-found',
                            'message': 'Snap not found for name=basic'}]
 
-        patcher = mock.patch.object(storeapi.StoreClient, 'push_precheck')
-        mock_precheck = patcher.start()
-        self.addCleanup(patcher.stop)
-        mock_precheck.side_effect = StorePushError(
+        self.mock_precheck.side_effect = StorePushError(
             'basic', MockResponse())
 
         raised = self.assertRaises(
@@ -365,20 +362,11 @@ class PushCommandTestCase(PushCommandBaseTestCase):
 
 class PushCommandDeltasTestCase(PushCommandBaseTestCase):
 
-    scenarios = [
-        ('with deltas', dict(enable_deltas=True)),
-        ('without deltas', dict(enable_deltas=False)),
-    ]
-
     def setUp(self):
         super().setUp()
 
         self.latest_snap_revision = 8
         self.new_snap_revision = self.latest_snap_revision + 1
-
-        patcher = mock.patch('snapcraft.storeapi.StoreClient.push_precheck')
-        patcher.start()
-        self.addCleanup(patcher.stop)
 
         mock_tracker = mock.Mock(storeapi._status_tracker.StatusTracker)
         mock_tracker.track.return_value = {
@@ -534,10 +522,6 @@ class PushCommandDeltasWithPruneTestCase(PushCommandBaseTestCase):
 
     def test_push_revision_prune_snap_cache(self):
         snap_revision = 9
-
-        patcher = mock.patch('snapcraft.storeapi.StoreClient.push_precheck')
-        patcher.start()
-        self.addCleanup(patcher.stop)
 
         patcher = mock.patch.object(storeapi.StoreClient, 'get_snap_revisions')
         mock_release = patcher.start()

--- a/tests/unit/test_deltas_xdelta3.py
+++ b/tests/unit/test_deltas_xdelta3.py
@@ -22,18 +22,14 @@ import shutil
 from unittest import mock
 
 from progressbar import AnimatedMarker, ProgressBar
-from testtools import TestCase
 from testtools import matchers as m
 
 from snapcraft import file_utils
 from snapcraft.internal import deltas  # noqa
-from tests import (
-    fixture_setup,
-    unit
-)
+from tests import fixture_setup, unit
 
 
-class XDelta3TestCase(TestCase):
+class XDelta3TestCase(unit.TestCase):
 
     def setUp(self):
         super().setUp()
@@ -41,12 +37,7 @@ class XDelta3TestCase(TestCase):
         self.fake_logger = fixtures.FakeLogger(level=logging.DEBUG)
         self.useFixture(self.fake_logger)
 
-        # patch the ProgressBar to avoid mess up the test output
-        patcher = mock.patch(
-            'tests.unit.test_deltas_xdelta3.ProgressBar',
-            new=unit.SilentProgressBar)
-        patcher.start()
-        self.addCleanup(patcher.stop)
+        self.patch(file_utils, 'executable_exists', lambda a: True)
 
         self.workdir = self.useFixture(fixtures.TempDir()).path
         self.source_file = os.path.join(self.workdir, 'source.snap')
@@ -93,12 +84,10 @@ class XDelta3TestCase(TestCase):
                 source_path=self.source_file, target_path=self.target_file),
             m.raises(deltas.errors.DeltaToolError)
         )
-        exception = self.assertRaises(deltas.errors.DeltaToolError,
-                                      deltas.XDelta3Generator,
-                                      source_path=self.source_file,
-                                      target_path=self.target_file)
-        expected = 'delta_tool_path must be set in subclass!'
-        self.assertThat(str(exception), m.Equals(expected))
+        self.assertRaises(deltas.errors.DeltaToolError,
+                          deltas.XDelta3Generator,
+                          source_path=self.source_file,
+                          target_path=self.target_file)
 
     def test_xdelta3(self):
         self.generate_snap_pair()


### PR DESCRIPTION
Replace the current implementation of using shutil.which with
snapcraft's `file_utils.get_tool_path` to properly find xdelta3 when
run from the snapcraft snap.

LP: #1769978
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
