### PR TITLE
meta: add assumes if using "full" app adapter

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -531,6 +531,10 @@ class _SnapPackaging:
             self._validate_command_chain(snap_yaml["apps"])
 
         self._process_passthrough_properties(snap_yaml)
+        assumes = _determine_assumes(self._config_data)
+        if assumes:
+            # Sorting for consistent results (order doesn't matter)
+            snap_yaml["assumes"] = sorted(set(snap_yaml.get("assumes", [])) | assumes)
 
         return snap_yaml
 
@@ -722,6 +726,19 @@ class _SnapPackaging:
             raise meta_errors.AmbiguousPassthroughKeyError(duplicates)
         section.update(passthrough)
         return bool(passthrough)
+
+
+def _determine_assumes(yaml_data: Dict[str, Any]) -> Set[str]:
+    # Order doesn't really matter, but we don't want duplicates, so use a set
+    assumes = set()
+
+    # Check to see if any apps use the "full" adapter, which requires command-chain
+    for app in yaml_data.get("apps", dict()).values():
+        adapter = project_loader.Adapter[app["adapter"].upper()]
+        if adapter == project_loader.Adapter.FULL:
+            assumes.add("command-chain")
+
+    return assumes
 
 
 def _find_bin(binary, basedir):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Currently the snapcraft CLI supports a "full" app adapter that utilizes snapd's new `command-chain` functionality instead of app wrappers. However, `command-chain` still isn't contained within a stable snapd release. This PR resolves [LP: #1799295](https://bugs.launchpad.net/snapcraft/+bug/1799295) by, automatically adding an `assumes: [command-chain]` when using the "full" app adapter.

**Note:** This PR depends on https://github.com/snapcore/snapd/pull/6029, and assumes (heh) it will make it into v2.36. If it doesn't, we'll have to hard-code snapd versions instead, which isn't ideal since it's easy to lose track of what that means.