### PR TITLE
many: automatically redo step for specified part

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -54,15 +54,15 @@ class MissingStateCleanError(SnapcraftError):
 class StepOutdatedError(SnapcraftError):
 
     fmt = (
-        'Failed to reuse files from previous build: '
+        'Failed to reuse files from previous run: '
         'The {step.name!r} step of {part!r} is out of date:\n'
         '{report}'
-        'To continue, clean that part\'s {step.name!r} step, run '
+        'To continue, clean that part\'s {step.name!r} step by running '
         '`snapcraft clean {parts_names} -s {step.name}`.'
     )
 
-    def __init__(self, *, step, part,
-                 dirty_properties=None, dirty_project_options=None,
+    def __init__(self, *, step, part, dirty_properties=None,
+                 dirty_project_options=None, changed_dependencies=None,
                  dependents=None):
         messages = []
         if dirty_properties:
@@ -83,6 +83,14 @@ class StepOutdatedError(SnapcraftError):
             messages.append(
                 'The {} project {} to have changed.\n'.format(
                     humanized_options, pluralized_connection))
+        if changed_dependencies:
+            dependencies = [
+                d['name'] for d in changed_dependencies]
+            messages.append('{} changed: {}\n'.format(
+                formatting_utils.pluralize(
+                    dependencies, 'A dependency has',
+                    'Some dependencies have'),
+                formatting_utils.humanize_list(dependencies, 'and')))
         if dependents:
             humanized_dependents = formatting_utils.humanize_list(
                 dependents, 'and')

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -269,34 +269,27 @@ class PluginHandler:
 
         # Retrieve the stored state for this step (assuming it has already run)
         state = states.get_state(self.plugin.statedir, step)
-        differing_properties = set()
-        differing_options = set()
-        changed_dependencies = set()
-
-        with contextlib.suppress(AttributeError):
+        if state:
             # state.properties contains the old YAML that this step cares
             # about, and we're comparing it to those same keys in the current
             # YAML (self._part_properties). If they've changed, then this step
             # is dirty and needs to run again.
-            differing_properties = state.diff_properties_of_interest(
+            properties = state.diff_properties_of_interest(
                 self._part_properties)
 
-        with contextlib.suppress(AttributeError):
             # state.project_options contains the old project options that this
             # step cares about, and we're comparing it to those same options in
             # the current project. If they've changed, then this step is dirty
             # and needs to run again.
-            differing_options = state.diff_project_options_of_interest(
+            options = state.diff_project_options_of_interest(
                 self._project_options)
 
-        with contextlib.suppress(AttributeError):
             # If dependencies have changed since this step ran, then it's dirty
             # and needs to run again.
-            changed_dependencies = state.changed_dependencies
+            dependencies = state.changed_dependencies
 
-        if differing_properties or differing_options or changed_dependencies:
-            return DirtyReport(
-                differing_properties, differing_options, changed_dependencies)
+            if properties or options or dependencies:
+                return DirtyReport(properties, options, dependencies)
 
         return None
 

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -50,9 +50,11 @@ logger = logging.getLogger(__name__)
 
 
 class DirtyReport:
-    def __init__(self, dirty_properties, dirty_project_options):
+    def __init__(self, dirty_properties, dirty_project_options,
+                 changed_dependencies):
         self.dirty_properties = dirty_properties
         self.dirty_project_options = dirty_project_options
+        self.changed_dependencies = changed_dependencies
 
 
 class PluginHandler:
@@ -228,9 +230,6 @@ class PluginHandler:
                 os.makedirs(self.plugin.statedir)
                 self.mark_done(steps.get_step_by_name(step))
 
-    def notify_part_progress(self, progress, hint=''):
-        logger.info('%s %s %s', progress, self.name, hint)
-
     def latest_step(self):
         for step in reversed(steps.STEPS):
             if os.path.exists(
@@ -272,6 +271,7 @@ class PluginHandler:
         state = states.get_state(self.plugin.statedir, step)
         differing_properties = set()
         differing_options = set()
+        changed_dependencies = set()
 
         with contextlib.suppress(AttributeError):
             # state.properties contains the old YAML that this step cares
@@ -289,8 +289,14 @@ class PluginHandler:
             differing_options = state.diff_project_options_of_interest(
                 self._project_options)
 
-        if differing_properties or differing_options:
-            return DirtyReport(differing_properties, differing_options)
+        with contextlib.suppress(AttributeError):
+            # If dependencies have changed since this step ran, then it's dirty
+            # and needs to run again.
+            changed_dependencies = state.changed_dependencies
+
+        if differing_properties or differing_options or changed_dependencies:
+            return DirtyReport(
+                differing_properties, differing_options, changed_dependencies)
 
         return None
 
@@ -309,6 +315,20 @@ class PluginHandler:
         # steps don't have a saved state.
         for step in step.next_steps():
                 self.mark_cleaned(step)
+
+    def mark_dependency_change(self, dependency_name, changed_step):
+        if changed_step <= steps.STAGE:
+            dirty_step = steps.next_step(None)
+        else:
+            dirty_step = changed_step
+
+        state = states.get_state(self.plugin.statedir, dirty_step)
+        if state:
+            state.changed_dependencies.append(
+                {'name': dependency_name, 'step': changed_step.name})
+            self.mark_done(dirty_step, state)
+            return True
+        return False
 
     def mark_cleaned(self, step):
         state_file = states.get_step_state_file(self.plugin.statedir, step)
@@ -338,7 +358,6 @@ class PluginHandler:
 
     def prepare_pull(self, force=False):
         self.makedirs()
-        self.notify_part_progress('Preparing to pull')
         self._fetch_stage_packages()
         self._unpack_stage_packages()
 
@@ -351,10 +370,7 @@ class PluginHandler:
             shutil.rmtree(self.plugin.sourcedir)
 
         self.makedirs()
-        self.notify_part_progress('Pulling')
-
         self._runner.pull()
-
         self.mark_pull_done()
 
     def _do_pull(self):
@@ -388,14 +404,10 @@ class PluginHandler:
             metadata_files=metadata_files,
             scriptlet_metadata=self._scriptlet_metadata[steps.PULL]))
 
-    def clean_pull(self, hint=''):
+    def clean_pull(self):
         if self.is_clean(steps.PULL):
-            hint = '{} {}'.format(hint, '(already clean)').strip()
-            self.notify_part_progress('Skipping cleaning pulled source for',
-                                      hint)
             return
 
-        self.notify_part_progress('Cleaning pulled source for', hint)
         # Remove ubuntu cache (where stage packages are fetched)
         if os.path.exists(self.plugin.osrepodir):
             shutil.rmtree(self.plugin.osrepodir)
@@ -411,14 +423,12 @@ class PluginHandler:
 
     def prepare_build(self, force=False):
         self.makedirs()
-        self.notify_part_progress('Preparing to build')
         # Stage packages are fetched and unpacked in the pull step, but we'll
         # unpack again here just in case the build step has been cleaned.
         self._unpack_stage_packages()
 
     def build(self, force=False):
         self.makedirs()
-        self.notify_part_progress('Building')
 
         if os.path.exists(self.plugin.build_basedir):
             shutil.rmtree(self.plugin.build_basedir)
@@ -504,14 +514,9 @@ class PluginHandler:
             'installed-snaps': repo.snaps.get_installed_snaps()
         }
 
-    def clean_build(self, hint=''):
+    def clean_build(self):
         if self.is_clean(steps.BUILD):
-            hint = '{} {}'.format(hint, '(already clean)').strip()
-            self.notify_part_progress('Skipping cleaning build for',
-                                      hint)
             return
-
-        self.notify_part_progress('Cleaning build for', hint)
 
         if os.path.exists(self.plugin.build_basedir):
             shutil.rmtree(self.plugin.build_basedir)
@@ -551,7 +556,6 @@ class PluginHandler:
 
     def stage(self, force=False):
         self.makedirs()
-        self.notify_part_progress('Staging')
         self._runner.stage()
 
         # Only mark this step done if _do_stage() didn't run, in which case
@@ -582,14 +586,9 @@ class PluginHandler:
             snap_files, snap_dirs, self._part_properties,
             self._project_options, self._scriptlet_metadata[steps.STAGE]))
 
