### PR TITLE
project_loader: add git to build-packages for version: git (#2403)

### DIFF
--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -225,6 +225,10 @@ class Config:
         self.build_tools = grammar_processor.get_build_packages()
         self.build_tools |= set(project.additional_build_packages)
 
+        # If version: git is used we want to add "git" to build-packages
+        if self.data.get("version") == "git":
+            self.build_tools.add("git")
+
         self.parts = PartsConfig(
             parts=self.data,
             project=project,

--- a/tests/unit/project_loader/test_build_packages.py
+++ b/tests/unit/project_loader/test_build_packages.py
@@ -145,3 +145,26 @@ class XCompileTest(ProjectLoaderBaseTest):
         project_config = self.make_snapcraft_project(self.snapcraft_yaml)
 
         self.assertThat(project_config.parts.build_tools, Equals(set()))
+
+
+class VersionGitBuildPackagesTest(ProjectLoaderBaseTest):
+    def test_git_added_for_version_git(self):
+        snapcraft_yaml = dedent(
+            """\
+            name: test
+            base: core18
+            version: "git"
+            summary: test
+            description: test
+            confinement: strict
+            grade: stable
+
+            parts:
+              part1:
+                plugin: nil
+            """
+        )
+
+        project_config = self.make_snapcraft_project(snapcraft_yaml)
+
+        self.assertThat(project_config.build_tools, Contains("git"))


### PR DESCRIPTION
When version is set to git, snapcraft should ensure that git makes it
into the build-packages set.

LP: #1802899
Fixes SNAPCRAFT-7P

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
