### PR TITLE
many: support for stage-snaps

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -651,6 +651,11 @@
                             },
                             "default": []
                         },
+                        "stage-snaps": {
+                            "$comment": "For some reason 'default' doesn't work if in the ref",
+                            "$ref": "#/definitions/grammar-array",
+                            "default": []
+                        },
                         "stage-packages": {
                             "$comment": "For some reason 'default' doesn't work if in the ref",
                             "$ref": "#/definitions/grammar-array",

--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -72,6 +72,7 @@ class BasePlugin:
     def __init__(self, name, options, project=None):
         self.name = name
         self.build_snaps = []
+        self.stage_snaps = []
         self.build_packages = []
         self._stage_packages = []
 
@@ -81,6 +82,8 @@ class BasePlugin:
             self.build_packages = options.build_packages.copy()
         with contextlib.suppress(AttributeError):
             self.build_snaps = options.build_snaps.copy()
+        with contextlib.suppress(AttributeError):
+            self.stage_snaps = options.stage_snaps.copy()
 
         self.project = project
         self.options = options
@@ -94,6 +97,7 @@ class BasePlugin:
         self.installdir = os.path.join(self.partdir, "install")
         self.statedir = os.path.join(self.partdir, "state")
         self.osrepodir = os.path.join(self.partdir, "ubuntu")
+        self.snapsdir = os.path.join(self.partdir, "snaps")
 
         self.build_basedir = os.path.join(self.partdir, "build")
         source_subdir = getattr(self.options, "source_subdir", None)

--- a/snapcraft/internal/project_loader/grammar_processing/_part_grammar_processor.py
+++ b/snapcraft/internal/project_loader/grammar_processing/_part_grammar_processor.py
@@ -85,6 +85,7 @@ class PartGrammarProcessor:
         self._repo = repo
 
         self.__build_snaps = set()  # type: Set[str]
+        self.__stage_snaps = set()  # type: Set[str]
         self.__build_packages = set()  # type: Set[str]
         self.__stage_packages = set()  # type: Set[str]
 
@@ -118,6 +119,17 @@ class PartGrammarProcessor:
             self.__build_snaps = processor.process()
 
         return self.__build_snaps
+
+    def get_stage_snaps(self) -> Set[str]:
+        if not self.__stage_snaps:
+            processor = grammar.GrammarProcessor(
+                getattr(self._plugin, "stage_snaps", []),
+                self._project,
+                repo.snaps.SnapPackage.is_valid_snap,
+            )
+            self.__stage_snaps = processor.process()
+
+        return self.__stage_snaps
 
     def get_build_packages(self) -> Set[str]:
         if not self.__build_packages:

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -141,6 +141,14 @@ class SnapInstallError(RepoError):
         super().__init__(snap_name=snap_name, snap_channel=snap_channel)
 
 
+class SnapDownloadError(RepoError):
+
+    fmt = "Error while downloading snap {snap_name!r} from channel {snap_channel!r}"
+
+    def __init__(self, *, snap_name, snap_channel):
+        super().__init__(snap_name=snap_name, snap_channel=snap_channel)
+
+
 class SnapGetAssertionError(RepoError):
 
     fmt = (

--- a/snapcraft/internal/sources/__init__.py
+++ b/snapcraft/internal/sources/__init__.py
@@ -93,6 +93,7 @@ if sys.platform == "linux":
     from ._7z import SevenZip  # noqa
     from ._deb import Deb  # noqa
     from ._rpm import Rpm  # noqa
+    from ._snap import Snap  # noqa: F401
 
     _source_handler = {
         "bzr": Bazaar,
@@ -107,6 +108,7 @@ if sys.platform == "linux":
         "local": Local,
         "deb": Deb,
         "rpm": Rpm,
+        "snap": Snap,
         "": Local,
     }
 
@@ -167,7 +169,7 @@ _tar_type_regex = re.compile(r".*\.((tar(\.(xz|gz|bz2))?)|tgz)$")
 
 
 def _get_source_type_from_uri(source, ignore_errors=False):  # noqa: C901
-    for extension in ["zip", "deb", "rpm", "7z"]:
+    for extension in ["zip", "deb", "rpm", "7z", "snap"]:
         if source.endswith(".{}".format(extension)):
             return extension
     source_type = ""

--- a/snapcraft/internal/sources/_snap.py
+++ b/snapcraft/internal/sources/_snap.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2019 Canonical
+# Copyright (C) 2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/snapcraft/internal/sources/_snap.py
+++ b/snapcraft/internal/sources/_snap.py
@@ -1,0 +1,116 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import shutil
+import tempfile
+
+from . import errors
+from ._base import FileBase
+from snapcraft import file_utils, yaml_utils
+
+
+class Snap(FileBase):
+    """Handles downloading and extractions for a snap source.
+
+    On provision, the meta directory is renamed to meta.<snap-name> and, if present,
+    the same applies for the snap directory which shall be renamed to
+    snap.<snap-name>.
+    """
+
+    def __init__(
+        self,
+        source: str,
+        source_dir: str,
+        source_tag: str = None,
+        source_commit: str = None,
+        source_branch: str = None,
+        source_depth: str = None,
+        source_checksum: str = None,
+    ) -> None:
+        super().__init__(
+            source,
+            source_dir,
+            source_tag,
+            source_commit,
+            source_branch,
+            source_depth,
+            source_checksum,
+            "unsquashfs",
+        )
+        if source_tag:
+            raise errors.SnapcraftSourceInvalidOptionError("snap", "source-tag")
+        elif source_commit:
+            raise errors.SnapcraftSourceInvalidOptionError("snap", "source-commit")
+        elif source_branch:
+            raise errors.SnapcraftSourceInvalidOptionError("snap", "source-branch")
+
+    def provision(
+        self,
+        dst: str,
+        clean_target: bool = True,
+        keep_snap: bool = False,
+        src: str = None,
+    ) -> None:
+        """
+        Provision the snap source to dst.
+
+        :param str dst: the destination directory to provision to.
+        :param bool clean_target: clean dst before provisioning if True.
+        :param bool keep_snap: keep the snap after provisioning is done if
+                               True.
+        :param str src: force a new source to use for extraction.
+        raises errors.InvalidSnapError: when trying to provision an invalid
+                                        snap.
+        """
+        if src:
+            snap_file = src
+        else:
+            snap_file = os.path.join(self.source_dir, os.path.basename(self.source))
+        snap_file = os.path.realpath(snap_file)
+
+        if clean_target:
+            tmp_snap = tempfile.NamedTemporaryFile().name
+            shutil.move(snap_file, tmp_snap)
+            shutil.rmtree(dst)
+            os.makedirs(dst)
+            shutil.move(tmp_snap, snap_file)
+
+        # unsquashfs [options] filesystem [directories or files to extract]
+        # options:
+        # -force: if file already exists then overwrite
+        # -dest <pathname>: unsquash to <pathname>
+        with tempfile.TemporaryDirectory(prefix=os.path.dirname(snap_file)) as temp_dir:
+            extract_command = ["unsquashfs", "-force", "-dest", temp_dir, snap_file]
+            self._run_output(extract_command)
+            snap_name = _get_snap_name(temp_dir)
+            # Rename meta and snap dirs from the snap
+            rename_paths = (os.path.join(temp_dir, d) for d in ["meta", "snap"])
+            rename_paths = (d for d in rename_paths if os.path.exists(d))
+            for rename in rename_paths:
+                shutil.move(rename, "{}.{}".format(rename, snap_name))
+            file_utils.link_or_copy_tree(source_tree=temp_dir, destination_tree=dst)
+
+        if not keep_snap:
+            os.remove(snap_file)
+
+
+def _get_snap_name(snap_dir: str) -> str:
+    try:
+        with open(os.path.join(snap_dir, "meta", "snap.yaml")) as snap_yaml:
+            return yaml_utils.load(snap_yaml)["name"]
+    except (FileNotFoundError, KeyError) as snap_error:
+        raise errors.InvalidSnapError() from snap_error

--- a/snapcraft/internal/sources/errors.py
+++ b/snapcraft/internal/sources/errors.py
@@ -90,9 +90,8 @@ class InvalidDebError(SnapcraftSourceError):
 class InvalidSnapError(SnapcraftSourceError):
 
     fmt = (
-        "The snap file used does not contain valid data. "
-        "Ensure a proper snap file is passed for .snap files "
-        "as sources."
+        "The snap file does not contain valid data. "
+        "Ensure the source lists a proper snap file"
     )
 
 

--- a/snapcraft/internal/sources/errors.py
+++ b/snapcraft/internal/sources/errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2017 Canonical Ltd
+# Copyright (C) 2015-2017, 2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -83,6 +83,15 @@ class InvalidDebError(SnapcraftSourceError):
     fmt = (
         "The {deb_file} used does not contain valid data. "
         "Ensure a proper deb file is passed for .deb files "
+        "as sources."
+    )
+
+
+class InvalidSnapError(SnapcraftSourceError):
+
+    fmt = (
+        "The snap file used does not contain valid data. "
+        "Ensure a proper snap file is passed for .snap files "
         "as sources."
     )
 

--- a/tests/spread/general/stage_snaps/task.yaml
+++ b/tests/spread/general/stage_snaps/task.yaml
@@ -1,0 +1,34 @@
+summary: stage-snaps
+
+# We currently only have core18 on a stable channel
+systems: [ubuntu-18*]
+
+environment:
+  STAGE_SNAPS/default: "hello"
+  STAGE_SNAPS/channel: "hello/latest/stable"
+  STAGE_SNAPS/n_snaps: "hello, black/latest/edge"
+
+prepare: |
+  mkdir test-snap
+  cd test-snap
+  snapcraft init
+  
+  echo "    stage-snaps: [$STAGE_SNAPS]" >> snap/snapcraft.yaml
+
+restore: |
+  rm -rf test-snap
+
+execute: |
+  cd test-snap
+
+  snapcraft stage
+
+  if [ ! -f stage/meta.hello ]; then
+      echo "Missing expected stage-snaps payload from hello"
+      exit 1
+  fi
+
+  if grep black snap/snapcraft.yaml && [ ! -f stage/meta.black ]; then
+      echo "Missing expected stage-snaps payload from black"
+      exit 1
+  fi

--- a/tests/spread/general/stage_snaps/task.yaml
+++ b/tests/spread/general/stage_snaps/task.yaml
@@ -23,12 +23,12 @@ execute: |
 
   snapcraft stage
 
-  if [ ! -f stage/meta.hello ]; then
+  if [ ! -f stage/meta.hello/snap.yaml ]; then
       echo "Missing expected stage-snaps payload from hello"
       exit 1
   fi
 
-  if grep black snap/snapcraft.yaml && [ ! -f stage/meta.black ]; then
+  if grep black snap/snapcraft.yaml && [ ! -f stage/meta.black/snap.yaml ]; then
       echo "Missing expected stage-snaps payload from black"
       exit 1
   fi

--- a/tests/unit/project_loader/grammar_processing/test_part_grammar_processor.py
+++ b/tests/unit/project_loader/grammar_processing/test_part_grammar_processor.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017, 2018 Canonical Ltd
+# Copyright (C) 2017, 2018-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -226,13 +226,13 @@ class PartGrammarSourceTestCase(unit.TestCase):
         self.assertThat(plugin.properties, Equals(self.properties))
 
 
-class PartGrammarBuildSnapsTestCase(unit.TestCase):
+class PartGrammarBuildAndStageSnapsTestCase(unit.TestCase):
 
     source_scenarios = [
         (
             "empty",
             {
-                "build_snaps": "",
+                "snaps": "",
                 "expected_amd64": set(),
                 "expected_i386": set(),
                 "expected_armhf": set(),
@@ -241,7 +241,7 @@ class PartGrammarBuildSnapsTestCase(unit.TestCase):
         (
             "single item",
             {
-                "build_snaps": ["foo"],
+                "snaps": ["foo"],
                 "expected_amd64": {"foo"},
                 "expected_i386": {"foo"},
                 "expected_armhf": {"foo"},
@@ -250,7 +250,7 @@ class PartGrammarBuildSnapsTestCase(unit.TestCase):
         (
             "on amd64",
             {
-                "build_snaps": [{"on amd64": ["foo"]}],
+                "snaps": [{"on amd64": ["foo"]}],
                 "expected_amd64": {"foo"},
                 "expected_i386": set(),
                 "expected_armhf": {"foo"},  # 'on' cares about host, not target
@@ -259,7 +259,7 @@ class PartGrammarBuildSnapsTestCase(unit.TestCase):
         (
             "try",
             {
-                "build_snaps": [{"try": ["hello"]}],
+                "snaps": [{"try": ["hello"]}],
                 "expected_amd64": {"hello"},
                 "expected_i386": {"hello"},
                 "expected_armhf": {"hello"},
@@ -268,7 +268,7 @@ class PartGrammarBuildSnapsTestCase(unit.TestCase):
         (
             "try optional",
             {
-                "build_snaps": [{"try": ["-invalid-"]}],
+                "snaps": [{"try": ["-invalid-"]}],
                 "expected_amd64": set(),
                 "expected_i386": set(),
                 "expected_armhf": set(),
@@ -277,7 +277,7 @@ class PartGrammarBuildSnapsTestCase(unit.TestCase):
         (
             "to armhf",
             {
-                "build_snaps": [{"to armhf": ["foo"]}],
+                "snaps": [{"to armhf": ["foo"]}],
                 "expected_amd64": set(),
                 "expected_i386": set(),
                 "expected_armhf": {"foo"},
@@ -286,7 +286,7 @@ class PartGrammarBuildSnapsTestCase(unit.TestCase):
         (
             "on amd64 to armhf",
             {
-                "build_snaps": [{"on amd64 to armhf": "foo"}],
+                "snaps": [{"on amd64 to armhf": "foo"}],
                 "expected_amd64": set(),
                 "expected_i386": set(),
                 "expected_armhf": {"foo"},
@@ -317,17 +317,18 @@ class PartGrammarBuildSnapsTestCase(unit.TestCase):
 
         repo = mock.Mock()
         plugin = mock.Mock()
-        plugin.build_snaps = self.build_snaps
+        plugin.build_snaps = self.snaps
+        plugin.stage_snaps = self.snaps
         expected = getattr(self, "expected_{}".format(self.target_arch))
-        self.assertThat(
-            PartGrammarProcessor(
-                plugin=plugin,
-                properties={},
-                project=project.Project(target_deb_arch=self.target_arch),
-                repo=repo,
-            ).get_build_snaps(),
-            Equals(expected),
+        processor = PartGrammarProcessor(
+            plugin=plugin,
+            properties={},
+            project=project.Project(target_deb_arch=self.target_arch),
+            repo=repo,
         )
+
+        self.assertThat(processor.get_build_snaps(), Equals(expected))
+        self.assertThat(processor.get_stage_snaps(), Equals(expected))
 
 
 class PartGrammarBuildAndStagePackagesTestCase(unit.TestCase):

--- a/tests/unit/sources/test_errors.py
+++ b/tests/unit/sources/test_errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018 Canonical Ltd
+# Copyright (C) 2018-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -57,6 +57,18 @@ class ErrorFormattingTestCase(unit.TestCase):
                     "Failed to pull source: "
                     "cannot specify both 'bar' and 'foo' for a test source.\n"
                     "See `snapcraft help sources` for more information."
+                ),
+            },
+        ),
+        (
+            "InvalidSnapError",
+            {
+                "exception": errors.InvalidSnapError,
+                "kwargs": {},
+                "expected_message": (
+                    "The snap file used does not contain valid data. "
+                    "Ensure a proper snap file is passed for .snap files "
+                    "as sources."
                 ),
             },
         ),

--- a/tests/unit/sources/test_errors.py
+++ b/tests/unit/sources/test_errors.py
@@ -66,9 +66,8 @@ class ErrorFormattingTestCase(unit.TestCase):
                 "exception": errors.InvalidSnapError,
                 "kwargs": {},
                 "expected_message": (
-                    "The snap file used does not contain valid data. "
-                    "Ensure a proper snap file is passed for .snap files "
-                    "as sources."
+                    "The snap file does not contain valid data. "
+                    "Ensure the source lists a proper snap file"
                 ),
             },
         ),

--- a/tests/unit/sources/test_snap.py
+++ b/tests/unit/sources/test_snap.py
@@ -1,0 +1,100 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015-2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import subprocess
+
+from unittest import mock
+from testtools.matchers import DirExists, Equals, FileExists, MatchesRegex
+
+from snapcraft.internal import sources
+from tests import unit
+
+
+class TestSnap(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_file_path = os.path.join(
+            os.path.dirname(unit.__file__), "..", "data", "test-snap.snap"
+        )
+
+        self.dest_dir = "dst"
+        os.makedirs(self.dest_dir)
+
+    def test_pull_snap_file_must_extract(self):
+        snap_source = sources.Snap(self.test_file_path, self.dest_dir)
+        snap_source.pull()
+
+        self.assertThat(os.path.join(self.dest_dir, "meta.basic"), DirExists())
+        self.assertThat(
+            os.path.join(self.dest_dir, "meta.basic", "snap.yaml"), FileExists()
+        )
+
+    @mock.patch.object(sources.Snap, "provision")
+    def test_pull_snap_must_not_clean_targets(self, mock_provision):
+        snap_source = sources.Snap(self.test_file_path, self.dest_dir)
+        snap_source.pull()
+
+        mock_provision.assert_called_once_with(
+            self.dest_dir,
+            clean_target=False,
+            src=os.path.join(self.dest_dir, "test-snap.snap"),
+        )
+
+    def test_has_source_handler_entry_on_linux(self):
+        if sys.platform == "linux":
+            self.assertTrue(sources._source_handler["snap"] is sources.Snap)
+        else:
+            self.assertRaises(KeyError, sources._source_handler["snap"])
+
+    @mock.patch(
+        "subprocess.check_output", side_effect=subprocess.CalledProcessError(1, [])
+    )
+    def test_pull_failure_bad_unsquash(self, mock_run):
+        snap_source = sources.Snap(self.test_file_path, self.dest_dir)
+        raised = self.assertRaises(sources.errors.SnapcraftPullError, snap_source.pull)
+        self.assertThat(
+            raised.command,
+            MatchesRegex(
+                r"unsquashfs -force -dest {0}/\w+ {0}/dst/test-snap.snap".format(
+                    self.path
+                )
+            ),
+        )
+        self.assertThat(raised.exit_code, Equals(1))
+
+
+class TestGetName(unit.TestCase):
+    def test_get_name(self):
+        os.mkdir("meta")
+        with open(os.path.join("meta", "snap.yaml"), "w") as snap_yaml_file:
+            print("name: my-snap", file=snap_yaml_file)
+        self.assertThat(sources._snap._get_snap_name("."), Equals("my-snap"))
+
+    def test_no_name_yaml(self):
+        os.mkdir("meta")
+        with open(os.path.join("meta", "snap.yaml"), "w") as snap_yaml_file:
+            print("summary: no name", file=snap_yaml_file)
+        self.assertRaises(
+            sources.errors.InvalidSnapError, sources._snap._get_snap_name, "."
+        )
+
+    def test_no_snap_yaml(self):
+        os.mkdir("meta")
+        self.assertRaises(
+            sources.errors.InvalidSnapError, sources._snap._get_snap_name, "."
+        )


### PR DESCRIPTION
Add support for stage-snaps, with support for advanced grammar. Support for a snap
source was added to be able to extract the downloaded snaps.

LP: #1805214

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
