### PR TITLE
pluginhandler: honour symlink directory paths for filesets (LP: #1833408)

### DIFF
--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -250,28 +250,26 @@ def link_or_copy_tree(
             copy_function(source, destination)
 
 
-def create_similar_directory(
-    source: str, destination: str, follow_symlinks: bool = False
-) -> None:
+def create_similar_directory(source: str, destination: str) -> None:
     """Create a directory with the same permission bits and owner information.
 
     :param str source: Directory from which to copy name, permission bits, and
                        owner information.
     :param str destintion: Directory to create and to which the `source`
                            information will be copied.
-    :param bool follow_symlinks: Whether or not symlinks should be followed.
     """
 
-    stat = os.stat(source, follow_symlinks=follow_symlinks)
+    stat = os.stat(source, follow_symlinks=False)
     uid = stat.st_uid
     gid = stat.st_gid
     os.makedirs(destination, exist_ok=True)
+
     try:
-        os.chown(destination, uid, gid, follow_symlinks=follow_symlinks)
+        os.chown(destination, uid, gid, follow_symlinks=False)
     except PermissionError as exception:
         logger.debug("Unable to chown {}: {}".format(destination, exception))
 
-    shutil.copystat(source, destination, follow_symlinks=follow_symlinks)
+    shutil.copystat(source, destination, follow_symlinks=False)
 
 
 def executable_exists(path: str) -> bool:

--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -398,3 +398,24 @@ def get_linker_version_from_file(linker_file: str) -> str:
     linker_version = m.group("linker_version")
 
     return linker_version
+
+
+def get_resolved_relative_path(relative_path: str, base_directory: str) -> str:
+    """Resolve path components against target base_directory.
+
+    If the resulting target path is a symlink, it will not be followed.
+    Only the path's parents are fully resolved against base_directory,
+    and the relative path is returned.
+
+    :param str relative_path: Path of target, relative to base_directory.
+    :param str base_directory: Base path of target.
+    :return: Resolved path, relative to base_directory.
+    :rtype: str
+    """
+    parent_relpath, filename = os.path.split(relative_path)
+    parent_abspath = os.path.realpath(os.path.join(base_directory, parent_relpath))
+
+    filename_abspath = os.path.join(parent_abspath, filename)
+    filename_relpath = os.path.relpath(filename_abspath, base_directory)
+
+    return filename_relpath

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -209,6 +209,105 @@ class PluginTestCase(unit.TestCase):
             "Expected migrated 'bar' to point to 'foo'",
         )
 
+    def test_migrate_files_preserves_symlink_file(self):
+        os.makedirs("install")
+        os.makedirs("stage")
+
+        with open(os.path.join("install", "foo"), "w") as f:
+            f.write("installed")
+
+        os.symlink("foo", os.path.join("install", "bar"))
+
+        files, dirs = pluginhandler._migratable_filesets(["*"], "install")
+        pluginhandler._migrate_files(files, dirs, "install", "stage")
+
+        # Verify that the symlinks were preserved
+        self.assertTrue(
+            os.path.islink(os.path.join("stage", "bar")),
+            "Expected migrated 'sym-a' to be a symlink.",
+        )
+
+    def test_migrate_files_preserves_symlink_nested_file(self):
+        os.makedirs(os.path.join("install", "a"))
+        os.makedirs("stage")
+
+        with open(os.path.join("install", "a", "foo"), "w") as f:
+            f.write("installed")
+
+        os.symlink(os.path.join("a", "foo"), os.path.join("install", "bar"))
+        os.symlink(os.path.join("foo"), os.path.join("install", "a", "bar"))
+
+        files, dirs = pluginhandler._migratable_filesets(["*"], "install")
+        pluginhandler._migrate_files(files, dirs, "install", "stage")
+
+        # Verify that the symlinks were preserved
+        self.assertTrue(
+            os.path.islink(os.path.join("stage", "bar")),
+            "Expected migrated 'sym-a' to be a symlink.",
+        )
+
+        self.assertTrue(
+            os.path.islink(os.path.join("stage", "a", "bar")),
+            "Expected migrated 'sym-a' to be a symlink.",
+        )
+
+    def test_migrate_files_preserves_symlink_empty_dir(self):
+        os.makedirs(os.path.join("install", "foo"))
+        os.makedirs("stage")
+
+        os.symlink("foo", os.path.join("install", "bar"))
+
+        files, dirs = pluginhandler._migratable_filesets(["*"], "install")
+        pluginhandler._migrate_files(files, dirs, "install", "stage")
+
+        # Verify that the symlinks were preserved
+        self.assertTrue(
+            os.path.islink(os.path.join("stage", "bar")),
+            "Expected migrated 'sym-a' to be a symlink.",
+        )
+
+    def test_migrate_files_preserves_symlink_nonempty_dir(self):
+        os.makedirs(os.path.join("install", "foo"))
+        os.makedirs("stage")
+
+        os.symlink("foo", os.path.join("install", "bar"))
+
+        with open(os.path.join("install", "foo", "xfile"), "w") as f:
+            f.write("installed")
+
+        files, dirs = pluginhandler._migratable_filesets(["*"], "install")
+        pluginhandler._migrate_files(files, dirs, "install", "stage")
+
+        # Verify that the symlinks were preserved
+        self.assertTrue(
+            os.path.islink(os.path.join("stage", "bar")),
+            "Expected migrated 'sym-a' to be a symlink.",
+        )
+
+    def test_migrate_files_preserves_symlink_nested_dir(self):
+        os.makedirs(os.path.join("install", "a", "b"))
+        os.makedirs("stage")
+
+        os.symlink(os.path.join("a", "b"), os.path.join("install", "bar"))
+        os.symlink(os.path.join("b"), os.path.join("install", "a", "bar"))
+
+        with open(os.path.join("install", "a", "b", "xfile"), "w") as f:
+            f.write("installed")
+
+        files, dirs = pluginhandler._migratable_filesets(["*"], "install")
+        pluginhandler._migrate_files(files, dirs, "install", "stage")
+
+        # Verify that the symlinks were preserved
+        self.assertTrue(
+            os.path.islink(os.path.join("stage", "bar")),
+            "Expected migrated 'bar' to be a symlink.",
+        )
+
+        self.assertTrue(
+            os.path.islink(os.path.join("stage", "a", "bar")),
+            "Expected migrated 'a/bar' to be a symlink.",
+        )
+
     def test_migrate_files_supports_follow_symlinks(self):
         os.makedirs("install")
         os.makedirs("stage")

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -334,42 +334,6 @@ class PluginTestCase(unit.TestCase):
                 "Expected migrated 'bar' to be a copy of 'foo'",
             )
 
