### PR TITLE
WIP: pluginhandler: after building a part, separate debug info from executables and strip them

### DIFF
--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -113,6 +113,7 @@ class BasePlugin:
         self.installdir = os.path.join(self.partdir, "install")
         self.statedir = os.path.join(self.partdir, "state")
         self.osrepodir = os.path.join(self.partdir, "ubuntu")
+        self.debugdir = os.path.join(self.partdir, "debug")
 
         self.build_basedir = os.path.join(self.partdir, "build")
         source_subdir = getattr(self.options, "source_subdir", None)

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -60,6 +60,17 @@ else:
     _DEBUG_INFO = b".debug_info"
     _GNU_VERSION_R = b".gnu.version_r"
 
+# Mappings from ElfArchitectureTuples to GCC style architecture triples
+_ARCH_TRIPLET = {
+    ("ELFCLASS64", "ELFDATA2LSB", "EM_X86_64"): "x86_64-linux-gnu",
+    ("ELFCLASS64", "ELFDATA2LSB", "EM_AARCH64"): "aarch64-linux-gnu",
+    ("ELFCLASS32", "ELFDATA2LSB", "EM_ARM"): "arm-linux-gnueabihf",
+    ("ELFCLASS32", "ELFDATA2LSB", "EM_386"): "i386-linux-gnu",
+    ("ELFCLASS32", "ELFDATA2MSB", "EM_PPC"): "powerpc-linux-gnu",
+    ("ELFCLASS64", "ELFDATA2LSB", "EM_PPC64"): "powerpc64le-linux-gnu",
+    ("ELFCLASS64", "ELFDATA2MSB", "EM_S390"): "s390x-linux-gnu",
+}
+
 
 class SonameCache:
     """A cache for sonames."""
@@ -290,6 +301,10 @@ class ElfFile:
             )
 
         return (arch, interp, soname, libs, execstack_set, build_id, has_debug_info)
+
+    @property
+    def arch_triplet(self) -> str:
+        return _ARCH_TRIPLET.get(self.arch)
 
     def is_linker_compatible(self, *, linker_version: str) -> bool:
         """Determines if linker will work given the required glibc version."""

--- a/snapcraft/internal/pluginhandler/_debuginfo.py
+++ b/snapcraft/internal/pluginhandler/_debuginfo.py
@@ -1,0 +1,92 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+import subprocess
+from typing import List
+
+from snapcraft import file_utils
+from snapcraft.internal import elf, errors
+
+logger = logging.getLogger(__name__)
+
+
+class DebugInfoCollector:
+    """DebugInfoCollector detaches and strips debug info from ELF files."""
+
+    def __init__(self, *, debug_dir: str) -> None:
+        self._debug_dir = debug_dir
+
+        self._objcopy_cmd = file_utils.get_tool_path("objcopy")
+        self._strip_cmd = file_utils.get_tool_path("strip")
+
+    def _debug_info_file(self, *, elf_file: elf.ElfFile) -> str:
+        build_id = elf_file.build_id
+        assert build_id != ""
+        return os.path.join(
+            self._debug_dir, ".build-id", build_id[:2], "{}.debug".format(build_id[2:])
+        )
+
+    def separate(self, *, elf_file: elf.ElfFile) -> None:
+        assert elf_file.has_debug_info
+        debug_file = self._debug_info_file(elf_file=elf_file)
+        os.makedirs(os.path.dirname(debug_file), exist_ok=True)
+
+        self._run(
+            [
+                self._objcopy_cmd,
+                "--only-keep-debug",
+                "--compress-debug-sections",
+                elf_file.path,
+                debug_file,
+            ]
+        )
+        # FIXME: consider being a bit more aggressive in stripping executable.
+        self._run([self._strip_cmd, "-g", elf_file.path])
+        self._run([self._objcopy_cmd, "--add-gnu-debuglink", debug_file, elf_file.path])
+
+    def _run(self, args: List[str]) -> None:
+        try:
+            subprocess.check_call(args)
+        except subprocess.CalledProcessError as call_error:
+            raise errors.SnapcraftCommandError(
+                command=" ".join(args), call_error=call_error
+            ) from call_error
+
+    def separate_tree(self, *, base_dir: str) -> None:
+        for directory, _, files in os.walk(base_dir):
+            for file_name in files:
+                if file_name.endswith(".o"):
+                    continue
+                file_path = os.path.join(directory, file_name)
+                if not elf.ElfFile.is_elf(file_path):
+                    continue
+
+                elf_file = elf.ElfFile(path=file_path)
+                if elf_file.has_debug_info:
+                    if elf_file.build_id != "":
+                        self.separate(elf_file=elf_file)
+                    else:
+                        # FIXME: consider how to handle files without
+                        # build-id, given we don't know the install
+                        # location ahead of time.
+                        logger.warn("No build ID for {}".format(file_path))
+                else:
+                    # FIXME: this will include files from staged
+                    # packages, which we should be able to locate
+                    # debug info for.
+                    logger.warn("No debug info found for {}".format(file_path))

