### PR TITLE
build providers: remove dead code

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -177,10 +177,6 @@ class Provider(abc.ABC):
         """Provider steps needed to make the project available to the instance.
         """
 
-    @abc.abstractmethod
-    def provision_project(self, tarball: str) -> None:
-        """Provider steps needed to copy project assests to the instance."""
-
     def execute_step(self, step: steps.Step) -> None:
         self._run(command=["snapcraft", step.name])
 
@@ -199,19 +195,6 @@ class Provider(abc.ABC):
             return True
         except FileNotFoundError:
             return False
-
-    @abc.abstractmethod
-    def build_project(self) -> None:
-        """Provider steps needed build the project on the instance."""
-
-    @abc.abstractmethod
-    def retrieve_snap(self) -> str:
-        """
-        Provider steps needed to retrieve the built snap from the instance.
-
-        :returns: the filename of the retrieved snap.
-        :rtype: str
-        """
 
     @abc.abstractmethod
     def pull_file(self, name: str, destination: str, delete: bool = False) -> None:

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -102,10 +102,8 @@ class MultipassTest(BaseProviderBaseTest):
         with Multipass(
             project=self.project, echoer=self.echoer_mock, is_ephemeral=True
         ) as instance:
-            instance.provision_project("source.tar")
-            instance.build_project()
-            instance.retrieve_snap()
-            instance.pull_file("src", "dest", delete=True)
+            instance.execute_step(steps.PULL)
+            instance.execute_step(steps.BUILD)
 
         self.multipass_cmd_mock().launch.assert_called_once_with(
             instance_name=self.instance_name,
@@ -121,29 +119,38 @@ class MultipassTest(BaseProviderBaseTest):
             [
                 mock.call(
                     instance_name=self.instance_name,
-                    command=["sudo", "-i", "mkdir", "~/project"],
-                ),
-                mock.call(
-                    instance_name=self.instance_name,
+                    hide_output=False,
                     command=[
                         "sudo",
                         "-i",
-                        "tar",
-                        "-xvf",
-                        "source.tar",
-                        "-C",
-                        "~/project",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "snapcraft",
+                        "refresh",
                     ],
                 ),
                 mock.call(
                     instance_name=self.instance_name,
+                    hide_output=False,
                     command=[
                         "sudo",
                         "-i",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
                         "snapcraft",
-                        "snap",
-                        "--output",
-                        "project-name_{}.snap".format(self.project.deb_arch),
+                        "pull",
+                    ],
+                ),
+                mock.call(
+                    instance_name=self.instance_name,
+                    hide_output=False,
+                    command=[
+                        "sudo",
+                        "-i",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "snapcraft",
+                        "build",
                     ],
                 ),
             ]
@@ -155,18 +162,44 @@ class MultipassTest(BaseProviderBaseTest):
                 mock.call(instance_name=self.instance_name, output_format="json"),
             ]
         )
-
-        self.multipass_cmd_mock().copy_files.assert_has_calls(
+        self.assertThat(self.multipass_cmd_mock().execute.call_count, Equals(3))
+        self.multipass_cmd_mock().execute.assert_has_calls(
             [
                 mock.call(
-                    destination="{}:source.tar".format(self.instance_name),
-                    source="source.tar",
+                    command=[
+                        "sudo",
+                        "-i",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "snapcraft",
+                        "refresh",
+                    ],
+                    hide_output=False,
+                    instance_name="snapcraft-project-name",
                 ),
                 mock.call(
-                    destination="project-name_{}.snap".format(self.project.deb_arch),
-                    source="{}:~/project/project-name_{}.snap".format(
-                        self.instance_name, self.project.deb_arch
-                    ),
+                    command=[
+                        "sudo",
+                        "-i",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "snapcraft",
+                        "pull",
+                    ],
+                    hide_output=False,
+                    instance_name="snapcraft-project-name",
+                ),
+                mock.call(
+                    command=[
+                        "sudo",
+                        "-i",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "snapcraft",
+                        "build",
+                    ],
+                    hide_output=False,
+                    instance_name="snapcraft-project-name",
                 ),
             ]
         )
@@ -227,87 +260,6 @@ class MultipassTest(BaseProviderBaseTest):
             image="snapcraft:core16",
             cloud_init=mock.ANY,
         )
-
-    def test_provision_project(self):
-        multipass = Multipass(project=self.project, echoer=self.echoer_mock)
-
-        # In the real world, MultipassCommand would return an error when
-        # calling this on an instance that does not exist.
-        multipass.provision_project("source.tar")
-
-        self.multipass_cmd_mock().execute.assert_has_calls(
-            [
-                mock.call(
-                    instance_name=self.instance_name,
-                    command=["sudo", "-i", "mkdir", "~/project"],
-                ),
-                mock.call(
-                    instance_name=self.instance_name,
-                    command=[
-                        "sudo",
-                        "-i",
-                        "tar",
-                        "-xvf",
-                        "source.tar",
-                        "-C",
-                        "~/project",
-                    ],
-                ),
-            ]
-        )
-        self.multipass_cmd_mock().copy_files.assert_called_once_with(
-            destination="{}:source.tar".format(self.instance_name), source="source.tar"
-        )
-
-        self.multipass_cmd_mock().launch.assert_not_called()
-        self.multipass_cmd_mock().info.assert_not_called()
-        self.multipass_cmd_mock().stop.assert_not_called()
-        self.multipass_cmd_mock().delete.assert_not_called()
-
-    def test_build_project(self):
-        multipass = Multipass(project=self.project, echoer=self.echoer_mock)
-
-        # In the real world, MultipassCommand would return an error when
-        # calling this on an instance that does not exist.
-        multipass.build_project()
-
-        self.multipass_cmd_mock().execute.assert_called_once_with(
-            instance_name=self.instance_name,
-            command=[
-                "sudo",
-                "-i",
-                "snapcraft",
-                "snap",
-                "--output",
-                "project-name_{}.snap".format(self.project.deb_arch),
-            ],
-        )
-
-        self.multipass_cmd_mock().copy_files.assert_not_called()
-        self.multipass_cmd_mock().launch.assert_not_called()
-        self.multipass_cmd_mock().info.assert_not_called()
-        self.multipass_cmd_mock().stop.assert_not_called()
-        self.multipass_cmd_mock().delete.assert_not_called()
-
-    def test_retrieve_snap(self):
-        multipass = Multipass(project=self.project, echoer=self.echoer_mock)
-
-        # In the real world, MultipassCommand would return an error when
-        # calling this on an instance that does not exist.
-        multipass.retrieve_snap()
-
-        self.multipass_cmd_mock().copy_files.assert_called_once_with(
-            destination="project-name_{}.snap".format(self.project.deb_arch),
-            source="{}:~/project/project-name_{}.snap".format(
-                self.instance_name, self.project.deb_arch
-            ),
-        )
-
-        self.multipass_cmd_mock().execute.assert_not_called()
-        self.multipass_cmd_mock().launch.assert_not_called()
-        self.multipass_cmd_mock().info.assert_not_called()
-        self.multipass_cmd_mock().stop.assert_not_called()
-        self.multipass_cmd_mock().delete.assert_not_called()
 
     def test_pull_file(self):
         multipass = Multipass(project=self.project, echoer=self.echoer_mock)


### PR DESCRIPTION
Remove methods from when build providers supported cleanbuild.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
