### PR TITLE
[legacy] integration tests: use correct series in get_package_version

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -735,7 +735,7 @@ def get_package_version(package_name, series, deb_arch):
         "text": "on",
     }
     query = requests.get(
-        "http://people.canonical.com/~ubuntu-archive/madison.cgi", params
+        "https://people.canonical.com/~ubuntu-archive/madison.cgi", params
     )
     query.raise_for_status()
     package = query.text.strip().split("\n")[-1]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR is a backport of #2548 for legacy.