### PR TITLE
cmake plugin: support disable-parallel option

### DIFF
--- a/snapcraft/plugins/cmake.py
+++ b/snapcraft/plugins/cmake.py
@@ -118,13 +118,7 @@ class CMakePlugin(snapcraft.BasePlugin):
         # TODO: there is a better way to specify the job count on newer versions of cmake
         # https://github.com/Kitware/CMake/commit/1ab3881ec9e809ac5f6cad5cd84048310b8683e2
         self.run(
-            [
-                "cmake",
-                "--build",
-                ".",
-                "--",
-                "-j{}".format(self.project.parallel_build_count),
-            ],
+            ["cmake", "--build", ".", "--", "-j{}".format(self.parallel_build_count)],
             env=env,
         )
 

--- a/tests/unit/plugins/test_cmake.py
+++ b/tests/unit/plugins/test_cmake.py
@@ -122,6 +122,23 @@ class CMakeTest(CMakeBaseTest):
             ]
         )
 
+    def test_build_disable_parallel(self):
+        self.options.disable_parallel = True
+
+        plugin = cmake.CMakePlugin("test-part", self.options, self.project)
+        os.makedirs(plugin.builddir)
+        plugin.build()
+
+        self.run_mock.assert_has_calls(
+            [
+                mock.call(
+                    ["cmake", "--build", ".", "--", "-j1"],
+                    cwd=plugin.builddir,
+                    env=mock.ANY,
+                )
+            ]
+        )
+
     def test_build_environment(self):
         plugin = cmake.CMakePlugin("test-part", self.options, self.project)
         os.makedirs(plugin.builddir)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Currently the cmake plugin utilizes the `parallel_build_count` attribute from `Project`. This PR switches it over to using the one from the `BasePlugin` to support the `disable-parallel` option. It also verifies that it works with a test.