### PR TITLE
base plugin: use shlex quoting for logged command in run()

### DIFF
--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -17,6 +17,7 @@
 import contextlib
 import logging
 import os
+import shlex
 from subprocess import CalledProcessError
 
 from snapcraft.internal import common, errors
@@ -186,7 +187,8 @@ class BasePlugin:
     def run(self, cmd, cwd=None, **kwargs):
         if not cwd:
             cwd = self.builddir
-        print(" ".join(cmd))
+        cmd_string = " ".join([shlex.quote(c) for c in cmd])
+        print(cmd_string)
         os.makedirs(cwd, exist_ok=True)
         try:
             return common.run(cmd, cwd=cwd, **kwargs)


### PR DESCRIPTION
Print a more accurate representation of the command being executed.
Similar to other runs throughout the codebase.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
