### PR TITLE
schema, tests: add more detail wrt numeric version errors

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -214,7 +214,7 @@
             "allOf": [
                 {
                     "type": "string",
-                    "validation-failure": "snap versions need to be strings."
+                    "validation-failure": "snap versions need to be strings. They must also be wrapped in quotes when the value will be interpreted by the YAML parser as a non-string. Examples: '1', '1.2', '1.2.3', git (will be replaced by a git describe based version string)."
                 },
                 {
                     "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9:.+~-]*[a-zA-Z0-9+~])?$",

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -865,7 +865,14 @@ class ValidVersionTest(ProjectBaseTest):
 
     scenarios = [
         (version, dict(version=version))
-        for version in ["buttered-popcorn", "1.2.3", "v12.4:1:2~", "HeLlo", "v+"]
+        for version in [
+            "'buttered-popcorn'",
+            "'1.2.3'",
+            '"1.2.3"',
+            "'v12.4:1:2~'",
+            "'HeLlo'",
+            "'v+'",
+        ]
     ]
 
     def test_valid_version(self):
@@ -874,7 +881,7 @@ class ValidVersionTest(ProjectBaseTest):
                 """\
             name: test
             base: core18
-            version: '{}'
+            version: {}
             summary: test
             description: test
             confinement: strict
@@ -963,7 +970,11 @@ class InvalidVersionSpecificTest(ProjectBaseTest):
             raised.message,
             Equals(
                 "The 'version' property does not match the required "
-                "schema: snap versions need to be strings."
+                "schema: snap versions need to be strings. They must "
+                "also be wrapped in quotes when the value will be "
+                "interpreted by the YAML parser as a non-string. "
+                "Examples: '1', '1.2', '1.2.3', git (will be replaced "
+                "by a git describe based version string)."
             ),
         )
 


### PR DESCRIPTION
Provide some more detail around numeric version error
messages as per the Snapcraft reference at
https://docs.snapcraft.io/snapcraft-yaml-reference.

Signed-off-by: Nathan Howard <adanhawthorn@gmail.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
