### PR TITLE
many: automatically detect dependency changes

### DIFF
--- a/snapcraft/formatting_utils.py
+++ b/snapcraft/formatting_utils.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Set
+from typing import Iterable, List, Sized
 
 
 def combine_paths(paths: List[str], prepend: str, separator: str) -> str:
@@ -48,7 +48,7 @@ def format_path_variable(envvar: str, paths: List[str],
             paths, prepend, separator))
 
 
-def humanize_list(items: List[str], conjunction: str,
+def humanize_list(items: Iterable[str], conjunction: str,
                   item_format: str = '{!r}') -> str:
     """Format a list into a human-readable string.
 
@@ -58,22 +58,22 @@ def humanize_list(items: List[str], conjunction: str,
     :param str item_format: Format string to use per item.
     """
 
-    if len(items) == 0:
+    if not items:
         return ''
 
     quoted_items = [item_format.format(item) for item in sorted(items)]
-    if len(items) == 1:
+    if len(quoted_items) == 1:
         return quoted_items[0]
 
     humanized = ', '.join(quoted_items[:-1])
 
-    if len(items) > 2:
+    if len(quoted_items) > 2:
         humanized += ','
 
     return '{} {} {}'.format(humanized, conjunction, quoted_items[-1])
 
 
-def pluralize(container: Set[str], if_one: str, if_multiple: str) -> str:
+def pluralize(container: Sized, if_one: str, if_multiple: str) -> str:
     if len(container) == 1:
         return if_one
     else:

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -65,7 +65,7 @@ class StepOutdatedError(SnapcraftError):
         messages = []
 
         if dirty_report:
-            messages.append(dirty_report.report())
+            messages.append(dirty_report.get_report())
 
         if dependents:
             humanized_dependents = formatting_utils.humanize_list(

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -61,36 +61,12 @@ class StepOutdatedError(SnapcraftError):
         '`snapcraft clean {parts_names} -s {step.name}`.'
     )
 
-    def __init__(self, *, step, part, dirty_properties=None,
-                 dirty_project_options=None, changed_dependencies=None,
-                 dependents=None):
+    def __init__(self, *, step, part, dirty_report=None, dependents=None):
         messages = []
-        if dirty_properties:
-            humanized_properties = formatting_utils.humanize_list(
-                dirty_properties, 'and')
-            pluralized_connection = formatting_utils.pluralize(
-                dirty_properties, 'property appears',
-                'properties appear')
-            messages.append(
-                'The {} part {} to have changed.\n'.format(
-                    humanized_properties, pluralized_connection))
-        if dirty_project_options:
-            humanized_options = formatting_utils.humanize_list(
-                dirty_project_options, 'and')
-            pluralized_connection = formatting_utils.pluralize(
-                dirty_project_options, 'option appears',
-                'options appear')
-            messages.append(
-                'The {} project {} to have changed.\n'.format(
-                    humanized_options, pluralized_connection))
-        if changed_dependencies:
-            dependencies = [
-                d['name'] for d in changed_dependencies]
-            messages.append('{} changed: {}\n'.format(
-                formatting_utils.pluralize(
-                    dependencies, 'A dependency has',
-                    'Some dependencies have'),
-                formatting_utils.humanize_list(dependencies, 'and')))
+
+        if dirty_report:
+            messages.append(dirty_report.report())
+
         if dependents:
             humanized_dependents = formatting_utils.humanize_list(
                 dependents, 'and')
@@ -105,6 +81,7 @@ class StepOutdatedError(SnapcraftError):
             parts_names = ['{!s}'.format(d) for d in sorted(dependents)]
         else:
             parts_names = [part]
+
         super().__init__(step=step, part=part,
                          report=''.join(messages),
                          parts_names=' '.join(parts_names))
@@ -607,10 +584,17 @@ class SnapcraftCopyFileNotFoundError(SnapcraftError):
 
 
 class InvalidStepError(SnapcraftError):
-    fmt = "{step_name!r} is not a valid lifecycle step"
+    fmt = '{step_name!r} is not a valid lifecycle step'
 
     def __init__(self, step_name):
         super().__init__(step_name=step_name)
+
+
+class StepHasNotRunError(SnapcraftError):
+    fmt = 'The {part_name!r} part has not yet run the {step.name!r} step'
+
+    def __init__(self, part_name, step):
+        super().__init__(part_name=part_name, step=step)
 
 
 class NoLatestStepError(SnapcraftError):

--- a/snapcraft/internal/lifecycle/__init__.py
+++ b/snapcraft/internal/lifecycle/__init__.py
@@ -19,4 +19,3 @@ from ._containers import containerbuild   # noqa
 from ._init import init                   # noqa
 from ._packer import pack                 # noqa
 from ._runner import execute              # noqa
-from ._status_cache import StatusCache    # noqa

--- a/snapcraft/internal/lifecycle/__init__.py
+++ b/snapcraft/internal/lifecycle/__init__.py
@@ -19,3 +19,4 @@ from ._containers import containerbuild   # noqa
 from ._init import init                   # noqa
 from ._packer import pack                 # noqa
 from ._runner import execute              # noqa
+from ._status_cache import StatusCache    # noqa

--- a/snapcraft/internal/lifecycle/_status_cache.py
+++ b/snapcraft/internal/lifecycle/_status_cache.py
@@ -1,0 +1,174 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import collections
+import contextlib
+from typing import Any, Dict, Set
+
+from snapcraft.internal import errors, pluginhandler, steps
+import snapcraft.internal.project_loader._config as _config
+
+
+class StatusCache:
+    """The StatusCache is a lazy caching interface for the status of parts."""
+
+    def __init__(self, config: _config.Config) -> None:
+        """Create a new StatusCache.
+
+        :param _config.Config config: Project config.
+        """
+        self.config = config
+        self._steps_run = dict()  # type: Dict[str, Set[steps.Step]]
+        self._dirty_reports = collections.defaultdict(dict)  # type: Dict[str, Dict[steps.Step, pluginhandler.DirtyReport]]  # noqa
+
+    def step_should_run(self, part: pluginhandler.PluginHandler,
+                        step: steps.Step) -> bool:
+        """Determine if a given step of a given part should run.
+
+        :param pluginhandler.PluginHandler part: Part in question.
+        :param steps.Step step: Step in question.
+        :return: Whether or not step should run.
+        :rtype: bool
+
+        A given step should run if it:
+            1. Hasn't yet run
+            2. Is dirty
+            3. Either (1) or (2) apply to any earlier steps in its lifecycle
+        """
+        if (not self.step_has_run(part, step) or
+                self.get_dirty_report(part, step) is not None):
+            return True
+
+        previous_step = step.previous_step()
+        if previous_step:
+            return self.step_should_run(part, previous_step)
+
+        return False
+
+    def add_step_run(self, part: pluginhandler.PluginHandler,
+                     step: steps.Step) -> None:
+        """Cache the fact that a given step has now run for the given part.
+
+        :param pluginhandler.PluginHandler part: Part in question.
+        :param steps.Step step: Step in question.
+        """
+        self._ensure_steps_run(part)
+        self._steps_run[part.name].add(step)
+
+    def step_has_run(self, part: pluginhandler.PluginHandler,
+                     step: steps.Step) -> bool:
+        """Determine if a given step of a given part has already run.
+
+        :param pluginhandler.PluginHandler part: Part in question.
+        :param steps.Step step: Step in question.
+        :return: Whether or not the step has run.
+        :rtype: bool
+        """
+        self._ensure_steps_run(part)
+        return step in self._steps_run[part.name]
+
+    def get_dirty_report(self, part: pluginhandler.PluginHandler,
+                         step: steps.Step) -> pluginhandler.DirtyReport:
+        """Obtain the dirty report for a given step of the given part.
+
+        :param pluginhandler.PluginHandler part: Part in question.
+        :param steps.Step step: Step in question.
+        :return: Dirty report (could be None)
+        :rtype: pluginhandler.DirtyReport
+        """
+        self._ensure_dirty_report(part, step)
+        return self._dirty_reports[part.name][step]
+
+    def clear_step(self, part: pluginhandler.PluginHandler,
+                   step: steps.Step) -> None:
+        """Clear the given step of the given part from the cache.
+
+        :param pluginhandler.PluginHandler part: Part in question.
+        :param steps.Step step: Step in question.
+
+        This function does nothing if the step wasn't cached.
+        """
+        if part.name in self._steps_run:
+            _remove_key(self._steps_run[part.name], step)
+            if not self._steps_run[part.name]:
+                _del_key(self._steps_run, part.name)
+        _del_key(self._dirty_reports[part.name], step)
+        if not self._dirty_reports[part.name]:
+            _del_key(self._dirty_reports, part.name)
+
+    def _ensure_steps_run(self, part: pluginhandler.PluginHandler) -> None:
+        if part.name not in self._steps_run:
+            self._steps_run[part.name] = _get_steps_run(part)
+
+    def _ensure_dirty_report(self, part: pluginhandler.PluginHandler,
+                             step: steps.Step) -> None:
+        if step not in self._dirty_reports[part.name]:
+            self._dirty_reports[part.name][step] = part.get_dirty_report(step)
+
+            # The dirty report from the PluginHandler only takes into account
+            # properties specific to that part. We need to expand that here to
+            # also take its dependencies (if any) into account, but only if
+            # it's not already dirty.
+            if not self._dirty_reports[part.name][step]:
+                dependencies = self.config.parts.get_dependencies(
+                    part.name, recursive=True)
+                prerequisite_step = steps.get_dependency_prerequisite_step(
+                    step)
+                changed_dependencies = []
+                with contextlib.suppress(errors.StepHasNotRunError):
+                    step_timestamp = part.step_timestamp(step)
+                    for dependency in dependencies:
+                        # Make sure the prerequisite step of this dependency
+                        # has not run more recently than (or should run
+                        # _before_) this step.
+                        try:
+                            prerequisite_timestamp = dependency.step_timestamp(
+                                prerequisite_step)
+                        except errors.StepHasNotRunError:
+                            dependency_changed = True
+                        else:
+                            dependency_changed = (
+                                step_timestamp < prerequisite_timestamp)
+                        if (dependency_changed or
+                                self.step_should_run(
+                                    dependency, prerequisite_step)):
+                            changed_dependencies.append({
+                                'name': dependency.name,
+                                'step': prerequisite_step})
+
+                    if changed_dependencies:
+                        self._dirty_reports[part.name][step] = (
+                            pluginhandler.DirtyReport(
+                                changed_dependencies=changed_dependencies))
+
+
+def _get_steps_run(part: pluginhandler.PluginHandler) -> Set[steps.Step]:
+    steps_run = set()  # type: Set[steps.Step]
+    for step in steps.STEPS:
+        if not part.should_step_run(step):
+            steps_run.add(step)
+
+    return steps_run
+
+
+def _del_key(c: Dict[Any, Any], key: Any) -> None:
+    with contextlib.suppress(KeyError):
+        del c[key]
+
+
+def _remove_key(c: Set[Any], key: Any) -> None:
+    with contextlib.suppress(KeyError):
+        c.remove(key)

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -45,7 +45,7 @@ from ._metadata_extraction import extract_metadata
 from ._plugin_loader import load_plugin  # noqa
 from ._runner import Runner
 from ._patchelf import PartPatcher
-from ._dirty_report import DirtyReport
+from ._dirty_report import Dependency, DirtyReport  # noqa
 
 logger = logging.getLogger(__name__)
 
@@ -288,9 +288,8 @@ class PluginHandler:
 
     def step_timestamp(self, step):
         try:
-            return os.stat(
-                states.get_step_state_file(
-                    self.plugin.statedir, step)).st_mtime
+            return os.stat(states.get_step_state_file(
+                self.plugin.statedir, step)).st_mtime
         except FileNotFoundError as e:
             raise errors.StepHasNotRunError(self.name, step) from e
 

--- a/snapcraft/internal/pluginhandler/_dirty_report.py
+++ b/snapcraft/internal/pluginhandler/_dirty_report.py
@@ -1,0 +1,97 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from snapcraft import formatting_utils
+
+
+class DirtyReport:
+    def __init__(self, *, dirty_properties=None, dirty_project_options=None,
+                 changed_dependencies=None):
+        self.dirty_properties = dirty_properties
+        self.dirty_project_options = dirty_project_options
+        self.changed_dependencies = changed_dependencies
+
+    def report(self):
+        messages = []
+
+        if self.dirty_properties:
+            humanized_properties = formatting_utils.humanize_list(
+                self.dirty_properties, 'and')
+            pluralized_connection = formatting_utils.pluralize(
+                self.dirty_properties, 'property appears',
+                'properties appear')
+            messages.append(
+                'The {} part {} to have changed.\n'.format(
+                    humanized_properties, pluralized_connection))
+
+        if self.dirty_project_options:
+            humanized_options = formatting_utils.humanize_list(
+                self.dirty_project_options, 'and')
+            pluralized_connection = formatting_utils.pluralize(
+                self.dirty_project_options, 'option appears',
+                'options appear')
+            messages.append(
+                'The {} project {} to have changed.\n'.format(
+                    humanized_options, pluralized_connection))
+
+        if self.changed_dependencies:
+            dependencies = [
+                d['name'] for d in self.changed_dependencies]
+            messages.append('{} changed: {}\n'.format(
+                formatting_utils.pluralize(
+                    dependencies, 'A dependency has',
+                    'Some dependencies have'),
+                formatting_utils.humanize_list(dependencies, 'and')))
+
+        return ''.join(messages)
+
+    def summary(self):
+        reasons = []
+
+        reason_count = 0
+        if self.dirty_properties:
+            reason_count += 1
+        if self.dirty_project_options:
+            reason_count += 1
+        if self.changed_dependencies:
+            reason_count += 1
+
+        if self.dirty_properties:
+            # Be specific only if this is the only reason
+            if reason_count > 1 or len(self.dirty_properties) > 1:
+                reasons.append('properties')
+            else:
+                reasons.append('{!r} property'.format(
+                    next(iter(self.dirty_properties))))
+
+        if self.dirty_project_options:
+            # Be specific only if this is the only reason
+            if reason_count > 1 or len(self.dirty_project_options) > 1:
+                reasons.append('options')
+            else:
+                reasons.append('{!r} option'.format(
+                    next(iter(self.dirty_project_options))))
+
+        if self.changed_dependencies:
+            # Be specific only if this is the only reason
+            if reason_count > 1 or len(self.changed_dependencies) > 1:
+                reasons.append('dependencies')
+            else:
+                reasons.append('{!r}'.format(
+                    next(iter(self.changed_dependencies))['name']))
+
+        return '{} changed'.format(
+            formatting_utils.humanize_list(reasons, 'and', '{}'))

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -131,30 +131,43 @@ class PartsConfig:
 
         return sorted_parts
 
-    def get_prereqs(self, part_name):
-        """Returns a set with all of part_names' prerequisites."""
-        return set(self.after_requests.get(part_name, []))
+    def get_dependencies(self, part_name, *, recursive=False):
+        # type: (str, bool) -> Set[pluginhandler.PluginHandler]
+        """Returns a set of all the parts upon which part_name depends."""
 
-    def get_dependents(self, part_name):
-        """Returns a set of all the parts that depend upon part_name."""
+        dependency_names = set(self.after_requests.get(part_name, []))
+        dependencies = {p for p in self.all_parts
+                        if p.name in dependency_names}
 
-        dependents = set()
-        for part, prerequisites in self.after_requests.items():
-            if part_name in prerequisites:
-                dependents.add(part)
-
-        return dependents
-
-    def get_reverse_dependencies(self, part_name):
-        """Returns all parts that recursively depend upon part_name."""
-
-        dependents = self.get_dependents(part_name)
-        for dependent in dependents.copy():
+        if recursive:
             # No need to worry about infinite recursion due to circular
             # dependencies since the YAML validation won't allow it.
-            dependents |= self.get_reverse_dependencies(dependent)
+            for dependency_name in dependency_names:
+                dependencies |= self.get_dependencies(
+                    dependency_name, recursive=recursive)
 
-        return dependents
+        return dependencies
+
+    def get_reverse_dependencies(self, part_name, *, recursive=False):
+        # type: (str, bool) -> Set[pluginhandler.PluginHandler]
+        """Returns a set of all the parts that depend upon part_name."""
+
+        reverse_dependency_names = set()
+        for part, dependencies in self.after_requests.items():
+            if part_name in dependencies:
+                reverse_dependency_names.add(part)
+
+        reverse_dependencies = {p for p in self.all_parts
+                                if p.name in reverse_dependency_names}
+
+        if recursive:
+            # No need to worry about infinite recursion due to circular
+            # dependencies since the YAML validation won't allow it.
+            for reverse_dependency_name in reverse_dependency_names:
+                reverse_dependencies |= self.get_reverse_dependencies(
+                    reverse_dependency_name, recursive=recursive)
+
+        return reverse_dependencies
 
     def get_part(self, part_name):
         for part in self.all_parts:

--- a/snapcraft/internal/states/_build_state.py
+++ b/snapcraft/internal/states/_build_state.py
@@ -48,8 +48,7 @@ class BuildState(PartState):
     def __init__(
             self, property_names, part_properties=None, project=None,
             plugin_assets=None, machine_assets=None, metadata=None,
-            metadata_files=None, scriptlet_metadata=None,
-            changed_dependencies=None):
+            metadata_files=None, scriptlet_metadata=None):
         # Save this off before calling super() since we'll need it
         # FIXME: for 3.x the name `schema_properties` is leaking
         #        implementation details from a higher layer.
