### PR TITLE
incorporate content provider snaps in dependency resolution

### DIFF
--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -87,9 +87,9 @@ def run_output(cmd: List[str], **kwargs) -> str:
         return output.decode("latin-1", "surrogateescape").strip()
 
 
-def get_core_path(base):
-    """Returns the path to the core base snap."""
-    return os.path.join(os.path.sep, "snap", base, "current")
+def get_installed_snap_path(snap_name: str):
+    """Returns the path to the currently installed snap."""
+    return os.path.join(os.path.sep, "snap", snap_name, "current")
 
 
 def format_snap_name(snap, *, allow_empty_version: bool = False) -> str:

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -22,13 +22,14 @@ from snapcraft import config
 from snapcraft.internal import (
     common,
     errors,
-    meta,
     pluginhandler,
     project_loader,
     repo,
     states,
     steps,
 )
+from snapcraft.internal.meta._snap_packaging import create_snap_packaging
+
 from ._status_cache import StatusCache
 
 
@@ -308,7 +309,7 @@ class _Executor:
 
     def _create_meta(self, step: steps.Step, part_names: Sequence[str]) -> None:
         if step == steps.PRIME and part_names == self.config.part_names:
-            meta.create_snap_packaging(self.config)
+            create_snap_packaging(self.config)
 
     def _handle_dirty(self, part, step, dirty_report, cli_config):
         dirty_action = cli_config.get_outdated_step_action()

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -65,6 +65,9 @@ def execute(
             "The repo backend is not returning the list of installed packages"
         )
 
+    content_snaps = project_config.project._get_content_snaps()
+    required_snaps = project_config.build_snaps | content_snaps
+
     if common.is_process_container():
         installed_snaps = []  # type: List[str]
         logger.warning(
@@ -73,12 +76,12 @@ def execute(
                 "is running inside docker or podman container: {}.\n"
                 "Please ensure the environment is properly setup before continuing.\n"
                 "Ignore this message if the appropriate measures have already been taken".format(
-                    ", ".join(project_config.build_snaps)
+                    ", ".join(required_snaps)
                 )
             )
         )
     else:
-        installed_snaps = repo.snaps.install_snaps(project_config.build_snaps)
+        installed_snaps = repo.snaps.install_snaps(required_snaps)
 
     try:
         global_state = states.GlobalState.load(

--- a/snapcraft/internal/meta/__init__.py
+++ b/snapcraft/internal/meta/__init__.py
@@ -13,5 +13,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-from snapcraft.internal.meta._snap_packaging import create_snap_packaging  # noqa

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -366,13 +366,8 @@ class _SnapPackaging:
         self._snap_meta.validate()
         _check_passthrough_duplicates(self._original_snapcraft_yaml)
 
-        common.env = self._project_config.snap_env()
-
-        try:
-            package_snap_path = os.path.join(self.meta_dir, "snap.yaml")
-            snap_yaml = self._snap_meta.write_snap_yaml(path=package_snap_path)
-        finally:
-            common.reset_env()
+        package_snap_path = os.path.join(self.meta_dir, "snap.yaml")
+        self._snap_meta.write_snap_yaml(path=package_snap_path)
 
     def setup_assets(self) -> None:
         # We do _setup_from_setup first since it is legacy and let the
@@ -426,6 +421,8 @@ class _SnapPackaging:
             meta_runner = os.path.join(
                 self._prime_dir, "snap", "command-chain", "snapcraft-runner"
             )
+
+            common.env = self._project_config.snap_env()
             assembled_env = common.assemble_env()
             assembled_env = assembled_env.replace(self._prime_dir, "$SNAP")
             assembled_env = self._install_path_pattern.sub("$SNAP", assembled_env)
@@ -441,6 +438,8 @@ class _SnapPackaging:
                     )
                     print('exec "$@"', file=f)
                 os.chmod(meta_runner, 0o755)
+
+            common.reset_env()
             command_chain.append(os.path.relpath(meta_runner, self._prime_dir))
 
         return command_chain

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -415,6 +415,7 @@ class _SnapPackaging:
         if (
             self._config_data["confinement"] == "classic"
             or not self._is_host_compatible_with_base
+            or not self._snap_meta.apps
         ):
             assembled_env = None
         else:

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import copy
-import collections
 import contextlib
 import itertools
 import logging
@@ -34,34 +33,10 @@ from snapcraft.internal import common, errors, project_loader
 from snapcraft.internal.project_loader import _config
 from snapcraft.extractors import _metadata
 from snapcraft.internal.deprecations import handle_deprecation_notice
-from snapcraft.internal.meta import (
-    application,
-    errors as meta_errors,
-    _manifest,
-    _version,
-)
-
+from snapcraft.internal.meta import errors as meta_errors, _manifest, _version
+from snapcraft.internal.meta.snap import Snap
 
 logger = logging.getLogger(__name__)
-
-
-_MANDATORY_PACKAGE_KEYS = ["name", "version", "summary", "description"]
-
-_OPTIONAL_PACKAGE_KEYS = [
-    "architectures",
-    "assumes",
-    "confinement",
-    "environment",
-    "epoch",
-    "grade",
-    "hooks",
-    "layout",
-    "license",
-    "plugs",
-    "slots",
-    "title",
-    "type",
-]
 
 
 # From snapd's snap/validate.go, appContentWhitelist, with a slight modification: don't
@@ -93,13 +68,12 @@ def create_snap_packaging(project_config: _config.Config) -> str:
     # Update default values
     _update_yaml_with_defaults(project_config.data, project_config.validator.schema)
 
-    # Ensure the YAML contains all required keywords before continuing to
-    # use it to generate the snap.yaml.
-    _ensure_required_keywords(project_config.data)
-
     packaging = _SnapPackaging(project_config, extracted_metadata)
     packaging.cleanup()
     packaging.validate_common_ids()
+    packaging.finalize_snap_meta_commands()
+    packaging.finalize_snap_meta_command_chains()
+    packaging.finalize_snap_meta_version()
     packaging.write_snap_yaml()
     packaging.setup_assets()
     packaging.generate_hook_wrappers()
@@ -298,22 +272,35 @@ def _update_yaml_with_defaults(config_data, schema):
             app["adapter"] = "full"
 
 
-def _ensure_required_keywords(config_data):
-    # Verify that all mandatory keys have been satisfied
-    missing_keys = []  # type: List[str]
-    for key in _MANDATORY_PACKAGE_KEYS:
-        if key not in config_data:
-            missing_keys.append(key)
+def _check_passthrough_duplicates_section(yaml: Dict[str, Any]) -> None:
+    # Any value already in the original dictionary must
+    # not be specified in passthrough at the same time.
+    if "passthrough" not in yaml:
+        return
 
-    if missing_keys:
-        raise meta_errors.MissingSnapcraftYamlKeysError(keys=missing_keys)
+    passthrough = yaml["passthrough"]
+    duplicates = list(yaml.keys() & passthrough.keys())
+    if duplicates:
+        raise meta_errors.AmbiguousPassthroughKeyError(duplicates)
+
+
+def _check_passthrough_duplicates(snap_yaml: Dict[str, Any]) -> None:
+    """Check passthrough properties for duplicate keys.
+
+    Passthrough options may override assumed/extracted configuration,
+    so this check must be done on the original YAML."""
+
+    for section in ["apps", "hooks"]:
+        if section not in snap_yaml:
+            continue
+
+        for value in snap_yaml[section].values():
+            _check_passthrough_duplicates_section(value)
+
+    _check_passthrough_duplicates_section(snap_yaml)
 
 
 class _SnapPackaging:
