### PR TITLE
dotnet plugin: fix parsing of newer sdk releases

### DIFF
--- a/snapcraft/plugins/dotnet.py
+++ b/snapcraft/plugins/dotnet.py
@@ -32,6 +32,7 @@ The plugin will take into account the following build-attributes:
 import os
 import shutil
 import fnmatch
+import urllib.parse
 import urllib.request
 import json
 
@@ -211,15 +212,21 @@ class DotNetPlugin(snapcraft.BasePlugin):
         if "sdk-linux-x64" in metadata[0]:
             # look for sdk-linux-x64 property, if it doesn't exist
             # look for ubuntu.14.04 entry as shipped during 1.1
-            sdk_packge_name = metadata[0]["sdk-linux-x64"]
+            sdk_package_url = metadata[0]["sdk-linux-x64"]
         elif "sdk-ubuntu.14.04" in metadata[0]:
-            sdk_packge_name = metadata[0]["sdk-ubuntu.14.04"]
+            sdk_package_url = metadata[0]["sdk-ubuntu.14.04"]
         else:
             raise DotNetBadReleaseDataError(version)
 
-        sdk_package_url = "{}{}".format(metadata[0]["blob-sdk"], sdk_packge_name)
+        # for older releases prepend the base sdk url
+        if not sdk_package_url.startswith("http"):
+            sdk_package_url = "{}{}".format(metadata[0]["blob-sdk"], sdk_package_url)
+
+        parsed_url = urllib.parse.urlparse(sdk_package_url)
+        filename = os.path.basename(parsed_url.path)
+
         sdk_checksum = self._get_package_checksum(
-            metadata[0]["checksums-sdk"], sdk_packge_name, version
+            metadata[0]["checksums-sdk"], filename, version
         )
 
         return {"package_url": sdk_package_url, "checksum": sdk_checksum}
@@ -245,7 +252,7 @@ class DotNetPlugin(snapcraft.BasePlugin):
         if not hash or not checksum:
             raise DotNetBadReleaseDataError(version)
 
-        return "{}/{}".format(hash.lower(), checksum)
+        return "{}/{}".format(hash.lower(), checksum.lower())
 
     def env(self, root):
         # Update the PATH only during the Build and Install step


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`? **Couldn't install black
- [ ] Have you successfully run `./runtests.sh tests/unit`? **Couldn't get tests to finish

-----

In the process of setting up snapcraft for a dotnet core project I ran into an issue when using newer runtime versions. The releases metadata file that is being parsed to find the right sdk file to download has newer releases in a slightly different format. They now include the full URL instead of just the filename. They also changed the checksum file to use upper case instead of lower case letters in the checksum values. You can see this [here](https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases.json) if you compare the releases at the top of the file to the ones lower down.


This updates the plugin to handle both release formats.

------

**I'm not developing on an ubuntu machine so running this test suite proved to be a challenge.