### PR TITLE
lifecycle: don't clean priming area if the snap is being tried

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -612,3 +612,12 @@ class RootNotMountedError(SnapcraftError):
 
     def __init__(self, root):
         super().__init__(root=root)
+
+
+class InvalidMountinfoFormat(SnapcraftError):
+    fmt = (
+        'Unable to parse mountinfo row: {row}'
+    )
+
+    def __init__(self, row):
+        super().__init__(row=row)

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -594,3 +594,21 @@ class SnapcraftCopyFileNotFoundError(SnapcraftError):
 
     def __init__(self, path):
         super().__init__(path=path)
+
+
+class MountPointNotFoundError(SnapcraftError):
+    fmt = (
+        'Nothing is mounted at {mount_point!r}'
+    )
+
+    def __init__(self, mount_point):
+        super().__init__(mount_point=mount_point)
+
+
+class RootNotMountedError(SnapcraftError):
+    fmt = (
+        '{root!r} is not mounted'
+    )
+
+    def __init__(self, root):
+        super().__init__(root=root)

--- a/snapcraft/internal/mountinfo.py
+++ b/snapcraft/internal/mountinfo.py
@@ -1,0 +1,77 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import collections
+import contextlib
+import csv
+from typing import Dict, List  # noqa: F401
+
+from snapcraft.internal import errors
+
+
+class Mount:
+    """A class to provide programmatic access to a specific mountpoint"""
+
+    def __init__(self, mountinfo_row: List[str]) -> None:
+        # Parse the row according to section 3.5 of
+        # https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+        self.mount_id = mountinfo_row[0]
+        self.parent_id = mountinfo_row[1]
+        self.st_dev = mountinfo_row[2]
+        self.root = mountinfo_row[3]
+        self.mount_point = mountinfo_row[4]
+        self.mount_options = mountinfo_row[5]
+        separator_index = mountinfo_row.index('-')
+        self.optional_fields = mountinfo_row[6:separator_index]
+        self.filesystem_type = mountinfo_row[separator_index+1]
+        self.mount_source = mountinfo_row[separator_index+2]
+        self.super_options = mountinfo_row[separator_index+3]
+
+
+class MountInfo:
+    """A class to provide programmatic access to /proc/self/mountinfo"""
+
+    def __init__(self, *,
+                 mountinfo_file: str = '/proc/self/mountinfo') -> None:
+        """Create a new MountInfo instance.
+
+        :param str mountinfo_file: Path to mountinfo file to be parsed.
+        """
+        # Maintain two dicts pointing to the same underlying objects:
+        # a dict of mount points to Mounts, and a dict of roots to Mounts.
+        self._mount_point_mounts = {}  # type: Dict[str, Mount]
+        root_mounts = collections.defaultdict(list)  # type: Dict[str, List[Mount]]  # noqa
+
+        with contextlib.suppress(FileNotFoundError):
+            with open(mountinfo_file) as f:
+                for row in csv.reader(f, delimiter=' '):
+                    mount = Mount(row)
+                    self._mount_point_mounts[mount.mount_point] = mount
+                    root_mounts[mount.root].append(mount)
+
+        self._root_mounts = dict(root_mounts)
+
+    def for_mount_point(self, mount_point: str) -> Mount:
+        try:
+            return self._mount_point_mounts[mount_point]
+        except KeyError:
+            raise errors.MountPointNotFoundError(mount_point)
+
+    def for_root(self, root: str) -> List[Mount]:
+        try:
+            return self._root_mounts[root]
+        except KeyError:
+            raise errors.RootNotMountedError(root)

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -474,6 +474,33 @@ class ErrorFormattingTestCase(unit.TestCase):
                 'https://status.snapcraft.io/'
             )
         }),
