### PR TITLE
many: automatically detect dependency changes

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -59,7 +59,7 @@ python3 -m coverage 1>/dev/null 2>&1 && coverage="true"
 run_static_tests(){
     SRC_PATHS="bin external_snaps_tests setup.py snapcraft snaps_tests tests"
     python3 -m flake8 --max-complexity=10 $SRC_PATHS
-    codespell -S "*.tar,*.xz,*.zip,*.bz2,*.7z,*.gz,*.deb,*.rpm,*.snap,*.gpg,*.pyc,*.png,*.ico,*.jar,./.git,changelog" -q4
+    codespell -S "*.tar,*.xz,*.zip,*.bz2,*.7z,*.gz,*.deb,*.rpm,*.snap,*.gpg,*.pyc,*.png,*.ico,*.jar,./.git,changelog,./.mypy_cache" -q4
     mypy --ignore-missing-imports --follow-imports=silent -p snapcraft
 }
 

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -61,36 +61,12 @@ class StepOutdatedError(SnapcraftError):
         '`snapcraft clean {parts_names} -s {step.name}`.'
     )
 
-    def __init__(self, *, step, part, dirty_properties=None,
-                 dirty_project_options=None, changed_dependencies=None,
-                 dependents=None):
+    def __init__(self, *, step, part, dirty_report=None, dependents=None):
         messages = []
-        if dirty_properties:
-            humanized_properties = formatting_utils.humanize_list(
-                dirty_properties, 'and')
-            pluralized_connection = formatting_utils.pluralize(
-                dirty_properties, 'property appears',
-                'properties appear')
-            messages.append(
-                'The {} part {} to have changed.\n'.format(
-                    humanized_properties, pluralized_connection))
-        if dirty_project_options:
-            humanized_options = formatting_utils.humanize_list(
-                dirty_project_options, 'and')
-            pluralized_connection = formatting_utils.pluralize(
-                dirty_project_options, 'option appears',
-                'options appear')
-            messages.append(
-                'The {} project {} to have changed.\n'.format(
-                    humanized_options, pluralized_connection))
-        if changed_dependencies:
-            dependencies = [
-                d['name'] for d in changed_dependencies]
-            messages.append('{} changed: {}\n'.format(
-                formatting_utils.pluralize(
-                    dependencies, 'A dependency has',
-                    'Some dependencies have'),
-                formatting_utils.humanize_list(dependencies, 'and')))
+
+        if dirty_report:
+            messages.append(dirty_report.report())
+
         if dependents:
             humanized_dependents = formatting_utils.humanize_list(
                 dependents, 'and')
@@ -105,6 +81,7 @@ class StepOutdatedError(SnapcraftError):
             parts_names = ['{!s}'.format(d) for d in sorted(dependents)]
         else:
             parts_names = [part]
+
         super().__init__(step=step, part=part,
                          report=''.join(messages),
                          parts_names=' '.join(parts_names))
@@ -607,10 +584,17 @@ class SnapcraftCopyFileNotFoundError(SnapcraftError):
 
 
 class InvalidStepError(SnapcraftError):
-    fmt = "{step_name!r} is not a valid lifecycle step"
+    fmt = '{step_name!r} is not a valid lifecycle step'
 
     def __init__(self, step_name):
         super().__init__(step_name=step_name)
+
+
+class StepHasNotRunError(SnapcraftError):
+    fmt = 'The {part_name!r} part has not yet run the {step.name!r} step'
+
+    def __init__(self, part_name, step):
+        super().__init__(part_name=part_name, step=step)
 
 
 class NoLatestStepError(SnapcraftError):

--- a/snapcraft/internal/lifecycle/__init__.py
+++ b/snapcraft/internal/lifecycle/__init__.py
@@ -13,10 +13,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from ._clean import clean                 # noqa
-from ._containers import cleanbuild       # noqa
-from ._containers import containerbuild   # noqa
-from ._init import init                   # noqa
-from ._packer import pack                 # noqa
-from ._packer import snap                 # noqa
-from ._runner import execute              # noqa
+from ._clean import clean                # noqa
+from ._containers import cleanbuild      # noqa
+from ._containers import containerbuild  # noqa
+from ._init import init                  # noqa
+from ._packer import pack                # noqa
+from ._packer import snap                # noqa
+from ._runner import execute             # noqa
+from ._status_cache import StatusCache   # noqa

