### PR TITLE
build providers: remove SIGUSR1 signal ignore workaround for multipass

### DIFF
--- a/snapcraft/internal/build_providers/_multipass/_multipass_command.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass_command.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import signal
 import shutil
 import subprocess
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union  # noqa: F401
@@ -36,14 +35,6 @@ def _run_output(command: Sequence[str], **kwargs) -> bytes:
     return subprocess.check_output(command, **kwargs)
 
 
-def _ignore_signal(sig, stack):
-    # We only do this for SIGUSR1 as it is the one we mostly
-    # care about.
-    if sig == signal.SIGUSR1:
-        sig = "SIGUSR1"
-    logger.debug("Ignoring {!r}: {!r}".format(sig, dir(stack)))
-
-
 class MultipassCommand:
     """An object representation of common multipass cli commands."""
 
@@ -59,8 +50,6 @@ class MultipassCommand:
         if not shutil.which(provider_cmd):
             raise errors.ProviderCommandNotFound(command=provider_cmd)
         self.provider_cmd = provider_cmd
-        # Workaround for https://github.com/CanonicalLtd/multipass/issues/221
-        signal.signal(signal.SIGUSR1, _ignore_signal)
 
     def launch(
         self,


### PR DESCRIPTION
The issue has been fixed upstream (CanonicalLtd/multipass#221).

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
