### PR TITLE
spread tests: enable LXD build provider tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -125,8 +125,15 @@ prepare: |
 
   if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ] || [ "$SPREAD_SYSTEM" = "ubuntu-18.04-64" ]; then
       snap install --classic --beta multipass
-      # Remove lxd and lxd-client deb packages
+      # Remove lxd and lxd-client deb packages as our implementation (pylxd) does not
+      # nicely handle the snap and deb being installed at the same time.
       apt-get remove --purge --yes lxd lxd-client
+      # Install and setup the lxd snap
+      snap install lxd
+      lxd waitready --timeout=30
+      lxd init --auto
+      # Add the ubuntu user to the lxd group.
+      adduser ubuntu lxd
   fi
 
   if [ "$SNAPCRAFT_PACKAGE_TYPE" = "deb" ]; then
@@ -159,9 +166,13 @@ suites:
  tests/spread/general/:
    summary: tests of snapcraft core functionality
 
+ # Use of multipass and lxd build providers
  tests/spread/build-providers/:
    summary: tests of snapcraft using build providers
-   systems: [ubuntu-18.04*]
+   systems: [ubuntu-18.04-64]
+   kill-timeout: 180m
+   warn-timeout: 9m  # Keep less than 10 minutes so Travis can't timeout
+   priority: 90  # Run this test relatively early since fetching images can take time
 
  # Plugin-specific suites
  tests/spread/plugins/ant/:

--- a/tests/spread/build-providers/lxd-basic/task.yaml
+++ b/tests/spread/build-providers/lxd-basic/task.yaml
@@ -1,6 +1,4 @@
 summary: Build a basic snap using LXD and ensure that it runs
-warn-timeout: 9m  # Keep less than 10 minutes so Travis can't timeout
-priority: 90  # Run this test relatively early since fetching images can take time
 
 environment:
   SNAP_DIR: ../snaps/make-hello
@@ -9,10 +7,6 @@ prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
-
-  snap install lxd
-  lxd waitready --timeout=30
-  lxd init --auto
 
 restore: |
   cd "$SNAP_DIR"

--- a/tests/spread/build-providers/lxd-prime-then-try/task.yaml
+++ b/tests/spread/build-providers/lxd-prime-then-try/task.yaml
@@ -9,8 +9,12 @@ prepare: |
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
 
 restore: |
+  # export the full path for sudo to work
+  SNAP_DIR="$(realpath "$SNAP_DIR")"
+  export SNAP_DIR
   cd "$SNAP_DIR"
