### PR TITLE
storeapi: add StoreErrorList to handle store errors

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -616,11 +616,10 @@ def push(snap_filename, release_channels=None):
                 "Error generating delta: {}\n"
                 "Falling back to pushing full snap...".format(str(e))
             )
-        except storeapi.errors.StorePushError as e:
-            store_error = e.error_list[0].get("message")
+        except storeapi.errors.StorePushError as push_error:
             logger.warning(
                 "Unable to push delta to store: {}\n"
-                "Falling back to pushing full snap...".format(store_error)
+                "Falling back to pushing full snap...".format(push_error.error_list)
             )
 
     if result is None:

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -19,7 +19,7 @@ from http.client import responses
 import logging
 from requests.packages import urllib3
 from simplejson.scanner import JSONDecodeError
-from typing import List  # noqa
+from typing import Dict, List
 
 from . import channels
 from . import status
@@ -43,6 +43,32 @@ class StoreError(SnapcraftError):
         with contextlib.suppress(KeyError, AttributeError):
             logger.debug("Store error response: {}".format(kwargs["response"].__dict__))
         super().__init__(**kwargs)
+
+
+class StoreErrorList:
+    def __str__(self) -> str:
+        error_list: List[str] = list()
+        for error in self._error_list:
+            error_list.append("- {}: {}".format(error["code"], error["message"]))
+        return "\n".join(error_list).strip()
+
+    def __repr__(self) -> str:
+        return "<StoreErrorList: {}>".format(
+            " ".join((e.get("code") for e in self._error_list))
+        )
+
+    def __contains__(self, error_code: str) -> bool:
+        return any((error.get("code") == error_code for error in self._error_list))
+
+    def __getitem__(self, error_code: str) -> Dict[str, str]:
+        for error in self._error_list:
+            if error.get("code") == error_code:
+                return error
+
+        raise KeyError(error_code)
+
+    def __init__(self, error_list: List[Dict[str, str]]) -> None:
+        self._error_list = error_list
 
 
 class InvalidCredentialsError(StoreError):
@@ -326,31 +352,35 @@ class StoreUploadError(StoreError):
 class StorePushError(StoreError):
 
     __FMT_NOT_REGISTERED = (
-        "You are not the publisher or allowed to push revisions for this "
-        "snap. To become the publisher, run `snapcraft register {snap_name}` "
-        "and try to push again."
+        "This snap is not registered. Register the snap and try again."
     )
 
-    fmt = "Received {status_code!r}: {text!r}"
+    __FMT_NOT_OWNER = (
+        "You are not the publisher or allowed to push revisions for this "
+        "snap. Ensure you are logged in with the proper account and try "
+        "again."
+    )
 
     def __init__(self, snap_name, response):
         try:
             response_json = response.json()
         except (AttributeError, JSONDecodeError):
-            response_json = {}
+            response_json = {"error_list": list()}
 
-        if response.status_code == 404:
+        error_list = StoreErrorList(error_list=response_json.pop("error_list"))
+
+        if "resource-forbidden" in error_list:
+            self.fmt = self.__FMT_NOT_OWNER
+        elif "resource-not-found" in error_list:
             self.fmt = self.__FMT_NOT_REGISTERED
-        elif response.status_code == 401 or response.status_code == 403:
-            try:
-                response_json["text"] = response.text
-            except AttributeError:
-                response_json["text"] = "error while pushing"
+        else:
+            self.fmt = "Received:\n{!s}".format(error_list)
 
         super().__init__(
             response=response,
             snap_name=snap_name,
             status_code=response.status_code,
+            error_list=error_list,
             **response_json
         )
 

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -463,9 +463,31 @@ class FakeStoreAPIServer(base.BaseFakeServer):
 
         name = request.json_body["name"]
         if name == "test-snap-unregistered":
-            payload = b""
+            payload = json.dumps(
+                {
+                    "error_list": [
+                        {
+                            "code": "resource-not-found",
+                            "message": "the snap name does not exist",
+                        }
+                    ]
+                }
+            ).encode()
             response_code = 404
