### PR TITLE
static: fix some valid flake8 issues

### DIFF
--- a/snapcraft/internal/lifecycle/_status_cache.py
+++ b/snapcraft/internal/lifecycle/_status_cache.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018 Canonical Ltd
+# Copyright (C) 2018,2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -34,9 +34,9 @@ class StatusCache:
         :param _config.Config config: Project config.
         """
         self.config = config
-        self._steps_run = dict()  # type: Dict[str, Set[steps.Step]]
-        self._outdated_reports = collections.defaultdict(dict)  # type: _OutdatedReport
-        self._dirty_reports = collections.defaultdict(dict)  # type: _DirtyReport
+        self._steps_run: Dict[str, Set[steps.Step]] = dict()
+        self._outdated_reports: _OutdatedReport = collections.defaultdict(dict)
+        self._dirty_reports: _DirtyReport = collections.defaultdict(dict)
 
     def should_step_run(
         self, part: pluginhandler.PluginHandler, step: steps.Step
@@ -159,7 +159,7 @@ class StatusCache:
         prerequisite_step = steps.get_dependency_prerequisite_step(step)
         dependencies = self.config.parts.get_dependencies(part.name, recursive=True)
 
-        changed_dependencies = []  # type: List[pluginhandler.Dependency]
+        changed_dependencies: List[pluginhandler.Dependency] = []
         with contextlib.suppress(errors.StepHasNotRunError):
             timestamp = part.step_timestamp(step)
             for dependency in dependencies:

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2018 Canonical Ltd
+# Copyright (C) 2015-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -198,7 +198,7 @@ class Config:
         return self.parts.all_parts
 
     def __init__(self, project: project.Project) -> None:
-        self.build_snaps = set()  # type: Set[str]
+        self.build_snaps: Set[str] = set()
         self.project = project
 
         # raw_snapcraft_yaml is read only, create a new copy
@@ -389,8 +389,8 @@ def _create_architecture_list(architectures, current_arch):
     if not architectures:
         return [_Architecture(build_on=[current_arch])]
 
-    build_architectures = []  # type: List[str]
-    architecture_list = []  # type: List[_Architecture]
+    build_architectures: List[str] = []
+    architecture_list: List[_Architecture] = []
     for item in architectures:
         if isinstance(item, str):
             build_architectures.append(item)

--- a/snapcraft/plugins/_python/_pip.py
+++ b/snapcraft/plugins/_python/_pip.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016-2019 Canonical Ltd
+# Copyright (C) 2016-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -463,7 +463,7 @@ class Pip:
         except subprocess.CalledProcessError:
             # --format requires a newer pip, so fall back to legacy output
             output = self._run_output(command)
-            json_output = []  # type: List[Dict[str, str]]
+            json_output: List[Dict[str, str]] = []
             version_regex = re.compile(r"\((.+)\)")
             for line in output.splitlines():
                 line = line.split()

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2019 Canonical Ltd
+# Copyright (C) 2015-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -921,9 +921,9 @@ def _handle_rosinstall_files(wstool, rosinstall_files):
 def _recursively_handle_rosinstall_files(wstool, source_path, *, cache=None):
     "Recursively find and merge rosinstall files and update workspace"
 
-    rosinstall_files = set()  # type: Set[str]
+    rosinstall_files: Set[str] = set()
     if not cache:
-        cache = set()  # type: Set[str]
+        cache: Set[str] = set()
 
     # Walk the entire source directory looking for rosinstall files. Keep track
     # of any we haven't seen previously.

--- a/snapcraft/project/errors.py
+++ b/snapcraft/project/errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018 Canonical Ltd
+# Copyright (C) 2018-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -131,7 +131,7 @@ def _determine_cause(error):
 
     # anyOf failures might have usable context... try to improve them a bit
     if error.validator == "anyOf":
-        contextual_messages = OrderedDict()  # type: Dict[str, str]
+        contextual_messages: Dict[str, str] = OrderedDict()
         for contextual_error in error.context:
             key = contextual_error.schema_path.popleft()
             if key not in contextual_messages:
@@ -141,7 +141,7 @@ def _determine_cause(error):
                 # Sure it starts lower-case (not all messages do)
                 contextual_messages[key].append(message[0].lower() + message[1:])
 
-        oneOf_messages = []  # type: List[str]
+        oneOf_messages: List[str] = []
         for key, value in contextual_messages.items():
             oneOf_messages.append(formatting_utils.humanize_list(value, "and", "{}"))
 


### PR DESCRIPTION
This was mostly from running a flake8 from 3.9, but they are valid issue to
fix nonetheless.

Running flake8
./snapcraft/plugins/catkin.py:82:1: F401 'typing.Set' imported but unused
./snapcraft/plugins/_python/_pip.py:28:1: F401 'typing.Dict' imported but unused
./snapcraft/project/errors.py:19:1: F401 'typing.Dict' imported but unused
./snapcraft/project/errors.py:19:1: F401 'typing.List' imported but unused
./snapcraft/internal/project_loader/_config.py:24:1:
    F401 'typing.List' imported but unused
./snapcraft/internal/project_loader/_config.py:24:1:
    F401 'typing.Set' imported but unused
./snapcraft/internal/lifecycle/_status_cache.py:19:1:
    F401 'typing.List' imported but unused

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
