### PR TITLE
meta: fix for missing content slot's 'content' property

### DIFF
--- a/snapcraft/internal/meta/slots.py
+++ b/snapcraft/internal/meta/slots.py
@@ -184,6 +184,9 @@ class ContentSlot(Slot):
         if "write" in source_data:
             slot.write = source_data["write"]
 
+        if "content" in source_data:
+            slot.content = source_data["content"]
+
         return slot
 
     def to_yaml_object(self) -> Dict[str, Any]:

--- a/tests/unit/meta/test_slots.py
+++ b/tests/unit/meta/test_slots.py
@@ -118,7 +118,13 @@ class ContentSlotTests(unit.TestCase):
         self.assertEqual(set(), slot.get_content_dirs(installed_path=""))
 
     def test_read_from_dict(self):
-        slot_dict = OrderedDict({"interface": "content", "read": ["some/path"]})
+        slot_dict = OrderedDict(
+            {
+                "interface": "content",
+                "content": "explicit-content",
+                "read": ["some/path"],
+            }
+        )
         slot_name = "slot-test"
 
         slot = ContentSlot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
@@ -130,6 +136,7 @@ class ContentSlotTests(unit.TestCase):
         self.assertEqual(
             set(slot_dict["read"]), slot.get_content_dirs(installed_path="")
         )
+        self.assertEqual(slot_dict["content"], slot.content)
 
     def test_read_from_dict_force_source_key(self):
         slot_dict = OrderedDict({"interface": "content", "read": ["some/path"]})

--- a/tests/unit/meta/test_snap.py
+++ b/tests/unit/meta/test_snap.py
@@ -514,6 +514,7 @@ class YAMLComparisons(testscenarios.WithScenarios, integration.TestCase):
             slots:
               long-form:
                 interface: content
+                content: explicit-content
                 read:
                 - /
               short-form: interface-name
@@ -537,6 +538,7 @@ class YAMLComparisons(testscenarios.WithScenarios, integration.TestCase):
             slots:
               long-form:
                 interface: content
+                content: explicit-content
                 read:
                 - /
               short-form: interface-name


### PR DESCRIPTION
Content was not being initialized correctly from the
snapcraft.yaml.  Ensure it is used to create ContentSlot.

Update existing tests to ensure coverage of explicit content.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
