### PR TITLE
build_providers: inject snaps when running from a snap

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -59,10 +59,6 @@ class Provider():
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.destroy()
 
-    @abc.abstractproperty
-    def _snaps_path_or_dev(self) -> str:
-        """Return the path or device exposed in the provider to mount."""
-
     @abc.abstractmethod
     def _run(self, command: List) -> None:
         """Run a command on the instance."""
@@ -74,6 +70,10 @@ class Provider():
     @abc.abstractmethod
     def _mount(self, *, mountpoint: str, dev_or_path: str) -> None:
         """Mount a path from the host inside the instance."""
+
+    @abc.abstractmethod
+    def _mount_snaps_directory(self) -> str:
+        """Mount the host directory with snaps into the provider."""
 
     @abc.abstractmethod
     def _push_file(self, *, source: str, destination: str) -> None:
@@ -142,8 +142,7 @@ class Provider():
         # TODO make mounting requirement smarter and depend on is_installed
         if common.is_snap():
             # Make the snaps available to the provider
-            self._mount(mountpoint=self._SNAPS_MOUNTPOINT,
-                        dev_or_path=self._snaps_path_or_dev)
+            self._mount_snaps_directory()
 
         # Now install the snapcraft required base/core.
         self.echoer.info('Setting up core')

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -15,13 +15,27 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import abc
+import contextlib
+import os
 import shlex
+import subprocess
+import tempfile
 from typing import List
 
 import petname
 
+from . import errors
+from snapcraft.internal import common, repo
+
+
+_STORE_ASSERTION_KEY = (
+    'BWDEoaqyr25nF5SNCvEv2v7QnM9QsfCc0PBMYD_i2NGSQ32EF2d4D0hqUel3m8ul')
+
 
 class Provider():
+
+    _SNAPS_MOUNTPOINT = os.path.join(os.path.sep, 'var', 'cache', 'snapcraft',
+                                     'snaps')
 
     def __init__(self, *, project, echoer) -> None:
         self.project = project
@@ -45,6 +59,10 @@ class Provider():
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.destroy()
 
+    @abc.abstractproperty
+    def _snaps_path_or_dev(self) -> str:
+        """Return the path or device exposed in the provider to mount."""
+
     @abc.abstractmethod
     def _run(self, command: List) -> None:
         """Run a command on the instance."""
@@ -52,6 +70,14 @@ class Provider():
     @abc.abstractmethod
     def _launch(self):
         """Launch the instance."""
+
+    @abc.abstractmethod
+    def _mount(self, *, mountpoint: str, dev_or_path: str) -> None:
+        """Mount a path from the host inside the instance."""
+
+    @abc.abstractmethod
+    def _push_file(self, *, source: str, destination: str) -> None:
+        """Push a file into the instance."""
 
     @abc.abstractmethod
     def create(self) -> None:
@@ -68,6 +94,11 @@ class Provider():
     @abc.abstractmethod
     def provision_project(self, tarball: str) -> None:
         """Provider steps needed to copy project assests to the instance."""
+
+    @abc.abstractmethod
+    def mount_project(self) -> None:
+        """Provider steps needed to make the project available to the instance.
+        """
 
     @abc.abstractmethod
     def build_project(self) -> None:
@@ -90,5 +121,78 @@ class Provider():
     def setup_snapcraft(self) -> None:
         self.echoer.info('Setting up snapcraft in {!r}'.format(
             self.instance_name))
+        if common.is_snap():
+            self._inject_snapcraft()
+        else:
+            self._install_snapcraft()
+
+    def _install_snapcraft(self) -> None:
+        """Install snapcraft from the store."""
         install_cmd = ['sudo', 'snap', 'install', 'snapcraft', '--classic']
         self._run(install_cmd)
