### PR TITLE
plugs/slots: match output format read in snapcraft.yaml

### DIFF
--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -369,11 +369,11 @@ class Snap:
             elif key == "plugs":
                 snap_dict[key] = dict()
                 for name, plug in sorted(self.plugs.items()):
-                    snap_dict[key][name] = plug.to_dict()
+                    snap_dict[key][name] = plug.to_yaml_object()
             elif key == "slots":
                 snap_dict[key] = dict()
                 for name, slot in sorted(self.slots.items()):
-                    snap_dict[key][name] = slot.to_dict()
+                    snap_dict[key][name] = slot.to_yaml_object()
             elif key == "system-usernames":
                 if not self.system_usernames:
                     continue

--- a/tests/unit/meta/test_plugs.py
+++ b/tests/unit/meta/test_plugs.py
@@ -35,14 +35,6 @@ class GenericPlugTests(unit.TestCase):
         self.assertEqual(plug_name, plug.plug_name)
         self.assertEqual(plug_name, plug_from_dict.plug_name)
 
-    def test_invalid_raises_exception(self):
-        plug_name = "plug-test"
-
-        plug = Plug(plug_name=plug_name)
-        plug._plug_dict = dict({})
-
-        self.assertRaises(errors.PlugValidationError, plug.validate)
-
     def test_from_empty_dict(self):
         plug_dict = OrderedDict({})
         plug_name = "plug-test"
@@ -63,13 +55,14 @@ class GenericPlugTests(unit.TestCase):
         plug = Plug.from_object(plug_name="plug-name", plug_object=None)
         plug.validate()
 
-        self.assertThat(plug._plug_dict["interface"], Equals("plug-name"))
+        self.assertThat(plug._plug_dict, Equals(dict()))
 
     def test_from_object_string(self):
         plug = Plug.from_object(plug_name="plug-name", plug_object="some-interface")
         plug.validate()
 
         self.assertThat(plug._plug_dict["interface"], Equals("some-interface"))
