### PR TITLE
local source: only filter out snapcraft artifacts

### DIFF
--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -31,15 +31,7 @@ from typing import Callable, List
 from snapcraft.internal import errors
 
 
-SNAPCRAFT_FILES = [
-    "snapcraft.yaml",
-    ".snapcraft.yaml",
-    ".snapcraft",
-    "parts",
-    "stage",
-    "prime",
-    "snap",
-]
+SNAPCRAFT_FILES = ["parts", "stage", "prime", os.path.join("snap", ".snapcraft")]
 _DEFAULT_PLUGINDIR = os.path.join(sys.prefix, "share", "snapcraft", "plugins")
 _plugindir = _DEFAULT_PLUGINDIR
 _DEFAULT_SCHEMADIR = os.path.join(sys.prefix, "share", "snapcraft", "schema")

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -23,7 +23,7 @@ import os
 import shutil
 import subprocess
 import sys
-from glob import glob, iglob
+from glob import iglob
 from typing import cast, Dict, Set, Sequence  # noqa: F401
 
 import snapcraft.extractors
@@ -494,28 +494,10 @@ class PluginHandler:
             if os.path.exists(self.plugin.build_basedir):
                 shutil.rmtree(self.plugin.build_basedir)
 
-            # FIXME: It's not necessary to ignore here anymore since it's now
-            # done in the Local source. However, it's left here so that it
-            # continues to work on old snapcraft trees that still have src
-            # symlinks.
-            def ignore(directory, files):
-                if directory == self.plugin.sourcedir:
-                    snaps = glob(os.path.join(directory, "*.snap"))
-                    if snaps:
-                        snaps = [os.path.basename(s) for s in snaps]
-                        return common.SNAPCRAFT_FILES + snaps
-                    else:
-                        return common.SNAPCRAFT_FILES
-                else:
-                    return []
-
             # No hard-links being used here in case the build process modifies
             # these files.
             shutil.copytree(
-                self.plugin.sourcedir,
-                self.plugin.build_basedir,
-                symlinks=True,
-                ignore=ignore,
+                self.plugin.sourcedir, self.plugin.build_basedir, symlinks=True
             )
 
         self._do_build()


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Currently, the local source filters out essentially everything related to the snapcraft CLI, including the entire `snap/` directory. However, this is over-zealous: the `snap/` directory and its contents are often committed to version control, and the process of filtering them out makes changes as far as version control is concerned, resulting in a dirty tree. This really becomes problematic if one then uses `git describe --dirty` to determine the version: it's always dirty.

This PR fixes [LP: #1662388](https://bugs.launchpad.net/snapcraft/+bug/1662388) by taking a more fine-grained approach to filtering out files related to the snapcraft CLI: only filter artifacts, i.e. things generated by the snapcraft CLI. This includes `parts/` `stage/`, `prime/` and `snap/.snapcraft/`.