### PR TITLE
sanity checks: allow snap/local dir

### DIFF
--- a/snapcraft/project/_sanity_checks.py
+++ b/snapcraft/project/_sanity_checks.py
@@ -27,6 +27,7 @@ _EXPECTED_SNAP_DIR_PATTERNS = {
     re.compile(r"^snapcraft.yaml$"),
     re.compile(r"^.snapcraft(/state)?$"),
     re.compile(r"^hooks(/.*)?$"),
+    re.compile(r"^local(/.*)?$"),
     re.compile(r"^plugins(/.*)?$"),
     re.compile(r"^gui(/.*\.(png|svg|desktop))?$"),
 }
@@ -58,7 +59,11 @@ def _check_snap_dir(snap_dir_path: str):
             "The snap/ directory is meant specifically for snapcraft, but it contains "
             "the following non-snapcraft-related paths, which is unsupported and will "
             "cause unexpected behavior:"
-            "\n- {}".format("\n- ".join(sorted(unexpected_paths)))
+            "\n- {}\n\n"
+            "If you must store these files within the snap/ directory, move them to "
+            "snap/local/, which is ignored by snapcraft.".format(
+                "\n- ".join(sorted(unexpected_paths))
+            )
         )
 
 

--- a/tests/spread/general/snap_local_dir/snaps/snap-local-dir/snap/local/dir/dir-file
+++ b/tests/spread/general/snap_local_dir/snaps/snap-local-dir/snap/local/dir/dir-file
@@ -1,0 +1,1 @@
+I'm in local/dir

--- a/tests/spread/general/snap_local_dir/snaps/snap-local-dir/snap/local/root-file
+++ b/tests/spread/general/snap_local_dir/snaps/snap-local-dir/snap/local/root-file
@@ -1,0 +1,1 @@
+I'm in local

--- a/tests/spread/general/snap_local_dir/snaps/snap-local-dir/snap/snapcraft.yaml
+++ b/tests/spread/general/snap_local_dir/snaps/snap-local-dir/snap/snapcraft.yaml
@@ -1,0 +1,16 @@
+name: snap-local-dir
+version: '1.0'
+summary: Snap to test snap/local dir
+description: Verify that the snap/local dir can be used for sources.
+
+grade: devel
+confinement: strict
+
+parts:
+  local-part:
+    plugin: dump
+    source: snap/local
+
+  local-subdir-part:
+    plugin: dump
+    source: snap/local/dir

--- a/tests/spread/general/snap_local_dir/task.yaml
+++ b/tests/spread/general/snap_local_dir/task.yaml
@@ -3,15 +3,23 @@ summary: Build a snap that uses snap/local and verify that it works without warn
 environment:
   SNAP_DIR: snaps/snap-local-dir
 
