### PR TITLE
remote-build: error when --user is required

### DIFF
--- a/snapcraft/cli/remote.py
+++ b/snapcraft/cli/remote.py
@@ -141,15 +141,15 @@ def remote_build(
         remote_info["provider"] = provider
         remote_info.save()
 
+    # TODO: change login strategy after launchpad infrastructure is ready (LP #1827679)
+    lp = LaunchpadClient(project=project, build_id=build_id, user=user)
+    lp.login()
+
     # Pull/update sources for project.
     worktree_dir = os.path.join(remote_dir, "worktree")
     wt = WorkTree(worktree_dir, project, package_all_sources=package_all_sources)
     repo_dir = wt.prepare_repository()
-
-    # TODO: change login strategy after launchpad infrastructure is ready (LP #1827679)
-    lp = LaunchpadClient(project, build_id)
-    lp.login(user)
-    url = lp.push_source_tree(user, repo_dir)
+    url = lp.push_source_tree(repo_dir)
 
     if status:
         # Show build status


### PR DESCRIPTION
When initializing LaunchpadClient, lookup user information from
snapcraft config.  If not present, and user not passed in, raise
error to inform user --user is required. I effectively broke
this behavior in 4253354cf3f995da19f1a568ffcaaa3a1c3359d3 because
this was done in login(), but not consistent with push_source_tree().

- Rename self.user -> self._user for consistency.

- Modify login() and push_source_tree() to use saved username.

- Move launchpad init up before worktree preparation so it fails
  soonest if --user was required.

- Shuffle config handling bits into _load_snapcraft_config() and
  _update_snapcraft_config().

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
