### PR TITLE
cli: do not report KeyboardInterrupt errors

### DIFF
--- a/snapcraft/cli/_errors.py
+++ b/snapcraft/cli/_errors.py
@@ -90,7 +90,9 @@ def _is_reportable_error(exc_info) -> bool:
         return exc_info[1].get_reportable()
 
     # Report non-snapcraft errors.
-    if not issubclass(exc_info[0], errors.SnapcraftError):
+    if not issubclass(exc_info[0], errors.SnapcraftError) and not isinstance(
+        exc_info[1], KeyboardInterrupt
+    ):
         return True
 
     # Report SnapcraftReportableError errors.

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -174,6 +174,12 @@ https://docs.snapcraft.io/the-snapcraft-format/8337"""
         self.assertEquals(50, _get_exception_exit_code(exception))
 
 
+class ReportableErrorTests(unit.TestCase):
+    def test_keyboard_interrupt(self):
+        exc_info = (KeyboardInterrupt, KeyboardInterrupt(), None)
+        self.assertFalse(_is_reportable_error(exc_info))
+
+
 class ErrorsBaseTestCase(unit.TestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
If the user chooses to kill snapcraft prematurely, that's OK
but it shouldn't be reported to Sentry.

Squelches SNAPCRAFT-1D

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
