### PR TITLE
meta: move Snap's from_dict() system-username parsing into SystemUser

### DIFF
--- a/tests/unit/meta/test_snap.py
+++ b/tests/unit/meta/test_snap.py
@@ -23,7 +23,7 @@ import testscenarios
 from testtools.matchers import Equals
 
 from snapcraft.internal.meta import errors
-from snapcraft.internal.meta.snap import SystemUserScope
+from snapcraft.internal.meta.system_user import SystemUserScope
 from snapcraft.internal.meta.snap import Snap
 from tests import integration, unit
 

--- a/tests/unit/meta/test_system_user.py
+++ b/tests/unit/meta/test_system_user.py
@@ -32,45 +32,45 @@ class SystemUserTests(unit.TestCase):
 
     def test_invalid_user_empty_scope(self):
         user = SystemUser(name="name", scope=None)
+
         error = self.assertRaises(errors.SystemUsernamesValidationError, user.validate)
-        self.assertThat(
-            error.get_brief(),
-            Equals("Invalid system-usernames for 'name': scope None is invalid"),
-        )
+
+        self.assertThat(error._name, Equals("name"))
+        self.assertThat(error._message, Equals("scope None is invalid"))
 
     def test_invalid_user_empty_scope_from_dict(self):
         user_dict = {"scope": None}
+
         error = self.assertRaises(
             errors.SystemUsernamesValidationError,
             SystemUser.from_dict,
             user_name="name",
             user_dict=user_dict,
         )
-        self.assertThat(
-            error.get_brief(),
-            Equals("Invalid system-usernames for 'name': 'scope' is undefined"),
-        )
+
+        self.assertThat(error._name, Equals("name"))
+        self.assertThat(error._message, Equals("'scope' is undefined"))
 
     def test_invalid_user_non_shared_scope(self):
         user = SystemUser(name="name", scope="none")
+
         error = self.assertRaises(errors.SystemUsernamesValidationError, user.validate)
-        self.assertThat(
-            error.get_brief(),
-            Equals("Invalid system-usernames for 'name': scope 'none' is invalid"),
-        )
+
+        self.assertThat(error._name, Equals("name"))
+        self.assertThat(error._message, Equals("scope 'none' is invalid"))
 
     def test_invalid_user_non_shared_scope_from_dict(self):
         user_dict = {"scope": "ghost"}
+
         error = self.assertRaises(
             errors.SystemUsernamesValidationError,
             SystemUser.from_dict,
             user_name="name",
             user_dict=user_dict,
         )
-        self.assertThat(
-            error.get_brief(),
-            Equals("Invalid system-usernames for 'name': scope 'ghost' is invalid"),
-        )
+
+        self.assertThat(error._name, Equals("name"))
+        self.assertThat(error._message, Equals("scope 'ghost' is invalid"))
 
     def test_from_object_dict(self):
         user_name = "name"
@@ -92,12 +92,8 @@ class SystemUserTests(unit.TestCase):
             user_object=user_object,
         )
 
-        self.assertThat(
-            error.get_brief(),
-            Equals(
-                "Invalid system-usernames for 'name': scope 'invalid_scope' is invalid"
-            ),
-        )
+        self.assertThat(error._name, Equals("name"))
+        self.assertThat(error._message, Equals("scope 'invalid_scope' is invalid"))
 
     def test_from_object_none(self):
         user_name = "name"
@@ -110,10 +106,8 @@ class SystemUserTests(unit.TestCase):
             user_object=user_object,
         )
 
-        self.assertThat(
-            error.get_brief(),
-            Equals("Invalid system-usernames for 'name': undefined user"),
-        )
+        self.assertThat(error._name, Equals("name"))
+        self.assertThat(error._message, Equals("undefined user"))
 
     def test_from_object_string(self):
         user_name = "name"
@@ -135,9 +129,5 @@ class SystemUserTests(unit.TestCase):
             user_object=user_object,
         )
 
-        self.assertThat(
-            error.get_brief(),
-            Equals(
-                "Invalid system-usernames for 'name': scope 'invalid_scope' is invalid"
-            ),
-        )
+        self.assertThat(error._name, Equals("name"))
+        self.assertThat(error._message, Equals("scope 'invalid_scope' is invalid"))

--- a/tests/unit/meta/test_system_user.py
+++ b/tests/unit/meta/test_system_user.py
@@ -71,3 +71,73 @@ class SystemUserTests(unit.TestCase):
             error.get_brief(),
             Equals("Invalid system-usernames for 'name': scope 'ghost' is invalid"),
         )
+
+    def test_from_object_dict(self):
+        user_name = "name"
+        user_object = {"scope": "shared"}
+
+        user = SystemUser.from_object(user_name=user_name, user_object=user_object)
+
+        self.assertThat(user.name, Equals(user_name))
+        self.assertThat(user.scope, Equals(SystemUserScope.SHARED))
+
+    def test_from_object_dict_invalid(self):
+        user_name = "name"
+        user_object = {"scope": "invalid_scope"}
+
+        error = self.assertRaises(
+            errors.SystemUsernamesValidationError,
+            SystemUser.from_object,
+            user_name=user_name,
+            user_object=user_object,
+        )
+
+        self.assertThat(
+            error.get_brief(),
+            Equals(
+                "Invalid system-usernames for 'name': scope 'invalid_scope' is invalid"
+            ),
+        )
+
+    def test_from_object_none(self):
+        user_name = "name"
+        user_object = None
+
+        error = self.assertRaises(
+            errors.SystemUsernamesValidationError,
+            SystemUser.from_object,
+            user_name=user_name,
+            user_object=user_object,
+        )
+
+        self.assertThat(
+            error.get_brief(),
+            Equals("Invalid system-usernames for 'name': undefined user"),
+        )
+
+    def test_from_object_string(self):
+        user_name = "name"
+        user_object = "shared"
+
+        user = SystemUser.from_object(user_name=user_name, user_object=user_object)
+
+        self.assertThat(user.name, Equals(user_name))
+        self.assertThat(user.scope, Equals(SystemUserScope.SHARED))
+
+    def test_from_object_string_invalid(self):
+        user_name = "name"
+        user_object = "invalid_scope"
+
+        error = self.assertRaises(
+            errors.SystemUsernamesValidationError,
+            SystemUser.from_object,
+            user_name=user_name,
+            user_object=user_object,
+        )
+
+        self.assertThat(
+            error.get_brief(),
+            Equals(
+                "Invalid system-usernames for 'name': scope 'invalid_scope' is invalid"
+            ),
+        )


### PR DESCRIPTION
Tidy it up a bit in preparation for further cleanup of from_dict().

No functional changes.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
