### PR TITLE
remote-build: configurable timeout/deadline for starting and monitoring build

### DIFF
--- a/snapcraft/cli/remote.py
+++ b/snapcraft/cli/remote.py
@@ -140,6 +140,7 @@ def remote_build(
 
     if status:
         _print_status(lp)
+        return
     elif recover:
         # Recover from interrupted build.
         if not lp.has_outstanding_build():
@@ -147,30 +148,24 @@ def remote_build(
             return
 
         echo.info("Recovering build...")
-        _monitor_build(lp)
-    elif lp.has_outstanding_build():
-        # There was a previous build that hasn't finished.
-        # Recover from interrupted build.
-        echo.info("Found previously started build.")
-        _print_status(lp)
-
-        if not echo.confirm("Do you wish to recover this build?", default=True):
-            _clean_build(lp)
-            _start_build(
-                lp=lp,
-                project=project,
-                build_id=build_id,
-                package_all_sources=package_all_sources,
-            )
-        _monitor_build(lp)
     else:
+        if lp.has_outstanding_build():
+            # There was a previous build that hasn't finished.
+            # Recover from interrupted build.
+            echo.info("Found previously started build.")
+            _print_status(lp)
+
+            if not echo.confirm("Do you wish to recover this build?", default=True):
+                _clean_build(lp)
+
         _start_build(
             lp=lp,
             project=project,
             build_id=build_id,
             package_all_sources=package_all_sources,
         )
-        _monitor_build(lp)
+
+    _monitor_build(lp)
 
 
 def _clean_build(lp: LaunchpadClient):

--- a/snapcraft/internal/remote_build/errors.py
+++ b/snapcraft/internal/remote_build/errors.py
@@ -89,9 +89,9 @@ class RemoteBuilderNotSupportedError(RemoteBuildBaseError):
         super().__init__(provider=provider)
 
 
-class RemoteBuilderNotReadyError(RemoteBuildBaseError):
+class RemoteBuildTimeoutError(RemoteBuildBaseError):
 
-    fmt = "Remote builder is not ready, please wait a few moments and try again."
+    fmt = "Remote build exceeded configured timeout."
 
 
 class RemoteBuilderError(RemoteBuildBaseError):


### PR DESCRIPTION
The error was ambiguous when the timeout was hit, and there was no recourse for the user.

Re-instate a configurable timeout as `--launchpad-timeout` but apply it to both the start_build and monitor_build as a deadline.  When Launchpad is slow, it may take some time to process the request, but as long as its Pending, we keep waiting for a response (unless deadline is hit).