### PR TITLE
unit tests: missing full adapter in extension test

### DIFF
--- a/tests/unit/project_loader/extensions/test_extensions.py
+++ b/tests/unit/project_loader/extensions/test_extensions.py
@@ -69,6 +69,7 @@ class ExtensionCombinationTest(ProjectLoaderBaseTest):
                 apps:
                     test-app:
                         command: test-command
+                        adapter: full
                         extensions: {extensions}
 
                 parts:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

This should have been a part of #2375, but was missed.