### PR TITLE
Remove legacy --no-compile option given to pip

### DIFF
--- a/snapcraft/plugins/_python/_pip.py
+++ b/snapcraft/plugins/_python/_pip.py
@@ -335,9 +335,6 @@ class Pip:
         #
         # --user: Install packages to PYTHONUSERBASE, which we've pointed to
         #         the installdir.
-        # --no-compile: Don't compile .pyc files. FIXME: This is legacy, and
-        #               should be removed once this refactor has been
-        #               validated.
         # --no-index: Don't hit pypi, assume the packages are already
         #             downloaded (i.e. by using `self.download()`)
         # --find-links: Provide the directory into which the packages should
@@ -349,7 +346,6 @@ class Pip:
             [
                 "install",
                 "--user",
-                "--no-compile",
                 "--no-index",
                 "--find-links",
                 self._python_package_dir,

--- a/tests/unit/plugins/python/test_pip.py
+++ b/tests/unit/plugins/python/test_pip.py
@@ -586,14 +586,7 @@ class PipInstallTest(PipCommandBaseTestCase):
     ]
 
     def _assert_mock_run_with(self, *args, **kwargs):
-        common_args = [
-            "install",
-            "--user",
-            "--no-compile",
-            "--no-index",
-            "--find-links",
-            mock.ANY,
-        ]
+        common_args = ["install", "--user", "--no-index", "--find-links", mock.ANY]
         common_args.extend(*args)
         self.mock_run.assert_called_once_with(common_args, **kwargs)
 


### PR DESCRIPTION
The python plugin will now byte compile (create *.pyc files)
when installing packages.

Byte compiling python source in the snap will allow it to start.

The use of --no-commit was marked for removal in the original
commit from more than a year ago so its a good time to remove it.

- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `./runtests.sh static`?
- [X] Have you successfully run `./runtests.sh tests/unit`?

-----
