### PR TITLE
tests: disable spread colcon tests

### DIFF
--- a/tests/spread/plugins/colcon/run/task.yaml
+++ b/tests/spread/plugins/colcon/run/task.yaml
@@ -1,6 +1,7 @@
 summary: Build and run a basic colcon snap
 warn-timeout: 9m  # Keep less than 10 minutes so Travis can't timeout
 priority: 100  # Run this test early so we're not waiting for it
+manual: true # LP: #1816565
 
 environment:
   SNAP_DIR: ../snaps/colcon-talker-listener


### PR DESCRIPTION
Upstream changes broke the plugin. Temporarily disable the spread tests.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
