### PR TITLE
project loader: remove special LD_LIBRARY_FLAGS handling for classic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: bash
-
-services: [docker]
+dist: xenial
 
 env:
   global:
@@ -8,6 +7,7 @@ env:
     - secure: "uWKJdJlHc8tg+98jGpcc/FvsssEbw2FARqtgO0smBp5x8JWCmAt5fAVPB8qRbbirdHS5Yjpk8SSSa3vWVizYeTIOV+Vo3w8/1oqymPnMEEMtcLkyGZP+fNMDgNnX+icOU/bmh8werhOn9+qiZfKmFuXgpjrXzYoWzrhn55EuDN68Yhe6gB1zznHihDtSKjwQrbZFlgNnTh13Wk9lY8y2XYsWZZVfQ25dP4PaQQv647nBhcWPvrB0N/vMmDS/twvUBcbbEjRg5yKtsqzuT2lEqdIpwosp3/gZjWAWK0FjjmnzRcSHbugtaxWHmghHDLHSpP4GF7bzYL01tklFWDSW9DDvVfZ3HgiN058LL1jsk+VjcMCgu7csUWUj2kib3/TjKQy32R1vALpgDOrLHutdVDXoED33qxcyAYLODNRwW9o+QQM2HoZD4PKVDcKW4WOvAKp7Z1NK+ag26WdA/bM7ZgAll40dY9yPtgg0fdMM9N1X9e4v2TJmjnSLXF8v0jXIwp3VL01c/RpsmD7ubTUp0ixSaiKK0cCvxdflsDSUGojckeA4OsGOf9X+anqxmJsiY7vW/TKULMgToKEYDIPB0EfJ0Tf8P/ve4veEZSnhFinrDk46jwSP2m4kpR2FHAMtjCwqWEXZWouIJOOclAk4IqUWGT88Iomdz/LFbQa2rdo="
     - LC_ALL: C.UTF-8
     - LANG: C.UTF-8
+    - SNAPCRAFT_SETUP_CORE: on
 
 matrix:
   include:
@@ -42,10 +42,8 @@ jobs:
       if: type != cron
       install:
         # Here until we have our snapcraft testing toolkit snap
-        - sudo add-apt-repository -y ppa:chris-lea/libsodium
         - sudo apt update
         - sudo apt install -y python3.5-dev git bzr subversion mercurial rpm2cpio p7zip-full libnacl-dev libssl-dev libsodium-dev libffi-dev libapt-pkg-dev squashfs-tools xdelta3 libyaml-dev
-        - sudo update-alternatives --install /usr/bin/python3 python3.5 /usr/bin/python3.5 0
         - curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && python3 /tmp/get-pip.py --user
         - pip3 install --user -r requirements-devel.txt -r requirements.txt codecov
       script:
@@ -57,18 +55,13 @@ jobs:
     - stage: snap
       if: type != cron
       install:
+        - sudo snap install core
+        # We have to test using the deb to bootstrap LP: #1817300
         - sudo apt update
-        - sudo apt install -y snapd
-        - sudo snap install lxd --channel 3.0/stable
-        - sudo snap install snapcraft --candidate --classic
-        - sudo /snap/bin/lxd waitready
-        - sudo /snap/bin/lxd init --auto
-        - mkdir -p "$TRAVIS_BUILD_DIR/snaps-cache"
+        - sudo apt install -y snapcraft
       script:
-        - export PATH=/snap/bin:$PATH
-        - sudo snapcraft cleanbuild
-        - sudo cp snapcraft_amd64.snap "snapcraft-pr$TRAVIS_PULL_REQUEST.snap"
-        - sudo cp snapcraft_amd64.snap "$TRAVIS_BUILD_DIR/snaps-cache/snapcraft-pr$TRAVIS_PULL_REQUEST.snap"
+        - sudo snapcraft snap --output "snapcraft-pr$TRAVIS_PULL_REQUEST.snap"
+        - sudo cp "snapcraft-pr$TRAVIS_PULL_REQUEST.snap" "$TRAVIS_BUILD_DIR/snaps-cache/snapcraft-pr$TRAVIS_PULL_REQUEST.snap"
       after_success:
         - sudo snap install transfer
         - timeout 180 sudo /snap/bin/transfer snapcraft-pr$TRAVIS_PULL_REQUEST.snap

