### PR TITLE
"snap debug validate-seed" fails if the slot is specified in the default-provider.

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
@@ -81,9 +81,7 @@ class ExtensionImpl(Extension):
                 platform_snap: {
                     "interface": "content",
                     "target": "$SNAP/gnome-platform",
-                    "default-provider": "{snap}".format(
-                        snap=platform_snap
-                    ),
+                    "default-provider": "{snap}".format(snap=platform_snap),
                 },
             },
             "environment": {"SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform"},

--- a/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
@@ -66,23 +66,23 @@ class ExtensionImpl(Extension):
                 "gtk-3-themes": {
                     "interface": "content",
                     "target": "$SNAP/data-dir/themes",
-                    "default-provider": "gtk-common-themes:gtk-3-themes",
+                    "default-provider": "gtk-common-themes",
                 },
                 "icon-themes": {
                     "interface": "content",
                     "target": "$SNAP/data-dir/icons",
-                    "default-provider": "gtk-common-themes:icon-themes",
+                    "default-provider": "gtk-common-themes",
                 },
                 "sound-themes": {
                     "interface": "content",
                     "target": "$SNAP/data-dir/sounds",
-                    "default-provider": "gtk-common-themes:sound-themes",
+                    "default-provider": "gtk-common-themes",
                 },
                 platform_snap: {
                     "interface": "content",
                     "target": "$SNAP/gnome-platform",
-                    "default-provider": "{snap}:{slot}".format(
-                        snap=platform_snap, slot=platform_snap
+                    "default-provider": "{snap}".format(
+                        snap=platform_snap
                     ),
                 },
             },

--- a/tests/unit/project_loader/extensions/test_gnome_3_28.py
+++ b/tests/unit/project_loader/extensions/test_gnome_3_28.py
@@ -35,22 +35,22 @@ class ExtensionTest(ProjectLoaderBaseTest):
                         "gtk-3-themes": {
                             "interface": "content",
                             "target": "$SNAP/data-dir/themes",
-                            "default-provider": "gtk-common-themes:gtk-3-themes",
+                            "default-provider": "gtk-common-themes",
                         },
                         "icon-themes": {
                             "interface": "content",
                             "target": "$SNAP/data-dir/icons",
-                            "default-provider": "gtk-common-themes:icon-themes",
+                            "default-provider": "gtk-common-themes",
                         },
                         "sound-themes": {
                             "interface": "content",
                             "target": "$SNAP/data-dir/sounds",
-                            "default-provider": "gtk-common-themes:sound-themes",
+                            "default-provider": "gtk-common-themes",
                         },
                         "gnome-3-28-1804": {
                             "interface": "content",
                             "target": "$SNAP/gnome-platform",
-                            "default-provider": "gnome-3-28-1804:gnome-3-28-1804",
+                            "default-provider": "gnome-3-28-1804",
                         },
                     },
                     "environment": {"SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform"},


### PR DESCRIPTION
This is breaking the iso image builds

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
