### PR TITLE
many: support the use of build-aux/snap

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -82,7 +82,6 @@ def _install_multipass():
 
 
 # TODO: when snap is a real step we can simplify the arguments here.
-# fmt: off
 def _execute(  # noqa: C901
     step: steps.Step,
     parts: str,
@@ -93,21 +92,32 @@ def _execute(  # noqa: C901
     destructive_mode: bool = False,
     **kwargs
 ) -> "Project":
-    # fmt: on
     _clean_provider_error()
     provider = "host" if destructive_mode else None
     build_environment = env.BuilderEnvironmentConfig(force_provider=provider)
     try:
         conduct_build_environment_sanity_check(build_environment.provider)
     except MultipassMissingInstallableError as e:
-        click.echo("You need multipass installed to build snaps "
-                   "(https://github.com/CanonicalLtd/multipass).")
+        click.echo(
+            "You need multipass installed to build snaps "
+            "(https://github.com/CanonicalLtd/multipass)."
+        )
         if click.confirm("Would you like to install it now?"):
             _install_multipass()
         else:
-            raise errors.SnapcraftEnvironmentError("multipass is required to continue.") from e
+            raise errors.SnapcraftEnvironmentError(
+                "multipass is required to continue."
+            ) from e
 
     project = get_project(is_managed_host=build_environment.is_managed_host, **kwargs)
+
+    echo.wrapped(
+        "Using {!r}: Project assets will be "
+        "searched for from the {!r} directory.".format(
+            project.info.snapcraft_yaml_file_path,
+            os.path.relpath(project._get_snapcraft_assets_dir(), project._project_dir),
+        )
+    )
 
     conduct_project_sanity_check(project)
 
@@ -146,8 +156,10 @@ def _execute(  # noqa: C901
                 if project.debug:
                     instance.shell()
                 else:
-                    echo.warning("Run the same command again with --debug to shell into the environment "
-                                 "if you wish to introspect this failure.")
+                    echo.warning(
+                        "Run the same command again with --debug to shell into the environment "
+                        "if you wish to introspect this failure."
+                    )
                     raise
             else:
                 if shell or shell_after:
@@ -187,8 +199,10 @@ def init():
     """Initialize a snapcraft project."""
     snapcraft_yaml_path = lifecycle.init()
     echo.info("Created {}.".format(snapcraft_yaml_path))
-    echo.wrapped("Go to https://docs.snapcraft.io/the-snapcraft-format/8337 for more "
-                 "information about the snapcraft.yaml format.")
+    echo.wrapped(
+        "Go to https://docs.snapcraft.io/the-snapcraft-format/8337 for more "
+        "information about the snapcraft.yaml format."
+    )
 
 
 @lifecyclecli.command()

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -436,7 +436,9 @@ class _SnapPackaging:
     def write_snap_directory(self) -> None:
         # First migrate the snap directory. It will overwrite any conflicting
         # files.
-        for root, directories, files in os.walk("snap"):
+        for root, directories, files in os.walk(
+            self._project_config.project._get_snapcraft_assets_dir()
+        ):
             with contextlib.suppress(ValueError):
                 directories.remove(".snapcraft")
             with contextlib.suppress(ValueError):
@@ -444,13 +446,21 @@ class _SnapPackaging:
                 files.remove("snapcraft.yaml")
 
             for directory in directories:
-                source = os.path.join(root, directory)
-                destination = os.path.join(self._prime_dir, source)
+                source = os.path.relpath(
+                    os.path.join(root, directory),
+                    self._project_config.project._work_dir,
+                )
+                # Also build-aux from destination
+                destination = os.path.join(self._prime_dir, source.lstrip("build-aux/"))
                 file_utils.create_similar_directory(source, destination)
 
             for file_path in files:
-                source = os.path.join(root, file_path)
-                destination = os.path.join(self._prime_dir, source)
+                source = os.path.relpath(
+                    os.path.join(root, file_path),
+                    self._project_config.project._work_dir,
+                )
+                # Also build-aux from destination
+                destination = os.path.join(self._prime_dir, source.lstrip("build-aux/"))
                 with contextlib.suppress(FileNotFoundError):
                     os.remove(destination)
                 file_utils.link_or_copy(source, destination)
@@ -458,7 +468,9 @@ class _SnapPackaging:
         # Now copy the assets contained within the snap directory directly into
         # meta.
         for origin in ["gui", "hooks"]:
-            src_dir = os.path.join("snap", origin)
+            src_dir = os.path.join(
+                self._project_config.project._get_snapcraft_assets_dir(), origin
+            )
             dst_dir = os.path.join(self.meta_dir, origin)
             if os.path.isdir(src_dir):
                 os.makedirs(dst_dir, exist_ok=True)

--- a/snapcraft/project/_get_snapcraft.py
+++ b/snapcraft/project/_get_snapcraft.py
@@ -22,6 +22,7 @@ from . import errors
 def get_snapcraft_yaml(base_dir=None):
     possible_yamls = [
         os.path.join("snap", "snapcraft.yaml"),
+        os.path.join("build-aux", "snap", "snapcraft.yaml"),
         "snapcraft.yaml",
         ".snapcraft.yaml",
     ]

--- a/snapcraft/project/_project.py
+++ b/snapcraft/project/_project.py
@@ -53,6 +53,14 @@ class Project(ProjectOptions):
 
         super().__init__(target_deb_arch, debug, work_dir=work_dir)
 
+    def _get_snapcraft_assets_dir(self) -> str:
+        if self.info.snapcraft_yaml_file_path.endswith(
+            os.path.join("build-aux", "snap", "snapcraft.yaml")
+        ):
+            return os.path.join(self._project_dir, "build-aux", "snap")
+        else:
+            return os.path.join(self._project_dir, "snap")
+
     def _get_global_state_file_path(self) -> str:
         if self._is_managed_host:
             state_file_path = os.path.join(self._work_dir, "state")

--- a/tests/spread/general/build-aux/task.yaml
+++ b/tests/spread/general/build-aux/task.yaml
@@ -1,0 +1,42 @@
+summary: Use build-aux for snapcraft assets
+
+# We currently only have core18 on a stable channel
+systems: [ubuntu-18*]
+
+environment:
+  SNAPCRAFT_BUILD_INFO: on
+
+prepare: |
+  mkdir test-snap
+  cd test-snap
+  snapcraft init
+  mkdir snap/hooks
+  touch snap/hooks/install
+  mkdir snap/gui
+  touch snap/gui/icon.png
+
+  mkdir build-aux
+  mv snap build-aux
+
+restore: |
+  rm -rf test-snap
+
+execute: |
+  cd test-snap
+
+  snapcraft prime
+
+  if [ ! -f prime/meta/gui/icon.png ]; then
+      echo "Missing expected snap icon"
+      exit 1
+  fi
+
+  if [ ! -f prime/meta/hooks/install ]; then
+      echo "Missing expected snap install hook"
+      exit 1
+  fi
+
+  if [ ! -f prime/snap/snapcraft.yaml ]; then
+      echo "Missing snapcraft.yaml in snap dir"
+      exit 1
+  fi

--- a/tests/unit/project/test_get_snapcraft.py
+++ b/tests/unit/project/test_get_snapcraft.py
@@ -27,6 +27,10 @@ class GetSnapcraftYamlTest(unit.TestCase):
     scenarios = [
         ("snapcraft.yaml", dict(file_path="snapcraft.yaml")),
         ("snap/snapcraft.yaml", dict(file_path=os.path.join("snap", "snapcraft.yaml"))),
+        (
+            "build-aux",
+            dict(file_path=os.path.join("build-aux", "snap", "snapcraft.yaml")),
+        ),
         (".snapcraft.yaml", dict(file_path=".snapcraft.yaml")),
     ]
 
@@ -62,6 +66,13 @@ class GetSnapcraftYamlDuplicateErrorsTest(unit.TestCase):
             ".snapcraft.yaml and snap/snapcraft.yaml",
             dict(
                 file_path1=".snapcraft.yaml",
+                file_path2=os.path.join("snap", "snapcraft.yaml"),
+            ),
+        ),
+        (
+            "build-aux and snap",
+            dict(
+                file_path1=os.path.join("build-aux", "snap", "snapcraft.yaml"),
                 file_path2=os.path.join("snap", "snapcraft.yaml"),
             ),
         ),

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -65,12 +65,16 @@ class CreateBaseTestCase(unit.TestCase):
         # Ensure the ensure snapcraft.yaml method has something to copy.
         _create_file(self.snapcraft_yaml_file_path)
 
-    def generate_meta_yaml(self, *, build=False, actual_prime_dir=None):
+    def generate_meta_yaml(
+        self, *, build=False, actual_prime_dir=None, snapcraft_yaml_file_path=None
+    ):
+        if snapcraft_yaml_file_path is None:
+            snapcraft_yaml_file_path = self.snapcraft_yaml_file_path
         os.makedirs("snap", exist_ok=True)
-        with open(self.snapcraft_yaml_file_path, "w") as f:
+        with open(snapcraft_yaml_file_path, "w") as f:
             f.write(yaml_utils.dump(self.config_data))
 
-        self.project = Project(snapcraft_yaml_file_path=self.snapcraft_yaml_file_path)
+        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_file_path)
         if actual_prime_dir is not None:
             self.project._prime_dir = actual_prime_dir
 
