### PR TITLE
catkin spread tests: use kinetic instead of indigo

### DIFF
--- a/tests/spread/general/cwd_not_on_sys_path/task.yaml
+++ b/tests/spread/general/cwd_not_on_sys_path/task.yaml
@@ -1,8 +1,5 @@
 summary: Build a snap that would crash snapcraft if it loaded modules from cwd
 
-# The python plugin doesn't work on trusty
-systems: [-ubuntu-14*]
-
 environment:
   SNAP_DIR: snaps/sys-path-test
 

--- a/tests/spread/legacy/command-define/task.yaml
+++ b/tests/spread/legacy/command-define/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure the define command outputs correctly
 
-systems: [ubuntu-14*, ubuntu-16*]
+systems: [ubuntu-16*]
 
 restore: |
   rm -rf ./parts

--- a/tests/spread/legacy/command-update/task.yaml
+++ b/tests/spread/legacy/command-update/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure the update command creates parts.yaml and headers.yaml
 
-systems: [ubuntu-14*, ubuntu-16*]
+systems: [ubuntu-16*]
 
 restore: |
   rm -rf ./parts
@@ -32,4 +32,3 @@ execute: |
     fi
   done
   test $nparts = 1
-

--- a/tests/spread/legacy/scriptlets/task.yaml
+++ b/tests/spread/legacy/scriptlets/task.yaml
@@ -1,6 +1,6 @@
 summary: Build a snap using legacy scriptlets
 
-systems: [ubuntu-14*, ubuntu-16*]
+systems: [ubuntu-16*]
 
 environment:
   SNAP_DIR: ../snaps/scriplets

--- a/tests/spread/legacy/wiki-filesets/task.yaml
+++ b/tests/spread/legacy/wiki-filesets/task.yaml
@@ -1,6 +1,6 @@
 summary: Build a snap that pulls parts with filesets from the wiki
 
-systems: [ubuntu-14*, ubuntu-16*]
+systems: [ubuntu-16*]
 
 environment:
   SNAP_DIR: snaps/wiki-filesets
@@ -27,4 +27,3 @@ execute: |
 
   # Verify the right files and directories made it to stage.
   [ -z "$(compare_dir_contents stage expected_staged.txt)" ]
-  

--- a/tests/spread/legacy/wiki/task.yaml
+++ b/tests/spread/legacy/wiki/task.yaml
@@ -1,6 +1,6 @@
 summary: Build a snap that pulls parts from the wiki
 
-systems: [ubuntu-14*, ubuntu-16*]
+systems: [ubuntu-16*]
 
 environment:
   SNAP_DIR: snaps/wiki

--- a/tests/spread/plugins/catkin/legacy-pull/task.yaml
+++ b/tests/spread/plugins/catkin/legacy-pull/task.yaml
@@ -8,14 +8,24 @@ priority: 100  # Run this test early so we're not waiting for it
 environment:
   SNAP_DIR: ../snaps/ros-talker-listener
 
+prepare: |
+  cd "$SNAP_DIR"
+
+  # By default this snap will end up using Indigo, which is EOL. Make sure it uses
+  # Kinetic instead.
+  echo "    rosdistro: kinetic" >> snap/snapcraft.yaml
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean
   rm -f ./*.snap
 
-# ROS Indigo doesn't support arm64 (there are no packages in the archive). Also,
-# Indigo snaps have trouble building past 16.04.
-systems: [-ubuntu-*-arm64, -ubuntu-18*]
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+# ROS Kinetic only supports 16.04
+systems: [ubuntu-16.04*]
 
 execute: |
   cd "$SNAP_DIR"

--- a/tests/spread/plugins/catkin/legacy-pull/task.yaml
+++ b/tests/spread/plugins/catkin/legacy-pull/task.yaml
@@ -11,8 +11,7 @@ environment:
 prepare: |
   cd "$SNAP_DIR"
 
-  # By default this snap will end up using Indigo, which is EOL. Make sure it uses
-  # Kinetic instead.
+  # Legacy requires the rosdistro to be specified
   echo "    rosdistro: kinetic" >> snap/snapcraft.yaml
 
 restore: |

--- a/tests/spread/plugins/meson/legacy-build-run/task.yaml
+++ b/tests/spread/plugins/meson/legacy-build-run/task.yaml
@@ -8,9 +8,6 @@ restore: |
   snapcraft clean
   rm -f ./*.snap
 
-# There is no meson on trusty
-systems: [-ubuntu-14.04*]
-
 execute: |
   cd "$SNAP_DIR"
   snapcraft


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Indigo snaps can no longer be built due to its being EOL (rosdep cannot discover dependencies for EOL distros without special flags). This PR resolves [LP: #1830769](https://bugs.launchpad.net/snapcraft/+bug/1830769) by updating the legacy pull test in the Catkin spread suite to use Kinetic instead of Indigo. It also removes all 14.04 spread filters given that no 14.04 runners exist anymore (it, too, is EOL).