### PR TITLE
qmake plugin: add support for bases

### DIFF
--- a/snapcraft/plugins/qmake.py
+++ b/snapcraft/plugins/qmake.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -39,6 +39,7 @@ import os
 
 import snapcraft
 from snapcraft import common
+from snapcraft.internal import errors
 
 
 class QmakePlugin(snapcraft.BasePlugin):
@@ -83,6 +84,9 @@ class QmakePlugin(snapcraft.BasePlugin):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
+
+        if project.info.base not in ("core16", "core18"):
+            raise errors.PluginBaseError(part_name=self.name, base=project.info.base)
 
         self.build_packages.append("make")
         if self.options.qt_version == "qt5":

--- a/spread.yaml
+++ b/spread.yaml
@@ -242,6 +242,10 @@ suites:
    summary: tests of snapcraft's Plainbox plugin
  tests/spread/plugins/python/:
    summary: tests of snapcraft's Python plugin
+ tests/spread/plugins/qmake/:
+   # Keep this 18.04 only for now as it is the only stable base.
+   systems: [ubuntu-18.04*]
+   summary: tests of snapcraft's qmake plugin
  tests/spread/plugins/ruby/:
    summary: tests of snapcraft's Ruby plugin
    kill-timeout: 180m

--- a/tests/spread/plugins/qmake/legacy-pull/task.yaml
+++ b/tests/spread/plugins/qmake/legacy-pull/task.yaml
@@ -1,0 +1,18 @@
+summary: |
+  Minimally ensure the plugin works without bases by running pull.
+  The plugin can be tested without bases in full through the legacy release of
+  snapcraft.
+
+systems: [ubuntu-*]
+
+environment:
+  SNAP_DIR: ../snaps/qmake-hello
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft pull

--- a/tests/spread/plugins/qmake/run/task.yaml
+++ b/tests/spread/plugins/qmake/run/task.yaml
@@ -1,0 +1,22 @@
+summary: Build and run a basic qmake snap
+
+environment:
+  SNAP_DIR: ../snaps/qmake-hello
+
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft
+  sudo snap install qmake-hello_*.snap --dangerous
+  [ "$(qmake-hello)" = "hello world" ]

--- a/tests/spread/plugins/qmake/snaps/qmake-hello/hello.c
+++ b/tests/spread/plugins/qmake/snaps/qmake-hello/hello.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main()
+{
+    printf("hello world\n");
+    return 0;
+}

--- a/tests/spread/plugins/qmake/snaps/qmake-hello/hello.pro
+++ b/tests/spread/plugins/qmake/snaps/qmake-hello/hello.pro
@@ -1,0 +1,4 @@
+CONFIG = console release
+SOURCES += hello.c
+target.path = /
+INSTALLS += target

--- a/tests/spread/plugins/qmake/snaps/qmake-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/qmake/snaps/qmake-hello/snap/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: qmake-hello
+version: "1.0"
+summary: test the qmake plugin
+description: |
+  This is a basic qmake snap. It just prints a hello world.
+  If you want to add other functionalities to this snap, please don't.
+  Make a new one.
+
+grade: devel
+confinement: strict
+
+apps:
+  qmake-hello:
+    command: hello
+
+parts:
+  project:
+    plugin: qmake
+    source: .

--- a/tests/unit/plugins/test_qmake.py
+++ b/tests/unit/plugins/test_qmake.py
@@ -15,11 +15,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import textwrap
 
 from unittest import mock
 from testtools.matchers import Equals, HasLength
 
 import snapcraft
+from snapcraft.internal import errors
 from snapcraft.plugins import qmake
 from tests import unit
 
@@ -28,7 +30,16 @@ class QMakeTestCase(unit.TestCase):
     def setUp(self):
         super().setUp()
 
-        self.project_options = snapcraft.ProjectOptions()
+        self.project = snapcraft.project.Project(
+            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
+                textwrap.dedent(
+                    """\
+                    name: test-snap
+                    base: core16
+                    """
+                )
+            )
+        )
 
         patcher = mock.patch("snapcraft.internal.common.run")
         self.run_mock = patcher.start()
