### PR TITLE
cli: disable raven if not running from package

### DIFF
--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -30,7 +30,6 @@ from . import echo
 import snapcraft
 from snapcraft.config import CLIConfig as _CLIConfig
 from snapcraft.internal import errors
-from snapcraft.internal.common import is_snap
 from snapcraft.internal.build_providers.errors import ProviderExecError
 
 # raven is not available on 16.04
@@ -114,7 +113,7 @@ def exception_handler(  # noqa: C901
     is_snapcraft_reportable_error = issubclass(
         exception_type, errors.SnapcraftReportableError
     )
-    is_raven_setup = RavenClient is not None if is_snap() else False
+    is_raven_setup = snapcraft.internal.common.is_snap()
     is_connected_to_tty = (
         # used by inner instance, variable set by outer instance
         (distutils.util.strtobool(os.getenv("SNAPCRAFT_HAS_TTY", "n")) == 1)

--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -30,6 +30,7 @@ from . import echo
 import snapcraft
 from snapcraft.config import CLIConfig as _CLIConfig
 from snapcraft.internal import errors
+from snapcraft.internal.common import is_snap
 from snapcraft.internal.build_providers.errors import ProviderExecError
 
 # raven is not available on 16.04
@@ -113,7 +114,7 @@ def exception_handler(  # noqa: C901
     is_snapcraft_reportable_error = issubclass(
         exception_type, errors.SnapcraftReportableError
     )
-    is_raven_setup = RavenClient is not None
+    is_raven_setup = RavenClient is not None if is_snap() else False
     is_connected_to_tty = (
         # used by inner instance, variable set by outer instance
         (distutils.util.strtobool(os.getenv("SNAPCRAFT_HAS_TTY", "n")) == 1)

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -100,8 +100,9 @@ class ErrorsTestCase(ErrorsBaseTestCase):
         super().setUp()
 
     @mock.patch.object(snapcraft.cli._errors, "RavenClient")
+    @mock.patch("snapcraft.internal.common.is_snap", return_value=False)
     def test_handler_no_raven_traceback_non_snapcraft_exceptions_debug(
-        self, raven_client_mock
+        self, is_snap_mock, raven_client_mock
     ):
         snapcraft.cli._errors.RavenClient = None
         try:

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -29,7 +29,7 @@ from testscenarios import multiply_scenarios
 import snapcraft.internal.errors
 from snapcraft.internal.build_providers.errors import ProviderExecError
 from snapcraft.cli._errors import exception_handler
-from tests import unit
+from tests import fixture_setup, unit
 
 
 class TestSnapcraftError(snapcraft.internal.errors.SnapcraftError):
@@ -46,6 +46,8 @@ class TestSnapcraftError(snapcraft.internal.errors.SnapcraftError):
 class ErrorsBaseTestCase(unit.TestCase):
     def setUp(self):
         super().setUp()
+
+        self.useFixture(fixture_setup.FakeSnapcraftIsASnap())
 
         patcher = mock.patch("sys.exit")
         self.exit_mock = patcher.start()


### PR DESCRIPTION
In order to avoid bogus environment misconfiguration reports, only allow
Sentry submissions if running from the packaged distribution.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
