### PR TITLE
remote-build: introduce --launchpad-snapcraft-channel option

### DIFF
--- a/snapcraft/cli/remote.py
+++ b/snapcraft/cli/remote.py
@@ -58,6 +58,15 @@ def remotecli():
     cls=PromptOption,
 )
 @click.option(
+    "--launchpad-snapcraft-channel",
+    default="stable",
+    metavar="<channel>",
+    nargs=1,
+    required=False,
+    type=str,
+    help="Specify Snapcraft channel for Launchpad to build with.",
+)
+@click.option(
     "--launchpad-timeout",
     metavar="<seconds>",
     type=int,
@@ -79,6 +88,7 @@ def remote_build(
     status: bool,
     build_on: str,
     launchpad_accept_public_upload: bool,
+    launchpad_snapcraft_channel: str,
     launchpad_timeout: int,
     package_all_sources: bool,
     echoer=echo,
@@ -136,6 +146,7 @@ def remote_build(
         build_id=build_id,
         architectures=architectures,
         deadline=deadline,
+        snapcraft_channel=launchpad_snapcraft_channel,
     )
 
     if status:

--- a/snapcraft/internal/remote_build/_launchpad.py
+++ b/snapcraft/internal/remote_build/_launchpad.py
@@ -183,6 +183,7 @@ class LaunchpadClient:
     def _issue_build_request(self, snap: Entry) -> Entry:
         dist = self._lp.distributions["ubuntu"]
         archive = dist.main_archive
+
         return snap.requestBuilds(
             archive=archive,
             channels={

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -72,3 +72,17 @@ class RemoteBuildTests(CommandBaseTestCase):
 
         self.mock_lc.start_build.assert_not_called()
         self.mock_lc.cleanup.assert_not_called()
+
+    def test_remote_build_snapcraft_channel(self):
+        result = self.run_command(
+            [
+                "remote-build",
+                "--launchpad-accept-public-upload",
+                "--launchpad-snapcraft-channel=edge",
+            ]
+        )
+
+        self.mock_lc.start_build.assert_called_once()
+        self.mock_lc.cleanup.assert_called_once()
+        self.assertThat(result.output, Contains("Building snap package for i386."))
+        self.assertThat(result.exit_code, Equals(0))


### PR DESCRIPTION
It may be useful to configure Launchpad to use a specific
snapcraft channel.  This commit changes the default from "edge"
to "stable", and allows the user to configure it.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
