### PR TITLE
elf: handle invalid elf files

### DIFF
--- a/tests/unit/test_elf.py
+++ b/tests/unit/test_elf.py
@@ -96,6 +96,15 @@ class TestElfFileSmoketest(unit.TestCase):
             )
 
 
+class TestInvalidElf(unit.TestCase):
+    def test_invalid_elf_file(self):
+        invalid_elf = os.path.join(self.path, "invalid-elf")
+        open(invalid_elf, "wb").write(b"\x7fELF\x00")
+
+        elf_files = elf.get_elf_files(self.path, ["invalid-elf"])
+        self.assertThat(elf_files, Equals(set()))
+
+
 class TestGetLibraries(TestElfBase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
When coming across invalid ELF files, handle exception thrown by
elftools.  If it's invalid, just silently ignore it, we only care
to analyze valid ELF flies.

Introduce test case to reproduce issue (that now passes).

LP #1838098

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
