### PR TITLE
lifecycle: pass commands to containerbuild, not steps

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -25,15 +25,16 @@ from snapcraft.internal import (deprecations, lifecycle, lxd, project_loader,
 from snapcraft.project.errors import YamlValidationError
 
 
-def _execute(command, parts, **kwargs):
+def _execute(step: steps.Step, parts, **kwargs):
     project = get_project(**kwargs)
     project_config = project_loader.load_config(project)
     build_environment = env.BuilderEnvironmentConfig()
 
     if build_environment.is_host:
-        lifecycle.execute(command, project_config, parts)
+        lifecycle.execute(step, project_config, parts)
     else:
-        lifecycle.containerbuild(command, project_config, parts)
+        # containerbuild takes a snapcraft command name, not a step
+        lifecycle.containerbuild(step.name, project_config, parts)
     return project
 
 

--- a/snapcraft/internal/lifecycle/_containers.py
+++ b/snapcraft/internal/lifecycle/_containers.py
@@ -38,7 +38,7 @@ def _create_tar_filter(tar_filename):
     return _tar_filter
 
 
-def containerbuild(command, project_config, output=None, args=None):
+def containerbuild(command: str, project_config, output=None, args=None):
     if args is None:
         args = []
 

--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -182,7 +182,7 @@ class Containerbuild:
             'environment.SNAPCRAFT_IMAGE_INFO',
             json.dumps(edited_image_info)])
 
-    def execute(self, step='snap', args=None):
+    def execute(self, step: str='snap', args=None):
         with self._container_running():
             self._setup_project()
             command = ['snapcraft', step]
@@ -225,6 +225,10 @@ class Containerbuild:
             else:
                 raise errors.ContainerRunError(command=original_cmd,
                                                exit_code=e.returncode)
+
+    def _setup_project(self):
+        # Must be implemented by subclasses
+        raise NotImplementedError
 
     def _wait_for_network(self):
         logger.info('Waiting for a network connection...')

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -507,6 +507,7 @@ class SnapCommandWithContainerBuildTestCase(SnapCommandBaseTestCase):
             call(['python3', '-c', mock.ANY]),
             call(['apt-get', 'update']),
             call(['apt-get', 'install', 'squashfuse', '-y']),
+            call(['snapcraft', 'prime'], cwd=mock.ANY, user=mock.ANY),
         ])
 
         self.pack_mock.assert_called_once_with(self.prime_dir, None)
@@ -540,6 +541,7 @@ class SnapCommandWithContainerBuildTestCase(SnapCommandBaseTestCase):
         ])
         mock_container_run.assert_has_calls([
             call(['python3', '-c', mock.ANY]),
+            call(['snapcraft', 'prime'], cwd=mock.ANY, user=mock.ANY),
         ])
 
         self.pack_mock.assert_called_once_with(self.prime_dir, None)
@@ -601,6 +603,7 @@ class SnapCommandWithContainerBuildTestCase(SnapCommandBaseTestCase):
         ])
         mock_container_run.assert_has_calls([
             call(['python3', '-c', mock.ANY]),
+            call(['snapcraft', 'prime'], cwd=mock.ANY, user=mock.ANY),
         ])
         # Ensure there's no unexpected calls eg. two network checks
         self.assertThat(mock_container_run.call_count, Equals(2))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

The snapcraft CLI recently switched from using hard-coded strings as lifecycle steps to an actual class. Unfortunately, containerbuilds also started using them, but they were never actually written to operate on steps: they require snapcraft commands instead. Sadly, this was never enshrined in tests.

This PR fixes [LP: #1780997](https://bugs.launchpad.net/snapcraft/+bug/1780997) by continuing to use string commands for containerbuilds, and adds tests to ensure things continue working that way.