### PR TITLE
many: better handling of appstream icons

### DIFF
--- a/snapcraft/extractors/appstream.py
+++ b/snapcraft/extractors/appstream.py
@@ -177,11 +177,8 @@ def _extract_icon(workdir: str, icon_path: str, desktop_file_paths: List[str]) -
     # we'll fall back to what's listed in the desktop file.
     if icon_path is None:
         return _get_icon_from_desktop_file(workdir, desktop_file_paths)
-    elif os.path.isabs(icon_path):
-        if os.path.exists(os.path.join(workdir, icon_path.lstrip("/"))):
-            return icon_path
-        else:
-            return _get_icon_from_desktop_file(workdir, desktop_file_paths)
+    elif os.path.exists(os.path.join(workdir, icon_path.lstrip("/"))):
+        return icon_path
     else:
         return _get_icon_from_desktop_file(workdir, desktop_file_paths)
 

--- a/snapcraft/extractors/appstream.py
+++ b/snapcraft/extractors/appstream.py
@@ -14,12 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import operator
 import os
 from io import StringIO
 from typing import List
 
 import lxml.etree
 
+from xdg.DesktopEntry import DesktopEntry
 from ._metadata import ExtractedMetadata
 from snapcraft.extractors import _errors
 
@@ -75,14 +77,20 @@ def extract(relpath: str, *, workdir: str) -> ExtractedMetadata:
     summary = _get_value_from_xml_element(dom, "summary")
     description = _get_value_from_xml_element(dom, "description")
 
-    icon = None
     node = dom.find("icon")
-    if node is not None and "type" in node.attrib and node.attrib["type"] == "local":
-        # TODO Currently we only support local icons.
+    icon = node.text.strip() if node is not None else None
+
+    if node is not None and "type" in node.attrib:
+        node_type = node.attrib["type"]
+    else:
+        node_type = None
+
+    if node_type == "remote":
+        # TODO Currently we only support local and stock icons.
         # See bug https://bugs.launchpad.net/snapcraft/+bug/1742348
         # for supporting remote icons.
         # --elopio -20180109
-        icon = node.text.strip()
+        icon = None
 
     desktop_file_paths = []
     desktop_file_ids = _get_desktop_file_ids_from_nodes(dom.findall("launchable"))
@@ -95,6 +103,11 @@ def extract(relpath: str, *, workdir: str) -> ExtractedMetadata:
         desktop_file_path = _desktop_file_id_to_path(desktop_file_id, workdir=workdir)
         if desktop_file_path:
             desktop_file_paths.append(desktop_file_path)
