### PR TITLE
tests/spread/cwd_not_on_sys_path: set base

### DIFF
--- a/tests/spread/general/cwd_not_on_sys_path/snaps/sys-path-test/snap/snapcraft.yaml
+++ b/tests/spread/general/cwd_not_on_sys_path/snaps/sys-path-test/snap/snapcraft.yaml
@@ -11,3 +11,4 @@ confinement: strict
 parts:
   part:
     plugin: python
+    source: .

--- a/tests/spread/general/cwd_not_on_sys_path/task.yaml
+++ b/tests/spread/general/cwd_not_on_sys_path/task.yaml
@@ -3,10 +3,19 @@ summary: Build a snap that would crash snapcraft if it loaded modules from cwd
 environment:
   SNAP_DIR: snaps/sys-path-test
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean
   rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
 
 execute: |
   cd "$SNAP_DIR"


### PR DESCRIPTION
This tests currently does not specify a base.

As this test is not labelled as legacy, set the base.
Also set `source: .` to comply with non-legacy schema.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
