### PR TITLE
ci: publish the CI built snap to the Snap Store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,9 +108,7 @@ jobs:
       workspaces:
         use: snaps
       script:
-        - [ -n "$SNAP_TOKEN" ] || echo '$SNAP_TOKEN not set'
-        - [ -n "$SNAP_TOKEN" ] || exit 1
-        - echo $SNAP_TOKEN | snapcraft login --with -
+        - echo "$SNAP_TOKEN" | snapcraft login --with -
         - snapcraft push "snapcraft-pr$TRAVIS_PULL_REQUEST.snap" --release "edge/pr-$TRAVIS_PULL_REQUEST"
     - stage: integration
       name: spread

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
 
     - stage: deploy
       name: Snap Store
-      if: head_repo = "snapcore/snapcraft" and type = pull_request
+      if: type = pull_request and env(SNAP_TOKEN) IS present
       addons:
         snaps:
           - name: snapcraft

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
 
     - stage: deploy
       name: Snap Store
-      if: repo = "snapcore/snapcraft" and type = pull_request
+      if: head_repo = "snapcore/snapcraft" and type = pull_request
       addons:
         snaps:
           - name: snapcraft

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,9 +107,15 @@ jobs:
             classic: true
       workspaces:
         use: snaps
-      script: |
-        echo $SNAP_TOKEN | snapcraft login --with -
-        snapcraft push "snapcraft-pr$TRAVIS_PULL_REQUEST.snap" --release "edge/pr-$TRAVIS_PULL_REQUEST"
+      script:
+        # Exit early if SNAP_TOKEN is not set.
+        - [ -n "$SNAP_TOKEN" ] || echo '$SNAP_TOKEN not set'
+        - [ -n "$SNAP_TOKEN" ] || exit 1
+        # Login with SNAP_TOKEN.
+        - echo $SNAP_TOKEN | snapcraft login --with -
+        # Push the snap built in the previous stage and release to channel
+        # of the form edge/pr-PR#.
+        - snapcraft push "snapcraft-pr$TRAVIS_PULL_REQUEST.snap" --release "edge/pr-$TRAVIS_PULL_REQUEST"
     - stage: integration
       name: spread
       workspaces:

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,13 +108,9 @@ jobs:
       workspaces:
         use: snaps
       script:
-        # Exit early if SNAP_TOKEN is not set.
         - [ -n "$SNAP_TOKEN" ] || echo '$SNAP_TOKEN not set'
         - [ -n "$SNAP_TOKEN" ] || exit 1
-        # Login with SNAP_TOKEN.
         - echo $SNAP_TOKEN | snapcraft login --with -
-        # Push the snap built in the previous stage and release to channel
-        # of the form edge/pr-PR#.
         - snapcraft push "snapcraft-pr$TRAVIS_PULL_REQUEST.snap" --release "edge/pr-$TRAVIS_PULL_REQUEST"
     - stage: integration
       name: spread

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
 
     - stage: deploy
       name: Snap Store
-      if: type = pull_request AND repo = snapcore/snapcraft
+      if: repo = "snapcore/snapcraft" and type = pull_request
       addons:
         snaps:
           - name: snapcraft

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
 
     - stage: deploy
       name: Snap Store
-      if: type = pull_request
+      if: type = pull_request AND repo = snapcore/snapcraft
       addons:
         snaps:
           - name: snapcraft

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,19 @@ jobs:
         - sudo journalctl -u snapd
         - /snap/bin/http https://api.snapcraft.io/v2/snaps/info/core architecture==amd64 Snap-Device-Series:16
 
+    - stage: deploy
+      name: Snap Store
+      if: type = pull_request
+      addons:
+        snaps:
+          - name: snapcraft
+            channel: candidate
+            classic: true
+      workspaces:
+        use: snaps
+      script: |
+        echo $SNAP_TOKEN | snapcraft login --with -
+        snapcraft push "snapcraft-pr$TRAVIS_PULL_REQUEST.snap" --release "edge/pr-$TRAVIS_PULL_REQUEST"
     - stage: integration
       name: spread
       workspaces:

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,9 +107,7 @@ jobs:
             classic: true
       workspaces:
         use: snaps
-      script:
-        - echo "$SNAP_TOKEN" | snapcraft login --with -
-        - snapcraft push "snapcraft-pr$TRAVIS_PULL_REQUEST.snap" --release "edge/pr-$TRAVIS_PULL_REQUEST"
+      script: ./tools/travis_deploy.sh
     - stage: integration
       name: spread
       workspaces:

--- a/tools/travis_deploy.sh
+++ b/tools/travis_deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+if [ -z "$TRAVIS_PULL_REQUEST" ]; then
+    echo "'$TRAVIS_PULL_REQUEST' is not set."
+    exit 1
+fi
+
+if [ -z "$SNAP_TOKEN" ]; then
+    echo '"$SNAP_TOKEN" is not set.'
+    exit 1
+fi
+
+# Login
+echo "$SNAP_TOKEN" | /snap/bin/snapcraft login --with -
+/snap/bin/snapcraft push \
+                    --release "edge/pr-$TRAVIS_PULL_REQUEST" \
+                    "snapcraft-pr$TRAVIS_PULL_REQUEST.snap"

--- a/tools/travis_deploy.sh
+++ b/tools/travis_deploy.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
 
 if [ -z "$TRAVIS_PULL_REQUEST" ]; then
-    echo "'$TRAVIS_PULL_REQUEST' is not set."
+    echo "'TRAVIS_PULL_REQUEST' is not set."
     exit 1
 fi
 
+
 if [ -z "$SNAP_TOKEN" ]; then
-    echo '"$SNAP_TOKEN" is not set.'
+    echo '"SNAP_TOKEN" is not set.'
     exit 1
 fi
 


### PR DESCRIPTION
It is often useful to allow for the snap being built during a PR review to be
available on the Snap Store.

This change should make version of each run through Travis CI available on the
edge/pr-$TRAVIS_PULL_REQUEST (e.g.; edge/pr-1050).

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
