### PR TITLE
cli: add support for 'http-proxy' and 'https-proxy' parameters

### DIFF
--- a/snapcraft/cli/_command.py
+++ b/snapcraft/cli/_command.py
@@ -20,7 +20,7 @@ import sys
 
 import click
 
-from ._options import get_build_environment, get_project
+from ._options import get_build_provider, get_project
 from snapcraft.internal import common, errors
 
 
@@ -53,9 +53,8 @@ class SnapcraftProjectCommand(click.Command):
 
     def _is_legacy(self) -> bool:
         try:
-            build_provider, is_managed_host = get_build_environment(
-                skip_sanity_checks=True
-            )
+            build_provider = get_build_provider(skip_sanity_checks=True)
+            is_managed_host = build_provider == "managed-host"
             project = get_project(is_managed_host=is_managed_host)
         except Exception:
             # If we cannot load the project, we assume we are in non legacy

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -21,7 +21,6 @@ import click
 from snapcraft.project import Project, get_snapcraft_yaml
 from snapcraft.cli.echo import confirm, prompt
 from snapcraft.internal import common, errors
-from typing import Tuple
 
 
 class PromptOption(click.Option):
@@ -116,7 +115,7 @@ def add_provider_options(hidden=False):
     return _add_provider_options
 
 
-def _sanity_check_build_environment_flags(**kwargs):
+def _sanity_check_build_provider_flags(**kwargs):
     provider = kwargs.get("provider")
     use_lxd = kwargs.get("use_lxd")
     destructive_mode = kwargs.get("destructive_mode")
@@ -156,14 +155,12 @@ def _sanity_check_build_environment_flags(**kwargs):
         )
 
 
-def get_build_environment(
-    skip_sanity_checks: bool = False, **kwargs
-) -> Tuple[str, bool]:
+def get_build_provider(skip_sanity_checks: bool = False, **kwargs) -> str:
     """Get build provider and determine if running as managed instance."""
 
     # Sanity checks may be skipped for the purpose of checking legacy.
     if not skip_sanity_checks:
-        _sanity_check_build_environment_flags(**kwargs)
+        _sanity_check_build_provider_flags(**kwargs)
 
     provider = kwargs.get("provider")
 
@@ -178,14 +175,7 @@ def get_build_environment(
             # Default is multipass.
             provider = "multipass"
 
-    # Handle special case for managed-host.
-    if provider == "managed-host":
-        provider = "host"
-        is_managed_host = True
-    else:
-        is_managed_host = False
-
-    return provider, is_managed_host
+    return provider
 
 
 def get_project(*, is_managed_host: bool = False, **kwargs):

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -115,7 +115,7 @@ def add_provider_options(hidden=False):
     return _add_provider_options
 
 
-def _sanity_check_build_provider_flags(**kwargs):
+def _sanity_check_build_provider_flags(**kwargs) -> None:
     provider = kwargs.get("provider")
     use_lxd = kwargs.get("use_lxd")
     destructive_mode = kwargs.get("destructive_mode")

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -259,3 +259,16 @@ def get_project(*, is_managed_host: bool = False, **kwargs):
         is_managed_host=is_managed_host,
     )
     return project
+
+
+def apply_host_provider_flags(build_provider_flags: Dict[str, str]) -> None:
+    """Set build environment flags in snapcraft process."""
+
+    # Snapcraft plugins currently check for environment variables,
+    # e.g. http_proxy and https_proxy.  Ensure they are set if configured.
+    for key, value in build_provider_flags.items():
+        if value is None:
+            if key in os.environ:
+                os.environ.pop(key)
+        else:
+            os.environ[key] = str(value)

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -93,6 +93,20 @@ _PROVIDER_OPTIONS = [
         type=click.Choice(_ALL_PROVIDERS),
         supported_providers=_ALL_PROVIDERS,
     ),
