### PR TITLE
schema: build-base support for the kernel type

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -859,11 +859,12 @@
         {
             "anyOf": [
                 {
-                    "usage": "type: <base|snapd> (without a base)",
+                    "usage": "type: <base|kernel|snapd> (without a base)",
                     "properties": {
                         "type": {
                             "enum": [
                                 "base",
+                                "kernel",
                                 "snapd"
                             ]
                         }
@@ -884,13 +885,12 @@
                     ]
                 },
                 {
-                    "usage": "base: <base> and type: <app|gadget|kernel> (without a build-base)",
+                    "usage": "base: <base> and type: <app|gadget> (without a build-base)",
                     "properties": {
                         "type": {
                             "enum": [
                                 "app",
-                                "gadget",
-                                "kernel"
+                                "gadget"
                             ]
                         }
                     },

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -223,11 +223,7 @@ class Config:
             self.build_tools.add("git")
 
         # Always add the base for building for non os and base snaps
-        if project.info.base is None and project.info.type in (
-            "app",
-            "gadget",
-            "kernel",
-        ):
+        if project.info.base is None and project.info.type in ("app", "gadget"):
             raise SnapcraftEnvironmentError(
                 "A base is required for snaps of type {!r}.".format(project.info.type)
             )

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -303,14 +303,14 @@ class ValidTypesTest(ValidationBaseTest):
     def test_valid_types(self):
         data = self.data.copy()
         data["type"] = self.type_
-        if self.type_ in ("base", "snapd"):
+        if self.type_ in ("base", "kernel", "snapd"):
             data.pop("base")
         Validator(data).validate()
 
 
 _BASE_TYPE_MSG = (
-    "must be one of 'base: <base> and type: <app|gadget|kernel> (without a build-base)' "
-    "or 'type: <base|snapd> (without a base)'"
+    "must be one of 'base: <base> and type: <app|gadget> (without a build-base)' "
+    "or 'type: <base|kernel|snapd> (without a base)'"
 )
 _TYPE_ENUM_TMPL = (
     "The 'type' property does not match the required schema: '{}' is not one of "


### PR DESCRIPTION
Enabled building these snap types using the build-base keyword.
It has been determined that until hooks are implemented for the
kernel type, that these snaps should not require a base.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
