### PR TITLE
rust plugin: fix usage of rust-channel

### DIFF
--- a/snapcraft/plugins/rust.py
+++ b/snapcraft/plugins/rust.py
@@ -119,18 +119,12 @@ class RustPlugin(snapcraft.BasePlugin):
         # Basic options:
         # -y: assume yes
         # --no-modify-path: do not modify bashrc
-        options = ["-y", "--no-modify-path"]
-
-        # Check if we want to initialize using a specific channel.
-        if self.options.rust_channel:
-            options.extend(["--channel", self.options.rust_channel])
+        options = ["-y", "--default-toolchain", "none", "--no-modify-path"]
 
         # Fetch rust
         self.run([rustup_init_cmd] + options, env=self._build_env())
 
     def _fetch_rust(self):
-        # Setup the channel in case rustup-init was run before or a revision which cannot be hanndled
-        # from rustup-init
         # https://rust-lang-nursery.github.io/edition-guide/rust-2018/rustup-for-managing-rust-versions.html
         toolchain = self._get_toolchain()
         self.run([self._rustup_cmd, "install", toolchain], env=self._build_env())
@@ -229,7 +223,6 @@ class RustPlugin(snapcraft.BasePlugin):
         return env
 
     def _get_toolchain(self) -> str:
-        toolchain = None
         if self.options.rust_revision:
             toolchain = self.options.rust_revision
         elif self.options.rust_channel:

--- a/tests/spread/plugins/rust/channel/task.yaml
+++ b/tests/spread/plugins/rust/channel/task.yaml
@@ -1,0 +1,33 @@
+summary: Build a rust snap using the nightly channel for the rust toolchain
+
+environment:
+  SNAP_DIR: ../snaps/rust-hello
+
+systems:
+   - ubuntu-18.04
+   - ubuntu-18.04-64
+   - ubuntu-18.04-amd64
+   - ubuntu-18.04-armhf
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+  # Set a specific version of rust to use
+  echo "    rust-channel: nightly" >> "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "$SNAP_DIR"
+
+  # Verify that it builds
+  snapcraft build

--- a/tests/unit/plugins/test_rust.py
+++ b/tests/unit/plugins/test_rust.py
@@ -162,6 +162,8 @@ class RustPluginCrossCompileTest(RustPluginBaseTest):
                     [
                         os.path.join(plugin._rust_dir, "rustup.sh"),
                         "-y",
+                        "--default-toolchain",
+                        "none",
                         "--no-modify-path",
                     ],
                     cwd=os.path.join(plugin.partdir, "build"),
@@ -261,6 +263,8 @@ class RustPluginTest(RustPluginBaseTest):
                     [
                         os.path.join(plugin._rust_dir, "rustup.sh"),
                         "-y",
+                        "--default-toolchain",
+                        "none",
                         "--no-modify-path",
                     ],
                     cwd=os.path.join(plugin.partdir, "build"),
@@ -302,9 +306,9 @@ class RustPluginTest(RustPluginBaseTest):
                     [
                         os.path.join(plugin._rust_dir, "rustup.sh"),
                         "-y",
+                        "--default-toolchain",
+                        "none",
                         "--no-modify-path",
-                        "--channel",
-                        "nightly",
                     ],
                     cwd=os.path.join(plugin.partdir, "build"),
                     env=plugin._build_env(),
@@ -345,6 +349,8 @@ class RustPluginTest(RustPluginBaseTest):
                     [
                         os.path.join(plugin._rust_dir, "rustup.sh"),
                         "-y",
+                        "--default-toolchain",
+                        "none",
                         "--no-modify-path",
                     ],
                     cwd=os.path.join(plugin.partdir, "build"),
@@ -385,6 +391,8 @@ class RustPluginTest(RustPluginBaseTest):
                     [
                         os.path.join(plugin._rust_dir, "rustup.sh"),
                         "-y",
+                        "--default-toolchain",
+                        "none",
                         "--no-modify-path",
                     ],
                     cwd=os.path.join(plugin.partdir, "build"),


### PR DESCRIPTION
rustup.sh no longer accepts a --channel argument. Fix by setting up the
toolchain using rustup.

For consistency, do not install the default toolchain on toolchain setup
and instead use the former mechanism for all code paths.

Lastly, remove an unsued variable in RustPlugin._get_toolchain

LP: #1825062

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
