### PR TITLE
spread: 64 workers for each system

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -35,10 +35,10 @@ backends:
     location: computeengine/us-east1-b
     systems:
       - ubuntu-16.04-64:
-          workers: 8
+          workers: 64
           image: ubuntu-1604-64
       - ubuntu-18.04-64:
-          workers: 18
+          workers: 64
           image: ubuntu-1804-64
   autopkgtest:
     type: adhoc


### PR DESCRIPTION
Still having routine timeout issues running spread tests.

Let's see what this does.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
