### PR TITLE
python plugin: first try processing setup.py without PyPI

### DIFF
--- a/snapcraft/plugins/_python/_pip.py
+++ b/snapcraft/plugins/_python/_pip.py
@@ -54,7 +54,7 @@ def _process_package_args(
     *,
     packages: Optional[Sequence[str]],
     requirements: Optional[Sequence[str]],
-    setup_py_dir: Optional[str]
+    setup_py_dir: Optional[str],
 ) -> List[str]:
     args = []
     if requirements:
@@ -243,7 +243,7 @@ class Pip:
         setup_py_dir: Optional[str] = None,
         constraints: Optional[Set[str]] = None,
         requirements: Optional[Sequence[str]] = None,
-        process_dependency_links: bool = False
+        process_dependency_links: bool = False,
     ):
         """Download packages into cache, but do not install them.
 
@@ -296,7 +296,8 @@ class Pip:
         process_dependency_links: bool = False,
         upgrade: bool = False,
         install_deps: bool = True,
-        ignore_installed: bool = False
+        ignore_installed: bool = False,
+        no_index: bool = True,
     ):
         """Install packages from cache.
 
@@ -313,6 +314,8 @@ class Pip:
         :param boolean install_deps: Install package dependencies.
         :param boolean ignore_installed: Reinstall packages if they're already
                                          installed
+        :param boolean no_index: do not hit PyPI to find missing packages.
+                                 assume packages are already downloaded.
         """
         package_args = _process_package_args(
             packages=packages, requirements=requirements, setup_py_dir=setup_py_dir
@@ -334,6 +337,11 @@ class Pip:
         if ignore_installed:
             args.append("--ignore-installed")
 
+        # --no-index: Don't hit pypi, assume the packages are already
+        #             downloaded (i.e. by using `self.download()`)
+        if no_index:
+            args.append("--no-index")
+
         # Using pip with a few special parameters:
         #
         # --user: Install packages to PYTHONUSERBASE, which we've pointed to
@@ -341,8 +349,6 @@ class Pip:
         # --no-compile: Don't compile .pyc files. FIXME: This is legacy, and
         #               should be removed once this refactor has been
         #               validated.
-        # --no-index: Don't hit pypi, assume the packages are already
-        #             downloaded (i.e. by using `self.download()`)
         # --find-links: Provide the directory into which the packages should
         #               have already been fetched
         #
@@ -353,7 +359,6 @@ class Pip:
                 "install",
                 "--user",
                 "--no-compile",
-                "--no-index",
                 "--find-links",
                 self._python_package_dir,
             ]
@@ -376,7 +381,7 @@ class Pip:
         setup_py_dir: Optional[str] = None,
         constraints: Optional[Set[str]] = None,
         requirements: Optional[Sequence[str]] = None,
-        process_dependency_links: bool = False
+        process_dependency_links: bool = False,
     ):
         """Build wheels of packages in the cache.
 

--- a/tests/spread/plugins/python/intra-dependency/task.yaml
+++ b/tests/spread/plugins/python/intra-dependency/task.yaml
@@ -1,0 +1,20 @@
+summary: "Ensure two dependencies in the same source work well together"
+
+environment:
+  SNAP_DIR: ../snaps/python-with-source-subdir-dependencies
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  cd "$SNAP_DIR"
+  snapcraft clean
+  restore_yaml snap/snapcraft.yaml
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft stage

--- a/tests/spread/plugins/python/snaps/python-with-source-subdir-dependencies/mod1/setup.py
+++ b/tests/spread/plugins/python/snaps/python-with-source-subdir-dependencies/mod1/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup(name="mod1", version="1.0.dev0")

--- a/tests/spread/plugins/python/snaps/python-with-source-subdir-dependencies/mod2/setup.py
+++ b/tests/spread/plugins/python/snaps/python-with-source-subdir-dependencies/mod2/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup(name="mod2", version="1.0.dev0", install_requires="mod1==1.0.dev0")

--- a/tests/spread/plugins/python/snaps/python-with-source-subdir-dependencies/snap/snapcraft.yaml
+++ b/tests/spread/plugins/python/snaps/python-with-source-subdir-dependencies/snap/snapcraft.yaml
@@ -1,0 +1,17 @@
+name: intra-dependencies
+version: "1.0"
+summary: Intra source dependency python package test
+description: |
+  Have two python packages in the same source, driven by source-subdir
+  two prove that they can be satisfied locally.
+
+parts:
+  mod1:
+    plugin: python
+    source: .
+    source-subdir: mod1
+  mod2:
+    plugin: python
+    source: .
+    source-subdir: mod2
+    after: [mod1]

--- a/tests/unit/plugins/python/test_pip.py
+++ b/tests/unit/plugins/python/test_pip.py
@@ -478,7 +478,7 @@ class PipInstallTest(PipCommandBaseTestCase):
             {
                 "packages": ["foo", "bar"],
                 "kwargs": {},
-                "expected_args": ["foo", "bar"],
+                "expected_args": ["--no-index", "foo", "bar"],
                 "expected_kwargs": {"cwd": None},
             },
         ),
