### PR TITLE
pluginhandler: use well-formed build package/snap lists

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -485,9 +485,9 @@ class PluginHandler:
     def mark_pull_done(self):
         pull_properties = self.plugin.get_pull_properties()
 
-        # Add the annotated list of build packages
-        part_build_packages = self._part_properties.get("build-packages", [])
-        part_build_snaps = self._part_properties.get("build-snaps", [])
+        # Add the processed list of build packages and snaps.
+        part_build_packages = self._grammar_processor.get_build_packages()
+        part_build_snaps = self._grammar_processor.get_build_snaps()
 
         # Extract any requested metadata available in the source directory
         metadata = snapcraft.extractors.ExtractedMetadata()


### PR DESCRIPTION
Use of build_packages and build_snaps throughout code assumes a list
of packages.  Prevent proliferation of the raw unprocessed
properties in the pull state info by first using the grammar
processor (as is done for stage packages).

Add a couple of tests for verification.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
