### PR TITLE
schema, meta: support layout

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -214,6 +214,9 @@ properties:
   passthrough:
     type: object
     description: properties to be passed into snap.yaml as-is
+  layout:
+    type: object
+    description: layout property to be passed into the snap.yaml as-is
   apps:
     type: object
     additionalProperties: false

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -56,6 +56,7 @@ _OPTIONAL_PACKAGE_KEYS = [
     "epoch",
     "grade",
     "hooks",
+    "layout",
     "license",
     "plugs",
     "slots",

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -301,6 +301,14 @@ class CreateTestCase(CreateBaseTestCase):
         with testtools.ExpectedException(meta_errors.CommandError):
             self.generate_meta_yaml()
 
+    def test_layout(self):
+        layout = {"/target": {"bind": "$SNAP/foo"}}
+        self.config_data["layout"] = layout
+
+        y = self.generate_meta_yaml()
+
+        self.assertThat(y["layout"], Equals(layout))
+
     def test_create_meta_with_app(self):
         os.mkdir(self.prime_dir)
         _create_file(os.path.join(self.prime_dir, "app.sh"))


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

snapd has experimental support for the `layout` property, which provides the ability to reorganize the environment seen by the snap using bind-mounts, etc. This PR resolves [LP: #1754639](https://bugs.launchpad.net/snapcraft/+bug/1754639) by exposing this feature in the snapcraft CLI, relying on `snap pack --check-skeleton` for validation.