### PR TITLE
build providers: remove use of cloud-init

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -15,12 +15,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import abc
+import base64
 import os
 import pathlib
 import logging
 import shlex
 import shutil
 import sys
+import tempfile
 from textwrap import dedent
 from typing import Optional, Sequence
 from typing import Any, Dict
@@ -40,28 +42,26 @@ def _get_platform() -> str:
     return sys.platform
 
 
-_CLOUD_USER_DATA = dedent(
-    """\
-    #cloud-config
-    manage_etc_hosts: true
-    package_update: false
-    growpart:
-        mode: growpart
-        devices: ["/"]
-        ignore_growroot_disabled: false
-    write_files:
-        - path: /root/.bashrc
-          permissions: 0644
-          content: |
+_SNAPCRAFT_FILES = [
+    {
+        "path": "/root/.bashrc",
+        "content": dedent(
+            """\
+            #!/bin/bash
             export SNAPCRAFT_BUILD_ENVIRONMENT=managed-host
-            export PS1="\h \$(/bin/_snapcraft_prompt)# "
+            export PS1="\\h \\$(/bin/_snapcraft_prompt)# "
             export PATH=/snap/bin:$PATH
-        - path: /bin/_snapcraft_prompt
-          permissions: 0755
-          content: |
+            """
+        ),
+        "permissions": "0600",
+    },
+    {
+        "path": "/bin/_snapcraft_prompt",
+        "content": dedent(
+            """\
             #!/bin/bash
             if [[ "$PWD" =~ ^$HOME.* ]]; then
-                path="${PWD/#$HOME/\ ..}"
+                path="${PWD/#$HOME/\\ ..}"
                 if [[ "$path" == " .." ]]; then
                     ps1=""
                 else
@@ -71,8 +71,11 @@ _CLOUD_USER_DATA = dedent(
                 ps1="$PWD"
             fi
             echo -n $ps1
-    """  # noqa: W605
-)
+            """
+        ),
+        "permissions": "0755",
+    },
+]
 
 
 class Provider(abc.ABC):
@@ -272,10 +275,9 @@ class Provider(abc.ABC):
             os.makedirs(self.provider_project_dir)
             # then launch
             self._launch()
-            # We need to setup snapcraft now to be able to refresh
-            self._setup_snapcraft()
-            # and do first boot related things
-            self._run(["snapcraft", "refresh"])
+            # and do first boot related things and if any failure occurs,
+            # then clean up.
+            self._setup_environment()
         else:
             # We always setup snapcraft after a start to bring it up to speed with
             # what is on the host
@@ -291,6 +293,29 @@ class Provider(abc.ABC):
                 )
             )
             self.clean_project()
+
+    def _setup_environment(self, *, tempfile_func=tempfile.NamedTemporaryFile) -> None:
+        # We need to setup snapcraft now to be able to refresh
+        self._setup_snapcraft()
+        self._run(["snapcraft", "refresh"])
+
+        for snapcraft_file in _SNAPCRAFT_FILES:
+            with tempfile_func() as temp_file:
+                temp_file.write(snapcraft_file["content"].encode())
+                temp_file.flush()
+                # Push to a location that can be written to by all backends
+                # with unique files depending on path.
+                remote_file = os.path.join(
+                    "/tmp", base64.b64encode(snapcraft_file["path"].encode()).decode()
+                )
+                self._push_file(source=temp_file.name, destination=remote_file)
+                self._run(["mv", remote_file, snapcraft_file["path"]])
+                # This chown is not necessarily needed. but does keep things
+                # consistent.
+                self._run(["chown", "root:root", snapcraft_file["path"]])
+                self._run(
+                    ["chmod", snapcraft_file["permissions"], snapcraft_file["path"]]
+                )
 
     def _setup_snapcraft(self) -> None:
         self._save_info(base=self.project.info.get_build_base())
@@ -334,18 +359,6 @@ class Provider(abc.ABC):
         snap_injector.add(snap_name="snapcraft")
 
         snap_injector.apply()
