### PR TITLE
tests: remove dependency on snapcraft for integration tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -259,5 +259,9 @@ suites:
      apt-get install --yes gcc g++ make python3-dev python3-pip python3-wheel libffi-dev libsodium-dev libapt-pkg-dev squashfs-tools xdelta3 bzr git mercurial subversion
      pip3 install --user --upgrade pip
      $PIP_COMMAND install --user -r /snapcraft/requirements.txt -r /snapcraft/requirements-devel.txt
+     # Move the snapcraft modules out of the way
+     mv /snapcraft/snapcraft /snapcraft.bak
+   restore: |
+     mv /snapcraft.bak /snapcraft/snapcraft
 
 path: /snapcraft/

--- a/tests/fake_servers/__init__.py
+++ b/tests/fake_servers/__init__.py
@@ -23,7 +23,11 @@ import os
 import urllib.parse
 import pymacaroons
 
-from snapcraft import yaml_utils
+# we do not want snapcraft imports for the integration tests
+try:
+    from snapcraft import yaml_utils
+except ImportError:
+    import yaml as yaml_utils
 
 logger = logging.getLogger(__name__)
 

--- a/tests/fixture_setup/__init__.py
+++ b/tests/fixture_setup/__init__.py
@@ -1,19 +1,32 @@
+import os
 import socket
 
 if hasattr(socket, "AF_UNIX"):
     from ._unix import FakeSnapd  # noqa: F401
