### PR TITLE
many: extract lifecycle ordering into own module

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -17,7 +17,13 @@
 import click
 import os
 
-from snapcraft.internal import deprecations, lifecycle, lxd, project_loader
+from snapcraft.internal import (
+    deprecations,
+    lifecycle,
+    lxd,
+    project_loader,
+    steps,
+)
 from ._options import add_build_options, get_project_options
 from . import echo
 from . import env
@@ -62,7 +68,7 @@ def pull(ctx, parts, **kwargs):
         snapcraft pull my-part1 my-part2
 
     """
-    _execute('pull', parts, **kwargs)
+    _execute(steps.PULL, parts, **kwargs)
 
 
 @lifecyclecli.command()
@@ -77,7 +83,7 @@ def build(parts, **kwargs):
         snapcraft build my-part1 my-part2
 
     """
-    _execute('build', parts, **kwargs)
+    _execute(steps.BUILD, parts, **kwargs)
 
 
 @lifecyclecli.command()
@@ -92,7 +98,7 @@ def stage(parts, **kwargs):
         snapcraft stage my-part1 my-part2
 
     """
-    _execute('stage', parts, **kwargs)
+    _execute(steps.STAGE, parts, **kwargs)
 
 
 @lifecyclecli.command()
@@ -107,7 +113,7 @@ def prime(parts, **kwargs):
         snapcraft prime my-part1 my-part2
 
     """
-    _execute('prime', parts, **kwargs)
+    _execute(steps.PRIME, parts, **kwargs)
 
 
 @lifecyclecli.command()
@@ -175,12 +181,12 @@ def clean(parts, step, **kwargs):
     project_options = get_project_options(**kwargs)
     build_environment = env.BuilderEnvironmentConfig()
     if build_environment.is_host:
-        step = step or 'pull'
+        step = step or steps.next_step(step).name
         if step == 'strip':
             echo.warning('DEPRECATED: Use `prime` instead of `strip` '
                          'as the step to clean')
