### PR TITLE
lifecycle: automatically clean dirty steps

### DIFF
--- a/snapcraft/config.py
+++ b/snapcraft/config.py
@@ -16,6 +16,7 @@
 
 import base64
 import configparser
+import enum
 import io
 import logging
 import os
@@ -31,6 +32,13 @@ from snapcraft.storeapi import constants, errors
 LOCAL_CONFIG_FILENAME = '.snapcraft/snapcraft.cfg'
 
 logger = logging.getLogger(__name__)
+
+
+@enum.unique
+class OutdatedStepAction(enum.Enum):
+    # Would like to use enum.auto(), but it's only available in >= 3.6
+    ERROR = 1
+    CLEAN = 2
 
 
 class CLIConfig:
@@ -127,6 +135,27 @@ class CLIConfig:
         string_value = self._get_option('Sentry', 'always_send')
         # Anything but "true" for string_value is considered False.
         return string_value == 'true'
+
+    def set_outdated_step_action(self, action: OutdatedStepAction) -> None:
+        """Setter to define action to take if outdated step is encountered.
+
+        :param OutdatedStepAction value: The action to take
+        """
+        self._set_option(
+            'Lifecycle', 'outdated_step_action', action.name.lower())
+
+    def get_outdated_step_action(self) -> OutdatedStepAction:
+        """Getter to define action to take if outdated step is encountered.
+
+        :returns: The action to take
+        :rtype: OutdatedStepAction.
+        """
+        action = self._get_option('Lifecycle', 'outdated_step_action')
+        if action:
+            return OutdatedStepAction[action.upper()]
+        else:
+            # Error by default
+            return OutdatedStepAction.ERROR
 
 
 class Config(object):

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -22,6 +22,7 @@ from tempfile import TemporaryDirectory
 import yaml
 
 import snapcraft
+from snapcraft import config
 from snapcraft.internal import (
     common,
     errors,
@@ -158,14 +159,16 @@ class _Executor:
 
         for part in self.config.all_parts:
             steps_run[part.name] = set()
-            for step in common.COMMAND_ORDER:
-                dirty_report = part.get_dirty_report(step)
-                if dirty_report:
-                    self._handle_dirty(part, step, dirty_report)
-                elif not (part.should_step_run(step)):
-                    steps_run[part.name].add(step)
-                    part.notify_part_progress('Skipping {}'.format(step),
-                                              '(already ran)')
+            with config.CLIConfig() as cli_config:
+                for step in common.COMMAND_ORDER:
+                    dirty_report = part.get_dirty_report(step)
+                    if dirty_report:
+                        self._handle_dirty(
+                            part, step, dirty_report, cli_config)
+                    elif not (part.should_step_run(step)):
+                        steps_run[part.name].add(step)
+                        part.notify_part_progress('Skipping {}'.format(step),
+                                                  '(already ran)')
 
         return steps_run
 
@@ -244,19 +247,22 @@ class _Executor:
                 self.config.original_snapcraft_yaml,
                 self.config.validator.schema)
 
-    def _handle_dirty(self, part, step, dirty_report):
+    def _handle_dirty(self, part, step, dirty_report, cli_config):
+        dirty_action = cli_config.get_outdated_step_action()
         if step not in constants.STEPS_TO_AUTOMATICALLY_CLEAN_IF_DIRTY:
-            raise errors.StepOutdatedError(
-                step=step, part=part.name,
-                dirty_properties=dirty_report.dirty_properties,
-                dirty_project_options=dirty_report.dirty_project_options)
+            if dirty_action == config.OutdatedStepAction.ERROR:
+                raise errors.StepOutdatedError(
+                    step=step, part=part.name,
+                    dirty_properties=dirty_report.dirty_properties,
+                    dirty_project_options=dirty_report.dirty_project_options)
 
         staged_state = self.config.get_project_state('stage')
         primed_state = self.config.get_project_state('prime')
 
         # We need to clean this step, but if it involves cleaning the stage
-        # step and it has dependents that have been built, we need to ask for
-        # them to first be cleaned (at least back to the build step).
+        # step and it has dependents that have been built, the dependents need
+        # to first be cleaned (at least back to the build step). Do it
+        # automatically if configured to do so.
         index = common.COMMAND_ORDER.index(step)
         dependents = self.parts_config.get_dependents(part.name)
         if (index <= common.COMMAND_ORDER.index('stage') and
@@ -264,7 +270,12 @@ class _Executor:
             for dependent in self.config.all_parts:
                 if (dependent.name in dependents and
                         not dependent.is_clean('build')):
-                    raise errors.StepOutdatedError(step=step, part=part.name,
-                                                   dependents=dependents)
+                    if dirty_action == config.OutdatedStepAction.ERROR:
+                        raise errors.StepOutdatedError(
+                            step=step, part=part.name, dependents=dependents)
+                    else:
+                        dependent.clean(
+                            staged_state, primed_state, 'build',
+                            '(out of date)')
 
         part.clean(staged_state, primed_state, step, '(out of date)')

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -53,6 +53,27 @@ class TestCLIConfig(unit.TestCase):
         new_cli_config.load()
         self.assertThat(new_cli_config.get_sentry_send_always(), Equals(True))
 
+    def test_set_and_get_outdated_step_action_with_contextmanager(self):
+        with config.CLIConfig() as cli_config:
+            cli_config.set_outdated_step_action(
+                config.OutdatedStepAction.CLEAN)
+
+        with config.CLIConfig() as cli_config:
+            self.assertThat(
+                cli_config.get_outdated_step_action(),
+                Equals(config.OutdatedStepAction.CLEAN))
+
+    def test_set_and_get_outdated_step_action(self):
+        cli_config = config.CLIConfig()
+        cli_config.set_outdated_step_action(config.OutdatedStepAction.CLEAN)
+        cli_config.save()
+
+        new_cli_config = config.CLIConfig()
+        new_cli_config.load()
+        self.assertThat(
+            new_cli_config.get_outdated_step_action(),
+            Equals(config.OutdatedStepAction.CLEAN))
+
     def test_set_when_read_only(self):
         cli_config = config.CLIConfig(read_only=True)
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently the snapcraft CLI will error out if a given step has already run, but has changed since doing so (e.g. if a part has been pulled, but then had a `stage-package` added).

This PR resolves [LP: #1774021](https://bugs.launchpad.net/snapcraft/+bug/1774021) by adding support for automatically cleaning the required steps instead of erroring. It leaves today's behavior as the default, but adds a configuration item to enable the new behavior. Simply add the following snippet to `~/.config/snapcraft/cli.cfg`:

    [Lifecycle]
    outdated_step_action = clean