### PR TITLE
build providers: get rid of attribute warnings from pylxd

### DIFF
--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -19,6 +19,7 @@ import os
 import subprocess
 import sys
 import urllib.parse
+import warnings
 from typing import Optional, Sequence
 
 import pylxd
@@ -31,6 +32,9 @@ from snapcraft.internal.errors import SnapcraftEnvironmentError
 
 
 logger = logging.getLogger(__name__)
+# Filter out attribute setting warnings for properties that exist in LXD operations
+# but are unhandled in pylxd.
+warnings.filterwarnings("ignore", module="pylxd.models.operation")
 
 
 class LXD(Provider):


### PR DESCRIPTION
Filter out this specific warning, and potentially others coming from
pylxd.models.operation which are irrelevant to the end user:

/snap/snapcraft/2839/lib/python3.5/site-packages/pylxd/models/operation.py:59: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
  .format(key, self.__class__.__name__))

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
