### PR TITLE
extensions: skip icon cache creation for theme and runtime snaps 

### DIFF
--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -393,6 +393,11 @@ if [ "$needs_update" = true ]; then
   rm -rf "$XDG_DATA_HOME/icons"
   mkdir -p "$XDG_DATA_HOME/icons"
   for ((i = 0; i < ${#data_dirs_array[@]}; i++)); do
+    # The runtime and theme content snaps should already contain icon caches
+    # so we skip them to optimise app start time.
+    if [[ "${data_dirs_array[$i]}" == "$SNAP/data-dir" || "${data_dirs_array[$i]}" == "$SNAP_DESKTOP_RUNTIME/"* ]]; then
+      continue
+    fi  
     for theme in "${data_dirs_array[$i]}"/icons/*; do
       if [ -f "$theme/index.theme" ] && [ ! -f "$theme/icon-theme.cache" ]; then
         theme_dir="$XDG_DATA_HOME/icons/$(basename "$theme")"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Some icon themes, such as cursor-only themes, can't have a cache. However, desktop-exports still tries to create a cache for every icon theme, which is surprisingly expensive. It takes up to 30% of the time of a cold desktop-launch run. This is partly due to the script creating additional directories and softlinks during this process.

This commit skips icon cache creation for everything in the theme and runtime snaps because those should already contain caches.

With this commit, the cold start time of the desktop-launch script is reduced by ~30%.

The KDE Neon apps also have an improved boot time with this fix, although it's less pronounced.

| App | without fix | with fix | reduction |
| --- | --- | --- | --- |
| [SDLPoP](https://github.com/galgalesh/sdlpop/tree/gnome-extension) | 1.146s | 0.675s | 40% |
| [Foliate](https://github.com/snapcrafters/foliate) | 0.848s | 0.619s | 27% |
| [KCalc](https://github.com/galgalesh/kcalc) | 2.980s | 2.673s | 10% |

Full benchmark results: https://gist.github.com/galgalesh/c6ff9b261668c0ce41f06661822c9fc3