### PR TITLE
python plugin: process deps before and separately from setup.py

### DIFF
--- a/tests/spread/plugins/python/setup-py-with-external-dep/task.yaml
+++ b/tests/spread/plugins/python/setup-py-with-external-dep/task.yaml
@@ -1,0 +1,31 @@
+summary: "Ensure that dependencies are collected first before processing setup.py"
+
+environment:
+  SNAP_DIR: ../snaps/python-setuppy-with-deps
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+  #shellcheck source=tests/spread/tools/config.sh
+  . "$TOOLS_DIR/config.sh"
+  set_outdated_step_action "clean"
+
+restore: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  #shellcheck source=tests/spread/tools/config.sh
+  . "$TOOLS_DIR/config.sh"
+  clear_config
+
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+  restore_yaml snap/snapcraft.yaml
+
+execute: |
+  cd "$SNAP_DIR"
+
+  # The build will fail if dependencies are not handled before
+  # processing setup.py
+  snapcraft build

--- a/tests/spread/plugins/python/snaps/python-setuppy-with-deps/hello
+++ b/tests/spread/plugins/python/snaps/python-setuppy-with-deps/hello
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print('hello world')

--- a/tests/spread/plugins/python/snaps/python-setuppy-with-deps/setup.py
+++ b/tests/spread/plugins/python/snaps/python-setuppy-with-deps/setup.py
@@ -1,0 +1,15 @@
+import setuptools
+
+# if dependencies are not handled first, processing of this
+# setup.py will fail.
+import six  # noqa: F401
+
+
+setuptools.setup(
+    name="hello-world",
+    version="0.0.1",
+    author="Canonical LTD",
+    author_email="snapcraft@lists.snapcraft.io",
+    description="A simple hello world in python",
+    scripts=["hello"],
+)

--- a/tests/spread/plugins/python/snaps/python-setuppy-with-deps/snap/snapcraft.yaml
+++ b/tests/spread/plugins/python/snaps/python-setuppy-with-deps/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: python-hello
+version: "1.0"
+summary: "A simple hello world in python that depends on six"
+description: >
+  Test that dependencies are provisioned before handling setup.py
+  as it may have dependencies.
+
+grade: devel
+confinement: strict
+
+apps:
+  python-hello:
+    command: hello
+
+parts:
+  python-part:
+    source: .
+    plugin: python
+    python-packages:
+    - six

--- a/tests/unit/plugins/test_python.py
+++ b/tests/unit/plugins/test_python.py
@@ -176,7 +176,7 @@ class PythonPluginTest(PythonPluginBaseTest):
             constraints=set(),
             process_dependency_links=False,
             requirements=set(),
-            setup_py_dir=plugin.sourcedir,
+            setup_py_dir=None,
         )
 
         self.mock_pip.return_value.wheel.assert_not_called()
@@ -200,7 +200,7 @@ class PythonPluginTest(PythonPluginBaseTest):
             constraints=set(),
             process_dependency_links=False,
             requirements={requirements_path},
-            setup_py_dir=plugin.sourcedir,
+            setup_py_dir=None,
         )
 
         self.mock_pip.return_value.wheel.assert_not_called()
@@ -224,7 +224,7 @@ class PythonPluginTest(PythonPluginBaseTest):
             constraints={constraints_path},
             process_dependency_links=False,
             requirements=set(),
-            setup_py_dir=plugin.sourcedir,
+            setup_py_dir=None,
         )
 
         self.mock_pip.return_value.wheel.assert_not_called()
@@ -268,22 +268,52 @@ class PythonPluginTest(PythonPluginBaseTest):
 
         # Pip should not attempt to download again in build (only pull)
         pip_download = self.mock_pip.return_value.download
