### PR TITLE
project: validate common-id against metadata filename

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -34,7 +34,10 @@ from snapcraft.internal import (
     project_loader,
     steps,
 )
-from snapcraft.project._sanity_checks import conduct_project_sanity_check
+from snapcraft.project._sanity_checks import (
+    conduct_project_sanity_check,
+    conduct_config_sanity_check,
+)
 from ._errors import TRACEBACK_MANAGED, TRACEBACK_HOST
 
 
@@ -74,6 +77,7 @@ def _execute(  # noqa: C901
 
     if build_environment.is_managed_host or build_environment.is_host:
         project_config = project_loader.load_config(project)
+        conduct_config_sanity_check(project_config)
         lifecycle.execute(step, project_config, parts)
         if pack_project:
             _pack(project.prime_dir, output=output)

--- a/snapcraft/formatting_utils.py
+++ b/snapcraft/formatting_utils.py
@@ -81,3 +81,16 @@ def pluralize(container: Sized, if_one: str, if_multiple: str) -> str:
         return if_one
     else:
         return if_multiple
+
+
+def remove_suffix(astring: str, suffix: str) -> str:
+    """Remove the suffix from the given string.
+
+    :param str astring: The string to remove the suffix from.
+    :param str suffix: The suffix to remove.
+    """
+    if not suffix:
+        return astring
+    if astring.endswith(suffix):
+        return astring[: -len(suffix)]
+    return astring

--- a/snapcraft/project/errors.py
+++ b/snapcraft/project/errors.py
@@ -110,6 +110,14 @@ class CommandChainWithLegacyAdapterError(SanityCheckError):
         super().__init__(app_name=app_name)
 
 
+class CommonIdMismatchError(SanityCheckError):
+
+    fmt = "Common ID {name!r} specified in app {app!r} doesn't match any metadata file."
+
+    def __init__(self, name: str, app: str) -> None:
+        super().__init__(name=name, app=app)
+
+
 def _determine_preamble(error):
     messages = []
     path = _determine_property_path(error)

--- a/tests/unit/test_formatting_utils.py
+++ b/tests/unit/test_formatting_utils.py
@@ -76,3 +76,14 @@ class FormatPathVariableTestCases(unit.TestCase):
         paths = ["/usr/bin", "/usr/sbin"]
         output = formatting_utils.format_path_variable("PATH", paths, "", ",")
         self.assertThat(output, Equals('PATH="$PATH,/usr/bin,/usr/sbin"'))
+
+
+class RemoveSuffixTestCases(unit.TestCase):
+    def test_remove_suffix(self):
+        self.assertThat(formatting_utils.remove_suffix("", ""), Equals(""))
+        self.assertThat(formatting_utils.remove_suffix("", "a"), Equals(""))
+        self.assertThat(formatting_utils.remove_suffix("a", "a"), Equals(""))
+        self.assertThat(formatting_utils.remove_suffix("a", ""), Equals("a"))
+        self.assertThat(formatting_utils.remove_suffix("a", "b"), Equals("a"))
+        self.assertThat(formatting_utils.remove_suffix("ab", "b"), Equals("a"))
+        self.assertThat(formatting_utils.remove_suffix("abb", "b"), Equals("ab"))


### PR DESCRIPTION
Appstream common IDs is also used in the metadata file names. To
prevent typos, add a consistency check and fail if any common ID is
not used in metadata files.

LP: #1814902

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
