### PR TITLE
extensions: block direct use of private extensions

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/_utils.py
+++ b/snapcraft/internal/project_loader/_extensions/_utils.py
@@ -86,6 +86,9 @@ def find_extension(extension_name: str) -> Type[Extension]:
     :rtype: type(Extension)
     :raises: errors.ExtensionNotFoundError if the extension is not found
     """
+    if extension_name.startswith("_"):
+        raise errors.ExtensionNotFoundError(extension_name)
+
     try:
         extension_module = importlib.import_module(
             "snapcraft.internal.project_loader._extensions.{}".format(extension_name)

--- a/tests/unit/commands/test_extensions.py
+++ b/tests/unit/commands/test_extensions.py
@@ -34,6 +34,7 @@ class ExtensionsCommandTest(CommandBaseTestCase):
         self.useFixture(_test1_extension_fixture())
         self.useFixture(_test2_extension_fixture())
         self.useFixture(_test3_extension_fixture())
+        self.useFixture(_test4_extension_fixture())
 
     @mock.patch(
         "pkgutil.iter_modules",
@@ -41,6 +42,7 @@ class ExtensionsCommandTest(CommandBaseTestCase):
             (None, "test1", None),
             (None, "test2", None),
             (None, "test3", None),
+            (None, "_test4", None),
         ),
     )
     def test_list_extensions(self, fake_iter_modules):
@@ -223,3 +225,14 @@ def _test3_extension_fixture():
             self.parts = {"extension-part": {"plugin": "nil"}}
 
     return fixture_setup.FakeExtension("test3", Test3Extension)
+
+
+def _test4_extension_fixture():
+    class Test4Extension(Extension):
+        supported_bases = ("core16", "core18")
+
+        def __init__(self, yaml_data):
+            super().__init__(yaml_data)
+            self.parts = {"extension-part": {"plugin": "nil"}}
+
+    return fixture_setup.FakeExtension("_test4", Test4Extension)


### PR DESCRIPTION
Don't directly load extensions if their name starts with an underscore. These
extensions are internal and shouldn't be available for public consumption,
to avoid spawn new unanticipated scenarios that need to be supported forever.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
