### PR TITLE
nodejs plugin: add support for ppc64el and s390x

### DIFF
--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -63,7 +63,14 @@ logger = logging.getLogger(__name__)
 _NODEJS_BASE = "node-v{version}-linux-{arch}"
 _NODEJS_VERSION = "6.14.2"
 _NODEJS_TMPL = "https://nodejs.org/dist/v{version}/{base}.tar.gz"
-_NODEJS_ARCHES = {"i386": "x86", "amd64": "x64", "armhf": "armv7l", "arm64": "arm64"}
+_NODEJS_ARCHES = {
+    "i386": "x86",
+    "amd64": "x64",
+    "armhf": "armv7l",
+    "arm64": "arm64",
+    "ppc64el": "ppc64le",
+    "s390x": "s390x",
+}
 _YARN_URL = "https://yarnpkg.com/latest.tar.gz"
 
 


### PR DESCRIPTION
LP: #1795531

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] (N/A) If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

The addition of the ppc64el and s390x to the list of nodejs plugin supported architectures has been tested with custom plugin x-nodejs to work with auto-building Hugo snaps Launchpad, see:

* Temporary workaround with x-nodejs plugin https://github.com/gohugoio/hugo/commit/91f49c0700dde13e16f42c745584a0bef60c6fe2 (Line 68)
* https://launchpad.net/~gohugoio/+snap/hugo
* Successful s390x buildlog: https://launchpadlibrarian.net/391166164/buildlog_snap_ubuntu_xenial_s390x_hugo_BUILDING.txt.gz