### PR TITLE
spread tests: do not attempt to remove snapd snap

### DIFF
--- a/tests/spread/tools/restore.sh
+++ b/tests/spread/tools/restore.sh
@@ -7,7 +7,7 @@ apt-get autoremove --purge -y
 snaps="$(snap list | awk '{if (NR!=1) {print $1}}')"
 for snap in $snaps; do
 	case "$snap" in
-		"core" | "core16" | "core18" | "snapcraft" | "multipass" | "lxd")
+		"core" | "core16" | "core18" | "snapcraft" | "multipass" | "lxd" | "snapd")
 			# Do not or cannot remove these
 			;;
 		*)


### PR DESCRIPTION
Fixes spread test errors with LXD using snapd snap.

error: cannot remove "snapd": snap "snapd" is not removable:
       remove all other snaps first

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
