### PR TITLE
project: read local plugins from build-aux

### DIFF
--- a/snapcraft/internal/pluginhandler/_plugin_loader.py
+++ b/snapcraft/internal/pluginhandler/_plugin_loader.py
@@ -17,6 +17,7 @@
 import contextlib
 import importlib
 import logging
+import os
 import sys
 
 import jsonschema
@@ -29,10 +30,19 @@ logger = logging.getLogger(__name__)
 
 
 def load_plugin(
-    plugin_name, part_name, project_options, properties, part_schema, definitions_schema
+    plugin_name,
+    part_name,
+    project_options,
+    properties,
+    part_schema,
+    definitions_schema,
+    local_plugins_dir=None,
 ):
+    if not local_plugins_dir:
+        local_plugins_dir = os.path.join(os.getcwd(), "snap", "plugins")
+
     module_name = plugin_name.replace("-", "_")
-    module = _load_module(module_name, plugin_name, project_options.local_plugins_dir)
+    module = _load_module(module_name, plugin_name, local_plugins_dir)
     plugin_class = _get_plugin(module)
     if not plugin_class:
         raise errors.PluginError("no plugin found in module {!r}".format(plugin_name))

--- a/snapcraft/internal/pluginhandler/_plugin_loader.py
+++ b/snapcraft/internal/pluginhandler/_plugin_loader.py
@@ -25,6 +25,7 @@ import jsonschema
 import snapcraft
 from snapcraft.project.errors import YamlValidationError
 from snapcraft.internal import errors
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +37,7 @@ def load_plugin(
     properties,
     part_schema,
     definitions_schema,
-    local_plugins_dir=None,
+    local_plugins_dir: Optional[str] = None,
 ):
     if not local_plugins_dir:
         local_plugins_dir = os.path.join(os.getcwd(), "snap", "plugins")

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -183,6 +183,7 @@ class PartsConfig:
             project_options=self._project,
             part_schema=self._validator.part_schema,
             definitions_schema=self._validator.definitions_schema,
