### PR TITLE
remote build: switch from core to core18

### DIFF
--- a/snapcraft/internal/remote_build/_launchpad.py
+++ b/snapcraft/internal/remote_build/_launchpad.py
@@ -49,7 +49,7 @@ class LaunchpadClient:
             raise errors.GitNotFoundProviderError(provider="Launchpad")
 
         self._id = build_id
-        self._core_channel = "stable"
+        self._core18_channel = "stable"
         self._snapcraft_channel = "edge"
         self._name = project.info.name
         self._waiting = []  # type: List[str]
@@ -131,7 +131,10 @@ class LaunchpadClient:
         snap = self._lp.snaps.getByName(name=self._id, owner=owner)
         snap_build_request = snap.requestBuilds(
             archive=dist.main_archive,
-            channels={"core": self._core_channel, "snapcraft": self._snapcraft_channel},
+            channels={
+                "core18": self._core18_channel,
+                "snapcraft": self._snapcraft_channel,
+            },
             pocket="Updates",
         )
         logger.debug("Request URL: {}".format(snap_build_request))


### PR DESCRIPTION
snapcraft on edge is now on core18.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
