### PR TITLE
store: support registering to a specific store

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -420,11 +420,11 @@ def register_key(name):
     )
 
 
-def register(snap_name, is_private=False):
+def register(snap_name: str, is_private: bool = False, store_id: str = None) -> None:
     logger.info("Registering {}.".format(snap_name))
     store = storeapi.StoreClient()
     with _requires_login():
-        store.register(snap_name, is_private)
+        store.register(snap_name, is_private=is_private, store_id=store_id)
 
 
 def _generate_snap_build(authority_id, snap_id, grade, key_name, snap_filename):

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -101,7 +101,7 @@ def _human_readable_acls(store: storeapi.StoreClient) -> str:
 @click.argument("snap-name", metavar="<snap-name>")
 @click.option("--private", is_flag=True, help="Register the snap as a private one")
 @click.option("--store", metavar="<store>", help="Store to register with")
-def register(snap_name, private, store_id):
+def register(snap_name, private, store):
     """Register <snap-name> with the store.
 
     You can use this command to register an available <snap-name> and become
@@ -114,7 +114,7 @@ def register(snap_name, private, store_id):
     if private:
         click.echo(_MESSAGE_REGISTER_PRIVATE.format(snap_name))
     if click.confirm(_MESSAGE_REGISTER_CONFIRM.format(snap_name)):
-        snapcraft.register(snap_name, is_private=private, store_id=store_id)
+        snapcraft.register(snap_name, is_private=private, store_id=store)
         click.echo(_MESSAGE_REGISTER_SUCCESS.format(snap_name))
     else:
         click.echo(_MESSAGE_REGISTER_NO.format(snap_name))

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -100,7 +100,8 @@ def _human_readable_acls(store: storeapi.StoreClient) -> str:
 @storecli.command()
 @click.argument("snap-name", metavar="<snap-name>")
 @click.option("--private", is_flag=True, help="Register the snap as a private one")
-def register(snap_name, private):
+@click.option("--store-id", metavar="<store>", help="Store ID to register with")
+def register(snap_name, private, store_id):
     """Register <snap-name> with the store.
 
     You can use this command to register an available <snap-name> and become
@@ -113,7 +114,7 @@ def register(snap_name, private):
     if private:
         click.echo(_MESSAGE_REGISTER_PRIVATE.format(snap_name))
     if click.confirm(_MESSAGE_REGISTER_CONFIRM.format(snap_name)):
-        snapcraft.register(snap_name, private)
+        snapcraft.register(snap_name, is_private=private, store_id=store_id)
         click.echo(_MESSAGE_REGISTER_SUCCESS.format(snap_name))
     else:
         click.echo(_MESSAGE_REGISTER_NO.format(snap_name))

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -100,7 +100,7 @@ def _human_readable_acls(store: storeapi.StoreClient) -> str:
 @storecli.command()
 @click.argument("snap-name", metavar="<snap-name>")
 @click.option("--private", is_flag=True, help="Register the snap as a private one")