-    def clean_stage(self, project_staged_state, hint=''):
+    def clean_stage(self, project_staged_state):
         if self.is_clean(steps.STAGE):
-            hint = '{} {}'.format(hint, '(already clean)').strip()
-            self.notify_part_progress('Skipping cleaning staging area for',
-                                      hint)
             return
-
-        self.notify_part_progress('Cleaning staging area for', hint)
 
         state = states.get_state(self.plugin.statedir, steps.STAGE)
 
@@ -603,7 +602,6 @@ class PluginHandler:
 
     def prime(self, force=False) -> None:
         self.makedirs()
-        self.notify_part_progress('Priming')
         self._runner.prime()
 
         # Only mark this step done if _do_prime() didn't run, in which case
@@ -669,12 +667,7 @@ class PluginHandler:
 
     def clean_prime(self, project_primed_state, hint=''):
         if self.is_clean(steps.PRIME):
-            hint = '{} {}'.format(hint, '(already clean)').strip()
-            self.notify_part_progress('Skipping cleaning priming area for',
-                                      hint)
             return
-
-        self.notify_part_progress('Cleaning priming area for', hint)
 
         state = self.get_prime_state()
 
@@ -752,7 +745,7 @@ class PluginHandler:
         return self.plugin.env(root)
 
     def clean(self, project_staged_state=None, project_primed_state=None,
-              step=None, hint=''):
+              step=None):
         if not project_staged_state:
             project_staged_state = {}
 
