### PR TITLE
kernel plugin: install .config as config-$kernelversion

### DIFF
--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -531,3 +531,8 @@ class KernelPlugin(kbuild.KBuildPlugin):
                 os.path.join(self.installdir, "lib", "firmware"), self.installdir
             )
         os.rmdir(os.path.join(self.installdir, "lib"))
+        # install .config as config-$version
+        config = "config-{}".format(self.kernel_release)
+        config_path = os.path.join(self.installdir, config)
+        dot_config_path = self.get_config_path()
+        os.link(dot_config_path, config_path)


### PR DESCRIPTION
In Ubuntu classic we ship the kernel config as config-$kernelversion in /boot, and the same we do for kernel snaps available in the store: they contain the kernel config file as config-$kernelversion in the root of the kernel snap.

Unfortunately the kernel plugin never shipped the .config used to build the kernel, so fix it by installing it as config-$kernelversion in the root of the freshly generated kernel snap.

This fixes [LP1786190](https://bugs.launchpad.net/snapcraft/+bug/1786190)

Signed-off-by: Paolo Pisati <p.pisati@gmail.com>

-----
