### PR TITLE
unit tests: make lifecycle tests more robust

### DIFF
--- a/tests/unit/lifecycle/test_lifecycle.py
+++ b/tests/unit/lifecycle/test_lifecycle.py
@@ -25,6 +25,7 @@ from unittest import mock
 
 import fixtures
 from testtools.matchers import (
+    Contains,
     DirExists,
     Equals,
     FileContains,
@@ -85,13 +86,7 @@ class ExecutionTestCase(LifecycleTestBase):
 
         self.assertThat(
             self.fake_logger.output,
-            Equals(
-                "'part2' has dependencies that need to be staged: part1\n"
-                "Pulling part1 \n"
-                "Building part1 \n"
-                "Staging part1 \n"
-                "Pulling part2 \n"
-            ),
+            Contains("'part2' has dependencies that need to be staged: part1"),
         )
 
     def test_no_exception_when_dependency_is_required_but_already_staged(self):
@@ -117,7 +112,8 @@ class ExecutionTestCase(LifecycleTestBase):
         ):
             lifecycle.execute(steps.PULL, project_config, part_names=["part2"])
 
-        self.assertThat(self.fake_logger.output, Equals("Pulling part2 \n"))
+        self.assertThat(self.fake_logger.output, Contains("Pulling part2"))
+        self.assertThat(self.fake_logger.output, Not(Contains("Pulling part1")))
 
     def test_os_type_returned_by_lifecycle(self):
         project_config = self.make_snapcraft_project(
@@ -318,7 +314,7 @@ class ExecutionTestCase(LifecycleTestBase):
         )
 
         self.assertThat(
-            self.fake_logger.output, Equals("Setting target machine to 'armhf'\n")
+            self.fake_logger.output, Contains("Setting target machine to 'armhf'")
         )
 
         self.assertThat(raised.step, Equals(steps.PULL))


### PR DESCRIPTION
Some fake webserver messages can sneak into the checked for
message output, using a more flexible check avoids this
situation.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
