### PR TITLE
catkin plugin: use build-packages for compilers

### DIFF
--- a/snapcraft/plugins/catkin_tools.py
+++ b/snapcraft/plugins/catkin_tools.py
@@ -26,7 +26,6 @@ import os
 import logging
 
 import snapcraft.plugins.catkin
-from snapcraft.plugins.catkin import Compilers
 
 import snapcraft
 
@@ -94,28 +93,11 @@ class CatkinToolsPlugin(snapcraft.plugins.catkin.CatkinPlugin):
         catkincmd.extend(["--install", "--install-space", self.rosdir])
 
         # Add any cmake-args requested from the plugin options.
-        compilers = Compilers(
-            self._compilers_path,
-            self.PLUGIN_STAGE_SOURCES,
-            self.PLUGIN_STAGE_KEYRINGS,
-            self.project,
-        )
-
         catkincmd.append("--cmake-args")
         build_type = "Release"
         if "debug" in self.options.build_attributes:
             build_type = "Debug"
-
-        catkincmd.extend(
-            [
-                '-DCMAKE_C_FLAGS="$CFLAGS {}"'.format(compilers.cflags),
-                '-DCMAKE_CXX_FLAGS="$CPPFLAGS {}"'.format(compilers.cxxflags),
-                '-DCMAKE_LD_FLAGS="$LDFLAGS {}"'.format(compilers.ldflags),
-                "-DCMAKE_C_COMPILER={}".format(compilers.c_compiler_path),
-                "-DCMAKE_CXX_COMPILER={}".format(compilers.cxx_compiler_path),
-                "-DCMAKE_BUILD_TYPE={}".format(build_type),
-            ]
-        )
+        catkincmd.append("-DCMAKE_BUILD_TYPE={}".format(build_type))
 
         catkincmd.extend(self.options.catkin_cmake_args)
 
@@ -138,13 +120,6 @@ class CatkinToolsPlugin(snapcraft.plugins.catkin.CatkinPlugin):
         if self.catkin_packages:
             catkincmd.extend(self.catkin_packages)
 
-        compilers = Compilers(
-            self._compilers_path,
-            self.PLUGIN_STAGE_SOURCES,
-            self.PLUGIN_STAGE_KEYRINGS,
-            self.project,
-        )
-
         # This command must run in bash due to a bug in Catkin that causes it
         # to explode if there are spaces in the cmake args (which there are).
-        self._run_in_bash(catkincmd, env=compilers.environment)
+        self._run_in_bash(catkincmd)

--- a/tests/unit/plugins/test_catkin_tools.py
+++ b/tests/unit/plugins/test_catkin_tools.py
@@ -64,10 +64,6 @@ class CatkinToolsPluginTestCase(CatkinToolsPluginBaseTest):
     def setUp(self):
         super().setUp()
 
-        self.compilers = catkin_tools.Compilers(
-            "compilers_path", "sources", ["keyring"], self.project
-        )
-
         patcher = mock.patch("snapcraft.repo.Ubuntu")
         self.ubuntu_mock = patcher.start()
         self.addCleanup(patcher.stop)
@@ -76,7 +72,6 @@ class CatkinToolsPluginTestCase(CatkinToolsPluginBaseTest):
         self.check_output_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
-    @mock.patch("snapcraft.plugins.catkin_tools.Compilers")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "run")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "_run_in_bash")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "run_output", return_value="foo")
@@ -89,7 +84,6 @@ class CatkinToolsPluginTestCase(CatkinToolsPluginBaseTest):
         run_output_mock,
         bashrun_mock,
         run_mock,
-        compilers_mock,
     ):
         self.properties.catkin_packages.append("package_2")
 
@@ -111,14 +105,13 @@ class CatkinToolsPluginTestCase(CatkinToolsPluginBaseTest):
                 self.test.assertIn("package_2", packages)
                 return True
 
-        bashrun_mock.assert_called_with(check_pkg_arguments(self), env=mock.ANY)
+        bashrun_mock.assert_called_with(check_pkg_arguments(self))
 
         finish_build_mock.assert_called_once_with()
 
-    @mock.patch("snapcraft.plugins.catkin_tools.Compilers")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "run")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "run_output", return_value="foo")
-    def test_build_runs_in_bash(self, run_output_mock, run_mock, compilers_mock):
+    def test_build_runs_in_bash(self, run_output_mock, run_mock):
         plugin = catkin_tools.CatkinToolsPlugin(
             "test-part", self.properties, self.project
         )
@@ -130,7 +123,6 @@ class CatkinToolsPluginTestCase(CatkinToolsPluginBaseTest):
             [mock.call(["/bin/bash", mock.ANY], cwd=mock.ANY, env=mock.ANY)]
         )
 
-    @mock.patch("snapcraft.plugins.catkin.Compilers")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "run")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "_run_in_bash")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "run_output", return_value="foo")
@@ -143,7 +135,6 @@ class CatkinToolsPluginTestCase(CatkinToolsPluginBaseTest):
         run_output_mock,
         bashrun_mock,
         run_mock,
-        compilers_mock,
     ):
         plugin = catkin_tools.CatkinToolsPlugin(
             "test-part", self.properties, self.project
@@ -163,7 +154,7 @@ class CatkinToolsPluginTestCase(CatkinToolsPluginBaseTest):
                     and "my_package" in command
                 )
 
-        bashrun_mock.assert_called_with(check_build_command(), env=mock.ANY)
+        bashrun_mock.assert_called_with(check_build_command())
 
         finish_build_mock.assert_called_once_with()
 
@@ -195,10 +186,9 @@ class PrepareBuildTestCase(CatkinToolsPluginBaseTest):
         self.properties.build_attributes.extend(self.build_attributes)
         self.properties.catkin_cmake_args = self.catkin_cmake_args
 
-    @mock.patch("snapcraft.plugins.catkin_tools.Compilers")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "_run_in_bash")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "_use_in_snap_python")
-    def test_prepare_build(self, use_python_mock, bashrun_mock, compilers_mock):
+    def test_prepare_build(self, use_python_mock, bashrun_mock):
         plugin = catkin_tools.CatkinToolsPlugin(
             "test-part", self.properties, self.project
         )


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Currently, the Catkin plugin pulls compilers off to the side rather than requesting that they be installed on the host. The reason for this is historical at this point: before bases existed, one could build a ROS snap on any version of Ubuntu, even versions unsupported by the ROS distribution being used. In an effort to ensure this worked as well as possible, the Catkin plugin did as much as it could without utilizing `build-packages` to ensure all components were compatible.

With the introduction of bases (and the fact that the only ROS1 releases available correspond to LTS releases, and thus bases), this is no longer a concern. It's no longer possible to build a ROS snap on an unsupported Ubuntu version in a supported manner. Add to that the fact that there's a bug in the plugin's use of the compilers that prevents rebuilds from working properly, and it's time to get rid of them.

Rather than pulling compilers off to the side, this PR fixes [LP: #1827148](https://bugs.launchpad.net/snapcraft/+bug/1827148) by simply specifying them as required `build-packages`.