### PR TITLE
elf: handle missing dependencies not found on system

### DIFF
--- a/tests/bin/elf/ldd
+++ b/tests/bin/elf/ldd
@@ -14,6 +14,12 @@ _LDD_OUT = {
         'barsnap.so.2 => {CORE_PATH}/barsnap.so.2 (0xbeef)',
         '/lib/baz.so.2 (0x1234)',
     ],
+    'fake_elf-with-missing-libs': [
+        'foo.so.1 => /lib/foo.so.1 (0xdead)',
+        'missing.so.2 => not found',
+        'barsnap.so.2 => {CORE_PATH}/barsnap.so.2 (0xbeef)',
+        '/lib/baz.so.2 (0x1234)',
+    ],
 }
 
 

--- a/tests/fixture_setup/_unittests.py
+++ b/tests/fixture_setup/_unittests.py
@@ -123,6 +123,7 @@ def _fake_elffile_extract(self, path):
         "fake_elf-2.26",
         "fake_elf-bad-ldd",
         "fake_elf-with-core-libs",
+        "fake_elf-with-missing-libs",
         "fake_elf-bad-patchelf",
     ]:
         glibc = elf.NeededLibrary(name="libc.so.6")
@@ -271,6 +272,9 @@ class FakeElf(fixtures.Fixture):
             ),
             "fake_elf-with-core-libs": elf.ElfFile(
                 path=os.path.join(self.root_path, "fake_elf-with-core-libs")
+            ),
+            "fake_elf-with-missing-libs": elf.ElfFile(
+                path=os.path.join(self.root_path, "fake_elf-with-missing-libs")
             ),
             "fake_elf-with-execstack": elf.ElfFile(
                 path=os.path.join(self.root_path, "fake_elf-with-execstack")

--- a/tests/unit/test_elf.py
+++ b/tests/unit/test_elf.py
@@ -108,6 +108,22 @@ class TestInvalidElf(unit.TestCase):
         self.assertThat(elf_files, Equals(set()))
 
 
+class TestMissingLibraries(TestElfBase):
+    def test_get_libraries_missing_libs(self):
+        elf_file = self.fake_elf["fake_elf-with-missing-libs"]
+        libs = elf_file.load_dependencies(
+            root_path=self.fake_elf.root_path,
+            core_base_path=self.fake_elf.core_base_path,
+            arch_triplet=self.arch_triplet,
+            content_dirs=self.content_dirs,
+        )
+
+        self.assertThat(
+            libs,
+            Equals(set([self.fake_elf.root_libraries["foo.so.1"], "missing.so.2"])),
+        )
+
+
 class TestGetLibraries(TestElfBase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
I believe that prior testing involved ldd picking up the
host-installed binaries to properly catch which libs are missing.

Handle the case where ldd may return "not found" or some other
invalid resolution.  In those cases, initialize soname_path to soname.

- Update load_dependencies so that it does not filter out libraries
that are not found.  If done, the returned set isn't very useful
for determining missing dependencies (unless they managed to get
found on host, which is why it has worked thus far).

- Refactor ldd into its own method and update it to parse ldd
output more reliably.

- Add unit test coverage for missing libraries in ldd output.