-        pip_download.assert_not_called()
-
-        pip_wheel.assert_called_once_with(
-            ["test", "packages"],
+        pip_download.assert_called_once_with(
+            [],
             constraints={constraints_path},
             process_dependency_links=False,
-            requirements={requirements_path},
+            requirements=set(),
             setup_py_dir=plugin.builddir,
         )
 
+        self.assertThat(pip_wheel.call_count, Equals(2))
+        pip_wheel.assert_has_calls(
+            [
+                mock.call(
+                    ["test", "packages"],
+                    constraints={constraints_path},
+                    process_dependency_links=False,
+                    requirements={requirements_path},
+                    setup_py_dir=None,
+                ),
+                mock.call(
+                    [],
+                    constraints={constraints_path},
+                    process_dependency_links=False,
+                    requirements=set(),
+                    setup_py_dir=plugin.builddir,
+                ),
+            ]
+        )
+
         pip_install = self.mock_pip.return_value.install
-        pip_install.assert_called_once_with(
-            ["foo", "bar"],
-            process_dependency_links=False,
-            upgrade=True,
-            install_deps=False,
+        self.assertThat(pip_wheel.call_count, Equals(2))
+        pip_install.assert_has_calls(
+            [
+                mock.call(
+                    ["foo", "bar"],
+                    process_dependency_links=False,
+                    upgrade=True,
+                    install_deps=False,
+                ),
+                mock.call(
+                    # Our mocking needs to be smarter to reflect this.
+                    ["foo", "bar"],
+                    process_dependency_links=False,
+                    upgrade=True,
+                    install_deps=False,
+                ),
+            ]
         )
 
     def test_pip_with_url(self):
@@ -301,26 +331,62 @@ class PythonPluginTest(PythonPluginBaseTest):
             plugin.build()
 
         pip_download = self.mock_pip.return_value.download
-        pip_download.assert_called_once_with(
-            [],
-            constraints=set(self.options.constraints),
-            process_dependency_links=False,
-            requirements=set(self.options.requirements),
-            setup_py_dir=plugin.sourcedir,
+        self.assertThat(pip_download.call_count, Equals(2))
+        pip_download.assert_has_calls(
+            [
+                mock.call(
+                    [],
+                    constraints=set(self.options.constraints),
+                    process_dependency_links=False,
+                    requirements=set(self.options.requirements),
+                    setup_py_dir=None,
+                ),
+                mock.call(
+                    [],
+                    constraints=set(self.options.constraints),
+                    process_dependency_links=False,
+                    requirements=set(),
+                    setup_py_dir=plugin.sourcedir,
+                ),
+            ]
         )
 
         pip_install = self.mock_pip.return_value.install
-        pip_install.assert_called_once_with(
-            [], upgrade=True, process_dependency_links=False, install_deps=False
+        self.assertThat(pip_install.call_count, Equals(2))
+        pip_install.assert_has_calls(
+            [
+                mock.call(
+                    [], upgrade=True, process_dependency_links=False, install_deps=False
+                ),
+                mock.call(
+                    [], upgrade=True, process_dependency_links=False, install_deps=False
+                ),
+            ]
         )
 
         pip_wheel = self.mock_pip.return_value.wheel
-        pip_wheel.assert_called_once_with(
-            [],
-            constraints=set(self.options.constraints),
-            process_dependency_links=False,
-            requirements=set(self.options.requirements),
-            setup_py_dir=plugin.sourcedir,
+        self.assertThat(pip_wheel.call_count, Equals(2))
+        pip_wheel.assert_has_calls(
+            [
+                mock.call(
+                    [],
+                    constraints=set(self.options.constraints),
+                    process_dependency_links=False,
+                    requirements=set(self.options.requirements),
+                    setup_py_dir=None,
+                )
+            ]
+        )
+        pip_wheel.assert_has_calls(
+            [
+                mock.call(
+                    [],
+                    constraints=set(self.options.constraints),
+                    process_dependency_links=False,
+                    requirements=set(),
+                    setup_py_dir=plugin.sourcedir,
+                )
+            ]
         )
 
     def test_fileset_ignores(self):
@@ -348,26 +414,63 @@ class PythonPluginTest(PythonPluginBaseTest):
         plugin.build()
 
         pip_download = self.mock_pip.return_value.download
-        pip_download.assert_called_once_with(
-            [],
-            constraints=set(),
-            process_dependency_links=True,
-            requirements=set(),
-            setup_py_dir=plugin.sourcedir,
+        self.assertThat(pip_download.call_count, Equals(2))
+        pip_download.assert_has_calls(
+            [
+                mock.call(
+                    [],
+                    constraints=set(),
+                    process_dependency_links=True,
+                    requirements=set(),
+                    setup_py_dir=None,
+                ),
+                mock.call(
+                    [],
+                    constraints=set(),
+                    process_dependency_links=True,
+                    requirements=set(),
+                    setup_py_dir=plugin.sourcedir,
+                ),
+            ]
         )
 
         pip_install = self.mock_pip.return_value.install
-        pip_install.assert_called_once_with(
-            [], upgrade=True, process_dependency_links=True, install_deps=False
+        self.assertThat(pip_install.call_count, Equals(2))
+        pip_install.assert_has_calls(
+            [
+                mock.call(
+                    [], upgrade=True, process_dependency_links=True, install_deps=False
+                ),
+                mock.call(
+                    [], upgrade=True, process_dependency_links=True, install_deps=False
+                ),
+            ]
         )
 
         pip_wheel = self.mock_pip.return_value.wheel
-        pip_wheel.assert_called_once_with(
-            [],
-            constraints=set(),
-            process_dependency_links=True,
-            requirements=set(),
-            setup_py_dir=plugin.sourcedir,
+        self.assertThat(pip_wheel.call_count, Equals(2))
+        # Double check to avoid annotating the magic methods.
+        pip_wheel.assert_has_calls(
+            [
+                mock.call(
+                    [],
+                    constraints=set(),
+                    process_dependency_links=True,
+                    requirements=set(),
+                    setup_py_dir=None,
+                )
+            ]
+        )
+        pip_wheel.assert_has_calls(
+            [
+                mock.call(
+                    [],
+                    constraints=set(),
+                    process_dependency_links=True,
+                    requirements=set(),
+                    setup_py_dir=plugin.sourcedir,
+                )
+            ]
         )
 
     def test_get_manifest_with_python_packages(self):


### PR DESCRIPTION
This change ensures that if setup.py has a dependency in order to be processed
that it can be handled by processing dependencies separately followed
by the handling of setup.py.

for increased cleanup, setup.py does not form part of the "download"
process.

LP: #1803573
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
