### PR TITLE
pluginhandler: remove big solidus workaround

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -379,10 +379,10 @@ properties:
     additionalProperties: false
     validation-failure:
         "{!r} is not a valid part name. Part names consist of lower-case
-        alphanumeric characters, hyphens, plus signs, and forward slashes. As a
+        alphanumeric characters, hyphens and plus signs. As a
         special case, 'plugins' is also not a valid part name."
     patternProperties:
-      ^(?!plugins$)[a-z0-9][a-z0-9+-\/]*$:
+      ^(?!plugins$)[a-z0-9][a-z0-9+-]*$:
         allOf:
           # Make sure snap/prime are mutually exclusive
           - not:

--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -98,15 +98,10 @@ class BasePlugin:
         self.project = project
         self.options = options
 
-        # The remote parts can have a '/' in them to separate the main project
-        # part with the subparts. This is rather unfortunate as it affects the
-        # the layout of parts inside the parts directory causing collisions
-        # between the main project part and its subparts.
-        part_dir = name.replace("/", "\N{BIG SOLIDUS}")
         if project:
-            self.partdir = os.path.join(project.parts_dir, part_dir)
+            self.partdir = os.path.join(project.parts_dir, name)
         else:
-            self.partdir = os.path.join(os.getcwd(), "parts", part_dir)
+            self.partdir = os.path.join(os.getcwd(), "parts", name)
 
         self.sourcedir = os.path.join(self.partdir, "src")
         self.installdir = os.path.join(self.partdir, "install")

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -191,12 +191,6 @@ class PartsConfig:
                 )
 
     def load_part(self, part_name, plugin_name, part_properties):
-        # Some legacy parts can have a '/' in them to separate the main project
-        # part with the subparts. This is rather unfortunate as it affects the
-        # the layout of parts inside the parts directory causing collisions
-        # between the main project part and its subparts.
-        part_name = part_name.replace("/", "\N{BIG SOLIDUS}")
-
         plugin = pluginhandler.load_plugin(
             plugin_name=plugin_name,
             part_name=part_name,

--- a/snapcraft/internal/project_loader/_schema.py
+++ b/snapcraft/internal/project_loader/_schema.py
@@ -40,7 +40,7 @@ class Validator:
         """Return part-specific schema properties."""
 
         sub = self.schema["parts"]["patternProperties"]
-        properties = sub["^(?!plugins$)[a-z0-9][a-z0-9+-\/]*$"]["properties"]
+        properties = sub["^(?!plugins$)[a-z0-9][a-z0-9+-]*$"]["properties"]
         return properties
 
     @property

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import unittest.mock
 
 from testtools.matchers import Equals
@@ -38,13 +37,6 @@ class TestBasePlugin(unit.TestCase):
         plugin = snapcraft.BasePlugin("test_plugin", options, self.project_options)
         unittest.mock.patch.object(self.project_options, "parallel_build_count", 2)
         self.assertThat(plugin.parallel_build_count, Equals(2))
-
-    def test_part_name_with_forward_slash_is_one_directory(self):
-        plugin = snapcraft.BasePlugin("test/part", options=None)
-
-        os.makedirs(plugin.sourcedir)
-
-        self.assertIn("test\N{BIG SOLIDUS}part", os.listdir("parts"))
 
     @unittest.mock.patch("snapcraft.internal.common.run")
     def test_run_without_specifying_cwd(self, mock_run):

--- a/tests/unit/project_loader/test_parts.py
+++ b/tests/unit/project_loader/test_parts.py
@@ -43,18 +43,6 @@ class TestParts(ProjectLoaderBaseTest):
         project_config = self.make_snapcraft_project([("part1", dict(plugin="nil"))])
         self.assertThat(project_config.parts.get_part("not-a-part"), Equals(None))
 
-    def test_slash_warning(self):
-        fake_logger = fixtures.FakeLogger(level=logging.WARN)
-        self.useFixture(fake_logger)
-
-        self.make_snapcraft_project([("part/1", dict(plugin="nil"))])
-        self.assertThat(
-            fake_logger.output,
-            Contains(
-                'DEPRECATED: Found a "/" in the name of the {!r} part'.format("part/1")
-            ),
-        )
-
     def test_snap_deprecation(self):
         """Test that using the 'snap' keyword results in a warning."""
 

--- a/tests/unit/project_loader/test_validation.py
+++ b/tests/unit/project_loader/test_validation.py
@@ -509,7 +509,14 @@ class InvalidPartNamesTest(ValidationBaseTest):
 
     scenarios = [
         (name, dict(name=name))
-        for name in ["plugins", "qwe#rty", "qwe_rty", "queue rty", "queue  rty"]
+        for name in [
+            "plugins",
+            "qwe#rty",
+            "qwe_rty",
+            "queue rty",
+            "queue  rty",
+            "part/sub",
+        ]
     ]
 
     def test_invalid_part_names(self):
@@ -521,9 +528,8 @@ class InvalidPartNamesTest(ValidationBaseTest):
         expected_message = (
             "The 'parts' property does not match the required schema: {!r} is "
             "not a valid part name. Part names consist of lower-case "
-            "alphanumeric characters, hyphens, plus signs, and forward "
-            "slashes. As a special case, 'plugins' is also not a valid part "
-            "name."
+            "alphanumeric characters, hyphens and plus signs. "
+            "As a special case, 'plugins' is also not a valid part name."
         ).format(self.name)
         self.assertThat(raised.message, Equals(expected_message), message=data)
 


### PR DESCRIPTION
With bases, wiki parts are gone so part names with forward
slashes can now be forbidden.

LP: #1796723

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
