### PR TITLE
spread tests: limit adapter test to amd64

### DIFF
--- a/tests/spread/general/adapter/task.yaml
+++ b/tests/spread/general/adapter/task.yaml
@@ -5,6 +5,7 @@ summary: Build a snap that tests adapter settings
 systems:
   - ubuntu-18.04-64
   - ubuntu-18.04-amd64
+  - ubuntu-18.04
 
 environment:
   SNAP_DIR: snaps/adapter-tests

--- a/tests/spread/general/adapter/task.yaml
+++ b/tests/spread/general/adapter/task.yaml
@@ -1,7 +1,10 @@
 summary: Build a snap that tests adapter settings
 
-# This test snap uses core18
-systems: [ubuntu-18*]
+# This test snap uses core18, and is limited to amd64 arch due to
+# architectures specified in expected_snap.yaml.
+systems:
+  - ubuntu-18.04-64
+  - ubuntu-18.04-amd64
 
 environment:
   SNAP_DIR: snaps/adapter-tests


### PR DESCRIPTION
The expected_snap.yaml includes the architecture definition,
which breaks when building on other architectures.  Since
adapter isn't relevant to arch, simply limit the tests to amd64.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
