### PR TITLE
extractors: better appstream support for descriptions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ tabulate==0.7.5
 python-debian==0.1.28
 chardet==3.0.4
 cx_Freeze>=5.0.2; sys_platform == 'win32'
+lxml==4.2.5

--- a/runtests.sh
+++ b/runtests.sh
@@ -65,7 +65,7 @@ run_static_tests(){
     mypy -p snapcraft
 
     echo "Running codespell"
-    codespell -S "*.tar,*.xz,*.zip,*.bz2,*.7z,*.gz,*.deb,*.rpm,*.snap,*.gpg,*.pyc,*.png,*.ico,*.jar,changelog,.git,.hg,.mypy_cache,.tox,.venv,_build,buck-out,__pycache__,build,dist,.vscode,parts,stage,prime" -q4
+    codespell -S "*.tar,*.xz,*.zip,*.bz2,*.7z,*.gz,*.deb,*.rpm,*.snap,*.gpg,*.pyc,*.png,*.ico,*.jar,changelog,.git,.hg,.mypy_cache,.tox,.venv,_build,buck-out,__pycache__,build,dist,.vscode,parts,stage,prime,test_appstream.py" -q4
 
     echo "Running shellcheck"
     # Need to skip 'demos/gradle/gradlew' as it wasn't written by us and has

--- a/snapcraft/extractors/appstream.py
+++ b/snapcraft/extractors/appstream.py
@@ -16,7 +16,6 @@
 
 import os
 from io import StringIO
-from textwrap import dedent
 
 import lxml.etree
 
@@ -25,8 +24,7 @@ from snapcraft.extractors import _errors
 
 
 _xslt = None
-_XSLT = dedent(
-    """\
+_XSLT = """\
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
@@ -61,7 +59,6 @@ _XSLT = dedent(
 
 </xsl:stylesheet>
 """
-)
 
 
 def extract(path: str) -> ExtractedMetadata:

--- a/snapcraft/extractors/appstream.py
+++ b/snapcraft/extractors/appstream.py
@@ -50,6 +50,15 @@ _XSLT = dedent(
     </xsl:for-each>
 </xsl:template>
 
+<xsl:template match="ol">
+<xsl:text>&#xA;</xsl:text>
+    <xsl:for-each select="li[not(@xml:lang)] | li[@xml:lang = en]">
+<xsl:number count="li[not(@xml:lang)] | li[@xml:lang = en]" format="1. "/>
+<xsl:value-of select="." />
+<xsl:text>&#xA;</xsl:text>
+    </xsl:for-each>
+</xsl:template>
+
 </xsl:stylesheet>
 """
 )

--- a/tests/unit/extractors/test_appstream.py
+++ b/tests/unit/extractors/test_appstream.py
@@ -100,6 +100,61 @@ class AppstreamTestCase(unit.TestCase):
         self.assertThat(appstream.extract(file_name), Equals(expected))
 
 
+class AppstreamTest(unit.TestCase):
+    def test_appstream(self):
+        file_name = "snapcraft.appdata.xml"
+        content = textwrap.dedent(
+            """\
+            <?xml version="1.0" encoding="utf-8"?>
+            <component type="desktop">
+              <id>io.snapcraft.snapcraft</id>
+              <metadata_license>CC0-1.0</metadata_license>
+              <project_license>GPL-3.0</project_license>
+              <name>snapcraft</name>
+              <name xml:lang="es">snapcraft</name>
+              <summary>Create snaps</summary>
+              <summary xml:lang="es">Crea snaps</summary>
+              <description>
+                <p>Command Line Utility to create snaps.</p>
+                <p xml:lang="es">Aplicativo de línea de comandos para crear snaps.</p>
+                <p>Features:</p>
+                <p xml:lang="es">Funciones:</p>
+                <ul>
+                  <li>Build snaps.</li>
+                  <li xml:lang="es">Construye snaps.</li>
+                  <li>Publish snaps to the store.</li>
+                  <li xml:lang="es">Publica snaps en la tienda.</li>
+                </ul>
+              </description>
+              <provides>
+                <binary>snapcraft</binary>
+              </provides>
+            </component>
+        """
+        )
+
+        with open(file_name, "w") as f:
+            print(content, file=f)
+
+        metadata = appstream.extract(file_name)
+
+        self.assertThat(metadata.get_summary(), Equals("Create snaps"))
+        self.assertThat(
+            metadata.get_description(),
+            Equals(
+                textwrap.dedent(
+                    """\
+            Command Line Utility to create snaps.
+
+            Features:
+
+            - Build snaps.
+            - Publish snaps to the store."""
+                )
+            ),
+        )
+
+
 class AppstreamUnhandledFileTestCase(unit.TestCase):
     def test_unhandled_file_test_case(self):
         raised = self.assertRaises(

--- a/tests/unit/extractors/test_appstream.py
+++ b/tests/unit/extractors/test_appstream.py
@@ -101,7 +101,7 @@ class AppstreamTestCase(unit.TestCase):
 
 
 class AppstreamTest(unit.TestCase):
-    def test_appstream(self):
+    def test_appstream_with_ul(self):
         file_name = "snapcraft.appdata.xml"
         content = textwrap.dedent(
             """\
@@ -150,6 +150,59 @@ class AppstreamTest(unit.TestCase):
 
             - Build snaps.
             - Publish snaps to the store."""
+                )
+            ),
+        )
+
+    def test_appstream_with_ol(self):
+        file_name = "snapcraft.appdata.xml"
+        content = textwrap.dedent(
+            """\
+            <?xml version="1.0" encoding="utf-8"?>
+            <component type="desktop">
+              <id>io.snapcraft.snapcraft</id>
+              <metadata_license>CC0-1.0</metadata_license>
+              <project_license>GPL-3.0</project_license>
+              <name>snapcraft</name>
+              <name xml:lang="es">snapcraft</name>
+              <summary>Create snaps</summary>
+              <summary xml:lang="es">Crea snaps</summary>
+              <description>
+                <p>Command Line Utility to create snaps.</p>
+                <p xml:lang="es">Aplicativo de línea de comandos para crear snaps.</p>
+                <p>Features:</p>
+                <p xml:lang="es">Funciones:</p>
+                <ol>
+                  <li>Build snaps.</li>
+                  <li xml:lang="es">Construye snaps.</li>
+                  <li>Publish snaps to the store.</li>
+                  <li xml:lang="es">Publica snaps en la tienda.</li>
+                </ol>
+              </description>
+              <provides>
+                <binary>snapcraft</binary>
+              </provides>
+            </component>
+        """
+        )
+
+        with open(file_name, "w") as f:
+            print(content, file=f)
+
+        metadata = appstream.extract(file_name)
+
+        self.assertThat(metadata.get_summary(), Equals("Create snaps"))
+        self.assertThat(
+            metadata.get_description(),
+            Equals(
+                textwrap.dedent(
+                    """\
+            Command Line Utility to create snaps.
+
+            Features:
+
+            1. Build snaps.
+            2. Publish snaps to the store."""
                 )
             ),
         )


### PR DESCRIPTION
Take into account more complex descriptions by transforming them using XSLT
prior to retrieving their contents by applying normalization into plain text
and taking into account language attributes (xml:lang).

LP: #1778545

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
