### PR TITLE
spread tests: install package marker into ament index

### DIFF
--- a/tests/spread/plugins/colcon/snaps/colcon-talker-listener/snap/snapcraft.yaml
+++ b/tests/spread/plugins/colcon/snaps/colcon-talker-listener/snap/snapcraft.yaml
@@ -11,6 +11,8 @@ apps:
   colcon-talker-listener:
     command: opt/ros/dashing/bin/ros2 launch listener_py talk_and_listen.launch.py
     plugs: [network, network-bind]
+    environment:
+      PYTHONUNBUFFERED: 1
 
   ros2:
     command: opt/ros/dashing/bin/ros2

--- a/tests/spread/plugins/colcon/snaps/colcon-talker-listener/src/listener_py/setup.py
+++ b/tests/spread/plugins/colcon/snaps/colcon-talker-listener/src/listener_py/setup.py
@@ -13,6 +13,10 @@ setup(
             os.path.join("share", package_name, "launch"),
             [os.path.join("launch", "talk_and_listen.launch.py")],
         ),
+        (
+            os.path.join("share", "ament_index", "resource_index", "packages"),
+            [os.path.join("resource", package_name)],
+        ),
     ],
     install_requires=["setuptools"],
     entry_points={"console_scripts": ["listener = listener:main"]},


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

A breaking change was recently made to upstream colcon that stopped doing this on behalf of the developers, expecting them to do it for themselves.