### PR TITLE
lifecyle: avoid installation of snaps in docker

### DIFF
--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+from typing import List  # noqa: F401
 from typing import Sequence
 
 from snapcraft import config
@@ -64,7 +65,20 @@ def execute(
             "The repo backend is not returning the list of installed packages"
         )
 
-    installed_snaps = repo.snaps.install_snaps(project_config.build_snaps)
+    if common.is_docker_instance():
+        installed_snaps = []  # type: List[str]
+        logger.warning(
+            (
+                "The following snaps are required but not installed as snapcraft "
+                "is running inside docker: {}.\n"
+                "Please ensure the environment is properly setup before continuing.\n"
+                "Ignore this message if the appropriate measures have already been taken".format(
+                    ", ".join(project_config.build_snaps)
+                )
+            )
+        )
+    else:
+        installed_snaps = repo.snaps.install_snaps(project_config.build_snaps)
 
     try:
         global_state = states.GlobalState.load(

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -24,7 +24,7 @@ import jsonschema
 from typing import Set  # noqa: F401
 
 from snapcraft import project, formatting_utils
-from snapcraft.internal import deprecations, repo, states, steps
+from snapcraft.internal import common, deprecations, repo, states, steps
 from snapcraft.project._sanity_checks import conduct_environment_sanity_check
 from snapcraft.project._schema import Validator
 from ._parts_config import PartsConfig
@@ -225,7 +225,11 @@ class Config:
         # Always add the base for building for non os and base snaps
         if project.info.base is not None and project.info.type not in ("base", "os"):
             # If the base is already installed by other means, skip its installation.
-            if not repo.snaps.SnapPackage.is_snap_installed(project.info.base):
+            # But, we should always add it when in a docker environment so
+            # the creator of said docker image is aware that it is required.
+            if common.is_docker_instance() or not repo.snaps.SnapPackage.is_snap_installed(
+                project.info.base
+            ):
                 self.build_snaps.add(project.info.base)
         elif project.info.type not in ("base", "os"):
             # This exception is here to help with porting issues with bases. In normal

--- a/tests/unit/lifecycle/test_snap_installation.py
+++ b/tests/unit/lifecycle/test_snap_installation.py
@@ -1,0 +1,70 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+from unittest import mock
+
+from testtools.matchers import Contains
+
+from snapcraft.internal import lifecycle, steps
+from . import LifecycleTestBase
+
+
+class LifecycleSnapTest(LifecycleTestBase):
+    @mock.patch("snapcraft.repo.snaps.install_snaps")
+    def test_part_with_build_snaps(self, mock_install_build_snaps):
+        project = self.make_snapcraft_project(
+            textwrap.dedent(
+                """\
+                parts:
+                  part1:
+                    plugin: nil
+                    build-snaps: [snap1, snap2]
+                """
+            )
+        )
+
+        lifecycle.execute(steps.PULL, project)
+
+        mock_install_build_snaps.assert_called_once_with({"snap1", "snap2"})
+
+    @mock.patch("snapcraft.internal.common.is_docker_instance", return_value=True)
+    @mock.patch("snapcraft.repo.snaps.install_snaps")
+    def test_part_with_build_snaps_on_docker(
+        self, mock_install_build_snaps, mock_docker_instance
+    ):
+        project = self.make_snapcraft_project(
+            textwrap.dedent(
+                """\
+                parts:
+                  part1:
+                    plugin: nil
+                    build-snaps: [snap1, snap2]
+                """
+            )
+        )
+
+        lifecycle.execute(steps.PULL, project)
+
+        mock_install_build_snaps.assert_not_called()
+
+        self.assertThat(
+            self.fake_logger.output,
+            Contains(
+                "The following snaps are required but not installed as snapcraft "
+                "is running inside docker: "
+            ),
+        )


### PR DESCRIPTION
Docker environments are not capable of installing snaps given there is no
snapd running. Instead of trying to install, inform the user about the
situation for them to take the appropriate measures.

LP: #1814148
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
