### PR TITLE
static: address black warnings

### DIFF
--- a/snapcraft/internal/deltas/_deltas.py
+++ b/snapcraft/internal/deltas/_deltas.py
@@ -159,7 +159,7 @@ class BaseDeltasGenerator:
                 count = 0
             progress_indicator.update(count)
             count += 1
-            time.sleep(.2)
+            time.sleep(0.2)
             ret = proc.poll()
         print("")
         # the caller should finish the progressbar outside

--- a/snapcraft/internal/lifecycle/_packer.py
+++ b/snapcraft/internal/lifecycle/_packer.py
@@ -126,7 +126,7 @@ def _run_mksquashfs(
                     count = 0
                 progress_indicator.update(count)
                 count += 1
-                time.sleep(.2)
+                time.sleep(0.2)
                 ret = proc.poll()
         print("")
         if ret != 0:

--- a/tests/unit/build_providers/multipass/test_instance_info.py
+++ b/tests/unit/build_providers/multipass/test_instance_info.py
@@ -20,7 +20,7 @@ from testtools.matchers import Equals
 
 from snapcraft.internal.build_providers import errors
 from snapcraft.internal.build_providers._multipass._instance_info import (
-    InstanceInfo
+    InstanceInfo,
 )  # noqa: E501
 from tests import unit
 

--- a/tests/unit/project_loader/grammar_processing/test_global_grammar_processor.py
+++ b/tests/unit/project_loader/grammar_processing/test_global_grammar_processor.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from snapcraft.internal.project_loader.grammar_processing import (
-    _global_grammar_processor as processor
+    _global_grammar_processor as processor,
 )
 
 import doctest


### PR DESCRIPTION
Address a couple of warnings reported by black in bionic.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
