### PR TITLE
Drop build_base check from make plugin. It is universal.

### DIFF
--- a/snapcraft/plugins/make.py
+++ b/snapcraft/plugins/make.py
@@ -50,7 +50,6 @@ Additionally, this plugin uses the following plugin-specific keywords:
 import os
 import snapcraft
 import snapcraft.common
-from snapcraft.internal import errors
 
 
 class MakePlugin(snapcraft.BasePlugin):
@@ -88,11 +87,6 @@ class MakePlugin(snapcraft.BasePlugin):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
-
-        if project.info.get_build_base() not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(
-                part_name=self.name, base=project.info.get_build_base()
-            )
 
         self.build_packages.append("make")
 

--- a/tests/unit/plugins/test_autotools.py
+++ b/tests/unit/plugins/test_autotools.py
@@ -23,7 +23,6 @@ from unittest import mock
 from testtools.matchers import Equals, HasLength
 
 import snapcraft
-from snapcraft.internal import errors
 from snapcraft.plugins import autotools
 from snapcraft.plugins import make
 from tests import unit
@@ -403,29 +402,6 @@ class AutotoolsPluginTestCase(unit.TestCase):
         expected_fileset = ["-**/*.la"]
         fileset = plugin.snap_fileset()
         self.assertListEqual(expected_fileset, fileset)
-
-    def test_unsupported_base(self):
-        project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: cmake-snap
-                    base: unsupported-base
-                    """
-                )
-            )
-        )
-
-        raised = self.assertRaises(
-            errors.PluginBaseError,
-            autotools.AutotoolsPlugin,
-            "test-part",
-            self.options,
-            project,
-        )
-
-        self.assertThat(raised.part_name, Equals("test-part"))
-        self.assertThat(raised.base, Equals("unsupported-base"))
 
 
 class AutotoolsCrossCompilePluginTestCase(unit.TestCase):

--- a/tests/unit/plugins/test_make.py
+++ b/tests/unit/plugins/test_make.py
@@ -21,7 +21,6 @@ from unittest import mock
 from testtools.matchers import Equals, HasLength
 
 import snapcraft
-from snapcraft.internal import errors
 from snapcraft.plugins import make
 from tests import unit
 
@@ -276,22 +275,3 @@ class MakePluginTestCase(unit.TestCase):
                 ),
             ]
         )
-
-    def test_unsupported_base(self):
-        project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: make-snap
-                    base: unsupported-base
-                    """
-                )
-            )
-        )
-
-        raised = self.assertRaises(
-            errors.PluginBaseError, make.MakePlugin, "test-part", self.options, project
-        )
-
-        self.assertThat(raised.part_name, Equals("test-part"))
-        self.assertThat(raised.base, Equals("unsupported-base"))


### PR DESCRIPTION
LP: #1842328

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

This is on a critical path blocking daily builds of Ubuntu Core images based on the published core20 snap. All other images for all other products are already produced daily for Focal Fossa release to become 20.04 LTS.

Please merge this, or equivalent functionality to edge channel as soon as possible. Alternatively please merge this into an a different branch "i.e. 20" and build snapcraft out of it into the snapstore published edge/20 branch such that all kernel / gadget / models can use it to start building core20 image due to be released in April 2020.

https://bugs.launchpad.net/snapcraft/+bug/1842328

Explaining the change. Unlike other plugins, make plugin is universal and has no dependencies or different codepaths which require adjustment between different build_bases. And even the package name "make" is universal across multiple distributions out there.

Until there is a code requirement, to adjust make plugin behaviour based on build_base, make plugin should not hardcode specific build_bases.
