### PR TITLE
travis: use LXD from 3.0 track

### DIFF
--- a/tools/travis/setup_lxd.sh
+++ b/tools/travis/setup_lxd.sh
@@ -35,7 +35,7 @@ apt-get remove --yes lxd lxd-client
 # - Setup snap "core" (3604) security profiles (cannot reload udev rules: exit status 2)
 # but the installation succeeds, so we just ingore it.
 snap install core || echo 'ignored error'
-snap install lxd
+snap install lxd --channel=3.0/stable
 # Wait while LXD first generates its keys. In a low entropy environment this
 # can take a while.
 
@@ -46,5 +46,3 @@ for i in $(seq 12); do
 done
 
 /snap/bin/lxd init --auto
-/snap/bin/lxc network create testbr0
-/snap/bin/lxc network attach-profile testbr0 default eth0


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----

An update to LXD was recently released that changes some of the networking stuff done by `init` such that Travis broke on us. Even though this breakage also effects 3.0, we should be using LXD 3.0 in CI so we don't get other random breakage. Also, stop setting up testbr0, which broke and doesn't seem to be necessary anymore.