### PR TITLE
build providers: only set the snapd flag when installing snapd

### DIFF
--- a/snapcraft/internal/build_providers/_snap.py
+++ b/snapcraft/internal/build_providers/_snap.py
@@ -362,7 +362,8 @@ class SnapInjector:
             return
 
         # Allow using snapd from the snapd snap to leverage newer snapd features.
-        self._enable_snapd_snap()
+        if any(s.snap_name == "snapd" for s in self._snaps):
+            self._enable_snapd_snap()
 
         # Disable refreshes so they do not interfere with installation ops.
         self._disable_and_wait_for_refreshes()

--- a/spread.yaml
+++ b/spread.yaml
@@ -230,7 +230,9 @@ suites:
  # Use of multipass and lxd build providers
  tests/spread/build-providers/:
    summary: tests of snapcraft using build providers
-   systems: [ubuntu-18.04-64]
+   systems:
+   - ubuntu-16.04-64
+   - ubuntu-18.04-64
    kill-timeout: 180m
    warn-timeout: 9m  # Keep less than 10 minutes so Travis can't timeout
    priority: 90  # Run this test relatively early since fetching images can take time

--- a/tests/spread/build-providers/lxd-env-passthrough/task.yaml
+++ b/tests/spread/build-providers/lxd-env-passthrough/task.yaml
@@ -3,6 +3,9 @@ summary: Verify environment passthrough flags are configured for LXD
 environment:
   SNAP_DIR: ../snaps/env-passthrough
 
+systems:
+- ubuntu-18.04-64
+
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"


### PR DESCRIPTION
When setting the experimental.snapd-snap to true, the system goes into a
deadlock expecting the snapd snap to be there. Given that the snapd snap
is not install when core is injected it causes a deadlock on the build
environment. Avoid the situation by only setting this flag when the snapd
snap is to be installed.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
