### PR TITLE
project: catch parent YAML exceptions

### DIFF
--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -63,23 +63,21 @@ def _load_yaml(*, yaml_file_path: str) -> OrderedDict:
     try:
         with open(yaml_file_path, encoding=encoding) as fp:  # type: ignore
             yaml_contents = yaml.safe_load(fp)  # type: ignore
-    except yaml.scanner.ScannerError as e:
+    except yaml.MarkedYAMLError as e:
         raise errors.YamlValidationError(
-            "{} on line {} of {}".format(
-                e.problem, e.problem_mark.line + 1, yaml_file_path
-            )
+            "{} on line {}, column {}".format(
+                e.problem, e.problem_mark.line + 1, e.problem_mark.column + 1
+            ),
+            yaml_file_path,
         ) from e
     except yaml.reader.ReaderError as e:
         raise errors.YamlValidationError(
-            "Invalid character {!r} at position {} of {}: {}".format(
+            "invalid character {!r} at position {} of {}: {}".format(
                 chr(e.character), e.position + 1, yaml_file_path, e.reason
-            )
+            ),
+            yaml_file_path,
         ) from e
-    except yaml.constructor.ConstructorError as e:
-        raise errors.YamlValidationError(
-            "{}, line {}, column {}".format(
-                e.problem, e.problem_mark.line + 1, e.problem_mark.column + 1
-            )
-        ) from e
+    except yaml.YAMLError as e:
+        raise errors.YamlValidationError(str(e), yaml_file_path) from e
 
     return yaml_contents

--- a/tests/integration/lifecycle/test_snap.py
+++ b/tests/integration/lifecycle/test_snap.py
@@ -216,7 +216,7 @@ class SnapTestCase(integration.TestCase):
         )
         self.assertIn(
             "Issues while validating snapcraft.yaml: found character '\\t' "
-            "that cannot start any token on line 13 of snapcraft.yaml",
+            "that cannot start any token on line 13, column 1",
             str(error.output),
         )
 

--- a/tests/unit/project_loader/test_validation.py
+++ b/tests/unit/project_loader/test_validation.py
@@ -24,7 +24,7 @@ from testtools.matchers import Contains, Equals, MatchesRegex
 
 from . import ProjectLoaderBaseTest
 from tests import fixture_setup, unit
-from snapcraft.project import Project, errors as project_errors
+from snapcraft.project import Project
 from snapcraft.internal.errors import PluginError
 from snapcraft.internal.project_loader import load_config, errors
 from snapcraft.internal.project_loader import Validator
@@ -939,30 +939,6 @@ class VersionTest(ProjectLoaderBaseTest):
                 "schema: 'abcdefghijklmnopqrstuvwxyz1234567' is too long "
                 "(maximum length is 32)"
             ),
-        )
-
-    def test_invalid_yaml_version_unhashable(self):
-        snapcraft_yaml = dedent(
-            """\
-            name: test
-            version: {{invalid}}
-            summary: test
-            description: test
-            confinement: strict
-            grade: stable
-            parts:
-              part1:
-                plugin: nil
-            """
-        )
-        raised = self.assertRaises(
-            project_errors.YamlValidationError,
-            self.make_snapcraft_project,
-            snapcraft_yaml,
-        )
-
-        self.assertThat(
-            raised.message, Equals("found unhashable key, line 2, column 10")
         )
 
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Currently `ProjectInfo` is pretty granular with the YAML exceptions it catches. There is no need for this since most of them inherit from `MarkedYAMLError` anyway, and it means we're constantly playing a game of whack-a-mole as new YAML exceptions are discovered. This PR fixes [LP: #1792049](https://bugs.launchpad.net/snapcraft/+bug/1792049) by catching `MarkedYAMLError`s and `ReaderError`s explicitly, and finally fall back to catching a `YAMLError` to avoid these tracebacks in the future.