### PR TITLE
plainbox spread tests: lock down python packages

### DIFF
--- a/tests/spread/plugins/plainbox/snaps/checkbox/snap/snapcraft.yaml
+++ b/tests/spread/plugins/plainbox/snaps/checkbox/snap/snapcraft.yaml
@@ -20,8 +20,9 @@ parts:
         python-packages:
             - checkbox-ng==1.0.0
             - idna==2.7
-            - requests-oauthlib
-            - xlsxwriter
+            - requests-oauthlib==1.2.0
+            - urllib3==1.24
+            - xlsxwriter==1.1.8
         build-packages:
             - libxml2-dev
             - libxslt1-dev

--- a/tests/spread/plugins/plainbox/snaps/provider-basic/snap/snapcraft.yaml
+++ b/tests/spread/plugins/plainbox/snaps/provider-basic/snap/snapcraft.yaml
@@ -19,17 +19,19 @@ parts:
             - build-essential
         python-packages:
             - idna==2.7
-            - requests-oauthlib
-            - XlsxWriter
-            - Jinja2
-            - guacamole
-            - padme
+            - requests-oauthlib==1.2.0
+            - urllib3==1.24
+            - xlsxwriter==1.1.8
+            - Jinja2==2.10.1
+            - guacamole==0.9.2
+            - padme==1.1.1
     checkbox-support-dev:
         plugin: python
         source: git://git.launchpad.net/checkbox-support
         source-type: git
         python-packages:
             - idna==2.7
+            - urllib3==1.24
     simple-plainbox-provider:
         plugin: plainbox-provider
         source: ./2016.com.example_simple

--- a/tests/spread/plugins/plainbox/snaps/provider-python-stage-package-mix/snap/snapcraft.yaml
+++ b/tests/spread/plugins/plainbox/snaps/provider-python-stage-package-mix/snap/snapcraft.yaml
@@ -13,8 +13,9 @@ parts:
     plugin: python
     python-packages:
       - idna==2.7
-      - checkbox-ng
-      - requests-oauthlib
+      - checkbox-ng==1.0.0
+      - requests-oauthlib==1.2.0
+      - urllib3==1.24
     stage-packages:
       - python3-requests-unixsocket
     build-packages:

--- a/tests/spread/plugins/plainbox/snaps/provider-with-deps/snap/snapcraft.yaml
+++ b/tests/spread/plugins/plainbox/snaps/provider-with-deps/snap/snapcraft.yaml
@@ -19,11 +19,12 @@ parts:
             - build-essential
         python-packages:
             - idna==2.7
-            - requests-oauthlib
-            - XlsxWriter
-            - Jinja2
-            - guacamole
-            - padme
+            - requests-oauthlib==1.2.0
+            - urllib3==1.24
+            - xlsxwriter==1.1.8
+            - Jinja2==2.10.1
+            - guacamole==0.9.2
+            - padme==1.1.1
     parent-plainbox-provider:
         plugin: plainbox-provider
         source: ./2017.com.example_parent

--- a/tests/spread/plugins/plainbox/snaps/provider-with-stage-packages/snap/snapcraft.yaml
+++ b/tests/spread/plugins/plainbox/snaps/provider-with-stage-packages/snap/snapcraft.yaml
@@ -13,8 +13,9 @@ parts:
         plugin: python
         python-packages:
             - idna==2.7
-            - checkbox-ng
-            - requests-oauthlib
+            - checkbox-ng==1.0.0
+            - requests-oauthlib==1.2.0
+            - urllib3==1.24
         build-packages:
             - libxml2-dev
             - libxslt1-dev


### PR DESCRIPTION
This should reduce inconsistencies due to conflicting dependencies being
satisfied and produce consistent results.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
