### PR TITLE
plainbox-provider plugin: add support for bases

### DIFF
--- a/snapcraft/plugins/plainbox_provider.py
+++ b/snapcraft/plugins/plainbox_provider.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016-2017 Canonical Ltd
+# Copyright (C) 2016-2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -32,22 +32,31 @@ For more information check the 'plugins' topic for the former and the
 import os
 
 import snapcraft
+from snapcraft.internal import errors
 from snapcraft.internal import mangling
 
 
 class PlainboxProviderPlugin(snapcraft.BasePlugin):
-    def __init__(self, name, options, project):
-        super().__init__(name, options, project)
-        self.build_packages.extend(["intltool"])
-        self.stage_packages.extend(
-            ["python3-pip", "python3-wheel", "python3-setuptools"]
-        )
-
     @classmethod
     def schema(cls):
         schema = super().schema()
         schema["required"] = ["source"]
         return schema
+
+    def __init__(self, name, options, project):
+        super().__init__(name, options, project)
+
+        self.build_packages.extend(["intltool"])
+        self._setup_base_tools(project.info.base)
+
+    def _setup_base_tools(self, base):
+        if base in ("core16", "core18"):
+            self.stage_packages.extend(
+                ["python3-pip", "python3-wheel", "python3-setuptools"]
+            )
+            self.build_packages.append("intltool")
+        else:
+            raise errors.PluginBaseError(part_name=self.name, base=base)
 
     def build(self):
         super().build()

--- a/spread.yaml
+++ b/spread.yaml
@@ -225,6 +225,8 @@ suites:
  tests/spread/plugins/nil/:
    summary: tests of snapcraft's Nil plugin
  tests/spread/plugins/plainbox/:
+   # Keep this 18.04 only for now as it is the only stable base.
+   systems: [ubuntu-18.04*]
    summary: tests of snapcraft's Plainbox plugin
  tests/spread/plugins/python/:
    summary: tests of snapcraft's Python plugin

--- a/tests/spread/plugins/plainbox/legacy-build-run/task.yaml
+++ b/tests/spread/plugins/plainbox/legacy-build-run/task.yaml
@@ -1,20 +1,14 @@
-summary: Build and run a basic checkbox snap
+summary: Build and run a basic checkbox snap with no base
 
 systems: [ubuntu-16*]
 
 environment:
   SNAP_DIR: ../snaps/checkbox
 
-prepare: |
-  . "$TOOLS_DIR/snapcraft-yaml.sh"
-  set_base "$SNAP_DIR/snap/snapcraft.yaml"
-
 restore: |
-  . "$TOOLS_DIR/snapcraft-yaml.sh"
   cd "$SNAP_DIR"
   snapcraft clean
   rm -f ./*.snap
-  restore_yaml snap/snapcraft.yaml
 
 execute: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/plainbox/provider-basic/task.yaml
+++ b/tests/spread/plugins/plainbox/provider-basic/task.yaml
@@ -5,9 +5,15 @@ systems: [ubuntu-16*, ubuntu-18*]
 environment:
   SNAP_DIR: ../snaps/provider-basic
 
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
   cd "$SNAP_DIR"
   snapcraft clean
+  restore_yaml snap/snapcraft.yaml
 
 execute: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/plainbox/provider-python-stage-package-mix/task.yaml
+++ b/tests/spread/plugins/plainbox/provider-python-stage-package-mix/task.yaml
@@ -5,9 +5,15 @@ systems: [ubuntu-16*, ubuntu-18*]
 environment:
   SNAP_DIR: ../snaps/provider-python-stage-package-mix
 
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
   cd "$SNAP_DIR"
   snapcraft clean
+  restore_yaml snap/snapcraft.yaml
 
 execute: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/plainbox/provider-with-deps/task.yaml
+++ b/tests/spread/plugins/plainbox/provider-with-deps/task.yaml
@@ -5,9 +5,15 @@ systems: [ubuntu-16*, ubuntu-18*]
 environment:
   SNAP_DIR: ../snaps/provider-with-deps
 
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
   cd "$SNAP_DIR"
   snapcraft clean
+  restore_yaml snap/snapcraft.yaml
 
 execute: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/plainbox/provider-with-stage-packages/task.yaml
+++ b/tests/spread/plugins/plainbox/provider-with-stage-packages/task.yaml
@@ -5,9 +5,15 @@ systems: [ubuntu-16*, ubuntu-18*]
 environment:
   SNAP_DIR: ../snaps/provider-with-stage-packages
 
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
   cd "$SNAP_DIR"
   snapcraft clean
+  restore_yaml snap/snapcraft.yaml
 
 execute: |
   cd "$SNAP_DIR"


### PR DESCRIPTION
Update the PlainboxProvider plugin to be base-aware, only supporting
core16 and core18.

LP: #1794802

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