+
+    if node_type == "stock":
+        icon = _get_icon_from_theme(workdir, "hicolor", icon)
+    else:
+        icon = _extract_icon(workdir, icon, desktop_file_paths)
 
     return ExtractedMetadata(
         common_id=common_id,
@@ -157,3 +170,72 @@ def _desktop_file_id_to_path(desktop_file_id: str, *, workdir: str) -> str:
             return desktop_file_path
     else:
         return None
+
+
+def _extract_icon(workdir: str, icon_path: str, desktop_file_paths: List[str]) -> str:
+    # If an icon path is specified and the icon file exists, we'll use that, otherwise
+    # we'll fall back to what's listed in the desktop file.
+    if icon_path is None:
+        return _get_icon_from_desktop_file(workdir, desktop_file_paths)
+    elif os.path.isabs(icon_path):
+        if os.path.exists(os.path.join(workdir, icon_path.lstrip("/"))):
+            return icon_path
+        else:
+            return _get_icon_from_desktop_file(workdir, desktop_file_paths)
+    else:
+        return _get_icon_from_desktop_file(workdir, desktop_file_paths)
+
+
+def _get_icon_from_desktop_file(workdir: str, desktop_file_paths: List[str]) -> str:
+    # Icons in the desktop file can be either a full path to the icon file, or a name
+    # to be searched in the standard locations. If the path is specified, use that,
+    # otherwise look for the icon in the hicolor theme (also covers icon type="stock").
+    # See https://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html
+    # for further information.
+    for path in desktop_file_paths:
+        entry = DesktopEntry()
+        entry.parse(os.path.join(workdir, path))
+        icon = entry.getIcon()
+        icon_path = (
+            icon
+            if os.path.isabs(icon)
+            else _get_icon_from_theme(workdir, "hicolor", icon)
+        )
+        return icon_path
+
+    return None
+
+
+def _get_icon_from_theme(workdir: str, theme: str, icon: str) -> str:
+    # Icon themes can carry icons in different pre-rendered sizes or scalable. Scalable
+    # implementation is optional, so we'll try the largest pixmap and then scalable if
+    # no other sizes are available.
+    theme_dir = os.path.join("usr", "share", "icons", theme)
+    if not os.path.exists(os.path.join(workdir, theme_dir)):
+        return None
+
+    entries = os.listdir(os.path.join(workdir, theme_dir))
+    sizes = {}
+    for entry in entries:
+        if "x" in entry:
+            sizes[int(entry.split("x")[0])] = entry
+
+    if sizes:
+        size = max(sizes.items(), key=operator.itemgetter(1))[0]
+        icon_size = sizes[size]
+        suffixes = [".png", ".xpm"]
+    elif "scalable" in entries:
+        icon_size = "scalable"
+        suffixes = [".svg", ".svgz"]
+    else:
+        icon_size = None
+
+    if icon_size:
+        for suffix in suffixes:
+            icon_path = os.path.join(theme_dir, icon_size, "apps", icon + suffix)
+            if os.path.exists(os.path.join(workdir, icon_path)):
+                break
+        else:
+            icon_path = None
+
+    return icon_path

--- a/snapcraft/internal/meta/_desktop.py
+++ b/snapcraft/internal/meta/_desktop.py
@@ -57,14 +57,14 @@ class DesktopFile:
             exec_value = "{}.{} %U".format(self._snap_name, self._name)
         self._parser[section]["Exec"] = exec_value
         if "Icon" in self._parser[section]:
+            icon = self._parser[section]["Icon"]
+
             # Extracted metadata (e.g. from the AppStream) can override the
             # icon location.
             if extracted_metadata:
-                metadata_dict = extracted_metadata.to_dict()
-                if "icon" in metadata_dict:
-                    icon = "/" + str(metadata_dict["icon"])
-            else:
-                icon = self._parser[section]["Icon"]
+                metadata_icon = extracted_metadata.get_icon()
+                if metadata_icon is not None:
+                    icon = "/" + metadata_icon
 
             if icon.startswith("/"):
                 icon = icon.lstrip("/")

--- a/snapcraft/internal/meta/_desktop.py
+++ b/snapcraft/internal/meta/_desktop.py
@@ -41,6 +41,7 @@ class DesktopFile:
 
     def parse_and_reformat(self, extracted_metadata: _metadata.ExtractedMetadata):
         self._parser = configparser.ConfigParser(interpolation=None)
+        # mypy type checking ignored, see https://github.com/python/mypy/issues/506
         self._parser.optionxform = str  # type: ignore
         self._parser.read(self._path, encoding="utf-8")
         section = "Desktop Entry"
@@ -64,17 +65,16 @@ class DesktopFile:
             if extracted_metadata:
                 metadata_icon = extracted_metadata.get_icon()
                 if metadata_icon is not None:
-                    icon = "/" + metadata_icon
+                    icon = metadata_icon
 
-            if icon.startswith("/"):
-                icon = icon.lstrip("/")
-                if os.path.exists(os.path.join(self._prime_dir, icon)):
-                    self._parser[section]["Icon"] = "${{SNAP}}/{}".format(icon)
-                else:
-                    logger.warning(
-                        "Icon {} specified in desktop file {} not found "
-                        "in prime directory".format(icon, self._filename)
-                    )
+            icon = icon.lstrip("/")
+            if os.path.exists(os.path.join(self._prime_dir, icon)):
+                self._parser[section]["Icon"] = "${{SNAP}}/{}".format(icon)
+            else:
+                logger.warning(
+                    "Icon {} specified in desktop file {} not found "
+                    "in prime directory".format(icon, self._filename)
+                )
 
     def write(self, *, gui_dir: str) -> None:
         # Rename the desktop file to match the app name. This will help

--- a/snapcraft/internal/pluginhandler/_metadata_extraction.py
+++ b/snapcraft/internal/pluginhandler/_metadata_extraction.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 def extract_metadata(
-    part_name: str, file_relpath: str, workdir: str, primedir: str = None
+    part_name: str, file_relpath: str, workdir: str
 ) -> extractors.ExtractedMetadata:
     if not os.path.exists(os.path.join(workdir, file_relpath)):
         raise MissingMetadataFileError(part_name, file_relpath)

--- a/snapcraft/internal/pluginhandler/_metadata_extraction.py
+++ b/snapcraft/internal/pluginhandler/_metadata_extraction.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017 Canonical Ltd
+# Copyright (C) 2017-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 def extract_metadata(
-    part_name: str, file_relpath: str, workdir: str
+    part_name: str, file_relpath: str, workdir: str, primedir: str = None
 ) -> extractors.ExtractedMetadata:
     if not os.path.exists(os.path.join(workdir, file_relpath)):
         raise MissingMetadataFileError(part_name, file_relpath)

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2018 Canonical Ltd
+# Copyright (C) 2015-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -1462,8 +1462,9 @@ class BaseWrapTest(unit.TestCase):
             yaml_utils.dump(self.snapcraft_yaml, stream=snapcraft_file)
         project = Project(snapcraft_yaml_file_path=snapcraft_yaml_file_path)
         config = project_loader.load_config(project)
