### PR TITLE
recording: expose the version of snapcraft

### DIFF
--- a/snapcraft/internal/meta/_manifest.py
+++ b/snapcraft/internal/meta/_manifest.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016-2017 Canonical Ltd
+# Copyright (C) 2016-2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -16,7 +16,10 @@
 
 import os
 import json
+from collections import OrderedDict
+from typing import Any, Dict  # noqa: F401
 
+import snapcraft
 from snapcraft.internal import errors
 from snapcraft.internal.states import (
     get_global_state,
@@ -25,6 +28,10 @@ from snapcraft.internal.states import (
 
 
 def annotate_snapcraft(data, parts_dir: str):
+    manifest = OrderedDict()  # type: Dict[str, Any]
+    manifest['snapcraft-version'] = snapcraft._get_version()
+    for k, v in data.items():
+        manifest[k] = v
     image_info = os.environ.get('SNAPCRAFT_IMAGE_INFO')
     if image_info:
         try:
@@ -32,19 +39,19 @@ def annotate_snapcraft(data, parts_dir: str):
         except json.decoder.JSONDecodeError as exception:
             raise errors.InvalidContainerImageInfoError(
                 image_info) from exception
-        data['image-info'] = image_info_dict
+        manifest['image-info'] = image_info_dict
     for field in ('build-packages', 'build-snaps'):
-        data[field] = get_global_state().assets.get(field, [])
+        manifest[field] = get_global_state().assets.get(field, [])
     for part in data['parts']:
         state_dir = os.path.join(parts_dir, part, 'state')
         pull_state = get_state(state_dir, 'pull')
-        data['parts'][part]['build-packages'] = (
+        manifest['parts'][part]['build-packages'] = (
            pull_state.assets.get('build-packages', []))
-        data['parts'][part]['stage-packages'] = (
+        manifest['parts'][part]['stage-packages'] = (
             pull_state.assets.get('stage-packages', []))
         source_details = pull_state.assets.get('source-details', {})
         if source_details:
-            data['parts'][part].update(source_details)
+            manifest['parts'][part].update(source_details)
         build_state = get_state(state_dir, 'build')
-        data['parts'][part].update(build_state.assets)
-    return data
+        manifest['parts'][part].update(build_state.assets)
+    return manifest

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -891,6 +891,11 @@ class RecordManifestBaseTestCase(BaseLifecycleTestCase):
 
     def setUp(self):
         super().setUp()
+
+        patcher = mock.patch('snapcraft._get_version', return_value='3.0')
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
         original_run_output = snapcraft.internal.common.run_output
 
         def fake_uname(cmd, *args, **kwargs):
@@ -939,6 +944,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         lifecycle.execute('prime', self.project_options)
 
         expected = textwrap.dedent("""\
+            snapcraft-version: '3.0'
             name: test
             version: 0
             summary: test
@@ -984,6 +990,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         lifecycle.execute('prime', self.project_options)
 
         expected = textwrap.dedent("""\
+            snapcraft-version: '3.0'
             name: test
             version: 0
             summary: test
@@ -1030,6 +1037,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         lifecycle.execute('prime', self.project_options)
 
         expected = textwrap.dedent("""\
+            snapcraft-version: '3.0'
             name: test
             version: 0
             summary: test
@@ -1077,6 +1085,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         lifecycle.execute('prime', self.project_options)
 
         expected = textwrap.dedent("""\
+            snapcraft-version: '3.0'
             name: test
             version: 0
             summary: test
@@ -1125,6 +1134,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         lifecycle.execute('prime', self.project_options)
 
         expected = textwrap.dedent("""\
+            snapcraft-version: '3.0'
             name: test
             version: 0
             summary: test
@@ -1173,6 +1183,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         lifecycle.execute('prime', self.project_options)
 
         expected = textwrap.dedent("""\
+            snapcraft-version: '3.0'
             name: test
             version: 0
             summary: test
@@ -1224,6 +1235,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         lifecycle.execute('prime', self.project_options)
 
         expected = textwrap.dedent("""\
+            snapcraft-version: '3.0'
             name: test
             version: 0
             summary: test
@@ -1272,6 +1284,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         lifecycle.execute('prime', self.project_options)
 
         expected = textwrap.dedent("""\
+            snapcraft-version: '3.0'
             name: test
             version: 0
             summary: test
@@ -1315,6 +1328,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         lifecycle.execute('prime', self.project_options)
 
         expected = textwrap.dedent("""\
+            snapcraft-version: '3.0'
             name: test
             version: 0
             summary: test
@@ -1360,6 +1374,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         lifecycle.execute('prime', self.project_options)
 
         expected = textwrap.dedent("""\
+            snapcraft-version: '3.0'
             name: test
             version: 0
             summary: test
@@ -1427,6 +1442,7 @@ class RecordManifestWithDeprecatedSnapKeywordTestCase(
         lifecycle.execute('prime', self.project_options)
 
         expected = textwrap.dedent("""\
+            snapcraft-version: '3.0'
             name: test
             version: 0
             summary: test


### PR DESCRIPTION
Expose the version of snapcraft used to create the snap in manifest.yaml

LP: #1768820
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----
