### PR TITLE
tests: remove obsolete env var

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -99,10 +99,6 @@ class TestCase(testtools.TestCase):
             'XDG_DATA_HOME', os.path.join(self.path, 'data')))
         self.useFixture(fixtures.EnvironmentVariable('TERM', 'dumb'))
 
-        # Do not send crash reports
-        self.useFixture(fixtures.EnvironmentVariable(
-            'SNAPCRAFT_SEND_ERROR_DATA', 'n'))
-
         patcher = mock.patch(
             'xdg.BaseDirectory.xdg_config_home',
             new=os.path.join(self.path, '.config'))


### PR DESCRIPTION
Logic around `SNAPCRAFT_SEND_ERROR_DATA` has been removed so it makes little
sense to keep it for tests.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----
