### PR TITLE
ruby plugin: add support for base

### DIFF
--- a/snapcraft/plugins/ruby.py
+++ b/snapcraft/plugins/ruby.py
@@ -37,7 +37,7 @@ import os
 import re
 
 from snapcraft import BasePlugin, file_utils
-from snapcraft.internal.errors import SnapcraftEnvironmentError
+from snapcraft.internal import errors
 from snapcraft.sources import Tar
 
 
@@ -69,6 +69,10 @@ class RubyPlugin(BasePlugin):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
+
+        if project.info.base not in ("core16", "core18"):
+            raise errors.PluginBaseError(part_name=self.name, base=project.info.base)
+
         # Beta Warning
         # Remove this comment and warning once ruby plugin is stable.
         logger.warn(
@@ -83,7 +87,6 @@ class RubyPlugin(BasePlugin):
         )
         self._ruby_tar = Tar(self._ruby_download_url, self._ruby_part_dir)
         self._gems = options.gems or []
-
         self.build_packages.extend(
             ["gcc", "g++", "make", "zlib1g-dev", "libssl-dev", "libreadline-dev"]
         )
@@ -139,7 +142,7 @@ class RubyPlugin(BasePlugin):
             # rbconfig.rb. There should only be one.
             paths = glob.glob(os.path.join(rubylib, "*", "rbconfig.rb"))
             if len(paths) != 1:
-                raise SnapcraftEnvironmentError(
+                raise errors.SnapcraftEnvironmentError(
                     "Expected a single rbconfig.rb, but found {}".format(len(paths))
                 )
 
@@ -147,7 +150,7 @@ class RubyPlugin(BasePlugin):
             env["GEM_HOME"] = os.path.join(rubydir, "gems", ruby_version)
             env["GEM_PATH"] = os.path.join(rubydir, "gems", ruby_version)
         elif len(versions) > 1:
-            raise SnapcraftEnvironmentError(
+            raise errors.SnapcraftEnvironmentError(
                 "Expected a single Ruby version, but found {}".format(len(versions))
             )
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -227,6 +227,8 @@ suites:
  tests/spread/plugins/ruby/:
    summary: tests of snapcraft's Ruby plugin
    kill-timeout: 180m
+   # Keep this 18.04 only for now as it is the only stable base.
+   systems: [ubuntu-18.04*]
  tests/spread/plugins/scons/:
    summary: tests of snapcraft's SCons plugin
  tests/spread/plugins/tar-content/:

--- a/tests/spread/plugins/ruby/bin-check/task.yaml
+++ b/tests/spread/plugins/ruby/bin-check/task.yaml
@@ -3,10 +3,17 @@ summary: Stage a Ruby part and verify all binaries are there
 environment:
   SNAP_DIR: ../snaps/ruby-bins-exist
 
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean
   rm -f ./*.snap
+
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
 
 execute: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/ruby/bundle/task.yaml
+++ b/tests/spread/plugins/ruby/bundle/task.yaml
@@ -1,15 +1,19 @@
 summary: Build and run a ruby snap using bundler
 
-# This snap only builds and runs on 16.04
-systems: [ubuntu-16.04*]
-
 environment:
   SNAP_DIR: ../snaps/ruby-bundle-install
+
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
 
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean
   rm -f ./*.snap
+
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
 
 execute: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/ruby/gem/task.yaml
+++ b/tests/spread/plugins/ruby/gem/task.yaml
@@ -1,15 +1,19 @@
 summary: Build and run a ruby snap using gems
 
-# This snap only builds and runs on 16.04
-systems: [ubuntu-16.04*]
-
 environment:
   SNAP_DIR: ../snaps/ruby-gem-install
+
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
 
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean
   rm -f ./*.snap
+
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
 
 execute: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/ruby/legacy-pull/task.yaml
+++ b/tests/spread/plugins/ruby/legacy-pull/task.yaml
@@ -1,0 +1,18 @@
+summary: |
+  Minimally ensure the plugin works without bases by running pull.
+  The plugin can be tested without bases in full through the legacy release of
+  snapcraft.
+
+systems: [ubuntu-*]
+
+environment:
+  SNAP_DIR: ../snaps/ruby-hello
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft pull

--- a/tests/spread/plugins/ruby/run/task.yaml
+++ b/tests/spread/plugins/ruby/run/task.yaml
@@ -1,15 +1,19 @@
 summary: Build and run a basic Ruby snap
 
-# This snap only builds and runs on 16.04
-systems: [ubuntu-16.04*]
-
 environment:
   SNAP_DIR: ../snaps/ruby-hello
+
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
 
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean
   rm -f ./*.snap
+
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
 
 execute: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/ruby/snaps/ruby-bins-exist/snap/snapcraft.yaml
+++ b/tests/spread/plugins/ruby/snaps/ruby-bins-exist/snap/snapcraft.yaml
@@ -10,6 +10,7 @@ confinement: strict
 parts:
   ruby-exists:
     plugin: ruby
+    source: .
     build-packages: [lsb-release]
     stage:
       - bin

--- a/tests/spread/plugins/ruby/snaps/ruby-bundle-install/snap/snapcraft.yaml
+++ b/tests/spread/plugins/ruby/snaps/ruby-bundle-install/snap/snapcraft.yaml
@@ -14,4 +14,5 @@ apps:
 parts:
   ruby-bundle-install:
     plugin: ruby
+    source: .
     use-bundler: true

--- a/tests/spread/plugins/ruby/snaps/ruby-gem-install/snap/snapcraft.yaml
+++ b/tests/spread/plugins/ruby/snaps/ruby-gem-install/snap/snapcraft.yaml
@@ -14,4 +14,5 @@ apps:
 parts:
   ruby-gem-install:
     plugin: ruby
+    source: .
     gems: ['hello-world']


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR resolves [LP: #1794800](https://bugs.launchpad.net/snapcraft/+bug/1794800) by updating the Ruby plugin to be base-aware, only supporting core16 and core18.