### PR TITLE
python plugin: graceful ret when no packages set

### DIFF
--- a/snapcraft/plugins/_python/_pip.py
+++ b/snapcraft/plugins/_python/_pip.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016-2017 Canonical Ltd
+# Copyright (C) 2016-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/snapcraft/plugins/_python/_pip.py
+++ b/snapcraft/plugins/_python/_pip.py
@@ -25,7 +25,7 @@ import stat
 import subprocess
 import sys
 import tempfile
-from typing import List, Set
+from typing import List, Optional, Sequence, Set
 
 import snapcraft
 from snapcraft import file_utils
@@ -37,26 +37,32 @@ logger = logging.getLogger(__name__)
 
 
 def _process_common_args(
-    *,
-    packages: List[str],
-    constraints: Set[str],
-    requirements: Set[str],
-    process_dependency_links: bool
+    *, constraints: Optional[Set[str]] = None, process_dependency_links: bool = False
 ) -> List[str]:
     args = []
     if constraints:
         for constraint in constraints:
             args.extend(["--constraint", constraint])
 
+    if process_dependency_links:
+        args.append("--process-dependency-links")
+
+    return args
+
+
+def _process_package_args(
+    *, packages: Sequence[str], requirements: Sequence[str], setup_py_dir: str
+) -> List[str]:
+    args = []
     if requirements:
         for requirement in requirements:
             args.extend(["--requirement", requirement])
 
-    if process_dependency_links:
-        args.append("--process-dependency-links")
-
     if packages:
         args.extend(packages)
+
+    if setup_py_dir:
+        args.append(".")
 
     return args
 
@@ -231,10 +237,10 @@ class Pip:
         self,
         packages,
         *,
-        setup_py_dir=None,
-        constraints=None,
-        requirements=None,
-        process_dependency_links=False
+        setup_py_dir: Optional[str] = None,
+        constraints: Optional[Set[str]] = None,
+        requirements: Optional[Sequence[str]] = None,
+        process_dependency_links: bool = False
     ):
         """Download packages into cache, but do not install them.
 
@@ -246,26 +252,25 @@ class Pip:
         :param boolean process_dependency_links: Enable the processing of
                                                  dependency links.
         """
-        args = _process_common_args(
-            process_dependency_links=process_dependency_links,
-            packages=packages,
-            constraints=constraints,
-            requirements=requirements,
+        package_args = _process_package_args(
+            packages=packages, requirements=requirements, setup_py_dir=setup_py_dir
         )
 
-        cwd = None
-        if setup_py_dir:
-            args.append(".")
-            cwd = setup_py_dir
-
-        if not args:
+        if not package_args:
             return  # No operation was requested
+
+        args = _process_common_args(
+            process_dependency_links=process_dependency_links, constraints=constraints
+        )
 
         # Using pip with a few special parameters:
         #
         # --disable-pip-version-check: Don't whine if pip is out-of-date with
         #                              the version on pypi.
         # --dest: Download packages into the directory we've set aside for it.
+        #
+        # For cwd, setup_py_dir will be the actual directory we need to be in
+        # or None.
         self._run(
             [
                 "download",
@@ -273,21 +278,22 @@ class Pip:
                 "--dest",
                 self._python_package_dir,
             ]
-            + args,
-            cwd=cwd,
+            + args
+            + package_args,
+            cwd=setup_py_dir,
         )
 
     def install(
         self,
         packages,
         *,
-        setup_py_dir=None,
-        constraints=None,
-        requirements=None,
-        process_dependency_links=False,
-        upgrade=False,
-        install_deps=True,
-        ignore_installed=False
+        setup_py_dir: Optional[str] = None,
+        constraints: Optional[Set[str]] = None,
+        requirements: Optional[Sequence[str]] = None,
+        process_dependency_links: bool = False,
+        upgrade: bool = False,
+        install_deps: bool = True,
+        ignore_installed: bool = False
     ):
         """Install packages from cache.
 
@@ -305,11 +311,15 @@ class Pip:
         :param boolean ignore_installed: Reinstall packages if they're already
                                          installed
         """
+        package_args = _process_package_args(
+            packages=packages, requirements=requirements, setup_py_dir=setup_py_dir
+        )
+
+        if not package_args:
+            return  # No operation was requested
+
         args = _process_common_args(
-            process_dependency_links=process_dependency_links,
-            packages=packages,
-            constraints=constraints,
-            requirements=requirements,
+            process_dependency_links=process_dependency_links, constraints=constraints
         )
 
         if upgrade:
@@ -320,14 +330,6 @@ class Pip:
 
         if ignore_installed:
             args.append("--ignore-installed")
-
-        cwd = None
-        if setup_py_dir:
-            args.append(".")
-            cwd = setup_py_dir
-
-        if not args:
-            return  # No operation was requested
 
         # Using pip with a few special parameters:
         #
@@ -340,6 +342,9 @@ class Pip:
         #             downloaded (i.e. by using `self.download()`)
         # --find-links: Provide the directory into which the packages should
         #               have already been fetched
+        #
+        # For cwd, setup_py_dir will be the actual directory we need to be in
+        # or None.
         self._run(
             [
                 "install",
@@ -349,8 +354,9 @@ class Pip:
                 "--find-links",
                 self._python_package_dir,
             ]
-            + args,
-            cwd=cwd,
+            + args
+            + package_args,
+            cwd=setup_py_dir,
         )
 
         # Installing with --user results in a directory with 700 permissions.
@@ -364,10 +370,10 @@ class Pip:
         self,
         packages,
         *,
-        setup_py_dir=None,
-        constraints=None,
-        requirements=None,
-        process_dependency_links=False
+        setup_py_dir: Optional[str] = None,
+        constraints: Optional[Set[str]] = None,
+        requirements: Optional[Sequence[str]] = None,
+        process_dependency_links: bool = False
     ):
         """Build wheels of packages in the cache.
 
@@ -384,22 +390,18 @@ class Pip:
         :return: List of paths to each wheel that was built.
         :rtype: list
         """
