### PR TITLE
meta: assume command-chain fix for prepending snapcraft-runner

### DIFF
--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -233,7 +233,7 @@ class Snap:
             return
 
         for app in self.apps.values():
-            if app.command_chain:
+            if app.command_chain or app.prepend_command_chain:
                 self.assumes.add("command-chain")
                 return
         for hook in self.hooks.values():

--- a/tests/spread/general/adapter/expected_snap.yaml
+++ b/tests/spread/general/adapter/expected_snap.yaml
@@ -19,6 +19,8 @@ apps:
     - snap/command-chain/snapcraft-runner
 architectures:
 - amd64
+assumes:
+- command-chain
 base: core18
 confinement: strict
 grade: devel

--- a/tests/unit/meta/test_meta.py
+++ b/tests/unit/meta/test_meta.py
@@ -351,6 +351,20 @@ class CreateTestCase(CreateBaseTestCase):
             y["apps"]["app"]["command-chain"],
             Equals([os.path.join("snap", "command-chain", "snapcraft-runner"), "bar"]),
         )
+        self.assertThat(y["assumes"], Equals(["command-chain"]))
+
+    def test_adapter_assumes_command_chain(self):
+        self.config_data["apps"] = {"app": {"command": "foo"}}
+        _create_file(os.path.join(self.prime_dir, "foo"), executable=True)
+
+        y = self.generate_meta_yaml()
+
+        self.expectThat(y["apps"]["app"]["command"], Equals("foo"))
+        self.expectThat(
+            y["apps"]["app"]["command-chain"],
+            Equals([os.path.join("snap", "command-chain", "snapcraft-runner")]),
+        )
+        self.assertThat(y["assumes"], Equals(["command-chain"]))
 
 
 class StopModeTestCase(CreateBaseTestCase):


### PR DESCRIPTION
`prepend_command_chain` was not checked when determining the need
for assuming command-chain.

- Add & update a test to ensure coverage of `assumes`.

- Check for use of `prepend_command_chain`.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
