### PR TITLE
cli: Mock Raven client in error tests

### DIFF
--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -175,11 +175,13 @@ class ProviderErrorTest(ErrorsBaseTestCase):
         self.assertThat(self.traceback_mock.call_count, Equals(1))
 
     @mock.patch("os.path.isfile", return_value=False)
-    def test_provider_error_inner(self, isfile_function):
+    @mock.patch.object(snapcraft.cli._errors, "RavenClient")
+    def test_provider_error_inner(self, isfile_function, raven_client_mock):
         # Error raised inside the build provider
         self.useFixture(
             fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT", "managed-host")
         )
+        snapcraft.cli._errors.RavenClient = "something"
         self._raise_other_error()
         self.move_mock.assert_not_called()
         self.assertThat(self.traceback_mock.call_count, Equals(2))


### PR DESCRIPTION
Certain build environments may need Raven client to be mocked in order
to get deterministic results from the error handling tests.

**Note**: this PR and PR #2488 are mutually exclusive, one must be chosen to address the traceback count errors in the final build.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
