### PR TITLE
yaml_utils: move _load_yaml from project for re-use (and add tests)

### DIFF
--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -14,11 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import codecs
-from collections import OrderedDict
 from copy import deepcopy
-
-import yaml
 
 from snapcraft import yaml_utils
 from . import _schema
@@ -30,7 +26,7 @@ class ProjectInfo:
 
     def __init__(self, *, snapcraft_yaml_file_path) -> None:
         self.snapcraft_yaml_file_path = snapcraft_yaml_file_path
-        self.__raw_snapcraft = _load_yaml(yaml_file_path=snapcraft_yaml_file_path)
+        self.__raw_snapcraft = yaml_utils.load_yaml_file(snapcraft_yaml_file_path)
 
         try:
             self.name = self.__raw_snapcraft["name"]
@@ -67,38 +63,3 @@ class ProjectInfo:
         # TODO this should be a MappingProxyType, but ordered writing
         #      depends on reading in the current code base.
         return deepcopy(self.__raw_snapcraft)
-
-
-def _load_yaml(*, yaml_file_path: str) -> OrderedDict:
-    with open(yaml_file_path, "rb") as fp:
-        bs = fp.read(2)
-
-    if bs == codecs.BOM_UTF16_LE or bs == codecs.BOM_UTF16_BE:
-        encoding = "utf-16"
-    else:
-        encoding = "utf-8"
-
-    try:
-        with open(yaml_file_path, encoding=encoding) as fp:  # type: ignore
-            yaml_contents = yaml_utils.load(fp)  # type: ignore
-    except yaml.MarkedYAMLError as e:
-        raise errors.YamlValidationError(
-            "{} on line {}, column {}".format(
-                e.problem, e.problem_mark.line + 1, e.problem_mark.column + 1
-            ),
-            yaml_file_path,
-        ) from e
-    except yaml.reader.ReaderError as e:
-        raise errors.YamlValidationError(
-            "invalid character {!r} at position {}: {}".format(
-                chr(e.character), e.position + 1, e.reason
-            ),
-            yaml_file_path,
-        ) from e
-    except yaml.YAMLError as e:
-        raise errors.YamlValidationError(str(e), yaml_file_path) from e
-
-    if yaml_contents is None:
-        yaml_contents = OrderedDict()
-
-    return yaml_contents

--- a/snapcraft/yaml_utils.py
+++ b/snapcraft/yaml_utils.py
@@ -14,9 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import codecs
 import collections
 import yaml
 from typing import Any, Dict, TextIO, Union
+
+from snapcraft.project.errors import YamlValidationError
 
 try:
     # The C-based loaders/dumpers aren't available everywhere, but they're much faster.
@@ -25,6 +28,42 @@ try:
     from yaml import CSafeLoader, CSafeDumper  # type: ignore
 except ImportError:
     raise RuntimeError("Snapcraft requires PyYAML to be built with libyaml bindings")
+
+
+def load_yaml_file(yaml_file_path: str) -> collections.OrderedDict:
+    """Load YAML with wrapped YamlValidationError."""
+    with open(yaml_file_path, "rb") as fp:
+        bs = fp.read(2)
+
+    if bs == codecs.BOM_UTF16_LE or bs == codecs.BOM_UTF16_BE:
+        encoding = "utf-16"
+    else:
+        encoding = "utf-8"
+
+    try:
+        with open(yaml_file_path, encoding=encoding) as fp:  # type: ignore
+            yaml_contents = load(fp)  # type: ignore
+    except yaml.MarkedYAMLError as e:
+        raise YamlValidationError(
+            "{} on line {}, column {}".format(
+                e.problem, e.problem_mark.line + 1, e.problem_mark.column + 1
+            ),
+            yaml_file_path,
+        ) from e
+    except yaml.reader.ReaderError as e:
+        raise YamlValidationError(
+            "invalid character {!r} at position {}: {}".format(
+                chr(e.character), e.position + 1, e.reason
+            ),
+            yaml_file_path,
+        ) from e
+    except yaml.YAMLError as e:
+        raise YamlValidationError(str(e), yaml_file_path) from e
+
+    if yaml_contents is None:
+        yaml_contents = collections.OrderedDict()
+
+    return yaml_contents
 
 
 def load(stream: TextIO) -> Any:

--- a/tests/unit/test_yaml_utils.py
+++ b/tests/unit/test_yaml_utils.py
@@ -15,11 +15,33 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
+import os
 
 from testtools.matchers import Equals
 
 from snapcraft import yaml_utils
+from snapcraft.project.errors import YamlValidationError
 from tests import unit
+
+
+class YamlLoadTests(unit.TestCase):
+    def test_load_yaml_file(self):
+        path = os.path.join(self.path, "test.yaml")
+        with open(path, "w") as f:
+            f.write("foo: bar")
+
+        cfg = yaml_utils.load_yaml_file(path)
+
+        self.assertThat(cfg, Equals({"foo": "bar"}))
+
+    def test_load_yaml_file_bad_yaml(self):
+        path = os.path.join(self.path, "test.yaml")
+        with open(path, "w") as f:
+            # Note the missing newlines...
+            f.write("foo: bar")
+            f.write("a-b-c: xyz")
+
+        self.assertRaises(YamlValidationError, yaml_utils.load_yaml_file, path)
 
 
 class OctIntTest(unit.TestCase):


### PR DESCRIPTION
Rename to `load_yaml_file`.

This version of load has the most complete error handling,
converting the assortment of yaml errors into a YamlValidationError.

We will re-use this logic for snapcraft's configuration file.