### PR TITLE
requirements.txt: stop using pymacaroons-pynacl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,7 @@ responses==0.5.1
 petname==1.12
 pyelftools==0.24
 pymacaroons==0.9.2; sys_platform != 'win32'
-pymacaroons==0.10.0; sys_platform == 'win32'
-pymacaroons-pynacl==0.9.3
+pymacaroons-pynacl==0.9.3; sys_platform == 'win32'
 pysha3==1.0.2; python_version < '3.6'
 raven==6.5.0
 simplejson==3.8.2


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR resolves [LP: #1794703](https://bugs.launchpad.net/snapcraft/+bug/1794703) by no longer using pymacaroons-pynacl. It doesn't seem necessary, clashes with pymacaroons, and results in failures to link at runtime.