### PR TITLE
Update README - remove obsolete unreliable links for support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ dependencies, they work on all major Linux systems without modification.
 
 ## Get support
 
-We’re here to help. Ask your questions at the [Snapcraft Forum](https://forum.snapcraft.io). Report bugs on [Launchpad](https://bugs.launchpad.net/snapcraft/+filebug).
+~~We’re here to help. Ask your questions at the [Snapcraft Forum](https://forum.snapcraft.io)~~. Report bugs on [Launchpad](https://bugs.launchpad.net/snapcraft/+filebug).
+
+Snapcraft forum should not be used anymore for any questions, forum staff is incompetent in many regard, good place to ask is stackexchange, there you will find competent staff and proper replies.
 
 Learn about the latest features by following Snapcraft on
 [Twitter](https://twitter.com/snapcraftio),
@@ -23,7 +25,7 @@ Learn about the latest features by following Snapcraft on
 
 ## Contribute to Snapcraft
 
-We love contributors. Read the [hacking guide](HACKING.md) if you're interested in helping out.
+~~We love contributors~~. Read the [hacking guide](HACKING.md) if you're interested ~~in helping out~~.
 
 
 [travis-image]: https://travis-ci.org/snapcore/snapcraft.svg?branch=master


### PR DESCRIPTION
Forum is bad place to send anybody to disucuss anything and should not be used. They ban and censor criticism which is in no way proper addressing of the issue.

staff closes instead to reply.

@sergiusens your forum is not proper place for disussion, you close each pull request because you do not want what? Let's talk here, as it is easiest, you can close this PR when we finish and John R Lenton should prove his words if you already claim that he is not a lier, I referenced to a post where he lied.

Beside that, how do you like choice of words by him "silencing". He seems to be really old in not knowing that I can register new account at any time and "silencing" is gone up to the point where you close your forum because you do not want new users, great goal istn it? 

You guys want to show the world how linux is easy and good in breaking it, claiming later falsely that it was broken where it wasnt and finally, silencing :) based on weather.

Snapcraft looked cool but all this in a pack just stinks, I cant trust you guys if you do break the code intentionally and it really should not be part of ubuntu then, especially if you do not care if pushing malicious code.