@@ -445,46 +449,6 @@ class CreateTestCase(CreateBaseTestCase):
         self.assertThat(snap_yaml, Not(FileContains("desktop: app2.desktop")))
         self.assertThat(snap_yaml, Not(FileContains("desktop: app3.desktop")))
         self.assertThat(snap_yaml, Not(FileContains("desktop: my-package.desktop")))
-
-    def test_create_meta_with_hook(self):
-        hooksdir = os.path.join(self.snap_dir, "hooks")
-        os.makedirs(hooksdir)
-        _create_file(os.path.join(hooksdir, "foo"), executable=True)
-        _create_file(os.path.join(hooksdir, "bar"), executable=True)
-        self.config_data["hooks"] = {"foo": {"plugs": ["plug"]}, "bar": {}}
-
-        y = self.generate_meta_yaml()
-
-        self.assertThat(
-            y, Contains("hooks"), "Expected generated YAML to contain 'hooks'"
-        )
-
-        for hook in ("foo", "bar"):
-            generated_hook_path = os.path.join(self.prime_dir, "meta", "hooks", hook)
-            self.assertThat(
-                generated_hook_path,
-                FileExists(),
-                "The {!r} hook was not setup correctly".format(hook),
-            )
-
-            self.assertThat(
-                y["hooks"],
-                Contains(hook),
-                "Expected generated hooks to contain {!r}".format(hook),
-            )
-
-        self.assertThat(
-            y["hooks"]["foo"],
-            Contains("plugs"),
-            "Expected generated 'foo' hook to contain 'plugs'",
-        )
-        self.assertThat(y["hooks"]["foo"]["plugs"], HasLength(1))
-        self.assertThat(y["hooks"]["foo"]["plugs"][0], Equals("plug"))
-        self.assertThat(
-            y["hooks"]["bar"],
-            Not(Contains("plugs")),
-            "Expected generated 'bar' hook to not contain 'plugs'",
-        )
 
 
 class StopModeTestCase(CreateBaseTestCase):
