### PR TITLE
Snapd doesn't actually honor the slot specified in the default-provider.

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/kde_neon.py
+++ b/snapcraft/internal/project_loader/_extensions/kde_neon.py
@@ -51,7 +51,7 @@ class ExtensionImpl(Extension):
                 "kde-frameworks-5-plug": {
                     "content": "kde-frameworks-5-core18-all",
                     "interface": "content",
-                    "default-provider": "{}:kde-frameworks-5-core18-slot".format(
+                    "default-provider": "{}".format(
                         platform_snap
                     ),
                     "target": "$SNAP/kf5",

--- a/snapcraft/internal/project_loader/_extensions/kde_neon.py
+++ b/snapcraft/internal/project_loader/_extensions/kde_neon.py
@@ -51,9 +51,7 @@ class ExtensionImpl(Extension):
                 "kde-frameworks-5-plug": {
                     "content": "kde-frameworks-5-core18-all",
                     "interface": "content",
-                    "default-provider": "{}".format(
-                        platform_snap
-                    ),
+                    "default-provider": platform_snap,
                     "target": "$SNAP/kf5",
                 }
             },

--- a/tests/unit/project_loader/extensions/test_kde_neon.py
+++ b/tests/unit/project_loader/extensions/test_kde_neon.py
@@ -36,7 +36,7 @@ class ExtensionTest(ProjectLoaderBaseTest):
                             "content": "kde-frameworks-5-core18-all",
                             "interface": "content",
                             "target": "$SNAP/kf5",
-                            "default-provider": "kde-frameworks-5-core18:kde-frameworks-5-core18-slot",
+                            "default-provider": "kde-frameworks-5-core18",
                         }
                     },
                     "environment": {"SNAP_DESKTOP_RUNTIME": "$SNAP/kf5"},


### PR DESCRIPTION
The default-provider should just be the content snap name.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
