### PR TITLE
docker: use apt-get to avoid warnings

### DIFF
--- a/docker/beta.Dockerfile
+++ b/docker/beta.Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:xenial as builder
 
 # Grab dependencies
-RUN apt update
-RUN apt dist-upgrade --yes
-RUN apt install --yes curl jq squashfs-tools
+RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes \
+  curl \
+  jq \
+  squashfs-tools
 
 # Grab the core snap from the stable channel and unpack it in the proper place
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
@@ -30,7 +31,7 @@ COPY --from=builder /snap/snapcraft /snap/snapcraft
 COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
 
 # Generate locale
-RUN apt update && apt dist-upgrade --yes && apt install --yes sudo locales && locale-gen en_US.UTF-8
+RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes sudo locales && locale-gen en_US.UTF-8
 
 # Set the proper environment
 ENV LANG="en_US.UTF-8"

--- a/docker/beta.Dockerfile
+++ b/docker/beta.Dockerfile
@@ -1,10 +1,12 @@
 FROM ubuntu:xenial as builder
 
 # Grab dependencies
-RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes \
-  curl \
-  jq \
-  squashfs-tools
+RUN apt-get update
+RUN apt-get dist-upgrade --yes
+RUN apt-get install --yes \
+      curl \
+      jq \
+      squashfs-tools
 
 # Grab the core snap from the stable channel and unpack it in the proper place
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap

--- a/docker/candidate.Dockerfile
+++ b/docker/candidate.Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:xenial as builder
 
 # Grab dependencies
-RUN apt update
-RUN apt dist-upgrade --yes
-RUN apt install --yes curl jq squashfs-tools
+RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes \
+  curl \
+  jq \
+  squashfs-tools
 
 # Grab the core snap from the stable channel and unpack it in the proper place
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
@@ -30,7 +31,7 @@ COPY --from=builder /snap/snapcraft /snap/snapcraft
 COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
 
 # Generate locale
-RUN apt update && apt dist-upgrade --yes && apt install --yes sudo locales && locale-gen en_US.UTF-8
+RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes sudo locales && locale-gen en_US.UTF-8
 
 # Set the proper environment
 ENV LANG="en_US.UTF-8"

--- a/docker/candidate.Dockerfile
+++ b/docker/candidate.Dockerfile
@@ -1,10 +1,12 @@
 FROM ubuntu:xenial as builder
 
 # Grab dependencies
-RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes \
-  curl \
-  jq \
-  squashfs-tools
+RUN apt-get update
+RUN apt-get dist-upgrade --yes
+RUN apt-get install --yes \
+      curl \
+      jq \
+      squashfs-tools
 
 # Grab the core snap from the stable channel and unpack it in the proper place
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap

--- a/docker/edge.Dockerfile
+++ b/docker/edge.Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:xenial as builder
 
 # Grab dependencies
-RUN apt update
-RUN apt dist-upgrade --yes
-RUN apt install --yes curl jq squashfs-tools
+RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes \
+  curl \
+  jq \
+  squashfs-tools
 
 # Grab the core snap from the stable channel and unpack it in the proper place
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
@@ -30,7 +31,7 @@ COPY --from=builder /snap/snapcraft /snap/snapcraft
 COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
 
 # Generate locale
-RUN apt update && apt dist-upgrade --yes && apt install --yes sudo locales && locale-gen en_US.UTF-8
+RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes sudo locales && locale-gen en_US.UTF-8
 
 # Set the proper environment
 ENV LANG="en_US.UTF-8"

--- a/docker/edge.Dockerfile
+++ b/docker/edge.Dockerfile
@@ -1,10 +1,12 @@
 FROM ubuntu:xenial as builder
 
 # Grab dependencies
-RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes \
-  curl \
-  jq \
-  squashfs-tools
+RUN apt-get update
+RUN apt-get dist-upgrade --yes
+RUN apt-get install --yes \
+      curl \
+      jq \
+      squashfs-tools
 
 # Grab the core snap from the stable channel and unpack it in the proper place
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap

--- a/docker/stable.Dockerfile
+++ b/docker/stable.Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:xenial as builder
 
 # Grab dependencies
-RUN apt update
-RUN apt dist-upgrade --yes
-RUN apt install --yes curl jq squashfs-tools
+RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes \
+  curl \
+  jq \
+  squashfs-tools
 
 # Grab the core snap from the stable channel and unpack it in the proper place
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
@@ -30,7 +31,7 @@ COPY --from=builder /snap/snapcraft /snap/snapcraft
 COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
 
 # Generate locale
-RUN apt update && apt dist-upgrade --yes && apt install --yes sudo locales && locale-gen en_US.UTF-8
+RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes sudo locales && locale-gen en_US.UTF-8
 
 # Set the proper environment
 ENV LANG="en_US.UTF-8"

--- a/docker/stable.Dockerfile
+++ b/docker/stable.Dockerfile
@@ -1,10 +1,12 @@
 FROM ubuntu:xenial as builder
 
 # Grab dependencies
-RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes \
-  curl \
-  jq \
-  squashfs-tools
+RUN apt-get update
+RUN apt-get dist-upgrade --yes
+RUN apt-get install --yes \
+      curl \
+      jq \
+      squashfs-tools
 
 # Grab the core snap from the stable channel and unpack it in the proper place
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap


### PR DESCRIPTION
```
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
