### PR TITLE
docker: support for testing snapcraft in proposed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM ubuntu:xenial
 
-# Enable multiverse as snapcraft cleanbuild does.
-RUN sed -i 's/ universe/ universe multiverse/' /etc/apt/sources.list
-
 RUN apt-get update && \
   apt-get dist-upgrade --yes && \
   apt-get install --yes \

--- a/docker/xenial-proposed.Dockerfile
+++ b/docker/xenial-proposed.Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:xenial
+
+# Enable proposed and pin snapcraft
+RUN echo "deb http://archive.ubuntu.com/ubuntu/ xenial-proposed restricted main multiverse universe" >> /etc/apt/sources.list
+RUN cat /etc/apt/sources.list
+RUN echo 'Package: *' > /etc/apt/preferences.d/snapcraft-proposed
+RUN echo 'Pin: release a=xenial-proposed' >> /etc/apt/preferences.d/snapcraft-proposed
+RUN echo 'Pin-Priority: 400' >> /etc/apt/preferences.d/snapcraft-proposed
+
+RUN apt-get update && \
+  apt-get dist-upgrade --yes && \
+  apt-get install --yes \
+  git \
+  snapcraft/xenial-proposed \
+  && \
+  apt-get autoclean --yes && \
+  apt-get clean --yes
+
+# Required by click.
+ENV LC_ALL C.UTF-8
+ENV SNAPCRAFT_SETUP_CORE 1

--- a/docker/xenial-proposed.Dockerfile
+++ b/docker/xenial-proposed.Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:xenial
 
 # Enable proposed and pin snapcraft
 RUN echo "deb http://archive.ubuntu.com/ubuntu/ xenial-proposed restricted main multiverse universe" >> /etc/apt/sources.list
-RUN cat /etc/apt/sources.list
 RUN echo 'Package: *' > /etc/apt/preferences.d/snapcraft-proposed
 RUN echo 'Pin: release a=xenial-proposed' >> /etc/apt/preferences.d/snapcraft-proposed
 RUN echo 'Pin-Priority: 400' >> /etc/apt/preferences.d/snapcraft-proposed


### PR DESCRIPTION
Adding a dockerfile specifically tailored for testing the snapcraft deb
in xenial-proposed.

Also remove the multiverse sed from the standard Dockerfile as
multiverse is already in the base image.

LP: #1791116
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
