### PR TITLE
[multipass] use stdio to get data in/out of Multipass

### DIFF
--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -135,7 +135,8 @@ class Multipass(Provider):
 
     def _push_file(self, *, source: str, destination: str) -> None:
         destination = "{}:{}".format(self.instance_name, destination)
-        self._multipass_cmd.copy_files(source=source, destination=destination)
+        with open(source, "rb") as file:
+            self._multipass_cmd.push_file(source=file, destination=destination)
 
     def __init__(
         self,
@@ -222,7 +223,8 @@ class Multipass(Provider):
 
         # copy file from instance
         source = "{}:{}".format(self.instance_name, name)
-        self._multipass_cmd.copy_files(source=source, destination=destination)
+        with open(destination, "wb") as file:
+            self._multipass_cmd.pull_file(source=source, destination=file)
         if delete:
             self._run(command=["rm", name])
 

--- a/snapcraft/internal/build_providers/_multipass/_multipass_command.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass_command.py
@@ -327,18 +327,17 @@ class MultipassCommand:
         assert isinstance(source, io.IOBase)
 
         # can't use std{in,out}=open(...) due to LP#1849753
-        data_to_read = True
-
         p = _popen(
             [self.provider_cmd, "transfer", "-", destination], stdin=subprocess.PIPE
         )
 
-        while data_to_read:
+        while True:
             read = source.read(bufsize)
-            p.stdin.write(read)
+            if read:
+                p.stdin.write(read)
             if len(read) < bufsize:
                 logger.debug("Finished streaming source file")
-                data_to_read = False
+                break
 
         while True:
             try:

--- a/snapcraft/internal/build_providers/_multipass/_multipass_command.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass_command.py
@@ -137,7 +137,6 @@ class MultipassCommand:
         mem: str = None,
         disk: str = None,
         remote: str = None,
-        cloud_init: str = None
     ) -> None:
         """Passthrough for running multipass launch.
 
@@ -147,13 +146,10 @@ class MultipassCommand:
         :param str mem: amount of RAM to assign to the launched instance.
         :param str disk: amount of disk space the instance will see.
         :param str remote: the remote server to retrieve the image from.
-        :param str cloud_init_file: path to a user-data cloud-init configuration.
         """
         if remote is not None:
             image = "{}:{}".format(remote, image)
         cmd = [self.provider_cmd, "launch", image, "--name", instance_name]
-        if cloud_init is not None:
-            cmd.extend(["--cloud-init", cloud_init])
         if cpus is not None:
             cmd.extend(["--cpus", cpus])
         if mem is not None:

--- a/snapcraft/internal/build_providers/_multipass/_multipass_command.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass_command.py
@@ -312,7 +312,7 @@ class MultipassCommand:
         :param str destination: the destination of the copied file, using
                                 syntax expected by multipass.
         """
-        cmd = [self.provider_cmd, "copy-files", source, destination]
+        cmd = [self.provider_cmd, "transfer", source, destination]
         try:
             _run(cmd)
         except subprocess.CalledProcessError as process_error:

--- a/snapcraft/internal/build_providers/_multipass/_multipass_command.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass_command.py
@@ -269,7 +269,7 @@ class MultipassCommand:
         source: str,
         target: str,
         uid_map: Dict[str, str] = None,
-        gid_map: Dict[str, str] = None
+        gid_map: Dict[str, str] = None,
     ) -> None:
         """Passthrough for running multipass mount.
 

--- a/tests/unit/build_providers/multipass/test_multipass_command.py
+++ b/tests/unit/build_providers/multipass/test_multipass_command.py
@@ -508,7 +508,6 @@ class MultipassCommandTransferTest(MultipassCommandPassthroughBaseTest):
                     ["multipass", "transfer", "-", destination], stdin=subprocess.PIPE
                 ),
                 mock.call().stdin.write(b"read data"),
-                mock.call().stdin.write(b""),
                 mock.call().communicate(timeout=1),
                 mock.call().communicate(timeout=1),
             ],

--- a/tests/unit/build_providers/multipass/test_multipass_command.py
+++ b/tests/unit/build_providers/multipass/test_multipass_command.py
@@ -458,23 +458,23 @@ class MultipassCommandMountTest(MultipassCommandPassthroughBaseTest):
         self.check_output_mock.assert_not_called()
 
 
-class MultipassCommandCopyFilesTest(MultipassCommandPassthroughBaseTest):
-    def test_copy_files(self):
+class MultipassCommandTransferTest(MultipassCommandPassthroughBaseTest):
+    def test_transfer(self):
         source = "source-file"
         destination = "{}/destination-file".format(self.instance_name)
         self.multipass_command.copy_files(source=source, destination=destination)
 
         self.check_call_mock.assert_called_once_with(
-            ["multipass", "copy-files", source, destination], stdin=subprocess.DEVNULL
+            ["multipass", "transfer", source, destination], stdin=subprocess.DEVNULL
         )
         self.check_output_mock.assert_not_called()
 
-    def test_copy_files_fails(self):
+    def test_transfer_fails(self):
         # multipass can fail due to several reasons and will display the error
         # right above this exception message.
         source = "source-file"
         destination = "destination-file"
-        cmd = ["multipass", "copy-files", source, destination]
+        cmd = ["multipass", "transfer", source, destination]
         self.check_call_mock.side_effect = subprocess.CalledProcessError(1, cmd)
 
         self.assertRaises(

--- a/tests/unit/build_providers/multipass/test_multipass_command.py
+++ b/tests/unit/build_providers/multipass/test_multipass_command.py
@@ -591,6 +591,22 @@ class MultipassCommandTransferTest(MultipassCommandPassthroughBaseTest):
             destination.write.mock_calls,
         )
 
+    def test_buffered_pull_no_communicate_stdout(self):
+        source = "source-file"
+        destination = mock.MagicMock(spec=io.BufferedIOBase)
+
+        self.popen_mock.return_value.stdin = None
+        self.popen_mock.return_value.stdout.read.return_value = ""
+
+        self.popen_mock.return_value.communicate.side_effect = (
+            subprocess.TimeoutExpired("foo", 1),
+            (b"", b"error"),
+        )
+
+        self.multipass_command.pull_file(source=source, destination=destination)
+
+        destination.write.assert_not_called()
+
     def test_push_fails(self):
         # multipass can fail due to several reasons and will display the error
         # right above this exception message.


### PR DESCRIPTION
With Multipass going strict, that's the reliable way.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

I've not found a better way around [LP#1849753](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1849753).

This does build the Multipass snap on strict Multipass from `snap refresh --channel edge/pr1074` fine.