@@ -77,7 +76,7 @@ class BuildState(PartState):
 
         self.scriptlet_metadata = scriptlet_metadata
 
-        super().__init__(part_properties, project, changed_dependencies)
+        super().__init__(part_properties, project)
 
     def properties_of_interest(self, part_properties):
         """Extract the properties concerning this step from part_properties."""

--- a/snapcraft/internal/states/_prime_state.py
+++ b/snapcraft/internal/states/_prime_state.py
@@ -32,9 +32,8 @@ class PrimeState(PartState):
     yaml_tag = u'!PrimeState'
 
     def __init__(self, files, directories, dependency_paths=None,
-                 part_properties=None, project=None, scriptlet_metadata=None,
-                 changed_dependencies=None):
-        super().__init__(part_properties, project, changed_dependencies)
+                 part_properties=None, project=None, scriptlet_metadata=None):
+        super().__init__(part_properties, project)
 
         if not scriptlet_metadata:
             scriptlet_metadata = snapcraft.extractors.ExtractedMetadata()

--- a/snapcraft/internal/states/_pull_state.py
+++ b/snapcraft/internal/states/_pull_state.py
@@ -50,7 +50,7 @@ class PullState(PartState):
     def __init__(self, property_names, part_properties=None, project=None,
                  stage_packages=None, build_snaps=None, build_packages=None,
                  source_details=None, metadata=None, metadata_files=None,
-                 scriptlet_metadata=None, changed_dependencies=None):
+                 scriptlet_metadata=None):
         # Save this off before calling super() since we'll need it
         # FIXME: for 3.x the name `schema_properties` is leaking
         #        implementation details from a higher layer.
