### PR TITLE
docker images: use newer info API to download snaps

### DIFF
--- a/docker/beta.Dockerfile
+++ b/docker/beta.Dockerfile
@@ -6,12 +6,12 @@ RUN apt dist-upgrade --yes
 RUN apt install --yes curl jq squashfs-tools
 
 # Grab the core snap from the stable channel and unpack it in the proper place
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
+RUN curl -L $(curl -s https://api.snapcraft.io/v2/snaps/info/core -H "Snap-Device-Series: 16" | jq '."channel-map" | .[] | select(.channel.name=="beta") | select(.channel.architecture=="amd64").download.url') --output core.snap
 RUN mkdir -p /snap/core
 RUN unsquashfs -d /snap/core/current core.snap
 
 # Grab the snapcraft snap from the beta channel and unpack it in the proper place
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=beta' | jq '.download_url' -r) --output snapcraft.snap
+RUN curl -L $(curl -s https://api.snapcraft.io/v2/snaps/info/snapcraft -H "Snap-Device-Series: 16" | jq '."channel-map" | .[] | select(.channel.name=="beta") | select(.channel.architecture=="amd64").download.url') --output core.snap
 RUN mkdir -p /snap/snapcraft
 RUN unsquashfs -d /snap/snapcraft/current snapcraft.snap
 

--- a/docker/candidate.Dockerfile
+++ b/docker/candidate.Dockerfile
@@ -6,12 +6,12 @@ RUN apt dist-upgrade --yes
 RUN apt install --yes curl jq squashfs-tools
 
 # Grab the core snap from the stable channel and unpack it in the proper place
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
+RUN curl -L $(curl -s https://api.snapcraft.io/v2/snaps/info/core -H "Snap-Device-Series: 16" | jq '."channel-map" | .[] | select(.channel.name=="candidate") | select(.channel.architecture=="amd64").download.url') --output core.snap
 RUN mkdir -p /snap/core
 RUN unsquashfs -d /snap/core/current core.snap
 
 # Grab the snapcraft snap from the candidate channel and unpack it in the proper place
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=candidate' | jq '.download_url' -r) --output snapcraft.snap
+RUN curl -L $(curl -s https://api.snapcraft.io/v2/snaps/info/snapcraft -H "Snap-Device-Series: 16" | jq '."channel-map" | .[] | select(.channel.name=="candidate") | select(.channel.architecture=="amd64").download.url') --output core.snap
 RUN mkdir -p /snap/snapcraft
 RUN unsquashfs -d /snap/snapcraft/current snapcraft.snap
 

--- a/docker/edge.Dockerfile
+++ b/docker/edge.Dockerfile
@@ -6,12 +6,12 @@ RUN apt dist-upgrade --yes
 RUN apt install --yes curl jq squashfs-tools
 
 # Grab the core snap from the stable channel and unpack it in the proper place
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
+RUN curl -L $(curl -s https://api.snapcraft.io/v2/snaps/info/core -H "Snap-Device-Series: 16" | jq '."channel-map" | .[] | select(.channel.name=="edge") | select(.channel.architecture=="amd64").download.url') --output core.snap
 RUN mkdir -p /snap/core
 RUN unsquashfs -d /snap/core/current core.snap
 
 # Grab the snapcraft snap from the edge channel and unpack it in the proper place
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=edge' | jq '.download_url' -r) --output snapcraft.snap
+RUN curl -L $(curl -s https://api.snapcraft.io/v2/snaps/info/snapcraft -H "Snap-Device-Series: 16" | jq '."channel-map" | .[] | select(.channel.name=="edge") | select(.channel.architecture=="amd64").download.url') --output core.snap
 RUN mkdir -p /snap/snapcraft
 RUN unsquashfs -d /snap/snapcraft/current snapcraft.snap
 

--- a/docker/stable.Dockerfile
+++ b/docker/stable.Dockerfile
@@ -6,12 +6,12 @@ RUN apt dist-upgrade --yes
 RUN apt install --yes curl jq squashfs-tools
 
 # Grab the core snap from the stable channel and unpack it in the proper place
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
+RUN curl -L $(curl -s https://api.snapcraft.io/v2/snaps/info/core -H "Snap-Device-Series: 16" | jq '."channel-map" | .[] | select(.channel.name=="stable") | select(.channel.architecture=="amd64").download.url') --output core.snap
 RUN mkdir -p /snap/core
 RUN unsquashfs -d /snap/core/current core.snap
 
 # Grab the snapcraft snap from the stable channel and unpack it in the proper place
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=stable' | jq '.download_url' -r) --output snapcraft.snap
+RUN curl -L $(curl -s https://api.snapcraft.io/v2/snaps/info/snapcraft -H "Snap-Device-Series: 16" | jq '."channel-map" | .[] | select(.channel.name=="stable") | select(.channel.architecture=="amd64").download.url') --output snapcraft.snap
 RUN mkdir -p /snap/snapcraft
 RUN unsquashfs -d /snap/snapcraft/current snapcraft.snap
 


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
