### PR TITLE
local source: don't include .snapcraft directory

### DIFF
--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -34,6 +34,7 @@ from snapcraft.internal import errors
 SNAPCRAFT_FILES = [
     "snapcraft.yaml",
     ".snapcraft.yaml",
+    ".snapcraft",
     "parts",
     "stage",
     "prime",

--- a/tests/unit/sources/test_local.py
+++ b/tests/unit/sources/test_local.py
@@ -119,11 +119,15 @@ class TestLocal(unit.TestCase):
         os.makedirs(os.path.join("src", "parts"))
         os.makedirs(os.path.join("src", "stage"))
         os.makedirs(os.path.join("src", "prime"))
+        os.makedirs(os.path.join("src", ".snapcraft"))
 
         # Make the snapcraft.yaml (and hidden one) and a built snap
         open(os.path.join("src", "snapcraft.yaml"), "w").close()
         open(os.path.join("src", ".snapcraft.yaml"), "w").close()
         open(os.path.join("src", "foo.snap"), "w").close()
+
+        # Make the global state cache
+        open(os.path.join("src", ".snapcraft", "state"), "w").close()
 
         # Now make some real files
         os.makedirs(os.path.join("src", "dir"))
@@ -140,6 +144,7 @@ class TestLocal(unit.TestCase):
         self.assertFalse(os.path.exists(os.path.join("destination", "prime")))
         self.assertFalse(os.path.exists(os.path.join("destination", "snapcraft.yaml")))
         self.assertFalse(os.path.exists(os.path.join("destination", ".snapcraft.yaml")))
+        self.assertFalse(os.path.exists(os.path.join("destination", ".snapcraft")))
         self.assertFalse(os.path.exists(os.path.join("destination", "foo.snap")))
 
         # Verify that the real stuff made it in.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR resolves [LP: #1791773](https://bugs.launchpad.net/snapcraft/+bug/1791773) by no longer copying the .snapcraft directory, and by no longer taking it into account when determining if a given part is out-of-date.