### PR TITLE
build providers: allow setting ram and disk size

### DIFF
--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import contextlib
 import os
 import shlex
 import sys
@@ -62,18 +63,24 @@ class Multipass(Provider):
         return image
 
     def _launch(self) -> None:
-        try:
+        with contextlib.suppress(errors.ProviderStartError):
             # An exception here means we need to create
             self._multipass_cmd.start(instance_name=self.instance_name)
-        except errors.ProviderStartError:
-            cloud_user_data_filepath = self._get_cloud_user_data()
-            image = self._get_disk_image()
+            return
 
-            self._multipass_cmd.launch(
-                instance_name=self.instance_name,
-                image=image,
-                cloud_init=cloud_user_data_filepath,
-            )
+        cloud_user_data_filepath = self._get_cloud_user_data()
+        image = self._get_disk_image()
+
+        mem = os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT_MEMORY", "2G")
+        disk = os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT_DISK", "256G")
+
+        self._multipass_cmd.launch(
+            instance_name=self.instance_name,
+            mem=mem,
+            disk=disk,
+            image=image,
+            cloud_init=cloud_user_data_filepath,
+        )
 
     def _mount(self, *, mountpoint: str, dev_or_path: str) -> None:
         target = "{}:{}".format(self.instance_name, mountpoint)

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -66,6 +66,8 @@ class Multipass(Provider):
         with contextlib.suppress(errors.ProviderStartError):
             # An exception here means we need to create
             self._multipass_cmd.start(instance_name=self.instance_name)
+            # start worked, which means the image existed, which means we can
+            # now return.
             return
 
         cloud_user_data_filepath = self._get_cloud_user_data()

--- a/snapcraft/internal/build_providers/_multipass/_multipass_command.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass_command.py
@@ -67,6 +67,8 @@ class MultipassCommand:
         *,
         instance_name: str,
         image: str,
+        mem: str = None,
+        disk: str = None,
         remote: str = None,
         cloud_init: str = None
     ) -> None:
@@ -74,6 +76,8 @@ class MultipassCommand:
 
         :param str instance_name: the name the launched instance will have.
         :param str image: the image to create the instance with.
+        :param str mem: amount of RAM to assign to the launched instance.
+        :param str disk: amount of disk space the instance will see.
         :param str remote: the remote server to retrieve the image from.
         :param str cloud_init_file: path to a user-data cloud-init configuration.
         """
@@ -82,6 +86,10 @@ class MultipassCommand:
         cmd = [self.provider_cmd, "launch", image, "--name", instance_name]
         if cloud_init is not None:
             cmd.extend(["--cloud-init", cloud_init])
+        if mem is not None:
+            cmd.extend(["--mem", mem])
+        if disk is not None:
+            cmd.extend(["--disk", disk])
         try:
             _run(cmd)
         except subprocess.CalledProcessError as process_error:

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -17,6 +17,8 @@
 from textwrap import dedent
 from unittest import mock
 
+import fixtures
+
 from tests.unit.build_providers import (
     BaseProviderBaseTest,
     BaseProviderWithBasesBaseTest,
@@ -100,7 +102,11 @@ class MultipassTest(BaseProviderBaseTest):
             instance.retrieve_snap()
 
         self.multipass_cmd_mock().launch.assert_called_once_with(
-            image="16.04", instance_name=self.instance_name, cloud_init=mock.ANY
+            instance_name=self.instance_name,
+            mem="2G",
+            disk="256G",
+            image="16.04",
+            cloud_init=mock.ANY,
         )
         # Given SnapInjector is mocked, we only need to verify the commands
         # called from the Multipass class.
@@ -147,6 +153,44 @@ class MultipassTest(BaseProviderBaseTest):
         )
         self.multipass_cmd_mock().delete.assert_called_once_with(
             instance_name=self.instance_name, purge=True
+        )
+
+    def test_launch_with_ram_from_environment(self):
+        self.useFixture(
+            fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT_MEMORY", "4G")
+        )
+        self.multipass_cmd_mock().start.side_effect = errors.ProviderStartError(
+            provider_name="multipass", exit_code=1
+        )
+
+        instance = Multipass(project=self.project, echoer=self.echoer_mock)
+        instance.create()
+
+        self.multipass_cmd_mock().launch.assert_called_once_with(
+            instance_name=self.instance_name,
+            mem="4G",
+            disk="256G",
+            image="16.04",
+            cloud_init=mock.ANY,
+        )
+
+    def test_launch_with_disk_from_environment(self):
+        self.useFixture(
+            fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT_DISK", "400G")
+        )
+        self.multipass_cmd_mock().start.side_effect = errors.ProviderStartError(
+            provider_name="multipass", exit_code=1
+        )
+
+        instance = Multipass(project=self.project, echoer=self.echoer_mock)
+        instance.create()
+
+        self.multipass_cmd_mock().launch.assert_called_once_with(
+            instance_name=self.instance_name,
+            mem="2G",
+            disk="400G",
+            image="16.04",
+            cloud_init=mock.ANY,
         )
 
     def test_provision_project(self):
@@ -292,8 +336,10 @@ class MultipassWithBasesTest(BaseProviderWithBasesBaseTest):
             instance.execute_step(steps.PULL)
 
         self.multipass_cmd_mock().launch.assert_called_once_with(
-            image=self.expected_image,
             instance_name=self.instance_name,
+            mem="2G",
+            disk="256G",
+            image=self.expected_image,
             cloud_init=mock.ANY,
         )
         self.multipass_cmd_mock().execute.assert_has_calls(

--- a/tests/unit/build_providers/multipass/test_multipass_command.py
+++ b/tests/unit/build_providers/multipass/test_multipass_command.py
@@ -72,6 +72,42 @@ class MultipassCommandLaunchTest(MultipassCommandPassthroughBaseTest):
         )
         self.check_output_mock.assert_not_called()
 
+    def test_launch_with_mem(self):
+        self.multipass_command.launch(
+            instance_name=self.instance_name, mem="2G", image="16.04"
+        )
+
+        self.check_call_mock.assert_called_once_with(
+            [
+                "multipass",
+                "launch",
+                "16.04",
+                "--name",
+                self.instance_name,
+                "--mem",
+                "2G",
+            ]
+        )
+        self.check_output_mock.assert_not_called()
+
+    def test_launch_with_disk(self):
+        self.multipass_command.launch(
+            instance_name=self.instance_name, disk="8G", image="16.04"
+        )
+
+        self.check_call_mock.assert_called_once_with(
+            [
+                "multipass",
+                "launch",
+                "16.04",
+                "--name",
+                self.instance_name,
+                "--disk",
+                "8G",
+            ]
+        )
+        self.check_output_mock.assert_not_called()
+
     def test_launch_with_remote(self):
         self.multipass_command.launch(
             instance_name=self.instance_name, image="18.04", remote="daily"


### PR DESCRIPTION
We do this only for multipass given that we want to leave
the general build provider class available as a base to
add support for container based build providers.

Two environment variables are added to be able to override
the default memory and disk values.

LP: #1791661

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
