### PR TITLE
manifest: track and annotate `primed-stage-packages`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ lxml==4.3.0; sys_platform == 'win32'
 launchpadlib==1.10.6
 lazr.restfulclient==0.14.2
 mypy-extensions==0.4.3
+xattr==0.9.6; sys_platform == 'linux'

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -685,3 +685,26 @@ class SnapDataExtractionError(SnapcraftError):
 
 class ProjectNotFoundError(SnapcraftReportableError):
     fmt = "Failed to find project files."
+
+
+class XAttributeTooLongError(SnapcraftReportableException):
+    def __init__(self, *, key: str, value: str, path: str) -> None:
+        self._key = key
+        self._value = value
+        self._path = path
+
+    def get_brief(self) -> str:
+        return "Unable to write extended attribute as the key and/or value is too long."
+
+    def get_details(self) -> str:
+        return (
+            f"Failed to write attribute to {self._path}:\n"
+            f"key={self._key!r} value={self._value!r}"
+        )
+
+    def get_resolution(self) -> str:
+        return (
+            "This issue is generally resolved by addressing/truncating "
+            "the data source of the long data value. In some cases, the "
+            "filesystem being used will limit the allowable size."
+        )

--- a/snapcraft/internal/meta/_manifest.py
+++ b/snapcraft/internal/meta/_manifest.py
@@ -18,7 +18,7 @@ import contextlib
 import os
 import json
 from collections import OrderedDict
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Any, Dict, Set, TYPE_CHECKING
 
 import snapcraft
 from snapcraft.internal import errors, os_release, steps
@@ -67,4 +67,13 @@ def annotate_snapcraft(project: "Project", data: Dict[str, Any]) -> Dict[str, An
             manifest["parts"][part].update(source_details)
         build_state = get_state(state_dir, steps.BUILD)
         manifest["parts"][part].update(build_state.assets)
+
+    # Assemble all primed stage packages into a single list...
+    primed_stage_packages: Set[str] = set()
+    for part in data["parts"]:
+        state_dir = os.path.join(project.parts_dir, part, "state")
+        prime_state = get_state(state_dir, steps.PRIME)
+        primed_stage_packages |= prime_state.primed_stage_packages
+    manifest["primed-stage-packages"] = sorted(primed_stage_packages)
+
     return manifest

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -26,6 +26,7 @@ import stat
 import string
 import subprocess
 import sys
+import tempfile
 import urllib
 import urllib.request
 from typing import Dict, Set, List, Tuple  # noqa: F401
@@ -556,14 +557,31 @@ class Ubuntu(BaseRepo):
 
         return pkg_list
 
+    def _extract_deb_name_version(self, deb_path: str) -> str:
+        try:
+            output = subprocess.check_output(
+                ["dpkg-deb", "--show", "--showformat=${Package}=${Version}", deb_path]
+            )
+        except subprocess.CalledProcessError:
+            raise errors.UnpackError(deb_path)
+
+        return output.decode().strip()
+
+    def _extract_deb(self, deb_path: str, extract_dir: str) -> None:
+        """Extract deb and return `<package-name>=<version>`."""
+        try:
+            subprocess.check_call(["dpkg-deb", "--extract", deb_path, extract_dir])
+        except subprocess.CalledProcessError:
+            raise errors.UnpackError(deb_path)
+
     def unpack(self, unpackdir) -> None:
         pkgs_abs_path = glob.glob(os.path.join(self._downloaddir, "*.deb"))
         for pkg in pkgs_abs_path:
-            # TODO needs elegance and error control
-            try:
-                subprocess.check_call(["dpkg-deb", "--extract", pkg, unpackdir])
-            except subprocess.CalledProcessError:
-                raise errors.UnpackError(pkg)
+            with tempfile.TemporaryDirectory() as temp_dir:
+                self._extract_deb(pkg, temp_dir)
+                deb_name = self._extract_deb_name_version(pkg)
+                self._mark_origin_stage_package(temp_dir, deb_name)
+                file_utils.link_or_copy_tree(temp_dir, unpackdir)
         self.normalize(unpackdir)
 
     def _manifest_dep_names(self, apt_cache):

--- a/snapcraft/internal/states/_prime_state.py
+++ b/snapcraft/internal/states/_prime_state.py
@@ -29,6 +29,7 @@ class PrimeState(PartState):
         part_properties=None,
         project=None,
         scriptlet_metadata=None,
+        primed_stage_packages=None,
     ):
         super().__init__(part_properties, project)
 
