### PR TITLE
WIP: extractors: match setuptools metadata keys

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -97,19 +97,19 @@ For example:
   * To run only the unit tests in the test_nodejs module:
 
     ```
-    python3 -m unittest tests.unit.plugins.tests_nodejs
+    python3 -m unittest tests.unit.plugins.test_nodejs
     ```
 
-  * To run only the unit tests in the NodePluginTestCase:
+  * To run only the unit tests in the NodePluginTest:
 
     ```
-    python3 -m unittest tests.unit.plugins.tests_nodejs.NodePluginTestCase
+    python3 -m unittest tests.unit.plugins.test_nodejs.NodePluginTest
     ```
 
-  * To run only the unit test named test_pull_executes_npm_run_commands:
+  * To run only the unit test named test_pull
 
     ```
-    python3 -m unittest tests.unit.plugins.tests_nodejs.NodePluginTestCase.test_pull_executes_npm_run_commands
+    python3 -m unittest tests.unit.plugins.test_nodejs.NodePluginTest.test_pull
     ```
 
 The snaps tests script has more complex arguments. For an explanation of them, run:

--- a/snapcraft/extractors/setuppy.py
+++ b/snapcraft/extractors/setuppy.py
@@ -56,6 +56,7 @@ def extract(relpath: str, *, workdir: str) -> ExtractedMetadata:
                 raise _errors.SetupPyImportError(path=relpath, error=str(e)) from e
 
     version = params.get("version")
-    description = params.get("description")
+    summary = params.get("description")
+    description = params.get("long_description")
 
-    return ExtractedMetadata(version=version, description=description)
+    return ExtractedMetadata(version=version, summary=summary, description=description)

--- a/tests/integration/general/test_metadata_setuppy.py
+++ b/tests/integration/general/test_metadata_setuppy.py
@@ -36,7 +36,8 @@ class SetupPyMetadataTestCase(integration.TestCase):
                 setup(
                     name='hello-world',
                     version='test-setuppy-version',
-                    description='test-setuppy-description',
+                    description='test-setuppy-summary',
+                    long_description='test-setuppy-description',
                     author='Canonical LTD',
                     author_email='snapcraft@lists.snapcraft.io',
                     scripts=['hello']
@@ -63,6 +64,7 @@ class SetupPyMetadataTestCase(integration.TestCase):
 
         self.assertThat(snap_yaml["version"], Equals("test-setuppy-version"))
         self.assertThat(snap_yaml["description"], Equals("test-setuppy-description"))
+        self.assertThat(snap_yaml["summary"], Equals("test-setuppy-summary"))
 
     def test_all_metadata_from_yaml(self):
         snapcraft_yaml = fixture_setup.SnapcraftYaml(

--- a/tests/unit/extractors/test_setuppy.py
+++ b/tests/unit/extractors/test_setuppy.py
@@ -29,13 +29,68 @@ class SetupPyTestCase(unit.TestCase):
 
     metadata = [
         (
-            "description",
-            dict(params=dict(version=None, description="test-description")),
+            "summary",
+            {
+                "params": [
+                    {
+                        "key": "description",
+                        "param_name": "summary",
+                        "value": "test-summary",
+                        "expect": "test-summary",
+                    }
+                ]
+            },
         ),
-        ("version", dict(params=dict(version="test-version", description=None))),
         (
-            "key and version",
-            dict(params=dict(description="test-description", version="test-version")),
+            "description",
+            {
+                "params": [
+                    {
+                        "key": "long_description",
+                        "param_name": "description",
+                        "value": "test-description",
+                        "expect": "test-description",
+                    }
+                ]
+            },
+        ),
+        (
+            "version",
+            {
+                "params": [
+                    {
+                        "key": "version",
+                        "param_name": "version",
+                        "value": "test-version",
+                        "expect": "test-version",
+                    }
+                ]
+            },
+        ),
+        (
+            "summary, description and version",
+            {
+                "params": [
+                    {
+                        "key": "description",
+                        "param_name": "summary",
+                        "value": "test-summary",
+                        "expect": "test-summary",
+                    },
+                    {
+                        "key": "long_description",
+                        "param_name": "description",
+                        "value": "test-description",
+                        "expect": "test-description",
+                    },
+                    {
+                        "key": "version",
+                        "param_name": "version",
+                        "value": "test-version",
+                        "expect": "test-version",
+                    },
+                ]
+            },
         ),
     ]
 
@@ -65,8 +120,12 @@ class SetupPyTestCase(unit.TestCase):
     def setUp(self):
         super().setUp()
 
-        params = ['    {}="{}",'.format(k, v) for k, v in self.params.items() if v]
-
+        params = [
+            '    {}="{}",'.format(p["key"], p["value"])
+            for p in self.params
+            if p["value"]
+        ]
+        print("params:::" + str(params))
         fmt = dict(
             params="\n".join(params),
             import_statement=self.import_statement,
@@ -91,7 +150,8 @@ class SetupPyTestCase(unit.TestCase):
             )
 
     def test_info_extraction(self):
-        expected = ExtractedMetadata(**self.params)
+        kwargs = {p["param_name"]: p["expect"] for p in self.params}
+        expected = ExtractedMetadata(**kwargs)
         actual = setuppy.extract("setup.py", workdir=".")
         self.assertThat(str(actual), Equals(str(expected)))
         self.assertThat(actual, Equals(expected))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

* Use setuptools' `description` as snapcraft's summary
* Use setuptools' `long_description` as snapcraft's description

Fixes LP https://bugs.launchpad.net/snapcraft/+bug/1813364
See also https://forum.snapcraft.io/t/using-external-metadata/4642/10

This was first proposed in March: https://github.com/snapcore/snapcraft/pull/2518, but the tests failed and the author didn't respond.