### PR TITLE
manifest: expose snapcraft-started-at

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -438,9 +438,7 @@ class _SnapPackaging:
             os.makedirs(prime_snap_dir, exist_ok=True)
             shutil.copy2(self._snapcraft_yaml_path, recorded_snapcraft_yaml_path)
             annotated_snapcraft = _manifest.annotate_snapcraft(
-                copy.deepcopy(self._config_data),
-                self._parts_dir,
-                self._global_state_file,
+                self._project_config.project, copy.deepcopy(self._config_data)
             )
             with open(manifest_file_path, "w") as manifest_file:
                 yaml_utils.dump(annotated_snapcraft, stream=manifest_file)

--- a/snapcraft/project/_project.py
+++ b/snapcraft/project/_project.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+from datetime import datetime
 
 from snapcraft.internal.deprecations import handle_deprecation_notice
 from ._project_options import ProjectOptions
@@ -55,6 +56,7 @@ class Project(ProjectOptions):
         super().__init__(target_deb_arch, debug, work_dir=work_dir)
 
         self.local_plugins_dir = self._get_local_plugins_dir()
+        self._start_time = datetime.now()
 
     def _get_snapcraft_assets_dir(self) -> str:
         # Many test cases don't set the yaml file path and assume the default dir
@@ -84,3 +86,7 @@ class Project(ProjectOptions):
             state_file_path = os.path.join(self._parts_dir, ".snapcraft_global_state")
 
         return state_file_path
+
+    def _get_start_time(self) -> datetime:
+        """Returns the timestamp for when a snapcraft project was loaded."""
+        return self._start_time

--- a/snapcraft/project/_project.py
+++ b/snapcraft/project/_project.py
@@ -56,7 +56,7 @@ class Project(ProjectOptions):
         super().__init__(target_deb_arch, debug, work_dir=work_dir)
 
         self.local_plugins_dir = self._get_local_plugins_dir()
-        self._start_time = datetime.now()
+        self._start_time = datetime.utcnow()
 
     def _get_snapcraft_assets_dir(self) -> str:
         # Many test cases don't set the yaml file path and assume the default dir

--- a/tests/unit/lifecycle/test_lifecycle.py
+++ b/tests/unit/lifecycle/test_lifecycle.py
@@ -18,6 +18,7 @@ import logging
 import os
 import subprocess
 import textwrap
+from datetime import datetime
 from unittest import mock
 
 import fixtures
@@ -556,6 +557,15 @@ class RecordManifestBaseTestCase(LifecycleTestBase):
         patcher.start()
         self.addCleanup(patcher.stop)
 
