### PR TITLE
schema: allow license field

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -156,6 +156,9 @@ properties:
   description:
     type: string
     description: long description of the package
+  license:
+    type: string
+    description: SPDX conform license of the package
   assumes:
     type: array
     description: featureset the snap requires in order to work.


### PR DESCRIPTION
We want snaps to also allow setting a license field. This was
discussed in https://forum.snapcraft.io/t/856/53

We got customer complains that `snap info core` shows
`license: unset` for locally installed snaps.

So it would be great if snapcraft could start allowing this.

When using `snap pack` this will also be validated.