### PR TITLE
build providers: make use of time for multipass stop

### DIFF
--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -22,6 +22,7 @@ from .. import errors
 from .._base_provider import Provider
 from ._instance_info import InstanceInfo
 from ._multipass_command import MultipassCommand
+from snapcraft.internal.errors import SnapcraftEnvironmentError
 
 
 def _get_platform() -> str:
@@ -32,7 +33,13 @@ def _get_stop_time() -> int:
     try:
         timeout = int(os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT_STOP_TIME", "10"))
     except ValueError:
-        timeout = 10
+        raise SnapcraftEnvironmentError(
+            "'SNAPCRAFT_BUILD_ENVIRONMENT_STOP_TIME' is incorrectly set, found {!r} "
+            "but expected a number representing the minutes to delay the actual stop "
+            "operation (or 0 to stop immediately).".format(
+                os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT_STOP_TIME")
+            )
+        )
 
     return timeout
 

--- a/snapcraft/internal/build_providers/_multipass/_multipass_command.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass_command.py
@@ -114,12 +114,17 @@ class MultipassCommand:
                 provider_name=self.provider_name, exit_code=process_error.returncode
             ) from process_error
 
-    def stop(self, *, instance_name: str) -> None:
+    def stop(self, *, instance_name: str, time: int = None) -> None:
         """Passthrough for running multipass stop.
 
         :param str instance_name: the name of the instance to stop.
+        :param str time: time from now, in minutes, to delay shutdown of the
+                         instance.
         """
-        cmd = [self.provider_cmd, "stop", instance_name]
+        cmd = [self.provider_cmd, "stop"]
+        if time:
+            cmd.extend(["--time", str(time)])
+        cmd.append(instance_name)
         try:
             _run(cmd)
         except subprocess.CalledProcessError as process_error:

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -26,6 +26,7 @@ from tests.unit.build_providers import (
     get_project,
 )
 from snapcraft.internal import steps
+from snapcraft.internal.errors import SnapcraftEnvironmentError
 from snapcraft.internal.build_providers import errors
 from snapcraft.internal.build_providers._multipass import Multipass, MultipassCommand
 
@@ -292,6 +293,50 @@ class MultipassTest(BaseProviderBaseTest):
         multipass = Multipass(project=self.project, echoer=self.echoer_mock)
 
         multipass.destroy()
+
+        self.multipass_cmd_mock().stop.assert_not_called()
+        self.multipass_cmd_mock().delete.assert_not_called()
+
+    def test_destroy_instance_with_stop_delay(self):
+        self.useFixture(
+            fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT_STOP_TIME", "60")
+        )
+
+        multipass = Multipass(project=self.project, echoer=self.echoer_mock)
+
+        multipass.create()
+        multipass.destroy()
+
+        self.multipass_cmd_mock().stop.assert_called_once_with(
+            instance_name=self.instance_name, time=60
+        )
+        self.multipass_cmd_mock().delete.assert_not_called()
+
+    def test_destroy_instance_with_stop_delay_0(self):
+        self.useFixture(
+            fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT_STOP_TIME", "0")
+        )
+
+        multipass = Multipass(project=self.project, echoer=self.echoer_mock)
+
+        multipass.create()
+        multipass.destroy()
+
+        self.multipass_cmd_mock().stop.assert_called_once_with(
+            instance_name=self.instance_name
+        )
+        self.multipass_cmd_mock().delete.assert_not_called()
+
+    def test_destroy_instance_with_stop_delay_invalid(self):
+        self.useFixture(
+            fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT_STOP_TIME", "A")
+        )
+
+        multipass = Multipass(project=self.project, echoer=self.echoer_mock)
+
+        multipass.create()
+
+        self.assertRaises(SnapcraftEnvironmentError, multipass.destroy)
 
         self.multipass_cmd_mock().stop.assert_not_called()
         self.multipass_cmd_mock().delete.assert_not_called()

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -156,7 +156,7 @@ class MultipassTest(BaseProviderBaseTest):
             ]
         )
         self.multipass_cmd_mock().stop.assert_called_once_with(
-            instance_name=self.instance_name
+            instance_name=self.instance_name, time=10
         )
         self.multipass_cmd_mock().delete.assert_called_once_with(
             instance_name=self.instance_name, purge=True
@@ -388,7 +388,7 @@ class MultipassWithBasesTest(BaseProviderWithBasesBaseTest):
         )
         self.multipass_cmd_mock().copy_files.assert_not_called()
         self.multipass_cmd_mock().stop.assert_called_once_with(
-            instance_name=self.instance_name
+            instance_name=self.instance_name, time=10
         )
         self.multipass_cmd_mock().delete.assert_not_called()
 

--- a/tests/unit/build_providers/multipass/test_multipass_command.py
+++ b/tests/unit/build_providers/multipass/test_multipass_command.py
@@ -195,6 +195,14 @@ class MultipassCommandStopTest(MultipassCommandPassthroughBaseTest):
         )
         self.check_output_mock.assert_not_called()
 
+    def test_stop_time(self):
+        self.multipass_command.stop(instance_name=self.instance_name, time=10)
+
+        self.check_call_mock.assert_called_once_with(
+            ["multipass", "stop", "--time", "10", self.instance_name]
+        )
+        self.check_output_mock.assert_not_called()
+
     def test_stop_fails(self):
         # multipass can fail due to several reasons and will display the error
         # right above this exception message.


### PR DESCRIPTION
LP: #1793288

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
