### PR TITLE
docker: add core18 snap that snapcraft now uses as a base

### DIFF
--- a/docker/beta.Dockerfile
+++ b/docker/beta.Dockerfile
@@ -8,17 +8,26 @@ RUN apt-get install --yes \
       jq \
       squashfs-tools
 
-# Grab the core snap from the stable channel and unpack it in the proper place
+# Grab the core snap (for backwards compatibility) from the stable channel and
+# unpack it in the proper place.
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
 RUN mkdir -p /snap/core
 RUN unsquashfs -d /snap/core/current core.snap
 
-# Grab the snapcraft snap from the beta channel and unpack it in the proper place
+# Grab the core18 snap (which snapcraft uses as a base) from the stable channel
+# and unpack it in the proper place.
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core18' | jq '.download_url' -r) --output core18.snap
+RUN mkdir -p /snap/core18
+RUN unsquashfs -d /snap/core18/current core18.snap
+
+# Grab the snapcraft snap from the beta channel and unpack it in the proper
+# place.
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=beta' | jq '.download_url' -r) --output snapcraft.snap
 RUN mkdir -p /snap/snapcraft
 RUN unsquashfs -d /snap/snapcraft/current snapcraft.snap
 
-# Create a snapcraft runner (TODO: move version detection to the core of snapcraft)
+# Create a snapcraft runner (TODO: move version detection to the core of
+# snapcraft).
 RUN mkdir -p /snap/bin
 RUN echo "#!/bin/sh" > /snap/bin/snapcraft
 RUN snap_version="$(awk '/^version:/{print $2}' /snap/snapcraft/current/meta/snap.yaml)" && echo "export SNAP_VERSION=\"$snap_version\"" >> /snap/bin/snapcraft
@@ -29,13 +38,14 @@ RUN chmod +x /snap/bin/snapcraft
 # time so they can be cached.
 FROM ubuntu:xenial
 COPY --from=builder /snap/core /snap/core
+COPY --from=builder /snap/core18 /snap/core18
 COPY --from=builder /snap/snapcraft /snap/snapcraft
 COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
 
-# Generate locale
+# Generate locale.
 RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes sudo locales && locale-gen en_US.UTF-8
 
-# Set the proper environment
+# Set the proper environment.
 ENV LANG="en_US.UTF-8"
 ENV LANGUAGE="en_US:en"
 ENV LC_ALL="en_US.UTF-8"

--- a/docker/candidate.Dockerfile
+++ b/docker/candidate.Dockerfile
@@ -8,17 +8,26 @@ RUN apt-get install --yes \
       jq \
       squashfs-tools
 
-# Grab the core snap from the stable channel and unpack it in the proper place
+# Grab the core snap (for backwards compatibility) from the stable channel and
+# unpack it in the proper place.
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
 RUN mkdir -p /snap/core
 RUN unsquashfs -d /snap/core/current core.snap
 
-# Grab the snapcraft snap from the candidate channel and unpack it in the proper place
+# Grab the core18 snap (which snapcraft uses as a base) from the stable channel
+# and unpack it in the proper place.
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core18' | jq '.download_url' -r) --output core18.snap
+RUN mkdir -p /snap/core18
+RUN unsquashfs -d /snap/core18/current core18.snap
+
+# Grab the snapcraft snap from the candidate channel and unpack it in the proper
+# place.
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=candidate' | jq '.download_url' -r) --output snapcraft.snap
 RUN mkdir -p /snap/snapcraft
 RUN unsquashfs -d /snap/snapcraft/current snapcraft.snap
 
-# Create a snapcraft runner (TODO: move version detection to the core of snapcraft)
+# Create a snapcraft runner (TODO: move version detection to the core of
+# snapcraft).
 RUN mkdir -p /snap/bin
 RUN echo "#!/bin/sh" > /snap/bin/snapcraft
 RUN snap_version="$(awk '/^version:/{print $2}' /snap/snapcraft/current/meta/snap.yaml)" && echo "export SNAP_VERSION=\"$snap_version\"" >> /snap/bin/snapcraft
@@ -29,6 +38,7 @@ RUN chmod +x /snap/bin/snapcraft
 # time so they can be cached.
 FROM ubuntu:xenial
 COPY --from=builder /snap/core /snap/core
+COPY --from=builder /snap/core18 /snap/core18
 COPY --from=builder /snap/snapcraft /snap/snapcraft
 COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
 

--- a/docker/edge.Dockerfile
+++ b/docker/edge.Dockerfile
@@ -8,17 +8,26 @@ RUN apt-get install --yes \
       jq \
       squashfs-tools
 
