### PR TITLE
cli: explicitly ensure type 'snapd' is non-legacy

### DIFF
--- a/snapcraft/cli/_command.py
+++ b/snapcraft/cli/_command.py
@@ -64,8 +64,8 @@ class SnapcraftProjectCommand(click.Command):
         # Not in an actual project.
         if project is None or project.info is None:
             return False
-        # Building a base is not legacy.
-        elif project.info.type == "base":
+        # Non-legacy types.
+        elif project.info.type in ["base", "snapd"]:
             return False
         elif project.info.build_base is not None:
             return False


### PR DESCRIPTION
While snapd should be using a build-base which would
result in non-legacy, explicitly ensure `type: snapd`
is non-legacy.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
