### PR TITLE
part grammar processor: lazily capture attributes from plugin

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -212,6 +212,8 @@ suites:
    summary: tests of snapcraft's Meson plugin
  tests/spread/plugins/nil/:
    summary: tests of snapcraft's Nil plugin
+ tests/spread/plugins/python/:
+   summary: tests of snapcraft's Python plugin
  tests/spread/plugins/ruby/:
    summary: tests of snapcraft's Ruby plugin
    kill-timeout: 180m

--- a/tests/spread/plugins/python/dirty-autoclean/task.yaml
+++ b/tests/spread/plugins/python/dirty-autoclean/task.yaml
@@ -1,0 +1,40 @@
+summary: Ensure a python part is automatically cleaned if dirty
+
+systems: [ubuntu-18*]
+
+environment:
+  SNAP_DIR: ../snaps/python-hello
+
+prepare: |
+  . "$SETUP_DIR/config.sh"
+  set_outdated_step_action "clean"
+
+restore: |
+  . "$SETUP_DIR/config.sh"
+  clear_config
+
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft
+  sudo snap install python-hello_*.snap --dangerous
+  [ "$(python-hello)" = "hello world" ]
+
+  # Alter the snapcraft.yaml in such a way as to make the pull step dirty,
+  # which should force the part back through its lifecycle.
+  cat << EOF >> snap/snapcraft.yaml
+      override-pull: |
+        snapcraftctl pull
+        echo "hi there"
+  EOF
+
+  # Running snapcraft again should clean pull and re-run the lifecycle
+  output="$(snapcraft)"
+  echo "$output" | MATCH "Cleaning later steps and re-pulling"
+
+  # Verify that it still works
+  sudo snap install python-hello_*.snap --dangerous
+  [ "$(python-hello)" = "hello world" ]

--- a/tests/spread/plugins/python/snaps/python-hello/hello
+++ b/tests/spread/plugins/python/snaps/python-hello/hello
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print('hello world')

--- a/tests/spread/plugins/python/snaps/python-hello/setup.py
+++ b/tests/spread/plugins/python/snaps/python-hello/setup.py
@@ -1,0 +1,11 @@
+import setuptools
+
+
+setuptools.setup(
+    name="hello-world",
+    version="0.0.1",
+    author="Canonical LTD",
+    author_email="snapcraft@lists.snapcraft.io",
+    description="A simple hello world in python",
+    scripts=["hello"],
+)

--- a/tests/spread/plugins/python/snaps/python-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/python/snaps/python-hello/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: python-hello
+version: '1.0'
+summary: A simple hello world in python
+description: |
+  This is a basic python snap. It just hosts a hello world.
+  If you want to add other functionalities to this snap, please don't.
+  Make a new one.
+
+base: core18
+grade: devel
+confinement: strict
+
+apps:
+  python-hello:
+    command: hello
+
+parts:
+  python-part:
+    source: .
+    plugin: python

--- a/tests/spread/setup/restore.sh
+++ b/tests/spread/setup/restore.sh
@@ -4,7 +4,7 @@
 snaps="$(snap list | awk '{if (NR!=1) {print $1}}')"
 for snap in $snaps; do
 	case "$snap" in
-		"core" | "snapcraft")
+		"core" | "core18" | "snapcraft")
 			# Don't want to remove these
 			;;
 		*)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Currently the part processor is handed a plugin and immediately saves off various grammar-powered attributes, such as stage- and build-packages, etc. However, there are plugins (specifically Python) that define these to be properties with definitions that change depending on the environment. For example, if it already finds Python, it won't add it to stage-packages. This proves to be problematic when a part is automatically cleaned because it was dirty: the grammar processor isn't created multiple times, just once before the part was cleaned. However, at least in the Python plugin case, once the part is cleaned it's stage-packages must be re-evaluated or Python will be missing when it's rebuilt.

This PR fixes [LP: #1794443](https://bugs.launchpad.net/snapcraft/+bug/1794443) by capturing the entire plugin and pulling attributes out of it when required instead of when the grammar processor is created.