+
+    def _inject_snapcraft(self) -> None:
+        """Install snapcraft using local assets."""
+        # Make the snaps available to the provider
+        self._mount(mountpoint=self._SNAPS_MOUNTPOINT,
+                    dev_or_path=self._snaps_path_or_dev)
+        # TODO this should be properly fixed in snapd.
+        self.echoer.info('Waiting for pending snap auto refreshes.')
+        with contextlib.suppress(errors.ProviderExecError):
+            self._run(['sudo', 'snap', 'watch', '--last=auto-refresh'])
+        # Add the store assertion, common to all snaps.
+        self._inject_assertions([
+            ['account-key', 'public-key-sha3-384={}'.format(
+                _STORE_ASSERTION_KEY)]])
+        self.echoer.info('Setting up core')
+        self._install_snap('core')
+        self.echoer.info('Setting up snapcraft')
+        self._install_snap('snapcraft')
+
+    def _inject_assertions(self, assertions: List[List[str]]):
+        with tempfile.NamedTemporaryFile() as assertion_file:
+            for assertion in assertions:
+                assertion_file.write(
+                    subprocess.check_output(['snap', 'known', *assertion]))
+                assertion_file.write(b'\n')
+            assertion_file.flush()
+
+            self._push_file(source=assertion_file.name,
+                            destination=assertion_file.name)
+            self._run(['sudo', 'snap', 'ack', assertion_file.name])
+
+    def _inject_snap(self, snap_file_path: str, *, is_dangerous: bool,
+                     is_classic: bool) -> None:
+        # Install: will do nothing if already installed
+        args = []
+        if is_dangerous:
+            args.append('--dangerous')
+        if is_classic:
+            args.append('--classic')
+
+        self._run(['sudo', 'snap', 'install', snap_file_path] + args)
+
+    def _install_snap(self, snap_name: str) -> None:
+        snap = repo.snaps.SnapPackage(snap_name)
+        if not snap.installed:
+            raise repo.errors.SnapFindError(snap_name=snap_name)
+        snap_info = snap.get_local_snap_info()
+        snap_id = snap_info['id']
+        snap_rev = snap_info['revision']
+        is_classic = snap_info['confinement'] == 'classic'
+        is_dangerous = snap_rev.startswith('x')
+
+        if not is_dangerous:
+            self._inject_assertions([
+                ['snap-declaration', 'snap-name={}'.format(snap_name)],
+                ['snap-revision', 'snap-revision={}'.format(snap_rev),
+                 'snap-id={}'.format(snap_id)],
+            ])
+
+        # https://github.com/snapcore/snapd/blob/master/snap/info.go
+        # MountFile
+        snap_file_name = '{}_{}.snap'.format(snap_name, snap_rev)
+        snap_file_path = os.path.join(self._SNAPS_MOUNTPOINT, snap_file_name)
+        self._inject_snap(snap_file_path,
+                          is_classic=is_classic,
+                          is_dangerous=is_dangerous)

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -16,6 +16,7 @@
 
 import abc
 import contextlib
+import datetime
 import os
 import shlex
 import tempfile
@@ -118,7 +119,12 @@ class Provider():
         self._launch()
 
     def _disable_and_wait_for_refreshes(self):
-        # Auto refresh may kick in at any moment
+        # Disable autorefresh for 15 minutes,
+        # https://github.com/snapcore/snapd/pull/5436/files
+        now_plus_15 = datetime.datetime.now() + datetime.timedelta(minutes=15)
+        self._run(['sudo', 'snap', 'set', 'core', 'refresh.hold={}Z'.format(
+            now_plus_15.isoformat())])
+        # Auto refresh may have kicked in while setting the hold.
         self.echoer.info('Waiting for pending snap auto refreshes.')
         with contextlib.suppress(errors.ProviderExecError):
             self._run(['sudo', 'snap', 'watch', '--last=auto-refresh'])

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -25,12 +25,6 @@ from ._multipass_command import MultipassCommand
 class Multipass(Provider):
     """A multipass provider for snapcraft to execute its lifecycle."""
 
-    @property
-    def _snaps_path_or_dev(self) -> str:
-        # https://github.com/snapcore/snapd/blob/master/dirs/dirs.go
-        # CoreLibExecDir
-        return os.path.join(os.path.sep, 'var', 'lib', 'snapd', 'snaps')
-
     def _run(self, command) -> None:
         self._multipass_cmd.execute(instance_name=self.instance_name,
                                     command=command)
@@ -42,6 +36,12 @@ class Multipass(Provider):
     def _mount(self, *, mountpoint: str, dev_or_path: str) -> None:
         target = '{}:{}'.format(self.instance_name, mountpoint)
         self._multipass_cmd.mount(source=dev_or_path, target=target)
+
+    def _mount_snaps_directory(self) -> None:
+        # https://github.com/snapcore/snapd/blob/master/dirs/dirs.go
+        # CoreLibExecDir
+        path = os.path.join(os.path.sep, 'var', 'lib', 'snapd', 'snaps')
+        self._mount(mountpoint=self._SNAPS_MOUNTPOINT, dev_or_path=path)
 
     def _push_file(self, *, source: str, destination: str) -> None:
         destination = '{}:{}'.format(self.instance_name, destination)

--- a/snapcraft/internal/build_providers/_multipass/_multipass_command.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass_command.py
@@ -124,6 +124,22 @@ class MultipassCommand:
                 command=command,
                 exit_code=process_error.returncode) from process_error
 
