### PR TITLE
snapcraft snap: refactor override-build into a script

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,26 +57,12 @@ parts:
         snapcraftctl set-grade "$grade"
     override-build: |
         snapcraftctl build
+
+        echo "Create libsodium symlink..."
         TRIPLET_PATH="$SNAPCRAFT_PART_INSTALL/usr/lib/$(gcc -print-multiarch)"
         LIBSODIUM="$(readlink -n "$TRIPLET_PATH/libsodium.so.18")"
         # Remove so the link can be recreated on re-builds
         rm -f "$TRIPLET_PATH/libsodium.so"
         ln -s "$LIBSODIUM" "$TRIPLET_PATH/libsodium.so"
 
-        # Restore patched files
-        PYTHON_PACKAGE_PATH="$SNAPCRAFT_PART_INSTALL/usr/lib/python3.5/"
-        [ -f "patched/ctypes/__init__.py.orig" ] && mv "patched/ctypes/__init__.py.orig" "$PYTHON_PACKAGE_PATH/ctypes/__init__.py"
-
-        # Apply patches
-        patch -b "$PYTHON_PACKAGE_PATH/ctypes/__init__.py" patches/ctypes_init.diff
-
-        # Save patches to allow rebuilding
-        mkdir -p patched/ctypes
-        [ -f "$PYTHON_PACKAGE_PATH/ctypes/__init__.py.orig" ] && mv "$PYTHON_PACKAGE_PATH/ctypes/__init__.py.orig" patched/ctypes
-    override-prime: |
-        snapcraftctl prime
-        # Now that everything is built, let's disable user site-packages
-        # as stated in PEP-0370
-        sed -i usr/lib/python3.5/site.py -e 's/^ENABLE_USER_SITE = None$/ENABLE_USER_SITE = False/'
-        # This is the last step, let's now compile all our pyc files.
-        ./usr/bin/python3 -m compileall .
+        ./tools/snapcraft-override-build.sh

--- a/tools/snapcraft-override-build.sh
+++ b/tools/snapcraft-override-build.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -e
+
+# Restore patched files
+PYTHON_PACKAGE_PATH="$SNAPCRAFT_PART_INSTALL/usr/lib/python3.5/"
+[ -f "patched/ctypes/__init__.py.orig" ] && mv "patched/ctypes/__init__.py.orig" "$PYTHON_PACKAGE_PATH/ctypes/__init__.py"
+
+# Apply patches
+echo "Patching ctypes..."
+patch -s -b "$PYTHON_PACKAGE_PATH/ctypes/__init__.py" patches/ctypes_init.diff
+
+# Save patches to allow rebuilding
+mkdir -p patched/ctypes
+[ -f "$PYTHON_PACKAGE_PATH/ctypes/__init__.py.orig" ] && mv "$PYTHON_PACKAGE_PATH/ctypes/__init__.py.orig" patched/ctypes
+
+# Now that everything is built, let's disable user site-packages
+# as stated in PEP-0370
+echo "Compiling pyc files..."
+sed -i "$SNAPCRAFT_PART_INSTALL/usr/lib/python3.5/site.py" -e 's/^ENABLE_USER_SITE = None$/ENABLE_USER_SITE = False/'
+# This is the last step, let's now compile all our pyc files.
+"$SNAPCRAFT_PART_INSTALL/usr/bin/python3" -m compileall -q .


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

In order to reduce duplication in the snapcraft.yaml as we work toward vendoring snapcraft within itself ([LP: #1793261](https://bugs.launchpad.net/snapcraft/+bug/1793261), refactor the current override-build into a script.