### PR TITLE
remote-build: gpg-signing and usability fixes

### DIFF
--- a/snapcraft/internal/remote_build/_launchpad.py
+++ b/snapcraft/internal/remote_build/_launchpad.py
@@ -432,12 +432,7 @@ class LaunchpadClient:
                 git_handler.add(f)
 
         # Commit files.
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
-        git_handler.commit(
-            "snapcraft commit\n\nversion: {}\ntimestamp: {}\n".format(
-                snapcraft.__version__, timestamp
-            )
-        )
+        git_handler.commit(f"committed by snapcraft version: {snapcraft.__version__}")
 
         return git_handler
 

--- a/snapcraft/internal/sources/_git.py
+++ b/snapcraft/internal/sources/_git.py
@@ -232,6 +232,7 @@ class Git(Base):
                 "-C",
                 self.source_dir,
                 "commit",
+                "--no-gpg-sign",
                 "--message",
                 message,
                 "--author",

--- a/snapcraft/internal/sources/_git.py
+++ b/snapcraft/internal/sources/_git.py
@@ -18,6 +18,7 @@ import os
 import re
 import subprocess
 import sys
+from typing import List
 
 from . import errors
 from ._base import Base
@@ -139,6 +140,16 @@ class Git(Base):
             self._call_kwargs["stdout"] = subprocess.DEVNULL
             self._call_kwargs["stderr"] = subprocess.DEVNULL
 
+    def _run_git_command(self, command: List[str]) -> None:
+        try:
+            subprocess.check_output(command)
+        except subprocess.CalledProcessError as error:
+            raise errors.GitCommandError(
+                command=command,
+                exit_code=error.returncode,
+                output=error.output.decode(),
+            )
+
     def _pull_existing(self):
         refspec = "HEAD"
         if self.source_branch:
@@ -203,43 +214,37 @@ class Git(Base):
         self.source_details = self._get_source_details()
 
     def push(self, url, refspec, force=False):
+        command = [self.command, "-C", self.source_dir, "push", url, refspec]
+
         if force:
-            self._run(
-                [self.command, "-C", self.source_dir, "push", "--force", url, refspec],
-                **self._call_kwargs
-            )
-        else:
-            self._run(
-                [self.command, "-C", self.source_dir, "push", url, refspec],
-                **self._call_kwargs
-            )
+            command.append("--force")
+
+        self._run_git_command(command)
 
     def init(self):
-        self._run([self.command, "-C", self.source_dir, "init"], **self._call_kwargs)
+        command = [self.command, "-C", self.source_dir, "init"]
+        self._run_git_command(command)
 
     def add(self, file):
         if file.startswith(self.source_dir):
             file = os.path.relpath(file, self.source_dir)
 
-        self._run(
-            [self.command, "-C", self.source_dir, "add", file], **self._call_kwargs
-        )
+        command = [self.command, "-C", self.source_dir, "add", file]
+        self._run_git_command(command)
 
     def commit(self, message, author="snapcraft <snapcraft@snapcraft.local>"):
-        self._run(
-            [
-                self.command,
-                "-C",
-                self.source_dir,
-                "commit",
-                "--no-gpg-sign",
-                "--message",
-                message,
-                "--author",
-                author,
-            ],
-            **self._call_kwargs
-        )
+        command = [
+            self.command,
+            "-C",
+            self.source_dir,
+            "commit",
+            "--no-gpg-sign",
+            "--message",
+            message,
+            "--author",
+            author,
+        ]
+        self._run_git_command(command)
 
     def _get_source_details(self):
         tag = self.source_tag

--- a/snapcraft/internal/sources/errors.py
+++ b/snapcraft/internal/sources/errors.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import shlex
+
 from snapcraft import formatting_utils
 from snapcraft.internal import errors
 
@@ -121,7 +123,7 @@ class SnapcraftPullError(SnapcraftSourceError):
 
     def __init__(self, command, exit_code):
         if isinstance(command, list):
-            string_command = " ".join(command)
+            string_command = " ".join(shlex.quote(i) for i in command)
         else:
             string_command = command
         super().__init__(command=string_command, exit_code=exit_code)

--- a/snapcraft/internal/sources/errors.py
+++ b/snapcraft/internal/sources/errors.py
@@ -132,3 +132,19 @@ class SnapcraftPullError(SnapcraftSourceError):
 class SnapcraftRequestError(SnapcraftSourceError):
 
     fmt = "Network request error: {message}"
+
+
+class GitCommandError(errors.SnapcraftException):
+    def __init__(self, *, command: List[str], exit_code: int, output: str) -> None:
+        self._command = " ".join(shlex.quote(i) for i in command)
+        self._exit_code = exit_code
+        self._output = output
+
+    def get_brief(self) -> str:
+        return f"Failed to execute git command: {self._command}"
+
+    def get_details(self) -> str:
+        return f"Command failed with exit code {self._exit_code!r} and output:\n{self._output}"
+
+    def get_resolution(self) -> str:
+        return "Consider checking your git configuration for settings which may cause issues."

--- a/tests/unit/sources/test_errors.py
+++ b/tests/unit/sources/test_errors.py
@@ -89,3 +89,33 @@ class ErrorFormattingTestCase(unit.TestCase):
         self.assertThat(
             str(self.exception(**self.kwargs)), Equals(self.expected_message)
         )
+
+
+class SnapcraftExceptionTests(unit.TestCase):
+
+    scenarios = (
+        (
+            "GitCommandError",
+            {
+                "exception": errors.GitCommandError,
+                "kwargs": dict(
+                    command=["echo", "hi", "$foo"],
+                    output="some error output",
+                    exit_code=0,
+                ),
+                "expected_brief": "Failed to execute git command: echo hi '$foo'",
+                "expected_resolution": "Consider checking your git configuration for settings which may cause issues.",
+                "expected_details": "Command failed with exit code 0 and output:\nsome error output",
+                "expected_docs_url": None,
+                "expected_reportable": False,
+            },
+        ),
+    )
+
+    def test_snapcraft_exception_handling(self):
+        exception = self.exception(**self.kwargs)
+        self.assertEquals(self.expected_brief, exception.get_brief())
+        self.assertEquals(self.expected_resolution, exception.get_resolution())
+        self.assertEquals(self.expected_details, exception.get_details())
+        self.assertEquals(self.expected_docs_url, exception.get_docs_url())
+        self.assertEquals(self.expected_reportable, exception.get_reportable())


### PR DESCRIPTION
remote-build: use easier to read git commit message format
sources: introduce GitCommandError for improved user-facing errors
sources: improve command quoting in SnapcraftPullError
sources: disable gpg signing for git commit

@flexiondotorg reported his git config enabled GPG signing which broke remote-build's use of git.

This series disables gpg-signing as well as improves user-facing messaging in a few areas so the user can more easily determine what went wrong.