### PR TITLE
ant, maven and gradle plugins: use correct defaults for jre

### DIFF
--- a/snapcraft/plugins/ant.py
+++ b/snapcraft/plugins/ant.py
@@ -154,16 +154,16 @@ class AntPlugin(snapcraft.BasePlugin):
             valid_versions = ["8", "11"]
 
         version = self.options.ant_openjdk_version
-        if version and version not in valid_versions:
+        if not version:
+            version = valid_versions[-1]
+        elif version not in valid_versions:
             raise UnsupportedJDKVersionError(
                 version=version, base=base, valid_versions=valid_versions
             )
-        elif not version:
-            # Get the latest version from the slice
-            version = valid_versions[-1]
 
         self.stage_packages.append("openjdk-{}-jre-headless".format(version))
         self.build_packages.append("openjdk-{}-jdk-headless".format(version))
+        self._java_version = version
 
     def _setup_ant(self):
         self._ant_tar_handle = None
@@ -206,7 +206,7 @@ class AntPlugin(snapcraft.BasePlugin):
         self._create_symlinks()
 
     def _create_symlinks(self):
-        if self.project.info.base not in ("core18", "core19"):
+        if self.project.info.base not in ("core18", "core16"):
             raise errors.PluginBaseError(
                 part_name=self.name, base=self.project.info.base
             )
@@ -218,7 +218,7 @@ class AntPlugin(snapcraft.BasePlugin):
                 "usr",
                 "lib",
                 "jvm",
-                "java-{}-openjdk-*".format(self.options.ant_openjdk_version),
+                "java-{}-openjdk-*".format(self._java_version),
                 "jre",
                 "bin",
                 "java",

--- a/snapcraft/plugins/ant.py
+++ b/snapcraft/plugins/ant.py
@@ -219,7 +219,6 @@ class AntPlugin(snapcraft.BasePlugin):
                 "lib",
                 "jvm",
                 "java-{}-openjdk-*".format(self._java_version),
-                "jre",
                 "bin",
                 "java",
             )

--- a/snapcraft/plugins/gradle.py
+++ b/snapcraft/plugins/gradle.py
@@ -247,7 +247,6 @@ class GradlePlugin(snapcraft.BasePlugin):
                 "lib",
                 "jvm",
                 "java-{}-openjdk-*".format(self._java_version),
-                "jre",
                 "bin",
                 "java",
             )

--- a/snapcraft/plugins/gradle.py
+++ b/snapcraft/plugins/gradle.py
@@ -160,17 +160,17 @@ class GradlePlugin(snapcraft.BasePlugin):
             valid_versions = ["8", "11"]
 
         version = self.options.gradle_openjdk_version
-        if version and version not in valid_versions:
+        if not version:
+            version = valid_versions[-1]
+        elif version not in valid_versions:
             raise UnsupportedJDKVersionError(
                 version=version, base=base, valid_versions=valid_versions
             )
-        elif not version:
-            # Get the latest version from the slice
-            version = valid_versions[-1]
 
         self.stage_packages.append("openjdk-{}-jre-headless".format(version))
         self.build_packages.append("openjdk-{}-jdk-headless".format(version))
         self.build_packages.append("ca-certificates-java")
+        self._java_version = version
 
     def _using_gradlew(self) -> bool:
         return os.path.isfile(os.path.join(self.sourcedir, "gradlew"))
@@ -234,7 +234,7 @@ class GradlePlugin(snapcraft.BasePlugin):
         self._create_symlinks()
 
     def _create_symlinks(self):
-        if self.project.info.base not in ("core18", "core19"):
+        if self.project.info.base not in ("core18", "core16"):
             raise errors.PluginBaseError(
                 part_name=self.name, base=self.project.info.base
             )
@@ -246,7 +246,7 @@ class GradlePlugin(snapcraft.BasePlugin):
                 "usr",
                 "lib",
                 "jvm",
-                "java-{}-openjdk-*".format(self.options.gradle_openjdk_version),
+                "java-{}-openjdk-*".format(self._java_version),
                 "jre",
                 "bin",
                 "java",

