### PR TITLE
meta: take charge of environment used to run commands

### DIFF
--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -349,15 +349,9 @@ class _Executor:
 
         self._run_step(step=step, part=part, progress=progress, hint=hint)
 
-    def _create_meta(self, step, part_names):
+    def _create_meta(self, step: steps.Step, part_names: Sequence[str]) -> None:
         if step == steps.PRIME and part_names == self.config.part_names:
-            common.env = self.config.snap_env()
-            meta.create_snap_packaging(
-                self.config.data,
-                self.config.parts,
-                self.project,
-                self.config.validator.schema,
-            )
+            meta.create_snap_packaging(self.config)
 
     def _handle_dirty(self, part, step, dirty_report, cli_config):
         dirty_action = cli_config.get_outdated_step_action()


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Today there's only a single environment used when generating the snap's snap.yaml, and it's set by the Lifecycle. However, as we move toward having separate environments per lifecycle step, generating the snap.yaml will involve using multiple environments. Instead of continuing to use Lifecycle for this, this PR makes progress on [LP: #1790978](https://bugs.launchpad.net/snapcraft/+bug/1790978) by moving the responsibility into meta.