-
-    def _get_cloud_user_data(self) -> str:
-        cloud_user_data_filepath = os.path.join(
-            self.provider_project_dir, "user-data.yaml"
-        )
-        if os.path.exists(cloud_user_data_filepath):
-            return cloud_user_data_filepath
-
-        with open(cloud_user_data_filepath, "w") as cloud_user_data_file:
-            print(_CLOUD_USER_DATA, file=cloud_user_data_file, end="")
-
-        return cloud_user_data_filepath
 
     def _get_env_command(self) -> Sequence[str]:
         """Get command sequence for `env` with configured flags."""

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -22,7 +22,6 @@ import urllib.parse
 import warnings
 from typing import Dict, Optional, Sequence
 
-from .._base_provider import _CLOUD_USER_DATA
 from .._base_provider import Provider
 from .._base_provider import errors
 from ._images import get_image_source
@@ -200,7 +199,6 @@ class LXD(Provider):
             raise errors.ProviderLaunchError(
                 provider_name=self._get_provider_name(), error_message=lxd_api_error
             ) from lxd_api_error
-        container.config["user.user-data"] = _CLOUD_USER_DATA
         # This is setup by cloud init, but set it here to be on the safer side.
         container.config["environment.SNAPCRAFT_BUILD_ENVIRONMENT"] = "managed-host"
         container.save(wait=True)

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -98,7 +98,6 @@ class Multipass(Provider):
         return "snapcraft:{}".format(self.project.info.get_build_base())
 
     def _launch(self) -> None:
-        cloud_user_data_filepath = self._get_cloud_user_data()
         image = self._get_disk_image()
 
         cpus = _MachineSetting(envvar="SNAPCRAFT_BUILD_ENVIRONMENT_CPU", default="2")
@@ -113,7 +112,6 @@ class Multipass(Provider):
             mem=mem.get_value(),
             disk=disk.get_value(),
             image=image,
-            cloud_init=cloud_user_data_filepath,
         )
 
     def _start(self):

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2019 Canonical Ltd
+# Copyright (C) 2019-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -141,10 +141,8 @@ class LXDBaseTest(BaseProviderBaseTest):
 class LXDInitTest(LXDBaseTest):
     def test_create(self):
         instance = LXD(project=self.project, echoer=self.echoer_mock)
-        with mock.patch.object(
-            LXD, "_get_cloud_user_data_string", return_value="fake-cloud"
-        ):
-            instance.create()
+
+        instance.create()
 
         self.fake_pylxd_client.containers.create_mock.assert_called_once_with(
             config={
@@ -159,7 +157,6 @@ class LXDInitTest(LXDBaseTest):
                     "alias": "16.04",
                 },
                 "environment.SNAPCRAFT_HAS_TTY": "False",
-                "user.user-data": "fake-cloud",
             },
             wait=True,
         )
@@ -167,15 +164,15 @@ class LXDInitTest(LXDBaseTest):
         container = self.fake_pylxd_client.containers.get(self.instance_name)
         container.start_mock.assert_called_once_with(wait=True)
         self.assertThat(container.save_mock.call_count, Equals(2))
-        self.assertThat(container.sync_mock.call_count, Equals(3))
-        self.assertThat(self.check_call_mock.call_count, Equals(2))
+        self.assertThat(container.sync_mock.call_count, Equals(11))
+        self.assertThat(self.check_call_mock.call_count, Equals(8))
         self.check_call_mock.assert_has_calls(
             [
                 mock.call(
                     [
                         "/snap/bin/lxc",
                         "exec",
-                        self.instance_name,
+                        "snapcraft-project-name",
                         "--",
                         "env",
                         "SNAPCRAFT_HAS_TTY=False",
@@ -188,12 +185,90 @@ class LXDInitTest(LXDBaseTest):
                     [
                         "/snap/bin/lxc",
                         "exec",
-                        self.instance_name,
+                        "snapcraft-project-name",
                         "--",
                         "env",
                         "SNAPCRAFT_HAS_TTY=False",
                         "snapcraft",
                         "refresh",
+                    ]
+                ),
+                mock.call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "mv",
+                        "/tmp/L3Jvb3QvLmJhc2hyYw==",
+                        "/root/.bashrc",
+                    ]
+                ),
+                mock.call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "chown",
+                        "root:root",
+                        "/root/.bashrc",
+                    ]
+                ),
+                mock.call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "chmod",
+                        "0600",
+                        "/root/.bashrc",
+                    ]
+                ),
+                mock.call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "mv",
+                        "/tmp/L2Jpbi9fc25hcGNyYWZ0X3Byb21wdA==",
+                        "/bin/_snapcraft_prompt",
+                    ]
+                ),
+                mock.call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "chown",
+                        "root:root",
+                        "/bin/_snapcraft_prompt",
+                    ]
+                ),
+                mock.call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "chmod",
+                        "0755",
+                        "/bin/_snapcraft_prompt",
                     ]
                 ),
             ]
