### PR TITLE
remote-build: remove need to specify user

### DIFF
--- a/snapcraft/cli/remote.py
+++ b/snapcraft/cli/remote.py
@@ -114,7 +114,6 @@ def remote_build(
     lp = LaunchpadClient(
         project=project, build_id=build_id, architectures=architectures
     )
-    lp.login()
 
     if status:
         _print_status(lp)

--- a/snapcraft/cli/remote.py
+++ b/snapcraft/cli/remote.py
@@ -57,14 +57,6 @@ def remotecli():
     cls=PromptOption,
 )
 @click.option(
-    "--launchpad-user",
-    metavar="<username>",
-    nargs=1,
-    required=True,
-    help="Launchpad username.",
-    prompt="Launchpad username",
-)
-@click.option(
     "--package-all-sources",
     is_flag=True,
     help="Package all sources to send to remote builder, not just local sources.",
@@ -74,7 +66,6 @@ def remote_build(
     status: int,
     build_on: str,
     launchpad_accept_public_upload: bool,
-    launchpad_user: str,
     package_all_sources: bool,
     echoer=echo,
 ) -> None:
@@ -94,11 +85,11 @@ def remote_build(
 
     \b
     Examples:
-        snapcraft remote-build --launchpad-user <user>
-        snapcraft remote-build --launchpad-user <user> --build-on=amd64
-        snapcraft remote-build --launchpad-user <user> --build-on=amd64,arm64,armhf,i386,ppc64el,s390x
-        snapcraft remote-build --launchpad-user <user> --recover 47860738
-        snapcraft remote-build --launchpad-user <user> --status 47860738
+        snapcraft remote-build
+        snapcraft remote-build --build-on=amd64
+        snapcraft remote-build --build-on=amd64,arm64,armhf,i386,ppc64el,s390x
+        snapcraft remote-build --recover 47860738
+        snapcraft remote-build --status 47860738
     """
     if not launchpad_accept_public_upload:
         raise errors.AcceptPublicUploadError()
@@ -121,10 +112,7 @@ def remote_build(
     architectures = _determine_architectures(project, build_on)
 
     lp = LaunchpadClient(
-        project=project,
-        build_id=build_id,
-        user=launchpad_user,
-        architectures=architectures,
+        project=project, build_id=build_id, architectures=architectures
     )
     lp.login()
 

--- a/snapcraft/internal/remote_build/_launchpad.py
+++ b/snapcraft/internal/remote_build/_launchpad.py
@@ -108,7 +108,7 @@ class LaunchpadClient:
         self._data_dir = self._create_data_directory()
         self._credentials = os.path.join(self._data_dir, "credentials")
 
-        self._lp: Launchpad = None
+        self._lp: Launchpad = self.login()
         self._waiting = []  # type: List[str]
 
         self.user = self._lp.me.name
@@ -189,7 +189,7 @@ class LaunchpadClient:
         try:
             return self._lp.load(url)
         except ConnectionResetError:
-            self.login()
+            self._lp = self.login()
             return self._lp.load(url)
 
     def _wait_for_build_request_acceptance(
@@ -237,7 +237,7 @@ class LaunchpadClient:
 
     def login(self) -> Launchpad:
         try:
-            self._lp = Launchpad.login_with(
+            return Launchpad.login_with(
                 "snapcraft remote-build {}".format(snapcraft.__version__),
                 "production",
                 self._cache_dir,

--- a/snapcraft/internal/remote_build/_launchpad.py
+++ b/snapcraft/internal/remote_build/_launchpad.py
@@ -109,8 +109,6 @@ class LaunchpadClient:
         self._credentials = os.path.join(self._data_dir, "credentials")
 
         self._lp: Launchpad = self.login()
-        self._waiting = []  # type: List[str]
-
         self.user = self._lp.me.name
 
     @property

--- a/snapcraft/internal/remote_build/_launchpad.py
+++ b/snapcraft/internal/remote_build/_launchpad.py
@@ -85,7 +85,6 @@ class LaunchpadClient:
         *,
         project: Project,
         build_id: str,
-        user: str,
         architectures: Sequence[str],
         git_branch: str = "master",
         core18_channel: str = "stable",
@@ -98,7 +97,6 @@ class LaunchpadClient:
         self._build_id = build_id
 
         self.architectures = architectures
-        self.user = user
 
         self._lp_name = build_id
         self._lp_git_branch = git_branch
@@ -112,6 +110,8 @@ class LaunchpadClient:
 
         self._lp: Launchpad = None
         self._waiting = []  # type: List[str]
+
+        self.user = self._lp.me.name
 
     @property
     def architectures(self) -> Sequence[str]:

--- a/snapcraft/internal/remote_build/errors.py
+++ b/snapcraft/internal/remote_build/errors.py
@@ -127,7 +127,7 @@ class AcceptPublicUploadError(RemoteBuildBaseError):
 
     fmt = (
         "Remote build needs explicit acknowledgement that data sent to build servers "
-        "is public.\nIn non-interactive runs, please use option --accept-public-upload."
+        "is public.\nIn non-interactive runs, please use option --launchpad-accept-public-upload."
     )
 
 

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -37,14 +37,7 @@ class RemoteBuildTests(CommandBaseTestCase):
         self.mock_lc.has_outstanding_build.return_value = False
 
     def test_remote_build(self):
-        result = self.run_command(
-            [
-                "remote-build",
-                "--launchpad-accept-public-upload",
-                "--launchpad-user",
-                "testuser",
-            ]
-        )
+        result = self.run_command(["remote-build", "--launchpad-accept-public-upload"])
 
         self.mock_lc.start_build.assert_called_once()
         self.mock_lc.cleanup.assert_called_once()
@@ -58,8 +51,6 @@ class RemoteBuildTests(CommandBaseTestCase):
             [
                 "remote-build",
                 "--launchpad-accept-public-upload",
-                "--launchpad-user",
-                "testuser",
                 "--build-on",
                 "i386,amd64,arm64",
             ]
@@ -76,14 +67,7 @@ class RemoteBuildTests(CommandBaseTestCase):
         self.assertRaises(
             errors.UnsupportedArchitectureError,
             self.run_command,
-            [
-                "remote-build",
-                "--launchpad-accept-public-upload",
-                "--launchpad-user",
-                "testuser",
-                "--build-on",
-                "x64",
-            ],
+            ["remote-build", "--launchpad-accept-public-upload", "--build-on", "x64"],
         )
 
         self.mock_lc.start_build.assert_not_called()

--- a/tests/unit/remote_build/test_launchpad.py
+++ b/tests/unit/remote_build/test_launchpad.py
@@ -151,6 +151,11 @@ class DistImpl(FakeLaunchpadObject):
         self.main_archive = "main_archive"
 
 
+class MeImpl(FakeLaunchpadObject):
+    def __init__(self):
+        self.name = "user"
+
+
 class LaunchpadImpl(FakeLaunchpadObject):
     def __init__(self):
         self._login_mock = mock.Mock()
@@ -163,6 +168,7 @@ class LaunchpadImpl(FakeLaunchpadObject):
         self.people = {"user": "/~user"}
         self.distributions = {"ubuntu": DistImpl()}
         self.rbi = self._rbi
+        self.me = MeImpl()
 
     def load(self, url: str, *args, **kw):
         self._load_mock(url, *args, **kw)
@@ -181,7 +187,7 @@ class LaunchpadTestCase(unit.TestCase):
         super().setUp()
         self._project = self._make_snapcraft_project()
         self.lpc = LaunchpadClient(
-            project=self._project, build_id="id", user="user", architectures=[]
+            project=self._project, build_id="id", architectures=[]
         )
 
     @mock.patch("launchpadlib.launchpad.Launchpad.login_with")


### PR DESCRIPTION
A few other tweaks/cleanup while we're here.

remote-build: remove requirement to specify user …

Thanks to @cjwatson for the great idea! :+1: 
https://bugs.launchpad.net/snapcraft/+bug/1852482

remote-build: login automatically when initialized …
remote-build: fix AcceptPublicUploadError option …
remote-build: remove _waiting from LaunchpadClient …