### PR TITLE
remote build: add option to skip public upload question

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -20,11 +20,32 @@ import click
 
 from . import env
 from snapcraft.project import Project, get_snapcraft_yaml
+from snapcraft.cli.echo import confirm, prompt
 
 
 class HiddenOption(click.Option):
     def get_help_record(self, ctx):
         pass
+
+
+class PromptOption(click.Option):
+    def prompt_for_value(self, ctx):
+        default = self.get_default(ctx)
+
+        # If this is a prompt for a flag we need to handle this
+        # differently.
+        if self.is_bool_flag:
+            return confirm(self.prompt, default)
+
+        return prompt(
+            self.prompt,
+            default=default,
+            type=self.type,
+            hide_input=self.hide_input,
+            show_choices=self.show_choices,
+            confirmation_prompt=self.confirmation_prompt,
+            value_proc=lambda x: self.process_value(ctx, x),
+        )
 
 
 _BUILD_OPTION_NAMES = [

--- a/snapcraft/cli/echo.py
+++ b/snapcraft/cli/echo.py
@@ -18,8 +18,11 @@
 These methods, which are named after common logging levels, wrap around
 click.echo adding the corresponding color codes for each level.
 """
+import sys
+
 import click
 
+from typing import Any
 from snapcraft.internal import common
 
 
@@ -55,3 +58,59 @@ def error(msg: str) -> None:
     If the terminal supports color the output will be red.
     """
     click.echo("\033[0;31m{}\033[0m".format(msg))
+
+
+def confirm(
+    msg: str,
+    default: bool = False,
+    abort: bool = False,
+    prompt_suffix: str = ": ",
+    show_default: bool = True,
+    err: bool = False,
+) -> bool:
+    """Output message as a confirmation prompt.
+    If not running on a tty, assume the default value.
+    """
+    return (
+        click.confirm(
+            msg,
+            default=default,
+            abort=abort,
+            prompt_suffix=prompt_suffix,
+            show_default=show_default,
+            err=err,
+        )
+        if sys.stdin.isatty()
+        else default
+    )
+
+
+def prompt(
+    msg: str,
+    default: Any = None,
+    hide_input: bool = False,
+    confirmation_prompt: bool = False,
+    type=None,
+    value_proc=None,
+    prompt_suffix: str = ": ",
+    show_default: bool = True,
+    err: bool = False,
+) -> Any:
+    """Output message as a generic prompt.
+    If not running on a tty, assume the default value.
+    """
+    return (
+        click.prompt(
+            msg,
+            default=default,
+            hide_input=hide_input,
+            confirmation_prompt=confirmation_prompt,
+            type=type,
+            value_proc=value_proc,
+            prompt_suffix=prompt_suffix,
+            show_default=show_default,
+            err=err,
+        )
+        if sys.stdin.isatty()
+        else default
+    )

--- a/snapcraft/cli/remote.py
+++ b/snapcraft/cli/remote.py
@@ -66,13 +66,25 @@ def remotecli():
     help="Set architectures to build.",
 )
 @click.option(
+    "--accept-public-upload",
+    is_flag=True,
+    required=False,
+    help="Acknowledge that uploaded code is public.",
+)
+@click.option(
     "--git", is_flag=True, required=False, help="Build a local git repository."
 )
 @click.option(
     "--user", metavar="<username>", nargs=1, required=False, help="Launchpad username."
 )
 def remote_build(
-    recover: int, status: int, user: str, arch: str, git: bool, echoer=echo
+    recover: int,
+    status: int,
+    user: str,
+    arch: str,
+    git: bool,
+    accept_public_upload: bool,
+    echoer=echo,
 ) -> None:
     """Dispatch a snap for remote build.
 
@@ -159,7 +171,7 @@ def remote_build(
         branch = "master"
 
         # Send local data to the remote repository
-        if not click.confirm(
+        if not accept_public_upload and not click.confirm(
             "All data sent to remote builders is public. Are you sure you want to continue?"
         ):
             return

--- a/snapcraft/cli/remote.py
+++ b/snapcraft/cli/remote.py
@@ -29,7 +29,7 @@ from snapcraft.formatting_utils import humanize_list
 from typing import List, Tuple
 from xdg import BaseDirectory
 from . import echo
-from ._options import get_project
+from ._options import get_project, PromptOption
 
 _SUPPORTED_ARCHS = ["amd64", "arm64", "armhf", "i386", "ppc64el", "s390x"]
 
@@ -68,8 +68,9 @@ def remotecli():
 @click.option(
     "--accept-public-upload",
     is_flag=True,
-    required=False,
+    prompt="All data sent to remote builders is public. Are you sure you want to continue?",
     help="Acknowledge that uploaded code is public.",
+    cls=PromptOption,
 )
 @click.option(
     "--git", is_flag=True, required=False, help="Build a local git repository."
@@ -113,6 +114,9 @@ def remote_build(
         snapcraft remote-build --recover 47860738
         snapcraft remote-build --status 47860738
     """
+    if not accept_public_upload:
+        raise errors.AcceptPublicUploadError()
+
     echo.warning(
         "snapcraft remote-build is offered as a preview. Authentication and transport "
         "mechanisms will change in future releases. Use with caution in scripts."
@@ -171,11 +175,6 @@ def remote_build(
         branch = "master"
 
         # Send local data to the remote repository
-        if not accept_public_upload and not click.confirm(
-            "All data sent to remote builders is public. Are you sure you want to continue?"
-        ):
-            return
-
         echo.info("Sending data to remote builder...")
 
         if git:

--- a/snapcraft/internal/remote_build/errors.py
+++ b/snapcraft/internal/remote_build/errors.py
@@ -87,3 +87,11 @@ class UnsupportedArchitectureError(RemoteBuildBaseError):
 
     def __init__(self, *, archs: List[str]) -> None:
         super().__init__(archs=", ".join(archs))
+
+
+class AcceptPublicUploadError(RemoteBuildBaseError):
+
+    fmt = (
+        "Remote build needs explicit acknowledgement that data sent to build servers "
+        "is public.\nIn non-interactive runs, please use option --accept-public-upload."
+    )


### PR DESCRIPTION
Add an option to prevent user interaction when running on a noninteractive
environment while still acknowledging that uploaded code will be public.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
