### PR TITLE
project loader: remove special LD_LIBRARY_FLAGS handling for classic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,23 +101,16 @@ jobs:
       if: type != cron
       addons:
         snaps:
-          - name: lxd
-            channel: 3.0/stable
           - name: snapcraft
-            channel: candidate
+            channel: edge
             classic: true
           - name: transfer
           - name: http
       install:
-        - sudo apt autoremove --purge --yes lxd lxd-client
-        - sudo /snap/bin/lxd waitready
-        - sudo /snap/bin/lxd init --auto
-        - mkdir -p "$TRAVIS_BUILD_DIR/snaps-cache"
+        - sudo apt update
       script:
-        - export PATH=/snap/bin:$PATH
-        - sudo snapcraft cleanbuild
-        - sudo cp snapcraft_amd64.snap "snapcraft-pr$TRAVIS_PULL_REQUEST.snap"
-        - sudo cp snapcraft_amd64.snap "$TRAVIS_BUILD_DIR/snaps-cache/snapcraft-pr$TRAVIS_PULL_REQUEST.snap"
+        - sudo snapcraft snap --output "snapcraft-pr$TRAVIS_PULL_REQUEST.snap"
+        - sudo cp "snapcraft-pr$TRAVIS_PULL_REQUEST.snap" "$TRAVIS_BUILD_DIR/snaps-cache/snapcraft-pr$TRAVIS_PULL_REQUEST.snap"
       after_success:
         - timeout 180 sudo /snap/bin/transfer snapcraft-pr$TRAVIS_PULL_REQUEST.snap
       after_failure:

--- a/snapcraft/internal/project_loader/_env.py
+++ b/snapcraft/internal/project_loader/_env.py
@@ -19,21 +19,6 @@ from snapcraft.internal import common, elf, pluginhandler
 from typing import Dict, List
 
 
-def env_for_classic(base: str, arch_triplet: str) -> List[str]:
-    """Set the required environment variables for a classic confined build."""
-    env = []
-
-    core_path = common.get_core_path(base)
-    paths = common.get_library_paths(core_path, arch_triplet, existing_only=False)
-    env.append(
-        formatting_utils.format_path_variable(
-            "LD_LIBRARY_PATH", paths, prepend="", separator=":"
-        )
-    )
-
-    return env
-
-
 def runtime_env(root: str, arch_triplet: str) -> List[str]:
     """Set the environment variables required for running binaries."""
     env = []

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -23,7 +23,6 @@ from typing import Set  # noqa: F401
 import snapcraft
 from snapcraft.internal import elf, pluginhandler, repo
 from ._env import (
-    env_for_classic,
     build_env,
     build_env_for_stage,
     runtime_env,
@@ -256,12 +255,6 @@ class PartsConfig:
             env += build_env_for_stage(
                 stagedir, self._project.info.name, self._project.arch_triplet
             )
-            # Only set the paths to the base snap if we are building on the
-            # same host. Failing to do so will cause Segmentation Faults.
-            if self._project.info.confinement == "classic":
-                env += env_for_classic(
-                    self._project.info.base, self._project.arch_triplet
-                )
 
             global_env = snapcraft_global_environment(self._project)
             part_env = snapcraft_part_environment(part)

--- a/snapcraft/plugins/dotnet.py
+++ b/snapcraft/plugins/dotnet.py
@@ -120,7 +120,6 @@ class DotNetPlugin(snapcraft.BasePlugin):
                     "lldb",
                     "libssl1.0.0",
                     "libgssapi-krb5-2",
-                    "libc6",
                     "zlib1g",
                     "libgcc1",
                 ]

--- a/tests/spread/plugins/autotools/classic/task.yaml
+++ b/tests/spread/plugins/autotools/classic/task.yaml
@@ -1,0 +1,25 @@
+summary: Build and run a classic confined basic Autotools snap
+
+environment:
+  SNAP_DIR: ../snaps/autotools-hello
+
+prepare: |
+  cd "$SNAP_DIR"
+  # Change the confinement to classic
+  sed -i -e "s/confinement: strict/confinement: classic/" snap/snapcraft.yaml
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+  git checkout snap/snapcraft.yaml
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft
+
+  # Ensure that what we built has confinement set to classic
+  MATCH -v "confinement: classic" < prime/meta/snap.yaml
+
+  sudo snap install autotools-hello_*.snap --dangerous --classic
+  [ "$(autotools-hello)" = "Hello, world!" ]

--- a/tests/spread/plugins/autotools/snaps/autotools-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/autotools/snaps/autotools-hello/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ confinement: strict
 
 apps:
   autotools-hello:
-    command: hello
+    command: bin/hello
 
 build-packages: [gcc]
 

--- a/tests/unit/project_loader/test_environment.py
+++ b/tests/unit/project_loader/test_environment.py
@@ -288,14 +288,18 @@ class EnvironmentTest(ProjectLoaderBaseTest):
         project_config = self.make_snapcraft_project(snapcraft_yaml)
         part = project_config.parts.get_part("part1")
         environment = project_config.parts.build_env_for_part(part, root_part=True)
-        self.assertIn(
-            'LD_LIBRARY_PATH="$LD_LIBRARY_PATH:{base_core_path}/lib:'
-            "{base_core_path}/usr/lib:{base_core_path}/lib/{arch_triplet}:"
-            '{base_core_path}/usr/lib/{arch_triplet}"'.format(
-                base_core_path=self.base_environment.core_path,
-                arch_triplet=project_config.project.arch_triplet,
-            ),
+        self.assertThat(
             environment,
+            Not(
+                Contains(
+                    'LD_LIBRARY_PATH="$LD_LIBRARY_PATH:{base_core_path}/lib:'
+                    "{base_core_path}/usr/lib:{base_core_path}/lib/{arch_triplet}:"
+                    '{base_core_path}/usr/lib/{arch_triplet}"'.format(
+                        base_core_path=self.base_environment.core_path,
+                        arch_triplet=project_config.project.arch_triplet,
+                    )
+                )
+            ),
         )
 
     def test_config_stage_environment(self):


### PR DESCRIPTION
This implementation can cause clashes with changes in the host with
regards to the base in use (i.e; core, core18, ...) as their might
be libc6 mismatches at the time that can lead to undefined behavior.

The issue comes up when the core snap is installed as it is when
the libraries are used, this specific behavior is no longer needed
as the library crawling feature has improved since this was first
introduced.

Additionally, the Travis CI job has been moved to using the edge
for the time being to overcome the bootstrapping issue that this
misbehavior creates.

This fix is based on the one introduced in the legacy branch
as snapcraft uses the legacy implementation to build itself.

LP: #1817300

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
