### PR TITLE
travis: stop setting up testbr0 for lxd

### DIFF
--- a/tools/travis/setup_lxd.sh
+++ b/tools/travis/setup_lxd.sh
@@ -46,5 +46,3 @@ for i in $(seq 12); do
 done
 
 /snap/bin/lxd init --auto
-/snap/bin/lxc network create testbr0
-/snap/bin/lxc network attach-profile testbr0 default eth0


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----

LXD 3.1 was recently released, and it doesn't like how we're configuring the network. Connectivity seems to work without it.