### PR TITLE
schema: remove support for os when using bases

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -264,7 +264,6 @@
                 "base",
                 "gadget",
                 "kernel",
-                "os",
                 "snapd"
             ]
         },

--- a/snapcraft/internal/lifecycle/_packer.py
+++ b/snapcraft/internal/lifecycle/_packer.py
@@ -96,7 +96,7 @@ def _run_mksquashfs(
     # These options need to match the review tools:
     # http://bazaar.launchpad.net/~click-reviewers/click-reviewers-tools/trunk/view/head:/clickreviews/common.py#L38
     mksquashfs_args = ["-noappend", "-comp", "xz", "-no-xattrs", "-no-fragments"]
-    if snap_type not in ("os", "base"):
+    if snap_type != "base":
         mksquashfs_args.append("-all-root")
 
     complete_command = [

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -223,7 +223,7 @@ class Config:
             self.build_tools.add("git")
 
         # Always add the base for building for non os and base snaps
-        if project.info.base is not None and project.info.type not in ("base", "os"):
+        if project.info.base is not None and project.info.type != "base":
             # If the base is already installed by other means, skip its installation.
             # But, we should always add it when in a docker environment so
             # the creator of said docker image is aware that it is required.
@@ -231,7 +231,7 @@ class Config:
                 project.info.base
             ):
                 self.build_snaps.add(project.info.base)
-        elif project.info.type not in ("base", "os"):
+        elif project.info.type != "base":
             # This exception is here to help with porting issues with bases. In normal
             # executions, when no base is set, the legacy snapcraft will be executed.
             raise RuntimeError(

--- a/tests/unit/commands/test_pack.py
+++ b/tests/unit/commands/test_pack.py
@@ -117,7 +117,7 @@ class PackCommandTestCase(PackCommandBaseTestCase):
 
         self.assertThat("mysnap_99_all.snap", FileExists())
 
-    def test_snap_from_dir_type_os_does_not_use_all_root(self):
+    def test_snap_from_dir_type_base_does_not_use_all_root(self):
         with open(self.snap_yaml, "w") as f:
             f.write(
                 dedent(
@@ -125,7 +125,7 @@ class PackCommandTestCase(PackCommandBaseTestCase):
                 name: mysnap
                 version: 99
                 architectures: [amd64, armhf]
-                type: os
+                type: base
             """
                 )
             )

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -113,7 +113,7 @@ class SnapCommandTestCase(SnapCommandBaseTestCase):
         self.assertThat(
             str(raised),
             Contains(
-                "bad-type' is not one of ['app', 'base', 'gadget', 'kernel', 'os', 'snapd']"
+                "bad-type' is not one of ['app', 'base', 'gadget', 'kernel', 'snapd']"
             ),
         )
 

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -258,7 +258,7 @@ version: 99
 
         self.assertThat("mysnap_99_all.snap", FileExists())
 
-    def test_snap_from_dir_type_os_does_not_use_all_root(self):
+    def test_snap_from_dir_type_base_does_not_use_all_root(self):
         fake_logger = fixtures.FakeLogger(level=logging.INFO)
         self.useFixture(fake_logger)
 
@@ -271,7 +271,7 @@ version: 99
                 name: mysnap
                 version: 99
                 architectures: [amd64, armhf]
-                type: os
+                type: base
             """
                 ),
                 file=f,

--- a/tests/unit/lifecycle/test_lifecycle.py
+++ b/tests/unit/lifecycle/test_lifecycle.py
@@ -114,32 +114,6 @@ class ExecutionTestCase(LifecycleTestBase):
         self.assertThat(self.fake_logger.output, Contains("Pulling part2"))
         self.assertThat(self.fake_logger.output, Not(Contains("Pulling part1")))
 
-    def test_os_type_returned_by_lifecycle(self):
-        project_config = self.make_snapcraft_project(
-            textwrap.dedent(
-                """\
-                parts:
-                  part1:
-                    plugin: nil
-                  part2:
-                    plugin: nil
-                    after:
-                      - part1
-                """
-            ),
-            "type: os",
-        )
-
-        snap_info = lifecycle.execute(steps.PULL, project_config)
-
-        expected_snap_info = {
-            "name": "test",
-            "version": "1.0",
-            "arch": [project_config.project.deb_arch],
-            "type": "os",
-        }
-        self.assertThat(snap_info, Equals(expected_snap_info))
-
     def test_dirty_stage_part_with_built_dependent_raises(self):
         # Set the option to error on dirty/outdated steps
         with snapcraft.config.CLIConfig() as cli_config:

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -284,7 +284,7 @@ class InvalidTypesTest(ValidationBaseTest):
         expected_message = (
             "The 'type' property does not match the required "
             "schema: '{}' is not one of "
-            "['app', 'base', 'gadget', 'kernel', 'os', 'snapd']"
+            "['app', 'base', 'gadget', 'kernel', 'snapd']"
         ).format(self.type_)
         self.assertThat(raised.message, Equals(expected_message), message=data)
 

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -260,7 +260,7 @@ class ValidTypesTest(ValidationBaseTest):
 
     scenarios = [
         (type_, dict(type_=type_))
-        for type_ in ["app", "gadget", "kernel", "os", "snapd"]
+        for type_ in ["app", "base", "gadget", "kernel", "snapd"]
     ]
 
     def test_valid_types(self):


### PR DESCRIPTION
Base support superseed the os type which should stay in legacy.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
