### PR TITLE
catkin spread test: allow python2 as well as python

### DIFF
--- a/tests/spread/plugins/catkin/run/task.yaml
+++ b/tests/spread/plugins/catkin/run/task.yaml
@@ -26,7 +26,7 @@ execute: |
 
   # Verify that the hardcoded /usr/bin/python in rosversion is changed to
   # use /usr/bin/env
-  [ "$(head -n 1 prime/usr/bin/rosversion)" = "#!/usr/bin/env python" ]
+  expr "$(head -n 1 prime/usr/bin/rosversion)" : '^#!/usr/bin/env\spython2\?$' > /dev/null
 
   # Regression test for LP: #1660852. Make sure --help actually gets passed to
   # roslaunch instead of being eaten by setup.sh.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Upstream ROS changed to start using python2. Both are valid, so make sure the test accounts for that.