@@ -236,10 +311,8 @@ class LXDInitTest(LXDBaseTest):
         self.project.info.base = None
 
         instance = LXD(project=self.project, echoer=self.echoer_mock)
-        with mock.patch.object(
-            LXD, "_get_cloud_user_data_string", return_value="fake-cloud"
-        ):
-            instance.create()
+
+        instance.create()
 
         self.fake_pylxd_client.containers.create_mock.assert_called_once_with(
             config={
@@ -254,7 +327,6 @@ class LXDInitTest(LXDBaseTest):
                     "alias": "18.04",
                 },
                 "environment.SNAPCRAFT_HAS_TTY": "False",
-                "user.user-data": "fake-cloud",
             },
             wait=True,
         )

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018-2019 Canonical Ltd
+# Copyright (C) 2018-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -111,24 +111,11 @@ class MultipassTest(BaseProviderBaseTest):
             mem="2G",
             disk="256G",
             image="snapcraft:core16",
-            cloud_init=mock.ANY,
         )
         # Given SnapInjector is mocked, we only need to verify the commands
         # called from the Multipass class.
         self.multipass_cmd_mock().execute.assert_has_calls(
             [
-                mock.call(
-                    instance_name=self.instance_name,
-                    hide_output=False,
-                    command=[
-                        "sudo",
-                        "-i",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "snapcraft",
-                        "refresh",
-                    ],
-                ),
                 mock.call(
                     instance_name=self.instance_name,
                     hide_output=False,
@@ -162,47 +149,6 @@ class MultipassTest(BaseProviderBaseTest):
                 mock.call(instance_name=self.instance_name, output_format="json"),
             ]
         )
-        self.assertThat(self.multipass_cmd_mock().execute.call_count, Equals(3))
-        self.multipass_cmd_mock().execute.assert_has_calls(
-            [
-                mock.call(
-                    command=[
-                        "sudo",
-                        "-i",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "snapcraft",
-                        "refresh",
-                    ],
-                    hide_output=False,
-                    instance_name="snapcraft-project-name",
-                ),
-                mock.call(
-                    command=[
-                        "sudo",
-                        "-i",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "snapcraft",
-                        "pull",
-                    ],
-                    hide_output=False,
-                    instance_name="snapcraft-project-name",
-                ),
-                mock.call(
-                    command=[
-                        "sudo",
-                        "-i",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "snapcraft",
-                        "build",
-                    ],
-                    hide_output=False,
-                    instance_name="snapcraft-project-name",
-                ),
-            ]
-        )
         self.multipass_cmd_mock().stop.assert_called_once_with(
             instance_name=self.instance_name, time=10
         )
@@ -224,7 +170,6 @@ class MultipassTest(BaseProviderBaseTest):
             mem="2G",
             disk="256G",
             image="snapcraft:core16",
-            cloud_init=mock.ANY,
         )
 
     def test_launch_for_type_base(self):
@@ -254,7 +199,6 @@ class MultipassTest(BaseProviderBaseTest):
             mem="2G",
             disk="256G",
             image="snapcraft:core18",
-            cloud_init=mock.ANY,
         )
 
     def test_launch_with_ram_from_environment(self):
@@ -271,7 +215,6 @@ class MultipassTest(BaseProviderBaseTest):
             mem="4G",
             disk="256G",
             image="snapcraft:core16",
-            cloud_init=mock.ANY,
         )
 
     def test_launch_with_disk_from_environment(self):
@@ -288,7 +231,6 @@ class MultipassTest(BaseProviderBaseTest):
             mem="2G",
             disk="400G",
             image="snapcraft:core16",
-            cloud_init=mock.ANY,
         )
 
     def test_pull_file(self):
