### PR TITLE
multipass: change default CPU value

### DIFF
--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import os
 import shlex
 import sys
@@ -23,6 +24,9 @@ from .._base_provider import Provider
 from ._instance_info import InstanceInfo
 from ._multipass_command import MultipassCommand
 from snapcraft.internal.errors import SnapcraftEnvironmentError
+
+
+logger = logging.getLogger(__name__)
 
 
 def _get_platform() -> str:
@@ -42,6 +46,23 @@ def _get_stop_time() -> int:
         )
 
     return timeout
+
+
+class _MachineSetting:
+    def __init__(self, *, envvar: str, default: str) -> None:
+        self._default = default
+        self._envvar = envvar
+
+    def get_value(self):
+        value = os.getenv(self._envvar, self._default)
+        if value != self._default:
+            logger.warning(
+                "{!r} was set to {!r} in the environment. "
+                "Changing the default allocation upon user request".format(
+                    self._envvar, value
+                )
+            )
+        return value
 
 
 class Multipass(Provider):
@@ -68,17 +89,17 @@ class Multipass(Provider):
         cloud_user_data_filepath = self._get_cloud_user_data()
         image = self._get_disk_image()
 
-        cpus = os.getenv(
-            "SNAPCRAFT_BUILD_ENVIRONMENT_CPU", str(self.project.parallel_build_count)
+        cpus = _MachineSetting(envvar="SNAPCRAFT_BUILD_ENVIRONMENT_CPU", default="2")
+        mem = _MachineSetting(envvar="SNAPCRAFT_BUILD_ENVIRONMENT_MEMORY", default="2G")
+        disk = _MachineSetting(
+            envvar="SNAPCRAFT_BUILD_ENVIRONMENT_DISK", default="256G"
         )
-        mem = os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT_MEMORY", "2G")
-        disk = os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT_DISK", "256G")
 
         self._multipass_cmd.launch(
             instance_name=self.instance_name,
-            cpus=cpus,
-            mem=mem,
-            disk=disk,
+            cpus=cpus.get_value(),
+            mem=mem.get_value(),
+            disk=disk.get_value(),
             image=image,
             cloud_init=cloud_user_data_filepath,
         )

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -106,7 +106,7 @@ class MultipassTest(BaseProviderBaseTest):
 
         self.multipass_cmd_mock().launch.assert_called_once_with(
             instance_name=self.instance_name,
-            cpus=mock.ANY,
+            cpus="2",
             mem="2G",
             disk="256G",
             image="snapcraft:core16",
@@ -190,7 +190,7 @@ class MultipassTest(BaseProviderBaseTest):
 
         self.multipass_cmd_mock().launch.assert_called_once_with(
             instance_name=self.instance_name,
-            cpus=mock.ANY,
+            cpus="2",
             mem="4G",
             disk="256G",
             image="snapcraft:core16",
@@ -207,7 +207,7 @@ class MultipassTest(BaseProviderBaseTest):
 
         self.multipass_cmd_mock().launch.assert_called_once_with(
             instance_name=self.instance_name,
-            cpus=mock.ANY,
+            cpus="2",
             mem="2G",
             disk="400G",
             image="snapcraft:core16",
@@ -410,7 +410,7 @@ class MultipassWithBasesTest(BaseProviderWithBasesBaseTest):
 
         self.multipass_cmd_mock().launch.assert_called_once_with(
             instance_name=self.instance_name,
-            cpus=mock.ANY,
+            cpus="2",
             mem="2G",
             disk="256G",
             image=self.expected_image,


### PR DESCRIPTION
Use a more conservative default which is more aligned with the default
memory allocation.

Also add messaging on changes due to overriding.

LP: #1795666

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
