### PR TITLE
meta: fix command-chain handling when Application adapter == "none"

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -568,7 +568,7 @@
                                 "legacy",
                                 "full"
                             ],
-                            "default": "legacy"
+                            "default": "full"
                         },
                         "command-chain": {
                             "type": "array",

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -367,8 +367,13 @@ class _SnapPackaging:
 
     def finalize_snap_meta_command_chains(self) -> None:
         prepend_command_chain = self._generate_command_chain()
+
+        # If there's nothing to prepend, we have nothing to do.
+        if not prepend_command_chain:
+            return
+
         for app_name, app in self._snap_meta.apps.items():
-            app.prepend_command_chain = prepend_command_chain
+            app.command_chain = prepend_command_chain + app.command_chain
 
     def finalize_snap_meta_version(self) -> None:
         # Reparse the version, the order should stick.

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -35,6 +35,7 @@ from snapcraft.extractors import _metadata
 from snapcraft.internal.deprecations import handle_deprecation_notice
 from snapcraft.internal.meta import errors as meta_errors, _manifest, _version
 from snapcraft.internal.meta.snap import Snap
+from snapcraft.internal.meta.application import ApplicationAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -373,6 +374,9 @@ class _SnapPackaging:
             return
 
         for app_name, app in self._snap_meta.apps.items():
+            if app.adapter == ApplicationAdapter.NONE:
+                continue
+
             app.command_chain = prepend_command_chain + app.command_chain
 
     def finalize_snap_meta_version(self) -> None:

--- a/snapcraft/internal/meta/application.py
+++ b/snapcraft/internal/meta/application.py
@@ -15,7 +15,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import enum
+import logging
 import os
+import re
+import shlex
 
 from copy import deepcopy
 from snapcraft import yaml_utils
@@ -23,12 +26,20 @@ from typing import Any, Dict, List, Optional, Sequence  # noqa: F401
 
 from . import errors
 from ._utils import _executable_is_valid
-from .command import Command
+from .command import _massage_command
 from .desktop import DesktopFile
 
 
-_COMMAND_ENTRIES = ["command", "stop-command"]
+logger = logging.getLogger(__name__)
+_COMMAND_PATTERN = re.compile("^[A-Za-z0-9. _#:$-][A-Za-z0-9/. _#:$-]*$")
 _MASSAGED_BASES = ["core", "core18"]
+_FMT_SNAPD_WRAPPER = (
+    "A shell wrapper will be generated for command {!r} as it does not conform "
+    "with the command pattern expected by the runtime. "
+    "Commands must be relative to the prime directory and can only consist "
+    "of alphanumeric characters, spaces, and the following special characters: "
+    "/ . _ # : $ -"
+)
 
 
 @enum.unique
@@ -46,11 +57,13 @@ class Application:
         *,
         app_name: str,
         app_properties: Dict[str, Any] = None,
-        adapter: ApplicationAdapter,
+        adapter: ApplicationAdapter = ApplicationAdapter.LEGACY,
+        command: Optional[str] = None,
+        command_chain: Optional[List[str]] = None,
         desktop: str = None,
-        command_chain: List[str] = None,
         passthrough: Dict[str, Any] = None,
-        commands: Dict[str, Command] = None
+        post_stop_command: Optional[str] = None,
+        stop_command: Optional[str] = None,
     ) -> None:
         """Initialize an application entry.
 
@@ -63,24 +76,28 @@ class Application:
             self._app_properties = app_properties
 
         self.adapter = adapter
-        self.desktop = desktop
+        self.command = command
 
         self.command_chain: List[str] = list()
         if command_chain:
             self.command_chain = command_chain
 
-        self.commands: Dict[str, Command] = dict()
-        if commands:
-            self.commands = commands
+        self.desktop = desktop
 
         self.passthrough: Dict[str, Any] = dict()
         if passthrough:
             self.passthrough = passthrough
 
+        self.post_stop_command = post_stop_command
+        self.stop_command = stop_command
+
     @property
     def app_name(self) -> str:
         """Read-only to ensure consistency with Snap dictionary mappings."""
         return self._app_name
+
+    def can_massage_commands(self, *, base: Optional[str]) -> bool:
+        return base in _MASSAGED_BASES
 
     def can_use_wrapper(self, base: Optional[str]) -> bool:
         """Return if an wrapper should be allowed for app entries."""
@@ -89,7 +106,7 @@ class Application:
             return False
 
         # We only allow wrappers for core and core18.
-        if not self._massage_commands(base=base):
+        if not self.can_massage_commands(base=base):
             return False
 
         # Now that command-chain and bases have been checked for,
@@ -99,22 +116,66 @@ class Application:
 
         return True
 
-    def _massage_commands(self, *, base: Optional[str]) -> bool:
-        return base in _MASSAGED_BASES
+    def _prime_command(
+        self, *, command: str, command_name: str, base: Optional[str], prime_dir: str
+    ) -> str:
+        """Finalize and prime command, massaging as necessary.
+
+        If a wrapper is required, it will be generated and primed.  The
+        command returned will point to the wrapper (the command will be
+        preserved in the wrapper).
+
+        Check if command is in prime_dir and raise exception if not valid."""
+
+        if self.can_massage_commands(base=base):
+            command = _massage_command(command=command, prime_dir=prime_dir)
+
+        # Check to see if the command requires a wrapper.
+        if command.startswith("/") or not _COMMAND_PATTERN.match(command):
+            if not self.can_use_wrapper(base):
+                raise errors.InvalidAppCommandFormatError(command, self._app_name)
+
+            if not _COMMAND_PATTERN.match(command):
+                logger.warning(_FMT_SNAPD_WRAPPER.format(command))
+
+            # Write command wrapper and update command to point to it.
+            command = self._write_command_wrapper(
+                command=command, command_name=command_name, prime_dir=prime_dir
+            )
+
+        command_parts = shlex.split(command)
+        command_path = os.path.join(prime_dir, command_parts[0])
+        if not _executable_is_valid(command_path):
+            raise errors.InvalidAppCommandNotExecutable(
+                command=command, app_name=self._app_name
+            )
+
+        return command
 
     def prime_commands(self, *, base: Optional[str], prime_dir: str) -> None:
-        can_use_wrapper = self.can_use_wrapper(base)
-        massage_command = self._massage_commands(base=base)
-        for command in self.commands.values():
-            command.prime_command(
-                can_use_wrapper=can_use_wrapper,
-                massage_command=massage_command,
+        if self.command:
+            self.command = self._prime_command(
+                command=self.command,
+                command_name="command",
+                base=base,
                 prime_dir=prime_dir,
             )
 
-    def write_command_wrappers(self, *, prime_dir: str) -> None:
-        for command in self.commands.values():
-            command.write_wrapper(prime_dir=prime_dir)
+        if self.post_stop_command:
+            self.post_stop_command = self._prime_command(
+                command=self.post_stop_command,
+                command_name="post-stop-command",
+                base=base,
+                prime_dir=prime_dir,
+            )
+
+        if self.stop_command:
+            self.stop_command = self._prime_command(
+                command=self.stop_command,
+                command_name="stop-command",
+                base=base,
+                prime_dir=prime_dir,
+            )
 
     def write_application_desktop_file(
         self, snap_name: str, prime_dir: str, gui_dir: str, icon_path: Optional[str]
@@ -130,6 +191,24 @@ class Application:
         )
 
         desktop_file.write(gui_dir=gui_dir, icon_path=icon_path)
+
+    def _write_command_wrapper(
+        self, *, command_name: str, command: str, prime_dir: str
+    ) -> str:
+        """Write command wrapper for this command."""
+        wrapped_command_name = f"{command_name}-{self._app_name}.wrapper"
+        command_wrapper = os.path.join(prime_dir, wrapped_command_name)
+
+        # We cannot exec relative paths in our wrappers.
+        if not command.startswith("/"):
+            command = os.path.join("$SNAP", command)
+
+        with open(command_wrapper, "w+") as command_file:
+            print("#!/bin/sh", file=command_file)
+            print('exec {} "$@"'.format(command), file=command_file)
+
+        os.chmod(command_wrapper, 0o755)
+        return wrapped_command_name
 
     def validate_command_chain_executables(self, prime_dir: str) -> None:
         for item in self.command_chain:
@@ -153,41 +232,34 @@ class Application:
 
         app_dict = deepcopy(app_dict)
 
-        adapter_string = app_dict.get("adapter", "full").upper()
+        adapter_string = app_dict.get("adapter", "legacy").upper()
         adapter = ApplicationAdapter[adapter_string]
 
-        app = Application(
+        return Application(
             app_name=app_name,
             app_properties=app_dict,
             adapter=adapter,
-            desktop=app_dict.get("desktop", None),
+            command=app_dict.get("command", None),
             command_chain=app_dict.get("command-chain", None),
+            desktop=app_dict.get("desktop", None),
             passthrough=app_dict.get("passthrough", None),
+            post_stop_command=app_dict.get("post-stop-command", None),
+            stop_command=app_dict.get("stop-command", None),
         )
-
-        # Populate commands from app_properties.
-        for command_name in _COMMAND_ENTRIES:
-            if command_name not in app_dict:
-                continue
-
-            app.commands[command_name] = Command(
-                app_name=app_name,
-                command_name=command_name,
-                command=app_dict[command_name],
-            )
-
-        return app
 
     def to_dict(self) -> Dict[str, Any]:
         """Returns and ordered dictonary with the transformed app entry."""
 
         app_dict = deepcopy(self._app_properties)
 
-        for command_name, command in self.commands.items():
-            app_dict[command_name] = command.command
+        if self.command:
+            app_dict["command"] = self.command
 
         if self.command_chain and self.adapter != ApplicationAdapter.NONE:
             app_dict["command-chain"] = self.command_chain
+
+        if self.post_stop_command:
+            app_dict["post-stop-command"] = self.post_stop_command
 
         # Adjust socket values to formats snap.yaml accepts
         sockets = app_dict.get("sockets", dict())
@@ -195,6 +267,9 @@ class Application:
             mode = socket.get("socket-mode")
             if mode is not None:
                 socket["socket-mode"] = yaml_utils.OctInt(mode)
+
+        if self.stop_command:
+            app_dict["stop-command"] = self.stop_command
 
         # Strip keys.
         for key in ["adapter", "desktop"]:

--- a/snapcraft/internal/meta/application.py
+++ b/snapcraft/internal/meta/application.py
@@ -49,7 +49,6 @@ class Application:
         adapter: ApplicationAdapter,
         desktop: str = None,
         command_chain: List[str] = None,
-        prepend_command_chain: List[str] = None,
         passthrough: Dict[str, Any] = None,
         commands: Dict[str, Command] = None
     ) -> None:
@@ -69,10 +68,6 @@ class Application:
         self.command_chain: List[str] = list()
         if command_chain:
             self.command_chain = command_chain
-
-        self.prepend_command_chain: List[str] = list()
-        if prepend_command_chain:
-            self.prepend_command_chain = prepend_command_chain
 
         self.commands: Dict[str, Command] = dict()
         if commands:
@@ -190,8 +185,8 @@ class Application:
         for command_name, command in self.commands.items():
             app_dict[command_name] = command.command
 
-        if self.prepend_command_chain or self.command_chain:
-            app_dict["command-chain"] = self.prepend_command_chain + self.command_chain
+        if self.command_chain:
+            app_dict["command-chain"] = self.command_chain
 
         # Adjust socket values to formats snap.yaml accepts
         sockets = app_dict.get("sockets", dict())

--- a/snapcraft/internal/meta/application.py
+++ b/snapcraft/internal/meta/application.py
@@ -142,9 +142,10 @@ class Application:
 
     def validate(self) -> None:
         """Validate application, raising exception on error."""
-
-        # No checks here (yet).
-        return
+        if self.adapter == ApplicationAdapter.NONE and self.command_chain:
+            raise errors.CommandChainWithIncompatibleAdapterError(
+                app_name=self.app_name, adapter=self.adapter.name
+            )
 
     @classmethod
     def from_dict(cls, *, app_dict: Dict[str, Any], app_name: str) -> "Application":
@@ -185,7 +186,7 @@ class Application:
         for command_name, command in self.commands.items():
             app_dict[command_name] = command.command
 
-        if self.command_chain:
+        if self.command_chain and self.adapter != ApplicationAdapter.NONE:
             app_dict["command-chain"] = self.command_chain
 
         # Adjust socket values to formats snap.yaml accepts

--- a/snapcraft/internal/meta/application.py
+++ b/snapcraft/internal/meta/application.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import enum
 import os
 
 from copy import deepcopy
@@ -30,6 +31,13 @@ _COMMAND_ENTRIES = ["command", "stop-command"]
 _MASSAGED_BASES = ["core", "core18"]
 
 
+@enum.unique
+class ApplicationAdapter(enum.Enum):
+    NONE = 1
+    LEGACY = 2
+    FULL = 3
+
+
 class Application:
     """Representation of an app entry in snapcraft.yaml"""
 
@@ -38,7 +46,7 @@ class Application:
         *,
         app_name: str,
         app_properties: Dict[str, Any] = None,
-        adapter: str = None,
+        adapter: ApplicationAdapter,
         desktop: str = None,
         command_chain: List[str] = None,
         prepend_command_chain: List[str] = None,
@@ -91,7 +99,7 @@ class Application:
 
         # Now that command-chain and bases have been checked for,
         # check if the none adapter has been forced.
-        if self.adapter == "none":
+        if self.adapter == ApplicationAdapter.NONE:
             return False
 
         return True
@@ -148,10 +156,14 @@ class Application:
         """Create application from dictionary."""
 
         app_dict = deepcopy(app_dict)
+
+        adapter_string = app_dict.get("adapter", "full").upper()
+        adapter = ApplicationAdapter[adapter_string]
+
         app = Application(
             app_name=app_name,
             app_properties=app_dict,
-            adapter=app_dict.get("adapter", None),
+            adapter=adapter,
             desktop=app_dict.get("desktop", None),
             command_chain=app_dict.get("command-chain", None),
             passthrough=app_dict.get("passthrough", None),

--- a/snapcraft/internal/meta/errors.py
+++ b/snapcraft/internal/meta/errors.py
@@ -209,3 +209,23 @@ class GradeDevelRequiredError(errors.SnapcraftException):
 
     def get_resolution(self) -> str:
         return "Set 'grade' to 'devel' or use a stable base for this snap."
+
+
+class CommandChainWithIncompatibleAdapterError(errors.SnapcraftException):
+    def __init__(self, *, app_name: str, adapter: str) -> None:
+        self._app_name = app_name
+        self._adapter = adapter
+
+    def get_brief(self) -> str:
+        return (
+            f"Use of 'command-chain' for app {self._app_name!r} is "
+            f"incompatible with adapter {self._adapter!r}."
+        )
+
+    def get_resolution(self) -> str:
+        return (
+            "Remove usage of 'command-chain' or set adapter to 'full'. "
+            "If you haven't specified either, you may be using an extension "
+            "that does. Run 'snapcraft expand-extensions' to see the "
+            "snapcraft.yaml with all extensions applied."
+        )

--- a/snapcraft/internal/project_loader/__init__.py
+++ b/snapcraft/internal/project_loader/__init__.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import enum
 from typing import cast, Dict, List, Union
 from typing import TYPE_CHECKING
 
@@ -32,13 +31,6 @@ from ._extensions import (  # noqa: F401
 
 if TYPE_CHECKING:
     from snapcraft.project import Project  # noqa: F401
-
-
-@enum.unique
-class Adapter(enum.Enum):
-    NONE = 1
-    LEGACY = 2
-    FULL = 3
 
 
 def load_config(project: "Project"):

--- a/snapcraft/project/errors.py
+++ b/snapcraft/project/errors.py
@@ -97,23 +97,6 @@ class DuplicateSnapcraftYamlError(SnapcraftError):
         )
 
 
-class SanityCheckError(SnapcraftError):
-    pass
-
-
-class CommandChainWithLegacyAdapterError(SanityCheckError):
-    fmt = (
-        "The {app_name!r} app is using 'command-chain' with the 'legacy' adapter.\n"
-        "'command-chain' is incompatible with the 'legacy' adapter. Either stop using "
-        "'command-chain', or use a different adapter. If you haven't specified either, "
-        "you may be using an extension that does. Run 'snapcraft expand-extensions' to "
-        "see the snapcraft.yaml with all extensions applied."
-    )
-
-    def __init__(self, app_name):
-        super().__init__(app_name=app_name)
-
-
 def _determine_preamble(error):
     messages = []
     path = _determine_property_path(error)

--- a/tests/unit/meta/test_application.py
+++ b/tests/unit/meta/test_application.py
@@ -64,33 +64,6 @@ class AppCommandTest(unit.TestCase):
         self.expectThat("command-foo.wrapper", Not(FileExists()))
         self.expectThat("stop-command-foo.wrapper", Not(FileExists()))
 
-    def test_mangling(self):
-        app = application.Application.from_dict(
-            app_name="foo", app_dict={"command": "$SNAP/test-command"}
-        )
-        app.prepend_command_chain = ["prepend-command-chain"]
-        app.prime_commands(base="core18", prime_dir=self.path)
-
-        self.assertThat(
-            app.to_dict(),
-            Equals(
-                {"command": "test-command", "command-chain": ["prepend-command-chain"]}
-            ),
-        )
-
-    def test_no_mangling(self):
-        app = application.Application.from_dict(
-            app_name="foo", app_dict={"command": "$SNAP/test-command"}
-        )
-        app.prepend_command_chain = ["prepend-command-chain"]
-
-        self.assertRaises(
-            errors.InvalidAppCommandNotExecutable,
-            app.prime_commands,
-            base="core20",
-            prime_dir=self.path,
-        )
-
     def test_app_with_wrapper(self):
         app = application.Application.from_dict(
             app_name="foo",
@@ -100,7 +73,6 @@ class AppCommandTest(unit.TestCase):
                 "daemon": "simple",
             },
         )
-        app.prepend_command_chain = ["prepend-command-chain"]
         app.prime_commands(base="core18", prime_dir=self.path)
         self.assertThat(
             app.to_dict(),
@@ -109,7 +81,6 @@ class AppCommandTest(unit.TestCase):
                     "command": "command-foo.wrapper",
                     "stop-command": "stop-command-foo.wrapper",
                     "daemon": "simple",
-                    "command-chain": ["prepend-command-chain"],
                 }
             ),
         )
@@ -139,7 +110,7 @@ class AppCommandTest(unit.TestCase):
             Equals(yaml_utils.OctInt),
         )
 
-    def test_no_command_chain_prepended(self):
+    def test_no_command_chain(self):
         app = application.Application.from_dict(
             app_name="foo", app_dict={"command": "test-command"}
         )
@@ -239,7 +210,6 @@ class DesktopFileTest(unit.TestCase):
         app = application.Application.from_dict(
             app_name="foo", app_dict=dict(command="/foo", desktop=desktop_file_path)
         )
-        app.prepend_command_chain = ["command-chain"]
 
         desktop_file = desktop.DesktopFile(
             snap_name="foo",

--- a/tests/unit/meta/test_errors.py
+++ b/tests/unit/meta/test_errors.py
@@ -185,6 +185,18 @@ class SnapcraftExceptionTests(unit.TestCase):
                 "expected_reportable": False,
             },
         ),
+        (
+            "CommandChainWithIncompatibleAdapterError",
+            {
+                "exception": errors.CommandChainWithIncompatibleAdapterError,
+                "kwargs": dict(adapter="someadapter", app_name="someapp"),
+                "expected_brief": "Use of 'command-chain' for app 'someapp' is incompatible with adapter 'someadapter'.",
+                "expected_resolution": "Remove usage of 'command-chain' or set adapter to 'full'. If you haven't specified either, you may be using an extension that does. Run 'snapcraft expand-extensions' to see the snapcraft.yaml with all extensions applied.",
+                "expected_details": None,
+                "expected_docs_url": None,
+                "expected_reportable": False,
+            },
+        ),
     )
 
     def test_snapcraft_exception_handling(self):


### PR DESCRIPTION
As reported by @chipaca, `command-chain` is being set when adapter is specified to none.  This should address that along with some minor related changes to clean things up a bit.

meta: fix command-chain handling when Application adapter == "none"
meta: remove Application's `prepend_command_chain`
meta: convert Application's `adapter` from string to enum
project: remove unused SanityCheckError and CommandChainWithLegacyAdapterError
schema: set app adapter default to full