### PR TITLE
docker/bin/snapcraft-wrapper: use dpkg for architecture

### DIFF
--- a/docker/bin/snapcraft-wrapper
+++ b/docker/bin/snapcraft-wrapper
@@ -2,7 +2,7 @@
 SNAP="/snap/snapcraft/current"
 SNAP_NAME="$(awk '/^name:/{print $2}' $SNAP/meta/snap.yaml)"
 SNAP_VERSION="$(awk '/^version:/{print $2}' $SNAP/meta/snap.yaml)"
-SNAP_ARCH="amd64"
+SNAP_ARCH="$(dpkg --print-architecture)"
 
 export SNAP
 export SNAP_NAME


### PR DESCRIPTION
This allows the wrapper to be used for architectures other than amd64 on
docker builds without modification.

Signed-off-by: Ian Johnson <ian.johnson@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
