### PR TITLE
errors: refactor exception/error handling

### DIFF
--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -30,7 +30,6 @@ from . import echo
 import snapcraft
 from snapcraft.config import CLIConfig as _CLIConfig
 from snapcraft.internal import errors
-from snapcraft.internal.build_providers.errors import ProviderExecError
 
 # raven is not available on 16.04
 try:
@@ -43,7 +42,6 @@ except ImportError:
 # - annotate the part and lifecycle step in the message
 # - add link to privacy policy
 _MSG_TRACEBACK_PRINT = "Sorry, an error occurred in Snapcraft:"
-_MSG_TRACEBACK_FILE = "Sorry, an error occurred in Snapcraft."
 _MSG_TRACEBACK_LOCATION = "You can find the traceback in file {!r}."
 _MSG_SEND_TO_SENTRY_TRACEBACK_PROMPT = dedent(
     """\
@@ -78,6 +76,127 @@ TRACEBACK_HOST = TRACEBACK_MANAGED + ".{}".format(os.getpid())
 logger = logging.getLogger(__name__)
 
 
+def _is_connected_to_tty() -> bool:
+    # Used by inner instance, SNAPCRAFT_HAS_TTY is set by outer instance.
+    if os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT") == "managed-host":
+        return distutils.util.strtobool(os.getenv("SNAPCRAFT_HAS_TTY", "n")) == 1
+
+    return sys.stdout.isatty()
+
+
+def _is_reportable_error(exc_info) -> bool:
+    # Report non-snapcraft errors.
+    if not issubclass(exc_info[0], errors.SnapcraftError):
+        return True
+
+    # Report snapcraft 'reportable' errors.
+    if issubclass(exc_info[0], errors.SnapcraftReportableError):
+        return True
+
+    return False
+
+
+def _is_printable_traceback(exc_info, debug) -> bool:
+    # Always print with debug.
+    if debug:
+        return True
+
+    # If it is not a reportable error, then it is not a printable traceback.
+    if not _is_reportable_error(exc_info):
+        return False
+
+    # Print if not connected to a tty.
+    if not _is_connected_to_tty():
+        return True
+
+    # Print if not using snap.
+    if not snapcraft.internal.common.is_snap():
+        return True
+
+    return False
+
+
+def _handle_sentry_submission(exc_info) -> None:
+    # Only attempt to submit reportable errors.
+    if not _is_reportable_error(exc_info):
+        return
+
+    # Only attempt if running as snap (with Raven requirement).
+    if not snapcraft.internal.common.is_snap():
+        # Suggest manual reporting instead.
+        click.echo(_MSG_MANUALLY_REPORT)
+        return
+
+    if _is_send_to_sentry(exc_info):
+        try:
+            _submit_trace(exc_info)
+        except Exception as exc:
+            # Failed to send - let user know and suggest manual reporting.
+            echo.error(
+                "Encountered an issue while trying to submit the report: {}".format(
+                    str(exc)
+                )
+            )
+            click.echo(_MSG_MANUALLY_REPORT)
+        else:
+            # Sent successfully.
+            click.echo(_MSG_SEND_TO_SENTRY_THANKS)
+
+
+def _print_exception_message(exc_info, debug) -> None:
+    click.echo(_MSG_TRACEBACK_PRINT)
+
+    # Print exception in exc_info[1].
+    message = str(exc_info[1])
+    echo.error(message)
+
+
+def _process_exception(exc_info, debug, trace_filepath):
+    _print_exception_message(exc_info, debug)
+
+    if _is_printable_traceback(exc_info, debug):
+        _print_trace_output(exc_info)
+
+    _handle_sentry_submission(exc_info)
+
+    if trace_filepath:
+        with open(trace_filepath, "w") as tf:
+            _print_trace_output(exc_info, tf)
+
+
+def _process_inner_exception(exc_info, debug):
+    # On inner host, always save trace output and process exception.
+    _process_exception(exc_info, debug, TRACEBACK_MANAGED)
+
+
+def _process_outer_exception(exc_info, debug):
+    # Temporary file path to store trace in, if needed.
+    trace_filepath = os.path.join(tempfile.mkdtemp(), "trace.txt")
+
+    # On outer host, check if we have traceback generated from inner.
+    if os.path.isfile(TRACEBACK_HOST):
+        # If traceback file exists, it has already been processed by
+        # the inside snapcraft (i.e. printing and sentry submission)
+        # we just need to retrieve it for the user if it's reportable.
+        if not _is_reportable_error(exc_info):
+            return
+
+        shutil.move(TRACEBACK_HOST, trace_filepath)
+    else:
+        # No traceback found, this must be captured and processed.
+        # If reportable or debug is enabled, capture trace file.
+        if _is_reportable_error(exc_info) or debug:
+            _process_exception(exc_info, debug, trace_filepath)
+        else:
+            _process_exception(exc_info, debug, None)
+
+            # No trace file, nothing left to do.
+            return
+
+    # This is a reportable error, let the user know where to find the trace.
+    click.echo(_MSG_TRACEBACK_LOCATION.format(trace_filepath))
+
+
 def exception_handler(  # noqa: C901
     exception_type, exception, exception_traceback, *, debug=False
 ) -> None:
@@ -88,116 +207,49 @@ def exception_handler(  # noqa: C901
 
     These are the rules of engagement:
 
-        - a non snapcraft handled error occurs and raven is setup,
-          so we go over confirmation logic showing the relevant traceback
-        - a non snapcraft handled error occurs and raven is not setup,
-          so we just show the traceback
-        - a snapcraft handled error occurs, debug=True so a traceback
-          is shown
-        - a snapcraft handled error occurs, debug=False so only the
-          exception message is shown
+        - Print exception message (always)
+
+        - Capture trace in temporary file and print path, conditionally if:
+          (1) Exception is SnapcraftReportableError or
+          (2) Exception is non-Snapcraft error
+          (3) debug is true
+
+        - Automatically send bug report if:
+          (1) SNAPCRAFT_ENABLE_SILENT_REPORT=y
+          (2) "Always" send has been previously set.
+
+        - Prompt to send bug report, conditionally if connected to TTY and:
+          (1) Exception is SnapcraftReportableError or
+          (2) Exception is non-Snapcraft error
+
+        - Print trace, conditionally if:
+          (1) debug is true, or
+          (2) Reportable (see above) and either:
+              (a) no TTY
+              (b) not running as snap
+
+        - Use exit code from snapcraft error (if available), otherwise 1.
     """
-    exc_info = (exception_type, exception, exception_traceback)
     exit_code = 1
-    # We're building directly on host (i.e. no inner instances have sent
-    # trace information to sentry), or crash is our own.
-    is_snapcraft_host = not os.path.isfile(TRACEBACK_HOST)
-    is_snapcraft_managed_host = (
-        os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT") == "managed-host"
-    )
-    # When inner instance crashes let it send its trace information. We filter
-    # out ProviderExecError to prevent sending another trace dump outside.
-    is_snapcraft_error = issubclass(exception_type, errors.SnapcraftError) and (
-        is_snapcraft_host or exception_type is not ProviderExecError
-    )
-    is_snapcraft_reportable_error = issubclass(
-        exception_type, errors.SnapcraftReportableError
-    )
-    is_raven_setup = snapcraft.internal.common.is_snap()
-    is_connected_to_tty = (
-        # used by inner instance, variable set by outer instance
-        (distutils.util.strtobool(os.getenv("SNAPCRAFT_HAS_TTY", "n")) == 1)
-        if is_snapcraft_managed_host
-        else sys.stdout.isatty()
-    )
-    ask_to_report = False
 
-    if not is_snapcraft_error:
-        ask_to_report = True
-    elif is_snapcraft_error and debug:
+    # If SnapcraftError, use defined exit code.
+    if issubclass(exception_type, errors.SnapcraftError):
         exit_code = exception.get_exit_code()
-        traceback.print_exception(*exc_info)
-    elif is_snapcraft_error and not debug:
-        exit_code = exception.get_exit_code()
-        echo.error(str(exception))
-        if is_snapcraft_reportable_error:
-            ask_to_report = True
+
+    exc_info = (exception_type, exception, exception_traceback)
+
+    if os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT") == "managed-host":
+        _process_inner_exception(exc_info, debug)
     else:
-        click.echo("Unhandled error case")
-        exit_code = -1
-
-    if ask_to_report:
-        if is_snapcraft_managed_host or is_snapcraft_host:
-            if not is_raven_setup:
-                click.echo(_MSG_TRACEBACK_PRINT)
-                traceback.print_exception(*exc_info, file=sys.stdout)
-                click.echo(_MSG_MANUALLY_REPORT)
-            else:
-                if is_snapcraft_managed_host:
-                    # On inner host, prepare our traceback data to be retrieved.
-                    traceback.print_exception(
-                        exc_info[0],
-                        exc_info[1],
-                        exc_info[2],
-                        file=open(TRACEBACK_MANAGED, "w"),
-                    )
-
-                # Print traceback if not on terminal
-                if is_connected_to_tty:
-                    click.echo(_MSG_TRACEBACK_FILE)
-                else:
-                    click.echo(_MSG_TRACEBACK_PRINT)
-                    traceback.print_exception(*exc_info, file=sys.stdout)
-
-                # Also ask the user to send traceback data to sentry.
-                if _is_send_to_sentry(exc_info):
-                    try:
-                        _submit_trace(exc_info)
-                    except Exception as exc:
-                        # we really cannot do much more from this exit handler.
-                        echo.error(
-                            "Encountered an issue while trying to submit the report: {}".format(
-                                str(exc)
-                            )
-                        )
-                    else:
-                        click.echo(_MSG_SEND_TO_SENTRY_THANKS)
-
-                if not is_snapcraft_managed_host:
-                    trace_filepath = _handle_trace_output(exc_info)
-                    click.echo(_MSG_TRACEBACK_LOCATION.format(trace_filepath))
-        else:
-            # On outer host, check if we have traceback from managed host
-            # and retrieve it.
-            if os.path.isfile(TRACEBACK_HOST):
-                trace_filepath = os.path.join(tempfile.mkdtemp(), "trace.txt")
-                shutil.move(TRACEBACK_HOST, trace_filepath)
-            else:
-                trace_filepath = _handle_trace_output(exc_info)
-            click.echo(_MSG_TRACEBACK_LOCATION.format(trace_filepath))
+        _process_outer_exception(exc_info, debug)
 
     sys.exit(exit_code)
 
 
-def _handle_trace_output(exc_info) -> str:
-    trace_filepath = os.path.join(tempfile.mkdtemp(), "trace.txt")
-    with open(trace_filepath, "w") as trace_file:
-        # mypy does not like *exc_info with a kwarg that follows
-        # snapcraft/cli/_errors.py:132: error: "print_exception" gets multiple values for keyword argument "file"
-        traceback.print_exception(
-            exc_info[0], exc_info[1], exc_info[2], file=trace_file
-        )
-    return trace_filepath
+def _print_trace_output(exc_info, file=sys.stdout) -> None:
+    # mypy does not like *exc_info with a kwarg that follows
+    # snapcraft/cli/_errors.py:132: error: "print_exception" gets multiple values for keyword argument "file"
+    traceback.print_exception(exc_info[0], exc_info[1], exc_info[2], file=file)
 
 
 def _is_send_to_sentry(exc_info) -> bool:  # noqa: C901
@@ -230,7 +282,10 @@ def _is_send_to_sentry(exc_info) -> bool:  # noqa: C901
 
     # Either ALWAYS has not been selected in a previous run or the
     # configuration for where that value is stored cannot be read, so
-    # resort to prompting.
+    # resort to prompting (if connected to TTY).
+    if not _is_connected_to_tty():
+        return False
+
     while True:
         try:
             response = _prompt_sentry()
@@ -241,9 +296,7 @@ def _is_send_to_sentry(exc_info) -> bool:  # noqa: C901
             return False
 
         if response in _VIEW_VALUES:
-            traceback.print_exception(
-                exc_info[0], exc_info[1], exc_info[2], file=sys.stdout
-            )
+            _print_trace_output(exc_info)
         elif response in _YES_VALUES:
             return True
         elif response in _NO_VALUES:

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import re
 import sys
 import tempfile
 import xdg
@@ -23,7 +24,7 @@ from textwrap import dedent
 from unittest import mock
 
 import fixtures
-from testtools.matchers import FileContains, MatchesRegex, Equals
+from testtools.matchers import FileContains, Equals
 from testscenarios import multiply_scenarios
 
 import snapcraft.internal.errors
@@ -76,23 +77,29 @@ class ErrorsBaseTestCase(unit.TestCase):
             exception_handler(*sys.exc_info(), debug=debug)
 
     def assert_exception_traceback_exit_1_with_debug(self):
-        self.error_mock.assert_not_called()
+        self.assertThat(self.error_mock.call_count, Equals(1))
         self.exit_mock.assert_called_once_with(1)
-        self.print_exception_mock.assert_called_once_with(
-            RuntimeError, mock.ANY, mock.ANY, file=_Tracefile(self)
-        )
 
-    def assert_exception_traceback_exit_1_without_raven(self):
-        self.error_mock.assert_not_called()
-        self.exit_mock.assert_called_once_with(1)
-        self.print_exception_mock.assert_called_once_with(
-            RuntimeError, mock.ANY, mock.ANY, file=sys.stdout
-        )
+        # called twice - once for stdout, once for trace file
+        self.assertThat(self.print_exception_mock.call_count, Equals(2))
 
     def assert_no_exception_traceback_exit_1_without_debug(self):
-        self.error_mock.assert_not_called()
+        self.assertThat(self.error_mock.call_count, Equals(1))
         self.exit_mock.assert_called_once_with(1)
         self.print_exception_mock.assert_not_called()
+
+    def assert_print_exception_called_only_tracefile(self, error):
+        self.print_exception_mock.assert_called_once_with(
+            error, mock.ANY, mock.ANY, file=_Tracefile(self)
+        )
+
+    def assert_print_exception_called_both_stdout_and_tempfile(self, error):
+        expected_calls = [
+            mock.call(error, mock.ANY, mock.ANY, file=_Tracefile(self)),
+            mock.call(error, mock.ANY, mock.ANY, file=_Stdout(self)),
+        ]
+
+        self.print_exception_mock.assert_has_calls(expected_calls, any_order=True)
 
 
 class ErrorsTestCase(ErrorsBaseTestCase):
@@ -110,7 +117,9 @@ class ErrorsTestCase(ErrorsBaseTestCase):
         except Exception:
             self.fail("Exception unexpectedly raised")
 
-        self.assert_exception_traceback_exit_1_without_raven()
+        self.error_mock.assert_called_once_with("not a SnapcraftError")
+        self.exit_mock.assert_called_once_with(1)
+        self.assert_print_exception_called_both_stdout_and_tempfile(RuntimeError)
 
     def test_handler_catches_snapcraft_exceptions_no_debug(self):
         try:
@@ -128,11 +137,9 @@ class ErrorsTestCase(ErrorsBaseTestCase):
         except Exception:
             self.fail("Exception unexpectedly raised")
 
-        self.error_mock.assert_not_called()
+        self.error_mock.assert_called_once_with("is a SnapcraftError")
         self.exit_mock.assert_called_once_with(123)
-        self.print_exception_mock.assert_called_once_with(
-            TestSnapcraftError, mock.ANY, mock.ANY
-        )
+        self.assert_print_exception_called_both_stdout_and_tempfile(TestSnapcraftError)
 
 
 class ProviderErrorTest(ErrorsBaseTestCase):
@@ -143,10 +150,6 @@ class ProviderErrorTest(ErrorsBaseTestCase):
         self.move_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = mock.patch("traceback.print_exception")
-        self.traceback_mock = patcher.start()
-        self.addCleanup(patcher.stop)
-
     @mock.patch("os.path.isfile", return_value=False)
     def test_provider_error_legit(self, isfile_function):
         # Provider exception was raised in host environment, no crash file
@@ -155,7 +158,7 @@ class ProviderErrorTest(ErrorsBaseTestCase):
         )
         self._raise_exec_error()
         self.move_mock.assert_not_called()
