### PR TITLE
Add gradle support for task other than just 'jar'

### DIFF
--- a/snapcraft/plugins/gradle.py
+++ b/snapcraft/plugins/gradle.py
@@ -104,7 +104,7 @@ class GradlePlugin(snapcraft.plugins.jdk.JdkPlugin):
             basedir = 'war'
             jarfiles = warfiles
         else:
-            raise RuntimeError("Could not find any built jar files for part")
+            raise RuntimeError("Could not find any built jar files for part in: " + src)
 
         snapcraft.file_utils.link_or_copy_tree(
             src, os.path.join(self.installdir, basedir),

--- a/snapcraft/plugins/gradle.py
+++ b/snapcraft/plugins/gradle.py
@@ -118,7 +118,7 @@ class GradlePlugin(snapcraft.plugins.jdk.JdkPlugin):
             basedir = 'war'
             jarfiles = warfiles
         else:
-            raise RuntimeError("Could not find any built jar files in the part directory:" + src)
+            raise RuntimeError("Could not find any built jar/war files in the part directory:" + src)
 
         snapcraft.file_utils.link_or_copy_tree(
             src, os.path.join(self.installdir, basedir),

--- a/snapcraft/plugins/gradle.py
+++ b/snapcraft/plugins/gradle.py
@@ -118,7 +118,7 @@ class GradlePlugin(snapcraft.plugins.jdk.JdkPlugin):
             basedir = 'war'
             jarfiles = warfiles
         else:
-            raise RuntimeError("Could not find any built jar/war files in the part directory:" + src)
+            raise RuntimeError('Could not find any built jar/war files in the part directory: {!r}'.format(src))
 
         snapcraft.file_utils.link_or_copy_tree(
             src, os.path.join(self.installdir, basedir),

--- a/snapcraft/plugins/gradle.py
+++ b/snapcraft/plugins/gradle.py
@@ -72,7 +72,7 @@ class GradlePlugin(snapcraft.plugins.jdk.JdkPlugin):
             'items': {
                 'type': 'string',
             },
-            'default': [jar],
+            'default': ['jar'],
         }
         schema['properties']['gradle-output-dir'] = {
             'type': 'string',

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -99,10 +99,6 @@ class TestCase(testtools.TestCase):
             'XDG_DATA_HOME', os.path.join(self.path, 'data')))
         self.useFixture(fixtures.EnvironmentVariable('TERM', 'dumb'))
 
-        # Do not send crash reports
-        self.useFixture(fixtures.EnvironmentVariable(
-            'SNAPCRAFT_SEND_ERROR_DATA', 'n'))
-
         patcher = mock.patch(
             'xdg.BaseDirectory.xdg_config_home',
             new=os.path.join(self.path, '.config'))

--- a/tests/unit/plugins/test_gradle.py
+++ b/tests/unit/plugins/test_gradle.py
@@ -48,6 +48,7 @@ class GradlePluginTestCase(BaseGradlePluginTestCase):
         schema = gradle.GradlePlugin.schema()
 
         properties = schema['properties']
+
         self.assertTrue('gradle-options' in properties,
                         'Expected "gradle-options" to be included in '
                         'properties')
@@ -75,16 +76,46 @@ class GradlePluginTestCase(BaseGradlePluginTestCase):
             gradle_options['uniqueItems'],
             'Expected "gradle-options" "uniqueItems" to be "True"')
 
+
+		# gradle-tasks schema checks
+        self.assertTrue('gradle-tasks' in properties,
+                        'Expected "gradle-tasks" to be included in '
+                        'properties')
+
+        gradle_options = properties['gradle-tasks']
+
+        self.assertTrue(
+            'type' in gradle_options,
+            'Expected "type" to be included in "gradle-tasks"')
+        self.assertThat(gradle_options['type'], Equals('array'),
+                        'Expected "gradle-tasks" "type" to be "array", but '
+                        'it was "{}"'.format(gradle_options['type']))
+
+        self.assertTrue(
+            'minitems' in gradle_tasks,
+            'Expected "minitems" to be included in "gradle-tasks"')
+        self.assertThat(gradle_tasks['minitems'], Equals(1),
+                        'Expected "gradle-tasks" "minitems" to be 1, but '
+                        'it was "{}"'.format(gradle_tasks['minitems']))
+
+        self.assertTrue(
+            'uniqueItems' in gradle_tasks,
+            'Expected "uniqueItems" to be included in "gradle-tasks"')
+        self.assertTrue(
+            gradle_tasks['uniqueItems'],
+            'Expected "gradle-tasks" "uniqueItems" to be "True"')
+
+		# schema checks for gradel-output-dir
         output_dir = properties['gradle-output-dir']
         self.assertTrue(
             'type' in output_dir,
-            'Expected "type" to be included in "gradle-options"')
+            'Expected "type" to be included in "gradle-output-dir"')
         self.assertThat(output_dir['type'], Equals('string'),
-                        'Expected "gradle-options" "type" to be "string", '
+                        'Expected "gradle-output-dir" "type" to be "string", '
                         'but it was "{}"'.format(output_dir['type']))
 
     def test_get_build_properties(self):
-        expected_build_properties = ['gradle-options', 'gradle-output-dir']
+        expected_build_properties = ['gradle-options', 'gradle-tasks', 'gradle-output-dir']
         resulting_build_properties = gradle.GradlePlugin.get_build_properties()
 
         self.assertThat(resulting_build_properties,
@@ -153,7 +184,7 @@ class GradlePluginTestCase(BaseGradlePluginTestCase):
         plugin.build()
 
         run_mock.assert_has_calls([
-            mock.call(['gradle', 'jar']),
+            mock.call(['gradle', 'war']),
         ])
 
     @mock.patch.object(gradle.GradlePlugin, 'run')
@@ -176,7 +207,7 @@ class GradlePluginTestCase(BaseGradlePluginTestCase):
         plugin.build()
 
         run_mock.assert_has_calls([
-            mock.call(['./gradlew', 'jar']),
+            mock.call(['./gradlew', 'war']),
         ])
 
     @mock.patch.object(gradle.GradlePlugin, 'run')
@@ -256,7 +287,7 @@ class GradleProxyTestCase(BaseGradlePluginTestCase):
         plugin.build()
 
         run_mock.assert_has_calls([
-            mock.call(['gradle'] + self.expected_args + ['jar'])
+            mock.call(['gradle'] + self.expected_args + ['war'])
         ])
 
     @mock.patch.object(gradle.GradlePlugin, 'run')
@@ -281,5 +312,5 @@ class GradleProxyTestCase(BaseGradlePluginTestCase):
         plugin.build()
 
         run_mock.assert_has_calls([
-            mock.call(['./gradlew'] + self.expected_args + ['jar'])
+            mock.call(['./gradlew'] + self.expected_args + ['war'])
         ])


### PR DESCRIPTION
improved error when no jar found by displaying the path that was searched. Will make diagnosing build problems faster.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----
