### PR TITLE
Stop expecting the deprecation message in test.

### DIFF
--- a/tests/integration/store/test_store_revisions.py
+++ b/tests/integration/store/test_store_revisions.py
@@ -149,7 +149,6 @@ class RevisionsTestCase(integration.StoreTestCase):
         datetime_re = "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"
         expected = "\n".join(
             (
-                ".*",
                 "Rev.    Uploaded              Arch       Version    Channels",
                 "1       {datetime_re}  Arch: All  1          candidate\*, beta\*.*",
             )


### PR DESCRIPTION
Out of the blue we started getting this weird error in the 'Pre-merging' tests:

https://travis-ci.org/snapcore/snapcraft/builds/412858741

The proposed fix stop matching a chunk of opaque data before the revisions table. I suspect it was there for coping with the 'deprecation' message when the `history` command is used, but I can't tell for sure if anything related changed in snapcraft.
