### PR TITLE
meta: always generate snapcraft-runner to workaround classic PATH bug

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -438,8 +438,8 @@ class _SnapPackaging:
 
         Return path relative to prime directory, if created."""
 
-        # If there are no apps, no need to create a runner.
-        if not self._snap_meta.apps:
+        # If there are no apps, or type is snapd, no need to create a runner.
+        if not self._snap_meta.apps or self._config_data.get("type", "") == "snapd":
             return None
 
         # Classic confinement or building on a host that does not match the target base

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -438,36 +438,42 @@ class _SnapPackaging:
 
         Return path relative to prime directory, if created."""
 
+        # If there are no apps, no need to create a runner.
+        if not self._snap_meta.apps:
+            return None
+
         # Classic confinement or building on a host that does not match the target base
         # means we cannot setup an environment that will work.
         if (
             self._config_data["confinement"] == "classic"
             or not self._is_host_compatible_with_base
-            or not self._snap_meta.apps
         ):
-            return None
+            # Temporary workaround for snapd bug not expanding PATH:
+            # We generate an empty runner which addresses the issue.
+            # https://bugs.launchpad.net/snapd/+bug/1860369
+            assembled_env = ""
+        else:
+            common.env = self._project_config.snap_env()
+            assembled_env = common.assemble_env()
+            assembled_env = assembled_env.replace(self._prime_dir, "$SNAP")
+            assembled_env = self._install_path_pattern.sub("$SNAP", assembled_env)
+            ld_library_env = (
+                "export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH"
+            )
+            assembled_env = "\n".join([assembled_env, ld_library_env])
+            common.reset_env()
 
         meta_runner = os.path.join(
             self._prime_dir, "snap", "command-chain", "snapcraft-runner"
         )
 
-        common.env = self._project_config.snap_env()
-        assembled_env = common.assemble_env()
-        assembled_env = assembled_env.replace(self._prime_dir, "$SNAP")
-        assembled_env = self._install_path_pattern.sub("$SNAP", assembled_env)
+        os.makedirs(os.path.dirname(meta_runner), exist_ok=True)
+        with open(meta_runner, "w") as f:
+            print("#!/bin/sh", file=f)
+            print(assembled_env, file=f)
+            print('exec "$@"', file=f)
+        os.chmod(meta_runner, 0o755)
 
-        if assembled_env:
-            os.makedirs(os.path.dirname(meta_runner), exist_ok=True)
-            with open(meta_runner, "w") as f:
-                print("#!/bin/sh", file=f)
-                print(assembled_env, file=f)
-                print(
-                    "export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH", file=f
-                )
-                print('exec "$@"', file=f)
-            os.chmod(meta_runner, 0o755)
-
-        common.reset_env()
         return os.path.relpath(meta_runner, self._prime_dir)
 
     def _record_manifest_and_source_snapcraft_yaml(self):

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -439,7 +439,7 @@ class _SnapPackaging:
         Return path relative to prime directory, if created."""
 
         # If there are no apps, or type is snapd, no need to create a runner.
-        if not self._snap_meta.apps or self._config_data.get("type", "") == "snapd":
+        if not self._snap_meta.apps or self._config_data.get("type") == "snapd":
             return None
 
         # Classic confinement or building on a host that does not match the target base

--- a/tests/fixture_setup/_fixtures.py
+++ b/tests/fixture_setup/_fixtures.py
@@ -578,10 +578,25 @@ class SnapcraftYaml(fixtures.Fixture):
         description="test-description",
         confinement="strict",
         architectures=None,
+        apps=None,
+        parts=None,
+        type="app",
     ):
         super().__init__()
+
+        if apps is None:
+            apps = dict()
+
+        if parts is None:
+            parts = dict()
+
         self.path = path
-        self.data = {"confinement": confinement, "parts": {}, "apps": {}}
+        self.data = {
+            "confinement": confinement,
+            "parts": parts,
+            "apps": apps,
+            "type": type,
+        }
         if name is not None:
             self.data["name"] = name
         if version is not None:

--- a/tests/unit/meta/test_snap_packaging.py
+++ b/tests/unit/meta/test_snap_packaging.py
@@ -1,0 +1,112 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+from pathlib import Path
+
+from testtools.matchers import Equals
+
+from snapcraft.internal.meta._snap_packaging import _SnapPackaging
+from snapcraft.internal.project_loader import load_config
+from snapcraft.project import Project
+from tests import fixture_setup, unit
+
+
+class SnapPackagingRunnerTests(unit.TestCase):
+    def _get_snap_packaging(self, **yaml_args):
+        parts = dict(part1=dict(plugin="nil"))
+
+        snapcraft_yaml = fixture_setup.SnapcraftYaml(
+            self.path, parts=parts, **yaml_args
+        )
+        self.useFixture(snapcraft_yaml)
+
+        project = Project(
+            snapcraft_yaml_file_path=snapcraft_yaml.snapcraft_yaml_file_path
+        )
+        config = load_config(project)
+
+        return _SnapPackaging(project_config=config, extracted_metadata=None)
+
+    def test_no_apps(self):
+        apps = dict()
+
+        sp = self._get_snap_packaging(apps=apps, confinement="strict")
+        runner = sp._generate_snapcraft_runner()
+
+        self.assertThat(runner, Equals(None))
+
+        sp = self._get_snap_packaging(apps=apps, confinement="strict")
+        runner = sp._generate_snapcraft_runner()
+
+        self.assertThat(runner, Equals(None))
+
+    def test_strict_app(self):
+        apps = dict(testapp=dict(command="echo"))
+
+        sp = self._get_snap_packaging(apps=apps, confinement="strict")
+        runner = sp._generate_snapcraft_runner()
+
+        self.assertThat(runner, Equals("snap/command-chain/snapcraft-runner"))
+
+        runner_path = Path(self.path, "prime", runner)
+
+        with open(runner_path, "r") as f:
+            snapcraft_runner = f.read()
+
+        expected_runner = textwrap.dedent(
+            """
+            #!/bin/sh
+            export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+            export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+            exec "$@"
+            """
+        ).lstrip()
+
+        self.assertThat(snapcraft_runner, Equals(expected_runner))
+
+    def test_classic_app(self):
+        apps = dict(testapp=dict(command="echo"))
+
+        sp = self._get_snap_packaging(apps=apps, confinement="classic")
+        runner = sp._generate_snapcraft_runner()
+
+        self.assertThat(runner, Equals("snap/command-chain/snapcraft-runner"))
+
+        runner_path = Path(self.path, "prime", runner)
+
+        with open(runner_path, "r") as f:
+            snapcraft_runner = f.read()
+
+        expected_runner = textwrap.dedent(
+            """
+            #!/bin/sh
+
+            exec "$@"
+            """
+        ).lstrip()
+
+        self.assertThat(snapcraft_runner, Equals(expected_runner))
+
+    def test_snapd(self):
+        apps = dict(testapp=dict(command="echo"))
+
+        sp = self._get_snap_packaging(
+            apps=apps, confinement="classic", type="snapd", base=None
+        )
+        runner = sp._generate_snapcraft_runner()
+
+        self.assertThat(runner, Equals(None))


### PR DESCRIPTION
Snapcraft previously generated wrappers for most commands.  Once
snapcraft became more conserative about generating unnecessary wrappers,
issues began to surface with regard to PATH being set incorrectly
for classic snap apps that did not use shell.

To work around the issue, this commit adds an empty snapcraft-runner to
the command-chain for all apps, where they typically would have none.
Once this issue is resolved in snapd, we can probably remove this
workaround.

LP#: 1860369

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