-    @property
-    def meta_dir(self) -> str:
-        return self._meta_dir
-
     def __init__(
         self,
         project_config: _config.Config,
@@ -324,54 +311,66 @@ class _SnapPackaging:
         self._snapcraft_yaml_path = project_config.project.info.snapcraft_yaml_file_path
         self._prime_dir = project_config.project.prime_dir
         self._parts_dir = project_config.project.parts_dir
+
         self._arch_triplet = project_config.project.arch_triplet
         self._global_state_file = project_config.project._get_global_state_file_path()
         self._is_host_compatible_with_base = (
             project_config.project.is_host_compatible_with_base
         )
-        self._meta_dir = os.path.join(self._prime_dir, "meta")
+        self.meta_dir = os.path.join(self._prime_dir, "meta")
+        self.meta_gui_dir = os.path.join(self.meta_dir, "gui")
         self._config_data = project_config.data.copy()
         self._original_snapcraft_yaml = project_config.project.info.get_raw_snapcraft()
-        self._command_chain = None  # type: List[str]
 
         self._install_path_pattern = re.compile(
             r"{}/[a-z0-9][a-z0-9+-]*/install".format(re.escape(self._parts_dir))
         )
 
-        self._apps = self._get_apps()
+        os.makedirs(self.meta_dir, exist_ok=True)
 
-        os.makedirs(self._meta_dir, exist_ok=True)
-
-    def _get_apps(self) -> Dict[str, application.Application]:
-        apps = dict()
-        for app_name, app_properties in self._config_data.get("apps", dict()).items():
-            apps[app_name] = application.Application(
-                app_name=app_name,
-                app_properties=app_properties,
-                base=self._project_config.project.info.base,
-                prime_dir=self._prime_dir,
-            )
-
-        return apps
+        # TODO: create_snap_packaging managles config data, so we create
+        # a new private instance of snap_meta.  Longer term, this needs
+        # to converge with project's snap_meta.
+        self._snap_meta = Snap.from_dict(project_config.data)
 
     def cleanup(self):
-        gui_dir = os.path.join(self.meta_dir, "gui")
-        if os.path.exists(gui_dir):
-            for f in os.listdir(gui_dir):
+        if os.path.exists(self.meta_gui_dir):
+            for f in os.listdir(self.meta_gui_dir):
                 if os.path.splitext(f)[1] == ".desktop":
-                    os.remove(os.path.join(gui_dir, f))
+                    os.remove(os.path.join(self.meta_gui_dir, f))
 
-    def write_snap_yaml(self) -> str:
+    def finalize_snap_meta_commands(self) -> None:
+        for app_name, app in self._snap_meta.apps.items():
+            app.prime_commands(
+                base=self._project_config.project.info.base, prime_dir=self._prime_dir
+            )
+
+    def finalize_snap_meta_command_chains(self) -> None:
+        prepend_command_chain = self._generate_command_chain()
+        for app_name, app in self._snap_meta.apps.items():
+            app.prepend_command_chain = prepend_command_chain
+
+    def finalize_snap_meta_version(self) -> None:
+        # Reparse the version, the order should stick.
+        version = self._config_data["version"]
+        version_script = self._config_data.get("version-script")
+
+        if version_script:
+            # Deprecation warning for use of version-script.
+            handle_deprecation_notice("dn10")
+
+        self._snap_meta.version = _version.get_version(version, version_script)
+
+    def write_snap_yaml(self) -> None:
+        # Ensure snap meta is valid before writing.
+        self._snap_meta.validate()
+        _check_passthrough_duplicates(self._original_snapcraft_yaml)
+
         common.env = self._project_config.snap_env()
 
         try:
             package_snap_path = os.path.join(self.meta_dir, "snap.yaml")
-            snap_yaml = self._compose_snap_yaml()
-
-            with open(package_snap_path, "w") as f:
-                yaml_utils.dump(snap_yaml, stream=f)
-
-            return snap_yaml
+            snap_yaml = self._snap_meta.write_snap_yaml(path=package_snap_path)
         finally:
             common.reset_env()
 
@@ -380,8 +379,6 @@ class _SnapPackaging:
         # declarative items take over.
         self._setup_gui()
 
-        gui_dir = os.path.join(self.meta_dir, "gui")
-
         # Extracted metadata (e.g. from the AppStream) can override the
         # icon location.
         if self._extracted_metadata:
@@ -389,19 +386,22 @@ class _SnapPackaging:
         else:
             icon_path = None
 
-        for app in self._apps:
-            self._apps[app].generate_command_wrappers()
-            self._apps[app].generate_desktop_file(
-                snap_name=self._project_config.project.info.name,
-                gui_dir=gui_dir,
+        snap_name = self._project_config.project.info.name
+        for app_name, app in self._snap_meta.apps.items():
+            app.write_command_wrappers(prime_dir=self._prime_dir)
+            app.write_application_desktop_file(
+                snap_name=snap_name,
+                prime_dir=self._prime_dir,
+                gui_dir=self.meta_gui_dir,
                 icon_path=icon_path,
             )
+            app.validate_command_chain_executables(self._prime_dir)
 
         if "icon" in self._config_data:
             # TODO: use developer.ubuntu.com once it has updated documentation.
             icon_ext = self._config_data["icon"].split(os.path.extsep)[-1]
-            icon_path = os.path.join(gui_dir, "icon.{}".format(icon_ext))
-            os.makedirs(gui_dir, exist_ok=True)
+            icon_path = os.path.join(self.meta_gui_dir, "icon.{}".format(icon_ext))
+            os.makedirs(self.meta_gui_dir, exist_ok=True)
             if os.path.exists(icon_path):
                 os.unlink(icon_path)
             file_utils.link_or_copy(self._config_data["icon"], icon_path)
@@ -414,9 +414,6 @@ class _SnapPackaging:
             )
 
     def _generate_command_chain(self) -> List[str]:
-        if self._command_chain is not None:
-            return self._command_chain
-
         command_chain = list()
         # Classic confinement or building on a host that does not match the target base
         # means we cannot setup an environment that will work.
@@ -446,8 +443,6 @@ class _SnapPackaging:
                 os.chmod(meta_runner, 0o755)
             command_chain.append(os.path.relpath(meta_runner, self._prime_dir))
 
-        self._command_chain = command_chain
-
         return command_chain
 
     def _record_manifest_and_source_snapcraft_yaml(self):
@@ -474,7 +469,7 @@ class _SnapPackaging:
         prime_snap_dir = os.path.join(self._prime_dir, "snap")
 
         snap_dir_iter = itertools.product([prime_snap_dir], ["hooks"])
-        meta_dir_iter = itertools.product([self._meta_dir], ["hooks", "gui"])
+        meta_dir_iter = itertools.product([self.meta_dir], ["hooks", "gui"])
 
         for origin in itertools.chain(snap_dir_iter, meta_dir_iter):
             src_dir = os.path.join(snap_assets_dir, origin[1])
@@ -493,7 +488,7 @@ class _SnapPackaging:
                     # Ensure that the hook is executable in meta/hooks, this is a moot
                     # point considering the prior link_or_copy call, but is technically
                     # correct and allows for this operation to take place only once.
-                    if origin[0] == self._meta_dir and origin[1] == "hooks":
+                    if origin[0] == self.meta_dir and origin[1] == "hooks":
                         _prepare_hook(destination)
 
         self._record_manifest_and_source_snapcraft_yaml()
@@ -524,66 +519,11 @@ class _SnapPackaging:
         handle_deprecation_notice("dn3")
 
         gui_src = os.path.join(setup_dir, "gui")
-        gui_dst = os.path.join(self.meta_dir, "gui")
         if os.path.exists(gui_src):
             for f in os.listdir(gui_src):
-                if not os.path.exists(gui_dst):
-                    os.mkdir(gui_dst)
-                shutil.copy2(os.path.join(gui_src, f), gui_dst)
-
-    def _compose_snap_yaml(self):
-        """Create a new dictionary from config_data to obtain snap.yaml.
-
-        Missing key exceptions will be raised if config_data does not contain
-        all the _MANDATORY_PACKAGE_KEYS, config_data can be validated against
-        the snapcraft schema.
-
-        Keys that are in _OPTIONAL_PACKAGE_KEYS are ignored if not there.
-        """
-        snap_yaml = collections.OrderedDict()
-
-        for key_name in _MANDATORY_PACKAGE_KEYS:
-            snap_yaml[key_name] = self._config_data[key_name]
-
-        # If the base is core in snapcraft.yaml we do not set it in
-        # snap.yaml LP: #1819290
-        if "base" in self._config_data and self._config_data["base"] != "core":
-            snap_yaml["base"] = self._config_data["base"]
-
-        # Reparse the version, the order should stick.
-        version = self._config_data["version"]
-        version_script = self._config_data.get("version-script")
-
-        if version_script:
-            # Deprecation warning for use of version-script.
-            handle_deprecation_notice("dn10")
-
-        snap_yaml["version"] = _version.get_version(version, version_script)
-
-        for key_name in _OPTIONAL_PACKAGE_KEYS:
-            if key_name in self._config_data:
-                snap_yaml[key_name] = self._config_data[key_name]
-
-        if self._apps:
-            # This really should be environment (PATH and LD_LIBRARY_PATH),
-            # anything else should be provided by an extension.
-            command_chain = self._generate_command_chain()
-            apps = {
-                k: v.get_yaml(prepend_command_chain=command_chain)
-                for k, v in self._apps.items()
-            }
-            snap_yaml["apps"] = apps
-
-            assumes = _determine_assumes(apps)
-            if assumes:
-                # Sorting for consistent results (order doesn't matter)
-                snap_yaml["assumes"] = sorted(
-                    set(snap_yaml.get("assumes", list())) | assumes
-                )
-
-        self._process_passthrough_properties(snap_yaml)
-
-        return snap_yaml
+                if not os.path.exists(self.meta_gui_dir):
+                    os.mkdir(self.meta_gui_dir)
+                shutil.copy2(os.path.join(gui_src, f), self.meta_gui_dir)
 
     def _write_wrap_exe(self, wrapexec, wrappath, shebang=None, args=None, cwd=None):
         if args:
@@ -642,47 +582,6 @@ class _SnapPackaging:
 
         return os.path.relpath(wrappath, self._prime_dir)
 
-    def _process_passthrough_properties(self, snap_yaml: Dict[str, Any]) -> None:
-        passthrough_applied = False
-
-        for section in ["apps", "hooks"]:
-            if section in snap_yaml:
-                for name, value in snap_yaml[section].items():
-                    if self._apply_passthrough(
-                        value,
-                        value.pop("passthrough", {}),
-                        self._original_snapcraft_yaml[section][name],
-                    ):
-                        passthrough_applied = True
-
-        if self._apply_passthrough(
-            snap_yaml,
-            self._config_data.get("passthrough", {}),
-            self._original_snapcraft_yaml,
-        ):
-            passthrough_applied = True
-
-        if passthrough_applied:
-            logger.warn(
-                "The 'passthrough' property is being used to "
-                "propagate experimental properties to snap.yaml "
-                "that have not been validated."
-            )
-
-    def _apply_passthrough(
-        self,
-        section: Dict[str, Any],
-        passthrough: Dict[str, Any],
-        original: collections.OrderedDict,
-    ) -> bool:
-        # Any value already in the original dictionary must
-        # not be specified in passthrough at the same time.
-        duplicates = list(original.keys() & passthrough.keys())
-        if duplicates:
-            raise meta_errors.AmbiguousPassthroughKeyError(duplicates)
-        section.update(passthrough)
-        return bool(passthrough)
-
     def validate_common_ids(self) -> None:
         if (
             not self._extracted_metadata
@@ -701,19 +600,6 @@ class _SnapPackaging:
                         common_id=app_common_id, app=app
                     )
                 )
-
-
-def _determine_assumes(apps_data: Dict[str, Any]) -> Set[str]:
-    # Order doesn't really matter, but we don't want duplicates, so use a set
-    assumes = set()
-
-    # Check to see if command-chain is in any apps entry.
-    for app_properties in apps_data.values():
-        if "command-chain" in app_properties:
-            assumes.add("command-chain")
-            break
-
-    return assumes
 
 
 def _find_bin(binary, basedir):

--- a/snapcraft/internal/meta/application.py
+++ b/snapcraft/internal/meta/application.py
@@ -15,14 +15,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+
 from copy import deepcopy
-from typing import Any, Dict, Optional, Sequence
+from snapcraft import yaml_utils
+from typing import Any, Dict, List, Optional, Sequence  # noqa: F401
 
 from . import errors
 from ._utils import _executable_is_valid
 from .command import Command
 from .desktop import DesktopFile
-from snapcraft import yaml_utils
 
 
 _COMMAND_ENTRIES = ["command", "stop-command"]
@@ -36,116 +37,168 @@ class Application:
         self,
         *,
         app_name: str,
-        app_properties: Dict[str, Any],
-        base: str,
-        prime_dir: str
+        app_properties: Dict[str, Any] = None,
+        adapter: str = None,
+        desktop: str = None,
+        command_chain: List[str] = None,
+        prepend_command_chain: List[str] = None,
+        passthrough: Dict[str, Any] = None,
+        commands: Dict[str, Command] = None
     ) -> None:
         """Initialize an application entry.
 
-        :param str app_name: the name of the application.
-        :param dict app_properties: the snapcraft.yaml application entry under
-                                    apps.
-        :param str prime_dir: directory containing the final assets to a snap.
-        :param str base:
+        TODO: Eliminate use of app_properties.
         """
         self._app_name = app_name
-        self._app_properties = deepcopy(app_properties)
-        self._base = base
-        self._prime_dir = prime_dir
 
-        # App Properties that should not make it to snap.yaml
-        self._adapter = self._app_properties.pop("adapter", None)
-        self._desktop_file = self._app_properties.pop("desktop", None)
+        self._app_properties = app_properties
+        if self._app_properties is None:
+            self._app_properties: Dict[str, Any] = dict()
 
-        self._commands = self._get_commands()
-        self._verify_paths()
+        self.adapter = adapter
+        self.desktop = desktop
 
-    def _is_adapter(self, adapter: str) -> bool:
-        if self._adapter is None:
-            return False
+        self.command_chain = command_chain
+        if self.command_chain is None:
+            self.command_chain: List[str] = list()
 
-        return self._adapter == adapter
+        self.prepend_command_chain = prepend_command_chain
+        if self.prepend_command_chain is None:
+            self.prepend_command_chain: List[str] = list()
 
-    def _can_use_wrapper(self) -> bool:
+        self.commands = commands
+        if self.commands is None:
+            self.commands: Dict[str, Command] = dict()
+
+        self.passthrough = passthrough
+        if self.passthrough is None:
+            self.passthrough: Dict[str, Any] = dict()
+
+    @property
+    def app_name(self) -> str:
+        """Read-only to ensure consistency with Snap dictionary mappings."""
+        return self._app_name
+
+    def can_use_wrapper(self, base: str) -> bool:
         """Return if an wrapper should be allowed for app entries."""
         # Force use of no wrappers when command-chain is set.
-        if "command-chain" in self._app_properties:
+        if self.command_chain:
             return False
 
         # We only allow wrappers for core and core18.
-        if self._base not in _MASSAGED_BASES:
+        if not self._massage_commands(base=base):
             return False
 
         # Now that command-chain and bases have been checked for,
         # check if the none adapter has been forced.
-        if self._is_adapter("none"):
+        if self.adapter == "none":
             return False
 
         return True
 
-    def _get_commands(self) -> Dict[str, Command]:
-        can_use_wrapper = self._can_use_wrapper()
-        commands = dict()
-        for c in _COMMAND_ENTRIES:
-            if c in self._app_properties:
-                commands[c] = Command(
-                    app_name=self._app_name,
-                    command_name=c,
-                    command=self._app_properties[c],
-                    prime_dir=self._prime_dir,
-                    can_use_wrapper=can_use_wrapper,
-                    massage_command=self._base in _MASSAGED_BASES,
-                )
+    def _massage_commands(self, *, base: str) -> bool:
+        return base in _MASSAGED_BASES
 
-        return commands
+    def prime_commands(self, *, base: str, prime_dir: str) -> None:
+        can_use_wrapper = self.can_use_wrapper(base)
+        massage_command = self._massage_commands(base=base)
+        for command in self.commands.values():
+            command.prime_command(
+                can_use_wrapper=can_use_wrapper,
+                massage_command=massage_command,
+                prime_dir=prime_dir,
+            )
 
-    def _verify_paths(self) -> None:
-        for item in self._app_properties.get("command-chain", []):
-            executable_path = os.path.join(self._prime_dir, item)
+    def write_command_wrappers(self, *, prime_dir: str) -> None:
+        for command in self.commands.values():
+            command.write_wrapper(prime_dir=prime_dir)
 
