### PR TITLE
deprecations: add deprecation notice for version-script (dn10)

### DIFF
--- a/snapcraft/internal/deprecations.py
+++ b/snapcraft/internal/deprecations.py
@@ -36,6 +36,8 @@ _DEPRECATION_MESSAGES = {
     "dn7": "The 'prepare' keyword has been replaced by 'override-build'",
     "dn8": "The 'build' keyword has been replaced by 'override-build'",
     "dn9": "The 'install' keyword has been replaced by 'override-build'",
+    "dn10": "The 'version-script' keyword has been deprecated in favour of "
+    "the 'snapcraftctl set-version' part scriptlet.",
 }
 
 _DEPRECATION_URL_FMT = "http://snapcraft.io/docs/deprecation-notices/{id}"

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -525,9 +525,14 @@ class _SnapPackaging:
             snap_yaml["base"] = self._config_data["base"]
 
         # Reparse the version, the order should stick.
-        snap_yaml["version"] = _version.get_version(
-            self._config_data["version"], self._config_data.get("version-script")
-        )
+        version = self._config_data["version"]
+        version_script = self._config_data.get("version-script")
+
+        if version_script:
+            # Deprecation warning for use of version-script.
+            handle_deprecation_notice("dn10")
+
+        snap_yaml["version"] = _version.get_version(version, version_script)
 
         for key_name in _OPTIONAL_PACKAGE_KEYS:
             if key_name in self._config_data:


### PR DESCRIPTION
Part script `snapcraftctl set-version` is the currently recommended
method for dynamically determining the snap version information.

See 'https://docs.snapcraft.io/using-external-metadata' for additional
information on `snapcraft set-version`.

Output looks something like:
```
  Priming <project>
  DEPRECATED: The 'version-script' keyword has been deprecated in favour of the 'snapcraftctl set-version' part scriptlet.
  See http://snapcraft.io/docs/deprecation-notices/dn10 for more information.
  Determining the version from the project repo (version-script).
  The version has been set to '<version>'
  Snapping '<project>' \
  Snapped <snap>
```

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