@@ -39,6 +40,9 @@ class PrimeState(PartState):
         self.directories = directories
         self.dependency_paths = set()
         self.scriptlet_metadata = scriptlet_metadata
+        self.primed_stage_packages = primed_stage_packages
+        if self.primed_stage_packages is None:
+            self.primed_stage_packages = set()
 
         if dependency_paths:
             self.dependency_paths = dependency_paths

--- a/snapcraft/internal/xattrs.py
+++ b/snapcraft/internal/xattrs.py
@@ -1,0 +1,67 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+from typing import Optional
+
+
+if sys.platform == "linux":
+    import xattr
+
+
+def _get_snapcraft_xattr_key(snapcraft_key: str) -> str:
+    return f"user.snapcraft.{snapcraft_key}"
+
+
+def _read_snapcraft_xattr(path: str, snapcraft_key: str) -> Optional[str]:
+    if sys.platform != "linux":
+        raise RuntimeError("xattr support only available for Linux")
+
+    # Extended attributes do not apply to symlinks.
+    if os.path.islink(path):
+        return None
+
+    key = _get_snapcraft_xattr_key(snapcraft_key)
+    try:
+        value = xattr.getxattr(path, key)
+    except OSError:
+        # OSError is raised if no xattr found.
+        return None
+
+    return value.decode().strip()
+
+
+def _write_snapcraft_xattr(path: str, snapcraft_key: str, value: str) -> Optional[str]:
+    if sys.platform != "linux":
+        raise RuntimeError("xattr support only available for Linux")
+
+    # Extended attributes do not apply to symlinks.
+    if os.path.islink(path):
+        return None
+
+    key = _get_snapcraft_xattr_key(snapcraft_key)
+    xattr.setxattr(path, key, value.encode())
+
+
+def read_origin_stage_package(path: str) -> Optional[str]:
+    """Read origin stage package."""
+    return _read_snapcraft_xattr(path, "origin_stage_package")
+
+
+def write_origin_stage_package(path: str, value: str) -> None:
+    """Write origin stage package."""
+    _write_snapcraft_xattr(path, "origin_stage_package", value)

--- a/snapcraft/internal/xattrs.py
+++ b/snapcraft/internal/xattrs.py
@@ -52,13 +52,13 @@ def _read_snapcraft_xattr(path: str, snapcraft_key: str) -> Optional[str]:
     return value.decode().strip()
 
 
-def _write_snapcraft_xattr(path: str, snapcraft_key: str, value: str) -> Optional[str]:
+def _write_snapcraft_xattr(path: str, snapcraft_key: str, value: str) -> None:
     if sys.platform != "linux":
         raise RuntimeError("xattr support only available for Linux")
 
     # Extended attributes do not apply to symlinks.
     if os.path.islink(path):
-        return None
+        return
 
     key = _get_snapcraft_xattr_key(snapcraft_key)
 

--- a/tests/unit/lifecycle/test_lifecycle.py
+++ b/tests/unit/lifecycle/test_lifecycle.py
@@ -607,17 +607,16 @@ class RecordManifestBaseTestCase(LifecycleTestBase):
         check_output_patcher.start()
         self.addCleanup(check_output_patcher.stop)
 