@@ -487,13 +429,101 @@ class MultipassWithBasesTest(BaseProviderWithBasesBaseTest):
             mem="2G",
             disk="256G",
             image=self.expected_image,
-            cloud_init=mock.ANY,
         )
+        self.assertThat(self.multipass_cmd_mock().execute.call_count, Equals(9))
         self.multipass_cmd_mock().execute.assert_has_calls(
             [
                 mock.call(
-                    instance_name=self.instance_name,
-                    hide_output=True,
+                    command=[
+                        "sudo",
+                        "-i",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "snapcraft",
+                        "refresh",
+                    ],
+                    hide_output=False,
+                    instance_name="snapcraft-project-name",
+                ),
+                mock.call(
+                    command=[
+                        "sudo",
+                        "-i",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "mv",
+                        "/tmp/L3Jvb3QvLmJhc2hyYw==",
+                        "/root/.bashrc",
+                    ],
+                    hide_output=False,
+                    instance_name="snapcraft-project-name",
+                ),
+                mock.call(
+                    command=[
+                        "sudo",
+                        "-i",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "chown",
+                        "root:root",
+                        "/root/.bashrc",
+                    ],
+                    hide_output=False,
+                    instance_name="snapcraft-project-name",
+                ),
+                mock.call(
+                    command=[
+                        "sudo",
+                        "-i",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "chmod",
+                        "0600",
+                        "/root/.bashrc",
+                    ],
+                    hide_output=False,
+                    instance_name="snapcraft-project-name",
+                ),
+                mock.call(
+                    command=[
+                        "sudo",
+                        "-i",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "mv",
+                        "/tmp/L2Jpbi9fc25hcGNyYWZ0X3Byb21wdA==",
+                        "/bin/_snapcraft_prompt",
+                    ],
+                    hide_output=False,
+                    instance_name="snapcraft-project-name",
+                ),
+                mock.call(
+                    command=[
+                        "sudo",
+                        "-i",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "chown",
+                        "root:root",
+                        "/bin/_snapcraft_prompt",
+                    ],
+                    hide_output=False,
+                    instance_name="snapcraft-project-name",
+                ),
+                mock.call(
+                    command=[
+                        "sudo",
+                        "-i",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "chmod",
+                        "0755",
+                        "/bin/_snapcraft_prompt",
+                    ],
+                    hide_output=False,
+                    instance_name="snapcraft-project-name",
+                ),
+                mock.call(
                     command=[
                         "sudo",
                         "-i",
@@ -502,10 +532,10 @@ class MultipassWithBasesTest(BaseProviderWithBasesBaseTest):
                         "printenv",
                         "HOME",
                     ],
+                    hide_output=True,
+                    instance_name="snapcraft-project-name",
                 ),
                 mock.call(
-                    instance_name=self.instance_name,
-                    hide_output=False,
                     command=[
                         "sudo",
                         "-i",
@@ -514,6 +544,8 @@ class MultipassWithBasesTest(BaseProviderWithBasesBaseTest):
                         "snapcraft",
                         "pull",
                     ],
+                    hide_output=False,
+                    instance_name="snapcraft-project-name",
                 ),
             ]
         )
@@ -531,7 +563,19 @@ class MultipassWithBasesTest(BaseProviderWithBasesBaseTest):
                 mock.call(instance_name=self.instance_name, output_format="json"),
             ]
         )
-        self.multipass_cmd_mock().copy_files.assert_not_called()
+        self.assertThat(self.multipass_cmd_mock().copy_files.call_count, Equals(2))
+        self.multipass_cmd_mock().copy_files.assert_has_calls(
+            [
+                mock.call(
+                    source=mock.ANY,
+                    destination="snapcraft-project-name:/tmp/L3Jvb3QvLmJhc2hyYw==",
+                ),
+                mock.call(
+                    source=mock.ANY,
+                    destination="snapcraft-project-name:/tmp/L2Jpbi9fc25hcGNyYWZ0X3Byb21wdA==",
+                ),
+            ]
+        )
         self.multipass_cmd_mock().stop.assert_called_once_with(
             instance_name=self.instance_name, time=10
         )


### PR DESCRIPTION
Make use of other build provider functionality to have the necessary
assets on the build environment (i.e.; ._run and ._push_file).

The initial "first run" setup has been moved to its own method.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