-        self.traceback_mock.assert_not_called()
+        self.print_exception_mock.assert_not_called()
 
     @mock.patch("os.path.isfile", return_value=True)
     def test_provider_error_outer(self, isfile_function):
@@ -164,8 +167,10 @@ class ProviderErrorTest(ErrorsBaseTestCase):
             fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT", "host")
         )
         self._raise_exec_error()
-        self.assertThat(self.move_mock.call_count, Equals(1))
-        self.traceback_mock.assert_not_called()
+
+        # Only moved if reportable
+        self.move_mock.assert_not_called()
+        self.print_exception_mock.assert_not_called()
 
     @mock.patch("os.path.isfile", return_value=False)
     def test_provider_error_host(self, isfile_function):
@@ -175,7 +180,7 @@ class ProviderErrorTest(ErrorsBaseTestCase):
         )
         self._raise_other_error()
         self.move_mock.assert_not_called()
-        self.assertThat(self.traceback_mock.call_count, Equals(1))
+        self.assertThat(self.print_exception_mock.call_count, Equals(1))
 
     @mock.patch("os.path.isfile", return_value=False)
     @mock.patch.object(snapcraft.cli._errors, "RavenClient")
@@ -187,7 +192,7 @@ class ProviderErrorTest(ErrorsBaseTestCase):
         snapcraft.cli._errors.RavenClient = "something"
         self._raise_other_error()
         self.move_mock.assert_not_called()
