### PR TITLE
 appstream: support legacy ids without desktop suffix 

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -97,19 +97,19 @@ For example:
   * To run only the unit tests in the test_nodejs module:
 
     ```
-    python3 -m unittest tests.unit.plugins.tests_nodejs
+    python3 -m unittest tests.unit.plugins.test_nodejs
     ```
 
-  * To run only the unit tests in the NodePluginTestCase:
+  * To run only the unit tests in the NodePluginTest:
 
     ```
-    python3 -m unittest tests.unit.plugins.tests_nodejs.NodePluginTestCase
+    python3 -m unittest tests.unit.plugins.test_nodejs.NodePluginTest
     ```
 
-  * To run only the unit test named test_pull_executes_npm_run_commands:
+  * To run only the unit test named test_pull
 
     ```
-    python3 -m unittest tests.unit.plugins.tests_nodejs.NodePluginTestCase.test_pull_executes_npm_run_commands
+    python3 -m unittest tests.unit.plugins.test_nodejs.NodePluginTest.test_pull
     ```
 
 The snaps tests script has more complex arguments. For an explanation of them, run:

--- a/snapcraft/extractors/appstream.py
+++ b/snapcraft/extractors/appstream.py
@@ -87,8 +87,11 @@ def extract(relpath: str, *, workdir: str) -> ExtractedMetadata:
     desktop_file_ids = _get_desktop_file_ids_from_nodes(dom.findall("launchable"))
     # if there are no launchables, use the appstream id to take into
     # account the legacy appstream definitions
-    if common_id and common_id.endswith(".desktop") and not desktop_file_ids:
-        desktop_file_ids.append(common_id)
+    if common_id and not desktop_file_ids:
+        if common_id.endswith(".desktop"):
+            desktop_file_ids.append(common_id)
+        else:
+            desktop_file_ids.append(common_id + ".desktop")
 
     for desktop_file_id in desktop_file_ids:
         desktop_file_path = _desktop_file_id_to_path(desktop_file_id, workdir=workdir)

--- a/tests/unit/extractors/test_appstream.py
+++ b/tests/unit/extractors/test_appstream.py
@@ -557,6 +557,26 @@ class AppstreamLegacyDesktopTest(unit.TestCase):
             extracted.get_desktop_file_paths(), Equals([self.desktop_file_path])
         )
 
+    def test_appstream_no_desktop_suffix(self):
+        with open("foo.metainfo.xml", "w") as f:
+            f.write(
+                textwrap.dedent(
+                    """\
+                <?xml version="1.0" encoding="UTF-8"?>
+                <component type="desktop">
+                  <id>com.example.test-app</id>
+                </component>"""
+                )
+            )
+
+        _create_desktop_file(self.desktop_file_path)
+
+        extracted = appstream.extract("foo.metainfo.xml", workdir=".")
+
+        self.assertThat(
+            extracted.get_desktop_file_paths(), Equals([self.desktop_file_path])
+        )
+
 
 class AppstreamMultipleLaunchableTestCase(unit.TestCase):
     def test_appstream_with_multiple_launchables(self):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Some desktop launchers are not found by Snapcraft because their AppStream file doesn't include any `launchable` entries and the component id does not end in `.desktop`.

This PR uses component id + ".desktop" as possible desktop file id if no launchables are found and the component id does not have `.desktop` suffix.

This was originally proposed in https://bugs.launchpad.net/snapcraft/+bug/1778546 but the initial fix did not include appending the suffix.

See https://github.com/snapcrafters/foliate/pull/3/files for an example of a snap using this feature.