### PR TITLE
synchronizing snapd supported schema to snapcraft

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -339,6 +339,9 @@
                         "command"
                     ],
                     "dependencies": {
+                        "bus-name": [
+                            "daemon"
+                        ],
                         "refresh-mode": [
                             "daemon"
                         ],
@@ -348,10 +351,25 @@
                         "stop-command": [
                             "daemon"
                         ],
+                        "start-timeout": [
+                            "daemon"
+                        ],
+                        "stop-timeout": [
+                            "daemon"
+                        ],
+                        "watchdog-timeout": [
+                            "daemon"
+                        ],
+                        "restart-delay": [
+                            "daemon"
+                        ],
                         "post-stop-command": [
                             "daemon"
                         ],
                         "reload-command": [
+                            "daemon"
+                        ],
+                        "restart-condition": [
                             "daemon"
                         ],
                         "before": [
@@ -359,13 +377,28 @@
                         ],
                         "after": [
                             "daemon"
+                        ],
+                        "timer": [
+                            "daemon"
                         ]
                     },
                     "additionalProperties": false,
                     "properties": {
+                        "autostart": {
+                            "type": "string",
+                            "description": "Name of the desktop file placed by the application in $SNAP_USER_DATA/.config/autostart to indicate that application should be started with the user's desktop session.",
+                            "pattern": "^[A-Za-z0-9. _#:$-]+\\.desktop$",
+                            "validation-failure": "{.instance!r} is not a valid desktop file name (e.g. myapp.desktop)"
+                        },
                         "common-id": {
                             "type": "string",
                             "description": "common identifier across multiple packaging formats"
+                        },
+                        "bus-name": {
+                            "type": "string",
+                            "description": "D-Bus name this service is reachable as (mandatory if daemon=dbus)",
+                            "pattern": "^[A-Za-z0-9/. _#:$-]*$",
+                            "validation-failure": "{.instance!r} is not a valid bus name."
                         },
                         "desktop": {
                             "type": "string",
@@ -387,11 +420,37 @@
                             "type": "string",
                             "description": "command executed after stopping a service"
                         },
+                        "start-timeout": {
+                            "type": "string",
+                            "pattern": "^[0-9]+(ns|us|ms|s|m)*$",
+                            "validation-failure": "{.instance!r} is not a valid timeout value.",
+                            "description": "Optional time to wait for daemon to start - <n>ns | <n>us | <n>ms | <n>s | <n>m"
+                        },
                         "stop-timeout": {
-                            "description": "timeout in seconds"
+                            "type": "string",
+                            "pattern": "^[0-9]+(ns|us|ms|s|m)*$",
+                            "validation-failure": "{.instance!r} is not a valid timeout value.",
+                            "description": "Optional time to wait for daemon to stop - <n>ns | <n>us | <n>ms | <n>s | <n>m"
+                        },
+                        "watchdog-timeout": {
+                            "type": "string",
+                            "pattern": "^[0-9]+(ns|us|ms|s|m)*$",
+                            "validation-failure": "{.instance!r} is not a valid timeout value.",
+                            "description": "Service watchdog timeout - <n>ns | <n>us | <n>ms | <n>s | <n>m"
                         },
                         "reload-command": {
-                            "description": "command executed to reload a service"
+                            "type": "string",
+                            "description": "Command to use to ask the service to reload its configuration."
+                        },
+                        "restart-delay": {
+                            "type": "string",
+                            "pattern": "^[0-9]+(ns|us|ms|s|m)*$",
+                            "validation-failure": "{.instance!r} is not a valid delay value.",
+                            "description": "Delay between service restarts - <n>ns | <n>us | <n>ms | <n>s | <n>m. Defaults to unset. See the systemd.service manual on RestartSec for details."
+                        },
+                        "timer": {
+                            "type": "string",
+                            "description": "The service is activated by a timer, app must be a daemon. (systemd.time calendar event string)"
                         },
                         "daemon": {
                             "type": "string",
@@ -400,7 +459,8 @@
                                 "simple",
                                 "forking",
                                 "oneshot",
-                                "notify"
+                                "notify",
+                                "dbus"
                             ]
                         },
                         "after": {
@@ -450,6 +510,7 @@
                                 "on-failure",
                                 "on-abnormal",
                                 "on-abort",
+                                "on-watchdog",
                                 "always",
                                 "never"
                             ]

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -115,6 +115,42 @@ class ValidationTest(ValidationBaseTest):
                 "reload-command": "binary7 --reload",
                 "daemon": "simple",
             },
