### PR TITLE
sources: properly handle pull failures

### DIFF
--- a/snapcraft/internal/sources/_7z.py
+++ b/snapcraft/internal/sources/_7z.py
@@ -17,7 +17,6 @@
 
 import os
 import shutil
-import subprocess
 import tempfile
 
 from . import errors
@@ -68,8 +67,7 @@ class SevenZip(FileBase):
             os.makedirs(dst)
             shutil.move(tmp_7z, seven_zip_file)
 
-        extract_command = ["7z", "x", seven_zip_file]
-        subprocess.check_output(extract_command, cwd=dst)
+        self._run_output(["7z", "x", seven_zip_file], cwd=dst)
 
         if not keep_7z:
             os.remove(seven_zip_file)

--- a/snapcraft/internal/sources/_bazaar.py
+++ b/snapcraft/internal/sources/_bazaar.py
@@ -73,7 +73,7 @@ class Bazaar(Base):
             os.rmdir(self.source_dir)
             cmd = [self.command, "branch"] + tag_opts + [self.source, self.source_dir]
 
-        subprocess.check_call(cmd, **self._call_kwargs)
+        self._run(cmd, **self._call_kwargs)
         self.source_details = self._get_source_details()
 
     def _get_source_details(self):
@@ -82,11 +82,7 @@ class Bazaar(Base):
 
         if not tag:
             if os.path.exists(self.source_dir):
-                commit = (
-                    subprocess.check_output(["bzr", "revno", self.source_dir])
-                    .decode("utf-8")
-                    .strip()
-                )
+                commit = self._run_output(["bzr", "revno", self.source_dir])
 
         branch = None
         source = self.source

--- a/snapcraft/internal/sources/_git.py
+++ b/snapcraft/internal/sources/_git.py
@@ -132,7 +132,7 @@ class Git(Base):
 
         reset_spec = refspec if refspec != "HEAD" else "origin/master"
 