--- a/tests/fixture_setup/_fixtures.py
+++ b/tests/fixture_setup/_fixtures.py
@@ -1051,37 +1051,85 @@ def _fake_elffile_extract(self, path):
         glibc = elf.NeededLibrary(name="libc.so.6")
         glibc.add_version("GLIBC_2.2.5")
         glibc.add_version("GLIBC_2.26")
-        return (arch, "/lib64/ld-linux-x86-64.so.2", "", {glibc.name: glibc}, False)
+        return (
+            arch,
+            "/lib64/ld-linux-x86-64.so.2",
+            "",
+            {glibc.name: glibc},
+            False,
+            "build-id-{}".format(name),
+            False,
+        )
     elif name == "fake_elf-2.23":
         glibc = elf.NeededLibrary(name="libc.so.6")
         glibc.add_version("GLIBC_2.2.5")
         glibc.add_version("GLIBC_2.23")
-        return (arch, "/lib64/ld-linux-x86-64.so.2", "", {glibc.name: glibc}, False)
+        return (
+            arch,
+            "/lib64/ld-linux-x86-64.so.2",
+            "",
+            {glibc.name: glibc},
+            False,
+            "build-id-fake_elf-2.23",
+            False,
+        )
     elif name == "fake_elf-1.1":
         glibc = elf.NeededLibrary(name="libc.so.6")
         glibc.add_version("GLIBC_1.1")
         glibc.add_version("GLIBC_0.1")
-        return (arch, "/lib64/ld-linux-x86-64.so.2", "", {glibc.name: glibc}, False)
+        return (
+            arch,
+            "/lib64/ld-linux-x86-64.so.2",
+            "",
+            {glibc.name: glibc},
+            False,
+            "build-id-fale_elf-1.1",
+            False,
+        )
     elif name == "fake_elf-static":
-        return arch, "", "", {}, False
+        return arch, "", "", {}, False, "build-id-fake_elf-static", False
     elif name == "fake_elf-shared-object":
         openssl = elf.NeededLibrary(name="libssl.so.1.0.0")
         openssl.add_version("OPENSSL_1.0.0")
-        return arch, "", "libfake_elf.so.0", {openssl.name: openssl}, False
+        return (
+            arch,
+            "",
+            "libfake_elf.so.0",
+            {openssl.name: openssl},
+            False,
+            "build-id-fake_elf-shared-object",
+            False,
+        )
     elif name == "fake_elf-with-execstack":
         glibc = elf.NeededLibrary(name="libc.so.6")
         glibc.add_version("GLIBC_2.23")
-        return (arch, "/lib64/ld-linux-x86-64.so.2", "", {glibc.name: glibc}, True)
+        return (
+            arch,
+            "/lib64/ld-linux-x86-64.so.2",
+            "",
+            {glibc.name: glibc},
+            True,
+            "build-id-fake_elf-with-execstack",
+            False,
+        )
     elif name == "fake_elf-with-bad-execstack":
         glibc = elf.NeededLibrary(name="libc.so.6")
         glibc.add_version("GLIBC_2.23")
