### PR TITLE
store: properly handle disabled deltas

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -624,6 +624,8 @@ def _push_delta(snap_name, snap_filename, source_snap):
             raise storeapi.errors.StoreDeltaApplicationError(str(e))
         else:
             raise
+    except storeapi.errors.StoreServerError as e:
+        raise storeapi.errors.StorePushError(snap_name, e.response)
     finally:
         if os.path.isfile(delta_filename):
             try:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

In 2.41, the snapcraft CLI properly handled the situation of deltas being disabled on the store, which returned a 501. However, there was no test for this, which means as of 2.42.1, the behavior has regressed. This PR fixes [LP: #1780851](https://bugs.launchpad.net/snapcraft/+bug/1780851) by by properly handling 501s when pushing deltas.