### PR TITLE
[WIP] plugin API: support command-chain

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -318,8 +318,10 @@ properties:
           adapter:
             type: string
             description: What kind of wrapper to generate for the given command
-            format: adapter
-            default: "legacy"
+            enum:
+              - none
+              - legacy
+            default: legacy
           sockets:
             type: object
             additionalProperties: false

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -318,8 +318,8 @@ properties:
           adapter:
             type: string
             description: What kind of wrapper to generate for the given command
-            enum:
-              - none
+            format: adapter
+            default: "legacy"
           sockets:
             type: object
             additionalProperties: false

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,6 +43,10 @@ parts:
         - patchelf
         - squashfs-tools
         - xdelta3
+    organize:
+        # Put snapcraftctl into its own directory that can be included in the PATH
+        # without including other binaries.
+        bin/snapcraftctl: bin/snapcraft-utils/snapcraftctl
     override-pull: |
         version="$(git describe --dirty --always | sed -e 's/-/+git/;y/-/./')"
         [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable

--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -329,5 +329,5 @@ def _env_list_to_ordered_dict(
     env = collections.OrderedDict()  # type: collections.OrderedDict[str, str]
     for item in env_list:
         variable_name, value = item.split("=", maxsplit=1)
-        env[variable_name] = value
+        env[variable_name] = value.strip("'\"")
     return env

--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -14,10 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import collections
 import contextlib
 import logging
 import os
 from subprocess import CalledProcessError
+from typing import List
 
 from snapcraft.internal import common, errors
 
@@ -88,6 +90,7 @@ class BasePlugin:
         self.build_snaps = []
         self.build_packages = []
         self._stage_packages = []
+        self.__dependencies = []  # type: List[BasePlugin]
 
         with contextlib.suppress(AttributeError):
             self._stage_packages = options.stage_packages.copy()
@@ -124,6 +127,12 @@ class BasePlugin:
         # By default, snapcraft does an in-source build. Set this property to
         # True if that's not desired.
         self.out_of_source_build = False
+
+    def add_dependency(self, plugin: "BasePlugin") -> None:
+        self.__dependencies.append(plugin)
+
+    def get_dependencies(self) -> List["BasePlugin"]:
+        return self.__dependencies.copy()
 
     # The API
     def pull(self):
@@ -170,16 +179,105 @@ class BasePlugin:
         """
         return []
 
-    def env(self, root):
+    def env(self, root: str) -> List[str]:
         """Return a list with the execution environment for building.
 
-        Plugins often need special environment variables exported to the
-        system for some builds to take place. This is a list of strings
-        of the form key=value. The parameter root is the path to this part.
+        Plugins often need special environment variables exported to the system for some
+        builds to take place. This is a list of strings of the form key=value. The
+        parameter root is the path to this part. More fine-grained control can be had
+        by implementing get_pull_env(), get_pull_command_chain(), and their family of
+        functions.
 
         :param str root: The root for the part
         """
         return []
+
+    def get_pull_env(self) -> "collections.OrderedDict[str, str]":
+        """Return a dict of environment variable names and values for pulling.
+
+        By default this function simply calls env() with the install directory as the
+        root.
+        """
+        # Maintain backward compatibility with the old-style env() function
+        return _env_list_to_ordered_dict(self.env(self.installdir))
+
+    def get_pull_command_chain(self) -> List[str]:
+        """Return a list of commands to be prepended to the commands when pulling.
+
+        Each item must either be in the PATH, or be an absolute path to an executable."""
+        return list()
+
+    def get_build_env(self) -> "collections.OrderedDict[str, str]":
+        """Return a dict of environment variable names and values for building.
+
+        By default this function simply calls env() with the install directory as the
+        root."""
+        # Maintain backward compatibility with the old-style env() function
+        return _env_list_to_ordered_dict(self.env(self.installdir))
+
+    def get_build_command_chain(self) -> List[str]:
+        """Return a list of commands to be prepended to the commands when building.
+
+        Each item must either be in the PATH, or be an absolute path to an executable."""
+        return list()
+
+    def get_stage_env(self) -> "collections.OrderedDict[str, str]":
+        """Return a dict of environment variable names and values for staging.
+
+        By default this function simply calls env() with the stage directory as the
+        root."""
+        # Maintain backward compatibility with the old-style env() function
+        return _env_list_to_ordered_dict(self.env(self.project.stage_dir))
+
+    def get_stage_command_chain(self) -> List[str]:
+        """Return a list of commands to be prepended to the commands when staging.
+
+        Each item must either be in the PATH, or be an absolute path to an executable."""
+        return list()
+
+    def get_prime_env(self) -> "collections.OrderedDict[str, str]":
+        """Return a dict of environment variable names and values for priming.
+
+        By default this function simply calls env() with the prime directory as the
+        root."""
+        # Maintain backward compatibility with the old-style env() function
+        return _env_list_to_ordered_dict(self.env(self.project.prime_dir))
+
+    def get_prime_command_chain(self) -> List[str]:
+        """Return a list of commands to be prepended to the commands when priming.
+
+        Each item must either be in the PATH, or be an absolute path to an executable."""
+        return list()
+
+    def get_dependency_env(self) -> "collections.OrderedDict[str, str]":
+        """Return a dict of environment variable names and values for use by dependents."""
+        return self.get_stage_env()
+
+    def get_dependency_command_chain(self) -> List[str]:
+        """Return a list of commands to be prepended to the actual commands used by dependents.
+
+        Each item must either be in the PATH, or be an absolute path to an executable.
+        """
+        return list()
+
+    def get_snap_env(self) -> "collections.OrderedDict[str, str]":
+        """Return a dict of environment variable names and values for apps in the final snap.
+
+        By default this function simply calls get_prime_env() and replaces all
+        occurrences of the prime directory with $SNAP."""
+        env = self.get_prime_env()
+        for variable_name, value in env.items():
+            env[variable_name] = value.replace(self.project.prime_dir, "$SNAP")
+
+        return env
+
+    def get_snap_command_chain(self) -> List[str]:
+        """Return a list of commands to be prepended to the apps in the final snap.
+
+        The paths returned should all be relative paths to the root of the snap, and
+        should not include any environment variables.
+        """
+        return list()
 
     def enable_cross_compilation(self):
         """Enable cross compilation for the plugin."""
@@ -223,3 +321,13 @@ class BasePlugin:
             raise errors.SnapcraftPluginCommandError(
                 command=cmd, part_name=self.name, exit_code=process_error.returncode
             ) from process_error
+
+
+def _env_list_to_ordered_dict(
+    env_list: List[str]
+) -> "collections.OrderedDict[str, str]":
+    env = collections.OrderedDict()  # type: collections.OrderedDict[str, str]
+    for item in env_list:
+        variable_name, value = item.split("=", maxsplit=1)
+        env[variable_name] = value
+    return env

--- a/snapcraft/internal/meta/__init__.py
+++ b/snapcraft/internal/meta/__init__.py
@@ -14,4 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from snapcraft.internal.meta._snap_packaging import create_snap_packaging  # noqa
+from snapcraft.internal.meta._snap_packaging import (  # noqa: F401
+    create_snap_packaging,
+    verify_apps,
+)

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -17,6 +17,7 @@
 import copy
 import collections
 import contextlib
+import enum
 import itertools
 import logging
 import os
@@ -61,6 +62,12 @@ _OPTIONAL_PACKAGE_KEYS = [
     "hooks",
     "environment",
 ]
+
+
+@enum.unique
+class Adapter(enum.Enum):
+    NONE = 1
+    LEGACY = 2
 
 
 class OctInt(int):
@@ -623,8 +630,8 @@ class _SnapPackaging:
             if os.path.splitext(f)[1] == ".desktop":
                 os.remove(os.path.join(gui_dir, f))
         for app_name, app in apps.items():
-            adapter = project_loader.Adapter[app.pop("adapter").upper()]
-            if adapter == project_loader.Adapter.LEGACY:
+            adapter = Adapter[app.pop("adapter").upper()]
+            if adapter == Adapter.LEGACY:
                 self._wrap_app(app_name, app)
             self._generate_desktop_file(app_name, app)
         return apps

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -430,7 +430,7 @@ class _SnapPackaging:
                     command += "{} ".format(assembled_command_chain)
                 command += '"$@"'
                 print(command, file=f)
-            os.chmod(self._meta_runner, 0o555)
+            os.chmod(self._meta_runner, 0o755)
 
     def _record_manifest_and_source_snapcraft_yaml(self):
         prime_snap_dir = os.path.join(self._prime_dir, "snap")

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -326,29 +326,6 @@ class _SnapPackaging:
         self._config_data = config_data.copy()
         self._original_snapcraft_yaml = project.info.get_raw_snapcraft()
 
-        # If we are dealing with classic confinement it means all our
-        # binaries are linked with `nodefaultlib` but we still do
-        # not want to leak PATH or other environment variables
-        # that would affect the applications view of the classic
-        # environment it is dropped into.
-        replace_path = re.compile(
-            r"{}/[a-z0-9][a-z0-9+-]*/install".format(re.escape(self._parts_dir))
-        )
-
-        self._assembled_command_chain = " ".join(
-            [os.path.join("$SNAP", shlex.quote(c)) for c in common.command_chain]
-        )
-        self._assembled_command_chain = self._assembled_command_chain.replace(
-            self._prime_dir, "$SNAP"
-        )
-        self._assembled_command_chain = replace_path.sub(
-            "$SNAP", self._assembled_command_chain
-        )
-
-        self._assembled_env = common.assemble_env()
-        self._assembled_env = self._assembled_env.replace(self._prime_dir, "$SNAP")
-        self._assembled_env = replace_path.sub("$SNAP", self._assembled_env)
-
         os.makedirs(self._meta_dir, exist_ok=True)
 
     def write_snap_yaml(self) -> str:

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -348,7 +348,10 @@ class _SnapPackaging:
         os.makedirs(self._meta_dir, exist_ok=True)
 
     def write_snap_yaml(self) -> str:
-        self._generate_command_chain()
+        # Only generate the meta command chain if there are apps that need it
+        if self._config_data.get("apps", dict()):
+            self._generate_command_chain()
+
         package_snap_path = os.path.join(self.meta_dir, "snap.yaml")
         snap_yaml = self._compose_snap_yaml()
 

--- a/snapcraft/internal/project_loader/__init__.py
+++ b/snapcraft/internal/project_loader/__init__.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import enum
 from typing import cast, Dict, List, Union
 from typing import TYPE_CHECKING
 
@@ -29,12 +28,6 @@ from ._extensions import apply_extensions, find_extension  # noqa: F401
 
 if TYPE_CHECKING:
     from snapcraft.project import Project  # noqa: F401
-
-
-@enum.unique
-class Adapter(enum.Enum):
-    NONE = 1
-    LEGACY = 2
 
 
 def load_config(project: "Project"):

--- a/snapcraft/internal/project_loader/__init__.py
+++ b/snapcraft/internal/project_loader/__init__.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import enum
 from typing import cast, Dict, List, Union
 from typing import TYPE_CHECKING
 
@@ -28,6 +29,12 @@ from ._extensions import apply_extensions, find_extension  # noqa: F401
 
 if TYPE_CHECKING:
     from snapcraft.project import Project  # noqa: F401
+
+
+@enum.unique
+class Adapter(enum.Enum):
+    NONE = 1
+    LEGACY = 2
 
 
 def load_config(project: "Project"):

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -21,6 +21,7 @@ import os.path
 import re
 
 import jsonschema
+from typing import List
 from typing import Set  # noqa: F401
 
 from snapcraft import project, formatting_utils
@@ -29,16 +30,23 @@ from snapcraft.internal import deprecations, remote_parts, states, steps
 from ._schema import Validator
 from ._parts_config import PartsConfig
 from ._extensions import apply_extensions
-from ._env import (
-    build_env_for_stage,
-    runtime_env,
-    snapcraft_global_environment,
-    environment_to_replacements,
-)
-from . import errors, grammar_processing, replace_attr
+from ._env import runtime_env, snapcraft_global_environment, environment_to_replacements
+from . import Adapter, errors, grammar_processing, replace_attr
 
 
 logger = logging.getLogger(__name__)
+
+
+@jsonschema.FormatChecker.cls_checks("adapter")
+def _validate_adapter(instance):
+    try:
+        Adapter[instance.upper()]
+    except KeyError:
+        raise jsonschema.exceptions.ValidationError(
+            "invalid adapter", instance=instance
+        )
+
+    return True
 
 
 @jsonschema.FormatChecker.cls_checks("icon-path")
@@ -265,27 +273,15 @@ class Config:
 
         return state
 
-    def stage_env(self):
-        stage_dir = self.project.stage_dir
-        env = []
-
-        env += runtime_env(stage_dir, self.project.arch_triplet)
-        env += build_env_for_stage(
-            stage_dir, self.data["name"], self.project.arch_triplet
-        )
-        for part in self.parts.all_parts:
-            env += part.env(stage_dir)
-
-        return env
-
-    def snap_env(self):
+    def prime_env(self):
         prime_dir = self.project.prime_dir
         env = []
 
         env += runtime_env(prime_dir, self.project.arch_triplet)
         dependency_paths = set()
         for part in self.parts.all_parts:
-            env += part.env(prime_dir)
+            part_env = part.plugin.get_prime_env()
+            env += ['{}="{}"'.format(k, v) for k, v in part_env.items()]
             dependency_paths |= part.get_primed_dependency_paths()
 
         # Dependency paths are only valid if they actually exist. Sorting them
@@ -301,6 +297,43 @@ class Config:
             )
 
         return env
+
+    def prime_command_chain(self) -> List[str]:
+        command_chain = []  # type: List[str]
+        for part in self.parts.all_parts:
+            command_chain += part.plugin.get_prime_command_chain()
+        return command_chain
+
+    def snap_env(self):
+        prime_dir = self.project.prime_dir
+        env = []
+
+        env += runtime_env(prime_dir, self.project.arch_triplet)
+        dependency_paths = set()
+        for part in self.parts.all_parts:
+            part_env = part.plugin.get_snap_env()
+            env += ['{}="{}"'.format(k, v) for k, v in part_env.items()]
+            dependency_paths |= part.get_primed_dependency_paths()
+
+        # Dependency paths are only valid if they actually exist. Sorting them
+        # here as well so the LD_LIBRARY_PATH is consistent between runs.
+        dependency_paths = sorted(
+            {path for path in dependency_paths if os.path.isdir(path)}
+        )
+
+        if dependency_paths:
+            # Add more specific LD_LIBRARY_PATH from the dependencies.
+            env.append(
+                'LD_LIBRARY_PATH="' + ":".join(dependency_paths) + ':$LD_LIBRARY_PATH"'
+            )
+
+        return env
+
+    def snap_command_chain(self) -> List[str]:
+        command_chain = []  # type: List[str]
+        for part in self.parts.all_parts:
+            command_chain += part.plugin.get_snap_command_chain()
+        return command_chain
 
     def project_env(self):
         return [

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -31,22 +31,10 @@ from ._schema import Validator
 from ._parts_config import PartsConfig
 from ._extensions import apply_extensions
 from ._env import runtime_env, snapcraft_global_environment, environment_to_replacements
-from . import Adapter, errors, grammar_processing, replace_attr
+from . import errors, grammar_processing, replace_attr
 
 
 logger = logging.getLogger(__name__)
-
-
-@jsonschema.FormatChecker.cls_checks("adapter")
-def _validate_adapter(instance):
-    try:
-        Adapter[instance.upper()]
-    except KeyError:
-        raise jsonschema.exceptions.ValidationError(
-            "invalid adapter", instance=instance
-        )
-
-    return True
 
 
 @jsonschema.FormatChecker.cls_checks("icon-path")

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -256,7 +256,7 @@ class PartsConfig:
     def get_part_env(
         self, part: pluginhandler.PluginHandler, step: steps.Step
     ) -> List[str]:
-        # The plugin environment needs to come before any {}/usr/bin
+        # The plugin environment needs to come before anything else
         env = _dict_to_env(getattr(part.plugin, "get_{}_env".format(step.name))())
 
         env += self._common_env(part)
@@ -305,14 +305,8 @@ class PartsConfig:
         return chain
 
     def get_part_snap_env(self, part: pluginhandler.PluginHandler) -> List[str]:
-        env = []  # type: List[str]
-
-        # Maintain backward compatibility with the deprecated .env() function.
-        # The plugin environment needs to come before any {}/usr/bin
-        try:
-            env += part.plugin.env(self._project.prime_dir)  # type: ignore
-        except AttributeError:
-            env += _dict_to_env(part.plugin.get_snap_env())
+        # The plugin environment needs to come before anything else
+        env = _dict_to_env(part.plugin.get_snap_env())
 
         env += self._common_env(part)
 

--- a/snapcraft/plugins/ament.py
+++ b/snapcraft/plugins/ament.py
@@ -263,4 +263,4 @@ deb http://${{security}}.ubuntu.com/${{suffix}} {0}-security main universe
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w") as f:
             f.write(script)
-        os.chmod(path, 0o555)
+        os.chmod(path, 0o755)

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -650,7 +650,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w") as f:
             f.write(script)
-        os.chmod(path, 0o555)
+        os.chmod(path, 0o755)
 
     @property
     def rosdir(self):

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -65,6 +65,7 @@ Additionally, this plugin uses the following plugin-specific keywords:
       to http://localhost:11311.
 """
 
+import collections
 import contextlib
 import glob
 import os
@@ -74,6 +75,7 @@ import re
 import shutil
 import subprocess
 import textwrap
+from typing import List
 
 import snapcraft
 from snapcraft.plugins import _ros
@@ -242,6 +244,10 @@ class CatkinPlugin(snapcraft.BasePlugin):
         self._catkin_path = os.path.join(self.partdir, "catkin")
         self._wstool_path = os.path.join(self.partdir, "wstool")
 
+        runner_name = "snapcraft-{}-runner.sh".format(name)
+        self._snapcraft_runner_path = os.path.join(self.partdir, runner_name)
+        self._snap_runner_path = os.path.join("snap", "command-chain", runner_name)
+
         # The path created via the `source` key (or a combination of `source`
         # and `source-subdir` keys) needs to point to a valid Catkin workspace
         # containing another subdirectory called the "source space." By
@@ -273,75 +279,125 @@ class CatkinPlugin(snapcraft.BasePlugin):
                 )
             )
 
