### PR TITLE
remote build: don't send log files back to remote

### DIFF
--- a/snapcraft/cli/remote.py
+++ b/snapcraft/cli/remote.py
@@ -224,7 +224,7 @@ def _copy_and_send_tree(
     wt = Worktree(
         ".",
         work_dir,
-        ignore=[name + "_*.snap", "buildlog_*.txt*", "parts", "stage", "prime"],
+        ignore=[name + "_*.snap", name + "_*.txt.gz*", "parts", "stage", "prime"],
     )
     url = wt.add_remote(provider, user, build_id)
     wt.sync()

--- a/tests/unit/remote_build/test_worktree.py
+++ b/tests/unit/remote_build/test_worktree.py
@@ -37,7 +37,7 @@ class WorktreeTestCase(unit.TestCase):
         self._wt = Worktree(
             self._source.path,
             self._dest.path,
-            ignore=["test_*.snap", "buildlog_*.txt*", "parts", "stage", "prime"],
+            ignore=["test_*.snap", "test_*.txt.gz*", "parts", "stage", "prime"],
         )
         self._wt.sync()
 
@@ -82,8 +82,8 @@ class WorktreeTestCase(unit.TestCase):
             ".gitignore",
             "test_0.1_amd64.snap",
             "other_0.1_amd64.snap",
-            "buildlog_i386.txt.gz",
-            "buildlog_amd64.txt",
+            "test_i386.txt.gz",
+            "test_amd64.txt.gz.2",
         ]:
             self._source.create_file(name)
         for dirname in [".svn", ".bzr", "parts", "stage", "prime"]:


### PR DESCRIPTION
Retrieved build logs are now saved using the project name, so update
our filters to prevent sending them back to the remote builder as
part of the local project files.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
