### PR TITLE
docs: quick init for lxd in HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -11,7 +11,7 @@ Clone these sources and make it your working directory:
 If you already have LXD setup you can skip this part, if not, run:
 
     sudo snap install lxd
-    sudo lxd init  # If unsure, pick `dir` as the storage backend.
+    sudo lxd init --auto --storage-backend=dir
     sudo adduser "$USER" lxd
     newgrp lxd
 


### PR DESCRIPTION
The user is unlikely to care about anything but the defaults, especially
when found in the `HACKING` docs. Use `--auto` with the suggested
storage-backend of `dir` for `lxd init`.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
