### PR TITLE
extensions: speed up desktop-launch by not calling mkdir -p

### DIFF
--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -117,7 +117,7 @@ prepend_dir XDG_DATA_DIRS "$SNAP_USER_DATA"
 
 # Set XDG_DATA_HOME to local path
 export XDG_DATA_HOME="$SNAP_USER_DATA/.local/share"
-mkdir -p "$XDG_DATA_HOME"
+ensure_dir_exists "$XDG_DATA_HOME"
 
 # Workaround for GLib < 2.53.2 not searching for schemas in $XDG_DATA_HOME:
 #   https://bugzilla.gnome.org/show_bug.cgi?id=741335
@@ -129,11 +129,11 @@ if [[ -d "$SNAP_USER_DATA/.cache" && ! -e "$XDG_CACHE_HOME" ]]; then
   # the .cache directory used to be stored under $SNAP_USER_DATA, migrate it
   mv "$SNAP_USER_DATA/.cache" "$SNAP_USER_COMMON/"
 fi
-mkdir -p "$XDG_CACHE_HOME"
+ensure_dir_exists "$XDG_CACHE_HOME"
 
 # Create $XDG_RUNTIME_DIR if not exists (to be removed when LP: #1656340 is fixed)
 # shellcheck disable=SC2174
-[ -n "$XDG_RUNTIME_DIR" ] && mkdir -p "$XDG_RUNTIME_DIR" -m 700
+[ -n "$XDG_RUNTIME_DIR" ] && ensure_dir_exists "$XDG_RUNTIME_DIR" -m 700
 
 # Ensure the app finds locale definitions (requires locales-all to be installed)
 append_dir LOCPATH "$SNAP_DESKTOP_RUNTIME/usr/lib/locale"
@@ -424,6 +424,6 @@ done
 # create symbolic link to ibus socket path for ibus to look up its socket files
 # (see comments #3 and #6 on https://launchpad.net/bugs/1580463)
 IBUS_CONFIG_PATH="$XDG_CONFIG_HOME/ibus"
-mkdir -p "$IBUS_CONFIG_PATH"
+ensure_dir_exists "$IBUS_CONFIG_PATH"
 [ -d "$IBUS_CONFIG_PATH/bus" ] && rm -rf "$IBUS_CONFIG_PATH/bus"
 ln -sfn "$REALHOME/.config/ibus/bus" "$IBUS_CONFIG_PATH"

--- a/extensions/desktop/common/init
+++ b/extensions/desktop/common/init
@@ -6,6 +6,15 @@
 # shellcheck disable=SC2034
 START=$(date +%s.%N)
 
+# ensure_dir_exists calls `mkdir -p` if the given path is not a directory.
+# This speeds up execution time by avoiding unnecessary calls to mkdir.
+#
+# Usage: ensure_dir_exists <path> [<mkdir-options>]...
+#
+function ensure_dir_exists() {
+  [ -d "$1" ] ||  mkdir -p "$@"
+}
+
 declare -A PIDS
 function async_exec() {
   "$@" &
@@ -31,7 +40,7 @@ REALHOME=$(getent passwd $UID | cut -d ':' -f 6)
 
 # Set config folder to local path
 export XDG_CONFIG_HOME="$SNAP_USER_DATA/.config"
-mkdir -p "$XDG_CONFIG_HOME"
+ensure_dir_exists "$XDG_CONFIG_HOME"
 chmod 700 "$XDG_CONFIG_HOME"
 
 # If the user has modified their user-dirs settings, force an update


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Calling `mkdir -p` is relatively expensive because it starts an external process. This commit uses bash to check if the directory exists to avoid calling `mkdir -p` altogether in a hot start. This saves ~20% execution time in a hot start and has no significant impact on a cold start.

As an example; the hot startup time of [the SDLPoP snap using `gtk-3-28-1804`](https://github.com/galgalesh/sdlpop/tree/gnome-extension) with fix:

```
0.069s /snap/core/7917/usr/lib/snapd/snap-confine
0.008s /usr/bin/realpath
0.008s /usr/bin/realpath
0.008s /usr/bin/realpath
0.008s /usr/bin/realpath
0.008s /usr/bin/realpath
0.008s /usr/bin/realpath
0.009s /usr/bin/realpath
0.008s /bin/rm
0.147s /snap/sdlpop/x1/snap/command-chain/desktop-launch
```

without fix:

```
0.071s /snap/core/7917/usr/lib/snapd/snap-confine
0.009s /bin/mkdir
0.009s /bin/mkdir
0.009s /bin/mkdir
0.008s /usr/bin/realpath
0.008s /usr/bin/realpath
0.008s /usr/bin/realpath
0.008s /usr/bin/realpath
0.009s /bin/mkdir
0.183s /snap/sdlpop/x1/snap/command-chain/desktop-launch
```