### PR TITLE
[legacy] pluginhandler: update build should overwrite organize

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -276,6 +276,14 @@ class SnapcraftPartConflictError(SnapcraftError):
         )
 
 
+class SnapcraftOrganizeError(SnapcraftError):
+
+    fmt = "Failed to organize part {part_name!r}: {message}"
+
+    def __init__(self, part_name, message):
+        super().__init__(part_name=part_name, message=message)
+
+
 class MissingCommandError(SnapcraftError):
 
     fmt = (

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -536,22 +536,30 @@ class PluginHandler:
                 return
             source.update()
 
-        self._do_build()
+        self._do_build(update=True)
 
-    def _do_build(self):
+    def _do_build(self, *, update=False):
         self._runner.prepare()
         self._runner.build()
         self._runner.install()
 
-        # Organize the installed files as requested. We do this in the build
-        # step for two reasons:
+        # Organize the installed files as requested. We do this in the build step for
+        # two reasons:
         #
-        #   1. So cleaning and re-running the stage step works even if
-        #      `organize` is used
-        #   2. So collision detection takes organization into account, i.e. we
-        #      can use organization to get around file collisions between
-        #      parts when staging.
-        self._organize()
+        #   1. So cleaning and re-running the stage step works even if `organize` is
+        #      used
+        #   2. So collision detection takes organization into account, i.e. we can use
+        #      organization to get around file collisions between parts when staging.
+        #
+        # If `update` is true, we give the snapcraft CLI permission to overwrite files
+        # that already exist. Typically we do NOT want this, so that parts don't
+        # accidentally clobber e.g. files brought in from stage-packages, but in the
+        # case of updating build, we want the part to have the ability to organize over
+        # the files it organized last time around. We can be confident that this won't
+        # overwrite anything else, because to do so would require changing the
+        # `organize` keyword, which will make the build step dirty and require a clean
+        # instead of an update.
+        self._organize(overwrite=update)
 
         self.mark_build_done()
 
@@ -669,10 +677,10 @@ class PluginHandler:
         fileset = getattr(self.plugin.options, option, default)
         return fileset if fileset else default
 
-    def _organize(self):
+    def _organize(self, *, overwrite=False):
         fileset = self._get_fileset("organize", {})
 
-        _organize_filesets(fileset.copy(), self.plugin.installdir)
+        _organize_filesets(self.name, fileset.copy(), self.plugin.installdir, overwrite)
 
     def stage(self, force=False):
         self.makedirs()
@@ -1079,7 +1087,7 @@ def _migrate_files(
         fixup_func(dst)
 
 
-def _organize_filesets(fileset, base_dir):
+def _organize_filesets(part_name, fileset, base_dir, overwrite):
     for key in sorted(fileset, key=lambda x: ["*" in x, x]):
         src = os.path.join(base_dir, key)
         # Remove the leading slash if there so os.path.join
@@ -1088,22 +1096,47 @@ def _organize_filesets(fileset, base_dir):
 
         sources = iglob(src, recursive=True)
 
+        # Keep track of the number of glob expansions so we can properly error if more
+        # than one tries to organize to the same file
+        src_count = 0
         for src in sources:
+            src_count += 1
+
             if os.path.isdir(src) and "*" not in key:
                 file_utils.link_or_copy_tree(src, dst)
                 # TODO create alternate organization location to avoid
                 # deletions.
                 shutil.rmtree(src)
+                continue
             elif os.path.isfile(dst):
-                raise errors.SnapcraftEnvironmentError(
-                    "Trying to organize file {key!r} to {dst!r}, "
-                    "but {dst!r} already exists".format(
-                        key=key, dst=os.path.relpath(dst, base_dir)
+                if overwrite and src_count <= 1:
+                    with contextlib.suppress(FileNotFoundError):
+                        os.remove(dst)
+                elif src_count > 1:
+                    raise errors.SnapcraftOrganizeError(
+                        part_name,
+                        "multiple files to be organized into {!r}. If this is supposed "
+                        "to be a directory, end it with a forward slash.".format(
+                            os.path.relpath(dst, base_dir)
+                        ),
                     )
-                )
-            else:
-                os.makedirs(os.path.dirname(dst), exist_ok=True)
-                shutil.move(src, dst)
+                else:
+                    raise errors.SnapcraftOrganizeError(
+                        part_name,
+                        "trying to organize file {key!r} to {dst!r}, but {dst!r} "
+                        "already exists".format(
+                            key=key, dst=os.path.relpath(dst, base_dir)
+                        ),
+                    )
+            if os.path.isdir(dst) and overwrite:
+                real_dst = os.path.join(dst, os.path.basename(src))
+                if os.path.isdir(real_dst):
+                    shutil.rmtree(real_dst)
+                else:
+                    with contextlib.suppress(FileNotFoundError):
+                        os.remove(real_dst)
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            shutil.move(src, dst)
 
 
 def _clean_migrated_files(snap_files, snap_dirs, directory):

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import contextlib
 import copy
 import os
 import shutil
@@ -23,7 +24,7 @@ from collections import OrderedDict
 from textwrap import dedent
 from unittest.mock import call, Mock, MagicMock, patch
 
-from testtools.matchers import Contains, Equals, FileExists, Not
+from testtools.matchers import Contains, Equals, FileExists, MatchesRegex, Not
 
 import snapcraft
 from . import mocks
@@ -368,6 +369,30 @@ class PluginTestCase(unit.TestCase):
 
         self.assertThat(raised.message, Equals('path "/abs/exclude" must be relative'))
 
+    @patch("snapcraft.internal.pluginhandler._organize_filesets")
+    def test_build_organizes(self, mock_organize):
+        handler = self.load_part("test-part")
+        handler.build()
+        mock_organize.assert_called_once_with(
+            "test-part", {}, handler.plugin.installdir, False
+        )
+
+    @patch("snapcraft.internal.pluginhandler._organize_filesets")
+    def test_update_build_organizes_with_overwrite(self, mock_organize):
+        class TestPlugin(snapcraft.BasePlugin):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.out_of_source_build = True
+
+        self.useFixture(fixture_setup.FakePlugin("test-plugin", TestPlugin))
+
+        handler = self.load_part("test-part", plugin_name="test-plugin")
+        handler.makedirs()
+        handler.update_build()
+        mock_organize.assert_called_once_with(
+            "test-part", {}, handler.plugin.installdir, True
+        )
+
 
 class MigratePluginTestCase(unit.TestCase):
 
@@ -566,7 +591,9 @@ class OrganizeTestCase(unit.TestCase):
                 setup_dirs=[],
                 setup_files=["foo", "bar"],
                 organize_set={"foo": "bar"},
-                expected=errors.SnapcraftEnvironmentError,
+                expected=errors.SnapcraftOrganizeError,
+                expected_message=".*trying to organize file 'foo' to 'bar', but 'bar' already exists.*",
+                expected_overwrite=[(["bar"], "")],
             ),
         ),
         (
@@ -584,7 +611,8 @@ class OrganizeTestCase(unit.TestCase):
                 setup_dirs=[],
                 setup_files=["foo.conf", "bar.conf"],
                 organize_set={"*.conf": "dir"},
-                expected=errors.SnapcraftEnvironmentError,
+                expected=errors.SnapcraftOrganizeError,
+                expected_message=".*multiple files to be organized into 'dir'.*",
             ),
         ),
         (
@@ -619,33 +647,62 @@ class OrganizeTestCase(unit.TestCase):
                 ],
             ),
         ),
