### PR TITLE
[legacy] catkin plugin: remove default rosdistro

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -30,7 +30,8 @@ Additionally, this plugin uses the following plugin-specific keywords:
       The source space containing Catkin packages. By default this is 'src'.
     - rosdistro:
       (string)
-      The ROS distro required by this system. Defaults to 'indigo'.
+      The ROS distro required by this system. Options are 'indigo', 'jade',
+      'kinetic', or 'lunar'.
     - include-roscore:
       (boolean)
       Whether or not to include roscore with the part. Defaults to true.
@@ -169,7 +170,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
     @classmethod
     def schema(cls):
         schema = super().schema()
-        schema["properties"]["rosdistro"] = {"type": "string", "default": "indigo"}
+        schema["properties"]["rosdistro"] = {"type": "string"}
         schema["properties"]["catkin-packages"] = {
             "type": "array",
             "minitems": 1,
@@ -217,6 +218,8 @@ class CatkinPlugin(snapcraft.BasePlugin):
             "type": "string",
             "default": "http://localhost:11311",
         }
+
+        schema["required"].append("rosdistro")
 
         return schema
 

--- a/tests/unit/plugins/test_catkin.py
+++ b/tests/unit/plugins/test_catkin.py
@@ -179,12 +179,14 @@ class CatkinPluginTestCase(CatkinPluginBaseTestCase):
 
         # Check rosdistro property
         rosdistro = schema["properties"]["rosdistro"]
-        expected = ("type", "default")
+        expected = ("type",)
         self.assertThat(rosdistro, HasLength(len(expected)))
         for prop in expected:
             self.assertThat(rosdistro, Contains(prop))
         self.assertThat(rosdistro["type"], Equals("string"))
-        self.assertThat(rosdistro["default"], Equals("indigo"))
+
+        # Ensure that it's required
+        self.assertThat(schema["required"], Contains("rosdistro"))
 
     def test_schema_catkin_packages(self):
         schema = catkin.CatkinPlugin.schema()


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

The Catkin plugin currently defaults to using Indigo, a now-EOL ROS distro. Anyone relying on that default is now unable to build a snap. They will probably need to start using another one to get unblocked. Rather than simply set the default to something else and potentially run into this issue again, this PR resolves [LP: #1830784](https://bugs.launchpad.net/snapcraft/+bug/1830784) by getting rid of the default altogether and making users specify which one they want, thus keeping behavior predictable in the future.