### PR TITLE
meta: convert Application's `adapter` from string to enum

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -34,6 +34,7 @@ from snapcraft.internal.project_loader import _config
 from snapcraft.extractors import _metadata
 from snapcraft.internal.deprecations import handle_deprecation_notice
 from snapcraft.internal.meta import errors as meta_errors, _manifest, _version
+from snapcraft.internal.meta.application import ApplicationAdapter
 from snapcraft.internal.meta.snap import Snap
 
 logger = logging.getLogger(__name__)
@@ -373,7 +374,7 @@ class _SnapPackaging:
 
         for app_name, app in self._snap_meta.apps.items():
             # Add runner to command chain if adapter is not "none".
-            if app.adapter != "none":
+            if app.adapter != ApplicationAdapter.NONE:
                 app.prepend_command_chain = prepend_command_chain
 
     def finalize_snap_meta_version(self) -> None:

--- a/snapcraft/internal/meta/application.py
+++ b/snapcraft/internal/meta/application.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import enum
 import os
 
 from copy import deepcopy
@@ -30,6 +31,13 @@ _COMMAND_ENTRIES = ["command", "stop-command"]
 _MASSAGED_BASES = ["core", "core18"]
 
 
+@enum.unique
+class ApplicationAdapter(enum.Enum):
+    NONE = 1
+    LEGACY = 2
+    FULL = 3
+
+
 class Application:
     """Representation of an app entry in snapcraft.yaml"""
 
@@ -38,7 +46,7 @@ class Application:
         *,
         app_name: str,
         app_properties: Dict[str, Any] = None,
-        adapter: str = None,
+        adapter: ApplicationAdapter,
         desktop: str = None,
         command_chain: List[str] = None,
         prepend_command_chain: List[str] = None,
@@ -91,7 +99,7 @@ class Application:
 
         # Now that command-chain and bases have been checked for,
         # check if the none adapter has been forced.
-        if self.adapter == "none":
+        if self.adapter == ApplicationAdapter.NONE:
             return False
 
         return True
@@ -148,10 +156,14 @@ class Application:
         """Create application from dictionary."""
 
         app_dict = deepcopy(app_dict)
+
+        adapter_string = app_dict.get("adapter", "full").upper()
+        adapter = ApplicationAdapter[adapter_string]
+
         app = Application(
             app_name=app_name,
             app_properties=app_dict,
-            adapter=app_dict.get("adapter", None),
+            adapter=adapter,
             desktop=app_dict.get("desktop", None),
             command_chain=app_dict.get("command-chain", None),
             passthrough=app_dict.get("passthrough", None),

--- a/snapcraft/internal/project_loader/__init__.py
+++ b/snapcraft/internal/project_loader/__init__.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import enum
 from typing import cast, Dict, List, Union
 from typing import TYPE_CHECKING
 
@@ -32,13 +31,6 @@ from ._extensions import (  # noqa: F401
 
 if TYPE_CHECKING:
     from snapcraft.project import Project  # noqa: F401
-
-
-@enum.unique
-class Adapter(enum.Enum):
-    NONE = 1
-    LEGACY = 2
-    FULL = 3
 
 
 def load_config(project: "Project"):


### PR DESCRIPTION
Introduce enum ApplicationAdapter to use instead of strings.
Remove the unused `Adapter` equivalent found in project loader.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
