### PR TITLE
tools: pull in imporved cla_check.py from snapd

### DIFF
--- a/tools/cla_check.py
+++ b/tools/cla_check.py
@@ -18,29 +18,32 @@ except ImportError:
 
 shortlog_email_rx = re.compile("^\s*\d+\s+.*<(\S+)>$", re.M)
 
+
 def get_emails_for_range(r):
     output = check_output(["git", "shortlog", "-se", r])
     return set(m.group(1) for m in shortlog_email_rx.finditer(output))
 
+
 if sys.stdout.isatty():
-    green="\033[32;1m"
-    red="\033[31;1m"
-    yellow="\033[33;1m"
-    reset="\033[0m"
-    clear="\033[0K"
+    green = "\033[32;1m"
+    red = "\033[31;1m"
+    yellow = "\033[33;1m"
+    reset = "\033[0m"
+    clear = "\033[0K"
 else:
-    green=""
-    red=""
-    yellow=""
-    reset=""
-    clear=""
+    green = ""
+    red = ""
+    yellow = ""
+    reset = ""
+    clear = ""
+
 
 def main():
     travis_commit_range = os.getenv("TRAVIS_COMMIT_RANGE", "")
 
     # This is just to have information in case things go wrong
     if clear:
-        print("travis_fold:start:checkout_info\r"+clear, end="")
+        print("travis_fold:start:checkout_info\r" + clear, end="")
     print("{}Debug information{}".format(yellow, reset))
     print("Commit range:", travis_commit_range)
     print("Remotes:")
@@ -51,7 +54,7 @@ def main():
     check_call(["git", "branch", "-v"])
     sys.stdout.flush()
     if clear:
-        print("travis_fold:end:checkout_info\r"+clear)
+        print("travis_fold:end:checkout_info\r" + clear)
 
     if travis_commit_range == "":
         sys.exit("No TRAVIS_COMMIT_RANGE set.")
@@ -71,13 +74,23 @@ def main():
             print("{}✓{} {:<{}} already on master".format(green, reset, email, width))
             continue
         if email.endswith("@canonical.com"):
-            print("{}✓{} {:<{}} @canonical.com account".format(green, reset, email, width))
+            print(
+                "{}✓{} {:<{}} @canonical.com account".format(green, reset, email, width)
+            )
             continue
         if email.endswith("@mozilla.com"):
-            print("{}✓{} {:<{}} @mozilla.com account (mozilla corp has signed the corp CLA)".format(green, reset, email, width))
+            print(
+                "{}✓{} {:<{}} @mozilla.com account (mozilla corp has signed the corp CLA)".format(
+                    green, reset, email, width
+                )
+            )
             continue
         if email.endswith("@users.noreply.github.com"):
-            print("{}‽{} {:<{}} privacy-enabled github web edit email address".format(yellow, reset, email, width))
+            print(
+                "{}‽{} {:<{}} privacy-enabled github web edit email address".format(
+                    yellow, reset, email, width
+                )
+            )
             continue
         if lp is None:
             print("Logging into Launchpad...")
@@ -86,14 +99,24 @@ def main():
         contributor = lp.people.getByEmail(email=email)
         if not contributor:
             failed = True
-            print("{}🛇{} {:<{}} has no Launchpad account".format(red, reset, email, width))
+            print(
+                "{}🛇{} {:<{}} has no Launchpad account".format(red, reset, email, width)
+            )
             continue
 
         if contributor in cla_folks:
-            print("{}✓{} {:<{}} ({}) has signed the CLA".format(green, reset, email, width, contributor))
+            print(
+                "{}✓{} {:<{}} ({}) has signed the CLA".format(
+                    green, reset, email, width, contributor
+                )
+            )
         else:
             failed = True
-            print("{}🛇{} {:<{}} ({}) has NOT signed the CLA".format(red, reset, email, width, contributor))
+            print(
+                "{}🛇{} {:<{}} ({}) has NOT signed the CLA".format(
+                    red, reset, email, width, contributor
+                )
+            )
     if failed:
         sys.exit(1)
 

--- a/tools/cla_check.py
+++ b/tools/cla_check.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import print_function
 
 # XXX copied from https://github.com/kyrofa/cla-check
+# (and then heavily modified)
 import collections
 import os
+import re
 import sys
 from subprocess import check_call, check_output
 
@@ -12,67 +16,86 @@ try:
 except ImportError:
     sys.exit("Install launchpadlib: sudo apt install python-launchpadlib")
 
-Commit = collections.namedtuple("Commit", ["email", "hash"])
+shortlog_email_rx = re.compile("^\s*\d+\s+.*<(\S+)>$", re.M)
 