+        self.assertThat(plug.use_string_representation, Equals(True))
 
     def test_from_object_dict(self):
         plug_dict = OrderedDict(
@@ -120,7 +113,7 @@ class ContentPlugTests(unit.TestCase):
         transformed_dict = plug_dict.copy()
         transformed_dict["default-provider"] = plug_provider
 
-        self.assertEqual(transformed_dict, plug.to_dict())
+        self.assertEqual(transformed_dict, plug.to_yaml_object())
         self.assertEqual(plug_name, plug.plug_name)
         self.assertEqual(plug_dict["content"], plug.content)
         self.assertEqual(plug_dict["target"], plug.target)

--- a/tests/unit/meta/test_slots.py
+++ b/tests/unit/meta/test_slots.py
@@ -35,14 +35,6 @@ class GenericSlotTests(unit.TestCase):
         self.assertEqual(slot_name, slot.slot_name)
         self.assertEqual(slot_name, slot_from_dict.slot_name)
 
-    def test_invalid_raises_exception(self):
-        slot_name = "slot-test"
-
-        slot = Slot(slot_name=slot_name)
-        slot._slot_dict = dict({})
-
-        self.assertRaises(errors.SlotValidationError, slot.validate)
-
     def test_from_empty_dict(self):
         slot_dict = OrderedDict({})
         slot_name = "slot-test"
@@ -63,13 +55,14 @@ class GenericSlotTests(unit.TestCase):
         slot = Slot.from_object(slot_name="slot-name", slot_object=None)
         slot.validate()
 
-        self.assertThat(slot._slot_dict["interface"], Equals("slot-name"))
+        self.assertThat(slot._slot_dict, Equals(dict()))
 
     def test_from_object_string(self):
         slot = Slot.from_object(slot_name="slot-name", slot_object="some-interface")
         slot.validate()
 
         self.assertThat(slot._slot_dict["interface"], Equals("some-interface"))
+        self.assertThat(slot.use_string_representation, Equals(True))
 
     def test_from_object_dict(self):
         slot_dict = OrderedDict(
@@ -80,7 +73,9 @@ class GenericSlotTests(unit.TestCase):
         slot = Slot.from_object(slot_object=slot_dict, slot_name=slot_name)
 
         slot.validate()
+
         self.assertThat(slot._slot_dict["interface"], Equals("some-interface"))
+        self.assertThat(slot._slot_dict["someprop"], Equals("somevalue"))
 
 
 class ContentSlotTests(unit.TestCase):
@@ -94,7 +89,7 @@ class ContentSlotTests(unit.TestCase):
         transformed_dict = slot_dict.copy()
         transformed_dict["source"] = {}
 
-        self.assertEqual(transformed_dict, slot.to_dict())
+        self.assertEqual(transformed_dict, slot.to_yaml_object())
         self.assertEqual(slot_name, slot.slot_name)
         self.assertRaises(errors.SlotValidationError, slot.validate)
         self.assertEqual(set(), slot.get_content_dirs(installed_path=""))
@@ -106,7 +101,7 @@ class ContentSlotTests(unit.TestCase):
         slot = Slot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
 
         self.assertIsInstance(slot, ContentSlot)
-        self.assertEqual(slot_dict, slot.to_dict())
+        self.assertEqual(slot_dict, slot.to_yaml_object())
         self.assertEqual(slot_name, slot.slot_name)
         self.assertRaises(errors.SlotValidationError, slot.validate)
         self.assertEqual(set(), slot.get_content_dirs(installed_path=""))
@@ -117,7 +112,7 @@ class ContentSlotTests(unit.TestCase):
 
         slot = ContentSlot(use_source_key=False, slot_name=slot_name)
 
-        self.assertEqual(slot_dict, slot.to_dict())
+        self.assertEqual(slot_dict, slot.to_yaml_object())
         self.assertEqual(slot_name, slot.slot_name)
         self.assertRaises(errors.SlotValidationError, slot.validate)
         self.assertEqual(set(), slot.get_content_dirs(installed_path=""))
@@ -129,7 +124,7 @@ class ContentSlotTests(unit.TestCase):
         slot = ContentSlot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
         slot.validate()
 
-        self.assertEqual(slot_dict, slot.to_dict())
+        self.assertEqual(slot_dict, slot.to_yaml_object())
         self.assertEqual(slot_name, slot.slot_name)
         self.assertEqual(slot_dict["read"], slot.read)
         self.assertEqual(
@@ -147,7 +142,7 @@ class ContentSlotTests(unit.TestCase):
         transformed_dict["source"] = dict()
         transformed_dict["source"]["read"] = transformed_dict.pop("read")
 
-        self.assertEqual(transformed_dict, slot.to_dict())
+        self.assertEqual(transformed_dict, slot.to_yaml_object())
         self.assertEqual(slot_name, slot.slot_name)
         self.assertEqual(slot_dict["read"], slot.read)
         self.assertEqual(
@@ -163,7 +158,7 @@ class ContentSlotTests(unit.TestCase):
         slot = ContentSlot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
         slot.validate()
 
-        self.assertEqual(slot_dict, slot.to_dict())
+        self.assertEqual(slot_dict, slot.to_yaml_object())
         self.assertEqual(slot_name, slot.slot_name)
         self.assertEqual(slot_dict["source"]["read"], slot.read)
         self.assertEqual(
@@ -177,7 +172,7 @@ class ContentSlotTests(unit.TestCase):
         slot = ContentSlot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
         slot.validate()
 
-        self.assertEqual(slot_dict, slot.to_dict())
+        self.assertEqual(slot_dict, slot.to_yaml_object())
         self.assertEqual(slot_name, slot.slot_name)
         self.assertEqual(slot_dict["write"], slot.write)
         self.assertEqual(
@@ -195,7 +190,7 @@ class ContentSlotTests(unit.TestCase):
         transformed_dict["source"] = dict()
         transformed_dict["source"]["write"] = transformed_dict.pop("write")
 
-        self.assertEqual(transformed_dict, slot.to_dict())
+        self.assertEqual(transformed_dict, slot.to_yaml_object())
         self.assertEqual(slot_name, slot.slot_name)
         self.assertEqual(slot_dict["write"], slot.write)
         self.assertEqual(
@@ -211,7 +206,7 @@ class ContentSlotTests(unit.TestCase):
         slot = ContentSlot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
         slot.validate()
 
-        self.assertEqual(slot_dict, slot.to_dict())
+        self.assertEqual(slot_dict, slot.to_yaml_object())
         self.assertEqual(slot_name, slot.slot_name)
         self.assertEqual(slot_dict["source"]["write"], slot.write)
         self.assertEqual(
@@ -251,7 +246,7 @@ class DbusSlotTests(unit.TestCase):
         )
         slot.validate()
 
-        self.assertEqual(slot_dict, slot.to_dict())
+        self.assertEqual(slot_dict, slot.to_yaml_object())
         self.assertEqual(slot_name, slot.slot_name)
         self.assertEqual(slot_dict["bus"], slot.bus)
         self.assertEqual(slot_dict["name"], slot.name)
@@ -263,7 +258,7 @@ class DbusSlotTests(unit.TestCase):
         slot = DbusSlot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
         slot.validate()
 
-        self.assertEqual(slot_dict, slot.to_dict())
+        self.assertEqual(slot_dict, slot.to_yaml_object())
         self.assertEqual(slot_name, slot.slot_name)
         self.assertEqual(slot_dict["bus"], slot.bus)
         self.assertEqual(slot_dict["name"], slot.name)


### PR DESCRIPTION
Snapcraft recently started always writing the long-form
of plugs for consistency, where the `interface` attribute
is always defined.

Unfortunately this seems to have tripped up a bug in review-tools
that won't likely be fixed for a while.  This commit restores
the 3.8 behavior to ensure the output snap.yaml matches the syntax
used in the snapcraft.yaml.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
