### PR TITLE
legacy backports: critical deb priority, updated black (and source formatting)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,21 @@ jobs:
     # Tests, only when not triggered by the daily cron.
     - stage: static
       if: type != cron
+      name: static tests
+      addons:
+        apt:
+          packages:
+            - libyaml-dev
+            - shellcheck
+            - snapd
+            - python3.5-dev
+        snaps:
+          - name: core
+            channel: stable
+          - name: black
+            channel: beta
+            confinement: devmode
       install:
-        - sudo apt update
-        - sudo apt install -y python3.5-dev snapd shellcheck libyaml-dev
-        # workaround for "cannot locate the core snap: No such file or directory"
-        - sudo snap install core
-        - sudo snap install black --devmode --edge
         - sudo update-alternatives --install /usr/bin/python3 python3.5 /usr/bin/python3.5 0
         - curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && python3 /tmp/get-pip.py --user
         - pip3 install --user -r requirements-devel.txt

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,4 +3,4 @@
 [mypy]
 python_version = 3.5
 ignore_missing_imports = True
-follow_imports=silent
+follow_imports = silent

--- a/snapcraft/cli/ci.py
+++ b/snapcraft/cli/ci.py
@@ -35,7 +35,7 @@ def cicli():
 @click.option(
     "--refresh",
     is_flag=True,
-    help=("Refresh the macaroon required to be able to push and release to channels"),
+    help="Refresh the macaroon required to be able to push and release to channels",
 )
 def enableci(ci_system, refresh):
     """Enable continuous-integration systems to build and release snaps."""

--- a/snapcraft/internal/deltas/_deltas.py
+++ b/snapcraft/internal/deltas/_deltas.py
@@ -159,7 +159,7 @@ class BaseDeltasGenerator:
                 count = 0
             progress_indicator.update(count)
             count += 1
-            time.sleep(.2)
+            time.sleep(0.2)
             ret = proc.poll()
         print("")
         # the caller should finish the progressbar outside
@@ -195,9 +195,13 @@ class BaseDeltasGenerator:
 
         delta_cmd = self.get_delta_cmd(self.source_path, self.target_path, delta_file)
 
