### PR TITLE
legacy/meta: make hooks executable instead of complaining they're not

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -401,14 +401,14 @@ class _SnapPackaging:
                     source = os.path.join(src_dir, asset)
                     destination = os.path.join(dst_dir, asset)
 
-                    # First, ensure that the hook is executable
-                    if origin == "hooks":
-                        _prepare_hook(source)
-
                     with contextlib.suppress(FileNotFoundError):
                         os.remove(destination)
 
                     file_utils.link_or_copy(source, destination)
+
+                    # Ensure that the hook is executable
+                    if origin == "hooks":
+                        _prepare_hook(destination)
 
         self._record_manifest_and_source_snapcraft_yaml()
 

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -401,9 +401,9 @@ class _SnapPackaging:
                     source = os.path.join(src_dir, asset)
                     destination = os.path.join(dst_dir, asset)
 
-                    # First, verify that the hook is actually executable
+                    # First, ensure that the hook is executable
                     if origin == "hooks":
-                        _validate_hook(source)
+                        _prepare_hook(source)
 
                     with contextlib.suppress(FileNotFoundError):
                         os.remove(destination)
@@ -419,11 +419,8 @@ class _SnapPackaging:
             os.makedirs(hooks_dir, exist_ok=True)
             for hook_name in os.listdir(snap_hooks_dir):
                 file_path = os.path.join(snap_hooks_dir, hook_name)
-                # First, verify that the hook is actually executable
-                if not os.stat(file_path).st_mode & stat.S_IEXEC:
-                    raise meta_errors.CommandError(
-                        "hook {!r} is not executable".format(hook_name)
-                    )
+                # Make sure the hook is executable
+                _prepare_hook(file_path)
 
                 hook_exec = os.path.join("$SNAP", "snap", "hooks", hook_name)
                 hook_path = os.path.join(hooks_dir, hook_name)
@@ -657,10 +654,10 @@ def _find_bin(binary, basedir):
         raise meta_errors.CommandError(binary)
 
 
-def _validate_hook(hook_path):
+def _prepare_hook(hook_path):
+    # Ensure hook is executable
     if not os.stat(hook_path).st_mode & stat.S_IEXEC:
-        asset = os.path.basename(hook_path)
-        raise meta_errors.CommandError("hook {!r} is not executable".format(asset))
+        os.chmod(hook_path, 0o755)
 
 
 def _verify_app_paths(basedir, apps):

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -19,6 +19,7 @@ import contextlib
 import logging
 import os
 from unittest.mock import patch
+import stat
 
 import fixtures
 import testscenarios
@@ -1055,17 +1056,19 @@ class WriteSnapDirectoryTestCase(CreateBaseTestCase):
             FileContains("from snap"),
         )
 
-    def test_snap_hooks_not_executable_raises(self):
+    def test_snap_hooks_not_executable_chmods(self):
         # Setup a snap directory containing a few things.
         _create_file(os.path.join(self.snap_dir, "snapcraft.yaml"))
         _create_file(os.path.join(self.snap_dir, "hooks", "test-hook"))
 
-        # Now write the snap directory. This process should fail as the hook
-        # isn't executable.
-        with testtools.ExpectedException(
-            meta_errors.CommandError, "hook 'test-hook' is not executable"
-        ):
-            self.generate_meta_yaml()
+        # Now write the snap directory.
+        self.generate_meta_yaml()
+
+        # Ensure the file is executable
+        self.assertThat(os.path.join(self.hooks_dir, "test-hook"), FileExists())
+        self.assertTrue(
+            os.stat(os.path.join(self.hooks_dir, "test-hook")).st_mode & stat.S_IEXEC
+        )
 
 
 class GenerateHookWrappersTestCase(CreateBaseTestCase):
@@ -1094,18 +1097,20 @@ class GenerateHookWrappersTestCase(CreateBaseTestCase):
                 ),
             )
 
-    def test_generate_hook_wrappers_not_executable_raises(self):
+    def test_generate_hook_wrappers_not_executable_chmods(self):
         # Set up the prime directory to contain a hook in snap/hooks that is
         # not executable.
         snap_hooks_dir = os.path.join(self.prime_dir, "snap", "hooks")
         _create_file(os.path.join(snap_hooks_dir, "test-hook"))
 
-        # Now attempt to generate hook wrappers. This should fail, as the hook
-        # itself is not executable.
-        with testtools.ExpectedException(
-            meta_errors.CommandError, "hook 'test-hook' is not executable"
-        ):
-            self.generate_meta_yaml()
+        # Now generate hook wrappers.
+        self.generate_meta_yaml()
+
+        # Ensure the file is executable
+        self.assertThat(os.path.join(self.hooks_dir, "test-hook"), FileExists())
+        self.assertTrue(
+            os.stat(os.path.join(self.hooks_dir, "test-hook")).st_mode & stat.S_IEXEC
+        )
 
 
 class CreateWithConfinementTestCase(CreateBaseTestCase):

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -1057,6 +1057,17 @@ class WriteSnapDirectoryTestCase(CreateBaseTestCase):
         )
 
     def test_snap_hooks_not_executable_chmods(self):
+        real_chmod = os.chmod
+
+        def chmod_noop(name, *args, **kwargs):
+            # Simulate a source filesystem that doesn't allow changing permissions
+            if name.startswith("snap"):
+                pass
+            else:
+                real_chmod(name, *args, **kwargs)
+
+        self.useFixture(fixtures.MonkeyPatch("os.chmod", chmod_noop))
+
         # Setup a snap directory containing a few things.
         _create_file(os.path.join(self.snap_dir, "snapcraft.yaml"))
         _create_file(os.path.join(self.snap_dir, "hooks", "test-hook"))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Fixes https://bugs.launchpad.net/snapcraft/+bug/1812003

This is a cherry-pick of #2440 