### PR TITLE
build providers: improve handling in snap logic

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -128,6 +128,10 @@ class Provider(abc.ABC):
     def _get_provider_name(cls) -> str:
         """Return the provider name."""
 
+    @abc.abstractclassmethod
+    def _get_is_snap_injection_capable(cls) -> bool:
+        """Return whether the provider can install snaps from the host."""
+
     @abc.abstractmethod
     def create(self) -> None:
         """Provider steps needed to create a fully functioning environment."""
@@ -257,8 +261,14 @@ class Provider(abc.ABC):
             self.provider_project_dir, "snap-registry.yaml"
         )
 
-        # We do not want to inject from the host if not running from the snap.
-        inject_from_host = common.is_snap()
+        # We do not want to inject from the host if not running from the snap
+        # or if the provider cannot handle snap mounts.
+        # This latter problem should go away when API for retrieving snaps
+        # through snapd is generally available.
+        if self._get_is_snap_injection_capable():
+            inject_from_host = common.is_snap()
+        else:
+            inject_from_host = False
 
         snap_injector = SnapInjector(
             snap_dir=self._SNAPS_MOUNTPOINT,

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -65,6 +65,10 @@ class Multipass(Provider):
     """A multipass provider for snapcraft to execute its lifecycle."""
 
     @classmethod
+    def _get_is_snap_injection_capable(cls) -> bool:
+        return True
+
+    @classmethod
     def _get_provider_name(cls):
         return "multipass"
 

--- a/snapcraft/internal/build_providers/_snap.py
+++ b/snapcraft/internal/build_providers/_snap.py
@@ -44,10 +44,9 @@ class _SnapOp(enum.Enum):
 
 def _get_snap_channel(snap_name: str) -> str:
     """Returns the channel to use for snap_name."""
-    if snap_name == "snapcraft":
-        channel = os.getenv(
-            "SNAPCRAFT_BUILD_ENVIRONMENT_CHANNEL_SNAPCRAFT", "latest/stable"
-        )
+    env_channel = os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT_CHANNEL_SNAPCRAFT", None)
+    if env_channel is not None and snap_name == "snapcraft":
+        channel = env_channel
         logger.warning(
             "SNAPCRAFT_BUILD_ENVIRONMENT_CHANNEL_SNAPCRAFT is set: installing "
             "snapcraft from {}".format(channel)
@@ -161,7 +160,7 @@ class _SnapManager:
     def _set_data(self) -> None:
         op = self.get_op()
         host_snap_repo = self._get_snap_repo()
-        install_cmd = ["sudo", "snap"]
+        install_cmd = ["snap"]
 
         if op == _SnapOp.INJECT:
             install_cmd.append("install")
@@ -299,21 +298,15 @@ class SnapInjector:
         # Disable autorefresh for 15 minutes,
         # https://github.com/snapcore/snapd/pull/5436/files
         now_plus_15 = datetime.datetime.now() + datetime.timedelta(minutes=15)
+        logger.debug("Holding refreshes for snaps.")
         self._runner(
-            [
-                "sudo",
-                "snap",
-                "set",
-                "core",
-                "refresh.hold={}Z".format(now_plus_15.isoformat()),
-            ]
+            ["snap", "set", "core", "refresh.hold={}Z".format(now_plus_15.isoformat())],
+            hide_output=True,
         )
         # Auto refresh may have kicked in while setting the hold.
         logger.debug("Waiting for pending snap auto refreshes.")
         with contextlib.suppress(errors.ProviderExecError):
-            self._runner(
-                ["sudo", "snap", "watch", "--last=auto-refresh"], hide_output=True
-            )
+            self._runner(["snap", "watch", "--last=auto-refresh"], hide_output=True)
 
     def _inject_assertions(self) -> None:
         assertions = []  # type: List[List[str]]
@@ -335,7 +328,7 @@ class SnapInjector:
             self._file_pusher(
                 source=assertion_file.name, destination=assertion_file.name
             )
-            self._runner(["sudo", "snap", "ack", assertion_file.name])
+            self._runner(["snap", "ack", assertion_file.name])
 
     def _get_latest_revision(self, snap_name) -> Optional[str]:
         try:

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -63,7 +63,12 @@ class ProviderImpl(Provider):
     def _push_file(self, *, source: str, destination: str) -> None:
         self.push_file_mock(source=source, destination=destination)
 
-    def _get_provider_name(self) -> str:
+    @classmethod
+    def _get_is_snap_injection_capable(cls) -> bool:
+        return True
+
+    @classmethod
+    def _get_provider_name(cls) -> str:
         return "stub-provider"
 
     def _umount(self):

--- a/tests/unit/build_providers/test_snap.py
+++ b/tests/unit/build_providers/test_snap.py
@@ -14,15 +14,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import os
 from textwrap import dedent
 from unittest.mock import call, patch, ANY
 
 import fixtures
-from testtools.matchers import FileContains
+from testtools.matchers import Contains, Equals, FileContains, Not
 
 from . import ProviderImpl, get_project
-from snapcraft.internal.build_providers._snap import SnapInjector, repo
+from snapcraft.internal.build_providers._snap import (
+    SnapInjector,
+    repo,
+    _get_snap_channel,
+)
 from tests import fixture_setup, unit
 
 
@@ -91,20 +96,12 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_has_calls(get_assertion_calls)
         self.provider.run_mock.assert_has_calls(
             [
-                call(["sudo", "snap", "set", "core", ANY]),
-                call(["sudo", "snap", "watch", "--last=auto-refresh"]),
-                call(["sudo", "snap", "ack", ANY]),
+                call(["snap", "set", "core", ANY]),
+                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "ack", ANY]),
+                call(["snap", "install", "/var/cache/snapcraft/snaps/core_123.snap"]),
                 call(
                     [
-                        "sudo",
-                        "snap",
-                        "install",
-                        "/var/cache/snapcraft/snaps/core_123.snap",
-                    ]
-                ),
-                call(
-                    [
-                        "sudo",
                         "snap",
                         "install",
                         "--classic",
@@ -156,12 +153,11 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_not_called()
         self.provider.run_mock.assert_has_calls(
             [
-                call(["sudo", "snap", "set", "core", ANY]),
-                call(["sudo", "snap", "watch", "--last=auto-refresh"]),
-                call(["sudo", "snap", "install", "--channel", "latest/stable", "core"]),
+                call(["snap", "set", "core", ANY]),
+                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "install", "--channel", "latest/stable", "core"]),
                 call(
                     [
-                        "sudo",
                         "snap",
                         "install",
                         "--classic",
@@ -232,20 +228,12 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_has_calls(get_assertion_calls)
         self.provider.run_mock.assert_has_calls(
             [
-                call(["sudo", "snap", "set", "core", ANY]),
-                call(["sudo", "snap", "watch", "--last=auto-refresh"]),
-                call(["sudo", "snap", "ack", ANY]),
+                call(["snap", "set", "core", ANY]),
+                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "ack", ANY]),
+                call(["snap", "install", "/var/cache/snapcraft/snaps/core_123.snap"]),
                 call(
                     [
-                        "sudo",
-                        "snap",
-                        "install",
-                        "/var/cache/snapcraft/snaps/core_123.snap",
-                    ]
-                ),
-                call(
-                    [
-                        "sudo",
                         "snap",
                         "install",
                         "--dangerous",
@@ -297,12 +285,11 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_not_called()
         self.provider.run_mock.assert_has_calls(
             [
-                call(["sudo", "snap", "set", "core", ANY]),
-                call(["sudo", "snap", "watch", "--last=auto-refresh"]),
-                call(["sudo", "snap", "install", "--channel", "latest/stable", "core"]),
+                call(["snap", "set", "core", ANY]),
+                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "install", "--channel", "latest/stable", "core"]),
                 call(
                     [
-                        "sudo",
                         "snap",
                         "install",
                         "--classic",
@@ -354,12 +341,11 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_not_called()
         self.provider.run_mock.assert_has_calls(
             [
-                call(["sudo", "snap", "set", "core", ANY]),
-                call(["sudo", "snap", "watch", "--last=auto-refresh"]),
-                call(["sudo", "snap", "install", "--channel", "latest/stable", "core"]),
+                call(["snap", "set", "core", ANY]),
+                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "install", "--channel", "latest/stable", "core"]),
                 call(
                     [
-                        "sudo",
                         "snap",
                         "install",
                         "--classic",
@@ -405,12 +391,11 @@ class SnapInjectionTest(unit.TestCase):
 
         self.provider.run_mock.assert_has_calls(
             [
-                call(["sudo", "snap", "set", "core", ANY]),
-                call(["sudo", "snap", "watch", "--last=auto-refresh"]),
-                call(["sudo", "snap", "install", "--channel", "latest/stable", "core"]),
+                call(["snap", "set", "core", ANY]),
+                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "install", "--channel", "latest/stable", "core"]),
                 call(
                     [
-                        "sudo",
                         "snap",
                         "install",
                         "--classic",
@@ -438,12 +423,11 @@ class SnapInjectionTest(unit.TestCase):
 
         self.provider.run_mock.assert_has_calls(
             [
-                call(["sudo", "snap", "set", "core", ANY]),
-                call(["sudo", "snap", "watch", "--last=auto-refresh"]),
-                call(["sudo", "snap", "install", "--channel", "latest/stable", "core"]),
+                call(["snap", "set", "core", ANY]),
+                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "install", "--channel", "latest/stable", "core"]),
                 call(
                     [
-                        "sudo",
                         "snap",
                         "install",
                         "--classic",
@@ -541,12 +525,11 @@ class SnapInjectionTest(unit.TestCase):
 
         self.provider.run_mock.assert_has_calls(
             [
-                call(["sudo", "snap", "set", "core", ANY]),
-                call(["sudo", "snap", "watch", "--last=auto-refresh"]),
-                call(["sudo", "snap", "refresh", "--channel", "latest/stable", "core"]),
+                call(["snap", "set", "core", ANY]),
+                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "refresh", "--channel", "latest/stable", "core"]),
                 call(
                     [
-                        "sudo",
                         "snap",
                         "refresh",
                         "--classic",
@@ -582,12 +565,11 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_not_called()
         self.provider.run_mock.assert_has_calls(
             [
-                call(["sudo", "snap", "set", "core", ANY]),
-                call(["sudo", "snap", "watch", "--last=auto-refresh"]),
-                call(["sudo", "snap", "install", "--channel", "latest/stable", "core"]),
+                call(["snap", "set", "core", ANY]),
+                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "install", "--channel", "latest/stable", "core"]),
                 call(
                     [
-                        "sudo",
                         "snap",
                         "install",
                         "--classic",
@@ -611,6 +593,70 @@ class SnapInjectionTest(unit.TestCase):
                     snapcraft:
                     - revision: '25'
                     """
+                )
+            ),
+        )
+
+
+class GetChannelTest(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.fake_logger = fixtures.FakeLogger(level=logging.WARNING)
+        self.useFixture(self.fake_logger)
+
+    def test_default_channel_for_snapcraft(self):
+        self.assertThat(_get_snap_channel("snapcraft"), Equals("latest/stable"))
+        self.assertThat(
+            self.fake_logger.output,
+            Not(
+                Contains(
+                    "SNAPCRAFT_BUILD_ENVIRONMENT_CHANNEL_SNAPCRAFT is set: installing "
+                    "snapcraft from"
+                )
+            ),
+        )
+
+    def test_channel_for_snapcraft_from_env(self):
+        self.useFixture(
+            fixtures.EnvironmentVariable(
+                "SNAPCRAFT_BUILD_ENVIRONMENT_CHANNEL_SNAPCRAFT", "latest/edge"
+            )
+        )
+        self.assertThat(_get_snap_channel("snapcraft"), Equals("latest/edge"))
+        self.assertThat(
+            self.fake_logger.output,
+            Contains(
+                "SNAPCRAFT_BUILD_ENVIRONMENT_CHANNEL_SNAPCRAFT is set: installing "
+                "snapcraft from latest/edge"
+            ),
+        )
+
+    def test_default_channel_for_other_snap(self):
+        self.assertThat(_get_snap_channel("core"), Equals("latest/stable"))
+        self.assertThat(
+            self.fake_logger.output,
+            Not(
+                Contains(
+                    "SNAPCRAFT_BUILD_ENVIRONMENT_CHANNEL_SNAPCRAFT is set: installing "
+                    "snapcraft from"
+                )
+            ),
+        )
+
+    def test_channel_for_other_snap_not_affected_by_env(self):
+        self.useFixture(
+            fixtures.EnvironmentVariable(
+                "SNAPCRAFT_BUILD_ENVIRONMENT_CHANNEL_SNAPCRAFT", "latest/edge"
+            )
+        )
+        self.assertThat(_get_snap_channel("core"), Equals("latest/stable"))
+        self.assertThat(
+            self.fake_logger.output,
+            Not(
+                Contains(
+                    "SNAPCRAFT_BUILD_ENVIRONMENT_CHANNEL_SNAPCRAFT is set: installing "
+                    "snapcraft from"
                 )
             ),
         )


### PR DESCRIPTION
Cleanup up the channel warning when the
SNAPCRAFT_BUILD_ENVIRONMENT_CHANNEL_SNAPCRAFT is not set.
Removed unnecessary use of sudo, given that the providers all run as
root.
Silenced the call on holds for refreshes as it is unnecessarily noisy
and adds little value to users.

LP: #1820864
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
