### PR TITLE
snap: revert to patchelf 0.9 with local patches

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,7 +39,7 @@ parts:
     plugin: autotools
     source: https://github.com/snapcore/patchelf
     source-type: git
-    source-branch: '0.10+snapcraft'
+    source-branch: '0.9+snapcraft'
     build-packages:
       - g++
       - make


### PR DESCRIPTION
After extensive tests with patchelf 0.10 on different architectures,
it seems that it's not producing reliable binaries on (at least) i386,
ppc64el and s390x. Revert back to 0.9 with local patches until 0.10
issues are properly addressed.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
