### PR TITLE
cli: show trace if no tty

### DIFF
--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -98,6 +98,7 @@ def exception_handler(
     is_snapcraft_managed_host = (
         distutils.util.strtobool(os.getenv("SNAPCRAFT_MANAGED_HOST", "n")) == 1
     )
+    is_connected_to_tty = sys.stdout.isatty()
     ask_to_report = False
 
     if not is_snapcraft_error:
@@ -124,6 +125,11 @@ def exception_handler(
             traceback.print_exception(*exc_info)
             click.echo(_MSG_MANUALLY_REPORT)
         else:
+            if is_connected_to_tty:
+                click.echo(_MSG_TRACEBACK_FILE)
+            else:
+                click.echo(_MSG_TRACEBACK_PRINT)
+                traceback.print_exception(*exc_info)
             trace_filepath = _handle_trace_output(exc_info)
             if _is_send_to_sentry(trace_filepath):
                 _submit_trace(exc_info)

--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -122,14 +122,14 @@ def exception_handler(
     if ask_to_report:
         if not is_raven_setup or is_snapcraft_managed_host:
             click.echo(_MSG_TRACEBACK_PRINT)
-            traceback.print_exception(*exc_info)
+            traceback.print_exception(*exc_info, file=sys.stdout)
             click.echo(_MSG_MANUALLY_REPORT)
         else:
             if is_connected_to_tty:
                 click.echo(_MSG_TRACEBACK_FILE)
             else:
                 click.echo(_MSG_TRACEBACK_PRINT)
-                traceback.print_exception(*exc_info)
+                traceback.print_exception(*exc_info, file=sys.stdout)
             trace_filepath = _handle_trace_output(exc_info)
             if _is_send_to_sentry(trace_filepath):
                 _submit_trace(exc_info)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Currently the snapcraft CLI writes any traceback into a tracefile, regardless of whether or not stdout is a tty. In practice this means that when running in CI or cleanbuild, errors are hidden within a tracefile that cannot be accessed.

This PR resolves [LP: #1790697](https://bugs.launchpad.net/snapcraft/+bug/1790697) by printing the traceback if stdout is not a tty.