### PR TITLE
Swap FROM in Dockerfiles from 'xenial' to 'bionic'.

### DIFF
--- a/docker/beta.Dockerfile
+++ b/docker/beta.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 RUN apt-get update && \
   apt-get dist-upgrade --yes && \

--- a/docker/candidate.Dockerfile
+++ b/docker/candidate.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 RUN apt-get update && \
   apt-get dist-upgrade --yes && \

--- a/docker/edge.Dockerfile
+++ b/docker/edge.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 RUN apt-get update && \
   apt-get dist-upgrade --yes && \

--- a/docker/stable.Dockerfile
+++ b/docker/stable.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 RUN apt-get update && \
   apt-get dist-upgrade --yes && \


### PR DESCRIPTION
Rebases the Docker images to the latest LTS. `docker build` runs successfully on my local machine for all four image channels.