### PR TITLE
catkin spread tests: restrict tests to Ubuntu 16.04

### DIFF
--- a/tests/spread/plugins/catkin/legacy-pull/task.yaml
+++ b/tests/spread/plugins/catkin/legacy-pull/task.yaml
@@ -13,9 +13,7 @@ restore: |
   snapcraft clean
   rm -f ./*.snap
 
-# ROS Indigo doesn't support arm64 (there are no packages in the archive). Also,
-# Indigo snaps have trouble building past 16.04.
-systems: [-ubuntu-*-arm64, -ubuntu-18*]
+systems: [ubuntu-16*]
 
 execute: |
   cd "$SNAP_DIR"


### PR DESCRIPTION
Ubuntu 14.04 LTS is in extended security maintenance mode.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
