### PR TITLE
lifecycle: switch to multipass by default

### DIFF
--- a/bin/snapcraft
+++ b/bin/snapcraft
@@ -37,6 +37,11 @@ if os.path.isdir(common.get_legacy_snapcraft_dir()):
             base_dir = os.path.expanduser(os.path.join("~", "project"))
         else:
             base_dir = None
+
+        # Backwards compatibility to allow legacy to keep working
+        if os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT") == "destructive-host":
+            del os.environ["SNAPCRAFT_BUILD_ENVIRONMENT"]
+
         snapcraft_yaml_path = project.get_snapcraft_yaml(base_dir=base_dir)
         with open(snapcraft_yaml_path, "r") as f:
             data = yaml_utils.load(f)

--- a/bin/snapcraft
+++ b/bin/snapcraft
@@ -37,11 +37,6 @@ if os.path.isdir(common.get_legacy_snapcraft_dir()):
             base_dir = os.path.expanduser(os.path.join("~", "project"))
         else:
             base_dir = None
-
-        # Backwards compatibility to allow legacy to keep working
-        if os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT") == "destructive-host":
-            del os.environ["SNAPCRAFT_BUILD_ENVIRONMENT"]
-
         snapcraft_yaml_path = project.get_snapcraft_yaml(base_dir=base_dir)
         with open(snapcraft_yaml_path, "r") as f:
             data = yaml_utils.load(f)

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -33,6 +33,7 @@ _BUILD_OPTION_NAMES = [
     "--debug",
     "--shell",
     "--shell-after",
+    "--destructive-mode",
 ]
 
 _BUILD_OPTIONS = [
@@ -45,6 +46,9 @@ _BUILD_OPTIONS = [
     dict(is_flag=True, help="Shells into the environment if the build fails."),
     dict(is_flag=True, help="Shells into the environment in lieu of the step to run."),
     dict(is_flag=True, help="Shells into the environment after the step has run."),
+    dict(
+        is_flag=True, help="Forces snapcraft to try and use the current host to build."
+    ),
 ]
 
 

--- a/snapcraft/cli/env.py
+++ b/snapcraft/cli/env.py
@@ -45,7 +45,7 @@ class BuilderEnvironmentConfig:
         """
         if force_provider:
             build_provider = force_provider
-        elif common.is_docker_instance:
+        elif common.is_docker_instance():
             build_provider = "host"
         else:
             build_provider = os.environ.get("SNAPCRAFT_BUILD_ENVIRONMENT", "multipass")

--- a/snapcraft/cli/env.py
+++ b/snapcraft/cli/env.py
@@ -24,11 +24,14 @@ class BuilderEnvironmentConfig:
 
     To determine the build environment, SNAPCRAFT_BUILD_ENVIRONMENT is
     retrieved from the environment and used to determine the build
-    provider. If it is not set, a value of `host` is assumed.
+    provider. An environment can be forced by use of force_provider
+    during initialization. The default environment is multipass
+    unless the snapcraft is run inside docker for which the preferred
+    environment will be to use the host.
 
     Valid values are:
 
-    - destructive-host: the host will drive the build.
+    - host: the host will drive the build.
     - managed-host: the host will drive the build, but work best for discardable
                     build providers.
     - multipass: a vm driven by multipass will be created to drive the build.
@@ -43,11 +46,11 @@ class BuilderEnvironmentConfig:
         if force_provider:
             build_provider = force_provider
         elif common.is_docker_instance:
-            build_provider = "destructive-host"
+            build_provider = "host"
         else:
             build_provider = os.environ.get("SNAPCRAFT_BUILD_ENVIRONMENT", "multipass")
 
-        valid_providers = ["destructive-host", "multipass", "managed-host"]
+        valid_providers = ["host", "multipass", "managed-host"]
         if build_provider not in valid_providers:
             raise errors.SnapcraftEnvironmentError(
                 "The snapcraft build environment must be one of: {}.".format(
@@ -56,6 +59,6 @@ class BuilderEnvironmentConfig:
             )
 
         self.provider = build_provider
-        self.is_host = build_provider == "destructive-host"
+        self.is_host = build_provider == "host"
         self.is_multipass = build_provider == "multipass"
         self.is_managed_host = build_provider == "managed-host"

--- a/snapcraft/cli/env.py
+++ b/snapcraft/cli/env.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017 Canonical Ltd
+# Copyright (C) 2017-2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -28,31 +28,32 @@ class BuilderEnvironmentConfig:
 
     Valid values are:
 
-    - host: the host will drive the build.
+    - destructive-host: the host will drive the build.
+    - managed-host: the host will drive the build, but work best for discardable
+                    build providers.
     - multipass: a vm driven by multipass will be created to drive the build.
     """
 
-    def __init__(self, *, default="host") -> None:
+    def __init__(self, *, force_provider: str = None) -> None:
         """Instantiate a BuildEnvironmentConfig.
 
-        :param str default: the default provider to use among the list of valid
-                            ones.
-        :param str additional_providers: Additional providers allowed in the
-                                         environment.
+        :param str force_provider: ignore the hints from the environment and use
+                                   the specified provider.
         """
-        valid_providers = ["host", "multipass", "managed-host"]
-        build_provider = os.environ.get("SNAPCRAFT_BUILD_ENVIRONMENT")
+        if force_provider:
+            build_provider = force_provider
+        else:
+            build_provider = os.environ.get("SNAPCRAFT_BUILD_ENVIRONMENT", "multipass")
 
-        if not build_provider:
-            build_provider = default
-        elif build_provider not in valid_providers:
+        valid_providers = ["destructive-host", "multipass", "managed-host"]
+        if build_provider not in valid_providers:
             raise errors.SnapcraftEnvironmentError(
-                "SNAPCRAFT_BUILD_ENVIRONMENT must be one of: {}.".format(
+                "The snapcraft build environment must be one of: {}.".format(
                     humanize_list(items=valid_providers, conjunction="or")
                 )
             )
 
         self.provider = build_provider
-        self.is_host = build_provider == "host"
+        self.is_host = build_provider == "destructive-host"
         self.is_multipass = build_provider == "multipass"
         self.is_managed_host = build_provider == "managed-host"

--- a/snapcraft/cli/env.py
+++ b/snapcraft/cli/env.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 
-from snapcraft.internal import errors
+from snapcraft.internal import common, errors
 from snapcraft.formatting_utils import humanize_list
 
 
@@ -42,6 +42,8 @@ class BuilderEnvironmentConfig:
         """
         if force_provider:
             build_provider = force_provider
+        elif common.is_docker_instance:
+            build_provider = "destructive-host"
         else:
             build_provider = os.environ.get("SNAPCRAFT_BUILD_ENVIRONMENT", "multipass")
 

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -49,7 +49,7 @@ def _execute(  # noqa: C901
     **kwargs
 ) -> "Project":
     # fmt: on
-    provider = "destructive-host" if destructive_mode else None
+    provider = "host" if destructive_mode else None
     build_environment = env.BuilderEnvironmentConfig(force_provider=provider)
     project = get_project(is_managed_host=build_environment.is_managed_host, **kwargs)
 

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
 import typing
 
 import click
@@ -46,22 +45,22 @@ def _execute(  # noqa: C901
     output: str = None,
     shell: bool = False,
     shell_after: bool = False,
+    destructive_mode: bool = False,
     **kwargs
 ) -> "Project":
     # fmt: on
-    if sys.platform == "darwin":
-        default_provider = "multipass"
-    else:
-        default_provider = "host"
-
-    build_environment = env.BuilderEnvironmentConfig(default=default_provider)
+    provider = "destructive-host" if destructive_mode else None
+    build_environment = env.BuilderEnvironmentConfig(force_provider=provider)
     project = get_project(is_managed_host=build_environment.is_managed_host, **kwargs)
 
     conduct_project_sanity_check(project)
 
-    #  When we are ready to pull the trigger we will trigger this when
-    # project.info.base is set
-    if build_environment.is_multipass:
+    if build_environment.is_managed_host or build_environment.is_host:
+        project_config = project_loader.load_config(project)
+        lifecycle.execute(step, project_config, parts)
+        if pack_project:
+            _pack(project.prime_dir, output=output)
+    else:
         build_provider_class = build_providers.get_provider_for(
             build_environment.provider
         )
@@ -96,14 +95,6 @@ def _execute(  # noqa: C901
             else:
                 if shell or shell_after:
                     instance.shell()
-    elif build_environment.is_managed_host or build_environment.is_host:
-        project_config = project_loader.load_config(project)
-        lifecycle.execute(step, project_config, parts)
-        if pack_project:
-            _pack(project.prime_dir, output=output)
-    else:
-        # TODO support destructive host
-        raise RuntimeError("Unexpected code path")
     return project
 
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -2,7 +2,7 @@ project: snapcraft
 
 environment:
   # Tell snapcraft to use the current host to build
-  SNAPCRAFT_BUILD_ENVIRONMENT: "destructive-host"
+  SNAPCRAFT_BUILD_ENVIRONMENT: "host"
 
   # This variable can be set to either "deb" or "snap". It defaults to "snap".
   SNAPCRAFT_PACKAGE_TYPE: "$(HOST: echo ${SNAPCRAFT_PACKAGE_TYPE:-snap})"

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,6 +1,9 @@
 project: snapcraft
 
 environment:
+  # Tell snapcraft to use the current host to build
+  SNAPCRAFT_BUILD_ENVIRONMENT: "destructive-host"
+
   # This variable can be set to either "deb" or "snap". It defaults to "snap".
   SNAPCRAFT_PACKAGE_TYPE: "$(HOST: echo ${SNAPCRAFT_PACKAGE_TYPE:-snap})"
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -94,9 +94,7 @@ class TestCase(testtools.TestCase):
 
         # Use this host to run through the lifecycle tests
         self.useFixture(
-            fixtures.EnvironmentVariable(
-                "SNAPCRAFT_BUILD_ENVIRONMENT", "destructive-host"
-            )
+            fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT", "host")
         )
 
         # Use a dumb terminal for tests

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -92,6 +92,13 @@ class TestCase(testtools.TestCase):
         self.xdg_path = self.useFixture(fixtures.TempDir()).path
         self.useFixture(fixture_setup.TempXDG(self.xdg_path))
 
+        # Use this host to run through the lifecycle tests
+        self.useFixture(
+            fixtures.EnvironmentVariable(
+                "SNAPCRAFT_BUILD_ENVIRONMENT", "destructive-host"
+            )
+        )
+
         # Use a dumb terminal for tests
         self.useFixture(fixtures.EnvironmentVariable("TERM", "dumb"))
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -159,9 +159,7 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
 
         # Use this host to run through the lifecycle tests
         self.useFixture(
-            fixtures.EnvironmentVariable(
-                "SNAPCRAFT_BUILD_ENVIRONMENT", "destructive-host"
-            )
+            fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT", "host")
         )
 
         # Avoid installing patchelf in the tests

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -157,6 +157,13 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         self.parts_dir = os.path.join(os.getcwd(), "parts")
         self.local_plugins_dir = os.path.join(self.snap_dir, "plugins")
 
+        # Use this host to run through the lifecycle tests
+        self.useFixture(
+            fixtures.EnvironmentVariable(
+                "SNAPCRAFT_BUILD_ENVIRONMENT", "destructive-host"
+            )
+        )
+
         # Avoid installing patchelf in the tests
         self.useFixture(fixtures.EnvironmentVariable("SNAPCRAFT_NO_PATCHELF", "1"))
 


### PR DESCRIPTION
Add a destructive mode to trigger building on the host.

LP: #1791201

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
