### PR TITLE
extensions: fix merging of build-environment

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/_utils.py
+++ b/snapcraft/internal/project_loader/_extensions/_utils.py
@@ -157,9 +157,17 @@ def _apply_extension(
     parts = yaml_data["parts"]
     for part_name, part_definition in parts.items():
         for property_name, property_value in part_extension.items():
-            part_definition[property_name] = _apply_extension_property(
-                part_definition.get(property_name), property_value
-            )
+            if property_name == "build-environment":
+                # Special case build-environment as we want to merge
+                # the lists in reverse of the typical order, and the
+                # above merge_lists only handles string lists.
+                part_definition[property_name] = property_value + part_definition.get(
+                    property_name
+                )
+            else:
+                part_definition[property_name] = _apply_extension_property(
+                    part_definition.get(property_name), property_value
+                )
 
     # Finally, add any parts specified in the extension
     for part_name, part_definition in extension.parts.items():

--- a/tests/unit/project_loader/extensions/test_utils.py
+++ b/tests/unit/project_loader/extensions/test_utils.py
@@ -32,6 +32,7 @@ class ExtensionTestBase(ProjectLoaderBaseTest):
         super().setUp()
 
         # Create a few fake extensions
+        self.useFixture(_build_environment_extension_fixture())
         self.useFixture(_environment_extension_fixture())
         self.useFixture(_plug_extension_fixture())
         self.useFixture(_plug2_extension_fixture())
@@ -250,6 +251,12 @@ class ExtensionMergeTest(ExtensionTestBase):
                     "command": "echo 'hello'",
                     "plugs": ["foo", "test-plug"],
                 },
+                "part_definition": textwrap.dedent(
+                    """\
+                    plugin: nil
+                    """
+                ),
+                "expected_part_definition": {"plugin": "nil", "prime": [], "stage": []},
             },
         ),
         (
@@ -267,6 +274,41 @@ class ExtensionMergeTest(ExtensionTestBase):
                     "command": "echo 'hello'",
                     "environment": {"FOO": "BAR", "TEST_EXTENSION": 1},
                 },
+                "part_definition": textwrap.dedent(
+                    """\
+                    plugin: nil
+                    """
+                ),
+                "expected_part_definition": {"plugin": "nil", "prime": [], "stage": []},
+            },
+        ),
+        (
+            "merge build environment",
+            {
+                "app_definition": textwrap.dedent(
+                    """\
+                    command: echo 'hello'
+                    extensions: [buildenvironment]
+                    """
+                ),
+                "expected_app_definition": {"command": "echo 'hello'"},
+                "part_definition": textwrap.dedent(
+                    """\
+                    plugin: nil
+                    build-environment:
+                      - PATH: "$PATH:/part-path"
+                    """
+                ),
+                "expected_part_definition": {
+                    "plugin": "nil",
+                    "build-environment": [
+                        {"PATH": "$PATH:/extension-path"},
+                        {"EXTKEY": "EXTVAL"},
+                        {"PATH": "$PATH:/part-path"},
+                    ],
+                    "prime": [],
+                    "stage": [],
+                },
             },
         ),
         (
@@ -283,6 +325,12 @@ class ExtensionMergeTest(ExtensionTestBase):
                     "command": "echo 'hello'",
                     "daemon": "forking",
                 },
+                "part_definition": textwrap.dedent(
+                    """\
+                    plugin: nil
+                    """
+                ),
+                "expected_part_definition": {"plugin": "nil", "prime": [], "stage": []},
             },
         ),
     ]
@@ -304,12 +352,13 @@ class ExtensionMergeTest(ExtensionTestBase):
 
             parts:
                 part1:
-                    plugin: nil
+            {part_definition}
             """
         )
         config = self.make_snapcraft_project(
             snapcraft_yaml.format(
-                app_definition=textwrap.indent(self.app_definition, " " * 8)
+                app_definition=textwrap.indent(self.app_definition, " " * 8),
+                part_definition=textwrap.indent(self.part_definition, " " * 8),
             )
         )
 
@@ -320,6 +369,10 @@ class ExtensionMergeTest(ExtensionTestBase):
         # Verify that the extension took effect on the app
         self.assertThat(
             config.data["apps"]["test-app"], Equals(self.expected_app_definition)
+        )
+        # Verify that the extension took effect on the part
+        self.assertThat(
+            config.data["parts"]["part1"], Equals(self.expected_part_definition)
         )
 
 
@@ -673,6 +726,32 @@ def _environment_extension_fixture():
             self.parts = {"extension-part": {"plugin": "nil"}}
 
     return fixture_setup.FakeExtension("environment", ExtensionImpl)
+
+
+def _build_environment_extension_fixture():
+    class ExtensionImpl(Extension):
+        @staticmethod
+        def get_supported_bases() -> Tuple[str, ...]:
+            return ("core18",)
+
+        @staticmethod
+        def get_supported_confinement() -> Tuple[str, ...]:
+            return ("strict",)
+
+        def __init__(self, extension_name, yaml_data):
+            super().__init__(extension_name=extension_name, yaml_data=yaml_data)
+            self.root_snippet = {}
+            self.app_snippet = {}
+            self.part_snippet = {
+                "after": ["extension-part"],
+                "build-environment": [
+                    {"PATH": "$PATH:/extension-path"},
+                    {"EXTKEY": "EXTVAL"},
+                ],
+            }
+            self.parts = {"extension-part": {"plugin": "nil"}}
+
+    return fixture_setup.FakeExtension("buildenvironment", ExtensionImpl)
 
 
 def _plug_extension_fixture():


### PR DESCRIPTION
    extensions: fix merging of build-environment
    
    When merging "build-environment", merge_lists will fail
    because OrderedDict is unhashable when calculating the "seen"
    set.
    
    In addition to this failure, build-environment should be merged
    with the extension definitions being listed first, followed by
    the user definitions.  So we append the lists in that order.
    
    Add tests to show coverage for "build-environment" using the
    part_snippet.