-        workdir, stdout_path, stdout_file, stderr_path, stderr_file = self._setup_std_output(
-            delta_file
-        )
+        (
+            workdir,
+            stdout_path,
+            stdout_file,
+            stderr_path,
+            stderr_file,
+        ) = self._setup_std_output(delta_file)
 
         proc = subprocess.Popen(
             delta_cmd, stdout=stdout_file, stderr=stderr_file, cwd=workdir

--- a/snapcraft/internal/lifecycle/_packer.py
+++ b/snapcraft/internal/lifecycle/_packer.py
@@ -102,7 +102,7 @@ def _run_mksquashfs(
                     count = 0
                 progress_indicator.update(count)
                 count += 1
-                time.sleep(.2)
+                time.sleep(0.2)
                 ret = proc.poll()
         print("")
         if ret != 0:

--- a/snapcraft/internal/project_loader/inspection/_latest_step.py
+++ b/snapcraft/internal/project_loader/inspection/_latest_step.py
@@ -23,7 +23,7 @@ from . import errors
 
 
 def latest_step(
-    parts: List[pluginhandler.PluginHandler]
+    parts: List[pluginhandler.PluginHandler],
 ) -> Tuple[pluginhandler.PluginHandler, steps.Step, int]:
     """Determine and return the latest step that was run.
 

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -328,10 +328,20 @@ class Ubuntu(BaseRepo):
         logger.info("Installing build dependencies: %s", " ".join(package_names))
         env = os.environ.copy()
         env.update(
-            {"DEBIAN_FRONTEND": "noninteractive", "DEBCONF_NONINTERACTIVE_SEEN": "true"}
+            {
+                "DEBIAN_FRONTEND": "noninteractive",
+                "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                "DEBIAN_PRIORITY": "critical",
+            }
         )
 
-        apt_command = ["sudo", "apt-get", "--no-install-recommends", "-y"]
+        apt_command = [
+            "sudo",
+            "--preserve-env",
+            "apt-get",
+            "--no-install-recommends",
+            "-y",
+        ]
         if not is_dumb_terminal():
             apt_command.extend(["-o", "Dpkg::Progress-Fancy=1"])
         apt_command.append("install")

--- a/snapcraft/plugins/dotnet.py
+++ b/snapcraft/plugins/dotnet.py
@@ -41,9 +41,7 @@ from snapcraft import formatting_utils
 from typing import List
 
 
-_DOTNET_RELEASE_METADATA_URL = (
-    "https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases.json"
-)  # noqa
+_DOTNET_RELEASE_METADATA_URL = "https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases.json"  # noqa
 _RUNTIME_DEFAULT = "2.0.5"
 
 # TODO extend for other architectures

--- a/snapcraft/storeapi/_sca_client.py
+++ b/snapcraft/storeapi/_sca_client.py
@@ -42,10 +42,9 @@ class SCAClient(Client):
 
     @staticmethod
     def _is_needs_refresh_response(response):
-        return response.status_code == requests.codes.unauthorized and response.headers.get(
-            "WWW-Authenticate"
-        ) == (
-            "Macaroon needs_refresh=1"
+        return (
+            response.status_code == requests.codes.unauthorized
+            and response.headers.get("WWW-Authenticate") == "Macaroon needs_refresh=1"
         )
 
     def request(self, *args, **kwargs):
@@ -242,9 +241,9 @@ class SCAClient(Client):
         try:
             response_json = response.json()
         except JSONDecodeError:
-            message = (
-                "Invalid response from the server when getting {}: {} {}"
-            ).format(endpoint, response.status_code, response)
+            message = "Invalid response from the server when getting {}: {} {}".format(
+                endpoint, response.status_code, response
+            )
             logger.debug(message)
             raise errors.StoreValidationError(
                 snap_id, response, message="Invalid response from the server"

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -389,9 +389,8 @@ class StoreServerError(StoreError):
         what = "The Snap Store encountered an error while processing your request"
         error_code = response.status_code
         error_text = responses[error_code].lower()
-        action = (
-            "The operational status of the Snap Store can be checked at "
-            "{}".format(_STORE_STATUS_URL)
+        action = "The operational status of the Snap Store can be checked at " "{}".format(
+            _STORE_STATUS_URL
         )
 
         super().__init__(

--- a/spread.yaml
+++ b/spread.yaml
@@ -21,6 +21,10 @@ environment:
 
   SETUP_DIR: /snapcraft/tests/spread/setup
 
+  # Ensure that we have the right debian configuration for legacy
+  DEBIAN_FRONTEND: noninteractive
+  DEBIAN_PRIORITY: critical
+
 backends:
   lxd:
     systems:

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -405,7 +405,7 @@ class FakeStoreAPIServer(base.BaseFakeServer):
                     "error_list": [
                         {
                             "code": "invalid-field",
-                            "message": ("The 'channels' field content is not valid."),
+                            "message": "The 'channels' field content is not valid.",
                         }
                     ]
                 }

--- a/tests/unit/build_providers/multipass/test_instance_info.py
+++ b/tests/unit/build_providers/multipass/test_instance_info.py
@@ -20,7 +20,7 @@ from testtools.matchers import Equals
 
 from snapcraft.internal.build_providers import errors
 from snapcraft.internal.build_providers._multipass._instance_info import (
-    InstanceInfo
+    InstanceInfo,
 )  # noqa: E501
 from tests import unit
 

--- a/tests/unit/build_providers/test_errors.py
+++ b/tests/unit/build_providers/test_errors.py
@@ -151,7 +151,7 @@ class ErrorFormattingTest(unit.TestCase):
             dict(
                 exception=errors.ProviderInstanceNotFoundError,
                 kwargs=dict(instance_name="test-build"),
-                expected_message=("Cannot find an instance named 'test-build'."),
+                expected_message="Cannot find an instance named 'test-build'.",
             ),
         ),
         (
@@ -257,9 +257,7 @@ class ErrorFormattingTest(unit.TestCase):
             dict(
                 exception=errors.UnsupportedHostError,
                 kwargs=dict(base="core66", platform="beos", provider="multipass"),
-                expected_message=(
-                    "Building for 'core66' is not supported on platform 'beos' using provider: 'multipass'."
-                ),
+                expected_message="Building for 'core66' is not supported on platform 'beos' using provider: 'multipass'.",
             ),
         ),
     ]

--- a/tests/unit/commands/__init__.py
+++ b/tests/unit/commands/__init__.py
@@ -27,15 +27,11 @@ from tests import fixture_setup, unit
 _sample_keys = [
     {
         "name": "default",
-        "sha3-384": (
-            "vdEeQvRxmZ26npJCFaGnl-VfGz0lU2jZZkWp_s7E-RxVCNtH2_mtjcxq2NkDKkIp"
-        ),
+        "sha3-384": "vdEeQvRxmZ26npJCFaGnl-VfGz0lU2jZZkWp_s7E-RxVCNtH2_mtjcxq2NkDKkIp",
     },
     {
         "name": "another",
-        "sha3-384": (
-            "JsfToV5hO2eN9l89pYYCKXUioTERrZIIHUgQQd47jW8YNNBskupiIjWYd3KXLY_D"
-        ),
+        "sha3-384": "JsfToV5hO2eN9l89pYYCKXUioTERrZIIHUgQQd47jW8YNNBskupiIjWYd3KXLY_D",
     },
 ]
 

--- a/tests/unit/lifecycle/test_lifecycle.py
+++ b/tests/unit/lifecycle/test_lifecycle.py
@@ -1,4 +1,3 @@
-
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
 # Copyright (C) 2015-2018 Canonical Ltd
@@ -1266,7 +1265,7 @@ class CoreSetupTestCase(unit.TestCase):
 
         lifecycle.execute(steps.PULL, project_config)
 
-        regex = (".*mkdir -p {}\nunsquashfs -d {} .*{}\n").format(
+        regex = ".*mkdir -p {}\nunsquashfs -d {} .*{}\n".format(
             os.path.dirname(self.core_path), self.core_path, core_snap_hash
         )
         self.assertThat(
@@ -1298,7 +1297,7 @@ class CoreSetupTestCase(unit.TestCase):
 
         lifecycle.execute(steps.PULL, project_config)
 
-        regex = (".*mkdir -p {}\nunsquashfs -d {} .*{}\n").format(
+        regex = ".*mkdir -p {}\nunsquashfs -d {} .*{}\n".format(
             os.path.dirname(self.core_path), self.core_path, core_snap_hash
         )
         self.assertThat(

--- a/tests/unit/lifecycle/test_status_cache.py
+++ b/tests/unit/lifecycle/test_status_cache.py
@@ -1,4 +1,3 @@
-
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
 # Copyright (C) 2018 Canonical Ltd

--- a/tests/unit/project/test_errors.py
+++ b/tests/unit/project/test_errors.py
@@ -41,7 +41,7 @@ class ErrorFormattingTest(unit.TestCase):
             {
                 "exception": errors.YamlValidationError,
                 "kwargs": {"source": ".snapcraft.yaml", "message": "error"},
-                "expected_message": ("Issues while validating .snapcraft.yaml: error"),
+                "expected_message": "Issues while validating .snapcraft.yaml: error",
             },
         ),
         (

--- a/tests/unit/project_loader/grammar_processing/test_global_grammar_processor.py
+++ b/tests/unit/project_loader/grammar_processing/test_global_grammar_processor.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from snapcraft.internal.project_loader.grammar_processing import (
-    _global_grammar_processor as processor
+    _global_grammar_processor as processor,
 )
 
 import doctest

--- a/tests/unit/project_loader/test_build_packages.py
+++ b/tests/unit/project_loader/test_build_packages.py
@@ -37,9 +37,7 @@ class VCSBuildPackagesTest(ProjectLoaderBaseTest):
         (
             "tar",
             dict(
-                source=(
-                    "https://github.com/ubuntu-core/snapcraft/archive/2.0.1.tar.gz"
-                ),
+                source="https://github.com/ubuntu-core/snapcraft/archive/2.0.1.tar.gz",
                 expected_package=None,
             ),
         ),

--- a/tests/unit/project_loader/test_validation.py
+++ b/tests/unit/project_loader/test_validation.py
@@ -853,7 +853,7 @@ class AliasesTest(ProjectLoaderBaseTest):
         )
         return load_config(project)
 
-    def test_aliases(self,):
+    def test_aliases(self):
         fake_logger = fixtures.FakeLogger(level=logging.WARNING)
         self.useFixture(fake_logger)
 
@@ -1341,8 +1341,7 @@ class InvalidGradeTest(ProjectLoaderBaseTest):
     ]
 
     def test_invalid_yaml_invalid_grade_types(self):
-        snapcraft_yaml = (
-            """\
+        snapcraft_yaml = """\
             name: test
             version: "1"
             summary: test
@@ -1353,8 +1352,9 @@ class InvalidGradeTest(ProjectLoaderBaseTest):
             parts:
               part1:
                 plugin: nil
-            """
-        ).format(self.grade)
+            """.format(
+            self.grade
+        )
 
         raised = self.assertRaises(
             errors.YamlValidationError, self.make_snapcraft_project, snapcraft_yaml

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -379,12 +379,13 @@ class BuildPackagesTestCase(unit.TestCase):
         mock_check_call.assert_has_calls(
             [
                 call(
-                    "sudo apt-get --no-install-recommends -y "
+                    "sudo --preserve-env apt-get --no-install-recommends -y "
                     "-o Dpkg::Progress-Fancy=1 install".split()
                     + sorted(set(installable)),
                     env={
                         "DEBIAN_FRONTEND": "noninteractive",
                         "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                        "DEBIAN_PRIORITY": "critical",
                     },
                 )
             ]
@@ -402,11 +403,12 @@ class BuildPackagesTestCase(unit.TestCase):
         mock_check_call.assert_has_calls(
             [
                 call(
-                    "sudo apt-get --no-install-recommends -y install".split()
+                    "sudo --preserve-env apt-get --no-install-recommends -y install".split()
                     + sorted(set(installable)),
                     env={
                         "DEBIAN_FRONTEND": "noninteractive",
                         "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                        "DEBIAN_PRIORITY": "critical",
                     },
                 )
             ]
@@ -424,6 +426,7 @@ class BuildPackagesTestCase(unit.TestCase):
                     env={
                         "DEBIAN_FRONTEND": "noninteractive",
                         "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                        "DEBIAN_PRIORITY": "critical",
                     },
                 )
             ]

--- a/tests/unit/store/test_store_client.py
+++ b/tests/unit/store/test_store_client.py
@@ -1714,15 +1714,13 @@ class PushBinaryMetadataTestCase(StoreTestCase):
                 metadata,
                 False,
             )
-        should = (
-            """
+        should = """
             Metadata not pushed!
             Conflict in 'icon' field:
                 In snapcraft.yaml: '{}'
                 In the Store:      'original-icon'
             You can repeat the push-metadata command with --force to force the local values into the Store
-        """
-        ).format(
+        """.format(
             filename
         )  # NOQA
         self.assertThat(str(raised), Equals(dedent(should).strip()))

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -717,7 +717,7 @@ class ErrorFormattingTestCase(unit.TestCase):
                 "kwargs": {
                     "exception": requests.exceptions.ConnectionError("bad error")
                 },
-                "expected_message": ("There seems to be a network error: bad error"),
+                "expected_message": "There seems to be a network error: bad error",
             },
         ),
         (
@@ -781,7 +781,7 @@ class ErrorFormattingTestCase(unit.TestCase):
             {
                 "exception": errors.MountPointNotFoundError,
                 "kwargs": {"mount_point": "test-mount-point"},
-                "expected_message": ("Nothing is mounted at 'test-mount-point'"),
+                "expected_message": "Nothing is mounted at 'test-mount-point'",
             },
         ),
         (
@@ -789,7 +789,7 @@ class ErrorFormattingTestCase(unit.TestCase):
             {
                 "exception": errors.RootNotMountedError,
                 "kwargs": {"root": "test-root"},
-                "expected_message": ("'test-root' is not mounted"),
+                "expected_message": "'test-root' is not mounted",
             },
         ),
         (
@@ -797,7 +797,7 @@ class ErrorFormattingTestCase(unit.TestCase):
             {
                 "exception": errors.InvalidMountinfoFormat,
                 "kwargs": {"row": [1, 2, 3]},
-                "expected_message": ("Unable to parse mountinfo row: [1, 2, 3]"),
+                "expected_message": "Unable to parse mountinfo row: [1, 2, 3]",
             },
         ),
         (
@@ -805,7 +805,7 @@ class ErrorFormattingTestCase(unit.TestCase):
             {
                 "exception": errors.InvalidStepError,
                 "kwargs": {"step_name": "test-step-name"},
-                "expected_message": ("'test-step-name' is not a valid lifecycle step"),
+                "expected_message": "'test-step-name' is not a valid lifecycle step",
             },
         ),
         (
@@ -813,7 +813,7 @@ class ErrorFormattingTestCase(unit.TestCase):
             {
                 "exception": errors.NoLatestStepError,
                 "kwargs": {"part_name": "test-part-name"},
-                "expected_message": ("The 'test-part-name' part hasn't run any steps"),
+                "expected_message": "The 'test-part-name' part hasn't run any steps",
             },
         ),
         (


### PR DESCRIPTION
tests/spread/general/cwd_not_on_sys_path tests are intermittently failing (see https://travis-ci.org/snapcore/snapcraft/jobs/551606315#L1020).  It takes the legacy code path as it doesn't specify a base.

The source: https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/1832522.
The diff: https://git.launchpad.net/ubuntu/+source/openssl/diff/?id=783a1f8c6e756eb395025d4bc37a2d046369349b

Did some testing to confirm that DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true DEBIAN_PRIORITY=critical  should be sufficient:
```
root@b4eb8bc50540:/# wget https//launchpad.net/~ci-train-ppa-service/+archive/ubuntu/3662-deletedppa/+build/16554812/+files/libssl1.1_1.1.1-1ubuntu2.1~18.04.1_amd64.deb
root@b4eb8bc50540:/# dpkg -i libssl1.1_1.1.1-1ubuntu2.1~18.04.1_amd64.deb 
dpkg: warning: downgrading libssl1.1:amd64 from 1.1.1-1ubuntu2.1~18.04.3 to 1.1.1-1ubuntu2.1~18.04.1
(Reading database ... 10045 files and directories currently installed.)
Preparing to unpack libssl1.1_1.1.1-1ubuntu2.1~18.04.1_amd64.deb ...
Unpacking libssl1.1:amd64 (1.1.1-1ubuntu2.1~18.04.1) over (1.1.1-1ubuntu2.1~18.04.3) ...
Setting up libssl1.1:amd64 (1.1.1-1ubuntu2.1~18.04.1) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.26.1 /usr/local/share/perl/5.26.1 /usr/lib/x86_64-linux-gnu/perl5/5.26 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.26 /usr/share/perl/5.26 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Processing triggers for libc-bin (2.27-3ubuntu1) ...
root@b4eb8bc50540:/# DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true DEBIAN_PRIORITY=critical apt-get install libssl1.1 -y
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages will be upgraded:
  libssl1.1
1 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 1295 kB of archives.
After this operation, 4096 B of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libssl1.1 amd64 1.1.1-1ubuntu2.1~18.04.3 [1295 kB]
Fetched 1295 kB in 1s (1460 kB/s)   
debconf: delaying package configuration, since apt-utils is not installed
(Reading database ... 10045 files and directories currently installed.)
Preparing to unpack .../libssl1.1_1.1.1-1ubuntu2.1~18.04.3_amd64.deb ...
Unpacking libssl1.1:amd64 (1.1.1-1ubuntu2.1~18.04.3) over (1.1.1-1ubuntu2.1~18.04.1) ...
Processing triggers for libc-bin (2.27-3ubuntu1) ...
Setting up libssl1.1:amd64 (1.1.1-1ubuntu2.1~18.04.3) ...
Checking for services that may need to be restarted...done.
Checking for services that may need to be restarted...done.
Checking init scripts...

Restarting services possibly affected by the upgrade:
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of restart.

Services restarted successfully.

Processing triggers for libc-bin (2.27-3ubuntu1) ...
```

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