+    def mount(self, *, source: str, target: str) -> None:
+        """Passthrough for running multipass mount.
+
+        :param str source: path to the local directory to mount.
+        :param str target: mountpoint inside the instance in the form of
+                           <instance-name>:path.
+        :raises errors.ProviderMountError: when the mount operation fails.
+        """
+        cmd = [self.provider_cmd, 'mount', source, target]
+        try:
+            _run(cmd)
+        except subprocess.CalledProcessError as process_error:
+            raise errors.ProviderMountError(
+                provider_name=self.provider_name,
+                exit_code=process_error.returncode) from process_error
+
     def copy_files(self, *, source: str, destination: str) -> None:
         """Passthrough for running multipass copy-files.
 

--- a/snapcraft/internal/build_providers/errors.py
+++ b/snapcraft/internal/build_providers/errors.py
@@ -101,6 +101,17 @@ class ProviderExecError(_SnapcraftError):
                          exit_code=exit_code)
 
 
+class ProviderMountError(_SnapcraftError):
+
+    fmt = (
+        'An error occurred when trying to mount using {provider_name!r}: '
+        'returned exit code {exit_code!r}.'
+    )
+
+    def __init__(self, *, provider_name: str, exit_code: int) -> None:
+        super().__init__(provider_name=provider_name, exit_code=exit_code)
+
+
 class ProviderFileCopyError(_SnapcraftError):
 
     fmt = (

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2017 Canonical Ltd
+# Copyright (C) 2015-2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -13,6 +13,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Sequence
 
 from snapcraft.internal.os_release import OsRelease
 from ._platform import _is_deb_based
@@ -136,6 +138,16 @@ class SnapInstallError(RepoError):
 
     def __init__(self, *, snap_name, snap_channel):
         super().__init__(snap_name=snap_name, snap_channel=snap_channel)
+
+
+class SnapGetAssertionError(RepoError):
+
+    fmt = ('Error while retrieving assertion with parameters '
+           '{assertion_params!r}\n'
+           'Verify the assertion exists and try again.')
+
+    def __init__(self, *, assertion_params: Sequence[str]) -> None:
+        super().__init__(assertion_params=assertion_params)
 
 
 class SnapRefreshError(RepoError):

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -120,6 +120,15 @@ class SnapUnavailableError(RepoError):
         super().__init__(snap_name=snap_name, snap_channel=snap_channel)
 
 
+class SnapFindError(RepoError):
+
+    fmt = ('Could not find the snap {snap_name!r} installed on this host.\n'
+           'Install the snap and try again.')
+
+    def __init__(self, *, snap_name):
+        super().__init__(snap_name=snap_name)
+
+
 class SnapInstallError(RepoError):
 
     fmt = ('Error while installing snap {snap_name!r} from channel '

--- a/snapcraft/internal/repo/snaps.py
+++ b/snapcraft/internal/repo/snaps.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017 Canonical Ltd
+# Copyright (C) 2017-2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -17,6 +17,7 @@ import contextlib
 import logging
 import sys
 from subprocess import check_call, check_output, CalledProcessError
+from typing import Sequence
 from urllib import parse
 
 import requests_unixsocket
@@ -224,6 +225,20 @@ def _snap_command_requires_sudo():
         logger.warning('snapd is not logged in, snap install '
                        'commands will use sudo')
     return requires_root
+
+
+def get_assertion(assertion_params: Sequence[str]) -> bytes:
+    """Get assertion information.
+
+    :param assertion_params: a sequence of strings to pas to 'snap known'.
+    :returns: a stream of bytes from the assertion.
+    :rtype: bytes
+    """
+    try:
+        return check_output(['snap', 'known', *assertion_params])
+    except CalledProcessError as call_error:
+        raise errors.SnapGetAssertionError(
+            assertion_params=assertion_params) from call_error
 
 
 def get_installed_snaps():

--- a/snapcraft/internal/repo/snaps.py
+++ b/snapcraft/internal/repo/snaps.py
@@ -230,7 +230,7 @@ def _snap_command_requires_sudo():
 def get_assertion(assertion_params: Sequence[str]) -> bytes:
     """Get assertion information.
 