--- a/bin/snapcraftctl
+++ b/bin/snapcraftctl
@@ -27,7 +27,7 @@ quote()
 
 # Which python3 are we using? By default, the one from the PATH. If
 # SNAPCRAFT_INTERPRETER is specified, use that one instead.
-python3_command="${SNAPCRAFT_INTERPRETER:-$(which python3)}"
+python3_command="${SNAPCRAFT_INTERPRETER:-$(command -v python3)}"
 
 snapcraftctl_command="$python3_command -I -c '
 import snapcraft.cli.__main__

--- a/runtests.sh
+++ b/runtests.sh
@@ -79,9 +79,9 @@ run_static_tests(){
 }
 
 run_snapcraft_tests(){
-    if [[ ! -z "$use_run" ]]; then
+    if [[ -n "$use_run" ]]; then
         python3 -m unittest -b -v run "$test_suite"
-    elif [[ ! -z "$coverage" ]] && [[ "$test_suite" == "tests/unit"* ]]; then
+    elif [[ -n "$coverage" ]] && [[ "$test_suite" == "tests/unit"* ]]; then
         python3 -m coverage erase
         python3 -m coverage run --branch --source snapcraft -m unittest discover -b -v -s "$test_suite" -t .
     else
@@ -109,7 +109,7 @@ fi
 
 parseargs "$@"
 
-if [[ ! -z "$coverage" ]] && [[ "$test_suite" == "tests/unit"* ]]; then
+if [[ -n "$coverage" ]] && [[ "$test_suite" == "tests/unit"* ]]; then
     coverage report
 
     echo

--- a/snapcraft/internal/project_loader/_env.py
+++ b/snapcraft/internal/project_loader/_env.py
@@ -19,21 +19,6 @@ from snapcraft.internal import common, elf, pluginhandler
 from typing import Dict, List
 
 
-def env_for_classic(base: str, arch_triplet: str) -> List[str]:
-    """Set the required environment variables for a classic confined build."""
-    env = []
-
-    core_path = common.get_core_path(base)
-    paths = common.get_library_paths(core_path, arch_triplet, existing_only=False)
-    env.append(
-        formatting_utils.format_path_variable(
-            "LD_LIBRARY_PATH", paths, prepend="", separator=":"
-        )
-    )
-
-    return env
-
-
 def runtime_env(root: str, arch_triplet: str) -> List[str]:
     """Set the environment variables required for running binaries."""
     env = []

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -23,7 +23,6 @@ from typing import Set  # noqa: F401
 import snapcraft
 from snapcraft.internal import deprecations, elf, pluginhandler, repo
 from ._env import (
-    env_for_classic,
     build_env,
     build_env_for_stage,
     runtime_env,
@@ -258,7 +257,6 @@ class PartsConfig:
 
         env = []  # type: List[str]
         stagedir = self._project.stage_dir
-        is_host_compat = self._project.is_host_compatible_with_base(self._base)
 
         if root_part:
             # this has to come before any {}/usr/bin
@@ -271,10 +269,6 @@ class PartsConfig:
             env += build_env_for_stage(
                 stagedir, self._snap_name, self._project.arch_triplet
             )
-            # Only set the paths to the base snap if we are building on the
-            # same host. Failing to do so will cause Segmentation Faults.
-            if self._confinement == "classic" and is_host_compat:
-                env += env_for_classic(self._base, self._project.arch_triplet)
 
             global_env = snapcraft_global_environment(self._project)
             part_env = snapcraft_part_environment(part)

--- a/snapcraft/plugins/dotnet.py
+++ b/snapcraft/plugins/dotnet.py
@@ -114,7 +114,6 @@ class DotNetPlugin(snapcraft.BasePlugin):
                 "lldb",
                 "libssl1.0.0",
                 "libgssapi-krb5-2",
-                "libc6",
                 "zlib1g",
                 "libgcc1",
             ]

--- a/tests/spread/plugins/autotools/classic/task.yaml
+++ b/tests/spread/plugins/autotools/classic/task.yaml
@@ -1,0 +1,25 @@
+summary: Build and run a classic confined basic Autotools snap
+
+environment:
+  SNAP_DIR: ../snaps/autotools-hello
+
+prepare: |
+  cd "$SNAP_DIR"
+  # Change the confinement to classic
+  sed -i -e "s/confinement: strict/confinement: classic/" snap/snapcraft.yaml
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+  git checkout snap/snapcraft.yaml
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft
+
+  # Ensure that what we built has confinement set to classic
+  MATCH -v "confinement: classic" < prime/meta/snap.yaml
+
+  sudo snap install autotools-hello_*.snap --dangerous --classic
+  [ "$(autotools-hello)" = "Hello, world!" ]

--- a/tests/spread/plugins/autotools/snaps/autotools-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/autotools/snaps/autotools-hello/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ confinement: strict
 
 apps:
   autotools-hello:
-    command: hello
+    command: bin/hello
 
 build-packages: [gcc]
 

--- a/tests/spread/plugins/plainbox/snaps/checkbox/launchers/checkbox-cli-wrapper
+++ b/tests/spread/plugins/plainbox/snaps/checkbox/launchers/checkbox-cli-wrapper
@@ -1,3 +1,3 @@
 #!/bin/sh
 export PATH="$PATH:$SNAP/usr/sbin"
-exec python3 "$(which checkbox-cli)" "$@"
+exec python3 "$(command -v checkbox-cli)" "$@"

--- a/tests/unit/project_loader/test_environment.py
+++ b/tests/unit/project_loader/test_environment.py
@@ -285,14 +285,18 @@ class EnvironmentTest(ProjectLoaderBaseTest):
         project_config = self.make_snapcraft_project(snapcraft_yaml)
         part = project_config.parts.get_part("part1")
         environment = project_config.parts.build_env_for_part(part, root_part=True)
-        self.assertIn(
-            'LD_LIBRARY_PATH="$LD_LIBRARY_PATH:{base_core_path}/lib:'
-            "{base_core_path}/usr/lib:{base_core_path}/lib/{arch_triplet}:"
-            '{base_core_path}/usr/lib/{arch_triplet}"'.format(
-                base_core_path=self.base_environment.core_path,
-                arch_triplet=project_config.project.arch_triplet,
-            ),
+        self.assertThat(
             environment,
+            Not(
+                Contains(
+                    'LD_LIBRARY_PATH="$LD_LIBRARY_PATH:{base_core_path}/lib:'
+                    "{base_core_path}/usr/lib:{base_core_path}/lib/{arch_triplet}:"
+                    '{base_core_path}/usr/lib/{arch_triplet}"'.format(
+                        base_core_path=self.base_environment.core_path,
+                        arch_triplet=project_config.project.arch_triplet,
+                    )
+                )
+            ),
         )
 
     def test_stage_environment_confinement_classic_with_incompat_host(self):


### PR DESCRIPTION
This implementation can cause clashes with changes in the host with
regards to the base in use (i.e; core, core18, ...) as their might
be libc6 mismatches at the time that can lead to undefined behavior.

The issue comes up when the core snap is installed as it is when
the libraries are used, this specific behavior is no longer needed
as the library crawling feature has improved since this was first
introduced.

Additionally, the Travis CI job has been moved to using the deb
for the time being to overcome the bootstrapping issue that this
misbehavior creates.

This fix also has to come into legacy first to as snapcraft builds with
legacy be

LP: #1817300

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
