### PR TITLE
meta: warn about command mangling

### DIFF
--- a/snapcraft/internal/deprecations.py
+++ b/snapcraft/internal/deprecations.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016 Canonical Ltd
+# Copyright (C) 2016-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/tests/unit/meta/test_command.py
+++ b/tests/unit/meta/test_command.py
@@ -14,8 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import os
 
+import fixtures
 from testtools.matchers import Equals, Is, FileContains, FileExists
 
 from snapcraft.internal.meta import command, errors
@@ -28,7 +30,18 @@ def _create_file(file_path: str, *, mode=0o755) -> None:
     os.chmod(file_path, mode)
 
 
-class CommandWithoutWrapperTest(unit.TestCase):
+class UnmodifiedCommandWithoutWrapperTest(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.fake_logger = fixtures.FakeLogger(level=logging.WARNING)
+        self.useFixture(self.fake_logger)
+
+    def tearDown(self):
+        super().tearDown()
+
+        self.assertThat(self.fake_logger.output, Equals(""))
+
     def test_command(self):
         _create_file(os.path.join(self.path, "foo"))
         cmd = command.Command(app_name="foo", command_name="command", command="foo")
@@ -86,6 +99,8 @@ class CommandWithoutWrapperTest(unit.TestCase):
             prime_dir=self.path,
         )
 
+        self.assertThat(self.fake_logger.output.strip(), Equals(""))
+
     def test_command_not_executable(self):
         _create_file(os.path.join(self.path, "foo"), mode=0o644)
         cmd = command.Command(app_name="foo", command_name="command", command="foo")
@@ -100,6 +115,12 @@ class CommandWithoutWrapperTest(unit.TestCase):
 
 
 class CommandWithWrapperTest(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.fake_logger = fixtures.FakeLogger(level=logging.WARNING)
+        self.useFixture(self.fake_logger)
+
     def test_command(self):
         _create_file(os.path.join(self.path, "foo"))
         cmd = command.Command(app_name="foo", command_name="command", command="foo")
@@ -108,6 +129,31 @@ class CommandWithWrapperTest(unit.TestCase):
         )
 
         self.assertThat(cmd.command, Equals("foo"))
+        self.assertThat(self.fake_logger.output, Equals(""))
+
+    def test_command_with_dollar_snap_and_does_not_match_snapd_pattern(self):
+        _create_file(os.path.join(self.path, "foo"))
+        cmd = command.Command(
+            app_name="foo", command_name="command", command="$SNAP/foo !option"
+        )
+        cmd.prime_command(
+            can_use_wrapper=True, massage_command=True, prime_dir=self.path
+        )
+
+        self.assertThat(cmd.command, Equals("command-foo.wrapper"))
+        self.assertThat(
+            self.fake_logger.output.strip(),
+            Equals(
+                "Stripped '$SNAP/' from command '$SNAP/foo !option'. "
+                "Relative paths from the prime are required by snapd."
+                "\n"
+                "A shell wrapper will be generated for command 'foo !option' "
+                "as it does not conform with the command pattern expected "
+                "by snapd. Commands must be relative to the prime directory "
+                "and can only consist of alphanumeric characters, spaces, and "
+                "the following special characters: / . _ # : $ -"
+            ),
+        )
 
     def test_command_with_args(self):
         _create_file(os.path.join(self.path, "foo"))
@@ -122,6 +168,7 @@ class CommandWithWrapperTest(unit.TestCase):
 
         self.expectThat(cmd.command, Equals("foo bar -baz"))
         self.expectThat(wrapper_path, Is(None))
+        self.assertThat(self.fake_logger.output, Equals(""))
 
     def test_command_does_not_match_snapd_pattern(self):
         _create_file(os.path.join(self.path, "foo"))
@@ -139,6 +186,16 @@ class CommandWithWrapperTest(unit.TestCase):
         self.assertThat(
             wrapper_path, FileContains('#!/bin/sh\nexec $SNAP/foo /!option "$@"\n')
         )
+        self.assertThat(
+            self.fake_logger.output.strip(),
+            Equals(
+                "A shell wrapper will be generated for command 'foo /!option' "
+                "as it does not conform with the command pattern expected by "
+                "snapd. Commands must be relative to the prime directory and "
+                "can only consist of alphanumeric characters, spaces, and the "
+                "following special characters: / . _ # : $ -"
+            ),
+        )
 
     def test_command_starts_with_slash(self):
         cmd = command.Command(app_name="foo", command_name="command", command="/foo")
@@ -151,6 +208,16 @@ class CommandWithWrapperTest(unit.TestCase):
         self.expectThat(cmd.command, Equals("command-foo.wrapper"))
         self.assertThat(wrapper_path, FileExists())
         self.assertThat(wrapper_path, FileContains('#!/bin/sh\nexec /foo "$@"\n'))
+        self.assertThat(
+            self.fake_logger.output.strip(),
+            Equals(
+                "A shell wrapper will be generated for command '/foo' "
+                "as it does not conform with the command pattern expected by "
+                "snapd. Commands must be relative to the prime directory and "
+                "can only consist of alphanumeric characters, spaces, and the "
+                "following special characters: / . _ # : $ -"
+            ),
+        )
 
     def test_command_relative_command_found_in_slash(self):
         cmd = command.Command(app_name="foo", command_name="command", command="sh")
@@ -163,6 +230,19 @@ class CommandWithWrapperTest(unit.TestCase):
         self.expectThat(cmd.command, Equals("command-foo.wrapper"))
         self.assertThat(wrapper_path, FileExists())
         self.assertThat(wrapper_path, FileContains('#!/bin/sh\nexec /bin/sh "$@"\n'))
+        self.assertThat(
+            self.fake_logger.output.strip(),
+            Equals(
+                "The command 'sh' was not found in the prime directory, it "
+                "has been changed to '/bin/sh'."
+                "\n"
+                "A shell wrapper will be generated for command '/bin/sh' "
+                "as it does not conform with the command pattern expected by "
+                "snapd. Commands must be relative to the prime directory and "
+                "can only consist of alphanumeric characters, spaces, and the "
+                "following special characters: / . _ # : $ -"
+            ),
+        )
 
     def test_command_not_executable(self):
         _create_file(os.path.join(self.path, "foo"), mode=0o644)
@@ -175,3 +255,4 @@ class CommandWithWrapperTest(unit.TestCase):
             massage_command=True,
             prime_dir=self.path,
         )
+        self.assertThat(self.fake_logger.output.strip(), Equals(""))


### PR DESCRIPTION
Warn when a wrapper is needed due to the command used or when the command
has changed to something more compatible with snapd's accepted format.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