-  snapcraft clean --use-lxd
+
+  sudo -iu ubuntu bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
   rm -f ./*.snap
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
@@ -18,6 +22,9 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 execute: |
+  # export the full path for sudo to work
+  SNAP_DIR="$(realpath "$SNAP_DIR")"
+  export SNAP_DIR
   cd "$SNAP_DIR"
 
   # lxd mounting as root is just not going to work.

--- a/tests/spread/build-providers/lxd-prime-then-try/task.yaml
+++ b/tests/spread/build-providers/lxd-prime-then-try/task.yaml
@@ -8,6 +8,8 @@ prepare: |
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
 
+  chown ubuntu "$SNAP_DIR"
+
 restore: |
   # export the full path for sudo to work
   SNAP_DIR="$(realpath "$SNAP_DIR")"
@@ -16,6 +18,8 @@ restore: |
 
   sudo -iu ubuntu bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
   rm -f ./*.snap
+
+  chown root "$SNAP_DIR"
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"

--- a/tests/spread/build-providers/lxd-prime-then-try/task.yaml
+++ b/tests/spread/build-providers/lxd-prime-then-try/task.yaml
@@ -1,10 +1,4 @@
 summary: Try a primed basic snap using LXD and ensure that it runs
-# TODO remove once either this version of snapcraft reaches stable
-#      or the new snap download is implemented using snapd's API
-#      introduced in 2.38
-manual: true
-warn-timeout: 9m  # Keep less than 10 minutes so Travis can't timeout
-priority: 90  # Run this test relatively early since fetching images can take time
 
 environment:
   SNAP_DIR: ../snaps/make-hello
@@ -13,10 +7,6 @@ prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
-
-  snap install lxd
-  lxd waitready --timeout=30
-  lxd init --auto
 
 restore: |
   cd "$SNAP_DIR"
@@ -30,13 +20,14 @@ restore: |
 execute: |
   cd "$SNAP_DIR"
 
-  snapcraft prime --use-lxd
+  # lxd mounting as root is just not going to work.
+  sudo -iu ubuntu bash -c "cd $SNAP_DIR && snapcraft prime --use-lxd"
   if [ -d prime ]; then
       echo "The prime directory should not be exposed"
       exit 1
   fi
 
-  snapcraft try --use-lxd
+  sudo -iu ubuntu bash -c "cd $SNAP_DIR && snapcraft try --use-lxd"
   snap try prime
   [ "$(make-hello)" = "hello world" ]
 

--- a/tests/spread/build-providers/lxd-try/task.yaml
+++ b/tests/spread/build-providers/lxd-try/task.yaml
@@ -1,10 +1,4 @@
 summary: Try a basic snap using LXD and ensure that it runs
-# TODO remove once either this version of snapcraft reaches stable
-#      or the new snap download is implemented using snapd's API
-#      introduced in 2.38
-manual: true
-warn-timeout: 9m  # Keep less than 10 minutes so Travis can't timeout
-priority: 90  # Run this test relatively early since fetching images can take time
 
 environment:
   SNAP_DIR: ../snaps/make-hello
@@ -13,10 +7,6 @@ prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
-
-  snap install lxd
-  lxd waitready --timeout=30
-  lxd init --auto
 
 restore: |
   cd "$SNAP_DIR"
@@ -30,12 +20,13 @@ restore: |
 execute: |
   cd "$SNAP_DIR"
 
-  snapcraft try --use-lxd
+  # lxd mounting as root is just not going to work.
+  sudo -iu ubuntu bash -c "cd $SNAP_DIR && snapcraft try --use-lxd"
   snap try prime
   [ "$(make-hello)" = "hello world" ]
 
   # snapcraft clean when trying keeps the dir
-  snapcraft clean --use-lxd
+  sudo -iu ubuntu bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
   if [ ! -d prime ]; then
       echo "The prime directory should not have been removed while trying"
       exit 1
@@ -43,7 +34,7 @@ execute: |
 
   # Remove the snap try and clean again
   snap remove make-hello
-  snapcraft clean --use-lxd
+  sudo -iu ubuntu bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
   if [ -d prime ]; then
       echo "The prime directory should have been removed"
       exit 1

--- a/tests/spread/build-providers/lxd-try/task.yaml
+++ b/tests/spread/build-providers/lxd-try/task.yaml
@@ -9,8 +9,12 @@ prepare: |
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
 
 restore: |
+  # export the full path for sudo to work
+  SNAP_DIR="$(realpath "$SNAP_DIR")"
+  export SNAP_DIR
   cd "$SNAP_DIR"
-  snapcraft clean --use-lxd
+
+  sudo -iu ubuntu bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
   rm -f ./*.snap
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
@@ -18,6 +22,9 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 execute: |
+  # export the full path for sudo to work
+  SNAP_DIR="$(realpath "$SNAP_DIR")"
+  export SNAP_DIR
   cd "$SNAP_DIR"
 
   # lxd mounting as root is just not going to work.

--- a/tests/spread/build-providers/lxd-try/task.yaml
+++ b/tests/spread/build-providers/lxd-try/task.yaml
@@ -8,6 +8,8 @@ prepare: |
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
 
+  chown ubuntu "$SNAP_DIR"
+
 restore: |
   # export the full path for sudo to work
   SNAP_DIR="$(realpath "$SNAP_DIR")"
@@ -16,6 +18,8 @@ restore: |
 
   sudo -iu ubuntu bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
   rm -f ./*.snap
+
+  chown root "$SNAP_DIR"
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"

--- a/tests/spread/build-providers/multipass-basic/task.yaml
+++ b/tests/spread/build-providers/multipass-basic/task.yaml
@@ -1,6 +1,4 @@
 summary: Build a basic snap using multipass and ensure that it runs
-warn-timeout: 9m  # Keep less than 10 minutes so Travis can't timeout
-priority: 90  # Run this test relatively early since fetching images can take time
 manual: true
 
 environment:

--- a/tests/spread/build-providers/multipass-error-handling/task.yaml
+++ b/tests/spread/build-providers/multipass-error-handling/task.yaml
@@ -1,6 +1,4 @@
 summary: A faulty snap to test error handling
-warn-timeout: 9m  # Keep less than 10 minutes so Travis can't timeout
-priority: 90  # Run this test relatively early since fetching images can take time
 manual: true
 
 environment:

--- a/tests/spread/tools/restore.sh
+++ b/tests/spread/tools/restore.sh
@@ -7,7 +7,7 @@ apt-get autoremove --purge -y
 snaps="$(snap list | awk '{if (NR!=1) {print $1}}')"
 for snap in $snaps; do
 	case "$snap" in
-		"core" | "core16" | "core18" | "snapcraft" | "multipass")
+		"core" | "core16" | "core18" | "snapcraft" | "multipass" | "lxd")
 			# Do not or cannot remove these
 			;;
 		*)


### PR DESCRIPTION
Move LXD setup to early prepare and do not remove at the end of each test
to avoid the setup overhead (including image download).

Additionally, move the common declarations from task.yaml to spread.yaml
for the build-providers suite.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