+        (
+            "*_into_dir",
+            dict(
+                setup_dirs=["dir"],
+                setup_files=[os.path.join("dir", "foo"), os.path.join("dir", "bar")],
+                organize_set={"dir/f*": "nested/dir/"},
+                expected=[
+                    (["dir", "nested"], ""),
+                    (["bar"], "dir"),
+                    (["dir"], "nested"),
+                    (["foo"], os.path.join("nested", "dir")),
+                ],
+            ),
+        ),
     ]
 
-    def test_organize_file(self):
+    def _organize_and_assert(self, overwrite):
         base_dir = "install"
-        os.makedirs(base_dir)
+        os.makedirs(base_dir, exist_ok=True)
 
         for directory in self.setup_dirs:
-            os.makedirs(os.path.join(base_dir, directory))
+            os.makedirs(os.path.join(base_dir, directory), exist_ok=True)
 
         for file_entry in self.setup_files:
             with open(os.path.join(base_dir, file_entry), "w") as f:
                 f.write(file_entry)
 
-        if isinstance(self.expected, type) and issubclass(self.expected, Exception):
-            self.assertRaises(
-                self.expected,
+        expected = self.expected
+        if overwrite:
+            with contextlib.suppress(AttributeError):
+                expected = self.expected_overwrite
+        if isinstance(expected, type) and issubclass(expected, Exception):
+            raised = self.assertRaises(
+                expected,
                 pluginhandler._organize_filesets,
+                "part-name",
                 self.organize_set,
                 base_dir,
+                overwrite,
             )
+            self.assertThat(str(raised), MatchesRegex(self.expected_message))
         else:
-            pluginhandler._organize_filesets(self.organize_set, base_dir)
-            for expect in self.expected:
+            pluginhandler._organize_filesets(
+                "part-name", self.organize_set, base_dir, overwrite
+            )
+            for expect in expected:
                 dir_path = os.path.join(base_dir, expect[1])
                 dir_contents = os.listdir(dir_path)
                 dir_contents.sort()
                 self.assertThat(dir_contents, Equals(expect[0]))
+
+    def test_organize(self):
+        self._organize_and_assert(False)
+
+        # Verify that it can be organized again by overwriting
+        self._organize_and_assert(True)
 
 
 class RealStageTestCase(unit.TestCase):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR is a backport of #2290, fixing [LP: #1794083](https://bugs.launchpad.net/snapcraft/+bug/1794083) for legacy.