### PR TITLE
schema, meta: support layout

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -214,6 +214,28 @@ properties:
   passthrough:
     type: object
     description: properties to be passed into snap.yaml as-is
+  layout:
+    type: object
+    additionalProperties: false
+    patternProperties:
+      "^.*$":
+        type: object
+        additionalProperties: false
+        properties:
+          bind:
+            type: string
+            description: bind-mount a directory
+          bind-file:
+            type: string
+            description: bind-mount a file
+          symlink:
+            type: string
+            description: create a symbolic link
+          type:
+            type: string
+            description: type of filesystem used for path
+            enum:
+              - tmpfs
   apps:
     type: object
     additionalProperties: false

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -56,6 +56,7 @@ _OPTIONAL_PACKAGE_KEYS = [
     "epoch",
     "grade",
     "hooks",
+    "layout",
     "license",
     "plugs",
     "slots",
@@ -531,6 +532,11 @@ class _SnapPackaging:
             self._render_socket_modes(snap_yaml["apps"])
 
         self._process_passthrough_properties(snap_yaml)
+
+        # FIXME: Remove this warning once layouts are stable and no longer behind a
+        # feature flag in snapd.
+        if "layout" in self._config_data:
+            logger.warn("Layouts are experimental and may break, use at your own risk")
 
         return snap_yaml
 

--- a/tests/spread/general/layout/snaps/layout-test/snap/snapcraft.yaml
+++ b/tests/spread/general/layout/snaps/layout-test/snap/snapcraft.yaml
@@ -1,0 +1,16 @@
+name: layout-test
+version: "1.0"
+summary: Test that a snap using layout can be created
+description: This is a snap that uses layout
+
+grade: devel
+confinement: strict
+
+layout:
+  /etc/test-dir:
+    bind: $SNAP/test-dir
+
+parts:
+  my-part:
+    plugin: dump
+    source: .

--- a/tests/spread/general/layout/snaps/layout-test/test-dir/file
+++ b/tests/spread/general/layout/snaps/layout-test/test-dir/file
@@ -1,0 +1,1 @@
+I'm a file

--- a/tests/spread/general/layout/task.yaml
+++ b/tests/spread/general/layout/task.yaml
@@ -1,0 +1,34 @@
+summary: Build a snap that uses layout
+
+# core18 is the only stable base right now
+systems: [ubuntu-18.04*]
+
+environment:
+  SNAP_DIR: snaps/layout-test
+
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "$SNAP_DIR"
+  output="$(snapcraft prime)"
+  echo "$output" | MATCH "Layouts are experimental and may break, use at your own risk"
+
+  # Verify that layouts made it into the final snap.yaml
+  cat << EOF > expected.txt
+  layout:
+    /etc/test-dir:
+      bind: $SNAP/test-dir
+  EOF
+
+  grep -A2 "layout:" prime/meta/snap.yaml > actual.txt
+  comm -3 expected.txt actual.txt

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -301,6 +301,14 @@ class CreateTestCase(CreateBaseTestCase):
         with testtools.ExpectedException(meta_errors.CommandError):
             self.generate_meta_yaml()
 
+    def test_layout(self):
+        layout = {"/target": {"bind": "$SNAP/foo"}}
+        self.config_data["layout"] = layout
+
+        y = self.generate_meta_yaml()
+
+        self.assertThat(y["layout"], Equals(layout))
+
     def test_create_meta_with_app(self):
         os.mkdir(self.prime_dir)
         _create_file(os.path.join(self.prime_dir, "app.sh"))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

snapd has experimental support for the `layout` property, which provides the ability to reorganize the environment seen by the snap using bind-mounts, etc. This PR resolves [LP: #1754639](https://bugs.launchpad.net/snapcraft/+bug/1754639) by exposing this feature in the snapcraft CLI, but it warns that it's still experimental.