### PR TITLE
remote_build: handle git push in detached head state

### DIFF
--- a/snapcraft/internal/remote_build/_repo.py
+++ b/snapcraft/internal/remote_build/_repo.py
@@ -56,7 +56,7 @@ class Repo:
 
         if provider == "launchpad":
             url = self._remote_url(user, build_id)
-            self._repo.git.push(url, branch, force=True)
+            self._repo.git.push(url, branch + ":refs/head/master", force=True)
             self._repo.git.push(url, "--tags")
         else:
             raise errors.RemoteBuilderNotSupportedError(provider=provider)
@@ -95,6 +95,9 @@ class Repo:
 
     @property
     def branch_name(self) -> str:
+        # Check whether we are in a detached HEAD state
+        if self._repo.git.rev_parse("--symbolic-full-name", "HEAD") == "HEAD":
+            return "HEAD"
         return self._repo.active_branch.name
 
     @staticmethod

--- a/tests/unit/remote_build/test_repo.py
+++ b/tests/unit/remote_build/test_repo.py
@@ -108,6 +108,15 @@ class RepoTestCase(unit.TestCase):
         )
         self.assertThat(str(raised), Contains("is not supported"))
 
+    def test_branch_name_detached_head(self):
+        repo = Repo(self._dir.path)
+        repo.add("foo")
+        repo.commit()
+        commit = self._check_output("git", "rev-parse", "HEAD")
+        commit = commit.decode("ascii").strip()
+        self._run("git", "checkout", commit)
+        self.assertThat(repo.branch_name, Equals("HEAD"))
+
     @mock.patch("git.Repo")
     def test_push_remote(self, mock_repo):
         repo = Repo(self._dir.path)
@@ -117,7 +126,7 @@ class RepoTestCase(unit.TestCase):
                 mock.call(self._dir.path),
                 mock.call().git.push(
                     "git+ssh://user@git.launchpad.net/~user/+git/id/",
-                    "branch",
+                    "branch:refs/head/master",
                     force=True,
                 ),
                 mock.call().git.push(


### PR DESCRIPTION
When dispatching a remote build job using --git and we're currently in
detached head state, branch name retrieval raises an exception. Fix that
by returning HEAD if detached head is detected.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
