### PR TITLE
Python plugin: add process-dependency-links to the pull_properties

### DIFF
--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -117,7 +117,13 @@ class PythonPlugin(snapcraft.BasePlugin):
     def get_pull_properties(cls):
         # Inform Snapcraft of the properties associated with pulling. If these
         # change in the YAML Snapcraft will consider the pull step dirty.
-        return ["requirements", "constraints", "python-packages", "python-version"]
+        return [
+            "requirements",
+            "constraints",
+            "python-packages",
+            "process-dependency-links",
+            "python-version",
+        ]
 
     @property
     def plugin_build_packages(self):

--- a/tests/unit/plugins/test_python.py
+++ b/tests/unit/plugins/test_python.py
@@ -108,6 +108,7 @@ class PythonPluginTestCase(BasePythonPluginTestCase):
             "requirements",
             "constraints",
             "python-packages",
+            "process-dependency-links",
             "python-version",
         ]
         resulting_pull_properties = python.PythonPlugin.get_pull_properties()


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
==> Contributor form ask me for my Launchpad ID but I don't know how to get it (the link provided lead me to https://login.launchpad.net/ which show my personal details, but not this id...)
==> Contributor form also ask me for a "Project contact", no idea what to put there
- [X] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [X] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [X] Have you successfully run `./runtests.sh static`?
- [X] Have you successfully run `./runtests.sh unit`?

-----

Currently `process-dependency-links` option is not considered as a pull_properties i.e. build of this part won't be restarted if this option change. I guess this is not intended given this option do change the dependencies resolution.