-        args = _process_common_args(
-            process_dependency_links=process_dependency_links,
-            packages=packages,
-            constraints=constraints,
-            requirements=requirements,
+        package_args = _process_package_args(
+            packages=packages, requirements=requirements, setup_py_dir=setup_py_dir
         )
 
-        cwd = None
-        if setup_py_dir:
-            args.append(".")
-            cwd = setup_py_dir
-
-        if not args:
+        if not package_args:
             return []  # No operation was requested
 
-        wheels = []
+        args = _process_common_args(
+            process_dependency_links=process_dependency_links, constraints=constraints
+        )
+
+        wheels = []  # type: List[str]
         with tempfile.TemporaryDirectory() as temp_dir:
 
             # Using pip with a few special parameters:
@@ -421,8 +423,9 @@ class Pip:
                     "--wheel-dir",
                     temp_dir,
                 ]
-                + args,
-                cwd=cwd,
+                + args
+                + package_args,
+                cwd=setup_py_dir,
             )
             wheels = os.listdir(temp_dir)
             for wheel in wheels:

--- a/tests/unit/plugins/python/test_pip.py
+++ b/tests/unit/plugins/python/test_pip.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017 Canonical Ltd
+# Copyright (C) 2017, 2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/tests/unit/plugins/python/test_pip.py
+++ b/tests/unit/plugins/python/test_pip.py
@@ -368,7 +368,7 @@ class PipCommandBaseTestCase(PipBaseTestCase):
         self.mock_run.reset_mock()
 
 
