### PR TITLE
ci: publish the CI built snap to the Snap Store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,17 @@ jobs:
         - sudo journalctl -u snapd
         - /snap/bin/http https://api.snapcraft.io/v2/snaps/info/core architecture==amd64 Snap-Device-Series:16
 
+    - stage: deploy
+      name: Snap Store
+      addons:
+        snaps:
+          - name: snapcraft
+            channel: candidate
+            classic: true
+      workspaces:
+        use: snaps
+      if: (type = pull_request) and (env(SNAP_TOKEN) IS present)
+      script: ./tools/travis_deploy.sh
     - stage: integration
       name: spread
       workspaces:

--- a/tools/travis_deploy.sh
+++ b/tools/travis_deploy.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ -z "$TRAVIS_PULL_REQUEST" ]; then
+    echo "'TRAVIS_PULL_REQUEST' is not set."
+    exit 1
+fi
+
+
+if [ -z "$SNAP_TOKEN" ]; then
+    echo '"SNAP_TOKEN" is not set.'
+    exit 1
+fi
+
+# Login
+echo "$SNAP_TOKEN" | /snap/bin/snapcraft login --with -
+/snap/bin/snapcraft push \
+                    --release "edge/pr-$TRAVIS_PULL_REQUEST" \
+                    "snapcraft-pr$TRAVIS_PULL_REQUEST.snap"


### PR DESCRIPTION
It is often useful to allow for the snap being built during a PR review to be
available on the Snap Store.

This change should make version of each run through Travis CI available on the
edge/pr-$TRAVIS_PULL_REQUEST (e.g.; edge/pr-1050).

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
