### PR TITLE
meta: ensure Snap's `assumes` is initialized as a set

### DIFF
--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -200,7 +200,11 @@ class Snap:
             elif key in _MANDATORY_PACKAGE_KEYS:
                 snap.__dict__[key] = snap_dict[key]
             elif key in _OPTIONAL_PACKAGE_KEYS:
-                snap.__dict__[key] = snap_dict[key]
+                if key == "assumes":
+                    # Treat `assumes` as a set, not as a list.
+                    snap.__dict__[key] = set(snap_dict[key])
+                else:
+                    snap.__dict__[key] = snap_dict[key]
             else:
                 logger.debug("ignoring or passing through unknown key: {}".format(key))
                 continue

--- a/tests/unit/meta/test_meta.py
+++ b/tests/unit/meta/test_meta.py
@@ -177,6 +177,20 @@ class CreateTestCase(CreateBaseTestCase):
         )
         self.assertThat(y["assumes"], Equals(["feature1", "feature2"]))
 
+    def test_create_meta_command_chain_with_assumes(self):
+        self.config_data["assumes"] = ["feature1", "feature2"]
+        self.config_data["apps"] = {"app": {"command": "foo", "command-chain": ["bar"]}}
+        _create_file(os.path.join(self.prime_dir, "foo"), executable=True)
+        _create_file(os.path.join(self.prime_dir, "bar"), executable=True)
+
+        y = self.generate_meta_yaml()
+        self.assertTrue(
+            "assumes" in y, 'Expected "assumes" property to be copied into snap.yaml'
+        )
+        self.assertThat(
+            y["assumes"], Equals(sorted(["feature1", "feature2", "command-chain"]))
+        )
+
     def test_create_gadget_meta_with_gadget_yaml(self):
         gadget_yaml = "stub entry: stub value"
         _create_file("gadget.yaml", content=gadget_yaml)

--- a/tests/unit/meta/test_snap.py
+++ b/tests/unit/meta/test_snap.py
@@ -156,7 +156,7 @@ class SnapTests(unit.TestCase):
         self.assertEqual(snap_dict["description"], snap.description)
         self.assertEqual(snap_dict["apps"]["test-app"], snap.apps["test-app"].to_dict())
         self.assertEqual(snap_dict["architectures"], snap.architectures)
-        self.assertEqual(snap_dict["assumes"], snap.assumes)
+        self.assertEqual(set(snap_dict["assumes"]), snap.assumes)
         self.assertEqual(snap_dict["base"], snap.base)
         self.assertEqual(snap_dict["environment"], snap.environment)
         self.assertEqual(snap_dict["license"], snap.license)
@@ -246,7 +246,7 @@ class SnapTests(unit.TestCase):
             snap.apps["test-app"].to_dict(),
         )
         self.assertEqual(["amd64"], snap.architectures)
-        self.assertEqual(["snapd2.39"], snap.assumes)
+        self.assertEqual({"snapd2.39"}, snap.assumes)
         self.assertEqual("core18", snap.base)
         self.assertEqual("classic", snap.confinement)
         self.assertEqual("devel", snap.grade)


### PR DESCRIPTION
When reading the config data dictionary, convert the list to a set.

The `assumes` property is defined as a set in Snap meta, but derives
from a list in the the snap meta.  This causes an exception when
using `command-chain`, but `command-chain` is not already in
the `assumes` (due to the use of Snap's usage of `.add()` on the
set, which is not available for lists).

Add a test for coverage/verification.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