@@ -487,7 +487,7 @@ class PipInstallTest(PipCommandBaseTestCase):
             {
                 "packages": [],
                 "kwargs": {"setup_py_dir": "test_setup_py_dir"},
-                "expected_args": ["."],
+                "expected_args": ["--no-index", "."],
                 "expected_kwargs": {"cwd": "test_setup_py_dir"},
             },
         ),
@@ -496,7 +496,7 @@ class PipInstallTest(PipCommandBaseTestCase):
             {
                 "packages": ["foo"],
                 "kwargs": {"constraints": ["constraint"]},
-                "expected_args": ["--constraint", "constraint", "foo"],
+                "expected_args": ["--constraint", "constraint", "--no-index", "foo"],
                 "expected_kwargs": {"cwd": None},
             },
         ),
@@ -510,6 +510,7 @@ class PipInstallTest(PipCommandBaseTestCase):
                     "constraint1",
                     "--constraint",
                     "constraint2",
+                    "--no-index",
                     "foo",
                 ],
                 "expected_kwargs": {"cwd": None},
@@ -520,7 +521,7 @@ class PipInstallTest(PipCommandBaseTestCase):
             {
                 "packages": [],
                 "kwargs": {"requirements": ["requirement"]},
-                "expected_args": ["--requirement", "requirement"],
+                "expected_args": ["--no-index", "--requirement", "requirement"],
                 "expected_kwargs": {"cwd": None},
             },
         ),
@@ -530,6 +531,7 @@ class PipInstallTest(PipCommandBaseTestCase):
                 "packages": [],
                 "kwargs": {"requirements": ["requirement1", "requirement2"]},
                 "expected_args": [
+                    "--no-index",
                     "--requirement",
                     "requirement1",
                     "--requirement",
@@ -543,8 +545,17 @@ class PipInstallTest(PipCommandBaseTestCase):
             {
                 "packages": ["foo"],
                 "kwargs": {"process_dependency_links": True},
-                "expected_args": ["--process-dependency-links", "foo"],
+                "expected_args": ["--process-dependency-links", "--no-index", "foo"],
                 "expected_kwargs": {"cwd": None},
+            },
+        ),
+        (
+            "use PyPI",
+            {
+                "packages": [],
+                "kwargs": {"setup_py_dir": "test_setup_py_dir", "no_index": False},
+                "expected_args": ["."],
+                "expected_kwargs": {"cwd": "test_setup_py_dir"},
             },
         ),
         (
@@ -552,7 +563,7 @@ class PipInstallTest(PipCommandBaseTestCase):
             {
                 "packages": ["foo"],
                 "kwargs": {"upgrade": True},
-                "expected_args": ["--upgrade", "foo"],
+                "expected_args": ["--upgrade", "--no-index", "foo"],
                 "expected_kwargs": {"cwd": None},
             },
         ),
@@ -561,7 +572,7 @@ class PipInstallTest(PipCommandBaseTestCase):
             {
                 "packages": ["foo"],
                 "kwargs": {"install_deps": False},
-                "expected_args": ["--no-deps", "foo"],
+                "expected_args": ["--no-deps", "--no-index", "foo"],
                 "expected_kwargs": {"cwd": None},
             },
         ),
@@ -570,7 +581,7 @@ class PipInstallTest(PipCommandBaseTestCase):
             {
                 "packages": ["foo"],
                 "kwargs": {"ignore_installed": True},
-                "expected_args": ["--ignore-installed", "foo"],
+                "expected_args": ["--ignore-installed", "--no-index", "foo"],
                 "expected_kwargs": {"cwd": None},
             },
         ),
@@ -579,21 +590,14 @@ class PipInstallTest(PipCommandBaseTestCase):
             {
                 "packages": ["foo", "bar"],
                 "kwargs": {"setup_py_dir": "test_setup_py_dir"},
-                "expected_args": ["foo", "bar", "."],
+                "expected_args": ["--no-index", "foo", "bar", "."],
                 "expected_kwargs": {"cwd": "test_setup_py_dir"},
             },
         ),
     ]
 
     def _assert_mock_run_with(self, *args, **kwargs):
-        common_args = [
-            "install",
-            "--user",
-            "--no-compile",
-            "--no-index",
-            "--find-links",
-            mock.ANY,
-        ]
+        common_args = ["install", "--user", "--no-compile", "--find-links", mock.ANY]
         common_args.extend(*args)
         self.mock_run.assert_called_once_with(common_args, **kwargs)
 


### PR DESCRIPTION
Try to install setup.py with dependencies satisfied from:
- python-packages
- requirements

If that fails, resort to using PyPI to satisfy missing install_requires
from setup.py

LP: #1841861

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
