### PR TITLE
meta: do not prime commands with adapter == "none"

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -360,9 +360,13 @@ class _SnapPackaging:
 
     def finalize_snap_meta_commands(self) -> None:
         for app_name, app in self._snap_meta.apps.items():
-            app.prime_commands(
-                base=self._project_config.project.info.base, prime_dir=self._prime_dir
-            )
+            # Prime commands only if adapter != "none",
+            # otherwise leave as-is.
+            if app.adapter != ApplicationAdapter.NONE:
+                app.prime_commands(
+                    base=self._project_config.project.info.base,
+                    prime_dir=self._prime_dir,
+                )
 
     def finalize_snap_meta_command_chains(self) -> None:
         snapcraft_runner = self._generate_snapcraft_runner()

--- a/tests/spread/general/adapter/expected_snap.yaml
+++ b/tests/spread/general/adapter/expected_snap.yaml
@@ -13,6 +13,8 @@ apps:
     - snap/command-chain/snapcraft-runner
   adapter-none:
     command: test-cmd
+  adapter-none-py:
+    command: test-cmd.py
   wrapped-default:
     command: command-wrapped-default.wrapper
     command-chain:

--- a/tests/spread/general/adapter/snaps/adapter-tests/snapcraft.yaml
+++ b/tests/spread/general/adapter/snaps/adapter-tests/snapcraft.yaml
@@ -18,6 +18,9 @@ apps:
   adapter-none:
     command: test-cmd
     adapter: none
+  adapter-none-py:
+    command: test-cmd.py
+    adapter: none
   adapter-full:
     command: test-cmd
     adapter: full

--- a/tests/spread/general/adapter/snaps/adapter-tests/test-cmd.py
+++ b/tests/spread/general/adapter/snaps/adapter-tests/test-cmd.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print("hi")

--- a/tests/unit/meta/test_meta.py
+++ b/tests/unit/meta/test_meta.py
@@ -366,6 +366,15 @@ class CreateTestCase(CreateBaseTestCase):
         )
         self.assertThat(y["assumes"], Equals(["command-chain"]))
 
+    def test_adapter_none(self):
+        # Adapter "none" will passthrough command as-is.
+        self.config_data["apps"] = {"app": {"adapter": "none", "command": "/foo"}}
+
+        y = self.generate_meta_yaml()
+
+        self.assertThat(y["apps"]["app"]["command"], Equals("/foo"))
+        self.assertThat(y["apps"]["app"].get("command-chain"), Equals(None))
+
 
 class StopModeTestCase(CreateBaseTestCase):
 


### PR DESCRIPTION
Snapcraft is priming (modifying) the commands when adapter is set
to "none".  These commands should be passed through as-is and never
modify them.  This will be consistent with snapcraft's behavior with
regards to wrappers and snapcraft-runner (it does not generate wrappers
or modify the command-chain).

Add unit test for "none" case and update adapter spread test to
include a case for a adapter "none" with a python script command.

LP #1862163

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