--- a/snapcraft/internal/lifecycle/_clean.py
+++ b/snapcraft/internal/lifecycle/_clean.py
@@ -35,22 +35,23 @@ def _clean_part(part_name, step, config, staged_state, primed_state):
     logger.info(template.format(step=step.name, part=part_name))
     config.parts.clean_part(part_name, staged_state, primed_state, step)
 
-    # If we just cleaned the root of a dependency tree, we need to mark all
-    # its dependents as dirty so they require cleaning.
-    return mark_dependents_dirty(part_name, step, config)
+    # If we just cleaned the root of a dependency tree. Return all dirty
+    # dependents.
+    return get_dirty_reverse_dependencies(part_name, step, config)
 
 
-def mark_dependents_dirty(part_name, cleaned_step, config):
-    dependent_part_names = config.parts.get_reverse_dependencies(part_name)
-    dependent_parts = {p for p in config.all_parts
-                       if p.name in dependent_part_names}
+def get_dirty_reverse_dependencies(part_name, step, config):
+    # If other parts are depending on this step of the part, they're now
+    # dirty
+    dirty_reverse_dependencies = set()
+    reverse_dependencies = config.parts.get_reverse_dependencies(
+        part_name, recursive=True)
+    dirty_step = steps.dirty_step_if_dependency_changes(step)
+    for reverse_dependency in reverse_dependencies:
+        if not reverse_dependency.should_step_run(dirty_step):
+            dirty_reverse_dependencies.add(reverse_dependency)
 
-    dirty_part_names = set()
-    for part in dependent_parts:
-        if part.mark_dependency_change(part_name, cleaned_step):
-            dirty_part_names.add(part.name)
-
-    return dirty_part_names
+    return dirty_reverse_dependencies
 
 
 def _clean_parts(part_names, step, config, staged_state, primed_state):
@@ -58,10 +59,11 @@ def _clean_parts(part_names, step, config, staged_state, primed_state):
         step = steps.next_step(None)
 
     for part_name in part_names:
