### PR TITLE
colcon plugin: support ROS 2 Eloquent

### DIFF
--- a/snapcraft/plugins/colcon.py
+++ b/snapcraft/plugins/colcon.py
@@ -36,8 +36,9 @@ Additionally, this plugin uses the following plugin-specific keywords:
       The source space containing colcon packages (defaults to 'src').
     - colcon-rosdistro:
       (string)
-      The ROS distro to use. Available options are bouncy and crystal (defaults to
-      crystal), both of which are only compatible with core18 as the base.
+      The ROS distro to use. Available options are bouncy, crystal, dashing, and
+      eloquent, all of which are only compatible with core18 as the base. The default
+      value is crystal.
     - colcon-cmake-args:
       (list of strings)
       Arguments to pass to cmake projects. Note that any arguments here which match
@@ -72,7 +73,12 @@ from snapcraft.internal import errors, mangling
 logger = logging.getLogger(__name__)
 
 # Map bases to ROS releases
-_ROSDISTRO_TO_BASE_MAP = {"bouncy": "core18", "crystal": "core18", "dashing": "core18"}
+_ROSDISTRO_TO_BASE_MAP = {
+    "bouncy": "core18",
+    "crystal": "core18",
+    "dashing": "core18",
+    "eloquent": "core18",
+}
 
 # Map bases to Ubuntu releases. Every base in _ROSDISTRO_TO_BASE_MAP needs to be
 # specified here.

--- a/tests/unit/plugins/test_colcon.py
+++ b/tests/unit/plugins/test_colcon.py
@@ -196,10 +196,11 @@ class ColconPluginTest(ColconPluginTestBase):
         self.assertThat(colcon_packages["default"], Equals("crystal"))
 
         enum = colcon_packages["enum"]
-        self.assertThat(enum, HasLength(3))
+        self.assertThat(enum, HasLength(4))
         self.assertThat(enum, Contains("bouncy"))
         self.assertThat(enum, Contains("crystal"))
         self.assertThat(enum, Contains("dashing"))
+        self.assertThat(enum, Contains("eloquent"))
 
     def test_schema_colcon_packages(self):
         schema = colcon.ColconPlugin.schema()


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR adds support for the newest ROS 2 release, Eloquent Elusor. For more information about the release, see https://github.com/ros2/ros2/issues/734.