### PR TITLE
spread: stop testing 17.10

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -14,7 +14,6 @@ backends:
   lxd:
     systems:
       - ubuntu-16.04
-      - ubuntu-17.10
       - ubuntu-18.04
   linode:
     key: "$(HOST: echo $SPREAD_LINODE_KEY)"
@@ -29,8 +28,6 @@ backends:
       - ubuntu-14.04-64:
           workers: 2
       - ubuntu-16.04-64:
-          workers: 2
-      - ubuntu-17.10-64:
           workers: 2
       - ubuntu-18.04-64:
           workers: 2


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

Ubuntu 17.10 is EOL as of July 19th, 2018. Stop testing it.