### PR TITLE
build providers: snapcraft images for multipass

### DIFF
--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -53,10 +53,10 @@ class Multipass(Provider):
         elif self.project.info.base in ("core16", None):
             image = "16.04"
         else:
-            raise EnvironmentError(
-                "Building for this base is not supported on {} hosts".format(
-                    sys.platform
-                )
+            raise errors.UnsupportedHostError(
+                base=self.project.info.base,
+                platform=_get_platform(),
+                provider=self._get_provider_name(),
             )
 
         return image

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -16,11 +16,17 @@
 
 import os
 import shlex
+import sys
 
 from .. import errors
 from .._base_provider import Provider
+from .._images import get_cached_image_filepath
 from ._instance_info import InstanceInfo
 from ._multipass_command import MultipassCommand
+
+
+def _get_platform() -> str:
+    return sys.platform
 
 
 class Multipass(Provider):
@@ -35,16 +41,37 @@ class Multipass(Provider):
             instance_name=self.instance_name, command=command, hide_output=hide_output
         )
 
+    def _get_disk_image(self) -> str:
+        if self.project.info.base is not None and _get_platform() == "linux":
+            image = "file://{}".format(
+                get_cached_image_filepath(
+                    base=self.project.info.base, snap_arch=self.project.deb_arch
+                )
+            )
+        elif self.project.info.base == "core18":
+            image = "18.04"
+        elif self.project.info.base in ("core16", None):
+            image = "16.04"
+        else:
+            raise EnvironmentError(
+                "Building for this base is not supported on {} hosts".format(
+                    sys.platform
+                )
+            )
+
+        return image
+
     def _launch(self) -> None:
         try:
             # An exception here means we need to create
             self._multipass_cmd.start(instance_name=self.instance_name)
         except errors.ProviderStartError:
             cloud_user_data_filepath = self._get_cloud_user_data()
+            image = self._get_disk_image()
 
             self._multipass_cmd.launch(
                 instance_name=self.instance_name,
-                image="16.04",
+                image=image,
                 cloud_init=cloud_user_data_filepath,
             )
 

--- a/snapcraft/internal/build_providers/errors.py
+++ b/snapcraft/internal/build_providers/errors.py
@@ -247,3 +247,13 @@ class BuildImageChecksumError(_SnapcraftError):
 
     def __init__(self, *, expected: str, calculated: str, algorithm: str) -> None:
         super().__init__(expected=expected, calculated=calculated, algorithm=algorithm)
+
+
+class UnsupportedHostError(_SnapcraftError):
+    fmt = (
+        "Building for {base!r} is not supported on platform {platform!r} using "
+        "provider: {provider!r}."
+    )
+
+    def __init__(self, *, base: str, platform: str, provider: str) -> None:
+        super().__init__(base=base, platform=platform, provider=provider)

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -86,9 +86,11 @@ class ProviderImpl(Provider):
         self.shell_mock("shell")
 
 
-def get_project() -> Project:
+def get_project(base: str = "") -> Project:
     with open("snapcraft.yaml", "w") as snapcraft_file:
         print("name: project-name", file=snapcraft_file)
+        if base:
+            print("base: {}".format(base), file=snapcraft_file)
 
     return Project(snapcraft_yaml_file_path="snapcraft.yaml")
 
@@ -106,5 +108,27 @@ class BaseProviderBaseTest(unit.TestCase):
         self.addCleanup(patcher.stop)
 
         self.project = get_project()
+
+        self.echoer_mock = mock.Mock()
+
+
+class BaseProviderWithBasesBaseTest(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.instance_name = "snapcraft-project-name"
+
+        patcher = mock.patch(
+            "snapcraft.internal.build_providers._base_provider.SnapInjector"
+        )
+        self.snap_injector_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch(
+            "snapcraft.internal.build_providers._images._Image.get",
+            return_value="fake-base.qcow2",
+        )
+        self.images_get_mock = patcher.start()
+        self.addCleanup(patcher.stop)
 
         self.echoer_mock = mock.Mock()

--- a/tests/unit/build_providers/test_errors.py
+++ b/tests/unit/build_providers/test_errors.py
@@ -244,6 +244,16 @@ class ErrorFormattingTest(unit.TestCase):
                 ),
             ),
         ),
+        (
+            "UnsupportedHostError",
+            dict(
+                exception=errors.UnsupportedHostError,
+                kwargs=dict(base="core66", platform="beos", provider="multipass"),
+                expected_message=(
+                    "Building for 'core66' is not supported on platform 'beos' using provider: 'multipass'."
+                ),
+            ),
+        ),
     ]
 
     def test_error_formatting(self):

--- a/tests/unit/build_providers/test_images.py
+++ b/tests/unit/build_providers/test_images.py
@@ -85,11 +85,6 @@ class SetupTest(unit.TestCase):
         call_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = mock.patch.object(_images, "get_tool_path")
-        tool_mock = patcher.start()
-        tool_mock.return_value = "qemu-img-fake-tool"
-        self.addCleanup(patcher.stop)
-
         _images.setup(
             base="core16", snap_arch="amd64", size="1G", image_path="image.qcow2"
         )
@@ -97,7 +92,7 @@ class SetupTest(unit.TestCase):
         image_get_mock.assert_called_once_with()
         call_mock.assert_called_once_with(
             [
-                "qemu-img-fake-tool",
+                "qemu-img",
                 "create",
                 "-q",
                 "-f",
@@ -119,11 +114,6 @@ class SetupTest(unit.TestCase):
         call_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = mock.patch.object(_images, "get_tool_path")
-        tool_mock = patcher.start()
-        tool_mock.return_value = "qemu-img-fake-tool"
-        self.addCleanup(patcher.stop)
-
         _images.setup(
             base="core16",
             snap_arch="amd64",
@@ -134,7 +124,7 @@ class SetupTest(unit.TestCase):
         self.assertThat("dir", DirExists())
         call_mock.assert_called_once_with(
             [
-                "qemu-img-fake-tool",
+                "qemu-img",
                 "create",
                 "-q",
                 "-f",
@@ -155,11 +145,6 @@ class SetupTest(unit.TestCase):
         patcher = mock.patch("subprocess.check_call")
         call_mock = patcher.start()
         call_mock.side_effect = subprocess.CalledProcessError(1, ["qemu-img"])
-        self.addCleanup(patcher.stop)
-
-        patcher = mock.patch.object(_images, "get_tool_path")
-        tool_mock = patcher.start()
-        tool_mock.return_value = "qemu-img-fake-tool"
         self.addCleanup(patcher.stop)
 
         self.assertRaises(


### PR DESCRIPTION
Use snapcraft build images for multipass environments.
Quirck it for darwin as there is no "launch" support available
on darwin yet.

LP: #1791821
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
