### PR TITLE
Fix multipass error handling spread test

### DIFF
--- a/tests/spread/multipass/error-handling/task.yaml
+++ b/tests/spread/multipass/error-handling/task.yaml
@@ -1,4 +1,4 @@
-summary: Build a basic snap using multipass and ensure that it runs
+summary: A faulty snap to test error handling
 warn-timeout: 9m  # Keep less than 10 minutes so Travis can't timeout
 priority: 90  # Run this test relatively early since fetching images can take time
 
@@ -25,6 +25,12 @@ execute: |
   # Ensure that snapcraft uses build VMs
   unset SNAPCRAFT_BUILD_ENVIRONMENT
 
+  # Building this snap returns an error inside the provider. This error must
+  # be handled by the outer environment and return code 2 instead of raising
+  # an exception (and return 1).
   err=0
   snapcraft || err=$?
-  [ $err -eq 2 ]
+  if [ $err -ne 2 ]; then
+    echo "Error handling legit error in build provider"
+    exit 1
+  fi

--- a/tests/spread/multipass/error-handling/task.yaml
+++ b/tests/spread/multipass/error-handling/task.yaml
@@ -25,5 +25,6 @@ execute: |
   # Ensure that snapcraft uses build VMs
   unset SNAPCRAFT_BUILD_ENVIRONMENT
 
-  snapcraft
-  [ $? -eq 2 ]
+  err=0
+  snapcraft || err=$?
+  [ $err -eq 2 ]


### PR DESCRIPTION
Fix the multipass error handler spread test but don't remove the manual switch as multipass tests in gcloud don't seem to be stable enough.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
