### PR TITLE
setup: improve dir setup for when running in legacy mode

### DIFF
--- a/snapcraft/internal/dirs.py
+++ b/snapcraft/internal/dirs.py
@@ -24,22 +24,29 @@ def setup_dirs() -> None:
     """
     from snapcraft.internal import common
 
+    parent_dir = ""
     topdir = os.path.abspath(os.path.join(__file__, "..", "..", ".."))
-    # Only change the default if we are running from a checkout or from the
+    # Change the default if we are running from a checkout or from the
     # snap.
-    if os.path.exists(os.path.join(topdir, "setup.py")):
-        common.set_plugindir(os.path.join(topdir, "snapcraft", "plugins"))
-        common.set_schemadir(os.path.join(topdir, "schema"))
-        common.set_librariesdir(os.path.join(topdir, "libraries"))
-        common.set_extensionsdir(os.path.join(topdir, "extensions"))
-
     # The default paths are relative to sys.prefix, which works well for
     # Snapcraft as a deb or in a venv. However, the Python plugin installs
     # packages into $SNAP/ as a prefix, while Python itself is contained in
     # $SNAP/usr/. As a result, using sys.prefix (which is '/usr') to find these
     # files won't work in the snap.
+    # We additionally need to check if we are in legacy snapcraft mode triggered
+    # from a newer snapcraft.
+    if os.path.exists(os.path.join(topdir, "setup.py")):
+        parent_dir = topdir
+    elif common.is_snap() and os.path.exists(
+        os.path.join(os.getenv("SNAP"), "legacy_snapcraft")
+    ):
+        parent_dir = os.path.join(
+            os.getenv("SNAP"), "legacy_snapcraft", "share", "snapcraft"
+        )
     elif common.is_snap():
-        parent_dir = os.path.join(os.environ.get("SNAP"), "share", "snapcraft")
+        parent_dir = os.path.join(os.getenv("SNAP"), "share", "snapcraft")
+
+    if parent_dir != "":
         common.set_plugindir(os.path.join(parent_dir, "plugins"))
         common.set_schemadir(os.path.join(parent_dir, "schema"))
         common.set_librariesdir(os.path.join(parent_dir, "libraries"))


### PR DESCRIPTION
When running in legacy mode, the directory paths for fixed assets differs.
Assets are found within legacy_snapcraft instead of the topdir $SNAP.

LP: #1795380
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
