### PR TITLE
project_loader: use hardened flags by default

### DIFF
--- a/snapcraft/internal/project_loader/_env.py
+++ b/snapcraft/internal/project_loader/_env.py
@@ -18,6 +18,16 @@ from snapcraft.internal import common, elf, pluginhandler
 
 from typing import Dict, List
 
+_HARDENED_FLAGS = [
+    "-Wformat",
+    "-Wformat-security",
+    "-fstack-protector-strong",
+    "-D_FORTIFY_SOURCE=2",
+    "-Wl,-z,relro",
+    "-pie",
+    "-Wl,-z,now",
+]
+
 
 def env_for_classic(base: str, arch_triplet: str) -> List[str]:
     """Set the required environment variables for a classic confined build."""
@@ -91,6 +101,18 @@ def build_env(root: str, snap_name: str, arch_triplet: str) -> List[str]:
         env.append(
             formatting_utils.format_path_variable(
                 "PKG_CONFIG_PATH", paths, prepend="", separator=":"
+            )
+        )
+
+    return env
+
+
+def hardened_flags() -> List[str]:
+    env = []  # type: List[str]
+    for envvar in ["CFLAGS", "CXXFLAGS"]:
+        env.append(
+            formatting_utils.format_path_variable(
+                envvar, _HARDENED_FLAGS, prepend="", separator=" "
             )
         )
 

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -26,6 +26,7 @@ from ._env import (
     env_for_classic,
     build_env,
     build_env_for_stage,
+    hardened_flags,
     runtime_env,
     snapcraft_global_environment,
     snapcraft_part_environment,
@@ -244,6 +245,7 @@ class PartsConfig:
         stagedir = self._project.stage_dir
 
         if root_part:
+            env += hardened_flags()
             # this has to come before any {}/usr/bin
             env += part.env(part.plugin.installdir)
             env += runtime_env(part.plugin.installdir, self._project.arch_triplet)


### PR DESCRIPTION
These are the same flags used when building with Ubuntu.

LP: #1805216

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