-        return (arch, "/lib64/ld-linux-x86-64.so.2", "", {glibc.name: glibc}, True)
+        return (
+            arch,
+            "/lib64/ld-linux-x86-64.so.2",
+            "",
+            {glibc.name: glibc},
+            True,
+            "build-id-fake_elf-with-bad-execstack",
+            False,
+        )
     elif name == "libc.so.6":
-        return arch, "", "libc.so.6", {}, False
+        return arch, "", "libc.so.6", {}, False, "build-id-libc", False
     elif name == "libssl.so.1.0.0":
-        return arch, "", "libssl.so.1.0.0", {}, False
+        return arch, "", "libssl.so.1.0.0", {}, False, "build-id-libssl", False
     else:
-        return arch, "", "", {}, False
+        return arch, "", "", {}, False, "", False
 
 
 class FakeElf(fixtures.Fixture):

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -1516,7 +1516,7 @@ class StateTestCase(StateBaseTestCase):
 
     @patch(
         "snapcraft.internal.elf.ElfFile._extract",
-        return_value=(("", "", ""), "EXEC", "", dict(), False),
+        return_value=(("", "", ""), "EXEC", "", dict(), False, "", False),
     )
     @patch("snapcraft.internal.elf.ElfFile.load_dependencies")
     @patch("snapcraft.internal.pluginhandler._migrate_files")
@@ -1592,7 +1592,7 @@ class StateTestCase(StateBaseTestCase):
 
     @patch(
         "snapcraft.internal.elf.ElfFile._extract",
-        return_value=(("", "", ""), "EXEC", "", dict(), False),
+        return_value=(("", "", ""), "EXEC", "", dict(), False, "", False),
     )
     @patch("snapcraft.internal.elf.ElfFile.load_dependencies")
     @patch("snapcraft.internal.pluginhandler._migrate_files")
@@ -1651,7 +1651,7 @@ class StateTestCase(StateBaseTestCase):
 
     @patch(
         "snapcraft.internal.elf.ElfFile._extract",
-        return_value=(("", "", ""), "EXEC", "", dict(), False),
+        return_value=(("", "", ""), "EXEC", "", dict(), False, "", False),
     )
     @patch(
         "snapcraft.internal.elf.ElfFile.load_dependencies",

--- a/tests/unit/test_elf.py
+++ b/tests/unit/test_elf.py
@@ -97,6 +97,14 @@ class TestElfFileSmoketest(unit.TestCase):
                 isinstance(version, str), "expected {!r} to be a string".format(version)
             )
 
+        # GCC adds a build ID to executables
+        self.assertThat(elf_file.build_id, NotEquals(""))
+
+        # If the Python interpreter is distro packaged, it probably
+        # doesn't have debug info, but we don't know for sure.
+        # Instead just check that it is a boolean.
+        self.assertTrue(isinstance(elf_file.has_debug_info, bool))
+
 
 class TestGetLibraries(TestElfBase):
     def setUp(self):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
This builds on top of PR #2229, extending the pluginhandler to strip binaries after build, placing the debug symbols in a hierarchy under `./parts/$partname/debug`.

For my test project, I was able to run the debugger on one of these stripped executables in my project tree like so (for a part called `open`):

    $ gdb
    ...
    (gdb) set debug-file-directory ./parts/open/debug:/usr/lib/debug
    (gdb) file ./parts/open/install/bin/open
    Reading symbols from ./parts/open/install/bin/open...Reading symbols from /home/james/src/ubuntu/open-experiment/parts/open/debug/.build-id/00/01ccfaac25c7fa189899f4051524b486f0d165.debug...done.
    done.
    (gdb) 

I needed to modify the part to actually build with debug information enabled.  I also need to work out some way to collect symbols from `.ddeb` packages related to files from `stage-packages`, and finally to select the debug symbols for files eventually primed into the package.