### PR TITLE
WIP: Enable support for strictly confined multipass

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -299,19 +299,10 @@ class Provider(abc.ABC):
 
         snap_injector.apply()
 
-    def _get_cloud_user_data(self, timezone=_get_tzdata()) -> str:
-        # TODO support users for the qemu provider.
-        cloud_user_data_filepath = os.path.join(
-            self.provider_project_dir, "user-data.yaml"
-        )
-        if os.path.exists(cloud_user_data_filepath):
-            return cloud_user_data_filepath
-
+    def _write_cloud_user_data_file(self, data_file: str, timezone=_get_tzdata()) -> None:
         user_data = _CLOUD_USER_DATA_TMPL.format(timezone=timezone)
-        with open(cloud_user_data_filepath, "w") as cloud_user_data_file:
-            print(user_data, file=cloud_user_data_file, end="")
-
-        return cloud_user_data_filepath
+        with open(data_file, "w") as open_data_file:
+            print(user_data, file=open_data_file, end="")
 
     def _base_has_changed(self, base: str, provider_base: str) -> bool:
         # Make it backwards compatible with instances without project info

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -299,7 +299,9 @@ class Provider(abc.ABC):
 
         snap_injector.apply()
 
-    def _write_cloud_user_data_file(self, data_file: str, timezone=_get_tzdata()) -> None:
+    def _write_cloud_user_data_file(
+        self, data_file: str, timezone=_get_tzdata()
+    ) -> None:
         # TODO support users for the qemu provider.
         user_data = _CLOUD_USER_DATA_TMPL.format(timezone=timezone)
         with open(data_file, "w") as open_data_file:

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -300,6 +300,7 @@ class Provider(abc.ABC):
         snap_injector.apply()
 
     def _write_cloud_user_data_file(self, data_file: str, timezone=_get_tzdata()) -> None:
+        # TODO support users for the qemu provider.
         user_data = _CLOUD_USER_DATA_TMPL.format(timezone=timezone)
         with open(data_file, "w") as open_data_file:
             print(user_data, file=open_data_file, end="")

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -119,8 +119,8 @@ class Multipass(Provider):
         return False
 
     def _prepare_cloud_user_data(self) -> str:
-        # If Multipass Snap confined, place cloud-init file in location both snapcraft
-        # (classicly confined) and multipass can access. For Multipass, the host directory
+        # If the Multipass Snap is confined, place cloud-init file in location both snapcraft
+        # (classicly confined) and Multipass can access. For Multipass, the host directory
         # $HOME/snap/multipass/current corresponds to its confined $HOME
         if self._is_multipass_confined():
             base_dir = os.path.join(

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -257,7 +257,7 @@ class Multipass(Provider):
 
         # Then copy the tarball over
         self._multipass_cmd.push_file(
-            source=tarball, instance=self.instance_name, destination=destination)
+            source=tarball, instance=self.instance_name, destination=tarball)
 
         # Finally extract it into project_dir.
         extract_cmd = [

--- a/snapcraft/internal/build_providers/_multipass/_multipass_command.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass_command.py
@@ -235,7 +235,7 @@ class MultipassCommand:
         :param str source: the in-instance path to the source file to pull
         :param str destination: the destination of the pulled file on the host
         """
-        vm_cmd = "echo '" + source + "'"
+        vm_cmd = "echo '{}'".format(source)
         cmd = [self.provider_cmd, "exec", instance, "--", "bash", "-c", vm_cmd]
         try:
             with open(destination, "wb") as pipe_out:
@@ -257,7 +257,7 @@ class MultipassCommand:
         :param str instance: the multipass instance to push the file to
         :param str destination: the destination of the pushed file on the instance
         """
-        vm_cmd = "cat > '" + destination + "'"
+        vm_cmd = "cat > '{}'".format(destination)
         cmd = [self.provider_cmd, "exec", instance, "--", "bash", "-c", vm_cmd]
 
         try:

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -156,20 +156,16 @@ class MultipassTest(BaseProviderBaseTest):
             ]
         )
 
