### PR TITLE
extensions: add opengl extension to support classic and strict

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -659,7 +659,8 @@
                             "items": {
                                 "enum": [
                                     "gnome-3-28",
-                                    "kde-neon"
+                                    "kde-neon",
+                                    "opengl"
                                 ]
                             }
                         }

--- a/snapcraft/internal/project_loader/_extensions/opengl.py
+++ b/snapcraft/internal/project_loader/_extensions/opengl.py
@@ -1,0 +1,100 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018-2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Import types and tell flake8 to ignore the "unused" List.
+
+import logging
+from typing import Any, Dict, Tuple
+
+from ._extension import Extension
+
+
+logger = logging.getLogger(__name__)
+
+
+class ExtensionImpl(Extension):
+    """This extension eases creation of snaps that integrate with OpenGL.
+
+    For easier desktop integration, it also configures each application
+    entry with these additional plugs if strictly confined (or devmode):
+
+    \b
+    - opengl (https://snapcraft.io/docs/opengl-interface)
+    """
+
+    @staticmethod
+    def get_supported_bases() -> Tuple[str, ...]:
+        return ("core18",)
+
+    @staticmethod
+    def get_supported_confinement() -> Tuple[str, ...]:
+        return ("strict", "devmode", "classic")
+
+    def __init__(self, *, extension_name: str, yaml_data: Dict[str, Any]) -> None:
+        super().__init__(extension_name=extension_name, yaml_data=yaml_data)
+
+        logger.warning(
+            "*EXPERIMENTAL*: The OpenGL extension is experimental and likely to change."
+        )
+
+        if yaml_data.get("confinement") == "classic":
+            # Use environment variables for classic snaps.
+            self.root_snippet = {
+                "environment": {
+                    "__EGL_VENDOR_LIBRARY_DIRS": "$SNAP/etc/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d",
+                    "LIBGL_DRIVERS_PATH": "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri",
+                }
+            }
+
+            # Mesa must use no-patchelf, otherwise driver will crash.
+            # TODO: develop/upstream patch to fix mesa.
+            self.parts = {
+                "mesa": {
+                    "plugin": "nil",
+                    "build-attributes": ["no-patchelf"],
+                    "prime": [
+                        "-lib/udev",
+                        "-usr/doc",
+                        "-usr/doc-base",
+                        "-usr/share/applications",
+                        "-usr/share/apport",
+                        "-usr/share/bug",
+                        "-usr/share/doc",
+                        "-usr/share/doc-base",
+                        "-usr/share/icons",
+                        "-usr/share/libdrm",
+                        "-usr/share/libwacom",
+                        "-usr/share/lintian",
+                        "-usr/share/man",
+                        "-usr/share/pkgconfig",
+                    ],
+                    "stage-packages": ["libgl1-mesa-dri", "libglx-mesa0"],
+                }
+            }
+        else:
+            # Use plugs and layouts for strict/devmode.
+
+            self.app_snippet = {"plugs": ["opengl"]}
+
+            self.root_snippet = {
+                "layout": {
+                    "/etc/glvnd": {"bind": "$SNAP/etc/glvnd"},
+                    "/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri": {
+                        "bind": "$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri"
+                    },
+                    "/usr/share/glvnd": {"bind": "$SNAP/etc/glvnd"},
+                }
+            }

--- a/tests/unit/project_loader/extensions/test_opengl.py
+++ b/tests/unit/project_loader/extensions/test_opengl.py
@@ -1,0 +1,103 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from testtools.matchers import Equals
+
+from snapcraft.internal.project_loader._extensions.opengl import ExtensionImpl
+
+from .. import ProjectLoaderBaseTest
+
+
+class ExtensionTest(ProjectLoaderBaseTest):
+    def test_supported_bases(self):
+        self.assertThat(ExtensionImpl.get_supported_bases(), Equals(("core18",)))
+
+    def test_supported_confinement(self):
+        self.assertThat(
+            ExtensionImpl.get_supported_confinement(),
+            Equals(("strict", "devmode", "classic")),
+        )
+
+    def test_extension_strict(self):
+        opengl_extension = ExtensionImpl(
+            extension_name="opengl", yaml_data=dict(base="core18", confinement="strict")
+        )
+
+        self.assertThat(
+            opengl_extension.root_snippet,
+            Equals(
+                {
+                    "layout": {
+                        "/etc/glvnd": {"bind": "$SNAP/etc/glvnd"},
+                        "/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri": {
+                            "bind": "$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri"
+                        },
+                        "/usr/share/glvnd": {"bind": "$SNAP/etc/glvnd"},
+                    }
+                }
+            ),
+        )
+        self.assertThat(opengl_extension.app_snippet, Equals({"plugs": ["opengl"]}))
+        self.assertThat(opengl_extension.part_snippet, Equals(dict()))
+        self.assertThat(opengl_extension.parts, Equals(dict()))
+
+    def test_extension_classic(self):
+        opengl_extension = ExtensionImpl(
+            extension_name="opengl",
+            yaml_data=dict(base="core18", confinement="classic"),
+        )
+
+        self.assertThat(
+            opengl_extension.root_snippet,
+            Equals(
+                {
+                    "environment": {
+                        "__EGL_VENDOR_LIBRARY_DIRS": "$SNAP/etc/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d",
+                        "LIBGL_DRIVERS_PATH": "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri",
+                    }
+                }
+            ),
+        )
+        self.assertThat(opengl_extension.app_snippet, Equals(dict()))
+        self.assertThat(opengl_extension.part_snippet, Equals(dict()))
+        self.assertThat(
+            opengl_extension.parts,
+            Equals(
+                {
+                    "mesa": {
+                        "plugin": "nil",
+                        "build-attributes": ["no-patchelf"],
+                        "prime": [
+                            "-lib/udev",
+                            "-usr/doc",
+                            "-usr/doc-base",
+                            "-usr/share/applications",
+                            "-usr/share/apport",
+                            "-usr/share/bug",
+                            "-usr/share/doc",
+                            "-usr/share/doc-base",
+                            "-usr/share/icons",
+                            "-usr/share/libdrm",
+                            "-usr/share/libwacom",
+                            "-usr/share/lintian",
+                            "-usr/share/man",
+                            "-usr/share/pkgconfig",
+                        ],
+                        "stage-packages": ["libgl1-mesa-dri", "libglx-mesa0"],
+                    }
+                }
+            ),
+        )


### PR DESCRIPTION
Based off the work done by Alan Griffiths:
https://github.com/MirServer/egmde-snap/blob/master/snap/snapcraft.yaml

In my prior attempts to make a classic OpenGL snap, I lacked the
"build-attributes": ["no-patchelf"] requirement for libgl1-mesa-dri and
the crashes were hard to diagnose.

Properly adding OpenGL support for snaps is a non-trivial excercise.
This is an attempt to create a single extension which can support
multiple types of snaps (classic & strict) and do the right thing
for OpenGL as the optimal approach to OpenGL changes over time.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>


---

A test case I have used for it: 
https://github.com/cjp256/alacritty/blob/snap-updates/extra/linux/snap/snapcraft.yaml

I am very much hoping for feedback for improvements, I am no expert on this! :smile: