### PR TITLE
build environment: detect base type and use name

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -841,26 +841,71 @@
             "type": "object"
         }
     },
-    "required": [
-        "name",
-        "base",
-        "parts"
-    ],
-
-    "$comment": "Either summary/description/version is required, or adopt-info is required to specify the part from which this metadata will be retrieved.",
-    "anyOf": [
+    "allOf": [
         {
-            "required": [
-                "summary",
-                "description",
-                "version"
+            "anyOf": [
+                {
+                    "usage": "type: base (without a base)",
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "base"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "required": [
+                                "type"
+                            ]
+                        },
+                        {
+                            "not": {
+                                "required": [
+                                    "base"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "usage": "base: <base> and type: <app|gadget|kernel|snapd>",
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "app",
+                                "gadget",
+                                "kernel",
+                                "snapd"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "base"
+                    ]
+                }
             ]
         },
         {
-            "required": [
-                "adopt-info"
+            "anyOf": [
+                {
+                    "required": [
+                        "summary",
+                        "description",
+                        "version"
+                    ]
+                },
+                {
+                    "required": [
+                        "adopt-info"
+                    ]
+                }
             ]
         }
+    ],
+    "required": [
+        "name",
+        "parts"
     ],
 
     "dependencies": {

--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -300,6 +300,10 @@
             "type": "string",
             "description": "the base snap to use"
         },
+        "build-base": {
+            "type": "string",
+            "description": "force a build environment based on base to create a snap"
+        },
         "epoch": {
             "description": "the snap epoch, used to specify upgrade paths",
             "format": "epoch"
@@ -869,7 +873,7 @@
                     ]
                 },
                 {
-                    "usage": "base: <base> and type: <app|gadget|kernel|snapd>",
+                    "usage": "base: <base> and type: <app|gadget|kernel|snapd> (without a build-base)",
                     "properties": {
                         "type": {
                             "enum": [
@@ -880,8 +884,19 @@
                             ]
                         }
                     },
-                    "required": [
-                        "base"
+                    "allOf": [
+                        {
+                            "required": [
+                                "base"
+                            ]
+                        },
+                        {
+                            "not":{
+                                "required": [
+                                    "build-base"
+                                ]
+                            }
+                        }
                     ]
                 }
             ]

--- a/snapcraft/cli/_command.py
+++ b/snapcraft/cli/_command.py
@@ -63,7 +63,10 @@ class SnapcraftProjectCommand(click.Command):
         # Not in an actual project.
         if project is None or project.info is None:
             return False
-        # In a project with no base set is legacy.
+        # Building a base is not legacy.
+        elif project.info.type == "base":
+            return False
+        # A project with no base set is legacy.
         elif project.info.base is None:
             return True
         else:

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -255,16 +255,18 @@ class Provider(abc.ABC):
     def _ensure_base(self) -> None:
         info = self._load_info()
         provider_base = info["base"] if "base" in info else None
-        if self._base_has_changed(self.project.info.base, provider_base):
+        if self._base_has_changed(
+            self.project.info.get_effective_base(), provider_base
+        ):
             self.echoer.warning(
                 "Project base changed from {!r} to {!r}, cleaning build instance.".format(
-                    provider_base, self.project.info.base
+                    provider_base, self.project.info.get_effective_base()
                 )
             )
             self.clean_project()
 
     def _setup_snapcraft(self) -> None:
-        self._save_info(base=self.project.info.base)
+        self._save_info(base=self.project.info.get_effective_base())
 
         registry_filepath = os.path.join(
             self.provider_project_dir, "snap-registry.yaml"
@@ -293,8 +295,8 @@ class Provider(abc.ABC):
         # This build can be driven from a non snappy enabled system, so we may
         # find ourself in a situation where the base is not set like on OSX or
         # Windows.
-        if self.project.info.base is not None:
-            snap_injector.add(snap_name=self.project.info.base)
+        if self.project.info.get_effective_base() is not None:
+            snap_injector.add(snap_name=self.project.info.get_effective_base())
 
         snap_injector.apply()
 

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -255,18 +255,16 @@ class Provider(abc.ABC):
     def _ensure_base(self) -> None:
         info = self._load_info()
         provider_base = info["base"] if "base" in info else None
-        if self._base_has_changed(
-            self.project.info.get_effective_base(), provider_base
-        ):
+        if self._base_has_changed(self.project.info.get_build_base(), provider_base):
             self.echoer.warning(
                 "Project base changed from {!r} to {!r}, cleaning build instance.".format(
-                    provider_base, self.project.info.get_effective_base()
+                    provider_base, self.project.info.get_build_base()
                 )
             )
             self.clean_project()
 
     def _setup_snapcraft(self) -> None:
-        self._save_info(base=self.project.info.get_effective_base())
+        self._save_info(base=self.project.info.get_build_base())
 
         registry_filepath = os.path.join(
             self.provider_project_dir, "snap-registry.yaml"
@@ -295,8 +293,8 @@ class Provider(abc.ABC):
         # This build can be driven from a non snappy enabled system, so we may
         # find ourself in a situation where the base is not set like on OSX or
         # Windows.
-        if self.project.info.get_effective_base() is not None:
-            snap_injector.add(snap_name=self.project.info.get_effective_base())
+        if self.project.info.get_build_base() is not None:
+            snap_injector.add(snap_name=self.project.info.get_build_base())
 
         snap_injector.apply()
 

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -148,7 +148,7 @@ class LXD(Provider):
     def _launch(self) -> None:
         config = {
             "name": self.instance_name,
-            "source": get_image_source(base=self.project.info.base),
+            "source": get_image_source(base=self.project.info.get_effective_base()),
         }
 
         try:

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -148,7 +148,7 @@ class LXD(Provider):
     def _launch(self) -> None:
         config = {
             "name": self.instance_name,
-            "source": get_image_source(base=self.project.info.get_effective_base()),
+            "source": get_image_source(base=self.project.info.get_build_base()),
         }
 
         try:

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -90,12 +90,7 @@ class Multipass(Provider):
         )
 
     def _get_disk_image(self) -> str:
-        if self.project.info.base is None:
-            image = "snapcraft:core16"
-        else:
-            image = "snapcraft:{}".format(self.project.info.base)
-
-        return image
+        return "snapcraft:{}".format(self.project.info.get_effective_base())
 
     def _launch(self) -> None:
         cloud_user_data_filepath = self._get_cloud_user_data()

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -90,7 +90,7 @@ class Multipass(Provider):
         )
 
     def _get_disk_image(self) -> str:
-        return "snapcraft:{}".format(self.project.info.get_effective_base())
+        return "snapcraft:{}".format(self.project.info.get_build_base())
 
     def _launch(self) -> None:
         cloud_user_data_filepath = self._get_cloud_user_data()

--- a/snapcraft/plugins/ant.py
+++ b/snapcraft/plugins/ant.py
@@ -158,12 +158,12 @@ class AntPlugin(snapcraft.BasePlugin):
         super().__init__(name, options, project)
 
         self._setup_ant()
-        self._setup_base_tools(project.info.base)
+        self._setup_base_tools(project.info.get_build_base())
 
     def _setup_base_tools(self, base):
         if base not in ("core", "core16", "core18"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=self.project.info.base
+                part_name=self.name, base=self.project.info.get_build_base()
             )
 
         if base in ("core", "core16"):
@@ -238,10 +238,9 @@ class AntPlugin(snapcraft.BasePlugin):
         self._create_symlinks()
 
     def _create_symlinks(self):
-        if self.project.info.base not in ("core18", "core16", "core"):
-            raise errors.PluginBaseError(
-                part_name=self.name, base=self.project.info.base
-            )
+        base = self.project.info.get_build_base()
+        if base not in ("core18", "core16", "core"):
+            raise errors.PluginBaseError(part_name=self.name, base=base)
 
         os.makedirs(os.path.join(self.installdir, "bin"), exist_ok=True)
         java_bin = glob(

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -262,7 +262,9 @@ class CatkinPlugin(snapcraft.BasePlugin):
                 ros_repo=ros_repo,
                 ubuntu_repo=ubuntu_repo,
                 security_repo=security_repo,
-                codename=_BASE_TO_UBUNTU_RELEASE_MAP[self.project.info.base],
+                codename=_BASE_TO_UBUNTU_RELEASE_MAP[
+                    self.project.info.get_build_base()
+                ],
             )
         )
 
@@ -273,10 +275,11 @@ class CatkinPlugin(snapcraft.BasePlugin):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        if project.info.base not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(part_name=self.name, base=project.info.base)
+        base = self.project.info.get_build_base()
+        if base not in ("core", "core16", "core18"):
+            raise errors.PluginBaseError(part_name=self.name, base=base)
 
-        self._rosdistro = _BASE_TO_ROS_RELEASE_MAP[project.info.base]
+        self._rosdistro = _BASE_TO_ROS_RELEASE_MAP[base]
 
         self.build_packages.extend(["gcc", "g++", "libc6-dev", "make", "python-pip"])
         self.__pip = None
@@ -489,7 +492,9 @@ class CatkinPlugin(snapcraft.BasePlugin):
             ros_distro=self._rosdistro,
             ros_package_path=self._ros_package_path,
             rosdep_path=self._rosdep_path,
-            ubuntu_distro=_BASE_TO_UBUNTU_RELEASE_MAP[self.project.info.base],
+            ubuntu_distro=_BASE_TO_UBUNTU_RELEASE_MAP[
+                self.project.info.get_build_base()
+            ],
             ubuntu_sources=self.PLUGIN_STAGE_SOURCES,
             ubuntu_keyrings=self.PLUGIN_STAGE_KEYRINGS,
             project=self.project,

--- a/snapcraft/plugins/cmake.py
+++ b/snapcraft/plugins/cmake.py
@@ -95,8 +95,10 @@ class CMakePlugin(snapcraft.BasePlugin):
         self.build_packages.append("cmake")
         self.out_of_source_build = True
 
-        if project.info.base not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(part_name=self.name, base=project.info.base)
+        if project.info.get_build_base() not in ("core", "core16", "core18"):
+            raise errors.PluginBaseError(
+                part_name=self.name, base=project.info.get_build_base()
+            )
 
         if options.make_parameters:
             logger.warning("make-paramaters is deprecated, ignoring.")

--- a/snapcraft/plugins/colcon.py
+++ b/snapcraft/plugins/colcon.py
@@ -227,7 +227,9 @@ class ColconPlugin(snapcraft.BasePlugin):
                 ros_repo=ros_repo,
                 ubuntu_repo=ubuntu_repo,
                 security_repo=security_repo,
-                codename=_BASE_TO_UBUNTU_RELEASE_MAP[self.project.info.base],
+                codename=_BASE_TO_UBUNTU_RELEASE_MAP[
+                    self.project.info.get_build_base()
+                ],
             )
         )
 
@@ -240,8 +242,10 @@ class ColconPlugin(snapcraft.BasePlugin):
         self.out_of_source_build = True
 
         self._rosdistro = options.colcon_rosdistro
-        if project.info.base != _ROSDISTRO_TO_BASE_MAP[self._rosdistro]:
-            raise ColconPluginBaseError(self.name, project.info.base, self._rosdistro)
+        if project.info.get_build_base() != _ROSDISTRO_TO_BASE_MAP[self._rosdistro]:
+            raise ColconPluginBaseError(
+                self.name, project.info.get_build_base(), self._rosdistro
+            )
 
         # Beta warning. Remove this comment and warning once plugin is stable.
         logger.warn(
@@ -335,7 +339,9 @@ class ColconPlugin(snapcraft.BasePlugin):
             ros_distro=self._rosdistro,
             ros_package_path=self._ros_package_path,
             rosdep_path=self._rosdep_path,
-            ubuntu_distro=_BASE_TO_UBUNTU_RELEASE_MAP[self.project.info.base],
+            ubuntu_distro=_BASE_TO_UBUNTU_RELEASE_MAP[
+                self.project.info.get_build_base()
+            ],
             ubuntu_sources=self.PLUGIN_STAGE_SOURCES,
             ubuntu_keyrings=self.PLUGIN_STAGE_KEYRINGS,
             project=self.project,

--- a/snapcraft/plugins/conda.py
+++ b/snapcraft/plugins/conda.py
@@ -96,8 +96,10 @@ class CondaPlugin(snapcraft.BasePlugin):
 
     def __init__(self, name, options, project) -> None:
         super().__init__(name, options, project)
-        if project.info.base not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(part_name=self.name, base=project.info.base)
+        if project.info.get_build_base() not in ("core", "core16", "core18"):
+            raise errors.PluginBaseError(
+                part_name=self.name, base=project.info.get_build_base()
+            )
 
         self._conda_home = os.path.join(self.partdir, "miniconda")
         self._miniconda_script = os.path.join(self.partdir, "miniconda.sh")

--- a/snapcraft/plugins/crystal.py
+++ b/snapcraft/plugins/crystal.py
@@ -58,8 +58,10 @@ class CrystalPlugin(snapcraft.BasePlugin):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        if project.info.base not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(part_name=self.name, base=project.info.base)
+        if project.info.get_build_base() not in ("core", "core16", "core18"):
+            raise errors.PluginBaseError(
+                part_name=self.name, base=project.info.get_build_base()
+            )
 
         self.build_snaps.append("crystal/{}".format(self.options.crystal_channel))
         self.build_packages.extend(
@@ -101,7 +103,7 @@ class CrystalPlugin(snapcraft.BasePlugin):
 
             elf_dependencies_path = elf_file.load_dependencies(
                 root_path=self.installdir,
-                core_base_path=common.get_core_path(self.project.info.base),
+                core_base_path=common.get_core_path(self.project.info.get_build_base()),
             )
             for elf_dependency_path in elf_dependencies_path:
                 lib_install_path = os.path.join(

--- a/snapcraft/plugins/dotnet.py
+++ b/snapcraft/plugins/dotnet.py
@@ -102,7 +102,7 @@ class DotNetPlugin(snapcraft.BasePlugin):
         self._dotnet_dir = os.path.join(self.partdir, "dotnet")
         self._dotnet_sdk_dir = os.path.join(self._dotnet_dir, "sdk")
 
-        self._setup_base_tools(project.info.base)
+        self._setup_base_tools(project.info.get_build_base())
 
         self._sdk = self._get_sdk()
         self._dotnet_cmd = os.path.join(self._dotnet_sdk_dir, "dotnet")

--- a/snapcraft/plugins/go.py
+++ b/snapcraft/plugins/go.py
@@ -102,7 +102,7 @@ class GoPlugin(snapcraft.BasePlugin):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        self._setup_base_tools(options.go_channel, project.info.base)
+        self._setup_base_tools(options.go_channel, project.info.get_build_base())
         self._is_classic = project.info.confinement == "classic"
 
         self._gopath = os.path.join(self.partdir, "go")

--- a/snapcraft/plugins/godeps.py
+++ b/snapcraft/plugins/godeps.py
@@ -104,7 +104,7 @@ class GodepsPlugin(snapcraft.BasePlugin):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        self._setup_base_tools(options.go_channel, project.info.base)
+        self._setup_base_tools(options.go_channel, project.info.get_build_base())
 
         self._gopath = os.path.join(self.partdir, "go")
         self._gopath_src = os.path.join(self._gopath, "src")

--- a/snapcraft/plugins/gradle.py
+++ b/snapcraft/plugins/gradle.py
@@ -146,12 +146,12 @@ class GradlePlugin(snapcraft.BasePlugin):
         super().__init__(name, options, project)
 
         self._setup_gradle()
-        self._setup_base_tools(project.info.base)
+        self._setup_base_tools(project.info.get_build_base())
 
     def _setup_base_tools(self, base):
         if base not in ("core", "core16", "core18"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=self.project.info.base
+                part_name=self.name, base=self.project.info.get_build_base()
             )
 
         if base in ("core", "core16"):
@@ -234,9 +234,9 @@ class GradlePlugin(snapcraft.BasePlugin):
         self._create_symlinks()
 
     def _create_symlinks(self):
-        if self.project.info.base not in ("core18", "core16", "core"):
+        if self.project.info.get_build_base() not in ("core18", "core16", "core"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=self.project.info.base
+                part_name=self.name, base=self.project.info.get_build_base()
             )
 
         os.makedirs(os.path.join(self.installdir, "bin"), exist_ok=True)

--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -102,8 +102,10 @@ class KBuildPlugin(snapcraft.BasePlugin):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        if project.info.base not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(part_name=self.name, base=project.info.base)
+        if project.info.get_build_base() not in ("core", "core16", "core18"):
+            raise errors.PluginBaseError(
+                part_name=self.name, base=project.info.get_build_base()
+            )
 
         self.build_packages.extend(["bc", "gcc", "make"])
 

--- a/snapcraft/plugins/make.py
+++ b/snapcraft/plugins/make.py
@@ -89,8 +89,10 @@ class MakePlugin(snapcraft.BasePlugin):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        if project.info.base not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(part_name=self.name, base=project.info.base)
+        if project.info.get_build_base() not in ("core", "core16", "core18"):
+            raise errors.PluginBaseError(
+                part_name=self.name, base=project.info.get_build_base()
+            )
 
         self.build_packages.append("make")
 

--- a/snapcraft/plugins/maven.py
+++ b/snapcraft/plugins/maven.py
@@ -150,12 +150,12 @@ class MavenPlugin(snapcraft.BasePlugin):
         super().__init__(name, options, project)
 
         self._setup_maven()
-        self._setup_base_tools(project.info.base)
+        self._setup_base_tools(project.info.get_build_base())
 
     def _setup_base_tools(self, base):
         if base not in ("core", "core16", "core18"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=self.project.info.base
+                part_name=self.name, base=self.project.info.get_build_base()
             )
 
         if base in ("core", "core16"):
@@ -243,9 +243,9 @@ class MavenPlugin(snapcraft.BasePlugin):
         self._create_symlinks()
 
     def _create_symlinks(self):
-        if self.project.info.base not in ("core18", "core16", "core"):
+        if self.project.info.get_build_base() not in ("core18", "core16", "core"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=self.project.info.base
+                part_name=self.name, base=self.project.info.get_build_base()
             )
 
         os.makedirs(os.path.join(self.installdir, "bin"), exist_ok=True)

--- a/snapcraft/plugins/meson.py
+++ b/snapcraft/plugins/meson.py
@@ -69,7 +69,7 @@ class MesonPlugin(snapcraft.BasePlugin):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        self._setup_base_tools(project.info.base)
+        self._setup_base_tools(project.info.get_build_base())
 
         self.snapbuildname = "snapbuild"
         self.mesonbuilddir = os.path.join(self.builddir, self.snapbuildname)

--- a/snapcraft/plugins/plainbox_provider.py
+++ b/snapcraft/plugins/plainbox_provider.py
@@ -46,7 +46,7 @@ class PlainboxProviderPlugin(snapcraft.BasePlugin):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        self._setup_base_tools(project.info.base)
+        self._setup_base_tools(project.info.get_build_base())
 
     def _setup_base_tools(self, base):
         if base in ("core", "core16", "core18"):

--- a/snapcraft/plugins/python.py
+++ b/snapcraft/plugins/python.py
@@ -145,12 +145,12 @@ class PythonPlugin(snapcraft.BasePlugin):
         elif self.options.python_version == "python3":
             python_base = "python3"
 
-        if self.project.info.base in ("core", "core16", "core18"):
+        if self.project.info.get_build_base() in ("core", "core16", "core18"):
             stage_packages = [python_base]
         else:
             stage_packages = []
 
-        if self.project.info.base == "core18" and python_base == "python3":
+        if self.project.info.get_build_base() == "core18" and python_base == "python3":
             stage_packages.append("{}-distutils".format(python_base))
 
         return stage_packages
@@ -183,7 +183,7 @@ class PythonPlugin(snapcraft.BasePlugin):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        self._setup_base_tools(project.info.base)
+        self._setup_base_tools(project.info.get_build_base())
 
         self._manifest = collections.OrderedDict()
 

--- a/snapcraft/plugins/qmake.py
+++ b/snapcraft/plugins/qmake.py
@@ -85,8 +85,10 @@ class QmakePlugin(snapcraft.BasePlugin):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        if project.info.base not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(part_name=self.name, base=project.info.base)
+        if project.info.get_build_base() not in ("core", "core16", "core18"):
+            raise errors.PluginBaseError(
+                part_name=self.name, base=project.info.get_build_base()
+            )
 
         self.build_packages.append("make")
         if self.options.qt_version == "qt5":

--- a/snapcraft/plugins/ruby.py
+++ b/snapcraft/plugins/ruby.py
@@ -74,8 +74,10 @@ class RubyPlugin(BasePlugin):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        if project.info.base not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(part_name=self.name, base=project.info.base)
+        if project.info.get_build_base() not in ("core", "core16", "core18"):
+            raise errors.PluginBaseError(
+                part_name=self.name, base=project.info.get_build_base()
+            )
 
         # Beta Warning
         # Remove this comment and warning once ruby plugin is stable.

--- a/snapcraft/plugins/rust.py
+++ b/snapcraft/plugins/rust.py
@@ -90,8 +90,10 @@ class RustPlugin(snapcraft.BasePlugin):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        if project.info.base not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(part_name=self.name, base=project.info.base)
+        if project.info.get_build_base() not in ("core", "core16", "core18"):
+            raise errors.PluginBaseError(
+                part_name=self.name, base=project.info.get_build_base()
+            )
 
         self.build_packages.extend(["gcc", "git", "curl", "file"])
         self._rust_dir = os.path.expanduser(os.path.join("~", ".cargo"))

--- a/snapcraft/plugins/scons.py
+++ b/snapcraft/plugins/scons.py
@@ -57,7 +57,7 @@ class SconsPlugin(snapcraft.BasePlugin):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
-        self._setup_base_tools(project.info.base)
+        self._setup_base_tools(project.info.get_build_base())
 
     def _setup_base_tools(self, base):
         if base in ("core", "core16", "core18"):

--- a/snapcraft/plugins/waf.py
+++ b/snapcraft/plugins/waf.py
@@ -56,7 +56,7 @@ class WafPlugin(snapcraft.BasePlugin):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        self._setup_base_tools(project.info.base)
+        self._setup_base_tools(project.info.get_build_base())
 
     def _setup_base_tools(self, base):
         if base in ("core", "core16", "core18"):

--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -51,6 +51,13 @@ class ProjectInfo:
         """Validate the snapcraft.yaml for this project."""
         _schema.Validator(self.__raw_snapcraft).validate()
 
+    def get_effective_base(self) -> str:
+        """Return name for type base or the base otherwise."""
+        if self.type == "base":
+            return self.name
+        else:
+            return self.base
+
     def get_raw_snapcraft(self):
         # TODO this should be a MappingProxyType, but ordered writing
         #      depends on reading in the current code base.

--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -51,7 +51,7 @@ class ProjectInfo:
         """Validate the snapcraft.yaml for this project."""
         _schema.Validator(self.__raw_snapcraft).validate()
 
-    def get_effective_base(self) -> str:
+    def get_build_base(self) -> str:
         """Return name for type base or the base otherwise."""
         if self.type == "base":
             return self.name

--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -45,6 +45,7 @@ class ProjectInfo:
         self.architectures = self.__raw_snapcraft.get("architectures")
         self.grade = self.__raw_snapcraft.get("grade")
         self.base = self.__raw_snapcraft.get("base")
+        self.build_base = self.__raw_snapcraft.get("build-base")
         self.type = self.__raw_snapcraft.get("type")
 
     def validate_raw_snapcraft(self):
@@ -52,8 +53,12 @@ class ProjectInfo:
         _schema.Validator(self.__raw_snapcraft).validate()
 
     def get_build_base(self) -> str:
-        """Return name for type base or the base otherwise."""
-        if self.type == "base":
+        """
+        Return name for type base or the base otherwise build-base is set
+        """
+        if self.build_base:
+            return self.build_base
+        elif self.type == "base":
             return self.name
         else:
             return self.base

--- a/snapcraft/project/errors.py
+++ b/snapcraft/project/errors.py
@@ -62,9 +62,12 @@ class YamlValidationError(SnapcraftError):
         if preamble:
             messages.append(preamble)
 
-        if supplement:
+        # If we have a preamble we are not at the root
+        if supplement and preamble:
             messages.append(error.message)
             messages.append("({})".format(supplement))
+        elif supplement:
+            messages.append(supplement)
         elif cause:
             messages.append(cause)
         else:

--- a/spread.yaml
+++ b/spread.yaml
@@ -38,8 +38,8 @@ backends:
           workers: 8
           image: ubuntu-1604-64
       - ubuntu-18.04-64:
-          workers: 16
-          image: ubuntu-1804-64-virt-enabled
+          workers: 18
+          image: ubuntu-1804-64
   autopkgtest:
     type: adhoc
     allocate: |

--- a/tests/spread/build-providers/lxd-type-base/task.yaml
+++ b/tests/spread/build-providers/lxd-type-base/task.yaml
@@ -1,0 +1,19 @@
+summary: Build a base snap using the snap-name as a base for the environment
+
+environment:
+  SNAP_DIR: ../snaps/core18-base
+
+restore: |
+  cd "$SNAP_DIR"
+
+  snapcraft clean --use-lxd
+  rm -f ./*.snap
+
+execute: |
+  cd "$SNAP_DIR"
+
+  snapcraft pull --use-lxd
+
+  /snap/bin/lxc start snapcraft-core18
+  /snap/bin/lxc exec snapcraft-core18 cat /etc/os-release | MATCH "VERSION_CODENAME=bionic"
+  /snap/bin/lxc stop snapcraft-core18

--- a/tests/spread/build-providers/snaps/core18-base/snap/snapcraft.yaml
+++ b/tests/spread/build-providers/snaps/core18-base/snap/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: core18
+type: base
+version: "1.0"
+summary: create a base using the correct environment
+description: |
+  Simple snap to ensure that the proper environment is
+  setup using `name` when we use `type: base`.
+
+grade: devel
+confinement: strict
+
+parts:
+  base:
+    plugin: nil

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -226,6 +226,35 @@ class LXDInitTest(LXDBaseTest):
         # This call should not fail
         instance.destroy()
 
+    def test_create_for_type_base(self):
+        self.project.info.name = "core18"
+        self.project.info.type = "base"
+        self.project.info.base = None
+
+        instance = LXD(project=self.project, echoer=self.echoer_mock)
+        with mock.patch.object(
+            LXD, "_get_cloud_user_data_string", return_value="fake-cloud"
+        ):
+            instance.create()
+
+        self.fake_pylxd_client.containers.create_mock.assert_called_once_with(
+            config={
+                "name": "snapcraft-core18",
+                "environment.SNAPCRAFT_BUILD_ENVIRONMENT": "managed-host",
+                "raw.idmap": "both 1000 0",
+                "source": {
+                    "mode": "pull",
+                    "type": "image",
+                    "server": "https://cloud-images.ubuntu.com/minimal/releases/",
+                    "protocol": "simplestreams",
+                    "alias": "18.04",
+                },
+                "environment.SNAPCRAFT_HAS_TTY": "False",
+                "user.user-data": "fake-cloud",
+            },
+            wait=True,
+        )
+
 
 class LXDLaunchedTest(LXDBaseTest):
     def setUp(self):

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -227,6 +227,36 @@ class MultipassTest(BaseProviderBaseTest):
             cloud_init=mock.ANY,
         )
 
+    def test_launch_for_type_base(self):
+        self.project.info.name = "core18"
+        self.project.info.type = "base"
+        self.project.info.base = None
+
+        instance = Multipass(project=self.project, echoer=self.echoer_mock)
+        self.useFixture(
+            fixtures.MockPatchObject(
+                instance,
+                "_get_instance_info",
+                side_effect=[
+                    errors.ProviderInfoError(
+                        provider_name="multipass", exit_code=1, stderr=b"error"
+                    ),
+                    {},
+                ],
+            )
+        )
+
+        instance.create()
+
+        self.multipass_cmd_mock().launch.assert_called_once_with(
+            instance_name="snapcraft-core18",
+            cpus="2",
+            mem="2G",
+            disk="256G",
+            image="snapcraft:core18",
+            cloud_init=mock.ANY,
+        )
+
     def test_launch_with_ram_from_environment(self):
         self.useFixture(
             fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT_MEMORY", "4G")

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -108,14 +108,7 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
     def test_snap_fails_with_bad_type(self):
         self.make_snapcraft_yaml(snap_type="bad-type")
 
-        raised = self.assertRaises(YamlValidationError, self.run_command, ["snap"])
-
-        self.assertThat(
-            str(raised),
-            Contains(
-                "bad-type' is not one of ['app', 'base', 'gadget', 'kernel', 'snapd']"
-            ),
-        )
+        self.assertRaises(YamlValidationError, self.run_command, ["snap"])
 
     def test_snap_is_the_default(self):
         self.make_snapcraft_yaml()

--- a/tests/unit/project/test_project_info.py
+++ b/tests/unit/project/test_project_info.py
@@ -144,6 +144,34 @@ class ProjectInfoTest(unit.TestCase):
         raw_snapcraft = info.get_raw_snapcraft()
         self.assertThat(raw_snapcraft.get("name"), Equals("foo"))
 
+    def test_get_effective_base_for_defined_base(self):
+        snapcraft_yaml_file_path = self.make_snapcraft_yaml(
+            dedent(
+                """\
+            name: test
+            base: core20
+        """
+            )
+        )
+
+        info = ProjectInfo(snapcraft_yaml_file_path=snapcraft_yaml_file_path)
+
+        self.assertThat(info.get_effective_base(), Equals("core20"))
+
+    def test_get_effective_base_for_defined_type_base(self):
+        snapcraft_yaml_file_path = self.make_snapcraft_yaml(
+            dedent(
+                """\
+            name: core20
+            type: base
+        """
+            )
+        )
+
+        info = ProjectInfo(snapcraft_yaml_file_path=snapcraft_yaml_file_path)
+
+        self.assertThat(info.get_effective_base(), Equals("core20"))
+
 
 class InvalidYamlTest(unit.TestCase):
     def test_tab_in_yaml(self):

--- a/tests/unit/project/test_project_info.py
+++ b/tests/unit/project/test_project_info.py
@@ -144,7 +144,7 @@ class ProjectInfoTest(unit.TestCase):
         raw_snapcraft = info.get_raw_snapcraft()
         self.assertThat(raw_snapcraft.get("name"), Equals("foo"))
 
-    def test_get_effective_base_for_defined_base(self):
+    def test_get_build_base_for_defined_base(self):
         snapcraft_yaml_file_path = self.make_snapcraft_yaml(
             dedent(
                 """\
@@ -156,9 +156,9 @@ class ProjectInfoTest(unit.TestCase):
 
         info = ProjectInfo(snapcraft_yaml_file_path=snapcraft_yaml_file_path)
 
-        self.assertThat(info.get_effective_base(), Equals("core20"))
+        self.assertThat(info.get_build_base(), Equals("core20"))
 
-    def test_get_effective_base_for_defined_type_base(self):
+    def test_get_build_base_for_defined_type_base(self):
         snapcraft_yaml_file_path = self.make_snapcraft_yaml(
             dedent(
                 """\
@@ -170,7 +170,7 @@ class ProjectInfoTest(unit.TestCase):
 
         info = ProjectInfo(snapcraft_yaml_file_path=snapcraft_yaml_file_path)
 
-        self.assertThat(info.get_effective_base(), Equals("core20"))
+        self.assertThat(info.get_build_base(), Equals("core20"))
 
 
 class InvalidYamlTest(unit.TestCase):

--- a/tests/unit/project/test_project_info.py
+++ b/tests/unit/project/test_project_info.py
@@ -172,6 +172,21 @@ class ProjectInfoTest(unit.TestCase):
 
         self.assertThat(info.get_build_base(), Equals("core20"))
 
+    def test_get_build_base_build_base_overrides(self):
+        snapcraft_yaml_file_path = self.make_snapcraft_yaml(
+            dedent(
+                """\
+            name: core20
+            type: base
+            build-base: core
+        """
+            )
+        )
+
+        info = ProjectInfo(snapcraft_yaml_file_path=snapcraft_yaml_file_path)
+
+        self.assertThat(info.get_build_base(), Equals("core"))
+
 
 class InvalidYamlTest(unit.TestCase):
     def test_tab_in_yaml(self):

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -309,7 +309,7 @@ class ValidTypesTest(ValidationBaseTest):
 
 
 _BASE_TYPE_MSG = (
-    "must be one of 'base: <base> and type: <app|gadget|kernel|snapd>' "
+    "must be one of 'base: <base> and type: <app|gadget|kernel|snapd> (without a build-base)' "
     "or 'type: base (without a base)'"
 )
 _TYPE_ENUM_TMPL = (
@@ -355,6 +355,22 @@ class CombinedBaseTypeTest(ValidationBaseTest):
         raised = self.assertRaises(errors.YamlValidationError, Validator(data).validate)
 
         self.assertThat(raised.message, Equals(_BASE_TYPE_MSG), message=data)
+
+    def test_build_base_and_base(self):
+        data = self.data.copy()
+        data["build-base"] = "fake-base"
+
+        raised = self.assertRaises(errors.YamlValidationError, Validator(data).validate)
+
+        self.assertThat(raised.message, Equals(_BASE_TYPE_MSG), message=data)
+
+    def test_build_base_and_type_base(self):
+        data = self.data.copy()
+        data.pop("base")
+        data["type"] = "base"
+        data["build-base"] = "fake-base"
+
+        Validator(data).validate()
 
 
 class ValidRestartConditionsTest(ValidationBaseTest):


### PR DESCRIPTION
If `type: base` is used, setup a build environment as if a `base`
were specified and use `name` to determine the environment.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
