### PR TITLE
errors: migrate handful of errors to SnapcraftException

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -18,7 +18,15 @@ from abc import ABC, abstractmethod
 from snapcraft import formatting_utils
 from snapcraft.internal import steps
 from subprocess import CalledProcessError
-from typing import Dict, List, Union, Optional
+from typing import Dict, List, Union, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from snapcraft.internal.pluginhandler._dirty_report import DirtyReport
+    from snapcraft.internal.pluginhandler._outdated_report import OutdatedReport
+
+
+# Commonly used resolution message to clean and retry build.
+CLEAN_RESOLUTION = "Run `snapcraft clean` and retry build."
 
 
 class SnapcraftError(Exception):
@@ -73,91 +81,105 @@ class SnapcraftException(Exception, ABC):
         return self.get_brief()
 
 
-class MissingStateCleanError(SnapcraftError):
-    fmt = (
-        "Failed to clean: "
-        "Missing state for {step.name!r}. "
-        "To clean the project, run `snapcraft clean`."
-    )
+class SnapcraftReportableException(SnapcraftException, ABC):
+    """Helper class for reportable Snapcraft Exceptions."""
 
-    def __init__(self, step):
-        super().__init__(step=step)
+    def get_reportable(self) -> bool:
+        return True
 
 
-class StepOutdatedError(SnapcraftError):
+class MissingStateCleanError(SnapcraftException):
+    def __init__(self, step: steps.Step) -> None:
+        self.step = step
 
-    fmt = (
-        "Failed to reuse files from previous run: "
-        "The {step.name!r} step of {part!r} is out of date:\n"
-        "{report}"
-        "To continue, clean that part's {step.name!r} step by running "
-        "`snapcraft clean {parts_names} -s {step.name}`."
-    )
+    def get_brief(self) -> str:
+        return f"Failed to clean for step {self.step.name!r}."
 
+    def get_resolution(self) -> str:
+        return CLEAN_RESOLUTION
+
+
+class StepOutdatedError(SnapcraftException):
     def __init__(
-        self, *, step, part, dirty_report=None, outdated_report=None, dependents=None
-    ):
+        self,
+        *,
+        step: steps.Step,
+        part: str,
+        dirty_report: "DirtyReport" = None,
+        outdated_report: "OutdatedReport" = None,
+    ) -> None:
+        self.step = step
+        self.part = part
+        self.parts_names = part
+        self.dirty_report = dirty_report
+        self.outdated_report = outdated_report
+        self.report = self._consolidate_reports()
+
+    def _consolidate_reports(self) -> str:
         messages = []
 
-        if dirty_report:
-            messages.append(dirty_report.get_report())
+        if self.dirty_report:
+            messages.append(self.dirty_report.get_report())
 
-        if outdated_report:
-            messages.append(outdated_report.get_report())
+        if self.outdated_report:
+            messages.append(self.outdated_report.get_report())
 
-        if dependents:
-            humanized_dependents = formatting_utils.humanize_list(dependents, "and")
-            pluralized_dependents = formatting_utils.pluralize(
-                dependents, "depends", "depend"
-            )
-            messages.append(
-                "The {0!r} step for {1!r} needs to be run again, "
-                "but {2} {3} on it.\n".format(
-                    step.name, part, humanized_dependents, pluralized_dependents
-                )
-            )
-            parts_names = ["{!s}".format(d) for d in sorted(dependents)]
-        else:
-            parts_names = [part]
+        return "".join(messages)
 
-        super().__init__(
-            step=step,
-            part=part,
-            report="".join(messages),
-            parts_names=" ".join(parts_names),
-        )
+    def get_brief(self) -> str:
+        return "Failed to reuse files from previous run."
+
+    def get_resolution(self) -> str:
+        return CLEAN_RESOLUTION
+
+    def get_details(self) -> Optional[str]:
+        # If non-empty string, return report (otherwise None).
+        if self.report:
+            return self.report
+
+        return None
 
 
-class SnapcraftEnvironmentError(SnapcraftError):
+class SnapcraftEnvironmentError(SnapcraftException):
+    """DEPRECATED: Too generic, create (or re-use) a tailored one."""
+
     # FIXME This exception is too generic.
     # https://bugs.launchpad.net/snapcraft/+bug/1734231
     # --elopio - 20171123
 
