### PR TITLE
build providers: recreate instance if base changed

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,51 @@
+snapcraft (3.1) xenial; urgency=medium
+
+  [ Sergio Schvezov ]
+  * cmake plugin: use native primitives (#2397) (LP: #1802314)
+  * cmake plugin: use build snaps to search paths (#2399) (LP: #1802314)
+  * static: update to the latest flake8 (#2420) (LP: #1807409)
+  * project: state file path change (#2419) (LP: #1806746)
+  * nodejs plugin: fail gracefully when a package.json is missing (#2424)
+    (LP: #1807971)
+  * tests: use fixed version for idna in plainbox (#2426)
+  * tests: remove obsolete snap and external tests (#2421)
+  * snap: re-add pyc files for snapcraft (#2425) (LP: #1808199)
+  * tests: increase test timeout for plainbox (#2428)
+  * lifecycle: query for multipass install on darwin (#2427) (LP: #1807737)
+  * extractors: better appstream support for descriptions (#2430) (LP: #1778545)
+  * tests: re-enable spread tests on gce
+  * rust plugin: refactor to use the latest rustup (LP: #1809259)
+  * tests: temporarily disable osx tests
+  * snap: add build-package for xml
+  * appstream extractor: properly find desktop files (LP: #1805431)
+  * appstream extractor: support legacy launchables (LP: #1778546)
+  * snap: add xslt dependencies for lxml
+  * schema: allow before and after (#2443) (LP: #1808148)
+  * build providers: remove SIGUSR1 signal ignore workaround for multipass (#2447)
+  * cli: enable cleaning of parts (#2442) (LP: #1779136)
+  * tests: appstream unit tests are xenial specific
+  * tests: skip rust unit tests on s390x
+  * tests: use more fine grained assertions in lifecycle tests
+  * tests: remove rust revision testing for i386
+
+  [ Johan Dahlin ]
+  * tests: do not use `bash` as a reserved package name on staging (#2423)
+
+  [ Ricardo N Feliciano ]
+  * cli: fix usage string in help command (#2429) (LP: #1745040)
+
+  [ Anatoli Babenia ]
+  * repo: document package purpose (#2390)
+
+  [ Kyle Fazzari ]
+  * repo,baseplugin: support trusting repo keys (#2437) (LP: #1811304)
+
+  [ Michał Sawicz ]
+  * meta: make hooks executable instead of complaining they are not (#2440)
+    (LP: #1812003)
+
+ -- Sergio Schvezov <sergio.schvezov@ubuntu.com>  Thu, 24 Jan 2019 10:27:23 +0000
+
 snapcraft (3.0.1) xenial; urgency=medium
 
   [ Sergio Schvezov ]

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -31,9 +31,6 @@ from snapcraft.internal import common, steps
 from snapcraft import yaml_utils
 
 
-logger = logging.getLogger(__name__)
-
-
 def _get_platform() -> str:
     return sys.platform
 
@@ -250,7 +247,7 @@ class Provider(abc.ABC):
         info = self._load_info()
         provider_base = info["base"] if "base" in info else None
         if self._base_has_changed(self.project.info.base, provider_base):
-            logger.warning(
+            self.echoer.warning(
                 "Project base changed from {!r} to {!r}, cleaning build instance.".format(
                     provider_base, self.project.info.base
                 )

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import abc
-import logging
 import os
 import shutil
 import sys

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -248,7 +248,6 @@ class Provider(abc.ABC):
 
     def _verify_base_change(self) -> None:
         info = self._load_info()
-        print(info, file=open("/tmp/lala", "w"))
         provider_base = info["base"] if "base" in info else None
         if self._base_has_changed(self.project.info.base, provider_base):
             self.clean_project()

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -224,7 +224,7 @@ class Provider(abc.ABC):
     def launch_instance(self) -> None:
         # Check provider base and clean project if base has changed.
         if os.path.exists(self.provider_project_dir):
-            self._verify_base_change()
+            self._ensure_base()
 
         try:
             # An ProviderStartError exception here means we need to create
@@ -246,10 +246,15 @@ class Provider(abc.ABC):
             # what is on the host
             self._setup_snapcraft()
 
-    def _verify_base_change(self) -> None:
+    def _ensure_base(self) -> None:
         info = self._load_info()
         provider_base = info["base"] if "base" in info else None
         if self._base_has_changed(self.project.info.base, provider_base):
+            logger.warning(
+                "Project base changed from {!r} to {!r}, cleaning build instance.".format(
+                    provider_base, self.project.info.base
+                )
+            )
             self.clean_project()
 
     def _setup_snapcraft(self) -> None:

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -21,12 +21,14 @@ import shutil
 import sys
 from textwrap import dedent
 from typing import Optional, Sequence
+from typing import Any, Dict
 
 from xdg import BaseDirectory
 
 from . import errors
 from ._snap import SnapInjector
 from snapcraft.internal import common, steps
+from snapcraft import yaml_utils
 
 
 logger = logging.getLogger(__name__)
@@ -220,6 +222,10 @@ class Provider(abc.ABC):
         """Provider steps to provide a shell into the instance."""
 
     def launch_instance(self) -> None:
+        # Check provider base and clean project if base has changed.
+        if os.path.exists(self.provider_project_dir):
+            self._verify_base_change()
+
         try:
             # An ProviderStartError exception here means we need to create
             self._start()
@@ -240,7 +246,16 @@ class Provider(abc.ABC):
             # what is on the host
             self._setup_snapcraft()
 
+    def _verify_base_change(self) -> None:
+        info = self._load_info()
+        print(info, file=open("/tmp/lala", "w"))
+        provider_base = info["base"] if "base" in info else None
+        if self._base_has_changed(self.project.info.base, provider_base):
+            self.clean_project()
+
     def _setup_snapcraft(self) -> None:
+        self._save_info(base=self.project.info.base)
+
         registry_filepath = os.path.join(
             self.provider_project_dir, "snap-registry.yaml"
         )
@@ -283,3 +298,30 @@ class Provider(abc.ABC):
             print(user_data, file=cloud_user_data_file, end="")
 
         return cloud_user_data_filepath
+
+    def _base_has_changed(self, base: str, provider_base: str) -> bool:
+        # Make it backwards compatible with instances without project info
+        if base == "core18" and provider_base is None:
+            return False
+        elif base != provider_base:
+            return True
+
+        return False
+
+    def _load_info(self) -> Dict[str, Any]:
+        filepath = os.path.join(self.provider_project_dir, "project-info.yaml")
+        if not os.path.exists(filepath):
+            return dict()
+
+        with open(filepath) as info_file:
+            return yaml_utils.load(info_file)
+
+    def _save_info(self, **data: Dict[str, Any]) -> None:
+        filepath = os.path.join(self.provider_project_dir, "project-info.yaml")
+
+        dirpath = os.path.dirname(filepath)
+        if dirpath:
+            os.makedirs(dirpath, exist_ok=True)
+
+        with open(filepath, "w") as info_file:
+            yaml_utils.dump(data, stream=info_file)

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -35,7 +35,9 @@ class ProviderImpl(Provider):
         self.create_mock = mock.Mock()
         self.destroy_mock = mock.Mock()
         self.mount_project_mock = mock.Mock()
+        self.clean_project_mock = mock.Mock()
         self.shell_mock = mock.Mock()
+        self.save_info_mock = mock.Mock()
 
     def _run(self, command, hide_output=False):
         self.run_mock(command)
@@ -67,6 +69,9 @@ class ProviderImpl(Provider):
     def _umount(self):
         raise NotImplementedError("test stub not implemented")
 
+    def _save_info(self, **data) -> None:
+        self.save_info_mock(data)
+
     def build_project(self) -> None:
         raise NotImplementedError("test stub not implemented")
 
@@ -78,6 +83,9 @@ class ProviderImpl(Provider):
 
     def mount_project(self):
         self.mount_project_mock("mount-project")
+
+    def clean_project(self):
+        self.clean_project_mock("clean-project")
 
     def provision_project(self):
         raise NotImplementedError("test stub not implemented")

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -85,7 +85,7 @@ class ProviderImpl(Provider):
         self.mount_project_mock("mount-project")
 
     def clean_project(self):
-        self.clean_project_mock("clean-project")
+        self.clean_project_mock()
 
     def provision_project(self):
         raise NotImplementedError("test stub not implemented")

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -96,7 +96,7 @@ class BaseProviderTest(BaseProviderBaseTest):
 
         self.assertThat(provider.provider_project_dir, DirExists())
 
-    def test_verify_base_change_same_base(self):
+    def test_ensure_base_same_base(self):
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
         provider.project.info.base = "core16"
 
@@ -108,10 +108,10 @@ class BaseProviderTest(BaseProviderBaseTest):
         patcher.start()
         self.addCleanup(patcher.stop)
 
-        provider._verify_base_change()
+        provider._ensure_base()
         provider.clean_project_mock.assert_not_called()
 
-    def test_verify_base_change_new_base(self):
+    def test_ensure_base_new_base(self):
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
         provider.project.info.base = "core16"
 
@@ -123,10 +123,10 @@ class BaseProviderTest(BaseProviderBaseTest):
         patcher.start()
         self.addCleanup(patcher.stop)
 
-        provider._verify_base_change()
+        provider._ensure_base()
         provider.clean_project_mock.assert_called_once_with()
 
-    def test_verify_base_change_no_base_clean(self):
+    def test_ensure_base_no_base_clean(self):
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
         provider.project.info.base = "core16"
 
@@ -139,10 +139,10 @@ class BaseProviderTest(BaseProviderBaseTest):
         patcher.start()
         self.addCleanup(patcher.stop)
 
-        provider._verify_base_change()
+        provider._ensure_base()
         provider.clean_project_mock.assert_called_once_with()
 
-    def test_verify_base_change_no_base_keep(self):
+    def test_ensure_base_no_base_keep(self):
 
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
         provider.project.info.base = "core18"
@@ -156,7 +156,7 @@ class BaseProviderTest(BaseProviderBaseTest):
         patcher.start()
         self.addCleanup(patcher.stop)
 
-        provider._verify_base_change()
+        provider._ensure_base()
         provider.clean_project_mock.assert_not_called()
 
     def test_start_instance(self):

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -124,7 +124,7 @@ class BaseProviderTest(BaseProviderBaseTest):
         self.addCleanup(patcher.stop)
 
         provider._verify_base_change()
-        provider.clean_project_mock.assert_called_once()
+        provider.clean_project_mock.assert_called_once_with()
 
     def test_verify_base_change_no_base_clean(self):
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
@@ -140,7 +140,7 @@ class BaseProviderTest(BaseProviderBaseTest):
         self.addCleanup(patcher.stop)
 
         provider._verify_base_change()
-        provider.clean_project_mock.assert_called_once()
+        provider.clean_project_mock.assert_called_once_with()
 
     def test_verify_base_change_no_base_keep(self):
 

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -17,7 +17,7 @@
 import contextlib
 import os
 from textwrap import dedent
-from unittest.mock import call, Mock
+from unittest.mock import call, patch, Mock
 
 from testtools.matchers import Equals, EndsWith, DirExists, FileContains, Not
 
@@ -91,9 +91,73 @@ class BaseProviderTest(BaseProviderBaseTest):
 
         provider.launch_mock.assert_any_call()
         provider.start_mock.assert_any_call()
+        provider.save_info_mock.assert_called_once_with({"base": "core16"})
         provider.run_mock.assert_called_once_with(["snapcraft", "refresh"])
 
         self.assertThat(provider.provider_project_dir, DirExists())
+
+    def test_verify_base_change_same_base(self):
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+        provider.project.info.base = "core16"
+
+        # Provider and project have the same base
+        patcher = patch(
+            "snapcraft.internal.build_providers._base_provider.Provider._load_info",
+            return_value={"base": "core16"},
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        provider._verify_base_change()
+        provider.clean_project_mock.assert_not_called()
+
+    def test_verify_base_change_new_base(self):
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+        provider.project.info.base = "core16"
+
+        # Provider and project have different bases
+        patcher = patch(
+            "snapcraft.internal.build_providers._base_provider.Provider._load_info",
+            return_value={"base": "core18"},
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        provider._verify_base_change()
+        provider.clean_project_mock.assert_called_once()
+
+    def test_verify_base_change_no_base_clean(self):
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+        provider.project.info.base = "core16"
+
+        # Provider has no base, project has base that's not core18
+        # (assume provider has core18 for backward compatibility)
+        patcher = patch(
+            "snapcraft.internal.build_providers._base_provider.Provider._load_info",
+            return_value={},
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        provider._verify_base_change()
+        provider.clean_project_mock.assert_called_once()
+
+    def test_verify_base_change_no_base_keep(self):
+
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+        provider.project.info.base = "core18"
+
+        # Provider has no base, project has base core18
+        # (assume provider has core18 for backward compatibility)
+        patcher = patch(
+            "snapcraft.internal.build_providers._base_provider.Provider._load_info",
+            return_value={},
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        provider._verify_base_change()
+        provider.clean_project_mock.assert_not_called()
 
     def test_start_instance(self):
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)


### PR DESCRIPTION
Once a build provider is provisioned, changes in project base are
ignored and the existing VM is used for new builds. To ensure base
and provider contents are consistent, we test base values at the
start of each build and force instance recreation if base has
changed.

LP: #1794506

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