-        self.multipass_cmd_mock().copy_files.assert_has_calls(
-            [
-                mock.call(
-                    destination="{}:source.tar".format(self.instance_name),
-                    source="source.tar",
-                ),
-                mock.call(
-                    destination="project-name_{}.snap".format(self.project.deb_arch),
-                    source="{}:~/project/project-name_{}.snap".format(
-                        self.instance_name, self.project.deb_arch
-                    ),
-                ),
-            ]
+        self.multipass_cmd_mock().push_file.assert_called_once_with(
+            source="source.tar", instance=self.instance_name, destination="source.tar"
         )
+
+        self.multipass_cmd_mock().pull_file.assert_called_once_with(
+            instance=self.instance_name,
+            source="~/project/project-name_{}.snap".format(self.project.deb_arch),
+            destination="project-name_{}.snap".format(self.project.deb_arch),
+        )
+
         self.multipass_cmd_mock().stop.assert_called_once_with(
             instance_name=self.instance_name, time=10
         )
@@ -255,10 +251,11 @@ class MultipassTest(BaseProviderBaseTest):
                 ),
             ]
         )
-        self.multipass_cmd_mock().copy_files.assert_called_once_with(
-            destination="{}:source.tar".format(self.instance_name), source="source.tar"
+        self.multipass_cmd_mock().push_file.assert_called_once_with(
+            source="source.tar", instance=self.instance_name, destination="source.tar"
         )
 
+        self.multipass_cmd_mock().pull_file.assert_not_called()
         self.multipass_cmd_mock().launch.assert_not_called()
         self.multipass_cmd_mock().info.assert_not_called()
         self.multipass_cmd_mock().stop.assert_not_called()
@@ -283,7 +280,8 @@ class MultipassTest(BaseProviderBaseTest):
             ],
         )
 
-        self.multipass_cmd_mock().copy_files.assert_not_called()
+        self.multipass_cmd_mock().pull_file.assert_not_called()
+        self.multipass_cmd_mock().push_file.assert_not_called()
         self.multipass_cmd_mock().launch.assert_not_called()
         self.multipass_cmd_mock().info.assert_not_called()
         self.multipass_cmd_mock().stop.assert_not_called()
@@ -296,13 +294,13 @@ class MultipassTest(BaseProviderBaseTest):
         # calling this on an instance that does not exist.
         multipass.retrieve_snap()
 
-        self.multipass_cmd_mock().copy_files.assert_called_once_with(
+        self.multipass_cmd_mock().pull_file.assert_called_once_with(
+            instance=self.instance_name,
+            source="~/project/project-name_{}.snap".format(self.project.deb_arch),
             destination="project-name_{}.snap".format(self.project.deb_arch),
-            source="{}:~/project/project-name_{}.snap".format(
-                self.instance_name, self.project.deb_arch
-            ),
         )
 
+        self.multipass_cmd_mock().push_file.assert_not_called()
         self.multipass_cmd_mock().execute.assert_not_called()
         self.multipass_cmd_mock().launch.assert_not_called()
         self.multipass_cmd_mock().info.assert_not_called()
@@ -515,7 +513,8 @@ class MultipassWithBasesTest(BaseProviderWithBasesBaseTest):
                 mock.call(instance_name=self.instance_name, output_format="json"),
             ]
         )
-        self.multipass_cmd_mock().copy_files.assert_not_called()
+        self.multipass_cmd_mock().pull_file.assert_not_called()
+        self.multipass_cmd_mock().push_file.assert_not_called()
         self.multipass_cmd_mock().stop.assert_called_once_with(
             instance_name=self.instance_name, time=10
         )

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -535,14 +535,8 @@ class MultipassPlatformBehaviourTest(BaseProviderBaseTest):
             "linux-multipass-unconfined",
             dict(platform="linux", returncode=0, expected_confined=False),
         ),
-        (
-            "darwin",
-            dict(platform="darwin", expected_confined=False),
-        ),
-        (
-            "windows",
-            dict(platform="win32", expected_confined=False),
-        ),
+        ("darwin", dict(platform="darwin", expected_confined=False)),
+        ("windows", dict(platform="win32", expected_confined=False)),
     )
 
     def setUp(self):
@@ -569,28 +563,24 @@ class MultipassPlatformBehaviourTest(BaseProviderBaseTest):
         self.popen_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
-
     def test_confinement_check(self):
         if hasattr(self, "returncode"):
             self.popen_mock().returncode = self.returncode
 
         with mock.patch("sys.platform", self.platform):