+try:
+    from ._unittests import (  # noqa: F401
+        FakeAptBaseDependency,
+        FakeAptCache,
+        FakeAptCachePackage,
+        FakeElf,
+        FakeExtension,
+        FakeMetadataExtractor,
+        FakePlugin,
+        FakeProjectOptions,
+        FakeSnapCommand,
+        FakeSnapcraftctl,
+        SilentSnapProgress,
+    )
+except ImportError as import_error:
+    if os.path.exists(os.path.join(os.path.dirname(__file__), "..", "snapcraft")):
+        raise import_error
+
 from ._fixtures import (  # noqa: F401
     BzrRepo,
     CleanEnvironment,
     GitRepo,
     HgRepo,
-    FakeAptBaseDependency,
-    FakeAptCache,
-    FakeAptCachePackage,
     FakeBaseEnvironment,
-    FakeElf,
-    FakeMetadataExtractor,
-    FakeProjectOptions,
     FakeParts,
     FakePartsServerRunning,
     FakePartsWiki,
@@ -22,9 +35,7 @@ from ._fixtures import (  # noqa: F401
     FakePartsWikiOrigin,
     FakePartsWikiOriginRunning,
     FakePartsWikiRunning,
-    FakePlugin,
     FakeServerRunning,
-    FakeSnapcraftctl,
     FakeSnapcraftIsASnap,
     FakeSSOServerRunning,
     FakeStore,
@@ -33,7 +44,6 @@ from ._fixtures import (  # noqa: F401
     FakeStoreUploadServerRunning,
     FakeTerminal,
     SharedCache,
-    SilentSnapProgress,
     SnapcraftYaml,
     StagingStore,
     SvnRepo,
@@ -41,5 +51,4 @@ from ._fixtures import (  # noqa: F401
     TempXDG,
     TestStore,
     WithoutSnapInstalled,
-    FakeExtension,
 )

--- a/tests/fixture_setup/_fixtures.py
+++ b/tests/fixture_setup/_fixtures.py
@@ -14,35 +14,32 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import collections
 import contextlib
 import copy
 import io
 import os
 import platform
-import pkgutil
 import shutil
 import subprocess
 import sys
 import tempfile
-import textwrap
 import threading
 import urllib.parse
 from functools import partial
-from types import ModuleType
 from unittest import mock
-from typing import Callable
 
 import fixtures
 import xdg
 
-import snapcraft
-from snapcraft import yaml_utils
-from snapcraft.internal import elf
 from tests import fake_servers
 from tests.fake_servers import api, search, upload
-from tests.file_utils import get_snapcraft_path
 from tests.subprocess_utils import call, call_with_output
+
+# we do not want snapcraft imports for the integration tests
+try:
+    from snapcraft import yaml_utils
+except ImportError:
+    import yaml as yaml_utils
 
 
 class TempCWD(fixtures.Fixture):
@@ -120,43 +117,6 @@ class TempXDG(fixtures.Fixture):
                 "XDG_CACHE_HOME", os.path.join(self.path, ".cache")
             )
         )
-
-
-class FakeProjectOptions(fixtures.Fixture):
-    def __init__(self, **kwargs):
-        self._kwargs = dict(
-            arch_triplet=kwargs.pop("arch_triplet", "x86_64-gnu-linux"),
-            parts_dir=kwargs.pop("parts_dir", "parts"),
-            stage_dir=kwargs.pop("stage_dir", "stage"),
-            prime_dir=kwargs.pop("prime_dir", "prime"),
-            parallel_build_count=kwargs.pop("parallel_build_count", "1"),
-        )
-        if kwargs:
-            raise NotImplementedError(
-                "Handling of {!r} is not implemented".format(kwargs.keys())
-            )
-
-    def setUp(self):
-        super().setUp()
-
-        patcher = mock.patch("snapcraft.project.Project")
-        patcher.start()
-        self.addCleanup(patcher.stop)
-
-        # Special handling is required as ProjectOptions attributes are
-        # handled with the @property decorator.
-        project_options_t = type(snapcraft.project.Project.return_value)
-        for key in self._kwargs:
-            setattr(project_options_t, key, self._kwargs[key])
-
-
-class SilentSnapProgress(fixtures.Fixture):
-    def setUp(self):
-        super().setUp()
-
-        patcher = mock.patch("snapcraft.internal.lifecycle._packer.ProgressBar")
-        patcher.start()
-        self.addCleanup(patcher.stop)
 
 
 class CleanEnvironment(fixtures.Fixture):
@@ -438,61 +398,6 @@ class TestStore(fixtures.Fixture):
             self.user_password = os.getenv("TEST_USER_PASSWORD")
 
 
-class FakePlugin(fixtures.Fixture):
-    """Dynamically generate a new module containing the provided plugin"""
-
-    def __init__(self, plugin_name, plugin_class):
-        super().__init__()
-        self._import_name = "snapcraft.plugins.{}".format(plugin_name.replace("-", "_"))
-        self._plugin_class = plugin_class
-
-    def _setUp(self):
-        plugin_module = ModuleType(self._import_name)
-        setattr(plugin_module, self._plugin_class.__name__, self._plugin_class)
-        sys.modules[self._import_name] = plugin_module
-        self.addCleanup(self._remove_module)
-
-    def _remove_module(self):
-        del sys.modules[self._import_name]
-
-
-class FakeMetadataExtractor(fixtures.Fixture):
-    """Dynamically generate a new module containing the provided extractor"""
-
-    def __init__(
-        self,
-        extractor_name: str,
-        extractor: Callable[[str], snapcraft.extractors.ExtractedMetadata],
-        exported_name="extract",
-    ) -> None:
-        super().__init__()
-        self._extractor_name = extractor_name
-        self._exported_name = exported_name
-        self._import_name = "snapcraft.extractors.{}".format(extractor_name)
-        self._extractor = extractor
-
-    def _setUp(self) -> None:
-        extractor_module = ModuleType(self._import_name)
-        setattr(extractor_module, self._exported_name, self._extractor)
-        sys.modules[self._import_name] = extractor_module
-        self.addCleanup(self._remove_module)
-
-        real_iter_modules = pkgutil.iter_modules
-
-        def _fake_iter_modules(path):
-            if path == snapcraft.extractors.__path__:
-                yield None, self._extractor_name, False
-            else:
-                yield real_iter_modules(path)
-
-        patcher = mock.patch("pkgutil.iter_modules", new=_fake_iter_modules)
-        patcher.start()
-        self.addCleanup(patcher.stop)
-
-    def _remove_module(self) -> None:
-        del sys.modules[self._import_name]
-
-
 class GitRepo(fixtures.Fixture):
     """Create a git repo in the current directory"""
 
@@ -630,204 +535,6 @@ class HgRepo(fixtures.Fixture):
             self.commit = revno
 
 
-class FakeAptCache(fixtures.Fixture):
-    class Cache:
-        def __init__(self):
-            super().__init__()
-            self.packages = collections.OrderedDict()
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *args):
-            pass
-
-        def __setitem__(self, key, item):
-            package_parts = key.split("=")
-            package_name = package_parts[0]
-            version = package_parts[1] if len(package_parts) > 1 else item.version
-            if package_name in self.packages:
-                self.packages[package_name].version = version
-            else:
-                if version and not item.version:
-                    item.version = version
-                self.packages[package_name] = item
-
-        def __getitem__(self, key):
-            if "=" in key:
-                key = key.split("=")[0]
-            return self.packages[key]
-
-        def __contains__(self, key):
-            return key in self.packages
-
-        def __iter__(self):
-            return iter(self.packages.values())
-
-        def open(self):
-            pass
-
-        def close(self):
-            pass
-
-        def update(self, *args, **kwargs):
-            pass
-
-        def get_changes(self):
-            return [
-                self.packages[package]
-                for package in self.packages
-                if self.packages[package].marked_install
-            ]
-
-        def get_providing_packages(self, package_name):
-            providing_packages = []
-            for package in self.packages:
-                if package_name in self.packages[package].provides:
-                    providing_packages.append(self.packages[package])
-            return providing_packages
-
-        def is_virtual_package(self, package_name):
-            is_virtual = False
-            if package_name not in self.packages:
-                for package in self.packages:
-                    if package_name in self.packages[package].provides:
-                        return True
-            return is_virtual
-
-    def __init__(self, packages=None):
-        super().__init__()
-        self.packages = packages if packages else []
-
-    def setUp(self):
-        super().setUp()
-        temp_dir_fixture = fixtures.TempDir()
-        self.useFixture(temp_dir_fixture)
-        self.path = temp_dir_fixture.path
-        patcher = mock.patch("snapcraft.repo._deb.apt.Cache")
-        self.mock_apt_cache = patcher.start()
-        self.addCleanup(patcher.stop)
-
-        self.cache = self.Cache()
-        self.mock_apt_cache.return_value = self.cache
-        for package, version in self.packages:
-            self.add_package(FakeAptCachePackage(package, version))
-
-        def fetch_binary(package_candidate, destination):
-            path = os.path.join(self.path, "{}.deb".format(package_candidate.name))
-            open(path, "w").close()
-            return path
-
-        patcher = mock.patch("snapcraft.repo._deb._AptCache.fetch_binary")
-        mock_fetch_binary = patcher.start()
-        mock_fetch_binary.side_effect = fetch_binary
-        self.addCleanup(patcher.stop)
-
-        # Add all the packages in the manifest.
-        with open(
-            os.path.join(
-                get_snapcraft_path(), "snapcraft", "internal", "repo", "manifest.txt"
-            )
-        ) as manifest_file:
-            self.add_packages([line.strip() for line in manifest_file])
-
-    def add_package(self, package):
-        package.temp_dir = self.path
-        self.cache[package.name] = package
-
-    def add_packages(self, package_names):
-        for name in package_names:
-            self.cache[name] = FakeAptCachePackage(name)
-
-
-class FakeAptCachePackage:
-    def __init__(
-        self,
-        name,
-        version=None,
-        installed=None,
-        temp_dir=None,
-        provides=None,
-        priority="non-essential",
-    ):
-        super().__init__()
-        self.temp_dir = temp_dir
-        self.name = name
-        self._version = None
-        self.versions = {}
-        self.version = version
-        self.candidate = self
-        self.dependencies = []
-        self.conflicts = []
-        self.provides = provides if provides else []
-        if installed:
-            # XXX The installed attribute requires some values that the fake
-            # package also requires. The shortest path to do it that I found
-            # was to get installed to return the same fake package.
-            self.installed = self
-        else:
-            self.installed = None
-        self.priority = priority
-        self.marked_install = False
-        self.is_auto_installed = False
-
-    def __str__(self):
-        if "=" in self.name:
-            return self.name
-        else:
-            return "{}={}".format(self.name, self.version)
-
-    @property
-    def version(self):
-        return self._version
-
-    @property
-    def is_auto_removable(self):
-        return self.marked_install and self.is_auto_installed
-
-    @version.setter
-    def version(self, version):
-        self._version = version
-        if version is not None:
-            self.versions.update({version: self})
-
-    def mark_install(self, *, auto_fix=True, from_user=True):
-        if not self.installed:
-            # First, verify dependencies are valid. If not, bail.
-            for or_set in self.dependencies:
-                for dep in or_set:
-                    if "broken" in dep.name:
-                        return
-
-            for or_set in self.dependencies:
-                if or_set and or_set[0].target_versions:
-                    # Install the first target version of the first OR
-                    or_set[0].target_versions[0].mark_install(
-                        auto_fix=auto_fix, from_user=from_user
-                    )
-            for conflict in self.conflicts:
-                conflict.mark_keep()
-
-            self.marked_install = True
-            self.is_auto_installed = not from_user
-
-    def mark_auto(self, auto=True):
-        self.is_auto_installed = auto
-
-    def mark_keep(self):
-        self.marked_install = False
-        self.is_auto_installed = False
-
-    def get_dependencies(self, _):
-        return []
-
-
-class FakeAptBaseDependency:
-    def __init__(self, name, target_versions):
-        self.name = name
-        self.target_versions = target_versions
-
-
 class WithoutSnapInstalled(fixtures.Fixture):
     """Assert that a snap is not installed and remove it on clean up.
 
@@ -841,7 +548,8 @@ class WithoutSnapInstalled(fixtures.Fixture):
 
     def setUp(self) -> None:
         super().setUp()
-        if snapcraft.repo.snaps.SnapPackage.is_snap_installed(self.snap_name):
+        with contextlib.suppress(subprocess.CalledProcessError):
+            subprocess.check_call(["snap", "list", self.snap_name])
             raise AssertionError(
                 "This test cannot run if you already have the {snap!r} snap "
                 "installed. Please uninstall it by running "
@@ -923,152 +631,6 @@ class SharedCache(fixtures.Fixture):
         self.addCleanup(patcher.stop)
 
 
-def _fake_elffile_extract(self, path):
-    arch = ("ELFCLASS64", "ELFDATA2LSB", "EM_X86_64")
-    name = os.path.basename(path)
-    if name in [
-        "fake_elf-2.26",
-        "fake_elf-bad-ldd",
-        "fake_elf-with-core-libs",
-        "fake_elf-bad-patchelf",
-    ]:
-        glibc = elf.NeededLibrary(name="libc.so.6")
-        glibc.add_version("GLIBC_2.2.5")
-        glibc.add_version("GLIBC_2.26")
-        return (arch, "/lib64/ld-linux-x86-64.so.2", "", {glibc.name: glibc}, False)
-    elif name == "fake_elf-2.23":
-        glibc = elf.NeededLibrary(name="libc.so.6")
-        glibc.add_version("GLIBC_2.2.5")
-        glibc.add_version("GLIBC_2.23")
-        return (arch, "/lib64/ld-linux-x86-64.so.2", "", {glibc.name: glibc}, False)
-    elif name == "fake_elf-1.1":
-        glibc = elf.NeededLibrary(name="libc.so.6")
-        glibc.add_version("GLIBC_1.1")
-        glibc.add_version("GLIBC_0.1")
-        return (arch, "/lib64/ld-linux-x86-64.so.2", "", {glibc.name: glibc}, False)
-    elif name == "fake_elf-static":
-        return arch, "", "", {}, False
-    elif name == "fake_elf-shared-object":
-        openssl = elf.NeededLibrary(name="libssl.so.1.0.0")
-        openssl.add_version("OPENSSL_1.0.0")
-        return arch, "", "libfake_elf.so.0", {openssl.name: openssl}, False
-    elif name == "fake_elf-with-execstack":
-        glibc = elf.NeededLibrary(name="libc.so.6")
-        glibc.add_version("GLIBC_2.23")
-        return (arch, "/lib64/ld-linux-x86-64.so.2", "", {glibc.name: glibc}, True)
-    elif name == "fake_elf-with-bad-execstack":
-        glibc = elf.NeededLibrary(name="libc.so.6")
-        glibc.add_version("GLIBC_2.23")
-        return (arch, "/lib64/ld-linux-x86-64.so.2", "", {glibc.name: glibc}, True)
-    elif name == "libc.so.6":
-        return arch, "", "libc.so.6", {}, False
-    elif name == "libssl.so.1.0.0":
-        return arch, "", "libssl.so.1.0.0", {}, False
-    else:
-        return arch, "", "", {}, False
-
-
-class FakeElf(fixtures.Fixture):
-    def __getitem__(self, item):
-        return self._elf_files[item]
-
-    def __init__(self, *, root_path, patchelf_version="0.10"):
-        super().__init__()
-
-        self.root_path = root_path
-        self.core_base_path = None
-        self._patchelf_version = patchelf_version
-
-    def _setUp(self):
-        super()._setUp()
-
-        self.core_base_path = self.useFixture(fixtures.TempDir()).path
-
-        binaries_path = os.path.join(get_snapcraft_path(), "tests", "bin", "elf")
-
-        new_binaries_path = self.useFixture(fixtures.TempDir()).path
-        current_path = os.environ.get("PATH")
-        new_path = "{}:{}".format(new_binaries_path, current_path)
-        self.useFixture(fixtures.EnvironmentVariable("PATH", new_path))
-
-        # Copy strip
-        for f in ["strip", "execstack"]:
-            shutil.copy(
-                os.path.join(binaries_path, f), os.path.join(new_binaries_path, f)
-            )
-            os.chmod(os.path.join(new_binaries_path, f), 0o755)
-
-        # Some values in ldd need to be set with core_path
-        with open(os.path.join(binaries_path, "ldd")) as rf:
-            with open(os.path.join(new_binaries_path, "ldd"), "w") as wf:
-                for line in rf.readlines():
-                    wf.write(line.replace("{CORE_PATH}", self.core_base_path))
-        os.chmod(os.path.join(new_binaries_path, "ldd"), 0o755)
-
-        # Some values in ldd need to be set with core_path
-        self.patchelf_path = os.path.join(new_binaries_path, "patchelf")
-        with open(os.path.join(binaries_path, "patchelf")) as rf:
-            with open(self.patchelf_path, "w") as wf:
-                for line in rf.readlines():
-                    wf.write(line.replace("{VERSION}", self._patchelf_version))
-        os.chmod(os.path.join(new_binaries_path, "patchelf"), 0o755)
-
-        patcher = mock.patch.object(
-            elf.ElfFile, "_extract", new_callable=lambda: _fake_elffile_extract
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
-
-        self._elf_files = {
-            "fake_elf-2.26": elf.ElfFile(
-                path=os.path.join(self.root_path, "fake_elf-2.26")
-            ),
-            "fake_elf-2.23": elf.ElfFile(
-                path=os.path.join(self.root_path, "fake_elf-2.23")
-            ),
-            "fake_elf-1.1": elf.ElfFile(
-                path=os.path.join(self.root_path, "fake_elf-1.1")
-            ),
-            "fake_elf-static": elf.ElfFile(
-                path=os.path.join(self.root_path, "fake_elf-static")
-            ),
-            "fake_elf-shared-object": elf.ElfFile(
-                path=os.path.join(self.root_path, "fake_elf-shared-object")
-            ),
-            "fake_elf-bad-ldd": elf.ElfFile(
-                path=os.path.join(self.root_path, "fake_elf-bad-ldd")
-            ),
-            "fake_elf-bad-patchelf": elf.ElfFile(
-                path=os.path.join(self.root_path, "fake_elf-bad-patchelf")
-            ),
-            "fake_elf-with-core-libs": elf.ElfFile(
-                path=os.path.join(self.root_path, "fake_elf-with-core-libs")
-            ),
-            "fake_elf-with-execstack": elf.ElfFile(
-                path=os.path.join(self.root_path, "fake_elf-with-execstack")
-            ),
-            "fake_elf-with-bad-execstack": elf.ElfFile(
-                path=os.path.join(self.root_path, "fake_elf-with-bad-execstack")
-            ),
-            "libc.so.6": elf.ElfFile(path=os.path.join(self.root_path, "libc.so.6")),
-            "libssl.so.1.0.0": elf.ElfFile(
-                path=os.path.join(self.root_path, "libssl.so.1.0.0")
-            ),
-        }
-
-        for elf_file in self._elf_files.values():
-            with open(elf_file.path, "wb") as f:
-                f.write(b"\x7fELF")
-                if elf_file.path.endswith("fake_elf-bad-patchelf"):
-                    f.write(b"nointerpreter")
-
-        self.root_libraries = {"foo.so.1": os.path.join(self.root_path, "foo.so.1")}
-
-        for root_library in self.root_libraries.values():
-            with open(root_library, "wb") as f:
-                f.write(b"\x7fELF")
-
-
 class FakeBaseEnvironment(fixtures.Fixture):
 
     _LINKER_FOR_ARCH = dict(
@@ -1139,43 +701,6 @@ class FakeBaseEnvironment(fixtures.Fixture):
         )
 
 
-class FakeSnapcraftctl(fixtures.Fixture):
-    def _setUp(self):
-        super()._setUp()
-
-        snapcraft_path = get_snapcraft_path()
-
-        tempdir = self.useFixture(fixtures.TempDir()).path
-        altered_path = "{}:{}".format(tempdir, os.environ.get("PATH"))
-        self.useFixture(fixtures.EnvironmentVariable("PATH", altered_path))
-
-        snapcraftctl_path = os.path.join(tempdir, "snapcraftctl")
-        with open(snapcraftctl_path, "w") as f:
-            f.write(
-                textwrap.dedent(
-                    """\
-                #!/usr/bin/env python3
-
-                # Make sure we can find snapcraft, even if it's not installed
-                # (like in CI).
-                import sys
-                sys.path.append('{snapcraft_path!s}')
-
-                import snapcraft.cli.__main__
-
-                if __name__ == '__main__':
-                    snapcraft.cli.__main__.run_snapcraftctl(
-                        prog_name='snapcraftctl')
-            """.format(
-                        snapcraft_path=snapcraft_path
-                    )
-                )
-            )
-            f.flush()
-
-        os.chmod(snapcraftctl_path, 0o755)
-
-
 class FakeSnapcraftIsASnap(fixtures.Fixture):
     def _setUp(self):
         super()._setUp()
@@ -1183,23 +708,3 @@ class FakeSnapcraftIsASnap(fixtures.Fixture):
         self.useFixture(fixtures.EnvironmentVariable("SNAP", "/snap/snapcraft/current"))
         self.useFixture(fixtures.EnvironmentVariable("SNAP_NAME", "snapcraft"))
         self.useFixture(fixtures.EnvironmentVariable("SNAP_VERSION", "devel"))
-
-
-class FakeExtension(fixtures.Fixture):
-    """Dynamically generate a new module containing the provided extension"""
-
-    def __init__(self, extension_name, extension_class):
-        super().__init__()
-        self._import_name = "snapcraft.internal.project_loader._extensions.{}".format(
-            extension_name
-        )
-        self._extension_class = extension_class
-
-    def _setUp(self):
-        extension_module = ModuleType(self._import_name)
-        setattr(extension_module, self._extension_class.__name__, self._extension_class)
-        sys.modules[self._import_name] = extension_module
-        self.addCleanup(self._remove_module)
-
-    def _remove_module(self):
-        del sys.modules[self._import_name]

--- a/tests/fixture_setup/_unittests.py
+++ b/tests/fixture_setup/_unittests.py
@@ -1,0 +1,591 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015-2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import collections
+import os
+import pkgutil
+import shutil
+import subprocess
+import sys
+import textwrap
+from types import ModuleType
+from unittest import mock
+from typing import Callable
+
+import fixtures
+
+
+import snapcraft
+from snapcraft.internal import elf
+from tests.file_utils import get_snapcraft_path
+
+
+class FakeProjectOptions(fixtures.Fixture):
+    def __init__(self, **kwargs):
+        self._kwargs = dict(
+            arch_triplet=kwargs.pop("arch_triplet", "x86_64-gnu-linux"),
+            parts_dir=kwargs.pop("parts_dir", "parts"),
+            stage_dir=kwargs.pop("stage_dir", "stage"),
+            prime_dir=kwargs.pop("prime_dir", "prime"),
+            parallel_build_count=kwargs.pop("parallel_build_count", "1"),
+        )
+        if kwargs:
+            raise NotImplementedError(
+                "Handling of {!r} is not implemented".format(kwargs.keys())
+            )
+
+    def setUp(self):
+        super().setUp()
+
+        patcher = mock.patch("snapcraft.project.Project")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        # Special handling is required as ProjectOptions attributes are
+        # handled with the @property decorator.
+        project_options_t = type(snapcraft.project.Project.return_value)
+        for key in self._kwargs:
+            setattr(project_options_t, key, self._kwargs[key])
+
+
+class FakeMetadataExtractor(fixtures.Fixture):
+    """Dynamically generate a new module containing the provided extractor"""
+
+    def __init__(
+        self,
+        extractor_name: str,
+        extractor: Callable[[str], snapcraft.extractors.ExtractedMetadata],
+        exported_name="extract",
+    ) -> None:
+        super().__init__()
+        self._extractor_name = extractor_name
+        self._exported_name = exported_name
+        self._import_name = "snapcraft.extractors.{}".format(extractor_name)
+        self._extractor = extractor
+
+    def _setUp(self) -> None:
+        extractor_module = ModuleType(self._import_name)
+        setattr(extractor_module, self._exported_name, self._extractor)
+        sys.modules[self._import_name] = extractor_module
+        self.addCleanup(self._remove_module)
+
+        real_iter_modules = pkgutil.iter_modules
+
+        def _fake_iter_modules(path):
+            if path == snapcraft.extractors.__path__:
+                yield None, self._extractor_name, False
+            else:
+                yield real_iter_modules(path)
+
+        patcher = mock.patch("pkgutil.iter_modules", new=_fake_iter_modules)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _remove_module(self) -> None:
+        del sys.modules[self._import_name]
+
+
+class FakePlugin(fixtures.Fixture):
+    """Dynamically generate a new module containing the provided plugin"""
+
+    def __init__(self, plugin_name, plugin_class):
+        super().__init__()
+        self._import_name = "snapcraft.plugins.{}".format(plugin_name.replace("-", "_"))
+        self._plugin_class = plugin_class
+
+    def _setUp(self):
+        plugin_module = ModuleType(self._import_name)
+        setattr(plugin_module, self._plugin_class.__name__, self._plugin_class)
+        sys.modules[self._import_name] = plugin_module
+        self.addCleanup(self._remove_module)
+
+    def _remove_module(self):
+        del sys.modules[self._import_name]
+
+
+def _fake_elffile_extract(self, path):
+    arch = ("ELFCLASS64", "ELFDATA2LSB", "EM_X86_64")
+    name = os.path.basename(path)
+    if name in [
+        "fake_elf-2.26",
+        "fake_elf-bad-ldd",
+        "fake_elf-with-core-libs",
+        "fake_elf-bad-patchelf",
+    ]:
+        glibc = elf.NeededLibrary(name="libc.so.6")
+        glibc.add_version("GLIBC_2.2.5")
+        glibc.add_version("GLIBC_2.26")
+        return (arch, "/lib64/ld-linux-x86-64.so.2", "", {glibc.name: glibc}, False)
+    elif name == "fake_elf-2.23":
+        glibc = elf.NeededLibrary(name="libc.so.6")
+        glibc.add_version("GLIBC_2.2.5")
+        glibc.add_version("GLIBC_2.23")
+        return (arch, "/lib64/ld-linux-x86-64.so.2", "", {glibc.name: glibc}, False)
+    elif name == "fake_elf-1.1":
+        glibc = elf.NeededLibrary(name="libc.so.6")
+        glibc.add_version("GLIBC_1.1")
+        glibc.add_version("GLIBC_0.1")
+        return (arch, "/lib64/ld-linux-x86-64.so.2", "", {glibc.name: glibc}, False)
+    elif name == "fake_elf-static":
+        return arch, "", "", {}, False
+    elif name == "fake_elf-shared-object":
+        openssl = elf.NeededLibrary(name="libssl.so.1.0.0")
+        openssl.add_version("OPENSSL_1.0.0")
+        return arch, "", "libfake_elf.so.0", {openssl.name: openssl}, False
+    elif name == "fake_elf-with-execstack":
+        glibc = elf.NeededLibrary(name="libc.so.6")
+        glibc.add_version("GLIBC_2.23")
+        return (arch, "/lib64/ld-linux-x86-64.so.2", "", {glibc.name: glibc}, True)
+    elif name == "fake_elf-with-bad-execstack":
+        glibc = elf.NeededLibrary(name="libc.so.6")
+        glibc.add_version("GLIBC_2.23")
+        return (arch, "/lib64/ld-linux-x86-64.so.2", "", {glibc.name: glibc}, True)
+    elif name == "libc.so.6":
+        return arch, "", "libc.so.6", {}, False
+    elif name == "libssl.so.1.0.0":
+        return arch, "", "libssl.so.1.0.0", {}, False
+    else:
+        return arch, "", "", {}, False
+
+
+class FakeElf(fixtures.Fixture):
+    def __getitem__(self, item):
+        return self._elf_files[item]
+
+    def __init__(self, *, root_path, patchelf_version="0.10"):
+        super().__init__()
+
+        self.root_path = root_path
+        self.core_base_path = None
+        self._patchelf_version = patchelf_version
+
+    def _setUp(self):
+        super()._setUp()
+
+        self.core_base_path = self.useFixture(fixtures.TempDir()).path
+
+        binaries_path = os.path.join(get_snapcraft_path(), "tests", "bin", "elf")
+
+        new_binaries_path = self.useFixture(fixtures.TempDir()).path
+        current_path = os.environ.get("PATH")
+        new_path = "{}:{}".format(new_binaries_path, current_path)
+        self.useFixture(fixtures.EnvironmentVariable("PATH", new_path))
+
+        # Copy strip
+        for f in ["strip", "execstack"]:
+            shutil.copy(
+                os.path.join(binaries_path, f), os.path.join(new_binaries_path, f)
+            )
+            os.chmod(os.path.join(new_binaries_path, f), 0o755)
+
+        # Some values in ldd need to be set with core_path
+        with open(os.path.join(binaries_path, "ldd")) as rf:
+            with open(os.path.join(new_binaries_path, "ldd"), "w") as wf:
+                for line in rf.readlines():
+                    wf.write(line.replace("{CORE_PATH}", self.core_base_path))
+        os.chmod(os.path.join(new_binaries_path, "ldd"), 0o755)
+
+        # Some values in ldd need to be set with core_path
+        self.patchelf_path = os.path.join(new_binaries_path, "patchelf")
+        with open(os.path.join(binaries_path, "patchelf")) as rf:
+            with open(self.patchelf_path, "w") as wf:
+                for line in rf.readlines():
+                    wf.write(line.replace("{VERSION}", self._patchelf_version))
+        os.chmod(os.path.join(new_binaries_path, "patchelf"), 0o755)
+
+        patcher = mock.patch.object(
+            elf.ElfFile, "_extract", new_callable=lambda: _fake_elffile_extract
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self._elf_files = {
+            "fake_elf-2.26": elf.ElfFile(
+                path=os.path.join(self.root_path, "fake_elf-2.26")
+            ),
+            "fake_elf-2.23": elf.ElfFile(
+                path=os.path.join(self.root_path, "fake_elf-2.23")
+            ),
+            "fake_elf-1.1": elf.ElfFile(
+                path=os.path.join(self.root_path, "fake_elf-1.1")
+            ),
+            "fake_elf-static": elf.ElfFile(
+                path=os.path.join(self.root_path, "fake_elf-static")
+            ),
+            "fake_elf-shared-object": elf.ElfFile(
+                path=os.path.join(self.root_path, "fake_elf-shared-object")
+            ),
+            "fake_elf-bad-ldd": elf.ElfFile(
+                path=os.path.join(self.root_path, "fake_elf-bad-ldd")
+            ),
+            "fake_elf-bad-patchelf": elf.ElfFile(
+                path=os.path.join(self.root_path, "fake_elf-bad-patchelf")
+            ),
+            "fake_elf-with-core-libs": elf.ElfFile(
+                path=os.path.join(self.root_path, "fake_elf-with-core-libs")
+            ),
+            "fake_elf-with-execstack": elf.ElfFile(
+                path=os.path.join(self.root_path, "fake_elf-with-execstack")
+            ),
+            "fake_elf-with-bad-execstack": elf.ElfFile(
+                path=os.path.join(self.root_path, "fake_elf-with-bad-execstack")
+            ),
+            "libc.so.6": elf.ElfFile(path=os.path.join(self.root_path, "libc.so.6")),
+            "libssl.so.1.0.0": elf.ElfFile(
+                path=os.path.join(self.root_path, "libssl.so.1.0.0")
+            ),
+        }
+
+        for elf_file in self._elf_files.values():
+            with open(elf_file.path, "wb") as f:
+                f.write(b"\x7fELF")
+                if elf_file.path.endswith("fake_elf-bad-patchelf"):
+                    f.write(b"nointerpreter")
+
+        self.root_libraries = {"foo.so.1": os.path.join(self.root_path, "foo.so.1")}
+
+        for root_library in self.root_libraries.values():
+            with open(root_library, "wb") as f:
+                f.write(b"\x7fELF")
+
+
+class FakeExtension(fixtures.Fixture):
+    """Dynamically generate a new module containing the provided extension"""
+
+    def __init__(self, extension_name, extension_class):
+        super().__init__()
+        self._import_name = "snapcraft.internal.project_loader._extensions.{}".format(
+            extension_name
+        )
+        self._extension_class = extension_class
+
+    def _setUp(self):
+        extension_module = ModuleType(self._import_name)
+        setattr(extension_module, self._extension_class.__name__, self._extension_class)
+        sys.modules[self._import_name] = extension_module
+        self.addCleanup(self._remove_module)
+
+    def _remove_module(self):
+        del sys.modules[self._import_name]
+
+
+class FakeSnapCommand(fixtures.Fixture):
+    def __init__(self):
+        self.calls = []
+        self.install_success = True
+        self.refresh_success = True
+        self._email = "-"
+
+    def _setUp(self):
+        original_check_call = snapcraft.internal.repo.snaps.check_call
+        original_check_output = snapcraft.internal.repo.snaps.check_output
+
+        def side_effect_check_call(cmd, *args, **kwargs):
+            return side_effect(original_check_call, cmd, *args, **kwargs)
+
+        def side_effect_check_output(cmd, *args, **kwargs):
+            return side_effect(original_check_output, cmd, *args, **kwargs)
+
+        def side_effect(original, cmd, *args, **kwargs):
+            if self._is_snap_command(cmd):
+                self.calls.append(cmd)
+                return self._fake_snap_command(cmd, *args, **kwargs)
+            else:
+                return original(cmd, *args, **kwargs)
+
+        check_call_patcher = mock.patch(
+            "snapcraft.internal.repo.snaps.check_call",
+            side_effect=side_effect_check_call,
+        )
+        self.mock_call = check_call_patcher.start()
+        self.addCleanup(check_call_patcher.stop)
+
+        check_output_patcher = mock.patch(
+            "snapcraft.internal.repo.snaps.check_output",
+            side_effect=side_effect_check_output,
+        )
+        self.mock_call = check_output_patcher.start()
+        self.addCleanup(check_output_patcher.stop)
+
+    def login(self, email):
+        self._email = email
+
+    def _get_snap_cmd(self, snap_cmd):
+        try:
+            snap_cmd_index = snap_cmd.index("snap")
+        except ValueError:
+            return ""
+
+        try:
+            return snap_cmd[snap_cmd_index + 1]
+        except IndexError:
+            return ""
+
+    def _is_snap_command(self, cmd):
+        return self._get_snap_cmd(cmd) in ["install", "refresh", "whoami"]
+
+    def _fake_snap_command(self, cmd, *args, **kwargs):
+        cmd = self._get_snap_cmd(cmd)
+        if cmd == "install" and not self.install_success:
+            raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
+        elif cmd == "refresh" and not self.refresh_success:
+            raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
+        elif cmd == "whoami":
+            return "email: {}".format(self._email).encode()
+
+
+class FakeAptCache(fixtures.Fixture):
+    class Cache:
+        def __init__(self):
+            super().__init__()
+            self.packages = collections.OrderedDict()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def __setitem__(self, key, item):
+            package_parts = key.split("=")
+            package_name = package_parts[0]
+            version = package_parts[1] if len(package_parts) > 1 else item.version
+            if package_name in self.packages:
+                self.packages[package_name].version = version
+            else:
+                if version and not item.version:
+                    item.version = version
+                self.packages[package_name] = item
+
+        def __getitem__(self, key):
+            if "=" in key:
+                key = key.split("=")[0]
+            return self.packages[key]
+
+        def __contains__(self, key):
+            return key in self.packages
+
+        def __iter__(self):
+            return iter(self.packages.values())
+
+        def open(self):
+            pass
+
+        def close(self):
+            pass
+
+        def update(self, *args, **kwargs):
+            pass
+
+        def get_changes(self):
+            return [
+                self.packages[package]
+                for package in self.packages
+                if self.packages[package].marked_install
+            ]
+
+        def get_providing_packages(self, package_name):
+            providing_packages = []
+            for package in self.packages:
+                if package_name in self.packages[package].provides:
+                    providing_packages.append(self.packages[package])
+            return providing_packages
+
+        def is_virtual_package(self, package_name):
+            is_virtual = False
+            if package_name not in self.packages:
+                for package in self.packages:
+                    if package_name in self.packages[package].provides:
+                        return True
+            return is_virtual
+
+    def __init__(self, packages=None):
+        super().__init__()
+        self.packages = packages if packages else []
+
+    def setUp(self):
+        super().setUp()
+        temp_dir_fixture = fixtures.TempDir()
+        self.useFixture(temp_dir_fixture)
+        self.path = temp_dir_fixture.path
+        patcher = mock.patch("snapcraft.repo._deb.apt.Cache")
+        self.mock_apt_cache = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.cache = self.Cache()
+        self.mock_apt_cache.return_value = self.cache
+        for package, version in self.packages:
+            self.add_package(FakeAptCachePackage(package, version))
+
+        def fetch_binary(package_candidate, destination):
+            path = os.path.join(self.path, "{}.deb".format(package_candidate.name))
+            open(path, "w").close()
+            return path
+
+        patcher = mock.patch("snapcraft.repo._deb._AptCache.fetch_binary")
+        mock_fetch_binary = patcher.start()
+        mock_fetch_binary.side_effect = fetch_binary
+        self.addCleanup(patcher.stop)
+
+        # Add all the packages in the manifest.
+        with open(
+            os.path.join(
+                get_snapcraft_path(), "snapcraft", "internal", "repo", "manifest.txt"
+            )
+        ) as manifest_file:
+            self.add_packages([line.strip() for line in manifest_file])
+
+    def add_package(self, package):
+        package.temp_dir = self.path
+        self.cache[package.name] = package
+
+    def add_packages(self, package_names):
+        for name in package_names:
+            self.cache[name] = FakeAptCachePackage(name)
+
+
+class FakeAptCachePackage:
+    def __init__(
+        self,
+        name,
+        version=None,
+        installed=None,
+        temp_dir=None,
+        provides=None,
+        priority="non-essential",
+    ):
+        super().__init__()
+        self.temp_dir = temp_dir
+        self.name = name
+        self._version = None
+        self.versions = {}
+        self.version = version
+        self.candidate = self
+        self.dependencies = []
+        self.conflicts = []
+        self.provides = provides if provides else []
+        if installed:
+            # XXX The installed attribute requires some values that the fake
+            # package also requires. The shortest path to do it that I found
+            # was to get installed to return the same fake package.
+            self.installed = self
+        else:
+            self.installed = None
+        self.priority = priority
+        self.marked_install = False
+        self.is_auto_installed = False
+
+    def __str__(self):
+        if "=" in self.name:
+            return self.name
+        else:
+            return "{}={}".format(self.name, self.version)
+
+    @property
+    def version(self):
+        return self._version
+
+    @property
+    def is_auto_removable(self):
+        return self.marked_install and self.is_auto_installed
+
+    @version.setter
+    def version(self, version):
+        self._version = version
+        if version is not None:
+            self.versions.update({version: self})
+
+    def mark_install(self, *, auto_fix=True, from_user=True):
+        if not self.installed:
+            # First, verify dependencies are valid. If not, bail.
+            for or_set in self.dependencies:
+                for dep in or_set:
+                    if "broken" in dep.name:
+                        return
+
+            for or_set in self.dependencies:
+                if or_set and or_set[0].target_versions:
+                    # Install the first target version of the first OR
+                    or_set[0].target_versions[0].mark_install(
+                        auto_fix=auto_fix, from_user=from_user
+                    )
+            for conflict in self.conflicts:
+                conflict.mark_keep()
+
+            self.marked_install = True
+            self.is_auto_installed = not from_user
+
+    def mark_auto(self, auto=True):
+        self.is_auto_installed = auto
+
+    def mark_keep(self):
+        self.marked_install = False
+        self.is_auto_installed = False
+
+    def get_dependencies(self, _):
+        return []
+
+
+class FakeAptBaseDependency:
+    def __init__(self, name, target_versions):
+        self.name = name
+        self.target_versions = target_versions
+
+
+class FakeSnapcraftctl(fixtures.Fixture):
+    def _setUp(self):
+        super()._setUp()
+
+        snapcraft_path = get_snapcraft_path()
+
+        tempdir = self.useFixture(fixtures.TempDir()).path
+        altered_path = "{}:{}".format(tempdir, os.environ.get("PATH"))
+        self.useFixture(fixtures.EnvironmentVariable("PATH", altered_path))
+
+        snapcraftctl_path = os.path.join(tempdir, "snapcraftctl")
+        with open(snapcraftctl_path, "w") as f:
+            f.write(
+                textwrap.dedent(
+                    """\
+                #!/usr/bin/env python3
+
+                # Make sure we can find snapcraft, even if it's not installed
+                # (like in CI).
+                import sys
+                sys.path.append('{snapcraft_path!s}')
+
+                import snapcraft.cli.__main__
+
+                if __name__ == '__main__':
+                    snapcraft.cli.__main__.run_snapcraftctl(
+                        prog_name='snapcraftctl')
+            """.format(
+                        snapcraft_path=snapcraft_path
+                    )
+                )
+            )
+            f.flush()
+
+        os.chmod(snapcraftctl_path, 0o755)
+
+
+class SilentSnapProgress(fixtures.Fixture):
+    def setUp(self):
+        super().setUp()
+
+        patcher = mock.patch("snapcraft.internal.lifecycle._packer.ProgressBar")
+        patcher.start()
+        self.addCleanup(patcher.stop)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -30,13 +30,13 @@ from typing import Callable, List, Union
 
 import fixtures
 import pexpect
-from pexpect import popen_spawn
 import requests
 import testtools
+import yaml as yaml_utils
+from pexpect import popen_spawn
 from testtools import content
 from testtools.matchers import MatchesRegex
 
-from snapcraft import yaml_utils
 from tests import fixture_setup, os_release, subprocess_utils
 from tests.integration import platform
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -458,10 +458,6 @@ class StoreTestCase(TestCase):
         process.expect_exact(
             "Enter your Ubuntu One e-mail address and password." + os.linesep
         )
-        process.expect_exact(
-            "If you do not have an Ubuntu One account, you can create one at "
-            "https://snapcraft.io/account" + os.linesep
-        )
         process.expect_exact("Email: ")
         process.sendline(email)
         process.expect_exact("Password: ")
@@ -540,10 +536,6 @@ class StoreTestCase(TestCase):
 
         process.expect_exact(
             "Enter your Ubuntu One e-mail address and password." + os.linesep
-        )
-        process.expect_exact(
-            "If you do not have an Ubuntu One account, you can create one at "
-            "https://snapcraft.io/account" + os.linesep
         )
         process.expect_exact("Email: ")
         process.sendline(email)

--- a/tests/integration/general/test_alias.py
+++ b/tests/integration/general/test_alias.py
@@ -17,9 +17,9 @@
 import os
 import stat
 
+import yaml as yaml_utils
 from testtools.matchers import Equals, FileExists
 
-from snapcraft import yaml_utils
 from tests import integration
 
 

--- a/tests/integration/general/test_architectures.py
+++ b/tests/integration/general/test_architectures.py
@@ -16,9 +16,9 @@
 
 import os
 
+import yaml as yaml_utils
 from testtools.matchers import Equals
 
-from snapcraft import yaml_utils
 from tests import integration
 
 

--- a/tests/integration/general/test_asset_recording.py
+++ b/tests/integration/general/test_asset_recording.py
@@ -24,9 +24,9 @@ import tempfile
 import apt
 import fixtures
 import testscenarios
+import yaml as yaml_utils
 from testtools.matchers import Contains, Equals
 
-from snapcraft import yaml_utils
 from tests.integration import repo
 from tests import integration, fixture_setup, os_release
 

--- a/tests/integration/general/test_list_plugins.py
+++ b/tests/integration/general/test_list_plugins.py
@@ -14,10 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import pkgutil
-
-from snapcraft import plugins
-
 from testtools.matchers import Equals
 
 from tests import integration
@@ -27,8 +23,33 @@ class ListPluginsTestCase(integration.TestCase):
     def test_list_plugins(self):
         output = self.run_snapcraft("list-plugins")
         plugins_list = set(output.split())
-        expected = set()
-        for _, modname, _ in pkgutil.iter_modules(plugins.__path__):
-            if not modname.startswith("_"):
-                expected.add(modname.replace("_", "-"))
+        expected = {
+            "ant",
+            "catkin-tools",
+            "dump",
+            "gradle",
+            "jhbuild",
+            "make",
+            "nil",
+            "python",
+            "rust",
+            "autotools",
+            "cmake",
+            "go",
+            "gulp",
+            "kbuild",
+            "maven",
+            "nodejs",
+            "qmake",
+            "scons",
+            "catkin",
+            "dotnet",
+            "godeps",
+            "jdk",
+            "kernel",
+            "meson",
+            "plainbox-provider",
+            "ruby",
+            "waf",
+        }
         self.assertThat(plugins_list, Equals(expected))

--- a/tests/integration/general/test_metadata_appstream.py
+++ b/tests/integration/general/test_metadata_appstream.py
@@ -18,9 +18,9 @@ import os
 import textwrap
 import shutil
 
+import yaml as yaml_utils
 from testtools.matchers import Equals, FileExists
 
-from snapcraft import yaml_utils
 import tests
 from tests import fixture_setup, integration
 

--- a/tests/integration/general/test_metadata_setuppy.py
+++ b/tests/integration/general/test_metadata_setuppy.py
@@ -17,9 +17,9 @@
 import os
 from textwrap import dedent
 
+import yaml as yaml_utils
 from testtools.matchers import Equals
 
-from snapcraft import yaml_utils
 from tests import integration, fixture_setup
 
 

--- a/tests/integration/general/test_snapcraftctl_set_grade.py
+++ b/tests/integration/general/test_snapcraftctl_set_grade.py
@@ -18,9 +18,9 @@ import os
 import subprocess
 import textwrap
 
+import yaml as yaml_utils
 from testtools.matchers import Equals, Contains
 
-from snapcraft import yaml_utils
 from tests import integration
 
 

--- a/tests/integration/general/test_snapcraftctl_set_version.py
+++ b/tests/integration/general/test_snapcraftctl_set_version.py
@@ -18,9 +18,9 @@ import os
 import subprocess
 import textwrap
 
+import yaml as yaml_utils
 from testtools.matchers import Equals, Contains
 
-from snapcraft import yaml_utils
 from tests import integration
 
 

--- a/tests/integration/general/test_version_script.py
+++ b/tests/integration/general/test_version_script.py
@@ -18,9 +18,9 @@ import subprocess
 from textwrap import dedent
 
 import testscenarios
+import yaml as yaml_utils
 from testtools.matchers import Contains, FileExists
 
-from snapcraft import yaml_utils
 from tests import integration
 
 

--- a/tests/integration/lifecycle/test_build_properties.py
+++ b/tests/integration/lifecycle/test_build_properties.py
@@ -16,9 +16,9 @@
 
 import os
 
+import yaml as yaml_utils
 from testtools.matchers import Equals, FileExists
 
-from snapcraft import yaml_utils
 from tests import integration
 
 

--- a/tests/integration/lifecycle/test_pull_properties.py
+++ b/tests/integration/lifecycle/test_pull_properties.py
@@ -19,9 +19,9 @@ import os
 import subprocess
 
 import testscenarios
+import yaml as yaml_utils
 from testtools.matchers import Equals, FileExists
 
-from snapcraft import yaml_utils
 from tests import fixture_setup, integration
 
 

--- a/tests/integration/lifecycle/test_pull_properties.py
+++ b/tests/integration/lifecycle/test_pull_properties.py
@@ -14,13 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import namedtuple
 import os
 import subprocess
+from collections import namedtuple
+from textwrap import dedent
 
 import testscenarios
-import yaml as yaml_utils
-from testtools.matchers import Equals, FileExists
+from testtools.matchers import Contains, FileContains, FileExists
 
 from tests import fixture_setup, integration
 
@@ -37,40 +37,51 @@ class PullPropertiesTestCase(integration.TestCase):
 
         state_file = os.path.join(self.parts_dir, "x-local-plugin", "state", "pull")
         self.assertThat(state_file, FileExists())
-        with open(state_file) as f:
-            state = yaml_utils.load(f)
-
         # Verify that the correct schema dependencies made it into the state.
-        self.assertTrue("foo" in state.schema_properties)
-        self.assertTrue("stage-packages" in state.schema_properties)
-
-        # Verify that the contents of the dependencies made it in as well.
-        self.assertTrue("foo" in state.properties)
-        self.assertTrue(len(state.assets["stage-packages"]) > 0)
-        self.assertIn("build-packages", state.assets)
-        self.assertTrue("stage-packages" in state.properties)
-        self.assertThat(state.properties["foo"], Equals("bar"))
-        self.assertThat(state.properties["stage-packages"], Equals(["curl"]))
-
-    def test_pull_with_arch(self):
-        if self.deb_arch == "armhf":
-            self.skipTest("For now, we just support crosscompile from amd64")
-        self.run_snapcraft(["pull", "--target-arch=i386", "go-hello"], "go-hello")
-        state_file = os.path.join(self.parts_dir, "go-hello", "state", "pull")
-        self.assertThat(state_file, FileExists())
-        with open(state_file) as f:
-            state = yaml_utils.load(f)
-        self.assertThat(state.project_options["deb_arch"], Equals("i386"))
-
-    def test_arch_with_pull(self):
-        if self.deb_arch == "armhf":
-            self.skipTest("For now, we just support crosscompile from amd64")
-        self.run_snapcraft(["--target-arch=i386", "pull", "go-hello"], "go-hello")
-        state_file = os.path.join(self.parts_dir, "go-hello", "state", "pull")
-        self.assertThat(state_file, FileExists())
-        with open(state_file) as f:
-            state = yaml_utils.load(f)
-        self.assertThat(state.project_options["deb_arch"], Equals("i386"))
+        # and that the contents of the dependencies made it in as well.
+        self.assertThat(
+            state_file,
+            FileContains(
+                matcher=Contains(
+                    dedent(
+                        """\
+                properties:
+                  foo: bar
+                  override-pull: snapcraftctl pull
+                  parse-info: []
+                  plugin: x-local-plugin
+                  source: .
+                  source-branch: ''
+                  source-commit: ''
+                  source-depth: 0
+                  source-subdir: ''
+                  source-tag: ''
+                  source-type: ''
+                  stage-packages: []
+                schema_properties:
+                - foo
+                - stage-packages
+              """
+                    )
+                )
+            ),
+        )
+        self.assertThat(
+            state_file,
+            FileContains(
+                matcher=Contains(
+                    dedent(
+                        """\
+                assets:
+                  build-packages: []
+                  build-snaps: []
+                  source-details: null
+                  stage-packages: []
+                """
+                    )
+                )
+            ),
+        )
 
 
 class AssetTrackingTestCase(integration.TestCase):
@@ -87,15 +98,27 @@ class AssetTrackingTestCase(integration.TestCase):
 
         state_file = os.path.join(self.parts_dir, "asset-tracking", "state", "pull")
         self.assertThat(state_file, FileExists())
-        with open(state_file) as f:
-            state = yaml_utils.load(f)
-
         # Verify that the correct version of 'hello' is installed
-        self.assertTrue(len(state.assets["stage-packages"]) > 0)
-        self.assertTrue(len(state.assets["build-packages"]) > 0)
-        self.assertIn("hello={}".format(stage_version), state.assets["stage-packages"])
-        self.assertIn("hello={}".format(build_version), state.assets["build-packages"])
-        self.assertIn("source-details", state.assets)
+        self.assertThat(
+            state_file,
+            FileContains(
+                matcher=Contains(
+                    dedent(
+                        """\
+                assets:
+                  build-packages:
+                  - hello={}
+                  build-snaps: []
+                  source-details: null
+                  stage-packages:
+                  - hello={}
+                """.format(
+                            build_version, stage_version
+                        )
+                    )
+                )
+            ),
+        )
 
     def test_pull_global_build_packages_are_excluded(self):
         """
