### PR TITLE
cli: clean up snapcraft push output

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2016-2017 Canonical Ltd
+# Copyright 2016-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -534,7 +534,9 @@ def push(snap_filename, release_channels=None):
     snap_name = snap_yaml["name"]
     store = storeapi.StoreClient()
 
-    logger.info("Preparing to push {!r} to the store.".format(snap_filename))
+    logger.debug(
+        "Run push precheck and verify cached data for {!r}.".format(snap_filename)
+    )
     with _requires_login():
         store.push_precheck(snap_name)
 
@@ -587,7 +589,7 @@ def _push_snap(snap_name, snap_filename):
 def _push_delta(snap_name, snap_filename, source_snap):
     store = storeapi.StoreClient()
     delta_format = "xdelta3"
-    logger.info("Found cached source snap {}.".format(source_snap))
+    logger.debug("Found cached source snap {}.".format(source_snap))
     target_snap = os.path.join(os.getcwd(), snap_filename)
 
     try:
@@ -605,7 +607,7 @@ def _push_delta(snap_name, snap_filename, source_snap):
     }
 
     try:
-        logger.info("Pushing delta {}.".format(delta_filename))
+        logger.debug("Pushing delta {!r}.".format(delta_filename))
         with _requires_login():
             delta_tracker = store.upload(
                 snap_name,

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -149,7 +149,7 @@ def push(snap_file, release):
         snapcraft push my-snap_0.2_amd64.snap --release edge
         snapcraft push my-snap_0.3_amd64.snap --release candidate,beta
     """
-    click.echo("Pushing {}".format(os.path.basename(snap_file)))
+    click.echo("Preparing to push {!r}.".format(os.path.basename(snap_file)))
     channel_list = []
     if release:
         channel_list = release.split(",")
@@ -183,7 +183,7 @@ def push_metadata(snap_file, force):
         snapcraft push-metadata my-snap_0.1_amd64.snap
         snapcraft push-metadata my-snap_0.1_amd64.snap --force
     """
-    click.echo("Pushing metadata from {}".format(os.path.basename(snap_file)))
+    click.echo("Pushing metadata from {!r}".format(os.path.basename(snap_file)))
     snapcraft.push_metadata(snap_file, force)
 
 

--- a/snapcraft/internal/deltas/_deltas.py
+++ b/snapcraft/internal/deltas/_deltas.py
@@ -170,9 +170,7 @@ class BaseDeltasGenerator:
         returns: generated delta file path
         """
         logger.info(
-            "Generating {} delta for {}.".format(
-                self.delta_format, os.path.basename(self.target_path)
-            )
+            "Generating delta for {!r}.".format(os.path.basename(self.target_path))
         )
 
         if output_dir is not None:

--- a/snapcraft/storeapi/_upload.py
+++ b/snapcraft/storeapi/_upload.py
@@ -48,7 +48,7 @@ def upload_files(binary_filename, updown_client):
         # Create a progress bar that looks like: Uploading foo [==  ] 50%
         progress_bar = ProgressBar(
             widgets=[
-                "Pushing {} ".format(os.path.basename(binary_filename)),
+                "Pushing {!r} ".format(os.path.basename(binary_filename)),
                 Bar(marker="=", left="[", right="]"),
                 " ",
                 Percentage(),

--- a/tests/unit/commands/test_push.py
+++ b/tests/unit/commands/test_push.py
@@ -71,9 +71,7 @@ class PushCommandTestCase(PushCommandBaseTestCase):
         self.assertThat(result.exit_code, Equals(0))
 
         self.assertRegexpMatches(
-            self.fake_logger.output,
-            r".*push '.*test-snap.snap' to the store\.\n"
-            r"Revision 9 of 'basic' created\.",
+            self.fake_logger.output, r"Revision 9 of 'basic' created\."
         )
         mock_upload.assert_called_once_with("basic", self.snap_file)
 

--- a/tests/unit/test_deltas_xdelta3.py
+++ b/tests/unit/test_deltas_xdelta3.py
@@ -164,7 +164,7 @@ class XDelta3TestCase(unit.TestCase):
         self.assertThat(
             self.fake_logger.output,
             m.Contains(
-                "Generating xdelta3 delta for {}".format(
+                "Generating delta for {!r}".format(
                     os.path.basename(base_delta.target_path)
                 )
             ),


### PR DESCRIPTION
The output of the 'snapcraft push' command shows too much information,
often displayed in inconsistent format and with seemingly arbitrary
colors (in fact, tied to the log level used for that line). This patch
partially cleans up the output, moving unnecessary messages to debug
level and making filename representation consistent across messages.

The final success message remains colored green, as does a log message
originary from the delta subsystem. We leave output colorization to be
discussed later and resolved globally.

LP: #1804439

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
