### PR TITLE
spread: disable journal debug dump unless configured

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - LC_ALL: "C.UTF-8"
     - LANG: "C.UTF-8"
     - PATH: "/snap/bin:$PATH"
+    - SPREAD_DEBUG_JOURNAL: "true"
 
 jobs:
   include:

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,6 +1,8 @@
 project: snapcraft
 
 environment:
+  SPREAD_DEBUG_JOURNAL: "$(HOST: echo ${SPREAD_DEBUG_JOURNAL:-false})"
+
   # Tell snapcraft to use the current host to build
   SNAPCRAFT_BUILD_ENVIRONMENT: "host"
 
@@ -166,13 +168,17 @@ prepare: |
   fi
 
 debug: |
-  journalctl -xe
+  if [ "$SPREAD_DEBUG_JOURNAL" == "true" ]; then
+    journalctl -xe
+  fi
 
 restore-each: |
   "$TOOLS_DIR"/restore.sh
 
 debug-each: |
-  journalctl -xe
+  if [ "$SPREAD_DEBUG_JOURNAL" == "true" ]; then
+    journalctl -xe
+  fi
 
 suites:
  # Unit tests


### PR DESCRIPTION
Most failures do not require the journal to debug.  To prevent flooding
the user with a lot of unnecessary information, only dump the journal
if SPREAD_DEBUG_JOURNAL=true.  Set this default for Travis CI.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
