### PR TITLE
extensions: support using gjs from gnome runtime

### DIFF
--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -252,6 +252,7 @@ fi
 # GI repository
 prepend_dir GI_TYPELIB_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/girepository-1.0"
 prepend_dir GI_TYPELIB_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/girepository-1.0"
+prepend_dir GI_TYPELIB_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/gjs/girepository-1.0"
 prepend_dir GI_TYPELIB_PATH "$SNAP/usr/lib/$ARCH/girepository-1.0"
 prepend_dir GI_TYPELIB_PATH "$SNAP/usr/lib/girepository-1.0"
 prepend_dir GI_TYPELIB_PATH "$SNAP/usr/lib/gjs/girepository-1.0"

--- a/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
@@ -88,6 +88,7 @@ class ExtensionImpl(Extension):
             },
             "environment": {"SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform"},
             "layout": {
+                "/usr/bin/gjs": {"symlink": "$SNAP/gnome-platform/usr/bin/gjs"},
                 "/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.0": {
                     "bind": "$SNAP/gnome-platform/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.0"
                 },

--- a/tests/unit/project_loader/extensions/test_gnome_3_28.py
+++ b/tests/unit/project_loader/extensions/test_gnome_3_28.py
@@ -55,6 +55,7 @@ class ExtensionTest(ProjectLoaderBaseTest):
                     },
                     "environment": {"SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform"},
                     "layout": {
+                        "/usr/bin/gjs": {"symlink": "$SNAP/gnome-platform/usr/bin/gjs"},
                         "/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.0": {
                             "bind": "$SNAP/gnome-platform/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.0"
                         },


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR enables snaps to use the gjs bundled in the gnome runtime snap ([MR](https://gitlab.gnome.org/Community/Ubuntu/gnome-3-28-1804/merge_requests/1) accepted, available in revision 87 and up).

I tested this with the foliate snap: https://github.com/snapcrafters/foliate/tree/gjs-via-gnome-extension

This removes a lot of boilerplate and reduces the `foliate` snap size from  `92M` to `324K`!

*Note:  `./runtests.sh static` gives the following error at the end, but this also happens on master.*

```
tests/unit/project_loader/grammar/test_compound_statement.py:223: error: Module has no attribute "errors"
tests/unit/project_loader/grammar/test_compound_statement.py:235: error: Module has no attribute "errors"
```
