### PR TITLE
meta: handle symlinked hooks

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -469,7 +469,7 @@ class _SnapPackaging:
                     with contextlib.suppress(FileNotFoundError):
                         os.remove(destination)
 
-                    file_utils.link_or_copy(source, destination)
+                    file_utils.link_or_copy(source, destination, follow_symlinks=True)
 
                     # Ensure that the hook is executable
                     if origin == "hooks":

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -1158,6 +1158,29 @@ class WriteSnapDirectoryTestCase(CreateBaseTestCase):
             os.stat(os.path.join(self.hooks_dir, "test-hook")).st_mode & stat.S_IEXEC
         )
 
+    def test_snap_hooks_not_does_not_fail_on_symlink(self):
+        # Setup a snap directory containing a few things.
+        _create_file(os.path.join(self.snap_dir, "snapcraft.yaml"))
+        _create_file(os.path.join(self.snap_dir, "hooks", "test-hook"))
+        # Create a working symlink
+        os.symlink(
+            "test-hook", os.path.join(self.snap_dir, "hooks", "test-hook-symlink")
+        )
+
+        # Now write the snap directory.
+        self.generate_meta_yaml()
+
+        # Ensure the file is executable
+        self.assertThat(os.path.join(self.hooks_dir, "test-hook"), FileExists())
+        test_hook_stat = os.stat(
+            os.path.join(self.hooks_dir, "test-hook"), follow_symlinks=False
+        )
+        test_hook_symlink_stat = os.stat(
+            os.path.join(self.hooks_dir, "test-hook-symlink"), follow_symlinks=False
+        )
+
+        self.assertThat(test_hook_symlink_stat.st_ino, Equals(test_hook_stat.st_ino))
+
 
 class GenerateHookWrappersTestCase(CreateBaseTestCase):
     def test_generate_hook_wrappers(self):


### PR DESCRIPTION
Handling of symlinked hooks broke with the introduction of #2440
which tries to change permissions of their file type which can
lead to FileNotFoundErrors as the symlinked file may not be
available at the time of the stat change.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
