### PR TITLE
meta: take no command-chain being prepended into account

### DIFF
--- a/snapcraft/internal/meta/application.py
+++ b/snapcraft/internal/meta/application.py
@@ -139,9 +139,12 @@ class Application:
         for command_entry, command in self._commands.items():
             self._app_properties[command_entry] = command.get_command()
 
-        self._app_properties[
-            "command-chain"
-        ] = prepend_command_chain + self._app_properties.get("command-chain", list())
+        if "command-chain" in self._app_properties or prepend_command_chain:
+            self._app_properties[
+                "command-chain"
+            ] = prepend_command_chain + self._app_properties.get(
+                "command-chain", list()
+            )
 
         self._fix_sockets()
 

--- a/tests/unit/meta/test_application.py
+++ b/tests/unit/meta/test_application.py
@@ -148,6 +148,18 @@ class AppCommandTest(unit.TestCase):
             Equals(yaml_utils.OctInt),
         )
 
+    def test_no_command_chain_prepended(self):
+        app = application.Application(
+            app_name="foo",
+            app_properties={"command": "test-command"},
+            base="core18",
+            prime_dir=self.path,
+        )
+
+        self.assertThat(
+            app.get_yaml(prepend_command_chain=[]), Equals({"command": "test-command"})
+        )
+
 
 class WrapperUseTest(unit.TestCase):
     scenarios = (


### PR DESCRIPTION
Avoid an empty command-chain in the apps entry from being set
as a result of using classic confinement for which snapcraft's
core does not prepend its own command-chain.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