--- a/snapcraft/plugins/maven.py
+++ b/snapcraft/plugins/maven.py
@@ -256,7 +256,6 @@ class MavenPlugin(snapcraft.BasePlugin):
                 "lib",
                 "jvm",
                 "java-{}-openjdk-*".format(self._java_version),
-                "jre",
                 "bin",
                 "java",
             )

--- a/snapcraft/plugins/maven.py
+++ b/snapcraft/plugins/maven.py
@@ -164,16 +164,16 @@ class MavenPlugin(snapcraft.BasePlugin):
             valid_versions = ["8", "11"]
 
         version = self.options.maven_openjdk_version
-        if version and version not in valid_versions:
+        if not version:
+            version = valid_versions[-1]
+        elif version not in valid_versions:
             raise UnsupportedJDKVersionError(
                 version=version, base=base, valid_versions=valid_versions
             )
-        elif not version:
-            # Get the latest version from the slice
-            version = valid_versions[-1]
 
         self.stage_packages.append("openjdk-{}-jre-headless".format(version))
         self.build_packages.append("openjdk-{}-jdk-headless".format(version))
+        self._java_version = version
 
     def _setup_maven(self):
         self._maven_tar_handle = None
@@ -243,7 +243,7 @@ class MavenPlugin(snapcraft.BasePlugin):
         self._create_symlinks()
 
     def _create_symlinks(self):
-        if self.project.info.base not in ("core18", "core19"):
+        if self.project.info.base not in ("core18", "core16"):
             raise errors.PluginBaseError(
                 part_name=self.name, base=self.project.info.base
             )
@@ -255,7 +255,7 @@ class MavenPlugin(snapcraft.BasePlugin):
                 "usr",
                 "lib",
                 "jvm",
-                "java-{}-openjdk-*".format(self.options.maven_openjdk_version),
+                "java-{}-openjdk-*".format(self._java_version),
                 "jre",
                 "bin",
                 "java",

--- a/spread.yaml
+++ b/spread.yaml
@@ -36,7 +36,7 @@ backends:
           workers: 5
           image: ubuntu-1604-64-virt-enabled
       - ubuntu-18.04-64:
-          workers: 8
+          workers: 10
           image: ubuntu-1804-64-virt-enabled
   autopkgtest:
     type: adhoc

--- a/spread.yaml
+++ b/spread.yaml
@@ -205,7 +205,8 @@ suites:
    systems: [ubuntu-18.04*]
  tests/spread/plugins/gradle/:
    summary: tests of snapcraft's Gradle plugin
-   kill-timeout: 30m
+   priority: 50  # Run this test early so we're not waiting for it
+   kill-timeout: 40m
    warn-timeout: 9m  # Keep less than 10 minutes so Travis can't timeout
    # Keep this 18.04 only for now as it is the only stable base.
    systems: [ubuntu-18.04*]

--- a/spread.yaml
+++ b/spread.yaml
@@ -203,6 +203,10 @@ suites:
    summary: tests of snapcraft's Godeps plugin
    # Keep this 18.04 only for now as it is the only stable base.
    systems: [ubuntu-18.04*]
+ tests/spread/plugins/gradle/:
+   summary: tests of snapcraft's Gradle plugin
+   # Keep this 18.04 only for now as it is the only stable base.
+   systems: [ubuntu-18.04*]
  tests/spread/plugins/kbuild/:
    summary: tests of snapcraft's Kbuild plugin
    # Keep this 18.04 only for now as it is the only stable base.

--- a/spread.yaml
+++ b/spread.yaml
@@ -205,6 +205,8 @@ suites:
    systems: [ubuntu-18.04*]
  tests/spread/plugins/gradle/:
    summary: tests of snapcraft's Gradle plugin
+   kill-timeout: 30m
+   warn-timeout: 9m  # Keep less than 10 minutes so Travis can't timeout
    # Keep this 18.04 only for now as it is the only stable base.
    systems: [ubuntu-18.04*]
  tests/spread/plugins/kbuild/:

--- a/tests/spread/plugins/ant/run/task.yaml
+++ b/tests/spread/plugins/ant/run/task.yaml
@@ -2,11 +2,15 @@ summary: Build and run a basic ant snap
 
 environment:
   SNAP_DIR: ../snaps/ant-hello
+  OPENJDK_VERSION/CURRENT: "CURRENT"
+  OPENJDK_VERSION/LATEST: "LATEST"  
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
+  # shellcheck disable=SC2153
+  set_openjdk_version "$SNAP_DIR/snap/snapcraft.yaml" ant "$OPENJDK_VERSION"
 
 restore: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/gradle/run-gradlew/task.yaml
+++ b/tests/spread/plugins/gradle/run-gradlew/task.yaml
@@ -1,5 +1,7 @@
 summary: Build and run a gradlew snap
 
+manual: true
+
 environment:
   SNAP_DIR: ../snaps/gradlew-hello
   OPENJDK_VERSION/CURRENT: "CURRENT"

--- a/tests/spread/plugins/gradle/run-gradlew/task.yaml
+++ b/tests/spread/plugins/gradle/run-gradlew/task.yaml
@@ -24,5 +24,5 @@ restore: |
 execute: |
   cd "$SNAP_DIR"
   snapcraft
-  sudo snap install maven-hello_*.snap --dangerous
+  sudo snap install gradle-hello_*.snap --dangerous
   [ "$(gradle-hello)" = "Hello Gradle" ]

--- a/tests/spread/plugins/gradle/run-gradlew/task.yaml
+++ b/tests/spread/plugins/gradle/run-gradlew/task.yaml
@@ -1,7 +1,7 @@
-summary: Build and run a gradle snap
+summary: Build and run a gradlew snap
 
 environment:
-  SNAP_DIR: ../snaps/gradle-hello
+  SNAP_DIR: ../snaps/gradlew-hello
   OPENJDK_VERSION/CURRENT: "CURRENT"
   OPENJDK_VERSION/LATEST: "LATEST"  
 

--- a/tests/spread/plugins/gradle/run/task.yaml
+++ b/tests/spread/plugins/gradle/run/task.yaml
@@ -24,5 +24,5 @@ restore: |
 execute: |
   cd "$SNAP_DIR"
   snapcraft
-  sudo snap install maven-hello_*.snap --dangerous
+  sudo snap install gradle-hello_*.snap --dangerous
   [ "$(gradle-hello)" = "Hello Gradle" ]

--- a/tests/spread/plugins/gradle/run/task.yaml
+++ b/tests/spread/plugins/gradle/run/task.yaml
@@ -3,11 +3,15 @@ summary: Build and run a gradle maven snap
 environment:
   SNAP_DIR/gradle: ../snaps/gradle-hello
   SNAP_DIR/gradlew: ../snaps/gradlew-hello
+  OPENJDK_VERSION/CURRENT: "CURRENT"
+  OPENJDK_VERSION/LATEST: "LATEST"  
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
+  # shellcheck disable=SC2153
+  set_openjdk_version "$SNAP_DIR/snap/snapcraft.yaml" gradle "$OPENJDK_VERSION"
 
 restore: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/maven/run/task.yaml
+++ b/tests/spread/plugins/maven/run/task.yaml
@@ -2,11 +2,15 @@ summary: Build and run a basic maven snap
 
 environment:
   SNAP_DIR: ../snaps/maven-hello
+  OPENJDK_VERSION/CURRENT: "CURRENT"
+  OPENJDK_VERSION/LATEST: "LATEST"  
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
+  # shellcheck disable=SC2153
+  set_openjdk_version "$SNAP_DIR/snap/snapcraft.yaml" maven "$OPENJDK_VERSION"
 
 restore: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/maven/snaps/maven-hello/my-app/pom.xml
+++ b/tests/spread/plugins/maven/snaps/maven-hello/my-app/pom.xml
@@ -7,6 +7,11 @@
   <version>1.0-SNAPSHOT</version>
   <name>my-app</name>
   <url>http://maven.apache.org</url>
+  <properties>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/tests/spread/tools/snapcraft-yaml.sh
+++ b/tests/spread/tools/snapcraft-yaml.sh
@@ -17,6 +17,30 @@ set_base()
     sed -i "1ibase: $base"  "$snapcraft_yaml_path"
 }
 