-        resulting_dirty_parts = _clean_part(
+        dirty_parts = _clean_part(
             part_name, step, config, staged_state, primed_state)
+        dirty_part_names = {p.name for p in dirty_parts}
 
-        parts_not_being_cleaned = resulting_dirty_parts.difference(part_names)
+        parts_not_being_cleaned = dirty_part_names.difference(part_names)
         if parts_not_being_cleaned:
             logger.warning(
                 'Cleaned {!r}, which makes the following {} out of date: '

--- a/snapcraft/internal/lifecycle/_status_cache.py
+++ b/snapcraft/internal/lifecycle/_status_cache.py
@@ -1,0 +1,123 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import collections
+import contextlib
+from typing import Any, Dict, Set
+
+from snapcraft.internal import errors, pluginhandler, steps
+
+
+class StatusCache:
+    def __init__(self, config):
+        self.config = config
+        self._steps_run = dict()  # type: Dict[str, Set[steps.Step]]
+        self._dirty_reports = collections.defaultdict(dict)  # type: Dict[str, Dict[steps.Step, pluginhandler.DirtyReport]]  # noqa
+
+    def step_should_run(self, part: pluginhandler.PluginHandler,
+                        step: steps.Step) -> bool:
+        return (not self.step_has_run(part, step) or
+                self.get_dirty_report(part, step) is not None)
+
+    def add_step_run(self, part: pluginhandler.PluginHandler,
+                     step: steps.Step) -> None:
+        self._ensure_steps_run(part)
+        self._steps_run[part.name].add(step)
+
+    def step_has_run(self, part: pluginhandler.PluginHandler,
+                     step: steps.Step) -> bool:
+        self._ensure_steps_run(part)
+        return step in self._steps_run[part.name]
+
+    def get_dirty_report(self, part: pluginhandler.PluginHandler,
+                         step: steps.Step) -> pluginhandler.DirtyReport:
+        self._ensure_dirty_report(part, step)
+        return self._dirty_reports[part.name][step]
+
+    def clear_step(self, part: pluginhandler.PluginHandler,
+                   step: steps.Step) -> None:
+        if part.name in self._steps_run:
+            _remove_key(self._steps_run[part.name], step)
+            if not self._steps_run[part.name]:
+                _del_key(self._steps_run, part.name)
+        _del_key(self._dirty_reports[part.name], step)
+        if not self._dirty_reports[part.name]:
+            _del_key(self._dirty_reports, part.name)
+
+    def clear_part(self, part: pluginhandler.PluginHandler) -> None:
+        _del_key(self._steps_run, part.name)
+        _del_key(self._dirty_reports, part.name)
+
+    def _ensure_steps_run(self, part: pluginhandler.PluginHandler) -> None:
+        if part.name not in self._steps_run:
+            self._steps_run[part.name] = _get_steps_run(part)
+
+    def _ensure_dirty_report(self, part: pluginhandler.PluginHandler,
+                             step: steps.Step) -> None:
+        if step not in self._dirty_reports[part.name]:
+            self._dirty_reports[part.name][step] = part.get_dirty_report(step)
+
+            # The dirty report from the PluginHandler only takes into account
+            # properties specific to that part. We need to expand that here to
+            # also take its dependencies (if any) into account, but only if
+            # it's not already dirty.
+            if not self._dirty_reports[part.name][step]:
+                dependencies = self.config.parts.get_dependencies(
+                    part.name, recursive=True)
+                prerequisite_step = steps.get_dependency_prerequisite_step(
+                    step)
+                changed_dependencies = []
+                with contextlib.suppress(errors.StepHasNotRunError):
+                    step_timestamp = part.step_timestamp(step)
+                    for dependency in dependencies:
+                        # Make sure the prerequisite step of this dependency
+                        # has not run more recently than this step
+                        try:
+                            prerequisite_timestamp = dependency.step_timestamp(
+                                prerequisite_step)
+                        except errors.StepHasNotRunError:
+                            dependency_changed = True
+                        else:
+                            dependency_changed = (
+                                step_timestamp < prerequisite_timestamp)
+                        if dependency_changed:
+                            changed_dependencies.append({
+                                'name': dependency.name,
+                                'step': prerequisite_step})
+
+                    if changed_dependencies:
+                        self._dirty_reports[part.name][step] = (
+                            pluginhandler.DirtyReport(
+                                changed_dependencies=changed_dependencies))
+
+
+def _get_steps_run(part: pluginhandler.PluginHandler) -> Set[steps.Step]:
+    steps_run = set()  # type: Set[steps.Step]
+    for step in steps.STEPS:
+        if not part.should_step_run(step):
+            steps_run.add(step)
+
+    return steps_run
+
+
+def _del_key(c: Dict[Any, Any], key: Any) -> None:
+    with contextlib.suppress(KeyError):
+        del c[key]
+
+
+def _remove_key(c: Set[Any], key: Any) -> None:
+    with contextlib.suppress(KeyError):
+        c.remove(key)

--- a/snapcraft/internal/pluginhandler/_dirty_report.py
+++ b/snapcraft/internal/pluginhandler/_dirty_report.py
@@ -1,0 +1,97 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from snapcraft import formatting_utils
+
+
+class DirtyReport:
+    def __init__(self, *, dirty_properties=None, dirty_project_options=None,
+                 changed_dependencies=None):
+        self.dirty_properties = dirty_properties
+        self.dirty_project_options = dirty_project_options
+        self.changed_dependencies = changed_dependencies
+
+    def report(self):
+        messages = []
+
+        if self.dirty_properties:
+            humanized_properties = formatting_utils.humanize_list(
+                self.dirty_properties, 'and')
+            pluralized_connection = formatting_utils.pluralize(
+                self.dirty_properties, 'property appears',
+                'properties appear')
+            messages.append(
+                'The {} part {} to have changed.\n'.format(
+                    humanized_properties, pluralized_connection))
+
+        if self.dirty_project_options:
+            humanized_options = formatting_utils.humanize_list(
+                self.dirty_project_options, 'and')
+            pluralized_connection = formatting_utils.pluralize(
+                self.dirty_project_options, 'option appears',
+                'options appear')
+            messages.append(
+                'The {} project {} to have changed.\n'.format(
+                    humanized_options, pluralized_connection))
+
+        if self.changed_dependencies:
+            dependencies = [
+                d['name'] for d in self.changed_dependencies]
+            messages.append('{} changed: {}\n'.format(
+                formatting_utils.pluralize(
+                    dependencies, 'A dependency has',
+                    'Some dependencies have'),
+                formatting_utils.humanize_list(dependencies, 'and')))
+
+        return ''.join(messages)
+
+    def summary(self):
+        reasons = []
+
+        reason_count = 0
+        if self.dirty_properties:
+            reason_count += 1
+        if self.dirty_project_options:
+            reason_count += 1
+        if self.changed_dependencies:
+            reason_count += 1
+
+        if self.dirty_properties:
+            # Be specific only if this is the only reason
+            if reason_count > 1 or len(self.dirty_properties) > 1:
+                reasons.append('properties')
+            else:
+                reasons.append('{!r} property'.format(
+                    self.dirty_properties[0]))
+
+        if self.dirty_project_options:
+            # Be specific only if this is the only reason
+            if reason_count > 1 or len(self.dirty_project_options) > 1:
+                reasons.append('options')
+            else:
+                reasons.append('{!r} option'.format(
+                    self.dirty_project_options[0]))
+
+        if self.changed_dependencies:
+            # Be specific only if this is the only reason
+            if reason_count > 1 or len(self.changed_dependencies) > 1:
+                reasons.append('dependencies')
+            else:
+                reasons.append('{!r}'.format(
+                    self.changed_dependencies[0]['name']))
+
+        return '{} changed'.format(
+            formatting_utils.humanize_list(reasons, 'and', '{}'))

--- a/snapcraft/internal/states/_build_state.py
+++ b/snapcraft/internal/states/_build_state.py
@@ -48,8 +48,7 @@ class BuildState(PartState):
     def __init__(
             self, property_names, part_properties=None, project=None,
             plugin_assets=None, machine_assets=None, metadata=None,
-            metadata_files=None, scriptlet_metadata=None,
-            changed_dependencies=None):
+            metadata_files=None, scriptlet_metadata=None):
         # Save this off before calling super() since we'll need it
         # FIXME: for 3.x the name `schema_properties` is leaking
         #        implementation details from a higher layer.
@@ -77,7 +76,7 @@ class BuildState(PartState):
 
         self.scriptlet_metadata = scriptlet_metadata
 
-        super().__init__(part_properties, project, changed_dependencies)
+        super().__init__(part_properties, project)
 
     def properties_of_interest(self, part_properties):
         """Extract the properties concerning this step from part_properties."""

--- a/snapcraft/internal/states/_prime_state.py
+++ b/snapcraft/internal/states/_prime_state.py
@@ -32,9 +32,8 @@ class PrimeState(PartState):
     yaml_tag = u'!PrimeState'
 
     def __init__(self, files, directories, dependency_paths=None,
-                 part_properties=None, project=None, scriptlet_metadata=None,
-                 changed_dependencies=None):
-        super().__init__(part_properties, project, changed_dependencies)
+                 part_properties=None, project=None, scriptlet_metadata=None):
+        super().__init__(part_properties, project)
 
         if not scriptlet_metadata:
             scriptlet_metadata = snapcraft.extractors.ExtractedMetadata()

