### PR TITLE
Error communication improvements

### DIFF
--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -175,7 +175,7 @@ def _is_send_to_sentry(trace_filepath: str) -> bool:  # noqa: C901
     # configuration for where that value is stored cannot be read, so
     # resort to prompting.
     try:
-        response = _prompt_sentry()
+        response = _prompt_sentry(trace_filepath)
     except click.exceptions.Abort:
         # This was most likely triggered by a KeyboardInterrupt so
         # adding a new line makes things look nice.
@@ -203,8 +203,8 @@ def _is_send_to_sentry(trace_filepath: str) -> bool:  # noqa: C901
         return False
 
 
-def _prompt_sentry():
-    msg = _MSG_SEND_TO_SENTRY_TRACEBACK_PROMPT
+def _prompt_sentry(trace_filepath: str):
+    msg = _MSG_SEND_TO_SENTRY_TRACEBACK_PROMPT.format(trace_filepath)
     all_valid = _YES_VALUES + _NO_VALUES + _ALWAYS_VALUES
 
     def validate(value):

--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -40,23 +40,13 @@ except ImportError:
 # TODO:
 # - annotate the part and lifecycle step in the message
 # - add link to privacy policy
-_MSG_TRACEBACK_PRINT = dedent(
-    """\
-    Sorry, Snapcraft ran into an error when trying to running through its
-    lifecycle that generated the following traceback:"""
-)
-_MSG_TRACEBACK_FILE = dedent(
-    """\
-    Sorry, Snapcraft ran into an error when trying to running through its
-    lifecycle that generated a trace that has been put in {!r}."""
-)
-_MSG_REPORTABLE_ERROR = "This is a problem in snapcraft; a trace has been put in {!r}."
+_MSG_TRACEBACK_PRINT = "Sorry, an error occurred in Snapcraft:"
+_MSG_TRACEBACK_FILE = "Sorry, an error occurred in Snapcraft."
 _MSG_SEND_TO_SENTRY_TRACEBACK_PROMPT = dedent(
     """\
-    You can anonymously report this issue to the snapcraft developers.
-    No other data than this traceback and the version of snapcraft in
-    use will be sent.
-    Would you like send this error data? (Yes/No/Always)"""
+    We would appreciate it if you anonymously reported this issue.
+    No other data than the traceback ({!r}) and the version of snapcraft in use will be sent.
+    Would you like to send this error data? (Yes/No/Always)"""
 )
 _MSG_SEND_TO_SENTRY_THANKS = "Thank you, sent."
 _MSG_SILENT_REPORT = (
@@ -67,12 +57,10 @@ _MSG_ALWAYS_REPORT = dedent(
     Sending an error report because ALWAYS was selected in a past prompt.
     This behavior can be changed by changing the always_send entry in {}."""
 )