+def get_emails_for_range(r):
+    output = check_output(["git", "shortlog", "-se", r])
+    return set(m.group(1) for m in shortlog_email_rx.finditer(output))
 
-def get_commits_for_range(range):
-    output = check_output(["git", "log", range, "--pretty=%aE|%H"])
-    split_output = (i.split("|") for i in output.split("\n") if i != "")
-    commits = [Commit(email=i[0], hash=i[1]) for i in split_output]
-    return commits
-
-
-def get_emails_from_commits(commits):
-    emails = set()
-    for c in commits:
-        output = check_output(["git", "branch", "--contains", c.hash])
-        in_master = any(["master" == b.strip() for b in output.split("\n")])
-        if in_master:
-            print(
-                'Commit {} from {} not in "master", found in '
-                "{!r}".format(c.hash, c.email, output)
-            )
-            emails.add(c.email)
-        else:  # just for debug
-            print("Skipping {}, found in:\n{}".format(c.hash, output))
-    return emails
-
+if sys.stdout.isatty():
+    green="\033[32;1m"
+    red="\033[31;1m"
+    yellow="\033[33;1m"
+    reset="\033[0m"
+    clear="\033[0K"
+else:
+    green=""
+    red=""
+    yellow=""
+    reset=""
+    clear=""
 
 def main():
+    travis_commit_range = os.getenv("TRAVIS_COMMIT_RANGE", "")
+
     # This is just to have information in case things go wrong
+    if clear:
+        print("travis_fold:start:checkout_info\r"+clear, end="")
+    print("{}Debug information{}".format(yellow, reset))
+    print("Commit range:", travis_commit_range)
     print("Remotes:")
     sys.stdout.flush()
     check_call(["git", "remote", "-v"])
     print("Branches:")
     sys.stdout.flush()
     check_call(["git", "branch", "-v"])
+    sys.stdout.flush()
+    if clear:
+        print("travis_fold:end:checkout_info\r"+clear)
 
-    travis_commit_range = os.getenv("TRAVIS_COMMIT_RANGE", "")
-    commits = get_commits_for_range(travis_commit_range)
-    emails = get_emails_from_commits(commits)
-    if not emails:
-        print("No emails to verify")
-        return
+    if travis_commit_range == "":
+        sys.exit("No TRAVIS_COMMIT_RANGE set.")
 
-    print("Logging into Launchpad...")
-    lp = Launchpad.login_anonymously("check CLA", "production")
-    cla_folks = lp.people["contributor-agreement-canonical"].participants
+    emails = get_emails_for_range(travis_commit_range)
+    if len(emails) == 0:
+        sys.exit("No emails found in in the given commit range.")
 
-    print("Amount of emails to check the CLA for {}".format(len(emails)))
+    master_emails = get_emails_for_range("master")
+
+    width = max(map(len, emails))
+    lp = None
+    failed = False
+    print("Need to check {} emails:".format(len(emails)))
     for email in emails:
-        print("Checking the CLA for {!r}".format(email))
-        if email.endswith("@canonical.com"):
-            print("Skipping @canonical.com account {}".format(email))
+        if email in master_emails:
+            print("{}✓{} {:<{}} already on master".format(green, reset, email, width))
             continue
+        if email.endswith("@canonical.com"):
+            print("{}✓{} {:<{}} @canonical.com account".format(green, reset, email, width))
+            continue
+        if email.endswith("@mozilla.com"):
+            print("{}✓{} {:<{}} @mozilla.com account (mozilla corp has signed the corp CLA)".format(green, reset, email, width))
+            continue
+        if email.endswith("@users.noreply.github.com"):
+            print("{}‽{} {:<{}} privacy-enabled github web edit email address".format(yellow, reset, email, width))
+            continue
+        if lp is None:
+            print("Logging into Launchpad...")
+            lp = Launchpad.login_anonymously("check CLA", "production")
+            cla_folks = lp.people["contributor-agreement-canonical"].participants
         contributor = lp.people.getByEmail(email=email)
         if not contributor:
-            sys.exit("The contributor does not have a Launchpad account.")
+            failed = True
+            print("{}🛇{} {:<{}} has no Launchpad account".format(red, reset, email, width))
+            continue
 
-        print("Contributor account for {}: {}".format(email, contributor))
         if contributor in cla_folks:
-            print("The contributor has signed the CLA.")
+            print("{}✓{} {:<{}} ({}) has signed the CLA".format(green, reset, email, width, contributor))
         else:
-            sys.exit("The contributor {} has not signed the CLA.".format(email))
+            failed = True
+            print("{}🛇{} {:<{}} ({}) has NOT signed the CLA".format(red, reset, email, width, contributor))
+    if failed:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tools/cla_check.py
+++ b/tools/cla_check.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 
 # XXX copied from https://github.com/kyrofa/cla-check
 # (and then heavily modified)
