### PR TITLE
sources: introduce SnapcraftSourceNotFoundError

### DIFF
--- a/snapcraft/internal/sources/_base.py
+++ b/snapcraft/internal/sources/_base.py
@@ -104,16 +104,19 @@ class FileBase(Base):
         source_file = None
         is_source_url = snapcraft.internal.common.isurl(self.source)
 
-        # If not, first check if it is a url and download and if not
+        # First check if it is a url and download and if not
         # it is probably locally referenced.
-        if not source_file and is_source_url:
+        if is_source_url:
             source_file = self.download()
-        elif not source_file:
+        else:
             basename = os.path.basename(self.source)
             source_file = os.path.join(self.source_dir, basename)
             # We make this copy as the provisioning logic can delete
             # this file and we don't want that.
-            shutil.copy2(self.source, source_file)
+            try:
+                shutil.copy2(self.source, source_file)
+            except FileNotFoundError as exc:
+                raise errors.SnapcraftSourceNotFoundError(self.source) from exc
 
         # Verify before provisioning
         if self.source_checksum:

--- a/snapcraft/internal/sources/errors.py
+++ b/snapcraft/internal/sources/errors.py
@@ -28,6 +28,18 @@ class VCSError(SnapcraftSourceError):
     fmt = "{message}"
 
 
+class SnapcraftSourceNotFoundError(SnapcraftSourceError):
+
+    fmt = (
+        "Failed to pull source: {source!r}.\n"
+        "Please ensure the source path is correct and that it is accessible.\n"
+        "See `snapcraft help sources` for more information."
+    )
+
+    def __init__(self, source):
+        super().__init__(source=source)
+
+
 class SnapcraftSourceUnhandledError(SnapcraftSourceError):
 
     fmt = (

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -52,6 +52,16 @@ class TestFileBase(unit.TestCase):
             file_src.source_dir, src=expected, clean_target=False
         )
 
+    @mock.patch("shutil.copy2", side_effect=FileNotFoundError())
+    def test_pull_copy_source_does_not_exist(self, mock_shutil_copy2):
+        file_src = self.get_mock_file_base("does-not-exist.tar.gz", ".")
+
+        raised = self.assertRaises(errors.SnapcraftSourceNotFoundError, file_src.pull)
+
+        self.assertThat(
+            str(raised), Contains("Failed to pull source: 'does-not-exist.tar.gz'")
+        )
+
     @mock.patch("snapcraft.internal.sources._base.requests")
     @mock.patch("snapcraft.internal.sources._base.download_requests_stream")
     @mock.patch("snapcraft.internal.sources._base.download_urllib_source")

--- a/tests/unit/sources/test_errors.py
+++ b/tests/unit/sources/test_errors.py
@@ -23,6 +23,18 @@ class ErrorFormattingTestCase(unit.TestCase):
 
     scenarios = (
         (
+            "SnapcraftSourceNotFoundError",
+            {
+                "exception": errors.SnapcraftSourceNotFoundError,
+                "kwargs": {"source": "file-not-found.tar.gz"},
+                "expected_message": (
+                    "Failed to pull source: 'file-not-found.tar.gz'.\n"
+                    "Please ensure the source path is correct and that it is accessible.\n"
+                    "See `snapcraft help sources` for more information."
+                ),
+            },
+        ),
+        (
             "SnapcraftSourceUnhandledError",
             {
                 "exception": errors.SnapcraftSourceUnhandledError,


### PR DESCRIPTION
Many of the errors seen by users indicate source not found.

- introduce SnapcraftSourceNotFoundError with helpful error
  message
- chain to FileNotFoundError raised by shutil.copy2(), a common
  cause of the captured FileNotFoundError exceptions

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
