### PR TITLE
isort: automatic formatting/sorting of imports

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,7 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88
+ensure_newline_before_comments=True

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -11,3 +11,4 @@ pycodestyle==2.5.0
 pyftpdlib==1.5.5
 pyramid==1.10.4
 pyinstaller==3.5; sys_platform == 'win32'
+isort==4.3.21

--- a/runtests.sh
+++ b/runtests.sh
@@ -48,6 +48,10 @@ run_static_tests() {
 
     echo "Running shellcheck inside spread yaml"
     ./tools/spread-shellcheck.py spread.yaml tests/spread/
+
+    echo "Running isort"
+    # Ignore whitespace due to black formatting differences.
+    isort --ignore-whitespace --check
 }
 
 run_snapcraft_tests(){

--- a/tools/format-code.sh
+++ b/tools/format-code.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+
+# Sort imports first (order matters at the moment due to a minor
+# difference between isort & black. See:
+# https://github.com/psf/black/issues/251
+isort -y
+
+# Apply formatting.
+black .


### PR DESCRIPTION
This commit adds an isort configuration that's pretty close to black with one exception.

- Add iscript config configuration that's pretty close to black with one exception. Ideally we'll enable this for a perfect match once available: https://github.com/psf/black/issues/251 

- Add a script to format source code (tools/format-code.sh) reliably.

- Add isort check (ignores whitespace) to static tests.

- Actually format code.  <-- this commit will need to be re-done once the current backlog of PRs is cleared (and this is ready to merge).