-    fmt = "{message}"
+    def __init__(self, message: str) -> None:
+        self.message = message
 
-    def __init__(self, message):
-        super().__init__(message=message)
+    def get_brief(self) -> str:
+        return self.message
 
-
-class SnapcraftDataDirectoryMissingError(SnapcraftReportableError):
-    fmt = (
-        "Cannot find snapcraft's data files required for proper operation.\n"
-        "Please re-install snapcraft or verify installation is correct."
-    )
+    def get_resolution(self) -> str:
+        return ""
 
 
-class SnapcraftMissingLinkerInBaseError(SnapcraftError):
+class SnapcraftDataDirectoryMissingError(SnapcraftReportableException):
+    def get_brief(self) -> str:
+        return "Cannot find snapcraft's data files."
 
-    fmt = (
-        "Cannot find the linker to use for the target base {base!r}.\n"
-        "Please verify that the linker exists at the expected path "
-        "{linker_path!r} and try again. If the linker does not exist "
-        "contact the author of the base (run `snap info {base}` to get "
-        "information for this base)."
-    )
+    def get_resolution(self) -> str:
+        return "Re-install snapcraft or verify installation is correct."
 
-    def __init__(self, *, base, linker_path):
-        super().__init__(base=base, linker_path=linker_path)
+
+class SnapcraftMissingLinkerInBaseError(SnapcraftException):
+    def __init__(self, *, base: str, linker_path: str) -> None:
+        self.base = base
+        self.linker_path = linker_path
+
+    def get_brief(self) -> str:
+        return f"Cannot find the linker to use for the target base {self.base!r}."
+
+    def get_resolution(self) -> str:
+        return (
+            f"Verify that the linker exists at the expected path "
+            f"{self.linker_path!r} and try again. If the linker "
+            f"does not exist contact the author of the base (run "
+            f"`snap info {self.base}` to get information for this base)."
+        )
 
 
 class IncompatibleBaseError(SnapcraftError):

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -39,200 +39,6 @@ class ErrorFormattingTestCase(unit.TestCase):
 
     scenarios = (
         (
-            "MissingStateCleanError",
-            {
-                "exception": errors.MissingStateCleanError,
-                "kwargs": {"step": steps.PULL},
-                "expected_message": (
-                    "Failed to clean: "
-                    "Missing state for 'pull'. "
-                    "To clean the project, run `snapcraft clean`."
-                ),
-            },
-        ),
-        (
-            "StepOutdatedError dependents",
-            {
-                "exception": errors.StepOutdatedError,
-                "kwargs": {
-                    "step": steps.PULL,
-                    "part": "test-part",
-                    "dependents": ["test-dependent"],
-                },
-                "expected_message": (
-                    "Failed to reuse files from previous run: "
-                    "The 'pull' step of 'test-part' is out of date:\n"
-                    "The 'pull' step for 'test-part' needs to be run again, "
-                    "but 'test-dependent' depends on it.\n"
-                    "To continue, clean that part's 'pull' step by running "
-                    "`snapcraft clean test-dependent -s pull`."
-                ),
-            },
-        ),
-        (
-            "StepOutdatedError dirty_properties",
-            {
-                "exception": errors.StepOutdatedError,
-                "kwargs": {
-                    "step": steps.PULL,
-                    "part": "test-part",
-                    "dirty_report": pluginhandler.DirtyReport(
-                        dirty_properties=["test-property1", "test-property2"]
-                    ),
-                },
-                "expected_message": (
-                    "Failed to reuse files from previous run: "
-                    "The 'pull' step of 'test-part' is out of date:\n"
-                    "The 'test-property1' and 'test-property2' part properties "
-                    "appear to have changed.\n"
-                    "To continue, clean that part's 'pull' step by running "
-                    "`snapcraft clean test-part -s pull`."
-                ),
-            },
-        ),
-        (
-            "StepOutdatedError dirty_project_options",
-            {
-                "exception": errors.StepOutdatedError,
-                "kwargs": {
-                    "step": steps.PULL,
-                    "part": "test-part",
-                    "dirty_report": pluginhandler.DirtyReport(
-                        dirty_project_options=["test-option"]
-                    ),
-                },
-                "expected_message": (
-                    "Failed to reuse files from previous run: "
-                    "The 'pull' step of 'test-part' is out of date:\n"
-                    "The 'test-option' project option appears to have changed.\n"
-                    "To continue, clean that part's 'pull' step by running "
-                    "`snapcraft clean test-part -s pull`."
-                ),
-            },
-        ),
-        (
-            "StepOutdatedError changed_dependencies",
-            {
-                "exception": errors.StepOutdatedError,
-                "kwargs": {
-                    "step": steps.PULL,
-                    "part": "test-part",
-                    "dirty_report": pluginhandler.DirtyReport(
-                        changed_dependencies=[
-                            pluginhandler.Dependency(
-                                part_name="another-part", step=steps.PULL
-                            )
-                        ]
-                    ),
-                },
-                "expected_message": (
-                    "Failed to reuse files from previous run: "
-                    "The 'pull' step of 'test-part' is out of date:\n"
-                    "A dependency has changed: 'another-part'\n"
-                    "To continue, clean that part's "
-                    "'pull' step by running "
-                    "`snapcraft clean test-part -s pull`."
-                ),
-            },
-        ),
-        (
-            "StepOutdatedError multiple changed_dependencies",
-            {
-                "exception": errors.StepOutdatedError,
-                "kwargs": {
-                    "step": steps.PULL,
-                    "part": "test-part",
-                    "dirty_report": pluginhandler.DirtyReport(
-                        changed_dependencies=[
-                            pluginhandler.Dependency(
-                                part_name="another-part1", step=steps.PULL
-                            ),
-                            pluginhandler.Dependency(
-                                part_name="another-part2", step=steps.PULL
-                            ),
-                        ]
-                    ),
-                },
-                "expected_message": (
-                    "Failed to reuse files from previous run: "
-                    "The 'pull' step of 'test-part' is out of date:\n"
-                    "Some dependencies have changed: 'another-part1' and "
-                    "'another-part2'\n"
-                    "To continue, clean that part's "
-                    "'pull' step by running "
-                    "`snapcraft clean test-part -s pull`."
-                ),
-            },
-        ),
-        (
-            "StepOutdatedError previous step updated",
-            {
-                "exception": errors.StepOutdatedError,
-                "kwargs": {
-                    "step": steps.STAGE,
-                    "part": "test-part",
-                    "outdated_report": pluginhandler.OutdatedReport(
-                        previous_step_modified=steps.BUILD
-                    ),
-                },
-                "expected_message": (
-                    "Failed to reuse files from previous run: "
-                    "The 'stage' step of 'test-part' is out of date:\n"
-                    "The 'build' step has run more recently.\n"
-                    "To continue, clean that part's "
-                    "'stage' step by running "
-                    "`snapcraft clean test-part -s stage`."
-                ),
-            },
-        ),
-        (
-            "StepOutdatedError source updated",
-            {
-                "exception": errors.StepOutdatedError,
-                "kwargs": {
-                    "step": steps.PULL,
-                    "part": "test-part",
-                    "outdated_report": pluginhandler.OutdatedReport(
-                        source_updated=True
-                    ),
-                },
-                "expected_message": (
-                    "Failed to reuse files from previous run: "
-                    "The 'pull' step of 'test-part' is out of date:\n"
-                    "The source has changed on disk.\n"
-                    "To continue, clean that part's "
-                    "'pull' step by running "
-                    "`snapcraft clean test-part -s pull`."
-                ),
-            },
-        ),
-        (
-            "SnapcraftEnvironmentError",
-            {
-                "exception": errors.SnapcraftEnvironmentError,
-                "kwargs": {"message": "test-message"},
-                "expected_message": "test-message",
-            },
-        ),
-        (
-            "SnapcraftMissingLinkerInBaseError",
-            {
-                "exception": errors.SnapcraftMissingLinkerInBaseError,
-                "kwargs": {
-                    "base": "core18",
-                    "linker_path": "/snap/core18/current/lib64/ld-linux.so.2",
-                },
-                "expected_message": (
-                    "Cannot find the linker to use for the target base 'core18'.\n"
-                    "Please verify that the linker exists at the expected path "
-                    "'/snap/core18/current/lib64/ld-linux.so.2' and try again. If "
-                    "the linker does not exist contact the author of the base "
-                    "(run `snap info core18` to get information for this "
-                    "base)."
-                ),
-            },
-        ),
-        (
             "IncompatibleBaseError",
             {
                 "exception": errors.IncompatibleBaseError,
@@ -858,6 +664,7 @@ class SnapcraftExceptionTests(unit.TestCase):
                 "expected_resolution": "who you gonna call? ghostbusters!!",
                 "expected_details": "i ain't afraid of no ghosts",
                 "expected_docs_url": "https://docs.snapcraft.io/the-snapcraft-format/8337",
+                "expected_reportable": False,
             },
         ),
         (
@@ -873,6 +680,177 @@ class SnapcraftExceptionTests(unit.TestCase):
                 "expected_resolution": "who you gonna call? Janine Melnitz!!",
                 "expected_details": "i ain't afraid of no ghosts: ['slimer', 'puft', 'vigo']",
                 "expected_docs_url": "https://docs.snapcraft.io/the-snapcraft-format/8337",
+                "expected_reportable": False,
+            },
+        ),
+        (
+            "MissingStateCleanError",
+            {
+                "exception": errors.MissingStateCleanError,
+                "kwargs": {"step": steps.PULL},
+                "expected_brief": "Failed to clean for step 'pull'.",
+                "expected_resolution": "Run `snapcraft clean` and retry build.",
+                "expected_details": None,
+                "expected_docs_url": None,
+                "expected_reportable": False,
+            },
+        ),
+        (
+            "StepOutdatedError dirty_properties",
+            {
+                "exception": errors.StepOutdatedError,
+                "kwargs": {
+                    "step": steps.PULL,
+                    "part": "test-part",
+                    "dirty_report": pluginhandler.DirtyReport(
+                        dirty_properties=["test-property1", "test-property2"]
+                    ),
+                },
+                "expected_brief": "Failed to reuse files from previous run.",
+                "expected_resolution": "Run `snapcraft clean` and retry build.",
+                "expected_details": "The 'test-property1' and 'test-property2' part properties appear to have changed.\n",
+                "expected_docs_url": None,
+                "expected_reportable": False,
+            },
+        ),
+        (
+            "StepOutdatedError dirty_project_options",
+            {
+                "exception": errors.StepOutdatedError,
+                "kwargs": {
+                    "step": steps.PULL,
+                    "part": "test-part",
+                    "dirty_report": pluginhandler.DirtyReport(
+                        dirty_project_options=["test-option"]
+                    ),
+                },
+                "expected_brief": "Failed to reuse files from previous run.",
+                "expected_resolution": "Run `snapcraft clean` and retry build.",
+                "expected_details": "The 'test-option' project option appears to have changed.\n",
+                "expected_docs_url": None,
+                "expected_reportable": False,
+            },
+        ),
+        (
+            "StepOutdatedError changed_dependencies",
+            {
+                "exception": errors.StepOutdatedError,
+                "kwargs": {
+                    "step": steps.PULL,
+                    "part": "test-part",
+                    "dirty_report": pluginhandler.DirtyReport(
+                        changed_dependencies=[
+                            pluginhandler.Dependency(
+                                part_name="another-part", step=steps.PULL
+                            )
+                        ]
+                    ),
+                },
+                "expected_brief": "Failed to reuse files from previous run.",
+                "expected_resolution": "Run `snapcraft clean` and retry build.",
+                "expected_details": "A dependency has changed: 'another-part'\n",
+                "expected_docs_url": None,
+                "expected_reportable": False,
+            },
+        ),
+        (
+            "StepOutdatedError multiple changed_dependencies",
+            {
+                "exception": errors.StepOutdatedError,
+                "kwargs": {
+                    "step": steps.PULL,
+                    "part": "test-part",
+                    "dirty_report": pluginhandler.DirtyReport(
+                        changed_dependencies=[
+                            pluginhandler.Dependency(
+                                part_name="another-part1", step=steps.PULL
+                            ),
+                            pluginhandler.Dependency(
+                                part_name="another-part2", step=steps.PULL
+                            ),
+                        ]
+                    ),
+                },
+                "expected_brief": "Failed to reuse files from previous run.",
+                "expected_resolution": "Run `snapcraft clean` and retry build.",
+                "expected_details": "Some dependencies have changed: 'another-part1' and 'another-part2'\n",
+                "expected_docs_url": None,
+                "expected_reportable": False,
+            },
+        ),
+        (
+            "StepOutdatedError previous step updated",
+            {
+                "exception": errors.StepOutdatedError,
+                "kwargs": {
+                    "step": steps.STAGE,
+                    "part": "test-part",
+                    "outdated_report": pluginhandler.OutdatedReport(
+                        previous_step_modified=steps.BUILD
+                    ),
+                },
+                "expected_brief": "Failed to reuse files from previous run.",
+                "expected_resolution": "Run `snapcraft clean` and retry build.",
+                "expected_details": "The 'build' step has run more recently.\n",
+                "expected_docs_url": None,
+                "expected_reportable": False,
+            },
+        ),
+        (
+            "StepOutdatedError source updated",
+            {
+                "exception": errors.StepOutdatedError,
+                "kwargs": {
+                    "step": steps.PULL,
+                    "part": "test-part",
+                    "outdated_report": pluginhandler.OutdatedReport(
+                        source_updated=True
+                    ),
+                },
+                "expected_brief": "Failed to reuse files from previous run.",
+                "expected_resolution": "Run `snapcraft clean` and retry build.",
+                "expected_details": "The source has changed on disk.\n",
+                "expected_docs_url": None,
+                "expected_reportable": False,
+            },
+        ),
+        (
+            "SnapcraftEnvironmentError",
+            {
+                "exception": errors.SnapcraftEnvironmentError,
+                "kwargs": {"message": "test-message"},
+                "expected_brief": "test-message",
+                "expected_resolution": "",
+                "expected_details": None,
+                "expected_docs_url": None,
+                "expected_reportable": False,
+            },
+        ),
+        (
+            "SnapcraftDataDirectoryMissingError",
+            {
+                "exception": errors.SnapcraftDataDirectoryMissingError,
+                "kwargs": {},
+                "expected_brief": "Cannot find snapcraft's data files.",
+                "expected_resolution": "Re-install snapcraft or verify installation is correct.",
+                "expected_details": None,
+                "expected_docs_url": None,
+                "expected_reportable": True,
+            },
+        ),
+        (
+            "SnapcraftMissingLinkerInBaseError",
+            {
+                "exception": errors.SnapcraftMissingLinkerInBaseError,
+                "kwargs": {
+                    "base": "core18",
+                    "linker_path": "/snap/core18/current/lib64/ld-linux.so.2",
+                },
+                "expected_brief": "Cannot find the linker to use for the target base 'core18'.",
+                "expected_resolution": "Verify that the linker exists at the expected path '/snap/core18/current/lib64/ld-linux.so.2' and try again. If the linker does not exist contact the author of the base (run `snap info core18` to get information for this base).",
+                "expected_details": None,
+                "expected_docs_url": None,
+                "expected_reportable": False,
             },
         ),
     )
@@ -883,3 +861,4 @@ class SnapcraftExceptionTests(unit.TestCase):
         self.assertEquals(self.expected_resolution, exception.get_resolution())
         self.assertEquals(self.expected_details, exception.get_details())
         self.assertEquals(self.expected_docs_url, exception.get_docs_url())
+        self.assertEquals(self.expected_reportable, exception.get_reportable())


### PR DESCRIPTION
- Add SnapcraftReportableException helper class for reportable
  errors, which simply flips the default value for get_reportable().
- Convert MissingStateClean, StepOutdatedError,
  SnapcraftEnvironmentError, SnapcraftDataDirectoryMissingError,
  and SnapcraftMissingLinkerInBaseError and associated tests.
- Add missing test for SnapcraftDataDirectoryMissingError.
- Update tests to verify expected "reportable" value as well.

The error messages are being shortened and I am also using
this opportunity to simplify them (and the resolution messages).

For example, when StepOutdatedError occurs, instead of suggesting
that the user clean just one part/step when something is out of date,
ask them to instead clean the whole project.  Something unusual has
happened and it's probably a good idea to clean the whole tree.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
