### PR TITLE
plugins: kbuild: read configs from source directory instead

### DIFF
--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -124,7 +124,7 @@ class KBuildPlugin(BasePlugin):
 
     def assemble_ubuntu_config(self, config_path):
         try:
-            with open(os.path.join("debian", "debian.env"), "r") as f:
+            with open(os.path.join(self.sourcedir, "debian", "debian.env"), "r") as f:
                 env = f.read()
         except OSError as e:
             raise RuntimeError("Unable to access {}: {}".format(e.filename, e.strerror))
@@ -136,8 +136,12 @@ class KBuildPlugin(BasePlugin):
         flavour = self.options.kconfigflavour
 
         configfiles = []
-        baseconfigdir = os.path.join("debian.{}".format(branch), "config")
-        archconfigdir = os.path.join("debian.{}".format(branch), "config", arch)
+        baseconfigdir = os.path.join(
+            self.sourcedir, "debian.{}".format(branch), "config"
+        )
+        archconfigdir = os.path.join(
+            self.sourcedir, "debian.{}".format(branch), "config", arch
+        )
         commonconfig = os.path.join(baseconfigdir, "config.common.ports")
         ubuntuconfig = os.path.join(baseconfigdir, "config.common.ubuntu")
         archconfig = os.path.join(archconfigdir, "config.common.{}".format(arch))

--- a/tests/unit/plugins/test_kernel.py
+++ b/tests/unit/plugins/test_kernel.py
@@ -963,12 +963,19 @@ ACCEPT=n
         branch = "master"
         flavour = "vanilla"
         self.options.kconfigflavour = flavour
-        os.mkdir("debian")
-        with open("debian/debian.env", "w") as f:
+
+        plugin = kernel.KernelPlugin("test-part", self.options, self.project_options)
+        self._simulate_build(plugin.sourcedir, plugin.builddir, plugin.installdir)
+
+        debiandir = os.path.join(plugin.sourcedir, "debian")
+        os.mkdir(debiandir)
+        with open(os.path.join(debiandir, "debian.env"), "w") as f:
             f.write("DEBIAN=debian.{}".format(branch))
-        os.mkdir("debian.{}".format(branch))
-        basedir = os.path.join("debian.{}".format(branch), "config")
-        archdir = os.path.join("debian.{}".format(branch), "config", arch)
+        os.mkdir(os.path.join(plugin.sourcedir, "debian.{}".format(branch)))
+        basedir = os.path.join(plugin.sourcedir, "debian.{}".format(branch), "config")
+        archdir = os.path.join(
+            plugin.sourcedir, "debian.{}".format(branch), "config", arch
+        )
         os.mkdir(basedir)
         os.mkdir(archdir)
         commoncfg = os.path.join(basedir, "config.common.ports")
@@ -984,10 +991,6 @@ ACCEPT=n
             f.write("ACCEPT=y\n")
         with open(flavourcfg, "w") as f:
             f.write("# ACCEPT is not set\n")
-
-        plugin = kernel.KernelPlugin("test-part", self.options, self.project_options)
-
-        self._simulate_build(plugin.sourcedir, plugin.builddir, plugin.installdir)
 
         plugin.build()
 


### PR DESCRIPTION
Configs should be read from source directory instead of TOPDIR, in order
to handle a remote git repo properly.

Signed-off-by: Wen-chien Jesse Sung <jesse.sung@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----