@@ -110,10 +133,22 @@ class AssetTrackingTestCase(integration.TestCase):
 
         state_file = os.path.join(self.parts_dir, "empty-part", "state", "pull")
         self.assertThat(state_file, FileExists())
-        with open(state_file) as f:
-            state = yaml_utils.load(f)
-
-        self.assertTrue(len(state.assets["build-packages"]) == 0)
+        self.assertThat(
+            state_file,
+            FileContains(
+                matcher=Contains(
+                    dedent(
+                        """\
+                assets:
+                  build-packages: []
+                  build-snaps: []
+                  source-details: null
+                  stage-packages: []
+                """
+                    )
+                )
+            ),
+        )
 
     def test_pull_build_package_with_any_architecture(self):
         self.copy_project_to_cwd("build-package")
@@ -126,9 +161,24 @@ class AssetTrackingTestCase(integration.TestCase):
         self.run_snapcraft("pull")
 
         state_file = os.path.join(self.parts_dir, "hello", "state", "pull")
-        with open(state_file) as f:
-            state = yaml_utils.load(f)
-        self.assertIn("hello", state.assets["build-packages"][0])
+        self.assertThat(state_file, FileExists())
+        self.assertThat(
+            state_file,
+            FileContains(
+                matcher=Contains(
+                    dedent(
+                        """\
+                assets:
+                  build-packages:
+                  - hello:any
+                  build-snaps: []
+                  source-details: null
+                  stage-packages: []
+                """
+                    )
+                )
+            ),
+        )
 
     def test_pull_with_virtual_build_package(self):
         virtual_package = "fortunes-off"
