### PR TITLE
extensions: improve docsting (used in the cli)

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
@@ -24,9 +24,28 @@ _PLATFORM_SNAP = dict(core18="gnome-3-28-1804")
 
 
 class ExtensionImpl(Extension):
-    """The Gnome extension.
+    """This extension eases creation of snaps that integrate with GNOME 3.28
 
-    This extension is to be used by applications that require GTK+.
+    At build time it ensures the right build dependencies are setup and for
+    the runtime it ensures the application is run in an environment catered
+    for GNOME applications.
+
+    It configures each application with the following plugs:
+
+    \b
+    - GTK3 Themes.
+    - Common Icon Themes.
+    - Common Sound Themes
+    - The GNOME runtime libraries and utilities corresponding to 3.28.
+
+    For easier desktop integration, it also configures each application
+    entry with these additional plugs:
+
+    \b
+    - desktop (https://snapcraft.io/docs/desktop-interface)
+    - desktop-legacy (https://snapcraft.io/docs/desktop-legacy-interface)
+    - wayland (https://snapcraft.io/docs/wayland-interface)
+    - x11 (https://snapcraft.io/docs/x11-interface)
     """
 
     @staticmethod


### PR DESCRIPTION
Provide a better explanation of what the goal of this extension is and
what it does when used, providing a much better output for
`snapcraft extension gnome-3-28`.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
