### PR TITLE
xattrs: switch to python's os package for reading/writing xattrs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,3 @@ lxml==4.3.0; sys_platform == 'win32'
 launchpadlib==1.10.6
 lazr.restfulclient==0.14.2
 mypy-extensions==0.4.3
-xattr==0.9.6; sys_platform == 'linux'

--- a/snapcraft/internal/xattrs.py
+++ b/snapcraft/internal/xattrs.py
@@ -21,10 +21,6 @@ from typing import Optional
 from snapcraft.internal.errors import XAttributeTooLongError
 
 
-if sys.platform == "linux":
-    import xattr
-
-
 def _get_snapcraft_xattr_key(snapcraft_key: str) -> str:
     return f"user.snapcraft.{snapcraft_key}"
 
@@ -39,7 +35,7 @@ def _read_snapcraft_xattr(path: str, snapcraft_key: str) -> Optional[str]:
 
     key = _get_snapcraft_xattr_key(snapcraft_key)
     try:
-        value = xattr.getxattr(path, key)
+        value = os.getxattr(path, key)
     except OSError as error:
         # No label present with:
         # OSError: [Errno 61] No data available: b'<path>'
@@ -63,7 +59,7 @@ def _write_snapcraft_xattr(path: str, snapcraft_key: str, value: str) -> None:
     key = _get_snapcraft_xattr_key(snapcraft_key)
 
     try:
-        xattr.setxattr(path, key, value.encode())
+        os.setxattr(path, key, value.encode())
     except OSError as error:
         # Label is too long for filesystem:
         # OSError: [Errno 7] Argument list too long: b'<path>'


### PR DESCRIPTION
I did not realize that python added xattrs to Linux's `os` package
in python 3.3.  Use that instead of the xattrs library.

https://docs.python.org/3/library/os.html#linux-extended-attributes

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
