### PR TITLE
mypy: add coverage to tests

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 # TODO migrate to PEP 518 once supported.
 # https://github.com/python/mypy/pull/5208
 [mypy]
-python_version = 3.5
+python_version = 3.6
 ignore_missing_imports = True
 follow_imports = silent

--- a/runtests.sh
+++ b/runtests.sh
@@ -36,7 +36,7 @@ run_static_tests() {
     python3 -m flake8 .
 
     echo "Running mypy"
-    mypy --python-version 3.6 -p snapcraft
+    mypy .
 
     echo "Running codespell"
     codespell -S "*.tar,*.xz,*.zip,*.bz2,*.7z,*.gz,*.deb,*.rpm,*.snap,*.gpg,*.pyc,*.png,*.ico,*.jar,changelog,.git,.hg,.mypy_cache,.tox,.venv,_build,buck-out,__pycache__,build,dist,.vscode,parts,stage,prime,test_appstream.py" -q4

--- a/tests/fake_servers/__init__.py
+++ b/tests/fake_servers/__init__.py
@@ -27,7 +27,7 @@ import pymacaroons
 try:
     from snapcraft import yaml_utils
 except ImportError:
-    import yaml as yaml_utils
+    import yaml as yaml_utils  # type: ignore
 
 logger = logging.getLogger(__name__)
 

--- a/tests/fixture_setup/_fixtures.py
+++ b/tests/fixture_setup/_fixtures.py
@@ -39,7 +39,7 @@ from tests.subprocess_utils import call, call_with_output
 try:
     from snapcraft import yaml_utils
 except ImportError:
-    import yaml as yaml_utils
+    import yaml as yaml_utils  # type: ignore
 
 
 class TempCWD(fixtures.Fixture):

--- a/tests/fixture_setup/_unittests.py
+++ b/tests/fixture_setup/_unittests.py
@@ -533,12 +533,12 @@ class FakeAptCachePackage:
             return "{}={}".format(self.name, self.version)
 
     @property
-    def version(self):
-        return self._version
-
-    @property
     def is_auto_removable(self):
         return self.marked_install and self.is_auto_installed
+
+    @property
+    def version(self):
+        return self._version
 
     @version.setter
     def version(self, version):

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -68,7 +68,7 @@ class ProviderImpl(Provider):
         """Fake provider check."""
 
     @classmethod
-    def setup_provider(cls) -> None:
+    def setup_provider(cls, *, echoer=None) -> None:
         """Fake provider setup."""
 
     @classmethod

--- a/tests/unit/plugins/test_cmake.py
+++ b/tests/unit/plugins/test_cmake.py
@@ -24,6 +24,7 @@ import snapcraft
 from snapcraft.internal import errors
 from snapcraft.plugins import cmake
 from tests import fixture_setup, unit
+from typing import Any, Dict, List, Tuple
 
 
 class CMakeBaseTest(unit.TestCase):
@@ -198,7 +199,7 @@ class CMakeTest(CMakeBaseTest):
 
 class CMakeBuildTest(CMakeBaseTest):
 
-    scenarios = (
+    scenarios: List[Tuple[str, Dict[str, Any]]] = [
         ("no snaps", dict(build_snaps=[], expected_root_paths=[])),
         (
             "one build snap",
@@ -232,7 +233,7 @@ class CMakeBuildTest(CMakeBaseTest):
                 ],
             ),
         ),
-    )
+    ]
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
mypy.ini: set python version to 3.6
tests: minor fixups for mypy to run successfully
runtests: add mypy coverage of unit tests for static target