### PR TITLE
remote-build: initial Windows support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ packages = [
 ]
 package_data = {"snapcraft.internal.repo": ["manifest.txt"]}
 license = "GPL v3"
-classifiers = (
+classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Developers",
@@ -81,7 +81,7 @@ classifiers = (
     "Programming Language :: Python :: 3.5",
     "Topic :: Software Development :: Build Tools",
     "Topic :: System :: Software Distribution",
-)
+]
 
 # look/set what version we have
 changelog = "debian/changelog"

--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -264,6 +264,11 @@ def create_similar_directory(source: str, destination: str) -> None:
     gid = stat.st_gid
     os.makedirs(destination, exist_ok=True)
 
+    # Windows does not have "os.chown" implementation and copystat
+    # is unlikely to be useful, so just bail after creating directory.
+    if sys.platform == "win32":
+        return
+
     try:
         os.chown(destination, uid, gid, follow_symlinks=False)
     except PermissionError as exception:

--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -423,8 +423,9 @@ def get_resolved_relative_path(relative_path: str, base_directory: str) -> str:
 
 
 def _remove_readonly(func, path, excinfo):
-    """Try setting file to writeable if error occurs.
-    Known to be required on Windows."""
+    # Try setting file to writeable if error occurs during rmtree.
+    # Known to be required on Windows where file is not "writeable",
+    # but it is owned by the user (who can set file permissions).
     os.chmod(path, stat.S_IWRITE)
     func(path)
 

--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -21,6 +21,7 @@ import logging
 import re
 import os
 import shutil
+import stat
 import subprocess
 import sys
 from typing import Pattern, Callable, Generator, List
@@ -419,3 +420,15 @@ def get_resolved_relative_path(relative_path: str, base_directory: str) -> str:
     filename_relpath = os.path.relpath(filename_abspath, base_directory)
 
     return filename_relpath
+
+
+def _remove_readonly(func, path, excinfo):
+    """Try setting file to writeable if error occurs.
+    Known to be required on Windows."""
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
+
+
+def rmtree(path: str) -> None:
+    """Cross-platform rmtree implementation."""
+    shutil.rmtree(path, onerror=_remove_readonly)

--- a/snapcraft/internal/remote_build/_worktree.py
+++ b/snapcraft/internal/remote_build/_worktree.py
@@ -25,6 +25,7 @@ from copy import deepcopy
 import snapcraft
 import snapcraft.internal.sources
 from snapcraft import yaml_utils
+from snapcraft.file_utils import rmtree
 from snapcraft.project import Project
 from snapcraft.internal.meta import _version
 from snapcraft.internal.remote_build import errors
@@ -68,7 +69,7 @@ class WorkTree:
         # Initialize clean repo to ship to remote builder.
         self._repo_dir = os.path.join(self._base_dir, "repo")
         if os.path.exists(self._repo_dir):
-            shutil.rmtree(self._repo_dir)
+            rmtree(self._repo_dir)
 
         self._repo_sources_dir = os.path.join(self._repo_dir, "sources")
         self._repo_snap_dir = os.path.join(self._repo_dir, "snap")
@@ -174,7 +175,7 @@ class WorkTree:
 
         # Remove existing cache directory (if exists)
         if os.path.exists(download_dir):
-            shutil.rmtree(download_dir, ignore_errors=True)
+            rmtree(download_dir)
 
         # Pull sources, but create directory first if part
         # is configured to use the `dump` plugin.
@@ -263,7 +264,7 @@ class WorkTree:
 
             # Remove existing assets, and update copy.
             if os.path.exists(self._repo_snap_dir):
-                shutil.rmtree(self._repo_snap_dir, ignore_errors=True)
+                rmtree(self._repo_snap_dir)
             shutil.copytree(assets_dir, self._repo_snap_dir)
         else:
             os.makedirs(self._repo_snap_dir, exist_ok=True)

--- a/snapcraft/internal/remote_build/_worktree.py
+++ b/snapcraft/internal/remote_build/_worktree.py
@@ -16,6 +16,7 @@
 
 import logging
 import os
+import pathlib
 import shutil
 import subprocess
 
@@ -145,7 +146,10 @@ class WorkTree:
         os.makedirs(os.path.split(archive_path)[0], exist_ok=True)
         command = ["tar", "czf", archive_path, "-C", source_path, "."]
         subprocess.check_call(command)
-        return os.path.relpath(archive_path, self._repo_dir)
+        relpath = os.path.relpath(archive_path, self._repo_dir)
+
+        # Ensure Linux path formatting is used.
+        return pathlib.Path(relpath).as_posix()
 
     def _pull_source(self, part_name: str, source: str, selector=None) -> str:
         """Pull source_url for part to source_dir. Returns source.

--- a/snapcraft/internal/sources/__init__.py
+++ b/snapcraft/internal/sources/__init__.py
@@ -111,7 +111,12 @@ if sys.platform == "linux":
         "snap": Snap,
         "": Local,
     }
+elif sys.platform == "win32":
+    from ._git import Git  # noqa
+    from ._local import Local  # noqa
+    from ._tar import Tar  # noqa
 
+    _source_handler = {"git": Git, "local": Local, "tar": Tar, "": Local}
 
 logging.getLogger("urllib3").setLevel(logging.CRITICAL)
 

--- a/tests/unit/remote_build/test_launchpad.py
+++ b/tests/unit/remote_build/test_launchpad.py
@@ -262,17 +262,21 @@ class LaunchpadTestCase(unit.TestCase):
 
     @mock.patch("snapcraft.internal.remote_build.LaunchpadClient._download_file")
     def test_monitor_build(self, mock_download_file):
-        open("test_i386.txt.gz", "w").close()
-        open("test_i386.txt.gz.1", "w").close()
+        open("test_i386.txt", "w").close()
+        open("test_i386.1.txt", "w").close()
         self.lpc._lp = LaunchpadImpl()
 
         self.lpc.start_build()
         self.lpc.monitor_build(interval=0)
         mock_download_file.assert_has_calls(
             [
-                mock.call("url_for/build_log_file_1", "test_i386.txt.gz.2"),
-                mock.call("url_for/snap_file_i386.snap", "snap_file_i386.snap"),
-                mock.call("url_for/build_log_file_2", "test_amd64.txt.gz"),
+                mock.call(
+                    url="url_for/build_log_file_1", gunzip=True, dst="test_i386.2.txt"
+                ),
+                mock.call(url="url_for/snap_file_i386.snap", dst="snap_file_i386.snap"),
+                mock.call(
+                    url="url_for/build_log_file_2", gunzip=True, dst="test_amd64.txt"
+                ),
             ]
         )
 
@@ -286,10 +290,14 @@ class LaunchpadTestCase(unit.TestCase):
         self.lpc.start_build()
         self.lpc.monitor_build(interval=0)
         mock_download_file.assert_has_calls(
-            [mock.call("url_for/build_log_file_2", "test_amd64.txt.gz")]
+            [
+                mock.call(
+                    url="url_for/build_log_file_2", gunzip=True, dst="test_amd64.txt"
+                )
+            ]
         )
         mock_log.assert_called_with(
-            "Build failed for arch amd64. Log file is 'test_amd64.txt.gz'."
+            "Build failed for arch amd64. Log file is 'test_amd64.txt'."
         )
 
     def test_get_build_status(self):


### PR DESCRIPTION
Requires: https://github.com/snapcore/snapcraft/pull/2759

Tested against: https://github.com/cjp256/figlet/tree/use-install