### PR TITLE
remote-build: increase number of launchpad start_build request attempts

### DIFF
--- a/snapcraft/cli/remote.py
+++ b/snapcraft/cli/remote.py
@@ -195,7 +195,7 @@ def remote_build(
         )
 
         # Start building
-        req_number = lp.start_build(timeout=5, attempts=5)
+        req_number = lp.start_build()
         echo.info(
             "If interrupted, resume with: 'snapcraft remote-build --recover {}'".format(
                 req_number


### PR DESCRIPTION
- Add some informative logging for user as well.
- Don't sleep after last attempt.


It seems to be happening a lot, even when the builders are not busy... there might be an underlying reason?
