### PR TITLE
snap: only ship .pyc files, strip shared objects

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -98,7 +98,9 @@ parts:
 
         echo "Compiling pyc files..."
         # This is the last step, let's now compile all our pyc files.
-        "$SNAPCRAFT_PART_INSTALL/usr/bin/python3" -m compileall -q .
+        "$SNAPCRAFT_PART_INSTALL/usr/bin/python3" -m compileall -b -q .
+        find . -type f -name '*.py' -exec rm {} \;
+        find . -type f -name "*.so" -exec strip -s {} \;
 
     after: [snapcraft-libs]
 
@@ -114,6 +116,7 @@ parts:
         $SNAPCRAFT_PROJECT_DIR/tools/snapcraft-override-build.sh
 
         sed -ri 's|(lib/.*/site-packages)|legacy_snapcraft/\1|' $SNAPCRAFT_PART_INSTALL/usr/lib/python3.6/sitecustomize.py
+        find . -type f -name "*.so" -exec strip -s {} \;
     organize:
         '*': legacy_snapcraft/
     after: [snapcraft-libs]


### PR DESCRIPTION
- [*] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [*] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [*] Have you successfully run `./runtests.sh static`?
- [*] Have you successfully run `./runtests.sh tests/unit`?

-----
To speed things up snapcraft ships .pyc files as part of its snap package, at the same times it also ships .py files. This is duplication and increases the size of the snap unneeded.

This PR also strips shared objects that are bundled with snapcraft.

The change reduces the download size of the snap by 15Mb