@@ -78,7 +78,7 @@ class PullState(PartState):
 
         self.scriptlet_metadata = scriptlet_metadata
 
-        super().__init__(part_properties, project, changed_dependencies)
+        super().__init__(part_properties, project)
 
     def properties_of_interest(self, part_properties):
         """Extract the properties concerning this step from part_properties."""

--- a/snapcraft/internal/states/_stage_state.py
+++ b/snapcraft/internal/states/_stage_state.py
@@ -32,8 +32,8 @@ class StageState(PartState):
     yaml_tag = u'!StageState'
 
     def __init__(self, files, directories, part_properties=None, project=None,
-                 scriptlet_metadata=None, changed_dependencies=None):
-        super().__init__(part_properties, project, changed_dependencies)
+                 scriptlet_metadata=None):
+        super().__init__(part_properties, project)
 
         if not scriptlet_metadata:
             scriptlet_metadata = snapcraft.extractors.ExtractedMetadata()

--- a/snapcraft/internal/states/_state.py
+++ b/snapcraft/internal/states/_state.py
@@ -38,18 +38,13 @@ class State(yaml.YAMLObject):
 
 class PartState(State):
 
-    def __init__(self, part_properties, project, changed_dependencies):
+    def __init__(self, part_properties, project):
         super().__init__()
         if not part_properties:
             part_properties = {}
 
         self.properties = self.properties_of_interest(part_properties)
         self.project_options = self.project_options_of_interest(project)
