### PR TITLE
integration tests: use correct series in get_package_version

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -741,7 +741,7 @@ def get_package_version(package_name, series, deb_arch):
         "text": "on",
     }
     query = requests.get(
-        "http://people.canonical.com/~ubuntu-archive/madison.cgi", params
+        "https://people.canonical.com/~ubuntu-archive/madison.cgi", params
     )
     query.raise_for_status()
     package = query.text.strip().split("\n")[-1]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Currently, `get_package_version` returns the results from the latest Ubuntu release, regardless of the series requested. Until recently, this happened to work out, whether that's because the versions all lined up (doubtful) or because people.canonical.com only recently started using HTTPS.
    
However, now tests are breaking. This is due to a [bug in requests](https://github.com/kennethreitz/requests/issues/5077) that double-encodes URL parameters upon redirect. Simply switching over to HTTPS works around the bug (i.e. no redirect needed) and solves the problem.