### PR TITLE
meta: ensure Application passthrough is scrubbed for snap.yaml

### DIFF
--- a/snapcraft/internal/meta/application.py
+++ b/snapcraft/internal/meta/application.py
@@ -202,6 +202,10 @@ class Application:
 
         # Apply passthrough keys.
         app_dict.update(self.passthrough)
+
+        # Ensure passthrough is removed.
+        app_dict.pop("passthrough", None)
+
         return app_dict
 
     def __repr__(self) -> str:

--- a/tests/spread/general/passthrough/expected_snap.yaml
+++ b/tests/spread/general/passthrough/expected_snap.yaml
@@ -1,0 +1,17 @@
+name: passthrough-tests
+version: '1.0'
+summary: passthrough-tests
+description: passthrough-tests
+apps:
+  test-cmd:
+    command: test-cmd
+    pt-test-app: pt-test-app
+architectures:
+- amd64
+base: core18
+confinement: strict
+grade: devel
+hooks:
+  configure:
+    pt-test-hook: pt-test-hook
+pt-test-snap: pt-test-snap

--- a/tests/spread/general/passthrough/snaps/passthrough-tests/snap/hooks/configure
+++ b/tests/spread/general/passthrough/snaps/passthrough-tests/snap/hooks/configure
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "configure"

--- a/tests/spread/general/passthrough/snaps/passthrough-tests/snap/snapcraft.yaml
+++ b/tests/spread/general/passthrough/snaps/passthrough-tests/snap/snapcraft.yaml
@@ -1,0 +1,30 @@
+name: passthrough-tests
+version: "1.0"
+summary: passthrough-tests
+description: passthrough-tests
+
+base: core18
+grade: devel
+confinement: strict
+
+parts:
+  passthrough-tests:
+    plugin: nil
+    source: .
+    override-build:
+      install -m 0755 test-cmd $SNAPCRAFT_PART_INSTALL/
+
+apps:
+  test-cmd:
+    adapter: none
+    command: test-cmd
+    passthrough:
+      pt-test-app: pt-test-app
+
+hooks:
+  configure:
+    passthrough:
+      pt-test-hook: pt-test-hook
+
+passthrough:
+  pt-test-snap: pt-test-snap

--- a/tests/spread/general/passthrough/snaps/passthrough-tests/test-cmd
+++ b/tests/spread/general/passthrough/snaps/passthrough-tests/test-cmd
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "hi"

--- a/tests/spread/general/passthrough/task.yaml
+++ b/tests/spread/general/passthrough/task.yaml
@@ -1,0 +1,27 @@
+summary: Build a snap that tests passthrough settings
+
+# This test snap uses core18, and is limited to amd64 arch due to
+# architectures specified in expected_snap.yaml.
+systems:
+  - ubuntu-18.04-64
+  - ubuntu-18.04-amd64
+  - ubuntu-18.04
+
+environment:
+  SNAP_DIR: snaps/passthrough-tests
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft prime
+
+  expected_snap_yaml="$PWD/../../expected_snap.yaml"
+
+  if ! diff -U10 prime/meta/snap.yaml "$expected_snap_yaml"; then
+      echo "The formatting for snap.yaml is incorrect"
+      exit 1
+  fi

--- a/tests/unit/meta/test_application.py
+++ b/tests/unit/meta/test_application.py
@@ -252,3 +252,53 @@ class DesktopFileTest(unit.TestCase):
 
         self.expectThat(app.to_dict(), Not(Contains("desktop")))
         self.expectThat(expected_desktop_file_path, FileExists())
+
+
+class AppPassthroughTests(unit.TestCase):
+    def test_no_passthroug(self):
+        app = application.Application(
+            app_name="foo",
+            adapter=application.ApplicationAdapter.NONE,
+            command_chain=["test-command-chain"],
+            passthrough=None,
+        )
+
+        app_dict = app.to_dict()
+
+        self.assertThat(app_dict, Equals({"command-chain": ["test-command-chain"]}))
+
+    def test_passthrough_to_dict(self):
+        app = application.Application(
+            app_name="foo",
+            adapter=application.ApplicationAdapter.NONE,
+            command_chain=["test-command-chain"],
+            passthrough={"test-property": "test-value"},
+        )
+
+        app_dict = app.to_dict()
+
+        self.assertThat(
+            app_dict,
+            Equals(
+                {"command-chain": ["test-command-chain"], "test-property": "test-value"}
+            ),
+        )
+
+    def test_passthrough_to_dict_from_dict(self):
+        app = application.Application.from_dict(
+            app_name="foo",
+            app_dict={
+                "adapter": "none",
+                "command-chain": ["test-command-chain"],
+                "passthrough": {"test-property": "test-value"},
+            },
+        )
+
+        app_dict = app.to_dict()
+
+        self.assertThat(
+            app_dict,
+            Equals(
+                {"command-chain": ["test-command-chain"], "test-property": "test-value"}
+            ),
+        )


### PR DESCRIPTION
The original `passthrough` was leaking through into the snap.yaml
from the app_dict.  Ensure "passthrough" is popped from the dict
used to create the snap.yaml.

Add unit tests for passthrough coverage of Application.

LP #1862197

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