-
-        if changed_dependencies:
-            self.changed_dependencies = changed_dependencies
-        else:
-            self.changed_dependencies = []
 
     def properties_of_interest(self, part_properties):
         """Extract the properties concerning this step from the options.

--- a/snapcraft/internal/steps.py
+++ b/snapcraft/internal/steps.py
@@ -129,3 +129,17 @@ def get_step_by_name(step_name):
         raise errors.InvalidStepError(step_name)
     else:
         return STEPS[0]
+
+
+def get_dependency_prerequisite_step(step):
+    if step <= STAGE:
+        return STAGE
+    else:
+        return step
+
+
+def dirty_step_if_dependency_changes(changed_step):
+    if changed_step <= STAGE:
+        return STEPS[0]
+    else:
+        return changed_step

--- a/tests/unit/lifecycle/test_lifecycle.py
+++ b/tests/unit/lifecycle/test_lifecycle.py
@@ -87,7 +87,7 @@ class ExecutionTestCase(LifecycleTestBase):
 
         self.assertThat(
             self.fake_logger.output,
-            Equals("'part2' has prerequisites that need to be staged: part1\n"
+            Equals("'part2' has dependencies that need to be staged: part1\n"
                    'Pulling part1 \n'
                    'Building part1 \n'
                    'Staging part1 \n'

--- a/tests/unit/lifecycle/test_lifecycle.py
+++ b/tests/unit/lifecycle/test_lifecycle.py
@@ -156,7 +156,8 @@ class ExecutionTestCase(LifecycleTestBase):
 
         def _fake_dirty_report(self, step):
             if step == steps.STAGE:
-                return pluginhandler.DirtyReport({'foo'}, {'bar'}, [])
+                return pluginhandler.DirtyReport(
+                    dirty_properties={'foo'}, dirty_project_options={'bar'})
             return None
 
         # Should stage no problem
@@ -204,7 +205,8 @@ class ExecutionTestCase(LifecycleTestBase):
 
         def _fake_dirty_report(self, step):
             if step == steps.BUILD:
-                return pluginhandler.DirtyReport({'foo', 'bar'}, set(), [])
+                return pluginhandler.DirtyReport(
+                    dirty_properties={'foo', 'bar'})
             return None
 
         # Should catch that the part needs to be rebuilt and raise an error.
@@ -244,7 +246,8 @@ class ExecutionTestCase(LifecycleTestBase):
 
         def _fake_dirty_report(self, step):
             if step == steps.PULL:
-                return pluginhandler.DirtyReport(set(), {'foo', 'bar'}, [])
+                return pluginhandler.DirtyReport(
+                    dirty_project_options={'foo', 'bar'})
             return None
 
         # Should catch that the part needs to be re-pulled and raise an error.

--- a/tests/unit/lifecycle/test_order.py
+++ b/tests/unit/lifecycle/test_order.py
@@ -23,6 +23,7 @@ from testtools.matchers import Contains, Equals, HasLength
 
 import snapcraft
 from snapcraft.internal import lifecycle, pluginhandler, steps
+from snapcraft.internal.lifecycle._status_cache import StatusCache
 
 from . import LifecycleTestBase
 
@@ -160,7 +161,7 @@ class OrderTestBase(LifecycleTestBase):
         return sorted(actual_order, key=lambda k: k['timestamp'])
 
     def assert_parts_dirty(self, expected_parts, hint):
-        cache = lifecycle.StatusCache(self.project_config)
+        cache = StatusCache(self.project_config)
         dirty_parts = []
         for part in self.project_config.parts.all_parts:
             for step in steps.STEPS:

--- a/tests/unit/lifecycle/test_status_cache.py
+++ b/tests/unit/lifecycle/test_status_cache.py
@@ -18,6 +18,7 @@
 import textwrap
 
 from snapcraft.internal import lifecycle, steps
+from snapcraft.internal.lifecycle._status_cache import StatusCache
 
 from . import LifecycleTestBase
 
@@ -37,38 +38,38 @@ class StatusCacheTestCase(LifecycleTestBase):
                     after: [main]
                 """))
 