+set_openjdk_version()
+{
+    snapcraft_yaml_path="$1"
+    plugin="$2"
+    openjdk_version="$3"
+
+    # if openjdk_version is not set to LATEST, then there is nothing
+    # to be done
+    if [[ "$openjdk_version" != "LATEST" ]]; then
+        return
+    fi
+
+    if [[ "$SPREAD_SYSTEM" =~ ubuntu-18.04 ]]; then
+        openjdk_version="11"
+    elif [[ "$SPREAD_SYSTEM" =~ ubuntu-16.04 ]]; then
+        openjdk_version="9"
+    else
+        echo "Test not supported for $SPREAD_SYSTEM"
+        exit 1
+    fi
+
+    sed -i -e "s/\(\s$plugin-openjdk-version:\).*/\1 \"$openjdk_version\"/" "$snapcraft_yaml_path"
+}
+
 restore_yaml()
 {
     snapcraft_yaml_path="$1"

--- a/tests/unit/plugins/test_ant.py
+++ b/tests/unit/plugins/test_ant.py
@@ -82,6 +82,33 @@ class AntPluginPropertiesTest(unit.TestCase):
 
 
 class AntPluginBaseTest(unit.TestCase):
+    scenarios = (
+        (
+            "core16 java version 8 ",
+            dict(base="core16", java_version="8", expected_java_version="8"),
+        ),
+        (
+            "core16 java version 8 ",
+            dict(base="core16", java_version="8", expected_java_version="8"),
+        ),
+        (
+            "core16 java version default ",
+            dict(base="core16", java_version="", expected_java_version="9"),
+        ),
+        (
+            "core18 java version 8 ",
+            dict(base="core18", java_version="8", expected_java_version="8"),
+        ),
+        (
+            "core18 java version 11",
+            dict(base="core18", java_version="11", expected_java_version="11"),
+        ),
+        (
+            "core18 java version default",
+            dict(base="core18", java_version="", expected_java_version="11"),
+        ),
+    )
+
     def setUp(self):
         super().setUp()
 
@@ -89,9 +116,9 @@ class AntPluginBaseTest(unit.TestCase):
             dedent(
                 """\
             name: test-snap
-            base: core18
+            base: {base}
         """
-            )
+            ).format(base=self.base)
         )
 
         self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
@@ -101,7 +128,7 @@ class AntPluginBaseTest(unit.TestCase):
             ant_build_targets = None
             ant_version = ant._DEFAULT_ANT_VERSION
             ant_version_checksum = ant._DEFAULT_ANT_CHECKSUM
-            ant_openjdk_version = "11"
+            ant_openjdk_version = self.java_version
 
         self.options = Options()
 
@@ -121,7 +148,7 @@ class AntPluginBaseTest(unit.TestCase):
             "usr",
             "lib",
             "jvm",
-            "java-11-openjdk-amd64",
+            "java-{}-openjdk-amd64".format(self.expected_java_version),
             "jre",
             "bin",
             "java",
@@ -137,23 +164,17 @@ class AntPluginBaseTest(unit.TestCase):
         os.makedirs(os.path.dirname(ant_tar_path))
         tarfile.TarFile(ant_tar_path, "w").close()
 
-
-class AntPluginTest(AntPluginBaseTest):
-    def test_get_defaul_openjdk(self):
-        self.options.ant_openjdk_version = ""
-
+    def test_stage_and_build_packages(self):
         plugin = ant.AntPlugin("test-part", self.options, self.project)
 