+    dict(
+        param_decls="--http-proxy",
+        metavar="<http-proxy>",
+        help="HTTP proxy for host build environments.",
+        envvar="http_proxy",
+        supported_providers=["host", "lxd", "managed-host", "multipass"],
+    ),
+    dict(
+        param_decls="--https-proxy",
+        metavar="<https-proxy>",
+        help="HTTPS proxy for host build environments.",
+        envvar="https_proxy",
+        supported_providers=["host", "lxd", "managed-host", "multipass"],
+    ),
 ]
 
 

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -172,7 +172,9 @@ class Provider(abc.ABC):
         """
 
     @abc.abstractmethod
-    def _run(self, command: Sequence[str]) -> Optional[bytes]:
+    def _run(
+        self, command: Sequence[str], hide_output: bool = False
+    ) -> Optional[bytes]:
         """Run a command on the instance."""
 
     @abc.abstractmethod

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -88,7 +88,14 @@ class Provider(abc.ABC):
 
     _INSTANCE_PROJECT_DIR = "~/project"
 
-    def __init__(self, *, project, echoer, is_ephemeral: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        project,
+        echoer,
+        is_ephemeral: bool = False,
+        build_provider_flags: Dict[str, str] = None,
+    ) -> None:
         self.project = project
         self.echoer = echoer
         self._is_ephemeral = is_ephemeral
@@ -110,6 +117,10 @@ class Provider(abc.ABC):
             project.info.name,
             self._get_provider_name(),
         )
+
+        if build_provider_flags is None:
+            build_provider_flags = dict()
+        self.build_provider_flags = build_provider_flags.copy()
 
     def __enter__(self):
         try:

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -350,6 +350,16 @@ class Provider(abc.ABC):
         has_tty = str(sys.stdout.isatty())
         env_list.append(f"SNAPCRAFT_HAS_TTY={has_tty}")
 
+        # Pass through configurable environment variables.
+        for key in ["http_proxy", "https_proxy"]:
+            value = self.build_provider_flags.get(key)
+            if not value:
+                continue
+
+            # Ensure item is treated as string and append it.
+            value = str(value)
+            env_list.append(f"{key}={value}")
+
         return env_list
 
     def _base_has_changed(self, base: str, provider_base: str) -> bool:

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -130,9 +130,14 @@ class LXD(Provider):
     ) -> Optional[bytes]:
         self._ensure_container_running()
 
-        logger.debug("Running {}".format(" ".join(command)))
+        env_command = self._get_env_command()
+
         # TODO: use pylxd
-        cmd = [self._LXC_BIN, "exec", self.instance_name, "--"] + list(command)
+        cmd = [self._LXC_BIN, "exec", self.instance_name, "--"]
+        cmd.extend(env_command)
+        cmd.extend(command)
+        self._log_run(cmd)
+
         try:
             if hide_output:
                 output = subprocess.check_output(cmd)

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 import urllib.parse
 import warnings
-from typing import Optional, Sequence
+from typing import Dict, Optional, Sequence
 
 from .._base_provider import Provider
 from .._base_provider import errors
@@ -229,8 +229,20 @@ class LXD(Provider):
                 provider_name=self._get_provider_name(), error_message=lxd_api_error
             )
 
-    def __init__(self, *, project, echoer, is_ephemeral: bool = False) -> None:
-        super().__init__(project=project, echoer=echoer, is_ephemeral=is_ephemeral)
+    def __init__(
+        self,
+        *,
+        project,
+        echoer,
+        is_ephemeral: bool = False,
+        build_provider_flags: Dict[str, str] = None,
+    ) -> None:
+        super().__init__(
+            project=project,
+            echoer=echoer,
+            is_ephemeral=is_ephemeral,
+            build_provider_flags=build_provider_flags,
+        )
         self.echoer.warning(
             "The LXD provider is offered as a technology preview for early adopters.\n"
             "The command line interface, container names or lifecycle handling may "

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -130,7 +130,7 @@ class Multipass(Provider):
         mountpoint: str,
         dev_or_path: str,
         uid_map: Dict[str, str] = None,
-        gid_map: Dict[str, str] = None
+        gid_map: Dict[str, str] = None,
     ) -> None:
         target = "{}:{}".format(self.instance_name, mountpoint)
         self._multipass_cmd.mount(
@@ -145,8 +145,20 @@ class Multipass(Provider):
         destination = "{}:{}".format(self.instance_name, destination)
         self._multipass_cmd.copy_files(source=source, destination=destination)
 
-    def __init__(self, *, project, echoer, is_ephemeral: bool = False) -> None:
-        super().__init__(project=project, echoer=echoer, is_ephemeral=is_ephemeral)
+    def __init__(
+        self,
+        *,
+        project,
+        echoer,
+        is_ephemeral: bool = False,
+        build_provider_flags: Dict[str, str] = None,
+    ) -> None:
+        super().__init__(
+            project=project,
+            echoer=echoer,
+            is_ephemeral=is_ephemeral,
+            build_provider_flags=build_provider_flags,
+        )
         self._multipass_cmd = MultipassCommand(platform=sys.platform)
         self._instance_info = None  # type: InstanceInfo
 

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -83,10 +83,15 @@ class Multipass(Provider):
     def _run(
         self, command: Sequence[str], hide_output: bool = False
     ) -> Optional[bytes]:
-        has_tty = "SNAPCRAFT_HAS_TTY={}".format(sys.stdout.isatty())
-        command = ["sudo", "-i", "env", has_tty] + list(command)
+        env_command = self._get_env_command()
+
+        cmd = ["sudo", "-i"]
+        cmd.extend(env_command)
+        cmd.extend(command)
+        self._log_run(cmd)
+
         return self._multipass_cmd.execute(
-            instance_name=self.instance_name, command=command, hide_output=hide_output
+            instance_name=self.instance_name, command=cmd, hide_output=hide_output
         )
 
     def _get_disk_image(self) -> str:

--- a/tests/spread/build-providers/host-env-passthrough/task.yaml
+++ b/tests/spread/build-providers/host-env-passthrough/task.yaml
@@ -1,0 +1,40 @@
+summary: Verify environment passthrough flags are configured for host
+
+environment:
+  SNAP_DIR: ../snaps/env-passthrough
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+  # Proxy is required so we don't break network connectivity
+  # when specifying http(s) proxies.  Tinyproxy automatically
+  # runs on all interfaces, on port 8888.
+  apt-get install -y tinyproxy
+  apt-mark auto tinyproxy
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean --destructive-mode
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "$SNAP_DIR"
+
+  cfg_http_proxy="http://127.0.0.1:8888"
+  cfg_https_proxy="https://127.0.0.1:8888"
+
+  output=$(snapcraft --destructive-mode --http-proxy "${cfg_http_proxy}" --https-proxy "${cfg_https_proxy}")
+  echo "$output" | MATCH "http_proxy=${cfg_http_proxy}"
+  echo "$output" | MATCH "https_proxy=${cfg_https_proxy}"
+
+  # Clean and run again using environment variable variants.
+  snapcraft clean --destructive-mode
+  output=$(http_proxy="${cfg_http_proxy}" https_proxy="${cfg_https_proxy}" snapcraft --destructive-mode)
+  echo "$output" | MATCH "http_proxy=${cfg_http_proxy}"
+  echo "$output" | MATCH "https_proxy=${cfg_https_proxy}"

--- a/tests/spread/build-providers/lxd-env-passthrough/task.yaml
+++ b/tests/spread/build-providers/lxd-env-passthrough/task.yaml
@@ -1,0 +1,55 @@
+summary: Verify environment passthrough flags are configured for LXD
+
+environment:
+  SNAP_DIR: ../snaps/env-passthrough
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+  # Proxy is required so we don't break network connectivity
+  # when specifying http(s) proxies.  Tinyproxy automatically
+  # runs on all interfaces, on port 8888.
+  apt-get install -y tinyproxy
+  apt-mark auto tinyproxy
+
+  # Setup tinyproxy allow rule for LXD bridge.
+  lxd_network=$(ip -f inet addr show lxdbr0 | awk '/inet / {print $2}')
+  echo "Allow ${lxd_network}" >> /etc/tinyproxy/tinyproxy.conf
+  service tinyproxy restart
+
+restore: |
+  cd "$SNAP_DIR"
+
+  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host.
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
+  snapcraft clean --use-lxd
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "$SNAP_DIR"
+
+  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host.
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
+  lxd_network=$(ip -f inet addr show lxdbr0 | awk '/inet / {print $2}')
+  lxd_ip=$(echo "${lxd_network}" | cut -f 1 -d "/")
+
+  cfg_http_proxy="http://${lxd_ip}:8888"
+  cfg_https_proxy="https://${lxd_ip}:8888"
+
+  output=$(snapcraft --use-lxd --http-proxy "${cfg_http_proxy}" --https-proxy "${cfg_https_proxy}")
+  echo "$output" | MATCH "http_proxy=${cfg_http_proxy}"
+  echo "$output" | MATCH "https_proxy=${cfg_https_proxy}"
+
+  # Clean and run again using environment variable variants.
+  snapcraft clean --use-lxd
+  output=$(http_proxy="${cfg_http_proxy}" https_proxy="${cfg_https_proxy}" snapcraft --use-lxd)
+  echo "$output" | MATCH "http_proxy=${cfg_http_proxy}"
+  echo "$output" | MATCH "https_proxy=${cfg_https_proxy}"

--- a/tests/spread/build-providers/snaps/env-passthrough/snap/snapcraft.yaml
+++ b/tests/spread/build-providers/snaps/env-passthrough/snap/snapcraft.yaml
@@ -1,0 +1,15 @@
+name: env-passthrough
+version: '0.1'
+summary: Help verify environment passthrough variables are set.
+description: |
+  Help verify environment passthrough variables are set.
+
+grade: devel
+confinement: devmode
+
+parts:
+  test:
+    plugin: nil
+    override-pull: |
+      echo "http_proxy=${http_proxy}"
+      echo "https_proxy=${https_proxy}"

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -24,8 +24,15 @@ from snapcraft.internal.build_providers._base_provider import Provider
 
 
 class ProviderImpl(Provider):
-    def __init__(self, *, project, echoer, is_ephemeral=False):
-        super().__init__(project=project, echoer=echoer, is_ephemeral=is_ephemeral)
+    def __init__(
+        self, *, project, echoer, is_ephemeral=False, build_provider_flags=None
+    ):
+        super().__init__(
+            project=project,
+            echoer=echoer,
+            is_ephemeral=is_ephemeral,
+            build_provider_flags=build_provider_flags,
+        )
 
         self.run_mock = mock.Mock()
         self.launch_mock = mock.Mock()

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -177,6 +177,8 @@ class LXDInitTest(LXDBaseTest):
                         "exec",
                         self.instance_name,
                         "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
                         "cloud-init",
                         "status",
                         "--wait",
@@ -188,6 +190,8 @@ class LXDInitTest(LXDBaseTest):
                         "exec",
                         self.instance_name,
                         "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
                         "snapcraft",
                         "refresh",
                     ]
@@ -315,7 +319,15 @@ class LXDLaunchedTest(LXDBaseTest):
         self.instance.shell()
 
         self.check_call_mock.assert_called_once_with(
-            ["/snap/bin/lxc", "exec", "snapcraft-project-name", "--", "/bin/bash"]
+            [
+                "/snap/bin/lxc",
+                "exec",
+                "snapcraft-project-name",
+                "--",
+                "env",
+                "SNAPCRAFT_HAS_TTY=False",
+                "/bin/bash",
+            ]
         )
 
     def test_mount_project(self):
@@ -336,7 +348,16 @@ class LXDLaunchedTest(LXDBaseTest):
         self.assertThat(self.fake_container.sync_mock.call_count, Equals(2))
         self.fake_container.save_mock.assert_called_once_with(wait=True)
         self.check_output_mock.assert_called_once_with(
-            ["/snap/bin/lxc", "exec", self.instance_name, "--", "printenv", "HOME"]
+            [
+                "/snap/bin/lxc",
+                "exec",
+                self.instance_name,
+                "--",
+                "env",
+                "SNAPCRAFT_HAS_TTY=False",
+                "printenv",
+                "HOME",
+            ]
         )
 
     def test_mount_prime_directory(self):
@@ -359,7 +380,16 @@ class LXDLaunchedTest(LXDBaseTest):
         self.assertThat(self.fake_container.sync_mock.call_count, Equals(2))
         self.fake_container.save_mock.assert_called_once_with(wait=True)
         self.check_output_mock.assert_called_once_with(
-            ["/snap/bin/lxc", "exec", self.instance_name, "--", "printenv", "HOME"]
+            [
+                "/snap/bin/lxc",
+                "exec",
+                self.instance_name,
+                "--",
+                "env",
+                "SNAPCRAFT_HAS_TTY=False",
+                "printenv",
+                "HOME",
+            ]
         )
 
     def test_run(self):
@@ -371,6 +401,8 @@ class LXDLaunchedTest(LXDBaseTest):
                 "exec",
                 "snapcraft-project-name",
                 "--",
+                "env",
+                "SNAPCRAFT_HAS_TTY=False",
                 "ls",
                 "/root/project",
             ]
@@ -453,7 +485,13 @@ class SetupLXDTest(LXDBaseTest):
             dict(name="lxd", channel="stable", revision="10")
         ]
         self.fake_snapd.find_result = [
-            dict(lxd=dict(channels={"latest/stable": dict(confinement="strict")}))
+            dict(
+                lxd=dict(
+                    channel="stable",
+                    type="app",
+                    channels={"latest/stable": dict(confinement="strict")},
+                )
+            )
         ]
 
     def test_install(self):

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -194,6 +194,46 @@ class BaseProviderTest(BaseProviderBaseTest):
             ["snapcraft", "clean", "part1", "part2"]
         )
 
+    def test_passthrough_environment_flags_empty(self):
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+        provider.build_provider_flags = dict()
+
+        results = provider._get_env_command()
+
+        self.assertThat(results, Equals(["env", "SNAPCRAFT_HAS_TTY=False"]))
+
+    def test_passthrough_environment_flags_non_string(self):
+        # Set http_proxy to a bool even though it doesn't make sense...
+        # This is to verify non-strings are treated as strings OK for environ.
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+        provider.build_provider_flags = dict(http_proxy=True)
+
+        results = provider._get_env_command()
+
+        self.assertThat(
+            results, Equals(["env", "SNAPCRAFT_HAS_TTY=False", "http_proxy=True"])
+        )
+
+    def test_passthrough_environment_flags_all(self):
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+        provider.build_provider_flags = dict(
+            http_proxy="http://127.0.0.1:8080", https_proxy="http://127.0.0.1:8080"
+        )
+
+        results = provider._get_env_command()
+
+        self.assertThat(
+            results,
+            Equals(
+                [
+                    "env",
+                    "SNAPCRAFT_HAS_TTY=False",
+                    "http_proxy=http://127.0.0.1:8080",
+                    "https_proxy=http://127.0.0.1:8080",
+                ]
+            ),
+        )
+
 
 class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
     def test_setup_snapcraft(self):

--- a/tests/unit/cli/test_options.py
+++ b/tests/unit/cli/test_options.py
@@ -1,0 +1,152 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import click
+from unittest import mock
+
+import fixtures
+from testtools.matchers import Equals
+
+import snapcraft.cli._options as options
+from tests import unit
+
+
+class TestProviderOptions(unit.TestCase):
+    scenarios = [
+        ("host empty", dict(provider="host", kwargs=dict())),
+        ("host http proxy", dict(provider="host", kwargs=dict(http_proxy="1.1.1.1"))),
+        ("host https proxy", dict(provider="host", kwargs=dict(https_proxy="1.1.1.1"))),
+        (
+            "host all",
+            dict(
+                provider="host",
+                kwargs=dict(http_proxy="1.1.1.1", https_proxy="1.1.1.1"),
+            ),
+        ),
+        ("lxd empty", dict(provider="lxd", kwargs=dict())),
+        ("lxd http proxy", dict(provider="lxd", kwargs=dict(http_proxy="1.1.1.1"))),
+        ("lxd https proxy", dict(provider="lxd", kwargs=dict(https_proxy="1.1.1.1"))),
+        (
+            "lxd all",
+            dict(
+                provider="lxd", kwargs=dict(http_proxy="1.1.1.1", https_proxy="1.1.1.1")
+            ),
+        ),
+        ("managed-host empty", dict(provider="managed-host", kwargs=dict())),
+        (
+            "managed-host http proxy",
+            dict(provider="managed-host", kwargs=dict(http_proxy="1.1.1.1")),
+        ),
+        (
+            "managed-host https proxy",
+            dict(provider="managed-host", kwargs=dict(https_proxy="1.1.1.1")),
+        ),
+        (
+            "managed-host all",
+            dict(
+                provider="managed-host",
+                kwargs=dict(http_proxy="1.1.1.1", https_proxy="1.1.1.1"),
+            ),
+        ),
+        ("multipass empty", dict(provider="multipass", kwargs=dict())),
+        (
+            "multipass http proxy",
+            dict(provider="multipass", kwargs=dict(http_proxy="1.1.1.1")),
+        ),
+        (
+            "multipass https proxy",
+            dict(provider="multipass", kwargs=dict(https_proxy="1.1.1.1")),
+        ),
+        (
+            "multipass all",
+            dict(
+                provider="multipass",
+                kwargs=dict(http_proxy="1.1.1.1", https_proxy="1.1.1.1"),
+            ),
+        ),
+    ]
+
+    def test_valid_flags(self):
+        flags = options.get_build_provider_flags(self.provider, **self.kwargs)
+
+        self.assertThat(flags, Equals(self.kwargs))
+
+
+class TestInvalidBuildProviderFlags(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.useFixture(
+            fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT", None)
+        )
+
+    def test_ignored(self):
+        kwargs = dict(notrelevant="foo")
+
+        flags = options.get_build_provider_flags("lxd", **kwargs)
+
+        self.assertThat(flags, Equals(dict()))
+
+    def test_host_missing_destructive_mode(self):
+        kwargs = dict(http_proxy="192.168.1.1")
+
+        self.assertRaisesRegex(
+            click.exceptions.BadArgumentUsage,
+            "^--provider=host requires --destructive-mode to acknowledge side effects$",
+            options._sanity_check_build_provider_flags,
+            "host",
+            **kwargs,
+        )
+
+    def test_build_environment_mismatch(self):
+        kwargs = dict(http_proxy="192.168.1.1")
+
+        self.useFixture(
+            fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT", "managed-host")
+        )
+
+        self.assertRaisesRegex(
+            click.exceptions.BadArgumentUsage,
+            "^mismatch between --provider=lxd and SNAPCRAFT_BUILD_ENVIRONMENT=managed-host$",
+            options._sanity_check_build_provider_flags,
+            "lxd",
+            **kwargs,
+        )
+
+    def test_wrong_provider_option_error(self):
+        kwargs = dict(http_proxy="192.168.1.1")
+        fake_args = ["--destructive-mode"]
+
+        with mock.patch("sys.argv", fake_args):
+            self.assertRaisesRegex(
+                click.exceptions.BadArgumentUsage,
+                "^--destructive-mode cannot be used with build provider 'lxd'$",
+                options._sanity_check_build_provider_flags,
+                "lxd",
+                **kwargs,
+            )
+
+    def test_unknown_provider(self):
+        kwargs = dict(http_proxy="192.168.1.1")
+        fake_args = ["--http-proxy", "192.168.1.1"]
+
+        with mock.patch("sys.argv", fake_args):
+            self.assertRaisesRegex(
+                click.exceptions.BadArgumentUsage,
+                "^--http-proxy cannot be used with build provider 'invalid-provider'$",
+                options._sanity_check_build_provider_flags,
+                "invalid-provider",
+                **kwargs,
+            )

--- a/tests/unit/commands/__init__.py
+++ b/tests/unit/commands/__init__.py
@@ -89,7 +89,8 @@ class CommandBaseTestCase(unit.TestCase):
             fixtures.MockPatch("snapcraft.cli.echo.is_tty_connected", return_value=True)
         )
 
-        return self.runner.invoke(run, args, catch_exceptions=False, **kwargs)
+        with mock.patch("sys.argv", args):
+            return self.runner.invoke(run, args, catch_exceptions=False, **kwargs)
 
 
 class LifecycleCommandsBaseTestCase(CommandBaseTestCase):


### PR DESCRIPTION
Some modules support configuration of http(s) proxies today (e.g.
ant, maven, nodejs) - but they are only honoured if building
with host provider and the environment variables are already in
the environment.

Add two explicit build options for http_proxy and https_proxy,
with matching environment variables to support typical application
behavior.

Only add these to the environment if provider is one of 'lxd',
'multipass', 'host', or 'managed-host'. Otherwise, either:
(a) warn if found in the user's environment.
(b) error if not found in environment, and therefor must have
    been configured with an explicit command-line option.

Add tests for coverage of get_build_environment_flags() with
new http_proxy and https_proxy handling.