### PR TITLE
project_loader: allow loading null parts

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -473,7 +473,7 @@ properties:
               validation-failure:
                   "Parts cannot contain both 'install' and 'override-*'
                   keywords. Use 'override-build' instead of 'install'."
-        type: object
+        type: [object, 'null']
         minProperties: 1
         properties:
           plugin:

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -341,6 +341,9 @@ class Config:
         new_parts = {}
 
         for part_name in parts:
+            if not parts[part_name]:
+                parts[part_name] = dict()
+
             if 'plugin' not in parts[part_name]:
                 properties = self._remote_parts.compose(part_name,
                                                         parts[part_name])

--- a/tests/unit/project_loader/test_config.py
+++ b/tests/unit/project_loader/test_config.py
@@ -342,6 +342,26 @@ grade: stable
 
 parts:
   part1:
+""")
+
+        remote_parts.update()
+        _config.Config()
+
+        self.mock_load_part.assert_called_with('part1', 'go', {
+            'source': 'http://source.tar.gz', 'plugin': 'go', 'stage': [],
+            'prime': []})
+
+    def test_config_composes_with_modified_remote_parts(self):
+        self.useFixture(fixture_setup.FakeParts())
+        self.make_snapcraft_yaml("""name: test
+version: "1"
+summary: test
+description: test
+confinement: strict
+grade: stable
+
+parts:
+  part1:
     stage-packages: [fswebcam]
 """)
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

This PR fixes [LP: #1772027](https://bugs.launchpad.net/snapcraft/+bug/1772027) by allowing one to specify remote parts without requiring the use of `after`, which implies a relationship which may not exist. With this PR, one can specify that the want a remote part simply by listing the part name, e.g.:

```yaml
parts:
  my-part:
    plugin: whatever
    # build my stuff

  # Also pull in gtk3, although my-part doesn't strictly depend on it for
  # pulling or building.
  desktop-gtk3:
```