### PR TITLE
[legacy] ruby plugin: support new download URL

### DIFF
--- a/snapcraft/plugins/ruby.py
+++ b/snapcraft/plugins/ruby.py
@@ -50,7 +50,11 @@ class RubyPlugin(BasePlugin):
         schema = super().schema()
 
         schema["properties"]["use-bundler"] = {"type": "boolean", "default": False}
-        schema["properties"]["ruby-version"] = {"type": "string", "default": "2.4.2"}
+        schema["properties"]["ruby-version"] = {
+            "type": "string",
+            "default": "2.4.2",
+            "pattern": r"^\d+\.\d+(\.\d+)?$",
+        }
         schema["properties"]["gems"] = {
             "type": "array",
             "minitems": 1,
@@ -77,8 +81,10 @@ class RubyPlugin(BasePlugin):
 
         self._ruby_version = options.ruby_version
         self._ruby_part_dir = os.path.join(self.partdir, "ruby")
-        self._ruby_download_url = "https://cache.ruby-lang.org/pub/ruby/ruby-{}.tar.gz".format(
-            self._ruby_version
+        feature_pattern = re.compile(r"^(\d+\.\d+)\..*$")
+        feature_version = feature_pattern.sub(r"\1", self._ruby_version)
+        self._ruby_download_url = "https://cache.ruby-lang.org/pub/ruby/{}/ruby-{}.tar.gz".format(
+            feature_version, self._ruby_version
         )
         self._ruby_tar = Tar(self._ruby_download_url, self._ruby_part_dir)
         self._gems = options.gems or []

--- a/tests/unit/plugins/test_ruby.py
+++ b/tests/unit/plugins/test_ruby.py
@@ -40,7 +40,11 @@ class RubyPluginTestCase(unit.TestCase):
     def test_schema(self):
         schema = ruby.RubyPlugin.schema()
         expected_use_bundler = {"type": "boolean", "default": False}
-        expected_ruby_version = {"type": "string", "default": "2.4.2"}
+        expected_ruby_version = {
+            "type": "string",
+            "default": "2.4.2",
+            "pattern": r"^\d+\.\d+(\.\d+)?$",
+        }
         expected_gems = {
             "type": "array",
             "minitems": 1,
@@ -144,7 +148,7 @@ class RubyPluginTestCase(unit.TestCase):
 
         self.assertThat(
             plugin._ruby_tar.source,
-            Equals("https://cache.ruby-lang.org/pub/ruby/ruby-2.4.2.tar.gz"),
+            Equals("https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.gz"),
         )
         self.assertThat(
             plugin._ruby_tar.source_dir,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [x] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR is a backport of #2466, fixing [LP: #1815336](https://bugs.launchpad.net/snapcraft/+bug/1815336) for legacy.