### PR TITLE
extensions: add gsettings plug to gnome-3-28 extension

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -60,7 +60,7 @@ In order to run these tests suites, first you will need to set up your developme
 
 Then, you'll need a few more dependencies:
 
-    sudo apt install squashfs-tools xdelta3 bzr git mercurial subversion
+    sudo apt install squashfs-tools xdelta3 bzr git mercurial subversion shellcheck
 
 ### Running the tests
 

--- a/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
@@ -44,6 +44,7 @@ class ExtensionImpl(Extension):
     \b
     - desktop (https://snapcraft.io/docs/desktop-interface)
     - desktop-legacy (https://snapcraft.io/docs/desktop-legacy-interface)
+    - gsettings (https://snapcraft.io/docs/gsettings-interface)
     - wayland (https://snapcraft.io/docs/wayland-interface)
     - x11 (https://snapcraft.io/docs/x11-interface)
     """
@@ -98,7 +99,7 @@ class ExtensionImpl(Extension):
 
         self.app_snippet = {
             "command-chain": ["snap/command-chain/desktop-launch"],
-            "plugs": ["desktop", "desktop-legacy", "wayland", "x11"],
+            "plugs": ["desktop", "desktop-legacy", "gsettings", "wayland", "x11"],
         }
 
         self.parts = {

--- a/tests/unit/project_loader/extensions/test_gnome_3_28.py
+++ b/tests/unit/project_loader/extensions/test_gnome_3_28.py
@@ -70,7 +70,13 @@ class ExtensionTest(ProjectLoaderBaseTest):
             Equals(
                 {
                     "command-chain": ["snap/command-chain/desktop-launch"],
-                    "plugs": ["desktop", "desktop-legacy", "wayland", "x11"],
+                    "plugs": [
+                        "desktop",
+                        "desktop-legacy",
+                        "gsettings",
+                        "wayland",
+                        "x11",
+                    ],
                 }
             ),
         )


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

The `gsettings` plug is needed for GTK applications to use the correct theme under Wayland. As a result, every GTK application should add this plug, so it seems better to just do it in the extension itself.

https://forum.snapcraft.io/t/gnome-3-28-extension-add-gsettings-to-plugs/13471