### PR TITLE
storeapi: remove exposure of series

### DIFF
--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2016-2019 Canonical Ltd
+# Copyright 2016-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -392,14 +392,8 @@ def close(snap_name, channels):
 @click.option(
     "--arch", metavar="<arch>", help="The snap architecture to get the status for"
 )
-@click.option(
-    "--series",
-    metavar="<series>",
-    default=DEFAULT_SERIES,
-    help="The snap series to get the status for",
-)
 @click.argument("snap-name", metavar="<snap-name>")
-def status(snap_name, series, arch):
+def status(snap_name, arch):
     """Get the status on the store for <snap-name>.
 
     \b
@@ -407,21 +401,15 @@ def status(snap_name, series, arch):
         snapcraft status my-snap
         snapcraft status my-snap --arch armhf
     """
-    snapcraft.status(snap_name, series, arch)
+    snapcraft.status(snap_name, arch)
 
 
 @storecli.command("list-revisions")
 @click.option(
     "--arch", metavar="<arch>", help="The snap architecture to get the status for"
 )
-@click.option(
-    "--series",
-    metavar="<series>",
-    default=DEFAULT_SERIES,
-    help="The snap series to get the status for",
-)
 @click.argument("snap-name", metavar="<snap-name>")
-def list_revisions(snap_name, series, arch):
+def list_revisions(snap_name, arch):
     """Get the history on the store for <snap-name>.
 
     This command has an alias of `revisions`.
@@ -432,7 +420,7 @@ def list_revisions(snap_name, series, arch):
         snapcraft list-revisions my-snap --arch armhf
         snapcraft revisions my-snap
     """
-    snapcraft.revisions(snap_name, series, arch)
+    snapcraft.revisions(snap_name, arch)
 
 
 @storecli.command("list-registered")
@@ -499,7 +487,7 @@ def export_login(login_file: str, snaps: str, channels: str, acls: str, expires:
     if snaps:
         snap_list = []
         for package in snaps.split(","):
-            snap_list.append({"name": package, "series": "16"})
+            snap_list.append({"name": package, "series": DEFAULT_SERIES})
 
     if channels:
         channel_list = channels.split(",")

--- a/snapcraft/storeapi/_snap_index_client.py
+++ b/snapcraft/storeapi/_snap_index_client.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2016-2019 Canonical Ltd
+# Copyright 2016-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -95,7 +95,7 @@ class SnapIndexClient(Client):
         url = "v2/snaps/info/{}".format(snap_name)
         resp = self.get(url, headers=headers, params=params)
         if resp.status_code == 404:
-            raise errors.SnapNotFoundError(snap_name, arch)
+            raise errors.SnapNotFoundError(snap_name=snap_name, arch=arch)
         resp.raise_for_status()
 
         return SnapInfo(resp.json())
@@ -117,7 +117,7 @@ class SnapIndexClient(Client):
         )
         response = self.get(url, headers=headers)
         if response.status_code != 200:
-            raise errors.SnapNotFoundError(snap_id, series=constants.DEFAULT_SERIES)
+            raise errors.SnapNotFoundError(snap_id=snap_id)
         return response.json()
 
     def get(self, url, headers=None, params=None, stream=False):

--- a/snapcraft/storeapi/_store_client.py
+++ b/snapcraft/storeapi/_store_client.py
@@ -362,7 +362,7 @@ class StoreClient:
         try:
             snap_id = account_info["snaps"][DEFAULT_SERIES][snap_name]["snap-id"]
         except KeyError:
-            raise errors.SnapNotFoundError(snap_name)
+            raise errors.SnapNotFoundError(snap_name=snap_name)
 
         if snap_id is None:
             raise errors.NoSnapIdError(snap_name)

--- a/snapcraft/storeapi/_store_client.py
+++ b/snapcraft/storeapi/_store_client.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2016-2019 Canonical Ltd
+# Copyright 2016-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -28,8 +28,8 @@ from snapcraft.internal.indicators import download_requests_stream
 
 from . import logger
 from . import _upload
-from . import constants
 from . import errors
+from .constants import DEFAULT_SERIES
 
 from ._sso_client import SSOClient
 from ._snap_index_client import SnapIndexClient