-        self.assertThat(self.traceback_mock.call_count, Equals(2))
+        self.assertThat(self.print_exception_mock.call_count, Equals(2))
 
     def _raise_exec_error(self):
         self.call_handler(
@@ -195,7 +200,7 @@ class ProviderErrorTest(ErrorsBaseTestCase):
         )
 
     def _raise_other_error(self):
-        self.call_handler(KeyError, True)
+        self.call_handler(KeyError, False)
 
 
 class SendToSentryBaseTest(ErrorsBaseTestCase):
@@ -253,35 +258,33 @@ class SendToSentryIsYesTest(SendToSentryBaseTest):
         self.mock_isatty.return_value = self.tty
 
         try:
-            self.call_handler(RuntimeError("not a SnapcraftError"), True)
+            self.call_handler(RuntimeError("not a SnapcraftError"), False)
         except Exception:
             self.fail("Exception unexpectedly raised")
 
-        self.raven_client_mock.assert_called_once_with(
-            mock.ANY,
-            transport=self.raven_request_mock,
-            name="snapcraft",
-            processors=mock.ANY,
-            release=mock.ANY,
-            auto_log_stacks=False,
-        )
+        if self.tty:
+            self.raven_client_mock.assert_called_once_with(
+                mock.ANY,
+                transport=self.raven_request_mock,
+                name="snapcraft",
+                processors=mock.ANY,
+                release=mock.ANY,
+                auto_log_stacks=False,
+            )
+        else:
+            # Cannot prompt if not connected to TTY.
+            self.raven_client_mock.assert_not_called()
 
         # It we have a tty, then the trace should be saved to a file and sent to sentry.
         # If we don't have a tty, then the same should happen, but the trace should
         # also be printed.
