### PR TITLE
project_loader: load build-environment after snapcraft environment

### DIFF
--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -259,12 +259,13 @@ class PartsConfig:
 
             global_env = snapcraft_global_environment(self._project)
             part_env = snapcraft_part_environment(part)
-            # Finally, add the declared environment from the part.
-            # This is done only for the "root" part.
-            env += part.build_environment
 
             for variable, value in ChainMap(part_env, global_env).items():
                 env.append('{}="{}"'.format(variable, value))
+
+            # Finally, add the declared environment from the part.
+            # This is done only for the "root" part.
+            env += part.build_environment
         else:
             env += part.env(stagedir)
             env += runtime_env(stagedir, self._project.arch_triplet)

--- a/tests/unit/project_loader/test_environment.py
+++ b/tests/unit/project_loader/test_environment.py
@@ -22,7 +22,7 @@ from textwrap import dedent
 from unittest import mock
 
 import fixtures
-from testtools.matchers import Contains, Equals, Not
+from testtools.matchers import Contains, Equals, GreaterThan, Not
 
 import snapcraft
 from snapcraft.internal import common
@@ -540,6 +540,86 @@ class EnvironmentTest(ProjectLoaderBaseTest):
         part = project_config.parts.get_part("part1")
         environment = project_config.parts.build_env_for_part(part)
         self.assertThat(environment, Contains('FOO="BAR"'))
+
+    def test_build_environment_can_depend_on_global_env(self):
+        self.useFixture(FakeOsRelease())
+
+        snapcraft_yaml = dedent(
+            """\
+            name: test
+            base: core18
+            version: "1"
+            summary: test
+            description: test
+            confinement: strict
+            grade: stable
+            base: core
+
+            parts:
+              part1:
+                plugin: nil
+                build-environment:
+                  - PROJECT_NAME: $SNAPCRAFT_PROJECT_NAME
+        """
+        )
+        project_config = self.make_snapcraft_project(snapcraft_yaml)
+        part = project_config.parts.get_part("part1")
+        environment = project_config.parts.build_env_for_part(part)
+        snapcraft_definition_index = -1
+        build_environment_definition_index = -1
+        for index, variable in enumerate(environment):
+            if variable.startswith("SNAPCRAFT_PROJECT_NAME="):
+                snapcraft_definition_index = index
+            if variable.startswith("PROJECT_NAME="):
+                build_environment_definition_index = index
+
+        # Assert that each definition was found, and the global env came before the
+        # build environment
+        self.assertThat(snapcraft_definition_index, GreaterThan(-1))
+        self.assertThat(build_environment_definition_index, GreaterThan(-1))
+        self.assertThat(
+            build_environment_definition_index, GreaterThan(snapcraft_definition_index)
+        )
+
+    def test_build_environment_can_depend_on_part_env(self):
+        self.useFixture(FakeOsRelease())
+
+        snapcraft_yaml = dedent(
+            """\
+            name: test
+            base: core18
+            version: "1"
+            summary: test
+            description: test
+            confinement: strict
+            grade: stable
+            base: core
+
+            parts:
+              part1:
+                plugin: nil
+                build-environment:
+                  - PART_INSTALL: $SNAPCRAFT_PART_INSTALL
+        """
+        )
+        project_config = self.make_snapcraft_project(snapcraft_yaml)
+        part = project_config.parts.get_part("part1")
+        environment = project_config.parts.build_env_for_part(part)
+        snapcraft_definition_index = -1
+        build_environment_definition_index = -1
+        for index, variable in enumerate(environment):
+            if variable.startswith("SNAPCRAFT_PART_INSTALL="):
+                snapcraft_definition_index = index
+            if variable.startswith("PART_INSTALL="):
+                build_environment_definition_index = index
+
+        # Assert that each definition was found, and the part env came before the
+        # build environment
+        self.assertThat(snapcraft_definition_index, GreaterThan(-1))
+        self.assertThat(build_environment_definition_index, GreaterThan(-1))
+        self.assertThat(
+            build_environment_definition_index, GreaterThan(snapcraft_definition_index)
+        )
 
     def test_build_environment_with_dependencies_does_not_leak(self):
         self.useFixture(FakeOsRelease())


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

Currently it's impossible to define a `build-environment` that uses variables defined by snapcraft itself (e.g. `$SNAPCRAFT_PART_INSTALL`), since the `build-environment` is evaluated before snapcraft's environment. Fix this by simply switching the order.