### PR TITLE
tests: update the push and release tests for staging

### DIFF
--- a/tests/integration/store/test_store_push.py
+++ b/tests/integration/store/test_store_push.py
@@ -73,7 +73,7 @@ class PushTestCase(integration.StoreTestCase):
         self.assertThat(os.path.join(snap_file_path), FileExists())
 
         output = self.run_snapcraft(["push", snap_file_path, "--release", "edge"])
-        expected = r".*Ready to release!.*".format(name)
+        expected = r".*edge *{version}.*".format(version=version)
         self.assertThat(output, MatchesRegex(expected, flags=re.DOTALL))
 
     def test_push_with_deprecated_upload(self):


### PR DESCRIPTION
When pushing and releasing, there is no "Ready to release" message anymore
as the store now handles the release on behalf of snapcraft with the new
calls which were introduced in f3c17a99b4e87a5412d80e64da4f3f1e9b3146d7

This updates the tests to work against the staging Snap Store.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
