### PR TITLE
rust plugin: refactor to use the latest rustup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,19 +54,6 @@ jobs:
         - coverage xml
         - codecov --token="$CODECOV_TOKEN"
 
-    - stage: osx-integration-store
-      if: type != cron
-      os: osx
-      install:
-        - brew upgrade python
-        # readlink -f doesn't work on osx.
-        - brew upgrade coreutils || brew install coreutils
-        - python3 ./tools/brew_install_from_source.py
-        - python3 -m pip install -r requirements.txt
-        - python3 -m pip install -r requirements-devel.txt
-      script:
-        - SNAPCRAFT_FROM_BREW=1 ./runtests.sh tests.integration.store.test_store_login_logout use-run
-
     - stage: snap
       if: type != cron
       install:

--- a/snapcraft/plugins/rust.py
+++ b/snapcraft/plugins/rust.py
@@ -1,7 +1,7 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
 # Copyright (C) 2016-2017 Marius Gripsgard (mariogrip@ubuntu.com)
-# Copyright (C) 2016-2017 Canonical Ltd
+# Copyright (C) 2016-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -39,8 +39,9 @@ Additionally, this plugin uses the following plugin-specific keywords:
 import collections
 import logging
 import os
-import shutil
 from contextlib import suppress
+from textwrap import dedent
+from typing import List
 
 import snapcraft
 from snapcraft import sources
@@ -55,7 +56,10 @@ class RustPlugin(snapcraft.BasePlugin):
     @classmethod
     def schema(cls):
         schema = super().schema()
