### PR TITLE
tests: make before/after items an array in schema test

### DIFF
--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -163,8 +163,8 @@ class DaemonDependencyTest(ValidationBaseTest):
             "post-stop-command",
             dict(option="post-stop-command", value="binary1 --post-stop"),
         ),
-        ("before", dict(option="before", value="service2")),
-        ("after", dict(option="after", value="service2")),
+        ("before", dict(option="before", value=["service2"])),
+        ("after", dict(option="after", value=["service2"])),
     ]
 
     def test_daemon_dependency(self):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

---

The theory for why this doesn't always fail is because, as of 2a2f798d0de8ad32cde48a8c9e6a48c53e6a9fb0, the schema is no longer an ordered dict, which makes the order in which validation finds multiple issues non-deterministic.

(We should consider ordering the loaded json, this may cause other issues)