-    @patch("os.chown")
-    def test_migrate_files_preserves_ownership(self, chown_mock):
-        os.makedirs("install")
-        os.makedirs("stage")
-
-        foo = os.path.join("install", "foo")
-
-        with open(foo, "w") as f:
-            f.write("installed")
-
-        files, dirs = pluginhandler._migratable_filesets(["*"], "install")
-        pluginhandler._migrate_files(
-            files, dirs, "install", "stage", follow_symlinks=True
-        )
-
-        self.assertTrue(chown_mock.called)
-
-    @patch("os.chown")
-    def test_migrate_files_chown_permissions(self, chown_mock):
-        os.makedirs("install")
-        os.makedirs("stage")
-
-        chown_mock.side_effect = PermissionError("No no no")
-
-        foo = os.path.join("install", "foo")
-
-        with open(foo, "w") as f:
-            f.write("installed")
-
-        files, dirs = pluginhandler._migratable_filesets(["*"], "install")
-        pluginhandler._migrate_files(
-            files, dirs, "install", "stage", follow_symlinks=True
-        )
-
-        self.assertTrue(chown_mock.called)
-
     def test_migrate_files_preserves_file_mode(self):
         os.makedirs("install")
         os.makedirs("stage")
@@ -395,9 +359,7 @@ class PluginTestCase(unit.TestCase):
             Equals(stat.S_IMODE(os.stat(os.path.join("stage", "foo")).st_mode)),
         )
 
-    @patch("os.chown")
-    def test_migrate_files_preserves_file_mode_chown_permissions(self, chown_mock):
-        chown_mock.side_effect = PermissionError("No no no")
+    def test_migrate_files_preserves_file_mode_chown_permissions(self):
         os.makedirs("install")
         os.makedirs("stage")
 
@@ -421,8 +383,6 @@ class PluginTestCase(unit.TestCase):
             new_mode,
             Equals(stat.S_IMODE(os.stat(os.path.join("stage", "foo")).st_mode)),
         )
-
-        self.assertTrue(chown_mock.called)
 
     def test_migrate_files_preserves_directory_mode(self):
         os.makedirs("install/foo")


### PR DESCRIPTION
Addresses the usr-merge issues discussed at https://bugs.launchpad.net/snapcraft/+bug/1833408

Adds tests to reproduce issue, fixup/remove faulty tests that are exposed with these changes.