### PR TITLE
spread tests: use source-depth: 1 for plainbox tests

### DIFF
--- a/tests/spread/plugins/plainbox/snaps/provider-basic/snap/snapcraft.yaml
+++ b/tests/spread/plugins/plainbox/snaps/provider-basic/snap/snapcraft.yaml
@@ -12,6 +12,7 @@ parts:
         plugin: python
         source: git://git.launchpad.net/checkbox-ng
         source-type: git
+        source-depth: 1
         build-packages:
             - libxml2-dev
             - libxslt1-dev
@@ -29,6 +30,7 @@ parts:
         plugin: python
         source: git://git.launchpad.net/checkbox-support
         source-type: git
+        source-depth: 1
         python-packages:
             - idna==2.7
             - urllib3==1.24

--- a/tests/spread/plugins/plainbox/snaps/provider-with-deps/snap/snapcraft.yaml
+++ b/tests/spread/plugins/plainbox/snaps/provider-with-deps/snap/snapcraft.yaml
@@ -11,6 +11,7 @@ parts:
     checkbox-ng-dev:
         plugin: python
         source: https://git.launchpad.net/checkbox-ng
+        source-depth: 1
         source-type: git
         build-packages:
             - libxml2-dev


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
