### PR TITLE
storeapi: use the channels attribute in push

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -36,7 +36,7 @@ run_static_tests() {
     python3 -m flake8 .
 
     echo "Running mypy"
-    mypy -p snapcraft
+    mypy --python-version 3.6 -p snapcraft
 
     echo "Running codespell"
     codespell -S "*.tar,*.xz,*.zip,*.bz2,*.7z,*.gz,*.deb,*.rpm,*.snap,*.gpg,*.pyc,*.png,*.ico,*.jar,changelog,.git,.hg,.mypy_cache,.tox,.venv,_build,buck-out,__pycache__,build,dist,.vscode,parts,stage,prime,test_appstream.py" -q4

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -165,7 +165,8 @@ def push(snap_file, release):
     if release:
         channel_list = release.split(",")
         click.echo(
-            "After pushing, an attempt will be made to release to {}"
+            "After pushing, the resulting snap revision will be released to "
+            "{} when it passes the Snap Store review."
             "".format(formatting_utils.humanize_list(channel_list, "and"))
         )
 

--- a/snapcraft/plugins/_ros/rospack.py
+++ b/snapcraft/plugins/_ros/rospack.py
@@ -18,11 +18,14 @@ import os
 import logging
 import subprocess
 import tempfile
-from typing import List, Set
+from typing import List, Set, TYPE_CHECKING
 
-import snapcraft
 from snapcraft.internal import common, repo
 from snapcraft import formatting_utils
+
+if TYPE_CHECKING:
+    from snapcraft.project import Project
+
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +39,7 @@ class Rospack:
         rospack_path: str,
         ubuntu_sources: str,
         ubuntu_keyrings: List[str],
-        project: snapcraft.project.Project
+        project: "Project"
     ) -> None:
         """Create a new Rospack instance.
 

--- a/snapcraft/storeapi/_sca_client.py
+++ b/snapcraft/storeapi/_sca_client.py
@@ -1,6 +1,7 @@
 import json
 import os
 import urllib.parse
+from typing import List, Optional
 
 import requests
 from simplejson.scanner import JSONDecodeError
@@ -129,7 +130,8 @@ class SCAClient(Client):
         source_hash=None,
         target_hash=None,
         built_at=None,
-    ):
+        channels: Optional[List[str]] = None,
+    ) -> StatusTracker:
         data = {
             "name": snap_name,
             "series": constants.DEFAULT_SERIES,
@@ -144,6 +146,8 @@ class SCAClient(Client):
             data["target_hash"] = target_hash
         if built_at is not None:
             data["built_at"] = built_at
+        if channels is not None:
+            data["channels"] = channels
         auth = _macaroon_auth(self.conf)
         response = self.post(
             "snap-push/",

--- a/snapcraft/storeapi/_store_client.py
+++ b/snapcraft/storeapi/_store_client.py
@@ -17,7 +17,7 @@
 import os
 import urllib.parse
 from time import sleep
-from typing import Dict, Iterable, List, TextIO, Union
+from typing import Dict, Iterable, List, Optional, TextIO, Union
 
 import pymacaroons
 import requests
@@ -178,6 +178,7 @@ class StoreClient:
         target_hash=None,
         delta_hash=None,
         built_at=None,
+        channels: Optional[List[str]] = None,
     ):
         # FIXME This should be raised by the function that uses the
         # discharge. --elopio -2016-06-20
@@ -197,6 +198,7 @@ class StoreClient:
             target_hash=target_hash,
             delta_hash=delta_hash,
             built_at=built_at,
+            channels=channels,
         )
 
     def release(self, snap_name, revision, channels):

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -407,6 +407,7 @@ class StoreServerError(StoreError):
         action = "The operational status of the Snap Store can be checked at {}".format(
             _STORE_STATUS_URL
         )
+        self.response = response
 
         super().__init__(
             response=response,

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -1101,6 +1101,29 @@ class FakeStoreAPIServer(base.BaseFakeServer):
             "channel_map_tree": {
                 "latest": {
                     "16": {
+                        "all": [
+                            {"info": "none", "channel": "stable"},
+                            {"info": "none", "channel": "candidate"},
+                            {
+                                "info": "specific",
+                                "version": "1.1-amd64",
+                                "channel": "beta",
+                                "revision": 6,
+                            },
+                            {
+                                "info": "specific",
+                                "version": "1.0-i386",
+                                "channel": "edge",
+                                "revision": 3,
+                            },
+                            {
+                                "info": "branch",
+                                "version": "1.1-i386",
+                                "channel": "edge/test",
+                                "revision": 9,
+                                "expires_at": "2019-05-30T01:17:06.465504",
+                            },
+                        ],
                         "i386": [
                             {"info": "none", "channel": "stable"},
                             {"info": "none", "channel": "candidate"},

--- a/tests/integration/store/test_store_close.py
+++ b/tests/integration/store/test_store_close.py
@@ -14,9 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from testtools.matchers import FileExists
+import os
 
-from testtools.matchers import Equals
+from testtools.matchers import Equals, FileExists
 
 from tests import integration
 
@@ -41,16 +41,28 @@ class ChannelClosingTestCase(integration.StoreTestCase):
         self.addCleanup(self.logout)
         self.login()
 
-        # Build a random snap, register, push and release it.
-        name = self.get_unique_name()
-        version = self.get_unique_version()
+        # Change to a random name and version when not on the fake store.
+        if not self.is_store_fake():
+            name = self.get_unique_name()
+            version = self.get_unique_version()
+        # If not, keep the name that is faked in our fake account.
+        else:
+            name = "basic"
+            version = "1.0"
+
         self.copy_project_to_cwd("basic")
         self.update_name_and_version(name, version)
+
         self.run_snapcraft("snap")
-        snap_path = "{}_{}_{}.snap".format(name, version, "all")
-        self.assertThat(snap_path, FileExists())
+
+        # Register the snap
         self.register(name)
-        self.assertThat(self.push(snap_path, release="edge,beta"), Equals(0))
+
+        # Upload the snap
+        snap_file_path = "{}_{}_{}.snap".format(name, version, "all")
+        self.assertThat(os.path.join(snap_file_path), FileExists())
+
+        self.assertThat(self.push(snap_file_path, release="edge,beta"), Equals(0))
 
         expected = "The beta channel is now closed."
         status = self.close(name, "beta", expected=expected)

--- a/tests/integration/store/test_store_push.py
+++ b/tests/integration/store/test_store_push.py
@@ -65,9 +65,15 @@ class PushTestCase(integration.StoreTestCase):
         self.addCleanup(self.logout)
         self.login()
 
-        # Change to a random name and version.
-        name = self.get_unique_name()
-        version = self.get_unique_version()
+        # Change to a random name and version when not on the fake store.
+        if not self.is_store_fake():
+            name = self.get_unique_name()
+            version = self.get_unique_version()
+        # If not, keep the name that is faked in our fake account.
+        else:
+            name = "basic"
+            version = "1.0"
+
         self.copy_project_to_cwd("basic")
         self.update_name_and_version(name, version)
 
@@ -75,14 +81,13 @@ class PushTestCase(integration.StoreTestCase):
 
         # Register the snap
         self.register(name)
+
         # Upload the snap
         snap_file_path = "{}_{}_{}.snap".format(name, version, "all")
         self.assertThat(os.path.join(snap_file_path), FileExists())
 
         output = self.run_snapcraft(["push", snap_file_path, "--release", "edge"])
         expected = r".*Ready to release!.*".format(name)
-        self.assertThat(output, MatchesRegex(expected, flags=re.DOTALL))
-        expected = r".*The \'edge\' channel is now open.*"
         self.assertThat(output, MatchesRegex(expected, flags=re.DOTALL))
 
     def test_push_with_deprecated_upload(self):

--- a/tests/integration/store/test_store_status.py
+++ b/tests/integration/store/test_store_status.py
@@ -76,7 +76,12 @@ class StatusTestCase(integration.StoreTestCase):
         expected = dedent(
             """\
             Track    Arch    Channel    Version    Revision    Expires at
