### PR TITLE
tty-aware echo prompt and confirm

### DIFF
--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -277,7 +277,7 @@ def _prompt_sentry():
             return value
         raise click.BadParameter("Please choose a valid answer.")
 
-    return click.prompt(msg, default="no", value_proc=validate).lower()
+    return echo.prompt(msg, default="no", value_proc=validate).lower()
 
 
 def _submit_trace(exc_info):

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -20,11 +20,32 @@ import click
 
 from . import env
 from snapcraft.project import Project, get_snapcraft_yaml
+from snapcraft.cli.echo import confirm, prompt
 
 
 class HiddenOption(click.Option):
     def get_help_record(self, ctx):
         pass
+
+
+class PromptOption(click.Option):
+    def prompt_for_value(self, ctx):
+        default = self.get_default(ctx)
+
+        # If this is a prompt for a flag we need to handle this
+        # differently.
+        if self.is_bool_flag:
+            return confirm(self.prompt, default)
+
+        return prompt(
+            self.prompt,
+            default=default,
+            type=self.type,
+            hide_input=self.hide_input,
+            show_choices=self.show_choices,
+            confirmation_prompt=self.confirmation_prompt,
+            value_proc=lambda x: self.process_value(ctx, x),
+        )
 
 
 _BUILD_OPTION_NAMES = [

--- a/snapcraft/cli/assertions.py
+++ b/snapcraft/cli/assertions.py
@@ -133,7 +133,7 @@ def edit_collaborators(snap_name, key_name):
                 " ".join(store_error.error_list[0]["extra"])
             )
         )
-        if click.confirm("Are you sure you want to continue?"):
+        if echo.confirm("Are you sure you want to continue?"):
             new_dev_assertion.push(force=True)
         else:
             echo.warning("The collaborators for this snap have not been altered.")

--- a/snapcraft/cli/ci.py
+++ b/snapcraft/cli/ci.py
@@ -17,8 +17,8 @@ import importlib
 
 import click
 
+from . import echo
 from ._options import get_project
-
 
 _SUPPORTED_CI_SYSTEMS = ("travis",)
 
@@ -45,5 +45,5 @@ def enableci(ci_system, refresh):
     if refresh:
         module.refresh(project)
     else:
-        if click.confirm(module.__doc__):
+        if echo.confirm(module.__doc__):
             module.enable(project)

--- a/snapcraft/cli/echo.py
+++ b/snapcraft/cli/echo.py
@@ -18,9 +18,10 @@
 These methods, which are named after common logging levels, wrap around
 click.echo adding the corresponding color codes for each level.
 """
-import sys
-
 import click
+import distutils.util
+import os
+import sys
 
 from typing import Any
 from snapcraft.internal import common
@@ -28,6 +29,9 @@ from snapcraft.internal import common
 
 def is_tty_connected() -> bool:
     """ Check to see if running under TTY. """
+    if distutils.util.strtobool(os.getenv("SNAPCRAFT_HAS_TTY", "n")) == 1:
+        return True
+
     return sys.stdin.isatty()
 
 

--- a/snapcraft/cli/echo.py
+++ b/snapcraft/cli/echo.py
@@ -18,8 +18,11 @@
 These methods, which are named after common logging levels, wrap around
 click.echo adding the corresponding color codes for each level.
 """
+import sys
+
 import click
 
+from typing import Any
 from snapcraft.internal import common
 
 