--- a/snapcraft/internal/states/_pull_state.py
+++ b/snapcraft/internal/states/_pull_state.py
@@ -50,7 +50,7 @@ class PullState(PartState):
     def __init__(self, property_names, part_properties=None, project=None,
                  stage_packages=None, build_snaps=None, build_packages=None,
                  source_details=None, metadata=None, metadata_files=None,
-                 scriptlet_metadata=None, changed_dependencies=None):
+                 scriptlet_metadata=None):
         # Save this off before calling super() since we'll need it
         # FIXME: for 3.x the name `schema_properties` is leaking
         #        implementation details from a higher layer.
@@ -78,7 +78,7 @@ class PullState(PartState):
 
         self.scriptlet_metadata = scriptlet_metadata
 
-        super().__init__(part_properties, project, changed_dependencies)
+        super().__init__(part_properties, project)
 
     def properties_of_interest(self, part_properties):
         """Extract the properties concerning this step from part_properties."""

--- a/snapcraft/internal/states/_stage_state.py
+++ b/snapcraft/internal/states/_stage_state.py
@@ -32,8 +32,8 @@ class StageState(PartState):
     yaml_tag = u'!StageState'
 
     def __init__(self, files, directories, part_properties=None, project=None,
-                 scriptlet_metadata=None, changed_dependencies=None):
-        super().__init__(part_properties, project, changed_dependencies)
+                 scriptlet_metadata=None):
+        super().__init__(part_properties, project)
 
         if not scriptlet_metadata:
             scriptlet_metadata = snapcraft.extractors.ExtractedMetadata()