+            local_plugins_dir=self._project.local_plugins_dir,
         )
 
         logger.debug(

--- a/snapcraft/project/_project.py
+++ b/snapcraft/project/_project.py
@@ -57,7 +57,7 @@ class Project(ProjectOptions):
         self.local_plugins_dir = self._get_local_plugins_dir()
 
     def _get_snapcraft_assets_dir(self) -> str:
-        # Use the default dir if the yaml file path is not specified
+        # Many test cases don't set the yaml file path and assume the default dir
         if not self.info:
             return os.path.join(self._project_dir, "snap")
 

--- a/snapcraft/project/_project.py
+++ b/snapcraft/project/_project.py
@@ -57,6 +57,7 @@ class Project(ProjectOptions):
         self.local_plugins_dir = self._get_local_plugins_dir()
 
     def _get_snapcraft_assets_dir(self) -> str:
+        # Use the default dir if the yaml file path is not specified
         if not self.info:
             return os.path.join(self._project_dir, "snap")
 

--- a/snapcraft/project/_project.py
+++ b/snapcraft/project/_project.py
@@ -16,6 +16,7 @@
 
 import os
 
+from snapcraft.internal.deprecations import handle_deprecation_notice
 from ._project_options import ProjectOptions
 from ._project_info import ProjectInfo  # noqa: F401
 
@@ -53,13 +54,27 @@ class Project(ProjectOptions):
 
         super().__init__(target_deb_arch, debug, work_dir=work_dir)
 
+        self.local_plugins_dir = self._get_local_plugins_dir()
+
     def _get_snapcraft_assets_dir(self) -> str:
+        if not self.info:
+            return os.path.join(self._project_dir, "snap")
+
         if self.info.snapcraft_yaml_file_path.endswith(
             os.path.join("build-aux", "snap", "snapcraft.yaml")
         ):
             return os.path.join(self._project_dir, "build-aux", "snap")
         else:
             return os.path.join(self._project_dir, "snap")
+
+    def _get_local_plugins_dir(self) -> str:
+        deprecated_plugins_dir = os.path.join(self._parts_dir, "plugins")
+        if os.path.exists(deprecated_plugins_dir):
+            handle_deprecation_notice("dn2")
+            return deprecated_plugins_dir
+        else:
+            assets_dir = self._get_snapcraft_assets_dir()
+            return os.path.join(assets_dir, "plugins")
 
     def _get_global_state_file_path(self) -> str:
         if self._is_managed_host:

--- a/snapcraft/project/_project_options.py
+++ b/snapcraft/project/_project_options.py
@@ -24,7 +24,6 @@ from typing import List, Set  # noqa: F401
 
 from snapcraft import file_utils
 from snapcraft.internal import common, errors, os_release
-from snapcraft.internal.deprecations import handle_deprecation_notice
 
 
 logger = logging.getLogger(__name__)
@@ -131,17 +130,6 @@ def _get_platform_architecture():
     return architecture
 
 
-def _get_local_plugins_dir(project_dir: str, parts_dir: str) -> str:
-    deprecated_plugins_dir = os.path.join(parts_dir, "plugins")
-    if os.path.exists(deprecated_plugins_dir):
-        handle_deprecation_notice("dn2")
-        local_plugins_dir = deprecated_plugins_dir
-    else:
-        local_plugins_dir = os.path.join(project_dir, "snap", "plugins")
-
-    return local_plugins_dir
-
-
 class ProjectOptions:
     @property
     def parallel_build_count(self) -> int:
@@ -198,10 +186,6 @@ class ProjectOptions:
         return self.__machine_info["kernel"]
 
     @property
-    def local_plugins_dir(self) -> str:
-        return self._local_plugins_dir
-
-    @property
     def parts_dir(self) -> str:
         return self._parts_dir
 
@@ -231,7 +215,6 @@ class ProjectOptions:
         self._parts_dir = os.path.join(work_dir, "parts")
         self._stage_dir = os.path.join(work_dir, "stage")
         self._prime_dir = os.path.join(work_dir, "prime")
-        self._local_plugins_dir = _get_local_plugins_dir(project_dir, self._parts_dir)
 
         logger.debug("Parts dir {}".format(self._parts_dir))
         logger.debug("Stage dir {}".format(self._stage_dir))

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import apt
-import contextlib
 import logging
 import os
 import stat

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -226,10 +226,10 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         )
         self.useFixture(fixture_setup.FakeSnapcraftctl())
 
-    def make_snapcraft_yaml(self, content, encoding="utf-8"):
-        with contextlib.suppress(FileExistsError):
-            os.mkdir("snap")
-        snapcraft_yaml = os.path.join("snap", "snapcraft.yaml")
+    def make_snapcraft_yaml(self, content, encoding="utf-8", location=""):
+        snap_dir = os.path.join(location, "snap")
+        os.makedirs(snap_dir, exist_ok=True)
+        snapcraft_yaml = os.path.join(snap_dir, "snapcraft.yaml")
         with open(snapcraft_yaml, "w", encoding=encoding) as fp:
             fp.write(content)
         return snapcraft_yaml

--- a/tests/unit/project/test_project.py
+++ b/tests/unit/project/test_project.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+
 from tests import unit
 
 from testtools.matchers import Equals, Is
@@ -49,3 +51,33 @@ class ProjectTest(unit.TestCase):
 
         # Only 1 value is enough
         self.assertThat(project.info.name, Equals("foo"))
+
+
+class ProjectLocationTest(unit.TestCase):
+
+    scenarios = [
+        ("standard", {"location": ""}),
+        ("alternative", {"location": "build-aux"}),
+    ]
+
+    def test_project_local_plugin_location(self):
+        snapcraft_yaml_file_path = self.make_snapcraft_yaml(
+            """\
+            name: foo
+            version: "1"
+            summary: bar
+            description: baz
+            confinement: strict
+
+            parts:
+              part1:
+                plugin: nil
+            """,
+            location=self.location,
+        )
+
+        project = Project(snapcraft_yaml_file_path=snapcraft_yaml_file_path)
+        self.assertThat(
+            project.local_plugins_dir,
+            Equals(os.path.join(os.getcwd(), self.location, "snap", "plugins")),
+        )


### PR DESCRIPTION
When loading snapcraft.yaml from the build-aux/snap instead of snap, we
should also read local plugins from the alternative location.

LP: #1827095

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
