### PR TITLE
repo: convey proper error message when refreshing to invalid channel

### DIFF
--- a/snapcraft/internal/repo/snaps.py
+++ b/snapcraft/internal/repo/snaps.py
@@ -213,6 +213,11 @@ class SnapPackage:
 
     def install(self):
         """Installs the snap onto the system."""
+        if not self.is_valid():
+            raise errors.SnapUnavailableError(
+                snap_name=self.name, snap_channel=self.channel
+            )
+
         snap_install_cmd = []
         if _snap_command_requires_sudo():
             snap_install_cmd = ["sudo"]
@@ -234,6 +239,11 @@ class SnapPackage:
 
     def refresh(self):
         """Refreshes a snap onto a channel on the system."""
+        if not self.is_valid():
+            raise errors.SnapUnavailableError(
+                snap_name=self.name, snap_channel=self.channel
+            )
+
         snap_refresh_cmd = []
         if _snap_command_requires_sudo():
             snap_refresh_cmd = ["sudo"]
@@ -292,11 +302,6 @@ def install_snaps(snaps_list: Union[Sequence[str], Set[str]]) -> List[str]:
                 "{snap_name}/latest/{channel}".format(
                     snap_name=snap_pkg.name, channel=snap_pkg_channel
                 )
-            )
-
-        if not snap_pkg.installed and not snap_pkg.is_valid():
-            raise errors.SnapUnavailableError(
-                snap_name=snap_pkg.name, snap_channel=snap_pkg.channel
             )
 
         if not snap_pkg.installed:

--- a/tests/unit/repo/test_snaps.py
+++ b/tests/unit/repo/test_snaps.py
@@ -641,6 +641,15 @@ class SnapPackageLifecycleTest(unit.TestCase):
             ["fake-snap/non-existent/edge"],
         )
 
+    def test_install_snaps_refresh_to_invalid_channel(self):
+        self.fake_snapd.find_result = [
+            {"fake-snap": {"channels": {"strict/edge": {"confinement": "strict"}}}}
+        ]
+
+        self.assertRaises(
+            errors.SnapUnavailableError, snaps.install_snaps, "fake-snap/strict/stable"
+        )
+
 
 class InstalledSnapsTestCase(unit.TestCase):
     def test_get_installed_snaps(self):


### PR DESCRIPTION
Refreshing to a channel that does not exist raised a KeyError, move
the is_valid check to be part of the class and generally catch the
issue there instead of from the helper methods.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