-@click.option("--store-id", metavar="<store>", help="Store ID to register with")
+@click.option("--store", metavar="<store>", help="Store to register with")
 def register(snap_name, private, store_id):
     """Register <snap-name> with the store.
 

--- a/snapcraft/storeapi/_sca_client.py
+++ b/snapcraft/storeapi/_sca_client.py
@@ -91,9 +91,13 @@ class SCAClient(Client):
         if not response.ok:
             raise errors.StoreKeyRegistrationError(response)
 
-    def register(self, snap_name, is_private, series):
+    def register(
+        self, snap_name: str, *, is_private: bool, series: str, store_id: str
+    ) -> None:
         auth = _macaroon_auth(self.conf)
         data = dict(snap_name=snap_name, is_private=is_private, series=series)
+        if store_id is not None:
+            data["store"] = store_id
         response = self.post(
             "register-name/",
             data=json.dumps(data),

--- a/snapcraft/storeapi/_store_client.py
+++ b/snapcraft/storeapi/_store_client.py
@@ -139,9 +139,13 @@ class StoreClient:
     def register_key(self, account_key_request):
         return self._refresh_if_necessary(self.sca.register_key, account_key_request)
 
-    def register(self, snap_name, is_private=False):
+    def register(self, snap_name: str, is_private: bool = False, store_id: str = None):
         return self._refresh_if_necessary(
-            self.sca.register, snap_name, is_private, constants.DEFAULT_SERIES
+            self.sca.register,
+            snap_name,
+            is_private=is_private,
+            store_id=store_id,
+            series=constants.DEFAULT_SERIES,
         )
 
     def push_precheck(self, snap_name):

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -644,8 +644,11 @@ class FakeStoreAPIServer(base.BaseFakeServer):
             "Handling registration request with content {}".format(request.json_body)
         )
         snap_name = request.json_body["snap_name"]
+        store = request.json_body.get("store")
 
-        if snap_name == "test-snap-name-already-registered":
+        if store == "snapcraft-test" and not snap_name.startswith("snapcraft-test-"):
+            return self._register_name_409_error("reserved_name")
+        elif snap_name == "test-snap-name-already-registered":
             return self._register_name_409_error("already_registered")
         elif snap_name == "test-reserved-snap-name":
             return self._register_name_409_error("reserved_name")

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -646,7 +646,9 @@ class FakeStoreAPIServer(base.BaseFakeServer):
         snap_name = request.json_body["snap_name"]
         store = request.json_body.get("store")
 
-        if store == "snapcraft-test" and not snap_name.startswith("snapcraft-test-"):
+        if store == "snapcraft-test" and not snap_name.startswith(
+            "test-snapcraft-in-store"
+        ):
             return self._register_name_409_error("reserved_name")
         elif snap_name == "test-snap-name-already-registered":
             return self._register_name_409_error("already_registered")

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -502,10 +502,12 @@ class StoreTestCase(TestCase):
         expected = r".*Credentials cleared.\n.*"
         self.assertThat(output, MatchesRegex(expected, flags=re.DOTALL))
 
-    def register(self, snap_name, private=False, wait=True):
+    def register(self, snap_name, private=False, store=None, wait=True):
         command = ["register", snap_name]
         if private:
             command.append("--private")
+        if store:
+            command.extend(["--store", store])
         process = self.spawn_snapcraft(command)
         process.expect(r".*\[y/N\]: ")
         process.sendline("y")
@@ -579,7 +581,7 @@ class StoreTestCase(TestCase):
         process.expect(pexpect.EOF)
         return process.wait()
 
-    def get_unique_name(self, prefix=""):
+    def get_unique_name(self, name_prefix="test-snapcraft", prefix=""):
         """Return a unique snap name.
 
         It uses a UUIDv4 to create unique names and limits its full size
@@ -590,7 +592,7 @@ class StoreTestCase(TestCase):
         # Do not change the test-snapcraft- prefix. Ensure that you
         # notify the store team if you need to use a different value when
         # working with the production store.
