### PR TITLE
spread: change virt-enabled image name

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -34,10 +34,10 @@ backends:
           workers: 3
       - ubuntu-16.04-64:
           workers: 5
-          image: ubuntu-1604-64-nested-vm
+          image: ubuntu-1604-64-virt-enabled
       - ubuntu-18.04-64:
           workers: 8
-          image: ubuntu-1804-64-nested-vm
+          image: ubuntu-1804-64-virt-enabled
   autopkgtest:
     type: adhoc
     allocate: |


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
 @sergiocazzolato let me know that the virt-enabled image names will be changing this week. Update the `spread.yaml` to use the new names.