### PR TITLE
plugin: update catkin plugin to support melodic

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -89,6 +89,7 @@ _ROS_RELEASE_MAP = {
     "jade": "trusty",
     "kinetic": "xenial",
     "lunar": "xenial",
+    "melodic": "bionic",
 }
 
 _SUPPORTED_DEPENDENCY_TYPES = {"apt", "pip"}

--- a/tests/unit/plugins/test_catkin.py
+++ b/tests/unit/plugins/test_catkin.py
@@ -355,8 +355,8 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
             str(raised),
             Equals(
                 "Unsupported rosdistro: 'invalid'. The supported ROS "
-                "distributions are 'indigo', 'jade', 'kinetic', and "
-                "'lunar'"
+                "distributions are 'indigo', 'jade', 'kinetic', 'lunar', "
+                "and 'melodic'"
             ),
         )
 
@@ -379,6 +379,12 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
         self.properties.rosdistro = "lunar"
         plugin = catkin.CatkinPlugin("test-part", self.properties, self.project_options)
         self.assertTrue("xenial" in plugin.PLUGIN_STAGE_SOURCES)
+    
+    def test_get_stage_sources_melodic(self):
+        self.properties.rosdistro = "melodic"
+        plugin = catkin.CatkinPlugin("test-part", self.properties, self.project_options)
+        self.assertTrue("bionic" in plugin.PLUGIN_STAGE_SOURCES)
+
 
     @mock.patch("snapcraft.plugins.catkin.Compilers")
     def test_pull_invalid_dependency(self, compilers_mock):

--- a/tests/unit/plugins/test_catkin.py
+++ b/tests/unit/plugins/test_catkin.py
@@ -379,12 +379,11 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
         self.properties.rosdistro = "lunar"
         plugin = catkin.CatkinPlugin("test-part", self.properties, self.project_options)
         self.assertTrue("xenial" in plugin.PLUGIN_STAGE_SOURCES)
-    
+
     def test_get_stage_sources_melodic(self):
         self.properties.rosdistro = "melodic"
         plugin = catkin.CatkinPlugin("test-part", self.properties, self.project_options)
         self.assertTrue("bionic" in plugin.PLUGIN_STAGE_SOURCES)
-
 
     @mock.patch("snapcraft.plugins.catkin.Compilers")
     def test_pull_invalid_dependency(self, compilers_mock):


### PR DESCRIPTION
ROS Melodic uses bionic as a base. 

I note that I'm required to `stage-packages['libc6']` now using this, which I wasn't before with kinetic, because the GLIBC version of the targeted core was 2.23, and most of the included libraries required 2.27.  I'm not sure how to change this.

Here's my snapcraft.yaml. I am building on Bionic 18.04.1. https://gist.github.com/NickZ/309fc17d5341c86e35f16a726cf48706
