### PR TITLE
pluginhandler, repo: find stage-packages from DT_NEEDED on host

### DIFF
--- a/snapcraft/internal/pluginhandler/_dependencies.py
+++ b/snapcraft/internal/pluginhandler/_dependencies.py
@@ -1,0 +1,91 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from typing import Sequence, Set
+
+from snapcraft.internal import repo
+
+
+_MSG_EXTEND_STAGE_PACKAGES = (
+    "The {part_name!r} part is missing libraries that are not "
+    "included in the snap or base. They can be satisfied by adding the following "
+    "entries to the existing stage-packages for this "
+    "part:\n{stage_packages}"
+)
+_MSG_ADD_STAGE_PACKAGES = (
+    "The {part_name!r} part is missing libraries that are not "
+    "included in the snap or base. They can be satisfied by adding the following "
+    "entry for this part\nstage-packages:\n{stage_packages}"
+)
+_MSG_UNHANDLED_DEPENDENCIES = (
+    "This part is missing libraries that cannot be satisfied with "
+    "any available stage-packages known to snapcraft:\n{unhandled_list}\n"
+    "These dependencies can be satisfied via additional parts or content sharing. "
+    "Consider validating configured filesets if this dependency was built."
+)
+
+
+def _get_formatted_list(items: Set[str]) -> str:
+    return "".join(["- {}\n".format(s) for s in sorted(items)]).strip()
+
+
+class MissingDependencyResolver:
+    """A missing DT_NEEDED resolver."""
+
+    def __init__(self, elf_files: Sequence[str]) -> None:
+        self._stage_packages_dependencies = set()  # type: Set[str]
+        self._unhandled_dependencies = set()  # type: Set[str]
+        self._process(elf_files)
+
+    def _process(self, elf_files: Sequence[str]) -> None:
+        for elf_file in elf_files:
+            try:
+                stage_package = repo.Repo.get_package_for_file(
+                    file_path=os.path.join(os.path.sep, elf_file)
+                )
+                self._stage_packages_dependencies.add(stage_package)
+            except repo.errors.FileProviderNotFound:
+                self._unhandled_dependencies.add(elf_file)
+
+    def print_resolutions(
+        self, *, part_name: str, stage_packages_exist: bool, echoer
+    ) -> None:
+        if not self._stage_packages_dependencies and not self._unhandled_dependencies:
+            return
+
+        if self._stage_packages_dependencies:
+            stage_packages_list = _get_formatted_list(self._stage_packages_dependencies)
+            if stage_packages_exist:
+                echoer.warning(
+                    _MSG_EXTEND_STAGE_PACKAGES.format(
+                        part_name=part_name, stage_packages=stage_packages_list
+                    )
+                )
+            else:
+                echoer.warning(
+                    _MSG_ADD_STAGE_PACKAGES.format(
+                        part_name=part_name, stage_packages=stage_packages_list
+                    )
+                )
+
+        if self._unhandled_dependencies:
+            unhandled_list = _get_formatted_list(self._unhandled_dependencies)
+            echoer.warning(
+                _MSG_UNHANDLED_DEPENDENCIES.format(
+                    part_name=part_name, unhandled_list=unhandled_list
+                )
+            )

--- a/snapcraft/internal/repo/_base.py
+++ b/snapcraft/internal/repo/_base.py
@@ -65,6 +65,18 @@ class BaseRepo:
         raise errors.NoNativeBackendError()
 
     @classmethod
