### PR TITLE
Hide progress bar for dumb terminals - legacy branch

### DIFF
--- a/snapcraft/internal/indicators.py
+++ b/snapcraft/internal/indicators.py
@@ -66,8 +66,9 @@ def download_requests_stream(request_stream, destination, message=None, total_re
     with open(destination, mode) as destination_file:
         for buf in request_stream.iter_content(1024):
             destination_file.write(buf)
-            total_read += len(buf)
-            progress_bar.update(total_read)
+            if not is_dumb_terminal():
+                total_read += len(buf)
+                progress_bar.update(total_read)
     progress_bar.finish()
 
 


### PR DESCRIPTION
https://forum.snapcraft.io/t/dump-plugin-overloads-ci-logs/8049/4

(cherry picked from commit 589b9c21e2fe66a0dec0873662f0e3f789ceac05)

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
