### PR TITLE
nodejs plugin: fail gracefully when a package.json is missing

### DIFF
--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -73,6 +73,15 @@ _YARN_VERSION_URL = (
 )
 
 
+class NodejsPluginMissingPackageJsonError(errors.SnapcraftError):
+
+    fmt = (
+        "Could not find a 'package.json' in the source tree.\n"
+        "Verify that a 'package.json' exists at the root of the source tree\n"
+        "or consider using the 'source-subdir' property if it is located in a subdirectory."
+    )
+
+
 class NodePlugin(snapcraft.BasePlugin):
     @classmethod
     def schema(cls):
@@ -246,8 +255,11 @@ class NodePlugin(snapcraft.BasePlugin):
         return env
 
     def _get_package_json(self, rootdir):
-        with open(os.path.join(rootdir, "package.json")) as json_file:
-            return json.load(json_file)
+        try:
+            with open(os.path.join(rootdir, "package.json")) as json_file:
+                return json.load(json_file)
+        except FileNotFoundError as not_found_error:
+            raise NodejsPluginMissingPackageJsonError() from not_found_error
 
     def _get_installed_node_packages(self, cwd):
         # There is no yarn ls


### PR DESCRIPTION
LP: #1807971
Fixes SNAPCRAFT-9X

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