+        ('MountPointNotFoundError', {
+            'exception': errors.MountPointNotFoundError,
+            'kwargs': {
+                'mount_point': 'test-mount-point',
+            },
+            'expected_message': (
+                "Nothing is mounted at 'test-mount-point'"
+            )
+        }),
+        ('RootNotMountedError', {
+            'exception': errors.RootNotMountedError,
+            'kwargs': {
+                'root': 'test-root',
+            },
+            'expected_message': (
+                "'test-root' is not mounted"
+            )
+        }),
+        ('InvalidMountinfoFormat', {
+            'exception': errors.InvalidMountinfoFormat,
+            'kwargs': {
+                'row': [1, 2, 3],
+            },
+            'expected_message': (
+                'Unable to parse mountinfo row: [1, 2, 3]'
+            )
+        }),
     )
 
     def test_error_formatting(self):

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -765,6 +765,20 @@ class CleanTestCase(BaseLifecycleTestCase):
             os.path.join('snap', '.snapcraft'),
             Not(DirExists()))
 
+    @mock.patch('snapcraft.internal.mountinfo.MountInfo.for_root')
+    def test_clean_leaves_prime_alone_for_tried(self, mock_for_root):
+        self.make_snapcraft_yaml(
+            textwrap.dedent("""\
+                parts:
+                  test-part:
+                    plugin: nil
+                """))
+        lifecycle.execute('prime', self.project_options)
+        lifecycle.clean(self.project_options, parts=None)
+        self.assertThat(
+            'prime', DirExists(),
+            'Expected prime directory to remain after cleaning for tried snap')
+
 
 class RecordSnapcraftYamlTestCase(BaseLifecycleTestCase):
 

--- a/tests/unit/test_mountinfo.py
+++ b/tests/unit/test_mountinfo.py
@@ -1,0 +1,114 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from textwrap import dedent
+
+from testtools.matchers import Equals, HasLength
+
+from snapcraft.internal import (
+    errors,
+    mountinfo,
+)
+
+from tests import unit
+
+
+class MountInfoTestCase(unit.TestCase):
+
+    def _write_mountinfo(self, contents):
+        path = 'mountinfo'
+        with open(path, 'w') as f:
+            f.write(contents)
+        return path
+
+    def test_mountinfo_by_root(self):
+        mounts = mountinfo.MountInfo(mountinfo_file=self._write_mountinfo(
+            dedent("""\
+                23 28 0:4 / /proc rw,nosuid,nodev,noexec,relatime shared:14 - proc proc rw
+                1341 28 7:6 / /snap/snapcraft/1 ro,nodev,relatime shared:39 - squashfs /dev/loop6 ro
+                1455 28 253:0 /test-snap/prime /snap/test-snap/x1 ro,relatime shared:1 - ext4 /dev/mapper/foo rw,errors=remount-ro,data=ordered
+                """)))  # noqa
+
+        root_mounts = mounts.for_root('/')
+        for mount_point in ('/proc', '/snap/snapcraft/1'):
+            self.assertTrue(
+                any(m for m in root_mounts if m.mount_point == mount_point),
+                'Expected {!r} to be included in root mounts'.format(
+                    mount_point))
+
+        test_snap_mounts = mounts.for_root('/test-snap/prime')
+        self.assertThat(test_snap_mounts, HasLength(1))
+        self.expectThat(
+            test_snap_mounts[0].mount_point, Equals('/snap/test-snap/x1'))
+
+    def test_mountinfo_by_mount_point(self):
+        mounts = mountinfo.MountInfo(mountinfo_file=self._write_mountinfo(
+            dedent("""\
+                23 28 0:4 / /proc rw,nosuid,nodev,noexec,relatime shared:14 - proc proc rw
+                1341 28 7:6 / /snap/snapcraft/1 ro,nodev,relatime shared:39 - squashfs /dev/loop6 ro
+                1455 28 253:0 /test-snap/prime /snap/test-snap/x1 ro,relatime shared:1 - ext4 /dev/mapper/foo rw,errors=remount-ro,data=ordered
+                """)))  # noqa
+
+        mount = mounts.for_mount_point('/proc')
+        self.assertThat(mount.mount_id, Equals('23'))
+        self.assertThat(mount.parent_id, Equals('28'))
+        self.assertThat(mount.st_dev, Equals('0:4'))
+        self.assertThat(mount.root, Equals('/'))
+        self.assertThat(mount.mount_point, Equals('/proc'))
+        self.assertThat(
+            mount.mount_options, Equals('rw,nosuid,nodev,noexec,relatime'))
+        self.assertThat(mount.optional_fields, Equals(['shared:14']))
+        self.assertThat(mount.filesystem_type, Equals('proc'))
+        self.assertThat(mount.mount_source, Equals('proc'))
+        self.assertThat(mount.super_options, Equals('rw'))
+
+        mount = mounts.for_mount_point('/snap/snapcraft/1')
+        self.assertThat(mount.mount_id, Equals('1341'))
+        self.assertThat(mount.parent_id, Equals('28'))
+        self.assertThat(mount.st_dev, Equals('7:6'))
+        self.assertThat(mount.root, Equals('/'))
+        self.assertThat(mount.mount_point, Equals('/snap/snapcraft/1'))
+        self.assertThat(mount.mount_options, Equals('ro,nodev,relatime'))
+        self.assertThat(mount.optional_fields, Equals(['shared:39']))
+        self.assertThat(mount.filesystem_type, Equals('squashfs'))
+        self.assertThat(mount.mount_source, Equals('/dev/loop6'))
+        self.assertThat(mount.super_options, Equals('ro'))
+
+        mount = mounts.for_mount_point('/snap/test-snap/x1')
+        self.assertThat(mount.mount_id, Equals('1455'))
+        self.assertThat(mount.parent_id, Equals('28'))
+        self.assertThat(mount.st_dev, Equals('253:0'))
+        self.assertThat(mount.root, Equals('/test-snap/prime'))
+        self.assertThat(mount.mount_point, Equals('/snap/test-snap/x1'))
+        self.assertThat(mount.mount_options, Equals('ro,relatime'))
+        self.assertThat(mount.optional_fields, Equals(['shared:1']))
+        self.assertThat(mount.filesystem_type, Equals('ext4'))
+        self.assertThat(mount.mount_source, Equals('/dev/mapper/foo'))
+        self.assertThat(
+            mount.super_options, Equals('rw,errors=remount-ro,data=ordered'))
+
+    def test_mountinfo_missing_root(self):
+        mounts = mountinfo.MountInfo(mountinfo_file=self._write_mountinfo(''))
+        raised = self.assertRaises(
+            errors.RootNotMountedError, mounts.for_root, 'test-root')
+        self.assertThat(raised.root, Equals('test-root'))
+
+    def test_mountinfo_missing_mount_point(self):
+        mounts = mountinfo.MountInfo(mountinfo_file=self._write_mountinfo(''))
+        raised = self.assertRaises(
+            errors.MountPointNotFoundError, mounts.for_mount_point,
+            'test-root')
+        self.assertThat(raised.mount_point, Equals('test-root'))

