### PR TITLE
snaps: if snap is installed, don't check is_valid()

### DIFF
--- a/snapcraft/internal/repo/snaps.py
+++ b/snapcraft/internal/repo/snaps.py
@@ -278,7 +278,7 @@ def install_snaps(snaps_list):
     snaps_installed = []
     for snap in snaps_list:
         snap_pkg = SnapPackage(snap)
-        if not snap_pkg.is_valid():
+        if not snap_pkg.installed and not snap_pkg.is_valid():
             raise errors.SnapUnavailableError(
                 snap_name=snap_pkg.name, snap_channel=snap_pkg.channel
             )


### PR DESCRIPTION
is_valid() requires reaching out to the snap store.  If it's
installed and a project dependency, it is presumably valid.

- Reduces some network traffic for users.
- Enables limited offline development when the project depends
  on build or content snaps.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