-            content_type = "text/plain"
+            content_type = "application/json"
+        elif name == "test-snap-forbidden":
+            payload = json.dumps(
+                {
+                    "error_list": [
+                        {
+                            "code": "resource-forbidden",
+                            "message": "not allowed to publish this snap name",
+                        }
+                    ]
+                }
+            ).encode()
+            response_code = 403
+            content_type = "application/json"
         else:
             response_code = 202
             content_type = "application/json"

--- a/tests/unit/commands/test_push.py
+++ b/tests/unit/commands/test_push.py
@@ -182,12 +182,16 @@ class PushCommandTestCase(PushCommandBaseTestCase):
     def test_push_unregistered_snap_must_raise_exception(self):
         class MockResponse:
             status_code = 404
-            error_list = [
-                {
-                    "code": "resource-not-found",
-                    "message": "Snap not found for name=basic",
-                }
-            ]
+
+            def json(self):
+                return dict(
+                    error_list=[
+                        {
+                            "code": "resource-not-found",
+                            "message": "Snap not found for name=basic",
+                        }
+                    ]
+                )
 
         self.mock_precheck.side_effect = StorePushError("basic", MockResponse())
 
@@ -197,11 +201,7 @@ class PushCommandTestCase(PushCommandBaseTestCase):
 
         self.assertThat(
             str(raised),
-            Contains(
-                "You are not the publisher or allowed to push revisions for this "
-                "snap. To become the publisher, run `snapcraft register "
-                "basic` and try to push again."
-            ),
+            Contains("This snap is not registered. Register the snap and try again."),
         )
 
     def test_push_with_updown_error(self):

--- a/tests/unit/commands/test_push_metadata.py
+++ b/tests/unit/commands/test_push_metadata.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2017-2018 Canonical Ltd
+# Copyright 2017-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -154,12 +154,16 @@ class PushMetadataCommandTestCase(CommandBaseTestCase):
     def test_unregistered_snap_must_raise_exception(self):
         class MockResponse:
             status_code = 404
-            error_list = [
-                {
-                    "code": "resource-not-found",
-                    "message": "Snap not found for name=basic",
-                }
-            ]
+
+            def json(self):
+                return dict(
+                    error_list=[
+                        {
+                            "code": "resource-not-found",
+                            "message": "Snap not found for name=basic",
+                        }
+                    ]
+                )
 
         patcher = mock.patch.object(storeapi.StoreClient, "push_precheck")
         mock_precheck = patcher.start()
@@ -174,11 +178,7 @@ class PushMetadataCommandTestCase(CommandBaseTestCase):
 
         self.assertThat(
             str(raised),
-            Contains(
-                "You are not the publisher or allowed to push revisions for this "
-                "snap. To become the publisher, run `snapcraft register "
-                "basic` and try to push again."
-            ),
+            Contains("This snap is not registered. Register the snap and try again."),
         )
 
     def test_forced(self):

--- a/tests/unit/store/test_store_client.py
+++ b/tests/unit/store/test_store_client.py
@@ -941,10 +941,23 @@ class UploadTestCase(StoreTestCase):
         )
         self.assertThat(
             str(raised),
+            Equals("This snap is not registered. Register the snap and try again."),
+        )
+
+    def test_push_forbidden_snap(self):
+        self.client.login("dummy", "test correct password")
+        raised = self.assertRaises(
+            errors.StorePushError,
+            self.client.upload,
+            "test-snap-forbidden",
+            self.snap_path,
+        )
+        self.assertThat(
+            str(raised),
             Equals(
                 "You are not the publisher or allowed to push revisions for "
-                "this snap. To become the publisher, run `snapcraft register "
-                "test-snap-unregistered` and try to push again."
+                "this snap. Ensure you are logged in with the proper account "
+                "and try again."
             ),
         )
 


### PR DESCRIPTION
This class should make it easy to query the error listing
and use the provided messages. It is meant to be used by
composing in the corresponding error classes. This commit
adds it to StorePushError.

StorePushError now properly handles resource-not-found and
resource-forbidden.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