--- a/tests/unit/test_mountinfo.py
+++ b/tests/unit/test_mountinfo.py
@@ -14,8 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 from textwrap import dedent
 
+import fixtures
 from testtools.matchers import Equals, HasLength
 
 from snapcraft.internal import (
@@ -112,3 +114,15 @@ class MountInfoTestCase(unit.TestCase):
             errors.MountPointNotFoundError, mounts.for_mount_point,
             'test-root')
         self.assertThat(raised.mount_point, Equals('test-root'))
+
+    def test_invalid_mountinfo(self):
+        self.fake_logger = fixtures.FakeLogger(level=logging.WARN)
+        self.useFixture(self.fake_logger)
+
+        mountinfo.MountInfo(mountinfo_file=self._write_mountinfo(
+            dedent("I'm invalid")))
+
+        # Assert that a warning was logged
+        self.assertThat(
+            self.fake_logger.output, Equals(
+                "Unable to parse mountinfo row: I'm invalid\n"))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently, if one uses 'snap try' and then runs 'snapcraft clean', one must 'snap try' again once the snap has been re-primed. This PR fixes [LP: #1774015](https://bugs.launchpad.net/snapcraft/+bug/1774015) by being smarter about this: checking to see if the priming area is being used by 'snap try', and if so, not removing it when cleaning, just its contents. Then once the snap has been re-primed, it'll just start working again, no 'snap try' required.