### PR TITLE
Catkin plugin: consider only 'local' workspaces

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -1038,14 +1038,14 @@ class _Catkin:
             # Source our own workspace so we have all of Catkin's dependencies,
             # then source the workspace we're actually supposed to be crawling.
             lines.append(
-                "_CATKIN_SETUP_DIR={} source {}".format(
+                "_CATKIN_SETUP_DIR={} source {} --local".format(
                     ros_path, os.path.join(ros_path, "setup.sh")
                 )
             )
 
             for workspace in self._workspaces:
                 lines.append(
-                    "_CATKIN_SETUP_DIR={} source {} --extend".format(
+                    "_CATKIN_SETUP_DIR={} source {} --local --extend".format(
                         workspace, os.path.join(workspace, "setup.sh")
                     )
                 )

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -579,9 +579,10 @@ class CatkinPlugin(snapcraft.BasePlugin):
             source_script = textwrap.dedent(
                 """
                 if [ -f {underlay_setup} ]; then
+                    set -- --local
                     _CATKIN_SETUP_DIR={underlay} . {underlay_setup}
                     if [ -f {rosdir_setup} ]; then
-                        set -- --extend
+                        set -- --local --extend
                         _CATKIN_SETUP_DIR={rosdir} . {rosdir_setup}
                     fi
                 fi
@@ -596,6 +597,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
             source_script = textwrap.dedent(
                 """
                 if [ -f {rosdir_setup} ]; then
+                    set -- --local
                     _CATKIN_SETUP_DIR={rosdir} . {rosdir_setup}
                 fi
             """

--- a/tests/unit/plugins/test_catkin.py
+++ b/tests/unit/plugins/test_catkin.py
@@ -931,7 +931,7 @@ class CatkinPluginTestCase(CatkinPluginBaseTest):
         lines_of_interest = [
             "set --",
             "if [ -f {} ]; then".format(underlay_setup_path),
-            "set -- --local"
+            "set -- --local",
             "_CATKIN_SETUP_DIR={} . {}".format("test-underlay", underlay_setup_path),
             "if [ -f {} ]; then".format(setup_path),
             "set -- --local --extend",

--- a/tests/unit/plugins/test_catkin.py
+++ b/tests/unit/plugins/test_catkin.py
@@ -898,6 +898,7 @@ class CatkinPluginTestCase(CatkinPluginBaseTest):
         lines_of_interest = [
             "set --",
             "if [ -f {} ]; then".format(setup_path),
+            "set -- --local",
             "_CATKIN_SETUP_DIR={} . {}".format(rosdir, setup_path),
             "fi",
             'eval "set -- $BACKUP_ARGS"',
@@ -930,9 +931,10 @@ class CatkinPluginTestCase(CatkinPluginBaseTest):
         lines_of_interest = [
             "set --",
             "if [ -f {} ]; then".format(underlay_setup_path),
+            "set -- --local"
             "_CATKIN_SETUP_DIR={} . {}".format("test-underlay", underlay_setup_path),
             "if [ -f {} ]; then".format(setup_path),
-            "set -- --extend",
+            "set -- --local --extend",
             "_CATKIN_SETUP_DIR={} . {}".format(rosdir, setup_path),
             "fi",
             "fi",


### PR DESCRIPTION
This PR fixes a bug when calling snapcraft with `--destructive-mode`.
Some installation paths from the host machine leak into the list of paths considered by the catkin plugin. It results in having dependencies being found (in the host path) and thus not being installed by the plugin in the expected 'parts' path.

In the 'pull' step, prior to building, the ROS dependencies of the package(s) to be built are retrieved.
When checking whether a dependency is available 'locally' or should be installed, the `catkin_find` tool will look into workspaces exported in `CMAKE_PREFIX_PATH` among other paths:
[`catkin_find` calls `find_in_workspaces`](https://github.com/ros/catkin/blob/kinetic-devel/bin/catkin_find#L41) which in turns [calls `get_workspaces`](https://github.com/ros/catkin/blob/kinetic-devel/python/catkin/find_in_workspaces.py#L114) which [retrieve those from `CMAKE_PREFIX_PATH`](https://github.com/ros/catkin/blob/kinetic-devel/python/catkin/workspace.py#L46).

Now, in order for `catkin_find` to work, some ROS-related environment variables are exported by sourcing an automatically generated (ag.) script.
The ag. script `opt/ros/melodic/_setup_util.py` (called by ag. `opt/ros/melodic/setup.sh`) [sets the variable `CMAKE_PREFIX_PATH` to `/opt/ros/<distro>`](https://github.com/ros/catkin/blob/kinetic-devel/cmake/templates/_setup_util.py.in#L273) by default. This results in having the path to the ROS install on the host being searched when looking for packages.
To prevent looking into `CMAKE_PREFIX_PATH`, the flag `--local` is passed to `opt/ros/<distro>/setup.sh` when sourcing it.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
