### PR TITLE
catkin spread tests: finer system filter for legacy-pull

### DIFF
--- a/tests/spread/plugins/catkin/legacy-pull/task.yaml
+++ b/tests/spread/plugins/catkin/legacy-pull/task.yaml
@@ -24,7 +24,12 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 # ROS Kinetic only supports 16.04
-systems: [ubuntu-16.04*]
+systems:
+   - ubuntu-16.04
+   - ubuntu-16.04-64
+   - ubuntu-16.04-amd64
+   - ubuntu-16.04-arm64
+   - ubuntu-16.04-armhf
 
 execute: |
   cd "$SNAP_DIR"


### PR DESCRIPTION
When moving to defaulting to indigo in:

    2c1b97bf41c4bf9e787c06bd85d3119a23263fb7

The finer architecture filter was lost and the spread task for catkin's
legacy-pull started to run on ppc64el. To solve this, the
relevant parts of the system filter at the suite level was brought
into this task.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
