### PR TITLE
use the stable risk level now that ant has been released

### DIFF
--- a/snapcraft/plugins/ant.py
+++ b/snapcraft/plugins/ant.py
@@ -78,7 +78,7 @@ logger = logging.getLogger(__name__)
 _ANT_ARCHIVE_FORMAT_URL = (
     "https://archive.apache.org/dist/ant/binaries/apache-ant-{version}-bin.tar.bz2"
 )
-_DEFAULT_ANT_SNAP_CHANNEL = "latest/edge"
+_DEFAULT_ANT_SNAP_CHANNEL = "latest/stable"
 
 
 class UnsupportedJDKVersionError(errors.SnapcraftError):


### PR DESCRIPTION
Signed-off-by: Stefan Bodewig <stefan.bodewig@freenet.de>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

I've just released the ant snaps from candidate to stable and I feel stable is a better default than edge.