### PR TITLE
baseplugin: add a proper exception for cross-compilation support

### DIFF
--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -164,10 +164,7 @@ class BasePlugin:
 
     def enable_cross_compilation(self):
         """Enable cross compilation for the plugin."""
-        raise NotImplementedError(
-            "The plugin used by {!r} does not support cross-compiling "
-            "to a different target architecture".format(self.name)
-        )
+        raise errors.CrossCompilationNotSupported(part_name=self.name)
 
     @property
     def parallel_build_count(self):

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -667,3 +667,13 @@ class InvalidMountinfoFormat(SnapcraftError):
 
     def __init__(self, row):
         super().__init__(row=row)
+
+
+class CrossCompilationNotSupported(SnapcraftError):
+    fmt = (
+        "The plugin used by {part_name!r} does not support cross-compiling "
+        "to a different target architecture."
+    )
+
+    def __init__(self, *, part_name: str) -> None:
+        super().__init__(part_name=part_name)

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -19,6 +19,7 @@ import unittest.mock
 from testtools.matchers import Equals
 
 import snapcraft
+from snapcraft.internal import errors
 from tests import unit
 
 
@@ -26,6 +27,13 @@ class TestBasePlugin(unit.TestCase):
     def setUp(self):
         super().setUp()
         self.project_options = snapcraft.ProjectOptions()
+
+    def test_cross_compilation_raises(self):
+        options = unit.MockOptions(disable_parallel=True)
+        plugin = snapcraft.BasePlugin("test_plugin", options, self.project_options)
+        self.assertRaises(
+            errors.CrossCompilationNotSupported, plugin.enable_cross_compilation
+        )
 
     def test_parallel_build_count_returns_1_when_disabled(self):
         options = unit.MockOptions(disable_parallel=True)

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -680,6 +680,17 @@ class ErrorFormattingTestCase(unit.TestCase):
             },
         ),
         (
+            "CrossCompilationNotSupported",
+            {
+                "exception": errors.CrossCompilationNotSupported,
+                "kwargs": {"part_name": "my-part"},
+                "expected_message": (
+                    "The plugin used by 'my-part' does not support "
+                    "cross-compiling to a different target architecture."
+                ),
+            },
+        ),
+        (
             "CacheUpdateFailedError",
             {
                 "exception": repo_errors.CacheUpdateFailedError,


### PR DESCRIPTION
Add a proper exception to notify the user when cross compilation is used
with parts using plugins that do not support it.

Fixes SNAPCRAFT-95
Fixes SNAPCRAFT-AQ
LP: #1808454
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