@@ -136,16 +186,23 @@ class AssetTrackingTestCase(integration.TestCase):
         self.run_snapcraft("pull", "build-virtual-package")
 
         state_file = os.path.join("snap", ".snapcraft", "state")
-        with open(state_file) as f:
-            state = yaml_utils.load(f)
-        self.assertIn(
-            "{}={}".format(
-                virtual_package,
-                integration.get_package_version(
-                    virtual_package, self.distro_series, self.deb_arch
-                ),
+        self.assertThat(state_file, FileExists())
+        self.assertThat(
+            state_file,
+            FileContains(
+                matcher=Contains(
+                    dedent(
+                        """\
+                  - {}={}
+                """.format(
+                            virtual_package,
+                            integration.get_package_version(
+                                virtual_package, self.distro_series, self.deb_arch
+                            ),
+                        )
+                    )
+                )
             ),
-            state.assets["build-packages"],
         )
 
 
@@ -155,20 +212,32 @@ TestDetail = namedtuple("TestDetail", ["field", "value"])
 class GitAssetTrackingTestCase(testscenarios.WithScenarios, integration.TestCase):
 
     scenarios = [
-        ("plain", {"part_name": "git-part", "expected_details": None}),
+        (
+            "plain",
+            dict(
+                part_name="git-part",
+                source_branch="''",
+                source_commit=True,
+                source_tag="''",
+            ),
+        ),
         (
             "branch",
-            {
-                "part_name": "git-part-branch",
-                "expected_details": TestDetail("source-branch", "test-branch"),
-            },
+            dict(
+                part_name="git-part-branch",
+                source_branch="test-branch",
+                source_commit=False,
+                source_tag="''",
+            ),
         ),
         (
             "tag",
-            {
-                "part_name": "git-part-tag",
-                "expected_details": TestDetail("source-tag", "feature-tag"),
-            },
+            dict(
+                part_name="git-part-tag",
+                source_branch="''",
+                source_commit=False,
+                source_tag="feature-tag",
+            ),
         ),
     ]
 
@@ -177,38 +246,49 @@ class GitAssetTrackingTestCase(testscenarios.WithScenarios, integration.TestCase
         self.useFixture(repo_fixture)
         project_dir = "asset-tracking-git"
 
+        source_commit = repo_fixture.commit if self.source_commit else "''"
+
         self.run_snapcraft(["pull", self.part_name], project_dir)
 
         state_file = os.path.join(self.parts_dir, self.part_name, "state", "pull")
         self.assertThat(state_file, FileExists())
-        with open(state_file) as f:
-            state = yaml_utils.load(f)
-
-        self.assertIn("source-details", state.assets)
-
         # fall back to the commit if no other source option is provided
         # snapcraft.source.Git doesn't allow both a tag and a commit
-        if self.expected_details:
-            self.assertThat(
-                state.assets["source-details"][self.expected_details.field],
-                Equals(self.expected_details.value),
-            )
-        else:
-            self.assertThat(
-                state.assets["source-details"]["source-commit"],
-                Equals(repo_fixture.commit),
-            )
+        self.assertThat(
+            state_file,
+            FileContains(
+                matcher=Contains(
+                    dedent(
+                        """\
+                assets:
+                  build-packages: []
+                  build-snaps: []
+                  source-details:
+                    source: git-source
+                    source-branch: {source_branch}
+                    source-checksum: ''
+                    source-commit: {source_commit}
+                    source-tag: {source_tag}
+                  stage-packages: []
+                """.format(
+                            source_branch=self.source_branch,
+                            source_commit=source_commit,
+                            source_tag=self.source_tag,
+                        )
+                    )
+                )
+            ),
+        )
 
 
 class BazaarAssetTrackingTestCase(testscenarios.WithScenarios, integration.TestCase):
     scenarios = [
-        ("plain", {"part_name": "bzr-part", "expected_details": None}),
+        ("plain", dict(part_name="bzr-part", source_commit=True, source_tag="''")),
         (
             "tag",
-            {
-                "part_name": "bzr-part-tag",
-                "expected_details": TestDetail("source-tag", "feature-tag"),
-            },
+            dict(
+                part_name="bzr-part-tag", source_commit=False, source_tag="feature-tag"
+            ),
         ),
     ]
 
@@ -216,37 +296,45 @@ class BazaarAssetTrackingTestCase(testscenarios.WithScenarios, integration.TestC
         repo_fixture = fixture_setup.BzrRepo("bzr-source")
         self.useFixture(repo_fixture)
         project_dir = "asset-tracking-bzr"
-        part = self.part_name
-        self.run_snapcraft(["pull", part], project_dir)
 
-        state_file = os.path.join(self.parts_dir, part, "state", "pull")
+        source_commit = repo_fixture.commit if self.source_commit else ""
+
+        self.run_snapcraft(["pull", self.part_name], project_dir)
+
+        state_file = os.path.join(self.parts_dir, self.part_name, "state", "pull")
         self.assertThat(state_file, FileExists())
-        with open(state_file) as f:
-            state = yaml_utils.load(f)
-
-        self.assertIn("source-details", state.assets)
-
-        if self.expected_details:
-            self.assertThat(
-                state.assets["source-details"][self.expected_details.field],
-                Equals(self.expected_details.value),
-            )
-        else:
-            self.assertThat(
-                state.assets["source-details"]["source-commit"],
-                Equals(repo_fixture.commit),
-            )
+        self.assertThat(
+            state_file,
+            FileContains(
+                matcher=Contains(
+                    dedent(
+                        """\
+                assets:
+                  build-packages: []
+                  build-snaps: []
+                  source-details:
+                    source: bzr-source
+                    source-branch: null
+                    source-commit: '{source_commit}'
+                    source-tag: {source_tag}
+                  stage-packages: []
+                """.format(
+                            source_commit=source_commit, source_tag=self.source_tag
+                        )
+                    )
+                )
+            ),
+        )
 
 
 class MercurialAssetTrackingTestCase(testscenarios.WithScenarios, integration.TestCase):
     scenarios = [
-        ("plain", {"part_name": "hg-part", "expected_details": None}),
+        ("plain", dict(part_name="hg-part", source_commit=True, source_tag="''")),
         (
             "tag",
-            {
-                "part_name": "hg-part-tag",
-                "expected_details": TestDetail("source-tag", "feature-tag"),
-            },
+            dict(
+                part_name="hg-part-tag", source_commit=False, source_tag="feature-tag"
+            ),
         ),
     ]
 
@@ -254,26 +342,35 @@ class MercurialAssetTrackingTestCase(testscenarios.WithScenarios, integration.Te
         repo_fixture = fixture_setup.HgRepo("hg-source")
         self.useFixture(repo_fixture)
         project_dir = "asset-tracking-hg"
-        part = self.part_name
-        self.run_snapcraft(["pull", part], project_dir)
 
-        state_file = os.path.join(self.parts_dir, part, "state", "pull")
+        source_commit = repo_fixture.commit if self.source_commit else "''"
+
+        self.run_snapcraft(["pull", self.part_name], project_dir)
+
+        state_file = os.path.join(self.parts_dir, self.part_name, "state", "pull")
         self.assertThat(state_file, FileExists())
-        with open(state_file) as f:
-            state = yaml_utils.load(f)
-
-        self.assertIn("source-details", state.assets)
-
-        if self.expected_details:
-            self.assertThat(
-                state.assets["source-details"][self.expected_details.field],
-                Equals(self.expected_details.value),
-            )
-        else:
-            self.assertThat(
-                state.assets["source-details"]["source-commit"],
-                Equals(repo_fixture.commit),
-            )
+        self.assertThat(
+            state_file,
+            FileContains(
+                matcher=Contains(
+                    dedent(
+                        """\
+                assets:
+                  build-packages: []
+                  build-snaps: []
+                  source-details:
+                    source: hg-source
+                    source-branch: ''
+                    source-commit: {source_commit}
+                    source-tag: {source_tag}
+                  stage-packages: []
+                """.format(
+                            source_commit=source_commit, source_tag=self.source_tag
+                        )
+                    )
+                )
+            ),
+        )
 
 
 class SubversionAssetTrackingTestCase(integration.TestCase):
@@ -281,16 +378,32 @@ class SubversionAssetTrackingTestCase(integration.TestCase):
         repo_fixture = fixture_setup.SvnRepo("svn-source")
         self.useFixture(repo_fixture)
         project_dir = "asset-tracking-svn"
-        part = "svn-part"
-        expected_commit = repo_fixture.commit
-        self.run_snapcraft(["pull", part], project_dir)
+        part_name = "svn-part"
 
-        state_file = os.path.join(self.parts_dir, part, "state", "pull")
+        self.run_snapcraft(["pull", part_name], project_dir)
+
+        state_file = os.path.join(self.parts_dir, part_name, "state", "pull")
         self.assertThat(state_file, FileExists())
-        with open(state_file) as f:
-            state = yaml_utils.load(f)
-
-        self.assertIn("source-details", state.assets)
+        self.assertThat(state_file, FileExists())
         self.assertThat(
-            state.assets["source-details"]["source-commit"], Equals(expected_commit)
+            state_file,
+            FileContains(
+                matcher=Contains(
+                    dedent(
+                        """\
+                assets:
+                  build-packages: []
+                  build-snaps: []
+                  source-details:
+                    source: svn-source
+                    source-branch: null
+                    source-commit: '{source_commit}'
+                    source-tag: null
+                  stage-packages: []
+                """.format(
+                            source_commit=repo_fixture.commit
+                        )
+                    )
+                )
+            ),
         )

--- a/tests/integration/lifecycle/test_snap.py
+++ b/tests/integration/lifecycle/test_snap.py
@@ -83,13 +83,13 @@ class SnapTestCase(integration.TestCase):
                 dedent(
                     """\
                 name: assemble
-                version: 1.0
+                version: '1.0'
                 summary: one line summary
                 description: a longer description
                 architectures:
                 - {}
                 confinement: strict
-                grade: stable
+                grade: devel
                 apps:
                   assemble-bin:
                     command: command-assemble-bin.wrapper
@@ -146,13 +146,10 @@ class SnapTestCase(integration.TestCase):
         self.run_snapcraft(["snap", "-o", "mysnap.snap"], "assemble")
         self.assertThat("mysnap.snap", FileExists())
 
-    def test_error_with_unexistent_build_package(self):
+    def test_error_with_inexistent_build_package(self):
         self.copy_project_to_cwd("assemble")
         with open("snapcraft.yaml", "a") as yaml_file:
             yaml_file.write("build-packages:\n  - inexistent-package\n")
-
-        # We update here to get a clean log/stdout later
-        self.run_snapcraft("update")
 
         exception = self.assertRaises(
             subprocess.CalledProcessError, self.run_snapcraft, "snap"
@@ -224,54 +221,3 @@ class SnapTestCase(integration.TestCase):
         self.copy_project_to_cwd("yaml-merge-tag")
         self.run_snapcraft("stage")
         self.assertThat(os.path.join(self.stage_dir, "test.txt"), FileExists())
-
-    def test_ordered_snap_yaml(self):
-        with open("snapcraft.yaml", "w") as s:
-            s.write(
-                dedent(
-                    """\
-                apps:
-                    stub-app:
-                        command: sh
-                grade: stable
-                version: "2"
-                assumes: [snapd_227]
-                architectures: [all]
-                description: stub description
-                summary: stub summary
-                confinement: strict
-                name: stub-snap
-                environment:
-                    stub_key: stub-value
-                epoch: 1
-                parts:
-                    nothing:
-                        plugin: nil
-            """
-                )
-            )
-        self.run_snapcraft("prime")
-
-        expected_snap_yaml = dedent(
-            """\
-            name: stub-snap
-            version: '2'
-            summary: stub summary
-            description: stub description
-            architectures:
-            - all
-            confinement: strict
-            grade: stable
-            assumes:
-            - snapd_227
-            epoch: 1
-            environment:
-              stub_key: stub-value
-            apps:
-              stub-app:
-                command: command-stub-app.wrapper
-        """
-        )
-        self.assertThat(
-            os.path.join("prime", "meta", "snap.yaml"), FileContains(expected_snap_yaml)
-        )

--- a/tests/integration/plugins/test_rust_plugin.py
+++ b/tests/integration/plugins/test_rust_plugin.py
@@ -20,9 +20,9 @@ import subprocess
 
 import fixtures
 import testscenarios
+import yaml as yaml_utils
 from testtools.matchers import Equals, FileExists, MatchesRegex, Not
 
-from snapcraft import yaml_utils
 from tests import integration
 from tests.matchers import HasArchitecture
 

--- a/tests/integration/plugins_nodejs/test_nodejs_plugin.py
+++ b/tests/integration/plugins_nodejs/test_nodejs_plugin.py
@@ -16,9 +16,9 @@
 import os
 
 import testscenarios
+import yaml as yaml_utils
 from testtools.matchers import FileExists
 
-from snapcraft import yaml_utils
 from tests import integration
 
 

--- a/tests/integration/snaps/assemble/binary1.after
+++ b/tests/integration/snaps/assemble/binary1.after
@@ -1,2 +1,4 @@
 #!/bin/sh
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 exec "$SNAP/binary1" "$@"

--- a/tests/integration/snaps/assemble/command-chain
+++ b/tests/integration/snaps/assemble/command-chain
@@ -1,4 +1,0 @@
-#!/bin/sh
-export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
-export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
-exec "$@"

--- a/tests/integration/snaps/local-plugin-build-properties/snapcraft.yaml
+++ b/tests/integration/snaps/local-plugin-build-properties/snapcraft.yaml
@@ -9,6 +9,5 @@ confinement: strict
 parts:
     x-local-plugin:
       plugin: x-local-plugin
-      stage-packages: [curl]
       foo: bar
       source: .

--- a/tests/integration/snaps/local-plugin-legacy-build-properties/snapcraft.yaml
+++ b/tests/integration/snaps/local-plugin-legacy-build-properties/snapcraft.yaml
@@ -9,6 +9,5 @@ confinement: strict
 parts:
     x-local-plugin:
       plugin: x-local-plugin
-      stage-packages: [curl]
       foo: bar
       source: .

--- a/tests/integration/snaps/local-plugin-legacy-pull-properties/snapcraft.yaml
+++ b/tests/integration/snaps/local-plugin-legacy-pull-properties/snapcraft.yaml
@@ -9,6 +9,5 @@ confinement: strict
 parts:
     x-local-plugin:
       plugin: x-local-plugin
-      stage-packages: [curl]
       foo: bar
       source: .

--- a/tests/integration/snaps/local-plugin-pull-properties/snapcraft.yaml
+++ b/tests/integration/snaps/local-plugin-pull-properties/snapcraft.yaml
@@ -9,6 +9,5 @@ confinement: strict
 parts:
     x-local-plugin:
       plugin: x-local-plugin
-      stage-packages: [curl]
       foo: bar
       source: .

--- a/tools/travis/run_integration_test.sh
+++ b/tools/travis/run_integration_test.sh
@@ -76,6 +76,7 @@ $lxc file push --recursive "$project_path" test-runner/root/
 $lxc exec test-runner -- sh -c "apt install -y bzr git libnacl-dev libssl-dev libsodium-dev libffi-dev libapt-pkg-dev mercurial python3-pip subversion sudo snapd"
 $lxc exec test-runner -- sh -c "python3 -m pip install -I pip==9.0.3"
 $lxc exec test-runner -- sh -c "python3 -m pip install -r snapcraft/requirements-devel.txt -r snapcraft/requirements.txt"
+$lxc exec test-runner -- sh -c "rm -rf snapcraft/snapcraft"
 $lxc exec test-runner -- sh -c "${SNAPCRAFT_INSTALL_COMMAND:-sudo snap install snapcraft-pr$TRAVIS_PULL_REQUEST.snap --dangerous --classic}"
 $lxc exec test-runner -- sh -c "cd snapcraft && ./runtests.sh $test_suite"
 

--- a/tools/travis/run_integration_test.sh
+++ b/tools/travis/run_integration_test.sh
@@ -76,6 +76,7 @@ $lxc file push --recursive "$project_path" test-runner/root/
 $lxc exec test-runner -- sh -c "apt install -y bzr git libnacl-dev libssl-dev libsodium-dev libffi-dev libapt-pkg-dev mercurial python3-pip subversion sudo snapd"
 $lxc exec test-runner -- sh -c "python3 -m pip install -I pip==9.0.3"
 $lxc exec test-runner -- sh -c "python3 -m pip install -r snapcraft/requirements-devel.txt -r snapcraft/requirements.txt"
+     # Do not let snapcraft imports get in the way of the actual SUT.
 $lxc exec test-runner -- sh -c "rm -rf snapcraft/snapcraft"
 $lxc exec test-runner -- sh -c "${SNAPCRAFT_INSTALL_COMMAND:-sudo snap install snapcraft-pr$TRAVIS_PULL_REQUEST.snap --dangerous --classic}"
 $lxc exec test-runner -- sh -c "cd snapcraft && ./runtests.sh $test_suite"


### PR DESCRIPTION
The integration tests import snapcraft into the suite, this causes all
sorts of problems, the most concerning one is test independence.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
