### PR TITLE
build providers: support for provider setup

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -14,12 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import subprocess
 import logging
 import typing
-import sys
 import os
-from time import sleep
 
 import click
 
@@ -27,19 +24,13 @@ from . import echo
 from . import env
 from ._options import add_build_options, get_project
 from snapcraft.internal import (
-    errors,
     build_providers,
     deprecations,
     lifecycle,
     project_loader,
     steps,
-    repo,
 )
-from snapcraft.project._sanity_checks import (
-    conduct_project_sanity_check,
-    conduct_build_environment_sanity_check,
-)
-from snapcraft.project.errors import MultipassMissingInstallableError
+from snapcraft.project._sanity_checks import conduct_project_sanity_check
 from ._errors import TRACEBACK_MANAGED, TRACEBACK_HOST
 
 
@@ -48,37 +39,6 @@ logger = logging.getLogger(__name__)
 
 if typing.TYPE_CHECKING:
     from snapcraft.internal.project import Project  # noqa: F401
-
-
-def _install_multipass():
-    if sys.platform == "linux":
-        repo.snaps.install_snaps(["multipass/latest/beta"])
-    elif sys.platform == "darwin":
-        try:
-            subprocess.check_call(["brew", "cask", "install", "multipass"])
-        except subprocess.CalledProcessError:
-            raise errors.SnapcraftEnvironmentError(
-                "Failed to install multipass using homebrew.\n"
-                "Verify your homebrew installation and try again.\n"
-                "Alternatively, manually install multipass by running 'brew cask install multipass'."
-            )
-
-    # wait for multipassd to be available
-    click.echo("Waiting for multipass...")
-    retry_count = 20
-    while retry_count:
-        try:
-            output = subprocess.check_output(["multipass", "version"]).decode()
-        except subprocess.CalledProcessError:
-            output = ""
-        # if multipassd is in the version information, it means the service is up
-        # and we can carry on
-        if "multipassd" in output:
-            break
-        retry_count -= 1
-        sleep(1)
-    # No need to worry about getting to this point by exhausting our retry count,
-    # the rest of the stack will handle the error appropriately.
 
 
 # TODO: when snap is a real step we can simplify the arguments here.
