### PR TITLE
nodejs pluging: support for type str bin entries

### DIFF
--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2018 Canonical Ltd
+# Copyright (C) 2015-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -290,28 +290,34 @@ class NodePlugin(snapcraft.BasePlugin):
 
 
 def _create_bins(package_json, directory):
-    binaries = package_json.get("bin")
-    if not binaries:
+    bin_entry = package_json.get("bin")
+    if not bin_entry:
         return
 
     bin_dir = os.path.join(directory, "bin")
     os.makedirs(bin_dir, exist_ok=True)
 
-    if type(binaries) == dict:
-        for bin_name, bin_path in binaries.items():
-            target = os.path.join(bin_dir, bin_name)
-            # The binary might be already created from upstream sources.
-            if os.path.exists(os.path.join(target)):
-                continue
-            source = os.path.join("..", bin_path)
-            os.symlink(source, target)
-            # Make it executable
-            os.chmod(os.path.realpath(target), 0o755)
+    if type(bin_entry) == dict:
+        binaries = bin_entry
+    elif type(bin_entry) == str:
+        # Support for scoped names of the form of @org/name
+        name = package_json["name"]
+        binaries = {name[name.find("/") + 1 :]: bin_entry}
     else:
         raise errors.SnapcraftEnvironmentError(
             "The plugin is not prepared to handle bin entries of "
-            "type {!r}".format(type(binaries))
+            "type {!r}".format(type(bin_entry))
         )
+
+    for bin_name, bin_path in binaries.items():
+        target = os.path.join(bin_dir, bin_name)
+        # The binary might be already created from upstream sources.
+        if os.path.exists(os.path.join(target)):
+            continue
+        source = os.path.join("..", bin_path)
+        os.symlink(source, target)
+        # Make it executable
+        os.chmod(os.path.realpath(target), 0o755)
 
 
 def _get_nodejs_base(node_engine, machine):

--- a/tests/unit/plugins/test_nodejs.py
+++ b/tests/unit/plugins/test_nodejs.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015, 2017-2018 Canonical Ltd
+# Copyright (C) 2015, 2017-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/tests/unit/plugins/test_nodejs.py
+++ b/tests/unit/plugins/test_nodejs.py
@@ -78,7 +78,11 @@ class NodePluginBaseTest(unit.TestCase):
         self.useFixture(fixture_setup.CleanEnvironment())
 
     def create_assets(
-        self, plugin, package_name="test-nodejs", skip_package_json=False
+        self,
+        plugin,
+        package_name="test-nodejs",
+        single_bin=False,
+        skip_package_json=False,
     ):
         for directory in (plugin.sourcedir, plugin.builddir):
             os.makedirs(directory)
@@ -553,6 +557,54 @@ class NodePluginYarnLockManifestTest(NodePluginBaseTest):
         expected_manifest["node-packages"] = []
 
         self.assertThat(plugin.get_manifest(), Equals(expected_manifest))
+
+
+class NodeBinTest(unit.TestCase):
+    scenarios = [
+        (
+            "dict",
+            dict(
+                package_json=dict(
+                    name="package-foo",
+                    bin=dict(run1="bin0/run1bin", run2="bin1/run2bin"),
+                ),
+                expected_bins=["run1", "run2"],
+            ),
+        ),
+        (
+            "single",
+            dict(
+                package_json=dict(name="package-foo", bin="bin0/run1bin"),
+                expected_bins=["package-foo"],
+            ),
+        ),
+        (
+            "single, scoped package",
+            dict(
+                package_json=dict(name="@org/package-foo", bin="bin1/run1bin"),
+                expected_bins=["package-foo"],
+            ),
+        ),
+    ]
+
+    def setUp(self):
+        super().setUp()
+
+        if type(self.package_json["bin"]) == dict:
+            binaries = self.package_json["bin"].values()
+        else:
+            binaries = [self.package_json["bin"]]
+
+        for binary in binaries:
+            os.makedirs(os.path.dirname(binary), exist_ok=True)
+            open(binary, "w").close()
+
+    def test_bins(self):
+        nodejs._create_bins(self.package_json, ".")
+        binary_paths = (os.path.join("bin", b) for b in self.expected_bins)
+
+        for binary in binary_paths:
+            self.assertThat(binary, FileExists())
 
 
 class NodeReleaseTest(unit.TestCase):


### PR DESCRIPTION
The plugin was only capable of parsing bin entries inside package.json
of type dict, this adds support for str entries, taking into account
scoped package names.

LP: #1817553
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
