### PR TITLE
dirs: support --user install on Linux

### DIFF
--- a/bin/snapcraftctl
+++ b/bin/snapcraftctl
@@ -29,7 +29,17 @@ quote()
 # SNAPCRAFT_INTERPRETER is specified, use that one instead.
 python3_command="${SNAPCRAFT_INTERPRETER:-$(command -v python3)}"
 
-snapcraftctl_command="$python3_command -I -c '
+# Is snapcraft installed in the user base? In that case, we can't use -I and
+# must settle on only -E
+parent_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)/"
+user_base_dir="$("$python3_command" -c 'import site; print(site.USER_BASE)')/"
+if [ "${parent_dir##$user_base_dir}" != "$parent_dir" ]; then
+    python_args="-E"
+else
+    python_args="-I"
+fi
+
+snapcraftctl_command="$python3_command $python_args -c '
 import snapcraft.cli.__main__
 
 # Click strips off the first arg by default, so the -c will not be passed

--- a/snapcraft/internal/dirs.py
+++ b/snapcraft/internal/dirs.py
@@ -20,8 +20,8 @@ import site
 import sys
 
 
-def _find_windows_data_dir(topdir):
-    # On Windows we need to search for data directory:
+def _find_data_dir(topdir):
+    # In some instances we need to search for data directory:
     #
     # Option (a) - Running with pip install --user.
     # > topdir=C:\Users\chris\AppData\Roaming\Python\Python37\site-packages
@@ -103,10 +103,10 @@ def setup_dirs() -> None:
         common.set_keyringsdir(os.path.join(parent_dir, "keyrings"))
         common.set_legacy_snapcraft_dir(os.path.join(snap_path, "legacy_snapcraft"))
 
-    elif sys.platform == "win32":
+    elif sys.platform == "win32" or (site.USER_BASE and topdir.startswith(site.USER_BASE + os.sep)):
         common.set_plugindir(os.path.join(topdir, "snapcraft", "plugins"))
 
-        data_dir = _find_windows_data_dir(topdir)
+        data_dir = _find_data_dir(topdir)
         common.set_schemadir(os.path.join(data_dir, "schema"))
         common.set_extensionsdir(os.path.join(data_dir, "extensions"))
         common.set_keyringsdir(os.path.join(data_dir, "keyrings"))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

Snapcraft includes explicit support for being installed in a number of situations, from the Debian package, to the snap, to a virtual environment. It supports a number of strategies on Windows as well, including being installed into the user base. There are times when snapcraft needs to be installed into the user base on Linux, too, for example when hacking on plugins related to Python 2, such as Catkin. Add support for running out of the user base on Linux.