-        self.assertThat(plugin.stage_packages, Equals(["openjdk-11-jre-headless"]))
-        self.assertThat(plugin.build_packages, Equals(["openjdk-11-jdk-headless"]))
-
-    def test_get_non_defaul_openjdk(self):
-        self.options.ant_openjdk_version = "8"
-
-        plugin = ant.AntPlugin("test-part", self.options, self.project)
-
-        self.assertThat(plugin.stage_packages, Equals(["openjdk-8-jre-headless"]))
-        self.assertThat(plugin.build_packages, Equals(["openjdk-8-jdk-headless"]))
+        self.assertThat(
+            plugin.stage_packages,
+            Equals(["openjdk-{}-jre-headless".format(self.expected_java_version)]),
+        )
+        self.assertThat(
+            plugin.build_packages,
+            Equals(["openjdk-{}-jdk-headless".format(self.expected_java_version)]),
+        )
 
     def test_build(self):
         plugin = ant.AntPlugin("test-part", self.options, self.project)
@@ -225,7 +246,7 @@ class AntPluginTest(AntPluginBaseTest):
         )
 
 
-class AntPluginUnsupportedBase(AntPluginBaseTest):
+class AntPluginUnsupportedBase(unit.TestCase):
     def setUp(self):
         super().setUp()
 
@@ -240,6 +261,15 @@ class AntPluginUnsupportedBase(AntPluginBaseTest):
 
         self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
 
+        class Options:
+            ant_properties = {}
+            ant_build_targets = None
+            ant_version = ant._DEFAULT_ANT_VERSION
+            ant_version_checksum = ant._DEFAULT_ANT_CHECKSUM
+            ant_openjdk_version = ""
+
+        self.options = Options()
+
     def test_unsupported_base_raises(self):
         self.assertRaises(
             errors.PluginBaseError,
@@ -250,7 +280,7 @@ class AntPluginUnsupportedBase(AntPluginBaseTest):
         )
 
 
-class UnsupportedJDKVersionErrorTest(AntPluginBaseTest):
+class UnsupportedJDKVersionErrorTest(unit.TestCase):
 
     scenarios = (
         (
@@ -291,9 +321,16 @@ class UnsupportedJDKVersionErrorTest(AntPluginBaseTest):
             )
         )
 
-        self.options.ant_openjdk_version = self.version
-
         self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+
+        class Options:
+            ant_properties = {}
+            ant_build_targets = None
+            ant_version = ant._DEFAULT_ANT_VERSION
+            ant_version_checksum = ant._DEFAULT_ANT_CHECKSUM
+            ant_openjdk_version = self.version
+
+        self.options = Options()
 
     def test_use_invalid_openjdk_version_fails(self):
         raised = self.assertRaises(

--- a/tests/unit/plugins/test_ant.py
+++ b/tests/unit/plugins/test_ant.py
@@ -149,7 +149,6 @@ class AntPluginBaseTest(unit.TestCase):
             "lib",
             "jvm",
             "java-{}-openjdk-amd64".format(self.expected_java_version),
-            "jre",
             "bin",
             "java",
         )

--- a/tests/unit/plugins/test_gradle.py
+++ b/tests/unit/plugins/test_gradle.py
@@ -55,7 +55,6 @@ class GradlePluginBaseTest(unit.TestCase):
             "lib",
             "jvm",
             "java-{}-openjdk-amd64".format(java_version),
-            "jre",
             "bin",
             "java",
         )

