### PR TITLE
erorrs: preserve quotes when printing SnapcraftPluginCommandError

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import shlex
+
 from abc import ABC, abstractmethod
 from snapcraft import formatting_utils
 from snapcraft.internal import steps
@@ -522,7 +524,7 @@ class SnapcraftPluginCommandError(SnapcraftError):
         self, *, command: Union[List, str], part_name: str, exit_code: int
     ) -> None:
         if isinstance(command, list):
-            command = " ".join(command)
+            command = " ".join([shlex.quote(c) for c in command])
         super().__init__(command=command, part_name=part_name, exit_code=exit_code)
 
 


### PR DESCRIPTION
The exception will not show any effective quotes in the command.
This uses shlex.quote() to print a more accurate description of
the command that failed.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