-            # command-chain entries must always be relative to the root of
-            # the snap, i.e. PATH is not used.
-            if not _executable_is_valid(executable_path):
-                raise errors.InvalidCommandChainError(item, self._app_name)
-
-    def generate_desktop_file(
-        self, *, snap_name: str, gui_dir: str, icon_path: Optional[str] = None
+    def write_application_desktop_file(
+        self, snap_name: str, prime_dir: str, gui_dir: str, icon_path: Optional[str]
     ) -> None:
-        if self._desktop_file is None:
+        if not self.desktop:
             return
 
         desktop_file = DesktopFile(
             snap_name=snap_name,
-            app_name=self._app_name,
-            filename=self._desktop_file,
-            prime_dir=self._prime_dir,
+            app_name=self.app_name,
+            filename=self.desktop,
+            prime_dir=prime_dir,
         )
+
         desktop_file.write(gui_dir=gui_dir, icon_path=icon_path)
 
-    def generate_command_wrappers(self) -> None:
-        for command in self._commands.values():
-            command.generate_wrapper()
+    def validate_command_chain_executables(self, prime_dir: str) -> None:
+        for item in self.command_chain:
+            executable_path = os.path.join(prime_dir, item)
 
-    def _fix_sockets(self) -> None:
+            # command-chain entries must always be relative to the root of
+            # the snap, i.e. PATH is not used.
+            if not _executable_is_valid(executable_path):
+                raise errors.InvalidCommandChainError(item, self.app_name)
+
+    def validate(self) -> None:
+        """Validate application, raising exception on error."""
+
+        # No checks here (yet).
+        return
+
+    @classmethod
+    def from_dict(cls, *, app_dict: Dict[str, Any], app_name: str) -> "Application":
+        """Create application from dictionary."""
+
+        app_dict = deepcopy(app_dict)
+        app = Application(
+            app_name=app_name,
+            app_properties=app_dict,
+            adapter=app_dict.get("adapter", None),
+            desktop=app_dict.get("desktop", None),
+            command_chain=app_dict.get("command-chain", None),
+            passthrough=app_dict.get("passthrough", None),
+        )
+
+        # Populate commands from app_properties.
+        for command_name in _COMMAND_ENTRIES:
+            if command_name not in app_dict:
+                continue
+
+            app.commands[command_name] = Command(
+                app_name=app_name,
+                command_name=command_name,
+                command=app_dict[command_name],
+            )
+
+        return app
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Returns and ordered dictonary with the transformed app entry."""
+
+        app_dict = deepcopy(self._app_properties)
+
+        for command_name, command in self.commands.items():
+            app_dict[command_name] = command.command
+
+        if self.prepend_command_chain or self.command_chain:
+            app_dict["command-chain"] = self.prepend_command_chain + self.command_chain
+
         # Adjust socket values to formats snap.yaml accepts
-        sockets = self._app_properties.get("sockets", dict())
+        sockets = app_dict.get("sockets", dict())
         for socket in sockets.values():
             mode = socket.get("socket-mode")
             if mode is not None:
                 socket["socket-mode"] = yaml_utils.OctInt(mode)
 
-    def get_yaml(self, *, prepend_command_chain: Sequence[str]) -> Dict[str, Any]:
-        """Returns and ordered dictonary with the transformed app entry."""
-        for command_entry, command in self._commands.items():
-            self._app_properties[command_entry] = command.get_command()
+        # Strip keys.
+        for key in ["adapter", "desktop"]:
+            if key in app_dict:
+                app_dict.pop(key)
 
-        if "command-chain" in self._app_properties or prepend_command_chain:
-            self._app_properties[
-                "command-chain"
-            ] = prepend_command_chain + self._app_properties.get(
-                "command-chain", list()
-            )
+        # Apply passthrough keys.
+        app_dict.update(self.passthrough)
+        return app_dict
 
-        self._fix_sockets()
+    def __repr__(self) -> str:
+        return repr(self.__dict__)
 
-        return self._app_properties
+    def __str__(self) -> str:
+        return str(self.__dict__)

--- a/snapcraft/internal/meta/errors.py
+++ b/snapcraft/internal/meta/errors.py
@@ -177,3 +177,24 @@ class ShebangNotFoundError(Exception):
 
 class ShebangInRoot(Exception):
     """Internal exception for when a shebang is part of the root."""
+
+
+class SlotValidationError(errors.SnapcraftError):
+    fmt = "failed to validate slot={slot_name}: {message}"
+
+    def __init__(self, *, slot_name: str, message: str) -> None:
+        super().__init__(slot_name=slot_name, message=message)
+
+
+class PlugValidationError(errors.SnapcraftError):
+    fmt = "failed to validate plug={plug_name}: {message}"
+
+    def __init__(self, *, plug_name: str, message: str) -> None:
+        super().__init__(plug_name=plug_name, message=message)
+
+
+class HookValidationError(errors.SnapcraftError):
+    fmt = "failed to validate hook={hook_name}: {message}"
+
+    def __init__(self, *, hook_name: str, message: str) -> None:
+        super().__init__(hook_name=hook_name, message=message)

--- a/snapcraft/internal/meta/hooks.py
+++ b/snapcraft/internal/meta/hooks.py
@@ -1,0 +1,79 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+
+from copy import deepcopy
+from snapcraft.internal.meta.errors import HookValidationError
+from typing import Any, Dict
+
+
+class Hook:
+    """Representation of a generic snap hook."""
+
+    def __init__(self, *, hook_name: str) -> None:
+        self._hook_name = hook_name
+        self._hook_properties: Dict[str, Any] = dict()
+        self.passthrough: Dict[str, Any] = dict()
+
+    @property
+    def hook_name(self) -> str:
+        """Read-only to ensure consistency with Snap dictionary mappings."""
+
+        return self._hook_name
+
+    def _validate_name(self) -> None:
+        """Validate hook name."""
+
+        if not re.match("^[a-z](?:-?[a-z0-9])*$", self.hook_name):
+            raise HookValidationError(
+                hook_name=self.hook_name,
+                message="{!r} is not a valid hook name. Hook names consist of lower-case alphanumeric characters and hyphens. They cannot start or end with a hyphen.".format(
+                    self.hook_name
+                ),
+            )
+
+    def validate(self) -> None:
+        """Validate hook, raising exception if invalid."""
+
+        self._validate_name()
+
+    @classmethod
+    def from_dict(cls, hook_dict: Dict[str, Any], hook_name: str) -> "Hook":
+        """Create hook from dictionary."""
+
+        hook = Hook(hook_name=hook_name)
+        hook._hook_properties = deepcopy(hook_dict)
+
+        if "passthrough" in hook._hook_properties:
+            hook.passthrough = hook._hook_properties.pop("passthrough")
+
+        return hook
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Create dictionary from hook."""
+
+        hook_dict = deepcopy(self._hook_properties)
+
+        # Apply passthrough keys.
+        hook_dict.update(self.passthrough)
+        return hook_dict
+
+    def __repr__(self) -> str:
+        return repr(self.__dict__)
+
+    def __str__(self) -> str:
+        return str(self.__dict__)

--- a/snapcraft/internal/meta/plugs.py
+++ b/snapcraft/internal/meta/plugs.py
@@ -1,0 +1,162 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+from collections import OrderedDict
+from copy import deepcopy
+from snapcraft.internal.meta.errors import PlugValidationError
+from typing import Any, Dict, Optional, Type
+
+logger = logging.getLogger(__name__)
+
+
+class Plug:
+    """Generic plug."""
+
+    def __init__(self, *, plug_name: str) -> None:
+        self._plug_name = plug_name
+        self._plug_dict: Dict[str, Any] = dict()
+
+    @property
+    def plug_name(self) -> str:
+        """Read-only to ensure consistency with Snap dictionary mappings."""
+
+        return self._plug_name
+
+    def validate(self) -> None:
+        """Validate plug, raising an exception on failure."""
+
+        if not self._plug_dict:
+            raise PlugValidationError(
+                plug_name=self.plug_name, message="plug has no defined attributes"
+            )
+
+        if "interface" not in self._plug_dict:
+            raise PlugValidationError(
+                plug_name=self.plug_name, message="plug has no defined interface"
+            )
+
+    @classmethod
+    def from_dict(cls, *, plug_dict: Dict[str, Any], plug_name: str) -> "Plug":
+        """Create plug from dictionary."""
+
+        interface = plug_dict.get("interface", None)
+        if interface in PLUG_MAPPINGS:
+            plug_class = PLUG_MAPPINGS.get(interface)
+            return plug_class.from_dict(plug_dict=plug_dict, plug_name=plug_name)
+
+        # Handle the general case.
+        plug = Plug(plug_name=plug_name)
+        plug._plug_dict = plug_dict
+        return plug
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Create dictionary from plug."""
+
+        return OrderedDict(deepcopy(self._plug_dict))
+
+    def __repr__(self) -> str:
+        return repr(self.__dict__)
+
+    def __str__(self) -> str:
+        return str(self.__dict__)
+
+
+class ContentPlug(Plug):
+    """Representation of a snap content plug."""
+
+    def __init__(
+        self,
+        *,
+        plug_name: str,
+        content: Optional[str] = None,
+        default_provider: Optional[str] = None,
+        target: str,
+    ) -> None:
+        super().__init__(plug_name=plug_name)
+
+        self._content = content
+        self._default_provider = default_provider
+        self.target = target
+
+    @property
+    def interface(self) -> str:
+        return "content"
+
+    @property
+    def content(self) -> str:
+        if self._content:
+            return self._content
+
+        # Defaults to plug_name if unspecified.
+        return self.plug_name
+
+    @content.setter
+    def content(self, content) -> None:
+        self._content = content
+
+    @property
+    def provider(self) -> str:
+        if ":" in self._default_provider:
+            return self._default_provider.split(":")[0]
+
+        return self._default_provider
+
+    def validate(self) -> None:
+        if not self.target:
+            raise PlugValidationError(
+                plug_name=self.plug_name,
+                message="`target` is required for content slot",
+            )
+
+    @classmethod
+    def from_dict(cls, *, plug_dict: Dict[str, str], plug_name: str) -> "ContentPlug":
+        interface = plug_dict.get("interface")
+        if interface != "content":
+            raise PlugValidationError(
+                plug_name=plug_name,
+                message="`interface={}` is invalid for content slot".format(interface),
+            )
+
+        if "target" not in plug_dict:
+            raise PlugValidationError(
+                plug_name=plug_name, message="`target` is required for content slot"
+            )
+
+        return ContentPlug(
+            plug_name=plug_name,
+            content=plug_dict.get("content", None),
+            target=plug_dict.get("target"),
+            default_provider=plug_dict.get("default-provider", None),
+        )
+
+    def to_dict(self) -> Dict[str, str]:
+        props = [("interface", self.interface)]
+
+        # Only include content if set explicitly.
+        if self._content:
+            props.append(("content", self.content))
+
+        props.append(("target", self.target))
+
+        if self.provider:
+            props.append(("default-provider", self.provider))
+
+        return OrderedDict(props)
+
+
+PLUG_MAPPINGS: Dict[str, Type[Plug]] = dict(content=ContentPlug)

--- a/snapcraft/internal/meta/slots.py
+++ b/snapcraft/internal/meta/slots.py
@@ -1,0 +1,248 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+import re
+
+from collections import OrderedDict
+from copy import deepcopy
+from snapcraft.internal.meta.errors import SlotValidationError
+from typing import Any, Dict, List, Set, Optional, Tuple, Type
+
+logger = logging.getLogger(__name__)
+
+
+class Slot:
+    """Representation of a generic snap slot."""
+
+    def __init__(self, *, slot_name: str) -> None:
+        self._slot_name = slot_name
+        self._slot_dict: Dict[str, Any] = dict()
+
+    @property
+    def slot_name(self) -> str:
+        """Read-only to ensure consistency with Snap dictionary mappings."""
+        return self._slot_name
+
+    def validate(self) -> None:
+        """Validate slot, raising exception on error."""
+
+        if not self._slot_dict:
+            raise SlotValidationError(
+                slot_name=self.slot_name, message="slot has no defined attributes"
+            )
+
+        if "interface" not in self._slot_dict:
+            raise SlotValidationError(
+                slot_name=self.slot_name, message="slot has no defined interface"
+            )
+
+    @classmethod
+    def from_dict(cls, *, slot_dict: Dict[str, Any], slot_name: str) -> "Slot":
+        """Return applicable Slot instance from dictionary properties."""
+
+        # If we explicitly support the type, use it instead.
+        interface = slot_dict.get("interface")
+
+        if interface in SLOT_MAPPINGS:
+            slot_class = SLOT_MAPPINGS.get(interface)
+            return slot_class.from_dict(slot_dict=slot_dict, slot_name=slot_name)
+
+        # Handle the general case.
+        slot = Slot(slot_name=slot_name)
+        slot._slot_dict = slot_dict
+        return slot
+
+    def to_dict(self) -> Dict[str, Any]:
+        return OrderedDict(deepcopy(self._slot_dict))
+
+    def __repr__(self) -> str:
+        return repr(self.__dict__)
+
+    def __str__(self) -> str:
+        return str(self.__dict__)
+
+
+class ContentSlot(Slot):
+    """Representation of a snap content slot."""
+
+    def __init__(
+        self,
+        *,
+        slot_name: str,
+        content: Optional[str] = None,
+        read: List[str] = None,
+        write: List[str] = None,
+        use_source_key: bool = True
+    ) -> None:
+        super().__init__(slot_name=slot_name)
+
+        if read is None:
+            self.read: List[str] = list()
+        else:
+            self.read = read
+
+        if write is None:
+            self.write: List[str] = list()
+        else:
+            self.write = write
+
+        self.use_source_key = use_source_key
+        self._content = content
+
+    @property
+    def content(self) -> str:
+        if self._content:
+            return self._content
+
+        # Defaults to slot_name if unspecified.
+        return self.slot_name
+
+    @content.setter
+    def content(self, content) -> None:
+        self._content = content
+
+    @property
+    def interface(self) -> str:
+        return "content"
+
+    def validate(self) -> None:
+        """Validate content slot, raising exception on error."""
+
+        if not self.read and not self.write:
+            raise SlotValidationError(
+                slot_name=self.slot_name,
+                message="`read` or `write` is required for slot",
+            )
+
+    def get_content_dirs(self, installed_path: str) -> Set[str]:
+        content_dirs: Set[str] = set()
+
+        for path in self.read + self.write:
+            # Strip leading "$SNAP" and "/".
+            path = re.sub(r"^\$SNAP", "", path)
+            path = re.sub(r"^/", "", path)
+            path = re.sub(r"^./", "", path)
+            content_dirs.add(os.path.join(installed_path, path))
+
+        return content_dirs
+
+    @classmethod
+    def from_dict(cls, *, slot_dict: Dict[str, Any], slot_name: str) -> "ContentSlot":
+        slot = ContentSlot(slot_name=slot_name)
+
+        # Content directories may be nested under "source",
+        # but they cannot be in both places according to snapd:
+        # https://github.com/snapcore/snapd/blob/master/interfaces/builtin/content.go#L81
+        if "source" in slot_dict:
+            source_data = slot_dict["source"]
+            slot.use_source_key = True
+        else:
+            source_data = slot_dict
+            slot.use_source_key = False
+
+        if "read" in source_data:
+            slot.read = source_data["read"]
+
+        if "write" in source_data:
+            slot.write = source_data["write"]
+
+        return slot
+
+    def to_dict(self) -> Dict[str, Any]:
+        props: List[Tuple[str, Any]] = [("interface", self.interface)]
+
+        # Only include content if set explicitly.
+        if self._content:
+            props.append(("content", self.content))
+
+        if self.use_source_key:
+            source = dict()
+            if self.read:
+                source["read"] = self.read
+            if self.write:
+                source["write"] = self.write
+            props.append(("source", source))
+        else:
+            if self.read:
+                props.append(("read", self.read))
+            if self.write:
+                props.append(("write", self.write))
+
+        return OrderedDict(props)
+
+
+class DbusSlot(Slot):
+    """Representation of a snap dbus slot."""
+
+    def __init__(self, *, slot_name: str, bus: str, name: str) -> None:
+        super().__init__(slot_name=slot_name)
+
+        self.bus = bus
+        self.name = name
+
+    @property
+    def interface(self) -> str:
+        return "dbus"
+
+    @classmethod
+    def from_dict(cls, *, slot_dict: Dict[str, Any], slot_name: str) -> "DbusSlot":
+        """Instantiate DbusSlot from dict."""
+
+        if slot_dict.get("interface") != "dbus":
+            raise SlotValidationError(
+                slot_name=slot_name, message="invalid interface for DbusSlot"
+            )
+
+        if "bus" not in slot_dict:
+            raise SlotValidationError(
+                slot_name=slot_name, message="bus required for DbusSlot"
+            )
+
+        if "name" not in slot_dict:
+            raise SlotValidationError(
+                slot_name=slot_name, message="name required for DbusSlot"
+            )
+
+        return DbusSlot(
+            slot_name=slot_name, bus=slot_dict["bus"], name=slot_dict["name"]
+        )
+
+    def validate(self) -> None:
+        """Validate dbus slot. Raise exception if invalid."""
+
+        if not self.bus:
+            raise SlotValidationError(
+                slot_name=self.slot_name,
+                message="valid `bus` is required for dbus slot",
+            )
+
+        if not self.name:
+            raise SlotValidationError(
+                slot_name=self.slot_name,
+                message="valid `name` is required for dbus slot",
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return dict of dbus slot."""
+
+        return OrderedDict(
+            [("interface", self.interface), ("bus", self.bus), ("name", self.name)]
+        )
+
+
+SLOT_MAPPINGS: Dict[str, Type[Slot]] = dict(content=ContentSlot, dbus=DbusSlot)

--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -1,0 +1,285 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+
+from collections import OrderedDict
+from copy import deepcopy
+from snapcraft.internal import common
+from snapcraft.internal.meta import errors
+from snapcraft.internal.meta.application import Application
+from snapcraft.internal.meta.hooks import Hook
+from snapcraft.internal.meta.plugs import ContentPlug, Plug
+from snapcraft.internal.meta.slots import ContentSlot, Slot
+
+from snapcraft import yaml_utils
+from typing import Dict, Set, Sequence, List, Any
+
+logger = logging.getLogger(__name__)
+
+
+_MANDATORY_PACKAGE_KEYS = ["name", "version", "summary", "description"]
+
+_OPTIONAL_PACKAGE_KEYS = [
+    "apps",
+    "architectures",
+    "assumes",
+    "base",
+    "confinement",
+    "environment",
+    "epoch",
+    "grade",
+    "hooks",
+    "layout",
+    "license",
+    "plugs",
+    "slots",
+    "title",
+    "type",
+]
+
+
+class Snap:
+    """Representation of snap meta object, writes snap.yaml."""
+
+    def __init__(self) -> None:
+        self.adopt_info: str = None
+        self.base: str = None
+        self.name: str = None
+        self.version: str = None
+        self.summary: str = None
+        self.description: str = None
+        self.architectures: Sequence[str] = list()
+        self.assumes: Set[str] = set()
+        self.confinement: str = None
+        self.environment: Dict[str, Any] = dict()
+        self.epoch: Any = None
+        self.grade: str = None
+        self.license: str = None
+        self.title: str = None
+        self.type: str = None
+        self.plugs: Dict[str, Plug] = dict()
+        self.slots: Dict[str, Slot] = dict()
+        self.apps: Dict[str, Application] = dict()
+        self.hooks: Dict[str, Hook] = dict()
+        self.passthrough: Dict[str, Any] = dict()
+        self.layout: Dict[str, Any] = dict()
+
+    @classmethod
+    def from_file(cls, snap_yaml_path: str) -> "Snap":
+        with open(snap_yaml_path, "r") as f:
+            snap_dict = yaml_utils.load(f)
+            return cls.from_dict(snap_dict=snap_dict)
+
+    @property
+    def is_passthrough_enabled(self) -> bool:
+        if self.passthrough:
+            return True
+
+        for app in self.apps.values():
+            if app.passthrough:
+                return True
+
+        for hook in self.hooks.values():
+            if hook.passthrough:
+                return True
+
+        return False
+
+    def get_content_plugs(self) -> List[ContentPlug]:
+        """Get list of content plugs."""
+        return [plug for plug in self.plugs.values() if isinstance(plug, ContentPlug)]
+
+    def get_content_slots(self) -> List[ContentSlot]:
+        """Get list of content slots."""
+        return [slot for slot in self.slots.values() if isinstance(slot, ContentSlot)]
+
+    def get_provider_content_directories(self) -> Set[str]:
+        """Get provider content directories from installed snaps."""
+        provider_dirs: Set[str] = set()
+
+        for plug in self.get_content_plugs():
+            # Get matching slot provider for plug.
+            provider = plug.provider
+            provider_path = common.get_core_path(provider)
+            yaml_path = os.path.join(provider_path, "meta", "snap.yaml")
+
+            snap = Snap.from_file(yaml_path)
+            for slot in snap.get_content_slots():
+                slot_installed_path = common.get_core_path(plug.provider)
+                provider_dirs |= slot.get_content_dirs(
+                    installed_path=slot_installed_path
+                )
+
+        return provider_dirs
+
+    def _validate_required_keys(self) -> None:
+        """Verify that all mandatory keys have been satisfied."""
+        missing_keys: List[str] = []
+        for key in _MANDATORY_PACKAGE_KEYS:
+            if key is "version" and self.adopt_info:
+                continue
+
+            if not self.__dict__[key]:
+                missing_keys.append(key)
+
+        if missing_keys:
+            raise errors.MissingSnapcraftYamlKeysError(keys=missing_keys)
+
+    def validate(self) -> None:
+        """Validate snap, raising exception on error."""
+        self._validate_required_keys()
+
+        for app in self.apps.values():
+            app.validate()
+
+        for hook in self.hooks.values():
+            hook.validate()
+
+        for plug in self.plugs.values():
+            plug.validate()
+
+        for slot in self.slots.values():
+            slot.validate()
+
+        if self.is_passthrough_enabled:
+            logger.warn(
+                "The 'passthrough' property is being used to "
+                "propagate experimental properties to snap.yaml "
+                "that have not been validated."
+            )
+
+    def _ensure_command_chain_assumption(self) -> None:
+        """Ensure command-chain is in assumes (if used)."""
+        if "command-chain" in self.assumes:
+            return
+
+        for app in self.apps.values():
+            if app.command_chain:
+                self.assumes.add("command-chain")
+                return
+
+    @classmethod  # noqa: C901
+    def from_dict(cls, snap_dict: Dict[str, Any]) -> "Snap":
+        snap_dict = deepcopy(snap_dict)
+
+        snap = Snap()
+
+        if "passthrough" in snap_dict:
+            snap.passthrough = snap_dict.pop("passthrough")
+
+        for key in snap_dict:
+            if key == "plugs":
+                for plug_name, plug_dict in snap_dict[key].items():
+                    plug = Plug.from_dict(plug_dict=plug_dict, plug_name=plug_name)
+                    snap.plugs[plug_name] = plug
+            elif key == "slots":
+                for slot_name, slot_dict in snap_dict[key].items():
+                    slot = Slot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
+                    snap.slots[slot_name] = slot
+            elif key == "apps":
+                for app_name, app_dict in snap_dict[key].items():
+                    app = Application.from_dict(app_dict=app_dict, app_name=app_name)
+                    snap.apps[app_name] = app
+            elif key == "hooks":
+                for hook_name, hook_dict in snap_dict[key].items():
+                    hook = Hook.from_dict(hook_dict=hook_dict, hook_name=hook_name)
+                    snap.hooks[hook_name] = hook
+            elif key in _MANDATORY_PACKAGE_KEYS:
+                snap.__dict__[key] = snap_dict[key]
+            elif key in _OPTIONAL_PACKAGE_KEYS:
+                snap.__dict__[key] = snap_dict[key]
+            else:
+                logger.debug("ignoring or passing through unknown key: {}".format(key))
+                continue
+
+        if "adopt-info" in snap_dict:
+            snap.adopt_info = snap_dict["adopt-info"]
+
+        return snap
+
+    def to_dict(self):  # noqa: C901
+        snap_dict = OrderedDict()
+
+        # Ensure command-chain is in assumes, if required.
+        self._ensure_command_chain_assumption()
+
+        for key in _MANDATORY_PACKAGE_KEYS + _OPTIONAL_PACKAGE_KEYS:
+            # Skip unset fields.
+            if self.__dict__[key] is None:
+                continue
+
+            # Skip fields that are empty lists/dicts.
+            if (
+                key
+                in [
+                    "apps",
+                    "architectures",
+                    "assumes",
+                    "environment",
+                    "hooks",
+                    "layout",
+                    "plugs",
+                    "slots",
+                ]
+                and not self.__dict__[key]
+            ):
+                continue
+
+            # Sort where possible for consistency.
+            if key == "apps":
+                snap_dict[key] = dict()
+                for name, app in sorted(self.apps.items()):
+                    snap_dict[key][name] = app.to_dict()
+            elif key == "assumes":
+                snap_dict[key] = sorted(set(self.assumes))
+            elif key == "hooks":
+                snap_dict[key] = dict()
+                for name, hook in sorted(self.hooks.items()):
+                    snap_dict[key][name] = hook.to_dict()
+            elif key == "plugs":
+                snap_dict[key] = dict()
+                for name, plug in sorted(self.plugs.items()):
+                    snap_dict[key][name] = plug.to_dict()
+            elif key == "slots":
+                snap_dict[key] = dict()
+                for name, slot in sorted(self.slots.items()):
+                    snap_dict[key][name] = slot.to_dict()
+            else:
+                snap_dict[key] = deepcopy(self.__dict__[key])
+
+        # Apply passthrough keys.
+        snap_dict.update(deepcopy(self.passthrough))
+        return snap_dict
+
+    def write_snap_yaml(self, path: str) -> None:
+        """Write snap.yaml contents to specified path."""
+        snap_dict = self.to_dict()
+
+        # If the base is core in snapcraft.yaml we do not set it in
+        # snap.yaml LP: #1819290
+        if self.base == "core":
+            snap_dict.pop("base")
+
+        with open(path, "w") as f:
+            yaml_utils.dump(snap_dict, stream=f)
+
+    def __repr__(self) -> str:
+        return repr(self.__dict__)
+
+    def __str__(self) -> str:
+        return str(self.__dict__)

--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -115,12 +115,12 @@ class Snap:
         for plug in self.get_content_plugs():
             # Get matching slot provider for plug.
             provider = plug.provider
-            provider_path = common.get_core_path(provider)
+            provider_path = common.get_installed_snap_path(provider)
             yaml_path = os.path.join(provider_path, "meta", "snap.yaml")
 
             snap = Snap.from_file(yaml_path)
             for slot in snap.get_content_slots():
-                slot_installed_path = common.get_core_path(plug.provider)
+                slot_installed_path = common.get_installed_snap_path(plug.provider)
                 provider_dirs |= slot.get_content_dirs(
                     installed_path=slot_installed_path
                 )

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -24,7 +24,7 @@ import shutil
 import subprocess
 import sys
 from glob import glob, iglob
-from typing import cast, Dict, List, Set, Sequence
+from typing import cast, Dict, List, Set, Sequence, TYPE_CHECKING
 
 import snapcraft.extractors
 from snapcraft import file_utils, yaml_utils
@@ -40,6 +40,9 @@ from ._patchelf import PartPatcher
 from ._dirty_report import Dependency, DirtyReport  # noqa
 from ._outdated_report import OutdatedReport
 
+if TYPE_CHECKING:
+    from snapcraft.project import Project
+
 logger = logging.getLogger(__name__)
 
 
@@ -53,7 +56,7 @@ class PluginHandler:
         *,
         plugin,
         part_properties,
-        project_options,
+        project_options: "Project",
         part_schema,
         definitions_schema,
         stage_packages_repo,
@@ -63,11 +66,11 @@ class PluginHandler:
         confinement,
         snap_type,
         soname_cache
-    ):
+    ) -> None:
         self.valid = False
         self.plugin = plugin
         self._part_properties = _expand_part_properties(part_properties, part_schema)
