### PR TITLE
deltas: code cleanup

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -35,11 +35,10 @@ from tabulate import tabulate
 from snapcraft.file_utils import calculate_sha3_384, get_tool_path
 from snapcraft import storeapi, yaml_utils
 from snapcraft.internal import cache, deltas, repo
-from snapcraft.internal.errors import SnapDataExtractionError
+from snapcraft.internal.errors import SnapDataExtractionError, ToolMissingError
 from snapcraft.internal.deltas.errors import (
     DeltaGenerationError,
     DeltaGenerationTooBigError,
-    DeltaToolError,
 )
 
 
@@ -605,7 +604,7 @@ def _push_delta(snap_name, snap_filename, source_snap, built_at):
             source_path=source_snap, target_path=target_snap
         )
         delta_filename = xdelta_generator.make_delta()
-    except (DeltaGenerationError, DeltaGenerationTooBigError, DeltaToolError) as e:
+    except (DeltaGenerationError, DeltaGenerationTooBigError, ToolMissingError) as e:
         raise storeapi.errors.StoreDeltaApplicationError(str(e))
 
     snap_hashes = {

--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -272,11 +272,6 @@ def create_similar_directory(source: str, destination: str) -> None:
     shutil.copystat(source, destination, follow_symlinks=False)
 
 
-def executable_exists(path: str) -> bool:
-    """Return True if 'path' exists and is readable and executable."""
-    return os.path.exists(path) and os.access(path, os.R_OK | os.X_OK)
-
-
 @contextmanager
 def requires_command_success(
     command: str, not_found_fmt: str = None, failure_fmt: str = None

--- a/snapcraft/internal/deltas/_xdelta3.py
+++ b/snapcraft/internal/deltas/_xdelta3.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016, 2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -13,25 +13,28 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import logging
 import subprocess
 
 from ._deltas import BaseDeltasGenerator
-from snapcraft import file_utils
 
 logger = logging.getLogger(__name__)
 
 
+_DELTA_TOOL = "xdelta3"
+_DELTA_FORMAT = "xdelta3"
+_DELTA_EXTNAME = "xdelta3"
+
+
 class XDelta3Generator(BaseDeltasGenerator):
     def __init__(self, *, source_path, target_path):
-        delta_format = "xdelta3"
-        delta_tool_path = file_utils.get_tool_path("xdelta3")
         super().__init__(
             source_path=source_path,
             target_path=target_path,
-            delta_file_extname="xdelta3",
-            delta_format=delta_format,
-            delta_tool_path=delta_tool_path,
+            delta_tool=_DELTA_TOOL,
+            delta_format=_DELTA_FORMAT,
+            delta_file_extname=_DELTA_EXTNAME,
         )
 
     def get_delta_cmd(self, source_path, target_path, delta_file):

--- a/snapcraft/internal/deltas/errors.py
+++ b/snapcraft/internal/deltas/errors.py
@@ -39,12 +39,6 @@ class DeltaGenerationTooBigError(SnapcraftError):
     fmt = "delta saving is less than {delta_min_percentage}%."
 
 
-class DeltaFormatError(SnapcraftError):
-    """A delta format must be set."""
-
-    fmt = "delta_format must be set in subclass!"
-
-
 class DeltaFormatOptionError(SnapcraftError):
     """A delta format option is not in the defined list."""
 
@@ -52,16 +46,3 @@ class DeltaFormatOptionError(SnapcraftError):
         "delta_format must be a option in {format_options_list}.\n"
         "for now delta_format={delta_format!r}"
     )
-
-
-class DeltaToolError(SnapcraftError):
-    """A delta tool executable error"""
-
-    fmt = "Cannot find the executable delta tool {delta_tool!r}."
-
-    def __init__(self, **kwargs):
-        # if no parameter passed, use the following error message instead
-        if len(kwargs) == 0:
-            self.fmt = "delta_tool_path must be set in subclass!"
-
-        super().__init__(**kwargs)

--- a/tests/unit/deltas/test_deltas_xdelta3.py
+++ b/tests/unit/deltas/test_deltas_xdelta3.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016-2018 Canonical Ltd
+# Copyright (C) 2016-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -18,14 +18,12 @@ import os
 import fixtures
 import logging
 import random
-import shutil
 from unittest import mock
 
 from progressbar import AnimatedMarker, ProgressBar
 from testtools import matchers as m
 
-from snapcraft import file_utils
-from snapcraft.internal import deltas  # noqa
+from snapcraft.internal import deltas
 from tests import fixture_setup, unit
 
 
@@ -35,8 +33,6 @@ class XDelta3TestCase(unit.TestCase):
         self.useFixture(fixture_setup.FakeTerminal())
         self.fake_logger = fixtures.FakeLogger(level=logging.DEBUG)
         self.useFixture(self.fake_logger)
-
-        self.patch(file_utils, "executable_exists", lambda a: True)
 
         self.workdir = self.useFixture(fixtures.TempDir()).path
         self.source_file = os.path.join(self.workdir, "source.snap")
@@ -74,23 +70,6 @@ class XDelta3TestCase(unit.TestCase):
                     target.write(os.urandom(1024))
                 else:
                     target.write(block)
-
-    def test_raises_DeltaToolError_when_xdelta3_not_installed(self):
-        self.patch(file_utils, "executable_exists", lambda a: False)
-        self.patch(shutil, "which", lambda a: None)
-
-        self.assertThat(
-            lambda: deltas.XDelta3Generator(
-                source_path=self.source_file, target_path=self.target_file
-            ),
-            m.raises(deltas.errors.DeltaToolError),
-        )
-        self.assertRaises(
-            deltas.errors.DeltaToolError,
-            deltas.XDelta3Generator,
-            source_path=self.source_file,
-            target_path=self.target_file,
-        )
 
     def test_xdelta3(self):
         self.generate_snap_pair()

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2018 Canonical Ltd
+# Copyright (C) 2015-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -19,7 +19,6 @@ import re
 import subprocess
 from unittest import mock
 
-import fixtures
 import testtools
 import testscenarios
 from testtools.matchers import Equals
@@ -188,41 +187,6 @@ class TestLinkOrCopy(unit.TestCase):
     def test_copy_nested_file(self):
         file_utils.link_or_copy("foo/bar/baz/4", "foo2/bar/baz/4")
         self.assertTrue(os.path.isfile("foo2/bar/baz/4"))
-
-
-class ExecutableExistsTestCase(unit.TestCase):
-    def test_file_does_not_exist(self):
-        workdir = self.useFixture(fixtures.TempDir()).path
-        self.assertFalse(
-            file_utils.executable_exists(os.path.join(workdir, "doesnotexist"))
-        )
-
-    def test_file_exists_but_not_readable(self):
-        workdir = self.useFixture(fixtures.TempDir()).path
-        path = os.path.join(workdir, "notreadable")
-        with open(path, "wb"):
-            pass
-        os.chmod(path, 0)
-
-        self.assertFalse(file_utils.executable_exists(path))
-
-    def test_file_exists_but_not_executable(self):
-        workdir = self.useFixture(fixtures.TempDir()).path
-        path = os.path.join(workdir, "notexecutable")
-        with open(path, "wb"):
-            pass
-        os.chmod(path, 0o444)
-
-        self.assertFalse(file_utils.executable_exists(path))
-
-    def test_executable_exists_and_executable(self):
-        workdir = self.useFixture(fixtures.TempDir()).path
-        path = os.path.join(workdir, "notexecutable")
-        with open(path, "wb"):
-            pass
-        os.chmod(path, 0o555)
-
-        self.assertTrue(file_utils.executable_exists(path))
 
 
 class RequiresCommandSuccessTestCase(unit.TestCase):


### PR DESCRIPTION
- Use more prominent error classes.
- Setup typing instead of runtime checks for class implementation.
- Remove duplication of logic.
- Move delta tests to own package.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
