### PR TITLE
ant plugin: correct default channel and improve help

### DIFF
--- a/snapcraft/plugins/ant.py
+++ b/snapcraft/plugins/ant.py
@@ -34,10 +34,9 @@ Additionally, this plugin uses the following plugin-specific keywords:
       Run the given ant targets.
 
     - ant-channel:
-      (string)
-      The channel to use for ant in the snap store, if not using tarball from
+      (string, default: latest/stable)
+      The channel to use for ant in the snap store, if not using tarballs from
       the ant archive (see ant-version and ant-version-checksum).
-      Defaults to latest/edge.
 
     - ant-version:
       (string)
@@ -55,11 +54,9 @@ Additionally, this plugin uses the following plugin-specific keywords:
       version available to the base will be used.
 
     - ant-buildfile
-      (string)
+      (string, default: build.xml)
       The path to the Ant buildfile to use, relative to the root of the
-      source tree
-      Defaults to a build.xml file in the root of the source tree.
-
+      source tree.
 """
 
 import logging


### PR DESCRIPTION
Change the documented default channel from latest/edge to
latest/stable and normalize how the default is presented.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
