### PR TITLE
appstream extractor: skip non icon file paths

### DIFF
--- a/snapcraft/extractors/appstream.py
+++ b/snapcraft/extractors/appstream.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import contextlib
 import operator
 import os
 from io import StringIO
@@ -212,11 +213,15 @@ def _get_icon_from_theme(workdir: str, theme: str, icon: str) -> Optional[str]:
     if not os.path.exists(os.path.join(workdir, theme_dir)):
         return None
 
+    # TODO: use index.theme
     entries = os.listdir(os.path.join(workdir, theme_dir))
+    # size is NxN
+    x_entries = (e.split("x") for e in entries if "x" in e)
+    sized_entries = (e[0] for e in x_entries if e[0] == e[1])
     sizes = {}
-    for entry in entries:
-        if "x" in entry:
-            sizes[int(entry.split("x")[0])] = entry
+    for icon_size in sized_entries:
+        with contextlib.suppress(ValueError):
+            sizes[int(icon_size)] = "{0}x{0}".format(icon_size)
 
     if sizes:
         size = max(sizes.items(), key=operator.itemgetter(1))[0]
@@ -228,12 +233,11 @@ def _get_icon_from_theme(workdir: str, theme: str, icon: str) -> Optional[str]:
     else:
         icon_size = None
 
+    icon_path = None
     if icon_size:
         for suffix in suffixes:
             icon_path = os.path.join(theme_dir, icon_size, "apps", icon + suffix)
             if os.path.exists(os.path.join(workdir, icon_path)):
                 break
-        else:
-            icon_path = None
 
     return icon_path

--- a/tests/unit/extractors/test_appstream.py
+++ b/tests/unit/extractors/test_appstream.py
@@ -154,6 +154,13 @@ class AppstreamIconsTestCase(unit.TestCase):
                     )
                 )
 
+    def _create_index_theme(self, theme: str):
+        # TODO: populate index.theme
+        dir_name = os.path.join("usr", "share", "icons", theme)
+        if not os.path.exists(dir_name):
+            os.makedirs(dir_name)
+        open(os.path.join(dir_name, "index.theme"), "w").close()
+
     def _create_icon_file(self, theme: str, size: str, filename: str) -> None:
         dir_name = os.path.join("usr", "share", "icons", theme, size, "apps")
         if not os.path.exists(dir_name):
@@ -164,6 +171,17 @@ class AppstreamIconsTestCase(unit.TestCase):
         expected = ExtractedMetadata(icon=icon)
         actual = appstream.extract("foo.appdata.xml", workdir=".")
         self.assertThat(actual.get_icon(), Equals(expected.get_icon()))
+
+    def test_appstream_NxN_size_not_int_is_skipped(self):
+        self._create_appstream_file(icon="icon", icon_type="stock")
+        dir_name = os.path.join("usr", "share", "icons", "hicolor", "NxN")
+        os.makedirs(dir_name)
+        self._expect_icon(None)
+
+    def test_appstream_index_theme_is_not_confused_for_size(self):
+        self._create_appstream_file(icon="icon", icon_type="stock")
+        self._create_index_theme("hicolor")
+        self._expect_icon(None)
 
     def test_appstream_stock_icon_exists_png(self):
         self._create_appstream_file(icon="icon", icon_type="stock")


### PR DESCRIPTION
Fixes SNAPCRAFT-Y0

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
