### PR TITLE
meta: Validate common ID against appstream metadata

### DIFF
--- a/snapcraft/extractors/_metadata.py
+++ b/snapcraft/extractors/_metadata.py
@@ -48,6 +48,7 @@ class ExtractedMetadata(yaml_utils.SnapcraftYAMLObject):
         """  # noqa
 
         self._data = {}  # type: Dict[str, Union[str, List[str]]]
+        self.common_id_list = []  # type: List[str]
 
         if common_id:
             self._data["common_id"] = common_id
@@ -73,6 +74,9 @@ class ExtractedMetadata(yaml_utils.SnapcraftYAMLObject):
         :param ExtractedMetadata other: Metadata from which to update
         """
         self._data.update(other.to_dict())
+        common_id = self.get_common_id()
+        if common_id:
+            self.common_id_list.append(common_id)
 
     def get_common_id(self) -> str:
         """Return extracted common_id.

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -755,7 +755,7 @@ class _SnapPackaging:
                 )
                 logger.warning(
                     "Common ID {common_id!r} specified in app {app!r} is "
-                    "not used in any appstream metafile.".format(
+                    "not used in any metadata file.".format(
                         common_id=app_common_id, app=app_name
                     )
                 )

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -117,6 +117,7 @@ def create_snap_packaging(project_config: _config.Config) -> str:
     _ensure_required_keywords(project_config.data)
 
     packaging = _SnapPackaging(project_config, extracted_metadata)
+    packaging.validate_common_ids()
     packaging.write_snap_yaml()
     packaging.setup_assets()
     packaging.generate_hook_wrappers()
@@ -736,6 +737,28 @@ class _SnapPackaging:
             raise meta_errors.AmbiguousPassthroughKeyError(duplicates)
         section.update(passthrough)
         return bool(passthrough)
+
+    def validate_common_ids(self) -> None:
+        if (
+            not self._extracted_metadata
+            or not self._extracted_metadata.common_id_list
+            or "apps" not in self._config_data
+        ):
+            return
+
+        common_id_list = self._extracted_metadata.common_id_list
+        for app in self._config_data["apps"]:
+            app_common_id = self._config_data["apps"][app].get("common-id")
+            if app_common_id not in common_id_list:
+                app_name = _get_app_name_from_common_id(
+                    self._config_data, app_common_id
+                )
+                logger.warning(
+                    "Common ID {common_id!r} specified in app {app!r} is "
+                    "not used in any appstream metafile.".format(
+                        common_id=app_common_id, app=app_name
+                    )
+                )
 
 
 def _determine_assumes(yaml_data: Dict[str, Any]) -> Set[str]:

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -750,13 +750,10 @@ class _SnapPackaging:
         for app in self._config_data["apps"]:
             app_common_id = self._config_data["apps"][app].get("common-id")
             if app_common_id not in common_id_list:
-                app_name = _get_app_name_from_common_id(
-                    self._config_data, app_common_id
-                )
                 logger.warning(
                     "Common ID {common_id!r} specified in app {app!r} is "
                     "not used in any metadata file.".format(
-                        common_id=app_common_id, app=app_name
+                        common_id=app_common_id, app=app
                     )
                 )
 

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -2031,7 +2031,7 @@ class CommonIdTestCase(CreateBaseTestCase):
         )
 
     def test_common_id_mismatch(self):
-        config = self.make_snapcraft_project(common_id="tset.id.2")
+        config = self.make_snapcraft_project(common_id="test.id.mismatch")
         for part in config.parts.all_parts:
             part.makedirs()
             part.mark_pull_done()
@@ -2040,7 +2040,7 @@ class CommonIdTestCase(CreateBaseTestCase):
             part.prime()
         _snap_packaging.create_snap_packaging(config)
         self.assertIn(
-            "Common ID 'tset.id.2' specified in app 'test-app' is not used in any appstream metafile.",
+            "Common ID 'test.id.mismatch' specified in app 'test-app' is not used in any appstream metafile.",
             self.fake_logger.output,
         )
 

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -2041,7 +2041,7 @@ class CommonIdTestCase(CreateBaseTestCase):
         _snap_packaging.create_snap_packaging(config)
         self.assertIn(
             "Common ID 'test.id.mismatch' specified in app 'test-app' is not used in any appstream metafile.",
-            self.fake_logger.output,
+            self.fake_logger.output.strip(),
         )
 
 

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -2040,7 +2040,7 @@ class CommonIdTestCase(CreateBaseTestCase):
             part.prime()
         _snap_packaging.create_snap_packaging(config)
         self.assertIn(
-            "Common ID 'test.id.mismatch' specified in app 'test-app' is not used in any appstream metafile.",
+            "Common ID 'test.id.mismatch' specified in app 'test-app' is not used in any metadata file.",
             self.fake_logger.output.strip(),
         )
 


### PR DESCRIPTION
Appstream common IDs should reference IDs actually used in the metadata.
To prevent typos, add a consistency check and fail if any common ID is
not found in appstream files.

LP: #1814902

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
