### PR TITLE
lifecycle: automatically stage dependencies

### DIFF
--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -207,15 +207,7 @@ class _Executor:
         step_prereqs = {p for p in prereqs
                         if required_step not in self._steps_run[p]}
 
-        if step_prereqs and not step_prereqs.issubset(part_names):
-            missing_parts = [part_name for part_name in self.config.part_names
-                             if part_name in step_prereqs]
-            if missing_parts:
-                raise RuntimeError(
-                    'Requested {!r} of {!r} but there are unsatisfied '
-                    'prerequisites: {!r}'.format(
-                        step, part.name, ' '.join(missing_parts)))
-        elif step_prereqs:
+        if step_prereqs:
             # prerequisites need to build all the way to the staging
             # step to be able to share the common assets that make them
             # a dependency.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Take the following situation: we have two parts, `A` and `B`. `A` depends on `B` by way of having `after: [B]`. Today, if one runs `snapcraft pull A`, the snapcraft CLI errors out complaining that it needs to stage `B` first, requiring one to run `snapcraft pull A B`. Not only is this an error, it's a `RuntimeError`, causing a traceback.

Stop erroring in this situation, and just stage `B` like the user wants.