### PR TITLE
yaml loading: properly handle unhashable types

### DIFF
--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -362,9 +362,9 @@ of the choice of plugin.
         build in Debug mode.
 """
 
-from collections import OrderedDict  # noqa
+import collections
 import pkg_resources  # noqa
-import yaml  # noqa
+import yaml
 
 
 def _get_version():
@@ -426,7 +426,17 @@ def dict_representer(dumper, data):
 def dict_constructor(loader, node):
     # Necessary in order to make yaml merge tags work
     loader.flatten_mapping(node)
-    return OrderedDict(loader.construct_pairs(node))
+    value = loader.construct_pairs(node)
+
+    try:
+        return collections.OrderedDict(value)
+    except TypeError:
+        raise yaml.constructor.ConstructorError(
+            "while constructing a mapping",
+            node.start_mark,
+            "found unhashable key",
+            node.start_mark,
+        )
 
 
 def str_presenter(dumper, data):
@@ -437,7 +447,7 @@ def str_presenter(dumper, data):
 
 yaml.add_representer(str, str_presenter)
 yaml.SafeDumper.add_representer(str, str_presenter)
-yaml.add_representer(OrderedDict, dict_representer)
-yaml.SafeDumper.add_representer(OrderedDict, dict_representer)
+yaml.add_representer(collections.OrderedDict, dict_representer)
+yaml.SafeDumper.add_representer(collections.OrderedDict, dict_representer)
 yaml.add_constructor(_mapping_tag, dict_constructor)
 yaml.SafeLoader.add_constructor(_mapping_tag, dict_constructor)

--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -75,5 +75,11 @@ def _load_yaml(*, yaml_file_path: str) -> OrderedDict:
                 chr(e.character), e.position + 1, yaml_file_path, e.reason
             )
         ) from e
+    except yaml.constructor.ConstructorError as e:
+        raise errors.YamlValidationError(
+            "{}, line {}, column {}".format(
+                e.problem, e.problem_mark.line + 1, e.problem_mark.column + 1
+            )
+        ) from e
 
     return yaml_contents

--- a/tests/unit/project_loader/test_validation.py
+++ b/tests/unit/project_loader/test_validation.py
@@ -24,7 +24,7 @@ from testtools.matchers import Contains, Equals, MatchesRegex
 
 from . import ProjectLoaderBaseTest
 from tests import fixture_setup, unit
-from snapcraft.project import Project
+from snapcraft.project import Project, errors as project_errors
 from snapcraft.internal.errors import PluginError
 from snapcraft.internal.project_loader import load_config, errors
 from snapcraft.internal.project_loader import Validator
@@ -939,6 +939,30 @@ class VersionTest(ProjectLoaderBaseTest):
                 "schema: 'abcdefghijklmnopqrstuvwxyz1234567' is too long "
                 "(maximum length is 32)"
             ),
+        )
+
+    def test_invalid_yaml_version_unhashable(self):
+        snapcraft_yaml = dedent(
+            """\
+            name: test
+            version: {{invalid}}
+            summary: test
+            description: test
+            confinement: strict
+            grade: stable
+            parts:
+              part1:
+                plugin: nil
+            """
+        )
+        raised = self.assertRaises(
+            project_errors.YamlValidationError,
+            self.make_snapcraft_project,
+            snapcraft_yaml,
+        )
+
+        self.assertThat(
+            raised.message, Equals("found unhashable key, line 2, column 10")
         )
 
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR resolves [LP: #1791187](https://bugs.launchpad.net/snapcraft/+bug/1791187) by checking for unhashable types and raising a `ConstructorError` if it finds one. PyYAML deals with this by default, but the snapcraft CLI uses a custom dict loader that doesn't.  It also updates `ProjectInfo` to properly handle `ConstructionError`s, and adds a test for the whole thing.