### PR TITLE
lifecycle: raise detailed error if mksquashfs fails

### DIFF
--- a/snapcraft/internal/lifecycle/_packer.py
+++ b/snapcraft/internal/lifecycle/_packer.py
@@ -129,8 +129,12 @@ def _run_mksquashfs(
                 time.sleep(0.2)
                 ret = proc.poll()
         print("")
-        if ret != 0:
-            logger.error(proc.stdout.read().decode("utf-8"))
-            raise RuntimeError("Failed to create snap {!r}".format(output_snap_name))
+        output = proc.stdout.read().decode("utf-8")
+        logger.debug(output)
 
-        logger.debug(proc.stdout.read().decode("utf-8"))
+        if ret != 0:
+            raise RuntimeError(
+                "Failed to create snap {!r}, mksquashfs failed:\n{}".format(
+                    output_snap_name, output
+                )
+            )


### PR DESCRIPTION
Sentry is full of bug reports related to RuntimeError for failing
to execute mksquashfs.  However, there is no clue as to the failure,
because snapcraft just prints it to logger.  Instead of logging the
error, include the output as part of the raised RuntimeError.

If we can get a better idea of the nature of the failures, we can
further refine handling here.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
