### PR TITLE
appstream extractor: add support for code

### DIFF
--- a/snapcraft/extractors/appstream.py
+++ b/snapcraft/extractors/appstream.py
@@ -71,6 +71,10 @@ _XSLT = """\
 <xsl:text>_</xsl:text>
 </xsl:template>
 
+<xsl:template match="code">
+<xsl:apply-templates />
+</xsl:template>
+
 </xsl:stylesheet>
 """
 

--- a/tests/unit/extractors/test_appstream.py
+++ b/tests/unit/extractors/test_appstream.py
@@ -592,6 +592,65 @@ class AppstreamTest(unit.TestCase):
             ),
         )
 
+    def test_appstream_code_tags_not_swallowed(self):
+        file_name = "foliate.appdata.xml"
+        content = textwrap.dedent(
+            """\
+            <?xml version="1.0" encoding="UTF-8"?>
+              <component type="desktop">
+              <id>com.github.maoschanz.drawing</id>
+              <metadata_license>CC0-1.0</metadata_license>
+              <project_license>GPL-3.0-or-later</project_license>
+              <content_rating type="oars-1.1"/>
+              <name>Drawing</name>
+              <description>
+                <p>Command Line Utility to <code>create snaps</code> quickly.</p>
+                <p xml:lang="es">Aplicativo de línea de comandos para crear snaps.</p>
+                <p>Ordered Features:</p>
+                <p xml:lang="es">Funciones:</p>
+                <ol>
+                  <li><code>Build snaps</code>.</li>
+                  <li xml:lang="es">Construye snaps.</li>
+                  <li>Publish snaps to the store.</li>
+                  <li xml:lang="es">Publica snaps en la tienda.</li>
+                </ol>
+                <p>Unordered Features:</p>
+                <ul>
+                  <li><code>Build snaps</code>.</li>
+                  <li xml:lang="es">Construye snaps.</li>
+                  <li>Publish snaps to the store.</li>
+                  <li xml:lang="es">Publica snaps en la tienda.</li>
+                </ul>
+              </description>
+              </component>
+        """
+        )
+
+        with open(file_name, "w") as f:
+            print(content, file=f)
+
+        metadata = appstream.extract(file_name, workdir=".")
+
+        self.expectThat(
+            metadata.get_description(),
+            Equals(
+                textwrap.dedent(
+                    """\
+            Command Line Utility to create snaps quickly.
+
+            Ordered Features:
+
+            1. Build snaps.
+            2. Publish snaps to the store.
+
+            Unordered Features:
+
+            - Build snaps.
+            - Publish snaps to the store."""
+                )
+            ),
+        )
+
 
 class AppstreamUnhandledFileTestCase(unit.TestCase):
     def test_unhandled_file_test_case(self):


### PR DESCRIPTION
The Markdown used by the Snap Store does not yet support "verbatim"
or code-like formatting while Appstream does.

The new XSLT snippet is added to ensure these code tags are not
swallowed during the transformation.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