+        metadata = extractors.ExtractedMetadata()
         # TODO move to use outer interface
-        self.packager = _snap_packaging._SnapPackaging(config)
+        self.packager = _snap_packaging._SnapPackaging(config, metadata)
         self.packager._is_host_compatible_with_base = True
 
 
@@ -1559,7 +1560,8 @@ class WrapExeTest(BaseWrapTest):
 
         project = Project(snapcraft_yaml_file_path=snapcraft_yaml_file_path)
         config = project_loader.load_config(project)
-        packager = _snap_packaging._SnapPackaging(config)
+        metadata = extractors.ExtractedMetadata()
+        packager = _snap_packaging._SnapPackaging(config, metadata)
         packager._is_host_compatible_with_base = True
 
         packager.write_snap_yaml()
@@ -1753,8 +1755,9 @@ class FullAdapterTest(unit.TestCase):
 
         project = Project(snapcraft_yaml_file_path="snapcraft.yaml")
         config = project_loader.load_config(project)
+        metadata = extractors.ExtractedMetadata()
         # TODO move to use outer interface
-        packager = _snap_packaging._SnapPackaging(config)
+        packager = _snap_packaging._SnapPackaging(config, metadata)
         packager._is_host_compatible_with_base = True
 
         return packager
@@ -1926,8 +1929,9 @@ class CommandChainTest(unit.TestCase):
 
         project = Project(snapcraft_yaml_file_path="snapcraft.yaml")
         config = project_loader.load_config(project)
+        metadata = extractors.ExtractedMetadata()
         # TODO move to use outer interface
-        packager = _snap_packaging._SnapPackaging(config)
+        packager = _snap_packaging._SnapPackaging(config, metadata)
         packager._is_host_compatible_with_base = True
 
         return packager


### PR DESCRIPTION
Appstream icons can be specified as a full path ("local") or just the
application name to be searched in the standard locations ("stock").
The system search for stock icons doesn't include directories that are
part of snap packages, so support stock icons by resolving the path
at packaging time. If icons are not specified in the AppStream file,
use the desktop file definition instead.

LP: #1814898

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
