### PR TITLE
extensions: kde-neon: add icon and sound themes

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
@@ -35,7 +35,7 @@ class ExtensionImpl(Extension):
     \b
     - GTK3 Themes.
     - Common Icon Themes.
-    - Common Sound Themes
+    - Common Sound Themes.
     - The GNOME runtime libraries and utilities corresponding to 3.28.
 
     For easier desktop integration, it also configures each application

--- a/snapcraft/internal/project_loader/_extensions/kde_neon.py
+++ b/snapcraft/internal/project_loader/_extensions/kde_neon.py
@@ -30,8 +30,22 @@ class ExtensionImpl(Extension):
     This extension makes it easy to assemble KDE based applications
     using the Neon stack.
 
-    The version of Neon used is dependent on the base used to create
-    the snap.
+    It configures each application with the following plugs:
+
+    \b
+    - Common Icon Themes.
+    - Common Sound Themes.
+    - The Qt5 and KDE Frameworks runtime libraries and utilities.
+
+    For easier desktop integration, it also configures each application
+    entry with these additional plugs:
+
+    \b
+    - desktop (https://snapcraft.io/docs/desktop-interface)
+    - desktop-legacy (https://snapcraft.io/docs/desktop-legacy-interface)
+    - gsettings (https://snapcraft.io/docs/gsettings-interface)
+    - wayland (https://snapcraft.io/docs/wayland-interface)
+    - x11 (https://snapcraft.io/docs/x11-interface)
     """
 
     @staticmethod
@@ -48,12 +62,22 @@ class ExtensionImpl(Extension):
         platform_snap = _PLATFORM_SNAP[yaml_data.get("base")]
         self.root_snippet = {
             "plugs": {
+                "icon-themes": {
+                    "interface": "content",
+                    "target": "$SNAP/data-dir/icons",
+                    "default-provider": "gtk-common-themes",
+                },
+                "sound-themes": {
+                    "interface": "content",
+                    "target": "$SNAP/data-dir/sounds",
+                    "default-provider": "gtk-common-themes",
+                },
                 "kde-frameworks-5-plug": {
                     "content": "kde-frameworks-5-core18-all",
                     "interface": "content",
                     "default-provider": platform_snap,
                     "target": "$SNAP/kf5",
-                }
+                },
             },
             "environment": {"SNAP_DESKTOP_RUNTIME": "$SNAP/kf5"},
         }

--- a/tests/unit/project_loader/extensions/test_kde_neon.py
+++ b/tests/unit/project_loader/extensions/test_kde_neon.py
@@ -32,12 +32,22 @@ class ExtensionTest(ProjectLoaderBaseTest):
             Equals(
                 {
                     "plugs": {
+                        "icon-themes": {
+                            "interface": "content",
+                            "target": "$SNAP/data-dir/icons",
+                            "default-provider": "gtk-common-themes",
+                        },
+                        "sound-themes": {
+                            "interface": "content",
+                            "target": "$SNAP/data-dir/sounds",
+                            "default-provider": "gtk-common-themes",
+                        },
                         "kde-frameworks-5-plug": {
                             "content": "kde-frameworks-5-core18-all",
                             "interface": "content",
                             "target": "$SNAP/kf5",
                             "default-provider": "kde-frameworks-5-core18",
-                        }
+                        },
                     },
                     "environment": {"SNAP_DESKTOP_RUNTIME": "$SNAP/kf5"},
                 }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR adds the common cursor, icon and sound themes to the `kde-neon` extension using the `gtk-common-themes` content snap. Unlike its name implies, the cursor, icon and sound themes are also applicable to Qt/KDE applications.

This fixes the issue where applications using this extension have a weird pixelated cursor on default Ubuntu.

I tested this by building the Krita snap using this extension: https://invent.kde.org/merlijnsebrechts/krita/blob/neon-extension/packaging/linux/snap/snapcraft.yaml Without this PR, the cursor is correct on Kubuntu, but incorrect on Ubuntu. With this PR, the cursor is correct on both flavors.