### PR TITLE
meta: transparently support command-chain

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -310,8 +310,10 @@ def _update_yaml_with_defaults(config_data, schema):
     ]
     default_adapter = app_schema["adapter"]["default"]
     for app in config_data.get("apps", {}).values():
-        if "adapter" not in app:
+        if "adapter" not in app and "command-chain" not in app:
             app["adapter"] = default_adapter
+        elif "adapter" not in app and "command-chain" in app:
+            app["adapter"] = "full"
 
 
 def _ensure_required_keywords(config_data):

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -25,7 +25,6 @@ from typing import Set  # noqa: F401
 
 from snapcraft import project, formatting_utils
 from snapcraft.internal import common, deprecations, repo, states, steps
-from snapcraft.project._sanity_checks import conduct_environment_sanity_check
 from snapcraft.project._schema import Validator
 from ._parts_config import PartsConfig
 from ._extensions import apply_extensions
@@ -249,8 +248,6 @@ class Config:
         self.data["architectures"] = _process_architectures(
             self.data.get("architectures"), project.deb_arch
         )
-
-        conduct_environment_sanity_check(self.project, self.data, self.validator.schema)
 
     def _ensure_no_duplicate_app_aliases(self):
         # Prevent multiple apps within a snap from having duplicate alias names

--- a/snapcraft/project/_sanity_checks.py
+++ b/snapcraft/project/_sanity_checks.py
@@ -14,15 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import copy
 import logging
 import os
 import re
-from typing import Any, Dict
 
 from snapcraft.project import Project
-from snapcraft.internal import project_loader
-from . import errors
 
 logger = logging.getLogger(__name__)
 
@@ -54,20 +50,6 @@ def conduct_project_sanity_check(project: Project) -> None:
         _check_snap_dir(snap_dir_path)
 
 
-def conduct_environment_sanity_check(
-    project: Project, yaml_data: Dict[str, Any], schema: Dict[str, Any]
-) -> None:
-    """Sanity check the build environment and expanded YAML.
-
-    :param snapcraft.Project project: Project settings
-    :param dict yaml_data: Validated YAML, with extensions applied
-    """
-    # Never modify the YAML data
-    yaml_data = copy.deepcopy(yaml_data)
-
-    _verify_command_chain_only_full_adapter(yaml_data, schema)
-
-
 def _check_snap_dir(snap_dir_path: str) -> None:
     unexpected_paths = set()
     for root, directories, files in os.walk(snap_dir_path):
@@ -97,22 +79,3 @@ def _snap_dir_path_expected(path: str) -> bool:
         if pattern.match(path):
             return True
     return False
-
-
-def _verify_command_chain_only_full_adapter(
-    yaml_data: Dict[str, Any], schema: Dict[str, Any]
-) -> None:
-    # Determine the default adapter
-    app_schema = schema["apps"]["patternProperties"]["^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$"][
-        "properties"
-    ]
-    default_adapter = app_schema["adapter"]["default"]
-
-    # Loop through all apps
-    for app_name, app_definition in yaml_data.get("apps", dict()).items():
-        # Verify that, if command-chain is used, the "full" adapter is also used
-        if "command-chain" in app_definition:
-            adapter_string = app_definition.get("adapter", default_adapter)
-            adapter = project_loader.Adapter[adapter_string.upper()]
-            if adapter == project_loader.Adapter.LEGACY:
-                raise errors.CommandChainWithLegacyAdapterError(app_name)

--- a/tests/unit/project/test_sanity_checks.py
+++ b/tests/unit/project/test_sanity_checks.py
@@ -21,11 +21,7 @@ import fixtures
 from testtools.matchers import Equals
 
 import snapcraft
-from snapcraft.project._sanity_checks import (
-    conduct_project_sanity_check,
-    conduct_environment_sanity_check,
-)
-from snapcraft.project import errors, _schema
+from snapcraft.project._sanity_checks import conduct_project_sanity_check
 
 from tests import fixture_setup, unit
 
@@ -159,72 +155,3 @@ class ProjectSanityChecksTest(unit.TestCase):
             snapcraft_yaml_file_path=snapcraft_yaml.snapcraft_yaml_file_path,
         )
         conduct_project_sanity_check(project)
