### PR TITLE
project: early snapcraft.yaml validation

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, List, Set  # noqa
 
 from snapcraft import file_utils, formatting_utils, yaml_utils
 from snapcraft import shell_utils
+from snapcraft.project import _schema
 from snapcraft.internal import common, errors, project_loader
 from snapcraft.internal.project_loader import _config
 from snapcraft.extractors import _metadata
@@ -103,7 +104,7 @@ def create_snap_packaging(project_config: _config.Config) -> str:
 
     # Now that we've updated config_data with random stuff extracted from
     # parts, re-validate it to ensure the it still conforms with the schema.
-    validator = project_loader.Validator(project_config.data)
+    validator = _schema.Validator(project_config.data)
     validator.validate(source="properties")
 
     # Update default values

--- a/snapcraft/internal/pluginhandler/_plugin_loader.py
+++ b/snapcraft/internal/pluginhandler/_plugin_loader.py
@@ -22,7 +22,7 @@ import sys
 import jsonschema
 
 import snapcraft
-from snapcraft.internal.project_loader.errors import YamlValidationError
+from snapcraft.project.errors import YamlValidationError
 from snapcraft.internal import errors
 
 logger = logging.getLogger(__name__)

--- a/snapcraft/internal/project_loader/__init__.py
+++ b/snapcraft/internal/project_loader/__init__.py
@@ -23,7 +23,6 @@ from ._env import (  # noqa: F401
     snapcraft_global_environment,
     snapcraft_part_environment,
 )