-            latest   amd64   stable     1.0-amd64  2
+            latest   all     stable     -          -
+                             candidate  -          -
+                             beta       1.1-amd64  6
+                             edge       1.0-i386   3
+                             edge/test  1.1-i386   9           2019-05-30T01:17:06.465504
+                     amd64   stable     1.0-amd64  2
                              candidate  -          -
                              beta       1.1-amd64  4
                              edge       ^          ^

--- a/tests/unit/store/test_store_client.py
+++ b/tests/unit/store/test_store_client.py
@@ -1371,6 +1371,29 @@ class GetSnapStatusTestCase(StoreTestCase):
                                 "expires_at": "2019-05-30T01:17:06.465504",
                             },
                         ],
+                        "all": [
+                            {"channel": "stable", "info": "none"},
+                            {"channel": "candidate", "info": "none"},
+                            {
+                                "channel": "beta",
+                                "info": "specific",
+                                "revision": 6,
+                                "version": "1.1-amd64",
+                            },
+                            {
+                                "channel": "edge",
+                                "info": "specific",
+                                "revision": 3,
+                                "version": "1.0-i386",
+                            },
+                            {
+                                "channel": "edge/test",
+                                "info": "branch",
+                                "revision": 9,
+                                "version": "1.1-i386",
+                                "expires_at": "2019-05-30T01:17:06.465504",
+                            },
+                        ],
                         "amd64": [
                             {
                                 "channel": "stable",


### PR DESCRIPTION
Switch from releasing  manually to adding the channels intent attribute
from the snap-push endpoint.
https://dashboard.staging.snapcraft.io/docs/api/snap.html#push-a-snap-build-to-the-store

Additional fixes for mypy were added to accomodate the new code.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
