### PR TITLE
internal: unknown apt packages aren't installed

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -443,6 +443,8 @@ class Ubuntu(BaseRepo):
     @classmethod
     def is_package_installed(cls, package_name):
         with apt.Cache() as apt_cache:
+            if package_name not in apt_cache:
+                return False
             return apt_cache[package_name].installed
 
     @classmethod


### PR DESCRIPTION
The `is_package_installed()` function was assuming the package was known to APT. There are cases where this is not true, e.g. `lxd` isn't currently available in Debian.

Rather than having to explicitly `check build_package_is_valid()` first, just return False from `is_package_installed()`. It's almost certainly the answer you want.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
