### PR TITLE
tests: skip spread tests for rust on s390x

### DIFF
--- a/tests/spread/plugins/rust/classic/task.yaml
+++ b/tests/spread/plugins/rust/classic/task.yaml
@@ -1,5 +1,17 @@
 summary: Build a classic rust snap
 
+systems:
+  - ubuntu-18.04
+  - ubuntu-18.04-64
+  - ubuntu-18.04-amd64
+  - ubuntu-18.04-i386
+  - ubuntu-18.04-armhf
+  - ubuntu-16.04
+  - ubuntu-16.04-64
+  - ubuntu-16.04-amd64
+  - ubuntu-16.04-i386
+  - ubuntu-16.04-armhf
+
 environment:
   SNAP_DIR: ../snaps/rust-hello
 

--- a/tests/spread/plugins/rust/conditional/task.yaml
+++ b/tests/spread/plugins/rust/conditional/task.yaml
@@ -1,5 +1,17 @@
 summary: Build a rust snap that uses conditional features
 
+systems:
+  - ubuntu-18.04
+  - ubuntu-18.04-64
+  - ubuntu-18.04-amd64
+  - ubuntu-18.04-i386
+  - ubuntu-18.04-armhf
+  - ubuntu-16.04
+  - ubuntu-16.04-64
+  - ubuntu-16.04-amd64
+  - ubuntu-16.04-i386
+  - ubuntu-16.04-armhf
+
 environment:
   SNAP_DIR: ../snaps/rust-with-conditional
 

--- a/tests/spread/plugins/rust/legacy-pull/task.yaml
+++ b/tests/spread/plugins/rust/legacy-pull/task.yaml
@@ -3,6 +3,18 @@ summary: |
   The plugin can be tested without bases in full through the legacy release of
   snapcraft.
 
+systems:
+  - ubuntu-18.04
+  - ubuntu-18.04-64
+  - ubuntu-18.04-amd64
+  - ubuntu-18.04-i386
+  - ubuntu-18.04-armhf
+  - ubuntu-16.04
+  - ubuntu-16.04-64
+  - ubuntu-16.04-amd64
+  - ubuntu-16.04-i386
+  - ubuntu-16.04-armhf
+
 environment:
   SNAP_DIR: ../snaps/rust-hello
 

--- a/tests/spread/plugins/rust/rebuild/task.yaml
+++ b/tests/spread/plugins/rust/rebuild/task.yaml
@@ -1,5 +1,17 @@
 summary: Build and rebuild a basic rust snap
 
+systems:
+  - ubuntu-18.04
+  - ubuntu-18.04-64
+  - ubuntu-18.04-amd64
+  - ubuntu-18.04-i386
+  - ubuntu-18.04-armhf
+  - ubuntu-16.04
+  - ubuntu-16.04-64
+  - ubuntu-16.04-amd64
+  - ubuntu-16.04-i386
+  - ubuntu-16.04-armhf
+
 environment:
   SNAP_DIR: ../snaps/rust-hello
 

--- a/tests/spread/plugins/rust/run/task.yaml
+++ b/tests/spread/plugins/rust/run/task.yaml
@@ -1,5 +1,17 @@
 summary: Build and run a basic rust snap
 
+systems:
+  - ubuntu-18.04
+  - ubuntu-18.04-64
+  - ubuntu-18.04-amd64
+  - ubuntu-18.04-i386
+  - ubuntu-18.04-armhf
+  - ubuntu-16.04
+  - ubuntu-16.04-64
+  - ubuntu-16.04-amd64
+  - ubuntu-16.04-i386
+  - ubuntu-16.04-armhf
+
 environment:
   SNAP_DIR: ../snaps/rust-hello
 


### PR DESCRIPTION
The stable toolchain is missing components in order to correctly test:

    error: some components unavailable for download for channel stable: 'clippy', 'rustfmt'

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
