### PR TITLE
appstream: extract title and version

### DIFF
--- a/snapcraft/extractors/_metadata.py
+++ b/snapcraft/extractors/_metadata.py
@@ -28,6 +28,7 @@ class ExtractedMetadata(yaml_utils.SnapcraftYAMLObject):
         self,
         *,
         common_id: str = "",
+        title: str = "",
         summary: str = "",
         description: str = "",
         version: str = "",
@@ -39,6 +40,7 @@ class ExtractedMetadata(yaml_utils.SnapcraftYAMLObject):
 
         :param str: common_id: The common identifier across multiple packaging
             formats
+        :param str title: Extracted title
         :param str summary: Extracted summary
         :param str description: Extracted description
         :param str version: Extracted version
@@ -52,6 +54,8 @@ class ExtractedMetadata(yaml_utils.SnapcraftYAMLObject):
 
         if common_id:
             self._data["common_id"] = common_id
+        if title:
+            self._data["title"] = title
         if summary:
             self._data["summary"] = summary
         if description:
@@ -86,6 +90,15 @@ class ExtractedMetadata(yaml_utils.SnapcraftYAMLObject):
         """
         common_id = self._data.get("common_id")
         return str(common_id) if common_id else None
+
+    def get_title(self) -> str:
+        """Return extracted title.
+
+        :returns: Extracted title
+        :rtype: str
+        """
+        title = self._data.get("title")
+        return str(title) if title else None
 
     def get_summary(self) -> str:
         """Return extracted summary.

--- a/snapcraft/extractors/appstream.py
+++ b/snapcraft/extractors/appstream.py
@@ -82,6 +82,8 @@ def extract(relpath: str, *, workdir: str) -> ExtractedMetadata:
     common_id = _get_value_from_xml_element(dom, "id")
     summary = _get_value_from_xml_element(dom, "summary")
     description = _get_value_from_xml_element(dom, "description")
+    title = _get_value_from_xml_element(dom, "name")
+    version = _get_latest_release_from_nodes(dom.findall("releases/release"))
 
     desktop_file_paths = []
     desktop_file_ids = _get_desktop_file_ids_from_nodes(dom.findall("launchable"))
@@ -99,8 +101,10 @@ def extract(relpath: str, *, workdir: str) -> ExtractedMetadata:
 
     return ExtractedMetadata(
         common_id=common_id,
+        title=title,
         summary=summary,
         description=description,
+        version=version,
         icon=icon,
         desktop_file_paths=desktop_file_paths,
     )
@@ -134,6 +138,13 @@ def _get_value_from_xml_element(tree, key) -> Optional[str]:
         return node.text.strip()
     else:
         return None
+
+
+def _get_latest_release_from_nodes(nodes) -> Optional[str]:
+    for node in nodes:
+        if "version" in node.attrib:
+            return node.attrib["version"]
+    return None
 
 
 def _get_desktop_file_ids_from_nodes(nodes) -> List[str]:

--- a/tests/unit/extractors/test_appstream.py
+++ b/tests/unit/extractors/test_appstream.py
@@ -91,6 +91,16 @@ class AppstreamTestCase(unit.TestCase):
                     "expect": "test-id",
                 },
             ),
+            (
+                "title",
+                {
+                    "key": "name",
+                    "attributes": {},
+                    "param_name": "title",
+                    "value": "test-title",
+                    "expect": "test-title",
+                },
+            ),
         ],
         [
             ("metainfo", {"file_extension": "metainfo.xml"}),
@@ -456,6 +466,77 @@ class AppstreamTest(unit.TestCase):
                 )
             ),
         )
