### PR TITLE
sources: avoid marking changes to the snap directory as dirty

### DIFF
--- a/snapcraft/internal/sources/_local.py
+++ b/snapcraft/internal/sources/_local.py
@@ -50,7 +50,7 @@ class Local(Base):
         self._updated_directories = set()
 
         for (root, directories, files) in os.walk(self.source_abspath, topdown=True):
-            ignored = set(self._ignore(root, directories + files))
+            ignored = set(self._ignore(root, directories + files, check=True))
             if ignored:
                 # Prune our search appropriately given an ignore list, i.e.
                 # don't walk into directories that are ignored.
@@ -96,9 +96,13 @@ class Local(Base):
             )
 
 
-def _ignore(source, current_directory, directory, files):
+def _ignore(source, current_directory, directory, files, check=False):
     if directory == source or directory == current_directory:
         ignored = copy.copy(common.SNAPCRAFT_FILES)
+        if check:
+            # TODO: We hardcode the snap directory here, but we really need
+            # to ignore the directory where snapcraft.yaml is hosted.
+            ignored.append("snap")
         snaps = glob.glob(os.path.join(directory, "*.snap"))
         if snaps:
             snaps = [os.path.basename(s) for s in snaps]

--- a/snapcraft/internal/sources/_local.py
+++ b/snapcraft/internal/sources/_local.py
@@ -102,7 +102,7 @@ def _ignore(source, current_directory, directory, files, check=False):
         if check:
             # TODO: We hardcode the snap directory here, but we really need
             # to ignore the directory where snapcraft.yaml is hosted.
-            ignored.append("snap")
+            ignored.extend(["snap", "snapcraft.yaml", ".snapcraft.yaml"])
         snaps = glob.glob(os.path.join(directory, "*.snap"))
         if snaps:
             snaps = [os.path.basename(s) for s in snaps]

--- a/tests/unit/sources/test_local.py
+++ b/tests/unit/sources/test_local.py
@@ -345,7 +345,10 @@ class TestLocalUpdateSnapcraftYaml(unit.TestCase):
     scenarios = [
         ("snapcraft.yaml", dict(snapcraft_file="snapcraft.yaml")),
         (".snapcraft.yaml", dict(snapcraft_file=".snapcraft.yaml")),
-        ("snap/snapcraft.yaml", dict(snapcraft_file=os.path.join("snap", "snapcraft.yaml"))),
+        (
+            "snap/snapcraft.yaml",
+            dict(snapcraft_file=os.path.join("snap", "snapcraft.yaml")),
+        ),
         ("snap/<content>", dict(snapcraft_file=os.path.join("snap", "test-file"))),
     ]
 

--- a/tests/unit/sources/test_local.py
+++ b/tests/unit/sources/test_local.py
@@ -339,19 +339,30 @@ class TestLocalUpdate(unit.TestCase):
         local.update()
         self.assertThat(os.path.join(destination, "dir", "file2"), FileExists())
 
-    def test_snap_directory_modification_ignored(self):
+
+class TestLocalUpdateSnapcraftYaml(unit.TestCase):
+
+    scenarios = [
+        ("snapcraft.yaml", dict(snapcraft_file="snapcraft.yaml")),
+        (".snapcraft.yaml", dict(snapcraft_file=".snapcraft.yaml")),
+        ("snap/snapcraft.yaml", dict(snapcraft_file=os.path.join("snap", "snapcraft.yaml"))),
+        ("snap/<content>", dict(snapcraft_file=os.path.join("snap", "test-file"))),
+    ]
+
+    def test_snapcraft_yaml_modification_ignored(self):
         source = "source"
-        source_dir = os.path.join(source, "snap")
         destination = "destination"
-        os.makedirs(source_dir)
+        snapcraft_source_path = os.path.join(source, self.snapcraft_file)
+        snapcraft_destination_path = os.path.join(destination, self.snapcraft_file)
+        os.makedirs(os.path.dirname(snapcraft_source_path))
         os.mkdir(destination)
 
-        with open(os.path.join(source_dir, "file1"), "w") as f:
+        with open(snapcraft_source_path, "w") as f:
             f.write("1")
 
         # Now make a reference file with a timestamp later than the file was
         # created. We'll ensure this by setting it ourselves
-        shutil.copy2(os.path.join(source_dir, "file1"), "reference")
+        shutil.copy2(snapcraft_source_path, "reference")
         access_time = os.stat("reference").st_atime
         modify_time = os.stat("reference").st_mtime
         os.utime("reference", (access_time, modify_time + 1))
@@ -361,15 +372,15 @@ class TestLocalUpdate(unit.TestCase):
         self.assertFalse(
             local.check("reference"), "Expected no updates to be available"
         )
-        self.assertThat(os.path.join(destination, "snap", "file1"), FileExists())
+        self.assertThat(snapcraft_destination_path, FileExists())
 
         # Now add a new file to the directory, and make sure it has a timestamp
         # later than our reference (this whole test happens too fast)
-        with open(os.path.join(source_dir, "file2"), "w") as f:
+        with open(snapcraft_source_path, "w") as f:
             f.write("2")
 
         access_time = os.stat("reference").st_atime
         modify_time = os.stat("reference").st_mtime
-        os.utime(os.path.join(source_dir, "file2"), (access_time, modify_time + 1))
+        os.utime(snapcraft_source_path, (access_time, modify_time + 1))
 
         self.assertFalse(local.check("reference"), "Expected no update to be available")


### PR DESCRIPTION
A regression was introduced with the fix in PR #2419 which fixed
LP: #1806746. Local sources were being marked as dirty when contents
of the snap directory changed.

LP: #1816397

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
