### PR TITLE
[backport] meta: fix missing provider case for get_provider_content_directories()

### DIFF
--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -113,12 +113,15 @@ class Snap:
         for plug in self.get_content_plugs():
             # Get matching slot provider for plug.
             provider = plug.provider
+            if not provider:
+                continue
+
             provider_path = common.get_installed_snap_path(provider)
             yaml_path = os.path.join(provider_path, "meta", "snap.yaml")
 
             snap = Snap.from_file(yaml_path)
             for slot in snap.get_content_slots():
-                slot_installed_path = common.get_installed_snap_path(plug.provider)
+                slot_installed_path = common.get_installed_snap_path(provider)
                 provider_dirs |= slot.get_content_dirs(
                     installed_path=slot_installed_path
                 )


### PR DESCRIPTION
Ignore plugs without defined provider in get_provider_content_directories().

The type is declared as optional and mypy uprev errors on the fact that
provider could be None.

If processing a plug without a provider, just skip it and move on.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
