### PR TITLE
rust plugin: fetch correct (locked) crates during pull

### DIFF
--- a/snapcraft/plugins/rust.py
+++ b/snapcraft/plugins/rust.py
@@ -106,6 +106,11 @@ class RustPlugin(snapcraft.BasePlugin):
 
         self._manifest = collections.OrderedDict()
 
+        if self.options.source_subdir:
+            self.source_path = Path(self.sourcedir, self.options.source_subdir)
+        else:
+            self.source_path = Path(self.sourcedir)
+
     def enable_cross_compilation(self):
         # The logic is applied transparently trough internal
         # rust tooling.
@@ -159,6 +164,9 @@ class RustPlugin(snapcraft.BasePlugin):
 
             self.run(add_target_cmd, env=self._build_env())
 
+    def _project_uses_cargo_lock(self) -> bool:
+        return Path(self.source_path, "Cargo.lock").exists()
+
     def _fetch_cargo_deps(self):
         if self.options.source_subdir:
             sourcedir = os.path.join(self.sourcedir, self.options.source_subdir)
@@ -199,10 +207,6 @@ class RustPlugin(snapcraft.BasePlugin):
                 )
             )
         return rust_target.format("unknown-linux", "gnu")
-
-    def _project_uses_cargo_lock(self) -> bool:
-        cargo_lock_path = Path(self.builddir, "Cargo.lock")
-        return cargo_lock_path.exists()
 
     def _project_uses_workspace(self) -> bool:
         cargo_toml_path = Path(self.builddir, "Cargo.toml")

--- a/tests/spread/plugins/rust/cargo-lock/task.yaml
+++ b/tests/spread/plugins/rust/cargo-lock/task.yaml
@@ -31,6 +31,17 @@ restore: |
 
 execute: |
   cd "$SNAP_DIR"
-  snapcraft 2>&1 | MATCH "time v0.2.0"
+  output="$(snapcraft 2>&1)"
+
+  echo "$output" | MATCH "Downloaded time v0.2.0"
+  echo "$output" | MATCH "Compiling time v0.2.0"
+
+  fetch_count="$(echo "$output" | grep "Downloaded time" -c)"
+  if [ "$fetch_count" -ne 1 ]; then
+    echo "Rust plugin appears to have multiple fetches for locked time:"
+    echo "$output"
+    exit 1
+  fi
+
   sudo snap install rust-hello-with-cargo-lock_*.snap --dangerous
   rust-hello-with-cargo-lock.rust-hello | MATCH "Hello"

--- a/tests/unit/plugins/test_rust.py
+++ b/tests/unit/plugins/test_rust.py
@@ -381,11 +381,8 @@ class RustPluginTest(RustPluginBaseTest):
     def test_pull_with_cargo_lock(self, script_mock):
         self.plugin.options.rust_revision = []
         self.plugin.options.rust_channel = []
-
-        with open(
-            os.path.join(self.plugin.builddir, "Cargo.lock"), "w"
-        ) as cargo_lock_file:
-            cargo_lock_file.write("test cargo lock contents")
+        with open(self.plugin.source_path / "Cargo.lock", "w") as f:
+            f.write("")
 
         self.plugin.pull()
 
@@ -694,10 +691,8 @@ class RustPluginTest(RustPluginBaseTest):
         )
 
     def test_build_with_cargo_lock(self):
-        with open(
-            os.path.join(self.plugin.builddir, "Cargo.lock"), "w"
-        ) as cargo_lock_file:
-            cargo_lock_file.write("test cargo lock contents")
+        with open(self.plugin.source_path / "Cargo.lock", "w") as f:
+            f.write("")
 
         self.plugin.build()
 


### PR DESCRIPTION
The previous PR was checking against the existence of the
Cargo.lock in builddir, which does not work at pull time.
So snapcraft it fetched the incorrect crate verisons at pull
time, but still built against the correct versions at build time.

Check for Cargo.lock in the source directory instead of the build
directory.  This will work anytime after the rust project's sources
have been fetched.

Improve the spread test to hopefully capture this error by
ensuring that "time" is downloaded only once.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