-        self.cache = lifecycle.StatusCache(self.project_config)
+        self.cache = StatusCache(self.project_config)
 
-    def test_step_has_run(self):
+    def test_has_step_run(self):
         # No steps should have run, yet
         main_part = self.project_config.parts.get_part('main')
-        self.assertFalse(self.cache.step_has_run(main_part, steps.PULL))
+        self.assertFalse(self.cache.has_step_run(main_part, steps.PULL))
 
         # Now run the pull step
         lifecycle.execute(
             steps.PULL, self.project_config, part_names=['main'])
 
         # Should still have cached that no steps have run
-        self.assertFalse(self.cache.step_has_run(main_part, steps.PULL))
+        self.assertFalse(self.cache.has_step_run(main_part, steps.PULL))
 
         # Now clear that step from the cache, and it should be up-to-date
         self.cache.clear_step(main_part, steps.PULL)
-        self.assertTrue(self.cache.step_has_run(main_part, steps.PULL))
+        self.assertTrue(self.cache.has_step_run(main_part, steps.PULL))
 
     def test_add_step_run(self):
         # No steps should have run, yet
         main_part = self.project_config.parts.get_part('main')
-        self.assertFalse(self.cache.step_has_run(main_part, steps.PULL))
+        self.assertFalse(self.cache.has_step_run(main_part, steps.PULL))
 
         # Tell the cache that the pull step has run though
         self.cache.add_step_run(main_part, steps.PULL)
 
         # Now it should think that it has actually run
-        self.assertTrue(self.cache.step_has_run(main_part, steps.PULL))
+        self.assertTrue(self.cache.has_step_run(main_part, steps.PULL))
 
         # Now clear that step from the cache, and it should no longer have ran
         self.cache.clear_step(main_part, steps.PULL)
-        self.assertFalse(self.cache.step_has_run(main_part, steps.PULL))
+        self.assertFalse(self.cache.has_step_run(main_part, steps.PULL))
 
     def test_get_dirty_report(self):
         # No dirty reports should be available, yet

