### PR TITLE
scons plugin: add support for bases

### DIFF
--- a/snapcraft/plugins/scons.py
+++ b/snapcraft/plugins/scons.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015, 2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -32,6 +32,7 @@ Additionally, this plugin uses the following plugin-specific keywords:
 import os
 
 import snapcraft
+from snapcraft.internal import errors
 
 
 class SconsPlugin(snapcraft.BasePlugin):
@@ -56,7 +57,13 @@ class SconsPlugin(snapcraft.BasePlugin):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
-        self.build_packages.append("scons")
+        self._setup_base_tools(project.info.base)
+
+    def _setup_base_tools(self, base):
+        if base in ("core16", "core18"):
+            self.build_packages.append("scons")
+        else:
+            raise errors.PluginBaseError(part_name=self.name, base=base)
 
     def build(self):
         super().build()

--- a/spread.yaml
+++ b/spread.yaml
@@ -230,6 +230,8 @@ suites:
    # Keep this 18.04 only for now as it is the only stable base.
    systems: [ubuntu-18.04*]
  tests/spread/plugins/scons/:
+   # Keep this 18.04 only for now as it is the only stable base.
+   systems: [ubuntu-18.04*]
    summary: tests of snapcraft's SCons plugin
  tests/spread/plugins/tar-content/:
    summary: tests of snapcraft's tar-content plugin when not using a base

--- a/tests/spread/plugins/scons/legacy-build-run/task.yaml
+++ b/tests/spread/plugins/scons/legacy-build-run/task.yaml
@@ -1,18 +1,14 @@
-summary: Build and run a basic SCons snap
+summary: Build and run a basic SCons snap with no base
+
+systems: [ubuntu-*]
 
 environment:
   SNAP_DIR: ../snaps/scons-hello
 
-prepare: |
-  . "$TOOLS_DIR/snapcraft-yaml.sh"
-  set_base "$SNAP_DIR/snap/snapcraft.yaml"
-
 restore: |
-  . "$TOOLS_DIR/snapcraft-yaml.sh"
   cd "$SNAP_DIR"
   snapcraft clean
   rm -f ./*.snap
-  restore_yaml snap/snapcraft.yaml
 
 execute: |
   cd "$SNAP_DIR"


### PR DESCRIPTION
Update the Scons plugin to be base-aware, only supporting core16 and
core18.

LP: #1794801

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
