### PR TITLE
cli: handle exception when cleaning a part with a fresh project

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -21,6 +21,7 @@ import click
 from . import env
 from snapcraft.project import Project, get_snapcraft_yaml
 from snapcraft.cli.echo import confirm, prompt
+from snapcraft.internal import errors
 
 
 class PromptOption(click.Option):
@@ -112,7 +113,11 @@ def get_build_environment(**kwargs):
 def get_project(*, is_managed_host: bool = False, **kwargs):
     # We need to do this here until we can get_snapcraft_yaml as part of Project.
     if is_managed_host:
-        os.chdir(os.path.expanduser(os.path.join("~", "project")))
+        try:
+            os.chdir(os.path.expanduser(os.path.join("~", "project")))
+        except FileNotFoundError:
+            # No project found (fresh environment).
+            raise errors.ProjectNotFoundError()
 
     snapcraft_yaml_file_path = get_snapcraft_yaml()
 

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -26,6 +26,7 @@ from ._options import add_build_options, get_build_environment, get_project
 from snapcraft.internal import (
     build_providers,
     deprecations,
+    errors,
     lifecycle,
     project_loader,
     steps,
@@ -309,7 +310,12 @@ def clean(parts, use_lxd, destructive_mode, unprime, step):
     build_environment = get_build_environment(
         use_lxd=use_lxd, destructive_mode=destructive_mode
     )
-    project = get_project(is_managed_host=build_environment.is_managed_host)
+
+    try:
+        project = get_project(is_managed_host=build_environment.is_managed_host)
+    except errors.ProjectNotFoundError:
+        # Fresh environment, nothing to clean.
+        return
 
     if unprime and not build_environment.is_managed_host:
         raise click.BadOptionUsage("--unprime", "no such option: --unprime")

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -709,3 +709,7 @@ class SnapDataExtractionError(SnapcraftError):
 
     def __init__(self, snap):
         super().__init__(snap=snap)
+
+
+class ProjectNotFoundError(SnapcraftReportableError):
+    fmt = "Failed to find project files."

--- a/tests/unit/commands/test_clean.py
+++ b/tests/unit/commands/test_clean.py
@@ -172,6 +172,14 @@ class CleanCommandPartsTestCase(CleanCommandBaseTestCase):
 
         self.assertThat(result.exit_code, Equals(0))
 
+    def test_everything_is_clean_part(self):
+        """Don't crash if everything is already clean."""
+        self.make_snapcraft_yaml(n=3, create=False)
+
+        result = self.run_command(["clean", "clean1"])
+
+        self.assertThat(result.exit_code, Equals(0))
+
 
 class CleanCommandReverseDependenciesTestCase(CommandBaseTestCase):
     def setUp(self):


### PR DESCRIPTION
When the project is fresh (i.e. not-built, or fully cleaned), the
multipass managed instance will fail to find the project and raise a
FileNotFound exception.  Handle it gracefully (ignore it).

- Add new ProjectNotFound exception, set as reportable because it shouldn't
have unhandled cases surfacing up to the user.

- Add test case which would expose the bug if the build provider was multipass.
It's not for unit testing, but we'll add it regardless.

LP #1839014

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