-        self.stage_packages = []
+        self.stage_packages: List[str] = list()
         self._stage_packages_repo = stage_packages_repo
         self._grammar_processor = grammar_processor
         self._snap_base_path = snap_base_path
@@ -85,7 +88,7 @@ class PluginHandler:
         self._prime_state = None  # type: states.PrimeState
 
         self._project_options = project_options
-        self.deps = []
+        self.deps: List[str] = list()
 
         self.stagedir = project_options.stage_dir
         self.primedir = project_options.prime_dir
@@ -106,9 +109,9 @@ class PluginHandler:
         )
 
         # Scriptlet data is a dict of dicts for each step
-        self._scriptlet_metadata = collections.defaultdict(
-            snapcraft.extractors.ExtractedMetadata
-        )
+        self._scriptlet_metadata: Dict[
+            steps.Step, snapcraft.extractors.ExtractedMetadata
+        ] = collections.defaultdict(snapcraft.extractors.ExtractedMetadata)
         self._runner = Runner(
             part_properties=self._part_properties,
             sourcedir=self.plugin.sourcedir,

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -813,7 +813,7 @@ class PluginHandler:
     def _handle_elf(self, snap_files: Sequence[str]) -> Set[str]:
         elf_files = elf.get_elf_files(self.primedir, snap_files)
         all_dependencies = set()
-        core_path = common.get_core_path(self._base)
+        core_path = common.get_installed_snap_path(self._base)
 
         # Clear the cache of all libs that aren't already in the primedir
         self._soname_cache.reset_except_root(self.primedir)

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -26,6 +26,7 @@ from typing import Set  # noqa: F401
 from snapcraft import project, formatting_utils
 from snapcraft.internal import common, deprecations, repo, states, steps
 from snapcraft.internal.errors import SnapcraftEnvironmentError
+from snapcraft.internal.meta.snap import Snap
 from snapcraft.project._schema import Validator
 from ._parts_config import PartsConfig
 from ._extensions import apply_extensions
@@ -209,6 +210,11 @@ class Config:
         snapcraft_yaml = self._expand_filesets(snapcraft_yaml)
 
         self.data = self._expand_env(snapcraft_yaml)
+
+        self.data["architectures"] = _process_architectures(
+            self.data.get("architectures"), project.deb_arch
+        )
+
         self._ensure_no_duplicate_app_aliases()
 
         grammar_processor = grammar_processing.GlobalGrammarProcessor(
@@ -221,6 +227,10 @@ class Config:
         # If version: git is used we want to add "git" to build-packages
         if self.data.get("version") == "git":
             self.build_tools.add("git")
+
+        # XXX: Resetting snap_meta due to above mangling of data.
+        # Convergence to operating on snap_meta will remove this requirement...
+        project._snap_meta = Snap.from_dict(self.data)
 
         # Always add the base for building for non os and base snaps
         if project.info.base is None and project.info.type in ("app", "gadget"):
@@ -242,10 +252,6 @@ class Config:
             validator=self.validator,
             build_snaps=self.build_snaps,
             build_tools=self.build_tools,
-        )
-
-        self.data["architectures"] = _process_architectures(
-            self.data.get("architectures"), project.deb_arch
         )
 
     def _ensure_no_duplicate_app_aliases(self):

--- a/snapcraft/plugins/crystal.py
+++ b/snapcraft/plugins/crystal.py
@@ -104,6 +104,8 @@ class CrystalPlugin(snapcraft.BasePlugin):
             elf_dependencies_path = elf_file.load_dependencies(
                 root_path=self.installdir,
                 core_base_path=common.get_core_path(self.project.info.get_build_base()),
+                arch_triplet=self.project.arch_triplet,
+                content_dirs=self.project._get_provider_content_dirs(),
             )
             for elf_dependency_path in elf_dependencies_path:
                 lib_install_path = os.path.join(

--- a/snapcraft/plugins/crystal.py
+++ b/snapcraft/plugins/crystal.py
@@ -103,7 +103,9 @@ class CrystalPlugin(snapcraft.BasePlugin):
 
             elf_dependencies_path = elf_file.load_dependencies(
                 root_path=self.installdir,
-                core_base_path=common.get_core_path(self.project.info.get_build_base()),
+                core_base_path=common.get_installed_snap_path(
+                    self.project.info.get_build_base()
+                ),
                 arch_triplet=self.project.arch_triplet,
                 content_dirs=self.project._get_provider_content_dirs(),
             )

--- a/snapcraft/project/_project.py
+++ b/snapcraft/project/_project.py
@@ -18,6 +18,8 @@ import os
 from datetime import datetime
 
 from snapcraft.internal.deprecations import handle_deprecation_notice
+from snapcraft.internal.meta.snap import Snap
+from typing import Set
 from ._project_options import ProjectOptions
 from ._project_info import ProjectInfo  # noqa: F401
 
@@ -42,10 +44,13 @@ class Project(ProjectOptions):
         else:
             work_dir = project_dir
 
+        super().__init__(target_deb_arch, debug, work_dir=work_dir)
+
         # This here check is mostly for backwards compatibility with the
         # rest of the code base.
         if snapcraft_yaml_file_path is None:
             self.info = None  # type: ProjectInfo
+
         else:
             self.info = ProjectInfo(snapcraft_yaml_file_path=snapcraft_yaml_file_path)
 
@@ -53,10 +58,13 @@ class Project(ProjectOptions):
         self._project_dir = project_dir
         self._work_dir = work_dir
 
-        super().__init__(target_deb_arch, debug, work_dir=work_dir)
-
         self.local_plugins_dir = self._get_local_plugins_dir()
         self._start_time = datetime.utcnow()
+
+        # XXX: (Re)set by Config because it mangles source data.
+        # Ideally everywhere wold converge to operating on snap_meta, and ww
+        # would only need to initialize it once (properly).
+        self._snap_meta = Snap()
 
     def _get_snapcraft_assets_dir(self) -> str:
         # Many test cases don't set the yaml file path and assume the default dir

--- a/snapcraft/project/_project.py
+++ b/snapcraft/project/_project.py
@@ -66,6 +66,14 @@ class Project(ProjectOptions):
         # would only need to initialize it once (properly).
         self._snap_meta = Snap()
 
+    def _get_content_snaps(self) -> Set[str]:
+        """Return the set of content snaps from snap_meta."""
+        return set([x.provider for x in self._snap_meta.get_content_plugs()])
+
+    def _get_provider_content_dirs(self) -> Set[str]:
+        """Return the set installed provider content directories."""
+        return self._snap_meta.get_provider_content_directories()
+
     def _get_snapcraft_assets_dir(self) -> str:
         # Many test cases don't set the yaml file path and assume the default dir
         if not self.info:

--- a/snapcraft/project/_project_options.py
+++ b/snapcraft/project/_project_options.py
@@ -215,6 +215,20 @@ class ProjectOptions:
 
         self._set_machine(target_deb_arch)
 
+    def _get_content_snaps(self) -> Set[str]:
+        """Temporary shim for unit tests using ProjectOptions
+        where Project is really required.  Will be removed in
+        future convergence work.
+        """
+        return set()
+
+    def _get_provider_content_dirs(self) -> Set[str]:
+        """Temporary shim for unit tests using ProjectOptions
+        where Project is really required.  Will be removed in
+        future convergence work.
+        """
+        return set()
+
     def is_static_base(self, base: str) -> bool:
         """Return True if a base that is intended to be static is used.
 

--- a/snapcraft/project/_project_options.py
+++ b/snapcraft/project/_project_options.py
@@ -271,7 +271,7 @@ class ProjectOptions:
         :raises snapcraft.internal.errors.SnapcraftEnvironmentError:
             if a loop is found while resolving the real path to the linker.
         """
-        core_path = common.get_core_path(base)
+        core_path = common.get_installed_snap_path(base)
         dynamic_linker_path = os.path.join(
             core_path,
             self.__machine_info.get("core-dynamic-linker", "lib/ld-linux.so.2"),

--- a/tests/fixture_setup/_fixtures.py
+++ b/tests/fixture_setup/_fixtures.py
@@ -693,6 +693,13 @@ class FakeBaseEnvironment(fixtures.Fixture):
         mock_core_path.return_value = self.core_path
         self.addCleanup(patcher.stop)
 
+        self.content_dirs = set([])
+        mock_content_dirs = fixtures.MockPatch(
+            "snapcraft.project._project.Project._get_provider_content_dirs",
+            return_value=self.content_dirs,
+        )
+        self.useFixture(mock_content_dirs)
+
         # Create file to represent the linker so it is found
         linker_path = os.path.join(self.core_path, self._LINKER_FOR_ARCH[self._machine])
         os.makedirs(os.path.dirname(linker_path), exist_ok=True)

--- a/tests/fixture_setup/_fixtures.py
+++ b/tests/fixture_setup/_fixtures.py
@@ -688,7 +688,7 @@ class FakeBaseEnvironment(fixtures.Fixture):
         self.addCleanup(patcher.stop)
 
         self.core_path = self.useFixture(fixtures.TempDir()).path
-        patcher = mock.patch("snapcraft.internal.common.get_core_path")
+        patcher = mock.patch("snapcraft.internal.common.get_installed_snap_path")
         mock_core_path = patcher.start()
         mock_core_path.return_value = self.core_path
         self.addCleanup(patcher.stop)

--- a/tests/spread/general/unicode-metadata/expected_snap.yaml
+++ b/tests/spread/general/unicode-metadata/expected_snap.yaml
@@ -19,8 +19,8 @@ description: |
   Programming mode supports conversion between common bases (binary, octal,
   decimal, and hexadecimal), boolean algebra, one’s and two’s complementation,
   character to character code conversion, and more.
-base: core18
 architectures:
 - amd64
+base: core18
 confinement: devmode
 grade: devel

--- a/tests/unit/meta/test_command.py
+++ b/tests/unit/meta/test_command.py
@@ -31,168 +31,147 @@ def _create_file(file_path: str, *, mode=0o755) -> None:
 class CommandWithoutWrapperTest(unit.TestCase):
     def test_command(self):
         _create_file(os.path.join(self.path, "foo"))
-        cmd = command.Command(
-            app_name="foo",
-            command_name="command",
-            command="foo",
-            prime_dir=self.path,
-            can_use_wrapper=False,
+        cmd = command.Command(app_name="foo", command_name="command", command="foo")
+
+        cmd.prime_command(
+            can_use_wrapper=False, massage_command=True, prime_dir=self.path
         )
 
-        self.assertThat(cmd.get_command(), Equals("foo"))
+        self.assertThat(cmd.command, Equals("foo"))
 
     def test_command_with_args(self):
         _create_file(os.path.join(self.path, "foo"))
         cmd = command.Command(
-            app_name="foo",
-            command_name="command",
-            command="foo bar -baz",
-            prime_dir=self.path,
-            can_use_wrapper=False,
+            app_name="foo", command_name="command", command="foo bar -baz"
+        )
+        cmd.prime_command(
+            can_use_wrapper=False, massage_command=True, prime_dir=self.path
         )
 
-        self.assertThat(cmd.get_command(), Equals("foo bar -baz"))
+        self.assertThat(cmd.command, Equals("foo bar -baz"))
 
     def test_command_does_not_match_snapd_pattern(self):
         _create_file(os.path.join(self.path, "foo"))
         cmd = command.Command(
-            app_name="foo",
-            command_name="command",
-            command="foo /!option",
-            prime_dir=self.path,
-            can_use_wrapper=False,
+            app_name="foo", command_name="command", command="foo /!option"
         )
 
-        self.assertRaises(errors.InvalidAppCommandFormatError, cmd.get_command)
+        self.assertRaises(
+            errors.InvalidAppCommandFormatError,
+            cmd.prime_command,
+            can_use_wrapper=False,
+            massage_command=True,
+            prime_dir=self.path,
+        )
 
     def test_command_starts_with_slash(self):
-        cmd = command.Command(
-            app_name="foo",
-            command_name="command",
-            command="/foo",
-            prime_dir=self.path,
-            can_use_wrapper=False,
-        )
+        cmd = command.Command(app_name="foo", command_name="command", command="/foo")
 
-        self.assertRaises(errors.InvalidAppCommandFormatError, cmd.get_command)
+        self.assertRaises(
+            errors.InvalidAppCommandFormatError,
+            cmd.prime_command,
+            can_use_wrapper=False,
+            massage_command=True,
+            prime_dir=self.path,
+        )
 
     def test_command_relative_command_found_in_slash(self):
-        cmd = command.Command(
-            app_name="foo",
-            command_name="command",
-            command="sh",
-            prime_dir=self.path,
-            can_use_wrapper=False,
-        )
+        cmd = command.Command(app_name="foo", command_name="command", command="sh")
 
-        self.assertRaises(errors.InvalidAppCommandFormatError, cmd.get_command)
+        self.assertRaises(
+            errors.InvalidAppCommandFormatError,
+            cmd.prime_command,
+            can_use_wrapper=False,
+            massage_command=True,
+            prime_dir=self.path,
+        )
 
     def test_command_not_executable(self):
         _create_file(os.path.join(self.path, "foo"), mode=0o644)
-        cmd = command.Command(
-            app_name="foo",
-            command_name="command",
-            command="foo",
-            prime_dir=self.path,
-            can_use_wrapper=False,
-        )
+        cmd = command.Command(app_name="foo", command_name="command", command="foo")
 
-        self.assertRaises(errors.InvalidAppCommandNotExecutable, cmd.get_command)
+        self.assertRaises(
+            errors.InvalidAppCommandNotExecutable,
+            cmd.prime_command,
+            can_use_wrapper=False,
+            massage_command=True,
+            prime_dir=self.path,
+        )
 
 
 class CommandWithWrapperTest(unit.TestCase):
     def test_command(self):
         _create_file(os.path.join(self.path, "foo"))
-        cmd = command.Command(
-            app_name="foo",
-            command_name="command",
-            command="foo",
-            prime_dir=self.path,
-            can_use_wrapper=True,
+        cmd = command.Command(app_name="foo", command_name="command", command="foo")
+        cmd.prime_command(
+            can_use_wrapper=True, massage_command=True, prime_dir=self.path
         )
 
-        self.assertThat(cmd.get_command(), Equals("foo"))
+        self.assertThat(cmd.command, Equals("foo"))
 
     def test_command_with_args(self):
         _create_file(os.path.join(self.path, "foo"))
         cmd = command.Command(
-            app_name="foo",
-            command_name="command",
-            command="foo bar -baz",
-            prime_dir=self.path,
-            can_use_wrapper=False,
+            app_name="foo", command_name="command", command="foo bar -baz"
         )
 
-        self.expectThat(cmd.get_command(), Equals("foo bar -baz"))
-        self.expectThat(cmd.generate_wrapper(), Is(None))
+        cmd.prime_command(
+            can_use_wrapper=True, massage_command=True, prime_dir=self.path
+        )
+        wrapper_path = cmd.write_wrapper(prime_dir=self.path)
+
+        self.expectThat(cmd.command, Equals("foo bar -baz"))
+        self.expectThat(wrapper_path, Is(None))
 
     def test_command_does_not_match_snapd_pattern(self):
         _create_file(os.path.join(self.path, "foo"))
         cmd = command.Command(
-            app_name="foo",
-            command_name="command",
-            command="foo /!option",
-            prime_dir=self.path,
-            can_use_wrapper=True,
+            app_name="foo", command_name="command", command="foo /!option"
         )
 
-        app_command = cmd.get_command()
-        wrapper_path = cmd.generate_wrapper()
-        self.expectThat(app_command, Equals("command-foo.wrapper"))
+        cmd.prime_command(
+            can_use_wrapper=True, massage_command=True, prime_dir=self.path
+        )
+        wrapper_path = cmd.write_wrapper(prime_dir=self.path)
+
+        self.expectThat(cmd.command, Equals("command-foo.wrapper"))
         self.assertThat(wrapper_path, FileExists())
         self.assertThat(
             wrapper_path, FileContains('#!/bin/sh\nexec $SNAP/foo /!option "$@"\n')
         )
 
     def test_command_starts_with_slash(self):
-        cmd = command.Command(
-            app_name="foo",
-            command_name="command",
-            command="/foo",
-            prime_dir=self.path,
-            can_use_wrapper=True,
-        )
+        cmd = command.Command(app_name="foo", command_name="command", command="/foo")
 
-        app_command = cmd.get_command()
-        wrapper_path = cmd.generate_wrapper()
-        self.expectThat(app_command, Equals("command-foo.wrapper"))
+        cmd.prime_command(
+            can_use_wrapper=True, massage_command=True, prime_dir=self.path
+        )
+        wrapper_path = cmd.write_wrapper(prime_dir=self.path)
+
+        self.expectThat(cmd.command, Equals("command-foo.wrapper"))
         self.assertThat(wrapper_path, FileExists())
         self.assertThat(wrapper_path, FileContains('#!/bin/sh\nexec /foo "$@"\n'))
 
     def test_command_relative_command_found_in_slash(self):
-        cmd = command.Command(
-            app_name="foo",
-            command_name="command",
-            command="sh",
-            prime_dir=self.path,
-            can_use_wrapper=True,
-        )
+        cmd = command.Command(app_name="foo", command_name="command", command="sh")
 
-        app_command = cmd.get_command()
-        wrapper_path = cmd.generate_wrapper()
-        self.expectThat(app_command, Equals("command-foo.wrapper"))
+        cmd.prime_command(
+            can_use_wrapper=True, massage_command=True, prime_dir=self.path
+        )
+        wrapper_path = cmd.write_wrapper(prime_dir=self.path)
+
+        self.expectThat(cmd.command, Equals("command-foo.wrapper"))
         self.assertThat(wrapper_path, FileExists())
         self.assertThat(wrapper_path, FileContains('#!/bin/sh\nexec /bin/sh "$@"\n'))
 
     def test_command_not_executable(self):
         _create_file(os.path.join(self.path, "foo"), mode=0o644)
-        cmd = command.Command(
-            app_name="foo",
-            command_name="command",
-            command="foo",
-            prime_dir=self.path,
+        cmd = command.Command(app_name="foo", command_name="command", command="foo")
+
+        self.assertRaises(
+            errors.InvalidAppCommandNotExecutable,
+            cmd.prime_command,
             can_use_wrapper=True,
-        )
-
-        self.assertRaises(errors.InvalidAppCommandNotExecutable, cmd.get_command)
-
-    def test_generate_wrapper_called_before_get_command(self):
-        cmd = command.Command(
-            app_name="foo",
-            command_name="command",
-            command="/foo",
+            massage_command=True,
             prime_dir=self.path,
-            can_use_wrapper=True,
         )
-
-        self.assertRaises(RuntimeError, cmd.generate_wrapper)

--- a/tests/unit/meta/test_hook.py
+++ b/tests/unit/meta/test_hook.py
@@ -1,0 +1,68 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections import OrderedDict
+from snapcraft.internal.meta.hooks import Hook
+from tests import unit
+
+
+class GenericHookTests(unit.TestCase):
+    def test_empty(self):
+        hook_dict = OrderedDict({})
+        hook_name = "hook-test"
+
+        hook = Hook(hook_name=hook_name)
+        hook.validate()
+
+        self.assertEqual(hook.to_dict(), hook_dict)
+        self.assertEqual(hook.hook_name, hook_name)
+
+    def test_empty_from_dict(self):
+        hook_dict = OrderedDict({})
+        hook_name = "hook-test"
+
+        hook = Hook.from_dict(hook_dict=hook_dict, hook_name=hook_name)
+        hook.validate()
+
+        self.assertEqual(hook.to_dict(), hook_dict)
+        self.assertEqual(hook.hook_name, hook_name)
+
+    def test_simple_dict(self):
+        hook_dict = OrderedDict({"somekey": "somevalue"})
+        hook_name = "hook-test"
+
+        hook = Hook.from_dict(hook_dict=hook_dict, hook_name=hook_name)
+        hook.validate()
+
+        self.assertEqual(hook.to_dict(), hook_dict)
+        self.assertEqual(hook.hook_name, hook_name)
+
+    def test_passthrough(self):
+        hook_dict = OrderedDict(
+            {"somekey": "somevalue", "passthrough": {"otherkey": "othervalue"}}
+        )
+        hook_name = "hook-test"
+
+        hook = Hook.from_dict(hook_dict=hook_dict, hook_name=hook_name)
+        hook.validate()
+
+        transformed_dict = OrderedDict(
+            {"somekey": "somevalue", "otherkey": "othervalue"}
+        )
+
+        self.assertEqual(hook.to_dict(), transformed_dict)
+        self.assertEqual(hook.hook_name, hook_name)
+        self.assertEqual(hook.passthrough, hook_dict["passthrough"])

--- a/tests/unit/meta/test_plugs.py
+++ b/tests/unit/meta/test_plugs.py
@@ -1,0 +1,100 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections import OrderedDict
+from snapcraft.internal.meta import errors
+from snapcraft.internal.meta.plugs import Plug, ContentPlug
+from tests import unit
+
+
+class GenericPlugTests(unit.TestCase):
+    def test_plug_name(self):
+        plug_name = "plug-test"
+
+        plug = Plug(plug_name=plug_name)
+        plug_from_dict = Plug.from_dict(
+            plug_dict={"interface": "somevalue"}, plug_name=plug_name
+        )
+
+        self.assertEqual(plug_name, plug.plug_name)
+        self.assertEqual(plug_name, plug_from_dict.plug_name)
+
+    def test_invalid_raises_exception(self):
+        plug_name = "plug-test"
+
+        plug = Plug(plug_name=plug_name)
+
+        self.assertRaises(errors.PlugValidationError, plug.validate)
+
+    def test_invalid_from_dict_raises_exception(self):
+        plug_dict = OrderedDict({})
+        plug_name = "plug-test"
+
+        plug = Plug.from_dict(plug_dict=plug_dict, plug_name=plug_name)
+
+        self.assertRaises(errors.PlugValidationError, plug.validate)
+
+    def test_valid_from_dict(self):
+        plug_dict = OrderedDict({"interface": "somevalue", "someprop": "somevalue"})
+        plug_name = "plug-test"
+
+        plug = Plug.from_dict(plug_dict=plug_dict, plug_name=plug_name)
+
+        plug.validate()
+
+
+class ContentPlugTests(unit.TestCase):
+    def test_invalid_target_raises_exception(self):
+        plug = ContentPlug(plug_name="plug-test", target="")
+
+        self.assertRaises(errors.PlugValidationError, plug.validate)
+
+    def test_invalid_target_from_dict_raise_exception(self):
+        plug_dict = OrderedDict({"interface": "content", "target": ""})
+
+        plug = Plug.from_dict(plug_dict=plug_dict, plug_name="plug-test")
+
+        self.assertRaises(errors.PlugValidationError, plug.validate)
+
+    def test_content_defaults_to_name(self):
+        plug = ContentPlug(plug_name="plug-test", target="target")
+
+        self.assertEqual("plug-test", plug.content)
+
+    def test_basic_from_dict(self):
+        plug_dict = OrderedDict(
+            {
+                "interface": "content",
+                "content": "content",
+                "target": "target",
+                "default-provider": "gtk-common-themes:gtk-3-themes",
+            }
+        )
+        plug_name = "plug-test"
+        plug_provider = "gtk-common-themes"
+
+        plug = ContentPlug.from_dict(plug_dict=plug_dict, plug_name=plug_name)
+        plug.validate()
+
+        # default-provider is not written as <provider>:<name>, just <provider>.
+        transformed_dict = plug_dict.copy()
+        transformed_dict["default-provider"] = plug_provider
+
+        self.assertEqual(transformed_dict, plug.to_dict())
+        self.assertEqual(plug_name, plug.plug_name)
+        self.assertEqual(plug_dict["content"], plug.content)
+        self.assertEqual(plug_dict["target"], plug.target)
+        self.assertEqual(plug_provider, plug.provider)

--- a/tests/unit/meta/test_slots.py
+++ b/tests/unit/meta/test_slots.py
@@ -1,0 +1,242 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections import OrderedDict
+from snapcraft.internal.meta import errors
+from snapcraft.internal.meta.slots import Slot, ContentSlot, DbusSlot
+from tests import unit
+
+
+class GenericSlotTests(unit.TestCase):
+    def test_slot_name(self):
+        slot_name = "slot-test"
+
+        slot = Slot(slot_name=slot_name)
+        slot_from_dict = Slot.from_dict(
+            slot_dict={"interface": "somevalue"}, slot_name=slot_name
+        )
+
+        self.assertEqual(slot_name, slot.slot_name)
+        self.assertEqual(slot_name, slot_from_dict.slot_name)
+
+    def test_invalid_raises_exception(self):
+        slot_name = "slot-test"
+
+        slot = Slot(slot_name=slot_name)
+
+        self.assertRaises(errors.SlotValidationError, slot.validate)
+
+    def test_invalid_from_dict_raises_exception(self):
+        slot_dict = OrderedDict({})
+        slot_name = "slot-test"
+
+        slot = Slot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
+
+        self.assertRaises(errors.SlotValidationError, slot.validate)
+
+    def test_valid_from_dict(self):
+        slot_dict = OrderedDict({"interface": "somevalue", "someprop": "somevalue"})
+        slot_name = "slot-test"
+
+        slot = Slot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
+
+        slot.validate()
+
+
+class ContentSlotTests(unit.TestCase):
+    def test_empty(self):
+        slot_dict = OrderedDict({"interface": "content"})
+        slot_name = "slot-test"
+
+        slot = ContentSlot(slot_name=slot_name)
+
+        # "use_source_key" is default, account for that.
+        transformed_dict = slot_dict.copy()
+        transformed_dict["source"] = {}
+
+        self.assertEqual(transformed_dict, slot.to_dict())
+        self.assertEqual(slot_name, slot.slot_name)
+        self.assertRaises(errors.SlotValidationError, slot.validate)
+        self.assertEqual(set(), slot.get_content_dirs(installed_path=""))
+
+    def test_empty_from_dict(self):
+        slot_dict = OrderedDict({"interface": "content"})
+        slot_name = "slot-name"
+
+        slot = Slot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
+
+        self.assertIsInstance(slot, ContentSlot)
+        self.assertEqual(slot_dict, slot.to_dict())
+        self.assertEqual(slot_name, slot.slot_name)
+        self.assertRaises(errors.SlotValidationError, slot.validate)
+        self.assertEqual(set(), slot.get_content_dirs(installed_path=""))
+
+    def test_empty_force_no_source(self):
+        slot_dict = OrderedDict({"interface": "content"})
+        slot_name = "slot-test"
+
+        slot = ContentSlot(use_source_key=False, slot_name=slot_name)
+
+        self.assertEqual(slot_dict, slot.to_dict())
+        self.assertEqual(slot_name, slot.slot_name)
+        self.assertRaises(errors.SlotValidationError, slot.validate)
+        self.assertEqual(set(), slot.get_content_dirs(installed_path=""))
+
+    def test_read_from_dict(self):
+        slot_dict = OrderedDict({"interface": "content", "read": ["some/path"]})
+        slot_name = "slot-test"
+
+        slot = ContentSlot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
+        slot.validate()
+
+        self.assertEqual(slot_dict, slot.to_dict())
+        self.assertEqual(slot_name, slot.slot_name)
+        self.assertEqual(slot_dict["read"], slot.read)
+        self.assertEqual(
+            set(slot_dict["read"]), slot.get_content_dirs(installed_path="")
+        )
+
+    def test_read_from_dict_force_source_key(self):
+        slot_dict = OrderedDict({"interface": "content", "read": ["some/path"]})
+        slot_name = "slot-test"
+
+        slot = ContentSlot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
+        slot.use_source_key = True
+        slot.validate()
+        transformed_dict = slot_dict.copy()
+        transformed_dict["source"] = dict()
+        transformed_dict["source"]["read"] = transformed_dict.pop("read")
+
+        self.assertEqual(transformed_dict, slot.to_dict())
+        self.assertEqual(slot_name, slot.slot_name)
+        self.assertEqual(slot_dict["read"], slot.read)
+        self.assertEqual(
+            set(slot_dict["read"]), slot.get_content_dirs(installed_path="")
+        )
+
+    def test_source_read_from_dict(self):
+        slot_dict = OrderedDict(
+            {"interface": "content", "source": {"read": ["some/path"]}}
+        )
+        slot_name = "slot-test"
+
+        slot = ContentSlot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
+        slot.validate()
+
+        self.assertEqual(slot_dict, slot.to_dict())
+        self.assertEqual(slot_name, slot.slot_name)
+        self.assertEqual(slot_dict["source"]["read"], slot.read)
+        self.assertEqual(
+            set(slot_dict["source"]["read"]), slot.get_content_dirs(installed_path="")
+        )
+
+    def test_write_from_dict(self):
+        slot_dict = OrderedDict({"interface": "content", "write": ["some/path"]})
+        slot_name = "slot-test"
+
+        slot = ContentSlot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
+        slot.validate()
+
+        self.assertEqual(slot_dict, slot.to_dict())
+        self.assertEqual(slot_name, slot.slot_name)
+        self.assertEqual(slot_dict["write"], slot.write)
+        self.assertEqual(
+            set(slot_dict["write"]), slot.get_content_dirs(installed_path="")
+        )
+
+    def test_write_from_dict_force_source_key(self):
+        slot_dict = OrderedDict({"interface": "content", "write": ["some/path"]})
+        slot_name = "slot-test"
+
+        slot = ContentSlot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
+        slot.use_source_key = True
+        slot.validate()
+        transformed_dict = slot_dict.copy()
+        transformed_dict["source"] = dict()
+        transformed_dict["source"]["write"] = transformed_dict.pop("write")
+
+        self.assertEqual(transformed_dict, slot.to_dict())
+        self.assertEqual(slot_name, slot.slot_name)
+        self.assertEqual(slot_dict["write"], slot.write)
+        self.assertEqual(
+            set(slot_dict["write"]), slot.get_content_dirs(installed_path="")
+        )
+
+    def test_source_write_from_dict(self):
+        slot_dict = OrderedDict(
+            {"interface": "content", "source": {"write": ["some/path"]}}
+        )
+        slot_name = "slot-test"
+
+        slot = ContentSlot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
+        slot.validate()
+
+        self.assertEqual(slot_dict, slot.to_dict())
+        self.assertEqual(slot_name, slot.slot_name)
+        self.assertEqual(slot_dict["source"]["write"], slot.write)
+        self.assertEqual(
+            set(slot_dict["source"]["write"]), slot.get_content_dirs(installed_path="")
+        )
+
+
+class DbusSlotTests(unit.TestCase):
+    def test_invalid_target_raises_exception(self):
+        slot = DbusSlot(slot_name="slot-test", bus="", name="")
+
+        self.assertRaises(errors.SlotValidationError, slot.validate)
+
+    def test_invalid_interface_from_dict_raises_exception(self):
+        slot_dict = OrderedDict({"interface": "content", "bus": "", "name": ""})
+
+        self.assertRaises(
+            errors.SlotValidationError,
+            DbusSlot.from_dict,
+            slot_dict=slot_dict,
+            slot_name="slot-test",
+        )
+
+    def test_invalid_target_from_dict_raises_exception(self):
+        slot_dict = OrderedDict({"interface": "dbus", "bus": "", "name": ""})
+
+        slot = DbusSlot.from_dict(slot_dict=slot_dict, slot_name="slot-test")
+
+        self.assertRaises(errors.SlotValidationError, slot.validate)
+
+    def test_basic(self):
+        slot_dict = OrderedDict({"interface": "dbus", "bus": "bus", "name": "name"})
+        slot_name = "slot-test"
+
+        slot = DbusSlot(
+            slot_name=slot_name, bus=slot_dict["bus"], name=slot_dict["name"]
+        )
+        slot.validate()
+
+        self.assertEqual(slot_dict, slot.to_dict())
+        self.assertEqual(slot_name, slot.slot_name)
+        self.assertEqual(slot_dict["bus"], slot.bus)
+        self.assertEqual(slot_dict["name"], slot.name)
+
+    def test_basic_from_dict(self):
+        slot_dict = OrderedDict({"interface": "dbus", "bus": "bus", "name": "name"})
+        slot_name = "slot-test"
+
+        slot = DbusSlot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
+        slot.validate()
+
+        self.assertEqual(slot_dict, slot.to_dict())
+        self.assertEqual(slot_name, slot.slot_name)
+        self.assertEqual(slot_dict["bus"], slot.bus)
+        self.assertEqual(slot_dict["name"], slot.name)

--- a/tests/unit/meta/test_snap.py
+++ b/tests/unit/meta/test_snap.py
@@ -1,0 +1,403 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from collections import OrderedDict
+from snapcraft.internal.meta import errors
+from snapcraft.internal.meta.snap import Snap
+from tests import unit
+from textwrap import dedent
+from unittest import mock
+
+
+class SnapTests(unit.TestCase):
+    """ Test the snaps.  Note that the ordering of ordereddicts must align
+    with Snap's use of _MANDATORY_PACKAGE_KEYS + _OPTIONAL_PACKAGE_KEYS.
+
+    This applies even for verifying YAMLs, which are (now) ordered."""
+
+    def test_empty(self):
+        snap_dict = OrderedDict({})
+
+        snap = Snap()
+
+        self.assertEqual(snap_dict, snap.to_dict())
+
+    def test_empty_from_dict(self):
+        snap_dict = OrderedDict({})
+
+        snap = Snap.from_dict(snap_dict=snap_dict)
+
+        self.assertEqual(snap_dict, snap.to_dict())
+
+    def test_missing_keys(self):
+        snap_dict = OrderedDict({"name": "snap-test"})
+
+        snap = Snap.from_dict(snap_dict=snap_dict)
+
+        self.assertEqual(snap_dict, snap.to_dict())
+        self.assertRaises(errors.MissingSnapcraftYamlKeysError, snap.validate)
+
+    def test_simple(self):
+        snap_dict = OrderedDict(
+            {
+                "name": "snap-test",
+                "version": "snap-version",
+                "summary": "snap-summary",
+                "description": "snap-description",
+            }
+        )
+
+        snap = Snap.from_dict(snap_dict=snap_dict)
+        snap.validate()
+
+        self.assertEqual(snap_dict, snap.to_dict())
+        self.assertEqual(False, snap.is_passthrough_enabled)
+        self.assertEqual(snap_dict["name"], snap.name)
+        self.assertEqual(snap_dict["version"], snap.version)
+        self.assertEqual(snap_dict["summary"], snap.summary)
+        self.assertEqual(snap_dict["description"], snap.description)
+
+    def test_passthrough(self):
+        snap_dict = OrderedDict(
+            {
+                "name": "snap-test",
+                "version": "snap-version",
+                "summary": "snap-summary",
+                "description": "snap-description",
+                "passthrough": {"otherkey": "othervalue"},
+            }
+        )
+
+        snap = Snap.from_dict(snap_dict=snap_dict)
+        snap.validate()
+
+        transformed_dict = snap_dict.copy()
+        passthrough = transformed_dict.pop("passthrough")
+        transformed_dict.update(passthrough)
+
+        self.assertEqual(transformed_dict, snap.to_dict())
+        self.assertEqual(True, snap.is_passthrough_enabled)
+        self.assertEqual(passthrough, snap.passthrough)
+        self.assertEqual(snap_dict["name"], snap.name)
+        self.assertEqual(snap_dict["version"], snap.version)
+        self.assertEqual(snap_dict["summary"], snap.summary)
+        self.assertEqual(snap_dict["description"], snap.description)
+
+    def test_all_keys(self):
+        snap_dict = OrderedDict(
+            {
+                "name": "snap-test",
+                "version": "test-version",
+                "summary": "test-summary",
+                "description": "test-description",
+                "apps": {"test-app": {"command": "test-app"}},
+                "architectures": ["all"],
+                "assumes": ["command-chain"],
+                "base": "core",
+                "confinement": "strict",
+                "environment": {"TESTING": "1"},
+                "epoch": 0,
+                "grade": "devel",
+                "hooks": {"test-hook": {"plugs": ["network"]}},
+                "layout": {"/target": {"bind": "$SNAP/foo"}},
+                "license": "GPL",
+                "plugs": {"test-plug": OrderedDict({"interface": "some-value"})},
+                "slots": {"test-slot": OrderedDict({"interface": "some-value"})},
+                "title": "test-title",
+                "type": "base",
+            }
+        )
+
+        snap = Snap.from_dict(snap_dict=snap_dict)
+        snap.validate()
+
+        self.assertEqual(snap_dict, snap.to_dict())
+        self.assertEqual(False, snap.is_passthrough_enabled)
+        self.assertEqual(snap_dict["name"], snap.name)
+        self.assertEqual(snap_dict["version"], snap.version)
+        self.assertEqual(snap_dict["summary"], snap.summary)
+        self.assertEqual(snap_dict["description"], snap.description)
+        self.assertEqual(snap_dict["apps"]["test-app"], snap.apps["test-app"].to_dict())
+        self.assertEqual(snap_dict["architectures"], snap.architectures)
+        self.assertEqual(snap_dict["assumes"], snap.assumes)
+        self.assertEqual(snap_dict["base"], snap.base)
+        self.assertEqual(snap_dict["environment"], snap.environment)
+        self.assertEqual(snap_dict["license"], snap.license)
+        self.assertEqual(
+            snap_dict["plugs"]["test-plug"], snap.plugs["test-plug"].to_dict()
+        )
+        self.assertEqual(
+            snap_dict["slots"]["test-slot"], snap.slots["test-slot"].to_dict()
+        )
+        self.assertEqual(snap_dict["confinement"], snap.confinement)
+        self.assertEqual(snap_dict["title"], snap.title)
+        self.assertEqual(snap_dict["type"], snap.type)
+
+    def test_is_passthrough_enabled_app(self):
+        snap_dict = OrderedDict(
+            {
+                "name": "snap-test",
+                "version": "test-version",
+                "summary": "test-summary",
+                "description": "test-description",
+                "apps": {
+                    "test-app": {
+                        "command": "test-app",
+                        "passthrough": {"some-key": "some-value"},
+                    }
+                },
+            }
+        )
+
+        snap = Snap.from_dict(snap_dict=snap_dict)
+        snap.validate()
+
+        self.assertEqual(True, snap.is_passthrough_enabled)
+
+    def test_is_passthrough_enabled_hook(self):
+        snap_dict = OrderedDict(
+            {
+                "name": "snap-test",
+                "version": "test-version",
+                "summary": "test-summary",
+                "description": "test-description",
+                "hooks": {"test-hook": {"passthrough": {"some-key": "some-value"}}},
+            }
+        )
+
+        snap = Snap.from_dict(snap_dict=snap_dict)
+        snap.validate()
+
+        self.assertEqual(True, snap.is_passthrough_enabled)
+
+    def test_from_file(self):
+        snap_yaml = dedent(
+            """
+            name: test-name
+            version: "1.0"
+            summary: test-summary
+            description: test-description
+            base: core18
+            architectures:
+            - amd64
+            assumes:
+            - snapd2.39
+            confinement: classic
+            grade: devel
+            apps:
+              test-app:
+                command: test-command
+                completer: test-completer
+        """
+        )
+
+        meta_path = os.path.join(self.path, "meta")
+        os.makedirs(meta_path)
+
+        snap_yaml_path = os.path.join(self.path, "meta", "snap.yaml")
+        open(snap_yaml_path, "w").write(snap_yaml)
+
+        snap = Snap.from_file(snap_yaml_path)
+        snap.validate()
+
+        self.assertEqual("test-name", snap.name)
+        self.assertEqual("1.0", snap.version)
+        self.assertEqual("test-summary", snap.summary)
+        self.assertEqual("test-description", snap.description)
+        self.assertEqual(
+            OrderedDict({"command": "test-command", "completer": "test-completer"}),
+            snap.apps["test-app"].to_dict(),
+        )
+        self.assertEqual(["amd64"], snap.architectures)
+        self.assertEqual(["snapd2.39"], snap.assumes)
+        self.assertEqual("core18", snap.base)
+        self.assertEqual("classic", snap.confinement)
+        self.assertEqual("devel", snap.grade)
+
+    def test_to_file(self):
+        # Ordering matters for verifying the YAML.
+        snap_yaml = dedent(
+            """
+            name: test-name
+            version: '1.0'
+            summary: test-summary
+            description: test-description
+            apps:
+              test-app:
+                command: test-command
+                completer: test-completer
+            architectures:
+            - amd64
+            assumes:
+            - snapd2.39
+            base: core18
+            confinement: classic
+            grade: devel
+        """
+        )
+
+        meta_path = os.path.join(self.path, "meta")
+        os.makedirs(meta_path)
+
+        snap_yaml_path = os.path.join(self.path, "meta", "snap.yaml")
+        open(snap_yaml_path, "w").write(snap_yaml)
+
+        snap = Snap.from_file(snap_yaml_path)
+        snap.validate()
+
+        # Write snap yaml.
+        snap.write_snap_yaml(path=snap_yaml_path)
+
+        # Read snap yaml.
+        written_snap_yaml = open(snap_yaml_path, "r").read()
+
+        # Compare stripped versions (to remove leading/trailing newlines).
+        self.assertEqual(snap_yaml.strip(), written_snap_yaml.strip())
+
+    def test_get_provider_content_directories_no_plugs(self):
+        snap = Snap()
+        self.assertEqual(set([]), snap.get_provider_content_directories())
+
+    def test_get_provider_content_directories_with_content_plugs(self):
+        snap_dict = OrderedDict(
+            {
+                "name": "snap-test",
+                "version": "test-version",
+                "summary": "test-summary",
+                "description": "test-description",
+                "plugs": {
+                    "test-plug": {
+                        "interface": "content",
+                        "content": "content",
+                        "target": "target",
+                        "default-provider": "gtk-common-themes:gtk-3-themes",
+                    }
+                },
+            }
+        )
+
+        meta_snap_yaml = dedent(
+            """
+            name: test-content-snap-meta-snap-yaml
+            version: "1.0"
+            summary: test-summary
+            description: test-description
+            base: core18
+            architectures:
+            - all
+            confinement: strict
+            grade: stable
+            slots:
+              test-slot-name:
+                interface: content
+                source:
+                  read:
+                  - $SNAP/dir1
+                  - $SNAP/dir2
+        """
+        )
+
+        snap = Snap.from_dict(snap_dict=snap_dict)
+        snap.validate()
+
+        patcher = mock.patch("snapcraft.internal.common.get_installed_snap_path")
+        mock_core_path = patcher.start()
+        mock_core_path.return_value = self.path
+        self.addCleanup(patcher.stop)
+
+        meta_path = os.path.join(self.path, "meta")
+        os.makedirs(meta_path)
+
+        snap_yaml_path = os.path.join(meta_path, "snap.yaml")
+        open(snap_yaml_path, "w").write(meta_snap_yaml)
+
+        expected_content_dirs = set(
+            [os.path.join(self.path, "dir1"), os.path.join(self.path, "dir2")]
+        )
+
+        self.assertEqual(expected_content_dirs, snap.get_provider_content_directories())
+
+    def test_ensure_command_chain_assumption(self):
+        snap_dict = OrderedDict(
+            {
+                "name": "snap-test",
+                "version": "snap-version",
+                "summary": "snap-summary",
+                "description": "snap-description",
+                "apps": {
+                    "test-app": {
+                        "command": "test-app",
+                        "command-chain": ["test-command-chain"],
+                    }
+                },
+            }
+        )
+
+        snap = Snap.from_dict(snap_dict=snap_dict)
+        snap._ensure_command_chain_assumption()
+        snap.validate()
+
+        self.assertEqual({"command-chain"}, snap.assumes)
+
+    def test_write_snap_yaml_skips_base_core(self):
+        snap_dict = OrderedDict(
+            {
+                "name": "snap-test",
+                "version": "snap-version",
+                "summary": "snap-summary",
+                "description": "snap-description",
+                "base": "core",
+            }
+        )
+
+        snap = Snap.from_dict(snap_dict=snap_dict)
+        snap.validate()
+
+        # Write snap yaml.
+        snap_yaml_path = os.path.join(self.path, "snap.yaml")
+        snap.write_snap_yaml(path=snap_yaml_path)
+
+        # Read snap yaml.
+        written_snap_yaml = open(snap_yaml_path, "r").read()
+
+        self.assertEqual(snap_dict, snap.to_dict())
+        self.assertFalse("base" in written_snap_yaml)
+
+    def test_write_snap_yaml_with_base_core18(self):
+        snap_dict = OrderedDict(
+            {
+                "name": "snap-test",
+                "version": "snap-version",
+                "summary": "snap-summary",
+                "description": "snap-description",
+                "base": "core18",
+            }
+        )
+
+        snap = Snap.from_dict(snap_dict=snap_dict)
+        snap.validate()
+
+        # Write snap yaml.
+        snap_yaml_path = os.path.join(self.path, "snap.yaml")
+        snap.write_snap_yaml(path=snap_yaml_path)
+
+        # Read snap yaml.
+        written_snap_yaml = open(snap_yaml_path, "r").read()
+
+        self.assertEqual(snap_dict, snap.to_dict())
+        self.assertTrue("base" in written_snap_yaml)

--- a/tests/unit/test_elf.py
+++ b/tests/unit/test_elf.py
@@ -22,6 +22,7 @@ import sys
 from testtools.matchers import Contains, EndsWith, Equals, NotEquals, StartsWith
 from unittest import mock
 
+from snapcraft import ProjectOptions
 from snapcraft.internal import errors, elf
 from tests import unit, fixture_setup
 
@@ -32,6 +33,8 @@ class TestElfBase(unit.TestCase):
 
         self.fake_elf = fixture_setup.FakeElf(root_path=self.path)
         self.useFixture(self.fake_elf)
+        self.content_dirs = []
+        self.arch_triplet = ProjectOptions().arch_triplet
 
 
 class TestLdLibraryPathParser(unit.TestCase):
@@ -123,6 +126,8 @@ class TestGetLibraries(TestElfBase):
         libs = elf_file.load_dependencies(
             root_path=self.fake_elf.root_path,
             core_base_path=self.fake_elf.core_base_path,
+            arch_triplet=self.arch_triplet,
+            content_dirs=self.content_dirs,
         )
 
         self.assertThat(
@@ -142,6 +147,8 @@ class TestGetLibraries(TestElfBase):
         libs = elf_file.load_dependencies(
             root_path=self.fake_elf.root_path,
             core_base_path=self.fake_elf.core_base_path,
+            arch_triplet=self.arch_triplet,
+            content_dirs=self.content_dirs,
             soname_cache=soname_cache,
         )
 
@@ -156,6 +163,8 @@ class TestGetLibraries(TestElfBase):
         libs = elf_file.load_dependencies(
             root_path=self.fake_elf.root_path,
             core_base_path=self.fake_elf.core_base_path,
+            arch_triplet=self.arch_triplet,
+            content_dirs=self.content_dirs,
         )
 
         self.assertThat(
@@ -177,6 +186,8 @@ class TestGetLibraries(TestElfBase):
         libs = elf_file.load_dependencies(
             root_path=self.fake_elf.root_path,
             core_base_path=self.fake_elf.core_base_path,
+            arch_triplet=self.arch_triplet,
+            content_dirs=self.content_dirs,
         )
 
         self.assertThat(libs, Equals(frozenset(["/lib/foo.so.1", "/usr/lib/bar.so.2"])))
@@ -186,6 +197,8 @@ class TestGetLibraries(TestElfBase):
         libs = elf_file.load_dependencies(
             root_path=self.fake_elf.root_path,
             core_base_path=self.fake_elf.core_base_path,
+            arch_triplet=self.arch_triplet,
+            content_dirs=self.content_dirs,
         )
 
         self.assertThat(
@@ -200,6 +213,8 @@ class TestGetLibraries(TestElfBase):
         libs = elf_file.load_dependencies(
             root_path=self.fake_elf.root_path,
             core_base_path=self.fake_elf.core_base_path,
+            arch_triplet=self.arch_triplet,
+            content_dirs=self.content_dirs,
         )
 
         self.assertThat(libs, Equals(set()))

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -180,7 +180,7 @@ class NativeOptionsTestCase(unit.TestCase):
                     options.get_core_dynamic_linker("core"),
                     Equals(
                         os.path.join(
-                            common.get_core_path("core"),
+                            common.get_installed_snap_path("core"),
                             self.expected_core_dynamic_linker,
                         )
                     ),


### PR DESCRIPTION
This removes the false-positive warnings associated with use of the gnome extension (and hopefully any users of content snaps).

Tested with gnome-calculator using gnome extension:
https://github.com/cjp256/gnome-calculator/commits/master

Still needs some tests, but open for feedback! :)

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
