### PR TITLE
build providers: inject snapd snap for latest feature availability

### DIFF
--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -211,12 +211,13 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
         )
         self.snap_injector_mock().add.assert_has_calls(
             [
+                call(snap_name="snapd"),
+                call(snap_name="core16"),
                 call(snap_name="core18"),
                 call(snap_name="snapcraft"),
-                call(snap_name="core16"),
             ]
         )
-        self.assertThat(self.snap_injector_mock().add.call_count, Equals(3))
+        self.assertThat(self.snap_injector_mock().add.call_count, Equals(4))
         self.snap_injector_mock().apply.assert_called_once_with()
 
     def test_ephemeral_setup_snapcraft(self):
@@ -236,9 +237,27 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
         )
         self.snap_injector_mock().add.assert_has_calls(
             [
+                call(snap_name="snapd"),
+                call(snap_name="core16"),
                 call(snap_name="core18"),
                 call(snap_name="snapcraft"),
-                call(snap_name="core16"),
+            ]
+        )
+        self.assertThat(self.snap_injector_mock().add.call_count, Equals(4))
+        self.snap_injector_mock().apply.assert_called_once_with()
+
+    def test_setup_snapcraft_with_core(self):
+        self.project.info.base = "core"
+        self.project.info.confinement = "classic"
+
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+        provider._setup_snapcraft()
+
+        self.snap_injector_mock().add.assert_has_calls(
+            [
+                call(snap_name="core"),
+                call(snap_name="core18"),
+                call(snap_name="snapcraft"),
             ]
         )
         self.assertThat(self.snap_injector_mock().add.call_count, Equals(3))
@@ -253,9 +272,9 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
 
         self.snap_injector_mock().add.assert_has_calls(
             [
+                call(snap_name="snapd"),
                 call(snap_name="core18"),
                 call(snap_name="snapcraft"),
-                call(snap_name="core18"),
             ]
         )
         self.assertThat(self.snap_injector_mock().add.call_count, Equals(3))
@@ -280,9 +299,9 @@ class MacProviderProvisionSnapcraftTest(MacBaseProviderWithBasesBaseTest):
         )
         self.snap_injector_mock().add.assert_has_calls(
             [
+                call(snap_name="snapd"),
                 call(snap_name="core18"),
                 call(snap_name="snapcraft"),
-                call(snap_name="core18"),
             ]
         )
         self.assertThat(self.snap_injector_mock().add.call_count, Equals(3))
@@ -327,9 +346,9 @@ class MacProviderProvisionSnapcraftTest(MacBaseProviderWithBasesBaseTest):
         )
         self.snap_injector_mock().add.assert_has_calls(
             [
+                call(snap_name="snapd"),
                 call(snap_name="core18"),
                 call(snap_name="snapcraft"),
-                call(snap_name="core18"),
             ]
         )
         self.assertThat(self.snap_injector_mock().add.call_count, Equals(3))

--- a/tests/unit/build_providers/test_snap.py
+++ b/tests/unit/build_providers/test_snap.py
@@ -107,6 +107,7 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_has_calls(get_assertion_calls)
         self.provider.run_mock.assert_has_calls(
             [
+                call(["snap", "set", "system", "experimental.snapd-snap=true"]),
                 call(["snap", "set", "core", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "ack", "/var/tmp/core.assert"]),
@@ -154,6 +155,7 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_not_called()
         self.provider.run_mock.assert_has_calls(
             [
+                call(["snap", "set", "system", "experimental.snapd-snap=true"]),
                 call(["snap", "set", "core", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
@@ -217,6 +219,7 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_has_calls(get_assertion_calls)
         self.provider.run_mock.assert_has_calls(
             [
+                call(["snap", "set", "system", "experimental.snapd-snap=true"]),
                 call(["snap", "set", "core", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "ack", "/var/tmp/core.assert"]),
@@ -271,6 +274,7 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_not_called()
         self.provider.run_mock.assert_has_calls(
             [
+                call(["snap", "set", "system", "experimental.snapd-snap=true"]),
                 call(["snap", "set", "core", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
@@ -315,6 +319,7 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_not_called()
         self.provider.run_mock.assert_has_calls(
             [
+                call(["snap", "set", "system", "experimental.snapd-snap=true"]),
                 call(["snap", "set", "core", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
@@ -353,6 +358,7 @@ class SnapInjectionTest(unit.TestCase):
 
         self.provider.run_mock.assert_has_calls(
             [
+                call(["snap", "set", "system", "experimental.snapd-snap=true"]),
                 call(["snap", "set", "core", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
@@ -375,6 +381,7 @@ class SnapInjectionTest(unit.TestCase):
 
         self.provider.run_mock.assert_has_calls(
             [
+                call(["snap", "set", "system", "experimental.snapd-snap=true"]),
                 call(["snap", "set", "core", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
@@ -459,6 +466,7 @@ class SnapInjectionTest(unit.TestCase):
 
         self.provider.run_mock.assert_has_calls(
             [
+                call(["snap", "set", "system", "experimental.snapd-snap=true"]),
                 call(["snap", "set", "core", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "refresh", "--channel", "stable", "core"]),
@@ -489,6 +497,7 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_not_called()
         self.provider.run_mock.assert_has_calls(
             [
+                call(["snap", "set", "system", "experimental.snapd-snap=true"]),
                 call(["snap", "set", "core", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "install", "--channel", "stable", "core"]),


### PR DESCRIPTION
The snapd snap is nimble and small when compared to having to add the core
snap always (an additional burden from always needing to add "core18" to
support snapcraft).

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
