### PR TITLE
build providers: use the new snapcraft: remote for multipass

### DIFF
--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -57,16 +57,10 @@ class Multipass(Provider):
         )
 
     def _get_disk_image(self) -> str:
-        if self.project.info.base == "core18":
-            image = "18.04"
-        elif self.project.info.base in ("core16", None):
-            image = "16.04"
+        if self.project.info.base is None:
+            image = "snapcraft:core16"
         else:
-            raise errors.UnsupportedHostError(
-                base=self.project.info.base,
-                platform=_get_platform(),
-                provider=self._get_provider_name(),
-            )
+            image = "snapcraft:{}".format(self.project.info.base)
 
         return image
 

--- a/snapcraft/internal/build_providers/errors.py
+++ b/snapcraft/internal/build_providers/errors.py
@@ -257,13 +257,3 @@ class BuildImageChecksumError(_SnapcraftError):
 
     def __init__(self, *, expected: str, calculated: str, algorithm: str) -> None:
         super().__init__(expected=expected, calculated=calculated, algorithm=algorithm)
-
-
-class UnsupportedHostError(_SnapcraftError):
-    fmt = (
-        "Building for {base!r} is not supported on platform {platform!r} using "
-        "provider: {provider!r}."
-    )
-
-    def __init__(self, *, base: str, platform: str, provider: str) -> None:
-        super().__init__(base=base, platform=platform, provider=provider)

--- a/tests/unit/build_providers/test_errors.py
+++ b/tests/unit/build_providers/test_errors.py
@@ -252,16 +252,6 @@ class ErrorFormattingTest(unit.TestCase):
                 ),
             ),
         ),
-        (
-            "UnsupportedHostError",
-            dict(
-                exception=errors.UnsupportedHostError,
-                kwargs=dict(base="core66", platform="beos", provider="multipass"),
-                expected_message=(
-                    "Building for 'core66' is not supported on platform 'beos' using provider: 'multipass'."
-                ),
-            ),
-        ),
     ]
 
     def test_error_formatting(self):


### PR DESCRIPTION
Multipass now offers a new remote, as support for new bases comes
it will grow into multipass on its own. Due to this, we now also
delegate the error message handling to multipass itself as we no
longer keep a static mapping in snapcraft for this.

LP: #1794361
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
