### PR TITLE
pluginhandler: update build should overwrite organize

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -276,6 +276,14 @@ class SnapcraftPartConflictError(SnapcraftError):
         )
 
 
+class SnapcraftOrganizeError(SnapcraftError):
+
+    fmt = "Failed to organize part {part_name!r}: {message}"
+
+    def __init__(self, part_name, message):
+        super().__init__(part_name=part_name, message=message)
+
+
 class MissingCommandError(SnapcraftError):
 
     fmt = (


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

If a part uses the `organize` keyword, in order for the `build` step to be updated, the organization must support happening twice without a clean. This PR resolves [LP: #1794083](https://bugs.launchpad.net/snapcraft/+bug/1794083) by adding the ability for `organize` to overwrite files and directories previously organized by the part.