### PR TITLE
build providers: inject the base for classic

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -203,8 +203,17 @@ class Provider(abc.ABC):
             snap_dir_unmounter=self._unmount_snaps_directory,
             file_pusher=self._push_file,
         )
+        # Inject snapcraft
         snap_injector.add(snap_name="core")
         snap_injector.add(snap_name="snapcraft")
+
+        # Also inject the base when confinement is set to classic to have real
+        # paths to the linker.
+        if (
+            self.project.info.base is not None
+            and self.project.info.confinement == "classic"
+        ):
+            snap_injector.add(snap_name=self.project.info.base)
 
         snap_injector.apply()
 

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -76,6 +76,7 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
         self.snap_injector_mock().add.assert_has_calls(
             [call(snap_name="core"), call(snap_name="snapcraft")]
         )
+        self.assertThat(self.snap_injector_mock().add.call_count, Equals(2))
         self.snap_injector_mock().apply.assert_called_once_with()
 
     def test_ephemeral_setup_snapcraft(self):
@@ -98,4 +99,35 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
         self.snap_injector_mock().add.assert_has_calls(
             [call(snap_name="core"), call(snap_name="snapcraft")]
         )
+        self.assertThat(self.snap_injector_mock().add.call_count, Equals(2))
+        self.snap_injector_mock().apply.assert_called_once_with()
+
+    def test_setup_snapcraft_for_classic_build(self):
+        self.project.info.base = "core18"
+        self.project.info.confinement = "classic"
+
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+        provider._setup_snapcraft()
+
+        self.snap_injector_mock().add.assert_has_calls(
+            [
+                call(snap_name="core"),
+                call(snap_name="snapcraft"),
+                call(snap_name="core18"),
+            ]
+        )
+        self.assertThat(self.snap_injector_mock().add.call_count, Equals(3))
+        self.snap_injector_mock().apply.assert_called_once_with()
+
+    def test_setup_snapcraft_for_with_base_but_not_a_classic_build(self):
+        self.project.info.base = "core18"
+        self.project.info.confinement = "strict"
+
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+        provider._setup_snapcraft()
+
+        self.snap_injector_mock().add.assert_has_calls(
+            [call(snap_name="core"), call(snap_name="snapcraft")]
+        )
+        self.assertThat(self.snap_injector_mock().add.call_count, Equals(2))
         self.snap_injector_mock().apply.assert_called_once_with()


### PR DESCRIPTION
Inject the base snap building against if we are doing classic
confinmenent to get the appropriate linker paths.

LP: #1791938

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
