### PR TITLE
pluginhandler: use uname from the host

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -573,7 +573,10 @@ class PluginHandler:
         # Use subprocess directly here. common.run_output will use binaries out
         # of the snap, and we want to use the one on the host.
         try:
-            output = subprocess.check_output(['uname', '-srvmpio'])
+            output = subprocess.check_output([
+                'uname', '--kernel-name', '--kernel-release',
+                '--kernel-version', '--machine', '--processor',
+                '--hardware-platform', '--operating-system'])
         except subprocess.CalledProcessError as e:
             logger.warning(
                 "'uname' exited with code {}: unable to record machine "

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -21,6 +21,7 @@ import filecmp
 import logging
 import os
 import shutil
+import subprocess
 import sys
 from glob import glob, iglob
 from typing import Dict, Set, Sequence  # noqa: F401
@@ -569,8 +570,11 @@ class PluginHandler:
             scriptlet_metadata=self._scriptlet_metadata[steps.BUILD]))
 
     def _get_machine_manifest(self):
+        # Use subprocess directly here. common.run_output will use binaries out
+        # of the snap, and we want to use the one on the host.
+        uname = subprocess.check_output(['uname', '-srvmpio'])
         return {
-            'uname': common.run_output(['uname', '-srvmpio']),
+            'uname': uname.decode(sys.getfilesystemencoding()).strip(),
             'installed-packages': repo.Repo.get_installed_packages(),
             'installed-snaps': repo.snaps.get_installed_snaps()
         }

--- a/tests/unit/lifecycle/test_lifecycle.py
+++ b/tests/unit/lifecycle/test_lifecycle.py
@@ -484,15 +484,15 @@ class RecordManifestBaseTestCase(LifecycleTestBase):
         patcher.start()
         self.addCleanup(patcher.stop)
 
-        original_run_output = snapcraft.internal.common.run_output
+        original_check_output = subprocess.check_output
 
         def fake_uname(cmd, *args, **kwargs):
             if 'uname' in cmd:
-                return 'Linux test uname 4.10 x86_64'
+                return b'Linux test uname 4.10 x86_64'
             else:
-                return original_run_output(cmd, *args, **kwargs)
+                return original_check_output(cmd, *args, **kwargs)
         check_output_patcher = mock.patch(
-            'snapcraft.internal.common.run_output', side_effect=fake_uname)
+            'subprocess.check_output', side_effect=fake_uname)
         check_output_patcher.start()
         self.addCleanup(check_output_patcher.stop)
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Currently, when recording the manifest from the `PluginHandler`, the snapcraft CLI runs `uname` using `common.run_output`, which is made for running binaries out of parts or the staging area. That's never desired in this case, so this PR fixes LP: [#1780825](https://bugs.launchpad.net/snapcraft/+bug/1780825) by using `subprocess` directly to always run `uname` from the host.