### PR TITLE
ci: use non virt-enabled gce instances for 16.04

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -34,7 +34,7 @@ backends:
           workers: 3
       - ubuntu-16.04-64:
           workers: 5
-          image: ubuntu-1604-64-virt-enabled
+          image: ubuntu-1604-64
       - ubuntu-18.04-64:
           workers: 10
           image: ubuntu-1804-64-virt-enabled


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