--- a/snapcraft/internal/states/_state.py
+++ b/snapcraft/internal/states/_state.py
@@ -38,18 +38,13 @@ class State(yaml.YAMLObject):
 
 class PartState(State):
 
-    def __init__(self, part_properties, project, changed_dependencies):
+    def __init__(self, part_properties, project):
         super().__init__()
         if not part_properties:
             part_properties = {}
 
         self.properties = self.properties_of_interest(part_properties)
         self.project_options = self.project_options_of_interest(project)
-
-        if changed_dependencies:
-            self.changed_dependencies = changed_dependencies
-        else:
-            self.changed_dependencies = []
 
     def properties_of_interest(self, part_properties):
         """Extract the properties concerning this step from the options.

--- a/snapcraft/internal/steps.py
+++ b/snapcraft/internal/steps.py
@@ -129,3 +129,17 @@ def get_step_by_name(step_name):
         raise errors.InvalidStepError(step_name)
     else:
         return STEPS[0]
+
+
+def get_dependency_prerequisite_step(step):
+    if step <= STAGE:
+        return STAGE
+    else:
+        return step
+
+
+def dirty_step_if_dependency_changes(changed_step):
+    if changed_step <= STAGE:
+        return STEPS[0]
+    else:
+        return changed_step

--- a/tests/unit/lifecycle/__init__.py
+++ b/tests/unit/lifecycle/__init__.py
@@ -1,0 +1,48 @@
+
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015-2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import fixtures
+import logging
+import textwrap
+
+import snapcraft
+from tests import unit
+
+
+class BaseLifecycleTestCase(unit.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.fake_logger = fixtures.FakeLogger(level=logging.INFO)
+        self.useFixture(self.fake_logger)
+        self.project_options = snapcraft.ProjectOptions()
+
+    def make_snapcraft_yaml(self, parts, snap_type=''):
+        yaml = textwrap.dedent("""\
+            name: test
+            version: 0
+            summary: test
+            description: test
+            confinement: strict
+            grade: stable
+            {type}
+
+            {parts}
+            """)
+
+        super().make_snapcraft_yaml(yaml.format(parts=parts, type=snap_type))

--- a/tests/unit/lifecycle/test_status_cache.py
+++ b/tests/unit/lifecycle/test_status_cache.py
@@ -1,0 +1,95 @@
+
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+
+from snapcraft.internal import lifecycle, steps
+import snapcraft.internal.project_loader._config as _config
+
+from . import BaseLifecycleTestCase
+
+
+class StatusCacheTestCase(BaseLifecycleTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.make_snapcraft_yaml(
+            textwrap.dedent("""\
+                parts:
+                  main:
+                    plugin: nil
+                  dependent:
+                    plugin: nil
+                    after: [main]
+                """))
+
+        self.config = _config.Config()
+        self.cache = lifecycle.StatusCache(self.config)
+
+    def test_step_has_run(self):
+        # No steps should have run, yet
+        main_part = self.config.parts.get_part('main')
+        self.assertFalse(self.cache.step_has_run(main_part, steps.PULL))
+
+        # Now run the pull step
+        lifecycle.execute(
+            steps.PULL, self.project_options, part_names=['main'])
+
+        # Should still have cached that no steps have run
+        self.assertFalse(self.cache.step_has_run(main_part, steps.PULL))
+
+        # Now clear that step from the cache, and it should be up-to-date
+        self.cache.clear_step(main_part, steps.PULL)
+        self.assertTrue(self.cache.step_has_run(main_part, steps.PULL))
+
+    def test_add_step_run(self):
+        # No steps should have run, yet
+        main_part = self.config.parts.get_part('main')
+        self.assertFalse(self.cache.step_has_run(main_part, steps.PULL))
+
+        # Tell the cache that the pull step has run though
+        self.cache.add_step_run(main_part, steps.PULL)
+
+        # Now it should think that it has actually run
+        self.assertTrue(self.cache.step_has_run(main_part, steps.PULL))
+
+        # Now clear that step from the cache, and it should no longer have ran
+        self.cache.clear_step(main_part, steps.PULL)
+        self.assertFalse(self.cache.step_has_run(main_part, steps.PULL))
+
+    def test_get_dirty_report(self):
+        # No dirty reports should be available, yet
+        dependent_part = self.config.parts.get_part('dependent')
+        self.assertFalse(self.cache.get_dirty_report(
+            dependent_part, steps.PULL))
+
+        # Now run the pull step
+        lifecycle.execute(steps.PULL, self.project_options)
+
+        # Re-stage main, which will make dependent dirty
+        lifecycle.execute(
+            steps.PULL, self.project_options, part_names=['main'])
+
+        # Should still have cached that it's not dirty, though
+        self.assertFalse(self.cache.get_dirty_report(
+            dependent_part, steps.PULL))
+
+        # Now clear that step from the cache, and it should be up-to-date
+        self.cache.clear_step(dependent_part, steps.PULL)
+        self.assertTrue(self.cache.get_dirty_report(
+            dependent_part, steps.PULL))

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -20,7 +20,7 @@ from subprocess import CalledProcessError
 from unittest import mock
 from testtools.matchers import Equals
 
-from snapcraft.internal import errors, steps
+from snapcraft.internal import errors, pluginhandler, steps
 from snapcraft.internal.meta import _errors as meta_errors
 from snapcraft.internal.repo import errors as repo_errors
 from snapcraft.storeapi import errors as store_errors
@@ -63,7 +63,8 @@ class ErrorFormattingTestCase(unit.TestCase):
             'kwargs': {
                 'step': steps.PULL,
                 'part': 'test-part',
-                'dirty_properties': ['test-property1', 'test-property2']
+                'dirty_report': pluginhandler.DirtyReport(
+                    dirty_properties=['test-property1', 'test-property2'])
             },
             'expected_message': (
                 "Failed to reuse files from previous run: "
@@ -77,7 +78,8 @@ class ErrorFormattingTestCase(unit.TestCase):
             'kwargs': {
                 'step': steps.PULL,
                 'part': 'test-part',
-                'dirty_project_options': ['test-option']
+                'dirty_report': pluginhandler.DirtyReport(
+                    dirty_project_options=['test-option'])
             },
             'expected_message': (
                 "Failed to reuse files from previous run: "
@@ -90,8 +92,9 @@ class ErrorFormattingTestCase(unit.TestCase):
             'kwargs': {
                 'step': steps.PULL,
                 'part': 'test-part',
-                'changed_dependencies': [
-                    {'name': 'another-part', 'step': 'another-step'}]
+                'dirty_report': pluginhandler.DirtyReport(
+                    changed_dependencies=[
+                        {'name': 'another-part', 'step': 'another-step'}])
             },
             'expected_message': (
                 "Failed to reuse files from previous run: "
@@ -105,10 +108,10 @@ class ErrorFormattingTestCase(unit.TestCase):
             'kwargs': {
                 'step': steps.PULL,
                 'part': 'test-part',
-                'changed_dependencies': [
-                    {'name': 'another-part1', 'step': 'another-step1'},
-                    {'name': 'another-part2', 'step': 'another-step2'},
-                ]
+                'dirty_report': pluginhandler.DirtyReport(
+                    changed_dependencies=[
+                        {'name': 'another-part1', 'step': 'another-step1'},
+                        {'name': 'another-part2', 'step': 'another-step2'}])
             },
             'expected_message': (
                 "Failed to reuse files from previous run: "


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----

Currently the only way parts know they're dirty from dependency changes is if the lifecycle tells them so. This is a very error-prone approach, since if the lifecycle forgets to tell the part, then it doesn't know it needs to be cleaned. Dependency changes should be automatically detected instead of being noted in code, which also simplifies the upcoming feature of detecting source changes.