### PR TITLE
cli: reserve the --debug option for snapcraft projects

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -89,3 +89,7 @@ snap run:
 e.g.; to update the list for 16.04,
 
     ./libraries/generate_lib_list.py libraries/16.04
+
+### Enabling debug output
+
+Given that the `--debug` option in snapcraft is reserved for project specific debugging, enabling for the `logger.debug` calls is achieved by setting the "SNAPCRAFT_ENABLE_DEVELOPER_DEBUG" environment variable to a truthful value. Snapcraft's internal tools, e.g.; `snapraftctl` should pick up this environment variable as well.

--- a/snapcraft/cli/_runner.py
+++ b/snapcraft/cli/_runner.py
@@ -17,6 +17,7 @@ import functools
 import logging
 import os
 import sys
+from distutils import util
 
 import click
 
@@ -55,16 +56,19 @@ command_groups = [
 )
 @click.pass_context
 @add_build_options(hidden=True)
-@click.option("--debug", "-d", is_flag=True, envvar="SNAPCRAFT_DEBUG")
+@click.option("--debug", "-d", is_flag=True)
 def run(ctx, debug, catch_exceptions=False, **kwargs):
     """Snapcraft is a delightful packaging tool."""
 
-    if debug:
+    # Debugging snapcraft itself is not tied to debugging a snapcraft project.
+    try:
+        is_snapcraft_developer_debug = util.strtobool(
+            os.getenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", "n")
+        )
+    except ValueError:
+        is_snapcraft_developer_debug = False
+    if is_snapcraft_developer_debug:
         log_level = logging.DEBUG
-
-        # Setting this here so that tools run within this are also in debug
-        # mode (e.g. snapcraftctl)
-        os.environ["SNAPCRAFT_DEBUG"] = "true"
         click.echo(
             "Starting snapcraft {} from {}.".format(
                 snapcraft.__version__, os.path.dirname(__file__)

--- a/snapcraft/cli/snapcraftctl/_runner.py
+++ b/snapcraft/cli/snapcraftctl/_runner.py
@@ -28,7 +28,7 @@ from snapcraft.internal import log
 
 
 @click.group()
-@click.option("--debug", "-d", is_flag=True, envvar="SNAPCRAFT_DEBUG")
+@click.option("--debug", "-d", is_flag=True, envvar="SNAPCRAFT_ENABLE_DEVELOPER_DEBUG")
 def run(debug):
     """snapcraftctl is how snapcraft.yaml can communicate with snapcraft"""
 

--- a/tests/integration/general/test_list_plugins.py
+++ b/tests/integration/general/test_list_plugins.py
@@ -18,7 +18,7 @@ import pkgutil
 
 from snapcraft import plugins
 
-from testtools.matchers import Equals, StartsWith
+from testtools.matchers import Equals
 
 from tests import integration
 
@@ -26,9 +26,7 @@ from tests import integration
 class ListPluginsTestCase(integration.TestCase):
     def test_list_plugins(self):
         output = self.run_snapcraft("list-plugins")
-        version, plugins_list = output.split("\n", 1)
-        self.assertThat(version, StartsWith("Starting snapcraft "))
-        plugins_list = set(plugins_list.split())
+        plugins_list = set(output.split())
         expected = set()
         for _, modname, _ in pkgutil.iter_modules(plugins.__path__):
             if not modname.startswith("_"):

--- a/tests/integration/store/test_store_push_metadata.py
+++ b/tests/integration/store/test_store_push_metadata.py
@@ -17,6 +17,7 @@
 import os
 import subprocess
 
+import fixtures
 from testtools.matchers import Contains, FileExists
 
 from tests import integration
@@ -53,6 +54,10 @@ class PushMetadataTestCase(integration.StoreTestCase):
         self.addCleanup(self.logout)
         self.login()
 
+        self.useFixture(
+            fixtures.EnvironmentVariable("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", "yes")
+        )
+
         # Build and register the snap
         name, snap_file_path = self._build_snap()
         self.register(name)
@@ -70,6 +75,10 @@ class PushMetadataTestCase(integration.StoreTestCase):
     def test_no_push_needed_first(self):
         self.addCleanup(self.logout)
         self.login()
+
+        self.useFixture(
+            fixtures.EnvironmentVariable("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", "yes")
+        )
 
         # Build and register the snap
         name, snap_file_path = self._build_snap()

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -162,8 +162,10 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         self.base_environment = fixture_setup.FakeBaseEnvironment(machine=machine)
         self.useFixture(self.base_environment)
 
-        # Make sure SNAPCRAFT_DEBUG is reset between tests
-        self.useFixture(fixtures.EnvironmentVariable("SNAPCRAFT_DEBUG"))
+        # Make sure "SNAPCRAFT_ENABLE_DEVELOPER_DEBUG" is reset between tests
+        self.useFixture(
+            fixtures.EnvironmentVariable("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG")
+        )
         self.useFixture(fixture_setup.FakeSnapcraftctl())
 
     def make_snapcraft_yaml(self, content, encoding="utf-8"):

--- a/tests/unit/commands/test_push_metadata.py
+++ b/tests/unit/commands/test_push_metadata.py
@@ -17,6 +17,7 @@
 import os
 from unittest import mock
 
+import fixtures
 from testtools.matchers import Contains, Equals, Not
 
 from snapcraft import storeapi
@@ -93,9 +94,12 @@ class PushMetadataCommandTestCase(CommandBaseTestCase):
         self.mock_metadata = patcher.start()
         self.addCleanup(patcher.stop)
 
+        self.useFixture(
+            fixtures.EnvironmentVariable("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", "yes")
+        )
         # push metadata
         with mock.patch("snapcraft.storeapi._status_tracker.StatusTracker"):
-            result = self.run_command(["--debug", "push-metadata", self.snap_file])
+            result = self.run_command(["push-metadata", self.snap_file])
         self.assertThat(result.exit_code, Equals(0))
 
         self.assertThat(
@@ -152,9 +156,11 @@ class PushMetadataCommandTestCase(CommandBaseTestCase):
         self.mock_metadata = patcher.start()
         self.addCleanup(patcher.stop)
 
-        result = self.run_command(
-            ["--debug", "push-metadata", self.snap_file, "--force"]
+        self.useFixture(
+            fixtures.EnvironmentVariable("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", "yes")
         )
+
+        result = self.run_command(["push-metadata", self.snap_file, "--force"])
 
         self.assertThat(
             result.output, Contains("Pushing metadata to the Store (force=True)")


### PR DESCRIPTION
--debug has been conflated to debug snapcraft as a project itself and
snapcraft projects users of snapcraft work on. For the former we
introduce an environment variable to enable the existing debug logs
statements in the snapcraft code base.

LP: #1782772

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
