### PR TITLE
catkin plugin: check workspace for dependencies

### DIFF
--- a/snapcraft/formatting_utils.py
+++ b/snapcraft/formatting_utils.py
@@ -14,10 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Iterable, List, Sized
+from typing import Iterable, Sized
 
 
-def combine_paths(paths: List[str], prepend: str, separator: str) -> str:
+def combine_paths(paths: Iterable[str], prepend: str, separator: str) -> str:
     """Combine list of paths into a string.
 
     :param list paths: List of paths to stringify.
@@ -30,7 +30,7 @@ def combine_paths(paths: List[str], prepend: str, separator: str) -> str:
 
 
 def format_path_variable(
-    envvar: str, paths: List[str], prepend: str, separator: str
+    envvar: str, paths: Iterable[str], prepend: str, separator: str
 ) -> str:
     """Return a path-like environment variable definition that appends.
 

--- a/snapcraft/plugins/_ros/__init__.py
+++ b/snapcraft/plugins/_ros/__init__.py
@@ -15,4 +15,5 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from snapcraft.plugins._ros import rosdep  # noqa
+from snapcraft.plugins._ros import rospack  # noqa
 from snapcraft.plugins._ros import wstool  # noqa

--- a/snapcraft/plugins/_ros/rospack.py
+++ b/snapcraft/plugins/_ros/rospack.py
@@ -1,0 +1,146 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import logging
+import subprocess
+import tempfile
+
+from snapcraft.internal import common, repo
+from snapcraft import formatting_utils
+
+logger = logging.getLogger(__name__)
+
+
+class Rospack:
+    def __init__(
+        self,
+        *,
+        ros_distro,
+        ros_package_path,
+        rospack_path,
+        ubuntu_sources,
+        ubuntu_keyrings,
+        project
+    ):
+        self._ros_distro = ros_distro
+        self._ros_package_path = ros_package_path
+        self._rospack_path = rospack_path
+        self._ubuntu_sources = ubuntu_sources
+        self._ubuntu_keyrings = ubuntu_keyrings
+        self._project = project
+
+        self._rospack_install_path = os.path.join(self._rospack_path, "install")
+        self._rospack_cache_path = os.path.join(self._rospack_path, "cache")
+
+    def setup(self):
+        # Make sure we can run multiple times without error
+        os.makedirs(self._rospack_install_path, exist_ok=True)
+
+        # rospack isn't necessarily a dependency of the project, so we'll unpack
+        # it off to the side and use it from there.
+        logger.info("Preparing to fetch rospack...")
+        ubuntu = repo.Ubuntu(
+            self._rospack_path,
+            sources=self._ubuntu_sources,
+            keyrings=self._ubuntu_keyrings,
+            project_options=self._project,
+        )
+
+        logger.info("Fetching rospack...")
+        ubuntu.get(
+            [
+                "ros-{}-rospack".format(self._ros_distro),
+                "ros-{}-catkin".format(self._ros_distro),
+            ]
+        )
+
+        logger.info("Installing rospack...")
+        ubuntu.unpack(self._rospack_install_path)
+
+    def list_names(self):
+        """Obtain list of packages present in the workspace."""
+        output = self._run(["list-names"]).strip()
+        if output:
+            return set(output.split("\n"))
+        else:
+            return set()
+
+    def _run(self, arguments):
+        with tempfile.NamedTemporaryFile(mode="w+") as f:
+            lines = [
+                'export PYTHONPATH="{}"'.format(
+                    os.path.join(
+                        self._rospack_install_path,
+                        "usr",
+                        "lib",
+                        "python2.7",
+                        "dist-packages",
+                    )
+                )
+            ]
+
+            ros_path = os.path.join(
+                self._rospack_install_path, "opt", "ros", self._ros_distro
+            )
+            bin_paths = (
+                os.path.join(ros_path, "bin"),
+                os.path.join(self._rospack_install_path, "usr", "bin"),
+            )
+            lines.append(
+                "export {}".format(
+                    formatting_utils.format_path_variable(
+                        "PATH", bin_paths, prepend="", separator=":"
+                    )
+                )
+            )
+
+            lib_paths = common.get_library_paths(
+                self._rospack_install_path, self._project.arch_triplet
+            )
+            if lib_paths:
+                lines.append(
+                    "export {}".format(
+                        formatting_utils.format_path_variable(
+                            "LD_LIBRARY_PATH", lib_paths, prepend="", separator=":"
+                        )
+                    )
+                )
+
+            # Source our own workspace so we have all of rospack's dependencies
+            lines.append(
+                "_CATKIN_SETUP_DIR={} source {}".format(
+                    ros_path, os.path.join(ros_path, "setup.sh")
+                )
+            )
+
+            # By default, rospack saves its cache in $HOME/.ros, which we shouldn't
+            # access here, so we'll redirect it with this environment variable.
+            lines.append('export ROS_HOME="{}"'.format(self._rospack_cache_path))
+
+            lines.append('export ROS_PACKAGE_PATH="{}"'.format(self._ros_package_path))
+
+            lines.append('exec "$@"')
+            f.write("\n".join(lines))
+            f.flush()
+            return (
+                subprocess.check_output(
+                    ["/bin/bash", f.name, "rospack"] + arguments,
+                    stderr=subprocess.STDOUT,
+                )
+                .decode("utf8")
+                .strip()
+            )