@@ -160,7 +160,7 @@ class StoreClient:
             snap_name,
             is_private=is_private,
             store_id=store_id,
-            series=constants.DEFAULT_SERIES,
+            series=DEFAULT_SERIES,
         )
 
     def push_precheck(self, snap_name):
@@ -218,47 +218,41 @@ class StoreClient:
             progressive_key=progressive_key,
         )
 
-    def get_snap_revisions(self, snap_name, series=None, arch=None):
-        if series is None:
-            series = constants.DEFAULT_SERIES
-
+    def get_snap_revisions(self, snap_name, arch=None):
         account_info = self.get_account_information()
         try:
-            snap_id = account_info["snaps"][series][snap_name]["snap-id"]
+            snap_id = account_info["snaps"][DEFAULT_SERIES][snap_name]["snap-id"]
         except KeyError:
-            raise errors.SnapNotFoundError(snap_name, series=series, arch=arch)
+            raise errors.SnapNotFoundError(snap_name=snap_name, arch=arch)
 
         if snap_id is None:
             raise errors.NoSnapIdError(snap_name)
 
         response = self._refresh_if_necessary(
-            self.sca.snap_revisions, snap_id, series, arch
+            self.sca.snap_revisions, snap_id, DEFAULT_SERIES, arch
         )
 
         if not response:
-            raise errors.SnapNotFoundError(snap_name, series=series, arch=arch)
+            raise errors.SnapNotFoundError(snap_name=snap_name, arch=arch)
 
         return response
 
-    def get_snap_status(self, snap_name, series=None, arch=None):
-        if series is None:
-            series = constants.DEFAULT_SERIES
-
+    def get_snap_status(self, snap_name, arch=None):
         account_info = self.get_account_information()
         try:
-            snap_id = account_info["snaps"][series][snap_name]["snap-id"]
+            snap_id = account_info["snaps"][DEFAULT_SERIES][snap_name]["snap-id"]
         except KeyError:
-            raise errors.SnapNotFoundError(snap_name, series=series, arch=arch)
+            raise errors.SnapNotFoundError(snap_name=snap_name, arch=arch)
 
         if snap_id is None:
             raise errors.NoSnapIdError(snap_name)
 
         response = self._refresh_if_necessary(
-            self.sca.snap_status, snap_id, series, arch
+            self.sca.snap_status, snap_id, DEFAULT_SERIES, arch
         )
 
         if not response:
-            raise errors.SnapNotFoundError(snap_name, series=series, arch=arch)
+            raise errors.SnapNotFoundError(snap_name=snap_name, arch=arch)
 
         return response
 
@@ -350,11 +344,10 @@ class StoreClient:
     def push_metadata(self, snap_name, metadata, force):
         """Push the metadata to the server."""
         account_info = self.get_account_information()
-        series = constants.DEFAULT_SERIES
         try:
-            snap_id = account_info["snaps"][series][snap_name]["snap-id"]
+            snap_id = account_info["snaps"][DEFAULT_SERIES][snap_name]["snap-id"]
         except KeyError:
-            raise errors.SnapNotFoundError(snap_name, series=series)
+            raise errors.SnapNotFoundError(snap_name=snap_name)
 
         if snap_id is None:
             raise errors.NoSnapIdError(snap_name)
@@ -366,11 +359,10 @@ class StoreClient:
     def push_binary_metadata(self, snap_name, metadata, force):
         """Push the binary metadata to the server."""
         account_info = self.get_account_information()
-        series = constants.DEFAULT_SERIES
         try:
-            snap_id = account_info["snaps"][series][snap_name]["snap-id"]
+            snap_id = account_info["snaps"][DEFAULT_SERIES][snap_name]["snap-id"]
         except KeyError:
-            raise errors.SnapNotFoundError(snap_name, series=series)
+            raise errors.SnapNotFoundError(snap_name)
 
         if snap_id is None:
             raise errors.NoSnapIdError(snap_name)

--- a/snapcraft/storeapi/assertions.py
+++ b/snapcraft/storeapi/assertions.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017 Canonical Ltd
+# Copyright (C) 2017,2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -57,7 +57,7 @@ class _BaseAssertion:
         try:
             return snaps[self._snap_name]["snap-id"]
         except KeyError:
