### PR TITLE
package management repository configuration

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -39,7 +39,7 @@ run_static_tests() {
     mypy .
 
     echo "Running codespell"
-    codespell -S "*.tar,*.xz,*.zip,*.bz2,*.7z,*.gz,*.deb,*.rpm,*.snap,*.gpg,*.pyc,*.png,*.ico,*.jar,changelog,.git,.hg,.mypy_cache,.tox,.venv,_build,buck-out,__pycache__,build,dist,.vscode,parts,stage,prime,test_appstream.py,./snapcraft.spec" -q4
+    codespell -S "*.tar,*.xz,*.zip,*.bz2,*.7z,*.gz,*.deb,*.rpm,*.snap,*.gpg,*.pyc,*.png,*.ico,*.jar,changelog,.git,.hg,.mypy_cache,.tox,.venv,_build,buck-out,__pycache__,build,dist,.vscode,parts,stage,prime,test_appstream.py,./snapcraft.spec" -q4 -L keyserver
 
     echo "Running shellcheck"
     # Need to skip 'demos/gradle/gradlew' as it wasn't written by us and has

--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -340,6 +340,50 @@
             "type": "object",
             "description": "layout property to be passed into the snap.yaml as-is"
         },
+        "package-management": {
+            "type": "object",
+            "description": "additional repository configuration.",
+            "additionalProperties": false,
+            "validation-failure": "{!r} is not a valid repository configuration.",
+            "properties": {
+                "repositories": {
+                    "type": "array",
+                    "validation-failure": "{!r} is not a valid repositories list.",
+                    "items": {
+                        "type": "object",
+                        "description": "repository",
+                        "validation-failure": "{!r} is not a valid repository.",
+                        "additionalProperties": false,
+                        "properties": {
+                            "source": {
+                                "type": "string",
+                                "description": "Repository source to fetch packages from.",
+                                "validation-failure": "{!r} is not a valid repository source."
+                            },
+                            "gpg-public-key": {
+                                "type": "string",
+                                "description": "GPG public key",
+                                "validation-failure": "{!r} is not a valid GPG key.  A GPG key must be a string starting with \"-----BEGIN PGP PUBLIC KEY BLOCK-----\".",
+                                "pattern": "^[\\s]*-----BEGIN PGP PUBLIC KEY BLOCK-----.*"
+                            },
+                            "gpg-public-key-id": {
+                                "type": "string",
+                                "description": "GPG public key ID",
+                                "validation-failure": "{!r} is not a valid GPG key identifier.",
+                                "pattern": "^[a-zA-Z0-9]*$"
+                            },
+                            "gpg-key-server": {
+                                "type": "string",
+                                "description": "GPG key server URL",
+                                "default": "keyserver.ubuntu.com",
+                                "validation-failure": "{!r} is not a valid gpg-keyserver."
+                            }
+                        },
+                        "required": ["source"]
+                    }
+                }
+            }
+        },
         "system-usernames": {
             "type": "object",
             "description": "system username",

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -27,6 +27,7 @@ from snapcraft.internal import (
     states,
     steps,
 )
+from snapcraft.internal.repo.package_management import configure_package_manager
 from snapcraft.internal.meta._snap_packaging import create_snap_packaging
 
 from ._status_cache import StatusCache
@@ -76,11 +77,17 @@ def execute(
                           over.
     :returns: A dict with the snap name, version, type and architectures.
     """
+    # First install the dependencies for adding repositories, if required.
+    repo_build_tools = configure_package_manager(
+        project_config.project._snap_meta.package_management
+    )
+
     installed_packages = repo.Repo.install_build_packages(project_config.build_tools)
     if installed_packages is None:
         raise ValueError(
             "The repo backend is not returning the list of installed packages"
         )
+    installed_packages += repo_build_tools
 
     build_snaps = project_config.build_snaps
     content_snaps = project_config.project._get_content_snaps()

--- a/snapcraft/internal/meta/errors.py
+++ b/snapcraft/internal/meta/errors.py
@@ -200,6 +200,34 @@ class HookValidationError(errors.SnapcraftError):
         super().__init__(hook_name=hook_name, message=message)
 
 
+class PackageManagementValidationError(errors.SnapcraftException):
+    def __init__(self, *, message: str) -> None:
+        self._message = message
+
+    def get_brief(self) -> str:
+        return f"Invalid package-management: {self._message}"
+
+    def get_resolution(self) -> str:
+        return "Please configure package-management according to documentation."
+
+    def get_docs_url(self) -> str:
+        return "<TODO>"
+
+
+class RepositoryValidationError(errors.SnapcraftException):
+    def __init__(self, *, message: str) -> None:
+        self._message = message
+
+    def get_brief(self) -> str:
+        return f"Invalid repository: {self._message}"
+
+    def get_resolution(self) -> str:
+        return "Please configure repository according to documentation."
+
+    def get_docs_url(self) -> str:
+        return "<TODO>"
+
+
 class SystemUsernamesValidationError(errors.SnapcraftException):
     def __init__(self, *, name: str, message: str) -> None:
         self._name = name

--- a/snapcraft/internal/meta/package_management.py
+++ b/snapcraft/internal/meta/package_management.py
@@ -1,0 +1,124 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from collections import OrderedDict
+from typing import Any, Dict, List, Optional
+
+from snapcraft.internal.meta import errors
+
+logger = logging.getLogger(__name__)
+
+
+class Repository:
+    def __init__(
+        self,
+        *,
+        source: str,
+        gpg_public_key: Optional[str] = None,
+        gpg_public_key_id: Optional[str] = None,
+        gpg_key_server: Optional[str] = None,
+    ) -> None:
+        self.source = source
+        self.gpg_public_key = gpg_public_key
+        self.gpg_public_key_id = gpg_public_key_id
+        self.gpg_key_server = gpg_key_server
+
+    @classmethod
+    def from_dict(cls, repo_dict: Dict[str, str]) -> "Repository":
+        source = repo_dict.get("source")
+        if not source:
+            raise errors.RepositoryValidationError(
+                message=f"'source' undefined for {repo_dict!r}"
+            )
+
+        gpg_public_key = repo_dict.get("gpg-public-key")
+        gpg_public_key_id = repo_dict.get("gpg-public-key-id")
+        gpg_key_server = repo_dict.get("gpg-key-server")
+
+        return Repository(
+            source=source,
+            gpg_public_key=gpg_public_key,
+            gpg_public_key_id=gpg_public_key_id,
+            gpg_key_server=gpg_key_server,
+        )
+
+    @classmethod
+    def from_object(cls, repo_object: Any) -> "Repository":
+        if repo_object is None:
+            raise errors.RepositoryValidationError(message=f"empty definition")
+
+        if not isinstance(repo_object, dict):
+            raise errors.RepositoryValidationError(
+                message=f"unknown syntax for {repo_object!r}"
+            )
+
+        return cls.from_dict(repo_object)
+
+    def to_dict(self):
+        repo_dict = OrderedDict()
+        repo_dict["source"] = self.source
+        repo_dict["gpg-public-key"] = self.gpg_public_key
+        repo_dict["gpg-public-key-id"] = self.gpg_public_key_id
+        repo_dict["gpg-key-server"] = self.gpg_key_server
+        return repo_dict
+
+    def validate(self):
+        if not self.source:
+            raise errors.RepositoryValidationError(
+                message=f"invalid source '{self.source!r}"
+            )
+
+    def __repr__(self):
+        return f"Repository(source={self.source!r}, gpg-public-key={self.gpg_public_key}, gpg-public-key-id={self.gpg_public_key_id!r}, gpg-key-server={self.gpg_key_server})"
+
+    def __eq__(self, other: Any) -> bool:
+        return repr(self) == repr(other)
+
+
+class PackageManagement:
+    def __init__(self, *, repositories: Optional[List[Repository]] = None):
+        if repositories is None:
+            self.repositories: List[Repository] = list()
+        else:
+            self.repositories = repositories
+
+    @classmethod
+    def from_dict(cls, pkg_management_dict: Dict[str, Any]) -> "PackageManagement":
+        pm = PackageManagement()
+
+        raw_repositories = pkg_management_dict.get("repositories", [])
+        for raw_repo in raw_repositories:
+            repo = Repository.from_object(raw_repo)
+            pm.repositories.append(repo)
+
+        return pm
+
+    @classmethod
+    def from_object(cls, pkg_management_object: Any) -> "PackageManagement":
+        if pkg_management_object is None:
+            return PackageManagement()
+
+        if not isinstance(pkg_management_object, dict):
+            raise errors.PackageManagementValidationError(
+                message=f"unknown syntax for {pkg_management_object!r}"
+            )
+
+        return cls.from_dict(pkg_management_object)
+
+    def validate(self):
+        for repo in self.repositories:
+            repo.validate()

--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -25,6 +25,7 @@ from snapcraft.internal import common
 from snapcraft.internal.meta import errors
 from snapcraft.internal.meta.application import Application
 from snapcraft.internal.meta.hooks import Hook
+from snapcraft.internal.meta.package_management import PackageManagement
 from snapcraft.internal.meta.plugs import ContentPlug, Plug
 from snapcraft.internal.meta.slots import ContentSlot, Slot
 from snapcraft.internal.meta.system_user import SystemUser
@@ -72,6 +73,7 @@ class Snap:
         layout: Optional[Dict[str, Any]] = None,
         license: Optional[str] = None,
         name: Optional[str] = None,
+        package_management: Optional[PackageManagement] = None,
         passthrough: Optional[Dict[str, Any]] = None,
         plugs: Optional[Dict[str, Plug]] = None,
         slots: Optional[Dict[str, Slot]] = None,
@@ -122,6 +124,11 @@ class Snap:
 
         self.license = license
         self.name = name
+
+        if package_management is None:
+            self.package_management = PackageManagement()
+        else:
+            self.package_management = package_management
 
         if passthrough is None:
             self.passthrough: Dict[str, Any] = dict()
@@ -306,6 +313,10 @@ class Snap:
 
         if "adopt-info" in snap_dict:
             snap.adopt_info = snap_dict["adopt-info"]
+
+        snap.package_management = PackageManagement.from_object(
+            snap_dict.get("package-management")
+        )
 
         return snap
 

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -19,7 +19,7 @@ from typing import Sequence
 from snapcraft.internal.os_release import OsRelease
 from ._platform import _is_deb_based
 from snapcraft.internal import errors
-
+from snapcraft.internal.meta.package_management import Repository
 from typing import List
 
 
@@ -194,3 +194,33 @@ class SnapdConnectionError(RepoError):
 
     def __init__(self, snap_name: str, url: str) -> None:
         super().__init__(snap_name=snap_name, url=url)
+
+
+class RepositoryError(errors.SnapcraftException):
+    def __init__(self, *, repo: Repository, message: str) -> None:
+        self._repo = repo
+        self._message = message
+
+    def get_brief(self) -> str:
+        return f"Error adding repository: {self._message}"
+
+    def get_resolution(self) -> str:
+        return f"Please ensure that the repository key configuration for {self._repo!r} is valid."
+
+    def get_docs_url(self) -> str:
+        return "<TODO>"
+
+
+class RepositoryKeyError(errors.SnapcraftException):
+    def __init__(self, *, repo: Repository, message: str) -> None:
+        self._repo = repo
+        self._message = message
+
+    def get_brief(self) -> str:
+        return f"Error adding repository key: {self._message}"
+
+    def get_resolution(self) -> str:
+        return f"Please ensure that the repository key configuration for {self._repo!r} is valid and that key server {self._repo.gpg_key_server!r} is accessible."
+
+    def get_docs_url(self) -> str:
+        return "<TODO>"

--- a/snapcraft/internal/repo/package_management.py
+++ b/snapcraft/internal/repo/package_management.py
@@ -1,0 +1,154 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from subprocess import PIPE, STDOUT, CalledProcessError, run
+from typing import List
+
+from snapcraft.internal.meta.package_management import PackageManagement, Repository
+from snapcraft.internal.os_release import OsRelease
+from . import errors
+from . import Repo
+
+logger = logging.getLogger(__name__)
+
+
+def _verify_supported_distribution() -> None:
+    # While it is likely that other debian-based distros will work as-is, this
+    # has only been tested against Ubuntu bases.  This code should never be
+    # reached if package-management is not configured, ensuring safety for
+    # those building with non-ubuntu bases.
+    os_name = OsRelease().id()
+    if os_name != "ubuntu":
+        raise RuntimeError(
+            f"unable to install repository for unsupported OS: {os_name}"
+        )
+
+
+def _apt_key_decoder_ring(output: bytes, repo: Repository) -> str:
+    message: str = output.decode()
+    message = message.replace(
+        "Warning: apt-key output should not be parsed (stdout is not a terminal)", ""
+    ).strip()
+
+    # Improve error messages that we can.
+    if "gpg: keyserver receive failed: No data" in message:
+        message = f"GPG key ID {repo.gpg_public_key_id!r} not found on key server {repo.gpg_key_server!r}"
+    elif "gpg: keyserver receive failed: Server indicated a failure" in message:
+        message = (
+            f"unable to establish connection to key server {repo.gpg_key_server!r}"
+        )
+    elif "gpg: keyserver receive failed: Connection timed out" in message:
+        message = f"unable to establish connection to key server {repo.gpg_key_server!r} (connection timed out)"
+
+    return message
+
+
+def _install_apt_repository_key_id(repo: Repository) -> None:
+    if not repo.gpg_public_key_id:
+        return
+
+    # Set default key-server if none specified.
+    if not repo.gpg_key_server:
+        repo.gpg_key_server = "keyserver.ubuntu.com"
+
+    cmd = [
+        "sudo",
+        "apt-key",
+        "adv",
+        "--keyserver",
+        repo.gpg_key_server,
+        "--recv-keys",
+        repo.gpg_public_key_id,
+    ]
+
+    try:
+        run(cmd, stdout=PIPE, stderr=STDOUT, check=True)
+    except CalledProcessError as error:
+        message = _apt_key_decoder_ring(error.output, repo)
+        raise errors.RepositoryKeyError(repo=repo, message=message) from error
+
+    logger.debug(
+        f"Installed apt repository GPG key ID {repo.gpg_public_key_id!r} from key server {repo.gpg_key_server!r}"
+    )
+
+
+def _install_apt_repository_key_block(repo: Repository) -> None:
+    if not repo.gpg_public_key:
+        return
+
+    cmd = ["sudo", "apt-key", "add", "-"]
+    try:
+        run(
+            cmd,
+            input=repo.gpg_public_key.encode(),
+            stdout=PIPE,
+            stderr=STDOUT,
+            check=True,
+        )
+    except CalledProcessError as error:
+        message = _apt_key_decoder_ring(error.output, repo)
+        raise errors.RepositoryKeyError(repo=repo, message=message) from error
+
+    logger.debug(f"Installed apt repository key:\n{repo.gpg_public_key}")
+
+
+def _install_apt_repository(repo: Repository) -> None:
+    cmd = ["sudo", "apt-add-repository", "-y", repo.source]
+    try:
+        run(cmd, stdout=PIPE, stderr=STDOUT, check=True)
+    except CalledProcessError as error:
+        raise errors.RepositoryKeyError(repo=repo, message=error.output) from error
+
+    logger.debug(f"Installed apt repository {repo.source!r}")
+
+
+def _get_repo_build_tools() -> List[str]:
+    return ["software-properties-common"]
+
+
+def _install_repository(repo: Repository) -> None:
+    if repo.gpg_public_key:
+        _install_apt_repository_key_block(repo)
+
+    if repo.gpg_public_key_id:
+        _install_apt_repository_key_id(repo)
+
+    _install_apt_repository(repo)
+
+
+def configure_package_manager(package_management: PackageManagement) -> List[str]:
+    """Configures package manager according to snapcraft.yaml configuration.
+
+    :returns: a list of installed build packages
+    """
+    if not package_management.repositories:
+        return list()
+
+    # There are repositories to configure, assert that we are
+    # using a supported platform.
+    _verify_supported_distribution()
+
+    # Install required build tools.
+    repo_build_tools = _get_repo_build_tools()
+    if repo_build_tools:
+        installed_tools = Repo.install_build_packages(repo_build_tools)
+
+    # Install repositories.
+    for repository in package_management.repositories:
+        _install_repository(repository)
+
+    return installed_tools

--- a/tests/spread/general/package-management-test-ppa-invalid-key-block/task.yaml
+++ b/tests/spread/general/package-management-test-ppa-invalid-key-block/task.yaml
@@ -1,0 +1,32 @@
+summary: Verify repository failure when using invalid key server.
+
+environment:
+  SNAP_DIR: test-ppa-invalid-key-block
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+  # Remove test-ppa repo.
+  sudo apt-add-repository -r ppa:cjp256/test-ppa -y
+
+  # Remove test-ppa apt-key.
+  sudo apt-key del "590C A3D8 E482 6565 BE32 0052 6A63 4116 E00F 4C82"
+
+execute: |
+  cd "$SNAP_DIR"
+  if output="$(snapcraft)"; then
+    echo "snapcraft should have exited with error: $output"
+    exit 1
+  fi
+  echo "$output" | MATCH "The following signatures couldn't be verified"

--- a/tests/spread/general/package-management-test-ppa-invalid-key-block/test-ppa-with-invalid-key-block/snap/snapcraft.yaml
+++ b/tests/spread/general/package-management-test-ppa-invalid-key-block/test-ppa-with-invalid-key-block/snap/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: test-ppa-with-invalid-key-block
+version: 'test1'
+summary: test
+description: test
+grade: stable
+confinement: strict
+
+parts:
+  test-ppa:
+    plugin: nil
+    stage-packages:
+      - test-ppa
+
+apps:
+    test-ppa:
+      command: test-ppa
+
+package-management:
+  repositories:
+    - source: http://ppa.launchpad.net/cjp256/test-ppa/ubuntu
+      gpg-public-key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+        -----END PGP PUBLIC KEY BLOCK-----

--- a/tests/spread/general/package-management-test-ppa-invalid-key-id/task.yaml
+++ b/tests/spread/general/package-management-test-ppa-invalid-key-id/task.yaml
@@ -1,0 +1,32 @@
+summary: Verify repository failure when using invalid key ID.
+
+environment:
+  SNAP_DIR: test-ppa-invalid-key-id
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+  # Remove test-ppa repo.
+  sudo apt-add-repository -r ppa:cjp256/test-ppa -y
+
+  # Remove test-ppa apt-key.
+  sudo apt-key del "590C A3D8 E482 6565 BE32 0052 6A63 4116 E00F 4C82"
+
+execute: |
+  cd "$SNAP_DIR"
+  if output="$(snapcraft)"; then
+    echo "snapcraft should have exited with error: $output"
+    exit 1
+  fi
+  echo "$output" | MATCH "The following signatures couldn't be verified"

--- a/tests/spread/general/package-management-test-ppa-invalid-key-id/test-ppa-invalid-key-id/snap/snapcraft.yaml
+++ b/tests/spread/general/package-management-test-ppa-invalid-key-id/test-ppa-invalid-key-id/snap/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: test-ppa-invalid-key-id
+version: 'test1'
+summary: test
+description: test
+grade: stable
+confinement: strict
+
+parts:
+  test-ppa:
+    plugin: nil
+    stage-packages:
+      - test-ppa
+
+apps:
+    test-ppa:
+      command: test-ppa
+
+package-management:
+  repositories:
+    - source: http://ppa.launchpad.net/cjp256/test-ppa/ubuntu
+      gpg-public-key-id: 00004116E00F4C82

--- a/tests/spread/general/package-management-test-ppa-invalid-key-server/task.yaml
+++ b/tests/spread/general/package-management-test-ppa-invalid-key-server/task.yaml
@@ -1,0 +1,32 @@
+summary: Verify repository failure when using invalid key server.
+
+environment:
+  SNAP_DIR: test-ppa-invalid-key-server
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+  # Remove test-ppa repo.
+  sudo apt-add-repository -r ppa:cjp256/test-ppa -y
+
+  # Remove test-ppa apt-key.
+  sudo apt-key del "590C A3D8 E482 6565 BE32 0052 6A63 4116 E00F 4C82"
+
+execute: |
+  cd "$SNAP_DIR"
+  if output="$(snapcraft)"; then
+    echo "snapcraft should have exited with error: $output"
+    exit 1
+  fi
+  echo "$output" | MATCH "The following signatures couldn't be verified"

--- a/tests/spread/general/package-management-test-ppa-invalid-key-server/test-ppa-invalid-key-server/snap/snapcraft.yaml
+++ b/tests/spread/general/package-management-test-ppa-invalid-key-server/test-ppa-invalid-key-server/snap/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: test-ppa-invalid-key-server
+version: 'test1'
+summary: test
+description: test
+grade: stable
+confinement: strict
+
+parts:
+  test-ppa:
+    plugin: nil
+    stage-packages:
+      - test-ppa
+
+apps:
+    test-ppa:
+      command: test-ppa
+
+package-management:
+  repositories:
+    - source: http://ppa.launchpad.net/cjp256/test-ppa/ubuntu
+      gpg-public-key-id: 00004116E00F4C82
+      gpg-key-server: www.google.com

--- a/tests/spread/general/package-management-test-ppa-long/task.yaml
+++ b/tests/spread/general/package-management-test-ppa-long/task.yaml
@@ -1,0 +1,32 @@
+summary: Verify repository using long-form traditional deb repo syntax.
+
+environment:
+  SNAP_DIR: test-ppa-long
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+  # Remove test-ppa repo.
+  sudo apt-add-repository -r ppa:cjp256/test-ppa -y
+
+  # Remove test-ppa apt-key.
+  sudo apt-key del "590C A3D8 E482 6565 BE32 0052 6A63 4116 E00F 4C82"
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft
+  snap install test-ppa-long*.snap --dangerous
+
+  # Run test-ppa.
+  test-ppa-long.test-ppa | MATCH "hello!"

--- a/tests/spread/general/package-management-test-ppa-long/test-ppa-long/snap/snapcraft.yaml
+++ b/tests/spread/general/package-management-test-ppa-long/test-ppa-long/snap/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: test-ppa-long
+version: 'test1'
+summary: test
+description: test
+grade: stable
+confinement: strict
+
+parts:
+  test-ppa:
+    plugin: nil
+    stage-packages:
+      - test-ppa
+
+apps:
+    test-ppa:
+      command: test-ppa
+
+package-management:
+  repositories:
+    - source: http://ppa.launchpad.net/cjp256/test-ppa/ubuntu
+      gpg-public-key-id: 6A634116E00F4C82

--- a/tests/spread/general/package-management-test-ppa-short/task.yaml
+++ b/tests/spread/general/package-management-test-ppa-short/task.yaml
@@ -1,0 +1,32 @@
+summary: Verify repository using short-form ppa syntax.
+
+environment:
+  SNAP_DIR: test-ppa-short
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+  # Remove test-ppa repo.
+  sudo apt-add-repository -r ppa:cjp256/test-ppa -y
+
+  # Remove test-ppa apt-key.
+  sudo apt-key del "590C A3D8 E482 6565 BE32 0052 6A63 4116 E00F 4C82"
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft
+  snap install test-ppa-short*.snap --dangerous
+
+  # Run test-ppa.
+  test-ppa-short.test-ppa | MATCH "hello!"

--- a/tests/spread/general/package-management-test-ppa-short/test-ppa-short/snap/snapcraft.yaml
+++ b/tests/spread/general/package-management-test-ppa-short/test-ppa-short/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: test-ppa-short
+version: 'test1'
+summary: test
+description: test
+grade: stable
+confinement: strict
+
+parts:
+  test-ppa:
+    plugin: nil
+    stage-packages:
+      - test-ppa
+
+apps:
+    test-ppa:
+      command: test-ppa
+
+package-management:
+  repositories:
+    - source: ppa:cjp256/test-ppa

--- a/tests/spread/general/package-management-test-ppa-with-build-package/task.yaml
+++ b/tests/spread/general/package-management-test-ppa-with-build-package/task.yaml
@@ -1,0 +1,32 @@
+summary: Repository that provides required build package
+
+environment:
+  SNAP_DIR: test-ppa-with-build-package
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+  # Remove test-ppa repo.
+  sudo apt-add-repository -r ppa:cjp256/test-ppa -y
+
+  # Remove test-ppa apt-key.
+  sudo apt-key del "590C A3D8 E482 6565 BE32 0052 6A63 4116 E00F 4C82"
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft
+  snap install test-ppa-with-build-package*.snap --dangerous
+
+  # Run test-ppa.
+  test-ppa-with-build-package.test-ppa | MATCH "hello!"

--- a/tests/spread/general/package-management-test-ppa-with-build-package/test-ppa-with-build-package/snap/snapcraft.yaml
+++ b/tests/spread/general/package-management-test-ppa-with-build-package/test-ppa-with-build-package/snap/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: test-ppa-with-build-package
+version: 'test1'
+summary: test
+description: test
+grade: stable
+confinement: strict
+
+parts:
+  test-ppa:
+    plugin: nil
+    stage-packages:
+      - test-ppa
+    build-packages:
+      - test-ppa
+
+apps:
+    test-ppa:
+      command: test-ppa
+
+package-management:
+  repositories:
+    - source: ppa:cjp256/test-ppa

--- a/tests/spread/general/package-management-test-ppa-with-key-block/task.yaml
+++ b/tests/spread/general/package-management-test-ppa-with-key-block/task.yaml
@@ -1,0 +1,32 @@
+summary: Verify encoded repository GPG key.
+
+environment:
+  SNAP_DIR: test-ppa-with-key-blob
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+  # Remove test-ppa repo.
+  sudo apt-add-repository -r ppa:cjp256/test-ppa -y
+
+  # Remove test-ppa apt-key.
+  sudo apt-key del "590C A3D8 E482 6565 BE32 0052 6A63 4116 E00F 4C82"
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft
+  snap install test-ppa-with-key-blob*.snap --dangerous
+
+  # Run test-ppa.
+  test-ppa-with-key-blob.test-ppa | MATCH "hello!"

--- a/tests/spread/general/package-management-test-ppa-with-key-block/test-ppa-with-key-block/snap/snapcraft.yaml
+++ b/tests/spread/general/package-management-test-ppa-with-key-block/test-ppa-with-key-block/snap/snapcraft.yaml
@@ -1,0 +1,49 @@
+name: test-ppa-with-key-block
+version: 'test1'
+summary: test
+description: test
+grade: stable
+confinement: strict
+
+parts:
+  test-ppa:
+    plugin: nil
+    stage-packages:
+      - test-ppa
+
+apps:
+    test-ppa:
+      command: test-ppa
+
+package-management:
+  repositories:
+    - source: http://ppa.launchpad.net/cjp256/test-ppa/ubuntu
+      gpg-public-key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+        mQINBF4y3MIBEAC6rYxrDtleK/OPftHKySm5nN8OIc+tBFnGr9pz4eu2CRukFxXc
+        Ap07pj5EkRbzI60BeGVK/spLFtrU7PPxBXJ3DiaxEaWmOUW/7MdukSWTVk9EgEAZ
+        dwKjbwNrrxmCif8RJzK9JFz1IqGqY/uzR7X90J2Wn4/+FvWNofE2kCQeGEpDQtmF
+        bpcBdHZmcru8g/t3KQy11i4GJ5gLXqFdDF3T3YcVgLyoOx910VK0Y41Rsux7PwlR
+        PmF3doZ+fjLBYVBo0l5ek56dc7p1Z6RL30IHgbwdSbDcYJ8d8dXR+gFUuB4xSYTk
+        XRD2Uzc+jDcwXEaTGFvxQNxIXW4ELwwB5ceqbt/l1w4Yo+pQrSKDjOeG80kwRWsw
+        bGnaAEa8ZKMHvQdr6wIGwiD6LfNAKGtr5xw4O7VzalF6KuzmrRt9RQc/bkso3DQV
+        tCC/nkI55gXEM6zH3NiGQiz47SrjENXWOwJvGrBT36eHCsLZ984SwRHCOqubEAwE
+        G7mkRcew/YC2xe6ic7ZMxVQ3DkmHKojO3qoS73KbuRgp6xwcBXxtPN2k/rAEmVTz
+        aXIPp46mXbwAfcuo5gFRknGzgyOP8cG5KMbl/AGJjRRfiWlIC5RmCcguGsgC5p0n
+        4cPX7+u0J9+pjyPdOntSm5WS1+2HYkd7vS0Qmio5/e7Sw1blCai1mxc7rQARAQAB
+        tCFMYXVuY2hwYWQgUFBBIGZvciBDaHJpcyBQYXR0ZXJzb26JAjgEEwECACIFAl4y
+        3MICGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEGpjQRbgD0yCanYP/001
+        tx9sgjfGCsA2WNbHAcoqN5Di1dIo4js5inFHWhFFDte4qY1uAx3lKxpq5iyqzwtB
+        rN/fbp3URd+ZqsVQ8IkfPf+lzMubf9YnKxbuBeXU+y5Kj8pmoL6sCpieobk9+3Go
+        rtAkrlmFw7GmpPeCzaHhr5YzOO82T75EEb2a6FYduPv+ONGJqk8P2f20CzlK84ze
+        G6ApSD7BdZ70iUvC0oy6AJoU8uSgoOfMdTIgT7NWXLfqzOIo+Fy5dlnmGS09y132
+        hpjqvx3VCFdGH+NSfcmEVCTcLnqoPqD6InXoROqi30c2D4PmX2h1Endac6BF9uCB
+        xdFBb8SKZ7mJ/dydAEV9KbUr+mQCAG5JO0+GnxgtKanHjMmDcF9BtmHMZsKDjILs
+        7iyiWEsrk+QsUpV5gxOdpOFvL2FfSVTTYhmKgCI9h+KqesAPnJwIhCI5Gz94MaYo
+        V8T+4ZjX36DNh5f7gzWLvajvKznOXGJkX6TgbqFo/wrijK75DPmuuR7m2Xa4AlAT
+        J0JZFdHWXuJnYI3vSZ2OfgHJKsLePheLFtJvpFJTPC0nOFwWgg2JH//UDbEIk5md
+        nLQl+agC5z32g+Qet+D/5y+xamJP/5HKgix8RhggPSIsaMi8ezNrF08jyollwDFk
+        c24ABjaDjM0uWKllldFtmpnW7V0tOFxm+RIA6dCM
+        =ulGo
+        -----END PGP PUBLIC KEY BLOCK-----

--- a/tests/unit/meta/test_errors.py
+++ b/tests/unit/meta/test_errors.py
@@ -186,6 +186,30 @@ class SnapcraftExceptionTests(unit.TestCase):
             },
         ),
         (
+            "PackageManagementValidationError",
+            {
+                "exception": errors.PackageManagementValidationError,
+                "kwargs": dict(message="invalid ..."),
+                "expected_brief": "Invalid package-management: invalid ...",
+                "expected_resolution": "Please configure package-management according to documentation.",
+                "expected_details": None,
+                "expected_docs_url": "<TODO>",
+                "expected_reportable": False,
+            },
+        ),
+        (
+            "RepositoryValidationError",
+            {
+                "exception": errors.RepositoryValidationError,
+                "kwargs": dict(message="invalid ..."),
+                "expected_brief": "Invalid repository: invalid ...",
+                "expected_resolution": "Please configure repository according to documentation.",
+                "expected_details": None,
+                "expected_docs_url": "<TODO>",
+                "expected_reportable": False,
+            },
+        ),
+        (
             "SystemUsernamesValidationError",
             {
                 "exception": errors.SystemUsernamesValidationError,

--- a/tests/unit/meta/test_package_management.py
+++ b/tests/unit/meta/test_package_management.py
@@ -1,0 +1,235 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from testtools.matchers import Equals
+
+from snapcraft.internal.meta import errors
+from snapcraft.internal.meta.package_management import PackageManagement, Repository
+from tests import unit
+
+
+class ValidRepositoriesTests(unit.TestCase):
+    scenarios = [
+        (
+            "minimal ppa",
+            dict(
+                source="test_ppa",
+                gpg_public_key=None,
+                gpg_public_key_id=None,
+                gpg_key_server=None,
+            ),
+        ),
+        (
+            "minimal url",
+            dict(
+                source="deb http://archive.canonical.com/ubuntu bionic partner",
+                gpg_public_key=None,
+                gpg_public_key_id=None,
+                gpg_key_server=None,
+            ),
+        ),
+        (
+            "url + gpg-public-key",
+            dict(
+                source="deb http://archive.canonical.com/ubuntu bionic partner",
+                gpg_public_key="-----BEGIN PGP PUBLIC KEY BLOCK-----\n...\n-----END PGP PUBLIC KEY BLOCK-----",
+                gpg_public_key_id=None,
+                gpg_key_server=None,
+            ),
+        ),
+        (
+            "url + gpg-public-key-id",
+            dict(
+                source="deb http://archive.canonical.com/ubuntu bionic partner",
+                gpg_public_key=None,
+                gpg_public_key_id="0ab215679c571d1c8325275b9bdb3d89ce49ec21",
+                gpg_key_server=None,
+            ),
+        ),
+        (
+            "url + gpg-public-key-id + gpg-key-server",
+            dict(
+                source="deb http://archive.canonical.com/ubuntu bionic partner",
+                gpg_public_key="0ab215679c571d1c8325275b9bdb3d89ce49ec21",
+                gpg_public_key_id=None,
+                gpg_key_server="keyserver.ubuntu.com",
+            ),
+        ),
+    ]
+
+    def test_repo_init(self):
+        repo = Repository(
+            source=self.source,
+            gpg_public_key=self.gpg_public_key,
+            gpg_public_key_id=self.gpg_public_key_id,
+            gpg_key_server=self.gpg_key_server,
+        )
+        repo.validate()
+
+        self.assertThat(repo.source, Equals(self.source))
+        self.assertThat(repo.gpg_public_key, Equals(self.gpg_public_key))
+        self.assertThat(repo.gpg_public_key_id, Equals(self.gpg_public_key_id))
+        self.assertThat(repo.gpg_key_server, Equals(self.gpg_key_server))
+
+    def test_repo_from_dict(self):
+        repo_dict = dict(source=self.source)
+        if self.gpg_public_key:
+            repo_dict["gpg-public-key"] = self.gpg_public_key
+        if self.gpg_public_key_id:
+            repo_dict["gpg-public-key-id"] = self.gpg_public_key_id
+        if self.gpg_key_server:
+            repo_dict["gpg-key-server"] = self.gpg_key_server
+
+        repo = Repository.from_dict(repo_dict)
+        repo.validate()
+
+        self.assertThat(repo.source, Equals(self.source))
+        self.assertThat(repo.gpg_public_key, Equals(self.gpg_public_key))
+        self.assertThat(repo.gpg_public_key_id, Equals(self.gpg_public_key_id))
+        self.assertThat(repo.gpg_key_server, Equals(self.gpg_key_server))
+
+    def test_repo_from_object(self):
+        repo_dict = dict(source=self.source)
+        if self.gpg_public_key:
+            repo_dict["gpg-public-key"] = self.gpg_public_key
+        if self.gpg_public_key_id:
+            repo_dict["gpg-public-key-id"] = self.gpg_public_key_id
+        if self.gpg_key_server:
+            repo_dict["gpg-key-server"] = self.gpg_key_server
+
+        repo = Repository.from_object(repo_dict)
+        repo.validate()
+
+        self.assertThat(repo.source, Equals(self.source))
+        self.assertThat(repo.gpg_public_key, Equals(self.gpg_public_key))
+        self.assertThat(repo.gpg_public_key_id, Equals(self.gpg_public_key_id))
+        self.assertThat(repo.gpg_key_server, Equals(self.gpg_key_server))
+
+
+class InvalidRepositoryTests(unit.TestCase):
+    def test_invalld_object_none(self):
+        repo_object = None
+
+        error = self.assertRaises(
+            errors.RepositoryValidationError, Repository.from_object, repo_object
+        )
+
+        self.assertThat(
+            error.get_brief(), Equals("Invalid repository: empty definition")
+        )
+
+    def test_invalid_object_missing_source(self):
+        repo_object = {"source": ""}
+
+        error = self.assertRaises(
+            errors.RepositoryValidationError, Repository.from_object, repo_object
+        )
+
+        self.assertThat(
+            error.get_brief(),
+            Equals("Invalid repository: 'source' undefined for {'source': ''}"),
+        )
+
+    def test_invalid_object_empty_source(self):
+        repo_object = {"source": ""}
+
+        error = self.assertRaises(
+            errors.RepositoryValidationError, Repository.from_object, repo_object
+        )
+
+        self.assertThat(
+            error.get_brief(),
+            Equals("Invalid repository: 'source' undefined for {'source': ''}"),
+        )
+
+    def test_invalid_object(self):
+        repo_object = "invalid-repository"
+
+        error = self.assertRaises(
+            errors.RepositoryValidationError, Repository.from_object, repo_object
+        )
+
+        self.assertThat(
+            error.get_brief(),
+            Equals("Invalid repository: unknown syntax for 'invalid-repository'"),
+        )
+
+
+class PackageManagementTests(unit.TestCase):
+    def test_from_object_none(self):
+        pm_object = None
+
+        pm = PackageManagement.from_object(pm_object)
+        self.assertThat(pm.repositories, Equals([]))
+
+    def test_from_object_list(self):
+        pm_object = ["invalid-list"]
+
+        error = self.assertRaises(
+            errors.PackageManagementValidationError,
+            PackageManagement.from_object,
+            pm_object,
+        )
+
+        self.assertThat(
+            error.get_brief(),
+            Equals("Invalid package-management: unknown syntax for ['invalid-list']"),
+        )
+
+    def test_from_object_string(self):
+        pm_object = "invalid-string"
+
+        error = self.assertRaises(
+            errors.PackageManagementValidationError,
+            PackageManagement.from_object,
+            pm_object,
+        )
+
+        self.assertThat(
+            error.get_brief(),
+            Equals("Invalid package-management: unknown syntax for 'invalid-string'"),
+        )
+
+    def test_from_object_empty(self):
+        pm_object = dict()
+
+        pm = PackageManagement.from_object(pm_object)
+        self.assertThat(pm.repositories, Equals([]))
+
+    def test_from_object_empty_list(self):
+        pm_object = dict(repositories=[])
+
+        pm = PackageManagement.from_object(pm_object)
+        self.assertThat(pm.repositories, Equals([]))
+
+    def test_from_object_one_repo(self):
+        pm_object = dict(repositories=[dict(source="ppa:test-ppa")])
+
+        pm = PackageManagement.from_object(pm_object)
+        self.assertThat(pm.repositories, Equals([Repository(source="ppa:test-ppa")]))
+
+    def test_from_object_two_repos(self):
+        pm_object = dict(
+            repositories=[dict(source="ppa:test-ppa"), dict(source="ppa:test-ppa2")]
+        )
+
+        pm = PackageManagement.from_object(pm_object)
+        self.assertThat(
+            pm.repositories,
+            Equals(
+                [Repository(source="ppa:test-ppa"), Repository(source="ppa:test-ppa2")]
+            ),
+        )

--- a/tests/unit/repo/test_errors.py
+++ b/tests/unit/repo/test_errors.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from testtools.matchers import Equals
 
+from snapcraft.internal.meta.package_management import Repository
 from snapcraft.internal.repo import errors
 from tests import unit
 
@@ -39,3 +40,57 @@ class ErrorFormattingTestCase(unit.TestCase):
         self.assertThat(
             str(self.exception(**self.kwargs)), Equals(self.expected_message)
         )
+
+
+class SnapcraftExceptionTests(unit.TestCase):
+
+    scenarios = [
+        (
+            "RepositoryError",
+            {
+                "exception": errors.RepositoryError,
+                "kwargs": dict(
+                    repo=Repository(
+                        source="ppa:test-source",
+                        gpg_public_key=None,
+                        gpg_public_key_id="TEST-GPG-KEYID",
+                        gpg_key_server="test.keyserver.com",
+                    ),
+                    message="some reason",
+                ),
+                "expected_brief": "Error adding repository: some reason",
+                "expected_resolution": "Please ensure that the repository key configuration for Repository(source='ppa:test-source', gpg-public-key=None, gpg-public-key-id='TEST-GPG-KEYID', gpg-key-server=test.keyserver.com) is valid.",
+                "expected_details": None,
+                "expected_docs_url": "<TODO>",
+                "expected_reportable": False,
+            },
+        ),
+        (
+            "RepositoryKeyError",
+            {
+                "exception": errors.RepositoryKeyError,
+                "kwargs": dict(
+                    repo=Repository(
+                        source="ppa:test-source",
+                        gpg_public_key=None,
+                        gpg_public_key_id="TEST-GPG-KEYID",
+                        gpg_key_server="test.keyserver.com",
+                    ),
+                    message="some reason",
+                ),
+                "expected_brief": "Error adding repository key: some reason",
+                "expected_resolution": "Please ensure that the repository key configuration for Repository(source='ppa:test-source', gpg-public-key=None, gpg-public-key-id='TEST-GPG-KEYID', gpg-key-server=test.keyserver.com) is valid and that key server 'test.keyserver.com' is accessible.",
+                "expected_details": None,
+                "expected_docs_url": "<TODO>",
+                "expected_reportable": False,
+            },
+        ),
+    ]
+
+    def test_snapcraft_exception_handling(self):
+        exception = self.exception(**self.kwargs)
+        self.assertEquals(self.expected_brief, exception.get_brief())
+        self.assertEquals(self.expected_resolution, exception.get_resolution())
+        self.assertEquals(self.expected_details, exception.get_details())
+        self.assertEquals(self.expected_docs_url, exception.get_docs_url())
+        self.assertEquals(self.expected_reportable, exception.get_reportable())

--- a/tests/unit/repo/test_package_management.py
+++ b/tests/unit/repo/test_package_management.py
@@ -1,0 +1,487 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from subprocess import PIPE, STDOUT, CalledProcessError
+from unittest.mock import MagicMock, call, patch
+
+import fixtures
+from testtools.matchers import Equals
+
+from snapcraft.internal.meta.package_management import PackageManagement, Repository
+from snapcraft.internal.repo import errors, package_management
+from tests import unit
+from tests.fixture_setup.os_release import FakeOsRelease
+
+
+class InstallAptRepositoryKeyIdTests(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.useFixture(FakeOsRelease())
+
+        self.fake_run = self.useFixture(
+            fixtures.MockPatch("snapcraft.internal.repo.package_management.run")
+        ).mock
+        self.fake_run.return_value = MagicMock(stdout="imported: 1".encode())
+
+    def test_no_key_id(self):
+        repo = Repository(source="ppa:source", gpg_public_key_id=None)
+        package_management._install_apt_repository_key_id(repo)
+
+    def test_with_key_id(self):
+        repo = Repository(source="ppa:source", gpg_public_key_id="KEYID")
+        package_management._install_apt_repository_key_id(repo)
+
+        self.fake_run.assert_has_calls(
+            [
+                call(
+                    [
+                        "sudo",
+                        "apt-key",
+                        "adv",
+                        "--keyserver",
+                        "keyserver.ubuntu.com",
+                        "--recv-keys",
+                        "KEYID",
+                    ],
+                    stdout=PIPE,
+                    stderr=STDOUT,
+                    check=True,
+                )
+            ]
+        )
+
+    def test_with_key_server(self):
+        repo = Repository(
+            source="ppa:source",
+            gpg_public_key_id="KEYID",
+            gpg_key_server="gpg.key.server",
+        )
+        package_management._install_apt_repository_key_id(repo)
+
+        self.fake_run.assert_has_calls(
+            [
+                call(
+                    [
+                        "sudo",
+                        "apt-key",
+                        "adv",
+                        "--keyserver",
+                        "gpg.key.server",
+                        "--recv-keys",
+                        "KEYID",
+                    ],
+                    stdout=PIPE,
+                    stderr=STDOUT,
+                    check=True,
+                )
+            ]
+        )
+
+
+class InstallAptRepositoryKeyIdErrorTests(unit.TestCase):
+    scenarios = [
+        (
+            "unknnown error",
+            dict(error_message="unknown error", expected="unknown error"),
+        ),
+        (
+            "unknnown error2",
+            dict(error_message="unknown error2", expected="unknown error2"),
+        ),
+        (
+            "ignore warning",
+            dict(
+                error_message="Warning: apt-key output should not be parsed (stdout is not a terminal)\nsome error",
+                expected="some error",
+            ),
+        ),
+        (
+            "no data",
+            dict(
+                error_message="gpg: keyserver receive failed: No data",
+                expected="GPG key ID 'KEYID' not found on key server 'gpg.key.server'",
+            ),
+        ),
+        (
+            "server filure",
+            dict(
+                error_message="gpg: keyserver receive failed: Server indicated a failure",
+                expected="unable to establish connection to key server 'gpg.key.server'",
+            ),
+        ),
+        (
+            "timeout",
+            dict(
+                error_message="gpg: keyserver receive failed: Connection timed out",
+                expected="unable to establish connection to key server 'gpg.key.server' (connection timed out)",
+            ),
+        ),
+    ]
+
+    def setUp(self):
+        super().setUp()
+        self.useFixture(FakeOsRelease())
+
+        self.fake_run = self.useFixture(
+            fixtures.MockPatch("snapcraft.internal.repo.package_management.run")
+        ).mock
+        self.fake_run.return_value = MagicMock(stdout=self.error_message.encode())
+
+    def test_error(self):
+        repo = Repository(
+            source="ppa:source",
+            gpg_public_key_id="KEYID",
+            gpg_key_server="gpg.key.server",
+        )
+
+        error = CalledProcessError(1, ["apt-key"])
+        error.output = self.error_message.encode()
+        self.fake_run.side_effect = error
+
+        error = self.assertRaises(
+            errors.RepositoryKeyError,
+            package_management._install_apt_repository_key_id,
+            repo,
+        )
+
+        self.assertThat(error._repo, Equals(repo))
+        self.assertThat(error._message, Equals(self.expected))
+
+
+class InstallAptRepositoryKeyBlockTests(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.useFixture(FakeOsRelease())
+
+    @patch("snapcraft.internal.repo.package_management.run")
+    def test_no_key_id(self, mock_run):
+        gpg_public_key = None
+        repo = Repository(source="ppa:source", gpg_public_key=gpg_public_key)
+        package_management._install_apt_repository_key_block(repo)
+
+        mock_run.assert_not_called()
+
+    @patch("snapcraft.internal.repo.package_management.run")
+    def test_with_key_id(self, mock_run):
+        gpg_public_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n...\n-----END PGP PUBLIC KEY BLOCK-----"
+        repo = Repository(source="ppa:source", gpg_public_key=gpg_public_key)
+        package_management._install_apt_repository_key_block(repo)
+
+        mock_run.assert_has_calls(
+            [
+                call(
+                    ["sudo", "apt-key", "add", "-"],
+                    input=gpg_public_key.encode(),
+                    stdout=PIPE,
+                    stderr=STDOUT,
+                    check=True,
+                )
+            ]
+        )
+
+
+class InstallAptRepositoryKeyBlockErrorTests(unit.TestCase):
+    scenarios = [
+        (
+            "unknnown error",
+            dict(error_message="unknown error", expected="unknown error"),
+        ),
+        (
+            "unknnown error2",
+            dict(error_message="unknown error2", expected="unknown error2"),
+        ),
+        (
+            "ignore warning",
+            dict(
+                error_message="Warning: apt-key output should not be parsed (stdout is not a terminal)\nsome error",
+                expected="some error",
+            ),
+        ),
+    ]
+
+    def setUp(self):
+        super().setUp()
+        self.useFixture(FakeOsRelease())
+
+    @patch("snapcraft.internal.repo.package_management.run")
+    def test_error_with_process_error(self, mock_run):
+        gpg_public_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n...\n-----END PGP PUBLIC KEY BLOCK-----"
+        repo = Repository(source="ppa:source", gpg_public_key=gpg_public_key)
+
+        error = CalledProcessError(1, ["apt-key"])
+        error.output = self.error_message.encode()
+        mock_run.side_effect = error
+
+        error = self.assertRaises(
+            errors.RepositoryKeyError,
+            package_management._install_apt_repository_key_block,
+            repo,
+        )
+
+        self.assertThat(error._repo, Equals(repo))
+        self.assertThat(error._message, Equals(self.expected))
+
+
+class InstallAptRepositoryTests(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+
+    @patch("snapcraft.internal.repo.package_management.run")
+    def test_source(self, mock_run):
+        repo = Repository(source="ppa:source")
+        package_management._install_apt_repository(repo)
+
+        mock_run.assert_has_calls(
+            [
+                call(
+                    ["sudo", "apt-add-repository", "-y", "ppa:source"],
+                    stdout=PIPE,
+                    stderr=STDOUT,
+                    check=True,
+                )
+            ]
+        )
+
+
+class InstallAptRepositoryScTests(unit.TestCase):
+    scenarios = [
+        (
+            "minimal ppa",
+            dict(
+                source="test_ppa",
+                gpg_public_key=None,
+                gpg_public_key_id=None,
+                gpg_key_server=None,
+                expected_calls=[
+                    call(
+                        ["sudo", "apt-add-repository", "-y", "test_ppa"],
+                        stdout=PIPE,
+                        stderr=STDOUT,
+                        check=True,
+                    )
+                ],
+            ),
+        ),
+        (
+            "minimal url",
+            dict(
+                source="deb http://archive.canonical.com/ubuntu bionic partner",
+                gpg_public_key=None,
+                gpg_public_key_id=None,
+                gpg_key_server=None,
+                expected_calls=[
+                    call(
+                        [
+                            "sudo",
+                            "apt-add-repository",
+                            "-y",
+                            "deb http://archive.canonical.com/ubuntu bionic partner",
+                        ],
+                        stdout=PIPE,
+                        stderr=STDOUT,
+                        check=True,
+                    )
+                ],
+            ),
+        ),
+        (
+            "url + gpg-public-key",
+            dict(
+                source="deb http://archive.canonical.com/ubuntu bionic partner",
+                gpg_public_key="-----BEGIN PGP PUBLIC KEY BLOCK-----\n...\n-----END PGP PUBLIC KEY BLOCK-----",
+                gpg_public_key_id=None,
+                gpg_key_server=None,
+                expected_calls=[
+                    call(
+                        ["sudo", "apt-key", "add", "-"],
+                        input=b"-----BEGIN PGP PUBLIC KEY BLOCK-----\n...\n-----END PGP PUBLIC KEY BLOCK-----",
+                        stdout=PIPE,
+                        stderr=STDOUT,
+                        check=True,
+                    ),
+                    call(
+                        [
+                            "sudo",
+                            "apt-add-repository",
+                            "-y",
+                            "deb http://archive.canonical.com/ubuntu bionic partner",
+                        ],
+                        stdout=PIPE,
+                        stderr=STDOUT,
+                        check=True,
+                    ),
+                ],
+            ),
+        ),
+        (
+            "url + gpg-public-key-id",
+            dict(
+                source="deb http://archive.canonical.com/ubuntu bionic partner",
+                gpg_public_key=None,
+                gpg_public_key_id="0ab215679c571d1c8325275b9bdb3d89ce49ec21",
+                gpg_key_server=None,
+                expected_calls=[
+                    call(
+                        [
+                            "sudo",
+                            "apt-key",
+                            "adv",
+                            "--keyserver",
+                            "keyserver.ubuntu.com",
+                            "--recv-keys",
+                            "0ab215679c571d1c8325275b9bdb3d89ce49ec21",
+                        ],
+                        stdout=PIPE,
+                        stderr=STDOUT,
+                        check=True,
+                    ),
+                    call(
+                        [
+                            "sudo",
+                            "apt-add-repository",
+                            "-y",
+                            "deb http://archive.canonical.com/ubuntu bionic partner",
+                        ],
+                        stdout=PIPE,
+                        stderr=STDOUT,
+                        check=True,
+                    ),
+                ],
+            ),
+        ),
+        (
+            "url + gpg-public-key-id + gpg-key-server",
+            dict(
+                source="deb http://archive.canonical.com/ubuntu bionic partner",
+                gpg_public_key="0ab215679c571d1c8325275b9bdb3d89ce49ec21",
+                gpg_public_key_id=None,
+                gpg_key_server="keyserver.ubuntu.com",
+                expected_calls=[
+                    call(
+                        ["sudo", "apt-key", "add", "-"],
+                        input=b"0ab215679c571d1c8325275b9bdb3d89ce49ec21",
+                        stdout=PIPE,
+                        stderr=STDOUT,
+                        check=True,
+                    ),
+                    call(
+                        [
+                            "sudo",
+                            "apt-add-repository",
+                            "-y",
+                            "deb http://archive.canonical.com/ubuntu bionic partner",
+                        ],
+                        stdout=PIPE,
+                        stderr=STDOUT,
+                        check=True,
+                    ),
+                ],
+            ),
+        ),
+    ]
+
+    def setUp(self):
+        super().setUp()
+        self.useFixture(FakeOsRelease())
+
+        self.fake_run = self.useFixture(
+            fixtures.MockPatch("snapcraft.internal.repo.package_management.run")
+        ).mock
+        self.fake_run.return_value = MagicMock(stdout="imported: 1".encode())
+
+    def test_repo_install(self):
+        repo = Repository(
+            source=self.source,
+            gpg_public_key=self.gpg_public_key,
+            gpg_public_key_id=self.gpg_public_key_id,
+            gpg_key_server=self.gpg_key_server,
+        )
+
+        package_management._install_repository(repo)
+
+        self.assertThat(self.fake_run.mock_calls, Equals(self.expected_calls))
+
+
+class GetBuildToolsTests(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+
+    @patch(
+        "snapcraft.internal.repo.package_management.OsRelease.id", return_value="ubuntu"
+    )
+    def test_ubuntu(self, mock_id):
+        build_tools = package_management._get_repo_build_tools()
+
+        self.assertThat(build_tools, Equals(["software-properties-common"]))
+
+
+class ConfigurePackageManagerTests(unit.TestCase):
+    @patch(
+        "snapcraft.internal.repo.package_management.OsRelease.id", return_value="centos"
+    )
+    def test_non_ubuntu_no_repos(self, mock_id):
+        # Make sure there is no exception thrown.
+        package_management.configure_package_manager(PackageManagement())
+
+    @patch(
+        "snapcraft.internal.repo.package_management.OsRelease.id", return_value="centos"
+    )
+    def test_non_ubuntu_with_repos(self, mock_id):
+        # Make sure exception is thrown.
+        self.assertRaises(
+            RuntimeError,
+            package_management.configure_package_manager,
+            PackageManagement(repositories=[Repository(source="ppa:test-ppa")]),
+        )
+
+    @patch(
+        "snapcraft.internal.repo.package_management.OsRelease.id", return_value="ubuntu"
+    )
+    @patch("snapcraft.internal.repo.package_management.Repo.install_build_packages")
+    @patch("snapcraft.internal.repo.package_management.run")
+    def test_ubuntu_with_repos(self, mock_run, mock_repo, mock_id):
+        package_management.configure_package_manager(
+            PackageManagement(
+                repositories=[
+                    Repository(source="ppa:test-ppa"),
+                    Repository(source="ppa:test-ppa2"),
+                ]
+            )
+        )
+
+        self.assertThat(
+            mock_repo.mock_calls,
+            Equals([call.install_build_packages(["software-properties-common"])]),
+        )
+        self.assertThat(
+            mock_run.mock_calls,
+            Equals(
+                [
+                    call(
+                        ["sudo", "apt-add-repository", "-y", "ppa:test-ppa"],
+                        stderr=STDOUT,
+                        stdout=PIPE,
+                        check=True,
+                    ),
+                    call(
+                        ["sudo", "apt-add-repository", "-y", "ppa:test-ppa2"],
+                        stderr=STDOUT,
+                        stdout=PIPE,
+                        check=True,
+                    ),
+                ]
+            ),
+        )


### PR DESCRIPTION
This adds a high-level key 'package-management', configured with
one property `repositories` for a generic approach to allowing additional
source repositories with a configurable/optional GPG key.

While I can't guarantee `repositories` will work for every scenario
for every possible OS, it appears that a common pattern is to require
a source URL and GPG key.  With the provided structure to support
OS-specific configuration (e.g. `package-management.apt`), this schema
remains extendable to support OS-specific requirements.

Example:

```
package-management:

  repositories:

    # Option 1: PPA shortcut (automatically imports PPA key from LP):
    - source: "ppa:mozillateam/ppa

    # Option 2: Use repository with OS-installed keys:
    - source: "deb http://ppa.launchpad.net/mozillateam/ppa/ubuntu bionic main"

    # Option 3: Use repository with GPG key fetched from keyserver:
    - source: "deb http://ppa.launchpad.net/mozillateam/ppa/ubuntu bionic main"
      gpg-key-server: keyserver.ubuntu.com
      gpg-public-key-id: 0ab215679c571d1c8325275b9bdb3d89ce49ec21

    # Option 4: Use repository with provided GPG key:
    - source: "deb http://ppa.launchpad.net/mozillateam/ppa/ubuntu bionic main"
      gpg-public-key: |
        -----BEGIN PGP PUBLIC KEY BLOCK-----
        <snipped>
        -----END PGP PUBLIC KEY BLOCK-----

    # EPEL example:
    - source: http://download.fedoraproject.org/pub/epel/testing/8/$basearch
      gpg-public-key: |
        -----BEGIN PGP PUBLIC KEY BLOCK-----
        <snipped>
        -----END PGP PUBLIC KEY BLOCK-----