### PR TITLE
cli: SNAPCRAFT_BUILD_ENVIRONMENT isn't deprecated

### DIFF
--- a/snapcraft/cli/env.py
+++ b/snapcraft/cli/env.py
@@ -73,7 +73,7 @@ class BuilderEnvironmentConfig:
             raise errors.SnapcraftEnvironmentError(
                 'SNAPCRAFT_BUILD_ENVIRONMENT and SNAPCRAFT_CONTAINER_BUILDS '
                 'cannot be used together.\n'
-                'Given that SNAPCRAFT_BUILD_ENVIRONMENT is deprecated, '
+                'Given that SNAPCRAFT_CONTAINER_BUILDS is deprecated, '
                 'unset that variable from the environment and try again.')
 
         if use_lxd:

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -200,7 +200,7 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
         self.assertThat(str(raised), Contains(
             'SNAPCRAFT_BUILD_ENVIRONMENT and SNAPCRAFT_CONTAINER_BUILDS '
             'cannot be used together.\n'
-            'Given that SNAPCRAFT_BUILD_ENVIRONMENT is deprecated, '
+            'Given that SNAPCRAFT_CONTAINER_BUILDS is deprecated, '
             'unset that variable from the environment and try again.'))
 
     def test_snap_type_os_does_not_use_all_root(self):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

SNAPCRAFT_CONTAINER_BUILDS is deprecated, but we have a confusing error message if both are provided, saying that SNAPCRAFT_BUILD_ENVIRONMENT is the one that's deprecated. Fix this to say that SNAPCRAFT_CONTAINER_BUILDS is the one that's deprecated.