### PR TITLE
elf: read ELF type when extracting attributes

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -268,6 +268,9 @@ class ElfFile:
         self.build_id: str = ""
         self.has_debug_info: bool = False
 
+        # String of elf enum type, e.g. "ET_DYN", "ET_EXEC", etc.
+        self.elf_type: str = "ET_NONE"
+
         try:
             self._extract_attributes()
         except (UnicodeDecodeError, AttributeError) as exception:
@@ -335,6 +338,8 @@ class ElfFile:
                 debug_info_section is not None
                 and debug_info_section.header.sh_type != "SHT_NOBITS"
             )
+
+            self.elf_type = elf.header["e_type"]
 
     def is_linker_compatible(self, *, linker_version: str) -> bool:
         """Determines if linker will work given the required glibc version."""

--- a/tests/unit/test_elf.py
+++ b/tests/unit/test_elf.py
@@ -106,6 +106,9 @@ class TestElfFileSmoketest(unit.TestCase):
         # Instead just check that it is a boolean.
         self.assertTrue(isinstance(elf_file.has_debug_info, bool))
 
+        # Ensure type is detered as executable.
+        self.assertThat(elf_file.elf_type, Equals("ET_EXEC"))
+
 
 class TestInvalidElf(unit.TestCase):
     def test_invalid_elf_file(self):


### PR DESCRIPTION
The elf type may be used for decision making when handling
executables.  This will be useful for determining what to do
when stripping executables, as different types should be handled
differently.

Use the enum strings provided by pyelftools instead of integer
value.  Initialize to "ET_NONE", but always read the entry
when extracting attributes from file.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
