### PR TITLE
cli: enable cleaning of parts

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -186,6 +186,9 @@ class Provider(abc.ABC):
     def execute_step(self, step: steps.Step) -> None:
         self._run(command=["snapcraft", step.name])
 
+    def clean(self, part_names: Sequence[str]) -> None:
+        self._run(command=["snapcraft", "clean"] + list(part_names))
+
     def pack_project(self, *, output: Optional[str] = None) -> None:
         command = ["snapcraft", "snap"]
         if output:

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -108,6 +108,22 @@ class BaseProviderTest(BaseProviderBaseTest):
         # TODO add robustness to start. (LP: #1792242)
         self.assertThat(provider.provider_project_dir, Not(DirExists()))
 
+    def test_clean_part(self):
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+
+        provider.clean(part_names=("part1",))
+
+        provider.run_mock.assert_called_once_with(["snapcraft", "clean", "part1"])
+
+    def test_clean_multiple_parts(self):
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+
+        provider.clean(part_names=("part1", "part2"))
+
+        provider.run_mock.assert_called_once_with(
+            ["snapcraft", "clean", "part1", "part2"]
+        )
+
 
 class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
     def test_setup_snapcraft(self):

--- a/tests/unit/commands/test_clean.py
+++ b/tests/unit/commands/test_clean.py
@@ -157,18 +157,6 @@ class CleanCommandPartsTestCase(CleanCommandBaseTestCase):
 
         self.assertThat(result.exit_code, Equals(0))
 
-    def test_cleaning_with_strip_does_prime_and_warns(self):
-        self.make_snapcraft_yaml(n=3)
-
-        result = self.run_command(["clean", "--step=strip"])
-
-        self.assertThat(result.exit_code, Equals(0))
-        self.assertThat(
-            result.output,
-            Contains("DEPRECATED: Use `prime` instead of `strip` as the step to clean"),
-        )
-        self.assertThat(self.prime_dir, Not(DirExists()))
-
 
 class CleanCommandReverseDependenciesTestCase(CommandBaseTestCase):
     def setUp(self):

--- a/tests/unit/commands/test_inspect.py
+++ b/tests/unit/commands/test_inspect.py
@@ -308,22 +308,22 @@ class InspectLifecycleStatusTest(CommandBaseTestCase):
             ),
         )
 
-        self.run_command(["clean", "part1", "--step=prime"])
+        self.run_command(["clean", "part1"])
         result = json.loads(self.run_command(["inspect", "--json"]).output)
         self.expectThat(
             result,
             Equals(
                 {
                     "part1": {
-                        "pull": "complete",
-                        "build": "complete",
-                        "stage": "complete",
+                        "pull": None,
+                        "build": None,
+                        "stage": None,
                         "prime": None,
                     },
                     "part2": {
                         "pull": "outdated (source changed)",
-                        "build": "complete",
-                        "stage": "complete",
+                        "build": "dirty ('part1' changed)",
+                        "stage": "dirty ('part1' changed)",
                         "prime": "dirty ('part1' changed)",
                     },
                 }


### PR DESCRIPTION
Bring back snapcraft clean <part-name> when using build providers.

LP: #1779136
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
