### PR TITLE
cli: Fix traceback count check in error test

### DIFF
--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -23,7 +23,7 @@ from textwrap import dedent
 from unittest import mock
 
 import fixtures
-from testtools.matchers import FileContains, MatchesRegex, Equals
+from testtools.matchers import FileContains, MatchesRegex, Equals, GreaterThan
 from testscenarios import multiply_scenarios
 
 import snapcraft.internal.errors
@@ -182,7 +182,7 @@ class ProviderErrorTest(ErrorsBaseTestCase):
         )
         self._raise_other_error()
         self.move_mock.assert_not_called()
-        self.assertThat(self.traceback_mock.call_count, Equals(2))
+        self.assertThat(self.traceback_mock.call_count, GreaterThan(0))
 
     def _raise_exec_error(self):
         self.call_handler(


### PR DESCRIPTION
Certain build environments may produce one or two traceback calls,
depending on external factors. This is an interim solution, the exact
environment should be mocked to produce deterministic results.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
