### PR TITLE
snap: legacy needs to now it is legacy for re-exec

### DIFF
--- a/snapcraft/cli/_runner.py
+++ b/snapcraft/cli/_runner.py
@@ -66,6 +66,7 @@ def run(ctx, debug, catch_exceptions=False, **kwargs):
 
     # Do this early, if we are in managed-host and not root yet we want to re-exec with
     # sudo keeping the current environment settings.
+    # TODO: LP: #1795680
     if os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT") == "managed-host" and os.geteuid() != 0:
         snap_path = os.getenv("SNAP")
         # Use -E to keep the environment.
@@ -73,7 +74,14 @@ def run(ctx, debug, catch_exceptions=False, **kwargs):
         # Pick the correct interpreter if running from a snap (in managed-host mode, this
         # is most likely the only scenario).
         if os.getenv("SNAP_NAME") == "snapcraft":
-            cmd.append(os.path.join(snap_path, "usr", "bin", "python3"))
+            # First append the root path of the snap
+            # If legacy exists, append it
+            if os.path.exists(os.path.join(snap_path, "legacy_snapcraft")):
+                interpreter = os.path.join(snap_path, "legacy_snapcraft")
+            else:
+                interpreter = snap_path
+            interpreter = os.path.join(interpreter, "usr", "bin", "python3")
+            cmd.append(interpreter)
         cmd.extend(sys.argv)
         os.execve("/usr/bin/sudo", cmd, os.environ)
 


### PR DESCRIPTION
When running in in re-exec mode and re-exec'ing as root
the wrong interpreter is used. This is solved by calling
the snapcraft "script" by prepending the interpreter.

LP: #1795501
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
