### PR TITLE
wstool: don't rely on host git

### DIFF
--- a/snapcraft/plugins/_ros/wstool.py
+++ b/snapcraft/plugins/_ros/wstool.py
@@ -163,9 +163,12 @@ class Wstool:
 
         env["PATH"] += ":" + os.path.join(self._wstool_install_path, "usr", "bin")
 
-        if "LD_LIBRARY_PATH" not in env:
-            env["LD_LIBRARY_PATH"] = ""
-        env["LD_LIBRARY_PATH"] += ":" + snapcraft.formatting_utils.combine_paths(
+        if "LD_LIBRARY_PATH" in env:
+            env["LD_LIBRARY_PATH"] += ":"
+        ld_library_path = env.get("LD_LIBRARY_PATH", "")
+        env[
+            "LD_LIBRARY_PATH"
+        ] = ld_library_path + snapcraft.formatting_utils.combine_paths(
             snapcraft.common.get_library_paths(
                 self._wstool_install_path, self._project.arch_triplet
             ),

--- a/snapcraft/plugins/_ros/wstool.py
+++ b/snapcraft/plugins/_ros/wstool.py
@@ -162,6 +162,23 @@ class Wstool:
         env = os.environ.copy()
 
         env["PATH"] += ":" + os.path.join(self._wstool_install_path, "usr", "bin")
+
+        if "LD_LIBRARY_PATH" not in env:
+            env["LD_LIBRARY_PATH"] = ""
+        env["LD_LIBRARY_PATH"] += ":" + snapcraft.formatting_utils.combine_paths(
+            snapcraft.common.get_library_paths(
+                self._wstool_install_path, self._project.arch_triplet
+            ),
+            prepend="",
+            separator=":",
+        )
+
+        # Make sure git can be used out of the wstool install path instead of needing
+        # to be a build-package
+        env["GIT_EXEC_PATH"] = os.path.join(
+            self._wstool_install_path, "usr", "lib", "git-core"
+        )
+
         env["PYTHONPATH"] = os.path.join(
             self._wstool_install_path, "usr", "lib", "python2.7", "dist-packages"
         )

--- a/tests/spread/plugins/catkin/catkin-with-python/task.yaml
+++ b/tests/spread/plugins/catkin/catkin-with-python/task.yaml
@@ -24,7 +24,7 @@ execute: |
 
   # rosinstall files shouldn't require git to be installed, and this test is only
   # completely valid if it ISN'T installed
-  apt remove --yes git || true
+  apt-get remove --yes git || true
 
   # Staging should cause no conflicts
   snapcraft stage

--- a/tests/spread/plugins/catkin/catkin-with-python/task.yaml
+++ b/tests/spread/plugins/catkin/catkin-with-python/task.yaml
@@ -22,5 +22,9 @@ restore: |
 execute: |
   cd "$SNAP_DIR"
 
+  # rosinstall files shouldn't require git to be installed, and this test is only
+  # completely valid if it ISN'T installed
+  apt remove --yes git || true
+
   # Staging should cause no conflicts
   snapcraft stage

--- a/tests/spread/plugins/catkin/snaps/catkin-with-python-part/snap/snapcraft.yaml
+++ b/tests/spread/plugins/catkin/snaps/catkin-with-python-part/snap/snapcraft.yaml
@@ -18,8 +18,6 @@ parts:
   catkin-part:
     plugin: catkin
     source: .
-    build-packages:
-    - git
     rosinstall-files: [ros_tutorials.rosinstall]
     catkin-packages:
       - roscpp_tutorials

--- a/tests/unit/plugins/ros/test_wstool.py
+++ b/tests/unit/plugins/ros/test_wstool.py
@@ -18,7 +18,7 @@ import os
 import subprocess
 
 from unittest import mock
-from testtools.matchers import Equals
+from testtools.matchers import Contains, Equals
 
 from snapcraft.plugins._ros import wstool
 
@@ -158,20 +158,67 @@ class WstoolTestCase(unit.TestCase):
 
     def test_run(self):
         wstool = self.wstool
+
+        # Create a single library directory for asserting LD_LIBRARY_PATH is set
+        # properly.
+        os.makedirs(os.path.join(wstool._wstool_install_path, "lib"))
+
         wstool._run(["init"])
 
         class check_env:
+            def __init__(self, test):
+                self.test = test
+
             def __eq__(self, env):
-                return env["PATH"] == os.environ["PATH"] + ":" + os.path.join(
-                    wstool._wstool_install_path, "usr", "bin"
-                ) and env["PYTHONPATH"] == os.path.join(
-                    wstool._wstool_install_path,
-                    "usr",
-                    "lib",
-                    "python2.7",
-                    "dist-packages",
+                for variable in (
+                    "PATH",
+                    "LD_LIBRARY_PATH",
+                    "GIT_EXEC_PATH",
+                    "PYTHONPATH",
+                ):
+                    self.test.assertThat(env, Contains(variable))
+
+                self.test.assertThat(
+                    env["PATH"],
+                    Equals(
+                        "{}:{}".format(
+                            os.environ["PATH"],
+                            os.path.join(wstool._wstool_install_path, "usr", "bin"),
+                        )
+                    ),
                 )
 
+                self.test.assertThat(
+                    env["LD_LIBRARY_PATH"],
+                    Equals(
+                        ":{}".format(os.path.join(wstool._wstool_install_path, "lib"))
+                    ),
+                )
+
+                self.test.assertThat(
+                    env["GIT_EXEC_PATH"],
+                    Equals(
+                        os.path.join(
+                            wstool._wstool_install_path, "usr", "lib", "git-core"
+                        )
+                    ),
+                )
+
+                self.test.assertThat(
+                    env["PYTHONPATH"],
+                    Equals(
+                        os.path.join(
+                            wstool._wstool_install_path,
+                            "usr",
+                            "lib",
+                            "python2.7",
+                            "dist-packages",
+                        )
+                    ),
+                )
+
+                return True
+
         self.check_output_mock.assert_called_with(
-            mock.ANY, env=check_env(), stderr=subprocess.PIPE
+            mock.ANY, env=check_env(self), stderr=subprocess.PIPE
         )

--- a/tests/unit/plugins/ros/test_wstool.py
+++ b/tests/unit/plugins/ros/test_wstool.py
@@ -191,7 +191,7 @@ class WstoolTestCase(unit.TestCase):
                 self.test.assertThat(
                     env["LD_LIBRARY_PATH"],
                     Equals(
-                        ":{}".format(os.path.join(wstool._wstool_install_path, "lib"))
+                        "{}".format(os.path.join(wstool._wstool_install_path, "lib"))
                     ),
                 )
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

The Catkin plugin utilizes wstool to support rosinstall files. While wstool is fetched into its own install area so as to not contaminate either the host or the snap, it doesn't properly use the git that is fetched along with it. This means that merging rosinstall files that include git repositories only works if git is already installed on the host. If the host doesn't include git, it errors out.

This PR properly sets the variables necessary to run git from wstool's install area, thereby no longer relying on the host already having git installed.