### PR TITLE
Plugin catkin: forward parallel build count

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -798,6 +798,9 @@ class CatkinPlugin(snapcraft.BasePlugin):
         # the ROS distro.
         catkincmd.extend(["--install-space", self.rosdir])
 
+        # Specify the number of workers
+        catkincmd.append("-j{}".format(self.parallel_build_count))
+
         # All the arguments that follow are meant for CMake
         catkincmd.append("--cmake-args")
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Plugin catkin : forward the `parallel-build-count`/`disable-parallel` options down to the build invocation command.

Replace #2665