@@ -864,12 +828,80 @@ class CreateMetadataFromSourceTestCase(CreateMetadataFromSourceBaseTestCase):
         self.assertThat(raised.keys, Equals("'summary'"))
 
 
+class CreateWithAssetsTestCase(CreateBaseTestCase):
+    scenarios = (
+        ("snap", dict(snapcraft_assets_dir="snap")),
+        ("build-aux", dict(snapcraft_assets_dir=os.path.join("build-aux", "snap"))),
+    )
+
+    def test_create_meta_with_hook(self):
+        hooksdir = os.path.join(self.snapcraft_assets_dir, "hooks")
+        os.makedirs(hooksdir)
+        _create_file(os.path.join(hooksdir, "foo"), executable=True)
+        _create_file(os.path.join(hooksdir, "bar"), executable=True)
+        self.config_data["hooks"] = {"foo": {"plugs": ["plug"]}, "bar": {}}
+
+        y = self.generate_meta_yaml(
+            snapcraft_yaml_file_path=os.path.join(
+                self.snapcraft_assets_dir, "snapcraft.yaml"
+            )
+        )
+
+        self.assertThat(
+            y, Contains("hooks"), "Expected generated YAML to contain 'hooks'"
+        )
+
+        for hook in ("foo", "bar"):
+            generated_hook_path = os.path.join(self.prime_dir, "meta", "hooks", hook)
+            self.assertThat(
+                generated_hook_path,
+                FileExists(),
+                "The {!r} hook was not setup correctly".format(hook),
+            )
+
+            self.assertThat(
+                y["hooks"],
+                Contains(hook),
+                "Expected generated hooks to contain {!r}".format(hook),
+            )
+
+        self.assertThat(
+            y["hooks"]["foo"],
+            Contains("plugs"),
+            "Expected generated 'foo' hook to contain 'plugs'",
+        )
+        self.assertThat(y["hooks"]["foo"]["plugs"], HasLength(1))
+        self.assertThat(y["hooks"]["foo"]["plugs"][0], Equals("plug"))
+        self.assertThat(
+            y["hooks"]["bar"],
+            Not(Contains("plugs")),
+            "Expected generated 'bar' hook to not contain 'plugs'",
+        )
+
+
 class MetadataFromSourceWithIconFileTestCase(CreateMetadataFromSourceBaseTestCase):
 
     scenarios = testscenarios.multiply_scenarios(
         (
-            ("setup/gui", dict(directory=os.path.join("setup", "gui"))),
-            ("snap/gui", dict(directory=os.path.join("snap", "gui"))),
+            (
+                "setup/gui",
+                dict(
+                    snapcraft_assets_dir="snap", directory=os.path.join("setup", "gui")
+                ),
+            ),
+            (
+                "snap/gui",
+                dict(
+                    snapcraft_assets_dir="snap", directory=os.path.join("snap", "gui")
+                ),
+            ),
+            (
+                "build-aux/snap/gui",
+                dict(
+                    snapcraft_assets_dir=os.path.join("build-aux", "snap"),
+                    directory=os.path.join("build-aux", "snap", "gui"),
+                ),
+            ),
         ),
         (
             ("icon.png", dict(file_name="icon.png")),
@@ -889,7 +921,12 @@ class MetadataFromSourceWithIconFileTestCase(CreateMetadataFromSourceBaseTestCas
 
         self.useFixture(fixture_setup.FakeMetadataExtractor("fake", _fake_extractor))
 
-        self.generate_meta_yaml(build=True)
+        self.generate_meta_yaml(
+            build=True,
+            snapcraft_yaml_file_path=os.path.join(
+                self.snapcraft_assets_dir, "snapcraft.yaml"
+            ),
+        )
 
         expected_icon = os.path.join(self.meta_dir, "gui", self.file_name)
         self.assertThat(expected_icon, FileContains(icon_content))
@@ -898,8 +935,21 @@ class MetadataFromSourceWithIconFileTestCase(CreateMetadataFromSourceBaseTestCas
 class MetadataFromSourceWithDesktopFileTestCase(CreateMetadataFromSourceBaseTestCase):
 
     scenarios = (
-        ("setup/gui", dict(directory=os.path.join("setup", "gui"))),
-        ("snap/gui", dict(directory=os.path.join("snap", "gui"))),
+        (
+            "setup/gui",
+            dict(snapcraft_assets_dir="snap", directory=os.path.join("setup", "gui")),
+        ),
+        (
+            "snap/gui",
+            dict(snapcraft_assets_dir="snap", directory=os.path.join("snap", "gui")),
+        ),
+        (
+            "build-aux/snap/gui",
+            dict(
+                snapcraft_assets_dir=os.path.join("build-aux", "snap"),
+                directory=os.path.join("build-aux", "snap", "gui"),
+            ),
+        ),
     )
 
     def test_metadata_doesnt_overwrite_desktop_file(self):
@@ -918,7 +968,12 @@ class MetadataFromSourceWithDesktopFileTestCase(CreateMetadataFromSourceBaseTest
 
         self.useFixture(fixture_setup.FakeMetadataExtractor("fake", _fake_extractor))
 
-        self.generate_meta_yaml(build=True)
+        self.generate_meta_yaml(
+            build=True,
+            snapcraft_yaml_file_path=os.path.join(
+                self.snapcraft_assets_dir, "snapcraft.yaml"
+            ),
+        )
 
         expected_desktop = os.path.join(self.meta_dir, "gui", "test-app.desktop")
         self.assertThat(expected_desktop, FileContains(desktop_content))


### PR DESCRIPTION
Many projects required an alternate snap directory to store
snapcraft related assets, in particular Gnome relate projects
have consolidated with the use of build-aux which snapcraft
is now adopting as an alternative as well.

LP: #1805219

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
