### PR TITLE
elf: search for host libraries within search paths

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -211,7 +211,7 @@ class Library:
 
         valid_search_paths = [p for p in self.search_paths if os.path.exists(p)]
         in_search_paths = any(
-            [self.soname_path.startswith(p) for p in valid_search_paths]
+            self.soname_path.startswith(p) for p in valid_search_paths
         )
 
         # Expedite path crawling if we have a valid elf file that lives

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -209,18 +209,23 @@ class Library:
 
         logger.debug("Crawling to find soname {!r}".format(self.soname))
 
-        if self._is_valid_elf(self.soname_path):
+        valid_search_paths = [p for p in self.search_paths if os.path.exists(p)]
+        in_search_paths = any(
+            [self.soname_path.startswith(p) for p in valid_search_paths]
+        )
+
+        # Expedite path crawling if we have a valid elf file that lives
+        # inside the search paths.
+        if in_search_paths and self._is_valid_elf(self.soname_path):
             self._update_soname_cache(self.soname_path)
             return self.soname_path
 
-        for path in self.search_paths:
-            if not os.path.exists(path):
-                continue
+        for path in valid_search_paths:
             for root, directories, files in os.walk(path):
                 if self.soname not in files:
                     continue
 
-                file_path = os.path.join(root, self.soname)
+                file_path = os.path.join(root, self.soname.strip("/"))
                 if self._is_valid_elf(file_path):
                     self._update_soname_cache(file_path)
                     return file_path

--- a/tests/bin/elf/ldd
+++ b/tests/bin/elf/ldd
@@ -20,6 +20,9 @@ _LDD_OUT = {
         'barsnap.so.2 => {CORE_PATH}/barsnap.so.2 (0xbeef)',
         '/lib/baz.so.2 (0x1234)',
     ],
+    'fake_elf-with-host-libraries': [
+        'moo.so.2 => /usr/lib/moo.so.2 (0xbeef)',
+    ]
 }
 
 

--- a/tests/fixture_setup/_unittests.py
+++ b/tests/fixture_setup/_unittests.py
@@ -128,6 +128,7 @@ def _fake_elffile_extract_attributes(self):
         "fake_elf-with-core-libs",
         "fake_elf-with-missing-libs",
         "fake_elf-bad-patchelf",
+        "fake_elf-with-host-libraries",
     ]:
         glibc = elf.NeededLibrary(name="libc.so.6")
         glibc.add_version("GLIBC_2.2.5")
@@ -299,6 +300,9 @@ class FakeElf(fixtures.Fixture):
             "fake_elf-shared-object": elf.ElfFile(
                 path=os.path.join(self.root_path, "fake_elf-shared-object")
             ),
+            "fake_elf-with-host-libraries": elf.ElfFile(
+                path=os.path.join(self.root_path, "fake_elf-with-host-libraries")
+            ),
             "fake_elf-bad-ldd": elf.ElfFile(
                 path=os.path.join(self.root_path, "fake_elf-bad-ldd")
             ),
@@ -329,9 +333,13 @@ class FakeElf(fixtures.Fixture):
                 if elf_file.path.endswith("fake_elf-bad-patchelf"):
                     f.write(b"nointerpreter")
 
-        self.root_libraries = {"foo.so.1": os.path.join(self.root_path, "foo.so.1")}
+        self.root_libraries = {
+            "foo.so.1": os.path.join(self.root_path, "foo.so.1"),
+            "moo.so.2": os.path.join(self.root_path, "non-standard", "moo.so.2"),
+        }
 
         for root_library in self.root_libraries.values():
+            os.makedirs(os.path.dirname(root_library), exist_ok=True)
             with open(root_library, "wb") as f:
                 f.write(b"\x7fELF")
 

--- a/tests/unit/test_elf.py
+++ b/tests/unit/test_elf.py
@@ -139,14 +139,7 @@ class TestGetLibraries(TestElfBase):
     def setUp(self):
         super().setUp()
 
-        patcher = mock.patch("os.path.exists")
-        self.path_exists_mock = patcher.start()
-        self.addCleanup(patcher.stop)
-
-        self.path_exists_mock.return_value = True
-
-        self.fake_logger = fixtures.FakeLogger(level=logging.WARNING)
-        self.useFixture(self.fake_logger)
+        self.useFixture(fixtures.MockPatch("os.path.exists", return_value=True))
 
     def test_get_libraries(self):
         elf_file = self.fake_elf["fake_elf-2.23"]
@@ -236,6 +229,9 @@ class TestGetLibraries(TestElfBase):
         )
 
     def test_get_libraries_ldd_failure_logs_warning(self):
+        self.fake_logger = fixtures.FakeLogger(level=logging.WARNING)
+        self.useFixture(self.fake_logger)
+
         elf_file = self.fake_elf["fake_elf-bad-ldd"]
         libs = elf_file.load_dependencies(
             root_path=self.fake_elf.root_path,
@@ -249,6 +245,29 @@ class TestGetLibraries(TestElfBase):
             self.fake_logger.output,
             Contains("Unable to determine library dependencies for"),
         )
+
+    def test_existing_host_library_searched_for(self):
+        elf_file = self.fake_elf["fake_elf-with-host-libraries"]
+
+        class MooLibrary(elf.Library):
+            """A Library implementation that always returns valid for moo."""
+
+            def _is_valid_elf(self, resolved_path: str) -> bool:
+                #  This path is defined in ldd for fake_elf-with-host-libraries.
+                if resolved_path == "/usr/lib/moo.so.2":
+                    return True
+                else:
+                    return super()._is_valid_elf(resolved_path)
+
+        with mock.patch("snapcraft.internal.elf.Library", side_effect=MooLibrary):
+            libs = elf_file.load_dependencies(
+                root_path=self.fake_elf.root_path,
+                core_base_path=self.fake_elf.core_base_path,
+                arch_triplet=self.arch_triplet,
+                content_dirs=self.content_dirs,
+            )
+
+        self.assertThat(libs, Equals({self.fake_elf.root_libraries["moo.so.2"]}))
 
 
 class TestGetElfFiles(TestElfBase):


### PR DESCRIPTION
A regression was introduced with commit 76e8a3f3f1c3f69d957b2806c9387ac3c57e926a
which considered elf files on the host system to be valid. Additionally, since
the host-found libraries were absolute paths, an os.path.join suffixing the
search paths snapcraft cared about were ignored.

A unit test which considers this scenario was added.

LP: #1860766

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
