### PR TITLE
logging: use .warning instead of deprecated .warn

### DIFF
--- a/snapcraft/config.py
+++ b/snapcraft/config.py
@@ -222,7 +222,7 @@ class Config(object):
 
                 # FIXME: We don't know this for sure when loading the config.
                 # Need a better separation of concerns.
-                logger.warn(
+                logger.warning(
                     "Using local configuration ({!r}), changes will not be "
                     "persisted.".format(file_path)
                 )

--- a/snapcraft/internal/lifecycle/_runner.py
+++ b/snapcraft/internal/lifecycle/_runner.py
@@ -130,7 +130,7 @@ def execute(
     executor = _Executor(project_config)
     executor.run(step, part_names)
     if not executor.steps_were_run:
-        logger.warn(
+        logger.warning(
             "The requested action has already been taken. Consider\n"
             "specifying parts, or clean the steps you want to run again."
         )

--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -236,7 +236,7 @@ class Snap:
             user.validate()
 
         if self.is_passthrough_enabled:
-            logger.warn(
+            logger.warning(
                 "The 'passthrough' property is being used to "
                 "propagate experimental properties to snap.yaml "
                 "that have not been validated."

--- a/snapcraft/internal/mountinfo.py
+++ b/snapcraft/internal/mountinfo.py
@@ -70,7 +70,7 @@ class MountInfo:
                         self._mount_point_mounts[mount.mount_point] = mount
                         root_mounts[mount.root].append(mount)
                     except errors.InvalidMountinfoFormat as e:
-                        logger.warn(str(e))
+                        logger.warning(str(e))
 
         self._root_mounts = dict(root_mounts)
 

--- a/snapcraft/internal/pluginhandler/_metadata_extraction.py
+++ b/snapcraft/internal/pluginhandler/_metadata_extraction.py
@@ -55,7 +55,7 @@ def extract_metadata(
             except extractors.UnhandledFileError:
                 pass  # Try the next extractor
             except AttributeError:
-                logger.warn(
+                logger.warning(
                     "Extractor {!r} doesn't include the 'extract' function. "
                     "Skipping...".format(module_name)
                 )

--- a/snapcraft/plugins/catkin_tools.py
+++ b/snapcraft/plugins/catkin_tools.py
@@ -45,7 +45,7 @@ class CatkinToolsPlugin(snapcraft.plugins.catkin.CatkinPlugin):
 
         # Beta Warning
         # Remove this comment and warning once catkin tools plugin is stable.
-        logger.warn(
+        logger.warning(
             "The catkin tools plugin is currently in beta, "
             "its API may break. Use at your own risk"
         )

--- a/snapcraft/plugins/colcon.py
+++ b/snapcraft/plugins/colcon.py
@@ -267,7 +267,7 @@ class ColconPlugin(snapcraft.BasePlugin):
             )
 
         # Beta warning. Remove this comment and warning once plugin is stable.
-        logger.warn(
+        logger.warning(
             "The colcon plugin is currently in beta, its API may break. Use at your "
             "own risk."
         )

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -475,7 +475,7 @@ class KernelPlugin(kbuild.KBuildPlugin):
                 elif opt == "CONFIG_DEVPTS_MULTIPLE_INSTANCES":
                     note = "(4.8.x and earlier versions only)"
                 warn += "{} {}\n".format(opt, note)
-            logger.warn(warn)
+            logger.warning(warn)
 
     def _do_check_initrd(self, builtin, modules):
         # check all required_boot[] items are either builtin or part of initrd
@@ -503,7 +503,7 @@ class KernelPlugin(kbuild.KBuildPlugin):
             warn = "\n{}\n".format(msg)
             for opt in missing:
                 warn += "{}\n".format(opt)
-            logger.warn(warn)
+            logger.warning(warn)
 
     def pull(self):
         super().pull()

--- a/snapcraft/plugins/ruby.py
+++ b/snapcraft/plugins/ruby.py
@@ -81,7 +81,7 @@ class RubyPlugin(BasePlugin):
 
         # Beta Warning
         # Remove this comment and warning once ruby plugin is stable.
-        logger.warn(
+        logger.warning(
             "The ruby plugin is currently in beta, "
             "its API may break. Use at your own risk"
         )


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
