### PR TITLE
build providers: remove tzdata workaround

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018-2019 Canonical Ltd
+# Copyright (C) 2018-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -40,20 +40,7 @@ def _get_platform() -> str:
     return sys.platform
 
 
-def _get_tzdata(timezone_filepath=os.path.join(os.path.sep, "etc", "timezone")) -> str:
-    """Return the host's timezone from timezone_filepath or Etc/UTC on error."""
-    try:
-        with open(timezone_filepath) as timezone_file:
-            timezone = timezone_file.read().strip()
-    except FileNotFoundError:
-        timezone = "Etc/UTC"
-
-    return timezone
-
-
-# cloud-init's timezone keyword is not used as it requires tzdata to be installed
-# and the images used may not have it preinstalled.
-_CLOUD_USER_DATA_TMPL = dedent(
+_CLOUD_USER_DATA = dedent(
     """\
     #cloud-config
     manage_etc_hosts: true
@@ -62,8 +49,6 @@ _CLOUD_USER_DATA_TMPL = dedent(
         mode: growpart
         devices: ["/"]
         ignore_growroot_disabled: false
-    runcmd:
-    - ["ln", "-s", "../usr/share/zoneinfo/{timezone}", "/etc/localtime"]
     write_files:
         - path: /root/.bashrc
           permissions: 0644
@@ -76,7 +61,7 @@ _CLOUD_USER_DATA_TMPL = dedent(
           content: |
             #!/bin/bash
             if [[ "$PWD" =~ ^$HOME.* ]]; then
-                path="${{PWD/#$HOME/\ ..}}"
+                path="${PWD/#$HOME/\ ..}"
                 if [[ "$path" == " .." ]]; then
                     ps1=""
                 else
@@ -350,20 +335,15 @@ class Provider(abc.ABC):
 
         snap_injector.apply()
 
-    def _get_cloud_user_data_string(self, timezone=_get_tzdata()) -> str:
-        return _CLOUD_USER_DATA_TMPL.format(timezone=timezone)
-
-    def _get_cloud_user_data(self, timezone=_get_tzdata()) -> str:
+    def _get_cloud_user_data(self) -> str:
         cloud_user_data_filepath = os.path.join(
             self.provider_project_dir, "user-data.yaml"
         )
         if os.path.exists(cloud_user_data_filepath):
             return cloud_user_data_filepath
 
-        user_data = self._get_cloud_user_data_string(timezone=timezone)
-
         with open(cloud_user_data_filepath, "w") as cloud_user_data_file:
-            print(user_data, file=cloud_user_data_file, end="")
+            print(_CLOUD_USER_DATA, file=cloud_user_data_file, end="")
 
         return cloud_user_data_filepath
 

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -22,6 +22,7 @@ import urllib.parse
 import warnings
 from typing import Dict, Optional, Sequence
 
+from .._base_provider import _CLOUD_USER_DATA
 from .._base_provider import Provider
 from .._base_provider import errors
 from ._images import get_image_source
@@ -199,7 +200,7 @@ class LXD(Provider):
             raise errors.ProviderLaunchError(
                 provider_name=self._get_provider_name(), error_message=lxd_api_error
             ) from lxd_api_error
-        container.config["user.user-data"] = self._get_cloud_user_data_string()
+        container.config["user.user-data"] = _CLOUD_USER_DATA
         # This is setup by cloud init, but set it here to be on the safer side.
         container.config["environment.SNAPCRAFT_BUILD_ENVIRONMENT"] = "managed-host"
         container.save(wait=True)

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -23,8 +23,7 @@ from unittest.mock import call, patch, Mock
 from testtools.matchers import Equals, EndsWith, DirExists, FileContains, Not
 
 from . import BaseProviderBaseTest, MacBaseProviderWithBasesBaseTest, ProviderImpl
-from snapcraft.internal.build_providers import errors, _base_provider
-from tests import unit
+from snapcraft.internal.build_providers import errors
 
 
 class BaseProviderTest(BaseProviderBaseTest):

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018-2019 Canonical Ltd
+# Copyright (C) 2018-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -431,9 +431,7 @@ class GetCloudUserDataTest(BaseProviderBaseTest):
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
         os.makedirs(provider.provider_project_dir)
 
-        cloud_data_filepath = provider._get_cloud_user_data(
-            timezone="America/Argentina/Cordoba"
-        )
+        cloud_data_filepath = provider._get_cloud_user_data()
         self.assertThat(
             cloud_data_filepath,
             FileContains(
@@ -446,8 +444,6 @@ class GetCloudUserDataTest(BaseProviderBaseTest):
                 mode: growpart
                 devices: ["/"]
                 ignore_growroot_disabled: false
-            runcmd:
-            - ["ln", "-s", "../usr/share/zoneinfo/America/Argentina/Cordoba", "/etc/localtime"]
             write_files:
                 - path: /root/.bashrc
                   permissions: 0644
@@ -473,19 +469,4 @@ class GetCloudUserDataTest(BaseProviderBaseTest):
         """  # noqa: W605
                 )
             ),
-        )
-
-
-class GetTzDataTest(unit.TestCase):
-    def test_path_found(self):
-        with open("timezone", "w") as timezone_file:
-            print("America/Argentina/Cordoba", file=timezone_file)
-
-        self.assertThat(
-            _base_provider._get_tzdata("timezone"), Equals("America/Argentina/Cordoba")
-        )
-
-    def test_path_not_found(self):
-        self.assertThat(
-            _base_provider._get_tzdata("timezone-not-found"), Equals("Etc/UTC")
         )


### PR DESCRIPTION
This workaround was put in place, but it is the wrong fix.
The underlying problem was fixed with the addition of --preserve-env
on commit:

97fdf64b731e23f02898e7921e838a2fc80a6c5d

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