@@ -760,8 +753,8 @@ class PluginHandler:
             project_primed_state = {}
 
         try:
-            self._clean_steps(project_staged_state, project_primed_state,
-                              step, hint)
+            self._clean_steps(
+                project_staged_state, project_primed_state, step)
         except errors.MissingStateCleanError:
             # If one of the step cleaning rules is missing state, it must be
             # running on the output of an old Snapcraft. In that case, if we
@@ -782,7 +775,7 @@ class PluginHandler:
             os.rmdir(self.plugin.partdir)
 
     def _clean_steps(self, project_staged_state, project_primed_state,
-                     step=None, hint=None):
+                     step=None):
         if step:
             if step not in steps.STEPS:
                 raise RuntimeError(
@@ -790,16 +783,16 @@ class PluginHandler:
                         step, self.name))
 
         if not step or step <= steps.PRIME:
-            self.clean_prime(project_primed_state, hint)
+            self.clean_prime(project_primed_state)
 
         if not step or step <= steps.STAGE:
-            self.clean_stage(project_staged_state, hint)
+            self.clean_stage(project_staged_state)
 
         if not step or step <= steps.BUILD:
-            self.clean_build(hint)
+            self.clean_build()
 
         if not step or step <= steps.PULL:
-            self.clean_pull(hint)
+            self.clean_pull()
 
 
 def _split_dependencies(dependencies, installdir, stagedir, primedir):

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -29,7 +29,7 @@ from typing import Set  # noqa: F401
 
 from snapcraft import project, formatting_utils
 from snapcraft.project._project_info import ProjectInfo
-from snapcraft.internal import deprecations, remote_parts, states
+from snapcraft.internal import deprecations, remote_parts, states, steps
 
 from ._schema import Validator
 from ._parts_config import PartsConfig
@@ -261,7 +261,7 @@ class Config:
         if duplicates:
             raise errors.DuplicateAliasError(aliases=duplicates)
 
