### PR TITLE
packaging: use our patchelf branch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,7 +39,7 @@ parts:
     plugin: autotools
     source: https://github.com/snapcore/patchelf
     source-type: git
-    source-tag: '0.10+snapcraft'
+    source-branch: '0.10+snapcraft'
     build-packages:
       - g++
       - make

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,7 +39,7 @@ parts:
     plugin: autotools
     source: https://github.com/snapcore/patchelf
     source-type: git
-    source-tag: '0.10'
+    source-tag: '0.10+snapcraft'
     build-packages:
       - g++
       - make


### PR DESCRIPTION
Upstream patchelf issue NixOS/patchelf#167 prevents package building on
s390x. The test failure is apparently not significant for our use cases, so
switch patchelf sources to a branch with the offending test disabled.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

Note: this PR requires patchelf PR snapcore/patchelf#1 to be merged before
running tests on s390x.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