@@ -197,17 +208,13 @@ class QMakeTestCase(unit.TestCase):
     def test_unsupported_qt_version(self):
         self.options.qt_version = "qt3"
         raised = self.assertRaises(
-            RuntimeError,
-            qmake.QmakePlugin,
-            "test-part",
-            self.options,
-            self.project_options,
+            RuntimeError, qmake.QmakePlugin, "test-part", self.options, self.project
         )
 
         self.assertThat(str(raised), Equals("Unsupported Qt version: 'qt3'"))
 
     def test_build_referencing_sourcedir_if_no_subdir(self):
-        plugin = qmake.QmakePlugin("test-part", self.options, self.project_options)
+        plugin = qmake.QmakePlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
         plugin.build()
 
@@ -226,7 +233,7 @@ class QMakeTestCase(unit.TestCase):
     def test_build_referencing_sourcedir_with_subdir(self):
         self.options.source_subdir = "subdir"
 
-        plugin = qmake.QmakePlugin("test-part", self.options, self.project_options)
+        plugin = qmake.QmakePlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
         plugin.build()
 
@@ -245,7 +252,7 @@ class QMakeTestCase(unit.TestCase):
     def test_build_with_project_file(self):
         self.options.project_files = ["project_file.pro"]
 
-        plugin = qmake.QmakePlugin("test-part", self.options, self.project_options)
+        plugin = qmake.QmakePlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
         plugin.build()
 
@@ -268,7 +275,7 @@ class QMakeTestCase(unit.TestCase):
         self.options.source_subdir = "subdir"
         self.options.project_files = ["project_file.pro"]
 
-        plugin = qmake.QmakePlugin("test-part", self.options, self.project_options)
+        plugin = qmake.QmakePlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
         plugin.build()
 
@@ -292,7 +299,7 @@ class QMakeTestCase(unit.TestCase):
     def test_build_with_options(self):
         self.options.options = ["-foo"]
 
-        plugin = qmake.QmakePlugin("test-part", self.options, self.project_options)
+        plugin = qmake.QmakePlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
         plugin.build()
 
@@ -309,7 +316,7 @@ class QMakeTestCase(unit.TestCase):
         )
 
     def test_build_with_libs_and_includes_in_installdir(self):
-        plugin = qmake.QmakePlugin("test-part", self.options, self.project_options)
+        plugin = qmake.QmakePlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
         os.makedirs(os.path.join(plugin.installdir, "include"))
         os.makedirs(os.path.join(plugin.installdir, "lib"))
@@ -336,7 +343,7 @@ class QMakeTestCase(unit.TestCase):
         )
 
     def test_build_with_libs_and_includes_in_stagedir(self):
-        plugin = qmake.QmakePlugin("test-part", self.options, self.project_options)
+        plugin = qmake.QmakePlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
         os.makedirs(os.path.join(plugin.project.stage_dir, "include"))
         os.makedirs(os.path.join(plugin.project.stage_dir, "lib"))
@@ -362,9 +369,32 @@ class QMakeTestCase(unit.TestCase):
             ]
         )
 
+    def test_unsupported_base(self):
+        project = snapcraft.project.Project(
+            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
+                textwrap.dedent(
+                    """\
+                    name: test-snap
+                    base: unsupported-base
+                    """
+                )
+            )
+        )
+
+        raised = self.assertRaises(
+            errors.PluginBaseError,
+            qmake.QmakePlugin,
+            "test-part",
+            self.options,
+            project,
+        )
+
+        self.assertThat(raised.part_name, Equals("test-part"))
+        self.assertThat(raised.base, Equals("unsupported-base"))
+
     def test_build_environment_qt4(self):
         self.options.qt_version = "qt4"
-        plugin = qmake.QmakePlugin("test-part", self.options, self.project_options)
+        plugin = qmake.QmakePlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
         plugin.build()
 
@@ -372,7 +402,7 @@ class QMakeTestCase(unit.TestCase):
 
     def test_build_environment_qt5(self):
         self.options.qt_version = "qt5"
-        plugin = qmake.QmakePlugin("test-part", self.options, self.project_options)
+        plugin = qmake.QmakePlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
         plugin.build()
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR resolves [LP: #1794799](https://bugs.launchpad.net/snapcraft/+bug/1794799) by updating the qmake plugin to be base-aware, limited to core16 and core18. It also creates a suite of spread tests for it.