### PR TITLE
repo: run `apt update` before `apt install`

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -331,13 +331,15 @@ class Ubuntu(BaseRepo):
             {"DEBIAN_FRONTEND": "noninteractive", "DEBCONF_NONINTERACTIVE_SEEN": "true"}
         )
 
-        apt_command = ["sudo", "apt-get", "--no-install-recommends", "-y"]
+        apt_command = ["sudo", "apt-get", "-y"]
         if not is_dumb_terminal():
             apt_command.extend(["-o", "Dpkg::Progress-Fancy=1"])
-        apt_command.append("install")
+        apt_update = apt_command + ["update"]
+        apt_install = apt_command + ["--no-install-recommends", "install"]
 
         try:
-            subprocess.check_call(apt_command + package_names, env=env)
+            subprocess.check_call(apt_update, env=env)
+            subprocess.check_call(apt_install + package_names, env=env)
         except subprocess.CalledProcessError:
             raise errors.BuildPackagesNotInstalledError(packages=package_names)
 

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -379,8 +379,15 @@ class BuildPackagesTestCase(unit.TestCase):
         mock_check_call.assert_has_calls(
             [
                 call(
-                    "sudo apt-get --no-install-recommends -y "
-                    "-o Dpkg::Progress-Fancy=1 install".split()
+                    "sudo apt-get -y -o Dpkg::Progress-Fancy=1 update".split(),
+                    env={
+                        "DEBIAN_FRONTEND": "noninteractive",
+                        "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                    }
+                ),
+                call(
+                    "sudo apt-get -y -o Dpkg::Progress-Fancy=1 "
+                    "--no-install-recommends install".split()
                     + sorted(set(installable)),
                     env={
                         "DEBIAN_FRONTEND": "noninteractive",
@@ -392,7 +399,7 @@ class BuildPackagesTestCase(unit.TestCase):
 
     @patch("snapcraft.repo._deb.is_dumb_terminal")
     @patch("subprocess.check_call")
-    def test_install_buid_package_in_dumb_terminal(
+    def test_install_build_package_in_dumb_terminal(
         self, mock_check_call, mock_is_dumb_terminal
     ):
         mock_is_dumb_terminal.return_value = True
@@ -402,7 +409,14 @@ class BuildPackagesTestCase(unit.TestCase):
         mock_check_call.assert_has_calls(
             [
                 call(
-                    "sudo apt-get --no-install-recommends -y install".split()
+                    "sudo apt-get -y update".split(),
+                    env={
+                        "DEBIAN_FRONTEND": "noninteractive",
+                        "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                    }
+                ),
+                call(
+                    "sudo apt-get -y --no-install-recommends install".split()
                     + sorted(set(installable)),
                     env={
                         "DEBIAN_FRONTEND": "noninteractive",

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -383,7 +383,7 @@ class BuildPackagesTestCase(unit.TestCase):
                     env={
                         "DEBIAN_FRONTEND": "noninteractive",
                         "DEBCONF_NONINTERACTIVE_SEEN": "true",
-                    }
+                    },
                 ),
                 call(
                     "sudo apt-get -y -o Dpkg::Progress-Fancy=1 "
@@ -393,7 +393,7 @@ class BuildPackagesTestCase(unit.TestCase):
                         "DEBIAN_FRONTEND": "noninteractive",
                         "DEBCONF_NONINTERACTIVE_SEEN": "true",
                     },
-                )
+                ),
             ]
         )
 
@@ -413,7 +413,7 @@ class BuildPackagesTestCase(unit.TestCase):
                     env={
                         "DEBIAN_FRONTEND": "noninteractive",
                         "DEBCONF_NONINTERACTIVE_SEEN": "true",
-                    }
+                    },
                 ),
                 call(
                     "sudo apt-get -y --no-install-recommends install".split()
@@ -422,7 +422,7 @@ class BuildPackagesTestCase(unit.TestCase):
                         "DEBIAN_FRONTEND": "noninteractive",
                         "DEBCONF_NONINTERACTIVE_SEEN": "true",
                     },
-                )
+                ),
             ]
         )
 


### PR DESCRIPTION
Fix installation failures due to expired package indexes.
Greatly affects `snapcraft` Docker images.

https://forum.snapcraft.io/t/ant-and-others-fails-using-docker-image/7673

Signed-off-by: Anatoli Babenia <anatoli@rainforce.org>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