--- a/tests/unit/plugins/test_gradle.py
+++ b/tests/unit/plugins/test_gradle.py
@@ -31,26 +31,6 @@ class GradlePluginBaseTest(unit.TestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: gradle-snap
-            base: core18
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
-
-        class Options:
-            gradle_options = []
-            gradle_output_dir = "build/libs"
-            gradle_version = gradle._DEFAULT_GRADLE_VERSION
-            gradle_version_checksum = gradle._DEFAULT_GRADLE_CHECKSUM
-            gradle_openjdk_version = "11"
-
-        self.options = Options()
-
         # unset http and https proxies.
         self.useFixture(fixtures.EnvironmentVariable("http_proxy", None))
         self.useFixture(fixtures.EnvironmentVariable("https_proxy", None))
@@ -63,7 +43,7 @@ class GradlePluginBaseTest(unit.TestCase):
         self.zip_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
-    def create_assets(self, plugin, use_gradlew=False):
+    def create_assets(self, plugin, java_version, use_gradlew=False):
         os.makedirs(plugin.sourcedir)
 
         if use_gradlew:
@@ -74,7 +54,7 @@ class GradlePluginBaseTest(unit.TestCase):
             "usr",
             "lib",
             "jvm",
-            "java-11-openjdk-amd64",
+            "java-{}-openjdk-amd64".format(java_version),
             "jre",
             "bin",
             "java",
@@ -173,32 +153,79 @@ class GradlePluginPropertiesTest(unit.TestCase):
 
 
 class GradlePluginTest(GradlePluginBaseTest):
-    def test_get_defaul_openjdk(self):
-        self.options.gradle_openjdk_version = ""
+    scenarios = (
+        (
+            "core16 java version 8 ",
+            dict(base="core16", java_version="8", expected_java_version="8"),
+        ),
+        (
+            "core16 java version 8 ",
+            dict(base="core16", java_version="8", expected_java_version="8"),
+        ),
+        (
+            "core16 java version default ",
+            dict(base="core16", java_version="", expected_java_version="9"),
+        ),
+        (
+            "core18 java version 8 ",
+            dict(base="core18", java_version="8", expected_java_version="8"),
+        ),
+        (
+            "core18 java version 11",
+            dict(base="core18", java_version="11", expected_java_version="11"),
+        ),
+        (
+            "core18 java version default",
+            dict(base="core18", java_version="", expected_java_version="11"),
+        ),
+    )
 
-        plugin = gradle.GradlePlugin("test-part", self.options, self.project)
+    def setUp(self):
+        super().setUp()
 
-        self.assertThat(plugin.stage_packages, Equals(["openjdk-11-jre-headless"]))
-        self.assertThat(
-            plugin.build_packages,
-            Equals(["openjdk-11-jdk-headless", "ca-certificates-java"]),
+        snapcraft_yaml_path = self.make_snapcraft_yaml(
+            dedent(
+                """\
+            name: gradle-snap
+            base: {base}
+        """
+            ).format(base=self.base)
         )
 
-    def test_get_non_defaul_openjdk(self):
-        self.options.gradle_openjdk_version = "8"
+        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
 
+        class Options:
+            gradle_options = []
+            gradle_output_dir = "build/libs"
+            gradle_version = gradle._DEFAULT_GRADLE_VERSION
+            gradle_version_checksum = gradle._DEFAULT_GRADLE_CHECKSUM
+            gradle_openjdk_version = self.java_version
+
+        self.options = Options()
+
+    def test_stage_and_build_packages(self):
         plugin = gradle.GradlePlugin("test-part", self.options, self.project)
 
-        self.assertThat(plugin.stage_packages, Equals(["openjdk-8-jre-headless"]))
+        self.assertThat(
+            plugin.stage_packages,
+            Equals(["openjdk-{}-jre-headless".format(self.expected_java_version)]),
+        )
         self.assertThat(
             plugin.build_packages,
-            Equals(["openjdk-8-jdk-headless", "ca-certificates-java"]),
+            Equals(
+                [
+                    "openjdk-{}-jdk-headless".format(self.expected_java_version),
+                    "ca-certificates-java",
+                ]
+            ),
         )
 
     def test_build_gradlew(self):
         plugin = gradle.GradlePlugin("test-part", self.options, self.project)
 
-        self.create_assets(plugin, use_gradlew=True)
+        self.create_assets(
+            plugin, java_version=self.expected_java_version, use_gradlew=True
+        )
 
         def side(l, **kwargs):
             os.makedirs(os.path.join(plugin.builddir, "build", "libs"))
@@ -217,7 +244,7 @@ class GradlePluginTest(GradlePluginBaseTest):
     def test_build_gradle(self):
         plugin = gradle.GradlePlugin("test-part", self.options, self.project)
 
-        self.create_assets(plugin)
+        self.create_assets(plugin, java_version=self.expected_java_version)
 
         def side(l, **kwargs):
             os.makedirs(os.path.join(plugin.builddir, "build", "libs"))
@@ -236,7 +263,7 @@ class GradlePluginTest(GradlePluginBaseTest):
     def test_build_war_gradle(self):
         plugin = gradle.GradlePlugin("test-part", self.options, self.project)
 
-        self.create_assets(plugin)
+        self.create_assets(plugin, java_version=self.expected_java_version)
 
         def side(l, **kwargs):
             os.makedirs(os.path.join(plugin.builddir, "build", "libs"))
@@ -255,7 +282,9 @@ class GradlePluginTest(GradlePluginBaseTest):
     def test_build_war_gradlew(self):
         plugin = gradle.GradlePlugin("test-part", self.options, self.project)
 
-        self.create_assets(plugin, use_gradlew=True)
+        self.create_assets(
+            plugin, java_version=self.expected_java_version, use_gradlew=True
+        )
 
         def side(l, **kwargs):
             os.makedirs(os.path.join(plugin.builddir, "build", "libs"))
@@ -337,10 +366,30 @@ class GradleProxyTestCase(GradlePluginBaseTest):
 
         self.useFixture(fixtures.EnvironmentVariable(*self.env_var))
 
+        snapcraft_yaml_path = self.make_snapcraft_yaml(
+            dedent(
+                """\
+            name: gradle-snap
+            base: core18
+        """
+            )
+        )
+
+        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+
+        class Options:
+            gradle_options = []
+            gradle_output_dir = "build/libs"
+            gradle_version = gradle._DEFAULT_GRADLE_VERSION
+            gradle_version_checksum = gradle._DEFAULT_GRADLE_CHECKSUM
+            gradle_openjdk_version = "11"
+
+        self.options = Options()
+
     def test_build_with_http_proxy_gradle(self):
         plugin = gradle.GradlePlugin("test-part", self.options, self.project)
 
-        self.create_assets(plugin)
+        self.create_assets(plugin, java_version="11")
 
         def side(l, **kwargs):
             os.makedirs(os.path.join(plugin.builddir, "build", "libs"))
@@ -359,7 +408,7 @@ class GradleProxyTestCase(GradlePluginBaseTest):
     def test_build_with_http_proxy_gradlew(self):
         plugin = gradle.GradlePlugin("test-part", self.options, self.project)
 
-        self.create_assets(plugin, use_gradlew=True)
+        self.create_assets(plugin, java_version="11", use_gradlew=True)
 
         def side(l, **kwargs):
             os.makedirs(os.path.join(plugin.builddir, "build", "libs"))
@@ -376,7 +425,7 @@ class GradleProxyTestCase(GradlePluginBaseTest):
         )
 
 
-class GradlePluginUnsupportedBase(GradlePluginBaseTest):
+class GradlePluginUnsupportedBase(unit.TestCase):
     def setUp(self):
         super().setUp()
 
@@ -391,6 +440,15 @@ class GradlePluginUnsupportedBase(GradlePluginBaseTest):
 
         self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
 
+        class Options:
+            gradle_options = []
+            gradle_output_dir = "build/libs"
+            gradle_version = gradle._DEFAULT_GRADLE_VERSION
+            gradle_version_checksum = gradle._DEFAULT_GRADLE_CHECKSUM
+            gradle_openjdk_version = ""
+
+        self.options = Options()
+
     def test_unsupported_base_raises(self):
         self.assertRaises(
             errors.PluginBaseError,
@@ -401,7 +459,7 @@ class GradlePluginUnsupportedBase(GradlePluginBaseTest):
         )
 
 
-class UnsupportedJDKVersionErrorTest(GradlePluginBaseTest):
+class UnsupportedJDKVersionErrorTest(unit.TestCase):
 
     scenarios = (
         (
@@ -442,9 +500,16 @@ class UnsupportedJDKVersionErrorTest(GradlePluginBaseTest):
             )
         )
 
-        self.options.gradle_openjdk_version = self.version
-
         self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+
+        class Options:
+            gradle_options = []
+            gradle_output_dir = "build/libs"
+            gradle_version = gradle._DEFAULT_GRADLE_VERSION
+            gradle_version_checksum = gradle._DEFAULT_GRADLE_CHECKSUM
+            gradle_openjdk_version = self.version
+
+        self.options = Options()
 
     def test_use_invalid_openjdk_version_fails(self):
         raised = self.assertRaises(

--- a/tests/unit/plugins/test_maven.py
+++ b/tests/unit/plugins/test_maven.py
@@ -200,7 +200,6 @@ class MavenPluginTest(unit.TestCase):
             "lib",
             "jvm",
             "java-{}-openjdk-amd64".format(self.expected_java_version),
-            "jre",
             "bin",
             "java",
         )

--- a/tests/unit/plugins/test_maven.py
+++ b/tests/unit/plugins/test_maven.py
@@ -132,6 +132,34 @@ class MavenPluginPropertiesTest(unit.TestCase):
 
 
 class MavenPluginTest(unit.TestCase):
+
+    scenarios = (
+        (
+            "core16 java version 8 ",
+            dict(base="core16", java_version="8", expected_java_version="8"),
+        ),
+        (
+            "core16 java version 8 ",
+            dict(base="core16", java_version="8", expected_java_version="8"),
+        ),
+        (
+            "core16 java version default ",
+            dict(base="core16", java_version="", expected_java_version="9"),
+        ),
+        (
+            "core18 java version 8 ",
+            dict(base="core18", java_version="8", expected_java_version="8"),
+        ),
+        (
+            "core18 java version 11",
+            dict(base="core18", java_version="11", expected_java_version="11"),
+        ),
+        (
+            "core18 java version default",
+            dict(base="core18", java_version="", expected_java_version="11"),
+        ),
+    )
+
     def setUp(self):
         super().setUp()
 
@@ -139,9 +167,9 @@ class MavenPluginTest(unit.TestCase):
             dedent(
                 """\
             name: maven-snap
-            base: core18
+            base: {base}
         """
-            )
+            ).format(base=self.base)
         )
 
         self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
