### PR TITLE
errors: Add InvalidAppCommand errors for non-existent and not-found

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -192,9 +192,8 @@ class InvalidAppCommandNotExecutable(SnapcraftError):
 
     fmt = (
         "Failed to generate snap metadata: "
-        "The specified command {command!r} defined in the app {app_name!r} does "
-        "not exist.\n"
-        "Ensure that {command!r} is executable."
+        "The specified command {command!r} defined in the app {app_name!r} "
+        "is not executable."
     )
 
     def __init__(self, command, app_name):

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -194,7 +194,7 @@ class InvalidAppCommandNotExecutable(SnapcraftError):
         "Failed to generate snap metadata: "
         "The specified command {command!r} defined in the app {app_name!r} does "
         "not exist.\n"
-        "Ensure that {command!r} is relative to the prime directory."
+        "Ensure that {command!r} is executable."
     )
 
     def __init__(self, command, app_name):

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -175,6 +175,32 @@ class InvalidAppCommandError(SnapcraftError):
         super().__init__(command=command, app_name=app_name)
 
 
+class InvalidAppCommandNotFound(SnapcraftError):
+
+    fmt = (
+        "Failed to generate snap metadata: "
+        "The specified command {command!r} defined in the app {app_name!r} does "
+        "not exist.\n"
+        "Ensure that {command!r} is relative to the prime directory."
+    )
+
+    def __init__(self, command, app_name):
+        super().__init__(command=command, app_name=app_name)
+
+
+class InvalidAppCommandNotExecutable(SnapcraftError):
+
+    fmt = (
+        "Failed to generate snap metadata: "
+        "The specified command {command!r} defined in the app {app_name!r} does "
+        "not exist.\n"
+        "Ensure that {command!r} is relative to the prime directory."
+    )
+
+    def __init__(self, command, app_name):
+        super().__init__(command=command, app_name=app_name)
+
+
 class InvalidAppCommandFormatError(SnapcraftError):
 
     fmt = (

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -168,7 +168,7 @@ class InvalidAppCommandError(SnapcraftError):
         "Failed to generate snap metadata: "
         "The specified command {command!r} defined in the app {app_name!r} does "
         "not exist or is not executable.\n"
-        "Ensure that {command!r} is relative to the prime directory."
+        "Ensure that {command!r} is installed with the correct path."
     )
 
     def __init__(self, command, app_name):
@@ -181,7 +181,7 @@ class InvalidAppCommandNotFound(SnapcraftError):
         "Failed to generate snap metadata: "
         "The specified command {command!r} defined in the app {app_name!r} does "
         "not exist.\n"
-        "Ensure that {command!r} is relative to the prime directory."
+        "Ensure that {command!r} is installed with the correct path."
     )
 
     def __init__(self, command, app_name):

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -642,7 +642,9 @@ class _SnapPackaging:
                 raise errors.InvalidAppCommandNotFound(command_without_args, app_name)
 
             if not is_executable:
-                raise errors.InvalidAppCommandNotExecutable(command_without_args, app_name)
+                raise errors.InvalidAppCommandNotExecutable(
+                    command_without_args, app_name
+                )
 
         # Finally, assuming there is a meta runner, add it to the BEGINNING of the
         # command chain. This is to ensure all subsequent commands in the chain get

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -633,14 +633,16 @@ class _SnapPackaging:
             command_without_args = command.split()[0]
             binary_path = os.path.join(self._prime_dir, command_without_args)
             is_executable = False
-            with contextlib.suppress(FileNotFoundError):
+            try:
                 mode = os.stat(binary_path).st_mode
                 is_executable = (
                     mode & stat.S_IXUSR or mode & stat.S_IXGRP or mode & stat.S_IXOTH
                 )
+            except FileNotFoundError:
+                raise errors.InvalidAppCommandNotFound(command_without_args, app_name)
 
             if not is_executable:
-                raise errors.InvalidAppCommandError(command_without_args, app_name)
+                raise errors.InvalidAppCommandNotExecutable(command_without_args, app_name)
 
         # Finally, assuming there is a meta runner, add it to the BEGINNING of the
         # command chain. This is to ensure all subsequent commands in the chain get
@@ -656,7 +658,7 @@ class _SnapPackaging:
             try:
                 new_command = self._wrap_exe(app[k], "{}-{}".format(k, name))
             except FileNotFoundError:
