### PR TITLE
Add -h short option for help

### DIFF
--- a/snapcraft/cli/_runner.py
+++ b/snapcraft/cli/_runner.py
@@ -54,7 +54,11 @@ command_groups = [
 ]
 
 
-@click.group(cls=SnapcraftGroup, invoke_without_command=True)
+@click.group(
+    cls=SnapcraftGroup,
+    invoke_without_command=True,
+    context_settings=dict(help_option_names=["-h", "--help"]),
+)
 @click.version_option(
     message=SNAPCRAFT_VERSION_TEMPLATE, version=snapcraft.__version__  # type: ignore
 )


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/snapcraft/+bug/1807423

https://click.palletsprojects.com/en/7.x/documentation/#help-parameter-customization

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
