### PR TITLE
snap: improve early base detection logic

### DIFF
--- a/bin/snapcraft
+++ b/bin/snapcraft
@@ -16,8 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import site
-import subprocess
 import sys
 
 from snapcraft import project, yaml_utils
@@ -33,7 +31,13 @@ from snapcraft.internal import common
 
 if os.path.isdir(common.get_legacy_snapcraft_dir()):
     try:
-        snapcraft_yaml_path = project.get_snapcraft_yaml()
+        # Early bootstrapping does not allow us to use the existing utilities we
+        # have to manage this check.
+        if os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT") == "managed-host":
+            base_dir = os.path.expanduser(os.path.join("~", "project"))
+        else:
+            base_dir = None
+        snapcraft_yaml_path = project.get_snapcraft_yaml(base_dir=base_dir)
         with open(snapcraft_yaml_path, "r") as f:
             data = yaml_utils.load(f)
         if data.get("base") is None:


### PR DESCRIPTION
The current logic missed the detection when running inside
a build provider given that by default snapcraft does not
run within the project directory.

LP: #1795501
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
