### PR TITLE
dirs: check for existence of required data directories

### DIFF
--- a/snapcraft/internal/dirs.py
+++ b/snapcraft/internal/dirs.py
@@ -109,4 +109,12 @@ def setup_dirs() -> None:
         common.set_keyringsdir(os.path.join(data_dir, "keyrings"))
 
     else:
-        raise snapcraft.internal.errors.SnapcraftDataDirectoryMissingError()
+        # Make sure required data directories exist in the default locations.
+        # Plugins and legacy snapcraft directory are not required.
+        for d in [
+            common.get_schemadir(),
+            common.get_extensionsdir(),
+            common.get_keyringsdir(),
+        ]:
+            if not os.path.exists(d):
+                raise snapcraft.internal.errors.SnapcraftDataDirectoryMissingError()


### PR DESCRIPTION
My previous commit 27e56863c576c3f0e5c4a5b15d093ca1619730d7 added
a check to ensure the data dirs were set.  This was done with the
incorrect assumption that one of those paths must occur, and did
not take into account the default values.  The defaults are used
within the development environment when installing snapcraft with pip.

Instead of raising exception, first check for the required schema,
extensions, and keyrings directories. Plugins and legacy snapcraft
directories are not required.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
