### PR TITLE
travis: use `stable` channel for shellcheck snap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ jobs:
           - name: core
           - name: core18
           - name: shellcheck
-            channel: edge
           - name: black
             channel: beta
             confinement: devmode


### PR DESCRIPTION
Fixes failure with:
```
shellcheck: src/ShellCheck/Analytics.hs:1825:10-27:
No instance nor default method for class operation mappend
```

It's probably not a good idea to use the edge channel for CI
when not required, so just pivot to stable channel.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
