### PR TITLE
cli: clean up StoreClientCLI

### DIFF
--- a/tests/unit/commands/test_promote.py
+++ b/tests/unit/commands/test_promote.py
@@ -141,7 +141,7 @@ class PromoteCommandTestCase(FakeStoreCommandsBaseTestCase):
 
         self.assertThat(result.exit_code, Equals(0))
         self.fake_store_release.mock.assert_called_once_with(
-            "snap-test", "2", ["candidate"]
+            snap_name="snap-test", revision="2", channels=["candidate"]
         )
 
     def test_promote_yes_option(self):
@@ -190,7 +190,7 @@ class PromoteCommandTestCase(FakeStoreCommandsBaseTestCase):
 
         self.assertThat(result.exit_code, Equals(0))
         self.fake_store_release.mock.assert_called_once_with(
-            "snap-test", "2", ["candidate"]
+            snap_name="snap-test", revision="2", channels=["candidate"]
         )
 
     def test_promote_confirm_no(self):

--- a/tests/unit/commands/test_push.py
+++ b/tests/unit/commands/test_push.py
@@ -77,7 +77,14 @@ class PushCommandTestCase(PushCommandBaseTestCase):
             self.fake_logger.output, r"Revision 9 of 'basic' created\."
         )
         mock_upload.assert_called_once_with(
-            "basic", self.snap_file, built_at=None, channels=[]
+            snap_name="basic",
+            snap_filename=self.snap_file,
+            built_at=None,
+            channels=[],
+            delta_format=None,
+            delta_hash=None,
+            source_hash=None,
+            target_hash=None,
         )
 
     def test_push_with_started_at(self):
@@ -108,7 +115,14 @@ class PushCommandTestCase(PushCommandBaseTestCase):
             self.fake_logger.output, r"Revision 9 of 'basic' created\."
         )
         mock_upload.assert_called_once_with(
-            "basic", snap_file, built_at="2019-05-07T19:25:53.939041Z", channels=[]
+            snap_name="basic",
+            snap_filename=snap_file,
+            built_at="2019-05-07T19:25:53.939041Z",
+            channels=[],
+            delta_format=None,
+            delta_hash=None,
+            source_hash=None,
+            target_hash=None,
         )
 
     def test_push_without_login_must_ask(self):
@@ -243,7 +257,14 @@ class PushCommandTestCase(PushCommandBaseTestCase):
         self.assertThat(result.exit_code, Equals(0))
         self.assertThat(result.output, Contains("Revision 9 of 'basic' created."))
         mock_upload.assert_called_once_with(
-            "basic", self.snap_file, built_at=None, channels=[]
+            snap_name="basic",
+            snap_filename=self.snap_file,
+            built_at=None,
+            channels=[],
+            delta_format=None,
+            delta_hash=None,
+            source_hash=None,
+            target_hash=None,
         )
 
     def test_push_and_release_a_snap(self):
@@ -271,7 +292,14 @@ class PushCommandTestCase(PushCommandBaseTestCase):
         self.assertThat(result.exit_code, Equals(0))
         self.assertThat(result.output, Contains("Revision 9 of 'basic' created"))
         mock_upload.assert_called_once_with(
-            "basic", self.snap_file, built_at=None, channels=["beta"]
+            snap_name="basic",
+            snap_filename=self.snap_file,
+            built_at=None,
+            channels=["beta"],
+            delta_format=None,
+            delta_hash=None,
+            source_hash=None,
+            target_hash=None,
         )
 
     def test_push_and_release_a_snap_to_N_channels(self):
@@ -302,10 +330,14 @@ class PushCommandTestCase(PushCommandBaseTestCase):
         self.assertThat(result.output, Contains("Revision 9 of 'basic' created"))
 
         mock_upload.assert_called_once_with(
-            "basic",
-            self.snap_file,
+            snap_name="basic",
+            snap_filename=self.snap_file,
             built_at=None,
             channels=["edge", "beta", "candidate"],
+            delta_format=None,
+            delta_hash=None,
+            source_hash=None,
+            target_hash=None,
         )
 
     def test_push_displays_humanized_message(self):
@@ -431,7 +463,14 @@ class PushCommandDeltasTestCase(PushCommandBaseTestCase):
             result = self.run_command(["push", self.snap_file])
         self.assertThat(result.exit_code, Equals(0))
         mock_upload.assert_called_once_with(
-            "basic", self.snap_file, built_at=None, channels=[]
+            snap_name="basic",
+            snap_filename=self.snap_file,
+            built_at=None,
+            channels=[],
+            delta_format=None,
+            delta_hash=None,
+            source_hash=None,
+            target_hash=None,
         )
 
     def test_push_with_delta_upload_failure_falls_back(self):
