### PR TITLE
build providers: preset the timezone

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ progressbar33==2.4
 http://pyyaml.org/download/pyyaml/PyYAML-3.13-cp35-cp35m-win_amd64.whl; sys_platform == 'win32'
 PyYAML==3.13; sys_platform != 'win32'
 pyxdg==0.25
-requests==2.9.1
+requests==2.20.0
 requests_unixsocket==0.1.5
 https://launchpad.net/ubuntu/+archive/primary/+files/python-apt_1.1.0~beta1build1.tar.xz; sys_platform == 'linux'
 https://launchpad.net/python-distutils-extra/trunk/2.39/+download/python-distutils-extra-2.39.tar.gz
@@ -20,5 +20,5 @@ raven==6.5.0
 simplejson==3.8.2
 tabulate==0.7.5
 python-debian==0.1.28
-chardet==2.3.0
+chardet==3.0.4
 cx_Freeze>=5.0.2; sys_platform == 'win32'

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -58,6 +58,8 @@ _CLOUD_USER_DATA_TMPL = dedent(
         mode: growpart
         devices: ["/"]
         ignore_growroot_disabled: false
+    runcmd:
+    - ["ln", "-s", "../usr/share/zoneinfo/{timezone}", "/etc/localtime"]
     write_files:
         - path: /root/.bashrc
           permissions: 0644
@@ -80,10 +82,6 @@ _CLOUD_USER_DATA_TMPL = dedent(
                 ps1="$PWD"
             fi
             echo -n $ps1
-        - path: /etc/timezone
-          permissions: 0644
-          content: |
-            {timezone}
     """
 )
 

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -285,6 +285,8 @@ class GetCloudUserDataTest(BaseProviderBaseTest):
                 mode: growpart
                 devices: ["/"]
                 ignore_growroot_disabled: false
+            runcmd:
+            - ["ln", "-s", "../usr/share/zoneinfo/{timezone}", "/etc/localtime"]
             write_files:
                 - path: /root/.bashrc
                   permissions: 0644
@@ -307,10 +309,6 @@ class GetCloudUserDataTest(BaseProviderBaseTest):
                         ps1="$PWD"
                     fi
                     echo -n $ps1
-                - path: /etc/timezone
-                  permissions: 0644
-                  content: |
-                    America/Argentina/Cordoba
         """
                 )
             ),

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -286,7 +286,7 @@ class GetCloudUserDataTest(BaseProviderBaseTest):
                 devices: ["/"]
                 ignore_growroot_disabled: false
             runcmd:
-            - ["ln", "-s", "../usr/share/zoneinfo/{timezone}", "/etc/localtime"]
+            - ["ln", "-s", "../usr/share/zoneinfo/America/Argentina/Cordoba", "/etc/localtime"]
             write_files:
                 - path: /root/.bashrc
                   permissions: 0644

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -16,12 +16,14 @@
 
 import contextlib
 import os
+from textwrap import dedent
 from unittest.mock import call, Mock
 
-from testtools.matchers import Equals, EndsWith, DirExists, Not
+from testtools.matchers import Equals, EndsWith, DirExists, FileContains, Not
 
 from . import BaseProviderBaseTest, MacBaseProviderWithBasesBaseTest, ProviderImpl
-from snapcraft.internal.build_providers import errors
+from snapcraft.internal.build_providers import errors, _base_provider
+from tests import unit
 
 
 class BaseProviderTest(BaseProviderBaseTest):
@@ -261,3 +263,70 @@ class MacProviderProvisionSnapcraftTest(MacBaseProviderWithBasesBaseTest):
         )
         self.assertThat(self.snap_injector_mock().add.call_count, Equals(3))
         self.snap_injector_mock().apply.assert_called_once_with()
+
+
+class GetCloudUserDataTest(BaseProviderBaseTest):
+    def test_get(self):
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+        os.makedirs(provider.provider_project_dir)
+
+        cloud_data_filepath = provider._get_cloud_user_data(
+            timezone="America/Argentina/Cordoba"
+        )
+        self.assertThat(
+            cloud_data_filepath,
+            FileContains(
+                dedent(
+                    """\
+            #cloud-config
+            manage_etc_hosts: true
+            package_update: false
+            growpart:
+                mode: growpart
+                devices: ["/"]
+                ignore_growroot_disabled: false
+            write_files:
+                - path: /root/.bashrc
+                  permissions: 0644
+                  content: |
+                    export SNAPCRAFT_BUILD_ENVIRONMENT=managed-host
+                    export PS1="\h \$(/bin/_snapcraft_prompt)# "
+                    export PATH=/snap/bin:$PATH
+                - path: /bin/_snapcraft_prompt
+                  permissions: 0755
+                  content: |
+                    #!/bin/bash
+                    if [[ "$PWD" =~ ^$HOME.* ]]; then
+                        path="${PWD/#$HOME/\ ..}"
+                        if [[ "$path" == " .." ]]; then
+                            ps1=""
+                        else
+                            ps1="$path"
+                        fi
+                    else
+                        ps1="$PWD"
+                    fi
+                    echo -n $ps1
+                - path: /etc/timezone
+                  permissions: 0644
+                  content: |
+                    America/Argentina/Cordoba
+        """
+                )
+            ),
+        )
+
+
+class GetTzDataTest(unit.TestCase):
+    def test_path_found(self):
+        with open("timezone", "w") as timezone_file:
+            print("America/Argentina/Cordoba", file=timezone_file)
+
+        self.assertThat(
+            _base_provider._get_tzdata("timezone"), Equals("America/Argentina/Cordoba")
+        )
+
+    def test_path_not_found(self):
+        self.assertThat(
+            _base_provider._get_tzdata("timezone-not-found"), Equals("Etc/UTC")
+        )


### PR DESCRIPTION
Use the value from the host if possible, if not, fallback to Etc/UTC.
Leverage cloud-init to set the timezone correctly.

LP: #1801742

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
