### PR TITLE
catkin plugin: use SnapcraftException

### DIFF
--- a/snapcraft/plugins/_ros/rosdep.py
+++ b/snapcraft/plugins/_ros/rosdep.py
@@ -43,6 +43,13 @@ class RosdepUnexpectedResultError(errors.SnapcraftError):
         super().__init__(dependency=dependency, output=output)
 
 
+class RosdepInitializationError(errors.SnapcraftError):
+    fmt = "Failed to initialize rosdep: {message}"
+
+    def __init__(self, message):
+        super().__init__(message=message)
+
+
 class Rosdep:
     def __init__(
         self,
@@ -95,14 +102,18 @@ class Rosdep:
             self._run(["init"])
         except subprocess.CalledProcessError as e:
             output = e.output.decode(sys.getfilesystemencoding()).strip()
-            raise RuntimeError("Error initializing rosdep database:\n{}".format(output))
+            raise RosdepInitializationError(
+                "Error initializing rosdep database:\n{}".format(output)
+            )
 
         logger.info("Updating rosdep database...")
         try:
             self._run(["update"])
         except subprocess.CalledProcessError as e:
             output = e.output.decode(sys.getfilesystemencoding()).strip()
-            raise RuntimeError("Error updating rosdep database:\n{}".format(output))
+            raise RosdepInitializationError(
+                "Error updating rosdep database:\n{}".format(output)
+            )
 
     def get_dependencies(self, package_name=None):
         """Obtain dependencies for a given package, or entire workspace.

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -134,7 +134,7 @@ class CatkinWorkspaceIsRootError(errors.SnapcraftError):
 
 
 class CatkinCannotResolveRoscoreError(errors.SnapcraftError):
-    fmt = "Failed to determine system dependency for roscore"
+    fmt = "Failed to determine system dependency for roscore."
 
 
 class CatkinAptDependencyFetchError(errors.SnapcraftError):

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -109,11 +109,53 @@ class CatkinInvalidSystemDependencyError(errors.SnapcraftError):
 class CatkinUnsupportedDependencyTypeError(errors.SnapcraftError):
     fmt = (
         "Package {dependency!r} resolved to an unsupported type of "
-        "dependency: {dependency_type!r}"
+        "dependency: {dependency_type!r}."
     )
 
     def __init__(self, dependency_type, dependency):
         super().__init__(dependency_type=dependency_type, dependency=dependency)
+
+
+class CatkinUnsupportedRosdistroError(errors.SnapcraftError):
+    fmt = (
+        "Unsupported ROS distribution: {rosdistro!r}. The supported ROS distributions "
+        "are {supported}."
+    )
+
+    def __init__(self, rosdistro):
+        super().__init__(
+            rosdistro=rosdistro,
+            supported=formatting_utils.humanize_list(_ROS_RELEASE_MAP.keys(), "and"),
+        )
+
+
+class CatkinWorkspaceIsRootError(errors.SnapcraftError):
+    fmt = "source-space cannot be the root of the Catkin workspace; use a subdirectory."
+
+
+class CatkinCannotResolveRoscoreError(errors.SnapcraftError):
+    fmt = "Failed to determine system dependency for roscore"
+
+
+class CatkinAptDependencyFetchError(errors.SnapcraftError):
+    fmt = "Failed to fetch apt dependencies: {message}"
+
+    def __init__(self, message):
+        super().__init__(message=message)
+
+
+class CatkinNoHighestVersionPathError(errors.SnapcraftError):
+    fmt = "Failed to determine highest path in {path!r}: nothing found."
+
+    def __init__(self, path):
+        super().__init__(path=path)
+
+
+class CatkinGccVersionError(errors.SnapcraftError):
+    fmt = "Failed to determine gcc version: {message}"
+
+    def __init__(self, message):
+        super().__init__(message=message)
 
 
 class CatkinPlugin(snapcraft.BasePlugin):
@@ -259,19 +301,11 @@ class CatkinPlugin(snapcraft.BasePlugin):
             )
 
         if os.path.abspath(self.sourcedir) == os.path.abspath(self._ros_package_path):
-            raise RuntimeError(
-                "source-space cannot be the root of the Catkin workspace"
-            )
+            raise CatkinWorkspaceIsRootError()
 
         # Validate selected ROS distro
         if self.options.rosdistro not in _ROS_RELEASE_MAP:
-            raise RuntimeError(
-                "Unsupported rosdistro: {!r}. The supported ROS distributions "
-                "are {}".format(
-                    self.options.rosdistro,
-                    formatting_utils.humanize_list(_ROS_RELEASE_MAP.keys(), "and"),
-                )
-            )
+            raise CatkinUnsupportedRosdistroError(self.options.rosdistro)
 
     def env(self, root):
         """Runtime environment for ROS binaries and services."""
@@ -466,7 +500,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
                         system_dependencies[dependency_type] = set()
                     system_dependencies[dependency_type] |= dependencies
             else:
-                raise RuntimeError("Unable to determine system dependency for roscore")
+                raise CatkinCannotResolveRoscoreError()
 
         # Pull down and install any apt dependencies that were discovered
         self._setup_apt_dependencies(system_dependencies.get("apt"))
@@ -490,9 +524,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
             try:
                 ubuntu.get(apt_dependencies)
             except repo.errors.PackageNotFoundError as e:
-                raise RuntimeError(
-                    "Failed to fetch apt dependencies: {}".format(e.message)
-                )
+                raise CatkinAptDependencyFetchError(e.message)
 
             logger.info("Installing apt dependencies...")
             ubuntu.unpack(self.installdir)
@@ -1001,8 +1033,8 @@ class Compilers:
                     )
                 )
             )
-        except RuntimeError as e:
-            raise RuntimeError("Unable to determine gcc version: {}".format(str(e)))
+        except CatkinNoHighestVersionPathError as e:
+            raise CatkinGccVersionError(str(e))
 
         return formatting_utils.combine_paths(paths, prepend="-I", separator=" ")
 
@@ -1104,6 +1136,6 @@ class _Catkin:
 def _get_highest_version_path(path):
     paths = sorted(glob.glob(os.path.join(path, "*")))
     if not paths:
-        raise RuntimeError("nothing found in {!r}".format(path))
+        raise CatkinNoHighestVersionPathError(path)
 
     return paths[-1]

--- a/tests/unit/plugins/ros/test_rosdep.py
+++ b/tests/unit/plugins/ros/test_rosdep.py
@@ -94,9 +94,14 @@ class RosdepTestCase(unit.TestCase):
 
         self.check_output_mock.side_effect = run
 
-        raised = self.assertRaises(RuntimeError, self.rosdep.setup)
+        raised = self.assertRaises(rosdep.RosdepInitializationError, self.rosdep.setup)
 
-        self.assertThat(str(raised), Equals("Error initializing rosdep database:\nbar"))
+        self.assertThat(
+            str(raised),
+            Equals(
+                "Failed to initialize rosdep: Error initializing rosdep database:\nbar"
+            ),
+        )
 
     def test_setup_update_failure(self):
         def run(args, **kwargs):
@@ -107,9 +112,12 @@ class RosdepTestCase(unit.TestCase):
 
         self.check_output_mock.side_effect = run
 
-        raised = self.assertRaises(RuntimeError, self.rosdep.setup)
+        raised = self.assertRaises(rosdep.RosdepInitializationError, self.rosdep.setup)
 
-        self.assertThat(str(raised), Equals("Error updating rosdep database:\nbar"))
+        self.assertThat(
+            str(raised),
+            Equals("Failed to initialize rosdep: Error updating rosdep database:\nbar"),
+        )
 
     def test_get_dependencies(self):
         self.check_output_mock.return_value = b"foo\nbar\nbaz"

--- a/tests/unit/plugins/test_catkin.py
+++ b/tests/unit/plugins/test_catkin.py
@@ -344,7 +344,7 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
     def test_invalid_rosdistro(self):
         self.properties.rosdistro = "invalid"
         raised = self.assertRaises(
-            RuntimeError,
+            catkin.CatkinUnsupportedRosdistroError,
             catkin.CatkinPlugin,
             "test-part",
             self.properties,
@@ -354,9 +354,8 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
         self.assertThat(
             str(raised),
             Equals(
-                "Unsupported rosdistro: 'invalid'. The supported ROS "
-                "distributions are 'indigo', 'jade', 'kinetic', and "
-                "'lunar'"
+                "Unsupported ROS distribution: 'invalid'. The supported ROS "
+                "distributions are 'indigo', 'jade', 'kinetic', and 'lunar'."
             ),
         )
 
@@ -390,7 +389,7 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
         mock_instance = self.ubuntu_mock.return_value
         mock_instance.get.side_effect = repo.errors.PackageNotFoundError("foo")
 
-        raised = self.assertRaises(RuntimeError, plugin.pull)
+        raised = self.assertRaises(catkin.CatkinAptDependencyFetchError, plugin.pull)
 
         self.assertThat(
             str(raised),
@@ -409,11 +408,7 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
 
         self.rosdep_mock.return_value.resolve_dependency.return_value = None
 
-        raised = self.assertRaises(RuntimeError, plugin.pull)
-
-        self.assertThat(
-            str(raised), Equals("Unable to determine system dependency for roscore")
-        )
+        self.assertRaises(catkin.CatkinCannotResolveRoscoreError, plugin.pull)
 
     @mock.patch.object(catkin.CatkinPlugin, "_generate_snapcraft_setup_sh")
     def test_pull_invalid_underlay(self, generate_setup_mock):
@@ -535,17 +530,12 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
         # sourcedir is expected to be the root of the Catkin workspace. Since
         # source_space was specified to be the same as the root, this should
         # fail.
-        raised = self.assertRaises(
-            RuntimeError,
+        self.assertRaises(
+            catkin.CatkinWorkspaceIsRootError,
             catkin.CatkinPlugin,
             "test-part",
             self.properties,
             self.project_options,
-        )
-
-        self.assertThat(
-            str(raised),
-            Equals("source-space cannot be the root of the Catkin workspace"),
         )
 
     @mock.patch("snapcraft.plugins.catkin.Compilers")
@@ -1701,7 +1691,7 @@ class FindSystemDependenciesTestCase(unit.TestCase):
             str(raised),
             Equals(
                 "Package 'bar' resolved to an unsupported type of dependency: "
-                "'unsupported-type'"
+                "'unsupported-type'."
             ),
         )
 
@@ -1906,7 +1896,9 @@ class CompilersTestCase(unit.TestCase):
     def test_cxxflags_without_include_path_raises(self):
         shutil.rmtree(self.compilers._compilers_install_path)
         with testtools.ExpectedException(
-            RuntimeError, "Unable to determine gcc version: nothing.*"
+            catkin.CatkinGccVersionError,
+            "Failed to determine gcc version: Failed to determine highest path in "
+            "'.*': nothing found",
         ):
             self.compilers.cxxflags
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

In the old days of the snapcraft CLI, we used a lot of built-in exceptions. Now that we have a base exception and are using Sentry, it's important to make sure we no longer do that. The catkin plugin, however, does. This PR resolves [LP: #1791743](https://bugs.launchpad.net/snapcraft/+bug/1791743) by fixing it.