+prepare: |
+  cd "$SNAP_DIR"
+  echo -e "dir\ndir/dir-file\nroot-file" | sort > expected_local_part_src.txt
+  echo -e "dir-file" > expected_local_part_subdir_src.txt
+  echo -e "dir\ndir/dir-file\nroot-file\ndir-file" | sort > expected_stage.txt
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean
   rm -f ./*.snap
+  rm -f ./*.txt
 
 execute: |
-  list_dir_contents()
+  compare_dir_contents()
   {
-      find "$1" ! -path "$1" -printf "%P\n" | sort | xargs
+      find "$1" ! -path "$1" -printf "%P\n" | sort > found.txt
+      comm -3 found.txt "$2"
   }
 
   cd "$SNAP_DIR"
@@ -20,9 +28,9 @@ execute: |
   snapcraft pull | MATCH -v "unsupported"
 
   # Verify that the parts were pulled as expected
-  [ "$(list_dir_contents parts/local-part/src)" = "dir dir/dir-file root-file" ]
-  [ "$(list_dir_contents parts/local-subdir-part/src)" = "dir-file" ]
+  [ -z "$(compare_dir_contents parts/local-part/src expected_local_part_src.txt)" ]
+  [ -z "$(compare_dir_contents parts/local-subdir-part/src expected_local_part_subdir_src.txt)" ]
 
   # Verify that the parts can now be staged, and end up as expected
   snapcraft stage | MATCH -v "unsupported"
-  [ "$(list_dir_contents stage)" = "dir dir/dir-file dir-file root-file" ]
+  [ -z "$(compare_dir_contents stage expected_stage.txt)" ]

--- a/tests/spread/general/snap_local_dir/task.yaml
+++ b/tests/spread/general/snap_local_dir/task.yaml
@@ -9,15 +9,20 @@ restore: |
   rm -f ./*.snap
 
 execute: |
+  list_dir_contents()
+  {
+      find "$1" ! -path "$1" -printf "%P\n" | sort | xargs
+  }
+
   cd "$SNAP_DIR"
 
   # Verify that no warning was printed
   snapcraft pull | MATCH -v "unsupported"
 
   # Verify that the parts were pulled as expected
-  [ "$(find parts/local-part/src -printf "%P ")" = "root-file dir dir/dir-file " ]
-  [ "$(find parts/local-subdir-part/src -printf "%P ")" = "dir-file " ]
+  [ "$(list_dir_contents parts/local-part/src)" = "dir dir/dir-file root-file" ]
+  [ "$(list_dir_contents parts/local-subdir-part/src)" = "dir-file" ]
 
   # Verify that the parts can now be staged, and end up as expected
   snapcraft stage | MATCH -v "unsupported"
-  [ "$(find stage -printf "%P ")" = "root-file dir-file dir dir/dir-file " ]
+  [ "$(list_dir_contents stage)" = "dir dir/dir-file dir-file root-file" ]

--- a/tests/spread/general/snap_local_dir/task.yaml
+++ b/tests/spread/general/snap_local_dir/task.yaml
@@ -1,0 +1,23 @@
+summary: Build a snap that uses snap/local and verify that it works without warning
+
+environment:
+  SNAP_DIR: snaps/snap-local-dir
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+execute: |
+  cd "$SNAP_DIR"
+
+  # Verify that no warning was printed
+  snapcraft pull | MATCH -v "unsupported"
+
+  # Verify that the parts were pulled as expected
+  [ "$(find parts/local-part/src -printf "%P ")" = "root-file dir dir/dir-file " ]
+  [ "$(find parts/local-subdir-part/src -printf "%P ")" = "dir-file " ]
+
+  # Verify that the parts can now be staged, and end up as expected
+  snapcraft stage | MATCH -v "unsupported"
+  [ "$(find stage -printf "%P ")" = "root-file dir-file dir dir/dir-file " ]

--- a/tests/spread/plugins/nil/basic/task.yaml
+++ b/tests/spread/plugins/nil/basic/task.yaml
@@ -9,8 +9,13 @@ restore: |
   rm -f ./*.snap
 
 execute: |
+  list_dir_contents()
+  {
+      find "$1" ! -path "$1" -printf "%P\n" | sort | xargs
+  }
+
   cd "$SNAP_DIR"
   snapcraft prime
 
   # Verify that the only thing here is the snap metadata
-  [ "$(find prime -printf "%p ")" = "prime prime/meta prime/meta/snap.yaml " ]
+  [ "$(list_dir_contents prime)" = "meta meta/snap.yaml" ]

--- a/tests/unit/project/test_sanity_checks.py
+++ b/tests/unit/project/test_sanity_checks.py
@@ -70,6 +70,14 @@ class PreflightChecksTest(unit.TestCase):
         open(os.path.join(plugins_dir, "random-hook-2"), "w").close()
         self.assert_check_passes()
 
+    def test_local(self):
+        local_dir = os.path.join("snap", "local")
+        local_subdir = os.path.join(local_dir, "subdir")
+        os.makedirs(local_subdir)
+        open(os.path.join(local_dir, "file1"), "w").close()
+        open(os.path.join(local_subdir, "file2"), "w").close()
+        self.assert_check_passes()
+
     def test_unexpected_things(self):
         dir1 = os.path.join("snap", "dir1")
         dir2 = os.path.join("snap", "dir2")
@@ -78,6 +86,7 @@ class PreflightChecksTest(unit.TestCase):
         fake_plugins_dir = os.path.join(dir1, "plugins")
         fake_hooks_dir = os.path.join(dir1, "hooks")
         fake_gui_dir = os.path.join(dir2, "gui")
+        fake_local_dir = os.path.join(dir2, "local")
         os.makedirs(dir1)
         os.makedirs(dir2)
         os.makedirs(gui_dir)
@@ -85,6 +94,7 @@ class PreflightChecksTest(unit.TestCase):
         os.makedirs(fake_plugins_dir)
         os.makedirs(fake_hooks_dir)
         os.makedirs(fake_gui_dir)
+        os.makedirs(fake_local_dir)
         open(os.path.join(dir1, "foo"), "w").close()
         open(os.path.join(dir2, "bar"), "w").close()
         open(os.path.join(gui_dir, "icon.jpg"), "w").close()
@@ -105,7 +115,10 @@ class PreflightChecksTest(unit.TestCase):
                 "- dir2\n"
                 "- dir2/bar\n"
                 "- dir2/gui\n"
-                "- gui/icon.jpg\n"
+                "- dir2/local\n"
+                "- gui/icon.jpg\n\n"
+                "If you must store these files within the snap/ directory, move them "
+                "to snap/local/, which is ignored by snapcraft.\n"
             ),
         )
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

It's natural for folks to want to put all snap-specific files into the `snap/` directory. This PR resolves [LP: #1792203](https://bugs.launchpad.net/snapcraft/+bug/1792203) by giving them a place to do that: `snap/local/`.