### PR TITLE
{catkin,python} plugin: support cleaning

### DIFF
--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -195,7 +195,7 @@ class PythonPlugin(snapcraft.BasePlugin):
         # Pip requires only the major version of python rather than the command
         # name like our option requires.
         match = re.match(
-            'python(?P<major_version>\d).*', self.options.python_version)
+            r'python(?P<major_version>\d).*', self.options.python_version)
         if not match:
             raise UnsupportedPythonVersionError(
                 python_version=self.options.python_version)

--- a/tests/integration/plugins_python/test_python_plugin.py
+++ b/tests/integration/plugins_python/test_python_plugin.py
@@ -256,3 +256,25 @@ class PythonPluginTestCase(integration.TestCase):
             self.run_snapcraft('stage')
         except subprocess.CalledProcessError:
             self.fail('These parts should not have conflicted')
+
+    def test_python_part_can_be_cleaned(self):
+        # Regression test for LP: #1778716
+
+        snapcraft_yaml = fixture_setup.SnapcraftYaml(self.path)
+        snapcraft_yaml.update_part('python-part', {
+            'plugin': 'python',
+            'source': '.',
+        })
+        snapcraft_yaml.update_part('dummy-part', {
+            'plugin': 'nil',
+        })
+        self.useFixture(snapcraft_yaml)
+
+        # First stage both parts
+        self.run_snapcraft('stage')
+
+        # Now clean the python one, which should succeed
+        try:
+            self.run_snapcraft(['clean', 'python-part'])
+        except subprocess.CalledProcessError:
+            self.fail('Expected python part to clean successfully')


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Both the Catkin and Python plugins utilize the Pip class in order to clean their pull steps (specifically, they tell the Pip class to clean its packages). However, when cleaning the pull step, Python has already been removed from the installdir, which means the Pip class cannot be instantiated, causing an error about being unable to find Python.

It's reasonable to ask Pip to clean any fetched packages, and doing so doesn't require Python. This PR fixes LP: [#1778716](https://bugs.launchpad.net/snapcraft/+bug/1778716) by lazily looking for Python only when it's required instead of upon class instantiation.