+    def get_package_for_file(cls, file_path: str) -> str:
+        """Return the package name that provides file_path.
+
+        :param str file_path: the absolute path to the file to search for.
+        :returns: package name that provides file_path.
+        :rtype: str
+        :raises snapcraft.repo.errors.FileProviderNotFound:
+            if file_path is not provided by any package.
+        """
+        raise errors.NoNativeBackendError()
+
+    @classmethod
     def get_packages_for_source_type(cls, source_type):
         """Return a list of packages required to to work with source_type.
 

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -55,6 +55,14 @@ class CacheUpdateFailedError(RepoError):
         super().__init__(errors=errors)
 
 
+class FileProviderNotFound(RepoError):
+
+    fmt = "{file_path} is not provided by any package."
+
+    def __init__(self, *, file_path: str) -> None:
+        super().__init__(file_path=file_path)
+
+
 class BuildPackageNotFoundError(RepoError):
 
     fmt = "Could not find a required package in 'build-packages': {package}"

--- a/tests/unit/pluginhandler/test_missing_dependency.py
+++ b/tests/unit/pluginhandler/test_missing_dependency.py
@@ -1,0 +1,120 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import mock
+
+from testtools.matchers import Equals
+import fixtures
+
+from snapcraft.internal import repo
+from snapcraft.internal.pluginhandler._dependencies import MissingDependencyResolver
+from tests import unit
+
+
+class MissingDependencyTest(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        packages = {"/bin/bash": "bash", "/bin/sh": "dash"}
+
+        def fake_repo_query(*args, **kwargs):
+            file_path = kwargs["file_path"]
+            try:
+                return packages[file_path]
+            except KeyError:
+                raise repo.errors.FileProviderNotFound(file_path=file_path)
+
+        self.useFixture(
+            fixtures.MockPatch(
+                "snapcraft.internal.repo.Repo.get_package_for_file",
+                side_effect=fake_repo_query,
+            )
+        )
+
+    def test_all_stage_packages(self):
+        d = MissingDependencyResolver(elf_files=["/bin/bash", "/bin/sh"])
+
+        self.assertThat(d._stage_packages_dependencies, Equals({"bash", "dash"}))
+        self.assertThat(d._unhandled_dependencies, Equals(set()))
+
+        echoer = mock.Mock()
+        d.print_resolutions(
+            part_name="fake-part", stage_packages_exist=True, echoer=echoer
+        )
+        echoer.warning.assert_called_once_with(
+            "The 'fake-part' part is missing libraries that are not included "
+            "in the snap or base. They can be satisfied by adding the "
+            "following entries to the existing stage-packages for this part:\n- bash\n- dash"
+        )
+
+        echoer.reset_mock()
+        d.print_resolutions(
+            part_name="fake-part", stage_packages_exist=False, echoer=echoer
+        )
+        echoer.warning.assert_called_once_with(
+            "The 'fake-part' part is missing libraries that are not included "
+            "in the snap or base. They can be satisfied by adding the "
+            "following entry for this part\nstage-packages:\n- bash\n- dash"
+        )
+
+    def test_unhandled_dependencies(self):
+        d = MissingDependencyResolver(elf_files=["/foo", "/bar", "/foo/bar"])
+
+        self.assertThat(d._stage_packages_dependencies, Equals(set()))
+        self.assertThat(d._unhandled_dependencies, Equals({"/foo", "/bar", "/foo/bar"}))
+
+        echoer = mock.Mock()
+        d.print_resolutions(
+            part_name="fake-part", stage_packages_exist=True, echoer=echoer
+        )
+        echoer.warning.assert_called_once_with(
+            "This part is missing libraries that cannot be satisfied with "
+            "any available stage-packages known to snapcraft:\n"
+            "- /bar\n- /foo\n- /foo/bar\n"
+            "These dependencies can be satisfied via additional parts or "
+            "content sharing. "
+            "Consider validating configured filesets if this dependency was built."
+        )
+
+    def test_stage_packages_and_unhandled_dependencies(self):
+        d = MissingDependencyResolver(
+            elf_files=["/bin/bash", "/bin/sh", "/foo", "/bar", "/foo/bar"]
+        )
+
+        self.assertThat(d._stage_packages_dependencies, Equals({"bash", "dash"}))
+        self.assertThat(d._unhandled_dependencies, Equals({"/foo", "/bar", "/foo/bar"}))
+
+        echoer = mock.Mock()
+        d.print_resolutions(
+            part_name="fake-part", stage_packages_exist=False, echoer=echoer
+        )
+        echoer.warning.assert_has_calls(
+            [
+                mock.call(
+                    "The 'fake-part' part is missing libraries that are not included "
+                    "in the snap or base. They can be satisfied by adding the "
+                    "following entry for this part\nstage-packages:\n- bash\n- dash"
+                ),
+                mock.call(
+                    "This part is missing libraries that cannot be satisfied with "
+                    "any available stage-packages known to snapcraft:\n"
+                    "- /bar\n- /foo\n- /foo/bar\n"
+                    "These dependencies can be satisfied via additional parts or "
+                    "content sharing. "
+                    "Consider validating configured filesets if this dependency was built."
+                ),
+            ]
+        )


### PR DESCRIPTION
After priming, DT_NEEDED is checked for in all the files that were primed
and a list of missing files is listed, `stage-packages` are now listed
for the cases where these can be satisfied by adding them.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
