### PR TITLE
hooks: enable command-chain

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -640,6 +640,14 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                        "command-chain": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "pattern": "^[A-Za-z0-9/._#:$-]*$",
+                                "validation-failure": "{.instance!r} is not a valid command-chain entry. Command chain entries must be strings, and can only use ASCII alphanumeric characters and the following special characters: / . _ # : $ -"
+                            }
+                        },
                         "plugs": {
                             "type": "array",
                             "minitems": 1,

--- a/snapcraft/internal/meta/hooks.py
+++ b/snapcraft/internal/meta/hooks.py
@@ -14,11 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import OrderedDict
 import re
+from collections import OrderedDict
+from typing import Any, Dict, List, Optional
 
 from snapcraft.internal.meta.errors import HookValidationError
-from typing import Any, Dict, List, Optional
 
 
 class Hook:

--- a/snapcraft/internal/meta/hooks.py
+++ b/snapcraft/internal/meta/hooks.py
@@ -30,7 +30,7 @@ class Hook:
         hook_name: str,
         command_chain: Optional[List[str]] = None,
         plugs: Optional[List[str]] = None,
-        passthrough: Optional[Dict[str, Any]] = None
+        passthrough: Optional[Dict[str, Any]] = None,
     ) -> None:
         self._hook_name = hook_name
 
@@ -63,10 +63,22 @@ class Hook:
                 ),
             )
 
+    def _validate_command_chain(self) -> None:
+        """Validate command-chain names."""
+
+        # Would normally get caught/handled by schema validation.
+        for command in self.command_chain:
+            if not re.match("^[A-Za-z0-9/._#:$-]*$", command):
+                raise HookValidationError(
+                    hook_name=self.hook_name,
+                    message=f"{command!r} is not a valid command-chain command.",
+                )
+
     def validate(self) -> None:
         """Validate hook, raising exception if invalid."""
 
         self._validate_name()
+        self._validate_command_chain()
 
     @classmethod
     def from_dict(cls, hook_dict: Dict[str, Any], hook_name: str) -> "Hook":

--- a/snapcraft/internal/meta/hooks.py
+++ b/snapcraft/internal/meta/hooks.py
@@ -28,10 +28,15 @@ class Hook:
         self,
         *,
         hook_name: str,
+        command_chain: Optional[List[str]] = None,
         plugs: Optional[List[str]] = None,
         passthrough: Optional[Dict[str, Any]] = None
     ) -> None:
         self._hook_name = hook_name
+
+        self.command_chain: List[str] = list()
+        if command_chain:
+            self.command_chain = command_chain
 
         self.plugs: List[str] = list()
         if plugs:
@@ -69,6 +74,7 @@ class Hook:
 
         return Hook(
             hook_name=hook_name,
+            command_chain=hook_dict.get("command-chain", None),
             plugs=hook_dict.get("plugs", None),
             passthrough=hook_dict.get("passthrough", None),
         )
@@ -77,6 +83,9 @@ class Hook:
         """Create dictionary from hook."""
 
         hook_dict: Dict[str, Any] = OrderedDict()
+
+        if self.command_chain:
+            hook_dict["command-chain"] = self.command_chain
 
         if self.plugs:
             hook_dict["plugs"] = self.plugs

--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -173,6 +173,10 @@ class Snap:
             if app.command_chain:
                 self.assumes.add("command-chain")
                 return
+        for hook in self.hooks.values():
+            if hook.command_chain:
+                self.assumes.add("command-chain")
+                return
 
     @classmethod  # noqa: C901
     def from_dict(cls, snap_dict: Dict[str, Any]) -> "Snap":

--- a/tests/unit/meta/test_hook.py
+++ b/tests/unit/meta/test_hook.py
@@ -62,3 +62,13 @@ class GenericHookTests(unit.TestCase):
 
         self.assertEqual(hook.to_dict(), hook_dict)
         self.assertEqual(hook.hook_name, hook_name)
+
+    def test_command_chain(self):
+        hook_dict = OrderedDict({"command-chain": ["cmd1", "cmd2"]})
+        hook_name = "hook-test"
+
+        hook = Hook.from_dict(hook_dict=hook_dict, hook_name=hook_name)
+        hook.validate()
+
+        self.assertEqual(hook.to_dict(), hook_dict)
+        self.assertEqual(hook.hook_name, hook_name)

