### PR TITLE
cli: add -s back to clean for legacy

### DIFF
--- a/snapcraft/cli/_runner.py
+++ b/snapcraft/cli/_runner.py
@@ -92,6 +92,10 @@ def run(ctx, debug, catch_exceptions=False, **kwargs):
 
     # In an ideal world, this logger setup would be replaced
     log.configure(log_level=log_level)
+
+    # Payload information about argv
+    ctx.obj = dict(argv=sys.argv)
+
     # The default command
     if not ctx.invoked_subcommand:
         snap_command = lifecyclecli.commands["snap"]

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -280,6 +280,7 @@ def pack(directory, output, **kwargs):
 
 
 @lifecyclecli.command(cls=SnapcraftProjectCommand)
+@click.pass_context
 @click.argument("parts", nargs=-1, metavar="<part>...", required=False)
 @click.option(
     "--use-lxd",
@@ -294,8 +295,8 @@ def pack(directory, output, **kwargs):
     help="Forces snapcraft to try and use the current host to clean.",
 )
 @click.option("--unprime", is_flag=True, required=False, hidden=True)
-@click.option("--step", required=False, hidden=True)
-def clean(parts, use_lxd, destructive_mode, unprime, step):
+@click.option("--step", "-s", required=False, hidden=True)
+def clean(ctx, parts, use_lxd, destructive_mode, unprime, step):
     """Remove a part's assets.
 
     \b
@@ -305,7 +306,8 @@ def clean(parts, use_lxd, destructive_mode, unprime, step):
     """
     # This option is only valid in legacy.
     if step:
-        raise click.BadOptionUsage("--step", "no such option: --step")
+        option = "--step" if "--step" in ctx.obj["argv"] else "-s"
+        raise click.BadOptionUsage(option, "no such option: {}".format(option))
 
     build_environment = get_build_environment(
         use_lxd=use_lxd, destructive_mode=destructive_mode

--- a/tests/spread/legacy/clean/task.yaml
+++ b/tests/spread/legacy/clean/task.yaml
@@ -1,0 +1,19 @@
+summary: Clean baseless projects with short and long options
+
+systems: [ubuntu-16*]
+
+environment:
+  OPTION/s: "-s"
+  OPTION/step: "--step"
+
+prepare: |
+  snapcraft init
+
+  # Remove the base
+  sed -i snap/snapcraft.yaml -e '/base: \w/d'
+
+restore: |
+  rm -rf snap
+
+execute: |
+  snapcraft clean "$OPTION" build


### PR DESCRIPTION
The command line is analyzed by the new code base before re-executing
into the legacy one. The short option scenario for --step in clean got
lost in that refactor.

LP: #1834628

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