@@ -95,20 +55,6 @@ def _execute(  # noqa: C901
     _clean_provider_error()
     provider = "host" if destructive_mode else None
     build_environment = env.BuilderEnvironmentConfig(force_provider=provider)
-    try:
-        conduct_build_environment_sanity_check(build_environment.provider)
-    except MultipassMissingInstallableError as e:
-        click.echo(
-            "You need multipass installed to build snaps "
-            "(https://github.com/CanonicalLtd/multipass)."
-        )
-        if click.confirm("Would you like to install it now?"):
-            _install_multipass()
-        else:
-            raise errors.SnapcraftEnvironmentError(
-                "multipass is required to continue."
-            ) from e
-
     project = get_project(is_managed_host=build_environment.is_managed_host, **kwargs)
 
     echo.wrapped(
@@ -130,6 +76,18 @@ def _execute(  # noqa: C901
         build_provider_class = build_providers.get_provider_for(
             build_environment.provider
         )
+        try:
+            build_provider_class.ensure_provider()
+        except build_providers.errors.ProviderNotFound as provider_error:
+            if provider_error.prompt_installable:
+                click.echo(str(provider_error))
+                if click.confirm("Would you like to install it now?"):
+                    build_provider_class.setup_provider(echoer=echo)
+                else:
+                    raise provider_error
+            else:
+                raise provider_error
+
         echo.info("Launching a VM.")
         with build_provider_class(project=project, echoer=echo) as instance:
             instance.mount_project()

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -124,10 +124,22 @@ class Provider(abc.ABC):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.destroy()
 
+    @classmethod
+    @abc.abstractclassmethod
+    def ensure_provider(cls) -> None:
+        """Necessary steps to ensure the provider is correctly setup."""
+
+    @classmethod
+    @abc.abstractclassmethod
+    def setup_provider(cls, *, echoer) -> None:
+        """Necessary steps to install the provider on the host."""
+
+    @classmethod
     @abc.abstractclassmethod
     def _get_provider_name(cls) -> str:
         """Return the provider name."""
 
+    @classmethod
     @abc.abstractclassmethod
     def _get_is_snap_injection_capable(cls) -> bool:
         """Return whether the provider can install snaps from the host."""

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -65,6 +65,14 @@ class Multipass(Provider):
     """A multipass provider for snapcraft to execute its lifecycle."""
 
     @classmethod
+    def ensure_provider(cls):
+        MultipassCommand.ensure_multipass(platform=sys.platform)
+
+    @classmethod
+    def setup_provider(cls, *, echoer) -> None:
+        MultipassCommand.setup_multipass(echoer=echoer, platform=sys.platform)
+
+    @classmethod
     def _get_is_snap_injection_capable(cls) -> bool:
         return True
 
@@ -153,7 +161,7 @@ class Multipass(Provider):
 
     def __init__(self, *, project, echoer, is_ephemeral: bool = False) -> None:
         super().__init__(project=project, echoer=echoer, is_ephemeral=is_ephemeral)
-        self._multipass_cmd = MultipassCommand()
+        self._multipass_cmd = MultipassCommand(platform=sys.platform)
         self._instance_info = None  # type: InstanceInfo
 
     def create(self) -> None:

--- a/snapcraft/internal/build_providers/errors.py
+++ b/snapcraft/internal/build_providers/errors.py
@@ -36,17 +36,19 @@ class ProviderNotSupportedError(ProviderBaseError):
         super().__init__(provider=provider)
 
 
-class ProviderCommandNotFound(ProviderBaseError):
+class ProviderNotFound(ProviderBaseError):
 
-    fmt = (
-        "{command!r} command not found: this command is necessary to build in "
-        "this environment.\n"
-        "Install {command!r} or if already installed, ensure it is "
-        "on the system PATH, and try again."
-    )
+    fmt = "You need {provider!r} setup to build snaps: {error_message}."
 
-    def __init__(self, *, command: str) -> None:
-        super().__init__(command=command)
+    def __init__(
+        self, *, provider: str, prompt_installable: bool, error_message: str
+    ) -> None:
+        super().__init__(
+            provider=provider,
+            prompt_installable=prompt_installable,
+            error_message=error_message,
+        )
+        self.prompt_installable = prompt_installable
 
 
 class _GenericProviderError(ProviderBaseError):

--- a/snapcraft/internal/build_providers/errors.py
+++ b/snapcraft/internal/build_providers/errors.py
@@ -38,7 +38,7 @@ class ProviderNotSupportedError(ProviderBaseError):
 
 class ProviderNotFound(ProviderBaseError):
 
-    fmt = "You need {provider!r} setup to build snaps: {error_message}."
+    fmt = "You need {provider!r} set-up to build snaps: {error_message}."
 
     def __init__(
         self, *, provider: str, prompt_installable: bool, error_message: str

--- a/snapcraft/project/_sanity_checks.py
+++ b/snapcraft/project/_sanity_checks.py
@@ -17,9 +17,7 @@
 import copy
 import logging
 import os
-import sys
 import re
-import shutil
 from typing import Any, Dict
 
 from snapcraft.project import Project
@@ -37,27 +35,6 @@ _EXPECTED_SNAP_DIR_PATTERNS = {
     re.compile(r"^plugins(/.*)?$"),
     re.compile(r"^gui(/.*\.(png|svg|desktop))?$"),
 }
-
-
-def conduct_build_environment_sanity_check(provider: str):
-    if provider == "multipass":
-        _check_multipass_installed()
-
-
-def _check_multipass_installed():
-    if shutil.which("multipass"):
-        return
-
-    if sys.platform == "darwin":
-        raise errors.MultipassMissingInstallableError()
-
-    if sys.platform == "linux" and shutil.which("snap"):
-        raise errors.MultipassMissingInstallableError()
-    elif sys.platform == "linux":
-        raise errors.SnapMissingLinuxError()
-
-    # Alas, we do not know where we are running from
-    raise errors.MultipassMissingNonInstallableError()
 
 
 def conduct_project_sanity_check(project: Project) -> None:

--- a/snapcraft/project/errors.py
+++ b/snapcraft/project/errors.py
@@ -206,22 +206,3 @@ def _interpret_anyOf(error):
         return ""
 
     return "must be one of {}".format(formatting_utils.humanize_list(usages, "or"))
-
-
-class MultipassMissingNonInstallableError(SanityCheckError):
-    fmt = (
-        "You need multipass installed to build snaps:\n"
-        "https://github.com/CanonicalLtd/multipass/releases"
-    )
-
-
-class MultipassMissingInstallableError(SanityCheckError):
-    fmt = "You need multipass installed to build snaps."
-
-
-class SnapMissingLinuxError(SanityCheckError):
-    fmt = (
-        "You need multipass installed to build snaps which use the base keyword.\n"
-        "Enable snap support (https://docs.snapcraft.io/core/install) and run:\n"
-        "snap install multipass --classic --beta"
-    )

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -65,6 +65,14 @@ class ProviderImpl(Provider):
         self.push_file_mock(source=source, destination=destination)
 
     @classmethod
+    def ensure_provider(cls) -> None:
+        """Fake provider check."""
+
+    @classmethod
+    def setup_provider(cls) -> None:
+        """Fake provider setup."""
+
+    @classmethod
     def _get_is_snap_injection_capable(cls) -> bool:
         return True
 

--- a/tests/unit/build_providers/test_errors.py
+++ b/tests/unit/build_providers/test_errors.py
@@ -35,15 +35,16 @@ class ErrorFormattingTest(unit.TestCase):
             ),
         ),
         (
-            "ProviderCommandNotFound",
+            "ProviderNotFound",
             dict(
-                exception=errors.ProviderCommandNotFound,
-                kwargs=dict(command="multipass"),
+                exception=errors.ProviderNotFound,
+                kwargs=dict(
+                    provider="multipass",
+                    prompt_installable=False,
+                    error_message="not installed",
+                ),
                 expected_message=(
-                    "'multipass' command not found: this command is necessary to "
-                    "build in this environment.\n"
-                    "Install 'multipass' or if already installed, ensure it is "
-                    "on the system PATH, and try again."
+                    "You need 'multipass' setup to build snaps: not installed."
                 ),
             ),
         ),

--- a/tests/unit/build_providers/test_errors.py
+++ b/tests/unit/build_providers/test_errors.py
@@ -44,7 +44,7 @@ class ErrorFormattingTest(unit.TestCase):
                     error_message="not installed",
                 ),
                 expected_message=(
-                    "You need 'multipass' setup to build snaps: not installed."
+                    "You need 'multipass' set-up to build snaps: not installed."
                 ),
             ),
         ),


### PR DESCRIPTION
Move checks and setup to the provider implementation.

LP: #1821586
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
