### PR TITLE
meta: do not set snapcraft-runner when adapter is "none"

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -367,8 +367,14 @@ class _SnapPackaging:
 
     def finalize_snap_meta_command_chains(self) -> None:
         prepend_command_chain = self._generate_command_chain()
+
+        if not prepend_command_chain:
+            return
+
         for app_name, app in self._snap_meta.apps.items():
-            app.prepend_command_chain = prepend_command_chain
+            # Add runner to command chain if adapter is not "none".
+            if app.adapter != "none":
+                app.prepend_command_chain = prepend_command_chain
 
     def finalize_snap_meta_version(self) -> None:
         # Reparse the version, the order should stick.

--- a/tests/spread/general/adapter/expected_snap.yaml
+++ b/tests/spread/general/adapter/expected_snap.yaml
@@ -1,0 +1,26 @@
+name: adapter-tests
+version: '1.0'
+summary: adapter-tests
+description: adapter-tests
+apps:
+  adapter-full:
+    command: test-cmd
+    command-chain:
+    - snap/command-chain/snapcraft-runner
+  adapter-legacy:
+    command: test-cmd
+    command-chain:
+    - snap/command-chain/snapcraft-runner
+  adapter-none:
+    command: test-cmd
+    command-chain:
+    - snap/command-chain/snapcraft-runner
+  wrapped-default:
+    command: command-wrapped-default.wrapper
+    command-chain:
+    - snap/command-chain/snapcraft-runner
+architectures:
+- amd64
+base: core18
+confinement: strict
+grade: devel

--- a/tests/spread/general/adapter/expected_snap.yaml
+++ b/tests/spread/general/adapter/expected_snap.yaml
@@ -13,8 +13,6 @@ apps:
     - snap/command-chain/snapcraft-runner
   adapter-none:
     command: test-cmd
-    command-chain:
-    - snap/command-chain/snapcraft-runner
   wrapped-default:
     command: command-wrapped-default.wrapper
     command-chain:

--- a/tests/spread/general/adapter/snaps/adapter-tests/snapcraft.yaml
+++ b/tests/spread/general/adapter/snaps/adapter-tests/snapcraft.yaml
@@ -1,0 +1,28 @@
+name: adapter-tests
+version: "1.0"
+summary: adapter-tests
+description: adapter-tests
+
+base: core18
+grade: devel
+confinement: strict
+
+parts:
+  adapter-tests:
+    plugin: nil
+    source: .
+    override-build:
+      install -m 0755 test-cmd $SNAPCRAFT_PART_INSTALL/
+
+apps:
+  adapter-none:
+    command: test-cmd
+    adapter: none
+  adapter-full:
+    command: test-cmd
+    adapter: full
+  adapter-legacy:
+    command: test-cmd
+    adapter: legacy
+  wrapped-default:
+    command: test-cmd --test "@"

--- a/tests/spread/general/adapter/snaps/adapter-tests/test-cmd
+++ b/tests/spread/general/adapter/snaps/adapter-tests/test-cmd
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "hi"

--- a/tests/spread/general/adapter/task.yaml
+++ b/tests/spread/general/adapter/task.yaml
@@ -1,0 +1,23 @@
+summary: Build a snap that tests adapter settings
+
+# This test snap uses core18
+systems: [ubuntu-18*]
+
+environment:
+  SNAP_DIR: snaps/adapter-tests
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft prime
+
+  expected_snap_yaml="$PWD/../../expected_snap.yaml"
+
+  if ! diff prime/meta/snap.yaml "$expected_snap_yaml"; then
+      echo "The formatting for snap.yaml is incorrect"
+      exit 1
+  fi

--- a/tests/spread/general/adapter/task.yaml
+++ b/tests/spread/general/adapter/task.yaml
@@ -17,7 +17,7 @@ execute: |
 
   expected_snap_yaml="$PWD/../../expected_snap.yaml"
 
-  if ! diff prime/meta/snap.yaml "$expected_snap_yaml"; then
+  if ! diff -U10 prime/meta/snap.yaml "$expected_snap_yaml"; then
       echo "The formatting for snap.yaml is incorrect"
       exit 1
   fi


### PR DESCRIPTION
When adapter == "none", snapcraft should not modify the
command or command-chain.  However snapcraft presently
ignores the adapter setting when it comes time to set
the command-chain.

Instead, honor when adapter is "none".

With these changes, given a snapcraft yaml:

```
<snipped>
apps:
  adapter-none:
    command: test-cmd
    adapter: none
  adapter-full:
    command: test-cmd
    adapter: full
  adapter-legacy:
    command: test-cmd
    adapter: legacy
  wrapped-default:
    command: test-cmd --test "@"
<snipped>
```

Will now yield:

```
apps:
  adapter-full:
    command: test-cmd
    command-chain:
    - snap/command-chain/snapcraft-runner
  adapter-legacy:
    command: test-cmd
    command-chain:
    - snap/command-chain/snapcraft-runner
  adapter-none:
    command: test-cmd
  wrapped-default:
    command: command-wrapped-default.wrapper
    command-chain:
    - snap/command-chain/snapcraft-runner
```

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
