### PR TITLE
manifest: sort package and snap lists for consistency

### DIFF
--- a/snapcraft/internal/meta/_manifest.py
+++ b/snapcraft/internal/meta/_manifest.py
@@ -50,17 +50,17 @@ def annotate_snapcraft(project: "Project", data: Dict[str, Any]) -> Dict[str, An
         manifest["image-info"] = image_info_dict
 
     global_state = GlobalState.load(filepath=project._get_global_state_file_path())
-    manifest["build-packages"] = global_state.get_build_packages()
-    manifest["build-snaps"] = global_state.get_build_snaps()
+    manifest["build-packages"] = sorted(global_state.get_build_packages())
+    manifest["build-snaps"] = sorted(global_state.get_build_snaps())
 
     for part in data["parts"]:
         state_dir = os.path.join(project.parts_dir, part, "state")
         pull_state = get_state(state_dir, steps.PULL)
-        manifest["parts"][part]["build-packages"] = pull_state.assets.get(
-            "build-packages", []
+        manifest["parts"][part]["build-packages"] = sorted(
+            pull_state.assets.get("build-packages", [])
         )
-        manifest["parts"][part]["stage-packages"] = pull_state.assets.get(
-            "stage-packages", []
+        manifest["parts"][part]["stage-packages"] = sorted(
+            pull_state.assets.get("stage-packages", [])
         )
         source_details = pull_state.assets.get("source-details", {})
         if source_details:

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -696,8 +696,8 @@ class PluginHandler:
 
         return {
             "uname": uname,
-            "installed-packages": repo.Repo.get_installed_packages(),
-            "installed-snaps": repo.snaps.get_installed_snaps(),
+            "installed-packages": sorted(repo.Repo.get_installed_packages()),
+            "installed-snaps": sorted(repo.snaps.get_installed_snaps()),
         }
 
     def clean_build(self):


### PR DESCRIPTION
Sort `build-packages`, `stage-packages`, `installed-packages`,
`installed-snaps`,  and `build-snaps`.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
