### PR TITLE
extensions: create the gnome-platform directory

### DIFF
--- a/extensions/desktop/gnome/Makefile
+++ b/extensions/desktop/gnome/Makefile
@@ -2,9 +2,10 @@
 
 SRC_DIR ?= .
 
-DATA_DIR	:= $(DESTDIR)/data-dir
-BIN_DIR		:= $(DESTDIR)/snap/command-chain
-LIB_DIR		:= $(DESTDIR)/lib
+PLATFORM_DIR := $(DESTDIR)/gnome-platform
+DATA_DIR     := $(DESTDIR)/data-dir
+BIN_DIR      := $(DESTDIR)/snap/command-chain
+LIB_DIR	     := $(DESTDIR)/lib
 DEST_LAUNCHER	:= desktop-launch
 BINDTEXTDOMAIN	:= bindtextdomain.so
 
@@ -17,13 +18,14 @@ clean:
 
 $(DEST_LAUNCHER):
 	@cat $(SRC_DIR)/init >> $(DEST_LAUNCHER)
-	# tail -n +2 to remove the shebang
+# tail -n +2 to remove the shebang
 	@tail -n +2 $(SRC_DIR)/desktop-exports >> $(DEST_LAUNCHER)
 	@tail -n +2 $(SRC_DIR)/launcher-specific >> $(DEST_LAUNCHER)
 	@tail -n +2 $(SRC_DIR)/mark-and-exec >> $(DEST_LAUNCHER)
 	gcc -Wall -O2 -o $(BINDTEXTDOMAIN) -fPIC -shared $(SRC_DIR)/../src/bindtextdomain.c -ldl
-		
+
 install: $(DEST_LAUNCHER)
+	install -d $(PLATFORM_DIR)
 	install -d $(DATA_DIR)
 	install -d $(DATA_DIR)/icons
 	install -d $(DATA_DIR)/sounds


### PR DESCRIPTION
This is the target directory for the gnome "platform" content interface plug.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
