### PR TITLE
Revert "lifecycle: make snapcraft init template use > not | (#2393)"

### DIFF
--- a/snapcraft/internal/lifecycle/_init.py
+++ b/snapcraft/internal/lifecycle/_init.py
@@ -26,7 +26,7 @@ _TEMPLATE_YAML = dedent(
     base: core18 # the base snap is the execution environment for this snap
     version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
     summary: Single-line elevator pitch for your amazing snap # 79 char long summary
-    description: >
+    description: |
       This is my-snap's description. You have a paragraph or two to tell the
       most important story about your snap. Keep it under 100 words though,
       we live in tweetspace and your description wants to look good in the snap

--- a/tests/unit/commands/test_init.py
+++ b/tests/unit/commands/test_init.py
@@ -30,7 +30,7 @@ class InitCommandTestCase(CommandBaseTestCase):
             base: core18 # the base snap is the execution environment for this snap
             version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
             summary: Single-line elevator pitch for your amazing snap # 79 char long summary
-            description: >
+            description: |
               This is my-snap's description. You have a paragraph or two to tell the
               most important story about your snap. Keep it under 100 words though,
               we live in tweetspace and your description wants to look good in the snap


### PR DESCRIPTION
This reverts commit 4e46b5a18f222d1f4e3084d642633e6d25bbd3bd after considering:
- https://forum.snapcraft.io/t/snap-multi-line-descriptions-need-newline-trim-on-store-import/3934/12
- https://forum.snapcraft.io/t/use-of-markdown-in-snap-metadata-summary-description/2128

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
