### PR TITLE
extensions: rename extension classes to known names

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/_utils.py
+++ b/snapcraft/internal/project_loader/_extensions/_utils.py
@@ -98,12 +98,8 @@ def find_extension(extension_name: str) -> Type[Extension]:
     except ImportError:
         raise errors.ExtensionNotFoundError(extension_name)
 
-    # This may throw an AttributeError, but that would be programmer error of whoever
-    # is hacking on extensions.
-    extension_class_name = "{}Extension".format(
-        extension_name.capitalize().replace("-", "_")
-    )
-    return getattr(extension_module, extension_class_name)
+    # The extension module requires a class named ExtensionImpl.
+    return getattr(extension_module, "ExtensionImpl")
 
 
 def supported_extension_names() -> List[str]:

--- a/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
@@ -20,11 +20,10 @@ from typing import Any, Dict, Tuple
 
 from ._extension import Extension
 
-
 _PLATFORM_SNAP = dict(core18="gnome-3-28-1804")
 
 
-class Gnome_3_28Extension(Extension):
+class ExtensionImpl(Extension):
     """The Gnome extension.
 
     This extension is to be used by applications that require GTK+.

--- a/tests/unit/commands/test_extensions.py
+++ b/tests/unit/commands/test_extensions.py
@@ -183,7 +183,7 @@ class ExtensionsCommandTest(CommandBaseTestCase):
 
 
 def _test1_extension_fixture():
-    class Test1Extension(Extension):
+    class ExtensionImpl(Extension):
         """This is the Test1 extension.
 
         It does stuff.
@@ -203,11 +203,11 @@ def _test1_extension_fixture():
             self.part_snippet = {"after": ["extension-part"]}
             self.parts = {"extension-part": {"plugin": "nil"}}
 
-    return fixture_setup.FakeExtension("test1", Test1Extension)
+    return fixture_setup.FakeExtension("test1", ExtensionImpl)
 
 
 def _test2_extension_fixture():
