### PR TITLE
click: update to 7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click~=6.0
+click~=7.0
 configparser==3.5.0
 jsonschema==2.5.1
 progressbar33==2.4

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -95,7 +95,8 @@ def get_build_environment(**kwargs):
 
     if force_destructive_mode and force_use_lxd:
         raise click.BadOptionUsage(
-            "--use-lxd and --destructive-mode cannot be used together."
+            "--destructive-mode",
+            "--use-lxd and --destructive-mode cannot be used together.",
         )
     elif force_use_lxd:
         provider = "lxd"

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -80,6 +80,8 @@ _BUILD_OPTIONS = [
 def add_build_options(hidden=False):
     def _add_build_options(func):
         for build_option in reversed(_BUILD_OPTIONS):
+            # Pop param_decls option to prevent exception further on down the
+            # line for: `got multiple values for keyword argument`.
             build_option = build_option.copy()
             param_decls = build_option.pop("param_decls")
             option = click.option(param_decls, **build_option, hidden=hidden)

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -23,11 +23,6 @@ from snapcraft.project import Project, get_snapcraft_yaml
 from snapcraft.cli.echo import confirm, prompt
 
 
-class HiddenOption(click.Option):
-    def get_help_record(self, ctx):
-        pass
-
-
 class PromptOption(click.Option):
     def prompt_for_value(self, ctx):
         default = self.get_default(ctx)
@@ -48,35 +43,46 @@ class PromptOption(click.Option):
         )
 
 
-_BUILD_OPTION_NAMES = [
-    "--target-arch",
-    "--debug",
-    "--shell",
-    "--shell-after",
-    "--destructive-mode",
-    "--use-lxd",
-]
-
 _BUILD_OPTIONS = [
-    dict(metavar="<arch>", help="Target architecture to cross compile to"),
-    dict(is_flag=True, help="Shells into the environment if the build fails."),
-    dict(is_flag=True, help="Shells into the environment in lieu of the step to run."),
-    dict(is_flag=True, help="Shells into the environment after the step has run."),
     dict(
-        is_flag=True, help="Forces snapcraft to try and use the current host to build."
+        param_decls="--target-arch",
+        metavar="<arch>",
+        help="Target architecture to cross compile to",
     ),
-    dict(is_flag=True, help="Forces snapcraft to use LXD to build."),
+    dict(
+        param_decls="--debug",
+        is_flag=True,
+        help="Shells into the environment if the build fails.",
+    ),
+    dict(
+        param_decls="--shell",
+        is_flag=True,
+        help="Shells into the environment in lieu of the step to run.",
+    ),
+    dict(
+        param_decls="--shell-after",
+        is_flag=True,
+        help="Shells into the environment after the step has run.",
+    ),
+    dict(
+        param_decls="--destructive-mode",
+        is_flag=True,
+        help="Forces snapcraft to try and use the current host to build.",
+    ),
+    dict(
+        param_decls="--use-lxd",
+        is_flag=True,
+        help="Forces snapcraft to use LXD to build.",
+    ),
 ]
 
 
 def add_build_options(hidden=False):
     def _add_build_options(func):
-        for name, params in zip(
-            reversed(_BUILD_OPTION_NAMES), reversed(_BUILD_OPTIONS)
-        ):
-            option = click.option(
-                name, **params, cls=HiddenOption if hidden else click.Option
-            )
+        for build_option in reversed(_BUILD_OPTIONS):
+            build_option = build_option.copy()
+            param_decls = build_option.pop("param_decls")
+            option = click.option(param_decls, **build_option, hidden=hidden)
             func = option(func)
         return func
 

--- a/snapcraft/cli/ci.py
+++ b/snapcraft/cli/ci.py
@@ -20,7 +20,7 @@ import click
 from . import echo
 from ._options import get_project
 
