### PR TITLE
snapcraft snap: vendor legacy snapcraft

### DIFF
--- a/bin/snapcraft
+++ b/bin/snapcraft
@@ -15,8 +15,40 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# This script is only needed as cx_Freeze does not support console scripts
-# thus there are no entry points.
-# We use __import__ to replicate somewhat what would happen if using
-# pkg_resources.
-__import__('snapcraft.cli.__main__', fromlist=['__name__'], level=0)
+import os
+import site
+import subprocess
+import sys
+
+from snapcraft import project, yaml_utils
+from snapcraft.internal import common
+
+# We need to determine the appropriate version of the snapcraft CLI: current, or legacy.
+# By default we use current, but we use legacy if all the following conditions are met:
+#
+#     1. A legacy snapcraft is available
+#     2. There is a snapcraft.yaml
+#     3. Reading the snapcraft.yaml doesn't toss exceptions
+#     3. The snapcraft.yaml is not using the 'base' keyword
+
+if os.path.isdir(common.get_legacy_snapcraft_dir()):
+    try:
+        snapcraft_yaml_path = project.get_snapcraft_yaml()
+        with open(snapcraft_yaml_path, "r") as f:
+            data = yaml_utils.load(f)
+        if data.get("base") is None:
+            legacy_python = os.path.join(
+                common.get_legacy_snapcraft_dir(), "usr", "bin", "python3"
+            )
+            legacy_snapcraft = os.path.join(
+                common.get_legacy_snapcraft_dir(), "bin", "snapcraft"
+            )
+            os.execv(legacy_python, [legacy_python, legacy_snapcraft] + sys.argv[1:])
+    except Exception:
+        # If there are issues loading/parsing the YAML, just pass off to the current version
+        # where the error should be properly handled
+        pass
+
+import snapcraft.cli.__main__
+
+snapcraft.cli.__main__.run()

--- a/setup.py
+++ b/setup.py
@@ -138,13 +138,11 @@ else:
         classifiers=classifiers,
         # non-cx_Freeze arguments
         entry_points={
-            "console_scripts": [
-                "snapcraft = snapcraft.cli.__main__:run",
-                "snapcraft-parser = snapcraft.internal.parser:main",
-            ]
+            "console_scripts": ["snapcraft-parser = snapcraft.internal.parser:main"]
         },
