### PR TITLE
pluginhandler: handle removal of inconsistent files

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -1134,8 +1134,8 @@ def _clean_migrated_files(snap_files, snap_dirs, directory):
             os.remove(os.path.join(directory, snap_file))
         except FileNotFoundError:
             logger.warning(
-                "File {name!r} not found. Did you remove it in a different "
-                "part?".format(name=snap_file)
+                "Attempted to remove file {name!r}, but it didn't exist. "
+                "Skipping...".format(name=snap_file)
             )
 
     # snap_dirs may not be ordered so that subdirectories come before
@@ -1150,8 +1150,8 @@ def _clean_migrated_files(snap_files, snap_dirs, directory):
                 os.rmdir(migrated_directory)
         except FileNotFoundError:
             logger.warning(
-                "Directory {name!r} not found. Did you remove it in a "
-                "different part?".format(name=snap_dir)
+                "Attempted to remove directory {name!r}, but it didn't exist. "
+                "Skipping...".format(name=snap_dir)
             )
 
 

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -1130,7 +1130,13 @@ def _organize_filesets(part_name, fileset, base_dir, overwrite):
 
 def _clean_migrated_files(snap_files, snap_dirs, directory):
     for snap_file in snap_files:
-        os.remove(os.path.join(directory, snap_file))
+        try:
+            os.remove(os.path.join(directory, snap_file))
+        except FileNotFoundError:
+            logger.warning(
+                "File {name!r} not found. Did you remove it in a different "
+                "part?".format(name=snap_file)
+            )
 
     # snap_dirs may not be ordered so that subdirectories come before
     # parents, and we want to be able to remove directories if possible, so
@@ -1139,8 +1145,14 @@ def _clean_migrated_files(snap_files, snap_dirs, directory):
 
     for snap_dir in snap_dirs:
         migrated_directory = os.path.join(directory, snap_dir)
-        if not os.listdir(migrated_directory):
-            os.rmdir(migrated_directory)
+        try:
+            if not os.listdir(migrated_directory):
+                os.rmdir(migrated_directory)
+        except FileNotFoundError:
+            logger.warning(
+                "Directory {name!r} not found. Did you remove it in a "
+                "different part?".format(name=snap_dir)
+            )
 
 
 def _get_file_list(stage_set):

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -1810,15 +1810,17 @@ class StateTestCase(StateBaseTestCase):
     def test_clean_prime_state_inconsistent_files(self):
         self.assertRaises(errors.NoLatestStepError, self.handler.latest_step)
         self.assertThat(self.handler.next_step(), Equals(steps.PULL))
-        bindir = os.path.join(self.prime_dir, "bin")
-        os.makedirs(bindir)
-        open(os.path.join(bindir, "1"), "w").close()
 
         self.handler.mark_done(steps.STAGE)
 
         self.handler.mark_done(
-            steps.PRIME, states.PrimeState({"bin/1", "bin/2"}, {"bin", "foo"})
+            steps.PRIME, states.PrimeState({"bin/1", "bin/2"}, {"bin", "not-there"})
         )
+
+        # Only create a subset of the files and directories that were marked as primed
+        bindir = os.path.join(self.prime_dir, "bin")
+        os.makedirs(bindir)
+        open(os.path.join(bindir, "1"), "w").close()
 
         self.handler.clean_prime({})
 

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -1807,6 +1807,25 @@ class StateTestCase(StateBaseTestCase):
         self.assertThat(self.handler.next_step(), Equals(steps.PRIME))
         self.assertFalse(os.path.exists(bindir))
 
+    def test_clean_prime_state_inconsistent_files(self):
+        self.assertRaises(errors.NoLatestStepError, self.handler.latest_step)
+        self.assertThat(self.handler.next_step(), Equals(steps.PULL))
+        bindir = os.path.join(self.prime_dir, "bin")
+        os.makedirs(bindir)
+        open(os.path.join(bindir, "1"), "w").close()
+
+        self.handler.mark_done(steps.STAGE)
+
+        self.handler.mark_done(
+            steps.PRIME, states.PrimeState({"bin/1", "bin/2"}, {"bin", "foo"})
+        )
+
+        self.handler.clean_prime({})
+
+        self.assertThat(self.handler.latest_step(), Equals(steps.STAGE))
+        self.assertThat(self.handler.next_step(), Equals(steps.PRIME))
+        self.assertFalse(os.path.exists(bindir))
+
     def test_clean_prime_state_multiple_parts(self):
         self.assertRaises(errors.NoLatestStepError, self.handler.latest_step)
         self.assertThat(self.handler.next_step(), Equals(steps.PULL))


### PR DESCRIPTION
When a part is cleaned, the system does its housekeeping by removing
all the files or directories it prepared for stage or prime. If the
user manually removes a file (say, in another part's override-prime),
we should ignore the non-existent file and issue a warning instead
of halting and catching fire.

See https://bugs.launchpad.net/snapcraft/+bug/1813033 for more details.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
