### PR TITLE
meta: put environment into runner instead of app wrapper

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -324,12 +324,24 @@ class _SnapPackaging:
         self._meta_dir = os.path.join(self._prime_dir, "meta")
         self._config_data = project_config.data.copy()
         self._original_snapcraft_yaml = project_config.project.info.get_raw_snapcraft()
+        self._meta_runner = os.path.join(
+            self._prime_dir, "snap", "command-chain", "snapcraft-runner"
+        )
+
+        self._install_path_pattern = re.compile(
+            r"{}/[a-z0-9][a-z0-9+-]*/install".format(re.escape(self._parts_dir))
+        )
 
         os.makedirs(self._meta_dir, exist_ok=True)
 
     def write_snap_yaml(self) -> str:
         common.env = self._project_config.snap_env()
+
         try:
+            # Only generate the meta command chain if there are apps that need it
+            if self._config_data.get("apps", None):
+                self._generate_command_chain()
+
             package_snap_path = os.path.join(self.meta_dir, "snap.yaml")
             snap_yaml = self._compose_snap_yaml()
 
@@ -362,6 +374,31 @@ class _SnapPackaging:
             file_utils.link_or_copy(
                 "gadget.yaml", os.path.join(self.meta_dir, "gadget.yaml")
             )
+
+    def _generate_command_chain(self):
+        # Classic confinement or building on a host that does not match the target base
+        # means we cannot setup an environment that will work.
+        if (
+            self._config_data["confinement"] == "classic"
+            or not self._is_host_compatible_with_base
+        ):
+            assembled_env = None
+        else:
+            assembled_env = common.assemble_env()
+            assembled_env = assembled_env.replace(self._prime_dir, "$SNAP")
+            assembled_env = self._install_path_pattern.sub("$SNAP", assembled_env)
+
+            if assembled_env:
+                os.makedirs(os.path.dirname(self._meta_runner), exist_ok=True)
+                with open(self._meta_runner, "w") as f:
+                    print("#!/bin/sh", file=f)
+                    print(assembled_env, file=f)
+                    print(
+                        "export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH",
+                        file=f,
+                    )
+                    print('exec "$@"', file=f)
+                os.chmod(self._meta_runner, 0o755)
 
     def _record_manifest_and_source_snapcraft_yaml(self):
         prime_snap_dir = os.path.join(self._prime_dir, "snap")
@@ -504,32 +541,12 @@ class _SnapPackaging:
         args = " ".join(quoted_args) + ' "$@"' if args else '"$@"'
         cwd = "cd {}".format(cwd) if cwd else ""
 
-        # If we are dealing with classic confinement it means all our
-        # binaries are linked with `nodefaultlib` but we still do
-        # not want to leak PATH or other environment variables
-        # that would affect the applications view of the classic
-        # environment it is dropped into.
-        replace_path = re.compile(
-            r"{}/[a-z0-9][a-z0-9+-]*/install".format(re.escape(self._parts_dir))
-        )
-        # Confinement classic or when building on a host that does not match
-        # the target base means we cannot setup an environment that will work.
-        if (
-            self._config_data["confinement"] == "classic"
-            or not self._is_host_compatible_with_base
-        ):
-            assembled_env = None
-        else:
-            assembled_env = common.assemble_env()
-            assembled_env = assembled_env.replace(self._prime_dir, "$SNAP")
-            assembled_env = replace_path.sub("$SNAP", assembled_env)
-
         executable = '"{}"'.format(wrapexec)
 
         if shebang:
             if shebang.startswith("/usr/bin/env "):
                 shebang = shell_utils.which(shebang.split()[1])
-            new_shebang = replace_path.sub("$SNAP", shebang)
+            new_shebang = self._install_path_pattern.sub("$SNAP", shebang)
             new_shebang = re.sub(self._prime_dir, "$SNAP", new_shebang)
             if new_shebang != shebang:
                 # If the shebang was pointing to and executable within the
@@ -539,11 +556,6 @@ class _SnapPackaging:
 
         with open(wrappath, "w+") as f:
             print("#!/bin/sh", file=f)
-            if assembled_env:
-                print("{}".format(assembled_env), file=f)
-                print(
-                    "export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH", file=f
-                )
             if cwd:
                 print("{}".format(cwd), file=f)
             print("exec {} {}".format(executable, args), file=f)
