### PR TITLE
snap: use apt from the archive instead of compiling

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,12 +32,15 @@ parts:
     requirements: requirements.txt
     build-packages:
         - build-essential
+        - libapt-pkg-dev
         - libffi-dev
         - libsodium-dev
         - liblzma-dev
         - patch
         - sed
     stage-packages:
+        - apt
+        - apt-utils
         - binutils
         - execstack
         - gpgv
@@ -60,48 +63,4 @@ parts:
         sed -i usr/lib/python3.5/site.py -e 's/^ENABLE_USER_SITE = None$/ENABLE_USER_SITE = False/'
         # This is the last step, let's now compile all our pyc files.
         ./usr/bin/python3 -m compileall .
-    after: [patches, apt]
-  apt:
-      source: https://salsa.debian.org/apt-team/apt.git
-      source-type: git
-      source-tag: 1.2.19
-      source-depth: 1
-      plugin: autotools
-      override-build: |
-          make startup
-          mkdir apt-build
-          cd apt-build
-          ../configure
-          make
-          install -d $SNAPCRAFT_PART_INSTALL/apt
-          cp -r bin/methods/* $SNAPCRAFT_PART_INSTALL/apt/
-          cp -r bin/methods/* $SNAPCRAFT_PART_INSTALL/apt/
-          install bin/apt-key $SNAPCRAFT_PART_INSTALL/apt/
-          install bin/apt-mark $SNAPCRAFT_PART_INSTALL/apt/
-          install bin/apt-internal-solver $SNAPCRAFT_PART_INSTALL/apt/
-          install bin/apt-helper $SNAPCRAFT_PART_INSTALL/apt/
-          install -d $SNAPCRAFT_PART_INSTALL/usr/lib
-          install bin/libapt-inst.so.2.0.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
-          install bin/libapt-pkg.so $SNAPCRAFT_PART_INSTALL/usr/lib/
-          install bin/libapt-pkg-5.0-0.symver $SNAPCRAFT_PART_INSTALL/usr/lib/
-          install bin/libapt-private.so $SNAPCRAFT_PART_INSTALL/usr/lib/
-          install bin/libapt-private-0.0-0.symver $SNAPCRAFT_PART_INSTALL/usr/lib/
-          install bin/libapt-private.so.0.0.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
-          install bin/libapt-inst.so.2.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
-          install bin/libapt-inst.so $SNAPCRAFT_PART_INSTALL/usr/lib/
-          install bin/libapt-pkg.so.5.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
-          install bin/libapt-inst-2.0-0.symver $SNAPCRAFT_PART_INSTALL/usr/lib/
-          install bin/libapt-pkg.so.5.0.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
-          install bin/libapt-private.so.0.0 $SNAPCRAFT_PART_INSTALL/usr/lib/
-          install -d $SNAPCRAFT_PART_INSTALL/usr/include
-          cp -r include/* $SNAPCRAFT_PART_INSTALL/usr/include/
-      prime:
-          - -usr/include
-      build-packages:
-          - gettext
-          - libbz2-dev
-          - libcurl4-gnutls-dev
-          - libdb-dev
-          - liblz4-dev
-          - liblzma-dev
-          - zlib1g-dev
+    after: [patches]

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -73,16 +73,18 @@ class _AptCache:
         # Methods and solvers dir for when in the SNAP
         if common.is_snap():
             snap_dir = os.getenv('SNAP')
-            apt_dir = os.path.join(snap_dir, 'apt')
+            apt_dir = os.path.join(snap_dir, 'usr', 'lib', 'apt')
             apt.apt_pkg.config.set('Dir', apt_dir)
             # yes apt is broken like that we need to append os.path.sep
+            methods_dir = os.path.join(apt_dir, 'methods')
             apt.apt_pkg.config.set('Dir::Bin::methods',
-                                   apt_dir + os.path.sep)
+                                   methods_dir + os.path.sep)
+            solvers_dir = os.path.join(apt_dir, 'solvers')
             apt.apt_pkg.config.set('Dir::Bin::solvers::',
-                                   apt_dir + os.path.sep)
-            apt_key_path = os.path.join(apt_dir, 'apt-key')
+                                   solvers_dir + os.path.sep)
+            apt_key_path = os.path.join(snap_dir, 'usr', 'bin', 'apt-key')
             apt.apt_pkg.config.set('Dir::Bin::apt-key', apt_key_path)
-            gpgv_path = os.path.join(snap_dir, 'bin', 'gpgv')
+            gpgv_path = os.path.join(snap_dir, 'usr', 'bin', 'gpgv')
             apt.apt_pkg.config.set('Apt::Key::gpgvcommand', gpgv_path)
             apt.apt_pkg.config.set('Dir::Etc::Trusted',
                                    '/etc/apt/trusted.gpg')


### PR DESCRIPTION
Since the introduction of patchelf, it is not necessary to compile apt
anymore, this brings in two important benefits:

- faster builds
- automatic USNs for CVEs where apt is affected

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----
On bionic the correct apt methods are being used and there is no SIGSEV, ps output follows
```
sergius+ 30148 30108  6 18:49 pts/3    00:00:04 /snap/snapcraft/x14/usr/bin/python3 /snap/snapcraft/x14/bin/snapcraft pull
sergius+ 30173 30148  0 18:49 pts/3    00:00:00 /snap/snapcraft/x14/usr/lib/apt/methods/http
sergius+ 30174 30148  0 18:49 pts/3    00:00:00 /snap/snapcraft/x14/usr/lib/apt/methods/http
sergius+ 30176 30148  0 18:49 pts/3    00:00:00 /snap/snapcraft/x14/usr/lib/apt/methods/gpgv
sergius+ 30222 30148  1 18:49 pts/3    00:00:00 /snap/snapcraft/x14/usr/lib/apt/methods/store
```
and the pull finished successfully.