-            step = 'prime'
-        lifecycle.clean(project_options, parts, step)
+            step = steps.PRIME.name
+        lifecycle.clean(project_options, parts, steps.Step(step))
     else:
         config = project_loader.load_config(project_options)
         lxd.Project(project_options=project_options,

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -180,13 +180,16 @@ def clean(parts, step, **kwargs):
     """
     project_options = get_project_options(**kwargs)
     build_environment = env.BuilderEnvironmentConfig()
-    if build_environment.is_host:
-        step = step or steps.next_step(step).name
+
+    if step:
         if step == 'strip':
             echo.warning('DEPRECATED: Use `prime` instead of `strip` '
                          'as the step to clean')
-            step = steps.PRIME.name
-        lifecycle.clean(project_options, parts, steps.Step(step))
+            step = 'prime'
+        step = steps.get_step_by_name(step)
+
+    if build_environment.is_host:
+        lifecycle.clean(project_options, parts, step)
     else:
         config = project_loader.load_config(project_options)
         lxd.Project(project_options=project_options,

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -166,11 +166,11 @@ def pack(directory, output, **kwargs):
 @lifecyclecli.command()
 @add_build_options()
 @click.argument('parts', nargs=-1, metavar='<part>...', required=False)
-@click.option('--step', '-s',
+@click.option('--step', '-s', 'step_name',
               type=click.Choice(['pull', 'build', 'stage', 'prime', 'strip']),
               help='only clean the specified step and those that '
                    'depend on it.')
-def clean(parts, step, **kwargs):
+def clean(parts, step_name, **kwargs):
     """Remove content - cleans downloads, builds or install artifacts.
 
     \b
@@ -181,12 +181,13 @@ def clean(parts, step, **kwargs):
     project_options = get_project_options(**kwargs)
     build_environment = env.BuilderEnvironmentConfig()
 
-    if step:
-        if step == 'strip':
+    step = None
+    if step_name:
+        if step_name == 'strip':
             echo.warning('DEPRECATED: Use `prime` instead of `strip` '
                          'as the step to clean')
-            step = 'prime'
-        step = steps.get_step_by_name(step)
+            step_name = 'prime'
+        step = steps.get_step_by_name(step_name)
 
     if build_environment.is_host:
         lifecycle.clean(project_options, parts, step)

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -33,7 +33,6 @@ from snapcraft.internal import errors
 
 SNAPCRAFT_FILES = ['snapcraft.yaml', '.snapcraft.yaml', 'parts', 'stage',
                    'prime', 'snap']
-COMMAND_ORDER = ['pull', 'build', 'stage', 'prime']
 _DEFAULT_PLUGINDIR = os.path.join(sys.prefix, 'share', 'snapcraft', 'plugins')
 _plugindir = _DEFAULT_PLUGINDIR
 _DEFAULT_SCHEMADIR = os.path.join(sys.prefix, 'share', 'snapcraft', 'schema')

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -604,10 +604,10 @@ class NoLatestStepError(SnapcraftError):
 
 
 class NoNextStepError(SnapcraftError):
-    fmt = '{step.name!r} is the final step'
+    fmt = "The {part_name!r} part has run through its entire lifecycle"
 
-    def __init__(self, step):
-        super().__init__(step=step)
+    def __init__(self, part_name):
+        super().__init__(part_name=part_name)
 
 
 class MountPointNotFoundError(SnapcraftError):

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -17,6 +17,7 @@ from subprocess import CalledProcessError
 from typing import List, Union
 
 from snapcraft import formatting_utils
+from snapcraft.internal import steps
 
 
 class SnapcraftError(Exception):
@@ -544,12 +545,13 @@ class ScriptletRunError(ScriptletBaseError):
 
 class ScriptletDuplicateDataError(ScriptletBaseError):
     fmt = (
-        'Failed to save data from scriptlet into {step!r} state: '
-        'The {humanized_keys} key(s) were already saved in the {other_step!r} '
-        'step.'
+        'Failed to save data from scriptlet into {step.name!r} state: '
+        'The {humanized_keys} key(s) were already saved in the '
+        '{other_step.name!r} step.'
     )
 
-    def __init__(self, step: str, other_step: str, keys: List[str]) -> None:
+    def __init__(self, step: steps.Step, other_step: steps.Step,
+                 keys: List[str]) -> None:
         self.keys = keys
         super().__init__(
             step=step, other_step=other_step,
@@ -559,10 +561,10 @@ class ScriptletDuplicateDataError(ScriptletBaseError):
 class ScriptletDuplicateFieldError(ScriptletBaseError):
     fmt = (
         'Unable to set {field}: '
-        'it was already set in the {step!r} step.'
+        'it was already set in the {step.name!r} step.'
     )
 
-    def __init__(self, field: str, step: str) -> None:
+    def __init__(self, field: str, step: steps.Step) -> None:
         super().__init__(field=field, step=step)
 
 

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -42,7 +42,7 @@ class SnapcraftError(Exception):
 class MissingStateCleanError(SnapcraftError):
     fmt = (
         "Failed to clean: "
-        "Missing state for {step!r}. "
+        "Missing state for {step.name!r}. "
         "To clean the project, run `snapcraft clean`."
     )
 
@@ -54,10 +54,10 @@ class StepOutdatedError(SnapcraftError):
 
     fmt = (
         'Failed to reuse files from previous build: '
-        'The {step!r} step of {part!r} is out of date:\n'
+        'The {step.name!r} step of {part!r} is out of date:\n'
         '{report}'
-        'To continue, clean that part\'s {step!r} step, run '
-        '`snapcraft clean {parts_names} -s {step}`.'
+        'To continue, clean that part\'s {step.name!r} step, run '
+        '`snapcraft clean {parts_names} -s {step.name}`.'
     )
 
     def __init__(self, *, step, part,
@@ -89,7 +89,7 @@ class StepOutdatedError(SnapcraftError):
                 dependents, "depends", "depend")
             messages.append('The {0!r} step for {1!r} needs to be run again, '
                             'but {2} {3} on it.\n'.format(
-                                step,
+                                step.name,
                                 part,
                                 humanized_dependents,
                                 pluralized_dependents))
@@ -594,6 +594,20 @@ class SnapcraftCopyFileNotFoundError(SnapcraftError):
 
     def __init__(self, path):
         super().__init__(path=path)
+
+
+class NoLatestStepError(SnapcraftError):
+    fmt = "The {part_name!r} part hasn't run any steps"
+
+    def __init__(self, part_name):
+        super().__init__(part_name=part_name)
+
+
+class NoNextStepError(SnapcraftError):
+    fmt = '{step.name!r} is the final step'
+
+    def __init__(self, step):
+        super().__init__(step=step)
 
 
 class MountPointNotFoundError(SnapcraftError):

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -596,6 +596,13 @@ class SnapcraftCopyFileNotFoundError(SnapcraftError):
         super().__init__(path=path)
 
 
+class InvalidStepError(SnapcraftError):
+    fmt = "{step_name!r} is not a valid lifecycle step"
+
+    def __init__(self, step_name):
+        super().__init__(step_name=step_name)
+
+
 class NoLatestStepError(SnapcraftError):
     fmt = "The {part_name!r} part hasn't run any steps"
 

--- a/snapcraft/internal/lifecycle/_clean.py
+++ b/snapcraft/internal/lifecycle/_clean.py
@@ -100,8 +100,8 @@ def _cleanup_common_directories(config, project_options):
             if not max_step or step > max_step:
                     max_step = step
 
-    with contextlib.suppress(errors.NoNextStepError):
-        next_step = steps.next_step(max_step)
+    next_step = steps.next_step(max_step)
+    if next_step:
         _cleanup_common_directories_for_step(next_step, project_options)
 
 

--- a/snapcraft/internal/lifecycle/_packer.py
+++ b/snapcraft/internal/lifecycle/_packer.py
@@ -22,7 +22,7 @@ import yaml
 from progressbar import AnimatedMarker, ProgressBar
 
 from snapcraft import file_utils
-from snapcraft.internal import common, repo
+from snapcraft.internal import common, repo, steps
 from snapcraft.internal.indicators import is_dumb_terminal
 from ._runner import execute
 
@@ -43,7 +43,7 @@ def _snap_data_from_dir(directory):
 def snap(project_options, directory=None, output=None):
     if not directory:
         directory = project_options.prime_dir
-        execute('prime', project_options)
+        execute(steps.PRIME, project_options)
 
     return pack(directory, output)
 

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -161,7 +161,7 @@ class _Executor:
         for part in self.config.all_parts:
             steps_run[part.name] = set()
             with config.CLIConfig() as cli_config:
-                for step in steps.STEPS:
+                for step in steps.ordered_steps():
                     dirty_report = part.get_dirty_report(step)
                     if dirty_report:
                         self._handle_dirty(
@@ -183,7 +183,7 @@ class _Executor:
             parts = self.config.all_parts
             part_names = self.config.part_names
 
-        for current_step in steps.steps_required_for(step):
+        for current_step in step.previous_steps() + [step]:
             if current_step == steps.STAGE:
                 # XXX check only for collisions on the parts that have already
                 # been built --elopio - 20170713

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -161,7 +161,7 @@ class _Executor:
         for part in self.config.all_parts:
             steps_run[part.name] = set()
             with config.CLIConfig() as cli_config:
-                for step in steps.ordered_steps():
+                for step in steps.STEPS:
                     dirty_report = part.get_dirty_report(step)
                     if dirty_report:
                         self._handle_dirty(

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -241,7 +241,7 @@ class _Executor:
 
     def _handle_dirty(self, part, step, dirty_report, cli_config):
         dirty_action = cli_config.get_outdated_step_action()
-        if step not in constants.STEPS_TO_AUTOMATICALLY_CLEAN_IF_DIRTY:
+        if not step.clean_if_dirty:
             if dirty_action == config.OutdatedStepAction.ERROR:
                 raise errors.StepOutdatedError(
                     step=step, part=part.name,

--- a/snapcraft/internal/lifecycle/constants.py
+++ b/snapcraft/internal/lifecycle/constants.py
@@ -15,5 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 
+from snapcraft.internal import steps
+
 SNAPCRAFT_INTERNAL_DIR = os.path.join('snap', '.snapcraft')
-STEPS_TO_AUTOMATICALLY_CLEAN_IF_DIRTY = {'stage', 'prime'}
+STEPS_TO_AUTOMATICALLY_CLEAN_IF_DIRTY = {steps.STAGE, steps.PRIME}

--- a/snapcraft/internal/lifecycle/constants.py
+++ b/snapcraft/internal/lifecycle/constants.py
@@ -18,4 +18,3 @@ import os
 from snapcraft.internal import steps
 
 SNAPCRAFT_INTERNAL_DIR = os.path.join('snap', '.snapcraft')
-STEPS_TO_AUTOMATICALLY_CLEAN_IF_DIRTY = {steps.STAGE, steps.PRIME}

--- a/snapcraft/internal/lifecycle/constants.py
+++ b/snapcraft/internal/lifecycle/constants.py
@@ -15,6 +15,4 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 
-from snapcraft.internal import steps
-
 SNAPCRAFT_INTERNAL_DIR = os.path.join('snap', '.snapcraft')

--- a/snapcraft/internal/lxd/_project.py
+++ b/snapcraft/internal/lxd/_project.py
@@ -22,7 +22,7 @@ from typing import List
 
 from . import errors
 from ._containerbuild import Containerbuild
-from snapcraft.internal import lifecycle
+from snapcraft.internal import lifecycle, steps
 from snapcraft.cli import echo
 
 logger = logging.getLogger(__name__)
@@ -112,10 +112,10 @@ class Project(Containerbuild):
                     print('Deleting {}'.format(self._container_name))
                     subprocess.check_call([
                         'lxc', 'delete', '-f', self._container_name])
-            step = 'pull'
+            step = steps.PULL.name
         # clean normally, without involving the container
         if step == 'strip':
             echo.warning('DEPRECATED: Use `prime` instead of `strip` '
                          'as the step to clean')
-            step = 'prime'
-        lifecycle.clean(self._project_options, parts, step)
+            step = steps.PRIME.name
+        lifecycle.clean(self._project_options, parts, steps.Step(step))

--- a/snapcraft/internal/lxd/_project.py
+++ b/snapcraft/internal/lxd/_project.py
@@ -23,7 +23,6 @@ from typing import List
 from . import errors
 from ._containerbuild import Containerbuild
 from snapcraft.internal import lifecycle, steps
-from snapcraft.cli import echo
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +102,7 @@ class Project(Containerbuild):
             self._container_run(['apt-get', 'upgrade', '-y'])
             self._container_run(['snap', 'refresh'])
 
-    def clean(self, parts: List[str], step: str):
+    def clean(self, parts: List[str], step: steps.Step):
         # clean with no parts deletes the container
         if not step:
             if not parts:
@@ -112,10 +111,6 @@ class Project(Containerbuild):
                     print('Deleting {}'.format(self._container_name))
                     subprocess.check_call([
                         'lxc', 'delete', '-f', self._container_name])
-            step = steps.PULL.name
-        # clean normally, without involving the container
-        if step == 'strip':
-            echo.warning('DEPRECATED: Use `prime` instead of `strip` '
-                         'as the step to clean')
-            step = steps.PRIME.name
-        lifecycle.clean(self._project_options, parts, steps.Step(step))
+            step = steps.PULL
+
+        lifecycle.clean(self._project_options, parts, step)

--- a/snapcraft/internal/meta/_manifest.py
+++ b/snapcraft/internal/meta/_manifest.py
@@ -21,8 +21,7 @@ from collections import OrderedDict
 from typing import Any, Dict  # noqa: F401
 
 import snapcraft
-from snapcraft.internal import errors
-from snapcraft.internal import os_release
+from snapcraft.internal import errors, os_release, steps
 from snapcraft.internal.states import (
     get_global_state,
     get_state
@@ -53,7 +52,7 @@ def annotate_snapcraft(data, parts_dir: str):
         manifest[field] = get_global_state().assets.get(field, [])
     for part in data['parts']:
         state_dir = os.path.join(parts_dir, part, 'state')
-        pull_state = get_state(state_dir, 'pull')
+        pull_state = get_state(state_dir, steps.PULL)
         manifest['parts'][part]['build-packages'] = (
            pull_state.assets.get('build-packages', []))
         manifest['parts'][part]['stage-packages'] = (
@@ -61,6 +60,6 @@ def annotate_snapcraft(data, parts_dir: str):
         source_details = pull_state.assets.get('source-details', {})
         if source_details:
             manifest['parts'][part].update(source_details)
-        build_state = get_state(state_dir, 'build')
+        build_state = get_state(state_dir, steps.BUILD)
         manifest['parts'][part].update(build_state.assets)
     return manifest

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -232,7 +232,7 @@ class PluginHandler:
         logger.info('%s %s %s', progress, self.name, hint)
 
     def latest_step(self):
-        for step in reversed(steps.ordered_steps()):
+        for step in reversed(steps.STEPS):
             if os.path.exists(
                     states.get_step_state_file(self.plugin.statedir, step)):
                 return step
@@ -784,7 +784,7 @@ class PluginHandler:
     def _clean_steps(self, project_staged_state, project_primed_state,
                      step=None, hint=None):
         if step:
-            if step not in steps.ordered_steps():
+            if step not in steps.STEPS:
                 raise RuntimeError(
                     '{!r} is not a valid step for part {!r}'.format(
                         step, self.name))

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -226,7 +226,7 @@ class PluginHandler:
             if step:
                 os.remove(self.plugin.statedir)
                 os.makedirs(self.plugin.statedir)
-                self.mark_done(steps.Step(step))
+                self.mark_done(steps.get_step_by_name(step))
 
     def notify_part_progress(self, progress, hint=''):
         logger.info('%s %s %s', progress, self.name, hint)

--- a/snapcraft/internal/states/_state.py
+++ b/snapcraft/internal/states/_state.py
@@ -17,6 +17,8 @@
 import os
 import yaml
 
+from snapcraft.internal import steps
+
 
 class State(yaml.YAMLObject):
 
@@ -91,7 +93,7 @@ def get_global_state():
         return yaml.load(state_file)
 
 
-def get_state(state_dir, step):
+def get_state(state_dir: str, step: steps.Step):
     state = None
     state_file = get_step_state_file(state_dir, step)
     if os.path.isfile(state_file):
@@ -101,5 +103,5 @@ def get_state(state_dir, step):
     return state
 
 
-def get_step_state_file(state_dir: str, step: str) -> str:
-    return os.path.join(state_dir, step)
+def get_step_state_file(state_dir: str, step: steps.Step) -> str:
+    return os.path.join(state_dir, step.name)

--- a/snapcraft/internal/steps.py
+++ b/snapcraft/internal/steps.py
@@ -1,0 +1,97 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from snapcraft.internal import errors
+
+
+class Step:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.__order = None  # type: int
+
+    @property
+    def _order(self) -> int:
+        if self.__order is None:
+            self.__order = STEPS.index(self)
+        return self.__order
+
+    def next_step(self) -> 'Step':
+        try:
+            return STEPS[self._order+1]
+        except IndexError as e:
+            raise errors.NoNextStepError(self) from e
+
+    def __lt__(self, other) -> bool:
+        if type(other) is type(self):
+            return self._order < other._order
+
+        return NotImplemented
+
+    def __le__(self, other) -> bool:
+        if type(other) is type(self):
+            return self._order <= other._order
+
+        return NotImplemented
+
+    def __eq__(self, other) -> bool:
+        if type(other) is type(self):
+            return self.name == other.name
+
+        return NotImplemented
+
+    def __gt__(self, other) -> bool:
+        if type(other) is type(self):
+            return self._order > other._order
+
+        return NotImplemented
+
+    def __ge__(self, other) -> bool:
+        if type(other) is type(self):
+            return self._order >= other._order
+
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __repr__(self):
+        return 'snapcraft.internal.steps.Step({!r})'.format(self.name)
+
+
+# Step names and order are now maintained in a single place: right here. If
+# another step is needed, add it here, and insert it into STEPS in the proper
+# order.
+PULL = Step('pull')
+BUILD = Step('build')
+STAGE = Step('stage')
+PRIME = Step('prime')
+
+STEPS = [PULL, BUILD, STAGE, PRIME]
+
+
+def next_step(step):
+    if step:
+        return step.next_step()
+    else:
+        return STEPS[0]
+
+
+def steps_required_for(step):
+    return [s for s in STEPS if s <= step]
+
+
+def steps_following(step):
+    return [s for s in STEPS if s > step]

--- a/snapcraft/internal/steps.py
+++ b/snapcraft/internal/steps.py
@@ -86,7 +86,7 @@ class Step:
         return hash(self.name)
 
     def __repr__(self):
-        return 'snapcraft.internal.steps.Step({!r})'.format(self.name)
+        return 'Step({!r})'.format(self.name)
 
 
 # Step names and order are now maintained in a single place: right here. If

--- a/snapcraft/internal/steps.py
+++ b/snapcraft/internal/steps.py
@@ -18,8 +18,9 @@ from typing import List
 
 
 class Step:
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, clean_if_dirty: bool) -> None:
         self.name = name
+        self.clean_if_dirty = clean_if_dirty
         self.__order = None  # type: int
 
     @property
@@ -86,10 +87,10 @@ class Step:
 # Step names and order are now maintained in a single place: right here. If
 # another step is needed, add it here, and insert it into STEPS in the proper
 # order.
-PULL = Step('pull')
-BUILD = Step('build')
-STAGE = Step('stage')
-PRIME = Step('prime')
+PULL = Step('pull', False)
+BUILD = Step('build', False)
+STAGE = Step('stage', True)
+PRIME = Step('prime', True)
 
 STEPS = [PULL, BUILD, STAGE, PRIME]
 

--- a/snapcraft/internal/steps.py
+++ b/snapcraft/internal/steps.py
@@ -14,35 +14,40 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from snapcraft.internal import errors
+from typing import List
 
 
 class Step:
     def __init__(self, name: str) -> None:
         self.name = name
-        self.__order = None  # type: int
+        self.previous_step = None  # type: Step
+        self.next_step = None  # type: Step
 
-    @property
-    def _order(self) -> int:
-        if self.__order is None:
-            self.__order = STEPS.index(self)
-        return self.__order
+    def previous_steps(self):
+        steps = []
+        previous_step = self.previous_step
+        while previous_step:
+            steps.insert(0, previous_step)
+            previous_step = previous_step.previous_step
+        return steps
 
-    def next_step(self) -> 'Step':
-        try:
-            return STEPS[self._order+1]
-        except IndexError as e:
-            raise errors.NoNextStepError(self) from e
+    def next_steps(self):
+        steps = []
+        next_step = self.next_step
+        while next_step:
+            steps.append(next_step)
+            next_step = next_step.next_step
+        return steps
 
     def __lt__(self, other) -> bool:
         if type(other) is type(self):
-            return self._order < other._order
+            return other in self.next_steps()
 
         return NotImplemented
 
     def __le__(self, other) -> bool:
         if type(other) is type(self):
-            return self._order <= other._order
+            return other == self or other in self.next_steps()
 
         return NotImplemented
 
@@ -54,13 +59,13 @@ class Step:
 
     def __gt__(self, other) -> bool:
         if type(other) is type(self):
-            return self._order > other._order
+            return other in self.previous_steps()
 
         return NotImplemented
 
     def __ge__(self, other) -> bool:
         if type(other) is type(self):
-            return self._order >= other._order
+            return other == self or other in self.previous_steps()
 
         return NotImplemented
 
@@ -71,27 +76,33 @@ class Step:
         return 'snapcraft.internal.steps.Step({!r})'.format(self.name)
 
 
+def _setup_step_order(steps: List[Step]):
+    for index, step in enumerate(steps):
+        if 0 <= index < len(steps)-1:
+            step.next_step = steps[index+1]
+        if index > 0:
+            step.previous_step = steps[index-1]
+
+
 # Step names and order are now maintained in a single place: right here. If
-# another step is needed, add it here, and insert it into STEPS in the proper
-# order.
+# another step is needed, add it here and to the _setup_step_order call in the
+# proper order.
 PULL = Step('pull')
 BUILD = Step('build')
 STAGE = Step('stage')
 PRIME = Step('prime')
 
-STEPS = [PULL, BUILD, STAGE, PRIME]
+FIRST_STEP = PULL
+
+_setup_step_order([PULL, BUILD, STAGE, PRIME])
 
 
 def next_step(step):
     if step:
-        return step.next_step()
+        return step.next_step
     else:
-        return STEPS[0]
+        return FIRST_STEP
 
 
-def steps_required_for(step):
-    return [s for s in STEPS if s <= step]
-
-
-def steps_following(step):
-    return [s for s in STEPS if s > step]
+def ordered_steps():
+    return [FIRST_STEP] + FIRST_STEP.next_steps()

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -28,7 +28,7 @@ import testscenarios
 import testtools
 
 import snapcraft
-from snapcraft.internal import common, elf
+from snapcraft.internal import common, elf, steps
 from snapcraft.internal.project_loader import grammar_processing
 from tests import fake_servers, fixture_setup
 from tests.file_utils import get_snapcraft_path
@@ -165,16 +165,15 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         with open(snapcraft_yaml, 'w', encoding=encoding) as fp:
             fp.write(content)
 
-    def verify_state(self, part_name, state_dir, expected_step):
+    def verify_state(self, part_name, state_dir, expected_step_name):
         self.assertTrue(os.path.isdir(state_dir),
                         'Expected state directory for {}'.format(part_name))
 
         # Expect every step up to and including the specified one to be run
-        index = common.COMMAND_ORDER.index(expected_step)
-        for step in common.COMMAND_ORDER[:index+1]:
-            self.assertTrue(os.path.exists(os.path.join(state_dir, step)),
+        for step in steps.steps_required_for(steps.Step(expected_step_name)):
+            self.assertTrue(os.path.exists(os.path.join(state_dir, step.name)),
                             'Expected {!r} to be run for {}'.format(
-                                step, part_name))
+                                step.name, part_name))
 
     def load_part(self, part_name, plugin_name=None, part_properties=None,
                   project_options=None, stage_packages_repo=None,

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -170,8 +170,8 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
                         'Expected state directory for {}'.format(part_name))
 
         # Expect every step up to and including the specified one to be run
-        step = steps.Step(expected_step_name)
-        for step in step.previous_steps + [step]:
+        step = steps.get_step_by_name(expected_step_name)
+        for step in step.previous_steps() + [step]:
             self.assertTrue(os.path.exists(os.path.join(state_dir, step.name)),
                             'Expected {!r} to be run for {}'.format(
                                 step.name, part_name))

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -170,7 +170,8 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
                         'Expected state directory for {}'.format(part_name))
 
         # Expect every step up to and including the specified one to be run
-        for step in steps.steps_required_for(steps.Step(expected_step_name)):
+        step = steps.Step(expected_step_name)
+        for step in step.previous_steps + [step]:
             self.assertTrue(os.path.exists(os.path.join(state_dir, step.name)),
                             'Expected {!r} to be run for {}'.format(
                                 step.name, part_name))

--- a/tests/unit/commands/test_clean.py
+++ b/tests/unit/commands/test_clean.py
@@ -20,7 +20,11 @@ from unittest.mock import call, patch, ANY
 
 from testtools.matchers import Contains, Equals, DirExists, FileExists, Not
 
-import snapcraft.internal.errors
+import snapcraft
+from snapcraft.internal import (
+    errors,
+    steps,
+)
 from tests import fixture_setup
 from . import CommandBaseTestCase
 
@@ -68,8 +72,8 @@ parts:
                 open(os.path.join(
                     handler.plugin.installdir, part_name), 'w').close()
 
-                handler.mark_done('pull')
-                handler.mark_done('build')
+                handler.mark_done(steps.PULL)
+                handler.mark_done(steps.BUILD)
 
                 handler.stage()
                 handler.prime()
@@ -83,7 +87,7 @@ class CleanCommandTestCase(CleanCommandBaseTestCase):
         self.make_snapcraft_yaml(n=3)
 
         raised = self.assertRaises(
-            snapcraft.internal.errors.SnapcraftEnvironmentError,
+            errors.SnapcraftEnvironmentError,
             self.run_command, ['clean', 'no-clean'])
 
         self.assertThat(str(raised), Equals(
@@ -142,7 +146,7 @@ class ContainerizedCleanCommandTestCase(CleanCommandBaseTestCase):
         self.assertThat(fake_lxd.check_call_mock.call_count, Equals(1))
         # clean should be called normally, outside of the container
         mock_lifecycle_clean.assert_has_calls([
-            call(ANY, (), 'pull')])
+            call(ANY, (), steps.PULL)])
 
     @patch('snapcraft.internal.lifecycle.clean')
     def test_clean_containerized_pull_retains_container(
@@ -163,7 +167,7 @@ class ContainerizedCleanCommandTestCase(CleanCommandBaseTestCase):
         fake_lxd.check_call_mock.assert_not_called()
         # clean should be called normally, outside of the container
         mock_lifecycle_clean.assert_has_calls([
-            call(ANY, (), 'pull')])
+            call(ANY, (), steps.PULL)])
 
     def test_clean_containerized_with_part(self):
         fake_lxd = fixture_setup.FakeLXD()

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -854,18 +854,18 @@ class StateBaseTestCase(unit.TestCase):
 class StateTestCase(StateBaseTestCase):
 
     def test_mark_done_clears_later_steps(self):
-        for step in steps.STEPS:
+        for step in steps.ordered_steps():
             shutil.rmtree(self.parts_dir)
             handler = self.load_part('foo')
             handler.makedirs()
 
-            for later_step in steps.steps_following(step):
+            for later_step in step.next_steps():
                 open(states.get_step_state_file(
                     handler.plugin.statedir, later_step), 'w').close()
 
             handler.mark_done(step)
 
-            for later_step in steps.steps_following(step):
+            for later_step in step.next_steps():
                 self.assertFalse(
                     os.path.exists(states.get_step_state_file(
                         handler.plugin.statedir, later_step)),
@@ -1726,7 +1726,8 @@ class StateTestCase(StateBaseTestCase):
 
 class StateFileMigrationTestCase(StateBaseTestCase):
 
-    scenarios = [(step.name, dict(step=step)) for step in steps.STEPS]
+    scenarios = [(step.name, dict(step=step))
+                 for step in steps.ordered_steps()]
 
     def test_state_file_migration(self):
         part_name = 'foo'

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -854,7 +854,7 @@ class StateBaseTestCase(unit.TestCase):
 class StateTestCase(StateBaseTestCase):
 
     def test_mark_done_clears_later_steps(self):
-        for step in steps.ordered_steps():
+        for step in steps.STEPS:
             shutil.rmtree(self.parts_dir)
             handler = self.load_part('foo')
             handler.makedirs()
@@ -1727,7 +1727,7 @@ class StateTestCase(StateBaseTestCase):
 class StateFileMigrationTestCase(StateBaseTestCase):
 
     scenarios = [(step.name, dict(step=step))
-                 for step in steps.ordered_steps()]
+                 for step in steps.STEPS]
 
     def test_state_file_migration(self):
         part_name = 'foo'

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -498,6 +498,15 @@ class ErrorFormattingTestCase(unit.TestCase):
                 'Unable to parse mountinfo row: [1, 2, 3]'
             )
         }),
