### PR TITLE
catkin, rosdep: stop using FileNotFoundErrors

### DIFF
--- a/snapcraft/plugins/_ros/rosdep.py
+++ b/snapcraft/plugins/_ros/rosdep.py
@@ -26,7 +26,14 @@ from snapcraft.internal import errors, repo
 logger = logging.getLogger(__name__)
 
 
-class RosdepDependencyNotFoundError(errors.SnapcraftError):
+class RosdepPackageNotFoundError(errors.SnapcraftError):
+    fmt = "rosdep cannot find Catkin package {package!r}"
+
+    def __init__(self, package):
+        super().__init__(package=package)
+
+
+class RosdepDependencyNotResolvedError(errors.SnapcraftError):
     fmt = "rosdep cannot resolve {dependency!r} into a valid dependency"
 
     def __init__(self, dependency):
@@ -141,9 +148,7 @@ class Rosdep:
             else:
                 return set()
         except subprocess.CalledProcessError:
-            raise FileNotFoundError(
-                'Unable to find Catkin package "{}"'.format(package_name)
-            )
+            raise RosdepPackageNotFoundError(package_name)
 
     def resolve_dependency(self, dependency_name):
         try:
@@ -164,7 +169,7 @@ class Rosdep:
                 ]
             )
         except subprocess.CalledProcessError:
-            raise RosdepDependencyNotFoundError(dependency_name)
+            raise RosdepDependencyNotResolvedError(dependency_name)
 
         # The output of rosdep follows the pattern:
         #

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -158,6 +158,13 @@ class CatkinGccVersionError(errors.SnapcraftError):
         super().__init__(message=message)
 
 
+class CatkinPackagePathNotFoundError(errors.SnapcraftError):
+    fmt = "Failed to find package path: {path!r}"
+
+    def __init__(self, path):
+        super().__init__(path=path)
+
+
 class CatkinPlugin(snapcraft.BasePlugin):
     @classmethod
     def schema(cls):
@@ -428,9 +435,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
             self.catkin_packages is None or len(self.catkin_packages) > 0
         )
         if packages_to_build and not os.path.exists(self._ros_package_path):
-            raise FileNotFoundError(
-                'Unable to find package path: "{}"'.format(self._ros_package_path)
-            )
+            raise CatkinPackagePathNotFoundError(self._ros_package_path)
 
         # Validate the underlay. Note that this validation can't happen in
         # __init__ as the underlay will probably only be valid once a
@@ -880,7 +885,7 @@ def _resolve_package_dependencies(
     # it.
     try:
         these_dependencies = rosdep.resolve_dependency(dependency)
-    except _ros.rosdep.RosdepDependencyNotFoundError:
+    except _ros.rosdep.RosdepDependencyNotResolvedError:
         raise CatkinInvalidSystemDependencyError(dependency)
 
     for key, value in these_dependencies.items():

--- a/tests/unit/plugins/ros/test_rosdep.py
+++ b/tests/unit/plugins/ros/test_rosdep.py
@@ -139,10 +139,10 @@ class RosdepTestCase(unit.TestCase):
         self.check_output_mock.side_effect = subprocess.CalledProcessError(1, "foo")
 
         raised = self.assertRaises(
-            FileNotFoundError, self.rosdep.get_dependencies, "bar"
+            rosdep.RosdepPackageNotFoundError, self.rosdep.get_dependencies, "bar"
         )
 
-        self.assertThat(str(raised), Equals('Unable to find Catkin package "bar"'))
+        self.assertThat(str(raised), Equals("rosdep cannot find Catkin package 'bar'"))
 
     def test_get_dependencies_entire_workspace(self):
         self.check_output_mock.return_value = b"foo\nbar\nbaz"
@@ -177,7 +177,9 @@ class RosdepTestCase(unit.TestCase):
         self.check_output_mock.side_effect = subprocess.CalledProcessError(1, "foo")
 
         raised = self.assertRaises(
-            rosdep.RosdepDependencyNotFoundError, self.rosdep.resolve_dependency, "bar"
+            rosdep.RosdepDependencyNotResolvedError,
+            self.rosdep.resolve_dependency,
+            "bar",
         )
 
         self.assertThat(

--- a/tests/unit/plugins/test_catkin.py
+++ b/tests/unit/plugins/test_catkin.py
@@ -454,12 +454,12 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
         # it does not contain a `src` folder and `source-space` is 'src', this
         # should fail.
         plugin = catkin.CatkinPlugin("test-part", self.properties, self.project_options)
-        raised = self.assertRaises(FileNotFoundError, plugin.pull)
+        raised = self.assertRaises(catkin.CatkinPackagePathNotFoundError, plugin.pull)
 
         self.assertThat(
             str(raised),
             Equals(
-                'Unable to find package path: "{}"'.format(
+                "Failed to find package path: {!r}".format(
                     os.path.join(plugin.sourcedir, "src")
                 )
             ),
@@ -483,12 +483,12 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
         # it does not contain a `src` folder and source_space wasn't
         # specified, this should fail.
         plugin = catkin.CatkinPlugin("test-part", self.properties, self.project_options)
-        raised = self.assertRaises(FileNotFoundError, plugin.pull)
+        raised = self.assertRaises(catkin.CatkinPackagePathNotFoundError, plugin.pull)
 
         self.assertThat(
             str(raised),
             Equals(
-                'Unable to find package path: "{}"'.format(
+                "Failed to find package path: {!r}".format(
                     os.path.join(plugin.sourcedir, self.properties.source_space)
                 )
             ),
@@ -502,12 +502,12 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
         # it does not contain a `src` folder and source_space wasn't
         # specified, this should fail.
         plugin = catkin.CatkinPlugin("test-part", self.properties, self.project_options)
-        raised = self.assertRaises(FileNotFoundError, plugin.pull)
+        raised = self.assertRaises(catkin.CatkinPackagePathNotFoundError, plugin.pull)
 
         self.assertThat(
             str(raised),
             Equals(
-                'Unable to find package path: "{}"'.format(
+                "Failed to find package path: {!r}".format(
                     os.path.join(plugin.sourcedir, self.properties.source_space)
                 )
             ),
@@ -1654,7 +1654,7 @@ class FindSystemDependenciesTestCase(unit.TestCase):
     def test_find_system_dependencies_missing_local_dependency(self):
         # Setup a dependency on a non-existing package, and it doesn't resolve
         # to a system dependency.'
-        exception = _ros.rosdep.RosdepDependencyNotFoundError("foo")
+        exception = _ros.rosdep.RosdepDependencyNotResolvedError("foo")
         self.rosdep_mock.resolve_dependency.side_effect = exception
 
         raised = self.assertRaises(


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Using non-`SnapcraftError`s results in tracebacks being sent to Sentry instead of nice error messages. Fix this by introducing `SnapcraftError`-derived exceptions for these cases instead of using `FileNotFoundError`s.