### PR TITLE
snap: set PYLXD_WARNINGS to inhibit unknown LXD attribute warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ requests-toolbelt==0.8.0
 responses==0.5.1
 petname==1.12
 pyelftools==0.24
-pylxd==2.2.9
+pylxd==2.2.10
 pymacaroons==0.9.2; sys_platform != 'win32'
 pymacaroons-pynacl==0.9.3; sys_platform == 'win32'
 pysha3==1.0.2; python_version < '3.6'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,9 @@ assumes:
 
 apps:
   snapcraft:
+    environment:
+      # https://github.com/lxc/pylxd/pull/361
+      PYLXD_WARNINGS: "none"
     command: bin/snapcraft
     completer: snapcraft-completion
 


### PR DESCRIPTION
pylxd is designed in such a way that it will display warnings every
attribute coming from the server that is unknown to the client.

pylxd 2.2.10 adds a way to inhibit these warnings.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
