### PR TITLE
meta: remove __dict__ usage in Snap 

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -19,6 +19,7 @@ import contextlib
 import itertools
 import logging
 import os
+from pathlib import Path
 import re
 import shlex
 import shutil
@@ -351,7 +352,7 @@ class _SnapPackaging:
         # TODO: create_snap_packaging managles config data, so we create
         # a new private instance of snap_meta.  Longer term, this needs
         # to converge with project's snap_meta.
-        self._snap_meta = Snap.from_dict(project_config.data)
+        self._snap_meta = Snap.from_snapcraft_yaml_dict(project_config.data)
 
     def cleanup(self):
         if os.path.exists(self.meta_gui_dir):
@@ -392,8 +393,8 @@ class _SnapPackaging:
         self._snap_meta.validate()
         _check_passthrough_duplicates(self._original_snapcraft_yaml)
 
-        package_snap_path = os.path.join(self.meta_dir, "snap.yaml")
-        self._snap_meta.write_snap_yaml(path=package_snap_path)
+        package_snap_path = Path(self.meta_dir, "snap.yaml")
+        self._snap_meta.write_snap_yaml(package_snap_path)
 
     def setup_assets(self) -> None:
         # We do _setup_from_setup first since it is legacy and let the

--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -185,12 +185,18 @@ class Snap:
     def _validate_required_keys(self) -> None:
         """Verify that all mandatory keys have been satisfied."""
         missing_keys: List[str] = []
-        for key in _MANDATORY_PACKAGE_KEYS:
-            if key == "version" and self.adopt_info:
-                continue
 
-            if not self.__dict__[key]:
-                missing_keys.append(key)
+        if not self.name:
+            missing_keys.append("name")
+
+        if not self.version and not self.adopt_info:
+            missing_keys.append("version")
+
+        if not self.summary:
+            missing_keys.append("summary")
+
+        if not self.description:
+            missing_keys.append("description")
 
         if missing_keys:
             raise errors.MissingSnapcraftYamlKeysError(keys=missing_keys)

--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -31,26 +31,6 @@ from snapcraft.internal.meta.slots import ContentSlot, Slot
 logger = logging.getLogger(__name__)
 
 
-_MANDATORY_PACKAGE_KEYS = ["name", "version", "summary", "description"]
-_OPTIONAL_PACKAGE_KEYS = [
-    "apps",
-    "architectures",
-    "assumes",
-    "base",
-    "confinement",
-    "environment",
-    "epoch",
-    "grade",
-    "hooks",
-    "layout",
-    "license",
-    "plugs",
-    "slots",
-    "title",
-    "type",
-]
-
-
 class Snap:
     """Representation of snap meta object, writes snap.yaml."""
 

--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -328,48 +328,70 @@ class Snap:
         # Ensure command-chain is in assumes, if required.
         self._ensure_command_chain_assumption()
 
-        for key in _MANDATORY_PACKAGE_KEYS + _OPTIONAL_PACKAGE_KEYS:
-            if self.__dict__[key] is None:
-                continue
+        if self.name is not None:
+            snap_dict["name"] = self.name
 
-            # Skip fields that are empty lists/dicts.
-            if (
-                key
-                in [
-                    "apps",
-                    "architectures",
-                    "assumes",
-                    "environment",
-                    "hooks",
-                    "layout",
-                    "plugs",
-                    "slots",
-                ]
-                and not self.__dict__[key]
-            ):
-                continue
+        if self.version is not None:
+            snap_dict["version"] = self.version
 
