### PR TITLE
cli: run review tools before pushing to the store if available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ packages = [
     "snapcraft.internal.project_loader._extensions",
     "snapcraft.internal.remote_build",
     "snapcraft.internal.repo",
+    "snapcraft.internal.review_tools",
     "snapcraft.internal.sources",
     "snapcraft.internal.states",
     "snapcraft.project",

--- a/snapcraft/cli/_review.py
+++ b/snapcraft/cli/_review.py
@@ -1,0 +1,43 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+
+import click
+
+from snapcraft.internal import review_tools
+from . import echo
+
+
+def review_snap(*, snap_file: str) -> None:
+    # Review the snap.
+    if review_tools.is_available():
+        echo.info(
+            "Running the review tools before pushing this snap to the Snap " "Store."
+        )
+        # TODO just raise when we can override.
+        try:
+            review_tools.run(snap_filename=snap_file)
+        except review_tools.errors.ReviewError as review_error:
+            echo.warning(review_error.get_brief())
+            echo.warning(review_error.get_resolution())
+            # This can get too colorful if we don't just print it.
+            click.echo(review_error.get_details())
+    elif sys.platform == "linux":
+        echo.warning(
+            "Install the review-tools from the Snap Store for enhanced checks "
+            "before uploading this snap."
+        )

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import contextlib
 import os
 import functools
@@ -29,6 +30,7 @@ import snapcraft
 from snapcraft import storeapi, formatting_utils
 from snapcraft.storeapi.constants import DEFAULT_SERIES
 from . import echo
+from ._review import review_snap
 
 
 _MESSAGE_REGISTER_PRIVATE = dedent(
@@ -171,6 +173,7 @@ def push(snap_file, release):
     else:
         channel_list = None
 
+    review_snap(snap_file=snap_file)
     snapcraft.push(snap_file, channel_list)
 
 

--- a/snapcraft/internal/review_tools/__init__.py
+++ b/snapcraft/internal/review_tools/__init__.py
@@ -1,0 +1,18 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from . import errors  # noqa: F401
+from ._runner import is_available, run  # noqa: F401

--- a/snapcraft/internal/review_tools/_runner.py
+++ b/snapcraft/internal/review_tools/_runner.py
@@ -1,0 +1,49 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import pathlib
+import subprocess
+
+from . import errors
+
+
+_REVIEW_TOOLS_PATH = pathlib.Path("/snap/bin/review-tools.snap-review")
+
+
+def is_available() -> bool:
+    return _REVIEW_TOOLS_PATH.exists()
+
+
+def run(*, snap_filename: str) -> None:
+    # TODO allow suppression of error and warn through project configuration.
+    command = [_REVIEW_TOOLS_PATH.as_posix(), snap_filename, "--json"]
+    # Speed up the process by not doing the re-squash tests.
+    env = dict(SNAP_ENFORCE_RESQUASHFS="0")
+
+    try:
+        subprocess.check_output(command, stderr=subprocess.STDOUT, env=env)
+    except FileNotFoundError:
+        raise errors.ReviewToolMissing()
+    except subprocess.CalledProcessError as call_error:
+        # Error codes:
+        # 2 -> warnings.
+        # 3 -> warnings and errors.
+        # Any of these trigger a store review.
+        if call_error.returncode not in (2, 3):
+            raise
+        # We only really care about v2_lint now.
+        raise errors.ReviewError(review_json=json.loads(call_error.output.decode()))

--- a/snapcraft/internal/review_tools/errors.py
+++ b/snapcraft/internal/review_tools/errors.py
@@ -1,0 +1,77 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Any, Dict, Optional
+
+from snapcraft.internal.errors import SnapcraftException
+
+
+class ReviewToolMissing(SnapcraftException):
+    def get_brief(self) -> str:
+        return "The Review Tools are not installed on this system."
+
+    def get_resolution(self) -> str:
+        return "Review Tools can be installed with:\nsnap install review-tools"
+
+
+class ReviewError(SnapcraftException):
+    def __init__(self, review_json: Dict[str, Any]) -> None:
+        self._review_json = review_json
+
+    def get_brief(self) -> str:
+        return "Review Tools did not fully pass for this snap."
+
+    def get_resolution(self) -> str:
+        return (
+            "Specific measures might need to be taken on the Snap Store before "
+            "this snap can be fully accepted."
+        )
+
+    def _get_issues(self, issue_type: str) -> Dict[str, Any]:
+        issues: Dict[str, Any] = dict()
+        for severity in ("error", "warn"):
+            issues.update(self._review_json[issue_type].get(severity))
+
+        return issues
+
+    def get_details(self) -> Optional[str]:
+        all_issues = {
+            "Linting Issues": self._get_issues("snap.v2_lint"),
+            "Functional Issues": self._get_issues("snap.v2_functional"),
+            "Security Issues": self._get_issues("snap.v2_security"),
+        }
+
+        # Reduce to actual issues.
+        existing_issues = {k: v for k, v in all_issues.items() if v is not None}
+
+        # Return early if there are no details.
+        if not existing_issues:
+            return None
+
+        details = ""
+        for issue_title, issues in sorted(existing_issues.items()):
+            if not issues:
+                continue
+            details += f"{issue_title}:\n"
+            for issue in issues.values():
+                if "link" in issue:
+                    details += "- {text} (Refer to {link})\n".format(**issue)
+                else:
+                    details += "- {text}\n".format(**issue)
+            else:
+                details += "\n"
+
+        return details.strip()

--- a/tests/unit/review_tools/test_errors.py
+++ b/tests/unit/review_tools/test_errors.py
@@ -1,0 +1,395 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from textwrap import dedent
+
+from testtools.matchers import Equals, Is
+
+from snapcraft.internal.review_tools import errors
+from tests import unit
+
+
+class SnapcraftExceptionTests(unit.TestCase):
+
+    scenarios = (
+        (
+            "ReviewError (linting error with link)",
+            {
+                "exception": errors.ReviewError,
+                "kwargs": dict(
+                    review_json={
+                        "snap.v2_functional": {"error": {}, "warn": {}},
+                        "snap.v2_lint": {
+                            "error": {
+                                "lint-snap-v2:lint_issue": {
+                                    "link": "https://issue-link",
+                                    "text": "(NEEDS REVIEW) linting message.",
+                                }
+                            },
+                            "warn": {},
+                        },
+                        "snap.v2_security": {"error": {}, "warn": {}},
+                    }
+                ),
+                "expected_details": dedent(
+                    """\
+                    Linting Issues:
+                    - (NEEDS REVIEW) linting message. (Refer to https://issue-link)"""
+                ),
+            },
+        ),
+        (
+            "ReviewError (linting warning with link)",
+            {
+                "exception": errors.ReviewError,
+                "kwargs": dict(
+                    review_json={
+                        "snap.v2_functional": {"error": {}, "warn": {}},
+                        "snap.v2_lint": {
+                            "warn": {
+                                "lint-snap-v2:lint_issue": {
+                                    "link": "https://issue-link",
+                                    "text": "(NEEDS REVIEW) linting message.",
+                                }
+                            },
+                            "error": {},
+                        },
+                        "snap.v2_security": {"error": {}, "warn": {}},
+                    }
+                ),
+                "expected_details": dedent(
+                    """\
+                    Linting Issues:
+                    - (NEEDS REVIEW) linting message. (Refer to https://issue-link)"""
+                ),
+            },
+        ),
+        (
+            "ReviewError (linting error without link)",
+            {
+                "exception": errors.ReviewError,
+                "kwargs": dict(
+                    review_json={
+                        "snap.v2_functional": {"error": {}, "warn": {}},
+                        "snap.v2_lint": {
+                            "error": {
+                                "lint-snap-v2:lint_issue": {
+                                    "text": "(NEEDS REVIEW) linting message."
+                                }
+                            },
+                            "warn": {},
+                        },
+                        "snap.v2_security": {"error": {}, "warn": {}},
+                    }
+                ),
+                "expected_details": dedent(
+                    """\
+                    Linting Issues:
+                    - (NEEDS REVIEW) linting message."""
+                ),
+            },
+        ),
+        (
+            "ReviewError (linting warning without link)",
+            {
+                "exception": errors.ReviewError,
+                "kwargs": dict(
+                    review_json={
+                        "snap.v2_functional": {"error": {}, "warn": {}},
+                        "snap.v2_lint": {
+                            "warn": {
+                                "lint-snap-v2:lint_issue": {
+                                    "text": "(NEEDS REVIEW) linting message."
+                                }
+                            },
+                            "error": {},
+                        },
+                        "snap.v2_security": {"error": {}, "warn": {}},
+                    }
+                ),
+                "expected_details": dedent(
+                    """\
+                    Linting Issues:
+                    - (NEEDS REVIEW) linting message."""
+                ),
+            },
+        ),
+        (
+            "ReviewError (security error with link)",
+            {
+                "exception": errors.ReviewError,
+                "kwargs": dict(
+                    review_json={
+                        "snap.v2_functional": {"error": {}, "warn": {}},
+                        "snap.v2_security": {
+                            "error": {
+                                "security-snap-v2:security_issue": {
+                                    "link": "https://issue-link",
+                                    "text": "(NEEDS REVIEW) security message.",
+                                }
+                            },
+                            "warn": {},
+                        },
+                        "snap.v2_lint": {"error": {}, "warn": {}},
+                    }
+                ),
+                "expected_details": dedent(
+                    """\
+                    Security Issues:
+                    - (NEEDS REVIEW) security message. (Refer to https://issue-link)"""
+                ),
+            },
+        ),
+        (
+            "ReviewError (security warning with link)",
+            {
+                "exception": errors.ReviewError,
+                "kwargs": dict(
+                    review_json={
+                        "snap.v2_functional": {"error": {}, "warn": {}},
+                        "snap.v2_security": {
+                            "warn": {
+                                "security-snap-v2:security_issue": {
+                                    "link": "https://issue-link",
+                                    "text": "(NEEDS REVIEW) security message.",
+                                }
+                            },
+                            "error": {},
+                        },
+                        "snap.v2_lint": {"error": {}, "warn": {}},
+                    }
+                ),
+                "expected_details": dedent(
+                    """\
+                    Security Issues:
+                    - (NEEDS REVIEW) security message. (Refer to https://issue-link)"""
+                ),
+            },
+        ),
+        (
+            "ReviewError (security error without link)",
+            {
+                "exception": errors.ReviewError,
+                "kwargs": dict(
+                    review_json={
+                        "snap.v2_functional": {"error": {}, "warn": {}},
+                        "snap.v2_security": {
+                            "error": {
+                                "security-snap-v2:security_issue": {
+                                    "text": "(NEEDS REVIEW) security message."
+                                }
+                            },
+                            "warn": {},
+                        },
+                        "snap.v2_lint": {"error": {}, "warn": {}},
+                    }
+                ),
+                "expected_details": dedent(
+                    """\
+                    Security Issues:
+                    - (NEEDS REVIEW) security message."""
+                ),
+            },
+        ),
+        (
+            "ReviewError (security warning without link)",
+            {
+                "exception": errors.ReviewError,
+                "kwargs": dict(
+                    review_json={
+                        "snap.v2_functional": {"error": {}, "warn": {}},
+                        "snap.v2_security": {
+                            "warn": {
+                                "security-snap-v2:security_issue": {
+                                    "text": "(NEEDS REVIEW) security message."
+                                }
+                            },
+                            "error": {},
+                        },
+                        "snap.v2_lint": {"error": {}, "warn": {}},
+                    }
+                ),
+                "expected_details": dedent(
+                    """\
+                    Security Issues:
+                    - (NEEDS REVIEW) security message."""
+                ),
+            },
+        ),
+        (
+            "ReviewError (functional error with link)",
+            {
+                "exception": errors.ReviewError,
+                "kwargs": dict(
+                    review_json={
+                        "snap.v2_security": {"error": {}, "warn": {}},
+                        "snap.v2_functional": {
+                            "error": {
+                                "functional-snap-v2:functional_issue": {
+                                    "link": "https://issue-link",
+                                    "text": "(NEEDS REVIEW) functional message.",
+                                }
+                            },
+                            "warn": {},
+                        },
+                        "snap.v2_lint": {"error": {}, "warn": {}},
+                    }
+                ),
+                "expected_details": dedent(
+                    """\
+                    Functional Issues:
+                    - (NEEDS REVIEW) functional message. (Refer to https://issue-link)"""
+                ),
+            },
+        ),
+        (
+            "ReviewError (functional warning with link)",
+            {
+                "exception": errors.ReviewError,
+                "kwargs": dict(
+                    review_json={
+                        "snap.v2_security": {"error": {}, "warn": {}},
+                        "snap.v2_functional": {
+                            "warn": {
+                                "functional-snap-v2:functional_issue": {
+                                    "link": "https://issue-link",
+                                    "text": "(NEEDS REVIEW) functional message.",
+                                }
+                            },
+                            "error": {},
+                        },
+                        "snap.v2_lint": {"error": {}, "warn": {}},
+                    }
+                ),
+                "expected_details": dedent(
+                    """\
+                    Functional Issues:
+                    - (NEEDS REVIEW) functional message. (Refer to https://issue-link)"""
+                ),
+            },
+        ),
+        (
+            "ReviewError (functional error without link)",
+            {
+                "exception": errors.ReviewError,
+                "kwargs": dict(
+                    review_json={
+                        "snap.v2_security": {"error": {}, "warn": {}},
+                        "snap.v2_functional": {
+                            "error": {
+                                "functional-snap-v2:functional_issue": {
+                                    "text": "(NEEDS REVIEW) functional message."
+                                }
+                            },
+                            "warn": {},
+                        },
+                        "snap.v2_lint": {"error": {}, "warn": {}},
+                    }
+                ),
+                "expected_details": dedent(
+                    """\
+                    Functional Issues:
+                    - (NEEDS REVIEW) functional message."""
+                ),
+            },
+        ),
+        (
+            "ReviewError (functional warning without link)",
+            {
+                "exception": errors.ReviewError,
+                "kwargs": dict(
+                    review_json={
+                        "snap.v2_security": {"error": {}, "warn": {}},
+                        "snap.v2_functional": {
+                            "warn": {
+                                "functional-snap-v2:functional_issue": {
+                                    "text": "(NEEDS REVIEW) functional message."
+                                }
+                            },
+                            "error": {},
+                        },
+                        "snap.v2_lint": {"error": {}, "warn": {}},
+                    }
+                ),
+                "expected_details": dedent(
+                    """\
+                    Functional Issues:
+                    - (NEEDS REVIEW) functional message."""
+                ),
+            },
+        ),
+        (
+            "ReviewError",
+            {
+                "exception": errors.ReviewError,
+                "kwargs": dict(
+                    review_json={
+                        "snap.v2_security": {
+                            "error": {},
+                            "warn": {
+                                "functional-snap-v2:security_issue": {
+                                    "text": "(NEEDS REVIEW) security message."
+                                }
+                            },
+                        },
+                        "snap.v2_functional": {
+                            "warn": {
+                                "functional-snap-v2:functional_issue": {
+                                    "text": "(NEEDS REVIEW) functional message."
+                                }
+                            },
+                            "error": {},
+                        },
+                        "snap.v2_lint": {
+                            "error": {},
+                            "warn": {
+                                "functional-snap-v2:lint_issue": {
+                                    "text": "(NEEDS REVIEW) lint message."
+                                }
+                            },
+                        },
+                    }
+                ),
+                "expected_details": dedent(
+                    """\
+                    Functional Issues:
+                    - (NEEDS REVIEW) functional message.
+
+                    Linting Issues:
+                    - (NEEDS REVIEW) lint message.
+
+                    Security Issues:
+                    - (NEEDS REVIEW) security message."""
+                ),
+            },
+        ),
+    )
+
+    def test_snapcraft_exception_handling(self):
+        exception = self.exception(**self.kwargs)
+        self.expectThat(
+            exception.get_brief(),
+            Equals("Review Tools did not fully pass for this snap."),
+        )
+        self.expectThat(
+            exception.get_resolution(),
+            Equals(
+                "Specific measures might need to be taken on the Snap Store before this snap can be fully accepted."
+            ),
+        )
+        self.expectThat(exception.get_details(), Equals(self.expected_details))
+        self.expectThat(exception.get_docs_url(), Is(None)),
+        self.expectThat(exception.get_reportable(), Is(False))

--- a/tests/unit/review_tools/test_runner.py
+++ b/tests/unit/review_tools/test_runner.py
@@ -1,0 +1,120 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import subprocess
+
+import fixtures
+
+from snapcraft.internal import review_tools
+from tests import unit
+
+
+class RunTest(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.review_tools_path = "/snap/bin/review-tools.snap-review"
+        self.fake_check_output = fixtures.MockPatch(
+            "subprocess.check_output", return_value=b""
+        )
+        self.useFixture(self.fake_check_output)
+
+    def assert_fake_check_output_called(self):
+        self.fake_check_output.mock.assert_called_once_with(
+            [self.review_tools_path, "fake.snap", "--json"],
+            env={"SNAP_ENFORCE_RESQUASHFS": "0"},
+            stderr=subprocess.STDOUT,
+        )
+
+    def test_review_good(self):
+        review_tools.run(snap_filename="fake.snap")
+
+        self.assert_fake_check_output_called()
+
+    def test_review_warnings(self):
+        self.fake_check_output.mock.side_effect = subprocess.CalledProcessError(
+            cmd=[self.review_tools_path, "fake.snap", "--json"],
+            returncode=2,
+            output=json.dumps(
+                {
+                    "snap.v2_functional": {"error": {}, "warn": {}},
+                    "snap.v2_security": {
+                        "warn": {
+                            "security-snap-v2:security_issue": {
+                                "text": "(NEEDS REVIEW) security message."
+                            }
+                        },
+                        "error": {},
+                    },
+                    "snap.v2_lint": {"error": {}, "warn": {}},
+                }
+            ).encode(),
+        )
+
+        self.assertRaises(
+            review_tools.errors.ReviewError, review_tools.run, snap_filename="fake.snap"
+        )
+        self.assert_fake_check_output_called()
+
+    def test_review_errors(self):
+        self.fake_check_output.mock.side_effect = subprocess.CalledProcessError(
+            cmd=[self.review_tools_path, "fake.snap", "--json"],
+            returncode=3,
+            output=json.dumps(
+                {
+                    "snap.v2_functional": {"error": {}, "warn": {}},
+                    "snap.v2_security": {
+                        "error": {
+                            "security-snap-v2:security_issue": {
+                                "text": "(NEEDS REVIEW) security message."
+                            }
+                        },
+                        "warn": {},
+                    },
+                    "snap.v2_lint": {"error": {}, "warn": {}},
+                }
+            ).encode(),
+        )
+
+        self.assertRaises(
+            review_tools.errors.ReviewError, review_tools.run, snap_filename="fake.snap"
+        )
+        self.assert_fake_check_output_called()
+
+    def test_review_unkown_error_bubbles_up(self):
+        self.fake_check_output.mock.side_effect = subprocess.CalledProcessError(
+            cmd=[self.review_tools_path, "fake.snap", "--json"],
+            returncode=4,
+            output=b"unknown",
+        )
+
+        self.assertRaises(
+            subprocess.CalledProcessError, review_tools.run, snap_filename="fake.snap"
+        )
+        self.assert_fake_check_output_called()
+
+    def test_review_tools_missing(self):
+        self.fake_check_output.mock.side_effect = FileNotFoundError(
+            "review-tools.snap-review"
+        )
+
+        self.assertRaises(
+            review_tools.errors.ReviewToolMissing,
+            review_tools.run,
+            snap_filename="fake.snap",
+        )
+        self.assert_fake_check_output_called()


### PR DESCRIPTION
Consider only snap v2 lint warnings and errors. On discovery of any issues,
emit warnings, but do not fail as we have no easy way to override
any of these issues.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