-_MSG_RAVEN_MISSING = dedent(
+_MSG_MANUALLY_REPORT = dedent(
     """\
-    "Submitting this error to the Snapcraft developers is not possible through the CLI
-    without Raven installed.
-    If you wish to report this issue, please copy the contents of the previous traceback
-    and submit manually at https://launchpad.net/snapcraft/+filebug."""
+    We would appreciate it if you created a bug report at 
+    https://launchpad.net/snapcraft/+filebug with the above text included."""
 )
 
 _YES_VALUES = ["yes", "y"]
@@ -110,14 +98,10 @@ def exception_handler(
     is_snapcraft_managed_host = (
         distutils.util.strtobool(os.getenv("SNAPCRAFT_MANAGED_HOST", "n")) == 1
     )
+    ask_to_report = False
 
     if not is_snapcraft_error:
-        _handle_trace_output(exc_info, is_snapcraft_managed_host, _MSG_TRACEBACK_FILE)
-        if not is_raven_setup:
-            echo.warning(_MSG_RAVEN_MISSING)
-        elif _is_send_to_sentry():
-            _submit_trace(exc_info)
-            click.echo(_MSG_SEND_TO_SENTRY_THANKS)
+        ask_to_report = True
     elif is_snapcraft_error and debug:
         exit_code = exception.get_exit_code()
         traceback.print_exception(*exc_info)
@@ -128,38 +112,38 @@ def exception_handler(
         # of a double error print
         if exception_type != lxd_errors.ContainerSnapcraftCmdError:
             echo.error(str(exception))
-        if is_snapcraft_reportable_error and is_raven_setup:
-            _handle_trace_output(
-                exc_info, is_snapcraft_managed_host, _MSG_REPORTABLE_ERROR
-            )
-            if _is_send_to_sentry():
-                _submit_trace(exc_info)
-                click.echo(_MSG_SEND_TO_SENTRY_THANKS)
+        if is_snapcraft_reportable_error:
+            ask_to_report = True
     else:
         click.echo("Unhandled error case")
         exit_code = -1
 
+    if ask_to_report:
+        if not is_raven_setup or is_snapcraft_managed_host:
+            click.echo(_MSG_TRACEBACK_PRINT)
+            traceback.print_exception(*exc_info)
+            click.echo(_MSG_MANUALLY_REPORT)
+        else:
+            trace_filepath = _handle_trace_output(exc_info)
+            if _is_send_to_sentry(trace_filepath):
+                _submit_trace(exc_info)
+                click.echo(_MSG_SEND_TO_SENTRY_THANKS)
+
     sys.exit(exit_code)
 
 
-def _handle_trace_output(
-    exc_info, is_snapcraft_managed_host: bool, trace_file_msg_tmpl: str
-) -> None:
-    if is_snapcraft_managed_host:
-        click.echo(_MSG_TRACEBACK_PRINT)
-        traceback.print_exception(*exc_info)
-    else:
-        trace_filepath = os.path.join(tempfile.mkdtemp(), "trace.txt")
-        with open(trace_filepath, "w") as trace_file:
-            # mypy does not like *exc_info with a kwarg that follows
-            # snapcraft/cli/_errors.py:132: error: "print_exception" gets multiple values for keyword argument "file"
-            traceback.print_exception(
-                exc_info[0], exc_info[1], exc_info[2], file=trace_file
-            )
-        click.echo(trace_file_msg_tmpl.format(trace_filepath))
+def _handle_trace_output(exc_info) -> str:
+    trace_filepath = os.path.join(tempfile.mkdtemp(), "trace.txt")
+    with open(trace_filepath, "w") as trace_file:
+        # mypy does not like *exc_info with a kwarg that follows
+        # snapcraft/cli/_errors.py:132: error: "print_exception" gets multiple values for keyword argument "file"
+        traceback.print_exception(
+            exc_info[0], exc_info[1], exc_info[2], file=trace_file
+        )
+    return trace_filepath
 
 
-def _is_send_to_sentry() -> bool:  # noqa: C901
+def _is_send_to_sentry(trace_filepath: str) -> bool:  # noqa: C901
     # Check to see if error reporting has been disabled
     if (
         distutils.util.strtobool(os.getenv("SNAPCRAFT_ENABLE_ERROR_REPORTING", "y"))

--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -59,7 +59,7 @@ _MSG_ALWAYS_REPORT = dedent(
 )
 _MSG_MANUALLY_REPORT = dedent(
     """\
-    We would appreciate it if you created a bug report at 
+    We would appreciate it if you created a bug report at
     https://launchpad.net/snapcraft/+filebug with the above text included."""
 )
 

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -69,6 +69,13 @@ class ErrorsBaseTestCase(unit.TestCase):
             RuntimeError, mock.ANY, mock.ANY, file=mock.ANY
         )
 
+    def assert_exception_traceback_exit_1_without_raven(self):
+        self.error_mock.assert_not_called
+        self.exit_mock.assert_called_once_with(1)
+        self.print_exception_mock.assert_called_once_with(
+            RuntimeError, mock.ANY, mock.ANY
+        )
+
     def assert_no_exception_traceback_exit_1_without_debug(self):
         self.error_mock.assert_not_called
         self.exit_mock.assert_called_once_with(1)
@@ -89,7 +96,7 @@ class ErrorsTestCase(ErrorsBaseTestCase):
         except Exception:
             self.fail("Exception unexpectedly raised")
 
-        self.assert_exception_traceback_exit_1_with_debug()
+        self.assert_exception_traceback_exit_1_without_raven()
 
     def test_handler_catches_snapcraft_exceptions_no_debug(self):
         try:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

I have not built a snap of snapcraft to test. Neither multipass nor the snapcore/snapcraft docker image are happy with me.

This branch:
- Prints a traceback of the error when Raven isn't installed, rather than writing to a file.
- Makes it more clear that internal errors are ours to fix, but we'd greatly appreciate sentry or LP reports.