### PR TITLE
kbuild: stop modifying kconfigfile

### DIFF
--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -174,7 +174,8 @@ class KBuildPlugin(BasePlugin):
         # elif kconfigflavour is provided, assemble the ubuntu.flavour config
         # otherwise use defconfig to seed the base config
         if self.options.kconfigfile:
-            snapcraft.file_utils.link_or_copy(self.options.kconfigfile, config_path)
+            # This file gets modified, no hard links here
+            snapcraft.file_utils.copy(self.options.kconfigfile, config_path)
         elif self.options.kconfigflavour:
             self.assemble_ubuntu_config(config_path)
         else:

--- a/tests/unit/plugins/test_kbuild.py
+++ b/tests/unit/plugins/test_kbuild.py
@@ -217,6 +217,11 @@ ACCEPT=n
 """
         self.assertThat(config_contents, Equals(expected_config))
 
+        # Finally, ensure that the original kconfigfile was not modified (it's back in
+        # the source tree)
+        with open(self.options.kconfigfile, "r") as f:
+            self.assertThat(f.read(), Equals("ACCEPT=y\n"))
+
     @mock.patch("subprocess.check_call")
     @mock.patch.object(kbuild.KBuildPlugin, "run")
     def test_build_with_defconfig_and_kconfigs(self, run_mock, check_call_mock):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh unit`?

-----

If the `kconfigfile` option is supplied, the kbuild plugin uses a hard link to put it into place. This becomes problematic if `kconfigfile` is used alongside `kconfigs`, because doing so modifies the config file, thereby modifying the original `kconfigfile` in the source tree.

This PR fixes [LP: #1786083](https://bugs.launchpad.net/snapcraft/+bug/1786083) by copying the `kconfigfile` instead of using hard links.