### PR TITLE
clean: error out on invalid or missing yaml

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016-2018 Canonical Ltd
+# Copyright (C) 2016-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -59,17 +59,12 @@ def add_build_options(hidden=False):
     return _add_build_options
 
 
-def get_project(
-    *, is_managed_host: bool = False, skip_snapcraft_yaml: bool = False, **kwargs
-):
+def get_project(*, is_managed_host: bool = False, **kwargs):
     # We need to do this here until we can get_snapcraft_yaml as part of Project.
     if is_managed_host:
         os.chdir(os.path.expanduser(os.path.join("~", "project")))
 
-    if skip_snapcraft_yaml:
-        snapcraft_yaml_file_path = None
-    else:
-        snapcraft_yaml_file_path = get_snapcraft_yaml()
+    snapcraft_yaml_file_path = get_snapcraft_yaml()
 
     ctx = click.get_current_context()
     for key, value in ctx.parent.params.items():

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017-2018 Canonical Ltd
+# Copyright (C) 2017-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -37,10 +37,7 @@ from snapcraft.project._sanity_checks import (
     conduct_project_sanity_check,
     conduct_build_environment_sanity_check,
 )
-from snapcraft.project.errors import (
-    YamlValidationError,
-    MultipassMissingInstallableError,
-)
+from snapcraft.project.errors import MultipassMissingInstallableError
 
 if typing.TYPE_CHECKING:
     from snapcraft.internal.project import Project  # noqa: F401
@@ -282,16 +279,7 @@ def clean(parts):
         snapcraft clean my-part
     """
     build_environment = env.BuilderEnvironmentConfig()
-    try:
-        project = get_project(
-            is_managed_host=build_environment.is_managed_host
-        )
-    except YamlValidationError:
-        # We need to be able to clean invalid projects too.
-        project = get_project(
-            is_managed_host=build_environment.is_managed_host,
-            skip_snapcraft_yaml=True
-        )
+    project = get_project(is_managed_host=build_environment.is_managed_host)
 
     if build_environment.is_managed_host or build_environment.is_host:
         lifecycle.clean(project, parts)

--- a/tests/unit/commands/test_clean.py
+++ b/tests/unit/commands/test_clean.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2018 Canonical Ltd
+# Copyright (C) 2015-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -22,6 +22,7 @@ from testtools.matchers import Contains, Equals, DirExists, FileExists, Not
 
 import snapcraft
 from snapcraft.internal import errors, steps
+from snapcraft.project import errors as project_errors
 from . import CommandBaseTestCase
 
 
@@ -306,3 +307,34 @@ class CleanCommandReverseDependenciesTestCase(CommandBaseTestCase):
         )
         self.assert_clean(["main", "dependent"])
         self.assert_not_clean(["nested-dependent"])
+
+
+class CleanCommandSnapcraftYamlTest(CommandBaseTestCase):
+    def test_clean_with_only_name_defined(self):
+        self.make_snapcraft_yaml(
+            dedent(
+                """\
+            name: clean-test
+        """
+            )
+        )
+
+        result = self.run_command(["clean"])
+        self.assertThat(result.exit_code, Equals(0))
+
+    def test_clean_with_missing_required_name_defined(self):
+        self.make_snapcraft_yaml(
+            dedent(
+                """\
+            base: core16
+        """
+            )
+        )
+        self.assertRaises(
+            project_errors.YamlValidationError, self.run_command, ["clean"]
+        )
+
+    def test_clean_with_no_snapcraft_yaml(self):
+        self.assertRaises(
+            project_errors.MissingSnapcraftYamlError, self.run_command, ["clean"]
+        )


### PR DESCRIPTION
Reduce the risk of cleaning a non snapcraft base project by erroring out
if the snapcraft.yaml or the name is not defined in it.

LP: #1777501
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
