### PR TITLE
tests: change default spread provider to lxd outside of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,7 @@ jobs:
       if: repo = "snapcore/snapcraft" or env(SPREAD_GOOGLE_KEY) IS present
       script:
         - cp "$TRAVIS_BUILD_DIR/snaps-cache/snapcraft-pr$TRAVIS_PULL_REQUEST.snap" .
-        - ./runtests.sh spread
+        - ./runtests.sh spread "google:"
     - stage: integration
       name: store
       addons:


### PR DESCRIPTION
Minor refactoring and cleanup for runtests script to make it easier
to follow and remove some of the cruft.

Modify travis config to specify google: for spread.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
