### PR TITLE
file utils: better error for NotADirectory

### DIFF
--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -197,12 +197,12 @@ def link_or_copy_tree(
     """
 
     if not os.path.isdir(source_tree):
-        raise NotADirectoryError("{!r} is not a directory".format(source_tree))
+        raise SnapcraftEnvironmentError("{!r} is not a directory".format(source_tree))
 
     if not os.path.isdir(destination_tree) and (
         os.path.exists(destination_tree) or os.path.islink(destination_tree)
     ):
-        raise NotADirectoryError(
+        raise SnapcraftEnvironmentError(
             "Cannot overwrite non-directory {!r} with directory "
             "{!r}".format(destination_tree, source_tree)
         )

--- a/tests/unit/sources/test_local.py
+++ b/tests/unit/sources/test_local.py
@@ -22,6 +22,7 @@ from unittest import mock
 from testtools.matchers import DirExists, Equals, FileContains, FileExists, Not
 
 from snapcraft.internal import common
+from snapcraft.internal import errors
 from snapcraft.internal import sources
 from tests import unit
 
@@ -84,7 +85,7 @@ class TestLocal(unit.TestCase):
         os.symlink("dummy", "destination")
 
         local = sources.Local("src", "destination")
-        self.assertRaises(NotADirectoryError, local.pull)
+        self.assertRaises(errors.SnapcraftEnvironmentError, local.pull)
 
     def test_pull_with_existing_source_file_error(self):
         os.makedirs(os.path.join("src", "dir"))
@@ -94,7 +95,7 @@ class TestLocal(unit.TestCase):
         open("destination", "w").close()
 
         local = sources.Local("src", "destination")
-        self.assertRaises(NotADirectoryError, local.pull)
+        self.assertRaises(errors.SnapcraftEnvironmentError, local.pull)
 
     def test_pulling_twice_with_existing_source_dir_recreates_hardlinks(self):
         os.makedirs(os.path.join("src", "dir"))

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -113,7 +113,7 @@ class TestLinkOrCopyTree(unit.TestCase):
 
     def test_link_file_to_file_raises(self):
         raised = self.assertRaises(
-            NotADirectoryError, file_utils.link_or_copy_tree, "1", "qux"
+            SnapcraftEnvironmentError, file_utils.link_or_copy_tree, "1", "qux"
         )
 
         self.assertThat(str(raised), Equals("'1' is not a directory"))
@@ -121,7 +121,7 @@ class TestLinkOrCopyTree(unit.TestCase):
     def test_link_file_into_directory(self):
         os.mkdir("qux")
         raised = self.assertRaises(
-            NotADirectoryError, file_utils.link_or_copy_tree, "1", "qux"
+            SnapcraftEnvironmentError, file_utils.link_or_copy_tree, "1", "qux"
         )
 
         self.assertThat(str(raised), Equals("'1' is not a directory"))
@@ -135,7 +135,7 @@ class TestLinkOrCopyTree(unit.TestCase):
     def test_link_directory_overwrite_file_raises(self):
         open("qux", "w").close()
         raised = self.assertRaises(
-            NotADirectoryError, file_utils.link_or_copy_tree, "foo", "qux"
+            SnapcraftEnvironmentError, file_utils.link_or_copy_tree, "foo", "qux"
         )
 
         self.assertThat(


### PR DESCRIPTION
Fixes SNAPCRAFT-W0

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
