### PR TITLE
lifecycle: only warn when a default provider snap is missing

### DIFF
--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -82,10 +82,10 @@ def execute(
             "The repo backend is not returning the list of installed packages"
         )
 
+    build_snaps = project_config.build_snaps
     content_snaps = project_config.project._get_content_snaps()
-    required_snaps = project_config.build_snaps | content_snaps
 
-    if common.is_process_container():
+    if common.is_process_container() and build_snaps:
         installed_snaps: List[str] = []
         logger.warning(
             (
@@ -93,12 +93,21 @@ def execute(
                 "is running inside docker or podman container: {}.\n"
                 "Please ensure the environment is properly setup before continuing.\n"
                 "Ignore this message if the appropriate measures have already been taken".format(
-                    ", ".join(required_snaps)
+                    ", ".join(build_snaps)
                 )
             )
         )
     else:
-        installed_snaps = repo.snaps.install_snaps(required_snaps)
+        installed_snaps = repo.snaps.install_snaps(build_snaps)
+        for content_snap in content_snaps:
+            try:
+                installed_snaps += repo.snaps.install_snaps([content_snap])
+            except repo.snaps.errors.SnapUnavailableError:
+                logger.warning(
+                    f"Could not install snap defined in a plug {content_snap!r}. "
+                    "The missing library report may have false positives listed if those "
+                    "libraries were to be provided by the content snap."
+                )
 
     try:
         global_state = states.GlobalState.load(

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2018 Canonical Ltd
+# Copyright (C) 2015-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -104,9 +104,9 @@ def execute(
                 installed_snaps += repo.snaps.install_snaps([content_snap])
             except repo.snaps.errors.SnapUnavailableError:
                 logger.warning(
-                    f"Could not install snap defined in a plug {content_snap!r}. "
+                    f"Could not install snap defined in plug {content_snap!r}. "
                     "The missing library report may have false positives listed if those "
-                    "libraries were to be provided by the content snap."
+                    "libraries are provided by the content snap."
                 )
 
     try:

--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2019 Canonical Ltd
+# Copyright (C) 2019-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -190,6 +190,9 @@ class Snap:
 
             provider_path = common.get_installed_snap_path(provider)
             yaml_path = os.path.join(provider_path, "meta", "snap.yaml")
+
+            if not os.path.exists(yaml_path):
+                continue
 
             snap = Snap.from_file(yaml_path)
             for slot in snap.get_content_slots():

--- a/snapcraft/internal/repo/snaps.py
+++ b/snapcraft/internal/repo/snaps.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017-2019 Canonical Ltd
+# Copyright (C) 2017-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/tests/spread/general/content-interface-provider-found/snaps/provider/snap/snapcraft.yaml
+++ b/tests/spread/general/content-interface-provider-found/snaps/provider/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: content-test
+version: '0.1'
+summary: snap using a plug with a content interface should install
+description: |
+  Defining a plug using the content interface should install the snap
+  listed under default-provider.
+
+grade: devel
+confinement: devmode
+
+plugs:
+  content-interface:
+    content: content-interface
+    interface: content
+    target: $SNAP/content
+    default-provider: hello
+
+parts:
+  empty:
+    plugin: nil

--- a/tests/spread/general/content-interface-provider-found/task.yaml
+++ b/tests/spread/general/content-interface-provider-found/task.yaml
@@ -1,0 +1,28 @@
+summary: Build a snap that uses the content interface
+
+environment:
+  SNAP_DIR: snaps/provider
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "$SNAP_DIR"
+
+  snapcraft pull
+
+  if ! snap list hello; then
+    echo "snap listed as default provider was not installed"
+    exit 1
+  fi
+

--- a/tests/spread/general/content-interface-provider-found/task.yaml
+++ b/tests/spread/general/content-interface-provider-found/task.yaml
@@ -19,7 +19,7 @@ restore: |
 execute: |
   cd "$SNAP_DIR"
 
-  snapcraft pull
+  snapcraft prime
 
   if ! snap list hello; then
     echo "snap listed as default provider was not installed"

--- a/tests/spread/general/content-interface-provider-not-found/snaps/provider/snap/snapcraft.yaml
+++ b/tests/spread/general/content-interface-provider-not-found/snaps/provider/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: content-test
+version: '0.1'
+summary: snap using a plug with a content interface that cannot be found
+description: |
+  Defining a plug using the content interface should only warn when it
+  cannot find the snap listed under default-provider.
+
+grade: devel
+confinement: devmode
+
+plugs:
+  content-interface:
+    content: content-interface
+    interface: content
+    target: $SNAP/content
+    default-provider: unknown-content-snap
+
+parts:
+  empty:
+    plugin: nil

--- a/tests/spread/general/content-interface-provider-not-found/task.yaml
+++ b/tests/spread/general/content-interface-provider-not-found/task.yaml
@@ -19,4 +19,4 @@ restore: |
 execute: |
   cd "$SNAP_DIR"
 
-  snapcraft pull | MATCH "Could not install snap defined in a plug"
+  snapcraft prime | MATCH "Could not install snap defined in a plug"

--- a/tests/spread/general/content-interface-provider-not-found/task.yaml
+++ b/tests/spread/general/content-interface-provider-not-found/task.yaml
@@ -1,0 +1,22 @@
+summary: Build a snap that uses the content interface with a non published snap
+
+environment:
+  SNAP_DIR: snaps/provider
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "$SNAP_DIR"
+
+  snapcraft pull | MATCH "Could not install snap defined in a plug"

--- a/tests/spread/general/content-interface-provider-not-found/task.yaml
+++ b/tests/spread/general/content-interface-provider-not-found/task.yaml
@@ -19,4 +19,6 @@ restore: |
 execute: |
   cd "$SNAP_DIR"
 
-  snapcraft prime | MATCH "Could not install snap defined in a plug"
+  output=$(snapcraft prime)
+
+  echo "$output" | MATCH "Could not install snap defined in a plug"

--- a/tests/spread/general/content-interface-provider-not-found/task.yaml
+++ b/tests/spread/general/content-interface-provider-not-found/task.yaml
@@ -21,4 +21,4 @@ execute: |
 
   output=$(snapcraft prime)
 
-  echo "$output" | MATCH "Could not install snap defined in a plug"
+  echo "$output" | MATCH "Could not install snap defined in plug"


### PR DESCRIPTION
Snapcraft gained the ability to check for artifacts from snaps listed as plugs
when using the content interface.

The side effect, is that the snap needs to be published on the main Snap Store,
this is a requirement brand stores cannot meet, so instead of failing,
Snapcraft resorts to warning instead.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
