### PR TITLE
remote-build: add initial command unit tests

### DIFF
--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -1,0 +1,90 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License remote_build 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import mock
+
+import fixtures
+from testtools.matchers import Contains, Equals
+
+import snapcraft.internal.remote_build.errors as errors
+from . import CommandBaseTestCase
+from tests import fixture_setup
+
+
+class RemoteBuildTests(CommandBaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.useFixture(fixture_setup.SnapcraftYaml(self.path))
+
+        self.mock_lc = self.useFixture(
+            fixtures.MockPatch("snapcraft.cli.remote.LaunchpadClient", autospec=True)
+        ).mock.return_value
+        self.mock_lc_architectures = mock.PropertyMock(return_value=["i386"])
+        type(self.mock_lc).architectures = self.mock_lc_architectures
+        self.mock_lc.has_outstanding_build.return_value = False
+
+    def test_remote_build(self):
+        result = self.run_command(
+            [
+                "remote-build",
+                "--launchpad-accept-public-upload",
+                "--launchpad-user",
+                "testuser",
+            ]
+        )
+
+        self.mock_lc.start_build.assert_called_once()
+        self.mock_lc.cleanup.assert_called_once()
+        self.assertThat(result.output, Contains("Building snap package for i386."))
+        self.assertThat(result.exit_code, Equals(0))
+
+    def test_remote_build_multiple_arch(self):
+        self.mock_lc_architectures.return_value = ["i386", "amd64", "arm64"]
+
+        result = self.run_command(
+            [
+                "remote-build",
+                "--launchpad-accept-public-upload",
+                "--launchpad-user",
+                "testuser",
+                "--build-on",
+                "i386,amd64,arm64",
+            ]
+        )
+
+        self.mock_lc.start_build.assert_called_once()
+        self.mock_lc.cleanup.assert_called_once()
+        self.assertThat(
+            result.output, Contains("Building snap package for amd64, arm64, and i386.")
+        )
+        self.assertThat(result.exit_code, Equals(0))
+
+    def test_remote_build_invalid_user_arch(self):
+        self.assertRaises(
+            errors.UnsupportedArchitectureError,
+            self.run_command,
+            [
+                "remote-build",
+                "--launchpad-accept-public-upload",
+                "--launchpad-user",
+                "testuser",
+                "--build-on",
+                "x64",
+            ],
+        )
+
+        self.mock_lc.start_build.assert_not_called()
+        self.mock_lc.cleanup.assert_not_called()


### PR DESCRIPTION
Add some tests test for `remote-build` and `build-on`
arch handling.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