--- a/snapcraft/plugins/_ros/rospack.py
+++ b/snapcraft/plugins/_ros/rospack.py
@@ -69,7 +69,7 @@ class Rospack:
         # rospack isn't necessarily a dependency of the project, so we'll unpack
         # it off to the side and use it from there.
         logger.info("Preparing to fetch rospack...")
-        ubuntu = repo.Ubuntu(
+        ubuntu_repo = repo.Ubuntu(
             self._rospack_path,
             sources=self._ubuntu_sources,
             keyrings=self._ubuntu_keyrings,
@@ -77,7 +77,7 @@ class Rospack:
         )
 
         logger.info("Fetching rospack...")
-        ubuntu.get(
+        ubuntu_repo.get(
             [
                 "ros-{}-rospack".format(self._ros_distro),
                 "ros-{}-catkin".format(self._ros_distro),
@@ -85,7 +85,7 @@ class Rospack:
         )
 
         logger.info("Installing rospack...")
-        ubuntu.unpack(self._rospack_install_path)
+        ubuntu_repo.unpack(self._rospack_install_path)
 
     def list_names(self) -> Set[str]:
         """Obtain list of packages present in the workspace."""

--- a/tests/spread/plugins/catkin/snaps/source-dependencies/snap/snapcraft.yaml
+++ b/tests/spread/plugins/catkin/snaps/source-dependencies/snap/snapcraft.yaml
@@ -1,0 +1,11 @@
+name: source-dependencies
+version: "1.0"
+summary: ROS example with source dependencies
+description: Contains a ROS workspace with source dependencies
+confinement: strict
+
+parts:
+  ros-project:
+    plugin: catkin
+    source: .
+    include-roscore: false

--- a/tests/spread/plugins/catkin/snaps/source-dependencies/src/CMakeLists.txt
+++ b/tests/spread/plugins/catkin/snaps/source-dependencies/src/CMakeLists.txt
@@ -1,0 +1,47 @@
+# toplevel CMakeLists.txt for a catkin workspace
+# catkin/cmake/toplevel.cmake
+
+cmake_minimum_required(VERSION 2.8.3)
+
+# optionally provide a cmake file in the workspace to override arbitrary stuff
+include(workspace.cmake OPTIONAL)
+
+set(CATKIN_TOPLEVEL TRUE)
+
+# include catkin directly or via find_package()
+if(EXISTS "${CMAKE_SOURCE_DIR}/catkin/cmake/all.cmake" AND EXISTS "${CMAKE_SOURCE_DIR}/catkin/CMakeLists.txt")
+  set(catkin_EXTRAS_DIR "${CMAKE_SOURCE_DIR}/catkin/cmake")
+  # include all.cmake without add_subdirectory to let it operate in same scope
+  include(catkin/cmake/all.cmake NO_POLICY_SCOPE)
+  add_subdirectory(catkin)
+
+else()
+  # use either CMAKE_PREFIX_PATH explicitly passed to CMake as a command line argument
+  # or CMAKE_PREFIX_PATH from the environment
+  if(NOT DEFINED CMAKE_PREFIX_PATH)
+    if(NOT "$ENV{CMAKE_PREFIX_PATH}" STREQUAL "")
+      string(REPLACE ":" ";" CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH})
+    endif()
+  endif()
+
+  # list of catkin workspaces
+  set(catkin_search_path "")
+  foreach(path ${CMAKE_PREFIX_PATH})
+    if(EXISTS "${path}/.CATKIN_WORKSPACE")
+      list(FIND catkin_search_path ${path} _index)
+      if(_index EQUAL -1)
+        list(APPEND catkin_search_path ${path})
+      endif()
+    endif()
+  endforeach()
+
+  # search for catkin in all workspaces
+  set(CATKIN_TOPLEVEL_FIND_PACKAGE TRUE)
+  find_package(catkin REQUIRED
+    NO_POLICY_SCOPE
+    PATHS ${catkin_search_path}
+    NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+  unset(CATKIN_TOPLEVEL_FIND_PACKAGE)
+endif()
+
+catkin_workspace()

--- a/tests/spread/plugins/catkin/snaps/source-dependencies/src/dependency/package.xml
+++ b/tests/spread/plugins/catkin/snaps/source-dependencies/src/dependency/package.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<package>
+  <name>dependency</name>
+  <version>0.0.0</version>
+  <description>The dependency package</description>
+  <maintainer email="me@example.com">me</maintainer>
+  <license>GPLv3</license>
+  <buildtool_depend>catkin</buildtool_depend>
+</package>

--- a/tests/spread/plugins/catkin/snaps/source-dependencies/src/dependent/package.xml
+++ b/tests/spread/plugins/catkin/snaps/source-dependencies/src/dependent/package.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<package>
+  <name>dependent</name>
+  <version>0.0.0</version>
+  <description>The dependent package</description>
+  <maintainer email="me@example.com">me</maintainer>
+  <license>GPLv3</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <run_depend>dependency</run_depend>
+</package>

--- a/tests/spread/plugins/catkin/source-dependencies/task.yaml
+++ b/tests/spread/plugins/catkin/source-dependencies/task.yaml
@@ -1,0 +1,27 @@
+summary: Pull a snap that uses dependencies satisfied by source
+warn-timeout: 9m  # Keep less than 10 minutes so Travis can't timeout
+priority: 100  # Run this test early so we're not waiting for it
+
+environment:
+  SNAP_DIR: ../snaps/source-dependencies
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "$SNAP_DIR"
+
+  # This will fail if the snapcraft CLI doesn't properly check the workspace for source
+  # dependencies
+  snapcraft pull

--- a/tests/unit/plugins/ros/test_rospack.py
+++ b/tests/unit/plugins/ros/test_rospack.py
@@ -1,0 +1,96 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+
+from unittest import mock
+from testtools.matchers import Equals
+
+from snapcraft.plugins._ros import rospack
+
+import snapcraft
+from tests import unit
+
+
+class RospackTestCase(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.project = snapcraft.ProjectOptions()
+
+        self.rospack = rospack.Rospack(
+            ros_distro="kinetic",
+            ros_package_path="package_path",
+            rospack_path="rospack_path",
+            ubuntu_sources="sources",
+            ubuntu_keyrings=["keyring"],
+            project=self.project,
+        )
+
+        patcher = mock.patch("snapcraft.repo.Ubuntu")
+        self.ubuntu_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch("subprocess.check_output")
+        self.check_output_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_setup(self):
+        # Return something other than a Mock to ease later assertions
+        self.check_output_mock.return_value = b""
+
+        self.rospack.setup()
+
+        # Verify that only rospack and catkin were installed (no other .debs)
+        self.assertThat(self.ubuntu_mock.call_count, Equals(1))
+        self.assertThat(self.ubuntu_mock.return_value.get.call_count, Equals(1))
+        self.assertThat(self.ubuntu_mock.return_value.unpack.call_count, Equals(1))
+        self.ubuntu_mock.assert_has_calls(
+            [
+                mock.call(
+                    self.rospack._rospack_path,
+                    sources="sources",
+                    keyrings=["keyring"],
+                    project_options=self.project,
+                ),
+                mock.call().get(["ros-kinetic-rospack", "ros-kinetic-catkin"]),
+                mock.call().unpack(self.rospack._rospack_install_path),
+            ]
+        )
+
+    def test_setup_can_run_multiple_times(self):
+        self.rospack.setup()
+
+        # Make sure running setup() again doesn't have problems with the old
+        # environment. An exception will be raised if setup can't be called twice.
+        self.rospack.setup()
+
+    def test_list_names(self):
+        self.check_output_mock.return_value = b"foo\nbar\nbaz"
+
+        self.assertThat(self.rospack.list_names(), Equals({"foo", "bar", "baz"}))
+
+        self.check_output_mock.assert_called_with(
+            ["/bin/bash", mock.ANY, "rospack", "list-names"], stderr=subprocess.STDOUT
+        )
+
+    def test_list_names_no_names(self):
+        self.check_output_mock.return_value = b""
+
+        self.assertThat(self.rospack.list_names(), Equals(set()))
+
+        self.check_output_mock.assert_called_with(
+            ["/bin/bash", mock.ANY, "rospack", "list-names"], stderr=subprocess.STDOUT
+        )


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Currently the Catkin plugin doesn't check the workspace for dependencies, which causes the build to fail if a declared dependency isn't contained within the rosdep index (even though it's satisfied by another package in the workspace). Until rosdep [grows the ability to do this on its own](https://github.com/ros-infrastructure/rosdep/issues/685), this PR resolves [LP: #1832044](https://bugs.launchpad.net/snapcraft/+bug/1832044) by adding the ability for the snapcraft CLI to do this manually, using `rospack` to enumerate the packages contained in the workspace and filtering dependencies through that list.