### PR TITLE
meta: enable Snap to be fully initialized with __init__ parameters

### DIFF
--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -54,28 +54,91 @@ _OPTIONAL_PACKAGE_KEYS = [
 class Snap:
     """Representation of snap meta object, writes snap.yaml."""
 
-    def __init__(self) -> None:
-        self.adopt_info: Optional[str] = None
-        self.base: Optional[str] = None
-        self.name: Optional[str] = None
-        self.version: Optional[str] = None
-        self.summary: Optional[str] = None
-        self.description: Optional[str] = None
-        self.architectures: Sequence[str] = list()
-        self.assumes: Set[str] = set()
-        self.confinement: Optional[str] = None
-        self.environment: Dict[str, Any] = dict()
-        self.epoch: Any = None
-        self.grade: Optional[str] = None
-        self.license: Optional[str] = None
-        self.title: Optional[str] = None
-        self.type: Optional[str] = None
-        self.plugs: Dict[str, Plug] = dict()
-        self.slots: Dict[str, Slot] = dict()
-        self.apps: Dict[str, Application] = dict()
-        self.hooks: Dict[str, Hook] = dict()
-        self.passthrough: Dict[str, Any] = dict()
-        self.layout: Dict[str, Any] = dict()
+    def __init__(
+        self,
+        adopt_info: Optional[str] = None,
+        apps: Optional[Dict[str, Application]] = None,
+        architectures: Optional[Sequence[str]] = None,
+        assumes: Optional[Set[str]] = None,
+        base: Optional[str] = None,
+        confinement: Optional[str] = None,
+        description: Optional[str] = None,
+        environment: Optional[Dict[str, Any]] = None,
+        epoch: Any = None,
+        grade: Optional[str] = None,
+        hooks: Optional[Dict[str, Hook]] = None,
+        layout: Optional[Dict[str, Any]] = None,
+        license: Optional[str] = None,
+        name: Optional[str] = None,
+        passthrough: Optional[Dict[str, Any]] = None,
+        plugs: Optional[Dict[str, Plug]] = None,
+        slots: Optional[Dict[str, Slot]] = None,
+        summary: Optional[str] = None,
+        title: Optional[str] = None,
+        type: Optional[str] = None,
+        version: Optional[str] = None,
+    ) -> None:
+        self.adopt_info = adopt_info
+
+        if apps is None:
+            self.apps: Dict[str, Application] = dict()
+        else:
+            self.apps = apps
+
+        if architectures is None:
+            self.architectures: Sequence[str] = list()
+        else:
+            self.architectures = architectures
+
+        if assumes is None:
+            self.assumes: Set[str] = set()
+        else:
+            self.assumes = assumes
+
+        self.base = base
+        self.confinement = confinement
+        self.description = description
+
+        if environment is None:
+            self.environment: Dict[str, Any] = dict()
+        else:
+            self.environment = environment
+
+        self.epoch = epoch
+        self.grade = grade
+
+        if hooks is None:
+            self.hooks: Dict[str, Hook] = dict()
+        else:
+            self.hooks = hooks
+
+        if layout is None:
+            self.layout: Dict[str, Any] = dict()
+        else:
+            self.layout = layout
+
+        self.license = license
+        self.name = name
+
+        if passthrough is None:
+            self.passthrough: Dict[str, Any] = dict()
+        else:
+            self.passthrough = passthrough
+
+        if plugs is None:
+            self.plugs: Dict[str, Plug] = dict()
+        else:
+            self.plugs = plugs
+
+        if slots is None:
+            self.slots: Dict[str, Slot] = dict()
+        else:
+            self.slots = slots
+
+        self.summary = summary
+        self.title = title
+        self.type = type
+        self.version = version
 
     @classmethod
     def from_file(cls, snap_yaml_path: str) -> "Snap":


### PR DESCRIPTION
Make Snap fully configurable upon init.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