-        self.error_mock.assert_not_called()
+        self.error_mock.assert_called_once_with("not a SnapcraftError")
         self.exit_mock.assert_called_once_with(1)
 
-        expected_calls = [
-            mock.call(RuntimeError, mock.ANY, mock.ANY, file=_Tracefile(self))
-        ]
-
-        if not self.tty:
-            expected_calls.append(
-                mock.call(RuntimeError, mock.ANY, mock.ANY, file=sys.stdout)
-            )
-
-        self.print_exception_mock.assert_has_calls(expected_calls, any_order=True)
+        if self.tty:
+            self.assert_print_exception_called_only_tracefile(RuntimeError)
+        else:
+            self.assert_print_exception_called_both_stdout_and_tempfile(RuntimeError)
 
 
 class SendToSentryIsNoTest(SendToSentryBaseTest):
@@ -299,7 +302,7 @@ class SendToSentryIsNoTest(SendToSentryBaseTest):
         self.mock_isatty.return_value = self.tty
 
         try:
-            self.call_handler(RuntimeError("not a SnapcraftError"), True)
+            self.call_handler(RuntimeError("not a SnapcraftError"), False)
         except Exception:
             self.fail("Exception unexpectedly raised")
 
@@ -308,19 +311,13 @@ class SendToSentryIsNoTest(SendToSentryBaseTest):
         # It we have a tty, then the trace should be saved to a file and sent to sentry.
         # If we don't have a tty, then the same should happen, but the trace should
         # also be printed.
