### PR TITLE
conda plugin: simplify source url/checksum handling

### DIFF
--- a/tests/unit/plugins/test_conda.py
+++ b/tests/unit/plugins/test_conda.py
@@ -229,7 +229,7 @@ class CondaPluginGetMinicondaSourceTest(CondaPluginBaseTest):
             conda_miniconda_version = self.miniconda_version
 
         plugin = conda.CondaPlugin("test-part", Options(), self.project)
-        source_script = plugin._get_miniconda_source()
+        source_script = plugin._get_miniconda_script()
 
         self.assertThat(source_script.source, Equals(self.expected_url))
         self.assertThat(source_script.source_checksum, Equals(self.expected_checksum))


### PR DESCRIPTION
Replace _MINICONDA_URL and _MINICONDA_UNKNOWN_URL dictionaries
with a helper function using a single format string
and dictionary to lookup known checksums.

This is motivated by an uprev of mypy which stumbles on
the type checking:

```
snapcraft/plugins/conda.py:111:
 error: Item "None" of "Optional[str]" has no attribute "format"
snapcraft/plugins/conda.py:116:
 error: Value of type "object" is not indexable
snapcraft/plugins/conda.py:118:
 error: Value of type "object" is not indexable
```

This helper was introduced as `_get_miniconda_source()`, and
CondaPlugin's method was renamed to `_get_miniconda_script()`
to better indicate its behavior.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
