### PR TITLE
catkin/legacy-pull: set test to manual

### DIFF
--- a/tests/spread/plugins/catkin/legacy-pull/task.yaml
+++ b/tests/spread/plugins/catkin/legacy-pull/task.yaml
@@ -1,3 +1,6 @@
+# The legacy tests intermittently fail when the backend is GCE, setting to
+# manual until we can properly address the issue.
+manual: true
 summary: |
   Minimally ensure the plugin works without bases by running pull.
   The plugin can be tested without bases in full through the legacy release of


### PR DESCRIPTION
The legacy tests intermittently fail when the backend is GCE, setting to
manual until we can properly address the issue.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

```
+ cd ../snaps/ros-talker-listener
+ snapcraft pull
This snapcraft project does not specify the base keyword, explicitly setting the base keyword enables the latest snapcraft features.
Read more about bases at https://docs.snapcraft.io/t/base-snaps/11198
Installing build dependencies: libexpat1-dev libpython-all-dev libpython-dev libpython2.7-dev python-all python-all-dev python-dev python-pip python-pip-whl python-wheel python2.7-dev
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  libexpat1-dev libpython-all-dev libpython-dev libpython2.7-dev python-all
  python-all-dev python-dev python-pip python-pip-whl python-wheel
  python2.7-dev
debconf: unable to initialize frontend: Dialog
debconf: (Dialog frontend will not work on a dumb terminal, an emacs shell buffer, or without a controlling terminal.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
dpkg-preconfigure: unable to re-open stdin: 
0 upgraded, 11 newly installed, 0 to remove and 22 not upgraded.
Need to get 0 B/29.5 MB of archives.
After this operation, 44.2 MB of additional disk space will be used.
Selecting previously unselected package libexpat1-dev:amd64.
(Reading database ... 121154 files and directories currently installed.)
Preparing to unpack .../libexpat1-dev_2.1.0-7ubuntu0.16.04.4_amd64.deb ...
Unpacking libexpat1-dev:amd64 (2.1.0-7ubuntu0.16.04.4) ...
Selecting previously unselected package libpython2.7-dev:amd64.
Preparing to unpack .../libpython2.7-dev_2.7.12-1ubuntu0~16.04.4_amd64.deb ...
Unpacking libpython2.7-dev:amd64 (2.7.12-1ubuntu0~16.04.4) ...
Selecting previously unselected package libpython-dev:amd64.
Preparing to unpack .../libpython-dev_2.7.12-1~16.04_amd64.deb ...
Unpacking libpython-dev:amd64 (2.7.12-1~16.04) ...
Selecting previously unselected package libpython-all-dev:amd64.
Preparing to unpack .../libpython-all-dev_2.7.12-1~16.04_amd64.deb ...
Unpacking libpython-all-dev:amd64 (2.7.12-1~16.04) ...
Selecting previously unselected package python-all.
Preparing to unpack .../python-all_2.7.12-1~16.04_amd64.deb ...
Unpacking python-all (2.7.12-1~16.04) ...
Selecting previously unselected package python2.7-dev.
Preparing to unpack .../python2.7-dev_2.7.12-1ubuntu0~16.04.4_amd64.deb ...
Unpacking python2.7-dev (2.7.12-1ubuntu0~16.04.4) ...
Selecting previously unselected package python-dev.
Preparing to unpack .../python-dev_2.7.12-1~16.04_amd64.deb ...
Unpacking python-dev (2.7.12-1~16.04) ...
Selecting previously unselected package python-all-dev.
Preparing to unpack .../python-all-dev_2.7.12-1~16.04_amd64.deb ...
Unpacking python-all-dev (2.7.12-1~16.04) ...
Selecting previously unselected package python-pip-whl.
Preparing to unpack .../python-pip-whl_8.1.1-2ubuntu0.4_all.deb ...
Unpacking python-pip-whl (8.1.1-2ubuntu0.4) ...
Selecting previously unselected package python-pip.
Preparing to unpack .../python-pip_8.1.1-2ubuntu0.4_all.deb ...
Unpacking python-pip (8.1.1-2ubuntu0.4) ...
Selecting previously unselected package python-wheel.
Preparing to unpack .../python-wheel_0.29.0-1_all.deb ...
Unpacking python-wheel (0.29.0-1) ...
Processing triggers for man-db (2.7.5-1) ...
Setting up libexpat1-dev:amd64 (2.1.0-7ubuntu0.16.04.4) ...
Setting up libpython2.7-dev:amd64 (2.7.12-1ubuntu0~16.04.4) ...
Setting up libpython-dev:amd64 (2.7.12-1~16.04) ...
Setting up libpython-all-dev:amd64 (2.7.12-1~16.04) ...
Setting up python-all (2.7.12-1~16.04) ...
Setting up python2.7-dev (2.7.12-1ubuntu0~16.04.4) ...
Setting up python-dev (2.7.12-1~16.04) ...
Setting up python-all-dev (2.7.12-1~16.04) ...
Setting up python-pip-whl (8.1.1-2ubuntu0.4) ...
Setting up python-pip (8.1.1-2ubuntu0.4) ...
Setting up python-wheel (0.29.0-1) ...
libexpat1-dev set to automatically installed.
libpython-all-dev set to automatically installed.
libpython-dev set to automatically installed.
libpython2.7-dev set to automatically installed.
python-all set to automatically installed.
python-all-dev set to automatically installed.
python-dev set to automatically installed.
python-pip set to automatically installed.
python-pip-whl set to automatically installed.
python-wheel set to automatically installed.
python2.7-dev set to automatically installed.
Hit http://security.ubuntu.com/ubuntu xenial-security InRelease
Hit http://packages.ros.org/ros/ubuntu xenial InRelease
Err http://packages.ros.org/ros/ubuntu xenial InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY F42ED6FBAB17C654
Hit http://archive.ubuntu.com/ubuntu xenial InRelease
Hit http://archive.ubuntu.com/ubuntu xenial-updates InRelease
Hit http://archive.ubuntu.com/ubuntu xenial-security InRelease
Fetched 0 B in 0s (0 B/s)
Failed to update the package cache: Some files could not be downloaded: Check that the sources on your host are configured correctly.
```