@@ -597,11 +609,16 @@ class _SnapPackaging:
         cmds = (k for k in ("command", "stop-command") if k in app)
         for k in cmds:
             try:
-                app[k] = self._wrap_exe(app[k], "{}-{}".format(k, name))
+                new_command = self._wrap_exe(app[k], "{}-{}".format(k, name))
             except FileNotFoundError:
                 raise errors.InvalidAppCommandError(command=app[k], app=app)
             except meta_errors.CommandError as e:
                 raise errors.InvalidAppCommandError(str(e), name)
+
+            if os.path.isfile(self._meta_runner):
+                snap_runner = os.path.relpath(self._meta_runner, self._prime_dir)
+                new_command = "{} $SNAP/{}".format(snap_runner, new_command)
+            app[k] = new_command
 
     def _generate_desktop_file(self, name, app):
         desktop_file_name = app.pop("desktop", "")

--- a/tests/integration/lifecycle/test_snap.py
+++ b/tests/integration/lifecycle/test_snap.py
@@ -41,6 +41,13 @@ class SnapTestCase(integration.TestCase):
             expected_binary1_wrapper = file_.read()
         self.assertThat(binary1_wrapper_path, FileContains(expected_binary1_wrapper))
 
+        command_chain_path = os.path.join(
+            self.prime_dir, "snap", "command-chain", "snapcraft-runner"
+        )
+        with open("command-chain", "r") as f:
+            expected_command_chain = f.read()
+        self.assertThat(command_chain_path, FileContains(expected_command_chain))
+
         self.useFixture(
             fixtures.EnvironmentVariable(
                 "SNAP", os.path.join(os.getcwd(), self.prime_dir)
@@ -54,7 +61,8 @@ class SnapTestCase(integration.TestCase):
         )
         for binary, expected_output in binary_scenarios:
             output = subprocess.check_output(
-                os.path.join(self.prime_dir, binary), universal_newlines=True
+                [command_chain_path, os.path.join(self.prime_dir, binary)],
+                universal_newlines=True,
             )
             self.assertThat(output, Equals(expected_output))
 
@@ -92,15 +100,15 @@ class SnapTestCase(integration.TestCase):
                 grade: stable
                 apps:
                   assemble-bin:
-                    command: command-assemble-bin.wrapper
+                    command: snap/command-chain/snapcraft-runner $SNAP/command-assemble-bin.wrapper
                   assemble-service:
-                    command: command-assemble-service.wrapper
+                    command: snap/command-chain/snapcraft-runner $SNAP/command-assemble-service.wrapper
                     daemon: simple
-                    stop-command: stop-command-assemble-service.wrapper
+                    stop-command: snap/command-chain/snapcraft-runner $SNAP/stop-command-assemble-service.wrapper
                   binary-wrapper-none:
                     command: subdir/binary3
                   binary2:
-                    command: command-binary2.wrapper
+                    command: snap/command-chain/snapcraft-runner $SNAP/command-binary2.wrapper
             """
                 ).format(self.deb_arch)
             ),
@@ -269,7 +277,7 @@ class SnapTestCase(integration.TestCase):
               stub_key: stub-value
             apps:
               stub-app:
-                command: command-stub-app.wrapper
+                command: snap/command-chain/snapcraft-runner $SNAP/command-stub-app.wrapper
         """
         )
         self.assertThat(

--- a/tests/integration/snaps/assemble/binary1.after
+++ b/tests/integration/snaps/assemble/binary1.after
@@ -1,4 +1,2 @@
 #!/bin/sh
-export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
-export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 exec "$SNAP/binary1" "$@"

--- a/tests/integration/snaps/assemble/command-chain
+++ b/tests/integration/snaps/assemble/command-chain
@@ -1,0 +1,4 @@
+#!/bin/sh
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+exec "$@"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Currently, the snapcraft CLI takes the environment and runnables from plugins and shoves them into a wrapper per app. In anticipation of moving to command-chain, this PR resolves [LP: #1794261](https://bugs.launchpad.net/snapcraft/+bug/1794261) by extracting this information into a separate script, leaving the app wrappers as bare-bones as possible.