### PR TITLE
errors: generic exception for common.run[_output]

### DIFF
--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -26,7 +26,7 @@ import sys
 import tempfile
 import urllib
 from contextlib import suppress
-from typing import List  # noqa
+from typing import Callable, List
 
 from snapcraft.internal import errors
 
@@ -54,7 +54,7 @@ def assemble_env():
     return '\n'.join(['export ' + e for e in env])
 
 
-def _run(cmd: List[str], caller, **kwargs):
+def _run(cmd: List[str], runner: Callable, **kwargs):
     assert isinstance(cmd, list), 'run command must be a list'
     cmd_string = ' '.join([shlex.quote(c) for c in cmd])
     # FIXME: This is gross to keep writing this, even when env is the same
@@ -64,7 +64,7 @@ def _run(cmd: List[str], caller, **kwargs):
         run_file.flush()
         run_file.seek(0)
         try:
-            return caller(['/bin/sh'], stdin=run_file, **kwargs)
+            return runner(['/bin/sh'], stdin=run_file, **kwargs)
         except subprocess.CalledProcessError as call_error:
             raise errors.SnapcraftCommandError(
                 command=cmd_string,

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -500,11 +500,11 @@ class SnapcraftCommandError(SnapcraftError, CalledProcessError):
     def __init__(self, *, command: str,
                  call_error: CalledProcessError) -> None:
         super().__init__(command=command, exit_code=call_error.returncode)
-        self.output = call_error.output
-        self.stdout = call_error.stdout
-        self.stderr = call_error.stderr
-        self.cmd = call_error.cmd
-        self.returncode = call_error.returncode
+        CalledProcessError.__init__(self,
+                                    returncode=call_error.returncode,
+                                    cmd=call_error.cmd,
+                                    output=call_error.output,
+                                    stderr=call_error.stderr)
 
 
 class SnapcraftPluginCommandError(SnapcraftError):

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from subprocess import CalledProcessError
 from typing import List, Union
 
 from snapcraft import formatting_utils
@@ -481,6 +482,29 @@ class InvalidExtractorValueError(MetadataExtractionError):
 
     def __init__(self, path: str, extractor_name: str) -> None:
         super().__init__(path=path, extractor_name=extractor_name)
+
+
+class SnapcraftCommandError(SnapcraftError, CalledProcessError):
+    """Exception for generic command errors.
+
+    Processes should capture this error for specific messaging.
+    This exception carries the signature of CalledProcessError for backwards
+    compatibility.
+    """
+
+    fmt = (
+            'Failed to run {command!r}: '
+            'Exited with code {exit_code}.'
+    )
+
+    def __init__(self, *, command: str,
+                 call_error: CalledProcessError) -> None:
+        super().__init__(command=command, exit_code=call_error.returncode)
+        self.output = call_error.output
+        self.stdout = call_error.stdout
+        self.stderr = call_error.stderr
+        self.cmd = call_error.cmd
+        self.returncode = call_error.returncode
 
 
 class SnapcraftPluginCommandError(SnapcraftError):

--- a/tests/unit/plugins/test_ament.py
+++ b/tests/unit/plugins/test_ament.py
@@ -108,8 +108,8 @@ class AmentPluginTestCase(unit.TestCase):
         mock_clean = self.bootstrapper_mock.return_value.clean
         mock_clean.assert_called_once_with()
 
-    @mock.patch('subprocess.check_call')
-    def test_build_builds_ros2_underlay(self, mock_check_call):
+    @mock.patch('snapcraft.internal.common.run')
+    def test_build_builds_ros2_underlay(self, mock_run):
         plugin = ament.AmentPlugin('test-part', self.properties, self.project)
 
         self.bootstrapper_mock.return_value.build.return_value = 'bootstrap'
@@ -137,8 +137,8 @@ class AmentPluginTestCase(unit.TestCase):
 
         # Verify that the source space was built as expected, and that the
         # system's PYTHONPATH was included while building
-        mock_check_call.assert_called_once_with([
-            mock.ANY, mock.ANY, 'ament', 'build', plugin.sourcedir,
+        mock_run.assert_called_once_with([
+            'ament', 'build', plugin.sourcedir,
             '--build-space', plugin.builddir, '--install-space',
             plugin.installdir, '--cmake-args', '-DCMAKE_BUILD_TYPE=Release'],
             cwd=mock.ANY, env=check_env())

--- a/tests/unit/plugins/test_dotnet.py
+++ b/tests/unit/plugins/test_dotnet.py
@@ -16,7 +16,6 @@
 
 import json
 import os
-import subprocess
 import tarfile
 from textwrap import dedent
 from unittest import mock
@@ -125,13 +124,13 @@ class DotNetProjectBaseTestCase(unit.TestCase):
         urlopen_mock.side_effect = fake_urlopen
         self.addCleanup(patcher.stop)
 
-        original_check_call = subprocess.check_call
-        patcher = mock.patch('subprocess.check_call')
+        original_check_call = snapcraft.internal.common.run
+        patcher = mock.patch('snapcraft.internal.common.run')
         self.mock_check_call = patcher.start()
         self.addCleanup(patcher.stop)
 
         def side_effect(cmd, *args, **kwargs):
-            if cmd[2].endswith('dotnet'):
+            if cmd[0].endswith('dotnet'):
                 pass
             else:
                 original_check_call(cmd, *args, **kwargs)
@@ -240,10 +239,10 @@ class DotNetProjectBuildCommandsTestCase(DotNetProjectBaseTestCase):
         self.assertThat(
             self.mock_check_call.mock_calls, Equals([
                 mock.call([
-                    mock.ANY, mock.ANY, dotnet_command,
+                    dotnet_command,
                     'build', '-c', self.configuration], cwd=mock.ANY),
                 mock.call([
-                    mock.ANY, mock.ANY, dotnet_command,
+                    dotnet_command,
                     'publish', '-c', self.configuration,
                     '-o', plugin.installdir,
                     '--self-contained', '-r', 'linux-x64'], cwd=mock.ANY)]))

--- a/tests/unit/plugins/test_ruby.py
+++ b/tests/unit/plugins/test_ruby.py
@@ -183,7 +183,7 @@ class RubyPluginTestCase(unit.TestCase):
                 plugin,
                 _ruby_tar=mock.DEFAULT,
                 _gem_install=mock.DEFAULT) as mocks:
-            with mock.patch('subprocess.check_call') as mock_check_call:
+            with mock.patch('snapcraft.internal.common.run') as mock_run:
                 plugin.pull()
 
         ruby_expected_dir = os.path.join(
@@ -191,18 +191,15 @@ class RubyPluginTestCase(unit.TestCase):
         mocks['_ruby_tar'].provision.assert_called_with(
             ruby_expected_dir,
             clean_target=False, keep_tarball=True)
-        mock_check_call.assert_has_calls([
+        mock_run.assert_has_calls([
             mock.call(
-                [mock.ANY, mock.ANY,
-                 './configure', '--disable-install-rdoc', '--prefix=/'],
+                ['./configure', '--disable-install-rdoc', '--prefix=/'],
                 cwd=ruby_expected_dir, env=mock.ANY),
             mock.call(
-                [mock.ANY, mock.ANY,
-                 'make', '-j{}'.format(plugin.parallel_build_count)],
+                ['make', '-j{}'.format(plugin.parallel_build_count)],
                 cwd=ruby_expected_dir, env=mock.ANY),
             mock.call(
-                [mock.ANY, mock.ANY,
-                 'make', 'install', 'DESTDIR={}'.format(plugin.installdir)],
+                ['make', 'install', 'DESTDIR={}'.format(plugin.installdir)],
                 cwd=ruby_expected_dir, env=mock.ANY)
         ])
 
@@ -212,13 +209,12 @@ class RubyPluginTestCase(unit.TestCase):
             'test-part', self.options, self.project_options)
         with mock.patch.multiple(
                 plugin, _ruby_tar=mock.DEFAULT, _ruby_install=mock.DEFAULT):
-            with mock.patch('subprocess.check_call') as mock_check_call:
+            with mock.patch('snapcraft.internal.common.run') as mock_run:
                 plugin.pull()
 
         test_part_dir = os.path.join(self.path, 'parts', 'test-part')
-        mock_check_call.assert_called_with(
-            [mock.ANY, mock.ANY,
-             os.path.join(test_part_dir, 'install', 'bin', 'ruby'),
+        mock_run.assert_called_with(
+            [os.path.join(test_part_dir, 'install', 'bin', 'ruby'),
              os.path.join(test_part_dir,  'install', 'bin', 'gem'),
              'install', '--env-shebang', 'test-gem-1', 'test-gem-2'],
             cwd=os.path.join(test_part_dir, 'build'),
@@ -232,21 +228,19 @@ class RubyPluginTestCase(unit.TestCase):
 
         with mock.patch.multiple(
                 plugin, _ruby_tar=mock.DEFAULT, _ruby_install=mock.DEFAULT):
-            with mock.patch('subprocess.check_call') as mock_check_call:
+            with mock.patch('snapcraft.internal.common.run') as mock_run:
                 plugin.pull()
         test_part_dir = os.path.join(self.path, 'parts', 'test-part')
-        mock_check_call.assert_has_calls([
+        mock_run.assert_has_calls([
             mock.call(
-                [mock.ANY, mock.ANY,
-                 os.path.join(test_part_dir, 'install', 'bin', 'ruby'),
+                [os.path.join(test_part_dir, 'install', 'bin', 'ruby'),
                  os.path.join(test_part_dir,  'install', 'bin', 'gem'),
                  'install', '--env-shebang',
                  'test-gem-1', 'test-gem-2', 'bundler'],
                 cwd=os.path.join(test_part_dir, 'build'),
                 env=mock.ANY),
             mock.call(
-                [mock.ANY, mock.ANY,
-                 os.path.join(test_part_dir, 'install', 'bin', 'ruby'),
+                [os.path.join(test_part_dir, 'install', 'bin', 'ruby'),
                  os.path.join(test_part_dir,  'install', 'bin', 'bundle'),
                  'install'],
                 cwd=os.path.join(test_part_dir, 'build'),

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -360,6 +360,17 @@ class ErrorFormattingTestCase(unit.TestCase):
                 'occurred.\nPlease try again.'
             )
         }),
+        ('SnapcraftCommandError', {
+            'exception': errors.SnapcraftCommandError,
+            'kwargs': {
+                    'command': 'pip install foo',
+                    'call_error': CalledProcessError(
+                        cmd=['/bin/sh'], returncode=1, output='failed')},
+            'expected_message': (
+                "Failed to run 'pip install foo': "
+                "Exited with code 1."
+            )
+        }),
         ('SnapcraftPluginCommandError string command', {
             'exception': errors.SnapcraftPluginCommandError,
             'kwargs': {

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -21,8 +21,6 @@ import logging
 import os
 import re
 import shutil
-import subprocess
-import sys
 import textwrap
 from unittest import mock
 
@@ -820,16 +818,15 @@ class RecordManifestBaseTestCase(BaseLifecycleTestCase):
 
     def setUp(self):
         super().setUp()
-        original_check_output = subprocess.check_output
+        original_run_output = snapcraft.internal.common.run_output
 
         def fake_uname(cmd, *args, **kwargs):
             if 'uname' in cmd:
-                return 'Linux test uname 4.10 x86_64'.encode(
-                    sys.getfilesystemencoding())
+                return 'Linux test uname 4.10 x86_64'
             else:
-                return original_check_output(cmd, *args, **kwargs)
+                return original_run_output(cmd, *args, **kwargs)
         check_output_patcher = mock.patch(
-            'subprocess.check_output', side_effect=fake_uname)
+            'snapcraft.internal.common.run_output', side_effect=fake_uname)
         check_output_patcher.start()
         self.addCleanup(check_output_patcher.stop)
 


### PR DESCRIPTION
Catch exceptions for subprocess.check_call and subprocess.check_output
in snapcraft.internal.common and display a consumable message.

Fixes SNAPCRAFT-11
Fixes SNAPCRAFT-G
Fixes SNAPCRAFT-P
Fixes SNAPCRAFT-5

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----