@@ -151,7 +179,7 @@ class MavenPluginTest(unit.TestCase):
             maven_targets = [""]
             maven_version = maven._DEFAULT_MAVEN_VERSION
             maven_version_checksum = maven._DEFAULT_MAVEN_CHECKSUM
-            maven_openjdk_version = "11"
+            maven_openjdk_version = self.java_version
 
         self.options = Options()
 
@@ -171,7 +199,7 @@ class MavenPluginTest(unit.TestCase):
             "usr",
             "lib",
             "jvm",
-            "java-11-openjdk-amd64",
+            "java-{}-openjdk-amd64".format(self.expected_java_version),
             "jre",
             "bin",
             "java",
@@ -215,21 +243,17 @@ class MavenPluginTest(unit.TestCase):
             Equals(self._canonicalize_settings(expected)),
         )
 
-    def test_get_defaul_openjdk(self):
-        self.options.maven_openjdk_version = ""
-
+    def test_stage_and_build_packages(self):
         plugin = maven.MavenPlugin("test-part", self.options, self.project)
 
-        self.assertThat(plugin.stage_packages, Equals(["openjdk-11-jre-headless"]))
-        self.assertThat(plugin.build_packages, Equals(["openjdk-11-jdk-headless"]))
-
-    def test_get_non_defaul_openjdk(self):
-        self.options.maven_openjdk_version = "8"
-
-        plugin = maven.MavenPlugin("test-part", self.options, self.project)
-
-        self.assertThat(plugin.stage_packages, Equals(["openjdk-8-jre-headless"]))
-        self.assertThat(plugin.build_packages, Equals(["openjdk-8-jdk-headless"]))
+        self.assertThat(
+            plugin.stage_packages,
+            Equals(["openjdk-{}-jre-headless".format(self.expected_java_version)]),
+        )
+        self.assertThat(
+            plugin.build_packages,
+            Equals(["openjdk-{}-jdk-headless".format(self.expected_java_version)]),
+        )
 
     def test_build(self):
         env_vars = (("http_proxy", None), ("https_proxy", None))


### PR DESCRIPTION
Ensure that the expected java version is properly set when the default
openjdk option is used so that the globbing mechanism can format the
path to the java binary correctly.

Also ensure that the sytem works end to end for core16 and core18,
removing the typo of core19 which was supposed to be core16.

LP: #1813637
LP: #1813636
Fixes SNAPCRAFT-D1

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
