### PR TITLE
Fix issue with multipass mount on win32

### DIFF
--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -16,7 +16,6 @@
 
 import logging
 import os
-import platform
 import sys
 from typing import Dict, Optional, Sequence
 

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -16,6 +16,7 @@
 
 import logging
 import os
+import platform
 import sys
 from typing import Dict, Optional, Sequence
 
@@ -198,13 +199,12 @@ class Multipass(Provider):
             return
 
         target = "{}:{}".format(self.instance_name, target)
-        if os.system.platform != "win32":
+        if platform.system() != "Windows":
             uid_map = {str(os.getuid()): "0"}
             gid_map = {str(os.getgid()): "0"}
         else:
-            uid_map = None
-            gid_map = None
-
+            uid_map = {"0": "0"}
+            gid_map = {"0": "0"}
         self._multipass_cmd.mount(
             source=host_source, target=target, uid_map=uid_map, gid_map=gid_map
         )

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -199,7 +199,7 @@ class Multipass(Provider):
             return
 
         target = "{}:{}".format(self.instance_name, target)
-        if platform.system() != "Windows":
+        if sys.platform() != "win32":
             uid_map = {str(os.getuid()): "0"}
             gid_map = {str(os.getgid()): "0"}
         else:

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -198,7 +198,7 @@ class Multipass(Provider):
             return
 
         target = "{}:{}".format(self.instance_name, target)
-        if sys.platform() != "win32":
+        if sys.platform != "win32":
             uid_map = {str(os.getuid()): "0"}
             gid_map = {str(os.getgid()): "0"}
         else:

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -198,8 +198,12 @@ class Multipass(Provider):
             return
 
         target = "{}:{}".format(self.instance_name, target)
-        uid_map = {str(os.getuid()): "0"}
-        gid_map = {str(os.getgid()): "0"}
+        if os.system.platform != "win32":
+            uid_map = {str(os.getuid()): "0"}
+            gid_map = {str(os.getgid()): "0"}
+        else:
+            uid_map = None
+            gid_map = None
 
         self._multipass_cmd.mount(
             source=host_source, target=target, uid_map=uid_map, gid_map=gid_map


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

os.getuid() does not exist on win32, so it will crash when called. I just disable the UID and GID map by setting it to `{"0":"0"}` if it's win32.