### PR TITLE
packaging: cleanup extension usage in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,6 @@ if sys.platform == "win32":
         "include_files": [
             ("libraries", os.path.join("share", "snapcraft", "libraries")),
             ("schema", os.path.join("share", "snapcraft", "schema")),
-            ("extensions", os.path.join("share", "snapcraft", "extensions")),
         ],
     }
 
@@ -150,10 +149,6 @@ else:
             (
                 "share/snapcraft/libraries",
                 ["libraries/" + x for x in os.listdir("libraries")],
-            ),
-            (
-                "share/snapcraft/extensions",
-                ["extensions/" + x for x in os.listdir("extensions")],
             ),
         ],
         install_requires=["pysha3", "pyxdg", "requests"],

--- a/spread.yaml
+++ b/spread.yaml
@@ -222,4 +222,8 @@ suites:
  tests/spread/plugins/waf/:
    summary: tests of snapcraft's Waf plugin
 
+ tests/spread/packaging/:
+   # TODO: we do not need the generalist prepare.
+   summary: tests that create different packagings for snapcraft
+
 path: /snapcraft/

--- a/tests/spread/packaging/python/task.yaml
+++ b/tests/spread/packaging/python/task.yaml
@@ -1,0 +1,16 @@
+summary: ensure that an setup.py sdist is installable
+
+systems: [ubuntu-16*]
+
+prepare: |
+  apt-get update
+  apt-get install -y python3 python3-pip
+  cp -R /snapcraft /snapcraft-sdist
+
+restore: |
+  rm -rf /snapcraft-sdist
+
+execute: |
+  cd /snapcraft-sdist
+  python3 setup.py sdist
+  pip3 install dist/*.tar.gz


### PR DESCRIPTION
The migration from template yamls to extensions and python
implementations for these missed some cleanups in setup.py
which made the generated sdist uninstallable.

LP: #1791172

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
