### PR TITLE
meta: handle plug & slot string objects

### DIFF
--- a/snapcraft/internal/meta/plugs.py
+++ b/snapcraft/internal/meta/plugs.py
@@ -53,8 +53,6 @@ class Plug:
     @classmethod
     def from_dict(cls, *, plug_dict: Dict[str, Any], plug_name: str) -> "Plug":
         """Create plug from dictionary."""
-
-        plug_dict = {} if plug_dict is None else plug_dict
         interface = plug_dict.get("interface", plug_name)
 
         plug_class = PLUG_MAPPINGS.get(interface, None)
@@ -65,6 +63,19 @@ class Plug:
         plug = Plug(plug_name=plug_name)
         plug._plug_dict.update(plug_dict)
         return plug
+
+    @classmethod
+    def from_object(cls, *, plug_object: Any, plug_name: str) -> "Plug":
+        if plug_object is None:
+            return Plug(plug_name=plug_name)
+        elif isinstance(plug_object, str):
+            plug = Plug(plug_name=plug_name)
+            plug._plug_dict["interface"] = plug_object
+            return plug
+        elif isinstance(plug_object, dict):
+            return Plug.from_dict(plug_dict=plug_object, plug_name=plug_name)
+
+        raise RuntimeError(f"unknown syntax for plug {plug_name!r}: {plug_object!r}")
 
     def to_dict(self) -> Dict[str, Any]:
         """Create dictionary from plug."""

--- a/snapcraft/internal/meta/slots.py
+++ b/snapcraft/internal/meta/slots.py
@@ -54,8 +54,6 @@ class Slot:
     @classmethod
     def from_dict(cls, *, slot_dict: Dict[str, Any], slot_name: str) -> "Slot":
         """Return applicable Slot instance from dictionary properties."""
-
-        slot_dict = {} if slot_dict is None else slot_dict
         interface = slot_dict.get("interface", slot_name)
 
         # If we explicitly support the type, use it instead.
@@ -67,6 +65,19 @@ class Slot:
         slot = Slot(slot_name=slot_name)
         slot._slot_dict.update(slot_dict)
         return slot
+
+    @classmethod
+    def from_object(cls, *, slot_object: Any, slot_name: str) -> "Slot":
+        if slot_object is None:
+            return Slot(slot_name=slot_name)
+        elif isinstance(slot_object, str):
+            slot = Slot(slot_name=slot_name)
+            slot._slot_dict["interface"] = slot_object
+            return slot
+        elif isinstance(slot_object, dict):
+            return Slot.from_dict(slot_dict=slot_object, slot_name=slot_name)
+
+        raise RuntimeError(f"unknown syntax for slot {slot_name!r}: {slot_object!r}")
 
     def to_dict(self) -> Dict[str, Any]:
         return OrderedDict(deepcopy(self._slot_dict))
@@ -88,7 +99,7 @@ class ContentSlot(Slot):
         content: Optional[str] = None,
         read: List[str] = None,
         write: List[str] = None,
-        use_source_key: bool = True
+        use_source_key: bool = True,
     ) -> None:
         super().__init__(slot_name=slot_name)
 

--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -264,12 +264,16 @@ class Snap:
 
         for key in snap_dict:
             if key == "plugs":
-                for plug_name, plug_dict in snap_dict[key].items():
-                    plug = Plug.from_dict(plug_dict=plug_dict, plug_name=plug_name)
+                for plug_name, plug_object in snap_dict[key].items():
+                    plug = Plug.from_object(
+                        plug_object=plug_object, plug_name=plug_name
+                    )
                     snap.plugs[plug_name] = plug
             elif key == "slots":
-                for slot_name, slot_dict in snap_dict[key].items():
-                    slot = Slot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
+                for slot_name, slot_object in snap_dict[key].items():
+                    slot = Slot.from_object(
+                        slot_object=slot_object, slot_name=slot_name
+                    )
                     snap.slots[slot_name] = slot
             elif key == "apps":
                 for app_name, app_dict in snap_dict[key].items():

--- a/tests/unit/meta/test_plugs.py
+++ b/tests/unit/meta/test_plugs.py
@@ -16,10 +16,10 @@
 
 from collections import OrderedDict
 
-from testtools.matchers import Is
+from testtools.matchers import Equals, Is
 
 from snapcraft.internal.meta import errors
-from snapcraft.internal.meta.plugs import Plug, ContentPlug
+from snapcraft.internal.meta.plugs import ContentPlug, Plug
 from tests import unit
 
 
@@ -58,6 +58,29 @@ class GenericPlugTests(unit.TestCase):
         plug = Plug.from_dict(plug_dict=plug_dict, plug_name=plug_name)
 
         plug.validate()
+
+    def test_from_object_none(self):
+        plug = Plug.from_object(plug_name="plug-name", plug_object=None)
+        plug.validate()
+
+        self.assertThat(plug._plug_dict["interface"], Equals("plug-name"))
+
+    def test_from_object_string(self):
+        plug = Plug.from_object(plug_name="plug-name", plug_object="some-interface")
+        plug.validate()
+
+        self.assertThat(plug._plug_dict["interface"], Equals("some-interface"))
+
+    def test_from_object_dict(self):
+        plug_dict = OrderedDict(
+            {"interface": "some-interface", "someprop": "somevalue"}
+        )
+        plug_name = "plug-test"
+
+        plug = Plug.from_object(plug_object=plug_dict, plug_name=plug_name)
+
+        plug.validate()
+        self.assertThat(plug._plug_dict["interface"], Equals("some-interface"))
 
 
 class ContentPlugTests(unit.TestCase):

--- a/tests/unit/meta/test_slots.py
+++ b/tests/unit/meta/test_slots.py
@@ -15,8 +15,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from collections import OrderedDict
+
+from testtools.matchers import Equals
+
 from snapcraft.internal.meta import errors
-from snapcraft.internal.meta.slots import Slot, ContentSlot, DbusSlot
+from snapcraft.internal.meta.slots import ContentSlot, DbusSlot, Slot
 from tests import unit
 
 
@@ -55,6 +58,29 @@ class GenericSlotTests(unit.TestCase):
         slot = Slot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
 
         slot.validate()
+
+    def test_from_object_none(self):
+        slot = Slot.from_object(slot_name="slot-name", slot_object=None)
+        slot.validate()
+
+        self.assertThat(slot._slot_dict["interface"], Equals("slot-name"))
+
+    def test_from_object_string(self):
+        slot = Slot.from_object(slot_name="slot-name", slot_object="some-interface")
+        slot.validate()
+
+        self.assertThat(slot._slot_dict["interface"], Equals("some-interface"))
+
+    def test_from_object_dict(self):
+        slot_dict = OrderedDict(
+            {"interface": "some-interface", "someprop": "somevalue"}
+        )
+        slot_name = "slot-test"
+
+        slot = Slot.from_object(slot_object=slot_dict, slot_name=slot_name)
+
+        slot.validate()
+        self.assertThat(slot._slot_dict["interface"], Equals("some-interface"))
 
 
 class ContentSlotTests(unit.TestCase):


### PR DESCRIPTION
Although undocumented, the plug and slot objects may in
fact be a string, such as the case here:
https://git.launchpad.net/~snappy-hwe-team/snappy-hwe-snaps/+git/modem-manager/tree/snapcraft.yaml#n16

If the object is a string, use that string as the interface.

To ease the handling of this, we introduce cls.from_object() for
Slot and Plug to handle None, string, and dict cases. Snap will
now use these methods when populating the slots and plugs, instead
of cls.from_dict().

Add tests for coverage of from_object() and the string case.

LP #1859806

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
