### PR TITLE
catkin, catkin-tools: add support for bases

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -16,6 +16,11 @@
 
 """The catkin plugin is useful for building ROS parts.
 
+The rosdistro used depends upon the base of the snap:
+
+  - core16: Uses Kinetic
+  - core18: Uses Melodic
+
 This plugin uses the common plugin keywords as well as those for "sources".
 For more information check the 'plugins' topic for the former and the
 'sources' topic for the latter.
@@ -28,9 +33,6 @@ Additionally, this plugin uses the following plugin-specific keywords:
     - source-space:
       (string)
       The source space containing Catkin packages. By default this is 'src'.
-    - rosdistro:
-      (string)
-      The ROS distro required by this system. Defaults to 'indigo'.
     - include-roscore:
       (boolean)
       Whether or not to include roscore with the part. Defaults to true.
@@ -83,13 +85,11 @@ from snapcraft.internal import errors, mangling
 
 logger = logging.getLogger(__name__)
 
-# Map ROS releases to Ubuntu releases
-_ROS_RELEASE_MAP = {
-    "indigo": "trusty",
-    "jade": "trusty",
-    "kinetic": "xenial",
-    "lunar": "xenial",
-}
+# Map bases to ROS releases
+_BASE_TO_ROS_RELEASE_MAP = {"core16": "kinetic", "core18": "melodic"}
+
+# Map bases to Ubuntu releases
+_BASE_TO_UBUNTU_RELEASE_MAP = {"core16": "xenial", "core18": "bionic"}
 
 _SUPPORTED_DEPENDENCY_TYPES = {"apt", "pip"}
 
@@ -114,19 +114,6 @@ class CatkinUnsupportedDependencyTypeError(errors.SnapcraftError):
 
     def __init__(self, dependency_type, dependency):
         super().__init__(dependency_type=dependency_type, dependency=dependency)
-
-
-class CatkinUnsupportedRosdistroError(errors.SnapcraftError):
-    fmt = (
-        "Unsupported ROS distribution: {rosdistro!r}. The supported ROS distributions "
-        "are {supported}."
-    )
-
-    def __init__(self, rosdistro):
-        super().__init__(
-            rosdistro=rosdistro,
-            supported=formatting_utils.humanize_list(_ROS_RELEASE_MAP.keys(), "and"),
-        )
 
 
 class CatkinWorkspaceIsRootError(errors.SnapcraftError):
@@ -169,7 +156,6 @@ class CatkinPlugin(snapcraft.BasePlugin):
     @classmethod
     def schema(cls):
         schema = super().schema()
-        schema["properties"]["rosdistro"] = {"type": "string", "default": "indigo"}
         schema["properties"]["catkin-packages"] = {
             "type": "array",
             "minitems": 1,
@@ -227,7 +213,6 @@ class CatkinPlugin(snapcraft.BasePlugin):
         # Inform Snapcraft of the properties associated with pulling. If these
         # change in the YAML Snapcraft will consider the pull step dirty.
         return [
-            "rosdistro",
             "catkin-packages",
             "source-space",
             "include-roscore",
@@ -259,6 +244,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
         ros_repo = "http://packages.ros.org/ros/ubuntu/"
         ubuntu_repo = "http://${prefix}.ubuntu.com/${suffix}/"
         security_repo = "http://${security}.ubuntu.com/${suffix}/"
+
         return textwrap.dedent(
             """
             deb {ros_repo} {codename} main
@@ -270,19 +256,24 @@ class CatkinPlugin(snapcraft.BasePlugin):
                 ros_repo=ros_repo,
                 ubuntu_repo=ubuntu_repo,
                 security_repo=security_repo,
-                codename=_ROS_RELEASE_MAP[self.options.rosdistro],
+                codename=_BASE_TO_UBUNTU_RELEASE_MAP[self.project.info.base],
             )
         )
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
+        if project.info.base not in ("core16", "core18"):
+            raise errors.PluginBaseError(part_name=self.name, base=project.info.base)
+
+        self._rosdistro = _BASE_TO_ROS_RELEASE_MAP[project.info.base]
+
         self.build_packages.extend(["libc6-dev", "make", "python-pip"])
         self.__pip = None
 
         # roslib is the base requiremet to actually create a workspace with
         # setup.sh and the necessary hooks.
-        self.stage_packages.append("ros-{}-roslib".format(self.options.rosdistro))
+        self.stage_packages.append("ros-{}-roslib".format(self._rosdistro))
 
         # Get a unique set of packages
         self.catkin_packages = None
@@ -311,10 +302,6 @@ class CatkinPlugin(snapcraft.BasePlugin):
 
         if os.path.abspath(self.sourcedir) == os.path.abspath(self._ros_package_path):
             raise CatkinWorkspaceIsRootError()
-
-        # Validate selected ROS distro
-        if self.options.rosdistro not in _ROS_RELEASE_MAP:
-            raise CatkinUnsupportedRosdistroError(self.options.rosdistro)
 
     def env(self, root):
         """Runtime environment for ROS binaries and services."""