+        ('InvalidStepError', {
+            'exception': errors.InvalidStepError,
+            'kwargs': {
+                'step_name': 'test-step-name',
+            },
+            'expected_message': (
+                "'test-step-name' is not a valid lifecycle step"
+            )
+        }),
         ('NoLatestStepError', {
             'exception': errors.NoLatestStepError,
             'kwargs': {

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -510,10 +510,11 @@ class ErrorFormattingTestCase(unit.TestCase):
         ('NoNextStepError', {
             'exception': errors.NoNextStepError,
             'kwargs': {
-                'step': steps.PULL,
+                'part_name': 'test-part-name',
             },
             'expected_message': (
-                "'pull' is the final step"
+                "The 'test-part-name' part has run through its entire "
+                "lifecycle"
             )
         }),
     )

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -20,7 +20,7 @@ from subprocess import CalledProcessError
 from unittest import mock
 from testtools.matchers import Equals
 
-from snapcraft.internal import errors
+from snapcraft.internal import errors, steps
 from snapcraft.internal.meta import _errors as meta_errors
 from snapcraft.internal.repo import errors as repo_errors
 from snapcraft.storeapi import errors as store_errors
@@ -38,56 +38,53 @@ class ErrorFormattingTestCase(unit.TestCase):
     scenarios = (
         ('MissingStateCleanError', {
             'exception': errors.MissingStateCleanError,
-            'kwargs': {'step': 'test-step'},
+            'kwargs': {'step': steps.PULL},
             'expected_message': (
                 "Failed to clean: "
-                "Missing state for 'test-step'. "
+                "Missing state for 'pull'. "
                 "To clean the project, run `snapcraft clean`."
                 )}),
         ('StepOutdatedError dependents', {
             'exception': errors.StepOutdatedError,
             'kwargs': {
-                'step': 'test-step',
+                'step': steps.PULL,
                 'part': 'test-part',
                 'dependents': ['test-dependent']
             },
             'expected_message': (
                 "Failed to reuse files from previous build: "
-                "The 'test-step' step of 'test-part' is out of date:\n"
-                "The 'test-step' step for 'test-part' needs to be run again, "
+                "The 'pull' step of 'test-part' is out of date:\n"
+                "The 'pull' step for 'test-part' needs to be run again, "
                 "but 'test-dependent' depends on it.\n"
-                "To continue, clean that part's "
-                "'test-step' step, run "
-                "`snapcraft clean test-dependent -s test-step`.")}),
+                "To continue, clean that part's 'pull' step, run "
+                "`snapcraft clean test-dependent -s pull`.")}),
         ('StepOutdatedError dirty_properties', {
             'exception': errors.StepOutdatedError,
             'kwargs': {
-                'step': 'test-step',
+                'step': steps.PULL,
                 'part': 'test-part',
                 'dirty_properties': ['test-property1', 'test-property2']
             },
             'expected_message': (
                 "Failed to reuse files from previous build: "
-                "The 'test-step' step of 'test-part' is out of date:\n"
+                "The 'pull' step of 'test-part' is out of date:\n"
                 "The 'test-property1' and 'test-property2' part properties "
                 "appear to have changed.\n"
-                "To continue, clean that part's "
-                "'test-step' step, run "
-                "`snapcraft clean test-part -s test-step`.")}),
+                "To continue, clean that part's 'pull' step, run "
+                "`snapcraft clean test-part -s pull`.")}),
         ('StepOutdatedError dirty_project_options', {
             'exception': errors.StepOutdatedError,
             'kwargs': {
-                'step': 'test-step',
+                'step': steps.PULL,
                 'part': 'test-part',
                 'dirty_project_options': ['test-option']
             },
             'expected_message': (
                 "Failed to reuse files from previous build: "
-                "The 'test-step' step of 'test-part' is out of date:\n"
+                "The 'pull' step of 'test-part' is out of date:\n"
                 "The 'test-option' project option appears to have changed.\n"
-                "To continue, clean that part's "
-                "'test-step' step, run "
-                "`snapcraft clean test-part -s test-step`.")}),
+                "To continue, clean that part's 'pull' step, run "
+                "`snapcraft clean test-part -s pull`.")}),
         ('SnapcraftEnvironmentError', {
             'exception': errors.SnapcraftEnvironmentError,
             'kwargs': {'message': 'test-message'},
@@ -499,6 +496,24 @@ class ErrorFormattingTestCase(unit.TestCase):
             },
             'expected_message': (
                 'Unable to parse mountinfo row: [1, 2, 3]'
+            )
+        }),
+        ('NoLatestStepError', {
+            'exception': errors.NoLatestStepError,
+            'kwargs': {
+                'part_name': 'test-part-name',
+            },
+            'expected_message': (
+                "The 'test-part-name' part hasn't run any steps"
+            )
+        }),
+        ('NoNextStepError', {
+            'exception': errors.NoNextStepError,
+            'kwargs': {
+                'step': steps.PULL,
+            },
+            'expected_message': (
+                "'pull' is the final step"
             )
         }),
     )

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -526,6 +526,16 @@ class ErrorFormattingTestCase(unit.TestCase):
                 "lifecycle"
             )
         }),
