### PR TITLE
scriplets: run override-pull on update_pull

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -126,6 +126,7 @@ class PluginHandler:
         )
 
         self._migrate_state_file()
+        self._current_step = None  # type: steps.Step
 
     def get_pull_state(self) -> states.PullState:
         if not self._pull_state:
@@ -187,9 +188,9 @@ class PluginHandler:
         except errors.ScriptletDuplicateDataError as e:
             raise errors.ScriptletDuplicateFieldError("grade", e.other_step)
 
-    def _set_scriptlet_metadata(self, metadata: snapcraft.extractors.ExtractedMetadata):
-        step = self.next_step()
-
+    def _check_scriplet_metadata_dupe(
+        self, metadata: snapcraft.extractors.ExtractedMetadata, step: steps.Step
+    ):
         # First, ensure the metadata set here doesn't conflict with metadata
         # already set for this step
         conflicts = metadata.overlap(self._scriptlet_metadata[step])
@@ -208,6 +209,18 @@ class PluginHandler:
                     raise errors.ScriptletDuplicateDataError(
                         step, other_step, list(conflicts)
                     )
+
+    def _set_scriptlet_metadata(self, metadata: snapcraft.extractors.ExtractedMetadata):
+        try:
+            step = self.next_step()
+            self._check_scriplet_metadata_dupe(metadata, step)
+        except errors.NoNextStepError:
+            # We've already run through all the steps, don't bother to
+            # check for duplication as it is not really necessary and
+            # _check_scriplet_metadata_dupe() assumes that all steps
+            # haven't already executed.  Determine the current step
+            # as saved by _do_runner_step().
+            step = self._current_step
 
         self._scriptlet_metadata[step].update(metadata)
 
@@ -439,7 +452,7 @@ class PluginHandler:
             shutil.rmtree(self.plugin.sourcedir)
 
         self.makedirs()
-        self._runner.pull()
+        self._do_runner_step(steps.PULL)
         self.mark_pull_done()
 
     def check_pull(self):
@@ -453,6 +466,7 @@ class PluginHandler:
         return None
 
     def update_pull(self):
+        self._do_runner_step(steps.PULL)
         self.source_handler.update()
         self.mark_pull_done()
 
@@ -575,7 +589,7 @@ class PluginHandler:
         self._do_build(update=True)
 
     def _do_build(self, *, update=False):
-        self._runner.build()
+        self._do_runner_step(steps.BUILD)
 
         # Organize the installed files as requested. We do this in the build step for
         # two reasons:
@@ -720,7 +734,7 @@ class PluginHandler:
 
     def stage(self, force=False):
         self.makedirs()
-        self._runner.stage()
+        self._do_runner_step(steps.STAGE)
 
         # Only mark this step done if _do_stage() didn't run, in which case
         # we have no directories or files to track.
@@ -774,9 +788,13 @@ class PluginHandler:
 
         self.mark_cleaned(steps.STAGE)
 
+    def _do_runner_step(self, step: steps.Step):
+        self._current_step = step
+        return getattr(self._runner, "{}".format(step.name))()
+
     def prime(self, force=False) -> None:
         self.makedirs()
-        self._runner.prime()
+        self._do_runner_step(steps.PRIME)
 
         # Only mark this step done if _do_prime() didn't run, in which case
         # we have no files, directories, or dependency paths to track.

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -451,7 +451,6 @@ class PluginHandler:
         elif os.path.isdir(self.plugin.sourcedir):
             shutil.rmtree(self.plugin.sourcedir)
 
-        self.makedirs()
         self._do_runner_step(steps.PULL)
         self.mark_pull_done()
 
@@ -733,7 +732,6 @@ class PluginHandler:
         _organize_filesets(self.name, fileset.copy(), self.plugin.installdir, overwrite)
 
     def stage(self, force=False):
-        self.makedirs()
         self._do_runner_step(steps.STAGE)
 
         # Only mark this step done if _do_stage() didn't run, in which case
@@ -789,11 +787,11 @@ class PluginHandler:
         self.mark_cleaned(steps.STAGE)
 
     def _do_runner_step(self, step: steps.Step):
+        self.makedirs()
         self._current_step = step
         return getattr(self._runner, "{}".format(step.name))()
 
     def prime(self, force=False) -> None:
-        self.makedirs()
         self._do_runner_step(steps.PRIME)
 
         # Only mark this step done if _do_prime() didn't run, in which case

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -236,6 +236,11 @@ class PluginHandler:
         for d in dirs:
             os.makedirs(d, exist_ok=True)
 
+    def _do_runner_step(self, step: steps.Step):
+        self.makedirs()
+        self._current_step = step
+        return getattr(self._runner, "{}".format(step.name))()
+
     def _migrate_state_file(self):
         # In previous versions of Snapcraft, the state directory was a file.
         # Rather than die if we're running on output from an old version,
@@ -785,11 +790,6 @@ class PluginHandler:
             raise errors.MissingStateCleanError(steps.STAGE)
 
         self.mark_cleaned(steps.STAGE)
-
-    def _do_runner_step(self, step: steps.Step):
-        self.makedirs()
-        self._current_step = step
-        return getattr(self._runner, "{}".format(step.name))()
 
     def prime(self, force=False) -> None:
         self._do_runner_step(steps.PRIME)


### PR DESCRIPTION
```
    Once a project is re-run, snapcraft loses metadata generated
    from scripts (i.e. snapcraftctl set-version and set-grade).
    Snapcraft itself will reproduce this issue when the sources change:
    
    ```
    Skipping stage bash-completion (already ran)
    Skipping stage snapcraft-libs (already ran)
    Skipping stage legacy-snapcraft (already ran)
    Skipping stage patchelf (already ran)
    Cleaning later steps and re-staging snapcraft ('build' step changed)
    Skipping prime bash-completion (already ran)
    Skipping prime snapcraft-libs (already ran)
    Skipping prime legacy-snapcraft (already ran)
    Skipping prime patchelf (already ran)
    Priming snapcraft
    Compiling pyc files...
    Failed to generate snap metadata: 'adopt-info' refers to part 'snapcraft', but that part is lacking the 'parse-info' property.
    ```
    
    - Since version information may have changed between
    runs, we now re-execute the override-pull scriplets when
    the pull step is re-run.
    
    - Track current step in pluginhandler when invoking a step
    inside the runner - we can use this to determine which
    scriplet metadata to update once called.  The previous logic
    assumed that the steps were cleaned and not being re-run when
    checking for metadata duplication.
    
    - Add test to reproduce failure (and pass it!)
    
    LP #1790651
```