### PR TITLE
cli: add list-extensions command

### DIFF
--- a/debian/snapcraft-completion
+++ b/debian/snapcraft-completion
@@ -6,7 +6,7 @@ _snapcraft()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="help init list-plugins plugins login logout export-login list-keys keys create-key register-key register registered list-registered push release clean cleanbuild pull build sign-build stage prime snap update define search gated validate history status close enable-ci"
+    opts="help init list-plugins plugins login logout export-login list-keys keys create-key register-key register registered list-registered push release clean cleanbuild pull build sign-build stage prime snap update define search gated validate history status close enable-ci extensions list-extensions"
 
     case "$prev" in
     help)

--- a/snapcraft/cli/_command_group.py
+++ b/snapcraft/cli/_command_group.py
@@ -32,6 +32,7 @@ _CMD_ALIASES = {
     "revisions": "list-revisions",
     "plugins": "list-plugins",
     "collaborators": "edit-collaborators",
+    "extensions": "list-extensions",
 }
 
 _CMD_DEPRECATION_NOTICES = {"history": "dn4"}

--- a/snapcraft/cli/extensions.py
+++ b/snapcraft/cli/extensions.py
@@ -31,9 +31,12 @@ def extensioncli(**kwargs):
     pass
 
 
-@extensioncli.command()
-def extensions(**kwargs):
-    """List available extensions."""
+@extensioncli.command("list-extensions")
+def list_extensions(**kwargs):
+    """List available extensions.
+
+    This command has an alias of `extensions`.
+    """
     from snapcraft.internal import project_loader
 
     extension_names = []


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR resolves [LP: #1788639](https://bugs.launchpad.net/snapcraft/+bug/1788639) by adding a `list-extensions` command. It also add both `list-extensions` and `extensions` to bash-completion.