### PR TITLE
snapcraft/extractors/setuppy.py: match setuptools metadata keys

### DIFF
--- a/snapcraft/extractors/setuppy.py
+++ b/snapcraft/extractors/setuppy.py
@@ -56,6 +56,7 @@ def extract(relpath: str, *, workdir: str) -> ExtractedMetadata:
                 raise _errors.SetupPyImportError(path=relpath, error=str(e)) from e
 
     version = params.get("version")
-    description = params.get("description")
+    summary = params.get("description")
+    description = params.get("long_description")
 
-    return ExtractedMetadata(version=version, description=description)
+    return ExtractedMetadata(version=version, summary=summary, description=description)


### PR DESCRIPTION
* Use setuptools' description as snapcraft's summary
* Use setuptools' long_description as snapcraft's description

Fixes LP https://bugs.launchpad.net/snapcraft/+bug/1813364

See also https://forum.snapcraft.io/t/using-external-metadata/4642/10

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

This fails for me, I get:

```
$ ./runtests.sh tests/unit
tests.unit (unittest.loader._FailedTest) ... ERROR

======================================================================
ERROR: tests.unit (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: tests.unit
Traceback (most recent call last):
  File "/usr/lib/python3.6/unittest/loader.py", line 462, in _find_test_path
    package = self._get_module_from_name(name)
  File "/usr/lib/python3.6/unittest/loader.py", line 369, in _get_module_from_name
    __import__(name)
  File "/home/ijohnson/git/snapcraft/tests/unit/__init__.py", line 24, in <module>
    import fixtures
ModuleNotFoundError: No module named 'fixtures'


----------------------------------------------------------------------
Ran 1 test in 0.000s

FAILED (errors=1)
```

-----

Also let me know if I need to change/modify any tests for this, this is my first PR to snapcraft :smiley: so I'm not sure what all should be changed for this 