### PR TITLE
cli: fix usage string in help command

### DIFF
--- a/snapcraft/cli/help.py
+++ b/snapcraft/cli/help.py
@@ -72,6 +72,7 @@ def help_command(ctx, topic, devel):
             )
         )
     elif topic in ctx.parent.command.commands:
+        ctx.info_name = topic
         click.echo(ctx.parent.command.commands[topic].get_help(ctx))
     elif topic == "topics":
         for key in _TOPICS:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

LP: https://bugs.launchpad.net/snapcraft/+bug/1745040
Forum: https://forum.snapcraft.io/t/snapcraft-help-command-showing-wrong-usage/9045?u=felicianotech

P.S. The last two items in the checklist above, aren't documented well in the HACKING guide and don't even pass on master.