### PR TITLE
plugin handler: process elf files only if base is specified

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -815,7 +815,7 @@ class PluginHandler:
         snap_files, snap_dirs = self.migratable_fileset_for(steps.PRIME)
         _migrate_files(snap_files, snap_dirs, self.stagedir, self.primedir)
 
-        if self._snap_type == "app":
+        if self._snap_type == "app" and self._base is not None:
             dependency_paths = self._handle_elf(snap_files)
         else:
             dependency_paths = set()

--- a/tests/spread/general/snapd-workaround/expected_snap.yaml
+++ b/tests/spread/general/snapd-workaround/expected_snap.yaml
@@ -1,0 +1,16 @@
+name: fake-snapd
+version: '1.0'
+summary: test snapd type
+description: |
+  some of the characteristics from the snapd snap
+  (1) adapter is none
+  (2) build-base is core
+  (3) no base is specified
+  (4) type is unspecified
+apps:
+  fake-snapd:
+    command: bin/fake-snapd
+architectures:
+- amd64
+confinement: strict
+grade: stable

--- a/tests/spread/general/snapd-workaround/snaps/fake-snapd/Makefile
+++ b/tests/spread/general/snapd-workaround/snaps/fake-snapd/Makefile
@@ -1,0 +1,7 @@
+# -*- Mode: Makefile; indent-tabs-mode:t; tab-width: 4 -*-
+
+all:
+	gcc -o fake-snapd fake-snapd.c
+
+install:
+	install -D -m755 fake-snapd "$(DESTDIR)/bin/fake-snapd"

--- a/tests/spread/general/snapd-workaround/snaps/fake-snapd/fake-snapd.c
+++ b/tests/spread/general/snapd-workaround/snaps/fake-snapd/fake-snapd.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main()
+{
+	printf("hello world\n");
+	return 0;
+}

--- a/tests/spread/general/snapd-workaround/snaps/fake-snapd/snapcraft.yaml
+++ b/tests/spread/general/snapd-workaround/snaps/fake-snapd/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: fake-snapd
+version: "1.0"
+summary: test snapd type
+description: |
+  some of the characteristics from the snapd snap
+  (1) adapter is none
+  (2) build-base is core
+  (3) no base is specified
+  (4) type is unspecified
+
+build-base: core
+grade: stable
+
+parts:
+  fake-snapd:
+    plugin: make
+    source: .
+    build-packages:
+      - gcc
+
+apps:
+  fake-snapd:
+    command: bin/fake-snapd
+    adapter: none

--- a/tests/spread/general/snapd-workaround/task.yaml
+++ b/tests/spread/general/snapd-workaround/task.yaml
@@ -1,0 +1,27 @@
+summary: Build a snapd-type snap.
+
+# This test snap uses core18, and is limited to amd64 arch due to
+# architectures specified in expected_snap.yaml.
+systems:
+  - ubuntu-18.04-64
+  - ubuntu-18.04-amd64
+  - ubuntu-18.04
+
+environment:
+  SNAP_DIR: snaps/fake-snapd
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft snap
+
+  expected_snap_yaml="$PWD/../../expected_snap.yaml"
+
+  if ! diff -U10 prime/meta/snap.yaml "$expected_snap_yaml"; then
+      echo "The formatting for snap.yaml is incorrect"
+      exit 1
+  fi


### PR DESCRIPTION
ELF files are always processed when `type: app`, where `app`
is the default type.

This causes an issue when snapd is building without specifying
the type, as it gets treated as `type: app` and its files
are processed like typical app snaps.  The schema currently
allows for this because it fails to set the default type `app`
in time for validation.

Since snapd does not have a base, check for the existence of the
base before attempting to process ELF files.  This will prevent
the error reported in LP #1857019 and allow snapd to build without
a type specified.

Once snapd moves to `type: snapd`, we can fix the schema to
ensure that the invalid configuration that led to this error
does not pass verification.

LP #1857019
LP #1862642

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
