### PR TITLE
build providers: re-exec as root

### DIFF
--- a/snapcraft/cli/_runner.py
+++ b/snapcraft/cli/_runner.py
@@ -75,7 +75,7 @@ def run(ctx, debug, catch_exceptions=False, **kwargs):
         if os.getenv("SNAP_NAME") == "snapcraft":
             cmd.append(os.path.join(snap_path, "usr", "bin", "python3"))
         cmd.extend(sys.argv)
-        os.execve("/usr/bin/sudo",  cmd, os.environ)
+        os.execve("/usr/bin/sudo", cmd, os.environ)
 
     # Debugging snapcraft itself is not tied to debugging a snapcraft project.
     try:


### PR DESCRIPTION
When snapcraft is called from managed-host environment, it needs to re-exec itself as root.

LP: #1791977
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
