### PR TITLE
travis: use apt addon to prevent apt update issues in CLA-check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,12 @@ jobs:
     # CLA check, only in pull requests, not coming from the bot.
     - stage: static
       name:  CLA check
+      addons:
+        apt:
+          packages:
+            - git
+            - python-launchpadlib
       if: type = pull_request AND sender != snappy-m-o
-      install:
-        - sudo apt update && sudo apt install -y git python-launchpadlib
       git:
         depth: false
       script:


### PR DESCRIPTION
The CLA check has been failing regularly during apt updates,
with "Hash sum mismatch".  Instead of installing the apt packages
manually, rely on the apt addon like the rest of the stages.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