-        original_check_call = subprocess.check_call
-
-        def _fake_dpkg_deb(command, *args, **kwargs):
-            if "dpkg-deb" not in command:
-                return original_check_call(command, *args, **kwargs)
-
-        check_call_patcher = mock.patch(
-            "subprocess.check_call", side_effect=_fake_dpkg_deb
+        self.useFixture(
+            fixtures.MockPatch(
+                "snapcraft.internal.repo._deb.Ubuntu._extract_deb_name_version",
+                return_value="test-1.0",
+            )
         )
-        check_call_patcher.start()
-        self.addCleanup(check_call_patcher.stop)
+
+        self.useFixture(
+            fixtures.MockPatch("snapcraft.internal.repo._deb.Ubuntu._extract_deb")
+        )
 
         self.fake_apt_cache = fixture_setup.FakeAptCache()
         self.useFixture(self.fake_apt_cache)
@@ -675,6 +674,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             - {}
             build-packages: []
             build-snaps: []
+            primed-stage-packages: []
             """.format(
                 project_config.project.deb_arch
             )
@@ -734,6 +734,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             - {}
             build-packages: []
             build-snaps: []
+            primed-stage-packages: []
             """.format(
                 project_config.project.deb_arch
             )
@@ -795,6 +796,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             - {}
             build-packages: []
             build-snaps: []
+            primed-stage-packages: []
             """.format(
                 project_config.project.deb_arch
             )
@@ -858,6 +860,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             - {}
             build-packages: []
             build-snaps: []
+            primed-stage-packages: []
             """.format(
                 project_config.project.deb_arch
             )
@@ -922,6 +925,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             architectures:
             - {}
             build-snaps: []
+            primed-stage-packages: []
             """.format(
                 project_config.project.deb_arch
             )
@@ -989,6 +993,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             build-packages:
             - git=testversion
             build-snaps: []
+            primed-stage-packages: []
             """.format(
                 project_config.project.deb_arch
             )
@@ -1049,6 +1054,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             build-packages:
             - test-package=test-version
             build-snaps: []
+            primed-stage-packages: []
             """.format(
                 project_config.project.deb_arch
             )
@@ -1113,6 +1119,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             build-packages:
             - test-provider-package=test-version
             build-snaps: []
+            primed-stage-packages: []
             """.format(
                 project_config.project.deb_arch
             )
@@ -1167,6 +1174,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
             - {}
             build-packages: []
             build-snaps: []
+            primed-stage-packages: []
             """.format(
                 project_config.project.deb_arch
             )
@@ -1230,6 +1238,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
               fingerprint: test-fingerprint
             build-packages: []
             build-snaps: []
+            primed-stage-packages: []
             """.format(
                 project_config.project.deb_arch
             )
@@ -1306,6 +1315,7 @@ class RecordManifestWithDeprecatedSnapKeywordTestCase(RecordManifestBaseTestCase
             - {}
             build-packages: []
             build-snaps: []
+            primed-stage-packages: []
             """.format(
                 project_config.project.deb_arch
             )

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -24,6 +24,7 @@ from collections import OrderedDict
 from textwrap import dedent
 from unittest.mock import call, Mock, MagicMock, patch
 
+import fixtures
 from testtools.matchers import Contains, Equals, FileExists, MatchesRegex, Not
 
 import snapcraft
@@ -975,6 +976,12 @@ class StateBaseTestCase(unit.TestCase):
         self.get_elf_files_mock = patcher.start()
         self.get_elf_files_mock.return_value = frozenset()
         self.addCleanup(patcher.stop)
+
+        self.useFixture(
+            fixtures.MockPatch(
+                "snapcraft.internal.xattrs.read_origin_stage_package", return_value=None
+            )
+        )
 
 
 class PullStateTestCase(StateBaseTestCase):
@@ -2200,7 +2207,7 @@ class IsOutdatedTest(unit.TestCase):
         os.utime(target, (access_time, modified_time + 1))
 
     def test_prime_is_outdated(self):
-        self.handler.mark_prime_done(set(), set(), set())
+        self.handler.mark_prime_done(set(), set(), set(), set())
         self.assertFalse(
             self.handler.is_outdated(steps.PRIME),
             "Prime step was unexpectedly outdated",

--- a/tests/unit/project_loader/inspection/test_lifecycle_status.py
+++ b/tests/unit/project_loader/inspection/test_lifecycle_status.py
@@ -94,10 +94,10 @@ class LifecycleStatusTest(ProjectLoaderBaseTest):
         )
 
         # Now prime them both
-        self.part1.mark_prime_done(set(), set(), set())
+        self.part1.mark_prime_done(set(), set(), set(), set())
         self.part2.mark_build_done()
         self.part2.mark_stage_done(set(), set())
-        self.part2.mark_prime_done(set(), set(), set())
+        self.part2.mark_prime_done(set(), set(), set(), set())
 
         self.assertThat(
             inspection.lifecycle_status(self.config),

--- a/tests/unit/project_loader/inspection/test_provides.py
+++ b/tests/unit/project_loader/inspection/test_provides.py
@@ -59,8 +59,8 @@ class ProvidesTest(unit.TestCase):
         file1_path = os.path.join(self.project.prime_dir, "file1")
         file2_path = os.path.join(self.project.prime_dir, "file2")
 
-        self.part1.mark_prime_done({"file1"}, set(), set())
-        self.part2.mark_prime_done({"file2"}, set(), set())
+        self.part1.mark_prime_done({"file1"}, set(), set(), set())
+        self.part2.mark_prime_done({"file2"}, set(), set(), set())
 
         open(file1_path, "w").close()
         open(file2_path, "w").close()

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -853,6 +853,18 @@ class SnapcraftExceptionTests(unit.TestCase):
                 "expected_reportable": False,
             },
         ),
+        (
+            "XAttributeTooLongError",
+            {
+                "exception": errors.XAttributeTooLongError,
+                "kwargs": {"path": "/tmp/foo", "key": "foo", "value": "bar"},
+                "expected_brief": "Unable to write extended attribute as the key and/or value is too long.",
+                "expected_resolution": "This issue is generally resolved by addressing/truncating the data source of the long data value. In some cases, the filesystem being used will limit the allowable size.",
+                "expected_details": "Failed to write attribute to /tmp/foo:\nkey='foo' value='bar'",
+                "expected_docs_url": None,
+                "expected_reportable": True,
+            },
+        ),
     )
 
     def test_snapcraft_exception_handling(self):

--- a/tests/unit/test_xattrs.py
+++ b/tests/unit/test_xattrs.py
@@ -1,0 +1,79 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+from testtools.matchers import Equals
+from unittest import mock
+
+from snapcraft.internal import xattrs
+from tests import unit
+
+
+class TestXattrs(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_file = os.path.join(self.path, "test-file")
+        open(self.test_file, "w").close()
+
+    def test_read_origin_stage_package(self):
+        if sys.platform == "linux":
+            result = xattrs.read_origin_stage_package(self.test_file)
+            self.assertThat(result, Equals(None))
+        else:
+            self.assertRaises(
+                RuntimeError, xattrs.read_origin_stage_package, self.test_file
+            )
+
+    def test_write_origin_stage_package(self):
+        package = "foo-1.0"
+        if sys.platform == "linux":
+            result = xattrs.read_origin_stage_package(self.test_file)
+            self.assertThat(result, Equals(None))
+
+            xattrs.write_origin_stage_package(self.test_file, package)
+            result = xattrs.read_origin_stage_package(self.test_file)
+            self.assertThat(result, Equals(package))
+        else:
+            self.assertRaises(
+                RuntimeError, xattrs.write_origin_stage_package, self.test_file, package
+            )
+
+    def test_symlink(self):
+        test_symlink = self.test_file + "-symlink"
+        os.symlink(self.test_file, test_symlink)
+
+        if sys.platform != "linux":
+            return
+
+        result = xattrs._read_snapcraft_xattr(test_symlink, "attr")
+        self.assertThat(result, Equals(None))
+
+        xattrs._write_snapcraft_xattr(test_symlink, "attr", "value")
+        result = xattrs._read_snapcraft_xattr(test_symlink, "attr")
+        self.assertThat(result, Equals(None))
+
+    @mock.patch("sys.platform", return_value="win32")
+    def test_read_non_linux(self, mock_platform):
+        self.assertRaises(
+            RuntimeError, xattrs._read_snapcraft_xattr, self.test_file, "attr"
+        )
+
+    @mock.patch("sys.platform", return_value="win32")
+    def test_write_non_linux(self, mock_platform):
+        self.assertRaises(
+            RuntimeError, xattrs._write_snapcraft_xattr, self.test_file, "attr", "value"
+        )

--- a/tests/unit/test_xattrs.py
+++ b/tests/unit/test_xattrs.py
@@ -19,6 +19,7 @@ import sys
 from testtools.matchers import Equals
 from unittest import mock
 
+from snapcraft.internal.errors import XAttributeTooLongError
 from snapcraft.internal import xattrs
 from tests import unit
 
@@ -47,6 +48,26 @@ class TestXattrs(unit.TestCase):
             xattrs.write_origin_stage_package(self.test_file, package)
             result = xattrs.read_origin_stage_package(self.test_file)
             self.assertThat(result, Equals(package))
+        else:
+            self.assertRaises(
+                RuntimeError, xattrs.write_origin_stage_package, self.test_file, package
+            )
+
+    def test_write_origin_stage_package_long(self):
+        package = "a" * 100000
+        if sys.platform == "linux":
+            result = xattrs.read_origin_stage_package(self.test_file)
+            self.assertThat(result, Equals(None))
+
+            self.assertRaises(
+                XAttributeTooLongError,
+                xattrs.write_origin_stage_package,
+                self.test_file,
+                package,
+            )
+
+            result = xattrs.read_origin_stage_package(self.test_file)
+            self.assertThat(result, Equals(None))
         else:
             self.assertRaises(
                 RuntimeError, xattrs.write_origin_stage_package, self.test_file, package


### PR DESCRIPTION
Use extended attributes to implement a low-overhead file-origin
tracking solution.  As debs are extracted, they are marked with
an attribute that indicates their source origin.

Primed files that carry the marker are expected to have originated
from the source package that it was extracted from.

Add `xattr` version 0.9.6 to requirements.txt.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
