### PR TITLE
remote-build: detect early build errors

### DIFF
--- a/snapcraft/internal/remote_build/errors.py
+++ b/snapcraft/internal/remote_build/errors.py
@@ -77,6 +77,14 @@ class RemoteBuilderNotReadyError(RemoteBuildBaseError):
     fmt = "Remote builder is not ready, please wait a few moments and try again."
 
 
+class RemoteBuilderError(RemoteBuildBaseError):
+
+    fmt = "Remote builder failed with error: {builder_error!r}"
+
+    def __init__(self, *, builder_error: str) -> None:
+        super().__init__(builder_error=builder_error)
+
+
 class UnsupportedArchitectureError(RemoteBuildBaseError):
 
     fmt = (


### PR DESCRIPTION
The easiest-to-reproduce example I have come across is to simply
ship the build repository to launchpad without a snapcraft.yaml. In
this case, snapcraft now fails with the following message from launchpad:

```
  Sorry, an error occurred in Snapcraft:
  Remote builder failed with error: 'Cannot find snapcraft.yaml in
  https://cjp256@git.launchpad.net/~cjp256/+git/snapcraft-6cf35d52abc44b19a021b100cb883c8a/ master'
```

The original assumption was that the builder was busy, but now we can
determine if that's the case by checking if status is still "Pending".
It's seemingly quite rare (if ever?) to have the timeout condition hit,
but this commit maintains the checks should it happen:
```
  Sorry, an error occurred in Snapcraft:
  Remote builder failed with error: 'Timeout exceeded waiting for builder
  to become ready.'
```

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