-import collections
 import os
 import re
 import sys
@@ -38,9 +37,53 @@ else:
     clear = ""
 
 
-def main():
-    travis_commit_range = os.getenv("TRAVIS_COMMIT_RANGE", "")
+def static_email_check(email, master_emails, width):
+    if email in master_emails:
+        print("{}✓{} {:<{}} already on master".format(green, reset, email, width))
+        return True
+    if email.endswith("@canonical.com"):
+        print("{}✓{} {:<{}} @canonical.com account".format(green, reset, email, width))
+        return True
+    if email.endswith("@mozilla.com"):
+        print(
+            "{}✓{} {:<{}} @mozilla.com account (mozilla corp has signed the corp CLA)".format(
+                green, reset, email, width
+            )
+        )
+        return True
+    if email.endswith("@users.noreply.github.com"):
+        print(
+            "{}‽{} {:<{}} privacy-enabled github web edit email address".format(
+                yellow, reset, email, width
+            )
+        )
+        return True
+    return False
 
+
+def lp_email_check(email, lp, cla_folks, width):
+    contributor = lp.people.getByEmail(email=email)
+    if not contributor:
+        print("{}🛇{} {:<{}} has no Launchpad account".format(red, reset, email, width))
+        return False
+
+    if contributor in cla_folks:
+        print(
+            "{}✓{} {:<{}} ({}) has signed the CLA".format(
+                green, reset, email, width, contributor
+            )
+        )
+        return True
+    else:
+        print(
+            "{}🛇{} {:<{}} ({}) has NOT signed the CLA".format(
+                red, reset, email, width, contributor
+            )
+        )
+        return False
+
+
+def print_checkout_info(travis_commit_range):
     # This is just to have information in case things go wrong
     if clear:
         print("travis_fold:start:checkout_info\r" + clear, end="")
@@ -56,6 +99,11 @@ def main():
     if clear:
         print("travis_fold:end:checkout_info\r" + clear)
 
+
+def main():
+    travis_commit_range = os.getenv("TRAVIS_COMMIT_RANGE", "")
+    print_checkout_info(travis_commit_range)
+
     if travis_commit_range == "":
         sys.exit("No TRAVIS_COMMIT_RANGE set.")
 
@@ -70,53 +118,16 @@ def main():
     failed = False
     print("Need to check {} emails:".format(len(emails)))
     for email in emails:
-        if email in master_emails:
-            print("{}✓{} {:<{}} already on master".format(green, reset, email, width))
+        if static_email_check(email, master_emails, width):
             continue
-        if email.endswith("@canonical.com"):
-            print(
-                "{}✓{} {:<{}} @canonical.com account".format(green, reset, email, width)
-            )
-            continue
-        if email.endswith("@mozilla.com"):
-            print(
-                "{}✓{} {:<{}} @mozilla.com account (mozilla corp has signed the corp CLA)".format(
-                    green, reset, email, width
-                )
-            )
-            continue
-        if email.endswith("@users.noreply.github.com"):
-            print(
-                "{}‽{} {:<{}} privacy-enabled github web edit email address".format(
-                    yellow, reset, email, width
-                )
-            )
-            continue
+        # in the normal case this isn't reached
         if lp is None:
             print("Logging into Launchpad...")
             lp = Launchpad.login_anonymously("check CLA", "production")
             cla_folks = lp.people["contributor-agreement-canonical"].participants
-        contributor = lp.people.getByEmail(email=email)
-        if not contributor:
+        if not lp_email_check(email, lp, cla_folks, width):
             failed = True
-            print(
-                "{}🛇{} {:<{}} has no Launchpad account".format(red, reset, email, width)
-            )
-            continue
 
-        if contributor in cla_folks:
-            print(
-                "{}✓{} {:<{}} ({}) has signed the CLA".format(
-                    green, reset, email, width, contributor
-                )
-            )
-        else:
-            failed = True
-            print(
-                "{}🛇{} {:<{}} ({}) has NOT signed the CLA".format(
-                    red, reset, email, width, contributor
-                )
-            )
     if failed:
         sys.exit(1)
 


### PR DESCRIPTION
We'll get to snap these sometime, but until then, here have the
cla_check.py we're using in snapd, based on yours (but much
improved). It's faster, more accurate, and has nicer, simpler, easier
to understand output.

Note that it does have an output of "I don't know", which still passes
the test. This can happen if a PR is done entirely using github's web
tools from a privacy-enabled account. You'd need to verify manually
then.
