### PR TITLE
project: ensure yaml load returns a dictionary

### DIFF
--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -86,4 +86,7 @@ def _load_yaml(*, yaml_file_path: str) -> OrderedDict:
     except yaml.YAMLError as e:
         raise errors.YamlValidationError(str(e), yaml_file_path) from e
 
+    if yaml_contents is None:
+        yaml_contents = OrderedDict()
+
     return yaml_contents

--- a/tests/unit/project/test_project_info.py
+++ b/tests/unit/project/test_project_info.py
@@ -44,6 +44,22 @@ class ProjectInfoTest(unit.TestCase):
         self.assertThat(info.description, Equals("baz"))
         self.assertThat(info.confinement, Equals("strict"))
 
+    def test_empty_yaml(self):
+        snapcraft_yaml_file_path = self.make_snapcraft_yaml("")
+
+        raised = self.assertRaises(
+            errors.YamlValidationError,
+            ProjectInfo,
+            snapcraft_yaml_file_path=snapcraft_yaml_file_path,
+        )
+
+        self.assertThat(
+            raised.message,
+            Equals(
+                "'name' is a required property in {!r}".format(snapcraft_yaml_file_path)
+            ),
+        )
+
     def test_minimal_load_with_name_only(self):
         snapcraft_yaml_file_path = self.make_snapcraft_yaml(
             dedent(


### PR DESCRIPTION
PyYAML yaml loading and parsing can return None if given an empty file
or empty string. When validating its yaml file, Snapcraft expects the
result to be subscriptable, so return an empty dictionary instead of None.

Fixes SNAPCRAFT-JQ

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
