### PR TITLE
rust plugin: split RUSTUP_HOME and CARGO_HOME

### DIFF
--- a/snapcraft/plugins/rust.py
+++ b/snapcraft/plugins/rust.py
@@ -96,11 +96,12 @@ class RustPlugin(snapcraft.BasePlugin):
             )
 
         self.build_packages.extend(["gcc", "git", "curl", "file"])
-        self._rust_dir = os.path.expanduser(os.path.join("~", ".cargo"))
-        self._rustup_cmd = os.path.join(self._rust_dir, "bin", "rustup")
-        self._cargo_cmd = os.path.join(self._rust_dir, "bin", "cargo")
-        self._rustc_cmd = os.path.join(self._rust_dir, "bin", "rustc")
-        self._rustdoc_cmd = os.path.join(self._rust_dir, "bin", "rustdoc")
+        self._rustup_dir = os.path.expanduser(os.path.join("~", ".rustup"))
+        self._cargo_dir = os.path.expanduser(os.path.join("~", ".cargo"))
+        self._rustup_cmd = os.path.join(self._cargo_dir, "bin", "rustup")
+        self._cargo_cmd = os.path.join(self._cargo_dir, "bin", "cargo")
+        self._rustc_cmd = os.path.join(self._cargo_dir, "bin", "rustc")
+        self._rustdoc_cmd = os.path.join(self._cargo_dir, "bin", "rustdoc")
 
         self._manifest = collections.OrderedDict()
 
@@ -117,13 +118,13 @@ class RustPlugin(snapcraft.BasePlugin):
 
     def _fetch_rustup(self):
         # if rustup-init has already been done, we can skip this.
-        if os.path.exists(os.path.join(self._rust_dir, "bin", "rustup")):
+        if os.path.exists(self._rustup_cmd):
             return
 
         # Download rustup-init.
-        os.makedirs(self._rust_dir, exist_ok=True)
-        rustup_init_cmd = os.path.join(self._rust_dir, "rustup.sh")
-        sources.Script(_RUSTUP, self._rust_dir).download(filepath=rustup_init_cmd)
+        os.makedirs(self._rustup_dir, exist_ok=True)
+        rustup_init_cmd = os.path.join(self._rustup_dir, "rustup.sh")
+        sources.Script(_RUSTUP, self._rustup_dir).download(filepath=rustup_init_cmd)
 
         # Basic options:
         # -y: assume yes
@@ -231,7 +232,7 @@ class RustPlugin(snapcraft.BasePlugin):
     def _build_env(self):
         env = os.environ.copy()
 
-        env.update(dict(RUSTUP_HOME=self._rust_dir, CARGO_HOME=self._rust_dir))
+        env.update(dict(RUSTUP_HOME=self._rustup_dir, CARGO_HOME=self._cargo_dir))
 
         rustflags = self._get_rustflags()
         if rustflags:

--- a/tests/unit/plugins/test_rust.py
+++ b/tests/unit/plugins/test_rust.py
@@ -162,7 +162,7 @@ class RustPluginCrossCompileTest(RustPluginBaseTest):
             [
                 mock.call(
                     [
-                        os.path.join(plugin._rust_dir, "rustup.sh"),
+                        os.path.join(plugin._rustup_dir, "rustup.sh"),
                         "-y",
                         "--no-modify-path",
                         "--default-toolchain",
@@ -243,7 +243,7 @@ class RustPluginCrossCompileTest(RustPluginBaseTest):
             [
                 mock.call(
                     [
-                        os.path.join(plugin._rust_dir, "rustup.sh"),
+                        os.path.join(plugin._rustup_dir, "rustup.sh"),
                         "-y",
                         "--no-modify-path",
                     ],
@@ -329,7 +329,7 @@ class RustPluginTest(RustPluginBaseTest):
             [
                 mock.call(
                     [
-                        os.path.join(plugin._rust_dir, "rustup.sh"),
+                        os.path.join(plugin._rustup_dir, "rustup.sh"),
                         "-y",
                         "--no-modify-path",
                         "--default-toolchain",
@@ -374,7 +374,7 @@ class RustPluginTest(RustPluginBaseTest):
             [
                 mock.call(
                     [
-                        os.path.join(plugin._rust_dir, "rustup.sh"),
+                        os.path.join(plugin._rustup_dir, "rustup.sh"),
                         "-y",
                         "--no-modify-path",
                     ],
@@ -409,7 +409,7 @@ class RustPluginTest(RustPluginBaseTest):
             [
                 mock.call(
                     [
-                        os.path.join(plugin._rust_dir, "rustup.sh"),
+                        os.path.join(plugin._rustup_dir, "rustup.sh"),
                         "-y",
                         "--no-modify-path",
                         "--default-toolchain",
@@ -452,7 +452,7 @@ class RustPluginTest(RustPluginBaseTest):
             [
                 mock.call(
                     [
-                        os.path.join(plugin._rust_dir, "rustup.sh"),
+                        os.path.join(plugin._rustup_dir, "rustup.sh"),
                         "-y",
                         "--no-modify-path",
                         "--default-toolchain",
@@ -494,7 +494,7 @@ class RustPluginTest(RustPluginBaseTest):
             [
                 mock.call(
                     [
-                        os.path.join(plugin._rust_dir, "rustup.sh"),
+                        os.path.join(plugin._rustup_dir, "rustup.sh"),
                         "-y",
                         "--no-modify-path",
                         "--default-toolchain",


### PR DESCRIPTION
RUSTUP_HOME is typically ~/.rustup
CARGO_HOME is typically ~/.cargo

They are both currently set to ~/.cargo.

It has been reported that overlapping the two may have side
effects.  While I have not yet reproduced this, it's probably
a good idea to decouple the two directories anyways.

LP: #1852545

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
