### PR TITLE
spread tests: update gnome extension tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -298,7 +298,6 @@ suites:
 # Extensions tests
  tests/spread/extensions/:
    summary: tests of snapcraft's extensions
-   systems: [ubuntu-18.04*]
 
 # Legacy tests
  tests/spread/legacy/:

--- a/tests/spread/extensions/gnome-3-28/task.yaml
+++ b/tests/spread/extensions/gnome-3-28/task.yaml
@@ -1,4 +1,14 @@
-summary: Build and run a basic gnome snap
+summary: Build and run a basic gnome snap using extensions
+
+# The content snap required for the test to succeed is only
+# available on a subset of all the architectures this testbed
+# can run on.
+systems:
+  - ubuntu-18.04
+  - ubuntu-18.04-amd64
+  - ubuntu-18.04-arm64
+  - ubuntu-18.04-i386
+  - ubuntu-18.04-armhf
 
 environment:
   SNAP_DIR: ../snaps/glib-hello

--- a/tests/spread/extensions/snaps/glib-hello/snap/snapcraft.yaml
+++ b/tests/spread/extensions/snaps/glib-hello/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: This is a basic gnome snap (*only* uses glib). It simply prints a h
 
 grade: devel
 confinement: strict
-base: core18
 
 apps:
   glib-hello:


### PR DESCRIPTION
Restrict to architectures the content snap is available on.
Clean up summary and use the base logic setup implemented in all the tests.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
