### PR TITLE
build providers: clean up LXD startup message

### DIFF
--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -235,7 +235,7 @@ class LXD(Provider):
                 ) from lxd_api_error
 
         # Ensure cloud init is done
-        self.echoer.wrapped("Waiting for cloud-init")
+        self.echoer.wrapped("Waiting for container to be ready")
         self._run(command=["cloud-init", "status", "--wait"])
 
     def _stop(self):


### PR DESCRIPTION
This message about waiting for cloud-init is an implementation detail.
This has confused users, some thought that their data was being
_sent to the cloud_ which is not what is happening considering
what cloud-init is meant to be doing.

The code base is also moving away from cloud-init to profile containers
for Snapcraft, it might as well be ready for that moment.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