+            "service8": {
+                "command": "binary8",
+                "daemon": "dbus",
+                "bus-name": "org.test.snapcraft",
+            },
+            "service9": {
+                "command": "binary9",
+                "daemon": "simple",
+                "start-timeout": "1s",
+            },
+            "service10": {
+                "command": "binary10",
+                "daemon": "simple",
+                "stop-timeout": "1s",
+            },
+            "service11": {
+                "command": "binary11",
+                "daemon": "simple",
+                "restart-delay": "1s",
+            },
+            "service12": {
+                "command": "binary12",
+                "daemon": "simple",
+                "watchdog-timeout": "1s",
+            },
+            "service13": {
+                "command": "binary13",
+                "daemon": "oneshot",
+                "timer": "mon,10:00-12:00",
+            },
+            "service14": {
+                "command": "binary14",
+                "daemon": "simple",
+                "restart-condition": "on-watchdog",
+                "watchdog-timeout": "30s",
+            },
         }
 
         Validator(self.data).validate()
@@ -124,7 +160,7 @@ class ValidationTest(ValidationBaseTest):
             "service1": {
                 "command": "binary1",
                 "daemon": "simple",
-                "restart-condition": "on-watchdog",
+                "restart-condition": "on-tuesday",
             }
         }
 
@@ -136,8 +172,9 @@ class ValidationTest(ValidationBaseTest):
             str(raised),
             Contains(
                 "The 'apps/service1/restart-condition' property does not match "
-                "the required schema: 'on-watchdog' is not one of ['on-success', "
-                "'on-failure', 'on-abnormal', 'on-abort', 'always', 'never']"
+                "the required schema: 'on-tuesday' is not one of ['on-success', "
+                "'on-failure', 'on-abnormal', 'on-abort', 'on-watchdog', 'always', "
+                "'never']"
             ),
         )
 
@@ -299,6 +336,7 @@ class ValidRestartConditionsTest(ValidationBaseTest):
             "on-failure",
             "on-abnormal",
             "on-abort",
+            "on-watchdog",
             "never",
         ]
     ]

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -346,6 +346,7 @@ class CreateTestCase(CreateBaseTestCase):
                 "environment": {"XDG_SOMETHING": "$SNAP_USER_DATA", "LANG": "C"},
             },
             "app5": {"command": "app.sh", "common-id": "test-common-id"},
+            "app6": {"command": "app.sh", "autostart": "app6.desktop"},
         }
         self.config_data["plugs"] = {"network-server": {"interface": "network-bind"}}
 
@@ -382,6 +383,10 @@ class CreateTestCase(CreateBaseTestCase):
                 "app5": {
                     "command": "snap/command-chain/snapcraft-runner $SNAP/command-app5.wrapper",
                     "common-id": "test-common-id",
+                },
+                "app6": {
+                    "command": "snap/command-chain/snapcraft-runner $SNAP/command-app6.wrapper",
+                    "autostart": "app6.desktop",
                 },
             },
             "description": "my description",


### PR DESCRIPTION
    synchronizing snapd supported schema to snapcraft
    
    - Explicitly specify type string for existing options with unspcecified type:
      - `stop-command`
      - `reload-command`
    - Add daemon type `dbus`
    - Add daemon options:
      - `bus-name` (for use with `daemon: dbus`) with regex pattern found in snapd
      - `restart-delay`
      - `start-timeout`
      - `timer`
      - `watchdog-timeout`
    - Add `on-watchdog` for `restart-condition`
    - Add `autostart` for apps installing autostart desktop files
    - Specify dependencies on daemon for new daemon options, as well
      as existing options (`stop-timeout`, `restart-condition`)
    - Add some tests for newly exposed schema items.
    - Update some descriptions to match https://docs.snapcraft.io/snap-format
    - Add regex patterns for stop timeout (to match introduced timeouts).
