### PR TITLE
pluginhandler: user directories scoped to partdir for snapcraftctl

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -114,6 +114,7 @@ class PluginHandler:
         ] = collections.defaultdict(snapcraft.extractors.ExtractedMetadata)
         self._runner = Runner(
             part_properties=self._part_properties,
+            partdir=self.plugin.partdir,
             sourcedir=self.plugin.sourcedir,
             builddir=self.plugin.build_basedir,
             stagedir=self.stagedir,

--- a/snapcraft/internal/pluginhandler/_runner.py
+++ b/snapcraft/internal/pluginhandler/_runner.py
@@ -37,6 +37,7 @@ class Runner:
         self,
         *,
         part_properties: Dict[str, Any],
+        partdir: str,
         sourcedir: str,
         builddir: str,
         stagedir: str,
@@ -45,6 +46,7 @@ class Runner:
     ) -> None:
         """Create a new Runner.
         :param dict part_properties: YAML properties set for this part.
+        :param str partdir: the root directory for this part.
         :param str sourcedir: The source directory for this part.
         :param str builddir: The build directory for this part.
         :param str stagedir: The staging area.
@@ -52,6 +54,7 @@ class Runner:
         :param dict builtin_functions: Dict of builtin function names to
                                        actual callables.
         """
+        self._partdir = partdir
         self._sourcedir = sourcedir
         self._builddir = builddir
         self._stagedir = stagedir
@@ -92,7 +95,7 @@ class Runner:
             )
 
     def _run_scriptlet(self, scriptlet_name: str, scriptlet: str, workdir: str) -> None:
-        with tempfile.TemporaryDirectory() as tempdir:
+        with tempfile.TemporaryDirectory(dir=self._partdir) as tempdir:
             call_fifo = _NonBlockingRWFifo(os.path.join(tempdir, "function_call"))
             feedback_fifo = _NonBlockingRWFifo(os.path.join(tempdir, "call_feedback"))
 

--- a/tests/unit/pluginhandler/test_runner.py
+++ b/tests/unit/pluginhandler/test_runner.py
@@ -44,11 +44,18 @@ def _fake_prime():
 
 
 class RunnerTestCase(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.partdir = os.path.abspath("partdir")
+        os.mkdir(self.partdir)
+
     def test_pull(self):
         os.mkdir("sourcedir")
 
         runner = _runner.Runner(
             part_properties={"override-pull": "touch pull"},
+            partdir=self.partdir,
             sourcedir="sourcedir",
             builddir="builddir",
             stagedir="stagedir",
@@ -65,6 +72,7 @@ class RunnerTestCase(unit.TestCase):
 
         runner = _runner.Runner(
             part_properties={"override-pull": "snapcraftctl pull"},
+            partdir=self.partdir,
             sourcedir="sourcedir",
             builddir="builddir",
             stagedir="stagedir",
@@ -83,6 +91,7 @@ class RunnerTestCase(unit.TestCase):
 
         runner = _runner.Runner(
             part_properties={"override-build": "echo $PATH > path"},
+            partdir=self.partdir,
             sourcedir="sourcedir",
             builddir="builddir",
             stagedir="stagedir",
@@ -105,6 +114,7 @@ class RunnerTestCase(unit.TestCase):
 
         runner = _runner.Runner(
             part_properties={"override-build": "touch build"},
+            partdir=self.partdir,
             sourcedir="sourcedir",
             builddir="builddir",
             stagedir="stagedir",
@@ -121,6 +131,7 @@ class RunnerTestCase(unit.TestCase):
 
         runner = _runner.Runner(
             part_properties={"override-build": "snapcraftctl build"},
+            partdir=self.partdir,
             sourcedir="sourcedir",
             builddir="builddir",
             stagedir="stagedir",
@@ -137,6 +148,7 @@ class RunnerTestCase(unit.TestCase):
 
         runner = _runner.Runner(
             part_properties={"override-stage": "touch stage"},
+            partdir=self.partdir,
             sourcedir="sourcedir",
             builddir="builddir",
             stagedir="stagedir",
@@ -153,6 +165,7 @@ class RunnerTestCase(unit.TestCase):
 
         runner = _runner.Runner(
             part_properties={"override-stage": "snapcraftctl stage"},
+            partdir=self.partdir,
             sourcedir="sourcedir",
             builddir="builddir",
             stagedir="stagedir",
@@ -169,6 +182,7 @@ class RunnerTestCase(unit.TestCase):
 
         runner = _runner.Runner(
             part_properties={"override-prime": "touch prime"},
+            partdir=self.partdir,
             sourcedir="sourcedir",
             builddir="builddir",
             stagedir="stagedir",
@@ -185,6 +199,7 @@ class RunnerTestCase(unit.TestCase):
 
         runner = _runner.Runner(
             part_properties={"override-prime": "snapcraftctl prime"},
+            partdir=self.partdir,
             sourcedir="sourcedir",
             builddir="builddir",
             stagedir="stagedir",
@@ -198,6 +213,12 @@ class RunnerTestCase(unit.TestCase):
 
 
 class RunnerFailureTestCase(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.partdir = os.path.abspath("partdir")
+        os.mkdir(self.partdir)
+
     def test_failure_on_last_script_command_results_in_failure(self):
         os.mkdir("builddir")
 
@@ -210,6 +231,7 @@ class RunnerFailureTestCase(unit.TestCase):
 
         runner = _runner.Runner(
             part_properties={"override-build": script},
+            partdir=self.partdir,
             sourcedir="sourcedir",
             builddir="builddir",
             stagedir="stagedir",
@@ -231,6 +253,7 @@ class RunnerFailureTestCase(unit.TestCase):
 
         runner = _runner.Runner(
             part_properties={"override-build": script},
+            partdir=self.partdir,
             sourcedir="sourcedir",
             builddir="builddir",
             stagedir="stagedir",
@@ -245,6 +268,7 @@ class RunnerFailureTestCase(unit.TestCase):
 
         runner = _runner.Runner(
             part_properties={"override-build": "alias snapcraftctl 2> /dev/null"},
+            partdir=self.partdir,
             sourcedir="sourcedir",
             builddir="builddir",
             stagedir="stagedir",
@@ -265,6 +289,7 @@ class RunnerFailureTestCase(unit.TestCase):
 
         runner = _runner.Runner(
             part_properties={"override-prime": "snapcraftctl prime"},
+            partdir=self.partdir,
             sourcedir="sourcedir",
             builddir="builddir",
             stagedir="stagedir",


### PR DESCRIPTION
snapcraftctl for each part creates a CALL_FIFO and a FEEDBACK_FIFO.
These live under /tmp on a random directory.

This change makes it so that this directory temporary directory is part of
partdir, which would scope these files to the part that is supposed to use
them.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
