### PR TITLE
yaml utils: move OctInt from meta

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -64,25 +64,6 @@ _OPTIONAL_PACKAGE_KEYS = [
 ]
 
 
-class OctInt(yaml_utils.SnapcraftYAMLObject):
-    """An int represented in octal form."""
-
-    yaml_tag = u"!OctInt"
-
-    def __init__(self, value):
-        super().__init__()
-        self._value = value
-
-    @classmethod
-    def to_yaml(cls, dumper, data):
-        """
-        Convert a Python object to a representation node.
-        """
-        return dumper.represent_scalar(
-            "tag:yaml.org,2002:int", "{:04o}".format(data._value)
-        )
-
-
 # From snapd's snap/validate.go, appContentWhitelist, with a slight modification: don't
 # allow leading slashes.
 _APP_COMMAND_PATTERN = re.compile("^[A-Za-z0-9. _#:$-][A-Za-z0-9/. _#:$-]*$")
@@ -694,7 +675,7 @@ class _SnapPackaging:
             for socket in sockets.values():
                 mode = socket.get("socket-mode")
                 if mode is not None:
-                    socket["socket-mode"] = OctInt(mode)
+                    socket["socket-mode"] = yaml_utils.OctInt(mode)
 
     def _validate_command_chain(self, apps: Dict[str, Any]) -> None:
         for app_name, app in apps.items():

--- a/snapcraft/yaml_utils.py
+++ b/snapcraft/yaml_utils.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018 Canonical Ltd
+# Copyright (C) 2018-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -87,3 +87,22 @@ def _str_presenter(dumper, data):
     if len(data.splitlines()) > 1:  # check for multiline string
         return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
     return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+class OctInt(SnapcraftYAMLObject):
+    """An int represented in octal form."""
+
+    yaml_tag = u"!OctInt"
+
+    def __init__(self, value):
+        super().__init__()
+        self._value = value
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        """
+        Convert a Python object to a representation node.
+        """
+        return dumper.represent_scalar(
+            "tag:yaml.org,2002:int", "{:04o}".format(data._value)
+        )

--- a/tests/unit/test_yaml_utils.py
+++ b/tests/unit/test_yaml_utils.py
@@ -1,0 +1,31 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import io
+
+from testtools.matchers import Equals
+
+from snapcraft import yaml_utils
+from tests import unit
+
+
+class OctIntTest(unit.TestCase):
+    def test_octint_dump(self):
+        output = io.StringIO()
+        yaml_utils.dump(dict(number=yaml_utils.OctInt(8)), stream=output)
+        output.seek(0)
+
+        self.assertThat(output.read().strip(), Equals("number: 0010"))


### PR DESCRIPTION
Also add a unit test for dumping yaml from OctInt

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
