### PR TITLE
tests: print journal logs when spread tests fail

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -157,8 +157,14 @@ prepare: |
     exit 1
   fi
 
+debug: |
+  journalctl -xe
+
 restore-each: |
   "$TOOLS_DIR"/restore.sh
+
+debug-each: |
+  journalctl -xe
 
 suites:
  # General, core suite


### PR DESCRIPTION
Use debug and debug-each to obtain information on when a test fails.
This could be an individual test or the entire (test) project setup.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
