### PR TITLE
tests: add spread test exercising multipass build VMs

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -186,9 +186,9 @@ Then, you can run them using a local LXD as the backend with:
 
     ./spread -v lxd:
 
-Or, you can run them in linode if you have a `SPREAD_LINODE_KEY`, with:
+Or, you can run them in google if you have a `SPREAD_GOOGLE_KEY`, with:
 
-    SPREAD_LINODE_KEY={key} ./spread -v linode:
+    SPREAD_GOOGLE_KEY={key} ./spread -v google:
 
 ## External snaps tests
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -26,12 +26,6 @@ backends:
     systems:
       - ubuntu-16.04
       - ubuntu-18.04
-  linode:
-    key: "$(HOST: echo $SPREAD_LINODE_KEY)"
-    systems:
-      - ubuntu-16.04-64:
-          kernel: GRUB 2
-          workers: 3
   google:
     key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
     location: computeengine/us-east1-b
@@ -40,8 +34,10 @@ backends:
           workers: 3
       - ubuntu-16.04-64:
           workers: 5
+          image: ubuntu-1604-64-nested-vm
       - ubuntu-18.04-64:
           workers: 8
+          image: ubuntu-1804-64-nested-vm
   autopkgtest:
     type: adhoc
     allocate: |
@@ -159,6 +155,10 @@ prepare: |
   fi
 
   apt-get install -y snapd
+
+  if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ] || [ "$SPREAD_SYSTEM" = "ubuntu-18.04-64" ]; then
+      sudo snap install --classic --beta multipass
+  fi
 
   if [ "$SNAPCRAFT_PACKAGE_TYPE" = "deb" ]; then
       apt-get install -y snapcraft

--- a/tests/spread/general/multipass/snaps/make-hello/Makefile
+++ b/tests/spread/general/multipass/snaps/make-hello/Makefile
@@ -1,0 +1,7 @@
+# -*- Mode: Makefile; indent-tabs-mode:t; tab-width: 4 -*-
+
+all:
+	gcc -o hello hello.c
+
+install:
+	install -D -m755 hello "$(DESTDIR)/bin/hello"

--- a/tests/spread/general/multipass/snaps/make-hello/hello.c
+++ b/tests/spread/general/multipass/snaps/make-hello/hello.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main()
+{
+	printf("hello world\n");
+	return 0;
+}

--- a/tests/spread/general/multipass/snaps/make-hello/snap/snapcraft.yaml
+++ b/tests/spread/general/multipass/snaps/make-hello/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: make-hello
+version: "1.0"
+summary: test the make plugin
+description: |
+  This is a basic make snap. It just prints a hello world.
+  If you want to add other functionalities to this snap, please don't.
+  Make a new one.
+
+grade: devel
+confinement: strict
+
+apps:
+  make-hello:
+    command: hello
+
+parts:
+  make-project:
+    plugin: make
+    source: .
+    build-packages: [gcc, libc6-dev]

--- a/tests/spread/general/multipass/task.yaml
+++ b/tests/spread/general/multipass/task.yaml
@@ -1,0 +1,31 @@
+summary: Build a basic snap using multipass and ensure that it runs
+warn-timeout: 9m  # Keep less than 10 minutes so Travis can't timeout
+priority: 90  # Run this test relatively early since fetching images can take time
+
+# Keep this 18.04 only for now as it is the only stable base.
+systems: [ubuntu-18.04-64]
+
+environment:
+  SNAP_DIR: snaps/make-hello
+
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "$SNAP_DIR"
+
+  # Ensure that snapcraft uses build VMs
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
+  snapcraft
+  sudo snap install make-hello_*.snap --dangerous
+  [ "$(make-hello)" = "hello world" ]

--- a/tests/spread/tools/restore.sh
+++ b/tests/spread/tools/restore.sh
@@ -7,7 +7,7 @@ apt-get autoremove --purge -y
 snaps="$(snap list | awk '{if (NR!=1) {print $1}}')"
 for snap in $snaps; do
 	case "$snap" in
-		"core" | "core16" | "core18" | "snapcraft")
+		"core" | "core16" | "core18" | "snapcraft" | "multipass")
 			# Do not or cannot remove these
 			;;
 		*)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR resolves [LP: #1798682](https://bugs.launchpad.net/snapcraft/+bug/1798682) by changing all amd64 Xenial and Bionic Spread tests to run on a GCE image with nested KVM enabled, and adding a test that uses multipass build VMs.

Hat tip to @sergiocazzolato who made this happen.