### PR TITLE
requirements: Update PyYAML requirement to 5.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,7 @@ click-config-file==0.5.0
 configparser==3.5.0
 jsonschema==2.5.1
 progressbar33==2.4
-https://pyyaml.org/download/pyyaml/PyYAML-5.3-cp37-cp37m-win_amd64.whl; sys_platform == 'win32' and python_version == "3.7"
-https://pyyaml.org/download/pyyaml/PyYAML-5.3-cp38-cp38-win_amd64.whl; sys_platform == 'win32' and python_version == "3.8"
-PyYAML==5.3; sys_platform != 'win32'
+PyYAML==5.3
 pyxdg==0.26
 requests==2.20.0
 requests_unixsocket==0.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,9 @@ click-config-file==0.5.0
 configparser==3.5.0
 jsonschema==2.5.1
 progressbar33==2.4
-https://pyyaml.org/download/pyyaml/PyYAML-3.13-cp37-cp37m-win_amd64.whl; sys_platform == 'win32'
-PyYAML==3.13; sys_platform != 'win32'
+https://pyyaml.org/download/pyyaml/PyYAML-5.3-cp37-cp37m-win_amd64.whl; sys_platform == 'win32' and python_version == "3.7"
+https://pyyaml.org/download/pyyaml/PyYAML-5.3-cp38-cp38-win_amd64.whl; sys_platform == 'win32' and python_version == "3.8"
+PyYAML==5.3; sys_platform != 'win32'
 pyxdg==0.26
 requests==2.20.0
 requests_unixsocket==0.1.5


### PR DESCRIPTION

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

They are no longer providing updated wheels for windows for newer python versions (>3.7). This updates snapcraft to use 5.3 instead, which is the current version and is being provided updated wheels for newer python versions.