### PR TITLE
schema: allow before and after

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -239,6 +239,8 @@ properties:
           stop-command: [daemon]
           post-stop-command: [daemon]
           reload-command: [daemon]
+          before: [daemon]
+          after: [daemon]
         additionalProperties: false
         properties:
           common-id:
@@ -271,6 +273,20 @@ properties:
               - forking
               - oneshot
               - notify
+          after:
+            type: array
+            description: List of applications that are ordered to be started after the current one
+            minitems: 1
+            uniqueItems: true
+            items:
+              type: string
+          before:
+            type: array
+            description: List of applications that are ordered to be started before the current one
+            minitems: 1
+            uniqueItems: true
+            items:
+              type: string
           refresh-mode:
               type: string
               description: controls if the app should be restarted at all

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -163,6 +163,8 @@ class DaemonDependencyTest(ValidationBaseTest):
             "post-stop-command",
             dict(option="post-stop-command", value="binary1 --post-stop"),
         ),
+        ("before", dict(option="before", value="service2")),
+        ("after", dict(option="after", value="service2")),
     ]
 
     def test_daemon_dependency(self):

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -526,6 +526,28 @@ class RefreshModeTestCase(CreateBaseTestCase):
         self.assertThat(y["apps"]["app1"]["refresh-mode"], Equals(self.mode))
 
 
+class BeforeAndAfterTest(CreateBaseTestCase):
+    def test_before_valid(self):
+        self.config_data["apps"] = {
+            "app-before": {"command": "sh", "daemon": "simple"},
+            "app": {"command": "sh", "daemon": "simple", "before": ["app-before"]},
+        }
+
+        y = self.generate_meta_yaml()
+
+        self.assertThat(y["apps"]["app"]["before"], Equals(["app-before"]))
+
+    def test_after_valid(self):
+        self.config_data["apps"] = {
+            "app-after": {"command": "sh", "daemon": "simple"},
+            "app": {"command": "sh", "daemon": "simple", "after": ["app-after"]},
+        }
+
+        y = self.generate_meta_yaml()
+
+        self.assertThat(y["apps"]["app"]["after"], Equals(["app-after"]))
+
+
 class PassthroughBaseTestCase(CreateBaseTestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Rely on most of the validation done by `snap pack`.

LP: #1808148
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