-    class Test2Extension(Extension):
+    class ExtensionImpl(Extension):
         """This is the Test2 extension.
 
         It does other stuff.
@@ -226,11 +226,11 @@ def _test2_extension_fixture():
             self.part_snippet = {"after": ["extension-part"]}
             self.parts = {"extension-part": {"plugin": "nil"}}
 
-    return fixture_setup.FakeExtension("test2", Test2Extension)
+    return fixture_setup.FakeExtension("test2", ExtensionImpl)
 
 
 def _test3_extension_fixture():
-    class Test3Extension(Extension):
+    class ExtensionImpl(Extension):
         @staticmethod
         def get_supported_bases() -> Tuple[str, ...]:
             return ("core16", "core18")
@@ -243,11 +243,11 @@ def _test3_extension_fixture():
             super().__init__(extension_name=extension_name, yaml_data=yaml_data)
             self.parts = {"extension-part": {"plugin": "nil"}}
 
-    return fixture_setup.FakeExtension("test3", Test3Extension)
+    return fixture_setup.FakeExtension("test3", ExtensionImpl)
 
 
 def _test4_extension_fixture():
-    class Test4Extension(Extension):
+    class ExtensionImpl(Extension):
         @staticmethod
         def get_supported_bases() -> Tuple[str, ...]:
             return ("core16", "core18")
@@ -260,4 +260,4 @@ def _test4_extension_fixture():
             super().__init__(extension_name=extension_name, yaml_data=yaml_data)
             self.parts = {"extension-part": {"plugin": "nil"}}
 
-    return fixture_setup.FakeExtension("_test4", Test4Extension)
+    return fixture_setup.FakeExtension("_test4", ExtensionImpl)

--- a/tests/unit/project_loader/extensions/test_gnome_3_28.py
+++ b/tests/unit/project_loader/extensions/test_gnome_3_28.py
@@ -16,14 +16,14 @@
 
 from testtools.matchers import Equals
 
-from snapcraft.internal.project_loader._extensions.gnome_3_28 import Gnome_3_28Extension
+from snapcraft.internal.project_loader._extensions.gnome_3_28 import ExtensionImpl
 
 from .. import ProjectLoaderBaseTest
 
 
-class Gnome_3_28_ExtensionTest(ProjectLoaderBaseTest):
+class ExtensionTest(ProjectLoaderBaseTest):
     def test_extension(self):
-        gnome_extension = Gnome_3_28Extension(
+        gnome_extension = ExtensionImpl(
             extension_name="gnome-3.28", yaml_data=dict(base="core18")
         )
 
@@ -90,10 +90,9 @@ class Gnome_3_28_ExtensionTest(ProjectLoaderBaseTest):
         )
 
     def test_supported_bases(self):
-        self.assertThat(Gnome_3_28Extension.get_supported_bases(), Equals(("core18",)))
+        self.assertThat(ExtensionImpl.get_supported_bases(), Equals(("core18",)))
 
     def test_supported_confinement(self):
         self.assertThat(
-            Gnome_3_28Extension.get_supported_confinement(),
-            Equals(("strict", "devmode")),
+            ExtensionImpl.get_supported_confinement(), Equals(("strict", "devmode"))
         )

--- a/tests/unit/project_loader/extensions/test_utils.py
+++ b/tests/unit/project_loader/extensions/test_utils.py
@@ -656,7 +656,7 @@ class InvalidExtensionTest(ExtensionTestBase):
 
 
 def _environment_extension_fixture():
-    class EnvironmentExtension(Extension):
+    class ExtensionImpl(Extension):
         @staticmethod
         def get_supported_bases() -> Tuple[str, ...]:
             return ("core18",)
@@ -672,11 +672,11 @@ def _environment_extension_fixture():
             self.part_snippet = {"after": ["extension-part"]}
             self.parts = {"extension-part": {"plugin": "nil"}}
 
-    return fixture_setup.FakeExtension("environment", EnvironmentExtension)
+    return fixture_setup.FakeExtension("environment", ExtensionImpl)
 
 
 def _plug_extension_fixture():
-    class PlugExtension(Extension):
+    class ExtensionImpl(Extension):
         @staticmethod
         def get_supported_bases() -> Tuple[str, ...]:
             return ("core18",)
@@ -689,11 +689,11 @@ def _plug_extension_fixture():
             super().__init__(extension_name=extension_name, yaml_data=yaml_data)
             self.app_snippet = {"plugs": ["test-plug"]}
 
-    return fixture_setup.FakeExtension("plug", PlugExtension)
+    return fixture_setup.FakeExtension("plug", ExtensionImpl)
 
 
 def _plug2_extension_fixture():
-    class Plug2Extension(Extension):
+    class ExtensionImpl(Extension):
         @staticmethod
         def get_supported_bases() -> Tuple[str, ...]:
             return ("core18",)
@@ -706,11 +706,11 @@ def _plug2_extension_fixture():
             super().__init__(extension_name=extension_name, yaml_data=yaml_data)
             self.app_snippet = {"plugs": ["test-plug2"]}
 
-    return fixture_setup.FakeExtension("plug2", Plug2Extension)
+    return fixture_setup.FakeExtension("plug2", ExtensionImpl)
 
 
 def _daemon_extension_fixture():
-    class DaemonExtension(Extension):
+    class ExtensionImpl(Extension):
         @staticmethod
         def get_supported_bases() -> Tuple[str, ...]:
             return ("core18",)
@@ -723,11 +723,11 @@ def _daemon_extension_fixture():
             super().__init__(extension_name=extension_name, yaml_data=yaml_data)
             self.app_snippet = {"daemon": "simple"}
 
-    return fixture_setup.FakeExtension("daemon", DaemonExtension)
+    return fixture_setup.FakeExtension("daemon", ExtensionImpl)
 
 
 def _adopt_info_extension_fixture():
-    class AdoptExtension(Extension):
+    class ExtensionImpl(Extension):
         @staticmethod
         def get_supported_bases() -> Tuple[str, ...]:
             return ("core18",)
@@ -740,11 +740,11 @@ def _adopt_info_extension_fixture():
             super().__init__(extension_name=extension_name, yaml_data=yaml_data)
             self.root_snippet = {"adopt-info": "some-part-name"}
 
-    return fixture_setup.FakeExtension("adopt", AdoptExtension)
+    return fixture_setup.FakeExtension("adopt", ExtensionImpl)
 
 
 def _invalid_extension_fixture():
-    class InvalidExtension(Extension):
+    class ExtensionImpl(Extension):
         @staticmethod
         def get_supported_bases() -> Tuple[str, ...]:
             return ("core18",)
@@ -757,4 +757,4 @@ def _invalid_extension_fixture():
             super().__init__(extension_name=extension_name, yaml_data=yaml_data)
             self.app_snippet = {"unsupported-key": "value"}
 
-    return fixture_setup.FakeExtension("invalid", InvalidExtension)
+    return fixture_setup.FakeExtension("invalid", ExtensionImpl)


### PR DESCRIPTION
This simplifies the logic and removes the need to parse
strings to get the implementation of the Extension class.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
