### PR TITLE
tests: disable sentry

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -99,6 +99,11 @@ class TestCase(testtools.TestCase):
             'XDG_DATA_HOME', os.path.join(self.path, 'data')))
         self.useFixture(fixtures.EnvironmentVariable('TERM', 'dumb'))
 
+        # Disable Sentry reporting for tests, otherwise they'll hang waiting
+        # for input
+        self.useFixture(fixtures.EnvironmentVariable(
+            'SNAPCRAFT_ENABLE_SENTRY', 'false'))
+
         patcher = mock.patch(
             'xdg.BaseDirectory.xdg_config_home',
             new=os.path.join(self.path, '.config'))

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -144,6 +144,11 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         self.useFixture(fixtures.EnvironmentVariable(
             'SNAPCRAFT_NO_PATCHELF', '1'))
 
+        # Disable Sentry reporting for tests, otherwise they'll hang waiting
+        # for input
+        self.useFixture(fixtures.EnvironmentVariable(
+            'SNAPCRAFT_ENABLE_SENTRY', 'false'))
+
         machine = os.environ.get('SNAPCRAFT_TEST_MOCK_MACHINE', None)
         self.base_environment = fixture_setup.FakeBaseEnvironment(
             machine=machine)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently, if an error occurs during a test, it just hangs waiting for user input that is never given. Fix this by disabling Sentry reporting when under test.