+        ('ScriptletDuplicateFieldError', {
+            'exception': errors.ScriptletDuplicateFieldError,
+            'kwargs': {
+                'field': 'foo',
+                'step': steps.PULL,
+            },
+            'expected_message': (
+                "Unable to set foo: it was already set in the 'pull' step."
+            )
+        }),
     )
 
     def test_error_formatting(self):

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -1,0 +1,105 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from testtools.matchers import Equals
+
+from snapcraft.internal import (
+    errors,
+    steps,
+)
+from tests import unit
+
+
+class StepsTestCase(unit.TestCase):
+
+    def test_no_next_step_raises(self):
+        raised = self.assertRaises(
+            errors.NoNextStepError, steps.next_step, steps.PRIME)
+        self.assertThat(raised.step, Equals(steps.PRIME))
+
+
+class NextStepTestCase(unit.TestCase):
+
+    scenarios = [
+        ('pull', {
+            'step': steps.PULL,
+            'expected_step': steps.BUILD,
+        }),
+        ('build', {
+            'step': steps.BUILD,
+            'expected_step': steps.STAGE,
+        }),
+        ('stage', {
+            'step': steps.STAGE,
+            'expected_step': steps.PRIME,
+        }),
+    ]
+
+    def test_steps_required_for(self):
+        self.assertThat(steps.next_step(self.step), Equals(self.expected_step))
+
+
+class StepsRequiredForTestCase(unit.TestCase):
+
+    scenarios = [
+        ('pull', {
+            'step': steps.PULL,
+            'expected_steps': [steps.PULL],
+        }),
+        ('build', {
+            'step': steps.BUILD,
+            'expected_steps': [steps.PULL, steps.BUILD],
+        }),
+        ('stage', {
+            'step': steps.STAGE,
+            'expected_steps': [steps.PULL, steps.BUILD, steps.STAGE],
+        }),
+        ('prime', {
+            'step': steps.PRIME,
+            'expected_steps': [
+                steps.PULL, steps.BUILD, steps.STAGE, steps.PRIME],
+        }),
+    ]
+
+    def test_steps_required_for(self):
+        self.assertThat(steps.steps_required_for(
+            self.step), Equals(self.expected_steps))
+
+
+class StepsFollowingTestCase(unit.TestCase):
+
+    scenarios = [
+        ('pull', {
+            'step': steps.PULL,
+            'expected_steps': [steps.BUILD, steps.STAGE, steps.PRIME],
+        }),
+        ('build', {
+            'step': steps.BUILD,
+            'expected_steps': [steps.STAGE, steps.PRIME],
+        }),
+        ('stage', {
+            'step': steps.STAGE,
+            'expected_steps': [steps.PRIME],
+        }),
+        ('prime', {
+            'step': steps.PRIME,
+            'expected_steps': [],
+        }),
+    ]
+
+    def test_steps_following(self):
+        self.assertThat(steps.steps_following(
+            self.step), Equals(self.expected_steps))

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -24,21 +24,21 @@ class StepsTestCase(unit.TestCase):
 
     def test_step_order(self):
         step = steps.PULL
-        step = step.next_step
+        step = step.next_step()
         self.expectThat(step, Equals(steps.BUILD))
-        step = step.next_step
+        step = step.next_step()
         self.expectThat(step, Equals(steps.STAGE))
-        step = step.next_step
+        step = step.next_step()
         self.expectThat(step, Equals(steps.PRIME))
-        self.assertIsNone(step.next_step)
+        self.assertIsNone(step.next_step())
 
-        step = step.previous_step
+        step = step.previous_step()
         self.expectThat(step, Equals(steps.STAGE))
-        step = step.previous_step
+        step = step.previous_step()
         self.expectThat(step, Equals(steps.BUILD))
-        step = step.previous_step
+        step = step.previous_step()
         self.expectThat(step, Equals(steps.PULL))
-        self.assertIsNone(step.previous_step)
+        self.assertIsNone(step.previous_step())
 
     def test_next_step_handles_none(self):
         self.assertThat(steps.next_step(None), Equals(steps.PULL))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently the snapcraft CLI has step names and ordering hard-coded in a number of places, and those areas where it isn't hard-coded, a difficult-to-read index method is used. Simplify and extract this logic into a single module used by the others to determine lifecycle steps and ordering.