-            # Sort where possible for consistency.
-            if key == "apps":
-                snap_dict[key] = dict()
-                for name, app in sorted(self.apps.items()):
-                    snap_dict[key][name] = app.to_dict()
-            elif key == "assumes":
-                snap_dict[key] = sorted(set(self.assumes))
-            elif key == "hooks":
-                snap_dict[key] = dict()
-                for name, hook in sorted(self.hooks.items()):
-                    snap_dict[key][name] = hook.to_dict()
-            elif key == "plugs":
-                snap_dict[key] = dict()
-                for name, plug in sorted(self.plugs.items()):
-                    snap_dict[key][name] = plug.to_dict()
-            elif key == "slots":
-                snap_dict[key] = dict()
-                for name, slot in sorted(self.slots.items()):
-                    snap_dict[key][name] = slot.to_dict()
-            else:
-                snap_dict[key] = deepcopy(self.__dict__[key])
+        if self.summary is not None:
+            snap_dict["summary"] = self.summary
+
+        if self.description is not None:
+            snap_dict["description"] = self.description
+
+        if self.apps:
+            snap_dict["apps"] = OrderedDict()
+            for name, app in sorted(self.apps.items()):
+                snap_dict["apps"][name] = deepcopy(app.to_dict())
+
+        if self.architectures:
+            snap_dict["architectures"] = deepcopy(self.architectures)
+
+        if self.assumes:
+            snap_dict["assumes"] = sorted(set(deepcopy(self.assumes)))
+
+        if self.base is not None:
+            snap_dict["base"] = self.base
+
+        if self.confinement is not None:
+            snap_dict["confinement"] = self.confinement
+
+        if self.environment:
+            snap_dict["environment"] = self.environment
+
+        if self.epoch is not None:
+            snap_dict["epoch"] = self.epoch
+
+        if self.grade is not None:
+            snap_dict["grade"] = self.grade
+
+        if self.hooks:
+            snap_dict["hooks"] = OrderedDict()
+            for name, hook in sorted(self.hooks.items()):
+                snap_dict["hooks"][name] = deepcopy(hook.to_dict())
+
+        if self.layout:
+            snap_dict["layout"] = deepcopy(self.layout)
+
+        if self.license is not None:
+            snap_dict["license"] = self.license
+
+        if self.plugs:
+            snap_dict["plugs"] = OrderedDict()
+            for name, plug in sorted(self.plugs.items()):
+                snap_dict["plugs"][name] = deepcopy(plug.to_dict())
+
+        if self.slots:
+            snap_dict["slots"] = OrderedDict()
+            for name, slot in sorted(self.slots.items()):
+                snap_dict["slots"][name] = deepcopy(slot.to_dict())
+
+        if self.title is not None:
+            snap_dict["title"] = self.title
+
+        if self.type is not None:
+            snap_dict["type"] = self.type
 
         # Apply passthrough keys.
         snap_dict.update(deepcopy(self.passthrough))

