### PR TITLE
[legacy] catkin spread tests: stop testing indigo

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -36,8 +36,6 @@ backends:
     key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
     location: computeengine/us-east1-b
     systems:
-      - ubuntu-14.04-64:
-          workers: 3
       - ubuntu-16.04-64:
           workers: 3
       - ubuntu-18.04-64:

--- a/tests/spread/general/cwd_not_on_sys_path/task.yaml
+++ b/tests/spread/general/cwd_not_on_sys_path/task.yaml
@@ -1,8 +1,5 @@
 summary: Build a snap that would crash snapcraft if it loaded modules from cwd
 
-# The python plugin doesn't work on trusty
-systems: [-ubuntu-14*]
-
 environment:
   SNAP_DIR: snaps/sys-path-test
 

--- a/tests/spread/legacy/command-define/task.yaml
+++ b/tests/spread/legacy/command-define/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure the define command outputs correctly
 
-systems: [ubuntu-14*, ubuntu-16*]
+systems: [ubuntu-16*]
 
 restore: |
   rm -rf ./parts

--- a/tests/spread/legacy/command-update/task.yaml
+++ b/tests/spread/legacy/command-update/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure the update command creates parts.yaml and headers.yaml
 
-systems: [ubuntu-14*, ubuntu-16*]
+systems: [ubuntu-16*]
 
 restore: |
   rm -rf ./parts

--- a/tests/spread/legacy/wiki-filesets/task.yaml
+++ b/tests/spread/legacy/wiki-filesets/task.yaml
@@ -1,6 +1,6 @@
 summary: Build a snap that pulls parts with filesets from the wiki
 
-systems: [ubuntu-14*, ubuntu-16*]
+systems: [ubuntu-16*]
 
 environment:
   SNAP_DIR: snaps/wiki-filesets
@@ -27,4 +27,3 @@ execute: |
 
   # Verify the right files and directories made it to stage.
   [ -z "$(compare_dir_contents stage expected_staged.txt)" ]
-  

--- a/tests/spread/legacy/wiki/task.yaml
+++ b/tests/spread/legacy/wiki/task.yaml
@@ -1,6 +1,6 @@
 summary: Build a snap that pulls parts from the wiki
 
-systems: [ubuntu-14*, ubuntu-16*]
+systems: [ubuntu-16*]
 
 environment:
   SNAP_DIR: snaps/wiki

--- a/tests/spread/plugins/catkin/run/task.yaml
+++ b/tests/spread/plugins/catkin/run/task.yaml
@@ -10,9 +10,8 @@ restore: |
   snapcraft clean
   rm -f ./*.snap
 
-# ROS Indigo doesn't support arm64 (there are no packages in the archive). Also,
-# Indigo snaps have trouble building past 16.04.
-systems: [-ubuntu-*-arm64, -ubuntu-18*]
+# ROS Kinetic only supports 16.04
+systems: [ubuntu-16.04*]
 
 execute: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/catkin/snaps/ros-talker-listener/snap/snapcraft.yaml
+++ b/tests/spread/plugins/catkin/snaps/ros-talker-listener/snap/snapcraft.yaml
@@ -13,4 +13,4 @@ parts:
   ros-project:
     plugin: catkin
     source: .
-    rosdistro: indigo
+    rosdistro: kinetic

--- a/tests/spread/plugins/go/classic/task.yaml
+++ b/tests/spread/plugins/go/classic/task.yaml
@@ -1,8 +1,5 @@
 summary: Build and run a basic Go snap
 
-# Classic snaps don't build on 14.04
-systems: [-ubuntu-14*]
-
 environment:
   SNAP_DIR: ../snaps/go-gotty
 

--- a/tests/spread/plugins/go/cross_compile_cgo/task.yaml
+++ b/tests/spread/plugins/go/cross_compile_cgo/task.yaml
@@ -1,8 +1,5 @@
 summary: Cross-compile Go snaps using cgo
 
-# cgo doesn't build on 14.04
-systems: [-ubuntu-14*]
-
 environment:
   SNAP_DIR: ../snaps/go-cgo
 

--- a/tests/spread/plugins/meson/run/task.yaml
+++ b/tests/spread/plugins/meson/run/task.yaml
@@ -8,9 +8,6 @@ restore: |
   snapcraft clean
   rm -f ./*.snap
 
-# There is no meson on trusty
-systems: [-ubuntu-14.04*]
-
 execute: |
   cd "$SNAP_DIR"
   snapcraft


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Indigo snaps can no longer be built due to its being EOL (rosdep cannot discover dependencies for EOL distros without special flags). This PR resolves [LP: #1830769](https://bugs.launchpad.net/snapcraft/+bug/1830769) for legacy by updating the Catkin spread tests to use Kinetic instead of Indigo.

Given that 14.04 is EOL as well, it also removes all 14.04 spread tests.