### PR TITLE
cli: retrieve error data from provider

### DIFF
--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -27,7 +27,6 @@ from typing import Dict  # noqa: F401
 import click
 
 from . import echo
-from . import env
 import snapcraft
 from snapcraft.config import CLIConfig as _CLIConfig
 from snapcraft.internal import errors
@@ -112,13 +111,10 @@ def exception_handler(  # noqa: C901
         os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT") == "managed-host"
     )
     is_connected_to_tty = (
-        sys.stdout.isatty()
-        if is_snapcraft_host
-        else (
-            # used by inner instance, variable set by outer instance
-            distutils.util.strtobool(os.getenv("SNAPCRAFT_HAS_TTY", "n"))
-            == 1
-        )
+        # used by inner instance, variable set by outer instance
+        (distutils.util.strtobool(os.getenv("SNAPCRAFT_HAS_TTY", "n")) == 1)
+        if is_snapcraft_managed_host
+        else sys.stdout.isatty()
     )
     ask_to_report = False
 

--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -99,6 +99,8 @@ def exception_handler(  # noqa: C901
     """
     exc_info = (exception_type, exception, exception_traceback)
     exit_code = 1
+    # When inner instance crashes let it send its trace information. We filter
+    # out ProviderExecError to prevent sending another trace dump outside.
     is_snapcraft_error = (
         issubclass(exception_type, errors.SnapcraftError)
         and exception_type is not ProviderExecError
@@ -107,7 +109,9 @@ def exception_handler(  # noqa: C901
         exception_type, errors.SnapcraftReportableError
     )
     is_raven_setup = RavenClient is not None
-    is_snapcraft_host = exc_info is not None and not os.path.isfile(TRACEBACK_HOST)
+    # We're building directly on host (i.e. no inner instances have sent
+    # trace information to sentry), or crash is our own.
+    is_snapcraft_host = not os.path.isfile(TRACEBACK_HOST)
     is_snapcraft_managed_host = (
         os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT") == "managed-host"
     )

--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -70,7 +70,7 @@ _YES_VALUES = ["yes", "y"]
 _NO_VALUES = ["no", "n"]
 _ALWAYS_VALUES = ["always", "a"]
 
-TRACEBACK_MANAGED = "/tmp/snapcraft_provider_traceback"
+TRACEBACK_MANAGED = os.path.join(tempfile.gettempdir(), "snapcraft_provider_traceback")
 TRACEBACK_HOST = TRACEBACK_MANAGED + ".{}".format(os.getpid())
 
 

--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -242,7 +242,9 @@ def _is_send_to_sentry(exc_info) -> bool:  # noqa: C901
             return False
 
         if response in _VIEW_VALUES:
-            traceback.print_exception(*exc_info, file=sys.stdout)
+            traceback.print_exception(
+                exc_info[0], exc_info[1], exc_info[2], file=sys.stdout
+            )
         elif response in _YES_VALUES:
             return True
         elif response in _NO_VALUES:
@@ -253,7 +255,9 @@ def _is_send_to_sentry(exc_info) -> bool:  # noqa: C901
                     "Not saving choice to always send data to Sentry as "
                     "the configuration file is corrupted.\n"
                     "Please edit and fix or alternatively remove the "
-                    "configuration file {!r} from disk.".format(config_errors.config_file)
+                    "configuration file {!r} from disk.".format(
+                        config_errors.config_file
+                    )
                 )  # type: ignore
             else:
                 click.echo("Saving choice to always send data to Sentry")

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -162,6 +162,7 @@ def _pack(directory: str, *, output: str) -> None:
     snap_name = lifecycle.pack(directory, output)
     echo.info("Snapped {}".format(snap_name))
 
+
 def _clean_provider_error() -> None:
     if os.path.isfile(TRACEBACK_FILEPATH):
         try:
@@ -169,11 +170,13 @@ def _clean_provider_error() -> None:
         except Exception as e:
             logger.debug("can't remove error file: {}", str(e))
 
+
 def _retrieve_provider_error(instance) -> None:
     try:
         instance.retrieve_file(TRACEBACK_FILEPATH, delete=True)
     except Exception as e:
         logger.debug("can't retrieve error file: {}", str(e))
+
 
 @click.group()
 @add_build_options()

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -43,7 +43,7 @@ from snapcraft.project.errors import (
     YamlValidationError,
     MultipassMissingInstallableError,
 )
-from ._errors import TRACEBACK_FILEPATH
+from ._errors import TRACEBACK_MANAGED, TRACEBACK_HOST
 
 
 logger = logging.getLogger(__name__)
@@ -164,16 +164,16 @@ def _pack(directory: str, *, output: str) -> None:
 
 
 def _clean_provider_error() -> None:
-    if os.path.isfile(TRACEBACK_FILEPATH):
+    if os.path.isfile(TRACEBACK_HOST):
         try:
-            os.remove(TRACEBACK_FILEPATH)
+            os.remove(TRACEBACK_HOST)
         except Exception as e:
             logger.debug("can't remove error file: {}", str(e))
 
 
 def _retrieve_provider_error(instance) -> None:
     try:
-        instance.retrieve_file(TRACEBACK_FILEPATH, delete=True)
+        instance.pull_file(TRACEBACK_MANAGED, TRACEBACK_HOST, delete=True)
     except Exception as e:
         logger.debug("can't retrieve error file: {}", str(e))
 

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -216,6 +216,18 @@ class Provider(abc.ABC):
         """
 
     @abc.abstractmethod
+    def retrieve_file(self, name: str, delete: bool = False) -> bool:
+        """
+        Provider steps needed to retrieve a file from the instance, optionally
+        deleting the file after a successful retrieval.
+
+        :param delete: whether the file should be deleted.
+        :type delete: bool
+        :returns: whether the file was successfully retrieved and deleted.
+        :rtype: bool
+        """
+
+    @abc.abstractmethod
     def shell(self) -> None:
         """Provider steps to provide a shell into the instance."""
 

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -216,15 +216,17 @@ class Provider(abc.ABC):
         """
 
     @abc.abstractmethod
-    def retrieve_file(self, name: str, delete: bool = False) -> bool:
+    def pull_file(self, name: str, destination: str, delete: bool = False) -> None:
         """
         Provider steps needed to retrieve a file from the instance, optionally
-        deleting the file after a successful retrieval.
+        deleting the source file after a successful retrieval.
 
+        :param name: the remote filename.
+        :type name: str
+        :param destination: the local filename.
+        :type destination: str
         :param delete: whether the file should be deleted.
         :type delete: bool
-        :returns: whether the file was successfully retrieved and deleted.
-        :rtype: bool
         """
 
     @abc.abstractmethod

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -16,6 +16,7 @@
 
 import logging
 import os
+import sys
 import shlex
 from typing import Dict, Sequence
 
@@ -69,7 +70,8 @@ class Multipass(Provider):
         return "multipass"
 
     def _run(self, command: Sequence[str], hide_output: bool = False) -> None:
-        command = ["sudo", "-i"] + list(command)
+        has_tty = "SNAPCRAFT_HAS_TTY={}".format(sys.stdout.isatty())
+        command = ["sudo", "-i", "env", has_tty] + list(command)
         self._multipass_cmd.execute(
             instance_name=self.instance_name, command=command, hide_output=hide_output
         )

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -251,6 +251,22 @@ class Multipass(Provider):
         self._multipass_cmd.copy_files(source=source, destination=self.snap_filename)
         return self.snap_filename
 
+    def retrieve_file(self, name: str, delete: bool = False):
+        # TODO add instance check.
+
+        # check if file exists in instance
+        self._multipass_cmd.execute(
+            command=["test", "-f", name], instance_name=self.instance_name
+        )
+
+        # copy file from instance
+        source = "{}:{}/{}".format(self.instance_name, self._INSTANCE_PROJECT_DIR, name)
+        self._multipass_cmd.copy_files(source=source, destination=name)
+        if delete:
+            self._multipass_cmd.execute(
+                instance_name=self.instance_name, command=["rm", "-f", name]
+            )
+
     def shell(self) -> None:
         self._multipass_cmd.execute(
             instance_name=self.instance_name, command=["sudo", "-i", "/bin/bash"]

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -253,7 +253,7 @@ class Multipass(Provider):
         self._multipass_cmd.copy_files(source=source, destination=self.snap_filename)
         return self.snap_filename
 
-    def retrieve_file(self, name: str, delete: bool = False):
+    def pull_file(self, name: str, destination: str, delete: bool = False) -> None:
         # TODO add instance check.
 
         # check if file exists in instance
@@ -262,11 +262,11 @@ class Multipass(Provider):
         )
 
         # copy file from instance
-        source = "{}:{}/{}".format(self.instance_name, self._INSTANCE_PROJECT_DIR, name)
-        self._multipass_cmd.copy_files(source=source, destination=name)
+        source = "{}:{}".format(self.instance_name, name)
+        self._multipass_cmd.copy_files(source=source, destination=destination)
         if delete:
             self._multipass_cmd.execute(
-                instance_name=self.instance_name, command=["rm", "-f", name]
+                instance_name=self.instance_name, command=["sudo", "-i", "rm", name]
             )
 
     def shell(self) -> None:

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -85,6 +85,9 @@ class ProviderImpl(Provider):
     def retrieve_snap(self):
         raise NotImplementedError("test stub not implemented")
 
+    def retrieve_file(self, name: str, delete: bool = False):
+        raise NotImplementedError("test stub not implemented")
+
     def shell(self):
         self.shell_mock("shell")
 

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -85,7 +85,7 @@ class ProviderImpl(Provider):
     def retrieve_snap(self):
         raise NotImplementedError("test stub not implemented")
 
-    def retrieve_file(self, name: str, delete: bool = False):
+    def pull_file(self, name: str, destination: str, delete: bool = False):
         raise NotImplementedError("test stub not implemented")
 
     def shell(self):

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -105,6 +105,7 @@ class MultipassTest(BaseProviderBaseTest):
             instance.provision_project("source.tar")
             instance.build_project()
             instance.retrieve_snap()
+            instance.retrieve_file("data", delete=True)
 
         self.multipass_cmd_mock().launch.assert_called_once_with(
             instance_name=self.instance_name,
@@ -304,6 +305,50 @@ class MultipassTest(BaseProviderBaseTest):
 
         self.multipass_cmd_mock().execute.assert_not_called()
         self.multipass_cmd_mock().launch.assert_not_called()
+        self.multipass_cmd_mock().info.assert_not_called()
+        self.multipass_cmd_mock().stop.assert_not_called()
+        self.multipass_cmd_mock().delete.assert_not_called()
+
+    def test_retrieve_file(self):
+        multipass = Multipass(project=self.project, echoer=self.echoer_mock)
+
+        multipass.retrieve_file("data.txt")
+
+        self.multipass_cmd_mock().execute.assert_called_once_with(
+            command=["test", "-f", "data.txt"], instance_name="snapcraft-project-name"
+        )
+
+        self.multipass_cmd_mock().copy_files.assert_called_once_with(
+            destination="data.txt",
+            source="{}:~/project/data.txt".format(self.instance_name),
+        )
+
+        self.multipass_cmd_mock().info.assert_not_called()
+        self.multipass_cmd_mock().stop.assert_not_called()
+        self.multipass_cmd_mock().delete.assert_not_called()
+
+    def test_retrieve_and_delete_file(self):
+        multipass = Multipass(project=self.project, echoer=self.echoer_mock)
+
+        multipass.retrieve_file("data.txt", delete=True)
+
+        self.multipass_cmd_mock().copy_files.assert_called_once_with(
+            destination="data.txt",
+            source="{}:~/project/data.txt".format(self.instance_name),
+        )
+
+        self.multipass_cmd_mock().execute.assert_has_calls(
+            [
+                mock.call(
+                    command=["test", "-f", "data.txt"],
+                    instance_name="snapcraft-project-name",
+                ),
+                mock.call(
+                    command=["rm", "-f", "data.txt"],
+                    instance_name="snapcraft-project-name",
+                ),
+            ]
+        )
         self.multipass_cmd_mock().info.assert_not_called()
         self.multipass_cmd_mock().stop.assert_not_called()
         self.multipass_cmd_mock().delete.assert_not_called()

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -205,13 +205,16 @@ class SendToSentryIsYesTest(SendToSentryBaseTest):
         self.error_mock.assert_not_called()
         self.exit_mock.assert_called_once_with(1)
 
-        if not self.tty:
-            # we don't have actual error content to be printed
-            self.print_mock.assert_called_once_with("")
+        expected_calls = [
+            mock.call(RuntimeError, mock.ANY, mock.ANY, file=_Tracefile(self))
+        ]
 
-        self.print_exception_mock.assert_called_once_with(
-            RuntimeError, mock.ANY, mock.ANY, file=_Tracefile(self)
-        )
+        if not self.tty:
+            expected_calls.append(
+                mock.call(RuntimeError, mock.ANY, mock.ANY, file=sys.stdout)
+            )
+
+        self.print_exception_mock.assert_has_calls(expected_calls, any_order=True)
 
 
 class SendToSentryIsNoTest(SendToSentryBaseTest):
@@ -241,13 +244,16 @@ class SendToSentryIsNoTest(SendToSentryBaseTest):
         self.error_mock.assert_not_called()
         self.exit_mock.assert_called_once_with(1)
 
-        if not self.tty:
-            # we don't have actual error content to be printed
-            self.print_mock.assert_called_once_with("")
+        expected_calls = [
+            mock.call(RuntimeError, mock.ANY, mock.ANY, file=_Tracefile(self))
+        ]
 
-        self.print_exception_mock.assert_called_once_with(
-            RuntimeError, mock.ANY, mock.ANY, file=_Tracefile(self)
-        )
+        if not self.tty:
+            expected_calls.append(
+                mock.call(RuntimeError, mock.ANY, mock.ANY, file=sys.stdout)
+            )
+
+        self.print_exception_mock.assert_has_calls(expected_calls, any_order=True)
 
 
 class SendToSentryIsAlwaysTest(SendToSentryBaseTest):
@@ -300,13 +306,16 @@ class SendToSentryIsAlwaysTest(SendToSentryBaseTest):
         self.error_mock.assert_not_called()
         self.exit_mock.assert_called_once_with(1)
 
-        if not self.tty:
-            # we don't have actual error content to be printed
-            self.print_mock.assert_called_once_with("")
+        expected_calls = [
+            mock.call(RuntimeError, mock.ANY, mock.ANY, file=_Tracefile(self))
+        ]
 
-        self.print_exception_mock.assert_called_once_with(
-            RuntimeError, mock.ANY, mock.ANY, file=_Tracefile(self)
-        )
+        if not self.tty:
+            expected_calls.append(
+                mock.call(RuntimeError, mock.ANY, mock.ANY, file=sys.stdout)
+            )
+
+        self.print_exception_mock.assert_has_calls(expected_calls, any_order=True)
 
 
 class SendToSentryAlreadyAlwaysTest(SendToSentryBaseTest):

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -50,6 +50,10 @@ class ErrorsBaseTestCase(unit.TestCase):
         self.exit_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
+        patcher = mock.patch("builtins.print")
+        self.print_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
         patcher = mock.patch("snapcraft.cli._errors.echo.error")
         self.error_mock = patcher.start()
         self.addCleanup(patcher.stop)
@@ -201,15 +205,13 @@ class SendToSentryIsYesTest(SendToSentryBaseTest):
         self.error_mock.assert_not_called()
         self.exit_mock.assert_called_once_with(1)
 
-        expected_calls = [
-            mock.call(RuntimeError, mock.ANY, mock.ANY, file=_Tracefile(self))
-        ]
         if not self.tty:
-            expected_calls.append(
-                mock.call(RuntimeError, mock.ANY, mock.ANY, file=sys.stdout)
-            )
+            # we don't have actual error content to be printed
+            self.print_mock.assert_called_once_with("")
 
-        self.print_exception_mock.assert_has_calls(expected_calls, any_order=True)
+        self.print_exception_mock.assert_called_once_with(
+            RuntimeError, mock.ANY, mock.ANY, file=_Tracefile(self)
+        )
 
 
 class SendToSentryIsNoTest(SendToSentryBaseTest):
@@ -239,15 +241,13 @@ class SendToSentryIsNoTest(SendToSentryBaseTest):
         self.error_mock.assert_not_called()
         self.exit_mock.assert_called_once_with(1)
 
-        expected_calls = [
-            mock.call(RuntimeError, mock.ANY, mock.ANY, file=_Tracefile(self))
-        ]
         if not self.tty:
-            expected_calls.append(
-                mock.call(RuntimeError, mock.ANY, mock.ANY, file=sys.stdout)
-            )
+            # we don't have actual error content to be printed
+            self.print_mock.assert_called_once_with("")
 
-        self.print_exception_mock.assert_has_calls(expected_calls, any_order=True)
+        self.print_exception_mock.assert_called_once_with(
+            RuntimeError, mock.ANY, mock.ANY, file=_Tracefile(self)
+        )
 
 
 class SendToSentryIsAlwaysTest(SendToSentryBaseTest):
@@ -300,15 +300,13 @@ class SendToSentryIsAlwaysTest(SendToSentryBaseTest):
         self.error_mock.assert_not_called()
         self.exit_mock.assert_called_once_with(1)
 
-        expected_calls = [
-            mock.call(RuntimeError, mock.ANY, mock.ANY, file=_Tracefile(self))
-        ]
         if not self.tty:
-            expected_calls.append(
-                mock.call(RuntimeError, mock.ANY, mock.ANY, file=sys.stdout)
-            )
+            # we don't have actual error content to be printed
+            self.print_mock.assert_called_once_with("")
 
-        self.print_exception_mock.assert_has_calls(expected_calls, any_order=True)
+        self.print_exception_mock.assert_called_once_with(
+            RuntimeError, mock.ANY, mock.ANY, file=_Tracefile(self)
+        )
 
 
 class SendToSentryAlreadyAlwaysTest(SendToSentryBaseTest):


### PR DESCRIPTION
Upon facing an unhandled exception, snapcraft generates traceback data and stores it in the filesystem. If running in a build provider, the filesystem location is not accessible from host, and to give user access to error details we need to retrieve this data from the managed provider.
    
This fix addresses this issue by letting inner instance to save error data in a known location, which is retrieved by outer instance before proceeding.
    
LP: #1793082

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

**Note:** this patch refactors CLI error handling to deal with formatted trace data from provider. Raw traceback data can't be easily pickled up for transferring, hence the pre-formatting. It's also hard to test since this version must also be injected in the build provider, but I strongly recommend it to be tested before merging. I ran my tests by manually setting up this version inside the multipass instance.

Expected behavior is as follows:
- Crashes happening inside the build provider are silent, but generate traceback data that's handled by the managing (outer) instance.
- When running non-interactively (no tty), the traceback data should also be printed.
- No temporary files used for traceback data retrieval should be present after building.
- Non-crashing builds should (obviously) not produce error data.
- Legacy modes are handled by legacy snapcraft and should not be affected by this change.
- When running without build providers (destructive mode), error data should be presented as usual.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
