### PR TITLE
build providers: allow snapcraft channel selection

### DIFF
--- a/tests/unit/build_providers/test_snap.py
+++ b/tests/unit/build_providers/test_snap.py
@@ -18,6 +18,7 @@ import os
 from textwrap import dedent
 from unittest.mock import call, patch, ANY
 
+import fixtures
 from testtools.matchers import FileContains
 
 from . import ProviderImpl, get_project
@@ -160,8 +161,18 @@ class SnapInjectionTest(unit.TestCase):
             [
                 call(["sudo", "snap", "set", "core", ANY]),
                 call(["sudo", "snap", "watch", "--last=auto-refresh"]),
-                call(["sudo", "snap", "install", "core"]),
-                call(["sudo", "snap", "install", "--classic", "snapcraft"]),
+                call(["sudo", "snap", "install", "--channel", "latest/stable", "core"]),
+                call(
+                    [
+                        "sudo",
+                        "snap",
+                        "install",
+                        "--classic",
+                        "--channel",
+                        "latest/stable",
+                        "snapcraft",
+                    ]
+                ),
             ]
         )
         self.provider.mount_mock.assert_not_called()
@@ -291,8 +302,75 @@ class SnapInjectionTest(unit.TestCase):
             [
                 call(["sudo", "snap", "set", "core", ANY]),
                 call(["sudo", "snap", "watch", "--last=auto-refresh"]),
-                call(["sudo", "snap", "install", "core"]),
-                call(["sudo", "snap", "install", "--classic", "snapcraft"]),
+                call(["sudo", "snap", "install", "--channel", "latest/stable", "core"]),
+                call(
+                    [
+                        "sudo",
+                        "snap",
+                        "install",
+                        "--classic",
+                        "--channel",
+                        "latest/stable",
+                        "snapcraft",
+                    ]
+                ),
+            ]
+        )
+        self.provider.mount_mock.assert_not_called()
+        self.provider.unmount_mock.assert_not_called()
+        self.provider.push_file_mock.assert_not_called()
+        self.assertThat(
+            self.registry_filepath,
+            FileContains(
+                dedent(
+                    """\
+                    core:
+                    - {revision: '10000'}
+                    snapcraft:
+                    - {revision: '25'}
+                    """
+                )
+            ),
+        )
+
+    def test_snapcraft_not_installed_on_host_with_channel_from_environment(self):
+        self.useFixture(fixture_setup.FakeStore())
+        self.useFixture(
+            fixtures.EnvironmentVariable(
+                "SNAPCRAFT_BUILD_ENVIRONMENT_CHANNEL_SNAPCRAFT", "latest/edge"
+            )
+        )
+
+        snap_injector = SnapInjector(
+            snap_dir=self.provider._SNAPS_MOUNTPOINT,
+            registry_filepath=self.registry_filepath,
+            snap_arch="amd64",
+            runner=self.provider._run,
+            snap_dir_mounter=self.provider._mount_snaps_directory,
+            snap_dir_unmounter=self.provider._unmount_snaps_directory,
+            file_pusher=self.provider._push_file,
+        )
+        snap_injector.add("core")
+        snap_injector.add("snapcraft")
+        snap_injector.apply()
+
+        self.get_assertion_mock.assert_not_called()
+        self.provider.run_mock.assert_has_calls(
+            [
+                call(["sudo", "snap", "set", "core", ANY]),
+                call(["sudo", "snap", "watch", "--last=auto-refresh"]),
+                call(["sudo", "snap", "install", "--channel", "latest/stable", "core"]),
+                call(
+                    [
+                        "sudo",
+                        "snap",
+                        "install",
+                        "--classic",
+                        "--channel",
+                        "latest/edge",
+                        "snapcraft",
+                    ]
+                ),
             ]
         )
         self.provider.mount_mock.assert_not_called()
@@ -332,8 +410,18 @@ class SnapInjectionTest(unit.TestCase):
             [
                 call(["sudo", "snap", "set", "core", ANY]),
                 call(["sudo", "snap", "watch", "--last=auto-refresh"]),
-                call(["sudo", "snap", "install", "core"]),
-                call(["sudo", "snap", "install", "--classic", "snapcraft"]),
+                call(["sudo", "snap", "install", "--channel", "latest/stable", "core"]),
+                call(
+                    [
+                        "sudo",
+                        "snap",
+                        "install",
+                        "--classic",
+                        "--channel",
+                        "latest/stable",
+                        "snapcraft",
+                    ]
+                ),
             ]
         )
         self.provider.run_mock.reset_mock()
@@ -355,8 +443,18 @@ class SnapInjectionTest(unit.TestCase):
             [
                 call(["sudo", "snap", "set", "core", ANY]),
                 call(["sudo", "snap", "watch", "--last=auto-refresh"]),
-                call(["sudo", "snap", "install", "core"]),
-                call(["sudo", "snap", "install", "--classic", "snapcraft"]),
+                call(["sudo", "snap", "install", "--channel", "latest/stable", "core"]),
+                call(
+                    [
+                        "sudo",
+                        "snap",
+                        "install",
+                        "--classic",
+                        "--channel",
+                        "latest/stable",
+                        "snapcraft",
+                    ]
+                ),
             ]
         )
 
@@ -448,8 +546,18 @@ class SnapInjectionTest(unit.TestCase):
             [
                 call(["sudo", "snap", "set", "core", ANY]),
                 call(["sudo", "snap", "watch", "--last=auto-refresh"]),
-                call(["sudo", "snap", "refresh", "core"]),
-                call(["sudo", "snap", "refresh", "--classic", "snapcraft"]),
+                call(["sudo", "snap", "refresh", "--channel", "latest/stable", "core"]),
+                call(
+                    [
+                        "sudo",
+                        "snap",
+                        "refresh",
+                        "--classic",
+                        "--channel",
+                        "latest/stable",
+                        "snapcraft",
+                    ]
+                ),
             ]
         )
 
@@ -479,8 +587,18 @@ class SnapInjectionTest(unit.TestCase):
             [
                 call(["sudo", "snap", "set", "core", ANY]),
                 call(["sudo", "snap", "watch", "--last=auto-refresh"]),
-                call(["sudo", "snap", "install", "core"]),
-                call(["sudo", "snap", "install", "--classic", "snapcraft"]),
+                call(["sudo", "snap", "install", "--channel", "latest/stable", "core"]),
+                call(
+                    [
+                        "sudo",
+                        "snap",
+                        "install",
+                        "--classic",
+                        "--channel",
+                        "latest/stable",
+                        "snapcraft",
+                    ]
+                ),
             ]
         )
         self.provider.mount_mock.assert_not_called()


### PR DESCRIPTION
Enabled for early testing when snapcraft is not injected from the host.
Warn the user when this is done.

LP: #1792185

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
