### PR TITLE
elf: resolve paths in `ldd()` to purge relative path components

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -104,19 +104,3 @@ parts:
         "$SNAPCRAFT_PART_INSTALL/usr/bin/python3" -m compileall -q .
 
     after: [snapcraft-libs]
-
-  legacy-snapcraft:
-    plugin: python
-    source: https://github.com/snapcore/snapcraft.git
-    source-branch: legacy
-    source-depth: 1
-    requirements:
-        - requirements.txt
-    override-build: |
-        snapcraftctl build
-        $SNAPCRAFT_PROJECT_DIR/tools/snapcraft-override-build.sh
-
-        sed -ri 's|(lib/.*/site-packages)|legacy_snapcraft/\1|' $SNAPCRAFT_PART_INSTALL/usr/lib/python3.6/sitecustomize.py
-    organize:
-        '*': legacy_snapcraft/
-    after: [snapcraft-libs]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -104,3 +104,19 @@ parts:
         "$SNAPCRAFT_PART_INSTALL/usr/bin/python3" -m compileall -q .
 
     after: [snapcraft-libs]
+
+  legacy-snapcraft:
+    plugin: python
+    source: https://github.com/snapcore/snapcraft.git
+    source-branch: legacy
+    source-depth: 1
+    requirements:
+        - requirements.txt
+    override-build: |
+        snapcraftctl build
+        $SNAPCRAFT_PROJECT_DIR/tools/snapcraft-override-build.sh
+
+        sed -ri 's|(lib/.*/site-packages)|legacy_snapcraft/\1|' $SNAPCRAFT_PART_INSTALL/usr/lib/python3.6/sitecustomize.py
+    organize:
+        '*': legacy_snapcraft/
+    after: [snapcraft-libs]

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -61,6 +61,7 @@ def ldd(path: str, ld_library_paths: List[str]) -> Dict[str, str]:
 
     env = os.environ.copy()
     env["LD_LIBRARY_PATH"] = ":".join(ld_library_paths)
+    logger.debug(f"invoking ldd with ld library paths: {ld_library_paths!r}")
 
     try:
         # ldd output sample:

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -38,13 +38,15 @@ logger = logging.getLogger(__name__)
 def _ldd_resolve(soname: str, soname_path: str) -> Tuple[str, str]:
     logger.debug(f"_ldd_resolve: {soname!r} {soname_path!r}")
 
-    # If found, resolve the path components.
-    if soname_path.startswith("/"):
+    # If found, resolve the path components.  We can safely determine that
+    # ldd found the match if it returns an absolute path.  For additional
+    # safety, check that it exists.  See example ldd output in ldd() below.
+    # If not found, ldd should use a string like "not found", but we do not
+    # really care what that string is with this approach as it has to start
+    # with "/" and point to a valid file.
+    if soname_path.startswith("/") and os.path.exists(soname_path):
         abs_path = os.path.abspath(soname_path)
-
-        # Use resolved path if confirmed to exist.
-        if os.path.exists(abs_path):
-            return soname, abs_path
+        return soname, abs_path
 
     # Not found, use the soname.
     return soname, soname

--- a/tests/fixture_setup/_unittests.py
+++ b/tests/fixture_setup/_unittests.py
@@ -338,7 +338,10 @@ class FakeElf(fixtures.Fixture):
             "moo.so.2": os.path.join(self.root_path, "non-standard", "moo.so.2"),
         }
 
-        for root_library in self.root_libraries.values():
+        barsnap_elf = os.path.join(self.core_base_path, "barsnap.so.2")
+        elf_list = [*self.root_libraries.values(), barsnap_elf]
+
+        for root_library in elf_list:
             os.makedirs(os.path.dirname(root_library), exist_ok=True)
             with open(root_library, "wb") as f:
                 f.write(b"\x7fELF")


### PR DESCRIPTION
elf: resolve paths in `ldd()` to purge relative path components

ldd may return paths with relative components such as "..", e.g.:
{
    'linux-vdso.so.1': '',
    'libc.so.6': '/snap/core/current/lib/x86_64-linux-gnu/libc.so.6',
    'libnvidia-container.so.1': '/root/prime/usr/bin/../lib/x86_64-linux-gnu/libnvidia-container.so.1',
    'libcap.so.2': '/snap/core/current/lib/x86_64-linux-gnu/libcap.so.2',
    'libdl.so.2': '/snap/core/current/lib/x86_64-linux-gnu/libdl.so.2',
    'libseccomp.so.2': '/snap/core/current/lib/x86_64-linux-gnu/libseccomp.so.2'
}

(1) Resolve the paths before using them to ensure we have a consistent
values that do not look odd in potential warnings/errors (e.g.
corrupted ELF).

This also appears to expose an issue with the FakeElf fixture which
was not creating a fake "barsnap.so.2" in the core base path.  This
updates the fixture to create one in the same manner as it does for
the root libraries.

(2) In the same example above, we can see linux-vdso has an empty string.
In Ubuntu 16.04, ldd will return a slightly different formatted string
which results in an empty path for the "found" shared object path. I do
not believe it has caused a problem before attempting to use abspath
on it.

Check for the empty-string case and ignore it.  We don't need to check
linux-vdso, and calling abspath on it will resolve to the current
working directory.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>