-from ._schema import Validator  # noqa: F401
 from ._parts_config import PartsConfig  # noqa: F401
 from ._extensions import (  # noqa: F401
     apply_extensions,

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -26,8 +26,7 @@ from typing import Set  # noqa: F401
 from snapcraft import project, formatting_utils
 from snapcraft.internal import deprecations, repo, states, steps
 from snapcraft.project._sanity_checks import conduct_environment_sanity_check
-
-from ._schema import Validator
+from snapcraft.project._schema import Validator
 from ._parts_config import PartsConfig
 from ._extensions import apply_extensions
 from ._env import (

--- a/snapcraft/internal/project_loader/_extensions/_utils.py
+++ b/snapcraft/internal/project_loader/_extensions/_utils.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Set, Type  # noqa: F401
 
 from .. import errors
 from ._extension import Extension
+from snapcraft.project import errors as project_errors
 
 logger = logging.getLogger(__name__)
 
@@ -209,8 +210,8 @@ def _validate_extension_format(extension_names):
                 extension_names, extension_schema, format_checker=format_check
             )
         except jsonschema.ValidationError as e:
-            raise errors.YamlValidationError(
+            raise project_errors.YamlValidationError(
                 "The 'extensions' property does not match the required schema: {}".format(
-                    errors.YamlValidationError.from_validation_error(e).message
+                    project_errors.YamlValidationError.from_validation_error(e).message
                 )
             )

--- a/snapcraft/internal/project_loader/errors.py
+++ b/snapcraft/internal/project_loader/errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017 Canonical Ltd
+# Copyright (C) 2017-2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,18 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import OrderedDict
-import contextlib
-
 import snapcraft.internal.errors
-from snapcraft import formatting_utils
-
-# dict of jsonschema validator -> cause pairs. Wish jsonschema just gave us
-# better messages.
-_VALIDATION_ERROR_CAUSES = {
-    "maxLength": "maximum length is {validator_value}",
-    "minLength": "minimum length is {validator_value}",
-}
 
 
 class ProjectLoaderError(snapcraft.internal.errors.SnapcraftError):
@@ -47,41 +36,6 @@ class DuplicateAliasError(ProjectLoaderError):
             self.aliases = ",".join(self.aliases)
 
         return super().__str__()
-
-
-class YamlValidationError(ProjectLoaderError):
-
-    fmt = "Issues while validating {source}: {message}"
-
-    @classmethod
-    def from_validation_error(cls, error, *, source="snapcraft.yaml"):
-        """Take a jsonschema.ValidationError and create a SnapcraftSchemaError.
-
-        The validation errors coming from jsonschema are a nightmare. This
-        class tries to make them a bit more understandable.
-        """
-
-        messages = []
-
-        preamble = _determine_preamble(error)
-        cause = _determine_cause(error)
-        supplement = _determine_supplemental_info(error)
-
-        if preamble:
-            messages.append(preamble)
-
-        if supplement:
-            messages.append(error.message)
-            messages.append("({})".format(supplement))
-        elif cause:
-            messages.append(cause)
-        else:
-            messages.append(error.message)
-
-        return cls(" ".join(messages), source)
-
-    def __init__(self, message, source="snapcraft.yaml"):
-        super().__init__(message=message, source=source)
 
 
 class SnapcraftLogicError(ProjectLoaderError):
@@ -153,101 +107,3 @@ class SnapcraftAfterPartMissingError(ProjectLoaderError):
 
     def __init__(self, part_name, after_part_name):
         super().__init__(part_name=part_name, after_part_name=after_part_name)
-
-
-def _determine_preamble(error):
-    messages = []
-    path = _determine_property_path(error)
-    if path:
-        messages.append(
-            "The '{}' property does not match the required schema:".format(
-                "/".join(path)
-            )
-        )
-    return " ".join(messages)
-
-
-def _determine_cause(error):
-    messages = []
-
-    # error.validator_value may contain a custom validation error message.
-    # If so, use it instead of the garbage message jsonschema gives us.
-    with contextlib.suppress(TypeError, KeyError):
-        messages.append(error.validator_value["validation-failure"].format(error))
-
-    # The schema itself may have a custom validation error message. If so,
-    # use it as well.
-    with contextlib.suppress(AttributeError, TypeError, KeyError):
-        key = error
-        if (
-            error.schema.get("type") == "object"
-            and error.validator == "additionalProperties"
-        ):
-            key = list(error.instance.keys())[0]
-
-        messages.append(error.schema["validation-failure"].format(key))
-
-    # anyOf failures might have usable context... try to improve them a bit
-    if error.validator == "anyOf":
-        contextual_messages = OrderedDict()  # type: Dict[str, str]
-        for contextual_error in error.context:
-            key = contextual_error.schema_path.popleft()
-            if key not in contextual_messages:
-                contextual_messages[key] = []
-            message = contextual_error.message
-            if message:
-                # Sure it starts lower-case (not all messages do)
-                contextual_messages[key].append(message[0].lower() + message[1:])
-
-        oneOf_messages = []  # type: List[str]
-        for key, value in contextual_messages.items():
-            oneOf_messages.append(formatting_utils.humanize_list(value, "and", "{}"))
-
-        messages.append(formatting_utils.humanize_list(oneOf_messages, "or", "{}"))
-
-    return " ".join(messages)
-
-
-def _determine_supplemental_info(error):
-    message = _VALIDATION_ERROR_CAUSES.get(error.validator, "").format(
-        validator_value=error.validator_value
-    )
-
-    if not message and error.validator == "anyOf":
-        message = _interpret_anyOf(error)
-
-    if not message and error.cause:
-        message = error.cause
-
-    return message
-
-
-def _determine_property_path(error):
-    path = []
-    while error.absolute_path:
-        element = error.absolute_path.popleft()
-        # assume numbers are indices and use 'xxx[123]' notation.
-        if isinstance(element, int):
-            path[-1] = "{}[{}]".format(path[-1], element)
-        else:
-            path.append(str(element))
-
-    return path
-
-
-def _interpret_anyOf(error):
-    """Interpret a validation error caused by the anyOf validator.
-
-    Returns:
-        A string containing a (hopefully) helpful validation error message. It
-        may be empty.
-    """
-
-    usages = []
-    try:
-        for validator in error.validator_value:
-            usages.append(validator["usage"])
-    except (TypeError, KeyError):
-        return ""
-
-    return "must be one of {}".format(formatting_utils.humanize_list(usages, "or"))

--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -21,6 +21,7 @@ from copy import deepcopy
 import yaml
 
 from snapcraft import yaml_utils
+from . import _schema
 from . import errors
 
 
@@ -45,6 +46,10 @@ class ProjectInfo:
         self.grade = self.__raw_snapcraft.get("grade")
         self.base = self.__raw_snapcraft.get("base")
         self.type = self.__raw_snapcraft.get("type")
+
+    def validate_raw_snapcraft(self):
+        """Validate the snapcraft.yaml for this project."""
+        _schema.Validator(self.__raw_snapcraft).validate()
 
     def get_raw_snapcraft(self):
         # TODO this should be a MappingProxyType, but ordered writing

--- a/snapcraft/project/_sanity_checks.py
+++ b/snapcraft/project/_sanity_checks.py
@@ -42,6 +42,11 @@ def conduct_project_sanity_check(project: Project) -> None:
 
     The checks done here are meant to be light, and not rely on the build environment.
     """
+    # The snapcraft.yaml should be valid even without extensions applied
+    # This here check is mostly for backwards compatibility with the
+    # rest of the code base.
+    if project.info is not None:
+        project.info.validate_raw_snapcraft()
 
     snap_dir_path = os.path.join(project._project_dir, "snap")
     if os.path.isdir(snap_dir_path):

--- a/snapcraft/project/_schema.py
+++ b/snapcraft/project/_schema.py
@@ -19,6 +19,7 @@ import os
 
 import jsonschema
 
+from . import errors
 from snapcraft import yaml_utils
 from snapcraft.internal import common
 
@@ -57,8 +58,6 @@ class Validator:
             with open(schema_file) as fp:
                 self._schema = yaml_utils.load(fp)
         except FileNotFoundError:
-            from snapcraft.internal.project_loader import errors
-
             raise errors.YamlValidationError(
                 "snapcraft validation file is missing from installation path"
             )
@@ -70,6 +69,4 @@ class Validator:
                 self._snapcraft, self._schema, format_checker=format_check
             )
         except jsonschema.ValidationError as e:
-            from snapcraft.internal.project_loader import errors
-
             raise errors.YamlValidationError.from_validation_error(e, source=source)

--- a/snapcraft/project/errors.py
+++ b/snapcraft/project/errors.py
@@ -14,7 +14,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import contextlib
+from collections import OrderedDict
+
+from snapcraft import formatting_utils
 from snapcraft.internal.errors import SnapcraftError
+
+
+# dict of jsonschema validator -> cause pairs. Wish jsonschema just gave us
+# better messages.
+_VALIDATION_ERROR_CAUSES = {
+    "maxLength": "maximum length is {validator_value}",
+    "minLength": "minimum length is {validator_value}",
+}
 
 
 class MissingSnapcraftYamlError(SnapcraftError):
@@ -32,6 +44,33 @@ class MissingSnapcraftYamlError(SnapcraftError):
 class YamlValidationError(SnapcraftError):
 
     fmt = "Issues while validating {source}: {message}"
+
+    @classmethod
+    def from_validation_error(cls, error, *, source="snapcraft.yaml"):
+        """Take a jsonschema.ValidationError and create a SnapcraftSchemaError.
+
+        The validation errors coming from jsonschema are a nightmare. This
+        class tries to make them a bit more understandable.
+        """
+
+        messages = []
+
+        preamble = _determine_preamble(error)
+        cause = _determine_cause(error)
+        supplement = _determine_supplemental_info(error)
+
+        if preamble:
+            messages.append(preamble)
+
+        if supplement:
+            messages.append(error.message)
+            messages.append("({})".format(supplement))
+        elif cause:
+            messages.append(cause)
+        else:
+            messages.append(error.message)
+
+        return cls(" ".join(messages), source)
 
     def __init__(self, message, source="snapcraft.yaml"):
         super().__init__(message=message, source=source)
@@ -69,3 +108,101 @@ class CommandChainWithLegacyAdapterError(SanityCheckError):
 
     def __init__(self, app_name):
         super().__init__(app_name=app_name)
+
+
+def _determine_preamble(error):
+    messages = []
+    path = _determine_property_path(error)
+    if path:
+        messages.append(
+            "The '{}' property does not match the required schema:".format(
+                "/".join(path)
+            )
+        )
+    return " ".join(messages)
+
+
+def _determine_cause(error):
+    messages = []
+
+    # error.validator_value may contain a custom validation error message.
+    # If so, use it instead of the garbage message jsonschema gives us.
+    with contextlib.suppress(TypeError, KeyError):
+        messages.append(error.validator_value["validation-failure"].format(error))
+
+    # The schema itself may have a custom validation error message. If so,
+    # use it as well.
+    with contextlib.suppress(AttributeError, TypeError, KeyError):
+        key = error
+        if (
+            error.schema.get("type") == "object"
+            and error.validator == "additionalProperties"
+        ):
+            key = list(error.instance.keys())[0]
+
+        messages.append(error.schema["validation-failure"].format(key))
+
+    # anyOf failures might have usable context... try to improve them a bit
+    if error.validator == "anyOf":
+        contextual_messages = OrderedDict()  # type: Dict[str, str]
+        for contextual_error in error.context:
+            key = contextual_error.schema_path.popleft()
+            if key not in contextual_messages:
+                contextual_messages[key] = []
+            message = contextual_error.message
+            if message:
+                # Sure it starts lower-case (not all messages do)
+                contextual_messages[key].append(message[0].lower() + message[1:])
+
+        oneOf_messages = []  # type: List[str]
+        for key, value in contextual_messages.items():
+            oneOf_messages.append(formatting_utils.humanize_list(value, "and", "{}"))
+
+        messages.append(formatting_utils.humanize_list(oneOf_messages, "or", "{}"))
+
+    return " ".join(messages)
+
+
+def _determine_supplemental_info(error):
+    message = _VALIDATION_ERROR_CAUSES.get(error.validator, "").format(
+        validator_value=error.validator_value
+    )
+
+    if not message and error.validator == "anyOf":
+        message = _interpret_anyOf(error)
+
+    if not message and error.cause:
+        message = error.cause
+
+    return message
+
+
+def _determine_property_path(error):
+    path = []
+    while error.absolute_path:
+        element = error.absolute_path.popleft()
+        # assume numbers are indices and use 'xxx[123]' notation.
+        if isinstance(element, int):
+            path[-1] = "{}[{}]".format(path[-1], element)
+        else:
+            path.append(str(element))
+
+    return path
+
+
+def _interpret_anyOf(error):
+    """Interpret a validation error caused by the anyOf validator.
+
+    Returns:
+        A string containing a (hopefully) helpful validation error message. It
+        may be empty.
+    """
+
+    usages = []
+    try:
+        for validator in error.validator_value:
+            usages.append(validator["usage"])
+    except (TypeError, KeyError):
+        return ""
+
+    return "must be one of {}".format(formatting_utils.humanize_list(usages, "or"))

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -28,6 +28,7 @@ import testscenarios
 import testtools
 
 import snapcraft
+from snapcraft.project import _schema
 from snapcraft.internal import common, elf, steps
 from snapcraft.internal.project_loader import grammar_processing
 from tests import fake_servers, fixture_setup
@@ -251,7 +252,7 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         if not project_options:
             project_options = snapcraft.ProjectOptions()
 
-        validator = snapcraft.internal.project_loader.Validator()
+        validator = _schema.Validator()
         schema = validator.part_schema
         definitions_schema = validator.definitions_schema
         plugin = snapcraft.internal.pluginhandler.load_plugin(

--- a/tests/unit/commands/test_build_providers.py
+++ b/tests/unit/commands/test_build_providers.py
@@ -14,16 +14,55 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from unittest import mock
 from typing import Optional
+from unittest import mock
 
 import fixtures
 from testtools.matchers import Equals
 
 from . import LifecycleCommandsBaseTestCase
-from tests.unit.build_providers import ProviderImpl
+from snapcraft import project
 from snapcraft.internal import steps
 from snapcraft.internal.build_providers.errors import ProviderExecError
+from tests import fixture_setup
+from tests.unit.build_providers import ProviderImpl
+
+
+class BuildProviderYamlValidationTest(LifecycleCommandsBaseTestCase):
+    scenarios = (("core18", dict(base="core18")), ("no base", dict(base=None)))
+
+    def setUp(self):
+        super().setUp()
+        self.useFixture(
+            fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT", "multipass")
+        )
+
+        patcher = mock.patch(
+            "snapcraft.internal.build_providers.get_provider_for",
+            return_value=ProviderImpl,
+        )
+        self.provider = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.make_snapcraft_yaml("test-part", base=self.base)
+
+    def test_validation_passes(self):
+        snapcraft_yaml = fixture_setup.SnapcraftYaml(self.path)
+        snapcraft_yaml.update_part("part1", dict(plugin="nil"))
+        self.useFixture(snapcraft_yaml)
+
+        result = self.run_command(["pull"])
+
+        self.assertThat(result.exit_code, Equals(0))
+
+    def test_validation_fails(self):
+        snapcraft_yaml = fixture_setup.SnapcraftYaml(self.path, name="name with spaces")
+        snapcraft_yaml.update_part("part1", dict(plugin="nil"))
+        self.useFixture(snapcraft_yaml)
+
+        self.assertRaises(
+            project.errors.YamlValidationError, self.run_command, ["pull"]
+        )
 
 
 class BuildProviderDebugCommandTestCase(LifecycleCommandsBaseTestCase):

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -16,17 +16,17 @@
 
 import logging
 import os
-import os.path
 import subprocess
 from textwrap import dedent
 from unittest import mock
-import snapcraft.internal.errors
-import snapcraft.internal.project_loader.errors
 
 import fixtures
 from testtools.matchers import Contains, Equals, FileContains, FileExists, Not
-from tests import fixture_setup
+
 from . import CommandBaseTestCase
+from snapcraft.internal import errors
+from snapcraft.project.errors import YamlValidationError
+from tests import fixture_setup
 
 
 class SnapCommandBaseTestCase(CommandBaseTestCase):
@@ -106,11 +106,7 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
     def test_snap_fails_with_bad_type(self):
         self.make_snapcraft_yaml(snap_type="bad-type")
 
-        raised = self.assertRaises(
-            snapcraft.internal.project_loader.errors.YamlValidationError,
-            self.run_command,
-            ["snap"],
-        )
+        raised = self.assertRaises(YamlValidationError, self.run_command, ["snap"])
 
         self.assertThat(
             str(raised),
@@ -405,9 +401,7 @@ type: os
             )
         )
 
-        raised = self.assertRaises(
-            snapcraft.internal.errors.PluginError, self.run_command, ["snap"]
-        )
+        raised = self.assertRaises(errors.PluginError, self.run_command, ["snap"])
 
         self.assertThat(raised.message, Equals("unknown plugin: 'does-not-exist'"))
 

--- a/tests/unit/project/__init__.py
+++ b/tests/unit/project/__init__.py
@@ -1,0 +1,42 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from snapcraft.project import Project as _Project
+from snapcraft.project import errors
+from tests import unit
+
+
+class ProjectBaseTest(unit.TestCase):
+    def make_snapcraft_project(self, snapcraft_yaml, project_kwargs=None):
+        snapcraft_yaml_file_path = self.make_snapcraft_yaml(snapcraft_yaml)
+        if project_kwargs is None:
+            project_kwargs = dict()
+        return _Project(
+            snapcraft_yaml_file_path=snapcraft_yaml_file_path, **project_kwargs
+        )
+
+    def assertValidationPasses(self, snapcraft_yaml):
+        project = self.make_snapcraft_project(snapcraft_yaml)
+        project.info.validate_raw_snapcraft()
+
+        return project.info.get_raw_snapcraft()
+
+    def assertValidationRaises(self, snapcraft_yaml):
+        project = self.make_snapcraft_project(snapcraft_yaml)
+
+        return self.assertRaises(
+            errors.YamlValidationError, project.info.validate_raw_snapcraft
+        )

--- a/tests/unit/project/test_sanity_checks.py
+++ b/tests/unit/project/test_sanity_checks.py
@@ -25,8 +25,7 @@ from snapcraft.project._sanity_checks import (
     conduct_project_sanity_check,
     conduct_environment_sanity_check,
 )
-from snapcraft.internal import project_loader
-from snapcraft.project import errors
+from snapcraft.project import errors, _schema
 
 from tests import unit
 
@@ -151,7 +150,7 @@ class EnvironmentSanityChecksTest(unit.TestCase):
 
         try:
             conduct_environment_sanity_check(
-                project, yaml_data, project_loader.Validator().schema
+                project, yaml_data, _schema.Validator().schema
             )
         except Exception:
             self.fail("No exception was expected")
@@ -166,7 +165,7 @@ class EnvironmentSanityChecksTest(unit.TestCase):
 
         try:
             conduct_environment_sanity_check(
-                project, yaml_data, project_loader.Validator().schema
+                project, yaml_data, _schema.Validator().schema
             )
         except Exception:
             self.fail("No exception was expected")
@@ -182,7 +181,7 @@ class EnvironmentSanityChecksTest(unit.TestCase):
             conduct_environment_sanity_check,
             project,
             yaml_data,
-            project_loader.Validator().schema,
+            _schema.Validator().schema,
         )
 
         self.assertThat(raised.app_name, Equals("test-app"))
@@ -203,7 +202,7 @@ class EnvironmentSanityChecksTest(unit.TestCase):
             conduct_environment_sanity_check,
             project,
             yaml_data,
-            project_loader.Validator().schema,
+            _schema.Validator().schema,
         )
 
         self.assertThat(raised.app_name, Equals("test-app"))

--- a/tests/unit/project_loader/extensions/test_utils.py
+++ b/tests/unit/project_loader/extensions/test_utils.py
@@ -18,6 +18,7 @@ import textwrap
 
 from testtools.matchers import Contains, Equals, Not
 
+from snapcraft.project import errors as project_errors
 from snapcraft.internal.project_loader import errors
 from snapcraft.internal.project_loader._extensions._extension import Extension
 
@@ -392,7 +393,7 @@ class ExtensionRootMergeTest(ExtensionTestBase):
 class InvalidExtensionTest(ExtensionTestBase):
     def test_invalid_app_extension_format(self):
         raised = self.assertRaises(
-            errors.YamlValidationError,
+            project_errors.YamlValidationError,
             self.make_snapcraft_project,
             textwrap.dedent(
                 """\
@@ -426,7 +427,7 @@ class InvalidExtensionTest(ExtensionTestBase):
 
     def test_duplicate_extensions(self):
         raised = self.assertRaises(
-            errors.YamlValidationError,
+            project_errors.YamlValidationError,
             self.make_snapcraft_project,
             textwrap.dedent(
                 """\
@@ -460,7 +461,7 @@ class InvalidExtensionTest(ExtensionTestBase):
 
     def test_invalid_extension_is_validated(self):
         raised = self.assertRaises(
-            errors.YamlValidationError,
+            project_errors.YamlValidationError,
             self.make_snapcraft_project,
             textwrap.dedent(
                 """\

--- a/tests/unit/project_loader/test_schema.py
+++ b/tests/unit/project_loader/test_schema.py
@@ -1,0 +1,301 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from textwrap import dedent
+
+import fixtures
+from testscenarios.scenarios import multiply_scenarios
+from testtools.matchers import Contains, Equals
+
+from . import ProjectLoaderBaseTest
+from snapcraft.internal.errors import PluginError
+from snapcraft.internal.project_loader import errors, load_config
+from snapcraft import project
+from tests import fixture_setup
+
+
+class ValidArchitecturesTest(ProjectLoaderBaseTest):
+
+    yaml_scenarios = [
+        (
+            "none",
+            {
+                "expected_amd64": ["amd64"],
+                "expected_i386": ["i386"],
+                "expected_armhf": ["armhf"],
+                "yaml": None,
+            },
+        ),
+        (
+            "single string list",
+            {
+                "expected_amd64": ["amd64"],
+                "expected_i386": ["i386"],
+                "expected_armhf": ["armhf"],
+                "yaml": "[amd64]",
+            },
+        ),
+        (
+            "multiple string list",
+            {
+                "expected_amd64": ["amd64", "i386"],
+                "expected_i386": ["amd64", "i386"],
+                "expected_armhf": ["armhf"],
+                "yaml": "[amd64, i386]",
+            },
+        ),
+        (
+            "single object list",
+            {
+                "expected_amd64": ["amd64"],
+                "expected_i386": ["i386"],
+                "expected_armhf": ["armhf"],
+                "yaml": dedent(
+                    """
+                - build-on: [amd64]
+                  run-on: [amd64]
+            """
+                ),
+            },
+        ),
+        (
+            "multiple object list",
+            {
+                "expected_amd64": ["amd64"],
+                "expected_i386": ["i386"],
+                "expected_armhf": ["armhf", "arm64"],
+                "yaml": dedent(
+                    """
+                - build-on: [amd64]
+                  run-on: [amd64]
+                - build-on: [i386]
+                  run-on: [i386]
+                - build-on: [armhf]
+                  run-on: [armhf, arm64]
+            """
+                ),
+            },
+        ),
+        (
+            "omit run-on",
+            {
+                "expected_amd64": ["amd64"],
+                "expected_i386": ["i386"],
+                "expected_armhf": ["armhf"],
+                "yaml": dedent(
+                    """
+                - build-on: [amd64]
+            """
+                ),
+            },
+        ),
+        (
+            "single build-on string, no list",
+            {
+                "expected_amd64": ["amd64"],
+                "expected_i386": ["i386"],
+                "expected_armhf": ["armhf"],
+                "yaml": dedent(
+                    """
+                - build-on: amd64
+            """
+                ),
+            },
+        ),
+        (
+            "build- and run-on string, no lists",
+            {
+                "expected_amd64": ["amd64"],
+                "expected_i386": ["amd64"],
+                "expected_armhf": ["armhf"],
+                "yaml": dedent(
+                    """
+                - build-on: i386
+                  run-on: amd64
+            """
+                ),
+            },
+        ),
+        (
+            "build on all",
+            {
+                "expected_amd64": ["amd64"],
+                "expected_i386": ["amd64"],
+                "expected_armhf": ["amd64"],
+                "yaml": dedent(
+                    """
+                - build-on: [all]
+                  run-on: [amd64]
+            """
+                ),
+            },
+        ),
+        (
+            "run on all",
+            {
+                "expected_amd64": ["all"],
+                "expected_i386": ["i386"],
+                "expected_armhf": ["armhf"],
+                "yaml": dedent(
+                    """
+                - build-on: [amd64]
+                  run-on: [all]
+            """
+                ),
+            },
+        ),
+    ]
+
+    arch_scenarios = [
+        ("amd64", {"target_arch": "amd64"}),
+        ("i386", {"target_arch": "i386"}),
+        ("armhf", {"target_arch": "armhf"}),
+    ]
+
+    scenarios = multiply_scenarios(yaml_scenarios, arch_scenarios)
+
+    def test_architectures(self):
+        snippet = ""
+        if self.yaml:
+            snippet = "architectures: {}".format(self.yaml)
+        snapcraft_yaml = dedent(
+            """\
+            name: test
+            base: core18
+            version: "1"
+            summary: test
+            description: test
+            {}
+            parts:
+              my-part:
+                plugin: nil
+        """
+        ).format(snippet)
+
+        try:
+            project_kwargs = dict(target_deb_arch=self.target_arch)
+            c = self.make_snapcraft_project(snapcraft_yaml, project_kwargs)
+
+            expected = getattr(self, "expected_{}".format(self.target_arch))
+            self.assertThat(c.data["architectures"], Equals(expected))
+        except errors.YamlValidationError as e:
+            self.fail("Expected YAML to be valid, got an error: {}".format(e))
+
+
+class AliasesTest(ProjectLoaderBaseTest):
+    def make_snapcraft_project(self, apps):
+        snapcraft_yaml = fixture_setup.SnapcraftYaml(self.path)
+        snapcraft_yaml.update_part("part1", dict(plugin="nil"))
+        for app_name, app in apps:
+            snapcraft_yaml.update_app(app_name, app)
+        self.useFixture(snapcraft_yaml)
+
+        p = project.Project(
+            snapcraft_yaml_file_path=snapcraft_yaml.snapcraft_yaml_file_path
+        )
+        return load_config(p)
+
+    def test_aliases(self,):
+        fake_logger = fixtures.FakeLogger(level=logging.WARNING)
+        self.useFixture(fake_logger)
+
+        apps = [("test", dict(command="test", aliases=["test-it", "testing"]))]
+        c = self.make_snapcraft_project(apps)
+
+        self.maxDiff = None
+
+        self.assertTrue(
+            "aliases" in c.data["apps"]["test"],
+            'Expected "aliases" property to be in snapcraft.yaml',
+        )
+        self.assertThat(
+            c.data["apps"]["test"]["aliases"], Equals(["test-it", "testing"])
+        )
+
+        # Verify that aliases are properly deprecated
+        self.assertThat(
+            fake_logger.output,
+            Contains(
+                "Aliases are now handled by the store, and shouldn't be declared "
+                "in the snap."
+            ),
+        )
+        self.assertThat(
+            fake_logger.output,
+            Contains("See http://snapcraft.io/docs/deprecation-notices/dn5"),
+        )
+
+    def test_duplicate_aliases(self):
+        apps = [
+            ("test1", dict(command="test", aliases=["testing"])),
+            ("test2", dict(command="test", aliases=["testing"])),
+        ]
+        raised = self.assertRaises(
+            errors.DuplicateAliasError, self.make_snapcraft_project, apps
+        )
+
+        self.assertThat(
+            str(raised),
+            Equals(
+                "Multiple parts have the same alias defined: {!r}".format("testing")
+            ),
+        )
+
+    def test_invalid_alias(self):
+        apps = [("test", dict(command="test", aliases=[".test"]))]
+        raised = self.assertRaises(
+            project.errors.YamlValidationError, self.make_snapcraft_project, apps
+        )
+        expected = (
+            "The {path!r} property does not match the required schema: "
+            "{alias!r} does not match ".format(
+                path="apps/test/aliases[0]", alias=".test"
+            )
+        )
+        self.assertThat(str(raised), Contains(expected))
+
+
+class AdditionalPartPropertiesTest(ProjectLoaderBaseTest):
+
+    scenarios = [("slots", dict(property="slots")), ("plugs", dict(property="plugs"))]
+
+    def test_loading_properties(self):
+        snapcraft_yaml = dedent(
+            """\
+            name: my-package-1
+            base: core18
+            version: 1.0-snapcraft1~ppa1
+            summary: my summary less that 79 chars
+            description: description which can be pretty long
+            parts:
+                part1:
+                    plugin: nil
+                    {property}: [{property}1]
+        """
+        ).format(property=self.property)
+
+        raised = self.assertRaises(
+            PluginError, self.make_snapcraft_project, snapcraft_yaml
+        )
+
+        self.assertThat(
+            raised.message,
+            Equals(
+                "properties failed to load for part1: Additional properties are "
+                "not allowed ('{}' was unexpected)".format(self.property)
+            ),
+        )

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -37,6 +37,7 @@ from testtools.matchers import (
 from snapcraft.internal.meta import _errors as meta_errors, _snap_packaging
 from snapcraft import extractors, yaml_utils
 from snapcraft.project import Project
+from snapcraft.project import errors as project_errors
 from snapcraft.internal import errors
 from snapcraft.internal import project_loader
 from tests import unit, fixture_setup
@@ -1000,9 +1001,7 @@ class InvalidMetadataTestCase(CreateMetadataFromSourceBaseTestCase):
         ] = "snapcraftctl {} {}".format(self.setter, self.value)
 
         raised = self.assertRaises(
-            project_loader.errors.YamlValidationError,
-            self.generate_meta_yaml,
-            build=True,
+            project_errors.YamlValidationError, self.generate_meta_yaml, build=True
         )
         self.assertThat(
             str(raised),
@@ -1022,9 +1021,7 @@ class InvalidMetadataTestCase(CreateMetadataFromSourceBaseTestCase):
         self.useFixture(fixture_setup.FakeMetadataExtractor("fake", _fake_extractor))
 
         raised = self.assertRaises(
-            project_loader.errors.YamlValidationError,
-            self.generate_meta_yaml,
-            build=True,
+            project_errors.YamlValidationError, self.generate_meta_yaml, build=True
         )
         self.assertThat(
             str(raised),


### PR DESCRIPTION
Avoid creating and invalid multipass instance by doing an early
validation of snapcraft.yaml. This has the benefit of faster turnaround
times too.

LP: #1794507

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
