### PR TITLE
build providers: refresh packages on bring up

### DIFF
--- a/snapcraft/cli/containers.py
+++ b/snapcraft/cli/containers.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017 Canonical Ltd
+# Copyright (C) 2017-2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
 import click
 import os
 
-from snapcraft.internal import errors, lxd
+from snapcraft.internal import lxd, repo
 from ._options import get_project
 from . import env
 
@@ -32,25 +32,17 @@ def containerscli():
     "--debug", is_flag=True, help="Shells into the environment if the build fails."
 )
 def refresh(debug, **kwargs):
-    """Refresh an existing LXD container.
+    """Refresh existing packages.
 
     \b
     Examples:
         snapcraft refresh
-
-    This will take care of updating the apt package cache, upgrading packages
-    as needed as well as refreshing snaps.
     """
 
     build_environment = env.BuilderEnvironmentConfig()
-    if build_environment.is_host:
-        raise errors.SnapcraftEnvironmentError(
-            "The 'refresh' command only applies to LXD containers but "
-            "SNAPCRAFT_BUILD_ENVIRONMENT is not set or set to host.\n"
-            "Maybe you meant to update the parts cache instead? "
-            "You can do that with the following command:\n\n"
-            "snapcraft update"
-        )
 
-    project = get_project(**kwargs, debug=debug)
-    lxd.Project(project=project, output=None, source=os.path.curdir).refresh()
+    if build_environment.is_lxd:
+        project = get_project(**kwargs, debug=debug)
+        lxd.Project(project=project, output=None, source=os.path.curdir).refresh()
+    else:
+        repo.Repo.refresh_build_packages()

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -23,6 +23,7 @@ from typing import List, Optional
 
 from xdg import BaseDirectory
 
+from . import errors
 from ._snap import SnapInjector
 from snapcraft.internal import steps
 
@@ -124,6 +125,10 @@ class Provider(abc.ABC):
         """Launch the instance."""
 
     @abc.abstractmethod
+    def _start(self):
+        """Start an existing the instance."""
+
+    @abc.abstractmethod
     def _push_file(self, *, source: str, destination: str) -> None:
         """Push a file into the instance."""
 
@@ -186,9 +191,25 @@ class Provider(abc.ABC):
         """Provider steps to provide a shell into the instance."""
 
     def launch_instance(self) -> None:
-        os.makedirs(self.provider_project_dir, exist_ok=True)
-        self._launch()
-        self._setup_snapcraft()
+        try:
+            # An ProviderStartError exception here means we need to create
+            self._start()
+        except errors.ProviderStartError:
+            # If starting failed, we need to make sure our data directory is
+            # clean
+            if os.path.exists(self.provider_project_dir):
+                shutil.rmtree(self.provider_project_dir)
+            os.makedirs(self.provider_project_dir)
+            # then launch
+            self._launch()
+            # We need to setup snapcraft now to be able to refresh
+            self._setup_snapcraft()
+            # and do first boot related things
+            self._run(["snapcraft", "refresh"])
+        else:
+            # We always setup snapcraft after a start to bring it up to speed with
+            # what is on the host
+            self._setup_snapcraft()
 
     def _setup_snapcraft(self) -> None:
         registry_filepath = os.path.join(

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import contextlib
 import os
 import shlex
 import sys
@@ -63,13 +62,6 @@ class Multipass(Provider):
         return image
 
     def _launch(self) -> None:
-        with contextlib.suppress(errors.ProviderStartError):
-            # An exception here means we need to create
-            self._multipass_cmd.start(instance_name=self.instance_name)
-            # start worked, which means the image existed, which means we can
-            # now return.
-            return
-
         cloud_user_data_filepath = self._get_cloud_user_data()
         image = self._get_disk_image()
 
@@ -83,6 +75,9 @@ class Multipass(Provider):
             image=image,
             cloud_init=cloud_user_data_filepath,
         )
+
+    def _start(self):
+        self._multipass_cmd.start(instance_name=self.instance_name)
 
     def _mount(self, *, mountpoint: str, dev_or_path: str) -> None:
         target = "{}:{}".format(self.instance_name, mountpoint)

--- a/snapcraft/internal/repo/_base.py
+++ b/snapcraft/internal/repo/_base.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017 Canonical Ltd
+# Copyright (C) 2017-2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -43,6 +43,7 @@ class BaseRepo:
     - unpack
     - get_package_libraries
     - get_packages_for_source_type
+    - refresh_build_packages
     - install_build_packages
     - is_package_installed
 
@@ -83,6 +84,18 @@ class BaseRepo:
         :param str source_type: a VCS source type to handle.
         :returns: a set of packages that need to be installed on the host.
         :rtype: set of strings.
+        """
+        raise errors.NoNativeBackendError()
+
+    @classmethod
+    def refresh_build_packages(cls) -> None:
+        """Refresh the build packages cache.
+
+        If refreshing is not possible
+        snapcraft.repo.errors.CacheUpdateFailedError should be raised
+
+        :raises snapcraft.repo.errors.NoNativeBackendError:
+            if the method is not implemented in the subclass.
         """
         raise errors.NoNativeBackendError()
 

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -245,6 +245,15 @@ class Ubuntu(BaseRepo):
         return packages
 
     @classmethod
+    def refresh_build_packages(cls) -> None:
+        try:
+            subprocess.check_call(["sudo", "apt", "update"])
+        except subprocess.CalledProcessError as call_error:
+            raise errors.CacheUpdateFailedError(
+                "failed to run apt update"
+            ) from call_error
+
+    @classmethod
     def install_build_packages(cls, package_names: List[str]) -> List[str]:
         """Install packages on the host required to build.
 

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -28,6 +28,7 @@ class ProviderImpl(Provider):
 
         self.run_mock = mock.Mock()
         self.launch_mock = mock.Mock()
+        self.start_mock = mock.Mock()
         self.mount_mock = mock.Mock()
         self.unmount_mock = mock.Mock()
         self.push_file_mock = mock.Mock()
@@ -41,6 +42,9 @@ class ProviderImpl(Provider):
 
     def _launch(self) -> None:
         self.launch_mock()
+
+    def _start(self) -> None:
+        self.start_mock()
 
     def _mount(self, *, mountpoint: str, dev_or_path: str) -> None:
         self.mount_mock(mountpoint=mountpoint, dev_or_path=dev_or_path)

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -464,3 +464,20 @@ class BuildPackagesTestCase(unit.TestCase):
             ["package-not-installable"],
         )
         self.assertThat(raised.packages, Equals("package-not-installable"))
+
+    @patch("subprocess.check_call")
+    def test_refresh_buid_packages(self, mock_check_call):
+        repo.Ubuntu.refresh_build_packages()
+
+        mock_check_call.assert_called_once_with(["sudo", "apt", "update"])
+
+    @patch(
+        "subprocess.check_call",
+        side_effect=CalledProcessError(returncode=1, cmd=["sudo", "apt", "update"]),
+    )
+    def test_refresh_buid_packages_fails(self, mock_check_call):
+        self.assertRaises(
+            errors.CacheUpdateFailedError, repo.Ubuntu.refresh_build_packages
+        )
+
+        mock_check_call.assert_called_once_with(["sudo", "apt", "update"])


### PR DESCRIPTION
Run packaging repo refresh tasks when bringing up an environment.
This requires adding start to the BaseProvider and bringing up logic
that was in the Multipass provider.

LP: #1792214

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
