### PR TITLE
remote build: default to snapcraft's stable channel

### DIFF
--- a/snapcraft/internal/remote_build/_launchpad.py
+++ b/snapcraft/internal/remote_build/_launchpad.py
@@ -88,7 +88,7 @@ class LaunchpadClient:
         architectures: Sequence[str],
         git_branch: str = "master",
         core18_channel: str = "stable",
-        snapcraft_channel: str = "edge",
+        snapcraft_channel: str = "stable",
         deadline: int = 0,
     ) -> None:
         if not Git.check_command_installed():

--- a/tests/unit/remote_build/test_launchpad.py
+++ b/tests/unit/remote_build/test_launchpad.py
@@ -293,6 +293,24 @@ class LaunchpadTestCase(unit.TestCase):
             str(raised), Equals("Remote build exceeded configured timeout.")
         )
 
+    def test_issue_build_request_defaults(self):
+        fake_snap = mock.MagicMock()
+
+        self.lpc._issue_build_request(fake_snap)
+
+        self.assertThat(
+            fake_snap.mock_calls,
+            Equals(
+                [
+                    mock.call.requestBuilds(
+                        archive="main_archive",
+                        channels={"core18": "stable", "snapcraft": "stable"},
+                        pocket="Updates",
+                    )
+                ]
+            ),
+        )
+
     @mock.patch("snapcraft.internal.remote_build.LaunchpadClient._download_file")
     def test_monitor_build(self, mock_download_file):
         open("test_i386.txt", "w").close()


### PR DESCRIPTION
Add a test to cover the default options to snap.requestBuilds().

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