-                raise errors.InvalidAppCommandError(command=app[k], app_name=app)
+                raise errors.InvalidAppCommandNotFound(command=app[k], app_name=app)
             except meta_errors.CommandError as e:
                 raise errors.InvalidAppCommandError(str(e), name)
 

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -278,6 +278,32 @@ class ErrorFormattingTestCase(unit.TestCase):
             },
         ),
         (
+            "InvalidAppCommandNotFound",
+            {
+                "exception": errors.InvalidAppCommandNotFound,
+                "kwargs": {"command": "test-command", "app_name": "test-app"},
+                "expected_message": (
+                    "Failed to generate snap metadata: "
+                    "The specified command 'test-command' defined in the app "
+                    "'test-app' does not exist.\n"
+                    "Ensure that 'test-command' is relative to the prime directory."
+                ),
+            },
+        ),
+        (
+            "InvalidAppCommandNotExecutable",
+            {
+                "exception": errors.InvalidAppCommandNotExecutable,
+                "kwargs": {"command": "test-command", "app_name": "test-app"},
+                "expected_message": (
+                    "Failed to generate snap metadata: "
+                    "The specified command 'test-command' defined in the app "
+                    "'test-app' does not exist.\n"
+                    "Ensure that 'test-command' is executable."
+                ),
+            },
+        ),
+        (
             "InvalidAppCommandFormatError",
             {
                 "exception": errors.InvalidAppCommandFormatError,

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -273,7 +273,7 @@ class ErrorFormattingTestCase(unit.TestCase):
                     "Failed to generate snap metadata: "
                     "The specified command 'test-command' defined in the app "
                     "'test-app' does not exist or is not executable.\n"
-                    "Ensure that 'test-command' is relative to the prime directory."
+                    "Ensure that 'test-command' is installed with the correct path."
                 ),
             },
         ),
@@ -286,7 +286,7 @@ class ErrorFormattingTestCase(unit.TestCase):
                     "Failed to generate snap metadata: "
                     "The specified command 'test-command' defined in the app "
                     "'test-app' does not exist.\n"
-                    "Ensure that 'test-command' is relative to the prime directory."
+                    "Ensure that 'test-command' is installed with the correct path."
                 ),
             },
         ),

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -298,8 +298,7 @@ class ErrorFormattingTestCase(unit.TestCase):
                 "expected_message": (
                     "Failed to generate snap metadata: "
                     "The specified command 'test-command' defined in the app "
-                    "'test-app' does not exist.\n"
-                    "Ensure that 'test-command' is executable."
+                    "'test-app' is not executable."
                 ),
             },
         ),

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -1800,7 +1800,7 @@ class FullAdapterTest(unit.TestCase):
 
     def test_missing_command(self):
         raised = self.assertRaises(
-            errors.InvalidAppCommandError, self._get_packager().write_snap_yaml
+            errors.InvalidAppCommandNotFound, self._get_packager().write_snap_yaml
         )
         self.assertThat(raised.command, Equals("test-command"))
         self.assertThat(raised.app_name, Equals("app"))
@@ -1808,7 +1808,7 @@ class FullAdapterTest(unit.TestCase):
     def test_missing_command_with_spaces(self):
         self.snapcraft_yaml["apps"]["app"]["command"] = "test-command arg1 arg2"
         raised = self.assertRaises(
-            errors.InvalidAppCommandError, self._get_packager().write_snap_yaml
+            errors.InvalidAppCommandNotFound, self._get_packager().write_snap_yaml
         )
         self.assertThat(raised.command, Equals("test-command"))
         self.assertThat(raised.app_name, Equals("app"))
@@ -1817,7 +1817,7 @@ class FullAdapterTest(unit.TestCase):
         _create_file(os.path.join(self.prime_dir, "test-command"), executable=False)
 
         raised = self.assertRaises(
-            errors.InvalidAppCommandError, self._get_packager().write_snap_yaml
+            errors.InvalidAppCommandNotExecutable, self._get_packager().write_snap_yaml
         )
         self.assertThat(raised.command, Equals("test-command"))
         self.assertThat(raised.app_name, Equals("app"))


### PR DESCRIPTION
Add a specific errors for

- command app not found
- command app not executable

LP: #1727425

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
