### PR TITLE
extensions: Handle case when user-dirs.dirs exits but not user-dirs.locale

### DIFF
--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -155,14 +155,19 @@ if [ "$HOME" != "$SNAP_USER_DATA" ] && ! is_subpath "$XDG_CONFIG_HOME" "$HOME"; 
   done
 fi
 
-if can_open_file "$REALHOME/.config/user-dirs.dirs" && can_open_file "$REALHOME/.config/user-dirs.locale"; then
+if can_open_file "$REALHOME/.config/user-dirs.dirs"; then
   # shellcheck disable=SC2154
   if [ "$needs_update" = true ] || [ "$needs_xdg_reload" = true ]; then
     sed "/^#/!s#\$HOME#${REALHOME}#g" "$REALHOME/.config/user-dirs.dirs" > "$XDG_CONFIG_HOME/user-dirs.dirs"
-    cp -a "$REALHOME/.config/user-dirs.locale" "$XDG_CONFIG_HOME"
-    for f in user-dirs.dirs user-dirs.locale; do
-      md5sum < "$REALHOME/.config/$f" > "$XDG_CONFIG_HOME/$f.md5sum"
-    done
+    md5sum < "$REALHOME/.config/user-dirs.dirs" > "$XDG_CONFIG_HOME/user-dirs.dirs.md5sum"
+    # It's possible user-dirs.dirs exists when user-dirs.locale doesn't. This
+    # simply means the user opted to never ask to translate their user dirs
+    if can_open_file "$REALHOME/.config/user-dirs.locale"; then
+      cp -a "$REALHOME/.config/user-dirs.locale" "$XDG_CONFIG_HOME"
+      md5sum < "$REALHOME/.config/user-dirs.locale" > "$XDG_CONFIG_HOME/user-dirs.locale.md5sum"
+    elif [ -f "$XDG_CONFIG_HOME/user-dirs.locale.md5sum" ]; then
+      rm "$XDG_CONFIG_HOME/user-dirs.locale.md5sum"
+    fi
     needs_xdg_reload=true
   fi
 else

--- a/extensions/desktop/common/init
+++ b/extensions/desktop/common/init
@@ -44,9 +44,10 @@ ensure_dir_exists "$XDG_CONFIG_HOME"
 chmod 700 "$XDG_CONFIG_HOME"
 
 # If the user has modified their user-dirs settings, force an update
-if [[ -f "$XDG_CONFIG_HOME/user-dirs.dirs.md5sum" && -f "$XDG_CONFIG_HOME/user-dirs.locale.md5sum" ]]; then
+if [[ -f "$XDG_CONFIG_HOME/user-dirs.dirs.md5sum" ]]; then
   if [[ "$(md5sum < "$REALHOME/.config/user-dirs.dirs")" != "$(cat "$XDG_CONFIG_HOME/user-dirs.dirs.md5sum")" ||
-        "$(md5sum < "$REALHOME/.config/user-dirs.locale")" != "$(cat "$XDG_CONFIG_HOME/user-dirs.locale.md5sum")" ]]; then
+        ( -f "$XDG_CONFIG_HOME/user-dirs.locale.md5sum" &&
+          "$(md5sum < "$REALHOME/.config/user-dirs.locale")" != "$(cat "$XDG_CONFIG_HOME/user-dirs.locale.md5sum")" ) ]]; then
     needs_update=true
   fi
 else


### PR DESCRIPTION
This is a fix for bug https://github.com/ubuntu/snapcraft-desktop-helpers/issues/173

This reduces hot run time for `desktop-launch` on *affected systems*. Depending on the snap, this can remove 1 - 10 seconds off its hot start time.

`desktop-launch` keeps needlessly setting `needs_xdg_reload=true` when `~/.config/user-dirs.dirs` exist but `~/.config/user-dirs.locale` doesn't. This happens when a user gets the `xdg-user-dirs-gtk` dialog (after changing the system language) and checks the "Don't ask me this again" option, which removes `~/.config/user-dirs.locale` .

This patch makes sure we only set `needs_xdg_reload=true` when something actually changes and removes the hash of `~/.config/user-dirs.locale` when the file itself is removed.

Note: depending on what logic runs when `needs_xdg_reload=true`, this will have more or less impact. Snaps using extensions don't generate the mime-cache, so they won't see a drastic change. Fixing this in the `desktop-helpers` repo will have a drastic impact on snaps such as VLC (- 10 seconds hot start time), but I want to get it merged here first.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