-    :param assertion_params: a sequence of strings to pas to 'snap known'.
+    :param assertion_params: a sequence of strings to pass to 'snap known'.
     :returns: a stream of bytes from the assertion.
     :rtype: bytes
     """

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -40,3 +40,7 @@ class BaseProviderBaseTest(unit.TestCase):
             snapcraft_yaml_file_path=snapcraft_yaml_file_path)
 
         self.echoer_mock = mock.Mock()
+
+        patcher = mock.patch('snapcraft.internal.repo.snaps.get_assertion')
+        self.get_assertion_mock = patcher.start()
+        self.addCleanup(patcher.stop)

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -17,6 +17,7 @@
 from textwrap import dedent
 from unittest import mock
 
+from tests.unit import fixture_setup
 from tests.unit.build_providers import BaseProviderBaseTest
 from snapcraft.internal.build_providers import errors
 from snapcraft.internal.build_providers._multipass import (
@@ -76,6 +77,22 @@ class MultipassTest(BaseProviderBaseTest):
             _DEFAULT_INSTANCE_INFO.encode()
 
     def test_instance_with_contextmanager(self):
+        fake_snapd = fixture_setup.FakeSnapd()
+        self.useFixture(fake_snapd)
+        fake_snapd.snaps_result = []
+        fake_snapd.find_result = [
+            {'core': {'id': '2kkitQ', 'channels': {'latest/stable': {
+                'confinement': 'strict',
+                'revision': '123'}}}},
+            {'snapcraft': {'id': '3lljuR', 'channels': {'latest/stable': {
+                'confinement': 'classic',
+                'revision': '345'}}}},
+        ]
+
+        self.get_assertion_mock.side_effect = [
+            b'fake-assertion-account-store',
+        ]
+
         with Multipass(project=self.project,
                        echoer=self.echoer_mock) as instance:
             instance.provision_project('source.tar')
@@ -87,8 +104,17 @@ class MultipassTest(BaseProviderBaseTest):
         self.multipass_cmd_mock().execute.assert_has_calls([
             mock.call(
                 instance_name=self.instance_name,
-                command=['sudo', 'snap', 'install', 'snapcraft',
-                         '--classic']),
+                command=['sudo', 'snap', 'watch', '--last=auto-refresh']),
+            mock.call(
+                instance_name=self.instance_name,
+                command=['sudo', 'snap', 'ack', mock.ANY]),
+            mock.call(
+                instance_name=self.instance_name,
+                command=['sudo', 'snap', 'install', 'core']),
+            mock.call(
+                instance_name=self.instance_name,
+                command=['sudo', 'snap', 'install', '--classic',
+                         'snapcraft']),
             mock.call(
                 instance_name=self.instance_name,
                 command=['mkdir', 'project-name']),

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -104,6 +104,9 @@ class MultipassTest(BaseProviderBaseTest):
         self.multipass_cmd_mock().execute.assert_has_calls([
             mock.call(
                 instance_name=self.instance_name,
+                command=['sudo', 'snap', 'set', 'core', mock.ANY]),
+            mock.call(
+                instance_name=self.instance_name,
                 command=['sudo', 'snap', 'watch', '--last=auto-refresh']),
             mock.call(
                 instance_name=self.instance_name,

--- a/tests/unit/build_providers/multipass/test_multipass_command.py
+++ b/tests/unit/build_providers/multipass/test_multipass_command.py
@@ -162,6 +162,33 @@ class MultipassCommandDeleteTest(MultipassCommandPassthroughBaseTest):
         self.check_output_mock.assert_not_called()
 
 
+class MultipassCommandMountTest(MultipassCommandPassthroughBaseTest):
+
+    def test_mount(self):
+        source = 'mountpath'
+        target = '{}/mountpoint'.format(self.instance_name)
+        self.multipass_command.mount(source=source,
+                                     target=target)
+
+        self.check_call_mock.assert_called_once_with([
+            'multipass', 'mount', source, target
+        ])
+        self.check_output_mock.assert_not_called()
+
+    def test_mount_fails(self):
+        source = 'mountpath'
+        target = '{}/mountpoint'.format(self.instance_name)
+        cmd = ['multipass', 'mount', source, target]
+        self.check_call_mock.side_effect = subprocess.CalledProcessError(
+            1, cmd)
+
+        self.assertRaises(errors.ProviderMountError,
+                          self.multipass_command.mount,
+                          source=source, target=target)
+        self.check_call_mock.assert_called_once_with(cmd)
+        self.check_output_mock.assert_not_called()
+
+
 class MultipassCommandCopyFilesTest(MultipassCommandPassthroughBaseTest):
 
     def test_copy_files(self):

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from unittest.mock import Mock, call, patch, ANY
+from unittest.mock import Mock, call, ANY
 
 import fixtures
 from testtools.matchers import Equals
@@ -82,14 +82,38 @@ class BaseProviderTest(BaseProviderBaseTest):
 class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
 
     def test_setup_snapcraft_non_snap(self):
+        fake_snapd = fixture_setup.FakeSnapd()
+        self.useFixture(fake_snapd)
+        fake_snapd.snaps_result = []
+        fake_snapd.find_result = [
+            {'core': {'id': '2kkitQ', 'channels': {'latest/stable': {
+                'confinement': 'strict',
+                'revision': '123'}}}},
+            {'snapcraft': {'id': '3lljuR', 'channels': {'latest/stable': {
+                'confinement': 'classic',
+                'revision': '345'}}}},
+        ]
+
+        self.get_assertion_mock.side_effect = [
+            b'fake-assertion-account-store',
+        ]
+
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
         provider.setup_snapcraft()
 
         provider.launch_mock.assert_not_called()
-        provider.run_mock.assert_called_once_with(
-            ['sudo', 'snap', 'install', 'snapcraft', '--classic'])
-        self.echoer_mock.info.assert_called_once_with(
-            'Setting up snapcraft in {!r}'.format(self.instance_name))
+        provider.run_mock.assert_has_calls([
+            call(['sudo', 'snap', 'watch', '--last=auto-refresh']),
+            call(['sudo', 'snap', 'ack', ANY]),
+            call(['sudo', 'snap', 'install', 'core']),
+            call(['sudo', 'snap', 'install', '--classic', 'snapcraft']),
+        ])
+        self.echoer_mock.info.assert_has_calls([
+            call('Waiting for pending snap auto refreshes.'),
+            call('Setting up snapcraft in {!r}'.format(self.instance_name)),
+            call('Setting up core'),
+            call('Setting up snapcraft'),
+        ])
 
     def test_setup_snapcraft_with_snap(self):
         self.useFixture(fixtures.EnvironmentVariable(
@@ -114,30 +138,24 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
 
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
 
-        snap_known_cmd = ['snap', 'known']
-        account_key_cmd = snap_known_cmd + [
-            'account-key', 'public-key-sha3-384={}'.format(
-                _STORE_ASSERTION_KEY)]
-        snap_decl_cmd = snap_known_cmd + ['snap-declaration']
-        snap_rev_cmd = snap_known_cmd + ['snap-revision']
-        check_output_calls = [
-            call(account_key_cmd),
-            call(snap_decl_cmd + ['snap-name=core']),
-            call(snap_rev_cmd + ['snap-revision=123', 'snap-id=2kkitQ']),
-            call(snap_decl_cmd + ['snap-name=snapcraft']),
-            call(snap_rev_cmd + ['snap-revision=345', 'snap-id=3lljuR']),
+        get_assertion_calls = [
+            call(['account-key', 'public-key-sha3-384={}'.format(
+                _STORE_ASSERTION_KEY)]),
+            call(['snap-declaration', 'snap-name=core']),
+            call(['snap-revision', 'snap-revision=123', 'snap-id=2kkitQ']),
+            call(['snap-declaration', 'snap-name=snapcraft']),
+            call(['snap-revision', 'snap-revision=345', 'snap-id=3lljuR']),
         ]
 
-        with patch('subprocess.check_output') as check_output_mock:
-            check_output_mock.side_effect = [
-                b'fake-assertion-account-store',
-                b'fake-assertion-declaration-core',
-                b'fake-assertion-revision-core-123',
-                b'fake-assertion-declaration-snapcraft',
-                b'fake-assertion-revision-snapcraft-345',
-            ]
-            provider.setup_snapcraft()
-            check_output_mock.assert_has_calls(check_output_calls)
+        self.get_assertion_mock.side_effect = [
+            b'fake-assertion-account-store',
+            b'fake-assertion-declaration-core',
+            b'fake-assertion-revision-core-123',
+            b'fake-assertion-declaration-snapcraft',
+            b'fake-assertion-revision-snapcraft-345',
+        ]
+        provider.setup_snapcraft()
+        self.get_assertion_mock.assert_has_calls(get_assertion_calls)
 
         provider.launch_mock.assert_not_called()
         provider.run_mock.assert_has_calls([
@@ -148,8 +166,8 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
                   '/var/cache/snapcraft/snaps/core_123.snap']),
             call(['sudo', 'snap', 'ack', ANY]),
             call(['sudo', 'snap', 'install',
-                  '/var/cache/snapcraft/snaps/snapcraft_345.snap',
-                  '--classic']),
+                  '--classic',
+                  '/var/cache/snapcraft/snaps/snapcraft_345.snap']),
         ])
         provider.mount_mock.assert_called_once_with(
             dev_or_path='snaps-dev', mountpoint='/var/cache/snapcraft/snaps')
@@ -177,26 +195,20 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
 
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
 
-        snap_known_cmd = ['snap', 'known']
-        account_key_cmd = snap_known_cmd + [
-            'account-key', 'public-key-sha3-384={}'.format(
-                _STORE_ASSERTION_KEY)]
-        snap_decl_cmd = snap_known_cmd + ['snap-declaration']
-        snap_rev_cmd = snap_known_cmd + ['snap-revision']
-        check_output_calls = [
-            call(account_key_cmd),
-            call(snap_decl_cmd + ['snap-name=core']),
-            call(snap_rev_cmd + ['snap-revision=123', 'snap-id=2kkitQ']),
+        get_assertion_calls = [
+            call(['account-key', 'public-key-sha3-384={}'.format(
+                _STORE_ASSERTION_KEY)]),
+            call(['snap-declaration', 'snap-name=core']),
+            call(['snap-revision', 'snap-revision=123', 'snap-id=2kkitQ']),
         ]
 
-        with patch('subprocess.check_output') as check_output_mock:
-            check_output_mock.side_effect = [
-                b'fake-assertion-account-store',
-                b'fake-assertion-declaration-core',
-                b'fake-assertion-revision-core-123',
-            ]
-            provider.setup_snapcraft()
-            check_output_mock.assert_has_calls(check_output_calls)
+        self.get_assertion_mock.side_effect = [
+            b'fake-assertion-account-store',
+            b'fake-assertion-declaration-core',
+            b'fake-assertion-revision-core-123',
+        ]
+        provider.setup_snapcraft()
+        self.get_assertion_mock.assert_has_calls(get_assertion_calls)
 
         provider.launch_mock.assert_not_called()
         provider.run_mock.assert_has_calls([
@@ -206,8 +218,8 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
             call(['sudo', 'snap', 'install',
                   '/var/cache/snapcraft/snaps/core_123.snap']),
             call(['sudo', 'snap', 'install',
-                  '/var/cache/snapcraft/snaps/snapcraft_x1.snap',
-                  '--dangerous', '--classic']),
+                  '--dangerous', '--classic',
+                  '/var/cache/snapcraft/snaps/snapcraft_x1.snap']),
         ])
         provider.mount_mock.assert_called_once_with(
             dev_or_path='snaps-dev', mountpoint='/var/cache/snapcraft/snaps')

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -14,12 +14,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from unittest import mock
+from unittest.mock import Mock, call, patch, ANY
 
+import fixtures
 from testtools.matchers import Equals
 
 from . import BaseProviderBaseTest
-from snapcraft.internal.build_providers._base_provider import Provider
+from snapcraft.internal.build_providers._base_provider import (
+    Provider, _STORE_ASSERTION_KEY)
+from tests.unit import fixture_setup
 
 
 class ProviderImpl(Provider):
@@ -27,14 +30,22 @@ class ProviderImpl(Provider):
     def __init__(self, *, project, echoer):
         super().__init__(project=project, echoer=echoer)
 
-        self.launch_mock = mock.Mock()
-        self.run_mock = mock.Mock()
+        self.run_mock = Mock()
+        self.launch_mock = Mock()
+        self.mount_mock = Mock()
+
+    @property
+    def _snaps_path_or_dev(self):
+        return 'snaps-dev'
 
     def _run(self, command):
         self.run_mock(command)
 
     def _launch(self):
         self.launch_mock()
+
+    def _mount(self, *, mountpoint: str, dev_or_path: str):
+        self.mount_mock(mountpoint=mountpoint, dev_or_path=dev_or_path)
 
 
 class BaseProviderTest(BaseProviderBaseTest):
@@ -67,7 +78,10 @@ class BaseProviderTest(BaseProviderBaseTest):
             'Creating a build environment named '
             '{!r}'.format(self.instance_name))
 
-    def test_setup_snapcraft(self):
+
+class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
+
+    def test_setup_snapcraft_non_snap(self):
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
         provider.setup_snapcraft()
 
@@ -76,3 +90,124 @@ class BaseProviderTest(BaseProviderBaseTest):
             ['sudo', 'snap', 'install', 'snapcraft', '--classic'])
         self.echoer_mock.info.assert_called_once_with(
             'Setting up snapcraft in {!r}'.format(self.instance_name))
+
+    def test_setup_snapcraft_with_snap(self):
+        self.useFixture(fixtures.EnvironmentVariable(
+            'SNAP_NAME', 'snapcraft'))
+        self.useFixture(fixtures.EnvironmentVariable(
+            'SNAP', '/snap/snapcraft/current'))
+
+        fake_snapd = fixture_setup.FakeSnapd()
+        self.useFixture(fake_snapd)
+        fake_snapd.snaps_result = [
+            {'name': 'core',
+             'confinement': 'strict',
+             'id': '2kkitQ',
+             'channel': 'stable',
+             'revision': '123'},
+            {'name': 'snapcraft',
+             'confinement': 'classic',
+             'id': '3lljuR',
+             'channel': 'edge',
+             'revision': '345'},
+        ]
+
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+
+        snap_known_cmd = ['snap', 'known']
+        account_key_cmd = snap_known_cmd + [
+            'account-key', 'public-key-sha3-384={}'.format(
+                _STORE_ASSERTION_KEY)]
+        snap_decl_cmd = snap_known_cmd + ['snap-declaration']
+        snap_rev_cmd = snap_known_cmd + ['snap-revision']
+        check_output_calls = [
+            call(account_key_cmd),
+            call(snap_decl_cmd + ['snap-name=core']),
+            call(snap_rev_cmd + ['snap-revision=123', 'snap-id=2kkitQ']),
+            call(snap_decl_cmd + ['snap-name=snapcraft']),
+            call(snap_rev_cmd + ['snap-revision=345', 'snap-id=3lljuR']),
+        ]
+
+        with patch('subprocess.check_output') as check_output_mock:
+            check_output_mock.side_effect = [
+                b'fake-assertion-account-store',
+                b'fake-assertion-declaration-core',
+                b'fake-assertion-revision-core-123',
+                b'fake-assertion-declaration-snapcraft',
+                b'fake-assertion-revision-snapcraft-345',
+            ]
+            provider.setup_snapcraft()
+            check_output_mock.assert_has_calls(check_output_calls)
+
+        provider.launch_mock.assert_not_called()
+        provider.run_mock.assert_has_calls([
+            call(['sudo', 'snap', 'watch', '--last=auto-refresh']),
+            call(['sudo', 'snap', 'ack', ANY]),
+            call(['sudo', 'snap', 'ack', ANY]),
+            call(['sudo', 'snap', 'install',
+                  '/var/cache/snapcraft/snaps/core_123.snap']),
+            call(['sudo', 'snap', 'ack', ANY]),
+            call(['sudo', 'snap', 'install',
+                  '/var/cache/snapcraft/snaps/snapcraft_345.snap',
+                  '--classic']),
+        ])
+        provider.mount_mock.assert_called_once_with(
+            dev_or_path='snaps-dev', mountpoint='/var/cache/snapcraft/snaps')
+
+    def test_setup_snapcraft_with_dangerous_snap(self):
+        self.useFixture(fixtures.EnvironmentVariable(
+            'SNAP_NAME', 'snapcraft'))
+        self.useFixture(fixtures.EnvironmentVariable(
+            'SNAP', '/snap/snapcraft/current'))
+
+        fake_snapd = fixture_setup.FakeSnapd()
+        self.useFixture(fake_snapd)
+        fake_snapd.snaps_result = [
+            {'name': 'core',
+             'confinement': 'strict',
+             'id': '2kkitQ',
+             'channel': 'stable',
+             'revision': '123'},
+            {'name': 'snapcraft',
+             'confinement': 'classic',
+             'id': '3lljuR',
+             'channel': 'edge',
+             'revision': 'x1'},
+        ]
+
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+
+        snap_known_cmd = ['snap', 'known']
+        account_key_cmd = snap_known_cmd + [
+            'account-key', 'public-key-sha3-384={}'.format(
+                _STORE_ASSERTION_KEY)]
+        snap_decl_cmd = snap_known_cmd + ['snap-declaration']
+        snap_rev_cmd = snap_known_cmd + ['snap-revision']
+        check_output_calls = [
+            call(account_key_cmd),
+            call(snap_decl_cmd + ['snap-name=core']),
+            call(snap_rev_cmd + ['snap-revision=123', 'snap-id=2kkitQ']),
+        ]
+
+        with patch('subprocess.check_output') as check_output_mock:
+            check_output_mock.side_effect = [
+                b'fake-assertion-account-store',
+                b'fake-assertion-declaration-core',
+                b'fake-assertion-revision-core-123',
+            ]
+            provider.setup_snapcraft()
+            check_output_mock.assert_has_calls(check_output_calls)
+
+        provider.launch_mock.assert_not_called()
+        provider.run_mock.assert_has_calls([
+            call(['sudo', 'snap', 'watch', '--last=auto-refresh']),
+            call(['sudo', 'snap', 'ack', ANY]),
+            call(['sudo', 'snap', 'ack', ANY]),
+            call(['sudo', 'snap', 'install',
+                  '/var/cache/snapcraft/snaps/core_123.snap']),
+            call(['sudo', 'snap', 'install',
+                  '/var/cache/snapcraft/snaps/snapcraft_x1.snap',
+                  '--dangerous', '--classic']),
+        ])
+        provider.mount_mock.assert_called_once_with(
+            dev_or_path='snaps-dev', mountpoint='/var/cache/snapcraft/snaps')

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -34,10 +34,6 @@ class ProviderImpl(Provider):
         self.launch_mock = Mock()
         self.mount_mock = Mock()
 
-    @property
-    def _snaps_path_or_dev(self):
-        return 'snaps-dev'
-
     def _run(self, command):
         self.run_mock(command)
 
@@ -46,6 +42,10 @@ class ProviderImpl(Provider):
 
     def _mount(self, *, mountpoint: str, dev_or_path: str):
         self.mount_mock(mountpoint=mountpoint, dev_or_path=dev_or_path)
+
+    def _mount_snaps_directory(self):
+        self._mount(mountpoint=self._SNAPS_MOUNTPOINT,
+                    dev_or_path='snaps-dev')
 
 
 class BaseProviderTest(BaseProviderBaseTest):

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -103,6 +103,7 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
 
         provider.launch_mock.assert_not_called()
         provider.run_mock.assert_has_calls([
+            call(['sudo', 'snap', 'set', 'core', ANY]),
             call(['sudo', 'snap', 'watch', '--last=auto-refresh']),
             call(['sudo', 'snap', 'ack', ANY]),
             call(['sudo', 'snap', 'install', 'core']),
@@ -159,6 +160,7 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
 
         provider.launch_mock.assert_not_called()
         provider.run_mock.assert_has_calls([
+            call(['sudo', 'snap', 'set', 'core', ANY]),
             call(['sudo', 'snap', 'watch', '--last=auto-refresh']),
             call(['sudo', 'snap', 'ack', ANY]),
             call(['sudo', 'snap', 'ack', ANY]),
@@ -212,6 +214,7 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
 
         provider.launch_mock.assert_not_called()
         provider.run_mock.assert_has_calls([
+            call(['sudo', 'snap', 'set', 'core', ANY]),
             call(['sudo', 'snap', 'watch', '--last=auto-refresh']),
             call(['sudo', 'snap', 'ack', ANY]),
             call(['sudo', 'snap', 'ack', ANY]),

--- a/tests/unit/build_providers/test_errors.py
+++ b/tests/unit/build_providers/test_errors.py
@@ -70,6 +70,13 @@ class ErrorFormattingTest(unit.TestCase):
                 "An error occurred when trying to execute "
                 "'snap install snapcraft --classic' with 'multipass': "
                 "returned exit code 1."))),
+        ('ProviderMountError', dict(
+            exception=errors.ProviderMountError,
+            kwargs=dict(provider_name='multipass', exit_code=1),
+            expected_message=(
+                "An error occurred when trying to mount using 'multipass': "
+                "returned exit code 1."
+            ))),
         ('ProviderFileCopyError', dict(
             exception=errors.ProviderFileCopyError,
             kwargs=dict(provider_name='multipass', exit_code=1),


### PR DESCRIPTION
If running from the snapcraft snap, inject the snapcraft and its "base"
from the host to ensure parity.
If not running from the snap, install from the store.

LP: #1779137
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh unit`?

-----

An easy way to test this is to install the snap, `snap run --shell snapcraft` and then run something like the following:
```python
import os

from snapcraft.cli import echo
from snapcraft.project import Project
from snapcraft.internal.build_providers import get_provider_for

os.chdir('/home/sergiusens/source/test-project')
Provider = get_provider_for('multipass')
project = Project(snapcraft_yaml_file_path='snap/snapcraft.yaml')

p = Provider(project=project, echoer=echo)
p.create()
```

Which would result in,
```
sergiusens@tupa:~/source/snapcraft$ snap run --shell snapcraft                                     
sergiusens@tupa:~/source/snapcraft$ /snap/snapcraft/current/usr/bin/python3
Python 3.5.2 (default, Nov 23 2017, 16:37:01) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> 
>>> from snapcraft.cli import echo
>>> from snapcraft.project import Project
>>> from snapcraft.internal.build_providers import get_provider_for
>>> 
>>> os.chdir('/home/sergiusens/source/test-project')
>>> Provider = get_provider_for('multipass')
>>> project = Project(snapcraft_yaml_file_path='snap/snapcraft.yaml')
>>> 
>>> p = Provider(project=project, echoer=echo)
>>> p.create()
Creating a build environment named 'oversubtle-jeremiah'
Launched: oversubtle-jeremiah                                                   
Setting up snapcraft in 'oversubtle-jeremiah'                                   
Waiting for pending snap auto refreshes.
error: no changes of type "auto-refresh" found
Setting up core
2018-06-29T15:35:27Z INFO Waiting for restart...
core 16-2.33 from 'canonical' installed
Setting up snapcraft
snapcraft 2.42.1+git26.055e84a installed
```