### PR TITLE
storeapi: handle releasing to curly braced branch

### DIFF
--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -440,15 +440,18 @@ class StoreReleaseError(StoreError):
 
     def __fmt_error_400(self, response):
         response_json = self.__to_json(response)
-
         try:
             fmt = ""
             for error in response_json["error_list"]:
-                fmt += self.__FMT_BAD_REQUEST.format(**error)
+                # Escape curly braces to avoid formatting errors.
+                message = error["message"].replace("{", "{{").replace("}", "}}")
+                code = error["code"].replace("{", "{{").replace("}", "}}")
+                fmt += self.__FMT_BAD_REQUEST.format(code=code, message=message)
+            # Strip the last new line from the error message
+            fmt = fmt.rstrip("\n")
 
         except (AttributeError, KeyError):
             fmt = self.__fmt_error_unknown(response)
-
         return fmt
 
     def __fmt_error_401_or_403(self, response):

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -491,7 +491,7 @@ class FakeStoreAPIServer(base.BaseFakeServer):
             payload, response_code, [("Content-Type", content_type)]
         )
 
-    def snap_release(self, request):
+    def snap_release(self, request):  # noqa: C901
         if self.fake_store.needs_refresh:
             return self._refresh_error()
         logger.debug(
@@ -509,6 +509,21 @@ class FakeStoreAPIServer(base.BaseFakeServer):
         elif "alpha" in channels:
             response_code = 400
             payload = json.dumps({"errors": "Not a valid channel: alpha"}).encode()
+        elif "edge/{curly}" in channels:
+            response_code = 400
+            payload = json.dumps(
+                {
+                    "error_list": [
+                        {
+                            "message": (
+                                "Invalid branch name: {curly}. Enter a value consisting of letters, numbers or hyphens. "
+                                "Hyphens cannot occur at the start or end of the chosen value."
+                            ),
+                            "code": "invalid-field",
+                        }
+                    ]
+                }
+            ).encode()
         elif "no-permission" in channels:
             response_code = 403
             payload = json.dumps(

--- a/tests/unit/store/test_store_client.py
+++ b/tests/unit/store/test_store_client.py
@@ -1082,7 +1082,26 @@ class ReleaseTestCase(StoreTestCase):
 
         self.assertThat(
             str(raised),
-            Equals("invalid-field: The 'revision' field must be an integer\n"),
+            Equals("invalid-field: The 'revision' field must be an integer"),
+        )
+
+    def test_release_to_curly_braced_channel(self):
+        self.client.login("dummy", "test correct password")
+        raised = self.assertRaises(
+            errors.StoreReleaseError,
+            self.client.release,
+            "test-snap",
+            "19",
+            ["edge/{curly}"],
+        )
+
+        self.assertThat(
+            str(raised),
+            Equals(
+                "invalid-field: Invalid branch name: {curly}. Enter a value consisting of "
+                "letters, numbers or hyphens. Hyphens cannot occur at the start or end of the "
+                "chosen value."
+            ),
         )
 
 


### PR DESCRIPTION
Releasing to a curly braced branch name should fail gracefully.

LP: #1788934

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
