### PR TITLE
tests: enable SNAPCRAFT_BUILD_INFO for spread

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -4,6 +4,9 @@ environment:
   # Tell snapcraft to use the current host to build
   SNAPCRAFT_BUILD_ENVIRONMENT: "host"
 
+  # Generate manifest when building snaps.
+  SNAPCRAFT_BUILD_INFO: "1"
+
   # This variable can be set to either "deb" or "snap". It defaults to "snap".
   SNAPCRAFT_PACKAGE_TYPE: "$(HOST: echo ${SNAPCRAFT_PACKAGE_TYPE:-snap})"
 

--- a/tests/spread/plugins/nil/basic/task.yaml
+++ b/tests/spread/plugins/nil/basic/task.yaml
@@ -2,6 +2,7 @@ summary: Build a nil snap
 
 environment:
   SNAP_DIR: ../snaps/nil-basic
+  SNAPCRAFT_BUILD_INFO: "1"
 
 restore: |
   cd "$SNAP_DIR"
@@ -18,4 +19,4 @@ execute: |
   snapcraft prime
 
   # Verify that the only thing here is the snap metadata
-  [ "$(list_dir_contents prime)" = "meta meta/snap.yaml" ]
+  [ "$(list_dir_contents prime)" = "meta meta/snap.yaml snap snap/manifest.yaml snap/snapcraft.yaml" ]

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -235,6 +235,9 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         )
         self.useFixture(fixture_setup.FakeSnapcraftctl())
 
+        # Don't let host SNAPCRAFT_BUILD_INFO variable leak into tests
+        self.useFixture(fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_INFO"))
+
     def make_snapcraft_yaml(self, content, encoding="utf-8", location=""):
         snap_dir = os.path.join(location, "snap")
         os.makedirs(snap_dir, exist_ok=True)


### PR DESCRIPTION
Provide additional test coverage of manifest-related changes.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