@@ -55,3 +58,59 @@ def error(msg: str) -> None:
     If the terminal supports color the output will be red.
     """
     click.echo("\033[0;31m{}\033[0m".format(msg))
+
+
+def confirm(
+    msg: str,
+    default: bool = False,
+    abort: bool = False,
+    prompt_suffix: str = ": ",
+    show_default: bool = True,
+    err: bool = False,
+) -> bool:
+    """Output message as a confirmation prompt.
+    If not running on a tty, assume the default value.
+    """
+    return (
+        click.confirm(
+            msg,
+            default=default,
+            abort=abort,
+            prompt_suffix=prompt_suffix,
+            show_default=show_default,
+            err=err,
+        )
+        if sys.stdin.isatty()
+        else default
+    )
+
+
+def prompt(
+    msg: str,
+    default: Any = None,
+    hide_input: bool = False,
+    confirmation_prompt: bool = False,
+    type=None,
+    value_proc=None,
+    prompt_suffix: str = ": ",
+    show_default: bool = True,
+    err: bool = False,
+) -> Any:
+    """Output message as a generic prompt.
+    If not running on a tty, assume the default value.
+    """
+    return (
+        click.prompt(
+            msg,
+            default=default,
+            hide_input=hide_input,
+            confirmation_prompt=confirmation_prompt,
+            type=type,
+            value_proc=value_proc,
+            prompt_suffix=prompt_suffix,
+            show_default=show_default,
+            err=err,
+        )
+        if sys.stdin.isatty()
+        else default
+    )

--- a/snapcraft/cli/echo.py
+++ b/snapcraft/cli/echo.py
@@ -26,6 +26,11 @@ from typing import Any
 from snapcraft.internal import common
 
 
+def is_tty_connected() -> bool:
+    """ Check to see if running under TTY. """
+    return sys.stdin.isatty()
+
+
 def wrapped(msg: str) -> None:
     """Output msg wrapped to the terminal width to stdout.
 
@@ -80,7 +85,7 @@ def confirm(
             show_default=show_default,
             err=err,
         )
-        if sys.stdin.isatty()
+        if is_tty_connected()
         else default
     )
 
@@ -111,6 +116,6 @@ def prompt(
             show_default=show_default,
             err=err,
         )
-        if sys.stdin.isatty()
+        if is_tty_connected()
         else default
     )

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -17,7 +17,6 @@
 import logging
 import typing
 import os
-import sys
 
 import click
 
