### PR TITLE
tests: fix mypy error with test_errors.py

### DIFF
--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -826,7 +826,7 @@ class StrangeExceptionSimple(errors.SnapcraftException):
 
 
 class StrangeExceptionWithFormatting(errors.SnapcraftException):
-    def __init__(self, neighborhood: str, contact: str, ghosts: List[str]):
+    def __init__(self, neighborhood: str, contact: str, ghosts: List[str]) -> None:
         self._neighborhood = neighborhood
         self._contact = contact
         self._ghosts = ghosts


### PR DESCRIPTION
Triggered by merging the mypy coverage and SnapcraftException
bits.  The SnapcraftException had a mypy issue in test_errors:
(__init__ must return None).

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
