### PR TITLE
pluginhandler: stop using alias for snapcraftctl

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,6 +44,10 @@ parts:
         - patchelf
         - squashfs-tools
         - xdelta3
+    organize:
+        # Put snapcraftctl into its own directory that can be included in the PATH
+        # without including other binaries.
+        bin/snapcraftctl: bin/snapcraft-utils/snapcraftctl
     override-pull: |
         version="$(git describe --dirty --always | sed -e 's/-/+git/;y/-/./')"
         [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,7 +47,7 @@ parts:
     organize:
         # Put snapcraftctl into its own directory that can be included in the PATH
         # without including other binaries.
-        bin/snapcraftctl: bin/snapcraft-utils/snapcraftctl
+        bin/snapcraftctl: bin/scriptlet-bin/snapcraftctl
     override-pull: |
         version="$(git describe --dirty --always | sed -e 's/-/+git/;y/-/./')"
         [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable

--- a/snapcraft/internal/pluginhandler/_runner.py
+++ b/snapcraft/internal/pluginhandler/_runner.py
@@ -255,7 +255,7 @@ def _get_env():
         # means snapcraftctl won't be found. We can't use aliases since they don't
         # persist into subshells. However, we know that snapcraftctl lives in its own
         # directory, so adding that to the PATH should have no ill side effects.
-        env += 'export PATH="$PATH:$SNAP/bin/snapcraft-utils"\n'
+        env += 'export PATH="$PATH:$SNAP/bin/scriptlet-bin"\n'
     env += common.assemble_env()
 
     return env

--- a/snapcraft/internal/pluginhandler/_runner.py
+++ b/snapcraft/internal/pluginhandler/_runner.py
@@ -251,12 +251,11 @@ class _NonBlockingRWFifo:
 def _get_env():
     env = ""
     if common.is_snap():
-        # Since the snap is classic, $SNAP/bin is not on the $PATH.
-        # Let's set an alias to make sure it's found (but only if it
-        # exists).
-        snapcraftctl_path = os.path.join(os.getenv("SNAP"), "bin", "snapcraftctl")
-        if os.path.exists(snapcraftctl_path):
-            env += 'alias snapcraftctl="$SNAP/bin/snapcraftctl"\n'
+        # Since the snap is classic, there is no $PATH pointing into the snap, which
+        # means snapcraftctl won't be found. We can't use aliases since they don't
+        # persist into subshells. However, we know that snapcraftctl lives in its own
+        # directory, so adding that to the PATH should have no ill side effects.
+        env += 'export PATH="$PATH:$SNAP/bin/snapcraft-utils"\n'
     env += common.assemble_env()
 
     return env

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -102,6 +102,9 @@ class TestCase(testtools.TestCase):
             fixtures.EnvironmentVariable("SNAPCRAFT_ENABLE_ERROR_REPORTING", "false")
         )
 
+        # Don't let the managed host variable leak into tests
+        self.useFixture(fixtures.EnvironmentVariable("SNAPCRAFT_MANAGED_HOST"))
+
         # Note that these directories won't exist when the test starts,
         # they might be created after calling the snapcraft command on the
         # project dir.

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -166,6 +166,9 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
             fixtures.EnvironmentVariable("SNAPCRAFT_ENABLE_ERROR_REPORTING", "false")
         )
 
+        # Don't let the managed host variable leak into tests
+        self.useFixture(fixtures.EnvironmentVariable("SNAPCRAFT_MANAGED_HOST"))
+
         machine = os.environ.get("SNAPCRAFT_TEST_MOCK_MACHINE", None)
         self.base_environment = fixture_setup.FakeBaseEnvironment(machine=machine)
         self.useFixture(self.base_environment)

--- a/tests/unit/pluginhandler/test_runner.py
+++ b/tests/unit/pluginhandler/test_runner.py
@@ -126,7 +126,7 @@ class RunnerTestCase(unit.TestCase):
 
         runner.prepare()
 
-        expected_path_segment = "/snap/snapcraft/current/bin/snapcraft-utils"
+        expected_path_segment = "/snap/snapcraft/current/bin/scriptlet-bin"
 
         self.assertThat(os.path.join("builddir", "path"), FileExists())
         self.assertThat(

--- a/tests/unit/pluginhandler/test_runner.py
+++ b/tests/unit/pluginhandler/test_runner.py
@@ -110,13 +110,13 @@ class RunnerTestCase(unit.TestCase):
 
         self.assertThat(os.path.join("builddir", "fake-build"), FileExists())
 
-    def test_snapcraftctl_alias_if_snap(self):
+    def test_snapcraft_utils_in_path_if_snap(self):
         self.useFixture(fixture_setup.FakeSnapcraftIsASnap())
 
         os.mkdir("builddir")
 
         runner = _runner.Runner(
-            part_properties={"prepare": "alias snapcraftctl > definition"},
+            part_properties={"prepare": "echo $PATH > path"},
             sourcedir="sourcedir",
             builddir="builddir",
             stagedir="stagedir",
@@ -124,15 +124,14 @@ class RunnerTestCase(unit.TestCase):
             builtin_functions={},
         )
 
-        with mock.patch("os.path.exists", return_value=True):
-            runner.prepare()
+        runner.prepare()
 
-        expected_snapcrafctl = "/snap/snapcraft/current/bin/snapcraftctl"
+        expected_path_segment = "/snap/snapcraft/current/bin/snapcraft-utils"
 
-        self.assertThat(os.path.join("builddir", "definition"), FileExists())
+        self.assertThat(os.path.join("builddir", "path"), FileExists())
         self.assertThat(
-            os.path.join("builddir", "definition"),
-            FileContains("snapcraftctl={!r}\n".format(expected_snapcrafctl)),
+            os.path.join("builddir", "path"),
+            FileContains(matcher=Contains(expected_path_segment)),
         )
 
     def test_old_build(self):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Once the snapcraft CLI supports plugins providing command chains, scriptlets will need to be run in a subshell, a boundary across which aliases cannot cross. Instead of using an alias when running from the snap, this PR makes progress on [LP: #1790978](https://bugs.launchpad.net/snapcraft/+bug/1790978) by simply installing snapcraftctl into its own directory and adding it to the PATH.