-    def env(self, root):
-        """Runtime environment for ROS binaries and services."""
+    def get_pull_env(self) -> "collections.OrderedDict[str, str]":
+        return collections.OrderedDict(
+            [
+                # Various ROS tools (e.g. rospack, roscore) keep a cache or a log, and use
+                # $ROS_HOME to determine where to put them.
+                ("ROS_HOME", os.path.join(tempfile.gettempdir(), "ros")),
+                # FIXME: LP: #1576411 breaks ROS snaps on the desktop, so we'll temporarily
+                # work around that bug by forcing the locale to C.UTF-8.
+                ("LC_ALL", "C.UTF-8"),
+            ]
+        )
 
-        paths = common.get_library_paths(root, self.project.arch_triplet)
+    def get_build_env(self) -> "collections.OrderedDict[str, str]":
+        paths = common.get_library_paths(self.installdir, self.project.arch_triplet)
         ld_library_path = formatting_utils.combine_paths(
             paths, prepend="", separator=":"
         )
 
-        env = [
-            # This environment variable tells ROS nodes where to find ROS
-            # master. It does not affect ROS master, however-- this is just the
-            # URI.
-            "ROS_MASTER_URI={}".format(self.options.catkin_ros_master_uri),
-            # Various ROS tools (e.g. rospack, roscore) keep a cache or a log,
-            # and use $ROS_HOME to determine where to put them.
-            "ROS_HOME=${SNAP_USER_DATA:-/tmp}/ros",
-            # FIXME: LP: #1576411 breaks ROS snaps on the desktop, so we'll
-            # temporarily work around that bug by forcing the locale to
-            # C.UTF-8.
-            "LC_ALL=C.UTF-8",
-            # The Snapcraft Core will ensure that we get a good LD_LIBRARY_PATH
-            # overall, but it defines it after this function runs. Some ROS
-            # tools will cause binaries to be run when we source the setup.sh,
-            # below, so we need to have a sensible LD_LIBRARY_PATH before then.
-            "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:{}".format(ld_library_path),
+        return collections.OrderedDict(
+            [
+                # Various ROS tools (e.g. rospack, roscore) keep a cache or a log, and use
+                # $ROS_HOME to determine where to put them.
+                ("ROS_HOME", os.path.join(tempfile.gettempdir(), "ros")),
+                # FIXME: LP: #1576411 breaks ROS snaps on the desktop, so we'll temporarily
+                # work around that bug by forcing the locale to C.UTF-8.
+                ("LC_ALL", "C.UTF-8"),
+                # The Snapcraft Core will ensure that we get a good LD_LIBRARY_PATH overall,
+                # but it defines it after this function runs. Some ROS tools will cause
+                # binaries to be run when we source the setup.sh in the command chain, so we
+                # need to have a sensible LD_LIBRARY_PATH before then.
+                ("LD_LIBRARY_PATH", "$LD_LIBRARY_PATH:{}".format(ld_library_path)),
+                # The setup.sh we source in the command chain requires the in-snap python.
+                # Make sure it's in the PATH before it's run.
+                ("PATH", "$PATH:{}/usr/bin".format(self.installdir)),
+                # The ROS packaging system tools (e.g. rospkg, etc.) don't go into the ROS
+                # install path (/opt/ros/$distro), so we need the PYTHONPATH to include the
+                # dist-packages in /usr/lib as well.
+                #
+                # Note: Empty segments in PYTHONPATH are interpreted as `.`, thus
+                # adding the current working directory to the PYTHONPATH. That is
+                # not desired in this situation, so take proper precautions when
+                # expanding PYTHONPATH: only add it if it's not empty.
+                (
+                    "PYTHONPATH",
+                    "{}${{PYTHONPATH:+:$PYTHONPATH}}".format(
+                        common.get_python2_path(self.installdir)
+                    ),
+                ),
+            ]
+        )
+
+    def get_build_command_chain(self) -> List[str]:
+        return [self._snapcraft_runner_path]
+
+    def get_prime_env(self) -> "collections.OrderedDict[str, str]":
+        # The priming environment and command chain are used to ensure binaries used in
+        # commands exist. However, we can't make a Catkin command chain that will work
+        # in both the priming area and the final snap. Instead, just re-use the build
+        # environment and chain to verify apps are valid.
+        return self.get_build_env()
+
+    def get_prime_command_chain(self) -> List[str]:
+        # The priming environment and command chain are used to ensure binaries used in
+        # commands exist. However, we can't make a Catkin command chain that will work
+        # in both the priming area and the final snap. Instead, just re-use the build
+        # environment and chain to verify apps are valid.
+        return self.get_build_command_chain()
+
+    def get_snap_env(self) -> "collections.OrderedDict[str, str]":
+        paths = common.get_library_paths(
+            self.project.prime_dir, self.project.arch_triplet
+        )
+        paths = [
+            os.path.join("$SNAP", os.path.relpath(p, self.project.prime_dir))
+            for p in paths
         ]
+        ld_library_path = formatting_utils.combine_paths(
+            paths, prepend="", separator=":"
+        )
+        python_path = os.path.join(
+            "$SNAP",
+            os.path.relpath(
+                common.get_python2_path(self.project.prime_dir), self.project.prime_dir
+            ),
+        )
 
-        # There's a chicken and egg problem here, everything run gets an
-        # env built, even package installation, so the first runs for these
-        # will likely fail.
-        try:
-            # The ROS packaging system tools (e.g. rospkg, etc.) don't go
-            # into the ROS install path (/opt/ros/$distro), so we need the
-            # PYTHONPATH to include the dist-packages in /usr/lib as well.
-            #
-            # Note: Empty segments in PYTHONPATH are interpreted as `.`, thus
-            # adding the current working directory to the PYTHONPATH. That is
-            # not desired in this situation, so take proper precautions when
-            # expanding PYTHONPATH: only add it if it's not empty.
-            env.append(
-                "PYTHONPATH={}${{PYTHONPATH:+:$PYTHONPATH}}".format(
-                    common.get_python2_path(root)
-                )
-            )
-        except errors.SnapcraftEnvironmentError as e:
-            logger.debug(e)
+        return collections.OrderedDict(
+            [
+                # This environment variable tells ROS nodes where to find ROS master. It
+                # does not affect ROS master, however-- this is just the URI.
+                ("ROS_MASTER_URI", self.options.catkin_ros_master_uri),
+                # Various ROS tools (e.g. rospack, roscore) keep a cache or a log, and use
+                # $ROS_HOME to determine where to put them.
+                ("ROS_HOME", "$SNAP_USER_DATA/ros"),
+                # FIXME: LP: #1576411 breaks ROS snaps on the desktop, so we'll temporarily
+                # work around that bug by forcing the locale to C.UTF-8.
+                ("LC_ALL", "C.UTF-8"),
+                # The Snapcraft Core will ensure that we get a good LD_LIBRARY_PATH overall,
+                # but it defines it after this function runs. Some ROS tools will cause
+                # binaries to be run when we source the setup.sh in the command chain, so we
+                # need to have a sensible LD_LIBRARY_PATH before then.
+                ("LD_LIBRARY_PATH", "$LD_LIBRARY_PATH:{}".format(ld_library_path)),
+                # The setup.sh we source in the command chain requires the in-snap python.
+                # Make sure it's in the PATH before it's run.
+                ("PATH", "$PATH:{}/usr/bin".format(self.installdir)),
+                # The ROS packaging system tools (e.g. rospkg, etc.) don't go into the ROS
+                # install path (/opt/ros/$distro), so we need the PYTHONPATH to include the
+                # dist-packages in /usr/lib as well.
+                #
+                # Note: Empty segments in PYTHONPATH are interpreted as `.`, thus
+                # adding the current working directory to the PYTHONPATH. That is
+                # not desired in this situation, so take proper precautions when
+                # expanding PYTHONPATH: only add it if it's not empty.
+                ("PYTHONPATH", "{}${{PYTHONPATH:+:$PYTHONPATH}}".format(python_path)),
+            ]
+        )
 
-        # The setup.sh we source below requires the in-snap python. Here we
-        # make sure it's in the PATH before it's run.
-        env.append("PATH=$PATH:{}/usr/bin".format(root))
-
-        if self.options.underlay:
-            script = textwrap.dedent(
-                """
-                if [ -f {snapcraft_setup} ]; then
-                    . {snapcraft_setup}
-                fi
-            """
-            ).format(snapcraft_setup=os.path.join(self.rosdir, "snapcraft-setup.sh"))
-        else:
-            script = self._source_setup_sh(root, None)
-
-        # Each of these lines is prepended with an `export` when the
-        # environment is actually generated. In order to inject real shell code
-        # we have to hack it in by appending it on the end of an item already
-        # in the environment. FIXME: There should be a better way to do this.
-        env[-1] = env[-1] + "\n\n" + script
-
-        return env
+    def get_snap_command_chain(self) -> List[str]:
+        return [self._snap_runner_path]
 
     def pull(self):
         """Copy source into build directory and fetch dependencies.
@@ -428,7 +484,9 @@ class CatkinPlugin(snapcraft.BasePlugin):
             )
             catkin.setup()
 
-            self._generate_snapcraft_setup_sh(self.installdir, underlay_build_path)
+        self._generate_snapcraft_setup_sh(
+            self._snapcraft_runner_path, self.installdir, underlay_build_path
+        )
 
         # Pull our own compilers so we use ones that match up with the version
         # of ROS we're using.
@@ -522,6 +580,10 @@ class CatkinPlugin(snapcraft.BasePlugin):
         with contextlib.suppress(FileNotFoundError):
             shutil.rmtree(self._catkin_path)
 
+        # Remove the runner
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(self._snapcraft_runner_path)
+
         # Clean pip packages, if any
         self._pip.clean_packages()
 
@@ -559,7 +621,9 @@ class CatkinPlugin(snapcraft.BasePlugin):
         # (LP: #1660852). So we'll backup all args, source the setup.sh, then
         # restore all args for the wrapper's `exec` line.
         return textwrap.dedent(
-            """
+            """\
+            #!/bin/sh
+
             # Shell quote arbitrary string by replacing every occurrence of '
             # with '\\'', then put ' at the beginning and end of the string.
             # Prepare yourself, fun regex ahead.
@@ -575,16 +639,18 @@ class CatkinPlugin(snapcraft.BasePlugin):
             set --
             {}
             eval "set -- $BACKUP_ARGS"
-        """
+            exec "$@"
+            """
         ).format(
             source_script
         )  # noqa
 
-    def _generate_snapcraft_setup_sh(self, root, underlay_path):
+    def _generate_snapcraft_setup_sh(self, path, root, underlay_path):
         script = self._source_setup_sh(root, underlay_path)
-        os.makedirs(self.rosdir, exist_ok=True)
-        with open(os.path.join(self.rosdir, "snapcraft-setup.sh"), "w") as f:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
             f.write(script)
+        os.chmod(path, 0o555)
 
     @property
     def rosdir(self):
@@ -693,9 +759,14 @@ class CatkinPlugin(snapcraft.BasePlugin):
                 f.truncate()
                 f.write(replaced)
 
+        underlay_run_path = None
         if self.options.underlay:
             underlay_run_path = self.options.underlay["run-path"]
-            self._generate_snapcraft_setup_sh("$SNAP", underlay_run_path)
+        self._generate_snapcraft_setup_sh(
+            os.path.join(self.installdir, self._snap_runner_path),
+            "$SNAP",
+            underlay_run_path,
+        )
 
         # If pip dependencies were installed, generate a sitecustomize that
         # allows access to them.

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -102,6 +102,9 @@ class TestCase(testtools.TestCase):
             fixtures.EnvironmentVariable("SNAPCRAFT_ENABLE_ERROR_REPORTING", "false")
         )
 
+        # Don't let the managed host variable leak into tests
+        self.useFixture(fixtures.EnvironmentVariable("SNAPCRAFT_MANAGED_HOST"))
+
         # Note that these directories won't exist when the test starts,
         # they might be created after calling the snapcraft command on the
         # project dir.

--- a/tests/integration/lifecycle/test_snap.py
+++ b/tests/integration/lifecycle/test_snap.py
@@ -41,6 +41,13 @@ class SnapTestCase(integration.TestCase):
             expected_binary1_wrapper = file_.read()
         self.assertThat(binary1_wrapper_path, FileContains(expected_binary1_wrapper))
 
+        command_chain_path = os.path.join(
+            self.prime_dir, "snap", "command-chain", "snapcraft-runner"
+        )
+        with open("command-chain", "r") as file_:
+            expected_command_chain = file_.read()
+        self.assertThat(command_chain_path, FileContains(expected_command_chain))
+
         self.useFixture(
             fixtures.EnvironmentVariable(
                 "SNAP", os.path.join(os.getcwd(), self.prime_dir)
@@ -54,7 +61,8 @@ class SnapTestCase(integration.TestCase):
         )
         for binary, expected_output in binary_scenarios:
             output = subprocess.check_output(
-                os.path.join(self.prime_dir, binary), universal_newlines=True
+                [command_chain_path, os.path.join(self.prime_dir, binary)],
+                universal_newlines=True,
             )
             self.assertThat(output, Equals(expected_output))
 
@@ -92,15 +100,15 @@ class SnapTestCase(integration.TestCase):
                 grade: stable
                 apps:
                   assemble-bin:
-                    command: command-assemble-bin.wrapper
+                    command: snap/command-chain/snapcraft-runner $SNAP/command-assemble-bin.wrapper
                   assemble-service:
-                    command: command-assemble-service.wrapper
+                    command: snap/command-chain/snapcraft-runner $SNAP/command-assemble-service.wrapper
                     daemon: simple
-                    stop-command: stop-command-assemble-service.wrapper
+                    stop-command: snap/command-chain/snapcraft-runner $SNAP/stop-command-assemble-service.wrapper
                   binary-wrapper-none:
                     command: subdir/binary3
                   binary2:
-                    command: command-binary2.wrapper
+                    command: snap/command-chain/snapcraft-runner $SNAP/command-binary2.wrapper
             """
                 ).format(self.deb_arch)
             ),
