### PR TITLE
schema: build-base support for the snapd type

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -859,11 +859,12 @@
         {
             "anyOf": [
                 {
-                    "usage": "type: base (without a base)",
+                    "usage": "type: <base|snapd> (without a base)",
                     "properties": {
                         "type": {
                             "enum": [
-                                "base"
+                                "base",
+                                "snapd"
                             ]
                         }
                     },
@@ -883,14 +884,13 @@
                     ]
                 },
                 {
-                    "usage": "base: <base> and type: <app|gadget|kernel|snapd> (without a build-base)",
+                    "usage": "base: <base> and type: <app|gadget|kernel> (without a build-base)",
                     "properties": {
                         "type": {
                             "enum": [
                                 "app",
                                 "gadget",
-                                "kernel",
-                                "snapd"
+                                "kernel"
                             ]
                         }
                     },

--- a/snapcraft/cli/_command.py
+++ b/snapcraft/cli/_command.py
@@ -66,6 +66,8 @@ class SnapcraftProjectCommand(click.Command):
         # Building a base is not legacy.
         elif project.info.type == "base":
             return False
+        elif project.info.build_base is not None:
+            return False
         # A project with no base set is legacy.
         elif project.info.base is None:
             return True

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -303,14 +303,14 @@ class ValidTypesTest(ValidationBaseTest):
     def test_valid_types(self):
         data = self.data.copy()
         data["type"] = self.type_
-        if self.type_ == "base":
+        if self.type_ in ("base", "snapd"):
             data.pop("base")
         Validator(data).validate()
 
 
 _BASE_TYPE_MSG = (
-    "must be one of 'base: <base> and type: <app|gadget|kernel|snapd> (without a build-base)' "
-    "or 'type: base (without a base)'"
+    "must be one of 'base: <base> and type: <app|gadget|kernel> (without a build-base)' "
+    "or 'type: <base|snapd> (without a base)'"
 )
 _TYPE_ENUM_TMPL = (
     "The 'type' property does not match the required schema: '{}' is not one of "


### PR DESCRIPTION
Enabled building these two snap types using the build-base keyword.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