+        patcher = mock.patch(
+            "snapcraft.project.Project._get_start_time",
+            return_value=datetime.strptime(
+                "2019-05-07T19:25:53.939041", "%Y-%m-%dT%H:%M:%S.%f"
+            ),
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
         original_check_output = subprocess.check_output
 
         def fake_uname(cmd, *args, **kwargs):
@@ -612,6 +622,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         expected = textwrap.dedent(
             """\
             snapcraft-version: '3.0'
+            snapcraft-started-at: '2019-05-07T19:25:53.939041Z'
             snapcraft-os-release-id: ubuntu
             snapcraft-os-release-version-id: '16.04'
             name: test
@@ -668,6 +679,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         expected = textwrap.dedent(
             """\
             snapcraft-version: '3.0'
+            snapcraft-started-at: '2019-05-07T19:25:53.939041Z'
             snapcraft-os-release-id: ubuntu
             snapcraft-os-release-version-id: '16.04'
             name: test
@@ -728,6 +740,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         expected = textwrap.dedent(
             """\
             snapcraft-version: '3.0'
+            snapcraft-started-at: '2019-05-07T19:25:53.939041Z'
             snapcraft-os-release-id: ubuntu
             snapcraft-os-release-version-id: '16.04'
             name: test
@@ -790,6 +803,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         expected = textwrap.dedent(
             """\
             snapcraft-version: '3.0'
+            snapcraft-started-at: '2019-05-07T19:25:53.939041Z'
             snapcraft-os-release-id: ubuntu
             snapcraft-os-release-version-id: '16.04'
             name: test
@@ -853,6 +867,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         expected = textwrap.dedent(
             """\
             snapcraft-version: '3.0'
+            snapcraft-started-at: '2019-05-07T19:25:53.939041Z'
             snapcraft-os-release-id: ubuntu
             snapcraft-os-release-version-id: '16.04'
             name: test
@@ -914,6 +929,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         expected = textwrap.dedent(
             """\
             snapcraft-version: '3.0'
+            snapcraft-started-at: '2019-05-07T19:25:53.939041Z'
             snapcraft-os-release-id: ubuntu
             snapcraft-os-release-version-id: '16.04'
             name: test
@@ -978,6 +994,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         expected = textwrap.dedent(
             """\
             snapcraft-version: '3.0'
+            snapcraft-started-at: '2019-05-07T19:25:53.939041Z'
             snapcraft-os-release-id: ubuntu
             snapcraft-os-release-version-id: '16.04'
             name: test
@@ -1041,6 +1058,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         expected = textwrap.dedent(
             """\
             snapcraft-version: '3.0'
+            snapcraft-started-at: '2019-05-07T19:25:53.939041Z'
             snapcraft-os-release-id: ubuntu
             snapcraft-os-release-version-id: '16.04'
             name: test
@@ -1095,6 +1113,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         expected = textwrap.dedent(
             """\
             snapcraft-version: '3.0'
+            snapcraft-started-at: '2019-05-07T19:25:53.939041Z'
             snapcraft-os-release-id: ubuntu
             snapcraft-os-release-version-id: '16.04'
             name: test
@@ -1154,6 +1173,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         expected = textwrap.dedent(
             """\
             snapcraft-version: '3.0'
+            snapcraft-started-at: '2019-05-07T19:25:53.939041Z'
             snapcraft-os-release-id: ubuntu
             snapcraft-os-release-version-id: '16.04'
             name: test
@@ -1232,6 +1252,7 @@ class RecordManifestWithDeprecatedSnapKeywordTestCase(RecordManifestBaseTestCase
         expected = textwrap.dedent(
             """\
             snapcraft-version: '3.0'
+            snapcraft-started-at: '2019-05-07T19:25:53.939041Z'
             snapcraft-os-release-id: ubuntu
             snapcraft-os-release-version-id: '16.04'
             name: test

--- a/tests/unit/project/test_project.py
+++ b/tests/unit/project/test_project.py
@@ -86,4 +86,4 @@ class ProjectLocationTest(unit.TestCase):
 class ProjectTimestampTest(unit.TestCase):
     def test_get_snapcraft_started(self):
         project = Project()
-        self.assertThat(project._get_start_time(), LessThan(datetime.now()))
+        self.assertThat(project._get_start_time(), LessThan(datetime.utcnow()))

--- a/tests/unit/project/test_project.py
+++ b/tests/unit/project/test_project.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2018 Canonical Ltd
+# Copyright (C) 2015-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -15,11 +15,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+from datetime import datetime
+
+from testtools.matchers import Equals, Is, LessThan
 
 from tests import unit
-
-from testtools.matchers import Equals, Is
-
 from snapcraft.project import Project
 
 
@@ -81,3 +81,9 @@ class ProjectLocationTest(unit.TestCase):
             project.local_plugins_dir,
             Equals(os.path.join(os.getcwd(), self.location, "snap", "plugins")),
         )
+
+
+class ProjectTimestampTest(unit.TestCase):
+    def test_get_snapcraft_started(self):
+        project = Project()
+        self.assertThat(project._get_start_time(), LessThan(datetime.now()))


### PR DESCRIPTION
Expose snapcraft-started-at in the manifest.yaml to use as an ordering
mechanism when processing snaps coming into the Snap Store.

LP: #1806658

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
