### PR TITLE
build providers: support injection for LXD

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,6 +8,8 @@ description: |
     into Snappy.
 adopt-info: snapcraft
 confinement: classic
+assumes:
+  - snapd2.39
 
 apps:
   snapcraft:

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -86,7 +86,6 @@ _CLOUD_USER_DATA_TMPL = dedent(
 
 class Provider(abc.ABC):
 
-    _SNAPS_MOUNTPOINT = os.path.join(os.path.sep, "var", "cache", "snapcraft", "snaps")
     _INSTANCE_PROJECT_DIR = "~/project"
 
     def __init__(self, *, project, echoer, is_ephemeral: bool = False) -> None:
@@ -171,14 +170,6 @@ class Provider(abc.ABC):
     @abc.abstractmethod
     def _push_file(self, *, source: str, destination: str) -> None:
         """Push a file into the instance."""
-
-    @abc.abstractmethod
-    def _mount_snaps_directory(self) -> None:
-        """Mount the host directory with snaps into the provider."""
-
-    @abc.abstractmethod
-    def _unmount_snaps_directory(self) -> None:
-        """Unmount the host directory with snaps from the provider."""
 
     @abc.abstractmethod
     def mount_project(self) -> None:
@@ -289,12 +280,9 @@ class Provider(abc.ABC):
             inject_from_host = False
 
         snap_injector = SnapInjector(
-            snap_dir=self._SNAPS_MOUNTPOINT,
             registry_filepath=registry_filepath,
             snap_arch=self.project.deb_arch,
             runner=self._run,
-            snap_dir_mounter=self._mount_snaps_directory,
-            snap_dir_unmounter=self._unmount_snaps_directory,
             file_pusher=self._push_file,
             inject_from_host=inject_from_host,
         )

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -120,7 +120,7 @@ class LXD(Provider):
 
     @classmethod
     def _get_is_snap_injection_capable(cls) -> bool:
-        return False
+        return True
 
     def _run(
         self, command: Sequence[str], hide_output: bool = False
@@ -212,25 +212,15 @@ class LXD(Provider):
                     provider_name=self._get_provider_name(), error_message=lxd_api_error
                 ) from lxd_api_error
 
-    def _mount_snaps_directory(self) -> None:
-        raise NotImplementedError(
-            "Feature not supported with provider {!r}".format(self._get_provider_name())
-        )
-
-    def _unmount_snaps_directory(self):
-        raise NotImplementedError(
-            "Feature not supported with provider {!r}".format(self._get_provider_name())
-        )
-
     def _push_file(self, *, source: str, destination: str) -> None:
         self._ensure_container_running()
 
         # TODO: better handling of larger files.
-        with open(source) as source_data:
+        with open(source, "rb") as source_data:
             source_contents = source_data.read()
 
         try:
-            self._container.files.put(destination, source_contents.encode())
+            self._container.files.put(destination, source_contents)
         except pylxd.exceptions.LXDAPIException as lxd_api_error:
             raise errors.ProviderFileCopyError(
                 provider_name=self._get_provider_name(), error_message=lxd_api_error

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -146,15 +146,6 @@ class Multipass(Provider):
         mount = "{}:{}".format(self.instance_name, mountpoint)
         self._multipass_cmd.umount(mount=mount)
 
-    def _mount_snaps_directory(self) -> None:
-        # https://github.com/snapcore/snapd/blob/master/dirs/dirs.go
-        # CoreLibExecDir
-        path = os.path.join(os.path.sep, "var", "lib", "snapd", "snaps")
-        self._mount(mountpoint=self._SNAPS_MOUNTPOINT, dev_or_path=path)
-
-    def _unmount_snaps_directory(self):
-        self._umount(mountpoint=self._SNAPS_MOUNTPOINT)
-
     def _push_file(self, *, source: str, destination: str) -> None:
         destination = "{}:{}".format(self.instance_name, destination)
         self._multipass_cmd.copy_files(source=source, destination=destination)

--- a/tests/fake_servers/snapd.py
+++ b/tests/fake_servers/snapd.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017-2018 Canonical Ltd
+# Copyright (C) 2017-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -32,6 +32,10 @@ class FakeSnapdRequestHandler(fake_servers.BaseHTTPRequestHandler):
         parsed_url = parse.urlparse(self.path)
         if parsed_url.path == "/v2/snaps":
             self._handle_snaps()
+        elif parsed_url.path.startswith("/v2/snaps/") and parsed_url.path.endswith(
+            "file"
+        ):
+            self._handle_snap_file(parsed_url)
         elif parsed_url.path.startswith("/v2/snaps/"):
             self._handle_snap_details(parsed_url)
         elif parsed_url.path == "/v2/find":
@@ -47,6 +51,13 @@ class FakeSnapdRequestHandler(fake_servers.BaseHTTPRequestHandler):
         self.end_headers()
         response = json.dumps({"result": params}).encode()
         self.wfile.write(response)
+
+    def _handle_snap_file(self, parsed_url):
+        self.send_response(200)
+        self.send_header("Content-Length", len(parsed_url))
+        self.send_header("Content-type", "text/plain")
+        self.end_headers()
+        self.wfile.write(parsed_url.encode())
 
     def _handle_snap_details(self, parsed_url):
         status_code = 404

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2018 Canonical Ltd
+# Copyright (C) 2015-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -42,7 +42,7 @@ class ProviderImpl(Provider):
         self.save_info_mock = mock.Mock()
 
     def _run(self, command, hide_output=False) -> Optional[bytes]:
-        self.run_mock(command)
+        return self.run_mock(command)
 
     def _launch(self) -> None:
         self.launch_mock()
@@ -55,12 +55,6 @@ class ProviderImpl(Provider):
 
     def _unmount(self, *, mountpoint: str) -> None:
         self.unmount_mock(mountpoint=mountpoint)
-
-    def _mount_snaps_directory(self) -> None:
-        self._mount(mountpoint=self._SNAPS_MOUNTPOINT, dev_or_path="snaps-dev")
-
-    def _unmount_snaps_directory(self) -> None:
-        self._unmount(mountpoint=self._SNAPS_MOUNTPOINT)
 
     def _push_file(self, *, source: str, destination: str) -> None:
         self.push_file_mock(source=source, destination=destination)

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018 Canonical Ltd
+# Copyright (C) 2018-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -201,14 +201,11 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
         provider._setup_snapcraft()
 
         self.snap_injector_mock.assert_called_once_with(
-            snap_dir=provider._SNAPS_MOUNTPOINT,
             registry_filepath=os.path.join(
                 provider.provider_project_dir, "snap-registry.yaml"
             ),
             snap_arch=self.project.deb_arch,
             runner=provider._run,
-            snap_dir_mounter=provider._mount_snaps_directory,
-            snap_dir_unmounter=provider._unmount_snaps_directory,
             file_pusher=provider._push_file,
             inject_from_host=True,
         )
@@ -229,14 +226,11 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
         provider._setup_snapcraft()
 
         self.snap_injector_mock.assert_called_once_with(
-            snap_dir=provider._SNAPS_MOUNTPOINT,
             registry_filepath=os.path.join(
                 provider.provider_project_dir, "snap-registry.yaml"
             ),
             snap_arch=self.project.deb_arch,
             runner=provider._run,
-            snap_dir_mounter=provider._mount_snaps_directory,
-            snap_dir_unmounter=provider._unmount_snaps_directory,
             file_pusher=provider._push_file,
             inject_from_host=True,
         )
@@ -276,14 +270,11 @@ class MacProviderProvisionSnapcraftTest(MacBaseProviderWithBasesBaseTest):
         provider._setup_snapcraft()
 
         self.snap_injector_mock.assert_called_once_with(
-            snap_dir=provider._SNAPS_MOUNTPOINT,
             registry_filepath=os.path.join(
                 provider.provider_project_dir, "snap-registry.yaml"
             ),
             snap_arch=self.project.deb_arch,
             runner=provider._run,
-            snap_dir_mounter=provider._mount_snaps_directory,
-            snap_dir_unmounter=provider._unmount_snaps_directory,
             file_pusher=provider._push_file,
             inject_from_host=False,
         )
@@ -304,14 +295,11 @@ class MacProviderProvisionSnapcraftTest(MacBaseProviderWithBasesBaseTest):
         provider._setup_snapcraft()
 
         self.snap_injector_mock.assert_called_once_with(
-            snap_dir=provider._SNAPS_MOUNTPOINT,
             registry_filepath=os.path.join(
                 provider.provider_project_dir, "snap-registry.yaml"
             ),
             snap_arch=self.project.deb_arch,
             runner=provider._run,
-            snap_dir_mounter=provider._mount_snaps_directory,
-            snap_dir_unmounter=provider._unmount_snaps_directory,
             file_pusher=provider._push_file,
             inject_from_host=False,
         )
@@ -329,14 +317,11 @@ class MacProviderProvisionSnapcraftTest(MacBaseProviderWithBasesBaseTest):
         provider._setup_snapcraft()
 
         self.snap_injector_mock.assert_called_once_with(
-            snap_dir=provider._SNAPS_MOUNTPOINT,
             registry_filepath=os.path.join(
                 provider.provider_project_dir, "snap-registry.yaml"
             ),
             snap_arch=self.project.deb_arch,
             runner=provider._run,
-            snap_dir_mounter=provider._mount_snaps_directory,
-            snap_dir_unmounter=provider._unmount_snaps_directory,
             file_pusher=provider._push_file,
             inject_from_host=False,
         )


### PR DESCRIPTION
By use of snapd's new snaps/<snap-name>/file API.
This also removes the use of mounts and leverages file
pushing.

Refactoring has been done for a better separation of concerns.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