--- a/tests/unit/lifecycle/test_status_cache.py
+++ b/tests/unit/lifecycle/test_status_cache.py
@@ -1,0 +1,93 @@
+
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+
+from snapcraft.internal import lifecycle, steps
+
+from . import LifecycleTestBase
+
+
+class StatusCacheTestCase(LifecycleTestBase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.project_config = self.make_snapcraft_project(
+            textwrap.dedent("""\
+                parts:
+                  main:
+                    plugin: nil
+                  dependent:
+                    plugin: nil
+                    after: [main]
+                """))
+
+        self.cache = lifecycle.StatusCache(self.project_config)
+
+    def test_step_has_run(self):
+        # No steps should have run, yet
+        main_part = self.project_config.parts.get_part('main')
+        self.assertFalse(self.cache.step_has_run(main_part, steps.PULL))
+
+        # Now run the pull step
+        lifecycle.execute(
+            steps.PULL, self.project_config, part_names=['main'])
+
+        # Should still have cached that no steps have run
+        self.assertFalse(self.cache.step_has_run(main_part, steps.PULL))
+
+        # Now clear that step from the cache, and it should be up-to-date
+        self.cache.clear_step(main_part, steps.PULL)
+        self.assertTrue(self.cache.step_has_run(main_part, steps.PULL))
+
+    def test_add_step_run(self):
+        # No steps should have run, yet
+        main_part = self.project_config.parts.get_part('main')
+        self.assertFalse(self.cache.step_has_run(main_part, steps.PULL))
+
+        # Tell the cache that the pull step has run though
+        self.cache.add_step_run(main_part, steps.PULL)
+
+        # Now it should think that it has actually run
+        self.assertTrue(self.cache.step_has_run(main_part, steps.PULL))
+
+        # Now clear that step from the cache, and it should no longer have ran
+        self.cache.clear_step(main_part, steps.PULL)
+        self.assertFalse(self.cache.step_has_run(main_part, steps.PULL))
+
+    def test_get_dirty_report(self):
+        # No dirty reports should be available, yet
+        dependent_part = self.project_config.parts.get_part('dependent')
+        self.assertFalse(self.cache.get_dirty_report(
+            dependent_part, steps.PULL))
+
+        # Now run the pull step
+        lifecycle.execute(steps.PULL, self.project_config)
+
+        # Re-stage main, which will make dependent dirty
+        lifecycle.execute(
+            steps.PULL, self.project_config, part_names=['main'])
+
+        # Should still have cached that it's not dirty, though
+        self.assertFalse(self.cache.get_dirty_report(
+            dependent_part, steps.PULL))
+
+        # Now clear that step from the cache, and it should be up-to-date
+        self.cache.clear_step(dependent_part, steps.PULL)
+        self.assertTrue(self.cache.get_dirty_report(
+            dependent_part, steps.PULL))

--- a/tests/unit/pluginhandler/test_dirty_report.py
+++ b/tests/unit/pluginhandler/test_dirty_report.py
@@ -1,0 +1,184 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from snapcraft.internal.pluginhandler._dirty_report import (
+    Dependency,
+    DirtyReport,
+)
+from snapcraft.internal import steps
+
+from testtools.matchers import Equals
+from testscenarios import multiply_scenarios
+
+from tests import unit
+
+
+class DirtyReportGetReportTest(unit.TestCase):
+
+    property_scenarios = [
+        ('no properties', dict(
+            dirty_properties=None,
+            properties_report=''
+        )),
+        ('single property', dict(
+            dirty_properties=['prop1'],
+            properties_report="The 'prop1' part property appears to have "
+                              "changed."
+        )),
+        ('multiple properties', dict(
+            dirty_properties=['prop1', 'prop2'],
+            properties_report="The 'prop1' and 'prop2' part properties appear "
+                              "to have changed."
+        )),
+    ]
+
+    option_scenarios = [
+        ('no project options', dict(
+            dirty_project_options=None,
+            options_report=''
+        )),
+        ('single project option', dict(
+            dirty_project_options=['op1'],
+            options_report="The 'op1' project option appears to have "
+                           "changed."
+        )),
+        ('multiple properties', dict(
+            dirty_project_options=['op1', 'op2'],
+            options_report="The 'op1' and 'op2' project options appear to "
+                           "have changed."
+        )),
+    ]
+
+    dependencies_scenarios = [
+        ('no changed dependencys', dict(
+            changed_dependencies=None,
+            dependencies_report=''
+        )),
+        ('single changed dependency', dict(
+            changed_dependencies=[
+                Dependency(part_name='dep1', step=steps.PULL),
+            ],
+            dependencies_report="A dependency has changed: 'dep1'"
+        )),
+        ('multiple changed dependency', dict(
+            changed_dependencies=[
+                Dependency(part_name='dep1', step=steps.PULL),
+                Dependency(part_name='dep2', step=steps.PULL),
+            ],
+            dependencies_report="Some dependencies have changed: 'dep1' and "
+                                "'dep2'"
+        )),
+    ]
+
+    scenarios = multiply_scenarios(
+        property_scenarios, option_scenarios, dependencies_scenarios)
+
+    def test_get_report(self):
+        dirty_report = DirtyReport(
+            dirty_properties=self.dirty_properties,
+            dirty_project_options=self.dirty_project_options,
+            changed_dependencies=self.changed_dependencies)
+
+        expected_report = []
+        if self.properties_report:
+            expected_report.append(self.properties_report)
+        if self.options_report:
+            expected_report.append(self.options_report)
+        if self.dependencies_report:
+            expected_report.append(self.dependencies_report)
+        if expected_report:
+            expected_report.append('')
+
+        self.assertThat(
+            dirty_report.get_report(), Equals('\n'.join(expected_report)))
+
+
+class DirtyReportGetSummaryTest(unit.TestCase):
+
+    scenarios = [
+        ('single property', dict(
+            dirty_properties=['foo'],
+            dirty_project_options=None,
+            changed_dependencies=None,
+            expected_summary="'foo' property changed"
+        )),
+        ('multiple properties', dict(
+            dirty_properties=['foo', 'bar'],
+            dirty_project_options=None,
+            changed_dependencies=None,
+            expected_summary='properties changed'
+        )),
+        ('single option', dict(
+            dirty_properties=None,
+            dirty_project_options=['foo'],
+            changed_dependencies=None,
+            expected_summary="'foo' option changed"
+        )),
+        ('multiple options', dict(
+            dirty_properties=None,
+            dirty_project_options=['foo', 'bar'],
+            changed_dependencies=None,
+            expected_summary='options changed'
+        )),
+        ('single dependency', dict(
+            dirty_properties=None,
+            dirty_project_options=None,
+            changed_dependencies=[
+                Dependency(part_name='foo', step=steps.PULL),
+            ],
+            expected_summary="'foo' changed"
+        )),
+        ('multiple dependencies', dict(
+            dirty_properties=None,
+            dirty_project_options=None,
+            changed_dependencies=[
+                Dependency(part_name='foo', step=steps.PULL),
+                Dependency(part_name='bar', step=steps.PULL),
+            ],
+            expected_summary='dependencies changed'
+        )),
+        ('property and option', dict(
+            dirty_properties=['foo'],
+            dirty_project_options=['bar'],
+            changed_dependencies=None,
+            expected_summary="options and properties changed"
+        )),
+        ('property and dependencies', dict(
+            dirty_properties=['foo'],
+            dirty_project_options=None,
+            changed_dependencies=[
+                Dependency(part_name='bar', step=steps.PULL),
+            ],
+            expected_summary="dependencies and properties changed"
+        )),
+        ('options and dependencies', dict(
+            dirty_properties=None,
+            dirty_project_options=['foo'],
+            changed_dependencies=[
+                Dependency(part_name='bar', step=steps.PULL),
+            ],
+            expected_summary="dependencies and options changed"
+        )),
+    ]
+
+    def test_get_summary(self):
+        dirty_report = DirtyReport(
+            dirty_properties=self.dirty_properties,
+            dirty_project_options=self.dirty_project_options,
+            changed_dependencies=self.changed_dependencies)
+
+        self.assertThat(
+            dirty_report.get_summary(), Equals(self.expected_summary))

--- a/tests/unit/project_loader/test_config.py
+++ b/tests/unit/project_loader/test_config.py
@@ -155,8 +155,10 @@ class VariableExpansionTest(LoadPartBaseTest):
 
 class DependenciesTest(ProjectLoaderBaseTest):
 
-    def test_get_prereqs(self):
-        project_config = self.make_snapcraft_project(dedent("""\
+    def setUp(self):
+        super().setUp()
+
+        self.config = self.make_snapcraft_project(dedent(dedent("""\
             name: test
             version: "1"
             summary: test
@@ -165,39 +167,56 @@ class DependenciesTest(ProjectLoaderBaseTest):
             grade: stable
 
             parts:
-              main:
-                plugin: nil
+                main:
+                    plugin: nil
 
-              dependent:
-                plugin: nil
-                after: [main]
-        """))
+                dependent:
+                    plugin: nil
+                    after: [main]
 
-        self.assertFalse(project_config.parts.get_prereqs('main'))
-        self.assertThat(project_config.parts.get_prereqs('dependent'),
-                        Equals({'main'}))
+                nested-dependent:
+                    plugin: nil
+                    after: [dependent]""")))
 
