### PR TITLE
meta: link the icon correctly across filesystems

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -366,7 +366,7 @@ class _SnapPackaging:
                 os.mkdir(icon_dir)
             if os.path.exists(icon_path):
                 os.unlink(icon_path)
-            os.link(self._config_data["icon"], icon_path)
+            file_utils.link_or_copy(self._config_data["icon"], icon_path)
 
         if self._config_data.get("type", "") == "gadget":
             if not os.path.exists("gadget.yaml"):

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -226,6 +226,17 @@ class CreateTestCase(CreateBaseTestCase):
             "See http://snapcraft.io/docs/deprecation-notices/dn3", fake_logger.output
         )
 
+    @patch("os.link", side_effect=OSError("Invalid cross-device link"))
+    def test_create_meta_with_declared_icon_when_os_link_raises(self, link_mock):
+        _create_file(os.path.join(os.curdir, "my-icon.png"))
+        self.config_data["icon"] = "my-icon.png"
+
+        y = self.generate_meta_yaml()
+
+        self.assertThat(os.path.join(self.meta_dir, "gui", "icon.png"), FileExists())
+
+        self.assertFalse("icon" in y, "icon found in snap.yaml {}".format(y))
+
     def test_create_meta_with_declared_icon_and_setup_ran_twice_ok(self):
         gui_path = os.path.join("setup", "gui")
         os.makedirs(gui_path)


### PR DESCRIPTION
Build VMs use a different fs mount than where the prime directory
actually is, use file_utils.link_or_copy to setup the
icon.

LP: #1794974
Fixes SNAPCRAFT-5J

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
