### PR TITLE
reporting: record the released version for errors

### DIFF
--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -20,13 +20,15 @@ import sys
 import tempfile
 import traceback
 from textwrap import dedent
+from typing import Dict  # noqa: F401
+
+import click
 
 from . import echo
+import snapcraft
 from snapcraft.config import CLIConfig as _CLIConfig
 from snapcraft.internal import errors
 from snapcraft.internal.lxd import errors as lxd_errors
-
-import click
 
 # raven is not available on 16.04
 try:
@@ -230,6 +232,10 @@ def _prompt_sentry():
 
 
 def _submit_trace(exc_info):
+    kwargs = dict()  # Dict[str,str]
+    if "+git" not in snapcraft.__version__:
+        kwargs["release"] = snapcraft.__version__
+
     client = RavenClient(
         "https://b0fef3e0ced2443c92143ae0d038b0a4:"
         "b7c67d7fa4ee46caae12b29a80594c54@sentry.io/277754",
@@ -247,5 +253,6 @@ def _submit_trace(exc_info):
             "raven.processors.RemoveStackLocalsProcessor",
             "raven.processors.SanitizePasswordsProcessor",
         ),
+        **kwargs
     )
     client.captureException(exc_info=exc_info)

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -160,6 +160,7 @@ class SendToSentryIsYesTest(SendToSentryBaseTest):
             transport=self.raven_request_mock,
             name="snapcraft",
             processors=mock.ANY,
+            release=mock.ANY,
             auto_log_stacks=False,
         )
 
@@ -203,6 +204,7 @@ class SendToSentryIsAlwaysTest(SendToSentryBaseTest):
             transport=self.raven_request_mock,
             name="snapcraft",
             processors=mock.ANY,
+            release=mock.ANY,
             auto_log_stacks=False,
         )
         config_path = os.path.join(
@@ -249,6 +251,7 @@ class SendToSentryAlreadyAlwaysTest(SendToSentryBaseTest):
             transport=self.raven_request_mock,
             name="snapcraft",
             processors=mock.ANY,
+            release=mock.ANY,
             auto_log_stacks=False,
         )
         self.prompt_mock.assert_not_called()
@@ -273,6 +276,7 @@ class SendToSentryAlreadyAlwaysTest(SendToSentryBaseTest):
             transport=self.raven_request_mock,
             name="snapcraft",
             processors=mock.ANY,
+            release=mock.ANY,
             auto_log_stacks=False,
         )
 


### PR DESCRIPTION
If an error occurs with a released version of snapcraft,
record it for the report.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
