### PR TITLE
pluginhandler: remove legacy plugin loading without project

### DIFF
--- a/snapcraft/internal/pluginhandler/_plugin_loader.py
+++ b/snapcraft/internal/pluginhandler/_plugin_loader.py
@@ -32,7 +32,7 @@ def load_plugin(
     plugin_name, part_name, project_options, properties, part_schema, definitions_schema
 ):
     module_name = plugin_name.replace("-", "_")
-    module = _load_module(module_name, plugin_name, project_options)
+    module = _load_module(module_name, plugin_name, project_options.local_plugins_dir)
     plugin_class = _get_plugin(module)
     if not plugin_class:
         raise errors.PluginError("no plugin found in module {!r}".format(plugin_name))
@@ -51,24 +51,7 @@ def load_plugin(
             "properties failed to load for {}: {}".format(part_name, error.message)
         )
 
-    # For backwards compatibility we add the project to the plugin
-    try:
-        plugin = plugin_class(part_name, options, project_options)
-    except TypeError:
-        logger.warning(
-            "DEPRECATED: the plugin used by part {!r} needs to be updated "
-            "to accept project options in its initializer. See "
-            "https://github.com/snapcore/snapcraft/blob/master/docs/"
-            "plugins.md#initializing-a-plugin for more information".format(part_name)
-        )
-        plugin = plugin_class(part_name, options)
-        # This is for plugins that don't inherit from BasePlugin
-        if not hasattr(plugin, "project"):
-            setattr(plugin, "project", project_options)
-        # This is for plugins that inherit from BasePlugin but don't have
-        # project in init.
-        if not plugin.project:
-            plugin.project = project_options
+    plugin = plugin_class(part_name, options, project_options)
 
     if project_options.is_cross_compiling:
         logger.debug(
@@ -81,12 +64,10 @@ def load_plugin(
     return plugin
 
 
-def _load_module(module_name, plugin_name, project_options):
+def _load_module(module_name, plugin_name, local_plugins_dir):
     module = None
     with contextlib.suppress(ImportError):
-        module = _load_local(
-            "x-{}".format(plugin_name), project_options.local_plugins_dir
-        )
+        module = _load_local("x-{}".format(plugin_name), local_plugins_dir)
         logger.info("Loaded local plugin for %s", plugin_name)
 
     if not module:
@@ -96,7 +77,7 @@ def _load_module(module_name, plugin_name, project_options):
     if not module:
         logger.info("Searching for local plugin for %s", plugin_name)
         with contextlib.suppress(ImportError):
-            module = _load_local(module_name, project_options.local_plugins_dir)
+            module = _load_local(module_name, local_plugins_dir)
         if not module:
             raise errors.PluginError("unknown plugin: {!r}".format(plugin_name))
 

--- a/tests/unit/pluginhandler/test_plugin_loader.py
+++ b/tests/unit/pluginhandler/test_plugin_loader.py
@@ -74,57 +74,6 @@ class PluginLoaderTestCase(unit.TestCase):
         import_mock.assert_called_with("snapcraft.plugins.mock")
         local_load_mock.assert_called_with("x-mock", self.local_plugins_dir)
 
-    def test_plugin_without_project(self):
-        class OldPlugin(snapcraft.BasePlugin):
-            @classmethod
-            def schema(cls):
-                schema = super().schema()
-                schema["properties"]["fake-property"] = {"type": "string"}
-                return schema
-
-            def __init__(self, name, options):
-                super().__init__(name, options)
-
-        self.useFixture(fixture_setup.FakePlugin("oldplugin", OldPlugin))
-        handler = self.load_part("fake-part", "oldplugin", {"fake-property": "."})
-
-        self.assertTrue(handler.plugin.project is not None)
-
-    @patch("importlib.import_module")
-    @patch("snapcraft.internal.pluginhandler._plugin_loader._load_local")
-    @patch("snapcraft.internal.pluginhandler._plugin_loader._get_plugin")
-    def test_plugin_without_project_not_from_base(
-        self, plugin_mock, local_load_mock, import_mock
-    ):
-        class NonBaseOldPlugin:
-            @classmethod
-            def schema(cls):
-                return {}
-
-            @classmethod
-            def get_pull_properties(cls):
-                return []
-
-            @classmethod
-            def get_build_properties(cls):
-                return []
-
-            def __init__(self, name, options):
-                self.name = "old_plugin"
-                self.osrepodir = "osrepodir"
-                self.statedir = "statedir"
-                self.sourcedir = "sourcedir"
-                self.build_basedir = "build_basedir"
-
-            def build(self):
-                pass
-
-        plugin_mock.return_value = NonBaseOldPlugin
-        local_load_mock.side_effect = ImportError()
-        handler = self.load_part("fake-part", "nonbaseoldplugin")
-
-        self.assertTrue(handler.plugin.project is not None)
-
     def test_plugin_schema_step_hint_pull(self):
         class Plugin(snapcraft.BasePlugin):
             @classmethod


### PR DESCRIPTION
Logic existed to be able to support plugins that did not support
a signature with Project, support for this is removed with the
move to bases.

LP: #1796668

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
