### PR TITLE
tests: new codespell, narrowed checks and better execution order

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,4 +1,4 @@
-codespell==1.11.0
+codespell==1.12.0
 coverage==4.1
 flake8==3.5.0
 pyflakes==1.6.0

--- a/runtests.sh
+++ b/runtests.sh
@@ -59,8 +59,8 @@ python3 -m coverage 1>/dev/null 2>&1 && coverage="true"
 run_static_tests(){
     SRC_PATHS="bin external_snaps_tests setup.py snapcraft snaps_tests tests"
     python3 -m flake8 --max-complexity=10 $SRC_PATHS
-    codespell -S "*.tar,*.xz,*.zip,*.bz2,*.7z,*.gz,*.deb,*.rpm,*.snap,*.gpg,*.pyc,*.png,*.ico,*.jar,./.git,changelog" -q4
     mypy --ignore-missing-imports --follow-imports=silent -p snapcraft
+    codespell -S "*.tar,*.xz,*.zip,*.bz2,*.7z,*.gz,*.deb,*.rpm,*.snap,*.gpg,*.pyc,*.png,*.ico,*.jar,./.git,changelog,.mypy_cache,parts,stage,prime" -q4
 }
 
 run_snapcraft_tests(){

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -55,7 +55,7 @@ class Provider():
 
     @abc.abstractmethod
     def create(self) -> None:
-        """Provider steps needed to create a fully functioning environemnt."""
+        """Provider steps needed to create a fully functioning environment."""
 
     @abc.abstractmethod
     def destroy(self) -> None:

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -134,7 +134,7 @@ def _validate_architectures(instance):
             path=['architectures'], instance=instance)
 
     # We want to ensure that multiple `run-on`s (or standalone `build-on`s)
-    # don't incude the same arch, or they'll clash with each other when
+    # don't include the same arch, or they'll clash with each other when
     # releasing.
     all_run_ons = run_ons + standalone_build_ons
     duplicates = {arch for (arch, count) in all_run_ons.items() if count > 1}

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -247,7 +247,7 @@ class KernelPlugin(kbuild.KBuildPlugin):
                 temp_dir, 'squashfs-root', initrd_path)
 
             decompressed = False
-            # Roll over valid decompression mecanisms until one works
+            # Roll over valid decompression mechanisms until one works
             for decompressor in ('xz', 'gzip'):
                 try:
                     subprocess.check_call(

--- a/snapcraft/plugins/ruby.py
+++ b/snapcraft/plugins/ruby.py
@@ -128,7 +128,7 @@ class RubyPlugin(BasePlugin):
         # Patch versions of ruby continue to use the minor version's RUBYLIB,
         # GEM_HOME, and GEM_PATH. Fortunately there should just be one, so we
         # can detect it by globbing instead of trying to determine what the
-        # minor version is programatically
+        # minor version is programmatically
         versions = glob.glob(os.path.join(rubydir, 'gems', '*'))
 
         # Before Ruby has been pulled/installed, no versions will be found.

--- a/snapcraft/project/_project_options.py
+++ b/snapcraft/project/_project_options.py
@@ -176,7 +176,7 @@ class ProjectOptions:
         try:
             # cross-compilation of x86 32bit binaries on a x86_64 host is
             # possible by reusing the native toolchain - let Kbuild figure
-            # it out by itself and pass down an empy cross-compiler-prefix
+            # it out by itself and pass down an empty cross-compiler-prefix
             # to start the build
             if (self.__platform_arch == 'x86_64' and
                     self.__target_machine == 'i686'):

--- a/tools/travis/run_tests.sh
+++ b/tools/travis/run_tests.sh
@@ -49,9 +49,6 @@ elif [ "$test_suite" = "tests/unit" ]; then
 elif [[ "$test_suite" = "tests/integration"* || "$test_suite" = "tests.integration"* ]]; then
     # TODO remove the need to install the snapcraft dependencies due to nesting
     #      the tests in the snapcraft package
-    # snap install core exits with this error message:
-    # - Setup snap "core" (2462) security profiles (cannot reload udev rules: exit status 2
-    # but the installation succeeds, so we just ingore it.
     dependencies="apt install -y bzr git libnacl-dev libssl-dev libsodium-dev libffi-dev libapt-pkg-dev mercurial python3-pip subversion sudo snapd && python3 -m pip install -r requirements-devel.txt -r requirements.txt && (snap install core || echo 'ignored error') && ${SNAPCRAFT_INSTALL_COMMAND:-sudo snap install snaps-cache/snapcraft-pr$TRAVIS_PULL_REQUEST.snap --dangerous --classic}"
 else
     echo "Unknown test suite: $test_suite"

--- a/tools/travis/setup_lxd.sh
+++ b/tools/travis/setup_lxd.sh
@@ -33,7 +33,7 @@ apt-get remove --yes lxd lxd-client
 # https://github.com/lxc/lxd/commit/004e7c361e1d914795d3ba7582654622e32ff193
 # snap install core exits with this error message:
 # - Setup snap "core" (3604) security profiles (cannot reload udev rules: exit status 2)
-# but the installation succeeds, so we just ingore it.
+# but the installation succeeds, so we just ignore it.
 snap install core || echo 'ignored error'
 snap install lxd --channel=3.0/stable
 # Wait while LXD first generates its keys. In a low entropy environment this


### PR DESCRIPTION
- Run mypy first and only then do spell checking.
- Update codespell to 0.12.0 which has better detection.
- Fix spelling issues discovered by codespell.
- Narrow down the list of directories searched for (no need to look in
  e.g.; parts).

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----
