### PR TITLE
catkin spread tests: dump apt-config on failures for legacy

### DIFF
--- a/tests/spread/plugins/catkin/legacy-pull/task.yaml
+++ b/tests/spread/plugins/catkin/legacy-pull/task.yaml
@@ -23,6 +23,12 @@ restore: |
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   restore_yaml "snap/snapcraft.yaml"
 
+# On failure print out the apt-config to ensure repository
+# failures are not related to original release image modifications
+# for a given series.
+debug: |
+  apt-config dump
+
 # ROS Kinetic only supports 16.04
 systems:
    - ubuntu-16.04


### PR DESCRIPTION
The legacy tests intermittently fail when the backend is GCE,
on failures the entire apt-config will be printed to verify
that the original expectations of a 16.04 release with regards
to apt's configuration are still valid.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