-    def get_project_state(self, step):
+    def get_project_state(self, step: steps.Step):
         """Returns a dict of states for the given step of each part."""
 
         state = {}

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -146,6 +146,17 @@ class PartsConfig:
 
         return dependents
 
+    def get_reverse_dependencies(self, part_name):
+        """Returns all parts that recursively depend upon part_name."""
+
+        dependents = self.get_dependents(part_name)
+        for dependent in dependents.copy():
+            # No need to worry about infinite recursion due to circular
+            # dependencies since the YAML validation won't allow it.
+            dependents |= self.get_reverse_dependencies(dependent)
+
+        return dependents
+
     def get_part(self, part_name):
         for part in self.all_parts:
             if part.name == part_name:

--- a/snapcraft/internal/states/_build_state.py
+++ b/snapcraft/internal/states/_build_state.py
@@ -48,7 +48,8 @@ class BuildState(PartState):
     def __init__(
             self, property_names, part_properties=None, project=None,
             plugin_assets=None, machine_assets=None, metadata=None,
-            metadata_files=None, scriptlet_metadata=None):
+            metadata_files=None, scriptlet_metadata=None,
+            changed_dependencies=None):
         # Save this off before calling super() since we'll need it
         # FIXME: for 3.x the name `schema_properties` is leaking
         #        implementation details from a higher layer.
@@ -76,7 +77,7 @@ class BuildState(PartState):
 
         self.scriptlet_metadata = scriptlet_metadata
 
-        super().__init__(part_properties, project)
+        super().__init__(part_properties, project, changed_dependencies)
 
     def properties_of_interest(self, part_properties):
         """Extract the properties concerning this step from part_properties."""

--- a/snapcraft/internal/states/_prime_state.py
+++ b/snapcraft/internal/states/_prime_state.py
@@ -32,8 +32,9 @@ class PrimeState(PartState):
     yaml_tag = u'!PrimeState'
 
     def __init__(self, files, directories, dependency_paths=None,
-                 part_properties=None, project=None, scriptlet_metadata=None):
-        super().__init__(part_properties, project)
+                 part_properties=None, project=None, scriptlet_metadata=None,
+                 changed_dependencies=None):
+        super().__init__(part_properties, project, changed_dependencies)
 
         if not scriptlet_metadata:
             scriptlet_metadata = snapcraft.extractors.ExtractedMetadata()

--- a/snapcraft/internal/states/_pull_state.py
+++ b/snapcraft/internal/states/_pull_state.py
@@ -50,7 +50,7 @@ class PullState(PartState):
     def __init__(self, property_names, part_properties=None, project=None,
                  stage_packages=None, build_snaps=None, build_packages=None,
                  source_details=None, metadata=None, metadata_files=None,
-                 scriptlet_metadata=None):
+                 scriptlet_metadata=None, changed_dependencies=None):
         # Save this off before calling super() since we'll need it
         # FIXME: for 3.x the name `schema_properties` is leaking
         #        implementation details from a higher layer.
@@ -78,7 +78,7 @@ class PullState(PartState):
 
         self.scriptlet_metadata = scriptlet_metadata
 
-        super().__init__(part_properties, project)
+        super().__init__(part_properties, project, changed_dependencies)
 
     def properties_of_interest(self, part_properties):
         """Extract the properties concerning this step from part_properties."""

--- a/snapcraft/internal/states/_stage_state.py
+++ b/snapcraft/internal/states/_stage_state.py
@@ -32,8 +32,8 @@ class StageState(PartState):
     yaml_tag = u'!StageState'
 
     def __init__(self, files, directories, part_properties=None, project=None,
-                 scriptlet_metadata=None):
-        super().__init__(part_properties, project)
+                 scriptlet_metadata=None, changed_dependencies=None):
+        super().__init__(part_properties, project, changed_dependencies)
 
         if not scriptlet_metadata:
             scriptlet_metadata = snapcraft.extractors.ExtractedMetadata()

--- a/snapcraft/internal/states/_state.py
+++ b/snapcraft/internal/states/_state.py
@@ -38,13 +38,18 @@ class State(yaml.YAMLObject):
 
 class PartState(State):
 
