### PR TITLE
file_utils: find tool when using docker and deb

### DIFF
--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -334,8 +334,9 @@ def calculate_hash(path: str, *, algorithm: str) -> str:
 def get_tool_path(command_name: str) -> str:
     """Return the path to the given command
 
-    Return a path to command_name, if Snapcraft is running out of the snap or out
-    of Docker, it ensures it is using the one in the snap, not the host.
+    Return a path to command_name, if Snapcraft is running out of the snap
+    or in legacy mode (snap or sources), it ensures it is using the one in
+    the snap, not the host.
     If a path cannot be resolved, ToolMissingError is raised.
 
     : param str command_name: the name of the command to resolve a path for.
@@ -343,12 +344,8 @@ def get_tool_path(command_name: str) -> str:
     :return: Path to command
     :rtype: str
     """
-    snapcraft_snap_path = os.path.join(os.sep, "snap", "snapcraft", "current")
-
     if common.is_snap():
         command_path = _command_path_in_root(os.getenv("SNAP"), command_name)
-    elif common.is_docker_instance() and os.path.exists(snapcraft_snap_path):
-        command_path = _command_path_in_root(snapcraft_snap_path, command_name)
     else:
         command_path = shutil.which(command_name)
 

--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -343,23 +343,24 @@ def get_tool_path(command_name: str) -> str:
     :return: Path to command
     :rtype: str
     """
+    snapcraft_snap_path = os.path.join(os.sep, "snap", "snapcraft", "current")
+
     if common.is_snap():
         command_path = _command_path_in_root(os.getenv("SNAP"), command_name)
-    elif common.is_docker_instance():
-        command_path = _command_path_in_root(
-            os.path.join(os.sep, "snap", "snapcraft", "current"), command_name
-        )
+    elif common.is_docker_instance() and os.path.exists(snapcraft_snap_path):
+        command_path = _command_path_in_root(snapcraft_snap_path, command_name)
     else:
         command_path = shutil.which(command_name)
 
-    # shutil.which will return None if it cannot find command_name
-    if command_path is None:
+    # shutil.which will return None if it cannot find command_name but
+    # _command_path_in_root will return an empty string.
+    if not command_path:
         raise ToolMissingError(command_name=command_name)
 
     return command_path
 
 
-def _command_path_in_root(root, command_name):
+def _command_path_in_root(root, command_name: str) -> str:
     for bin_directory in (
         os.path.join("usr", "local", "sbin"),
         os.path.join("usr", "local", "bin"),


### PR DESCRIPTION
The case of returning an empty string was missed. More so,
the case of using the deb inside docker was not covered.

LP: #1790665
Fixes SNAPCRAFT-2E

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
