### PR TITLE
Revert "ci: disable osx tests until a new pyyaml is released"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,10 @@ jobs:
       script: SNAPCRAFT_TEST_MOCK_MACHINE=armv7l sudo ./tools/travis/run_tests.sh tests/unit
     - if: type != cron
       script: SNAPCRAFT_TEST_MOCK_MACHINE=aarch64 sudo ./tools/travis/run_tests.sh tests/unit
-    # Disabled, LP: #1779855
-    # - stage: osx-integration-store
-    #   if: type != cron
-    #   os: osx
-    #   script: SNAPCRAFT_FROM_BREW=1 ./tools/travis/run_tests.sh tests.integration.store.test_store_login_logout use-run
+    - stage: osx-integration-store
+      if: type != cron
+      os: osx
+      script: SNAPCRAFT_FROM_BREW=1 ./tools/travis/run_tests.sh tests.integration.store.test_store_login_logout use-run
     - stage: snap
       if: type != cron
       script: sudo ./tools/travis/build_snapcraft_snap.sh


### PR DESCRIPTION
pyyaml has been released and the brew formula has been updated.

This reverts commit 75c06e46561b6f8a57b2968c44d45e647358ef0b.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
