### PR TITLE
{kbuild,kernel} plugin: add support for bases

### DIFF
--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -65,14 +65,13 @@ import os
 import subprocess
 import re
 
-from snapcraft import BasePlugin
-
 import snapcraft
+from snapcraft.internal import errors
 
 logger = logging.getLogger(__name__)
 
 
-class KBuildPlugin(BasePlugin):
+class KBuildPlugin(snapcraft.BasePlugin):
     @classmethod
     def schema(cls):
         schema = super().schema()
@@ -102,6 +101,10 @@ class KBuildPlugin(BasePlugin):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
+
+        if project.info.base not in ("core16", "core18"):
+            raise errors.PluginBaseError(part_name=self.name, base=project.info.base)
+
         self.build_packages.extend(["bc", "gcc", "make"])
 
         self.make_targets = []

--- a/spread.yaml
+++ b/spread.yaml
@@ -222,6 +222,8 @@ suites:
    systems: [ubuntu-18.04*]
  tests/spread/plugins/kbuild/:
    summary: tests of snapcraft's Kbuild plugin
+   # Keep this 18.04 only for now as it is the only stable base.
+   systems: [ubuntu-18.04*]
  tests/spread/plugins/make/:
    # Keep this 18.04 only for now as it is the only stable base.
    systems: [ubuntu-18.04*]

--- a/tests/spread/plugins/kbuild/cross_compile/task.yaml
+++ b/tests/spread/plugins/kbuild/cross_compile/task.yaml
@@ -3,10 +3,17 @@ summary: Cross-compile a Kbuild snap
 environment:
   SNAP_DIR: ../snaps/kbuild-hello
 
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean
   rm -f ./*.snap
+
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
 
 execute: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/kbuild/legacy-pull/task.yaml
+++ b/tests/spread/plugins/kbuild/legacy-pull/task.yaml
@@ -1,0 +1,18 @@
+summary: |
+  Minimally ensure the plugin works without bases by running pull.
+  The plugin can be tested without bases in full through the legacy release of
+  snapcraft.
+
+systems: [ubuntu-*]
+
+environment:
+  SNAP_DIR: ../snaps/kbuild-hello
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft pull

--- a/tests/spread/plugins/kbuild/run/task.yaml
+++ b/tests/spread/plugins/kbuild/run/task.yaml
@@ -3,10 +3,17 @@ summary: Build and run a basic Kbuild snap
 environment:
   SNAP_DIR: ../snaps/kbuild-hello
 
+prepare: |
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean
   rm -f ./*.snap
+
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
 
 execute: |
   cd "$SNAP_DIR"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR resolves 
[LP: #1794790](https://bugs.launchpad.net/snapcraft/+bug/1794790) and [LP: #1794791](https://bugs.launchpad.net/snapcraft/+bug/1794791) by updating the KBuild plugin (and the Kernel plugin, which inherits from it) to support bases, specifically core16 and core18.