### PR TITLE
meson plugin: Allow duplicate items in meson-parameters

### DIFF
--- a/snapcraft/plugins/meson.py
+++ b/snapcraft/plugins/meson.py
@@ -49,7 +49,7 @@ class MesonPlugin(snapcraft.BasePlugin):
         schema["properties"]["meson-parameters"] = {
             "type": "array",
             "minitems": 1,
-            "uniqueItems": True,
+            "uniqueItems": False,
             "items": {"type": "string"},
             "default": [],
         }


### PR DESCRIPTION
It is possible that the `meson-parameters`'s value contains duplicate items, e.g., multiple `-D PROJECTOPTIONS`s resulting multiple `-D`s in the array.  This patch sets the `uniqueItems` schema property to `False` to allow this syntax.

Refer-to: Should the meson plugin allow non-uniqueItems? - snapcraft - snapcraft.io <https://forum.snapcraft.io/t/should-the-meson-plugin-allow-non-uniqueitems/8544>
Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