-    def test_get_dependents(self):
-        project_config = self.make_snapcraft_project(dedent("""\
-            name: test
-            version: "1"
-            summary: test
-            description: test
-            confinement: strict
-            grade: stable
+    def assert_part_names(self, part_names, parts):
+        self.assertThat({p.name for p in parts}, Equals(part_names))
 
-            parts:
-              main:
-                plugin: nil
+    def test_get_dependencies(self):
+        self.assertFalse(self.config.parts.get_dependencies('main'))
+        self.assert_part_names(
+            {'main'}, self.config.parts.get_dependencies('dependent'))
+        self.assert_part_names(
+            {'dependent'}, self.config.parts.get_dependencies(
+                'nested-dependent'))
 
-              dependent:
-                plugin: nil
-                after: [main]
-        """))
+    def test_get_dependencies_recursive(self):
+        self.assertFalse(self.config.parts.get_dependencies(
+            'main', recursive=True))
+        self.assert_part_names(
+            {'main'}, self.config.parts.get_dependencies(
+                'dependent', recursive=True))
+        self.assert_part_names(
+            {'main', 'dependent'}, self.config.parts.get_dependencies(
+                'nested-dependent', recursive=True))
 
-        self.assertFalse(project_config.parts.get_dependents('dependent'))
-        self.assertThat(project_config.parts.get_dependents('main'),
-                        Equals({'dependent'}))
+    def test_get_reverse_dependencies(self):
+        self.assertFalse(self.config.parts.get_reverse_dependencies(
+            'nested-dependent'))
+        self.assert_part_names(
+            {'nested-dependent'}, self.config.parts.get_reverse_dependencies(
+                'dependent'))
+        self.assert_part_names(
+            {'dependent'}, self.config.parts.get_reverse_dependencies('main'))
+
+    def test_get_reverse_dependencies_recursive(self):
+        self.assertFalse(self.config.parts.get_reverse_dependencies(
+            'nested-dependent', recursive=True))
+        self.assert_part_names(
+            {'nested-dependent'}, self.config.parts.get_reverse_dependencies(
+                'dependent', recursive=True))
+        self.assert_part_names(
+            {'dependent', 'nested-dependent'},
+            self.config.parts.get_reverse_dependencies('main', recursive=True))
 
     def test_dependency_loop(self):
         snapcraft_yaml = dedent("""\

--- a/tests/unit/states/test_state.py
+++ b/tests/unit/states/test_state.py
@@ -55,7 +55,7 @@ class StateTestCase(unit.TestCase):
         self.project = _TestProject(self.old)
         self.part_properties = self.old
 
-        self.state = _TestState(self.part_properties, self.project, [])
+        self.state = _TestState(self.part_properties, self.project)
         self.state.properties = self.old
         self.state.project_options = self.old
 

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -94,7 +94,10 @@ class ErrorFormattingTestCase(unit.TestCase):
                 'part': 'test-part',
                 'dirty_report': pluginhandler.DirtyReport(
                     changed_dependencies=[
-                        {'name': 'another-part', 'step': 'another-step'}])
+                        pluginhandler.Dependency(
+                            part_name='another-part',
+                            step=steps.PULL),
+                    ])
             },
             'expected_message': (
                 "Failed to reuse files from previous run: "
@@ -110,8 +113,13 @@ class ErrorFormattingTestCase(unit.TestCase):
                 'part': 'test-part',
                 'dirty_report': pluginhandler.DirtyReport(
                     changed_dependencies=[
-                        {'name': 'another-part1', 'step': 'another-step1'},
-                        {'name': 'another-part2', 'step': 'another-step2'}])
+                        pluginhandler.Dependency(
+                            part_name='another-part1',
+                            step=steps.PULL),
+                        pluginhandler.Dependency(
+                            part_name='another-part2',
+                            step=steps.PULL),
+                    ])
             },
             'expected_message': (
                 "Failed to reuse files from previous run: "

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -20,7 +20,7 @@ from subprocess import CalledProcessError
 from unittest import mock
 from testtools.matchers import Equals
 
-from snapcraft.internal import errors, steps
+from snapcraft.internal import errors, pluginhandler, steps
 from snapcraft.internal.meta import _errors as meta_errors
 from snapcraft.internal.repo import errors as repo_errors
 from snapcraft.storeapi import errors as store_errors
@@ -63,7 +63,8 @@ class ErrorFormattingTestCase(unit.TestCase):
             'kwargs': {
                 'step': steps.PULL,
                 'part': 'test-part',
-                'dirty_properties': ['test-property1', 'test-property2']
+                'dirty_report': pluginhandler.DirtyReport(
+                    dirty_properties=['test-property1', 'test-property2'])
             },
             'expected_message': (
                 "Failed to reuse files from previous run: "
@@ -77,7 +78,8 @@ class ErrorFormattingTestCase(unit.TestCase):
             'kwargs': {
                 'step': steps.PULL,
                 'part': 'test-part',
-                'dirty_project_options': ['test-option']
+                'dirty_report': pluginhandler.DirtyReport(
+                    dirty_project_options=['test-option'])
             },
             'expected_message': (
                 "Failed to reuse files from previous run: "
@@ -90,8 +92,9 @@ class ErrorFormattingTestCase(unit.TestCase):
             'kwargs': {
                 'step': steps.PULL,
                 'part': 'test-part',
-                'changed_dependencies': [
-                    {'name': 'another-part', 'step': 'another-step'}]
+                'dirty_report': pluginhandler.DirtyReport(
+                    changed_dependencies=[
+                        {'name': 'another-part', 'step': 'another-step'}])
             },
             'expected_message': (
                 "Failed to reuse files from previous run: "
@@ -105,10 +108,10 @@ class ErrorFormattingTestCase(unit.TestCase):
             'kwargs': {
                 'step': steps.PULL,
                 'part': 'test-part',
-                'changed_dependencies': [
-                    {'name': 'another-part1', 'step': 'another-step1'},
-                    {'name': 'another-part2', 'step': 'another-step2'},
-                ]
+                'dirty_report': pluginhandler.DirtyReport(
+                    changed_dependencies=[
+                        {'name': 'another-part1', 'step': 'another-step1'},
+                        {'name': 'another-part2', 'step': 'another-step2'}])
             },
             'expected_message': (
                 "Failed to reuse files from previous run: "
@@ -557,6 +560,16 @@ class ErrorFormattingTestCase(unit.TestCase):
             'expected_message': (
                 "The 'test-part-name' part has run through its entire "
                 "lifecycle"
+            )
+        }),
+        ('StepHasNotRunError', {
+            'exception': errors.StepHasNotRunError,
+            'kwargs': {
+                'part_name': 'test-part-name',
+                'step': steps.BUILD,
+            },
+            'expected_message': (
+                "The 'test-part-name' part has not yet run the 'build' step"
             )
         }),
         ('ScriptletDuplicateFieldError', {


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently the only way parts know they're dirty from dependency changes is if the lifecycle tells them so. This is a very error-prone approach, since if the lifecycle forgets to tell the part, then it doesn't know it needs to be cleaned. This PR fixes [LP: #1778081](https://bugs.launchpad.net/snapcraft/+bug/1778081) by automatically detecting changes instead of noting them in code, which also simplifies the upcoming feature of detecting source changes.

Note that this PR breaks backward state compatibility with #2152 (i.e. running on trees made dirty since then will break). This was judged to be acceptable based on the fact that it has not yet been contained in a release.