-# Grab the core snap from the stable channel and unpack it in the proper place
+# Grab the core snap (for backwards compatibility) from the stable channel and
+# unpack it in the proper place.
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
 RUN mkdir -p /snap/core
 RUN unsquashfs -d /snap/core/current core.snap
 
-# Grab the snapcraft snap from the edge channel and unpack it in the proper place
+# Grab the core18 snap (which snapcraft uses as a base) from the stable channel
+# and unpack it in the proper place
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core18' | jq '.download_url' -r) --output core18.snap
+RUN mkdir -p /snap/core18
+RUN unsquashfs -d /snap/core18/current core18.snap
+
+# Grab the snapcraft snap from the edge channel and unpack it in the proper
+# place.
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=edge' | jq '.download_url' -r) --output snapcraft.snap
 RUN mkdir -p /snap/snapcraft
 RUN unsquashfs -d /snap/snapcraft/current snapcraft.snap
 
-# Create a snapcraft runner (TODO: move version detection to the core of snapcraft)
+# Create a snapcraft runner (TODO: move version detection to the core of
+# snapcraft).
 RUN mkdir -p /snap/bin
 RUN echo "#!/bin/sh" > /snap/bin/snapcraft
 RUN snap_version="$(awk '/^version:/{print $2}' /snap/snapcraft/current/meta/snap.yaml)" && echo "export SNAP_VERSION=\"$snap_version\"" >> /snap/bin/snapcraft
@@ -29,13 +38,14 @@ RUN chmod +x /snap/bin/snapcraft
 # time so they can be cached.
 FROM ubuntu:xenial
 COPY --from=builder /snap/core /snap/core
+COPY --from=builder /snap/core18 /snap/core18
 COPY --from=builder /snap/snapcraft /snap/snapcraft
 COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
 
-# Generate locale
+# Generate locale.
 RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes sudo locales && locale-gen en_US.UTF-8
 
-# Set the proper environment
+# Set the proper environment.
 ENV LANG="en_US.UTF-8"
 ENV LANGUAGE="en_US:en"
 ENV LC_ALL="en_US.UTF-8"

--- a/docker/stable.Dockerfile
+++ b/docker/stable.Dockerfile
@@ -8,17 +8,26 @@ RUN apt-get install --yes \
       jq \
       squashfs-tools
 
-# Grab the core snap from the stable channel and unpack it in the proper place
+# Grab the core snap (for backwards compatibility) from the stable channel and
+# unpack it in the proper place.
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
 RUN mkdir -p /snap/core
 RUN unsquashfs -d /snap/core/current core.snap
 
-# Grab the snapcraft snap from the stable channel and unpack it in the proper place
+# Grab the core18 snap (which snapcraft uses as a base) from the stable channel
+# and unpack it in the proper place.
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core18' | jq '.download_url' -r) --output core18.snap
+RUN mkdir -p /snap/core18
+RUN unsquashfs -d /snap/core18/current core18.snap
+
+# Grab the snapcraft snap from the stable channel and unpack it in the proper
+# place.
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=stable' | jq '.download_url' -r) --output snapcraft.snap
 RUN mkdir -p /snap/snapcraft
 RUN unsquashfs -d /snap/snapcraft/current snapcraft.snap
 
-# Create a snapcraft runner (TODO: move version detection to the core of snapcraft)
+# Create a snapcraft runner (TODO: move version detection to the core of
+# snapcraft).
 RUN mkdir -p /snap/bin
 RUN echo "#!/bin/sh" > /snap/bin/snapcraft
 RUN snap_version="$(awk '/^version:/{print $2}' /snap/snapcraft/current/meta/snap.yaml)" && echo "export SNAP_VERSION=\"$snap_version\"" >> /snap/bin/snapcraft
@@ -29,13 +38,14 @@ RUN chmod +x /snap/bin/snapcraft
 # time so they can be cached.
 FROM ubuntu:xenial
 COPY --from=builder /snap/core /snap/core
+COPY --from=builder /snap/core18 /snap/core18
 COPY --from=builder /snap/snapcraft /snap/snapcraft
 COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
 
-# Generate locale
+# Generate locale.
 RUN apt-get update && apt-get dist-upgrade --yes && apt-get install --yes sudo locales && locale-gen en_US.UTF-8
 
-# Set the proper environment
+# Set the proper environment.
 ENV LANG="en_US.UTF-8"
 ENV LANGUAGE="en_US:en"
 ENV LC_ALL="en_US.UTF-8"


### PR DESCRIPTION
Also update comments for correctness and syntax.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