-            raise errors.SnapNotFoundError(self._snap_name)
+            raise errors.SnapNotFoundError(snap_name=self._snap_name)
 
     def __init__(self, *, snap_name, signing_key=None):
         """Create an instance to handle an assertion.

--- a/snapcraft/storeapi/info.py
+++ b/snapcraft/storeapi/info.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2019 Canonical Ltd
+# Copyright (C) 2019-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -242,7 +242,7 @@ class SnapInfo:
 
         if not risk_match:
             channel = "{}/{}".format(track, risk) if track else risk
-            raise errors.SnapNotFoundError(name=self.name, channel=channel)
+            raise errors.SnapNotFoundError(snap_name=self.name, channel=channel)
 
         # We assume the API will not return duplicate mappings
         return risk_match[0]

--- a/tests/integration/store/test_store_revisions.py
+++ b/tests/integration/store/test_store_revisions.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016-2019 Canonical Ltd
+# Copyright (C) 2016-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -16,6 +16,7 @@
 
 import re
 import subprocess
+from textwrap import dedent
 
 from testtools.matchers import Contains, Equals, FileExists, MatchesRegex
 
@@ -30,18 +31,19 @@ class RevisionsTestCase(integration.StoreTestCase):
         error = self.assertRaises(
             subprocess.CalledProcessError, self.run_snapcraft, ["revisions", "mysnap"]
         )
-        self.assertIn("Snap 'mysnap' was not found in '16' series.", str(error.output))
+        self.assertThat(
+            str(error.output),
+            Contains(
+                dedent(
+                    """\
+            Snap 'mysnap' was not found.
 
