### PR TITLE
project_loader: raise error if part in after is undefined

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -216,41 +216,6 @@ class InvalidDesktopFileError(SnapcraftError):
         super().__init__(filename=filename, message=message)
 
 
-class SnapcraftPartMissingError(SnapcraftError):
-
-    fmt = (
-        "Failed to get part information: "
-        "Cannot find the definition for part {part_name!r}. "
-        "If it is a remote part, run `snapcraft update` "
-        "to refresh the remote parts cache. "
-        "If it is a local part, make sure that it is defined in the "
-        "`snapcraft.yaml`."
-    )
-
-
-class RemotePartsError(SnapcraftError):
-    pass
-
-
-class PartNotInCacheError(RemotePartsError):
-
-    fmt = (
-        "Failed to get remote part information: "
-        "Cannot find the part name {part_name!r} in the cache. "
-        "If it is an existing remote part, run `snapcraft update` and try "
-        "again. If it has not been defined, consider going to "
-        "https://wiki.ubuntu.com/snapcraft/parts to add it."
-    )
-
-
-class RemotePartsUpdateConnectionError(RemotePartsError):
-
-    fmt = "Failed to update cache of remote parts: {message}\nPlease try again."
-
-    def __init__(self, requests_exception):
-        super().__init__(message=requests_exception.__doc__)
-
-
 class PluginError(SnapcraftError):
 
     fmt = (

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -78,11 +78,12 @@ class PartsConfig:
 
         for part in self.all_parts:
             dep_names = self.after_requests.get(part.name, [])
-            for dep in dep_names:
-                for i in range(len(self.all_parts)):
-                    if dep == self.all_parts[i].name:
-                        part.deps.append(self.all_parts[i])
-                        break
+            for dep_name in dep_names:
+                dep = self.get_part(dep_name)
+                if not dep:
+                    raise errors.SnapcraftAfterPartMissingError(part.name, dep_name)
+
+                part.deps.append(dep)
 
     def _sort_parts(self):
         """Performs an inneficient but easy to follow sorting of parts."""

--- a/snapcraft/internal/project_loader/errors.py
+++ b/snapcraft/internal/project_loader/errors.py
@@ -141,6 +141,20 @@ class ExtensionMissingDocumentationError(ProjectLoaderError):
         super().__init__(extension_name=extension_name)
 
 
+class SnapcraftAfterPartMissingError(ProjectLoaderError):
+
+    fmt = (
+        "Failed to get part information: "
+        "Cannot find the definition for part {after_part_name!r}, required by part "
+        "{part_name!r}.\n"
+        "Remote parts are not supported with bases, so make sure that this part is "
+        "defined in the `snapcraft.yaml`."
+    )
+
+    def __init__(self, part_name, after_part_name):
+        super().__init__(part_name=part_name, after_part_name=after_part_name)
+
+
 def _determine_preamble(error):
     messages = []
     path = _determine_property_path(error)

--- a/tests/unit/project_loader/test_parts.py
+++ b/tests/unit/project_loader/test_parts.py
@@ -41,6 +41,16 @@ class TestParts(ProjectLoaderBaseTest):
         project_config = self.make_snapcraft_project([("part1", dict(plugin="nil"))])
         self.assertThat(project_config.parts.get_part("not-a-part"), Equals(None))
 
+    def test_after_inexistent_part(self):
+        raised = self.assertRaises(
+            project_loader.errors.SnapcraftAfterPartMissingError,
+            self.make_snapcraft_project,
+            [("part1", dict(plugin="nil", after=["inexistent-part"]))],
+        )
+
+        self.assertThat(raised.part_name, Equals("part1"))
+        self.assertThat(raised.after_part_name, Equals("inexistent-part"))
+
 
 class PartOrderTestCase(ProjectLoaderBaseTest):
 

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -24,6 +24,7 @@ from snapcraft.internal import errors, pluginhandler, steps
 from snapcraft.internal.meta import _errors as meta_errors
 from snapcraft.internal.repo import errors as repo_errors
 from snapcraft.storeapi import errors as store_errors
+from snapcraft.internal.project_loader import errors as project_loader_errors
 from snapcraft.internal.project_loader.inspection import errors as inspection_errors
 from tests import unit
 
@@ -315,31 +316,16 @@ class ErrorFormattingTestCase(unit.TestCase):
             },
         ),
         (
-            "SnapcraftPartMissingError",
+            "SnapcraftAfterPartMissingError",
             {
-                "exception": errors.SnapcraftPartMissingError,
-                "kwargs": {"part_name": "test-part"},
+                "exception": project_loader_errors.SnapcraftAfterPartMissingError,
+                "kwargs": {"part_name": "test-part1", "after_part_name": "test-part2"},
                 "expected_message": (
                     "Failed to get part information: "
-                    "Cannot find the definition for part 'test-part'. "
-                    "If it is a remote part, run `snapcraft update` "
-                    "to refresh the remote parts cache. "
-                    "If it is a local part, make sure that it is defined in the "
-                    "`snapcraft.yaml`."
-                ),
-            },
-        ),
-        (
-            "PartNotInCacheError",
-            {
-                "exception": errors.PartNotInCacheError,
-                "kwargs": {"part_name": "test-part"},
-                "expected_message": (
-                    "Failed to get remote part information: "
-                    "Cannot find the part name 'test-part' in the cache. "
-                    "If it is an existing remote part, run `snapcraft update` "
-                    "and try again. If it has not been defined, consider going to "
-                    "https://wiki.ubuntu.com/snapcraft/parts to add it."
+                    "Cannot find the definition for part 'test-part2', required by "
+                    "part 'test-part1'.\n"
+                    "Remote parts are not supported with bases, so make sure that this "
+                    "part is defined in the `snapcraft.yaml`."
                 ),
             },
         ),
@@ -641,21 +627,6 @@ class ErrorFormattingTestCase(unit.TestCase):
                     "'libc6' is required inside the snap for this "
                     "part to work properly.\nAdd it as a `stage-packages` "
                     "entry for this part."
-                ),
-            },
-        ),
-        (
-            "RemotePartsUpdateConnectionError",
-            {
-                "exception": errors.RemotePartsUpdateConnectionError,
-                "kwargs": {
-                    "requests_exception": requests.exceptions.ConnectionError(
-                        "I'm a naughty error"
-                    )
-                },
-                "expected_message": (
-                    "Failed to update cache of remote parts: A Connection error "
-                    "occurred.\nPlease try again."
                 ),
             },
         ),


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

The removal of remote parts in 06532fe0cea61462f371c6a87439771bfa6d67d6 also removed the sanity checking of parts contained within the `after` keyword. As a result, the snapcraft CLI simply ignores part names specified in `after` that aren't defined in the `snapcraft.yaml`. This isn't very helpful, and also makes the migration from remote parts incredibly difficult since they magically don't work instead of erroring nicely.

This PR fixes [LP: #1799596](https://bugs.launchpad.net/snapcraft/+bug/1799596) by raising an error if a part specified in `after` isn't defined.