### PR TITLE
build providers: use multipass from stable

### DIFF
--- a/snapcraft/internal/build_providers/_multipass/_multipass_command.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass_command.py
@@ -100,7 +100,7 @@ class MultipassCommand:
     @classmethod
     def setup_multipass(cls, *, echoer, platform: str) -> None:
         if platform == "linux":
-            repo.snaps.install_snaps(["multipass/latest/beta"])
+            repo.snaps.install_snaps(["multipass/latest/stable"])
         elif platform == "darwin":
             try:
                 subprocess.check_call(["brew", "cask", "install", "multipass"])

--- a/tests/spread/build-providers/multipass-basic/task.yaml
+++ b/tests/spread/build-providers/multipass-basic/task.yaml
@@ -5,7 +5,7 @@ environment:
   SNAP_DIR: ../snaps/make-hello
 
 prepare: |
-  snap list multipass || snap install --classic --beta multipass
+  snap list multipass || snap install --classic multipass
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"

--- a/tests/spread/build-providers/multipass-error-handling/task.yaml
+++ b/tests/spread/build-providers/multipass-error-handling/task.yaml
@@ -5,7 +5,7 @@ environment:
   SNAP_DIR: ../snaps/exit1
 
 prepare: |
-  snap list multipass || snap install --classic --beta multipass
+  snap list multipass || snap install --classic multipass
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"

--- a/tests/unit/build_providers/multipass/test_multipass_command.py
+++ b/tests/unit/build_providers/multipass/test_multipass_command.py
@@ -117,7 +117,7 @@ class MultipassCommandSetupMultipassTest(MultipassCommandBaseTest):
                 multipass=dict(
                     channel="beta",
                     type="app",
-                    channels={"latest/beta": dict(confinement="classic")},
+                    channels={"latest/stable": dict(confinement="classic")},
                 )
             )
         ]


### PR DESCRIPTION
Multipass 1.0 has been released to the stable channel. Consume multipass from
there from now on.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
