### PR TITLE
meta: always generate snapcraft-runner to workaround classic (#2889)

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -432,7 +432,7 @@ class _SnapPackaging:
             )
 
     def _generate_command_chain(self) -> List[str]:
-        command_chain = list()
+        command_chain: List[str] = list()
 
         # command-chain is not required in these situations.
         if (

--- a/tests/fixture_setup/_fixtures.py
+++ b/tests/fixture_setup/_fixtures.py
@@ -578,10 +578,25 @@ class SnapcraftYaml(fixtures.Fixture):
         description="test-description",
         confinement="strict",
         architectures=None,
+        apps=None,
+        parts=None,
+        type="app",
     ):
         super().__init__()
+
+        if apps is None:
+            apps = dict()
+
+        if parts is None:
+            parts = dict()
+
         self.path = path
-        self.data = {"confinement": confinement, "parts": {}, "apps": {}}
+        self.data = {
+            "confinement": confinement,
+            "parts": parts,
+            "apps": apps,
+            "type": type,
+        }
         if name is not None:
             self.data["name"] = name
         if version is not None:

--- a/tests/unit/meta/test_snap_packaging.py
+++ b/tests/unit/meta/test_snap_packaging.py
@@ -1,0 +1,111 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+from pathlib import Path
+
+from testtools.matchers import Equals
+
+from snapcraft.internal.meta._snap_packaging import _SnapPackaging
+from snapcraft.internal.project_loader import load_config
+from snapcraft.project import Project
+from tests import fixture_setup, unit
+
+
+class SnapPackagingCommandChainTests(unit.TestCase):
+    def _get_snap_packaging(self, **yaml_args):
+        parts = dict(part1=dict(plugin="nil"))
+
+        snapcraft_yaml = fixture_setup.SnapcraftYaml(
+            self.path, parts=parts, **yaml_args
+        )
+        self.useFixture(snapcraft_yaml)
+
+        project = Project(
+            snapcraft_yaml_file_path=snapcraft_yaml.snapcraft_yaml_file_path
+        )
+        config = load_config(project)
+
+        return _SnapPackaging(project_config=config, extracted_metadata=None)
+
+    def test_no_apps(self):
+        apps = dict()
+
+        sp = self._get_snap_packaging(apps=apps, confinement="strict")
+        command_chain = sp._generate_command_chain()
+
+        self.assertThat(command_chain, Equals([]))
+
+        sp = self._get_snap_packaging(apps=apps, confinement="strict")
+        command_chain = sp._generate_command_chain()
+
+        self.assertThat(command_chain, Equals([]))
+
+    def test_strict_app(self):
+        apps = dict(testapp=dict(command="echo"))
+
+        sp = self._get_snap_packaging(apps=apps, confinement="strict")
+        command_chain = sp._generate_command_chain()
+
+        self.assertThat(command_chain, Equals(["snap/command-chain/snapcraft-runner"]))
+
+        runner_path = Path(self.path, "prime", command_chain[0])
+
+        with open(runner_path, "r") as f:
+            snapcraft_runner = f.read()
+
+        expected_runner = textwrap.dedent(
+            """
+            #!/bin/sh
+            export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+            export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+            exec "$@"
+            """
+        ).lstrip()
+
+        self.assertThat(snapcraft_runner, Equals(expected_runner))
+
+    def test_classic_app(self):
+        apps = dict(testapp=dict(command="echo"))
+
+        sp = self._get_snap_packaging(apps=apps, confinement="classic")
+        command_chain = sp._generate_command_chain()
+
+        self.assertThat(command_chain, Equals(["snap/command-chain/snapcraft-runner"]))
+
+        runner_path = Path(self.path, "prime", command_chain[0])
+
+        with open(runner_path, "r") as f:
+            snapcraft_runner = f.read()
+
+        expected_runner = textwrap.dedent(
+            """
+            #!/bin/sh
+            exec "$@"
+            """
+        ).lstrip()
+
+        self.assertThat(snapcraft_runner, Equals(expected_runner))
+
+    def test_snapd(self):
+        apps = dict(testapp=dict(command="echo"))
+
+        sp = self._get_snap_packaging(
+            apps=apps, confinement="classic", type="snapd", base=None
+        )
+        command_chain = sp._generate_command_chain()
+
+        self.assertThat(command_chain, Equals([]))


### PR DESCRIPTION
Snapcraft previously generated wrappers for most commands.  Once
snapcraft became more conserative about generating unnecessary wrappers,
issues began to surface with regard to PATH being set incorrectly
for classic snap apps that did not use shell.

To work around the issue, this commit adds an empty snapcraft-runner to
the command-chain for all apps, where they typically would have none.
Once this issue is resolved in snapd, we can probably remove this
workaround.

Add unit tests for snapcraft-runner generation

Add some additional parameters to the SnapcraftYaml fixture
to make it more configurable.

LP#: 1860369

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
