### PR TITLE
[experimental] debug splitting

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -21,7 +21,7 @@ import click
 from typing import Any, Dict, List
 
 from snapcraft.project import Project, get_snapcraft_yaml
-from snapcraft.cli.echo import confirm, prompt
+from snapcraft.cli.echo import confirm, prompt, warning
 from snapcraft.internal import common, errors
 
 
@@ -256,6 +256,9 @@ def get_build_provider_flags(build_provider: str, **kwargs) -> Dict[str, str]:
         key_formatted = _param_decls_to_kwarg(key)
         if key_formatted in kwargs:
             build_provider_flags[key_formatted] = kwargs[key_formatted]
+
+    if build_provider_flags.get("split_debug", False):
+        warning("*EXPERIMENTAL*: Splitting debug information enabled!")
 
     return build_provider_flags
 

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -18,7 +18,7 @@ import os
 import sys
 
 import click
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from snapcraft.project import Project, get_snapcraft_yaml
 from snapcraft.cli.echo import confirm, prompt
@@ -45,7 +45,7 @@ class PromptOption(click.Option):
         )
 
 
-_BUILD_OPTIONS = [
+_BUILD_OPTIONS: List[Dict[str, Any]] = [
     dict(
         param_decls="--target-arch",
         metavar="<arch>",
@@ -71,7 +71,7 @@ _BUILD_OPTIONS = [
 _SUPPORTED_PROVIDERS = ["host", "lxd", "multipass"]
 _HIDDEN_PROVIDERS = ["managed-host"]
 _ALL_PROVIDERS = _SUPPORTED_PROVIDERS + _HIDDEN_PROVIDERS
-_PROVIDER_OPTIONS = [
+_PROVIDER_OPTIONS: List[Dict[str, Any]] = [
     dict(
         param_decls="--destructive-mode",
         is_flag=True,
@@ -114,6 +114,14 @@ _PROVIDER_OPTIONS = [
         envvar="SNAPCRAFT_BIND_SSH",
         supported_providers=["lxd", "multipass"],
     ),
+    dict(
+        param_decls="--split-debug",
+        is_flag=True,
+        help="Split and collect debug symbols.",
+        envvar="split_debug",
+        supported_providers=["host", "lxd", "managed-host", "multipass"],
+        hidden=True,
+    ),
 ]
 
 
@@ -128,7 +136,12 @@ def _add_options(options, func, hidden):
         if "supported_providers" in option:
             option.pop("supported_providers")
 
-        click_option = click.option(param_decls, **option, hidden=hidden)
+        # If option's hidden attribute is specified, it overrides the default.
+        if "hidden" in option:
+            click_option = click.option(param_decls, **option)
+        else:
+            click_option = click.option(param_decls, **option, hidden=hidden)
+
         func = click_option(func)
     return func
 

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -377,7 +377,7 @@ class Provider(abc.ABC):
         env_list.append(f"SNAPCRAFT_HAS_TTY={has_tty}")
 
         # Pass through configurable environment variables.
-        for key in ["http_proxy", "https_proxy"]:
+        for key in ["http_proxy", "https_proxy", "split_debug"]:
             value = self.build_provider_flags.get(key)
             if not value:
                 continue

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -32,7 +32,7 @@ from typing import Callable, List
 from snapcraft.internal import errors
 
 
-SNAPCRAFT_FILES = ["parts", "stage", "prime"]
+SNAPCRAFT_FILES = ["debug", "parts", "stage", "prime"]
 _DEFAULT_PLUGINDIR = os.path.join(sys.prefix, "share", "snapcraft", "plugins")
 _plugindir = _DEFAULT_PLUGINDIR
 _DEFAULT_SCHEMADIR = os.path.join(sys.prefix, "share", "snapcraft", "schema")

--- a/snapcraft/internal/lifecycle/_clean.py
+++ b/snapcraft/internal/lifecycle/_clean.py
@@ -138,6 +138,10 @@ def _cleanup_common_directories_for_step(step, project: "Project", parts=None):
             project.prime_dir, steps.PRIME, message, parts, remove_dir=remove_dir
         )
 
+        if os.path.isdir(project.debug_dir):
+            logger.info("Cleaning up debug directory")
+            _remove_directory(project.debug_dir)
+
     if step <= steps.STAGE:
         # Remove the staging area.
         _cleanup_common(

--- a/snapcraft/internal/pluginhandler/_debug_split.py
+++ b/snapcraft/internal/pluginhandler/_debug_split.py
@@ -1,0 +1,163 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+import shlex
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Set, Tuple
+
+from snapcraft import file_utils
+from snapcraft.internal import errors
+from snapcraft.internal.elf import ElfFile
+
+logger = logging.getLogger(__name__)
+
+
+def _cross_command(cmd: str, arch_triplet: Optional[str]) -> str:
+    if arch_triplet:
+        cmd = f"{arch_triplet}-{cmd}"
+    return file_utils.get_tool_path(cmd)
+
+
+def _run(cmd: List[str]) -> None:
+    command_string = " ".join([shlex.quote(c) for c in cmd])
+    logger.debug(f"running: {command_string}")
+
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as call_error:
+        raise errors.SnapcraftCommandError(
+            command=command_string, call_error=call_error
+        ) from call_error
+
+
+class DebugSplitter:
+    def __init__(self, *, arch_triplet: str, debug_dir: Path) -> None:
+        self.objcopy_cmd = _cross_command("objcopy", arch_triplet)
+        self.strip_cmd = _cross_command("strip", arch_triplet)
+        self.debug_dir = debug_dir
+
+    def _get_debug_file_path(self, build_id: str) -> Path:
+        return Path(self.debug_dir, build_id[:2], build_id[2:])
+
+    def _make_debug(self, elf_file: ElfFile, debug_file: str) -> None:
+        _run(
+            [
+                self.objcopy_cmd,
+                "--only-keep-debug",
+                "--compress-debug-sections",
+                elf_file.path,
+                debug_file,
+            ]
+        )
+
+    def _attach_debug(self, elf_file: ElfFile, debug_file: str) -> None:
+        _run([self.objcopy_cmd, "--add-gnu-debuglink", debug_file, elf_file.path])
+
+    def _strip_debug_command(self, elf_file: ElfFile) -> None:
+        # dh_strip use 0o111 to verify executable:
+        # https://github.com/Debian/debhelper/blob/423cfce04719f41d7224d75155c4e7f9a97a10e9/dh_strip#L229
+        if os.stat(elf_file.path).st_mode & 0o111 == 0o111:
+            # Executable.
+            cmd = [
+                self.strip_cmd,
+                "--remove-section=.comment",
+                "--remove-section=.note",
+                elf_file.path,
+            ]
+        else:
+            # Shared object.
+            cmd = [
+                self.strip_cmd,
+                "--remove-section=.comment",
+                "--remove-section=.note",
+                "--strip-unneeded",
+                elf_file.path,
+            ]
+
+        _run(cmd)
+
+    def split(self, elf_file: ElfFile) -> Optional[Path]:
+        # Matching the pattern used in dh_strip:
+        # https://github.com/Debian/debhelper/blob/master/dh_strip#L359
+
+        if not elf_file.has_debug_info:
+            logger.debug(f"No debug info found for {elf_file.path!r}.")
+            return None
+
+        if not elf_file.build_id:
+            logger.debug(
+                f"No debug info extracted for {elf_file.path!r} due to missing build-id."
+            )
+            return None
+
+        if elf_file.elf_type not in ["ET_EXEC", "ET_DYN"]:
+            logger.warning(
+                f"Skipping debug extraction for {elf_file.path!r} with ELF type {elf_file.elf_type!r}"
+            )
+            return None
+
+        debug_file = self._get_debug_file_path(elf_file.build_id)
+        debug_file.parent.mkdir(exist_ok=True, parents=True)
+
+        # Copy debug information to debug directory.
+        self._make_debug(elf_file, debug_file.as_posix())
+
+        # Strip debug from binary.
+        self._strip_debug_command(elf_file)
+
+        # Link/attach debug symbol file to executable.
+        self._attach_debug(elf_file, debug_file.as_posix())
+
+        return debug_file
+
+
+def split_debug_info(
+    *, debug_dir: str, arch_triplet: str, prime_dir: str, file_paths: Set[str]
+) -> Tuple[Set[str], Set[str]]:
+    """Split files in file_paths, saving debug artifacts to debug_dir.
+
+    :param debug_dir: Directory to save artifacts to.
+    :param arch_triplet: Project's arch triplet, used to determine which
+           objcopy and strip command to use.
+    :param file_paths: Set of file paths (string) to process.
+    :return: a tuple of the set of (debug_files, debug_dirs) artifacts.
+    """
+
+    debug_files: Set[str] = set()
+    debug_dirs: Set[str] = set()
+
+    logger.warning(f"Collected debug information may be found in: {debug_dir}")
+
+    collector = DebugSplitter(arch_triplet=arch_triplet, debug_dir=Path(debug_dir))
+    for file_path in file_paths:
+        file_path = os.path.join(prime_dir, file_path)
+        if not ElfFile.is_elf(file_path):
+            continue
+
+        logger.debug(f"Checking debug info for: {file_path!r}")
+
+        debug_file = collector.split(ElfFile(path=file_path))
+        if debug_file is None:
+            continue
+
+        debug_file = debug_file.relative_to(debug_dir)
+        debug_files.add(debug_file.as_posix())
+        debug_dirs.add(debug_file.parent.as_posix())
+
+    return debug_files, debug_dirs

--- a/snapcraft/internal/states/_prime_state.py
+++ b/snapcraft/internal/states/_prime_state.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Optional, Set
+
 import snapcraft.extractors
 from snapcraft.internal.states._state import PartState
 
@@ -30,6 +32,8 @@ class PrimeState(PartState):
         project=None,
         scriptlet_metadata=None,
         primed_stage_packages=None,
+        debug_files: Optional[Set[str]] = None,
+        debug_dirs: Optional[Set[str]] = None,
     ):
         super().__init__(part_properties, project)
 
@@ -38,7 +42,7 @@ class PrimeState(PartState):
 
         self.files = files
         self.directories = directories
-        self.dependency_paths = set()
+        self.dependency_paths: Set[str] = set()
         self.scriptlet_metadata = scriptlet_metadata
         self.primed_stage_packages = primed_stage_packages
         if self.primed_stage_packages is None:
@@ -46,6 +50,16 @@ class PrimeState(PartState):
 
         if dependency_paths:
             self.dependency_paths = dependency_paths
+
+        if debug_files is None:
+            self.debug_files: Set[str] = set()
+        else:
+            self.debug_files = debug_files
+
+        if debug_dirs is None:
+            self.debug_dirs: Set[str] = set()
+        else:
+            self.debug_dirs = debug_dirs
 
     def properties_of_interest(self, part_properties):
         """Extract the properties concerning this step from part_properties.

--- a/snapcraft/project/_project_options.py
+++ b/snapcraft/project/_project_options.py
@@ -178,6 +178,10 @@ class ProjectOptions:
         return self.__machine_info["kernel"]
 
     @property
+    def debug_dir(self) -> str:
+        return self._debug_dir
+
+    @property
     def parts_dir(self) -> str:
         return self._parts_dir
 
@@ -204,10 +208,12 @@ class ProjectOptions:
 
         self._debug = debug
 
+        self._debug_dir = os.path.join(work_dir, "debug")
         self._parts_dir = os.path.join(work_dir, "parts")
         self._stage_dir = os.path.join(work_dir, "stage")
         self._prime_dir = os.path.join(work_dir, "prime")
 
+        logger.debug("Debug dir {}".format(self._parts_dir))
         logger.debug("Parts dir {}".format(self._parts_dir))
         logger.debug("Stage dir {}".format(self._stage_dir))
         logger.debug("Prime dir {}".format(self._prime_dir))

--- a/tests/unit/commands/test_help.py
+++ b/tests/unit/commands/test_help.py
@@ -19,10 +19,11 @@ import pydoc
 from unittest import mock
 
 import fixtures
-from testtools.matchers import Contains, Equals, StartsWith
+from testtools.matchers import Contains, Equals, Not, StartsWith
 
-from snapcraft.cli.help import _TOPICS
+from snapcraft.cli import _options
 from snapcraft.cli._runner import run
+from snapcraft.cli.help import _TOPICS
 
 from . import CommandBaseTestCase
 
@@ -174,3 +175,29 @@ class TestHelpForCommand(HelpCommandBaseTestCase):
         self.assertThat(
             result.output, Contains(run.commands[self.command].help.split("\n")[0])
         )
+
+
+class TestHelpProviderOptionVisibilty(HelpCommandBaseTestCase):
+    def test_visible_options(self):
+        visible_opts = [
+            x["param_decls"]
+            for x in _options._PROVIDER_OPTIONS
+            if x.get("hidden", False) is False
+        ]
+
+        result = self.run_command(["help", "snap"])
+
+        for opt in visible_opts:
+            self.assertThat(result.output, Contains(opt))
+
+    def test_hidden_options(self):
+        hidden_opts = [
+            x["param_decls"]
+            for x in _options._PROVIDER_OPTIONS
+            if x.get("hidden", False) is True
+        ]
+
+        result = self.run_command(["help", "snap"])
+
+        for opt in hidden_opts:
+            self.assertThat(result.output, Not(Contains(opt)))

--- a/tests/unit/pluginhandler/test_debug_split.py
+++ b/tests/unit/pluginhandler/test_debug_split.py
@@ -1,0 +1,235 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import fixtures
+from testtools.matchers import Equals
+
+from snapcraft import ProjectOptions
+from snapcraft.internal.pluginhandler._debug_split import (
+    DebugSplitter,
+    split_debug_info,
+)
+from tests import unit
+
+
+original_stat = os.stat
+
+
+def fake_stat(path):
+    basename = os.path.basename(path)
+    if basename == "fake-elf-executable":
+        return mock.Mock(st_mode=0o755)
+    elif basename.startswith("fake-"):
+        return mock.Mock(st_mode=0o644)
+    else:
+        return original_stat(path)
+
+
+class FakeElfFile:
+    def __init__(self, path: str) -> None:
+        basename = os.path.basename(path)
+
+        self.path = path
+        self.build_id = f"fbid-{basename}"
+        self.elf_type = "ET_EXEC"
+        self.has_debug_info = True
+
+        if basename == "fake-elf-shared-object":
+            self.elf_type = "ET_DYN"
+        elif basename == "fake-elf-core":
+            self.elf_type = "ET_CORE"
+        elif basename == "fake-elf-no-debug-info":
+            self.has_debug_info = False
+        elif basename == "fake-elf-no-build-id":
+            self.build_id = ""
+
+    @classmethod
+    def is_elf(cls, path: str) -> bool:
+        basename = os.path.basename(path)
+        if basename.startswith("fake-elf"):
+            return True
+        return False
+
+
+class SplitDebugTests(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        # Shared properties.
+        self.arch_triplet = ProjectOptions().arch_triplet
+        self.debug_dir = Path(self.path)
+        self.strip_cmd = f"{self.arch_triplet}-strip"
+        self.objcopy_cmd = f"{self.arch_triplet}-objcopy"
+
+        # Mock _debug_split._run().
+        self.fake_run = fixtures.MockPatch(
+            "snapcraft.internal.pluginhandler._debug_split._run"
+        )
+        self.useFixture(self.fake_run)
+
+        # Mock os.stat().
+        self.useFixture(fixtures.MockPatch("os.stat", side_effect=fake_stat))
+
+        # Mock ElfFile.
+        self.useFixture(
+            fixtures.MockPatch(
+                "snapcraft.internal.pluginhandler._debug_split.ElfFile", new=FakeElfFile
+            )
+        )
+
+    def test_no_debug_info(self):
+        elf = FakeElfFile("fake-elf-no-debug-info")
+
+        splitter = DebugSplitter(
+            arch_triplet=self.arch_triplet, debug_dir=self.debug_dir
+        )
+        split_path = splitter.split(elf)
+
+        self.assertThat(split_path, Equals(None))
+
+    def test_no_build_id(self):
+        elf = FakeElfFile("fake-elf-no-build-id")
+
+        splitter = DebugSplitter(
+            arch_triplet=self.arch_triplet, debug_dir=self.debug_dir
+        )
+        split_path = splitter.split(elf)
+
+        self.assertThat(split_path, Equals(None))
+
+    def test_ignored_elf_type(self):
+        elf = FakeElfFile("fake-elf-core")
+
+        splitter = DebugSplitter(
+            arch_triplet=self.arch_triplet, debug_dir=self.debug_dir
+        )
+        split_path = splitter.split(elf)
+
+        self.assertThat(split_path, Equals(None))
+
+    def test_executable(self):
+        elf = FakeElfFile("fake-elf-executable")
+
+        expected_dst = Path(self.debug_dir, "fb/id-fake-elf-executable")
+
+        splitter = DebugSplitter(
+            arch_triplet=self.arch_triplet, debug_dir=self.debug_dir
+        )
+        split_path = splitter.split(elf)
+
+        self.assertThat(split_path, Equals(expected_dst))
+
+        self.fake_run.mock.assert_has_calls(
+            [
+                mock.call(
+                    [
+                        self.objcopy_cmd,
+                        "--only-keep-debug",
+                        "--compress-debug-sections",
+                        elf.path,
+                        expected_dst.as_posix(),
+                    ]
+                ),
+                mock.call(
+                    [
+                        self.strip_cmd,
+                        "--remove-section=.comment",
+                        "--remove-section=.note",
+                        elf.path,
+                    ]
+                ),
+                mock.call(
+                    [
+                        self.objcopy_cmd,
+                        "--add-gnu-debuglink",
+                        expected_dst.as_posix(),
+                        elf.path,
+                    ]
+                ),
+            ]
+        )
+
+    def test_shared_object(self):
+        elf = FakeElfFile("fake-elf-shared-object")
+
+        expected_dst = Path(self.debug_dir, "fb/id-fake-elf-shared-object")
+
+        splitter = DebugSplitter(
+            arch_triplet=self.arch_triplet, debug_dir=self.debug_dir
+        )
+        split_path = splitter.split(elf)
+
+        self.assertThat(split_path, Equals(expected_dst))
+
+        self.fake_run.mock.assert_has_calls(
+            [
+                mock.call(
+                    [
+                        self.objcopy_cmd,
+                        "--only-keep-debug",
+                        "--compress-debug-sections",
+                        elf.path,
+                        expected_dst.as_posix(),
+                    ]
+                ),
+                mock.call(
+                    [
+                        self.strip_cmd,
+                        "--remove-section=.comment",
+                        "--remove-section=.note",
+                        "--strip-unneeded",
+                        elf.path,
+                    ]
+                ),
+                mock.call(
+                    [
+                        self.objcopy_cmd,
+                        "--add-gnu-debuglink",
+                        expected_dst.as_posix(),
+                        elf.path,
+                    ]
+                ),
+            ]
+        )
+
+    def test_split_debug_info(self):
+        file_paths = set(
+            [
+                "fake-elf-executable",
+                "fake-elf-shared-object",
+                "fake-elf-core",
+                "fake-elf-no-debug-info",
+                "fake-elf-no-build-id",
+                "fake-data",
+            ]
+        )
+
+        debug_files, debug_dirs = split_debug_info(
+            debug_dir=self.debug_dir,
+            arch_triplet=self.arch_triplet,
+            prime_dir=self.path,
+            file_paths=file_paths,
+        )
+
+        self.assertThat(
+            debug_files,
+            Equals({"fb/id-fake-elf-executable", "fb/id-fake-elf-shared-object"}),
+        )
+        self.assertThat(debug_dirs, Equals({"fb"}))


### PR DESCRIPTION
# Debug symbol extraction / splitting (EXPERIMENTAL)

The goal of this effort is to provide the initial capability to strip
debug symbols from ELF executables and shared objects, reducing the
overall size of snaps.  As debug symbols are important for debugging,
the snapcraft ecosystem seeks to provide a way of distributing them,
akin to `<package>-dbg` deb packages.

# Background Information

## Build IDs

The linker `ld` provides `--build-id` to request the creation of
the `.note.gnu.build-id` ELF note section.  GCC may invoke the linker
with this flag using `-Wl,--build-id`.

The build ID may be read using `readelf -n <ELF>`.

## Build ID Directory Organization

`.build-id` is organized as two levels, with the first level of directories
being the first two characters of the build ID and files underneath those
named `<remaining characters of build ID>.debug`.

Example:

```
$ find /usr/lib/debug/.build-id

/usr/lib/debug/.build-id/
/usr/lib/debug/.build-id/42
/usr/lib/debug/.build-id/42/ead3f90c7b9d9817828397efc16de391f03652.debug
/usr/lib/debug/.build-id/39
/usr/lib/debug/.build-id/39/560457911d968d9e06088da015970b0018153f.debug
<snipped>
```

# How snapcraft splits debug information

## What gets stripped?

Snapcraft will only actively strip files being "primed", files that have
been built (or pre-built) and installed by snapcraft. 

There a number of ELF types, but snapcraft will ignore ELFs that are not
of type "ET_EXEC" (executable) or "ET_DYN" (dynamic executable).  It is
possible that other types could be considered in the future, but for
safety, we restrict splitting two the primary files of interest.

## What about stage-packages

Generally speaking, stage-packages are already stripped as part of the debian
packaging process and may have their own associated -dbg packages. Snapcraft
does not attempt to (re)strip stage-packages.  Attempting to do so may affect
the runtime behavior accounted for in the debian packaging.

Future work could incorporate fetching applicable debug-packages that are
associated with the installed stage-packages.


## Stripping debug symbols

Now that we have captured the debugging information, we can strip
the debug symbols from the original file.  The process for stripping
varies, but the best example for stripping rules can probably be found
by the defaults performed by the debhelper program `dh_strip`:

- For executables [1]:
  - `--remove-section=.comment`
  - `--remove-section=.note`
- For shared libraries [2]:
  - `--remove-section=.comment`
  - `--remove-section=.note`
  - `--strip-unneeded`
- For static libraries [3]:
  - `--strip-debug`
  - `--remove-section=.comment`
  - `--remove-section=.note`
  - `--enable-deterministic-archives`

Ubuntu generally ships debug symbols to `/usr/lib/debug/`
with most artifacts residing in `/usr/lib/debug/.build-id/`.

### Distinguishing between Executables and Shared Objects

Many executables are of type dynamic.  In order to distinguish between
an executable and shared object, `dh_strip` simply resorts to checking
the executable bits (o111). If all executable bits are set, the target
is treated as an executable.

## Linking the split debug file to the original executable

To provide a hint in the executable for GDB, etc. to find the debug symbols
associated for the ELF under test, objcopy provides a mechanism to link them:
`ojbcopy --add-gnu-debuglink <debug-file> <ELF>`

You may read this using: `readelf --string-dump=.gnu_debuglink <ELF>`.

# Possible future work

As the feature matures, I think it may make sense to promote the debug/strip
process to graduate to a proper "step" in snapcraft.  This will enable a few things:

Assuming the step name is "split-debug":

- The user will be able to execute `snapcraft split-debug` will run the step.

- An `override-split-debug` scriplet will enable the snap developer to customize
the behavior of split-debug for application-specific cases.

# Using it in snapcraft

Run `snapcraft --split-debug`.  This is going to change, so use with caution
in any scripts.

Once the snap is built, the debug files will be available in the project's `debug`
directory.

## Fetching artifacts

### Destructive mode (host)

You will find the files under `./debug`.

### LXD

You will find the files in the container's `/root/debug`, which can be
fetched with:

```
lxc start snapcraft-<project-name>
lxc file pull --recursive snapcraft-<project-name>/root/debug <out-dir>
```

### Multipass

You will find the files in the VM's `/root/debug`, which can be fetched with:

```
multipass exec snapcraft-figlet -- sudo tar czvf /tmp/debug.tgz /root/debug
multipass transfer snapcraft-figlet:/tmp/debug.tgz debug.tgz
```

# References

[1] https://github.com/Debian/debhelper/blob/423cfce04719f41d7224d75155c4e7f9a97a10e9/dh_strip#L361
[2] https://github.com/Debian/debhelper/blob/423cfce04719f41d7224d75155c4e7f9a97a10e9/dh_strip#L367
[3] https://github.com/Debian/debhelper/blob/423cfce04719f41d7224d75155c4e7f9a97a10e9/dh_strip#L374
[4] https://github.com/Debian/debhelper/blob/423cfce04719f41d7224d75155c4e7f9a97a10e9/dh_strip#L229