-        schema["properties"]["rust-channel"] = {"type": "string"}
+        schema["properties"]["rust-channel"] = {
+            "type": "string",
+            "enum": ["stable", "beta", "nightly"],
+        }
         schema["properties"]["rust-revision"] = {"type": "string"}
         schema["properties"]["rust-features"] = {
             "type": "array",
@@ -78,84 +82,87 @@ class RustPlugin(snapcraft.BasePlugin):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
         self.build_packages.extend(["gcc", "git", "curl", "file"])
-        self._rustpath = os.path.join(self.partdir, "rust")
-        self._rustc = os.path.join(self._rustpath, "bin", "rustc")
-        self._rustdoc = os.path.join(self._rustpath, "bin", "rustdoc")
-        self._cargo = os.path.join(self._rustpath, "bin", "cargo")
-        self._cargo_dir = os.path.join(self.builddir, ".cargo")
-        self._rustlib = os.path.join(self._rustpath, "lib")
-        self._rustup_get = sources.Script(_RUSTUP, self._rustpath)
-        self._rustup = os.path.join(self._rustpath, "rustup.sh")
+        self._rust_dir = os.path.expanduser(os.path.join("~", ".cargo"))
+        self._rustup_cmd = os.path.join(self._rust_dir, "bin", "rustup")
+        self._cargo_cmd = os.path.join(self._rust_dir, "bin", "cargo")
+        self._rustc_cmd = os.path.join(self._rust_dir, "bin", "rustc")
+        self._rustdoc_cmd = os.path.join(self._rust_dir, "bin", "rustdoc")
+
         self._manifest = collections.OrderedDict()
 
-    def _test(self):
-        if self.project.is_cross_compiling:
-            logger.warning(
-                "Skipping the test target run as this is a cross compilation."
-            )
-            return
-
-        cmd = [self._cargo, "test", "-j{}".format(self.parallel_build_count)]
-        if self.options.rust_features:
-            cmd.append("--features")
-            cmd.append(" ".join(self.options.rust_features))
-        self.run(cmd, env=self._build_env())
-
-    def build(self):
-        super().build()
-
-        self._write_cross_compile_config()
-
-        self._test()
-
-        cmd = [
-            self._cargo,
-            "install",
-            "-j{}".format(self.parallel_build_count),
-            "--root",
-            self.installdir,
-            "--path",
-            self.builddir,
-        ]
-        if self.options.rust_features:
-            cmd.append("--features")
-            cmd.append(" ".join(self.options.rust_features))
-        self.run(cmd, env=self._build_env())
-        self._record_manifest()
-
-    def _write_cross_compile_config(self):
-        if not self.project.is_cross_compiling:
-            return
-
-        # Cf. http://doc.crates.io/config.html
-        os.makedirs(self._cargo_dir, exist_ok=True)
-        with open(os.path.join(self._cargo_dir, "config"), "w") as f:
-            f.write(
-                """
-                [build]
-                target = "{}"
-
-                [target.{}]
-                linker = "{}"
-                """.format(
-                    self._target,
-                    self._target,
-                    "{}-gcc".format(self.project.arch_triplet),
-                )
-            )
-
-    def _record_manifest(self):
-        self._manifest["rustup-version"] = self.run_output([self._rustup, "--version"])
-        self._manifest["rustc-version"] = self.run_output([self._rustc, "--version"])
-        self._manifest["cargo-version"] = self.run_output([self._cargo, "--version"])
-        with suppress(FileNotFoundError, IsADirectoryError):
-            with open(os.path.join(self.builddir, "Cargo.lock")) as lock_file:
-                self._manifest["cargo-lock-contents"] = lock_file.read()
-
-    def get_manifest(self):
-        return self._manifest
-
     def enable_cross_compilation(self):
+        # The logic is applied transparently trough internal
+        # rust tooling.
+        pass
+
+    def pull(self):
+        super().pull()
+        self._fetch_rustup()
+        self._fetch_rust()
+        self._fetch_cargo_deps()
+
+    def _fetch_rustup(self):
+        # if rustup-init has already been done, we can skip this.
+        if os.path.exists(os.path.join(self._rust_dir, "bin", "rustup")):
+            return
+
+        # Download rustup-init.
+        os.makedirs(self._rust_dir, exist_ok=True)
+        sources.Script(_RUSTUP, self._rust_dir).download()
+        rustup_init_cmd = os.path.join(self._rust_dir, "rustup.sh")
+
+        # Basic options:
+        # -y: assume yes
+        # --no-modify-path: do not modify bashrc
+        options = ["-y", "--no-modify-path"]
+
+        # Check if we want to initialize using a specific channel.
+        if self.options.rust_channel:
+            options.extend(["--channel", self.options.rust_channel])
+
+        # Fetch rust
+        self.run([rustup_init_cmd] + options, env=self._build_env())
+
+    def _fetch_rust(self):
+        # Setup the channel in case rustup-init was run before or a revision which cannot be hanndled
+        # from rustup-init
+        # https://rust-lang-nursery.github.io/edition-guide/rust-2018/rustup-for-managing-rust-versions.html
+        toolchain = self._get_toolchain()
+        self.run([self._rustup_cmd, "install", toolchain], env=self._build_env())
+
+        # Add the appropriate target cross compilation target if necessary.
+        # https://github.com/rust-lang/rustup.rs/blob/master/README.md#cross-compilation
+        if self.project.is_cross_compiling:
+            self.run(
+                [
+                    self._rustup_cmd,
+                    "target",
+                    "add",
+                    "--toolchain",
+                    toolchain,
+                    self._get_target(),
+                ],
+                env=self._build_env(),
+            )
+
+    def _fetch_cargo_deps(self):
+        if self.options.source_subdir:
+            sourcedir = os.path.join(self.sourcedir, self.options.source_subdir)
+        else:
+            sourcedir = self.sourcedir
+
+        self.run(
+            [
+                self._cargo_cmd,
+                "+{}".format(self._get_toolchain()),
+                "fetch",
+                "--manifest-path",
+                os.path.join(sourcedir, "Cargo.toml"),
+            ],
+            env=self._build_env(),
+        )
+
+    def _get_target(self) -> str:
         # Cf. rustc --print target-list
         targets = {
             "armhf": "armv7-{}-{}eabihf",
@@ -164,88 +171,130 @@ class RustPlugin(snapcraft.BasePlugin):
             "amd64": "x86_64-{}-{}",
             "ppc64el": "powerpc64le-{}-{}",
         }
-        fmt = targets.get(self.project.deb_arch)
-        if not fmt:
-            raise NotImplementedError(
+        rust_target = targets.get(self.project.deb_arch)
+        if not rust_target:
+            raise errors.SnapcraftEnvironmentError(
                 "{!r} is not supported as a target architecture when "
                 "cross-compiling with the rust plugin".format(self.project.deb_arch)
             )
-        self._target = fmt.format("unknown-linux", "gnu")
+        return rust_target.format("unknown-linux", "gnu")
+
+    def build(self):
+        super().build()
+
+        # Write a minimal config.
+        self._write_cargo_config()
+
+        install_cmd = [
+            self._cargo_cmd,
+            "+{}".format(self._get_toolchain()),
+            "install",
+            "--path",
+            self.builddir,
+            "--root",
+            self.installdir,
+        ]
+
+        # Even though this is mostly harmless when not cross compiling
+        # the flag is in place to avoid a situation where an earlier
+        # version of the toolchain is used.
+        if self.project.is_cross_compiling:
+            install_cmd.extend(["--target", self._get_target()])
+
+        if self.options.rust_features:
+            install_cmd.append("--features")
+            install_cmd.append(" ".join(self.options.rust_features))
+
+        # build and install.
+        self.run(install_cmd, env=self._build_env())
+
+        # Finally, record.
+        self._record_manifest()
 
     def _build_env(self):
         env = os.environ.copy()
-        env.update(
-            {
-                "RUSTC": self._rustc,
-                "RUSTDOC": self._rustdoc,
-                "RUST_PATH": self._rustlib,
-                "RUSTFLAGS": self._rustflags(),
-            }
-        )
+
+        env.update(dict(RUSTUP_HOME=self._rust_dir, CARGO_HOME=self._rust_dir))
+
+        rustflags = self._get_rustflags()
+        if rustflags:
+            string_fmt = " ".join(["{}".format(i) for i in rustflags]).strip()
+            env.update(RUSTFLAGS=string_fmt)
+
         return env
 
-    def _rustflags(self):
+    def _get_toolchain(self) -> str:
+        toolchain = None
+        if self.options.rust_revision:
+            toolchain = self.options.rust_revision
+        elif self.options.rust_channel:
+            toolchain = self.options.rust_channel
+        else:
+            toolchain = "stable"
+
+        return toolchain
+
+    def _write_cargo_config(self) -> None:
+        # python toml's output dumps sections for targets with quotes that
+        # cargo later cannot pickup.
+        config = dict(
+            arch_triplet=self.project.arch_triplet,
+            target=self._get_target(),
+            jobs=self.parallel_build_count,
+            rustc_cmd=self._rustc_cmd,
+            rustdoc_cmd=self._rustdoc_cmd,
+        )
+
+        cargo_config_path = os.path.join(self.builddir, ".cargo", "config")
+        os.makedirs(os.path.dirname(cargo_config_path), exist_ok=True)
+
+        # Cf. http://doc.crates.io/config.html
+        with open(cargo_config_path, "w") as toml_config_file:
+            print(
+                dedent(
+                    """\
+                [build]
+                jobs = {jobs}
+                target = "{target}"
+                rustc = "{rustc_cmd}"
+                rustdoc = "{rustdoc_cmd}"
+
+                [target.{target}]
+                linker = "{arch_triplet}-gcc"
+            """
+                ).format(**config),
+                file=toml_config_file,
+            )
+
+    def _get_rustflags(self) -> List[str]:
         ldflags = shell_utils.getenv("LDFLAGS")
-        rustldflags = ""
+        rustldflags = []
         flags = {flag for flag in ldflags.split(" ") if flag}
         for flag in flags:
-            rustldflags += "-C link-arg={} ".format(flag)
-        return rustldflags.strip()
+            rustldflags.extend(["-C", "link-arg={}".format(flag)])
 
-    def pull(self):
-        super().pull()
-        self._fetch_rust()
-        self._fetch_deps()
-
-    def clean_pull(self):
-        super().clean_pull()
-
-        with suppress(FileNotFoundError):
-            shutil.rmtree(self._rustpath)
-
-    def clean_build(self):
-        super().clean_build()
-
-        with suppress(FileNotFoundError):
-            shutil.rmtree(self._cargo_dir)
-
-    def _fetch_rust(self):
-        options = []
-
-        if self.options.rust_revision:
-            options.append("--revision={}".format(self.options.rust_revision))
-
-        if self.options.rust_channel:
-            if self.options.rust_channel in ["stable", "beta", "nightly"]:
-                options.append("--channel={}".format(self.options.rust_channel))
-            else:
-                raise errors.SnapcraftEnvironmentError(
-                    "{} is not a valid rust channel".format(self.options.rust_channel)
-                )
-        os.makedirs(self._rustpath, exist_ok=True)
-        self._rustup_get.download()
-        cmd = [
-            self._rustup,
-            "--prefix={}".format(self._rustpath),
-            "--disable-sudo",
-            "--save",
-        ] + options
         if self.project.is_cross_compiling:
-            cmd.append("--with-target={}".format(self._target))
-        self.run(cmd)
+            rustldflags.extend(
+                ["-C", "linker={}-gcc".format(self.project.arch_triplet)]
+            )
 
-    def _fetch_deps(self):
-        if self.options.source_subdir:
-            sourcedir = os.path.join(self.sourcedir, self.options.source_subdir)
-        else:
-            sourcedir = self.sourcedir
+        return rustldflags
 
-        self.run(
-            [
-                self._cargo,
-                "fetch",
-                "--manifest-path",
-                os.path.join(sourcedir, "Cargo.toml"),
-            ],
-            env=self._build_env(),
+    def _record_manifest(self):
+        toolchain_option = "+{}".format(self._get_toolchain())
+
+        self._manifest["rustup-version"] = self.run_output(
+            [self._rustup_cmd, "--version"], env=self._build_env()
         )
+        self._manifest["rustc-version"] = self.run_output(
+            [self._rustc_cmd, toolchain_option, "--version"], env=self._build_env()
+        )
+        self._manifest["cargo-version"] = self.run_output(
+            [self._cargo_cmd, toolchain_option, "--version"], env=self._build_env()
+        )
+        with suppress(FileNotFoundError, IsADirectoryError):
+            with open(os.path.join(self.builddir, "Cargo.lock")) as lock_file:
+                self._manifest["cargo-lock-contents"] = lock_file.read()
+
+    def get_manifest(self):
+        return self._manifest

--- a/tests/integration/plugins/test_rust_plugin.py
+++ b/tests/integration/plugins/test_rust_plugin.py
@@ -60,7 +60,7 @@ class RustPluginTestCase(RustPluginBaseTestCase):
         binary_output = self.get_output_ignoring_non_zero_exit(
             os.path.join(self.stage_dir, "bin", "rust-with-revision")
         )
-        self.assertIn("Rust revision: 1.12.0", binary_output)
+        self.assertIn("Rust revision: 1.30.0", binary_output)
 
     def test_stage_rust_plugin_with_conditional_feature(self):
         self.run_snapcraft("stage", "rust-with-conditional")

--- a/tests/integration/snaps/rust-with-revision/Cargo.toml
+++ b/tests/integration/snaps/rust-with-revision/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["Marius Gripsgard <mariogrip@ubuntu.com>"]
 
 [dependencies]
-rustc_version = "= 0.1.2"
-rustc_version_runtime = "0.1.0"
+rustc_version = "= 0.2.3"
+rustc_version_runtime = "0.1.5"

--- a/tests/integration/snaps/rust-with-revision/snapcraft.yaml
+++ b/tests/integration/snaps/rust-with-revision/snapcraft.yaml
@@ -9,5 +9,5 @@ confinement: strict
 parts:
   rust-with-revision:
     plugin: rust
-    rust-revision: 1.12.0
+    rust-revision: 1.30.0
     source: .

--- a/tests/unit/plugins/test_rust.py
+++ b/tests/unit/plugins/test_rust.py
@@ -18,27 +18,21 @@
 import collections
 import os
 import subprocess
+
+from testtools.matchers import Contains, Equals, FileExists, Not
 from unittest import mock
 
-from testtools.matchers import Contains, DirExists, Equals, FileExists, Not
-
 import snapcraft
+from snapcraft.internal import errors
 from snapcraft.plugins import rust
-from tests import unit
+from tests import fixture_setup, unit
 
 
-class RustPluginCrossCompileTestCase(unit.TestCase):
-
-    scenarios = [
-        ("armv7l", dict(deb_arch="armhf", target="armv7-unknown-linux-gnueabihf")),
-        ("aarch64", dict(deb_arch="arm64", target="aarch64-unknown-linux-gnu")),
-        ("i386", dict(deb_arch="i386", target="i686-unknown-linux-gnu")),
-        ("x86_64", dict(deb_arch="amd64", target="x86_64-unknown-linux-gnu")),
-        ("ppc64le", dict(deb_arch="ppc64el", target="powerpc64le-unknown-linux-gnu")),
-    ]
-
+class RustPluginBaseTest(unit.TestCase):
     def setUp(self):
         super().setUp()
+
+        self.useFixture(fixture_setup.CleanEnvironment())
 
         class Options:
             makefile = None
@@ -49,7 +43,6 @@ class RustPluginCrossCompileTestCase(unit.TestCase):
             source_subdir = ""
 
         self.options = Options()
-        self.project_options = snapcraft.ProjectOptions(target_deb_arch=self.deb_arch)
 
         patcher = mock.patch("snapcraft.internal.common.run")
         self.run_mock = patcher.start()
@@ -59,100 +52,20 @@ class RustPluginCrossCompileTestCase(unit.TestCase):
         patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = mock.patch("snapcraft.ProjectOptions.is_cross_compiling")
+        original_exists = os.path.exists
+
+        def exists_mock(*args, **kwargs):
+            if args[0].endswith("rustup"):
+                return False
+            else:
+                return original_exists(args[0])
+
+        patcher = mock.patch("os.path.exists", side_effect=exists_mock)
         patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = mock.patch.dict(os.environ, {})
-        self.env_mock = patcher.start()
-        self.addCleanup(patcher.stop)
 
-    @mock.patch("snapcraft.internal.sources._script.Script.download")
-    def test_cross_compile(self, mock_download):
-        plugin = rust.RustPlugin("test-part", self.options, self.project_options)
-        os.makedirs(plugin.sourcedir)
-
-        plugin.enable_cross_compilation()
-        self.assertThat(plugin._target, Equals(self.target))
-
-        plugin.pull()
-        mock_download.assert_called_once_with()
-        self.assertThat(self.run_mock.call_count, Equals(2))
-        self.run_mock.assert_has_calls(
-            [
-                mock.call(
-                    [
-                        plugin._rustup,
-                        "--prefix={}".format(os.path.join(plugin._rustpath)),
-                        "--disable-sudo",
-                        "--save",
-                        "--with-target={}".format(self.target),
-                    ],
-                    cwd=os.path.join(plugin.partdir, "build"),
-                ),
-                mock.call(
-                    [
-                        plugin._cargo,
-                        "fetch",
-                        "--manifest-path",
-                        os.path.join(plugin.sourcedir, "Cargo.toml"),
-                    ],
-                    cwd=os.path.join(plugin.partdir, "build"),
-                    env=plugin._build_env(),
-                ),
-            ]
-        )
-
-        plugin.build()
-        self.assertThat(os.path.join(plugin._cargo_dir, "config"), FileExists())
-
-        self.assertThat(self.run_mock.call_count, Equals(3))
-        self.run_mock.assert_has_calls(
-            [
-                mock.call(
-                    [
-                        plugin._cargo,
-                        "install",
-                        "-j{}".format(plugin.project.parallel_build_count),
-                        "--root",
-                        plugin.installdir,
-                        "--path",
-                        plugin.builddir,
-                    ],
-                    cwd=os.path.join(plugin.partdir, "build"),
-                    env=plugin._build_env(),
-                )
-            ]
-        )
-
-        plugin.clean_build()
-        self.assertThat(plugin._cargo_dir, Not(DirExists()))
-        plugin.clean_pull()
-        self.assertThat(plugin._rustpath, Not(DirExists()))
-        # Cleaning again shouldn't raise an exception
-        plugin.clean_build()
-        plugin.clean_pull()
-
-
-class RustPluginTestCase(unit.TestCase):
-    def setUp(self):
-        super().setUp()
-
-        patcher = mock.patch.dict(os.environ, {})
-        self.env_mock = patcher.start()
-        self.addCleanup(patcher.stop)
-
-        class Options:
-            makefile = None
-            make_parameters = []
-            rust_features = []
-            rust_revision = ""
-            rust_channel = ""
-            source_subdir = ""
-
-        self.options = Options()
-        self.project_options = snapcraft.ProjectOptions()
-
+class RustPluginPropertiesTest(unit.TestCase):
     def test_schema(self):
         schema = rust.RustPlugin.schema()
 
@@ -166,11 +79,11 @@ class RustPluginTestCase(unit.TestCase):
             'Expected "rust-revision to be included in properties',
         )
 
+        # rust-channel
         rust_channel = properties["rust-channel"]
         self.assertTrue(
             "type" in rust_channel, 'Expected "type" to be included in "rust-channel"'
         )
-
         rust_channel_type = rust_channel["type"]
         self.assertThat(
             rust_channel_type,
@@ -178,12 +91,22 @@ class RustPluginTestCase(unit.TestCase):
             'Expected "rust-channel" "type" to be "string", '
             'but it was "{}"'.format(rust_channel_type),
         )
+        self.assertTrue(
+            "enum" in rust_channel, 'Expected "enum" to be included in "rust-channel"'
+        )
+        rust_channel_enum = rust_channel["enum"]
+        self.assertThat(
+            rust_channel_enum,
+            Equals(["stable", "beta", "nightly"]),
+            'Expected "rust-channel" "enum" to be "["stable", "beta", "nightly"]", '
+            'but it was "{}"'.format(rust_channel_enum),
+        )
 
+        # rust-revision
         rust_revision = properties["rust-revision"]
         self.assertTrue(
             "type" in rust_revision, 'Expected "type" to be included in "rust-revision"'
         )
-
         rust_revision_type = rust_revision["type"]
         self.assertThat(
             rust_revision_type,
@@ -192,221 +115,329 @@ class RustPluginTestCase(unit.TestCase):
             'but it was "{}"'.format(rust_revision_type),
         )
 
-    @mock.patch.object(rust.RustPlugin, "run")
-    @mock.patch.object(rust.RustPlugin, "run_output")
-    def test_build_with_conditional_compilation(self, _, run_mock):
-        plugin = rust.RustPlugin("test-part", self.options, self.project_options)
-        plugin.options.rust_features = ["conditional-compilation"]
+
+class RustPluginCrossCompileTest(RustPluginBaseTest):
+
+    scenarios = [
+        ("armv7l", dict(deb_arch="armhf", target="armv7-unknown-linux-gnueabihf")),
+        ("aarch64", dict(deb_arch="arm64", target="aarch64-unknown-linux-gnu")),
+        ("i386", dict(deb_arch="i386", target="i686-unknown-linux-gnu")),
+        ("x86_64", dict(deb_arch="amd64", target="x86_64-unknown-linux-gnu")),
+        ("ppc64le", dict(deb_arch="ppc64el", target="powerpc64le-unknown-linux-gnu")),
+    ]
+
+    def setUp(self):
+        super().setUp()
+
+        self.project = snapcraft.ProjectOptions(target_deb_arch=self.deb_arch)
+
+        patcher = mock.patch(
+            "snapcraft.ProjectOptions.is_cross_compiling", return_value=True
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    @mock.patch("snapcraft.internal.sources._script.Script.download")
+    def test_cross_compile(self, mock_download):
+        plugin = rust.RustPlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
 
-        plugin.build()
+        plugin.pull()
 
-        self.assertThat(run_mock.call_count, Equals(2))
-        run_mock.assert_has_calls(
+        self.assertThat(self.run_mock.call_count, Equals(4))
+        self.run_mock.assert_has_calls(
             [
                 mock.call(
                     [
-                        plugin._cargo,
-                        "test",
-                        "-j{}".format(plugin.project.parallel_build_count),
-                        "--features",
-                        "conditional-compilation",
+                        os.path.join(plugin._rust_dir, "rustup.sh"),
+                        "-y",
+                        "--no-modify-path",
                     ],
+                    cwd=os.path.join(plugin.partdir, "build"),
+                    env=plugin._build_env(),
+                ),
+                mock.call(
+                    [plugin._rustup_cmd, "install", "stable"],
+                    cwd=plugin.builddir,
                     env=plugin._build_env(),
                 ),
                 mock.call(
                     [
-                        plugin._cargo,
-                        "install",
-                        "-j{}".format(plugin.project.parallel_build_count),
-                        "--root",
-                        plugin.installdir,
-                        "--path",
-                        plugin.builddir,
-                        "--features",
-                        "conditional-compilation",
+                        plugin._rustup_cmd,
+                        "target",
+                        "add",
+                        "--toolchain",
+                        "stable",
+                        self.target,
                     ],
+                    cwd=plugin.builddir,
+                    env=plugin._build_env(),
+                ),
+                mock.call(
+                    [
+                        plugin._cargo_cmd,
+                        "+stable",
+                        "fetch",
+                        "--manifest-path",
+                        os.path.join(plugin.sourcedir, "Cargo.toml"),
+                    ],
+                    cwd=plugin.builddir,
                     env=plugin._build_env(),
                 ),
             ]
         )
 
+        self.run_mock.reset_mock()
+
+        plugin.build()
+
+        self.assertThat(os.path.join(plugin.builddir, ".cargo", "config"), FileExists())
+
+        self.assertThat(self.run_mock.call_count, Equals(1))
+        self.run_mock.assert_has_calls(
+            [
+                mock.call(
+                    [
+                        plugin._cargo_cmd,
+                        "+stable",
+                        "install",
+                        "--path",
+                        plugin.builddir,
+                        "--root",
+                        plugin.installdir,
+                        "--target",
+                        self.target,
+                    ],
+                    cwd=os.path.join(plugin.partdir, "build"),
+                    env=plugin._build_env(),
+                )
+            ]
+        )
+
+
+class RustPluginTest(RustPluginBaseTest):
+    def setUp(self):
+        super().setUp()
+
+        self.project = snapcraft.ProjectOptions()
+
     @mock.patch.object(rust.sources, "Script")
-    @mock.patch.object(rust.RustPlugin, "run")
-    def test_pull(self, run_mock, script_mock):
-        plugin = rust.RustPlugin("test-part", self.options, self.project_options)
+    def test_pull(self, script_mock):
+        plugin = rust.RustPlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
         plugin.options.rust_revision = []
         plugin.options.rust_channel = []
 
         plugin.pull()
 
-        self.assertThat(run_mock.call_count, Equals(2))
+        self.assertThat(self.run_mock.call_count, Equals(3))
 
-        rustdir = os.path.join(plugin.partdir, "rust")
-        run_mock.assert_has_calls(
+        self.run_mock.assert_has_calls(
             [
                 mock.call(
                     [
-                        os.path.join(rustdir, "rustup.sh"),
-                        "--prefix={}".format(rustdir),
-                        "--disable-sudo",
-                        "--save",
-                    ]
+                        os.path.join(plugin._rust_dir, "rustup.sh"),
+                        "-y",
+                        "--no-modify-path",
+                    ],
+                    cwd=os.path.join(plugin.partdir, "build"),
+                    env=plugin._build_env(),
+                ),
+                mock.call(
+                    [plugin._rustup_cmd, "install", "stable"],
+                    cwd=plugin.builddir,
+                    env=plugin._build_env(),
                 ),
                 mock.call(
                     [
-                        plugin._cargo,
+                        plugin._cargo_cmd,
+                        "+stable",
                         "fetch",
                         "--manifest-path",
                         os.path.join(plugin.sourcedir, "Cargo.toml"),
                     ],
+                    cwd=plugin.builddir,
                     env=plugin._build_env(),
                 ),
             ]
         )
 
     @mock.patch.object(rust.sources, "Script")
-    @mock.patch.object(rust.RustPlugin, "run")
-    def test_pull_with_channel(self, run_mock, script_mock):
-        plugin = rust.RustPlugin("test-part", self.options, self.project_options)
+    def test_pull_with_channel(self, script_mock):
+        plugin = rust.RustPlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
         plugin.options.rust_revision = ""
         plugin.options.rust_channel = "nightly"
 
         plugin.pull()
 
-        self.assertThat(run_mock.call_count, Equals(2))
+        self.assertThat(self.run_mock.call_count, Equals(3))
 
-        rustdir = os.path.join(plugin.partdir, "rust")
-        run_mock.assert_has_calls(
+        self.run_mock.assert_has_calls(
             [
                 mock.call(
                     [
-                        os.path.join(rustdir, "rustup.sh"),
-                        "--prefix={}".format(rustdir),
-                        "--disable-sudo",
-                        "--save",
-                        "--channel=nightly",
-                    ]
+                        os.path.join(plugin._rust_dir, "rustup.sh"),
+                        "-y",
+                        "--no-modify-path",
+                        "--channel",
+                        "nightly",
+                    ],
+                    cwd=os.path.join(plugin.partdir, "build"),
+                    env=plugin._build_env(),
+                ),
+                mock.call(
+                    [plugin._rustup_cmd, "install", "nightly"],
+                    cwd=plugin.builddir,
+                    env=plugin._build_env(),
                 ),
                 mock.call(
                     [
-                        plugin._cargo,
+                        plugin._cargo_cmd,
+                        "+nightly",
                         "fetch",
                         "--manifest-path",
                         os.path.join(plugin.sourcedir, "Cargo.toml"),
                     ],
+                    cwd=plugin.builddir,
                     env=plugin._build_env(),
                 ),
             ]
         )
 
     @mock.patch.object(rust.sources, "Script")
-    @mock.patch.object(rust.RustPlugin, "run")
-    def test_pull_with_revision(self, run_mock, script_mock):
-        plugin = rust.RustPlugin("test-part", self.options, self.project_options)
+    def test_pull_with_revision(self, script_mock):
+        plugin = rust.RustPlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
         plugin.options.rust_revision = "1.13.0"
         plugin.options.rust_channel = ""
 
         plugin.pull()
 
-        self.assertThat(run_mock.call_count, Equals(2))
+        self.assertThat(self.run_mock.call_count, Equals(3))
 
-        rustdir = os.path.join(plugin.partdir, "rust")
-        run_mock.assert_has_calls(
+        self.run_mock.assert_has_calls(
             [
                 mock.call(
                     [
-                        os.path.join(rustdir, "rustup.sh"),
-                        "--prefix={}".format(rustdir),
-                        "--disable-sudo",
-                        "--save",
-                        "--revision=1.13.0",
-                    ]
+                        os.path.join(plugin._rust_dir, "rustup.sh"),
+                        "-y",
+                        "--no-modify-path",
+                    ],
+                    cwd=os.path.join(plugin.partdir, "build"),
+                    env=plugin._build_env(),
+                ),
+                mock.call(
+                    [plugin._rustup_cmd, "install", "1.13.0"],
+                    cwd=plugin.builddir,
+                    env=plugin._build_env(),
                 ),
                 mock.call(
                     [
-                        plugin._cargo,
+                        plugin._cargo_cmd,
+                        "+1.13.0",
                         "fetch",
                         "--manifest-path",
                         os.path.join(plugin.sourcedir, "Cargo.toml"),
                     ],
+                    cwd=plugin.builddir,
                     env=plugin._build_env(),
                 ),
             ]
         )
 
     @mock.patch.object(rust.sources, "Script")
-    @mock.patch.object(rust.RustPlugin, "run")
-    def test_pull_with_source_and_source_subdir(self, run_mock, script_mock):
-        plugin = rust.RustPlugin("test-part", self.options, self.project_options)
+    def test_pull_with_source_and_source_subdir(self, script_mock):
+        plugin = rust.RustPlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
         plugin.options.source_subdir = "test-subdir"
 
         plugin.pull()
 
-        run_mock.assert_has_calls(
+        self.assertThat(self.run_mock.call_count, Equals(3))
+
+        self.run_mock.assert_has_calls(
             [
-                mock.ANY,
                 mock.call(
                     [
-                        plugin._cargo,
+                        os.path.join(plugin._rust_dir, "rustup.sh"),
+                        "-y",
+                        "--no-modify-path",
+                    ],
+                    cwd=os.path.join(plugin.partdir, "build"),
+                    env=plugin._build_env(),
+                ),
+                mock.call(
+                    [plugin._rustup_cmd, "install", "stable"],
+                    cwd=plugin.builddir,
+                    env=plugin._build_env(),
+                ),
+                mock.call(
+                    [
+                        plugin._cargo_cmd,
+                        "+stable",
                         "fetch",
                         "--manifest-path",
                         os.path.join(plugin.sourcedir, "test-subdir", "Cargo.toml"),
                     ],
+                    cwd=plugin.builddir,
                     env=plugin._build_env(),
                 ),
             ]
         )
 
     @mock.patch("snapcraft.ProjectOptions.deb_arch", "fantasy-arch")
-    def test_cross_compiling_unsupported_arch_raises_exception(self):
-        plugin = rust.RustPlugin("test-part", self.options, self.project_options)
+    def test_unsupported_target_arch_raises_exception(self):
+        plugin = rust.RustPlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
 
-        self.assertRaises(NotImplementedError, plugin.enable_cross_compilation)
+        self.assertRaises(errors.SnapcraftEnvironmentError, plugin._get_target)
 
-    @mock.patch.object(rust.RustPlugin, "run")
-    @mock.patch.object(rust.RustPlugin, "run_output")
-    def test_build(self, _, run_mock):
-        plugin = rust.RustPlugin("test-part", self.options, self.project_options)
+    def test_build(self):
+        plugin = rust.RustPlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
 
         plugin.build()
 
-        self.assertThat(run_mock.call_count, Equals(2))
-        run_mock.assert_has_calls(
+        self.run_mock.assert_called_once_with(
             [
-                mock.call(
-                    [
-                        plugin._cargo,
-                        "test",
-                        "-j{}".format(plugin.project.parallel_build_count),
-                    ],
-                    env=plugin._build_env(),
-                ),
-                mock.call(
-                    [
-                        plugin._cargo,
-                        "install",
-                        "-j{}".format(plugin.project.parallel_build_count),
-                        "--root",
-                        plugin.installdir,
-                        "--path",
-                        plugin.builddir,
-                    ],
-                    env=plugin._build_env(),
-                ),
-            ]
+                plugin._cargo_cmd,
+                "+stable",
+                "install",
+                "--path",
+                plugin.builddir,
+                "--root",
+                plugin.installdir,
+            ],
+            cwd=os.path.join(plugin.partdir, "build"),
+            env=plugin._build_env(),
         )
 
-    @mock.patch.object(rust.RustPlugin, "run")
-    @mock.patch.object(rust.RustPlugin, "run_output")
-    def test_get_manifest_with_cargo_lock_file(self, *_):
-        plugin = rust.RustPlugin("test-part", self.options, self.project_options)
+    def test_build_with_conditional_compilation(self):
+        plugin = rust.RustPlugin("test-part", self.options, self.project)
+        plugin.options.rust_features = ["conditional-compilation"]
+        os.makedirs(plugin.sourcedir)
+
+        plugin.build()
+
+        self.run_mock.assert_called_once_with(
+            [
+                plugin._cargo_cmd,
+                "+stable",
+                "install",
+                "--path",
+                plugin.builddir,
+                "--root",
+                plugin.installdir,
+                "--features",
+                "conditional-compilation",
+            ],
+            cwd=os.path.join(plugin.partdir, "build"),
+            env=plugin._build_env(),
+        )
+
+    def test_get_manifest_with_cargo_lock_file(self):
+        plugin = rust.RustPlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
         os.makedirs(plugin.builddir)
 
@@ -420,10 +451,8 @@ class RustPluginTestCase(unit.TestCase):
             Equals("test cargo lock contents"),
         )
 
-    @mock.patch.object(rust.RustPlugin, "run")
-    @mock.patch.object(rust.RustPlugin, "run_output")
-    def test_get_manifest_with_unexisting_cargo_lock(self, *_):
-        plugin = rust.RustPlugin("test-part", self.options, self.project_options)
+    def test_get_manifest_with_unexisting_cargo_lock(self):
+        plugin = rust.RustPlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
         os.makedirs(plugin.builddir)
 
@@ -431,10 +460,8 @@ class RustPluginTestCase(unit.TestCase):
 
         self.assertThat(plugin.get_manifest(), Not(Contains("cargo-lock-contents")))
 
-    @mock.patch.object(rust.RustPlugin, "run")
-    @mock.patch.object(rust.RustPlugin, "run_output")
     def test_get_manifest_with_cargo_lock_dir(self, *_):
-        plugin = rust.RustPlugin("test-part", self.options, self.project_options)
+        plugin = rust.RustPlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
         os.makedirs(plugin.builddir)
 
@@ -444,16 +471,15 @@ class RustPluginTestCase(unit.TestCase):
 
         self.assertThat(plugin.get_manifest(), Not(Contains("cargo-lock-contents")))
 
-    @mock.patch.object(rust.RustPlugin, "run")
-    def test_get_manifest_with_versions(self, _):
-        plugin = rust.RustPlugin("test-part", self.options, self.project_options)
+    def test_get_manifest_with_versions(self):
+        plugin = rust.RustPlugin("test-part", self.options, self.project)
         os.makedirs(plugin.sourcedir)
 
         original_check_output = subprocess.check_output
 
         def side_effect(cmd, *args, **kwargs):
             if cmd[-1] == "--version":
-                binary = os.path.basename(cmd[-2])
+                binary = os.path.basename(cmd[0])
                 return "test {} version".format(binary)
             return original_check_output(cmd, *args, **kwargs)
 
@@ -462,7 +488,7 @@ class RustPluginTestCase(unit.TestCase):
             plugin.build()
 
         expected_manifest = collections.OrderedDict()
-        expected_manifest["rustup-version"] = "test rustup.sh version"
+        expected_manifest["rustup-version"] = "test rustup version"
         expected_manifest["rustc-version"] = "test rustc version"
         expected_manifest["cargo-version"] = "test cargo version"
 


### PR DESCRIPTION
- Latest versions of rustup removed --prefix, --disable-sudo and --save.
- Using command qualifiers for channels and revisions.
- A global rustup and cargo area is now in place for multiple parts
  to reuse.
- Removed the test target as it was inconsitent with other plugins.
- Made use of .cargo/config for consistency across execution.

LP: #1809259
LP: #1803466
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
