### PR TITLE
cli: improve the remote-build upload messaging

### DIFF
--- a/snapcraft/cli/remote.py
+++ b/snapcraft/cli/remote.py
@@ -49,8 +49,11 @@ def remotecli():
 @click.option(
     "--launchpad-accept-public-upload",
     is_flag=True,
-    prompt="All data sent to remote builders is public. Are you sure you want to continue?",
-    help="Acknowledge that uploaded code is public.",
+    prompt=(
+        "All data sent to remote builders will be publicly available. "
+        "Are you sure you want to continue?"
+    ),
+    help="Acknowledge that uploaded code will be publicly available.",
     cls=PromptOption,
 )
 @click.option(


### PR DESCRIPTION
It was pointed out that something being public has a very different connotation
to something being publicly available. In this case the code or artifacts do
not necessarily become public but publicly available.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
