### PR TITLE
store: handle invalid snap file errors

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -677,3 +677,10 @@ class CrossCompilationNotSupported(SnapcraftError):
 
     def __init__(self, *, part_name: str) -> None:
         super().__init__(part_name=part_name)
+
+
+class SnapDataExtractionError(SnapcraftError):
+    fmt = "Cannot read data from snap {snap!r}. The file may be corrupted."
+
+    def __init__(self, snap):
+        super().__init__(snap=snap)

--- a/tests/data/invalid.snap
+++ b/tests/data/invalid.snap
@@ -1,0 +1,1 @@
+invalid file

--- a/tests/unit/commands/test_push.py
+++ b/tests/unit/commands/test_push.py
@@ -19,7 +19,7 @@ from unittest import mock
 from testtools.matchers import Contains, Equals, FileExists, Not
 from xdg import BaseDirectory
 
-from snapcraft import file_utils, storeapi
+from snapcraft import file_utils, storeapi, internal
 from snapcraft.storeapi.errors import (
     StoreDeltaApplicationError,
     StorePushError,
@@ -87,6 +87,19 @@ class PushCommandTestCase(PushCommandBaseTestCase):
     def test_push_nonexisting_snap_must_raise_exception(self):
         result = self.run_command(["push", "test-unexisting-snap"])
         self.assertThat(result.exit_code, Equals(2))
+
+    def test_push_invalid_snap_must_raise_exception(self):
+        snap_path = os.path.join(
+            os.path.dirname(tests.__file__), "data", "invalid.snap"
+        )
+
+        raised = self.assertRaises(
+            internal.errors.SnapDataExtractionError,
+            self.run_command,
+            ["push", snap_path],
+        )
+
+        self.assertThat(str(raised), Contains("Cannot read data from snap"))
 
     def test_push_unregistered_snap_must_raise_exception(self):
         class MockResponse:


### PR DESCRIPTION
Properly handle corrupt or invalid snap files when extracting package
data for signing or push.

Fixes SNAPCRAFT-GE

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
