### PR TITLE
plugins: improve python and go schema validation

### DIFF
--- a/snapcraft/plugins/go.py
+++ b/snapcraft/plugins/go.py
@@ -83,6 +83,7 @@ class GoPlugin(snapcraft.BasePlugin):
             "items": {"type": "string"},
             "default": [],
         }
+        schema["anyOf"] = [{"required": ["source"]}, {"required": ["go-packages"]}]
 
         return schema
 

--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -122,6 +122,7 @@ class PythonPlugin(snapcraft.BasePlugin):
             "default": "python3",
             "enum": ["python2", "python3"],
         }
+        schema["anyOf"] = [{"required": ["source"]}, {"required": ["python-packages"]}]
 
         return schema
 

--- a/tests/unit/plugins/test_go.py
+++ b/tests/unit/plugins/test_go.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import jsonschema
 from textwrap import dedent
 from unittest import mock
 
@@ -607,6 +608,36 @@ class GoPluginTest(GoPluginBaseTest):
             cwd=plugin._gopath_src,
             env=mock.ANY,
         )
+
+
+class GoPluginSchemaValidationTest(unit.TestCase):
+    def test_sources_validation_neither(self):
+        schema = self._get_schema()
+        properties = {}
+        self.assertRaises(
+            jsonschema.ValidationError, jsonschema.validate, properties, schema
+        )
+
+    def test_sources_validation_source(self):
+        schema = self._get_schema()
+        properties = {"source": ""}
+        jsonschema.validate(properties, schema)
+
+    def test_sources_validation_packages(self):
+        schema = self._get_schema()
+        properties = {"go-packages": []}
+        jsonschema.validate(properties, schema)
+
+    def test_sources_validation_both(self):
+        schema = self._get_schema()
+        properties = {"source": "foo", "go-packages": []}
+        jsonschema.validate(properties, schema)
+
+    def _get_schema(self):
+        schema = go.GoPlugin.schema()
+        # source definition comes from the main schema
+        schema["properties"]["source"] = {"type": "string"}
+        return schema
 
 
 class GoPluginToolSetupTest(GoPluginBaseTest):

--- a/tests/unit/plugins/test_python.py
+++ b/tests/unit/plugins/test_python.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import collections
+import jsonschema
 import os
 from textwrap import dedent
 from unittest import mock
@@ -152,6 +153,36 @@ class PythonPluginPropertiesTest(unit.TestCase):
 
         for property in expected_pull_properties:
             self.assertIn(property, resulting_pull_properties)
+
+
+class PythonPluginSchemaValidationTest(unit.TestCase):
+    def test_sources_validation_neither(self):
+        schema = self._get_schema()
+        properties = {}
+        self.assertRaises(
+            jsonschema.ValidationError, jsonschema.validate, properties, schema
+        )
+
+    def test_sources_validation_source(self):
+        schema = self._get_schema()
+        properties = {"source": ""}
+        jsonschema.validate(properties, schema)
+
+    def test_sources_validation_packages(self):
+        schema = self._get_schema()
+        properties = {"python-packages": []}
+        jsonschema.validate(properties, schema)
+
+    def test_sources_validation_both(self):
+        schema = self._get_schema()
+        properties = {"source": "", "python-packages": []}
+        jsonschema.validate(properties, schema)
+
+    def _get_schema(self):
+        schema = python.PythonPlugin.schema()
+        # source definition comes from the main schema
+        schema["properties"]["source"] = {"type": "string"}
+        return schema
 
 
 class PythonPluginTest(PythonPluginBaseTest):


### PR DESCRIPTION
When using build providers, validate our yaml file schema prior to
executing ourselves inside the provider instance. This allows us
to quickly interrupt execution if validation fails. Also added
extra validation entries to the Go and Python plugins, to require
either sources or packages and prevent crashes in the test case
listed in the original bug report.

LP: #1806055

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