-        # This is not in console_scripts because we need a clean environment
-        scripts=["bin/snapcraftctl"],
+        # snapcraftctl is not in console_scripts because we need a clean environment.
+        # snapcraft isn't in console_scripts so we can dispatch to legacy depending on bases
+        scripts=["bin/snapcraft", "bin/snapcraftctl"],
         data_files=[
             ("share/snapcraft/schema", ["schema/" + x for x in os.listdir("schema")]),
             (

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,26 +13,26 @@ apps:
     command: bin/snapcraft
     completer: snapcraft-completion
 
+build-packages:
+  - build-essential
+  - libapt-pkg-dev
+  - libffi-dev
+  - libssl-dev
+  - libsodium-dev
+  - liblzma-dev
+  - libyaml-dev
+  - patch
+  - sed
+
 parts:
   bash-completion:
     source: debian
     plugin: dump
     stage:
       - snapcraft-completion
-  snapcraft:
-    source: .
-    plugin: python
-    requirements: requirements.txt
-    build-packages:
-        - build-essential
-        - libapt-pkg-dev
-        - libffi-dev
-        - libssl-dev
-        - libsodium-dev
-        - liblzma-dev
-        - libyaml-dev
-        - patch
-        - sed
+
+  snapcraft-libs:
+    plugin: nil
     stage-packages:
         - apt
         - apt-transport-https
@@ -45,6 +45,20 @@ parts:
         - patchelf
         - squashfs-tools
         - xdelta3
+    override-build: |
+      snapcraftctl build
+
+      echo "Create libsodium symlink..."
+      TRIPLET_PATH="$SNAPCRAFT_PART_INSTALL/usr/lib/$(gcc -print-multiarch)"
+      LIBSODIUM="$(readlink -n "$TRIPLET_PATH/libsodium.so.18")"
+      # Remove so the link can be recreated on re-builds
+      rm -f "$TRIPLET_PATH/libsodium.so"
+      ln -s "$LIBSODIUM" "$TRIPLET_PATH/libsodium.so"
+
+  snapcraft:
+    source: .
+    plugin: python
+    requirements: requirements.txt
     organize:
         # Put snapcraftctl into its own directory that can be included in the PATH
         # without including other binaries.
@@ -57,12 +71,20 @@ parts:
         snapcraftctl set-grade "$grade"
     override-build: |
         snapcraftctl build
-
-        echo "Create libsodium symlink..."
-        TRIPLET_PATH="$SNAPCRAFT_PART_INSTALL/usr/lib/$(gcc -print-multiarch)"
-        LIBSODIUM="$(readlink -n "$TRIPLET_PATH/libsodium.so.18")"
-        # Remove so the link can be recreated on re-builds
-        rm -f "$TRIPLET_PATH/libsodium.so"
-        ln -s "$LIBSODIUM" "$TRIPLET_PATH/libsodium.so"
-
         ./tools/snapcraft-override-build.sh
+    after: [snapcraft-libs]
+
+  legacy-snapcraft:
+    plugin: python
+    source: https://github.com/snapcore/snapcraft.git
+    source-branch: legacy
+    source-depth: 1
+    requirements: requirements.txt
+    override-build: |
+        snapcraftctl build
+        ./tools/snapcraft-override-build.sh
+
+        sed -ri 's|(lib/.*/site-packages)|legacy_snapcraft/\1|' $SNAPCRAFT_PART_INSTALL/usr/lib/python3.5/sitecustomize.py
+    organize:
+        '*': legacy_snapcraft/
+    after: [snapcraft-libs]

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -48,6 +48,8 @@ _DEFAULT_LIBRARIESDIR = os.path.join(sys.prefix, "share", "snapcraft", "librarie
 _librariesdir = _DEFAULT_LIBRARIESDIR
 _DEFAULT_EXTENSIONSDIR = os.path.join(sys.prefix, "share", "snapcraft", "extensions")
 _extensionsdir = _DEFAULT_EXTENSIONSDIR
+_DEFAULT_LEGACY_SNAPCRAFT_DIR = os.path.join(sys.prefix, "legacy_snapcraft")
+_legacy_snapcraft_dir = _DEFAULT_LEGACY_SNAPCRAFT_DIR
 _DOCKERENV_FILE = "/.dockerenv"
 
 MAX_CHARACTERS_WRAP = 120
@@ -180,6 +182,15 @@ def set_librariesdir(librariesdir):
 
 def get_librariesdir():
     return _librariesdir
+
+
+def set_legacy_snapcraft_dir(snapcraftdir):
+    global _legacy_snapcraft_dir
+    _legacy_snapcraft_dir = snapcraftdir
+
+
+def get_legacy_snapcraft_dir():
+    return _legacy_snapcraft_dir
 
 
 def get_python2_path(root):

--- a/snapcraft/internal/dirs.py
+++ b/snapcraft/internal/dirs.py
@@ -44,3 +44,6 @@ def setup_dirs() -> None:
         common.set_schemadir(os.path.join(parent_dir, "schema"))
         common.set_librariesdir(os.path.join(parent_dir, "libraries"))
         common.set_extensionsdir(os.path.join(parent_dir, "extensions"))
+        common.set_legacy_snapcraft_dir(
+            os.path.join(os.environ.get("SNAP"), "legacy_snapcraft")
+        )


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR resolves [LP: #1793261](https://bugs.launchpad.net/snapcraft/+bug/1793261), continuing support for the lack of a base by vendoring legacy snapcraft into the snapcraft snap and dispatching to it if there is no base specified in the snapcraft.yaml.

**Note:** These tests will fail until #2283 lands in legacy.