-class PipDownloadTestCase(PipCommandBaseTestCase):
+class PipDownloadTest(PipCommandBaseTestCase):
 
     scenarios = [
         (
@@ -392,22 +392,23 @@ class PipDownloadTestCase(PipCommandBaseTestCase):
         (
             "single constraint",
             {
-                "packages": [],
+                "packages": ["foo"],
                 "kwargs": {"constraints": ["constraint"]},
-                "expected_args": ["--constraint", "constraint"],
+                "expected_args": ["--constraint", "constraint", "foo"],
                 "expected_kwargs": {"cwd": None},
             },
         ),
         (
             "multiple constraints",
             {
-                "packages": [],
+                "packages": ["foo"],
                 "kwargs": {"constraints": ["constraint1", "constraint2"]},
                 "expected_args": [
                     "--constraint",
                     "constraint1",
                     "--constraint",
                     "constraint2",
+                    "foo",
                 ],
                 "expected_kwargs": {"cwd": None},
             },
@@ -438,9 +439,9 @@ class PipDownloadTestCase(PipCommandBaseTestCase):
         (
             "process dependency links",
             {
-                "packages": [],
+                "packages": ["foo"],
                 "kwargs": {"process_dependency_links": True},
-                "expected_args": ["--process-dependency-links"],
+                "expected_args": ["--process-dependency-links", "foo"],
                 "expected_kwargs": {"cwd": None},
             },
         ),
@@ -460,16 +461,16 @@ class PipDownloadTestCase(PipCommandBaseTestCase):
         common_args.extend(*args)
         self.mock_run.assert_called_once_with(common_args, **kwargs)
 
-    def test_without_packages_or_kwargs_should_noop(self):
+    def test_without_packages_or_setup_py_or_requirements_should_noop(self):
         self.pip.download([])
         self.mock_run.assert_not_called()
 
-    def test_with_packages_and_kwargs(self):
+    def test_with_packages_or_setup_py_or_requirements(self):
         self.pip.download(self.packages, **self.kwargs)
         self._assert_mock_run_with(self.expected_args, **self.expected_kwargs)
 
 
-class PipInstallTestCase(PipCommandBaseTestCase):
+class PipInstallTest(PipCommandBaseTestCase):
 
     scenarios = [
         (
@@ -493,22 +494,23 @@ class PipInstallTestCase(PipCommandBaseTestCase):
         (
             "single constraint",
             {
-                "packages": [],
+                "packages": ["foo"],
                 "kwargs": {"constraints": ["constraint"]},
-                "expected_args": ["--constraint", "constraint"],
+                "expected_args": ["--constraint", "constraint", "foo"],
                 "expected_kwargs": {"cwd": None},
             },
         ),
         (
             "multiple constraints",
             {
-                "packages": [],
+                "packages": ["foo"],
                 "kwargs": {"constraints": ["constraint1", "constraint2"]},
                 "expected_args": [
                     "--constraint",
                     "constraint1",
                     "--constraint",
                     "constraint2",
+                    "foo",
                 ],
                 "expected_kwargs": {"cwd": None},
             },
@@ -539,36 +541,36 @@ class PipInstallTestCase(PipCommandBaseTestCase):
         (
             "process dependency links",
             {
-                "packages": [],
+                "packages": ["foo"],
                 "kwargs": {"process_dependency_links": True},
-                "expected_args": ["--process-dependency-links"],
+                "expected_args": ["--process-dependency-links", "foo"],
                 "expected_kwargs": {"cwd": None},
             },
         ),
         (
             "upgrade",
             {
-                "packages": [],
+                "packages": ["foo"],
                 "kwargs": {"upgrade": True},
-                "expected_args": ["--upgrade"],
+                "expected_args": ["--upgrade", "foo"],
                 "expected_kwargs": {"cwd": None},
             },
         ),
         (
-            "install_deps",
+            "no install_deps",
             {
-                "packages": [],
+                "packages": ["foo"],
                 "kwargs": {"install_deps": False},
-                "expected_args": ["--no-deps"],
+                "expected_args": ["--no-deps", "foo"],
                 "expected_kwargs": {"cwd": None},
             },
         ),
         (
             "ignore_installed",
             {
-                "packages": [],
+                "packages": ["foo"],
                 "kwargs": {"ignore_installed": True},
-                "expected_args": ["--ignore-installed"],
+                "expected_args": ["--ignore-installed", "foo"],
                 "expected_kwargs": {"cwd": None},
             },
         ),
@@ -595,11 +597,11 @@ class PipInstallTestCase(PipCommandBaseTestCase):
         common_args.extend(*args)
         self.mock_run.assert_called_once_with(common_args, **kwargs)
 
-    def test_without_packages_or_kwargs_should_noop(self):
+    def test_without_packages_or_setup_py_or_requirements_should_noop(self):
         self.pip.install([])
         self.mock_run.assert_not_called()
 
-    def test_with_packages_and_kwargs(self):
+    def test_with_packages_or_setup_py_or_requirements(self):
         self.pip.install(self.packages, **self.kwargs)
         self._assert_mock_run_with(self.expected_args, **self.expected_kwargs)
 
@@ -724,7 +726,7 @@ class PipInstallFixupPermissionsTestCase(PipCommandBaseTestCase):
         self.assertFalse(mock_chmod.called)
 
 
-class PipWheelTestCase(PipCommandBaseTestCase):
+class PipWheelTest(PipCommandBaseTestCase):
 
     scenarios = [
         (
@@ -748,22 +750,23 @@ class PipWheelTestCase(PipCommandBaseTestCase):
         (
             "single constraint",
             {
-                "packages": [],
+                "packages": ["foo"],
                 "kwargs": {"constraints": ["constraint"]},
-                "expected_args": ["--constraint", "constraint"],
+                "expected_args": ["--constraint", "constraint", "foo"],
                 "expected_kwargs": {"cwd": None},
             },
         ),
         (
             "multiple constraints",
             {
-                "packages": [],
+                "packages": ["foo"],
                 "kwargs": {"constraints": ["constraint1", "constraint2"]},
                 "expected_args": [
                     "--constraint",
                     "constraint1",
                     "--constraint",
                     "constraint2",
+                    "foo",
                 ],
                 "expected_kwargs": {"cwd": None},
             },
@@ -794,9 +797,9 @@ class PipWheelTestCase(PipCommandBaseTestCase):
         (
             "process dependency links",
             {
-                "packages": [],
+                "packages": ["foo"],
                 "kwargs": {"process_dependency_links": True},
-                "expected_args": ["--process-dependency-links"],
+                "expected_args": ["--process-dependency-links", "foo"],
                 "expected_kwargs": {"cwd": None},
             },
         ),
@@ -823,11 +826,11 @@ class PipWheelTestCase(PipCommandBaseTestCase):
         common_args.extend(*args)
         self.mock_run.assert_called_once_with(common_args, **kwargs)
 
-    def test_without_packages_or_kwargs_should_noop(self):
+    def test_without_packages_or_setup_py_or_requirements_should_noop(self):
         self.pip.wheel([])
         self.mock_run.assert_not_called()
 
-    def test_with_packages_and_kwargs(self):
+    def test_with_packages_or_setup_py_or_requirements(self):
         self.pip.wheel(self.packages, **self.kwargs)
         self._assert_mock_run_with(self.expected_args, **self.expected_kwargs)
 


### PR DESCRIPTION
Return gracefully when no packages are provided in the package
related commands, these are:

- explicit python_packages
- requirements files
- setup.py directory

LP: #1794216
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