--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -54,28 +54,82 @@ _OPTIONAL_PACKAGE_KEYS = [
 class Snap:
     """Representation of snap meta object, writes snap.yaml."""
 
-    def __init__(self) -> None:
-        self.adopt_info: Optional[str] = None
-        self.base: Optional[str] = None
-        self.name: Optional[str] = None
-        self.version: Optional[str] = None
-        self.summary: Optional[str] = None
-        self.description: Optional[str] = None
-        self.architectures: Sequence[str] = list()
-        self.assumes: Set[str] = set()
-        self.confinement: Optional[str] = None
-        self.environment: Dict[str, Any] = dict()
-        self.epoch: Any = None
-        self.grade: Optional[str] = None
-        self.license: Optional[str] = None
-        self.title: Optional[str] = None
-        self.type: Optional[str] = None
-        self.plugs: Dict[str, Plug] = dict()
-        self.slots: Dict[str, Slot] = dict()
+    def __init__(
+        self,
+        adopt_info: Optional[str] = None,
+        apps: Optional[Dict[str, Application]] = None,
+        architectures: Optional[Sequence[str]] = None,
+        assumes: Optional[Set[str]] = None,
+        base: Optional[str] = None,
+        confinement: Optional[str] = None,
+        description: Optional[str] = None,
+        environment: Optional[Dict[str, Any]] = None,
+        epoch: Any = None,
+        grade: Optional[str] = None,
+        hooks: Optional[Dict[str, Hook]] = None,
+        layout: Optional[Dict[str, Any]] = None,
+        license: Optional[str] = None,
+        name: Optional[str] = None,
+        passthrough: Optional[Dict[str, Any]] = None,
+        plugs: Optional[Dict[str, Plug]] = None,
+        slots: Optional[Dict[str, Slot]] = None,
+        summary: Optional[str] = None,
+        title: Optional[str] = None,
+        type: Optional[str] = None,
+        version: Optional[str] = None,
+    ) -> None:
+        self.adopt_info = adopt_info
+
         self.apps: Dict[str, Application] = dict()
+        if apps:
+            self.apps = apps
+
+        self.architectures: Sequence[str] = list()
+        if architectures:
+            self.architectures = architectures
+
+        self.assumes: Set[str] = set()
+        if assumes:
+            self.assumes = assumes
+
+        self.base = base
+        self.confinement = confinement
+        self.description = description
+
+        self.environment: Dict[str, Any] = dict()
+        if environment:
+            self.environment = environment
+
+        self.epoch = epoch
+        self.grade = grade
+
         self.hooks: Dict[str, Hook] = dict()
-        self.passthrough: Dict[str, Any] = dict()
+        if hooks:
+            self.hooks = hooks
+
         self.layout: Dict[str, Any] = dict()
+        if layout:
+            self.layout = layout
+
+        self.license = license
+        self.name = name
+
+        self.passthrough: Dict[str, Any] = dict()
+        if passthrough:
+            self.passthrough = passthrough
+
+        self.plugs: Dict[str, Plug] = dict()
+        if plugs:
+            self.plugs = plugs
+
+        self.slots: Dict[str, Slot] = dict()
+        if slots:
+            self.slots = slots
+
+        self.summary = summary
+        self.title = title
+        self.type = type
+        self.version = version
 
     @classmethod
     def from_file(cls, snap_yaml_path: str) -> "Snap":

--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -14,10 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
-import os
 from collections import OrderedDict
 from copy import deepcopy
+import logging
+from pathlib import Path
 from typing import Any, Dict, List, Set, Sequence, Optional
 
 from snapcraft import yaml_utils
@@ -111,12 +111,6 @@ class Snap:
         self.type = type
         self.version = version
 
-    @classmethod
-    def from_file(cls, snap_yaml_path: str) -> "Snap":
-        with open(snap_yaml_path, "r") as f:
-            snap_dict = yaml_utils.load(f)
-            return cls.from_dict(snap_dict=snap_dict)
-
     @property
     def is_passthrough_enabled(self) -> bool:
         if self.passthrough:
@@ -151,9 +145,9 @@ class Snap:
                 continue
 
             provider_path = common.get_installed_snap_path(provider)
-            yaml_path = os.path.join(provider_path, "meta", "snap.yaml")
+            yaml_path = Path(provider_path, "meta", "snap.yaml")
 
-            snap = Snap.from_file(yaml_path)
+            snap = Snap.from_snap_yaml(yaml_path)
             for slot in snap.get_content_slots():
                 slot_installed_path = common.get_installed_snap_path(provider)
                 provider_dirs |= slot.get_content_dirs(
@@ -219,7 +213,7 @@ class Snap:
                 return
 
     @classmethod  # noqa: C901
-    def from_dict(cls, snap_dict: Dict[str, Any]) -> "Snap":
+    def from_snapcraft_yaml_dict(cls, snap_dict: Dict[str, Any]) -> "Snap":
         snap_dict = deepcopy(snap_dict)
 
         # Using pop() so we can catch if we *miss* fields
@@ -308,7 +302,100 @@ class Snap:
 
         return snap
 
-    def to_dict(self):  # noqa: C901
+    @classmethod  # noqa: C901
+    def from_snap_yaml(cls, path: Path) -> "Snap":
+        snap_dict = yaml_utils.load_yaml_file(path.as_posix())
+
+        # Using pop() so we can catch if we *miss* fields
+        # with whatever remains in the dictionary.
+        architectures = snap_dict.pop("architectures", None)
+
+        # Process apps into Applications.
+        apps: Dict[str, Application] = dict()
+        apps_dict = snap_dict.pop("apps", None)
+        if apps_dict is not None:
+            for app_name, app_dict in apps_dict.items():
+                app = Application.from_dict(app_dict=app_dict, app_name=app_name)
+                apps[app_name] = app
+
+        # Treat `assumes` as a set, not as a list.
+        assumes = set(snap_dict.pop("assumes", set()))
+
+        base = snap_dict.pop("base", None)
+        confinement = snap_dict.pop("confinement", None)
+        description = snap_dict.pop("description", None)
+        environment = snap_dict.pop("environment", None)
+        epoch = snap_dict.pop("epoch", None)
+        grade = snap_dict.pop("grade", None)
+
+        # Process hooks into Hooks.
+        hooks: Dict[str, Hook] = dict()
+        hooks_dict = snap_dict.pop("hooks", None)
+        if hooks_dict is not None:
+            for hook_name, hook_dict in hooks_dict.items():
+                hook = Hook.from_dict(hook_dict=hook_dict, hook_name=hook_name)
+                hooks[hook_name] = hook
+
+        layout = snap_dict.pop("layout", None)
+        license = snap_dict.pop("license", None)
+        name = snap_dict.pop("name", None)
+        passthrough = snap_dict.pop("passthrough", None)
+
+        # Process plugs into Plugs.
+        plugs: Dict[str, Plug] = dict()
+        plugs_dict = snap_dict.pop("plugs", None)
+        if plugs_dict is not None:
+            for plug_name, plug_dict in plugs_dict.items():
+                plug = Plug.from_dict(plug_dict=plug_dict, plug_name=plug_name)
+                plugs[plug_name] = plug
+
+        # Process slots into Slots.
+        slots: Dict[str, Slot] = dict()
+        slots_dict = snap_dict.pop("slots", None)
+        if slots_dict is not None:
+            for slot_name, slot_dict in slots_dict.items():
+                slot = Slot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
+                slots[slot_name] = slot
+
+        summary = snap_dict.pop("summary", None)
+        title = snap_dict.pop("title", None)
+        type = snap_dict.pop("type", None)
+        version = snap_dict.pop("version", None)
+
+        snap = Snap(
+            architectures=architectures,
+            apps=apps,
+            assumes=assumes,
+            base=base,
+            confinement=confinement,
+            description=description,
+            environment=environment,
+            epoch=epoch,
+            grade=grade,
+            hooks=hooks,
+            layout=layout,
+            license=license,
+            name=name,
+            passthrough=passthrough,
+            plugs=plugs,
+            slots=slots,
+            summary=summary,
+            title=title,
+            type=type,
+            version=version,
+        )
+
+        for key, value in snap_dict.items():
+            logger.debug(f"ignoring or passing through unknown {key}={value}")
+
+        return snap
+
+    @classmethod
+    def from_snapcraft_yaml(cls, path: Path) -> "Snap":
+        snap_dict = yaml_utils.load_yaml_file(path.as_posix())
+        return cls.from_snapcraft_yaml_dict(snap_dict)
+
+    def to_snap_yaml_dict(self):  # noqa: C901
         snap_dict = OrderedDict()
 
         # Ensure command-chain is in assumes, if required.
@@ -337,7 +424,9 @@ class Snap:
         if self.assumes:
             snap_dict["assumes"] = sorted(set(deepcopy(self.assumes)))
 
-        if self.base is not None:
+        # If the base is core in snapcraft.yaml we do not set it in
+        # snap.yaml LP: #1819290
+        if self.base is not None and self.base != "core":
             snap_dict["base"] = self.base
 
         if self.confinement is not None:
@@ -383,14 +472,92 @@ class Snap:
         snap_dict.update(deepcopy(self.passthrough))
         return snap_dict
 
-    def write_snap_yaml(self, path: str) -> None:
-        """Write snap.yaml contents to specified path."""
-        snap_dict = self.to_dict()
+    def to_snapcraft_yaml_dict(self):  # noqa: C901
+        snap_dict = OrderedDict()
 
-        # If the base is core in snapcraft.yaml we do not set it in
-        # snap.yaml LP: #1819290
-        if self.base == "core":
-            snap_dict.pop("base")
+        if self.name is not None:
+            snap_dict["name"] = self.name
+
+        if self.version is not None:
+            snap_dict["version"] = self.version
+
+        if self.summary is not None:
+            snap_dict["summary"] = self.summary
+
+        if self.description is not None:
+            snap_dict["description"] = self.description
+
+        if self.adopt_info is not None:
+            snap_dict["adopt-info"] = self.adopt_info
+
+        if self.apps:
+            snap_dict["apps"] = OrderedDict()
+            for name, app in sorted(self.apps.items()):
+                snap_dict["apps"][name] = deepcopy(app.to_dict())
+
+        if self.architectures:
+            snap_dict["architectures"] = deepcopy(self.architectures)
+
+        if self.assumes:
+            snap_dict["assumes"] = sorted(set(deepcopy(self.assumes)))
+
+        if self.base is not None:
+            snap_dict["base"] = self.base
+
+        if self.confinement is not None:
+            snap_dict["confinement"] = self.confinement
+
+        if self.environment:
+            snap_dict["environment"] = self.environment
+
+        if self.epoch is not None:
+            snap_dict["epoch"] = self.epoch
+
+        if self.grade is not None:
+            snap_dict["grade"] = self.grade
+
+        if self.hooks:
+            snap_dict["hooks"] = OrderedDict()
+            for name, hook in sorted(self.hooks.items()):
+                snap_dict["hooks"][name] = deepcopy(hook.to_dict())
+
+        if self.layout:
+            snap_dict["layout"] = deepcopy(self.layout)
+
+        if self.license is not None:
+            snap_dict["license"] = self.license
+
+        if self.passthrough:
+            snap_dict["passthrough"] = self.passthrough
+
+        if self.plugs:
+            snap_dict["plugs"] = OrderedDict()
+            for name, plug in sorted(self.plugs.items()):
+                snap_dict["plugs"][name] = deepcopy(plug.to_dict())
+
+        if self.slots:
+            snap_dict["slots"] = OrderedDict()
+            for name, slot in sorted(self.slots.items()):
+                snap_dict["slots"][name] = deepcopy(slot.to_dict())
+
+        if self.title is not None:
+            snap_dict["title"] = self.title
+
+        if self.type is not None:
+            snap_dict["type"] = self.type
+
+        return snap_dict
+
+    def write_snap_yaml(self, path: Path) -> None:
+        """Write snap.yaml contents to specified path."""
+        snap_dict = self.to_snap_yaml_dict()
+
+        with open(path, "w") as f:
+            yaml_utils.dump(snap_dict, stream=f)
+
+    def write_snapcraft_yaml(self, path: Path) -> None:
+        """Write snapcraft.yaml contents to specified path."""
+        snap_dict = self.to_snapcraft_yaml_dict()
 
         with open(path, "w") as f:
             yaml_utils.dump(snap_dict, stream=f)

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -230,7 +230,7 @@ class Config:
 
         # XXX: Resetting snap_meta due to above mangling of data.
         # Convergence to operating on snap_meta will remove this requirement...
-        project._snap_meta = Snap.from_dict(self.data)
+        project._snap_meta = Snap.from_snapcraft_yaml_dict(self.data)
 
         # Always add the base for building for non os and base snaps
         if project.info.base is None and project.info.type in ("app", "gadget"):

--- a/tests/unit/meta/test_snap.py
+++ b/tests/unit/meta/test_snap.py
@@ -26,7 +26,7 @@ from tests import unit
 
 class SnapTests(unit.TestCase):
     """ Test the snaps.  Note that the ordering of ordereddicts must align
-    with Snap's use of _MANDATORY_PACKAGE_KEYS + _OPTIONAL_PACKAGE_KEYS.
+    with Snap's ordering in to_dict().
 
     This applies even for verifying YAMLs, which are (now) ordered."""
 


### PR DESCRIPTION
- Remove `__dict__` usage in Snap and detail everything explicitly `from_dict()`, `to_dict()`, and `validate_required_keys()`.

- Make Snap fully configurable upon init with exhaustive __init__ parameters.

These changes will allow us to be more flexible going forward.  There should be no behavioral changes other than changing a few dictionaries to OrderedDict(), which they presumably should be since we expected them to be ordered (as can be seen with the paired `sorted()` use).