### PR TITLE
reporting: fail gracefully on submit errors

### DIFF
--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -68,7 +68,7 @@ _NO_VALUES = ["no", "n"]
 _ALWAYS_VALUES = ["always", "a"]
 
 
-def exception_handler(
+def exception_handler(  # noqa: C901
     exception_type, exception, exception_traceback, *, debug=False
 ) -> None:
     """Catch all Snapcraft exceptions unless debugging.
@@ -132,8 +132,17 @@ def exception_handler(
                 traceback.print_exception(*exc_info, file=sys.stdout)
             trace_filepath = _handle_trace_output(exc_info)
             if _is_send_to_sentry(trace_filepath):
-                _submit_trace(exc_info)
-                click.echo(_MSG_SEND_TO_SENTRY_THANKS)
+                try:
+                    _submit_trace(exc_info)
+                except Exception as exc:
+                    # we really cannot do much more from this exit handler.
+                    echo.error(
+                        "Encountered an issue while trying to submit the report: {}".format(
+                            str(exc)
+                        )
+                    )
+                else:
+                    click.echo(_MSG_SEND_TO_SENTRY_THANKS)
 
     sys.exit(exit_code)
 

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -153,6 +153,20 @@ class SendToSentryBaseTest(ErrorsBaseTestCase):
         )
 
 
+class SendToSentryFails(SendToSentryBaseTest):
+    def test_send_fails(self):
+        self.prompt_mock.return_value = "yes"
+        self.mock_isatty.return_value = True
+
+        self.raven_client_mock().captureException.side_effect = RuntimeError(
+            "raven is broken"
+        )
+        try:
+            self.call_handler(RuntimeError("not a SnapcraftError"), True)
+        except Exception:
+            self.fail("Exception unexpectedly raised")
+
+
 class SendToSentryIsYesTest(SendToSentryBaseTest):
 
     yes_scenarios = [


### PR DESCRIPTION
Errors can occur during submission. This handles failing gracefully.

LP: #1791968

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
