### PR TITLE
introduce `--apt-mirror` build provider flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ jobs:
           - name: core
           - name: core18
           - name: shellcheck
-            channel: edge
           - name: black
             channel: beta
             confinement: devmode

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -94,6 +94,15 @@ _PROVIDER_OPTIONS = [
         supported_providers=_ALL_PROVIDERS,
     ),
     dict(
+        param_decls="--apt-mirror",
+        metavar="<apt-mirror>",
+        help="Override primary apt-mirror for supported build environments. "
+        "Must be configured on initial creation of build environment. "
+        "If environment is already initialized, you may purge it using "
+        "`snapcraft clean`.",
+        supported_providers=["lxd", "multipass"],
+    ),
+    dict(
         param_decls="--http-proxy",
         metavar="<http-proxy>",
         help="HTTP proxy for host build environments.",

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -103,6 +103,13 @@ _PROVIDER_OPTIONS = [
         supported_providers=["lxd", "multipass"],
     ),
     dict(
+        param_decls="--bind-ssh",
+        is_flag=True,
+        help="Bind ~/.ssh directory to locally-run build environments.",
+        envvar="SNAPCRAFT_BIND_SSH",
+        supported_providers=["lxd", "multipass"],
+    ),
+    dict(
         param_decls="--http-proxy",
         metavar="<http-proxy>",
         help="HTTP proxy for host build environments.",
@@ -115,13 +122,6 @@ _PROVIDER_OPTIONS = [
         help="HTTPS proxy for host build environments.",
         envvar="https_proxy",
         supported_providers=["host", "lxd", "managed-host", "multipass"],
-    ),
-    dict(
-        param_decls="--bind-ssh",
-        is_flag=True,
-        help="Bind ~/.ssh directory to locally-run build environments.",
-        envvar="SNAPCRAFT_BIND_SSH",
-        supported_providers=["lxd", "multipass"],
     ),
 ]
 

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -89,6 +89,15 @@ _CLOUD_USER_DATA_TMPL = dedent(
     """  # noqa: W605
 )
 
+_CLOUD_USER_DATA_APT_MIRROR_TMPL = dedent(
+    """
+    apt:
+        primary:
+            - arches: [default]
+              uri: {primary_mirror}
+    """
+)
+
 
 class Provider(abc.ABC):
 
@@ -351,7 +360,13 @@ class Provider(abc.ABC):
         snap_injector.apply()
 
     def _get_cloud_user_data_string(self, timezone=_get_tzdata()) -> str:
-        return _CLOUD_USER_DATA_TMPL.format(timezone=timezone)
+        config = _CLOUD_USER_DATA_TMPL.format(timezone=timezone)
+
+        mirror = self.build_provider_flags.get("apt_mirror")
+        if mirror:
+            config += _CLOUD_USER_DATA_APT_MIRROR_TMPL.format(primary_mirror=mirror)
+
+        return config
 
     def _get_cloud_user_data(self, timezone=_get_tzdata()) -> str:
         cloud_user_data_filepath = os.path.join(

--- a/tests/unit/cli/test_options.py
+++ b/tests/unit/cli/test_options.py
@@ -37,12 +37,27 @@ class TestProviderOptions(unit.TestCase):
             ),
         ),
         ("lxd empty", dict(provider="lxd", kwargs=dict())),
+        (
+            "lxd apt mirror",
+            dict(
+                provider="lxd",
+                kwargs=dict(apt_mirror="http://de.archive.ubuntu.com/ubuntu"),
+            ),
+        ),
+        ("lxd bind ssh true", dict(provider="lxd", kwargs=dict(bind_ssh=True))),
+        ("lxd bind ssh false", dict(provider="lxd", kwargs=dict(bind_ssh=False))),
         ("lxd http proxy", dict(provider="lxd", kwargs=dict(http_proxy="1.1.1.1"))),
         ("lxd https proxy", dict(provider="lxd", kwargs=dict(https_proxy="1.1.1.1"))),
         (
             "lxd all",
             dict(
-                provider="lxd", kwargs=dict(http_proxy="1.1.1.1", https_proxy="1.1.1.1")
+                provider="lxd",
+                kwargs=dict(
+                    apt_mirror="http://de.archive.ubuntu.com/ubuntu",
+                    bind_ssh=True,
+                    http_proxy="1.1.1.1",
+                    https_proxy="1.1.1.1",
+                ),
             ),
         ),
         ("managed-host empty", dict(provider="managed-host", kwargs=dict())),
@@ -63,6 +78,21 @@ class TestProviderOptions(unit.TestCase):
         ),
         ("multipass empty", dict(provider="multipass", kwargs=dict())),
         (
+            "multipass apt mirror",
+            dict(
+                provider="multipass",
+                kwargs=dict(apt_mirror="http://de.archive.ubuntu.com/ubuntu"),
+            ),
+        ),
+        (
+            "multipass bind ssh true",
+            dict(provider="multipass", kwargs=dict(bind_ssh=True)),
+        ),
+        (
+            "multipass bind ssh false",
+            dict(provider="multipass", kwargs=dict(bind_ssh=False)),
+        ),
+        (
             "multipass http proxy",
             dict(provider="multipass", kwargs=dict(http_proxy="1.1.1.1")),
         ),
@@ -74,7 +104,12 @@ class TestProviderOptions(unit.TestCase):
             "multipass all",
             dict(
                 provider="multipass",
-                kwargs=dict(http_proxy="1.1.1.1", https_proxy="1.1.1.1"),
+                kwargs=dict(
+                    apt_mirror="http://de.archive.ubuntu.com/ubuntu",
+                    bind_ssh=True,
+                    http_proxy="1.1.1.1",
+                    https_proxy="1.1.1.1",
+                ),
             ),
         ),
     ]


### PR DESCRIPTION
Allow user to set their primary apt mirror for LXD and Multipass instances.