-    def __init__(self, part_properties, project):
+    def __init__(self, part_properties, project, changed_dependencies):
         super().__init__()
         if not part_properties:
             part_properties = {}
 
         self.properties = self.properties_of_interest(part_properties)
         self.project_options = self.project_options_of_interest(project)
+
+        if changed_dependencies:
+            self.changed_dependencies = changed_dependencies
+        else:
+            self.changed_dependencies = []
 
     def properties_of_interest(self, part_properties):
         """Extract the properties concerning this step from the options.

--- a/tests/integration/lifecycle/test_clean_build_step.py
+++ b/tests/integration/lifecycle/test_clean_build_step.py
@@ -72,14 +72,10 @@ class CleanBuildStepBuiltTestCase(integration.TestCase):
         part1_output = [line.strip() for line in output if 'part1' in line]
         part2_output = [line.strip() for line in output if 'part2' in line]
         self.expectThat(part1_output, Equals([
-            'Skipping cleaning priming area for part1 (already clean)',
-            'Skipping cleaning staging area for part1 (already clean)',
-            'Cleaning build for part1'
+            'Cleaning build step (and all subsequent steps) for part1'
         ]))
         self.expectThat(part2_output, Equals([
-            'Skipping cleaning priming area for part2 (already clean)',
-            'Skipping cleaning staging area for part2 (already clean)',
-            'Cleaning build for part2'
+            'Cleaning build step (and all subsequent steps) for part2'
         ]))
 
         # Now try to build again

--- a/tests/unit/commands/test_prime.py
+++ b/tests/unit/commands/test_prime.py
@@ -72,9 +72,7 @@ class PrimeCommandTestCase(LifecycleCommandsBaseTestCase):
         self.assertThat(result.exit_code, Equals(0))
         self.assertThat(
             fake_logger.output,
-            Equals('Preparing to pull prime0 \n'
-                   'Pulling prime0 \n'
-                   'Preparing to build prime0 \n'
+            Equals('Pulling prime0 \n'
                    'Building prime0 \n'
                    'Staging prime0 \n'
                    'Priming prime0 \n'))
@@ -96,4 +94,7 @@ class PrimeCommandTestCase(LifecycleCommandsBaseTestCase):
             Equals('Skipping pull prime0 (already ran)\n'
                    'Skipping build prime0 (already ran)\n'
                    'Skipping stage prime0 (already ran)\n'
-                   'Skipping prime prime0 (already ran)\n'))
+                   'Skipping prime prime0 (already ran)\n'
+                   'The requested action has already been taken. Consider\n'
+                   'specifying parts, or clean the steps you want to run '
+                   'again.\n'))

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -256,7 +256,10 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
                 'Skipping pull part1 (already ran)\n'
                 'Skipping build part1 (already ran)\n'
                 'Skipping stage part1 (already ran)\n'
-                'Skipping prime part1 (already ran)\n'))
+                'Skipping prime part1 (already ran)\n'
+                'The requested action has already been taken. Consider\n'
+                'specifying parts, or clean the steps you want to run again.\n'
+            ))
 
         self.popen_spy.assert_called_once_with([
             'mksquashfs', self.prime_dir, 'snap-test_1.0_amd64.snap',
@@ -356,9 +359,7 @@ type: os
             'Snapped mysnap.snap\n'))
 
         self.assertThat(fake_logger.output, Equals(
-            'Preparing to pull part1 \n'
             'Pulling part1 \n'
-            'Preparing to build part1 \n'
             'Building part1 \n'
             'Staging part1 \n'
             'Priming part1 \n'))
@@ -414,9 +415,7 @@ type: os
         self.assertThat(
             fake_logger.output.splitlines(),
             Equals([
-                'Preparing to pull part1 ',
                 'Pulling part1 ',
-                'Preparing to build part1 ',
                 'Building part1 ',
                 'Staging part1 ',
                 'Priming part1 ',

--- a/tests/unit/commands/test_stage.py
+++ b/tests/unit/commands/test_stage.py
@@ -72,9 +72,7 @@ class StageCommandTestCase(LifecycleCommandsBaseTestCase):
         self.assertThat(result.exit_code, Equals(0))
         self.assertThat(
             fake_logger.output,
-            Equals('Preparing to pull stage0 \n'
-                   'Pulling stage0 \n'
-                   'Preparing to build stage0 \n'
+            Equals('Pulling stage0 \n'
                    'Building stage0 \n'
                    'Staging stage0 \n'))
 
@@ -95,4 +93,7 @@ class StageCommandTestCase(LifecycleCommandsBaseTestCase):
             Equals(
                 'Skipping pull stage0 (already ran)\n'
                 'Skipping build stage0 (already ran)\n'
-                'Skipping stage stage0 (already ran)\n'))
+                'Skipping stage stage0 (already ran)\n'
+                'The requested action has already been taken. Consider\n'
+                'specifying parts, or clean the steps you want to run again.\n'
+            ))

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -2296,28 +2296,16 @@ class PerStepCleanTestCase(unit.TestCase):
 
         self.handler = self.load_part('test_part')
 
-    def test_clean_with_hint(self):
-        self.handler.clean(step=steps.PULL, hint='foo')
-
-        # Verify the step cleaning order
-        self.assertThat(len(self.manager_mock.mock_calls), Equals(4))
-        self.manager_mock.assert_has_calls([
-            call.clean_prime({}, 'foo'),
-            call.clean_stage({}, 'foo'),
-            call.clean_build('foo'),
-            call.clean_pull('foo'),
-        ])
-
     def test_clean_pull_order(self):
         self.handler.clean(step=steps.PULL)
 
         # Verify the step cleaning order
         self.assertThat(len(self.manager_mock.mock_calls), Equals(4))
         self.manager_mock.assert_has_calls([
-            call.clean_prime({}, ''),
-            call.clean_stage({}, ''),
-            call.clean_build(''),
-            call.clean_pull(''),
+            call.clean_prime({}),
+            call.clean_stage({}),
+            call.clean_build(),
+            call.clean_pull(),
         ])
 
     def test_clean_build_order(self):
@@ -2326,9 +2314,9 @@ class PerStepCleanTestCase(unit.TestCase):
         # Verify the step cleaning order
         self.assertThat(len(self.manager_mock.mock_calls), Equals(3))
         self.manager_mock.assert_has_calls([
-            call.clean_prime({}, ''),
-            call.clean_stage({}, ''),
-            call.clean_build(''),
+            call.clean_prime({}),
+            call.clean_stage({}),
+            call.clean_build(),
         ])
 
     def test_clean_stage_order(self):
@@ -2337,8 +2325,8 @@ class PerStepCleanTestCase(unit.TestCase):
         # Verify the step cleaning order
         self.assertThat(len(self.manager_mock.mock_calls), Equals(2))
         self.manager_mock.assert_has_calls([
-            call.clean_prime({}, ''),
-            call.clean_stage({}, ''),
+            call.clean_prime({}),
+            call.clean_stage({}),
         ])
 
     def test_clean_prime_order(self):
@@ -2347,7 +2335,7 @@ class PerStepCleanTestCase(unit.TestCase):
         # Verify the step cleaning order
         self.assertThat(len(self.manager_mock.mock_calls), Equals(1))
         self.manager_mock.assert_has_calls([
-            call.clean_prime({}, ''),
+            call.clean_prime({}),
         ])
 
 

--- a/tests/unit/states/test_state.py
+++ b/tests/unit/states/test_state.py
@@ -55,7 +55,7 @@ class StateTestCase(unit.TestCase):
         self.project = _TestProject(self.old)
         self.part_properties = self.old
 
-        self.state = _TestState(self.part_properties, self.project)
+        self.state = _TestState(self.part_properties, self.project, [])
         self.state.properties = self.old
         self.state.project_options = self.old
 

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -52,11 +52,11 @@ class ErrorFormattingTestCase(unit.TestCase):
                 'dependents': ['test-dependent']
             },
             'expected_message': (
-                "Failed to reuse files from previous build: "
+                "Failed to reuse files from previous run: "
                 "The 'pull' step of 'test-part' is out of date:\n"
                 "The 'pull' step for 'test-part' needs to be run again, "
                 "but 'test-dependent' depends on it.\n"
-                "To continue, clean that part's 'pull' step, run "
+                "To continue, clean that part's 'pull' step by running "
                 "`snapcraft clean test-dependent -s pull`.")}),
         ('StepOutdatedError dirty_properties', {
             'exception': errors.StepOutdatedError,
@@ -66,11 +66,11 @@ class ErrorFormattingTestCase(unit.TestCase):
                 'dirty_properties': ['test-property1', 'test-property2']
             },
             'expected_message': (
-                "Failed to reuse files from previous build: "
+                "Failed to reuse files from previous run: "
                 "The 'pull' step of 'test-part' is out of date:\n"
                 "The 'test-property1' and 'test-property2' part properties "
                 "appear to have changed.\n"
-                "To continue, clean that part's 'pull' step, run "
+                "To continue, clean that part's 'pull' step by running "
                 "`snapcraft clean test-part -s pull`.")}),
         ('StepOutdatedError dirty_project_options', {
             'exception': errors.StepOutdatedError,
@@ -80,10 +80,43 @@ class ErrorFormattingTestCase(unit.TestCase):
                 'dirty_project_options': ['test-option']
             },
             'expected_message': (
-                "Failed to reuse files from previous build: "
+                "Failed to reuse files from previous run: "
                 "The 'pull' step of 'test-part' is out of date:\n"
                 "The 'test-option' project option appears to have changed.\n"
-                "To continue, clean that part's 'pull' step, run "
+                "To continue, clean that part's 'pull' step by running "
+                "`snapcraft clean test-part -s pull`.")}),
+        ('StepOutdatedError changed_dependencies', {
+            'exception': errors.StepOutdatedError,
+            'kwargs': {
+                'step': steps.PULL,
+                'part': 'test-part',
+                'changed_dependencies': [
+                    {'name': 'another-part', 'step': 'another-step'}]
+            },
+            'expected_message': (
+                "Failed to reuse files from previous run: "
+                "The 'pull' step of 'test-part' is out of date:\n"
+                "A dependency has changed: 'another-part'\n"
+                "To continue, clean that part's "
+                "'pull' step by running "
+                "`snapcraft clean test-part -s pull`.")}),
+        ('StepOutdatedError multiple changed_dependencies', {
+            'exception': errors.StepOutdatedError,
+            'kwargs': {
+                'step': steps.PULL,
+                'part': 'test-part',
+                'changed_dependencies': [
+                    {'name': 'another-part1', 'step': 'another-step1'},
+                    {'name': 'another-part2', 'step': 'another-step2'},
+                ]
+            },
+            'expected_message': (
+                "Failed to reuse files from previous run: "
+                "The 'pull' step of 'test-part' is out of date:\n"
+                "Some dependencies have changed: 'another-part1' and "
+                "'another-part2'\n"
+                "To continue, clean that part's "
+                "'pull' step by running "
                 "`snapcraft clean test-part -s pull`.")}),
         ('SnapcraftEnvironmentError', {
             'exception': errors.SnapcraftEnvironmentError,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently, if a step for a given part has already run, the snapcraft CLI won't run it again without it first being cleaned. For example, if the `pull` step of part `A` had already run, running `snapcraft pull A` would say that it had already run, and skip it. This PR resolves [LP: #1774260](https://bugs.launchpad.net/snapcraft/+bug/1774260) by changing this behavior so that, if a part is specified, that step for that part is cleaned and re-run.