### PR TITLE
sanity checks: run properly on build VMs

### DIFF
--- a/snapcraft/project/_sanity_checks.py
+++ b/snapcraft/project/_sanity_checks.py
@@ -41,7 +41,7 @@ def conduct_project_sanity_check(project: snapcraft.project.Project):
     The checks done here are meant to be light, and not rely on the build environment.
     """
 
-    snap_dir_path = os.path.join(project._work_dir, "snap")
+    snap_dir_path = os.path.join(project._project_dir, "snap")
     if os.path.isdir(snap_dir_path):
         _check_snap_dir(snap_dir_path)
 

--- a/tests/unit/project/test_sanity_checks.py
+++ b/tests/unit/project/test_sanity_checks.py
@@ -27,12 +27,20 @@ from tests import unit
 
 
 class PreflightChecksTest(unit.TestCase):
+    scenarios = [
+        ("managed", dict(is_managed_host=True)),
+        ("unmanaged", dict(is_managed_host=False)),
+    ]
+
     def setUp(self):
         super().setUp()
         self.fake_logger = self.useFixture(fixtures.FakeLogger(level=logging.WARN))
+        self.useFixture(
+            fixtures.EnvironmentVariable("HOME", os.path.join(self.path, "fake-home"))
+        )
 
     def assert_check_passes(self):
-        _run_check()
+        self.run_check()
         self.assertThat(self.fake_logger.output, Equals(""))
 
     def test_no_snap_dir(self):
@@ -100,7 +108,7 @@ class PreflightChecksTest(unit.TestCase):
         open(os.path.join(gui_dir, "icon.jpg"), "w").close()
         open(os.path.join(state_dir, "baz"), "w").close()
 
-        _run_check()
+        self.run_check()
         self.assertThat(
             self.fake_logger.output,
             Equals(
@@ -122,7 +130,6 @@ class PreflightChecksTest(unit.TestCase):
             ),
         )
 
-
-def _run_check():
-    project = snapcraft.project.Project()
-    conduct_project_sanity_check(project)
+    def run_check(self):
+        project = snapcraft.project.Project(is_managed_host=self.is_managed_host)
+        conduct_project_sanity_check(project)


### PR DESCRIPTION
The snapcraft CLI runs sanity checks. The check of the snap/ directory is currently relative to cwd, which breaks in build VMs. This PR fixes [LP: #1792962](https://bugs.launchpad.net/snapcraft/+bug/1792962) by making it relative to the project directory instead.