-        subprocess.check_call(
+        self._run(
             [
                 self.command,
                 "-C",
@@ -143,13 +143,14 @@ class Git(Base):
             ],
             **self._call_kwargs
         )
-        subprocess.check_call(
+
+        self._run(
             [self.command, "-C", self.source_dir, "reset", "--hard", reset_spec],
             **self._call_kwargs
         )
 
         # Merge any updates for the submodules (if any).
-        subprocess.check_call(
+        self._run(
             [
                 self.command,
                 "-C",
@@ -168,12 +169,10 @@ class Git(Base):
             command.extend(["--branch", self.source_tag or self.source_branch])
         if self.source_depth:
             command.extend(["--depth", str(self.source_depth)])
-        subprocess.check_call(
-            command + [self.source, self.source_dir], **self._call_kwargs
-        )
+        self._run(command + [self.source, self.source_dir], **self._call_kwargs)
 
         if self.source_commit:
-            subprocess.check_call(
+            self._run(
                 [self.command, "-C", self.source_dir, "checkout", self.source_commit],
                 **self._call_kwargs
             )
@@ -193,12 +192,8 @@ class Git(Base):
         checksum = self.source_checksum
 
         if not tag and not branch and not commit:
-            commit = (
-                subprocess.check_output(
-                    ["git", "-C", self.source_dir, "rev-parse", "HEAD"]
-                )
-                .decode("utf-8")
-                .strip()
+            commit = self._run_output(
+                ["git", "-C", self.source_dir, "rev-parse", "HEAD"]
             )
 
         return {

--- a/snapcraft/internal/sources/_mercurial.py
+++ b/snapcraft/internal/sources/_mercurial.py
@@ -86,7 +86,7 @@ class Mercurial(Base):
                 ]
             cmd = [self.command, "clone"] + ref + [self.source, self.source_dir]
 
-        subprocess.check_call(cmd, **self._call_kwargs)
+        self._run(cmd, **self._call_kwargs)
         self.source_details = self._get_source_details()
 
     def _get_source_details(self):
@@ -96,12 +96,7 @@ class Mercurial(Base):
         source = self.source
 
         if not (tag or commit or branch):
-            commit = (
-                subprocess.check_output(["hg", "id", self.source_dir])
-                .split()[0]
-                .decode("utf-8")
-                .strip()
-            )
+            commit = self._run_output(["hg", "id", self.source_dir]).split()[0]
 
         return {
             "source-commit": commit,

--- a/snapcraft/internal/sources/_rpm.py
+++ b/snapcraft/internal/sources/_rpm.py
@@ -17,7 +17,6 @@
 import os
 import shlex
 import shutil
-import subprocess
 import tempfile
 
 from . import errors
@@ -67,7 +66,7 @@ class Rpm(FileBase):
             shutil.move(tmp_rpm, rpm_file)
 
         extract_command = "rpm2cpio {} | cpio -idmv".format(shlex.quote(rpm_file))
-        subprocess.check_output(extract_command, shell=True, cwd=dst)
+        self._run_output(extract_command, shell=True, cwd=dst)
 
         if not keep_rpm:
             os.remove(rpm_file)

--- a/snapcraft/internal/sources/_subversion.py
+++ b/snapcraft/internal/sources/_subversion.py
@@ -64,14 +64,14 @@ class Subversion(Base):
             opts = ["-r", self.source_commit]
 
         if os.path.exists(os.path.join(self.source_dir, ".svn")):
-            subprocess.check_call(
+            self._run(
                 [self.command, "update"] + opts,
                 cwd=self.source_dir,
                 **self._call_kwargs
             )
         else:
             if os.path.isdir(self.source):
-                subprocess.check_call(
+                self._run(
                     [
                         self.command,
                         "checkout",
@@ -82,7 +82,7 @@ class Subversion(Base):
                     **self._call_kwargs
                 )
             else:
-                subprocess.check_call(
+                self._run(
                     [self.command, "checkout", self.source, self.source_dir] + opts,
                     **self._call_kwargs
                 )
@@ -96,19 +96,15 @@ class Subversion(Base):
         commit = self.source_commit
 
         if not commit:
-            commit = (
-                subprocess.check_output(
-                    [
-                        "svn",
-                        "info",
-                        "--show-item",
-                        "last-changed-revision",
-                        "--no-newline",
-                        self.source_dir,
-                    ]
-                )
-                .decode("utf-8")
-                .strip()
+            commit = self._run_output(
+                [
+                    "svn",
+                    "info",
+                    "--show-item",
+                    "last-changed-revision",
+                    "--no-newline",
+                    self.source_dir,
+                ]
             )
 
         return {

--- a/snapcraft/internal/sources/errors.py
+++ b/snapcraft/internal/sources/errors.py
@@ -93,3 +93,15 @@ class SourceUpdateUnsupportedError(SnapcraftSourceError):
 
     def __init__(self, source):
         super().__init__(source=source)
+
+
+class SnapcraftPullError(SnapcraftSourceError):
+
+    fmt = "Failed to pull source, command {command!r} exited with code {exit_code}."
+
+    def __init__(self, command, exit_code):
+        if isinstance(command, list):
+            string_command = " ".join(command)
+        else:
+            string_command = command
+        super().__init__(command=string_command, exit_code=exit_code)

--- a/tests/unit/sources/test_bazaar.py
+++ b/tests/unit/sources/test_bazaar.py
@@ -15,8 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from unittest import mock
+import subprocess
 
+from unittest import mock
 from testtools.matchers import Equals
 
 from snapcraft.internal import sources
@@ -132,6 +133,14 @@ class TestBazaar(unit.sources.SourceTestCase):  # type: ignore
 
     def test_has_source_handler_entry(self):
         self.assertTrue(sources._source_handler["bzr"] is sources.Bazaar)
+
+    def test_pull_failure(self):
+        self.mock_run.side_effect = subprocess.CalledProcessError(1, [])
+
+        bzr = sources.Bazaar("lp:my-source", "source_dir")
+        raised = self.assertRaises(sources.errors.SnapcraftPullError, bzr.pull)
+        self.assertThat(raised.command, Equals("bzr branch lp:my-source source_dir"))
+        self.assertThat(raised.exit_code, Equals(1))
 
 
 class BazaarDetailsTestCase(unit.TestCase):

--- a/tests/unit/sources/test_git.py
+++ b/tests/unit/sources/test_git.py
@@ -331,6 +331,16 @@ class TestGit(unit.sources.SourceTestCase):  # type: ignore
     def test_has_source_handler_entry(self):
         self.assertTrue(sources._source_handler["git"] is sources.Git)
 
+    def test_pull_failure(self):
+        self.mock_run.side_effect = CalledProcessError(1, [])
+
+        git = sources.Git("git://my-source", "source_dir")
+        raised = self.assertRaises(sources.errors.SnapcraftPullError, git.pull)
+        self.assertThat(
+            raised.command, Equals("git clone --recursive git://my-source source_dir")
+        )
+        self.assertThat(raised.exit_code, Equals(1))
+
 
 class GitBaseTestCase(unit.TestCase):
     def rm_dir(self, dir):

--- a/tests/unit/sources/test_mercurial.py
+++ b/tests/unit/sources/test_mercurial.py
@@ -16,8 +16,9 @@
 
 import os
 import shutil
-from unittest import mock
+import subprocess
 
+from unittest import mock
 from testtools.matchers import Equals
 
 from snapcraft.internal import sources
@@ -173,6 +174,14 @@ class TestMercurial(unit.sources.SourceTestCase):  # type: ignore
 
     def test_has_source_handler_entry(self):
         self.assertTrue(sources._source_handler["mercurial"] is sources.Mercurial)
+
+    def test_pull_failure(self):
+        self.mock_run.side_effect = subprocess.CalledProcessError(1, [])
+
+        hg = sources.Mercurial("hg://my-source", "source_dir")
+        raised = self.assertRaises(sources.errors.SnapcraftPullError, hg.pull)
+        self.assertThat(raised.command, Equals("hg clone hg://my-source source_dir"))
+        self.assertThat(raised.exit_code, Equals(1))
 
 
 class MercurialBaseTestCase(unit.TestCase):

--- a/tests/unit/sources/test_subversion.py
+++ b/tests/unit/sources/test_subversion.py
@@ -16,6 +16,7 @@
 
 import os
 import shutil
+import subprocess
 from unittest import mock
 
 from testtools.matchers import Equals
@@ -123,6 +124,16 @@ class TestSubversion(unit.sources.SourceTestCase):  # type: ignore
 
     def test_has_source_handler_entry(self):
         self.assertTrue(sources._source_handler["subversion"] is sources.Subversion)
+
+    def test_pull_failure(self):
+        self.mock_run.side_effect = subprocess.CalledProcessError(1, [])
+
+        svn = sources.Subversion("svn://my-source", "source_dir")
+        raised = self.assertRaises(sources.errors.SnapcraftPullError, svn.pull)
+        self.assertThat(
+            raised.command, Equals("svn checkout svn://my-source source_dir")
+        )
+        self.assertThat(raised.exit_code, Equals(1))
 
 
 class SubversionBaseTestCase(unit.TestCase):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

Currently, the snapcraft CLI doesn't handle any `CalledProcessError`s coming from the sources (e.g. `git clone [...]`). This means that any network issues or invalid repo URLs result in tracebacks and error submissions to Sentry. This PR fixes [LP: #1794272](https://bugs.launchpad.net/snapcraft/+bug/1794272) by properly handling this situation and printing an error.