@@ -269,7 +277,7 @@ class SnapTestCase(integration.TestCase):
               stub_key: stub-value
             apps:
               stub-app:
-                command: command-stub-app.wrapper
+                command: snap/command-chain/snapcraft-runner $SNAP/command-stub-app.wrapper
         """
         )
         self.assertThat(

--- a/tests/integration/snaps/assemble/binary1.after
+++ b/tests/integration/snaps/assemble/binary1.after
@@ -1,4 +1,2 @@
 #!/bin/sh
-export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
-export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 exec "$SNAP/binary1" "$@"

--- a/tests/integration/snaps/assemble/command-chain
+++ b/tests/integration/snaps/assemble/command-chain
@@ -1,0 +1,4 @@
+#!/bin/sh
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+exec "$@"

--- a/tests/spread/plugins/ament/snaps/ros2-talker-listener/snap/snapcraft.yaml
+++ b/tests/spread/plugins/ament/snaps/ros2-talker-listener/snap/snapcraft.yaml
@@ -1,8 +1,7 @@
 name: ros2-talker-listener
 version: '1.0'
 summary: ROS2 Example
-description: |
-  A ROS2 workspace containing a talker and a listener.
+description: A ROS2 workspace containing a talker and a listener.
 
 grade: stable
 confinement: strict

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -166,6 +166,9 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
             fixtures.EnvironmentVariable("SNAPCRAFT_ENABLE_ERROR_REPORTING", "false")
         )
 
+        # Don't let the managed host variable leak into tests
+        self.useFixture(fixtures.EnvironmentVariable("SNAPCRAFT_MANAGED_HOST"))
+
         machine = os.environ.get("SNAPCRAFT_TEST_MOCK_MACHINE", None)
         self.base_environment = fixture_setup.FakeBaseEnvironment(machine=machine)
         self.useFixture(self.base_environment)

--- a/tests/unit/pluginhandler/test_runner.py
+++ b/tests/unit/pluginhandler/test_runner.py
@@ -110,13 +110,13 @@ class RunnerTestCase(unit.TestCase):
 
         self.assertThat(os.path.join("builddir", "fake-build"), FileExists())
 
-    def test_snapcraftctl_alias_if_snap(self):
+    def test_snapcraft_utils_in_path_if_snap(self):
         self.useFixture(fixture_setup.FakeSnapcraftIsASnap())
 
         os.mkdir("builddir")
 
         runner = _runner.Runner(
-            part_properties={"prepare": "alias snapcraftctl > definition"},
+            part_properties={"prepare": "echo $PATH > path"},
             sourcedir="sourcedir",
             builddir="builddir",
             stagedir="stagedir",
@@ -124,15 +124,14 @@ class RunnerTestCase(unit.TestCase):
             builtin_functions={},
         )
 
-        with mock.patch("os.path.exists", return_value=True):
-            runner.prepare()
+        runner.prepare()
 
-        expected_snapcrafctl = "/snap/snapcraft/current/bin/snapcraftctl"
+        expected_path_segment = "/snap/snapcraft/current/bin/snapcraft-utils"
 
-        self.assertThat(os.path.join("builddir", "definition"), FileExists())
+        self.assertThat(os.path.join("builddir", "path"), FileExists())
         self.assertThat(
-            os.path.join("builddir", "definition"),
-            FileContains("snapcraftctl={!r}\n".format(expected_snapcrafctl)),
+            os.path.join("builddir", "path"),
+            FileContains(matcher=Contains(expected_path_segment)),
         )
 
     def test_old_build(self):

--- a/tests/unit/project_loader/test_validation.py
+++ b/tests/unit/project_loader/test_validation.py
@@ -1451,6 +1451,68 @@ class InvalidEpochsTest(ProjectLoaderBaseTest):
         )
 
 
+class ValidAdaptersTest(ProjectLoaderBaseTest):
+
+    scenarios = [("none", {"yaml": "none"}), ("legacy", {"yaml": "legacy"})]
+
+    def test_yaml_valid_adapters(self):
+        self.make_snapcraft_project(
+            dedent(
+                """\
+                name: test
+                version: "1"
+                summary: test
+                description: nothing
+                apps:
+                  app:
+                    command: foo
+                    adapter: {}
+                parts:
+                  part1:
+                    plugin: nil
+                """
+            ).format(self.yaml)
+        )
+
+
+class InvalidAdapterTest(ProjectLoaderBaseTest):
+
+    scenarios = [
+        ("NONE", {"yaml": "NONE"}),
+        ("none-", {"yaml": "none-"}),
+        ("invalid", {"yaml": "invalid"}),
+        ("LeGaCY", {"yaml": "LeGaCY"}),
+        ("leg-acy", {"yaml": "leg-acy"}),
+    ]
+
+    def test_invalid_yaml_invalid_adapters(self):
+        snapcraft_yaml = dedent(
+            """\
+            name: test
+            version: "1"
+            summary: test
+            description: nothing
+            apps:
+              app:
+                command: foo
+                adapter: {}
+            parts:
+              part1:
+                plugin: nil
+            """
+        ).format(self.yaml)
+
+        raised = self.assertRaises(
+            errors.YamlValidationError, self.make_snapcraft_project, snapcraft_yaml
+        )
+
+        self.assertRegex(
+            raised.message,
+            "The 'apps/app/adapter' property does not match the required schema:.*is "
+            "not one of \['none', 'legacy'\]",
+        )
+
+
 class ValidArchitecturesTest(ProjectLoaderBaseTest):
 
     yaml_scenarios = [


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

**Don't review yet.**

In order to move from generating wrappers to using command-chain, plugins need to be able to specify command-chains for their lifecycle steps as well as dependents and the final snap. This PR resolves [LP: #1790978](https://bugs.launchpad.net/snapcraft/+bug/1790978) by doing this, and by also implementing functions for obtaining the environment for each lifecycle step as well as dependents and the final snap.

See the [forum topic](https://forum.snapcraft.io/t/6018) for more details.