### PR TITLE
python plugin: do not leak snapcraft's site-packages

### DIFF
--- a/snapcraft/plugins/_python/_sitecustomize.py
+++ b/snapcraft/plugins/_python/_sitecustomize.py
@@ -35,7 +35,7 @@ _SITECUSTOMIZE_TEMPLATE = dedent(
     # Do not include snap_dir during builds as this will include
     # snapcraft's in-snap site directory.
     # snapcraftctl exports SNAPCRAFT_INTERPRETER
-    if os.getenv("SNAPCRAFT_INTERPRETER"):
+    if not os.getenv("SNAPCRAFT_INTERPRETER"):
         site_directories = [snap_dir] + site_directories
 
     for d in site_directories:

--- a/snapcraft/plugins/_python/_sitecustomize.py
+++ b/snapcraft/plugins/_python/_sitecustomize.py
@@ -31,12 +31,12 @@ _SITECUSTOMIZE_TEMPLATE = dedent(
     snapcraft_stage_dir = os.getenv("SNAPCRAFT_STAGE")
     snapcraft_part_install = os.getenv("SNAPCRAFT_PART_INSTALL")
 
-    site_directories = [snapcraft_stage_dir, snapcraft_part_install]
     # Do not include snap_dir during builds as this will include
     # snapcraft's in-snap site directory.
-    # snapcraftctl exports SNAPCRAFT_INTERPRETER
-    if not os.getenv("SNAPCRAFT_INTERPRETER"):
-        site_directories = [snap_dir] + site_directories
+    if snapcraft_stage_dir is not None and snapcraft_part_install is not None:
+        site_directories = [snapcraft_stage_dir, snapcraft_part_install]
+    else:
+        site_directories = [snap_dir]
 
     for d in site_directories:
         if d:

--- a/snapcraft/plugins/_python/_sitecustomize.py
+++ b/snapcraft/plugins/_python/_sitecustomize.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017 Canonical Ltd
+# Copyright (C) 2017,2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -31,7 +31,14 @@ _SITECUSTOMIZE_TEMPLATE = dedent(
     snapcraft_stage_dir = os.getenv("SNAPCRAFT_STAGE")
     snapcraft_part_install = os.getenv("SNAPCRAFT_PART_INSTALL")
 
-    for d in (snap_dir, snapcraft_stage_dir, snapcraft_part_install):
+    site_directories = [snapcraft_stage_dir, snapcraft_part_install]
+    # Do not include snap_dir during builds as this will include
+    # snapcraft's in-snap site directory.
+    # snapcraftctl exports SNAPCRAFT_INTERPRETER
+    if os.getenv("SNAPCRAFT_INTERPRETER"):
+        site_directories = [snap_dir] + site_directories
+
+    for d in site_directories:
         if d:
             site_dir = os.path.join(d, "{site_dir}")
             site.addsitedir(site_dir)

--- a/tests/spread/plugins/python/site-packages/task.yaml
+++ b/tests/spread/plugins/python/site-packages/task.yaml
@@ -1,0 +1,24 @@
+summary: "Ensure snapcraft's site-packages do not leak"
+
+environment:
+  SNAP_DIR: ../snaps/python-site-packages
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+  restore_yaml snap/snapcraft.yaml
+
+execute: |
+  cd "$SNAP_DIR"
+
+  # Ensure sys.path does not contain anything related to snapcraft.
+  snapcraft build | MATCH "sys.path: " | MATCH -v "/snap/snapcraft"

--- a/tests/spread/plugins/python/snaps/python-site-packages/snap/snapcraft.yaml
+++ b/tests/spread/plugins/python/snaps/python-site-packages/snap/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: python-site-packages
+version: "0.1"
+summary: "ensure snapcraft's site-packages do not leak"
+description: |
+  Ensure that the python plugin's added sitecustomize.py does
+  not take into account the in-snap site-packages directory
+  meant to be used during runtime as $SNAP would be snapcraft's
+  which is also using the python plugin.
+grade: devel
+confinement: strict
+
+parts:
+  python-path-test:
+    plugin: python
+    python-packages:
+      - petname
+    override-build: |
+      snapcraftctl build
+      python3 -c "import sys; import print; print("sys.path: {}".format(sys.path))"

--- a/tests/unit/plugins/python/test_sitecustomize.py
+++ b/tests/unit/plugins/python/test_sitecustomize.py
@@ -51,7 +51,7 @@ class SiteCustomizeTestCase(PythonBaseTestCase):
             # Do not include snap_dir during builds as this will include
             # snapcraft's in-snap site directory.
             # snapcraftctl exports SNAPCRAFT_INTERPRETER
-            if os.getenv("SNAPCRAFT_INTERPRETER"):
+            if not os.getenv("SNAPCRAFT_INTERPRETER"):
                 site_directories = [snap_dir] + site_directories
 
             for d in site_directories:

--- a/tests/unit/plugins/python/test_sitecustomize.py
+++ b/tests/unit/plugins/python/test_sitecustomize.py
@@ -47,12 +47,12 @@ class SiteCustomizeTestCase(PythonBaseTestCase):
             snapcraft_stage_dir = os.getenv("SNAPCRAFT_STAGE")
             snapcraft_part_install = os.getenv("SNAPCRAFT_PART_INSTALL")
 
-            site_directories = [snapcraft_stage_dir, snapcraft_part_install]
             # Do not include snap_dir during builds as this will include
             # snapcraft's in-snap site directory.
-            # snapcraftctl exports SNAPCRAFT_INTERPRETER
-            if not os.getenv("SNAPCRAFT_INTERPRETER"):
-                site_directories = [snap_dir] + site_directories
+            if snapcraft_stage_dir is not None and snapcraft_part_install is not None:
+                site_directories = [snapcraft_stage_dir, snapcraft_part_install]
+            else:
+                site_directories = [snap_dir]
 
             for d in site_directories:
                 if d:

--- a/tests/unit/plugins/python/test_sitecustomize.py
+++ b/tests/unit/plugins/python/test_sitecustomize.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017 Canonical Ltd
+# Copyright (C) 2017,2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -15,11 +15,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+from textwrap import dedent
 
 from testtools.matchers import Contains, FileContains
 
 from snapcraft.plugins import _python
-
 from ._basesuite import PythonBaseTestCase
 
 
@@ -35,6 +35,34 @@ def _create_user_site_packages(base_dir):
 
 
 class SiteCustomizeTestCase(PythonBaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.expected_sitecustomize = dedent(
+            """\
+            import site
+            import os
+
+            snap_dir = os.getenv("SNAP")
+            snapcraft_stage_dir = os.getenv("SNAPCRAFT_STAGE")
+            snapcraft_part_install = os.getenv("SNAPCRAFT_PART_INSTALL")
+
+            site_directories = [snapcraft_stage_dir, snapcraft_part_install]
+            # Do not include snap_dir during builds as this will include
+            # snapcraft's in-snap site directory.
+            # snapcraftctl exports SNAPCRAFT_INTERPRETER
+            if os.getenv("SNAPCRAFT_INTERPRETER"):
+                site_directories = [snap_dir] + site_directories
+
+            for d in site_directories:
+                if d:
+                    site_dir = os.path.join(d, "lib/pythontest/site-packages")
+                    site.addsitedir(site_dir)
+
+            if snap_dir:
+                site.ENABLE_USER_SITE = False"""
+        )
+
     def test_generate_sitecustomize_staged(self):
         stage_dir = "stage_dir"
         install_dir = "install_dir"
@@ -53,29 +81,10 @@ class SiteCustomizeTestCase(PythonBaseTestCase):
             "test", stage_dir=stage_dir, install_dir=install_dir
         )
 
-        expected_sitecustomize = (
-            "import site\n"
-            "import os\n"
-            "\n"
-            'snap_dir = os.getenv("SNAP")\n'
-            'snapcraft_stage_dir = os.getenv("SNAPCRAFT_STAGE")\n'
-            'snapcraft_part_install = os.getenv("SNAPCRAFT_PART_INSTALL")\n'
-            "\n"
-            "for d in (snap_dir, snapcraft_stage_dir, "
-            "snapcraft_part_install):\n"
-            "    if d:\n"
-            "        site_dir = os.path.join(d, "
-            '"lib/pythontest/site-packages")\n'
-            "        site.addsitedir(site_dir)\n"
-            "\n"
-            "if snap_dir:\n"
-            "    site.ENABLE_USER_SITE = False"
-        )
-
         site_path = os.path.join(
             install_dir, "usr", "lib", "pythontest", "sitecustomize.py"
         )
-        self.assertThat(site_path, FileContains(expected_sitecustomize))
+        self.assertThat(site_path, FileContains(self.expected_sitecustomize))
 
     def test_generate_sitecustomize_installed(self):
         stage_dir = "stage_dir"
@@ -95,29 +104,10 @@ class SiteCustomizeTestCase(PythonBaseTestCase):
             "test", stage_dir=stage_dir, install_dir=install_dir
         )
 
-        expected_sitecustomize = (
-            "import site\n"
-            "import os\n"
-            "\n"
-            'snap_dir = os.getenv("SNAP")\n'
-            'snapcraft_stage_dir = os.getenv("SNAPCRAFT_STAGE")\n'
-            'snapcraft_part_install = os.getenv("SNAPCRAFT_PART_INSTALL")\n'
-            "\n"
-            "for d in (snap_dir, snapcraft_stage_dir, "
-            "snapcraft_part_install):\n"
-            "    if d:\n"
-            "        site_dir = os.path.join(d, "
-            '"lib/pythontest/site-packages")\n'
-            "        site.addsitedir(site_dir)\n"
-            "\n"
-            "if snap_dir:\n"
-            "    site.ENABLE_USER_SITE = False"
-        )
-
         site_path = os.path.join(
             install_dir, "usr", "lib", "pythontest", "sitecustomize.py"
         )
-        self.assertThat(site_path, FileContains(expected_sitecustomize))
+        self.assertThat(site_path, FileContains(self.expected_sitecustomize))
 
     def test_generate_sitecustomize_missing_user_site_raises(self):
         stage_dir = "stage_dir"


### PR DESCRIPTION
The current sitecustomize generated by the python plugin always considers
adding site-packages from $SNAP which is only meant for runtime. This is a
problem as snapcraft runs in the context of a snap, so $SNAP always exists
in the environment.

When building, snapcraft exports SNAPCRAFT_INTERPRETER, use this as a condition
to export site-packages found under $SNAP.

LP: #1860884

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