@@ -468,8 +507,8 @@ class PushCommandDeltasTestCase(PushCommandBaseTestCase):
         mock_upload.assert_has_calls(
             [
                 mock.call(
-                    "basic",
-                    mock.ANY,
+                    snap_name="basic",
+                    snap_filename=mock.ANY,
                     built_at=None,
                     channels=[],
                     delta_format="xdelta3",
@@ -479,7 +518,16 @@ class PushCommandDeltasTestCase(PushCommandBaseTestCase):
                 ),
                 mock.call().track(),
                 mock.call().raise_for_code(),
-                mock.call("basic", self.snap_file, built_at=None, channels=[]),
+                mock.call(
+                    snap_name="basic",
+                    snap_filename=self.snap_file,
+                    built_at=None,
+                    channels=[],
+                    delta_format=None,
+                    delta_hash=None,
+                    source_hash=None,
+                    target_hash=None,
+                ),
                 mock.call().track(),
                 mock.call().raise_for_code(),
             ]
@@ -494,10 +542,10 @@ class PushCommandDeltasTestCase(PushCommandBaseTestCase):
         original_upload = storeapi.StoreClient.upload
         called = False
 
-        def _fake_upload(self, *args, **kwargs):
+        def _fake_upload(*args, **kwargs):
             nonlocal called
             if called:
-                return original_upload(self, *args, **kwargs)
+                return original_upload(*args, **kwargs)
             else:
                 called = True
 
@@ -529,8 +577,8 @@ class PushCommandDeltasTestCase(PushCommandBaseTestCase):
         mock_upload.assert_has_calls(
             [
                 mock.call(
-                    "basic",
-                    mock.ANY,
+                    snap_name="basic",
+                    snap_filename=mock.ANY,
                     built_at=None,
                     channels=[],
                     delta_format="xdelta3",
@@ -538,7 +586,16 @@ class PushCommandDeltasTestCase(PushCommandBaseTestCase):
                     source_hash=mock.ANY,
                     target_hash=mock.ANY,
                 ),
-                mock.call("basic", self.snap_file, built_at=None, channels=[]),
+                mock.call(
+                    snap_name="basic",
+                    snap_filename=self.snap_file,
+                    built_at=None,
+                    channels=[],
+                    delta_format=None,
+                    delta_hash=None,
+                    source_hash=None,
+                    target_hash=None,
+                ),
             ]
         )
 

--- a/tests/unit/commands/test_push_metadata.py
+++ b/tests/unit/commands/test_push_metadata.py
@@ -55,7 +55,9 @@ class PushMetadataCommandTestCase(CommandBaseTestCase):
             "description": "Description of the most simple snap",
             "summary": "Summary of the most simple snap",
         }
-        self.mock_metadata.assert_called_once_with("basic", text_metadata, force)
+        self.mock_metadata.assert_called_once_with(
+            snap_name="basic", metadata=text_metadata, force=force
+        )
         # binary metadata
         args, _ = self.mock_binary_metadata.call_args
         self.assertEqual(args[0], "basic")

--- a/tests/unit/commands/test_release.py
+++ b/tests/unit/commands/test_release.py
@@ -66,7 +66,9 @@ class ReleaseCommandTestCase(FakeStoreCommandsBaseTestCase):
                 )
             ),
         )
-        self.fake_store_release.mock.assert_called_once_with("nil-snap", "19", ["beta"])
+        self.fake_store_release.mock.assert_called_once_with(
+            snap_name="nil-snap", revision="19", channels=["beta"]
+        )
 
     def test_release_snap_with_lts_channel(self):
         self.fake_store_release.mock.return_value = {
@@ -108,7 +110,7 @@ class ReleaseCommandTestCase(FakeStoreCommandsBaseTestCase):
             ),
         )
         self.fake_store_release.mock.assert_called_once_with(
-            "nil-snap", "19", ["2.1/beta"]
+            snap_name="nil-snap", revision="19", channels=["2.1/beta"]
         )
 
     def test_release_snap_with_branch(self):
@@ -159,7 +161,7 @@ class ReleaseCommandTestCase(FakeStoreCommandsBaseTestCase):
             ),
         )  # noqa
         self.fake_store_release.mock.assert_called_once_with(
-            "nil-snap", "20", ["stable/hotfix1"]
+            snap_name="nil-snap", revision="20", channels=["stable/hotfix1"]
         )
 
     def test_release_snap_opens_more_than_one_channel(self):
@@ -201,7 +203,9 @@ class ReleaseCommandTestCase(FakeStoreCommandsBaseTestCase):
                 )
             ),
         )  # noqa
-        self.fake_store_release.mock.assert_called_once_with("nil-snap", "19", ["beta"])
+        self.fake_store_release.mock.assert_called_once_with(
+            snap_name="nil-snap", revision="19", channels=["beta"]
+        )
 
     def test_release_with_bad_channel_info(self):
         self.fake_store_release.mock.return_value = {
@@ -228,7 +232,9 @@ class ReleaseCommandTestCase(FakeStoreCommandsBaseTestCase):
 
         self.assertThat(result.exit_code, Equals(0))
 
-        self.fake_store_release.mock.assert_called_once_with("nil-snap", "19", ["beta"])
+        self.fake_store_release.mock.assert_called_once_with(
+            snap_name="nil-snap", revision="19", channels=["beta"]
+        )
 
         # output will include the channel with no info, but there will be a log
         # in error alerting the problem


### PR DESCRIPTION
- Use obvious decorators for login
- Add type annotations and force keyword arguments in StoreClientCLI

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