-        return "test-snapcraft-{}{}".format(prefix, unique_id)[:40]
+        return "{}-{}{}".format(name_prefix, prefix, unique_id)[:40]
 
     def get_unique_version(self):
         """Return a unique snap version.

--- a/tests/integration/store/test_store_register.py
+++ b/tests/integration/store/test_store_register.py
@@ -32,6 +32,11 @@ class RegisterTestCase(integration.StoreTestCase):
         snap_name = self.get_unique_name()
         self.register(snap_name, private=True)
 
+    def test_successful_registration_with_store(self):
+        self.login()
+        snap_name = self.get_unique_name(name_prefix="snapcraft-test")
+        self.register(snap_name, store="snapcraft-test")
+
     def test_failed_registration_already_registered(self):
         self.login()
         # The snap name is already registered.
@@ -87,6 +92,24 @@ class RegisterTestCase(integration.StoreTestCase):
                 "then please claim the name at".format(
                     self.test_store.reserved_snap_name
                 )
+            ),
+        )
+
+    def test_registration_of_reserved_name_with_store(self):
+        self.login()
+        snap_name = self.get_unique_name(name_prefix="not-snapcraft-test")
+        # The snap name is already registered.
+        error = self.assertRaises(
+            integration.RegisterError, self.register, snap_name, store="snapcraft-test"
+        )
+        self.assertThat(
+            str(error), Contains("The name {0!r} is reserved".format(snap_name))
+        )
+        self.assertThat(
+            str(error),
+            Contains(
+                "If you are the publisher most users expect for {0!r} "
+                "then please claim the name at".format(snap_name)
             ),
         )
 

--- a/tests/integration/store/test_store_register.py
+++ b/tests/integration/store/test_store_register.py
@@ -34,7 +34,7 @@ class RegisterTestCase(integration.StoreTestCase):
 
     def test_successful_registration_with_store(self):
         self.login()
-        snap_name = self.get_unique_name(name_prefix="snapcraft-test")
+        snap_name = self.get_unique_name(name_prefix="test-snapcraft-in-store")
         self.register(snap_name, store="snapcraft-test")
 
     def test_failed_registration_already_registered(self):
@@ -97,7 +97,7 @@ class RegisterTestCase(integration.StoreTestCase):
 
     def test_registration_of_reserved_name_with_store(self):
         self.login()
-        snap_name = self.get_unique_name(name_prefix="not-snapcraft-test")
+        snap_name = self.get_unique_name(name_prefix="not-test-snapcraft-in-store")
         # The snap name is already registered.
         error = self.assertRaises(
             integration.RegisterError, self.register, snap_name, store="snapcraft-test"

--- a/tests/unit/commands/test_register.py
+++ b/tests/unit/commands/test_register.py
@@ -58,12 +58,12 @@ class RegisterTestCase(CommandBaseTestCase):
             "test-snap", is_private=False, series="16", store_id=None
         )
 
-    def test_register_name_to_brand_successfully(self):
+    def test_register_name_to_specific_store_successfully(self):
         with mock.patch.object(
             storeapi._sca_client.SCAClient, "register"
         ) as mock_register:
             result = self.run_command(
-                ["register", "test-snap", "--store-id", "my-brand"], input="y\n"
+                ["register", "test-snap", "--store", "my-brand"], input="y\n"
             )
 
         self.assertThat(result.exit_code, Equals(0))

--- a/tests/unit/commands/test_register.py
+++ b/tests/unit/commands/test_register.py
@@ -54,7 +54,31 @@ class RegisterTestCase(CommandBaseTestCase):
             result.output,
             Not(Contains("Congratulations! You're now the publisher for 'test-snap'.")),
         )
-        mock_register.assert_called_once_with("test-snap", False, "16")
+        mock_register.assert_called_once_with(
+            "test-snap", is_private=False, series="16", store_id=None
+        )
+
+    def test_register_name_to_brand_successfully(self):
+        with mock.patch.object(
+            storeapi._sca_client.SCAClient, "register"
+        ) as mock_register:
+            result = self.run_command(
+                ["register", "test-snap", "--store-id", "my-brand"], input="y\n"
+            )
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(result.output, Contains("Registering test-snap"))
+        self.assertThat(
+            result.output,
+            Contains("Congrats! You are now the publisher of 'test-snap'."),
+        )
+        self.assertThat(
+            result.output,
+            Not(Contains("Congratulations! You're now the publisher for 'test-snap'.")),
+        )
+        mock_register.assert_called_once_with(
+            "test-snap", is_private=False, series="16", store_id="my-brand"
+        )
 
     def test_register_private_name_successfully(self):
         with mock.patch.object(
@@ -78,7 +102,9 @@ class RegisterTestCase(CommandBaseTestCase):
             result.output,
             Not(Contains("Congratulations! You're now the publisher for 'test-snap'.")),
         )
-        mock_register.assert_called_once_with("test-snap", True, "16")
+        mock_register.assert_called_once_with(
+            "test-snap", is_private=True, series="16", store_id=None
+        )
 
     def test_registration_failed(self):
         response = mock.Mock()

--- a/tests/unit/store/test_store_client.py
+++ b/tests/unit/store/test_store_client.py
@@ -590,6 +590,11 @@ class RegisterTestCase(StoreTestCase):
         # No exception will be raised if this is successful
         self.client.register("test-good-snap-name")
 
+    def test_register_name_successfully_to_store_id(self):
+        self.client.login("dummy", "test correct password")
+        # No exception will be raised if this is successful
+        self.client.register("test-good-snap-name", store_id="my-brand")
+
     def test_register_private_name_successfully(self):
         self.client.login("dummy", "test correct password")
         # No exception will be raised if this is successful


### PR DESCRIPTION
Add a --store-id option to the register command.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] If this is a bugfix. Have you checked that there is a bug report open for the issue you are trying to fix on [bug reports](https://bugs.launchpad.net/snapcraft)?
- [ ] If this is a new feature. Have you discussed the design on the [forum](https://forum.snapcraft.io)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
