### PR TITLE
repo: handle deb package fetch error

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2017 Canonical Ltd
+# Copyright (C) 2015-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -500,10 +500,13 @@ class Ubuntu(BaseRepo):
         pkg_list = []
         for package in apt_cache.get_changes():
             pkg_list.append(str(package.candidate))
-            source = self._apt.fetch_binary(
-                package_candidate=package.candidate,
-                destination=self._cache.packages_dir,
-            )
+            try:
+                source = self._apt.fetch_binary(
+                    package_candidate=package.candidate,
+                    destination=self._cache.packages_dir,
+                )
+            except apt.package.FetchError as e:
+                raise errors.PackageFetchError(str(e))
             destination = os.path.join(self._downloaddir, os.path.basename(source))
             with contextlib.suppress(FileNotFoundError):
                 os.remove(destination)

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2018 Canonical Ltd
+# Copyright (C) 2015-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -69,6 +69,14 @@ class BuildPackagesNotInstalledError(RepoError):
 
     def __init__(self, *, packages: List[str]) -> None:
         super().__init__(packages=" ".join(packages))
+
+
+class PackageFetchError(RepoError):
+
+    fmt = "Package fetch error: {message}"
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message=message)
 
 
 class PackageBrokenError(RepoError):

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2018 Canonical Ltd
+# Copyright (C) 2015-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -151,6 +151,18 @@ class UbuntuTestCase(RepoBaseTestCase):
             os.path.join(self.path, "fake-trusted-parts").lstrip("/"),
         )
         self.assertThat(os.listdir(trusted_parts_dir), Equals(["trusted-part.gpg"]))
+
+    @patch("snapcraft.internal.repo._deb._AptCache.fetch_binary")
+    @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
+    def test_get_package_fetch_error(self, mock_apt_pkg, mock_fetch_binary):
+        mock_fetch_binary.side_effect = apt.package.FetchError("foo")
+        self.mock_cache().is_virtual_package.return_value = False
+        project_options = snapcraft.ProjectOptions()
+        ubuntu = repo.Ubuntu(self.tempdir, project_options=project_options)
+        raised = self.assertRaises(
+            errors.PackageFetchError, ubuntu.get, ["fake-package"]
+        )
+        self.assertThat(str(raised), Equals("Package fetch error: foo"))
 
     @patch("snapcraft.internal.repo._deb._AptCache.fetch_binary")
     @patch("snapcraft.internal.repo._deb.apt.apt_pkg")


### PR DESCRIPTION
End gracefully instead of crashing if a deb package can't be
fetched.

Fixes SNAPCRAFT-JE
Fixes SNAPCRAFT-JF

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
