### PR TITLE
uprev mypy to 0.740! (and address remaining errors)

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -4,7 +4,7 @@ flake8==3.7.9
 pyflakes==2.1.1
 fixtures==3.0.0
 mccabe==0.6.1
-mypy==0.590
+mypy==0.740
 testscenarios==0.5.0
 pexpect==4.7.0
 pycodestyle==2.5.0

--- a/snapcraft/internal/lifecycle/_status_cache.py
+++ b/snapcraft/internal/lifecycle/_status_cache.py
@@ -16,13 +16,13 @@
 
 import collections
 import contextlib
-from typing import Any, Dict, List, Set  # noqa: F401
+from typing import Any, Dict, List, Optional, Set
 
 from snapcraft.internal import errors, pluginhandler, steps
 import snapcraft.internal.project_loader._config as _config
 
-_DirtyReport = Dict[str, Dict[steps.Step, pluginhandler.DirtyReport]]
-_OutdatedReport = Dict[str, Dict[steps.Step, pluginhandler.OutdatedReport]]
+_DirtyReport = Dict[str, Dict[steps.Step, Optional[pluginhandler.DirtyReport]]]
+_OutdatedReport = Dict[str, Dict[steps.Step, Optional[pluginhandler.OutdatedReport]]]
 
 
 class StatusCache:
@@ -101,7 +101,7 @@ class StatusCache:
 
     def get_dirty_report(
         self, part: pluginhandler.PluginHandler, step: steps.Step
-    ) -> pluginhandler.DirtyReport:
+    ) -> Optional[pluginhandler.DirtyReport]:
         """Obtain the dirty report for a given step of the given part.
 
         :param pluginhandler.PluginHandler part: Part in question.
@@ -151,8 +151,6 @@ class StatusCache:
         # Get the dirty report from the PluginHandler. If it's dirty, we can
         # stop here
         self._dirty_reports[part.name][step] = part.get_dirty_report(step)
-        if self._dirty_reports[part.name][step]:
-            return
 
         # The dirty report from the PluginHandler only takes into account
         # properties specific to that part. If it's not dirty because of those,

--- a/snapcraft/project/_project.py
+++ b/snapcraft/project/_project.py
@@ -50,7 +50,7 @@ class Project(ProjectOptions):
         # This here check is mostly for backwards compatibility with the
         # rest of the code base.
         if snapcraft_yaml_file_path is None:
-            self.info = None  # type: ProjectInfo
+            self.info: ProjectInfo = None
 
         else:
             self.info = ProjectInfo(snapcraft_yaml_file_path=snapcraft_yaml_file_path)

--- a/snapcraft/project/_project.py
+++ b/snapcraft/project/_project.py
@@ -50,7 +50,7 @@ class Project(ProjectOptions):
         # This here check is mostly for backwards compatibility with the
         # rest of the code base.
         if snapcraft_yaml_file_path is None:
-            self.info: ProjectInfo = None
+            self.info: ProjectInfo = None  # type: ignore
 
         else:
             self.info = ProjectInfo(snapcraft_yaml_file_path=snapcraft_yaml_file_path)

--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from copy import deepcopy
+from typing import Optional
 
 from snapcraft import yaml_utils
 from . import _schema
@@ -48,7 +49,7 @@ class ProjectInfo:
         """Validate the snapcraft.yaml for this project."""
         _schema.Validator(self.__raw_snapcraft).validate()
 
-    def get_build_base(self) -> str:
+    def get_build_base(self) -> Optional[str]:
         """
         Return name for type base or the base otherwise build-base is set
         """


### PR DESCRIPTION
lifecycle: add optionals to StatusCache reports
project: label get_build_base() return as optional
project: ignore project.info's Optional[ProjectInfo] type
requirements-devel: uprev mypy to 0.740

The ignore on ProjectInfo is an unfortunate hack, but I would like to see it fixed properly by going down the road of something like:
https://github.com/snapcore/snapcraft/pull/2818

