### PR TITLE
Add SNAPCRAFT_PROJECT_DIR environment variable.

### DIFF
--- a/snapcraft/internal/project_loader/_env.py
+++ b/snapcraft/internal/project_loader/_env.py
@@ -110,6 +110,7 @@ def snapcraft_global_environment(project: project.Project) -> Dict[str, str]:
         "SNAPCRAFT_PARALLEL_BUILD_COUNT": str(project.parallel_build_count),
         "SNAPCRAFT_PROJECT_NAME": name,
         "SNAPCRAFT_PROJECT_VERSION": version,
+        "SNAPCRAFT_PROJECT_DIR": project._project_dir,
         "SNAPCRAFT_PROJECT_GRADE": grade,
         "SNAPCRAFT_STAGE": project.stage_dir,
         "SNAPCRAFT_PRIME": project.prime_dir,

--- a/tests/unit/project/test_project_info.py
+++ b/tests/unit/project/test_project_info.py
@@ -17,7 +17,7 @@
 from tests import unit
 from textwrap import dedent
 
-from testtools.matchers import Equals, Is
+from testtools.matchers import Equals, Is, MatchesRegex
 
 from snapcraft.project._project_info import ProjectInfo
 from snapcraft.project import errors
@@ -172,12 +172,11 @@ class InvalidYamlTest(unit.TestCase):
         )
 
         self.assertThat(raised.source, Equals(snapcraft_yaml_file_path))
-        self.assertThat(
-            raised.message,
-            Equals(
-                "found a tab character that violate indentation on line 5, column 1"
-            ),
-        )
+        # libyaml had a spelling mistake indentation/intendation
+        self.assertThat(raised.message, MatchesRegex(
+            "found a tab character that violate (indentation|intendation)"
+            " on line 5, column 1"
+        ))
 
     def test_invalid_yaml_invalid_unicode_chars(self):
         snapcraft_yaml_file_path = self.make_snapcraft_yaml(

--- a/tests/unit/project/test_project_info.py
+++ b/tests/unit/project/test_project_info.py
@@ -175,7 +175,7 @@ class InvalidYamlTest(unit.TestCase):
         self.assertThat(
             raised.message,
             Equals(
-                "found a tab character that violate intendation on line 5, column 1"
+                "found a tab character that violate indentation on line 5, column 1"
             ),
         )
 

--- a/tests/unit/project/test_project_info.py
+++ b/tests/unit/project/test_project_info.py
@@ -173,10 +173,13 @@ class InvalidYamlTest(unit.TestCase):
 
         self.assertThat(raised.source, Equals(snapcraft_yaml_file_path))
         # libyaml had a spelling mistake indentation/intendation
-        self.assertThat(raised.message, MatchesRegex(
-            "found a tab character that violate (indentation|intendation)"
-            " on line 5, column 1"
-        ))
+        self.assertThat(
+            raised.message,
+            MatchesRegex(
+                "found a tab character that violate (indentation|intendation)"
+                " on line 5, column 1"
+            ),
+        )
 
     def test_invalid_yaml_invalid_unicode_chars(self):
         snapcraft_yaml_file_path = self.make_snapcraft_yaml(

--- a/tests/unit/project_loader/test_environment.py
+++ b/tests/unit/project_loader/test_environment.py
@@ -258,6 +258,7 @@ class EnvironmentTest(ProjectLoaderBaseTest):
                     'SNAPCRAFT_PART_INSTALL="{}/parts/main/install"'.format(self.path),
                     'SNAPCRAFT_PART_SRC="{}/parts/main/src"'.format(self.path),
                     'SNAPCRAFT_PRIME="{}/prime"'.format(self.path),
+                    'SNAPCRAFT_PROJECT_DIR="{}"'.format(self.path),
                     'SNAPCRAFT_PROJECT_GRADE="stable"',
                     'SNAPCRAFT_PROJECT_NAME="test"',
                     'SNAPCRAFT_PROJECT_VERSION="1"',
@@ -508,6 +509,11 @@ class EnvironmentTest(ProjectLoaderBaseTest):
         ][0]
         env = project_config.parts.build_env_for_part(part1)
         self.assertThat(env, Contains('SNAPCRAFT_EXTENSIONS_DIR="/foo"'))
+
+    def test_project_dir(self):
+        project_config = self.make_snapcraft_project(self.snapcraft_yaml)
+        env = project_config.parts.build_env_for_part(project_config.parts.all_parts[0])
+        self.assertThat(env, Contains('SNAPCRAFT_PROJECT_DIR="{}"'.format(self.path)))
 
     def test_build_environment(self):
         self.useFixture(FakeOsRelease())


### PR DESCRIPTION
New variable pointing to the project directory, the directory
the snapcraft command was run from. This variable should be correct
regardless of what build environment (container or host) the build
is running in. This allows easy reference to supporting script or
other resources inside snapcraft.yaml overrides sections.

Fixes https://bugs.launchpad.net/snapcraft/+bug/1824417

- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `./runtests.sh static`?
- [X] Have you successfully run `./runtests.sh tests/unit`?

-----
