### PR TITLE
remote-build: include project name in build-id

### DIFF
--- a/snapcraft/cli/remote.py
+++ b/snapcraft/cli/remote.py
@@ -136,7 +136,7 @@ def remote_build(
         if "provider" in remote_info:
             provider = remote_info["provider"]
     else:
-        build_id = "snapcraft-{}".format(uuid.uuid4().hex)
+        build_id = "snapcraft-{}-{}".format(project.info.name, uuid.uuid4().hex)
         remote_info["id"] = build_id
         remote_info["provider"] = provider
         remote_info.save()


### PR DESCRIPTION
Incorporate the project name into the build-id so it's identifiable when
looking at the list of snaps from the launchpad web portal.

When building `figlet`, instead of having a git repo like:
- snapcraft-891d00183565470496c42f4bdaed4388

It would now be:
- snapcraft-figlet-891d00183565470496c42f4bdaed4388

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