-            with Multipass(
-                project=self.project, echoer=self.echoer_mock
-            ) as instance:
-                self.assertEqual(instance._is_multipass_confined(), self.expected_confined)
+            with Multipass(project=self.project, echoer=self.echoer_mock) as instance:
+                self.assertEqual(
+                    instance._is_multipass_confined(), self.expected_confined
+                )
 
         if hasattr(self, "returncode"):
             self.popen_mock.assert_has_calls(
                 [
                     mock.call(
-                        [
-                            "snap",
-                            "run",
-                            "--shell",
-                            "multipass",
-                        ],
-                        input="ls '{}'\n".format(BaseDirectory.save_data_path("snapcraft")),
+                        ["snap", "run", "--shell", "multipass"],
+                        input="ls '{}'\n".format(
+                            BaseDirectory.save_data_path("snapcraft")
+                        ),
                         encoding="utf-8",
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
@@ -599,5 +589,3 @@ class MultipassPlatformBehaviourTest(BaseProviderBaseTest):
             )
         else:
             self.popen_mock.assert_not_called()
-
-

--- a/tests/unit/build_providers/multipass/test_multipass_command.py
+++ b/tests/unit/build_providers/multipass/test_multipass_command.py
@@ -492,7 +492,7 @@ class MultipassCommandCopyFilesTest(MultipassCommandPassthroughBaseTest):
         source = "source-file-missing"
         destination = "destination-file"
         self.open_mock.side_effect = OSError()
-        self.popen_mock.reset_mock() # reset to check popen never called 
+        self.popen_mock.reset_mock()  # reset to check popen never called
 
         self.assertRaises(
             errors.ProviderFileCopyError,

--- a/tests/unit/build_providers/multipass/test_multipass_command.py
+++ b/tests/unit/build_providers/multipass/test_multipass_command.py
@@ -397,8 +397,6 @@ class MultipassCommandCopyFilesTest(MultipassCommandPassthroughBaseTest):
             ]
         )
 
-        self.check_output_mock.assert_not_called()
-
     def test_pull_file(self):
         source = "source-file"
         destination = "destination-file"
@@ -427,8 +425,6 @@ class MultipassCommandCopyFilesTest(MultipassCommandPassthroughBaseTest):
             ]
         )
 
-        self.check_output_mock.assert_not_called()
-
     def test_pull_file_fails(self):
         # multipass can fail due to several reasons and will display the error
         # right above this exception message.
@@ -452,7 +448,6 @@ class MultipassCommandCopyFilesTest(MultipassCommandPassthroughBaseTest):
             source=source,
             destination=destination,
         )
-        self.check_output_mock.assert_not_called()
 
     def test_pull_file_cannot_be_written_to(self):
         # if file to be created cannot be written to, should throw error
@@ -467,7 +462,6 @@ class MultipassCommandCopyFilesTest(MultipassCommandPassthroughBaseTest):
             source=source,
             destination=destination,
         )
-        self.check_output_mock.assert_not_called()
 
     def test_push_file_fails(self):
         # multipass can fail due to several reasons and will display the error
@@ -492,7 +486,6 @@ class MultipassCommandCopyFilesTest(MultipassCommandPassthroughBaseTest):
             instance=self.instance_name,
             destination=destination,
         )
-        self.check_output_mock.assert_not_called()
 
     def test_push_file_missing_fails(self):
         # if file to be pushed is missing, should throw error
@@ -507,8 +500,7 @@ class MultipassCommandCopyFilesTest(MultipassCommandPassthroughBaseTest):
             instance=self.instance_name,
             destination=destination,
         )
-        self.check_call_mock.assert_not_called()  # bails before running multipass command
-        self.check_output_mock.assert_not_called()
+        self.popen_mock.assert_not_called()  # bails before running multipass command
 
 
 class MultipassCommandInfoTest(MultipassCommandPassthroughBaseTest):

--- a/tests/unit/build_providers/multipass/test_multipass_command.py
+++ b/tests/unit/build_providers/multipass/test_multipass_command.py
@@ -492,6 +492,7 @@ class MultipassCommandCopyFilesTest(MultipassCommandPassthroughBaseTest):
         source = "source-file-missing"
         destination = "destination-file"
         self.open_mock.side_effect = OSError()
+        self.popen_mock.reset_mock() # reset to check popen never called 
 
         self.assertRaises(
             errors.ProviderFileCopyError,


### PR DESCRIPTION
Multipass is planning to become a strictly confined snap. This causes some limitations, chief of which is this: the multipass command line tool cannot open arbitrary files on the filesystem when confined.

This means "multipass push/pull" are not reliable ways to getting files in/out of the VM. But also multipass is unable to access the $HOME/.snapcraft directory, so the cloud-init file snapcraft generates is not accessible.

This PR resolves these problems by:
1. use pipes instead of push/pull, to avoid confinement issues
2. detect if multipass is confined, and if so, put the cloud-init file in a location suitable for it.

These changes support both confined and unconfined multipass, so should cause no regression.



- [Y] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [Y] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [N/A] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [N/A] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [Y] Have you successfully run `./runtests.sh static`?
- [Y] Have you successfully run `./runtests.sh tests/unit`?

-----
