### PR TITLE
spread tests: minor performance improvements

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -35,7 +35,7 @@ backends:
     location: computeengine/us-east1-b
     systems:
       - ubuntu-16.04-64:
-          workers: 8
+          workers: 12
           image: ubuntu-1604-64
       - ubuntu-18.04-64:
           workers: 18
@@ -124,7 +124,6 @@ prepare: |
   apt-get install -y snapd
 
   if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ] || [ "$SPREAD_SYSTEM" = "ubuntu-18.04-64" ]; then
-      snap install --classic --beta multipass
       # Remove lxd and lxd-client deb packages as our implementation (pylxd) does not
       # nicely handle the snap and deb being installed at the same time.
       apt-get remove --purge --yes lxd lxd-client

--- a/tests/spread/build-providers/multipass-basic/task.yaml
+++ b/tests/spread/build-providers/multipass-basic/task.yaml
@@ -5,6 +5,8 @@ environment:
   SNAP_DIR: ../snaps/make-hello
 
 prepare: |
+  snap list multipass || snap install --classic --beta multipass
+
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "$SNAP_DIR/snap/snapcraft.yaml"

--- a/tests/spread/build-providers/multipass-error-handling/task.yaml
+++ b/tests/spread/build-providers/multipass-error-handling/task.yaml
@@ -5,6 +5,8 @@ environment:
   SNAP_DIR: ../snaps/exit1
 
 prepare: |
+  snap list multipass || snap install --classic --beta multipass
+
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "$SNAP_DIR/snap/snapcraft.yaml"

--- a/tests/spread/tools/restore.sh
+++ b/tests/spread/tools/restore.sh
@@ -11,7 +11,7 @@ for snap in $snaps; do
 			# Do not or cannot remove these
 			;;
 		*)
-			snap remove "$snap"
+			snap remove --purge "$snap"
 			;;
 	esac
 done


### PR DESCRIPTION
- Only install multipass for the tests that need it (they are manual).
- --purge on snap removals to avoid snapshotting.
- More workers for 16.04 on GCE (8->12).

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
