### PR TITLE
runtests: run black with --diff

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -61,7 +61,7 @@ coverage 1>/dev/null 2>&1 && coverage="true"
 
 run_static_tests(){
     echo "Running black"
-    black --check .
+    black --check --diff .
 
     echo "Running flake8"
     python3 -m flake8 .


### PR DESCRIPTION
This helps to see the exact error and save some time on checking out and rerunning the check locally.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
