### PR TITLE
meta: support the case of a plug without a default provider

### DIFF
--- a/snapcraft/internal/meta/plugs.py
+++ b/snapcraft/internal/meta/plugs.py
@@ -110,7 +110,10 @@ class ContentPlug(Plug):
         self._content = content
 
     @property
-    def provider(self) -> str:
+    def provider(self) -> Optional[str]:
+        if self._default_provider is None:
+            return None
+
         if ":" in self._default_provider:
             return self._default_provider.split(":")[0]
 

--- a/snapcraft/project/_project.py
+++ b/snapcraft/project/_project.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018 Canonical Ltd
+# Copyright (C) 2018-2019 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -68,7 +68,13 @@ class Project(ProjectOptions):
 
     def _get_content_snaps(self) -> Set[str]:
         """Return the set of content snaps from snap_meta."""
-        return set([x.provider for x in self._snap_meta.get_content_plugs()])
+        return set(
+            [
+                x.provider
+                for x in self._snap_meta.get_content_plugs()
+                if x.provider is not None
+            ]
+        )
 
     def _get_provider_content_dirs(self) -> Set[str]:
         """Return the set installed provider content directories."""

--- a/tests/unit/meta/test_plugs.py
+++ b/tests/unit/meta/test_plugs.py
@@ -15,6 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from collections import OrderedDict
+
+from testtools.matchers import Is
+
 from snapcraft.internal.meta import errors
 from snapcraft.internal.meta.plugs import Plug, ContentPlug
 from tests import unit
@@ -98,3 +101,12 @@ class ContentPlugTests(unit.TestCase):
         self.assertEqual(plug_dict["content"], plug.content)
         self.assertEqual(plug_dict["target"], plug.target)
         self.assertEqual(plug_provider, plug.provider)
+
+    def test_basic_from_dict_no_default(self):
+        plug_dict = OrderedDict(
+            {"interface": "content", "content": "content", "target": "target"}
+        )
+        plug_name = "plug-test"
+        plug = ContentPlug.from_dict(plug_dict=plug_dict, plug_name=plug_name)
+
+        self.assertThat(plug.provider, Is(None))


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
