### PR TITLE
xattrs: ignore errors if SNAPCRAFT_BUILD_INFO is unset

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -687,6 +687,22 @@ class ProjectNotFoundError(SnapcraftReportableError):
     fmt = "Failed to find project files."
 
 
+class XAttributeError(SnapcraftReportableException):
+    def __init__(self, *, action: str, key: str, path: str) -> None:
+        self._action = action
+        self._key = key
+        self._path = path
+
+    def get_brief(self) -> str:
+        return f"Unable to {self._action} extended attribute."
+
+    def get_details(self) -> str:
+        return f"Failed to {self._action} attribute {self._key!r} on {self._path!r}."
+
+    def get_resolution(self) -> str:
+        return "Check that your filesystem supports extended attributes."
+
+
 class XAttributeTooLongError(SnapcraftReportableException):
     def __init__(self, *, key: str, value: str, path: str) -> None:
         self._key = key
@@ -698,7 +714,7 @@ class XAttributeTooLongError(SnapcraftReportableException):
 
     def get_details(self) -> str:
         return (
-            f"Failed to write attribute to {self._path}:\n"
+            f"Failed to write attribute to {self._path!r}:\n"
             f"key={self._key!r} value={self._value!r}"
         )
 

--- a/snapcraft/internal/xattrs.py
+++ b/snapcraft/internal/xattrs.py
@@ -18,7 +18,7 @@ import os
 import sys
 from typing import Optional
 
-from snapcraft.internal.errors import XAttributeTooLongError
+from snapcraft.internal.errors import XAttributeError, XAttributeTooLongError
 
 
 if sys.platform == "linux":
@@ -46,8 +46,8 @@ def _read_snapcraft_xattr(path: str, snapcraft_key: str) -> Optional[str]:
         if error.errno == 61:
             return None
 
-        # Raise unknown variants of OSError as-is.
-        raise
+        # Chain unknown variants of OSError.
+        raise XAttributeError(action="read", key=key, path=path) from error
 
     return value.decode().strip()
 
@@ -70,15 +70,26 @@ def _write_snapcraft_xattr(path: str, snapcraft_key: str, value: str) -> None:
         if error.errno == 7:
             raise XAttributeTooLongError(path=path, key=key, value=value)
 
-        # Raise unknown variants of OSError as-is.
-        raise
+        # Chain unknown variants of OSError.
+        raise XAttributeError(action="write", key=key, path=path) from error
 
 
 def read_origin_stage_package(path: str) -> Optional[str]:
     """Read origin stage package."""
-    return _read_snapcraft_xattr(path, "origin_stage_package")
+    try:
+        return _read_snapcraft_xattr(path, "origin_stage_package")
+    except XAttributeError:
+        # Ignore error if origin stage package not required.
+        if os.environ.get("SNAPCRAFT_BUILD_INFO"):
+            raise
+        return None
 
 
 def write_origin_stage_package(path: str, value: str) -> None:
     """Write origin stage package."""
-    _write_snapcraft_xattr(path, "origin_stage_package", value)
+    try:
+        _write_snapcraft_xattr(path, "origin_stage_package", value)
+    except XAttributeError:
+        # Ignore error if origin stage package not required.
+        if os.environ.get("SNAPCRAFT_BUILD_INFO"):
+            raise

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -854,13 +854,25 @@ class SnapcraftExceptionTests(unit.TestCase):
             },
         ),
         (
+            "XAttributeError",
+            {
+                "exception": errors.XAttributeError,
+                "kwargs": {"path": "/tmp/foo", "key": "foo", "action": "read"},
+                "expected_brief": "Unable to read extended attribute.",
+                "expected_resolution": "Check that your filesystem supports extended attributes.",
+                "expected_details": "Failed to read attribute 'foo' on '/tmp/foo'.",
+                "expected_docs_url": None,
+                "expected_reportable": True,
+            },
+        ),
+        (
             "XAttributeTooLongError",
             {
                 "exception": errors.XAttributeTooLongError,
                 "kwargs": {"path": "/tmp/foo", "key": "foo", "value": "bar"},
                 "expected_brief": "Unable to write extended attribute as the key and/or value is too long.",
                 "expected_resolution": "This issue is generally resolved by addressing/truncating the data source of the long data value. In some cases, the filesystem being used will limit the allowable size.",
-                "expected_details": "Failed to write attribute to /tmp/foo:\nkey='foo' value='bar'",
+                "expected_details": "Failed to write attribute to '/tmp/foo':\nkey='foo' value='bar'",
                 "expected_docs_url": None,
                 "expected_reportable": True,
             },


### PR DESCRIPTION
As SNAPCRAFT_BUILD_INFO is not always enabled, ignore errors
setting xattrs to record origin stage packages.  This data
will not be used if there is no manifest being generated.

This should prevent unnecessary errors being raised to the user
if their file system doesn't support xattrs (or are otherwise
limited from reading/modifying them).

Introduce XAttributeError() to improve the error messaging
to the user should reading/writing xattrs fail.  Mark as
reportable for now, but ultimately this should be False once
the feature is stable and extensively used by the community.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
