### PR TITLE
build providers: inject core18 instead of core

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -287,7 +287,7 @@ class Provider(abc.ABC):
             inject_from_host=inject_from_host,
         )
         # Inject snapcraft
-        snap_injector.add(snap_name="core")
+        snap_injector.add(snap_name="core18")
         snap_injector.add(snap_name="snapcraft")
 
         # This build can be driven from a non snappy enabled system, so we may

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -211,7 +211,7 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
         )
         self.snap_injector_mock().add.assert_has_calls(
             [
-                call(snap_name="core"),
+                call(snap_name="core18"),
                 call(snap_name="snapcraft"),
                 call(snap_name="core16"),
             ]
@@ -236,7 +236,7 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
         )
         self.snap_injector_mock().add.assert_has_calls(
             [
-                call(snap_name="core"),
+                call(snap_name="core18"),
                 call(snap_name="snapcraft"),
                 call(snap_name="core16"),
             ]
@@ -253,7 +253,7 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
 
         self.snap_injector_mock().add.assert_has_calls(
             [
-                call(snap_name="core"),
+                call(snap_name="core18"),
                 call(snap_name="snapcraft"),
                 call(snap_name="core18"),
             ]
@@ -280,7 +280,7 @@ class MacProviderProvisionSnapcraftTest(MacBaseProviderWithBasesBaseTest):
         )
         self.snap_injector_mock().add.assert_has_calls(
             [
-                call(snap_name="core"),
+                call(snap_name="core18"),
                 call(snap_name="snapcraft"),
                 call(snap_name="core18"),
             ]
@@ -304,7 +304,7 @@ class MacProviderProvisionSnapcraftTest(MacBaseProviderWithBasesBaseTest):
             inject_from_host=False,
         )
         self.snap_injector_mock().add.assert_has_calls(
-            [call(snap_name="core"), call(snap_name="snapcraft")]
+            [call(snap_name="core18"), call(snap_name="snapcraft")]
         )
         self.assertThat(self.snap_injector_mock().add.call_count, Equals(2))
         self.snap_injector_mock().apply.assert_called_once_with()
@@ -327,7 +327,7 @@ class MacProviderProvisionSnapcraftTest(MacBaseProviderWithBasesBaseTest):
         )
         self.snap_injector_mock().add.assert_has_calls(
             [
-                call(snap_name="core"),
+                call(snap_name="core18"),
                 call(snap_name="snapcraft"),
                 call(snap_name="core18"),
             ]


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
