### PR TITLE
project: use os.sched_getaffinity instead of multiprocessing.cpu_count

### DIFF
--- a/snapcraft/project/_project_options.py
+++ b/snapcraft/project/_project_options.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import multiprocessing
 import os
 import platform
 import sys
@@ -133,13 +132,7 @@ def _get_platform_architecture():
 class ProjectOptions:
     @property
     def parallel_build_count(self) -> int:
-        build_count = 1
-        try:
-            build_count = multiprocessing.cpu_count()
-        except NotImplementedError:
-            logger.warning("Unable to determine CPU count; disabling parallel builds")
-
-        return build_count
+        return len(os.sched_getaffinity(0))
 
     @property
     def is_cross_compiling(self):

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -155,9 +155,9 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
             apt.apt_pkg.config.find_file("Dir::Etc::TrustedParts"),
         )
 
-        patcher = mock.patch("multiprocessing.cpu_count")
+        patcher = mock.patch("os.sched_getaffinity")
         self.cpu_count = patcher.start()
-        self.cpu_count.return_value = 2
+        self.cpu_count.return_value = {1, 2}
         self.addCleanup(patcher.stop)
 
         # We do not want the paths to affect every test we have.

--- a/tests/unit/project_loader/test_environment.py
+++ b/tests/unit/project_loader/test_environment.py
@@ -492,7 +492,7 @@ class EnvironmentTest(ProjectLoaderBaseTest):
             ),
         )
 
-    @mock.patch("multiprocessing.cpu_count", return_value=42)
+    @mock.patch("os.sched_getaffinity", return_value=set(range(0, 42)))
     def test_parts_build_env_contains_parallel_build_count(self, cpu_mock):
         project_config = self.make_snapcraft_project(self.snapcraft_yaml)
         part1 = [


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

`multiprocessing.cpu_count` always returns the number of raw hardware CPUs available. However, in the context snapcraft is using it, what is actually desired is the number of _usable_ CPUs (taking cgroups, affinity, etc. into account). For example, if you limit a LXD container to a single CPU, `multiprocessing.cpu_count` will continue to detect the number of CPUs available on the host, not 1.

This PR moves snapcraft away from this, and starts using `os.sched_getaffinity` instead, which detects the CPUs actually available for use by the process.