### PR TITLE
sentry: support disabling error reporting

### DIFF
--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -158,6 +158,13 @@ def _handle_trace_output(
 
 
 def _is_send_to_sentry() -> bool:  # noqa: C901
+    # Check to see if error reporting has been disabled
+    if (
+        distutils.util.strtobool(os.getenv("SNAPCRAFT_ENABLE_ERROR_REPORTING", "y"))
+        == 0
+    ):
+        return False
+
     # Check the environment to see if we should allow for silent reporting
     if distutils.util.strtobool(os.getenv("SNAPCRAFT_ENABLE_SILENT_REPORT", "n")) == 1:
         click.echo(_MSG_SILENT_REPORT)

--- a/spread.yaml
+++ b/spread.yaml
@@ -13,6 +13,12 @@ environment:
   # nothing.
   SNAPCRAFT_CHANNEL: "$(HOST: echo ${SNAPCRAFT_CHANNEL})"
 
+  # Show error tracebacks
+  SNAPCRAFT_MANAGED_HOST: "yes"
+
+  # Disable all Sentry error reporting
+  SNAPCRAFT_ENABLE_ERROR_REPORTING: "no"
+
   SETUP_DIR: /snapcraft/tests/spread/setup
 
 backends:

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -99,7 +99,7 @@ class TestCase(testtools.TestCase):
         # Disable Sentry reporting for tests, otherwise they'll hang waiting
         # for input
         self.useFixture(
-            fixtures.EnvironmentVariable("SNAPCRAFT_ENABLE_SENTRY", "false")
+            fixtures.EnvironmentVariable("SNAPCRAFT_ENABLE_ERROR_REPORTING", "false")
         )
 
         # Note that these directories won't exist when the test starts,

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -162,7 +162,7 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         # Disable Sentry reporting for tests, otherwise they'll hang waiting
         # for input
         self.useFixture(
-            fixtures.EnvironmentVariable("SNAPCRAFT_ENABLE_SENTRY", "false")
+            fixtures.EnvironmentVariable("SNAPCRAFT_ENABLE_ERROR_REPORTING", "false")
         )
 
         machine = os.environ.get("SNAPCRAFT_TEST_MOCK_MACHINE", None)

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -56,6 +56,10 @@ class ErrorsBaseTestCase(unit.TestCase):
         self.print_exception_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
+        self.useFixture(
+            fixtures.EnvironmentVariable("SNAPCRAFT_ENABLE_ERROR_REPORTING", "yes")
+        )
+
     def call_handler(self, exception, debug):
         try:
             raise exception

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -56,10 +56,6 @@ class ErrorsBaseTestCase(unit.TestCase):
         self.print_exception_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
-        self.useFixture(
-            fixtures.EnvironmentVariable("SNAPCRAFT_ENABLE_ERROR_REPORTING", "yes")
-        )
-
     def call_handler(self, exception, debug):
         try:
             raise exception
@@ -138,6 +134,10 @@ class SendToSentryBaseTest(ErrorsBaseTestCase):
         patcher = mock.patch("snapcraft.cli._errors.RavenClient")
         self.raven_client_mock = patcher.start()
         self.addCleanup(patcher.stop)
+
+        self.useFixture(
+            fixtures.EnvironmentVariable("SNAPCRAFT_ENABLE_ERROR_REPORTING", "yes")
+        )
 
 
 class SendToSentryIsYesTest(SendToSentryBaseTest):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

We recently regressed on #2154 by removing the ability to disable Sentry, which can cause tests to hang. Add this ability back.