-    def test_revisions_with_login_bad_snap_with_series(self):
-        self.addCleanup(self.logout)
-        self.login()
-
-        error = self.assertRaises(
-            subprocess.CalledProcessError,
-            self.run_snapcraft,
-            ["revisions", "mysnap", "--series=16"],
+            Recommended resolution:
+            Ensure you have proper access rights for 'mysnap'.
+        """
+                )
+            ),
         )
-        self.assertIn("Snap 'mysnap' was not found in '16' series.", str(error.output))
 
     def test_revisions_with_login_bad_snap_with_arch(self):
         self.addCleanup(self.logout)
@@ -52,8 +54,19 @@ class RevisionsTestCase(integration.StoreTestCase):
             self.run_snapcraft,
             ["revisions", "mysnap", "--arch=i386"],
         )
-        self.assertIn(
-            "Snap 'mysnap' for 'i386' was not found in '16' series.", str(error.output)
+        self.assertThat(
+            str(error.output),
+            Contains(
+                dedent(
+                    """\
+            Snap 'mysnap' for architecture 'i386' was not found.
+
+            Recommended resolution:
+            Ensure you have proper access rights for 'mysnap'.
+            Also ensure the correct architecture was used.
+        """
+                )
+            ),
         )
 
     def test_revisions_fake_store(self):

--- a/tests/integration/store/test_store_status.py
+++ b/tests/integration/store/test_store_status.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016-2019 Canonical Ltd
+# Copyright (C) 2016-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -30,18 +30,20 @@ class StatusTestCase(integration.StoreTestCase):
         error = self.assertRaises(
             subprocess.CalledProcessError, self.run_snapcraft, ["status", "mysnap"]
         )
-        self.assertIn("Snap 'mysnap' was not found in '16' series.", str(error.output))
 
-    def test_status_with_login_bad_snap_with_series(self):
-        self.addCleanup(self.logout)
-        self.login()
+        self.assertThat(
+            str(error.output),
+            Contains(
+                dedent(
+                    """\
+            Snap 'mysnap' was not found.
 
-        error = self.assertRaises(
-            subprocess.CalledProcessError,
-            self.run_snapcraft,
-            ["status", "mysnap", "--series=16"],
+            Recommended resolution:
+            Ensure you have proper access rights for 'mysnap'.
+        """
+                )
+            ),
         )
-        self.assertIn("Snap 'mysnap' was not found in '16' series.", str(error.output))
 
     def test_status_with_login_bad_snap_with_arch(self):
         self.addCleanup(self.logout)
@@ -52,8 +54,20 @@ class StatusTestCase(integration.StoreTestCase):
             self.run_snapcraft,
             ["status", "mysnap", "--arch=i386"],
         )
-        self.assertIn(
-            "Snap 'mysnap' for 'i386' was not found in '16' series.", str(error.output)
+
+        self.assertThat(
+            str(error.output),
+            Contains(
+                dedent(
+                    """\
+            Snap 'mysnap' for architecture 'i386' was not found.
+
+            Recommended resolution:
+            Ensure you have proper access rights for 'mysnap'.
+            Also ensure the correct architecture was used.
+        """
+                )
+            ),
         )
 
     def test_status_fake_store(self):

--- a/tests/unit/commands/test_list_registered.py
+++ b/tests/unit/commands/test_list_registered.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016-2019 Canonical Ltd
+# Copyright (C) 2016-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -54,9 +54,7 @@ class ListRegisteredTestCase(FakeStoreCommandsBaseTestCase):
         result = self.run_command([self.command_name])
 
         self.assertThat(result.exit_code, Equals(0))
-        self.assertThat(
-            result.output, Contains("There are no registered snaps for series '16'.")
-        )
+        self.assertThat(result.output, Contains("There are no registered snaps."))
 
     def test_list_registered_successfully(self):
         self.fake_store_account_info.mock.return_value = {

--- a/tests/unit/commands/test_list_revisions.py
+++ b/tests/unit/commands/test_list_revisions.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016-2019 Canonical Ltd
+# Copyright (C) 2016-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -81,61 +81,24 @@ class RevisionsCommandTestCase(RevisionsCommandBaseTestCase):
         )
 
     def test_revisions_with_3rd_party_snap(self):
-        raised = self.assertRaises(
+        self.assertRaises(
             storeapi.errors.SnapNotFoundError,
             self.run_command,
             [self.command_name, "snap-test"],
         )
 
-        self.assertThat(
-            str(raised), Equals("Snap 'snap-test' was not found in '16' series.")
-        )
-
     def test_revisions_with_3rd_party_snap_by_arch(self):
-        raised = self.assertRaises(
+        self.assertRaises(
             storeapi.errors.SnapNotFoundError,
             self.run_command,
             [self.command_name, "snap-test", "--arch=arm64"],
         )
 
-        self.assertThat(
-            str(raised),
-            Equals("Snap 'snap-test' for 'arm64' was not found in '16' series."),
-        )
-
-    def test_revisions_with_3rd_party_snap_by_series(self):
-        raised = self.assertRaises(
-            storeapi.errors.SnapNotFoundError,
-            self.run_command,
-            [self.command_name, "snap-test", "--series=18"],
-        )
-
-        self.assertThat(
-            str(raised), Equals("Snap 'snap-test' was not found in '18' series.")
-        )
-
     def test_revisions_by_unknown_arch(self):
-        raised = self.assertRaises(
+        self.assertRaises(
             storeapi.errors.SnapNotFoundError,
             self.run_command,
             [self.command_name, "snap-test", "--arch=some-arch"],
-        )
-
-        self.assertThat(
-            str(raised),
-            Equals("Snap 'snap-test' for 'some-arch' was not found in '16' series."),
-        )
-
-    def test_revisions_by_unknown_series(self):
-        raised = self.assertRaises(
-            storeapi.errors.SnapNotFoundError,
-            self.run_command,
-            [self.command_name, "snap-test", "--series=some-series"],
-        )
-
-        self.assertThat(
-            str(raised),
-            Equals("Snap 'snap-test' was not found in 'some-series' series."),
         )
 
     def test_revisions(self):
@@ -179,27 +142,6 @@ class RevisionsCommandTestCase(RevisionsCommandBaseTestCase):
         )
         self.fake_store_revisions.mock.assert_called_once_with(
             "snap-test-snap-id", "16", "amd64"
-        )
-
-    def test_revisions_by_series(self):
-        self.fake_store_revisions.mock.return_value = self.expected
-
-        result = self.run_command([self.command_name, "snap-test", "--series=16"])
-
-        self.assertThat(result.exit_code, Equals(0))
-        self.assertThat(
-            result.output,
-            Contains(
-                dedent(
-                    """\
-            Rev.    Uploaded              Arch    Version    Channels
-            2       2016-09-27T19:23:40Z  i386    2.0.1      -
-            1       2016-09-27T18:38:43Z  amd64   2.0.2      stable*, edge"""
-                )
-            ),
-        )  # noqa
-        self.fake_store_revisions.mock.assert_called_once_with(
-            "snap-test-snap-id", "16", None
         )
 
 

--- a/tests/unit/commands/test_status.py
+++ b/tests/unit/commands/test_status.py
@@ -78,59 +78,22 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
         )
 
     def test_status_with_3rd_party_snap(self):
-        raised = self.assertRaises(
+        self.assertRaises(
             storeapi.errors.SnapNotFoundError, self.run_command, ["status", "snap-test"]
         )
 
-        self.assertThat(
-            str(raised), Equals("Snap 'snap-test' was not found in '16' series.")
-        )
-
     def test_status_with_3rd_party_snap_by_arch(self):
-        raised = self.assertRaises(
+        self.assertRaises(
             storeapi.errors.SnapNotFoundError,
             self.run_command,
             ["status", "snap-test", "--arch=arm64"],
         )
 
-        self.assertThat(
-            str(raised),
-            Equals("Snap 'snap-test' for 'arm64' was not found in '16' series."),
-        )
-
-    def test_status_with_3rd_party_snap_by_series(self):
-        raised = self.assertRaises(
-            storeapi.errors.SnapNotFoundError,
-            self.run_command,
-            ["status", "snap-test", "--series=18"],
-        )
-
-        self.assertThat(
-            str(raised), Equals("Snap 'snap-test' was not found in '18' series.")
-        )
-
     def test_status_by_unknown_arch(self):
-        raised = self.assertRaises(
+        self.assertRaises(
             storeapi.errors.SnapNotFoundError,
             self.run_command,
             ["status", "snap-test", "--arch=some-arch"],
-        )
-
-        self.assertThat(
-            str(raised),
-            Equals("Snap 'snap-test' for 'some-arch' was not found in '16' series."),
-        )
-
-    def test_status_by_unknown_series(self):
-        raised = self.assertRaises(
-            storeapi.errors.SnapNotFoundError,
-            self.run_command,
-            ["status", "snap-test", "--series=some-series"],
-        )
-
-        self.assertThat(
-            str(raised),
-            Equals("Snap 'snap-test' was not found in 'some-series' series."),
         )
 
     def test_status(self):
@@ -182,33 +145,6 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
         )
         self.fake_store_status.mock.assert_called_once_with(
             "snap-test-snap-id", "16", "i386"
-        )
-
-    def test_status_by_series(self):
-        self.fake_store_status.mock.return_value = {
-            "channel_map_tree": {"latest": {"16": self.expected}}
-        }
-
-        result = self.run_command(["status", "snap-test", "--series=16"])
-
-        self.assertThat(result.exit_code, Equals(0))
-        self.assertThat(
-            result.output,
-            Contains(
-                dedent(
-                    """\
-            Track    Arch    Channel    Version    Revision    Notes
-            latest   amd64   stable     1.0-amd64  2           -
-                             beta       1.1-amd64  4           -
-                             edge       ^          ^           -
-                     i386    stable     -          -           -
-                             beta       -          -           -
-                             edge       1.0-i386   3           -"""
-                )
-            ),
-        )
-        self.fake_store_status.mock.assert_called_once_with(
-            "snap-test-snap-id", "16", None
         )
 
     def test_status_including_branch(self):

--- a/tests/unit/lifecycle/test_lifecycle.py
+++ b/tests/unit/lifecycle/test_lifecycle.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2018 Canonical Ltd
+# Copyright (C) 2015-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -466,7 +466,7 @@ class GlobalStateTest(LifecycleTestBase):
 
     def test_stable_grade_for_non_stable_base(self):
         self.fake_storeapi_get_info.mock.side_effect = snapcraft.storeapi.errors.SnapNotFoundError(
-            name="core18"
+            snap_name="core18"
         )
         lifecycle.execute(steps.PULL, self.project_config)
 

--- a/tests/unit/store/test_errors.py
+++ b/tests/unit/store/test_errors.py
@@ -1,0 +1,109 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from textwrap import dedent
+
+from testtools.matchers import Equals
+
+from snapcraft.storeapi import errors
+from tests import unit
+
+
+class SnapcraftExceptionTests(unit.TestCase):
+    scenarios = (
+        (
+            "SnapNotFoundError snap_name",
+            dict(
+                exception=errors.SnapNotFoundError,
+                kwargs=dict(snap_name="not-found"),
+                expected_brief="Snap 'not-found' was not found.",
+                expected_resolution="Ensure you have proper access rights for 'not-found'.",
+                expected_details=None,
+                expected_docs_url=None,
+                expected_reportable=False,
+            ),
+        ),
+        (
+            "SnapNotFoundError snap_id",
+            dict(
+                exception=errors.SnapNotFoundError,
+                kwargs=dict(snap_id="1234567890"),
+                expected_brief="Cannot find snap with snap_id '1234567890'.",
+                expected_resolution="Ensure you have proper access rights for '1234567890'.",
+                expected_details=None,
+                expected_docs_url=None,
+                expected_reportable=False,
+            ),
+        ),
+        (
+            "SnapNotFoundError snap_name, channel and arch",
+            dict(
+                exception=errors.SnapNotFoundError,
+                kwargs=dict(
+                    snap_name="not-found", channel="default/stable", arch="foo"
+                ),
+                expected_brief="Snap 'not-found' for architecture 'foo' was not found on channel 'default/stable'.",
+                expected_resolution=dedent(
+                    """\
+                Ensure you have proper access rights for 'not-found'.
+                Also ensure the correct channel and architecture was used."""
+                ),
+                expected_details=None,
+                expected_docs_url=None,
+                expected_reportable=False,
+            ),
+        ),
+        (
+            "SnapNotFoundError snap_name and channel",
+            dict(
+                exception=errors.SnapNotFoundError,
+                kwargs=dict(snap_name="not-found", channel="default/stable"),
+                expected_brief="Snap 'not-found' was not found on channel 'default/stable'.",
+                expected_resolution=dedent(
+                    """\
+                Ensure you have proper access rights for 'not-found'.
+                Also ensure the correct channel was used."""
+                ),
+                expected_details=None,
+                expected_docs_url=None,
+                expected_reportable=False,
+            ),
+        ),
+        (
+            "SnapNotFoundError snap_name and arch",
+            dict(
+                exception=errors.SnapNotFoundError,
+                kwargs=dict(snap_name="not-found", arch="foo"),
+                expected_brief="Snap 'not-found' for architecture 'foo' was not found.",
+                expected_resolution=dedent(
+                    """\
+                Ensure you have proper access rights for 'not-found'.
+                Also ensure the correct architecture was used."""
+                ),
+                expected_details=None,
+                expected_docs_url=None,
+                expected_reportable=False,
+            ),
+        ),
+    )
+
+    def test_snapcraft_exception_handling(self):
+        exception = self.exception(**self.kwargs)
+        self.expectThat(exception.get_brief(), Equals(self.expected_brief))
+        self.expectThat(exception.get_resolution(), Equals(self.expected_resolution))
+        self.expectThat(exception.get_details(), Equals(self.expected_details))
+        self.expectThat(exception.get_docs_url(), Equals(self.expected_docs_url))
+        self.expectThat(exception.get_reportable(), Equals(self.expected_reportable))

--- a/tests/unit/store/test_store_client.py
+++ b/tests/unit/store/test_store_client.py
@@ -1803,4 +1803,4 @@ class SnapNotFoundTestCase(StoreTestCase):
 
         self.expectThat(raised._snap_name, Equals("test-nonexistent-snap"))
         self.expectThat(raised._channel, Is(None))
-        self.expectThat(raised._channel, Is(None))
+        self.expectThat(raised._arch, Is(None))

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017-2018 Canonical Ltd
+# Copyright (C) 2017-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as


### PR DESCRIPTION
Series, mostly used with constants.DEFAULT_SERIES has been long deprecated and
has not use.

Remove its broad exposure across the code base. No great changes should be
observed aside from reworking how SnapNotFoundError is implemented by making
use of the new SnapcraftException.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
