### PR TITLE
project: remove unused errors

### DIFF
--- a/snapcraft/project/errors.py
+++ b/snapcraft/project/errors.py
@@ -97,23 +97,6 @@ class DuplicateSnapcraftYamlError(SnapcraftError):
         )
 
 
-class SanityCheckError(SnapcraftError):
-    pass
-
-
-class CommandChainWithLegacyAdapterError(SanityCheckError):
-    fmt = (
-        "The {app_name!r} app is using 'command-chain' with the 'legacy' adapter.\n"
-        "'command-chain' is incompatible with the 'legacy' adapter. Either stop using "
-        "'command-chain', or use a different adapter. If you haven't specified either, "
-        "you may be using an extension that does. Run 'snapcraft expand-extensions' to "
-        "see the snapcraft.yaml with all extensions applied."
-    )
-
-    def __init__(self, app_name):
-        super().__init__(app_name=app_name)
-
-
 def _determine_preamble(error):
     messages = []
     path = _determine_property_path(error)


### PR DESCRIPTION
Remove SanityCheckError and CommandChainWithLegacyAdapterError.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