-
-
-class EnvironmentSanityChecksTest(unit.TestCase):
-    def test_command_chain_with_none_adapter(self):
-        project = snapcraft.project.Project()
-        yaml_data = {
-            "apps": {
-                "test-app": {"command-chain": ["test-command-chain"], "adapter": "none"}
-            }
-        }
-
-        try:
-            conduct_environment_sanity_check(
-                project, yaml_data, _schema.Validator().schema
-            )
-        except Exception:
-            self.fail("No exception was expected")
-
-    def test_command_chain_with_full_adapter(self):
-        project = snapcraft.project.Project()
-        yaml_data = {
-            "apps": {
-                "test-app": {"command-chain": ["test-command-chain"], "adapter": "full"}
-            }
-        }
-
-        try:
-            conduct_environment_sanity_check(
-                project, yaml_data, _schema.Validator().schema
-            )
-        except Exception:
-            self.fail("No exception was expected")
-
-    # FIXME: This test should fail once the default adapter changes to "full", just
-    # remove it
-    def test_command_chain_without_adapter_raises(self):
-        project = snapcraft.project.Project()
-        yaml_data = {"apps": {"test-app": {"command-chain": ["test-command-chain"]}}}
-
-        raised = self.assertRaises(
-            errors.CommandChainWithLegacyAdapterError,
-            conduct_environment_sanity_check,
-            project,
-            yaml_data,
-            _schema.Validator().schema,
-        )
-
-        self.assertThat(raised.app_name, Equals("test-app"))
-
-    def test_command_chain_with_legacy_adapter_raises(self):
-        project = snapcraft.project.Project()
-        yaml_data = {
-            "apps": {
-                "test-app": {
-                    "command-chain": ["test-command-chain"],
-                    "adapter": "legacy",
-                }
-            }
-        }
-
-        raised = self.assertRaises(
-            errors.CommandChainWithLegacyAdapterError,
-            conduct_environment_sanity_check,
-            project,
-            yaml_data,
-            _schema.Validator().schema,
-        )
-
-        self.assertThat(raised.app_name, Equals("test-app"))

--- a/tests/unit/project_loader/test_config.py
+++ b/tests/unit/project_loader/test_config.py
@@ -16,7 +16,6 @@
 
 from textwrap import dedent
 
-from unittest import mock
 from testtools.matchers import Contains, Equals
 
 from . import LoadPartBaseTest, ProjectLoaderBaseTest
@@ -272,33 +271,4 @@ class FilesetsTest(unit.TestCase):
             Contains(
                 "'$3' referred to in the 'stage' fileset but it is not in filesets"
             ),
-        )
-
-
-class SanityChecksTest(LoadPartBaseTest):
-    @mock.patch(
-        "snapcraft.internal.project_loader._config.conduct_environment_sanity_check"
-    )
-    def test_sanity_checks_called(self, mock_sanity_check):
-        project_config = self.make_snapcraft_project(
-            dedent(
-                """\
-                name: test
-                base: core18
-                version: "1.0"
-                summary: test summary
-                description: test description
-
-                grade: devel
-                confinement: strict
-
-                parts:
-                    test-part:
-                        plugin: nil
-                """
-            )
-        )
-
-        mock_sanity_check.assert_called_once_with(
-            project_config.project, project_config.data, project_config.validator.schema
         )

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -333,6 +333,19 @@ class CreateTestCase(CreateBaseTestCase):
 
         self.assertThat(y["layout"], Equals(layout))
 
+    def test_adapter_full_with_command_chain(self):
+        self.config_data["apps"] = {"app": {"command": "foo", "command-chain": ["bar"]}}
+        _create_file(os.path.join(self.prime_dir, "foo"), executable=True)
+        _create_file(os.path.join(self.prime_dir, "bar"), executable=True)
+
+        y = self.generate_meta_yaml()
+
+        self.expectThat(y["apps"]["app"]["command"], Equals("foo"))
+        self.expectThat(
+            y["apps"]["app"]["command-chain"],
+            Equals([os.path.join("snap", "command-chain", "snapcraft-runner"), "bar"]),
+        )
+
     def test_create_meta_with_app(self):
         os.mkdir(self.prime_dir)
         _create_file(os.path.join(self.prime_dir, "app.sh"))


### PR DESCRIPTION
Remove checks that invalidated the use of command-chain without
any other adapter than full.
Instead, transparently move to full-mode if a command-chain is
present in an apps entry.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
