### PR TITLE
project loader: use get_build_base() to assign plugin handler base

### DIFF
--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -216,7 +216,7 @@ class PartsConfig:
             stage_packages_repo=stage_packages_repo,
             grammar_processor=grammar_processor,
             snap_base_path=path.join("/", "snap", self._project.info.name, "current"),
-            base=self._project.info.base,
+            base=self._project.info.get_build_base(),
             confinement=self._project.info.confinement,
             snap_type=self._snap_type,
             soname_cache=self._soname_cache,


### PR DESCRIPTION
Various spots in the code assume "base" is always used and points
to the underlying (build) base.  Assign base to the build-base,
if specified, by using project.info.get_build_base().

This will propogate to PartPatcher()'s `core-base`, etc. which
should solve other potential build-base related issues.

LP #1857019

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
