### PR TITLE
spread: stop running catkin tests on 18.10

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -34,7 +34,7 @@ backends:
           workers: 3
   google:
     key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
-    location: computeengine/us-west1-b
+    location: computeengine/us-east1-b
     systems:
       - ubuntu-14.04-64:
           workers: 3

--- a/tests/spread/plugins/catkin/run/task.yaml
+++ b/tests/spread/plugins/catkin/run/task.yaml
@@ -12,7 +12,7 @@ restore: |
 
 # ROS Indigo doesn't support arm64 (there are no packages in the archive). Also,
 # Indigo snaps have trouble building past 16.04.
-systems: [-ubuntu-*-arm64, -ubuntu-18.04*]
+systems: [-ubuntu-*-arm64, -ubuntu-18*]
 
 execute: |
   cd "$SNAP_DIR"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Also switch Google zones to us-east1-b.