### PR TITLE
build providers: use multipass automatically when on darwin

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -51,7 +51,12 @@ def _execute(  # noqa: C901
     **kwargs
 ) -> "Project":
     # fmt: on
-    build_environment = env.BuilderEnvironmentConfig()
+    if sys.platform == "darwin":
+        default_provider = "multipass"
+    else:
+        default_provider = "host"
+
+    build_environment = env.BuilderEnvironmentConfig(default=default_provider)
     project = get_project(is_managed_host=build_environment.is_managed_host, **kwargs)
 
     conduct_project_sanity_check(project)
@@ -314,9 +319,7 @@ def cleanbuild(remote, **kwargs):
     else:
         default_provider = "lxd"
 
-    build_environment = env.BuilderEnvironmentConfig(
-        default=default_provider, additional_providers=["multipass"]
-    )
+    build_environment = env.BuilderEnvironmentConfig(default=default_provider)
     project = get_project(
         is_managed=build_environment.is_managed_host, **kwargs
     )


### PR DESCRIPTION
LP: #1793512

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
