### PR TITLE
meta: friendlier message for incorrect app command

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -167,10 +167,8 @@ class InvalidAppCommandError(SnapcraftError):
     fmt = (
         "Failed to generate snap metadata: "
         "The specified command {command!r} defined in the app {app!r} does "
-        "not exist or is not executable"
-        # FIXME split the errors to include in the message how to fix them.
-        # https://bugs.launchpad.net/snapcraft/+bug/1727425
-        # --elopio - 2017-10-25
+        "not exist or is not executable.\n"
+        "Ensure that {command!r} is relative to the prime directory."
     )
 
     def __init__(self, command, app):

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -531,11 +531,6 @@ class _SnapPackaging:
     def _wrap_exe(self, command, basename=None):
         execparts = shlex.split(command)
         exepath = os.path.join(self._prime_dir, execparts[0])
-        if not os.path.exists(exepath) and "/" not in execparts[0]:
-            logger.warning(
-                "For better results ensure that the specified command {command!r} is "
-                "relative to the prime directory.".format(command=execparts[0])
-            )
         if basename:
             wrappath = os.path.join(self._prime_dir, basename) + ".wrapper"
         else:

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -531,6 +531,11 @@ class _SnapPackaging:
     def _wrap_exe(self, command, basename=None):
         execparts = shlex.split(command)
         exepath = os.path.join(self._prime_dir, execparts[0])
+        if not os.path.exists(exepath) and "/" not in execparts[0]:
+            logger.warning(
+                "For better results ensure that the specified command {command!r} is "
+                "relative to the prime directory.".format(command=execparts[0])
+            )
         if basename:
             wrappath = os.path.join(self._prime_dir, basename) + ".wrapper"
         else:
@@ -575,6 +580,8 @@ class _SnapPackaging:
         for k in cmds:
             try:
                 app[k] = self._wrap_exe(app[k], "{}-{}".format(k, name))
+            except FileNotFoundError:
+                raise errors.InvalidAppCommandError(command=app[k], app=app)
             except meta_errors.CommandError as e:
                 raise errors.InvalidAppCommandError(str(e), name)
 

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -271,7 +271,8 @@ class ErrorFormattingTestCase(unit.TestCase):
                 "expected_message": (
                     "Failed to generate snap metadata: "
                     "The specified command 'test-command' defined in the app "
-                    "'test-app' does not exist or is not executable"
+                    "'test-app' does not exist or is not executable.\n"
+                    "Ensure that 'test-command' is relative to the prime directory."
                 ),
             },
         ),

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -534,7 +534,6 @@ class PassthroughErrorTestCase(PassthroughBaseTestCase):
         self.config_data["apps"] = {
             "foo": {"command": "echo", "passthrough": {"foo": "bar", "spam": "eggs"}}
         }
-        _create_file(os.path.join(self.prime_dir, self.config_data["apps"]["foo"]["command"]))
         self.config_data["hooks"] = {
             "foo": {"plugs": ["network"], "passthrough": {"foo": "bar", "spam": "eggs"}}
         }

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -534,6 +534,7 @@ class PassthroughErrorTestCase(PassthroughBaseTestCase):
         self.config_data["apps"] = {
             "foo": {"command": "echo", "passthrough": {"foo": "bar", "spam": "eggs"}}
         }
+        _create_file(os.path.join(self.prime_dir, self.config_data["apps"]["foo"]["command"]))
         self.config_data["hooks"] = {
             "foo": {"plugs": ["network"], "passthrough": {"foo": "bar", "spam": "eggs"}}
         }
@@ -1217,8 +1218,7 @@ class CreateWithGradeTestCase(CreateBaseTestCase):
             )
 
 
-# TODO this needs more tests.
-class WrapExeTestCase(unit.TestCase):
+class BaseWrapTest(unit.TestCase):
     def setUp(self):
         super().setUp()
 
@@ -1240,6 +1240,14 @@ class WrapExeTestCase(unit.TestCase):
         self.packager = _snap_packaging._SnapPackaging(config)
         self.packager._is_host_compatible_with_base = True
 
+
+class WrapAppTest(BaseWrapTest):
+    def test_app_not_fount(self):
+        self.assertRaises(errors.InvalidAppCommandError, self.packager._wrap_apps, apps=dict(app=dict(command="test-command")))
+
+
+# TODO this needs more tests.
+class WrapExeTest(BaseWrapTest):
     @patch("snapcraft.internal.common.assemble_env")
     def test_wrap_exe_must_write_wrapper(self, mock_assemble_env):
         mock_assemble_env.return_value = "PATH={0}/part1/install/usr/bin:{0}/part1/install/bin".format(

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -1242,7 +1242,11 @@ class BaseWrapTest(unit.TestCase):
 
 class WrapAppTest(BaseWrapTest):
     def test_app_not_fount(self):
-        self.assertRaises(errors.InvalidAppCommandError, self.packager._wrap_apps, apps=dict(app=dict(command="test-command")))
+        self.assertRaises(
+            errors.InvalidAppCommandError,
+            self.packager._wrap_apps,
+            apps=dict(app=dict(command="test-command")),
+        )
 
 
 # TODO this needs more tests.

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -1241,7 +1241,7 @@ class BaseWrapTest(unit.TestCase):
 
 
 class WrapAppTest(BaseWrapTest):
-    def test_app_not_fount(self):
+    def test_app_not_found(self):
         self.assertRaises(
             errors.InvalidAppCommandError,
             self.packager._wrap_apps,


### PR DESCRIPTION
Provide a nicer error for when the command entires under
an specific application cannot be found.

Also, for future proofing, ensure a warning is raised when these
commands are not relative to the prime directory.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