@@ -461,7 +448,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
 
             # Use catkin_find to discover dependencies already in the underlay
             catkin = _Catkin(
-                self.options.rosdistro,
+                self._rosdistro,
                 underlay_build_path,
                 self._catkin_path,
                 self.PLUGIN_STAGE_SOURCES,
@@ -480,10 +467,10 @@ class CatkinPlugin(snapcraft.BasePlugin):
 
         # Use rosdep for dependency detection and resolution
         rosdep = _ros.rosdep.Rosdep(
-            ros_distro=self.options.rosdistro,
+            ros_distro=self._rosdistro,
             ros_package_path=self._ros_package_path,
             rosdep_path=self._rosdep_path,
-            ubuntu_distro=_ROS_RELEASE_MAP[self.options.rosdistro],
+            ubuntu_distro=_BASE_TO_UBUNTU_RELEASE_MAP[self.project.info.base],
             ubuntu_sources=self.PLUGIN_STAGE_SOURCES,
             project=self.project,
         )
@@ -565,7 +552,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
         self._pip.clean_packages()
 
     def _source_setup_sh(self, root, underlay_path):
-        rosdir = os.path.join(root, "opt", "ros", self.options.rosdistro)
+        rosdir = os.path.join(root, "opt", "ros", self._rosdistro)
         if underlay_path:
             source_script = textwrap.dedent(
                 """
@@ -627,7 +614,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
 
     @property
     def rosdir(self):
-        return os.path.join(self.installdir, "opt", "ros", self.options.rosdistro)
+        return os.path.join(self.installdir, "opt", "ros", self._rosdistro)
 
     def _run_in_bash(self, commandlist, cwd=None, env=None):
         with tempfile.NamedTemporaryFile(mode="w") as f:
@@ -723,9 +710,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
             with open(setup_sh_file, "r+") as f:
                 pattern = re.compile(r"\${_CATKIN_SETUP_DIR:=.*}")
                 replaced = pattern.sub(
-                    "${{_CATKIN_SETUP_DIR:=$SNAP/opt/ros/{}}}".format(
-                        self.options.rosdistro
-                    ),
+                    "${{_CATKIN_SETUP_DIR:=$SNAP/opt/ros/{}}}".format(self._rosdistro),
                     f.read(),
                 )
                 f.seek(0)
@@ -822,9 +807,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
 
         fileset = super().snap_fileset()
         fileset.append(
-            "-{}".format(
-                os.path.join("opt", "ros", self.options.rosdistro, ".rosinstall")
-            )
+            "-{}".format(os.path.join("opt", "ros", self._rosdistro, ".rosinstall"))
         )
         return fileset
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -195,6 +195,8 @@ suites:
  tests/spread/plugins/catkin/:
    summary: tests of snapcraft's Catkin plugin
    kill-timeout: 180m
+   # Keep this 18.04 only for now as it is the only stable base.
+   systems: [ubuntu-18.04*]
  tests/spread/plugins/copy/:
    summary: tests of snapcraft's Copy plugin when not using a base
  tests/spread/plugins/cmake/:

--- a/tests/spread/plugins/catkin/catkin-with-python/task.yaml
+++ b/tests/spread/plugins/catkin/catkin-with-python/task.yaml
@@ -5,13 +5,17 @@ priority: 100  # Run this test early so we're not waiting for it
 environment:
   SNAP_DIR: ../snaps/catkin-with-python-part
 
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean
   rm -f ./*.snap
 
-# ROS Kinetic only supports 16.04
-systems: [ubuntu-16.04*]
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
 
 execute: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/catkin/content-sharing/task.yaml
+++ b/tests/spread/plugins/catkin/content-sharing/task.yaml
@@ -6,21 +6,36 @@ environment:
   PRODUCER_DIR: ../snaps/catkin-shared-ros/producer
   CONSUMER_DIR: ../snaps/catkin-shared-ros/consumer
 
+prepare: |
+  CWD="$(pwd)"
+  PRODUCER_DIR="$CWD/$PRODUCER_DIR"
+  CONSUMER_DIR="$CWD/$CONSUMER_DIR"
+
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$PRODUCER_DIR/snap/snapcraft.yaml"
+  set_base "$CONSUMER_DIR/snap/snapcraft.yaml"
+
+  if [[ "$SPREAD_SYSTEM" =~ ubuntu-18.04 ]]; then
+      sed -i 's/kinetic/melodic/' "$PRODUCER_DIR/snap/snapcraft.yaml"
+      sed -i 's/kinetic/melodic/' "$CONSUMER_DIR/snap/snapcraft.yaml"
+  fi
+
 restore: |
   CWD="$(pwd)"
   PRODUCER_DIR="$CWD/$PRODUCER_DIR"
   CONSUMER_DIR="$CWD/$CONSUMER_DIR"
 
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+
   cd "$PRODUCER_DIR"
   snapcraft clean
   rm -f ./*.snap
+  restore_yaml "snap/snapcraft.yaml"
 
   cd "$CONSUMER_DIR"
   snapcraft clean
   rm -f ./*.snap
-
-# ROS Kinetic only supports 16.04
-systems: [ubuntu-16.04*]
+  restore_yaml "snap/snapcraft.yaml"
 
 execute: |
   CWD="$(pwd)"

--- a/tests/spread/plugins/catkin/legacy-pull/task.yaml
+++ b/tests/spread/plugins/catkin/legacy-pull/task.yaml
@@ -1,0 +1,22 @@
+summary: |
+  Minimally ensure the plugin works without bases by running pull.
+  The plugin can be tested without bases in full through the legacy release of
+  snapcraft.
+warn-timeout: 9m  # Keep less than 10 minutes so Travis can't timeout
+priority: 100  # Run this test early so we're not waiting for it
+
+environment:
+  SNAP_DIR: ../snaps/ros-talker-listener
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+# ROS Indigo doesn't support arm64 (there are no packages in the archive). Also,
+# Indigo snaps have trouble building past 16.04.
+systems: [-ubuntu-*-arm64, -ubuntu-18*]
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft pull

--- a/tests/spread/plugins/catkin/pip-support/task.yaml
+++ b/tests/spread/plugins/catkin/pip-support/task.yaml
@@ -5,13 +5,17 @@ priority: 100  # Run this test early so we're not waiting for it
 environment:
   SNAP_DIR: ../snaps/ros-pip
 
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean
   rm -f ./*.snap
 
-# ROS Kinetic only supports 16.04
-systems: [ubuntu-16.04*]
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
 
 execute: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/catkin/recursive-rosinstall/task.yaml
+++ b/tests/spread/plugins/catkin/recursive-rosinstall/task.yaml
@@ -5,13 +5,17 @@ priority: 100  # Run this test early so we're not waiting for it
 environment:
   SNAP_DIR: ../snaps/catkin-recursive-rosinstall
 
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean
   rm -f ./*.snap
 
-# ROS Kinetic only supports 16.04
-systems: [ubuntu-16.04*]
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
 
 execute: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/catkin/run/task.yaml
+++ b/tests/spread/plugins/catkin/run/task.yaml
@@ -5,14 +5,17 @@ priority: 100  # Run this test early so we're not waiting for it
 environment:
   SNAP_DIR: ../snaps/ros-talker-listener
 
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean
   rm -f ./*.snap
 
-# ROS Indigo doesn't support arm64 (there are no packages in the archive). Also,
-# Indigo snaps have trouble building past 16.04.
-systems: [-ubuntu-*-arm64, -ubuntu-18*]
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
 
 execute: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/catkin/snaps/catkin-recursive-rosinstall/snap/snapcraft.yaml
+++ b/tests/spread/plugins/catkin/snaps/catkin-recursive-rosinstall/snap/snapcraft.yaml
@@ -10,6 +10,6 @@ confinement: strict
 parts:
   catkin-part:
     plugin: catkin
-    rosdistro: kinetic
+    source: .
     rosinstall-files: [root.rosinstall]
     recursive-rosinstall: true

--- a/tests/spread/plugins/catkin/snaps/catkin-shared-ros/consumer/snap/snapcraft.yaml
+++ b/tests/spread/plugins/catkin/snaps/catkin-shared-ros/consumer/snap/snapcraft.yaml
@@ -18,7 +18,7 @@ parts:
   # producer.
   overlay:
     plugin: catkin
-    rosdistro: kinetic
+    source: .
     include-roscore: false
     catkin-packages: [overlay_package]
     underlay:

--- a/tests/spread/plugins/catkin/snaps/catkin-shared-ros/producer/snap/snapcraft.yaml
+++ b/tests/spread/plugins/catkin/snaps/catkin-shared-ros/producer/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ parts:
   # Create the underlay, the stuff shared from the producer.
   underlay:
     plugin: catkin
-    rosdistro: kinetic
+    source: .
     include-roscore: false
     catkin-packages: [underlay_package]
 

--- a/tests/spread/plugins/catkin/snaps/catkin-with-python-part/snap/snapcraft.yaml
+++ b/tests/spread/plugins/catkin/snaps/catkin-with-python-part/snap/snapcraft.yaml
@@ -17,7 +17,7 @@ parts:
 
   catkin-part:
     plugin: catkin
-    rosdistro: kinetic
+    source: .
     rosinstall-files: [ros_tutorials.rosinstall]
     catkin-packages:
       - roscpp_tutorials

--- a/tests/spread/plugins/catkin/snaps/ros-pip/snap/snapcraft.yaml
+++ b/tests/spread/plugins/catkin/snaps/ros-pip/snap/snapcraft.yaml
@@ -14,7 +14,6 @@ parts:
   ros-project:
     plugin: catkin
     source: .
-    rosdistro: kinetic
     catkin-packages:
       - timezone_test
     include-roscore: true

--- a/tests/spread/plugins/catkin/snaps/ros-talker-listener/snap/snapcraft.yaml
+++ b/tests/spread/plugins/catkin/snaps/ros-talker-listener/snap/snapcraft.yaml
@@ -13,4 +13,3 @@ parts:
   ros-project:
     plugin: catkin
     source: .
-    rosdistro: indigo

--- a/tests/unit/plugins/test_catkin_tools.py
+++ b/tests/unit/plugins/test_catkin_tools.py
@@ -16,6 +16,7 @@
 import os
 import os.path
 import re
+import textwrap
 
 from unittest import mock
 from testtools.matchers import Contains, Equals
@@ -25,7 +26,7 @@ from snapcraft.plugins import catkin_tools
 from tests import unit
 
 
-class CatkinToolsPluginBaseTestCase(unit.TestCase):
+class CatkinToolsPluginBaseTest(unit.TestCase):
     def setUp(self):
         super().setUp()
 
@@ -42,7 +43,16 @@ class CatkinToolsPluginBaseTestCase(unit.TestCase):
             build_attributes = []
 
         self.properties = props()
-        self.project_options = snapcraft.ProjectOptions()
+        self.project = snapcraft.project.Project(
+            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
+                textwrap.dedent(
+                    """\
+                    name: catkin-snap
+                    base: core16
+                    """
+                )
+            )
+        )
 
         patcher = mock.patch("snapcraft.plugins._python.Pip")
         self.pip_mock = patcher.start()
@@ -50,11 +60,10 @@ class CatkinToolsPluginBaseTestCase(unit.TestCase):
         self.pip_mock.return_value.list.return_value = {}
 
 
-class CatkinToolsPluginTestCase(CatkinToolsPluginBaseTestCase):
+class CatkinToolsPluginTestCase(CatkinToolsPluginBaseTest):
     def setUp(self):
         super().setUp()
 
-        self.project = snapcraft.ProjectOptions()
         self.compilers = catkin_tools.Compilers(
             "compilers_path", "sources", self.project
         )
@@ -85,7 +94,7 @@ class CatkinToolsPluginTestCase(CatkinToolsPluginBaseTestCase):
         self.properties.catkin_packages.append("package_2")
 
         plugin = catkin_tools.CatkinToolsPlugin(
-            "test-part", self.properties, self.project_options
+            "test-part", self.properties, self.project
         )
         os.makedirs(os.path.join(plugin.sourcedir, "src"))
 
@@ -111,7 +120,7 @@ class CatkinToolsPluginTestCase(CatkinToolsPluginBaseTestCase):
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "run_output", return_value="foo")
     def test_build_runs_in_bash(self, run_output_mock, run_mock, compilers_mock):
         plugin = catkin_tools.CatkinToolsPlugin(
-            "test-part", self.properties, self.project_options
+            "test-part", self.properties, self.project
         )
         os.makedirs(os.path.join(plugin.sourcedir, "src"))
 
@@ -137,7 +146,7 @@ class CatkinToolsPluginTestCase(CatkinToolsPluginBaseTestCase):
         compilers_mock,
     ):
         plugin = catkin_tools.CatkinToolsPlugin(
-            "test-part", self.properties, self.project_options
+            "test-part", self.properties, self.project
         )
         os.makedirs(os.path.join(plugin.sourcedir, "src"))
 
@@ -159,7 +168,7 @@ class CatkinToolsPluginTestCase(CatkinToolsPluginBaseTestCase):
         finish_build_mock.assert_called_once_with()
 
 
-class PrepareBuildTestCase(CatkinToolsPluginBaseTestCase):
+class PrepareBuildTestCase(CatkinToolsPluginBaseTest):
 
     scenarios = [
         (
@@ -191,7 +200,7 @@ class PrepareBuildTestCase(CatkinToolsPluginBaseTestCase):
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "_use_in_snap_python")
     def test_prepare_build(self, use_python_mock, bashrun_mock, compilers_mock):
         plugin = catkin_tools.CatkinToolsPlugin(
-            "test-part", self.properties, self.project_options
+            "test-part", self.properties, self.project
         )
         os.makedirs(os.path.join(plugin.rosdir, "test"))
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR resolves [LP: #1794778](https://bugs.launchpad.net/snapcraft/+bug/1794778) and [LP: #1794779](https://bugs.launchpad.net/snapcraft/+bug/1794779) by updating the Catkin plugin (and by extension the Catkin Tools plugin) to be base-aware. It removes the `rosdistro` option and use only the LTS ROS release corresponding to the base being used, specifically Kinetic if core16 and Melodic if core18. Finally, it updates all Catkin Spread tests to use bases except for one legacy test that ensures legacy gets dispatched when no bases are being used.