### PR TITLE
Plugin catkin: disable parallel option

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -68,6 +68,10 @@ Additionally, this plugin uses the following plugin-specific keywords:
       (string)
       The URI to ros master setting the env variable ROS_MASTER_URI. Defaults
       to http://localhost:11311.
+    - disable-parallel:
+      (boolean)
+      Disable parallel build, effectively using a single worker.
+      Defaults to False.
 """
 
 import contextlib
@@ -210,6 +214,8 @@ class CatkinPlugin(snapcraft.BasePlugin):
             "default": "http://localhost:11311",
         }
 
+        schema["properties"]["disable-parallel"] = {"type": "boolean", "default": False}
+
         schema["required"] = ["source"]
 
         return schema
@@ -231,7 +237,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
     def get_build_properties(cls):
         # Inform Snapcraft of the properties associated with building. If these
         # change in the YAML Snapcraft will consider the build step dirty.
-        return ["catkin-cmake-args"]
+        return ["catkin-cmake-args", "disable-parallel"]
 
     @property
     def _pip(self):
@@ -797,6 +803,10 @@ class CatkinPlugin(snapcraft.BasePlugin):
         # Specify that the package should be installed along with the rest of
         # the ROS distro.
         catkincmd.extend(["--install-space", self.rosdir])
+
+        if self.disable_parallel:
+            # Specify using a single worker
+            catkincmd.append("-j1")
 
         # All the arguments that follow are meant for CMake
         catkincmd.append("--cmake-args")

--- a/tests/unit/plugins/test_catkin.py
+++ b/tests/unit/plugins/test_catkin.py
@@ -329,6 +329,18 @@ class CatkinPluginTestCase(CatkinPluginBaseTest):
             catkin_ros_master_uri["default"], Equals("http://localhost:11311")
         )
 
+    def test_schema_disable_parallel(self):
+        schema = catkin.CatkinPlugin.schema()
+
+        # Check disable-parallel property
+        disable_parallel = schema["properties"]["disable-parallel"]
+        expected = ("type", "default")
+        self.assertThat(disable_parallel, HasLength(len(expected)))
+        for prop in expected:
+            self.assertThat(disable_parallel, Contains(prop))
+        self.assertThat(disable_parallel["type"], Equals("boolean"))
+        self.assertThat(disable_parallel["default"], Equals(False))
+
     def test_get_pull_properties(self):
         expected_pull_properties = [
             "catkin-packages",
@@ -348,7 +360,7 @@ class CatkinPluginTestCase(CatkinPluginBaseTest):
             self.assertIn(property, actual_pull_properties)
 
     def test_get_build_properties(self):
-        expected_build_properties = ["catkin-cmake-args"]
+        expected_build_properties = ["catkin-cmake-args", "disable-parallel"]
         actual_build_properties = catkin.CatkinPlugin.get_build_properties()
 
         self.assertThat(


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

Catkin plugin : add an option to disable parallel building.

Note: running tests using `spread`, some bits are failing. However the same bits are failing on `master` branch as well.
