### PR TITLE
ci: remove unused cron tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
     - if: type != cron
       script: SNAPCRAFT_TEST_MOCK_MACHINE=aarch64 sudo ./tools/travis/run_tests.sh tests/unit
     - stage: osx-integration-store
+      if: type != cron
       os: osx
       script: SNAPCRAFT_FROM_BREW=1 ./tools/travis/run_tests.sh tests.integration.store.test_store_login_logout use-run
     - stage: snap
@@ -36,7 +37,7 @@ jobs:
       if: type != cron
       script: sudo ./tools/travis/run_tests.sh tests/integration/general
     - if: type != cron
-      script: LXD_IMAGE="ubuntu-daily:bionic" sudo ./tools/travis/run_tests.sh tests/integration/general
+      script: LXD_IMAGE="ubuntu:bionic" sudo ./tools/travis/run_tests.sh tests/integration/general
     - if: type != cron
       script: sudo ./tools/travis/run_tests.sh tests/integration/lifecycle
     - if: type != cron
@@ -73,52 +74,3 @@ jobs:
     # Run spread tests for the snapcraft snap in edge.
       if: type = cron
       script: ./runtests.sh spread
-    # Run autopkgtests in LXD amd64 for the snapcraft-daily PPA
-    - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-general
-    - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-store
-    - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-plugins
-    - if: type = cron
-      script:
-      - "travis_wait 30 sleep 1800 &"
-      - sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-plugins-nodejs
-    - if: type = cron
-      script:
-      - "travis_wait 30 sleep 1800 &"
-      - sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-plugins-java
-    - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-plugins-python
-    - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-plugins-catkin
-    - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu:xenial integrationtests-snapd
-    - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-general
-    - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-store
-    - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-plugins
-    - if: type = cron
-      script:
-      - "travis_wait 30 sleep 1800 &"
-      - sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-plugins-nodejs
-    - if: type = cron
-      script:
-      - "travis_wait 30 sleep 1800 &"
-      - sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-plugins-java
-    - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-plugins-python
-    - if: type = cron
-      script: sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-plugins-catkin
-    - if: type = cron
-      script:
-      - "travis_wait 20 sleep 1200 &"
-      - sudo ./tools/travis/run_autopkgtests.sh ubuntu-daily:bionic integrationtests-snapd
-    # Trigger autopkgtests in all the supported distros and architectures for the snapcraft-daily PPA
-    - if: type = cron
-      script: sudo ./tools/travis/run_ppa_autopkgtests.sh
-    # Collect the results for the PPA autopkgtests that were triggered the day before.
-    - if: type = cron
-      script: sudo ./tools/travis/collect_ppa_autopkgtests_results.sh $(date -d "yesterday" "+%Y%m%d")


### PR DESCRIPTION
The autopkgtest which are cronned aren't really used and cause
unnecessary overhead we can do without.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----
