### PR TITLE
project loader: do not leak a part's build-environment

### DIFF
--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -265,6 +265,10 @@ class PartsConfig:
 
             global_env = snapcraft_global_environment(self._project)
             part_env = snapcraft_part_environment(part)
+            # Finally, add the declared environment from the part.
+            # This is done only for the "root" part.
+            env += part.build_environment
+
             for variable, value in ChainMap(part_env, global_env).items():
                 env.append('{}="{}"'.format(variable, value))
         else:
@@ -274,8 +278,6 @@ class PartsConfig:
         for dep_part in part.deps:
             env += dep_part.env(stagedir)
             env += self.build_env_for_part(dep_part, root_part=False)
-
-        env += part.build_environment
 
         # LP: #1767625
         # Remove duplicates from using the same plugin in dependent parts.

--- a/tests/spread/general/build_environment/task.yaml
+++ b/tests/spread/general/build_environment/task.yaml
@@ -18,10 +18,9 @@ execute: |
   # Verify that part1 had FOO defined as expected
   echo "$output" | MATCH "part1: BAR"
 
-  # Verify that part2 had FOO defined as expected, including taking its dependency into
-  # account.
-  echo "$output" | MATCH "part2: BAR BAZ QUX"
+  # Verify that part2 had FOO defined as expected, but not its dependencies.
+  echo "$output" | MATCH "part2:  BAZ QUX"
 
-  # Finally, install it and ensure FOO didn't make it into the final app
+  # Finally, install it and ensure FOO didn't make it into the final app.
   sudo snap install build-environment-test_*.snap --dangerous
   [ "$(build-environment-test)" = "" ]

--- a/tests/unit/project_loader/test_environment.py
+++ b/tests/unit/project_loader/test_environment.py
@@ -22,7 +22,7 @@ from textwrap import dedent
 from unittest import mock
 
 import fixtures
-from testtools.matchers import Contains, Equals
+from testtools.matchers import Contains, Equals, Not
 
 import snapcraft
 from snapcraft.internal import common
@@ -531,7 +531,7 @@ class EnvironmentTest(ProjectLoaderBaseTest):
         environment = project_config.parts.build_env_for_part(part)
         self.assertThat(environment, Contains('FOO="BAR"'))
 
-    def test_build_environment_with_dependencies(self):
+    def test_build_environment_with_dependencies_does_not_leak(self):
         self.useFixture(FakeOsRelease())
 
         snapcraft_yaml = dedent(
@@ -565,7 +565,7 @@ class EnvironmentTest(ProjectLoaderBaseTest):
             project_config.parts.build_env_for_part(part1), Contains('FOO="BAR"')
         )
         self.assertThat(
-            project_config.parts.build_env_for_part(part2), Contains('FOO="BAR"')
+            project_config.parts.build_env_for_part(part2), Not(Contains('FOO="BAR"'))
         )
         self.assertThat(
             project_config.parts.build_env_for_part(part2), Contains('BAZ="QUX"')


### PR DESCRIPTION
When using after, all components related to the environment get
concatenated when using after, that is not an intuitive behavior from a
user's point of view.

LP: #1815658
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
