### PR TITLE
extensions: fix install path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ else:
                 ["libraries/" + x for x in os.listdir("libraries")],
             ),
             (
-                "share/snapcraft/extension-data",
+                "share/snapcraft/extensions",
                 ["extensions/" + x for x in os.listdir("extensions")],
             ),
         ],


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Extensions are currently being installed into "extensions-data" instead of the expected "extensions". This PR resolves [LP: #1790197](https://bugs.launchpad.net/snapcraft/+bug/1790197) by installing extension parts into "extensions".