### PR TITLE
spread: fix unbound variable error

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -44,7 +44,7 @@ backends:
     type: adhoc
     allocate: |
       echo "Allocating ad-hoc $SPREAD_SYSTEM"
-      if [ -z "${ADT_ARTIFACTS}" ]; then
+      if [ -z "${ADT_ARTIFACTS:-}" ]; then
         FATAL "adhoc only works inside autopkgtest"
         exit 1
       fi


### PR DESCRIPTION
After accidentally running spread's autopkgtest, an error occurred with
unbound variables.
```
...
Allocating ad-hoc ubuntu-16.04-amd64
/bin/bash: line 18: ADT_ARTIFACTS: unbound variable
...
```

Spread sets -u, which will causes incorrect behavior when checking
against an unset variable:
```
$ set +u
$ if [ -z "${unsetvariable}" ]; then echo "empty"; fi
empty

$ set -u
$ if [ -z "${unsetvariable}" ]; then echo "empty"; fi
bash: unsetvariable: unbound variable
```

Fix it by checking if set.

```
$ setvariable=set
$ if [ -z "${setvariable:-}" ]; then echo "empty"; fi
$ if [ -z "${unsetvariable:-}" ]; then echo "empty"; fi
empty
```

Simply do the same for ADT_ARTIFACTS, and allow the check to happen as
originally intended:
```
2019-08-22 17:34:40 Allocating autopkgtest:ubuntu-16.04-amd64...
2019-08-22 17:34:40 Cannot allocate autopkgtest:ubuntu-16.04-s390x:
adhoc only works inside autopkgtest
```
Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
