### PR TITLE
[legacy] catkin plugin: ensure cxxflags are consistent

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -1015,31 +1015,31 @@ class Compilers:
 
     @property
     def cxxflags(self):
-        paths = set(
-            common.get_include_paths(
-                self._compilers_install_path, self._project.arch_triplet
-            )
+        paths = common.get_include_paths(
+            self._compilers_install_path, self._project.arch_triplet
         )
 
         try:
-            paths.add(
-                _get_highest_version_path(
-                    os.path.join(self._compilers_install_path, "usr", "include", "c++")
-                )
+            arch_independent_path = _get_highest_version_path(
+                os.path.join(self._compilers_install_path, "usr", "include", "c++")
             )
-            paths.add(
-                _get_highest_version_path(
-                    os.path.join(
-                        self._compilers_install_path,
-                        "usr",
-                        "include",
-                        self._project.arch_triplet,
-                        "c++",
-                    )
+            arch_dependent_path = _get_highest_version_path(
+                os.path.join(
+                    self._compilers_install_path,
+                    "usr",
+                    "include",
+                    self._project.arch_triplet,
+                    "c++",
                 )
             )
         except CatkinNoHighestVersionPathError as e:
             raise CatkinGccVersionError(str(e))
+
+        if arch_independent_path not in paths:
+            paths.append(arch_independent_path)
+
+        if arch_dependent_path not in paths:
+            paths.append(arch_dependent_path)
 
         return formatting_utils.combine_paths(paths, prepend="-I", separator=" ")
 

--- a/tests/unit/plugins/test_catkin.py
+++ b/tests/unit/plugins/test_catkin.py
@@ -1877,18 +1877,18 @@ class CompilersTestCase(unit.TestCase):
         cxx_include_dir = os.path.join(
             self.compilers._compilers_install_path, "usr", "include"
         )
-        self.assertThat(
-            self.compilers.cxxflags, Contains("-I{}".format(cxx_include_dir))
-        )
-        self.assertThat(
-            self.compilers.cxxflags,
-            Contains("-I{}".format(os.path.join(cxx_include_dir, "c++", "5"))),
-        )
+
+        # Order matters here
         self.assertThat(
             self.compilers.cxxflags,
-            Contains(
-                "-I{}".format(
-                    os.path.join(cxx_include_dir, self.project.arch_triplet, "c++", "5")
+            Equals(
+                "-I{} -I{} -I{} -I{}".format(
+                    cxx_include_dir,
+                    os.path.join(cxx_include_dir, self.project.arch_triplet),
+                    os.path.join(cxx_include_dir, "c++", "5"),
+                    os.path.join(
+                        cxx_include_dir, self.project.arch_triplet, "c++", "5"
+                    ),
                 )
             ),
         )


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Currently some of the include paths aren't ordered deterministically, and they change between builds, which ruins the rebuilding story because Catkin takes it as a sign that it needs to start the build over. This PR fixes [LP: #1827148](https://bugs.launchpad.net/snapcraft/+bug/1827148) for legacy by making sure they stay the same between builds.