### PR TITLE
sources: handle network request errors

### DIFF
--- a/snapcraft/internal/sources/_base.py
+++ b/snapcraft/internal/sources/_base.py
@@ -144,8 +144,11 @@ class FileBase(Base):
         if snapcraft.internal.common.get_url_scheme(self.source) == "ftp":
             download_urllib_source(self.source, self.file)
         else:
-            request = requests.get(self.source, stream=True, allow_redirects=True)
-            request.raise_for_status()
+            try:
+                request = requests.get(self.source, stream=True, allow_redirects=True)
+                request.raise_for_status()
+            except requests.exceptions.RequestException as e:
+                raise errors.SnapcraftRequestError(message=e)
 
             download_requests_stream(request, self.file)
 

--- a/snapcraft/internal/sources/errors.py
+++ b/snapcraft/internal/sources/errors.py
@@ -113,3 +113,8 @@ class SnapcraftPullError(SnapcraftSourceError):
         else:
             string_command = command
         super().__init__(command=string_command, exit_code=exit_code)
+
+
+class SnapcraftRequestError(SnapcraftSourceError):
+
+    fmt = "Network request error: {message}"


### PR DESCRIPTION
When pulling sources, handle network connection errors and HTTP request
errors.

Fixes SNAPCRAFT-DQ
Fixes SNAPCRAFT-G7
Fixes SNAPCRAFT-FJ

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
