### PR TITLE
build providers: enforce well-known temp dir

### DIFF
--- a/snapcraft/internal/build_providers/_snap.py
+++ b/snapcraft/internal/build_providers/_snap.py
@@ -318,7 +318,7 @@ class SnapInjector:
         if not assertions:
             return
 
-        with tempfile.NamedTemporaryFile() as assertion_file:
+        with tempfile.NamedTemporaryFile(dir="/tmp") as assertion_file:
             for assertion in assertions:
                 assertion_file.write(repo.snaps.get_assertion(assertion))
                 assertion_file.write(b"\n")


### PR DESCRIPTION
Use a fixed well-known path for temporary files when copying files to
the build provider. If the user environment specifies a non-standard
temporary directory, the file may fail to copy to a multipass instance.

LP: #1833292
Signed-off-by: Mike Miller <mtmiller@debian.org>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
