### PR TITLE
extractors: fix typo in appstream icon unit test

### DIFF
--- a/tests/unit/extractors/test_appstream.py
+++ b/tests/unit/extractors/test_appstream.py
@@ -207,7 +207,7 @@ class AppstreamIconsTestCase(unit.TestCase):
     def test_appstream_no_icon_desktop_fallback_icon_exists(self):
         self._create_appstream_file()
         _create_desktop_file("usr/share/applications/my.app.desktop", icon="/icon.png")
-        open("myicon.png", "w").close()
+        open("icon.png", "w").close()
         self._expect_icon("/icon.png")
 
     def test_appstream_no_icon_theme_fallback_png(self):


### PR DESCRIPTION
A typo in the existing icon test in the appstream desktop file fallback
test cases caused the the missing icon scenario to be tested twice. Fix
the test so the existing icon case is also tested.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
