### PR TITLE
repo: fix fetch_binary()'s return type for deb repo

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -247,7 +247,7 @@ class _AptCache:
 
         return _get_local_sources_list()
 
-    def fetch_binary(self, *, package_candidate, destination: str) -> None:
+    def fetch_binary(self, *, package_candidate, destination: str) -> str:
         # This is a workaround for the overly verbose python-apt we use.
         # There is an unreleased patch which once released could replace
         # this code https://salsa.debian.org/apt-team/python-apt/commit/d122f9142df614dbb5f7644112280140dc155ecc  # noqa


### PR DESCRIPTION
It returns a string path, not None.

Addresses mypy uprev errors.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
