### PR TITLE
lifecycle: make snapcraft init template use > not |

### DIFF
--- a/snapcraft/internal/lifecycle/_init.py
+++ b/snapcraft/internal/lifecycle/_init.py
@@ -25,7 +25,7 @@ _TEMPLATE_YAML = dedent(
     name: my-snap-name # you probably want to 'snapcraft register <name>'
     version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
     summary: Single-line elevator pitch for your amazing snap # 79 char long summary
-    description: |
+    description: >
       This is my-snap's description. You have a paragraph or two to tell the
       most important story about your snap. Keep it under 100 words though,
       we live in tweetspace and your description wants to look good in the snap

--- a/tests/unit/commands/test_init.py
+++ b/tests/unit/commands/test_init.py
@@ -26,7 +26,7 @@ class InitCommandTestCase(CommandBaseTestCase):
         expected_yaml = """name: my-snap-name # you probably want to 'snapcraft register <name>'
 version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
 summary: Single-line elevator pitch for your amazing snap # 79 char long summary
-description: |
+description: >
   This is my-snap's description. You have a paragraph or two to tell the
   most important story about your snap. Keep it under 100 words though,
   we live in tweetspace and your description wants to look good in the snap


### PR DESCRIPTION
snapcraft init should use > (folded style) not | (literal style) for the description

- [ :heavy_check_mark: ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ :heavy_check_mark: ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ :heavy_check_mark:  ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)? [lp:1801973](https://bugs.launchpad.net/snapcraft/+bug/1801973)
- [ N/A ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ :heavy_check_mark: ] Have you successfully run `./runtests.sh static`?
- [ :x: ] Have you successfully run `./runtests.sh tests/unit`? - existing tests fail for me, but confirmed that relevant tests pass

-----