-        self.error_mock.assert_not_called()
+        self.error_mock.assert_called_once_with("not a SnapcraftError")
         self.exit_mock.assert_called_once_with(1)
 
-        expected_calls = [
-            mock.call(RuntimeError, mock.ANY, mock.ANY, file=_Tracefile(self))
-        ]
-
-        if not self.tty:
-            expected_calls.append(
-                mock.call(RuntimeError, mock.ANY, mock.ANY, file=sys.stdout)
-            )
-
-        self.print_exception_mock.assert_has_calls(expected_calls, any_order=True)
+        if self.tty:
+            self.assert_print_exception_called_only_tracefile(RuntimeError)
+        else:
+            self.assert_print_exception_called_both_stdout_and_tempfile(RuntimeError)
 
 
 class SendToSentryIsAlwaysTest(SendToSentryBaseTest):
@@ -339,50 +336,47 @@ class SendToSentryIsAlwaysTest(SendToSentryBaseTest):
         self.mock_isatty.return_value = self.tty
 
         try:
-            self.call_handler(RuntimeError("not a SnapcraftError"), True)
+            self.call_handler(RuntimeError("not a SnapcraftError"), False)
         except Exception:
             self.fail("Exception unexpectedly raised")
 
-        self.raven_client_mock.assert_called_once_with(
-            mock.ANY,
-            transport=self.raven_request_mock,
-            name="snapcraft",
-            processors=mock.ANY,
-            release=mock.ANY,
-            auto_log_stacks=False,
-        )
-        config_path = os.path.join(
-            xdg.BaseDirectory.save_config_path("snapcraft"), "cli.cfg"
-        )
-        self.assertThat(
-            config_path,
-            FileContains(
-                dedent(
-                    """\
-            [Sentry]
-            always_send = true
-
-            """
-                )
-            ),
-        )
-
-        # It we have a tty, then the trace should be saved to a file and sent to sentry.
-        # If we don't have a tty, then the same should happen, but the trace should
-        # also be printed.
-        self.error_mock.assert_not_called()
-        self.exit_mock.assert_called_once_with(1)
-
-        expected_calls = [
-            mock.call(RuntimeError, mock.ANY, mock.ANY, file=_Tracefile(self))
-        ]
-
-        if not self.tty:
-            expected_calls.append(
-                mock.call(RuntimeError, mock.ANY, mock.ANY, file=sys.stdout)
+        if self.tty:
+            self.raven_client_mock.assert_called_once_with(
+                mock.ANY,
+                transport=self.raven_request_mock,
+                name="snapcraft",
+                processors=mock.ANY,
+                release=mock.ANY,
+                auto_log_stacks=False,
             )
 
-        self.print_exception_mock.assert_has_calls(expected_calls, any_order=True)
+            config_path = os.path.join(
+                xdg.BaseDirectory.save_config_path("snapcraft"), "cli.cfg"
+            )
+            self.assertThat(
+                config_path,
+                FileContains(
+                    dedent(
+                        """\
+                [Sentry]
+                always_send = true
+
+                """
+                    )
+                ),
+            )
+
+            # It we have a tty, then the trace should be saved to a file and sent to sentry.
+            self.assert_print_exception_called_only_tracefile(RuntimeError)
+        else:
+            # Cannot prompt if not connected to TTY.
+            self.raven_client_mock.assert_not_called()
+
+            # If we don't have a tty, the trace should be printed and saved to file.
+            self.assert_print_exception_called_both_stdout_and_tempfile(RuntimeError)
+
+        self.error_mock.assert_called_once_with("not a SnapcraftError")
+        self.exit_mock.assert_called_once_with(1)
 
 
 class SendToSentryAlreadyAlwaysTest(SendToSentryBaseTest):
@@ -466,10 +460,24 @@ class _Tracefile:
         self._test = test
 
     def __eq__(self, other):
-        try:
-            self._test.assertThat(
-                other.name, MatchesRegex("{}.*/trace.txt".format(tempfile.gettempdir()))
-            )
-        except AttributeError:
+        if not hasattr(other, "name"):
             return False
-        return True
+
+        if re.match("{}.*/trace.txt".format(tempfile.gettempdir()), other.name):
+            return True
+
+        return False
+
+
+class _Stdout:
+    def __init__(self, test):
+        self._test = test
+
+    def __eq__(self, other):
+        if not hasattr(other, "name"):
+            return False
+
+        if other.name == "<stdout>":
+            return True
+
+        return False


### PR DESCRIPTION
- Ensure that exception message is _always_ printed.

- Tweak rules of engagement
  - Print exception message (always)

  - Capture trace in temporary file and print path, conditionally if:
    (1) Exception is SnapcraftReportableError or
    (2) Exception is non-Snapcraft error
    (3) debug is true

  - Automatically send bug report if:
    (1) SNAPCRAFT_ENABLE_SILENT_REPORT=y
    (2) "Always" send has been previously set.

  - Prompt to send bug report, conditionally if connected to TTY and:
    (1) Exception is SnapcraftReportableError or
    (2) Exception is non-Snapcraft error

  - Print trace, conditionally if:
    (1) debug is true, or
    (2) Reportable (see above) and either:
      (a) no TTY
      (b) not running as snap

  - Use exit code from snapcraft error (if available), otherwise 1.

- Fixup unit tests to comply with changes.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
