### PR TITLE
extensions: support adding root properties

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/_extension.py
+++ b/snapcraft/internal/project_loader/_extensions/_extension.py
@@ -26,6 +26,8 @@ class Extension:
 
     :cvar supported_bases: Class variable, tuple of base names supported by the
                            extension.
+    :ivar root_snippet: Instance variable, dict of properties to apply to root of the
+                        snapcraft.yaml.
     :ivar app_snippet: Instance variable, dict of properties to apply to apps using this
                        extension.
     :ivar part_snippet: Instance variable, dict of properties to apply to parts using
@@ -40,6 +42,7 @@ class Extension:
 
         :param dict yaml_data: Loaded snapcraft.yaml data.
         """
+        self.root_snippet = dict()  # type: Dict[str, Any]
         self.app_snippet = dict()  # type: Dict[str, Any]
         self.part_snippet = dict()  # type: Dict[str, Any]
         self.parts = dict()  # type: Dict[str, Any]

--- a/snapcraft/internal/project_loader/_extensions/_utils.py
+++ b/snapcraft/internal/project_loader/_extensions/_utils.py
@@ -126,6 +126,13 @@ def _load_extension(base: str, extension_name: str, yaml_data) -> Extension:
 def _apply_extension(
     yaml_data: Dict[str, Any], app_name: str, extension_name: str, extension: Extension
 ):
+    # Apply the root components of the extension (if any)
+    root_extension = extension.root_snippet
+    for property_name, property_value in root_extension.items():
+        yaml_data[property_name] = _apply_extension_property(
+            yaml_data.get(property_name), property_value
+        )
+
     # Apply the app-specific components of the extension (if any)
     app_extension = extension.app_snippet
     app_definition = yaml_data["apps"][app_name]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Currently, extensions are limited to adding YAML snippets to apps and parts, and adding new parts. In order to facilitate adding e.g. new plugs and slots, this PR resolves [LP: #1794531](https://bugs.launchpad.net/snapcraft/+bug/1794531) by adding the ability for extensions to also add YAML snippets to the root of the snapcraft.yaml.