### PR TITLE
elf: ensure _GNU_VERSION_R section is of type GNUVerNeedSection

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -322,10 +322,7 @@ class ElfFile:
             # If we are processing a detached debug info file, these
             # sections will be present but empty.
             verneed_section = elf.get_section_by_name(_GNU_VERSION_R)
-            if (
-                verneed_section is not None
-                and verneed_section.header.sh_type != "SHT_NOBITS"
-            ):
+            if isinstance(verneed_section, elftools.elf.gnuversions.GNUVerNeedSection):
                 for library, versions in verneed_section.iter_versions():
                     library_name = _ensure_str(library.name)
                     # If the ELF file only references weak symbols


### PR DESCRIPTION
If it the gnu_version_r section is not an instance of
GNUVerNeedSection, then we cannot use the iter_versions()
interface.  Just ignore processing needed in those cases.

Since the section type will be "SHT_GNU_verneed" [1], we
don't have to check that it is != "SHT_NOBITS".

LP #1862318

[1] https://github.com/eliben/pyelftools/blob/46dea162e8154328d4e4c6ede630d8b235bf91f9/elftools/elf/elffile.py#L491

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