--- a/tests/unit/meta/test_hook.py
+++ b/tests/unit/meta/test_hook.py
@@ -15,6 +15,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from collections import OrderedDict
+
+from testtools.matchers import Equals
+
+from snapcraft.internal.meta import errors
 from snapcraft.internal.meta.hooks import Hook
 from tests import unit
 
@@ -72,3 +76,17 @@ class GenericHookTests(unit.TestCase):
 
         self.assertEqual(hook.to_dict(), hook_dict)
         self.assertEqual(hook.hook_name, hook_name)
+
+    def test_invalid_command_chain(self):
+        hook_dict = OrderedDict({"command-chain": ["&/foo/bar"]})
+        hook_name = "hook-test"
+
+        hook = Hook.from_dict(hook_dict=hook_dict, hook_name=hook_name)
+
+        error = self.assertRaises(errors.HookValidationError, hook.validate)
+        self.assertThat(
+            str(error),
+            Equals(
+                "failed to validate hook=hook-test: '&/foo/bar' is not a valid command-chain command."
+            ),
+        )

--- a/tests/unit/meta/test_hook.py
+++ b/tests/unit/meta/test_hook.py
@@ -40,8 +40,21 @@ class GenericHookTests(unit.TestCase):
         self.assertEqual(hook.to_dict(), hook_dict)
         self.assertEqual(hook.hook_name, hook_name)
 
-    def test_simple_dict(self):
-        hook_dict = OrderedDict({"somekey": "somevalue"})
+    def test_passthrough(self):
+        hook_dict = OrderedDict({"passthrough": {"otherkey": "othervalue"}})
+        hook_name = "hook-test"
+
+        hook = Hook.from_dict(hook_dict=hook_dict, hook_name=hook_name)
+        hook.validate()
+
+        transformed_dict = OrderedDict({"otherkey": "othervalue"})
+
+        self.assertEqual(hook.to_dict(), transformed_dict)
+        self.assertEqual(hook.hook_name, hook_name)
+        self.assertEqual(hook.passthrough, hook_dict["passthrough"])
+
+    def test_plugs(self):
+        hook_dict = OrderedDict({"plugs": ["plug1", "plug2"]})
         hook_name = "hook-test"
 
         hook = Hook.from_dict(hook_dict=hook_dict, hook_name=hook_name)
@@ -49,20 +62,3 @@ class GenericHookTests(unit.TestCase):
 
         self.assertEqual(hook.to_dict(), hook_dict)
         self.assertEqual(hook.hook_name, hook_name)
-
-    def test_passthrough(self):
-        hook_dict = OrderedDict(
-            {"somekey": "somevalue", "passthrough": {"otherkey": "othervalue"}}
-        )
-        hook_name = "hook-test"
-
-        hook = Hook.from_dict(hook_dict=hook_dict, hook_name=hook_name)
-        hook.validate()
-
-        transformed_dict = OrderedDict(
-            {"somekey": "somevalue", "otherkey": "othervalue"}
-        )
-
-        self.assertEqual(hook.to_dict(), transformed_dict)
-        self.assertEqual(hook.hook_name, hook_name)
-        self.assertEqual(hook.passthrough, hook_dict["passthrough"])

--- a/tests/unit/meta/test_snap.py
+++ b/tests/unit/meta/test_snap.py
@@ -135,7 +135,9 @@ class SnapTests(unit.TestCase):
                 "environment": {"TESTING": "1"},
                 "epoch": 0,
                 "grade": "devel",
-                "hooks": {"test-hook": {"plugs": ["network"]}},
+                "hooks": {
+                    "test-hook": {"command-chain": ["cmd1"], "plugs": ["network"]}
+                },
                 "layout": {"/target": {"bind": "$SNAP/foo"}},
                 "license": "GPL",
                 "plugs": {"test-plug": OrderedDict({"interface": "some-value"})},
@@ -159,6 +161,9 @@ class SnapTests(unit.TestCase):
         self.assertEqual(set(snap_dict["assumes"]), snap.assumes)
         self.assertEqual(snap_dict["base"], snap.base)
         self.assertEqual(snap_dict["environment"], snap.environment)
+        self.assertEqual(
+            snap_dict["hooks"]["test-hook"], snap.hooks["test-hook"].to_dict()
+        )
         self.assertEqual(snap_dict["license"], snap.license)
         self.assertEqual(
             snap_dict["plugs"]["test-plug"], snap.plugs["test-plug"].to_dict()


### PR DESCRIPTION
Enables command-chain regardless of base, but does not actively enable or otherwise use it. It just passes it through if the user configures it in their snapcraft yaml.