### PR TITLE
Partial Revert "build providers: fix osx non base and injection"

### DIFF
--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -20,7 +20,7 @@ import shlex
 from typing import Dict, Sequence
 
 from .. import errors
-from .._base_provider import Provider, _get_platform
+from .._base_provider import Provider
 from ._instance_info import InstanceInfo
 from ._multipass_command import MultipassCommand
 from snapcraft.internal.errors import SnapcraftEnvironmentError
@@ -191,21 +191,13 @@ class Multipass(Provider):
         )
         project_mountpoint = os.path.join(home_dir, "project")
 
-        # The mapping only makes sense on Linux
-        if _get_platform() == "linux":
-            uid_map = {str(os.getuid()): "0"}
-            gid_map = {str(os.getgid()): "0"}
-        else:
-            uid_map = None
-            gid_map = None
-
         # multipass keeps the mount active, so check if it is there first.
         if not self._instance_info.is_mounted(project_mountpoint):
             self._mount(
                 mountpoint=project_mountpoint,
                 dev_or_path=self.project._project_dir,
-                uid_map=uid_map,
-                gid_map=gid_map,
+                uid_map={str(os.getuid()): "0"},
+                gid_map={str(os.getgid()): "0"},
             )
 
     def provision_project(self, tarball: str) -> None:

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -391,13 +391,6 @@ class MultipassWithBasesTest(BaseProviderWithBasesBaseTest):
         super().setUp()
 
         patcher = mock.patch(
-            "snapcraft.internal.build_providers._multipass._multipass._get_platform",
-            return_value=self.platform,
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
-
-        patcher = mock.patch(
             "snapcraft.internal.build_providers._multipass."
             "_multipass.MultipassCommand",
             spec=MultipassCommand,

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -371,43 +371,19 @@ class MultipassWithBasesTest(BaseProviderWithBasesBaseTest):
     scenarios = (
         (
             "linux",
-            dict(
-                platform="linux",
-                base="core16",
-                expected_uid_map={str(os.getuid()): "0"},
-                expected_gid_map={str(os.getgid()): "0"},
-                expected_image="snapcraft:core16",
-            ),
+            dict(platform="linux", base="core16", expected_image="snapcraft:core16"),
         ),
         (
             "linux",
-            dict(
-                platform="linux",
-                base="core18",
-                expected_uid_map={str(os.getuid()): "0"},
-                expected_gid_map={str(os.getgid()): "0"},
-                expected_image="snapcraft:core18",
-            ),
+            dict(platform="linux", base="core18", expected_image="snapcraft:core18"),
         ),
         (
             "darwin",
-            dict(
-                platform="darwin",
-                base="core18",
-                expected_uid_map=None,
-                expected_gid_map=None,
-                expected_image="snapcraft:core18",
-            ),
+            dict(platform="darwin", base="core18", expected_image="snapcraft:core18"),
         ),
         (
             "darwin",
-            dict(
-                platform="darwin",
-                base="core16",
-                expected_uid_map=None,
-                expected_gid_map=None,
-                expected_image="snapcraft:core16",
-            ),
+            dict(platform="darwin", base="core16", expected_image="snapcraft:core16"),
         ),
     )
 
@@ -449,6 +425,9 @@ class MultipassWithBasesTest(BaseProviderWithBasesBaseTest):
             _DEFAULT_INSTANCE_INFO.encode(),
             _DEFAULT_INSTANCE_INFO.encode(),
         ]
+
+        self.expected_uid_map = {str(os.getuid()): "0"}
+        self.expected_gid_map = {str(os.getgid()): "0"}
 
     def test_lifecycle(self):
         with Multipass(


### PR DESCRIPTION
The uid and gid mapping removal for when on non Linux was the wrong
solution to the problem to solve a multipass problem which is now fixed.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
