### PR TITLE
schema: allow 'snapd' snap type

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -264,7 +264,8 @@
                 "base",
                 "gadget",
                 "kernel",
-                "os"
+                "os",
+                "snapd"
             ]
         },
         "frameworks": {

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -113,7 +113,7 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
         self.assertThat(
             str(raised),
             Contains(
-                "bad-type' is not one of ['app', 'base', 'gadget', 'kernel', 'os']"
+                "bad-type' is not one of ['app', 'base', 'gadget', 'kernel', 'os', 'snapd']"
             ),
         )
 

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -259,7 +259,8 @@ class InvalidNamesTest(ValidationBaseTest):
 class ValidTypesTest(ValidationBaseTest):
 
     scenarios = [
-        (type_, dict(type_=type_)) for type_ in ["app", "gadget", "kernel", "os", "snapd"]
+        (type_, dict(type_=type_))
+        for type_ in ["app", "gadget", "kernel", "os", "snapd"]
     ]
 
     def test_valid_types(self):

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -259,7 +259,7 @@ class InvalidNamesTest(ValidationBaseTest):
 class ValidTypesTest(ValidationBaseTest):
 
     scenarios = [
-        (type_, dict(type_=type_)) for type_ in ["app", "gadget", "kernel", "os"]
+        (type_, dict(type_=type_)) for type_ in ["app", "gadget", "kernel", "os", "snapd"]
     ]
 
     def test_valid_types(self):
@@ -283,7 +283,7 @@ class InvalidTypesTest(ValidationBaseTest):
         expected_message = (
             "The 'type' property does not match the required "
             "schema: '{}' is not one of "
-            "['app', 'base', 'gadget', 'kernel', 'os']"
+            "['app', 'base', 'gadget', 'kernel', 'os', 'snapd']"
         ).format(self.type_)
         self.assertThat(raised.message, Equals(expected_message), message=data)
 


### PR DESCRIPTION
Allow "snapd" snap type in the schema.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
