### PR TITLE
snap: workaround the dirty tree

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,7 +65,7 @@ parts:
         bin/snapcraftctl: bin/scriptlet-bin/snapcraftctl
     override-pull: |
         snapcraftctl pull
-        version="$(git describe --dirty --always | sed -e 's/-/+git/;y/-/./')"
+        version="$(git describe --always | sed -e 's/-/+git/;y/-/./')"
         [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable
         snapcraftctl set-version "$version"
         snapcraftctl set-grade "$grade"


### PR DESCRIPTION
Remove --dirty from git-describe to workaround LP: #1662388

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
