### PR TITLE
build providers: modify the _run signature

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018 Canonical Ltd
+# Copyright (C) 2018-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -145,7 +145,7 @@ class Provider(abc.ABC):
         """
 
     @abc.abstractmethod
-    def _run(self, command: Sequence[str]) -> None:
+    def _run(self, command: Sequence[str]) -> Optional[bytes]:
         """Run a command on the instance."""
 
     @abc.abstractmethod

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018 Canonical Ltd
+# Copyright (C) 2018-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
 import logging
 import os
 import sys
-from typing import Dict, Sequence
+from typing import Dict, Optional, Sequence
 
 from .. import errors
 from .._base_provider import Provider
@@ -72,10 +72,12 @@ class Multipass(Provider):
     def _get_provider_name(cls):
         return "multipass"
 
-    def _run(self, command: Sequence[str], hide_output: bool = False) -> None:
+    def _run(
+        self, command: Sequence[str], hide_output: bool = False
+    ) -> Optional[bytes]:
         has_tty = "SNAPCRAFT_HAS_TTY={}".format(sys.stdout.isatty())
         command = ["sudo", "-i", "env", has_tty] + list(command)
-        self._multipass_cmd.execute(
+        return self._multipass_cmd.execute(
             instance_name=self.instance_name, command=command, hide_output=hide_output
         )
 
@@ -186,13 +188,7 @@ class Multipass(Provider):
     def mount_project(self) -> None:
         # Resolve the home directory
         home_dir = (
-            self._multipass_cmd.execute(
-                command=["sudo", "-i", "printenv", "HOME"],
-                hide_output=True,
-                instance_name=self.instance_name,
-            )
-            .decode()
-            .strip()
+            self._run(command=["printenv", "HOME"], hide_output=True).decode().strip()
         )
         project_mountpoint = os.path.join(home_dir, "project")
 
@@ -215,22 +211,16 @@ class Multipass(Provider):
         # TODO add instance check.
 
         # check if file exists in instance
-        self._multipass_cmd.execute(
-            command=["test", "-f", name], instance_name=self.instance_name
-        )
+        self._run(command=["test", "-f", name])
 
         # copy file from instance
         source = "{}:{}".format(self.instance_name, name)
         self._multipass_cmd.copy_files(source=source, destination=destination)
         if delete:
-            self._multipass_cmd.execute(
-                instance_name=self.instance_name, command=["sudo", "-i", "rm", name]
-            )
+            self._run(command=["rm", name])
 
     def shell(self) -> None:
-        self._multipass_cmd.execute(
-            instance_name=self.instance_name, command=["sudo", "-i", "/bin/bash"]
-        )
+        self._run(command=["/bin/bash"])
 
     def _get_instance_info(self):
         instance_info_raw = self._multipass_cmd.info(

--- a/snapcraft/internal/build_providers/_snap.py
+++ b/snapcraft/internal/build_providers/_snap.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018 Canonical Ltd
+# Copyright (C) 2018-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -246,7 +246,7 @@ class SnapInjector:
         snap_dir: str,
         registry_filepath: str,
         snap_arch: str,
-        runner: Callable[..., None],
+        runner: Callable[..., Optional[bytes]],
         snap_dir_mounter: Callable[[], None],
         snap_dir_unmounter: Callable[[], None],
         file_pusher: Callable[..., None],

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018 Canonical Ltd
+# Copyright (C) 2018-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Optional
 from unittest import mock
 
 from snapcraft.project import Project
@@ -39,7 +40,7 @@ class ProviderImpl(Provider):
         self.shell_mock = mock.Mock()
         self.save_info_mock = mock.Mock()
 
-    def _run(self, command, hide_output=False):
+    def _run(self, command, hide_output=False) -> Optional[bytes]:
         self.run_mock(command)
 
     def _launch(self) -> None:

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018 Canonical Ltd
+# Copyright (C) 2018-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -267,7 +267,17 @@ class MultipassTest(BaseProviderBaseTest):
         multipass.pull_file("src.txt", "dest.txt")
 
         self.multipass_cmd_mock().execute.assert_called_once_with(
-            command=["test", "-f", "src.txt"], instance_name="snapcraft-project-name"
+            command=[
+                "sudo",
+                "-i",
+                "env",
+                "SNAPCRAFT_HAS_TTY=False",
+                "test",
+                "-f",
+                "src.txt",
+            ],
+            hide_output=False,
+            instance_name="snapcraft-project-name",
         )
 
         self.multipass_cmd_mock().copy_files.assert_called_once_with(
@@ -290,11 +300,28 @@ class MultipassTest(BaseProviderBaseTest):
         self.multipass_cmd_mock().execute.assert_has_calls(
             [
                 mock.call(
-                    command=["test", "-f", "src.txt"],
+                    command=[
+                        "sudo",
+                        "-i",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "test",
+                        "-f",
+                        "src.txt",
+                    ],
+                    hide_output=False,
                     instance_name="snapcraft-project-name",
                 ),
                 mock.call(
-                    command=["sudo", "-i", "rm", "src.txt"],
+                    command=[
+                        "sudo",
+                        "-i",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "rm",
+                        "src.txt",
+                    ],
+                    hide_output=False,
                     instance_name="snapcraft-project-name",
                 ),
             ]
@@ -396,7 +423,7 @@ class MultipassWithBasesTest(BaseProviderWithBasesBaseTest):
         self.project = get_project(base=self.base)
 
         def execute_effect(*, command, instance_name, hide_output):
-            if command == ["sudo", "-i", "printenv", "HOME"]:
+            if command[-2] == "printenv" and command[-1] == "HOME":
                 return "/root".encode()
             elif hide_output:
                 return None
@@ -437,7 +464,14 @@ class MultipassWithBasesTest(BaseProviderWithBasesBaseTest):
                 mock.call(
                     instance_name=self.instance_name,
                     hide_output=True,
-                    command=["sudo", "-i", "printenv", "HOME"],
+                    command=[
+                        "sudo",
+                        "-i",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "printenv",
+                        "HOME",
+                    ],
                 ),
                 mock.call(
                     instance_name=self.instance_name,


### PR DESCRIPTION
Extend the signature for _run to be able to return output. Use this
across the Multipass implementation which wraps execute instead of
calling exectute for everywhere.

LP: #1821401
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
