### PR TITLE
build providers: provide support to shell in

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -181,6 +181,10 @@ class Provider(abc.ABC):
         :rtype: str
         """
 
+    @abc.abstractmethod
+    def shell(self) -> None:
+        """Provider steps to provide a shell into the instance."""
+
     def launch_instance(self) -> None:
         os.makedirs(self.provider_project_dir, exist_ok=True)
         self._launch()

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -105,7 +105,7 @@ class Multipass(Provider):
         # multipass keeps the mount active, so check if it is there first.
         if not self._instance_info.is_mounted(project_mountpoint):
             self._mount(
-                mountpoint=project_mountpoint, dev_or_path=self.project.project_dir
+                mountpoint=project_mountpoint, dev_or_path=self.project._project_dir
             )
 
     def provision_project(self, tarball: str) -> None:
@@ -150,6 +150,9 @@ class Multipass(Provider):
         )
         self._multipass_cmd.copy_files(source=source, destination=self.snap_filename)
         return self.snap_filename
+
+    def shell(self) -> None:
+        self._multipass_cmd.shell(instance_name=self.instance_name)
 
     def _get_instance_info(self):
         instance_info_raw = self._multipass_cmd.info(

--- a/snapcraft/internal/build_providers/_multipass/_multipass_command.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass_command.py
@@ -153,6 +153,18 @@ class MultipassCommand:
                 exit_code=process_error.returncode,
             ) from process_error
 
+    def shell(self, *, instance_name: str) -> None:
+        """Passthrough for running multipass shell.
+
+        :param str instance_name: the name of the instance to execute command.
+        """
+        try:
+            _run([self.provider_cmd, "shell", instance_name])
+        except subprocess.CalledProcessError as process_error:
+            raise errors.ProviderShellError(
+                provider_name=self.provider_name, exit_code=process_error.returncode
+            ) from process_error
+
     def mount(self, *, source: str, target: str) -> None:
         """Passthrough for running multipass mount.
 

--- a/snapcraft/internal/build_providers/errors.py
+++ b/snapcraft/internal/build_providers/errors.py
@@ -112,6 +112,17 @@ class ProviderExecError(_SnapcraftError):
         )
 
 
+class ProviderShellError(_SnapcraftError):
+
+    fmt = (
+        "An error occurred when trying to provide a shell with "
+        "{provider_name!r}: returned exit code {exit_code!r}."
+    )
+
+    def __init__(self, *, provider_name: str, exit_code: int) -> None:
+        super().__init__(provider_name=provider_name, exit_code=exit_code)
+
+
 class ProviderMountError(_SnapcraftError):
 
     fmt = (

--- a/snapcraft/project/_project.py
+++ b/snapcraft/project/_project.py
@@ -52,6 +52,7 @@ class Project(ProjectOptions):
             self.info = ProjectInfo(snapcraft_yaml_file_path=snapcraft_yaml_file_path)
 
         self._global_state_file = os.path.join(internal_dir, "state")
+        self._project_dir = project_dir
         self._work_dir = work_dir
         self._internal_dir = internal_dir
 

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -77,6 +77,9 @@ class ProviderImpl(Provider):
     def retrieve_snap(self):
         raise NotImplementedError("test stub not implemented")
 
+    def shell(self):
+        raise NotImplementedError("test stub not implemented")
+
 
 def get_project() -> Project:
     with open("snapcraft.yaml", "w") as snapcraft_file:

--- a/tests/unit/build_providers/multipass/test_multipass_command.py
+++ b/tests/unit/build_providers/multipass/test_multipass_command.py
@@ -102,6 +102,30 @@ class MultipassCommandLaunchTest(MultipassCommandPassthroughBaseTest):
         self.check_output_mock.assert_not_called()
 
 
+class MultipassCommandShellTest(MultipassCommandPassthroughBaseTest):
+    def test_shell(self):
+        self.multipass_command.shell(instance_name=self.instance_name)
+
+        self.check_call_mock.assert_called_once_with(
+            ["multipass", "shell", self.instance_name]
+        )
+        self.check_output_mock.assert_not_called()
+
+    def test_shell_fails(self):
+        # multipass can fail due to several reasons and will display the error
+        # right above this exception message.
+        cmd = ["multipass", "shell", self.instance_name]
+        self.check_call_mock.side_effect = subprocess.CalledProcessError(1, cmd)
+
+        self.assertRaises(
+            errors.ProviderShellError,
+            self.multipass_command.shell,
+            instance_name=self.instance_name,
+        )
+        self.check_call_mock.assert_called_once_with(cmd)
+        self.check_output_mock.assert_not_called()
+
+
 class MultipassCommandStopTest(MultipassCommandPassthroughBaseTest):
     def test_stop(self):
         self.multipass_command.stop(instance_name=self.instance_name)

--- a/tests/unit/build_providers/test_errors.py
+++ b/tests/unit/build_providers/test_errors.py
@@ -103,6 +103,17 @@ class ErrorFormattingTest(unit.TestCase):
             ),
         ),
         (
+            "ProviderShellError",
+            dict(
+                exception=errors.ProviderShellError,
+                kwargs=dict(provider_name="multipass", exit_code=1),
+                expected_message=(
+                    "An error occurred when trying to provide a shell with "
+                    "'multipass': returned exit code 1."
+                ),
+            ),
+        ),
+        (
             "ProviderMountError",
             dict(
                 exception=errors.ProviderMountError,


### PR DESCRIPTION
Add support to shell into the provider,

    $ $SNAP/usr/bin/python3
    Python 3.5.2 (default, Nov 23 2017, 16:37:01)
    [GCC 5.4.0 20160609] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> from snapcraft.cli import echo
    >>> from snapcraft.project import Project
    >>> from snapcraft.internal.build_providers import get_provider_for
    >>> p = Project(snapcraft_yaml_file_path="snapcraft.yaml")
    >>> mp = get_provider_for("multipass")
    >>> instance = mp(project=p, echoer=echo)
    >>> instance.create()
    snapcraft 2.42.1+git81.gca11846.dirty installed
    >>> instance.shell()
    Welcome to Ubuntu 16.04.5 LTS (GNU/Linux 4.4.0-134-generic x86_64)

     * Documentation:  https://help.ubuntu.com
     * Management:     https://landscape.canonical.com
     * Support:        https://ubuntu.com/advantage

      Get cloud support with Ubuntu Advantage Cloud Guest:
        http://www.ubuntu.com/business/services/cloud

    0 packages can be updated.
    0 updates are security updates.

    New release '18.04.1 LTS' available.
    Run 'do-release-upgrade' to upgrade to it.

    Last login: Fri Sep  7 17:01:08 2018 from 10.72.100.1
    snapcraft-make-hello # ls
    parts  prime  project  snap  stage  state
    snapcraft-make-hello # logout
    >>> instance.destroy()
    >>>

LP: #1782775

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
