### PR TITLE
tests: update rust-toolchain test so it pulls from beta

### DIFF
--- a/tests/spread/plugins/rust/rust-toolchain/task.yaml
+++ b/tests/spread/plugins/rust/rust-toolchain/task.yaml
@@ -13,9 +13,8 @@ prepare: |
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
 
-  # Set the toolchain file to an at least week old release to avoid any
-  # potentially old nightly being cleared in the future.
-  echo "nightly-$(date --date "last Tue" +%F)" > "$SNAP_DIR/rust-toolchain"
+  # Set the toolchain to pull from the beta channel.
+  echo "beta" > "$SNAP_DIR/rust-toolchain"
 
 restore: |
   cd "$SNAP_DIR"
@@ -35,4 +34,5 @@ execute: |
   snapcraft build
 
   # Verify that nightly was used instead of the default stable
-  MATCH 'rustc-version: rustc .*-nightly' < parts/rust-hello/state/build
+  # e.g.; MATCH 'rustc-version: rustc 1.39.0-beta.1 (968967007 2019-09-24)'
+  MATCH 'rustc-version: rustc .*-beta.*' < parts/rust-hello/state/build


### PR DESCRIPTION
Nightlies do not seem to be generated nightly anymore which breaks
the assumptions the test made.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
