### PR TITLE
lp 1768233 workaround for plainbox_provider plugin

### DIFF
--- a/snapcraft/plugins/plainbox_provider.py
+++ b/snapcraft/plugins/plainbox_provider.py
@@ -40,6 +40,8 @@ class PlainboxProviderPlugin(snapcraft.BasePlugin):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
         self.build_packages.extend(['intltool'])
+        self.stage_packages.extend(['python3-pip', 'python3-wheel',
+                                    'python3-setuptools'])
 
     def build(self):
         super().build()

--- a/tests/integration/plugins/test_plainbox_provider_plugin.py
+++ b/tests/integration/plugins/test_plainbox_provider_plugin.py
@@ -58,3 +58,9 @@ class PlainboxProviderPluginTestCase(integration.TestCase):
         # provider in this project
         self.assertRaises(subprocess.CalledProcessError, self.run_snapcraft,
                           'prime', project_dir)
+
+    def test_python_stage_pkg_mix(self):
+        project_dir = 'plainbox-provider-python-stage-pkg-mix'
+        self.run_snapcraft('snap', project_dir)
+        # Tests bug where snap would fail to build with error:
+        # "Failed building wheel for bitstring"

--- a/tests/integration/plugins/test_plainbox_provider_plugin.py
+++ b/tests/integration/plugins/test_plainbox_provider_plugin.py
@@ -61,6 +61,6 @@ class PlainboxProviderPluginTestCase(integration.TestCase):
 
     def test_python_stage_pkg_mix(self):
         project_dir = 'plainbox-provider-python-stage-pkg-mix'
-        self.run_snapcraft('snap', project_dir)
+        self.run_snapcraft('stage', project_dir)
         # Tests bug where snap would fail to build with error:
         # "Failed building wheel for bitstring"

--- a/tests/integration/snaps/plainbox-provider-python-stage-pkg-mix/com.example_simple/manage.py
+++ b/tests/integration/snaps/plainbox-provider-python-stage-pkg-mix/com.example_simple/manage.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+from plainbox.provider_manager import setup, N_
+
+
+setup(
+    name='plainbox-provider-simple',
+    namespace='com.example',
+    version="1.0",
+    description=N_("A really simple Plainbox provider"),
+    gettext_domain="com_example_simple",
+)

--- a/tests/integration/snaps/plainbox-provider-python-stage-pkg-mix/com.example_simple/units/simple.pxu
+++ b/tests/integration/snaps/plainbox-provider-python-stage-pkg-mix/com.example_simple/units/simple.pxu
@@ -1,0 +1,32 @@
+
+unit: category
+id: simple
+_name: Simple
+
+unit: job
+id: always-pass
+category_id: simple
+_summary: A test that always passes
+_description:
+   A test that always passes
+   .
+   This simple test will always succeed, assuming your
+   platform has a 'true' command that returns 0.
+plugin: shell
+estimated_duration: 0.01
+command: true
+flags: preserve-locale
+
+unit: job
+id: always-fail
+category_id: simple
+_summary: A test that always fails
+_description:
+   A test that always fails
+   .
+   This simple test will always fail, assuming your
+   platform has a 'false' command that returns 1.
+plugin: shell
+estimated_duration: 0.01
+command: false
+flags: preserve-locale

--- a/tests/integration/snaps/plainbox-provider-python-stage-pkg-mix/snap/snapcraft.yaml
+++ b/tests/integration/snaps/plainbox-provider-python-stage-pkg-mix/snap/snapcraft.yaml
@@ -1,0 +1,35 @@
+name: plainbox-provider-python-stage-pkg-mix
+summary: test the python plugin
+version: '1'
+description: |
+  This is a snap with parts in some cases using python stage-packages
+  and other python-packages. It is required to test
+  https://bugs.launchpad.net/snapcraft/+bug/1768233
+confinement: strict
+grade: devel
+
+parts:
+  checkbox-ng-local:
+    plugin: python
+    python-packages:
+      - checkbox-ng
+      - requests-oauthlib
+    stage-packages:
+      - python3-requests-unixsocket
+    build-packages:
+      - libxml2-dev
+      - libxslt1-dev
+      - zlib1g-dev
+      - build-essential
+  simple-plainbox-provider-with-stage-pkg:
+    plugin: plainbox-provider
+    source: ./com.example_simple
+    after: [checkbox-ng-local]
+    stage-packages:
+      - python3-yaml
+  part-with-python-pkg:
+    plugin: python
+    python-packages:
+      - bitstring
+    after:
+      - simple-plainbox-provider-with-stage-pkg


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Launchpad bug 1768233 discussed a problem that was encountered when building checkbox snaps using the plainbox-provider plugin. This PR includes the workaround discussed so builds can begin working again. Integration test included for the original report.