### PR TITLE
cli: snapcraft init with a base

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -115,7 +115,9 @@ def init():
     """Initialize a snapcraft project."""
     snapcraft_yaml_path = lifecycle.init()
     echo.info("Created {}.".format(snapcraft_yaml_path))
-    echo.info("Edit the file to your liking or run `snapcraft` to get started")
+    echo.wrapped("Edit the file to your liking or run `snapcraft` to get started. "
+                 "For more information about the format and values accepted in "
+                 "snapcraft.yaml go to https://docs.snapcraft.io/the-snapcraft-format/8337.")
 
 
 @lifecyclecli.command()

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -115,9 +115,8 @@ def init():
     """Initialize a snapcraft project."""
     snapcraft_yaml_path = lifecycle.init()
     echo.info("Created {}.".format(snapcraft_yaml_path))
-    echo.wrapped("Edit the file to your liking or run `snapcraft` to get started. "
-                 "For more information about the format and values accepted in "
-                 "snapcraft.yaml go to https://docs.snapcraft.io/the-snapcraft-format/8337.")
+    echo.wrapped("Go to https://docs.snapcraft.io/the-snapcraft-format/8337 for more "
+                 "information about the snapcraft.yaml format.")
 
 
 @lifecyclecli.command()

--- a/snapcraft/internal/lifecycle/_init.py
+++ b/snapcraft/internal/lifecycle/_init.py
@@ -23,7 +23,7 @@ from snapcraft.internal import errors
 _TEMPLATE_YAML = dedent(
     """\
     name: my-snap-name # you probably want to 'snapcraft register <name>'
-    base: core18
+    base: core18 # the base snap is the execution environment for this snap
     version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
     summary: Single-line elevator pitch for your amazing snap # 79 char long summary
     description: >

--- a/snapcraft/internal/lifecycle/_init.py
+++ b/snapcraft/internal/lifecycle/_init.py
@@ -23,6 +23,7 @@ from snapcraft.internal import errors
 _TEMPLATE_YAML = dedent(
     """\
     name: my-snap-name # you probably want to 'snapcraft register <name>'
+    base: core18
     version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
     summary: Single-line elevator pitch for your amazing snap # 79 char long summary
     description: >

--- a/tests/spread/legacy/command-define/task.yaml
+++ b/tests/spread/legacy/command-define/task.yaml
@@ -12,6 +12,9 @@ execute: |
   # Create a snapcraft.yaml with no base entry
   snapcraft init
 
+  # Remove the base entry
+  sed -i '/base: core18/d' snap/snapcraft.yaml
+
   # Now update
   snapcraft update
   snapcraft define curl > define.txt

--- a/tests/spread/legacy/command-update/task.yaml
+++ b/tests/spread/legacy/command-update/task.yaml
@@ -11,6 +11,9 @@ execute: |
   # Create a snapcraft.yaml with no base entry
   snapcraft init
 
+  # Remove the base entry
+  sed -i '/base: core18/d' snap/snapcraft.yaml
+
   # Now update
   snapcraft update
 

--- a/tests/unit/commands/test_init.py
+++ b/tests/unit/commands/test_init.py
@@ -50,11 +50,9 @@ class InitCommandTestCase(CommandBaseTestCase):
         self.assertThat(
             result.output,
             Contains(
-                "Created snap/snapcraft.yaml.\nEdit the file to your liking or "
-                "run `snapcraft` to get started. "
-                "For more information about the format and values\n"
-                "accepted in snapcraft.yaml go to "
-                "https://docs.snapcraft.io/the-snapcraft-format/8337."
+                "Created snap/snapcraft.yaml.\n"
+                "Go to https://docs.snapcraft.io/the-snapcraft-format/8337 for more "
+                "information about the snapcraft.yaml format."
             ),
         )
 

--- a/tests/unit/commands/test_init.py
+++ b/tests/unit/commands/test_init.py
@@ -14,39 +14,47 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
+from textwrap import dedent
 
 import snapcraft.internal.errors
-from testtools.matchers import Equals, FileContains
+from testtools.matchers import Contains, Equals, FileContains
 
 from . import CommandBaseTestCase
 
 
 class InitCommandTestCase(CommandBaseTestCase):
     def test_init_must_write_snapcraft_yaml(self):
-        expected_yaml = """name: my-snap-name # you probably want to 'snapcraft register <name>'
-version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
-summary: Single-line elevator pitch for your amazing snap # 79 char long summary
-description: >
-  This is my-snap's description. You have a paragraph or two to tell the
-  most important story about your snap. Keep it under 100 words though,
-  we live in tweetspace and your description wants to look good in the snap
-  store.
+        expected_yaml = dedent(
+            """\
+            name: my-snap-name # you probably want to 'snapcraft register <name>'
+            base: core18
+            version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
+            summary: Single-line elevator pitch for your amazing snap # 79 char long summary
+            description: >
+              This is my-snap's description. You have a paragraph or two to tell the
+              most important story about your snap. Keep it under 100 words though,
+              we live in tweetspace and your description wants to look good in the snap
+              store.
 
-grade: devel # must be 'stable' to release into candidate/stable channels
-confinement: devmode # use 'strict' once you have the right plugs and slots
+            grade: devel # must be 'stable' to release into candidate/stable channels
+            confinement: devmode # use 'strict' once you have the right plugs and slots
 
-parts:
-  my-part:
-    # See 'snapcraft plugins'
-    plugin: nil\n"""  # noqa, lines too long
+            parts:
+              my-part:
+                # See 'snapcraft plugins'
+                plugin: nil\n"""
+        )
 
         result = self.run_command(["init"])
 
         self.assertThat(
             result.output,
-            Equals(
+            Contains(
                 "Created snap/snapcraft.yaml.\nEdit the file to your liking or "
-                "run `snapcraft` to get started\n"
+                "run `snapcraft` to get started. "
+                "For more information about the format and values\n"
+                "accepted in snapcraft.yaml go to "
+                "https://docs.snapcraft.io/the-snapcraft-format/8337."
             ),
         )
 

--- a/tests/unit/commands/test_init.py
+++ b/tests/unit/commands/test_init.py
@@ -27,7 +27,7 @@ class InitCommandTestCase(CommandBaseTestCase):
         expected_yaml = dedent(
             """\
             name: my-snap-name # you probably want to 'snapcraft register <name>'
-            base: core18
+            base: core18 # the base snap is the execution environment for this snap
             version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
             summary: Single-line elevator pitch for your amazing snap # 79 char long summary
             description: >


### PR DESCRIPTION
Add a link to where the syntax is defined after doing an init.

LP: #1803776
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
