### PR TITLE
sanity_checks: fix sanity check on Windows

### DIFF
--- a/snapcraft/project/_sanity_checks.py
+++ b/snapcraft/project/_sanity_checks.py
@@ -25,11 +25,11 @@ logger = logging.getLogger(__name__)
 
 _EXPECTED_SNAP_DIR_PATTERNS = {
     re.compile(r"^snapcraft.yaml$"),
-    re.compile(r"^.snapcraft(/state)?$"),
-    re.compile(r"^hooks(/.*)?$"),
-    re.compile(r"^local(/.*)?$"),
-    re.compile(r"^plugins(/.*)?$"),
-    re.compile(r"^gui(/.*\.(png|svg|desktop))?$"),
+    re.compile(r"^.snapcraft([/|\\]state)?$"),
+    re.compile(r"^hooks([/|\\].*)?$"),
+    re.compile(r"^local([/|\\].*)?$"),
+    re.compile(r"^plugins([/|\\].*)?$"),
+    re.compile(r"^gui([/|\\].*\.(png|svg|desktop))?$"),
 }
 
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
The sanity checks for expected snap directories were not checking to see if the path had backslashes in it, so the sanity check was failing on Windows. This fixes it.