### PR TITLE
project: truncate project directory hash

### DIFF
--- a/snapcraft/project/_project.py
+++ b/snapcraft/project/_project.py
@@ -70,7 +70,7 @@ class Project(ProjectOptions):
     def _get_project_directory_hash(self) -> str:
         m = hashlib.sha1()
         m.update(self._project_dir.encode())
-        return m.hexdigest()
+        return m.hexdigest()[:6]
 
     def _get_content_snaps(self) -> Set[str]:
         """Return the set of content snaps from snap_meta."""


### PR DESCRIPTION
A full sha1 hash is admittedly a bit excessive, truncate
it to 6 characters.  Security is irrelevant and collisions
are not a realistic concern for these use cases.

Shorten it before it proliferates beyond remote-build :)

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