+
+    def test_appstream_multilang_title(self):
+        file_name = "foliate.appdata.xml"
+        content = textwrap.dedent(
+            """\
+            <?xml version="1.0" encoding="UTF-8"?>
+            <component type="desktop">
+            <name>Foliate</name>
+            <name xml:lang="id_ID">Foliate_id</name>
+            <name xml:lang="pt_BR">Foliate_pt</name>
+            <name xml:lang="ru_RU">Foliate_ru</name>
+            <name xml:lang="nl_NL">Foliate_nl</name>
+            <name xml:lang="fr_FR">Foliate_fr</name>
+            <name xml:lang="cs_CS">Foliate_cs</name>
+            </component>
+        """
+        )
+
+        with open(file_name, "w") as f:
+            print(content, file=f)
+
+        metadata = appstream.extract(file_name, workdir=".")
+
+        self.expectThat(metadata.get_title(), Equals("Foliate"))
+
+    def test_appstream_release(self):
+        file_name = "foliate.appdata.xml"
+        content = textwrap.dedent(
+            """\
+            <?xml version="1.0" encoding="UTF-8"?>
+            <component type="desktop">
+            <releases>
+                <release version="1.5.3" date="2019-07-25">
+                <description>
+                    <ul>
+                    <li>Fixed Flatpak version not being able to open .mobi, .azw, and .azw3 files</li>
+                    <li>Improved Wiktionary lookup, now with links and example sentences</li>
+                    <li>Improved popover footnote extraction and formatting</li>
+                    <li>Added option to export annotations to BibTeX</li>
+                    </ul>
+                </description>
+                </release>
+                <release version="1.5.2" date="2019-07-19">
+                <description>
+                    <ul>
+                    <li>Fixed table of contents navigation not working with some books</li>
+                    <li>Fixed not being able to zoom images with Kindle books</li>
+                    <li>Fixed not being able to open books with .epub3 filename extension</li>
+                    <li>Fixed temporary directory not being cleaned after closing</li>
+                    </ul>
+                </description>
+                </release>
+                <release version="1.5.1" date="2019-07-17">
+                <description>
+                    <ul>
+                    <li>Fixed F9 shortcut not working</li>
+                    <li>Updated translations</li>
+                    </ul>
+                </description>
+                </release>
+            </releases>
+            </component>
+        """
+        )
+
+        with open(file_name, "w") as f:
+            print(content, file=f)
+
+        metadata = appstream.extract(file_name, workdir=".")
+
+        self.expectThat(metadata.get_version(), Equals("1.5.3"))
 
 
 class AppstreamUnhandledFileTestCase(unit.TestCase):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR extracts `title` and `version` from AppStream's `name` tag and
from the `version` property of the first `release` tag.

According to the AppStream docs:

> `<name/>`: A human-readable name for this software component.

> Each release of the software component should have a `<release/>`
> tag describing it, but at least one release child must be present
> for the current release of the software. **The release children
> should be sorted in a latest-to-oldest order to simplify reading
> the metadata file.**

[source](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-releases)

This PR assumes the AppStream follows the spec in that the first `<release>` element describes the latest release. It's possible to check the `date` and `timestamp` properties of each release to find the latest, however, parsing the dates is non-trivial:

> The date property can have any time in ISO 8601 format as its value and should be present for every release. At least day-level granularity is required, which means that the ISO 8601 string must contain at least a full date (e.g. 2019-08-12).

As a result, we can't simply use `strptime` because we don't know what the granularity of the date is beforehand. `python-dateutil` could be used to parse this date, however, I didn't want to add another dependency just to support AppStream files who don't follow the spec.

I looked at a bunch of AppStream files in the wild and they all seem to follow the spec.

* [GNOME Calculator](https://gitlab.gnome.org/GNOME/gnome-calculator/blob/master/data/org.gnome.Calculator.appdata.xml.in)
* [Foliate](https://github.com/johnfactotum/foliate/blob/master/data/com.github.johnfactotum.Foliate.appdata.xml.in)
* [Krita](https://invent.kde.org/kde/krita/blob/master/krita/org.kde.krita.appdata.xml)
* [Nautilus](https://github.com/GNOME/nautilus/blob/mainline/data/org.gnome.Nautilus.appdata.xml.in.in)

I also tested this PR manually with the Foliate snaps: https://github.com/snapcrafters/foliate/pull/4