### PR TITLE
extensions: use extension docstring

### DIFF
--- a/snapcraft/internal/lifecycle/__init__.py
+++ b/snapcraft/internal/lifecycle/__init__.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from ._clean import clean  # noqa: F401
-from ._init import init, get_init_data  # noqa: F401
+from ._init import init  # noqa: F401
 from ._packer import pack  # noqa: F401
 from ._runner import execute  # noqa: F401
 from ._status_cache import StatusCache  # noqa: F401

--- a/snapcraft/internal/lifecycle/_init.py
+++ b/snapcraft/internal/lifecycle/_init.py
@@ -18,7 +18,6 @@ import os
 from textwrap import dedent
 
 from snapcraft.internal import errors
-from snapcraft import yaml_utils
 
 
 _TEMPLATE_YAML = dedent(
@@ -62,7 +61,3 @@ def init():
         f.write(text)
 
     return snapcraft_yaml_path
-
-
-def get_init_data():
-    return yaml_utils.load(_TEMPLATE_YAML)

--- a/snapcraft/internal/project_loader/errors.py
+++ b/snapcraft/internal/project_loader/errors.py
@@ -130,6 +130,17 @@ class ExtensionUnsupportedBaseError(ProjectLoaderError):
         super().__init__(extension_name=extension_name, base=base)
 
 
+class ExtensionMissingDocumentationError(ProjectLoaderError):
+    fmt = (
+        "The {extension_name!r} extension appears to be missing documentation.\n"
+        "We would appreciate it if you created a bug report about this at "
+        "https://launchpad.net/snapcraft/+filebug"
+    )
+
+    def __init__(self, extension_name: str) -> None:
+        super().__init__(extension_name=extension_name)
+
+
 def _determine_preamble(error):
     messages = []
     path = _determine_property_path(error)

--- a/tests/unit/commands/test_extensions.py
+++ b/tests/unit/commands/test_extensions.py
@@ -19,6 +19,7 @@ import textwrap
 from unittest import mock
 from testtools.matchers import Equals
 
+from snapcraft.internal.project_loader import errors
 from snapcraft.internal.project_loader._extensions._extension import Extension
 
 from tests import fixture_setup
@@ -70,19 +71,10 @@ class ExtensionsCommandTest(CommandBaseTestCase):
             Equals(
                 textwrap.dedent(
                     """\
-                    The test1 extension adds the following to apps that use it:
-                        environment:
-                          EXTENSION_NAME: test1
+                    This is the Test1 extension.
 
-                    It adds the following to all parts:
-                        after:
-                        - extension-part
-
-                    It adds the following part definitions:
-                        extension-part:
-                          plugin: nil
-
-                    """  # Extra line break due to click.echo
+                    It does stuff.
+                    """
                 )
             ),
         )
@@ -95,33 +87,27 @@ class ExtensionsCommandTest(CommandBaseTestCase):
             Equals(
                 textwrap.dedent(
                     """\
-                    The test2 extension adds the following to all parts:
-                        after:
-                        - extension-part
+                    This is the Test2 extension.
 
-                    It adds the following part definitions:
-                        extension-part:
-                          plugin: nil
-
-                    """  # Extra line break due to click.echo
+                    It does other stuff.
+                    """
                 )
             ),
         )
 
-        result = self.run_command(["extension", "test3"])
+    def test_extension_missing_docs(self):
+        raised = self.assertRaises(
+            errors.ExtensionMissingDocumentationError,
+            self.run_command,
+            ["extension", "test3"],
+        )
 
-        self.assertThat(result.exit_code, Equals(0))
         self.assertThat(
-            result.output,
+            str(raised),
             Equals(
-                textwrap.dedent(
-                    """\
-                    The test3 extension adds the following part definitions:
-                        extension-part:
-                          plugin: nil
-
-                    """  # Extra line break due to click.echo
-                )
+                "The 'test3' extension appears to be missing documentation.\n"
+                "We would appreciate it if you created a bug report about this at "
+                "https://launchpad.net/snapcraft/+filebug"
             ),
         )
 
@@ -184,6 +170,11 @@ class ExtensionsCommandTest(CommandBaseTestCase):
 
 def _test1_extension_fixture():
     class Test1Extension(Extension):
+        """This is the Test1 extension.
+
+        It does stuff.
+        """
+
         supported_bases = ("core16",)
 
         def __init__(self, yaml_data):
@@ -197,6 +188,11 @@ def _test1_extension_fixture():
 
 def _test2_extension_fixture():
     class Test2Extension(Extension):
+        """This is the Test2 extension.
+
+        It does other stuff.
+        """
+
         supported_bases = ("core16",)
 
         def __init__(self, yaml_data):


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

Currently, `snapcraft extension` is not the most obvious description of what the extension does or how to use it. This PR resolves [LP: #1797655](https://bugs.launchpad.net/snapcraft/+bug/1797655) by using documentation provided by the extension instead.