### PR TITLE
storeapi: Use structured data for the conflicted current value

### DIFF
--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -516,7 +516,7 @@ class StoreMetadataError(StoreError):
                     (
                         "Conflict in {!r} field:".format(field_name),
                         "    In snapcraft.yaml: {!r}".format(sent),
-                        "    In the Store:      {!r}".format(error["message"]),
+                        "    In the Store:      {!r}".format(error["extra"]["current"]),
                     )
                 )
             parts.append(

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -800,14 +800,19 @@ class FakeStoreAPIServer(base.BaseFakeServer):
                 error_list = []
                 for name, value in request.json_body.items():
                     if name == "test-conflict-with-braces":
-                        message = "value with {braces}"
+                        conflict_value = "value with {braces}"
                     else:
-                        message = value + "-changed"
+                        conflict_value = value + "-changed"
                     error_list.append(
                         {
-                            "message": message,
+                            "message": "Conflict on {}".format(name),
                             "code": "conflict",
-                            "extra": {"name": name},
+                            "extra": {
+                                "name": name,
+                                "field": name,
+                                "current": conflict_value,
+                                "value": value,
+                            },
                         }
                     )
                 payload = json.dumps({"error_list": error_list}).encode("utf8")
@@ -856,9 +861,14 @@ class FakeStoreAPIServer(base.BaseFakeServer):
                 # POST, return error
                 error_list = [
                     {
-                        "message": "original-icon",
+                        "message": "Conflict on icon",
                         "code": "conflict",
-                        "extra": {"name": "icon"},
+                        "extra": {
+                            "name": "icon",
+                            "field": "icon",
+                            "current": "original-icon",
+                            "value": "<posted-icon>",
+                        },
                     }
                 ]
                 payload = json.dumps({"error_list": error_list}).encode("utf8")
@@ -867,9 +877,14 @@ class FakeStoreAPIServer(base.BaseFakeServer):
                 # POST, return error
                 error_list = [
                     {
-                        "message": "original icon with {braces}",
+                        "message": "Conflict on icon",
                         "code": "conflict",
-                        "extra": {"name": "icon"},
+                        "extra": {
+                            "name": "icon",
+                            "field": "icon",
+                            "current": "original icon with {braces}",
+                            "value": "<posted-icon>",
+                        },
                     }
                 ]
                 payload = json.dumps({"error_list": error_list}).encode("utf8")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [X] Have you successfully run `./runtests.sh static`?
- [X] Have you successfully run `./runtests.sh tests/unit`?

-----

Part of the fix for [lp:1795416](https://bugs.launchpad.net/snapcraft/+bug/1795416) when there's a conflict with the metadata, snapcraft should use the structured data coming from the conflict error in the store, instead of the message.

The fake store here is updated to the WiP branch I have for the store, which will remove the user supplied values from the error's message.