@@ -87,7 +86,7 @@ def _execute(  # noqa: C901
             build_provider_class.ensure_provider()
         except build_providers.errors.ProviderNotFound as provider_error:
             if provider_error.prompt_installable:
-                if os.isatty(sys.stdin.fileno()) and click.confirm(
+                if echo.is_tty_connected() and echo.confirm(
                     "Support for {!r} needs to be set up. "
                     "Would you like to do that it now?".format(provider_error.provider)
                 ):

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -123,7 +123,7 @@ def register(snap_name, private, store):
     """
     if private:
         click.echo(_MESSAGE_REGISTER_PRIVATE.format(snap_name))
-    if click.confirm(_MESSAGE_REGISTER_CONFIRM.format(snap_name)):
+    if echo.confirm(_MESSAGE_REGISTER_CONFIRM.format(snap_name)):
         snapcraft.register(snap_name, is_private=private, store_id=store)
         click.echo(_MESSAGE_REGISTER_SUCCESS.format(snap_name))
     else:
@@ -311,7 +311,7 @@ def promote(snap_name, from_channel, to_channel, yes):
             tablefmt="plain",
         )
     )
-    if yes or click.confirm(
+    if yes or echo.confirm(
         "Do you want to promote the current set to the {!r} channel?".format(
             parsed_to_channel
         )

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -100,6 +100,9 @@ class TestCase(testtools.TestCase):
         # Use a dumb terminal for tests
         self.useFixture(fixtures.EnvironmentVariable("TERM", "dumb"))
 
+        # Force appearance of TTY for pexpect to work with echo.is_connected_tty()
+        self.useFixture(fixtures.EnvironmentVariable("SNAPCRAFT_HAS_TTY", "y"))
+
         # Disable Sentry reporting for tests, otherwise they'll hang waiting
         # for input
         self.useFixture(

--- a/tests/unit/cli/test_echo.py
+++ b/tests/unit/cli/test_echo.py
@@ -1,0 +1,115 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017-2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import fixtures
+from unittest import mock
+from tests import unit
+
+from snapcraft.cli import echo
+
+
+class EchoTestCase(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.click_confirm = self.useFixture(
+            fixtures.MockPatch("click.confirm", return_value=True)
+        )
+        self.click_prompt = self.useFixture(
+            fixtures.MockPatch("click.prompt", return_value=True)
+        )
+
+    @mock.patch("sys.stdin.isatty", return_value=False)
+    def test_is_tty_disconnected(self, tty_mock):
+        result = echo.is_tty_connected()
+
+        self.assertEqual(result, False)
+
+    @mock.patch("sys.stdin.isatty", return_value=True)
+    def test_is_tty_connected(self, tty_mock):
+        result = echo.is_tty_connected()
+
+        self.assertEqual(result, True)
+
+    @mock.patch("snapcraft.cli.echo.is_tty_connected", return_value=False)
+    def test_echo_confirm_is_not_tty(self, tty_mock):
+        echo.confirm("message")
+
+        self.click_confirm.mock.assert_not_called()
+
+    @mock.patch("snapcraft.cli.echo.is_tty_connected", return_value=True)
+    def test_echo_confirm_is_tty(self, tty_mock):
+        echo.confirm("message")
+
+        self.click_confirm.mock.assert_called_once_with(
+            "message",
+            default=False,
+            abort=False,
+            prompt_suffix=": ",
+            show_default=True,
+            err=False,
+        )
+
+    @mock.patch("snapcraft.cli.echo.is_tty_connected", return_value=True)
+    def test_echo_confirm_default(self, tty_mock):
+        echo.confirm("message", default="the new default")
+
+        self.click_confirm.mock.assert_called_once_with(
+            "message",
+            default="the new default",
+            abort=False,
+            prompt_suffix=": ",
+            show_default=True,
+            err=False,
+        )
+
+    @mock.patch("snapcraft.cli.echo.is_tty_connected", return_value=False)
+    def test_echo_prompt_is_not_tty(self, tty_mock):
+        echo.prompt("message")
+
+        self.click_prompt.mock.assert_not_called()
+
+    @mock.patch("snapcraft.cli.echo.is_tty_connected", return_value=True)
+    def test_echo_prompt_is_tty(self, tty_mock):
+        echo.prompt("message")
+
+        self.click_prompt.mock.assert_called_once_with(
+            "message",
+            default=None,
+            hide_input=False,
+            confirmation_prompt=False,
+            type=None,
+            value_proc=None,
+            prompt_suffix=": ",
+            show_default=True,
+            err=False,
+        )
+
+    @mock.patch("snapcraft.cli.echo.is_tty_connected", return_value=True)
+    def test_echo_prompt_default(self, tty_mock):
+        echo.prompt("message", default="the new default")
+
+        self.click_prompt.mock.assert_called_once_with(
+            "message",
+            default="the new default",
+            hide_input=False,
+            confirmation_prompt=False,
+            type=None,
+            value_proc=None,
+            prompt_suffix=": ",
+            show_default=True,
+            err=False,
+        )

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -26,6 +26,7 @@ import fixtures
 from testtools.matchers import FileContains, MatchesRegex, Equals
 from testscenarios import multiply_scenarios
 
+import snapcraft.cli.echo
 import snapcraft.internal.errors
 from snapcraft.internal.build_providers.errors import ProviderExecError
 from snapcraft.cli._errors import exception_handler
@@ -207,7 +208,7 @@ class SendToSentryBaseTest(ErrorsBaseTestCase):
         except ImportError:
             self.skipTest("raven needs to be installed for this test.")
 
-        patcher = mock.patch("click.prompt")
+        patcher = mock.patch("snapcraft.cli.echo.prompt")
         self.prompt_mock = patcher.start()
         self.addCleanup(patcher.stop)
 

--- a/tests/unit/commands/__init__.py
+++ b/tests/unit/commands/__init__.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import fixtures
 import json
 import os
 from textwrap import dedent
@@ -22,7 +23,6 @@ from click.testing import CliRunner
 from snapcraft import storeapi
 from snapcraft.cli._runner import run
 from tests import fixture_setup, unit
-
 
 _sample_keys = [
     {
@@ -73,6 +73,12 @@ class CommandBaseTestCase(unit.TestCase):
         self.runner = CliRunner()
 
     def run_command(self, args, **kwargs):
+        # For click testing, runner will overwrite the descriptors for stdio -
+        # ensure TTY always appears connected.
+        self.useFixture(
+            fixtures.MockPatch("snapcraft.cli.echo.is_tty_connected", return_value=True)
+        )
+
         return self.runner.invoke(run, args, catch_exceptions=False, **kwargs)
 
 


### PR DESCRIPTION
Adapted from @cmatsuoka's remote-build work.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
