### PR TITLE
project_loader: process parts in consistent order

### DIFF
--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -108,6 +108,11 @@ class PartsConfig:
         '''Performs an inneficient but easy to follow sorting of parts.'''
         sorted_parts = []
 
+        # We want to process parts in a consistent order between runs. The
+        # simplest way to do this is to sort them by name.
+        self.all_parts = sorted(
+            self.all_parts, key=lambda part: part.name, reverse=True)
+
         while self.all_parts:
             top_part = None
             for part in self.all_parts:

--- a/tests/unit/project_loader/test_parts.py
+++ b/tests/unit/project_loader/test_parts.py
@@ -175,7 +175,26 @@ class PartOrderTestCase(unit.TestCase):
                 """),
             'expected_order': ['part1', 'part2'],
         }),
-        ('after', {
+        ('single after', {
+            'contents': dedent("""\
+                name: test
+                version: "1"
+                summary: test
+                description: test
+                confinement: strict
+
+                parts:
+                  part2:
+                    plugin: nil
+                    after: [part3]
+                  part1:
+                    plugin: nil
+                  part3:
+                    plugin: nil
+                """),
+            'expected_order': ['part1', 'part3', 'part2'],
+        }),
+        ('multiple after', {
             'contents': dedent("""\
                 name: test
                 version: "1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently, if parts are not strictly ordered by using `after`, the snapcraft CLI will process them in a completely non-deterministic order that changes between runs. This can make it extremely difficult to track down bugs that only occur when building in a specific order. This PR resolves [LP: #1759875](https://bugs.launchpad.net/snapcraft/+bug/1759875) by processing parts consistently and deterministically by sorting them by name.