-_SUPPORTED_CI_SYSTEMS = ("travis",)
+_SUPPORTED_CI_SYSTEMS = ["travis"]
 
 
 @click.group()

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -22,12 +22,7 @@ import click
 
 from . import echo
 from ._command import SnapcraftProjectCommand
-from ._options import (
-    add_build_options,
-    get_build_environment,
-    get_project,
-    HiddenOption,
-)
+from ._options import add_build_options, get_build_environment, get_project
 from snapcraft.internal import (
     build_providers,
     deprecations,
@@ -297,8 +292,8 @@ def pack(directory, output, **kwargs):
     required=False,
     help="Forces snapcraft to try and use the current host to clean.",
 )
-@click.option("--unprime", is_flag=True, required=False, cls=HiddenOption)
-@click.option("--step", required=False, cls=HiddenOption)
+@click.option("--unprime", is_flag=True, required=False, hidden=True)
+@click.option("--step", required=False, hidden=True)
 def clean(parts, use_lxd, destructive_mode, unprime, step):
     """Remove a part's assets.
 

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -304,7 +304,7 @@ def clean(parts, use_lxd, destructive_mode, unprime, step):
     """
     # This option is only valid in legacy.
     if step:
-        raise click.BadOptionUsage("no such option: --step")
+        raise click.BadOptionUsage("--step", "no such option: --step")
 
     build_environment = get_build_environment(
         use_lxd=use_lxd, destructive_mode=destructive_mode
@@ -312,7 +312,7 @@ def clean(parts, use_lxd, destructive_mode, unprime, step):
     project = get_project(is_managed_host=build_environment.is_managed_host)
 
     if unprime and not build_environment.is_managed_host:
-        raise click.BadOptionUsage("not such option: --unprime")
+        raise click.BadOptionUsage("--unprime", "no such option: --unprime")
 
     if build_environment.is_managed_host or build_environment.is_host:
         step = steps.PRIME if unprime else None

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -294,13 +294,14 @@ def promote(snap_name, from_channel, to_channel, yes):
 
     if parsed_from_channel == parsed_to_channel:
         raise click.BadOptionUsage(
-            "--from-channel and --to-channel cannot be the same."
+            "--to-channel", "--from-channel and --to-channel cannot be the same."
         )
     elif parsed_from_channel.risk == "edge" and parsed_from_channel.branch is None:
         raise click.BadOptionUsage(
+            "--from-channel",
             "{!r} is not a valid set value for --from-channel.".format(
                 parsed_from_channel
-            )
+            ),
         )
 
     store = storeapi.StoreClient()

--- a/tests/unit/commands/test_enable_ci.py
+++ b/tests/unit/commands/test_enable_ci.py
@@ -28,7 +28,9 @@ class EnableCITestCase(CommandBaseTestCase):
         self.assertThat(result.exit_code, Equals(2))
         self.assertThat(
             result.output,
-            Contains('Missing argument "ci-system".  Choose from travis.'),
+            Contains(
+                'Error: Missing argument "<ci-system>".  Choose from:\n\ttravis.\n'
+            ),
         )
 
     def test_enable_ci_unknown(self):

--- a/tests/unit/commands/test_sign_build.py
+++ b/tests/unit/commands/test_sign_build.py
@@ -76,7 +76,10 @@ class SignBuildTestCase(CommandBaseTestCase):
 
         self.assertThat(result.exit_code, Equals(2))
         self.assertThat(
-            result.output, Contains('Path "nonexisting.snap" does not exist')
+            result.output,
+            Contains(
+                'Error: Invalid value for "<snap-file>": File "nonexisting.snap" does not exist.\n'
+            ),
         )
         self.assertThat(mock_check_output.call_count, Equals(0))
 


### PR DESCRIPTION
cli: drop custom HiddenOption and use click's hidden flag

Hidden flag now available as first-class option in Click 7.0.

While here, consolidate add_build_options()'s two lists,
_BUILD_OPTION_NAMES and _BUILD_OPTIONS, as they are zipped
together anyhow.
