### PR TITLE
[WIP] extensions: add cleanup extension

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -659,7 +659,8 @@
                             "items": {
                                 "enum": [
                                     "gnome-3-28",
-                                    "kde-neon"
+                                    "kde-neon",
+                                    "z-cleanup"
                                 ]
                             }
                         }

--- a/snapcraft/internal/project_loader/_extensions/_utils.py
+++ b/snapcraft/internal/project_loader/_extensions/_utils.py
@@ -48,7 +48,6 @@ def apply_extensions(yaml_data: Dict[str, Any]) -> Dict[str, Any]:
     """
     # Don't modify the dict passed in
     yaml_data = copy.deepcopy(yaml_data)
-    original_yaml_data = copy.deepcopy(yaml_data)
     base: Optional[str] = yaml_data.get("base")
 
     # Mapping of extension names to set of app names to which the extension needs to be
@@ -69,7 +68,7 @@ def apply_extensions(yaml_data: Dict[str, Any]) -> Dict[str, Any]:
 
     # Process extensions in a consistent order
     for extension_name in sorted(declared_extensions.keys()):
-        extension = _load_extension(base, extension_name, original_yaml_data)
+        extension = _load_extension(base, extension_name, yaml_data)
         _apply_extension(
             yaml_data, declared_extensions[extension_name], extension_name, extension
         )

--- a/snapcraft/internal/project_loader/_extensions/z_cleanup.py
+++ b/snapcraft/internal/project_loader/_extensions/z_cleanup.py
@@ -1,0 +1,69 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018-2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Import types and tell flake8 to ignore the "unused" List.
+
+from typing import Any, Dict, Tuple
+
+from ._extension import Extension
+
+
+_CLEAN_SCRIPT = """
+set -eux
+for snap in {snaps}; do
+    cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$SNAPCRAFT_PRIME/{{}}" \\;
+done
+"""
+
+
+class ExtensionImpl(Extension):
+    """This extension cleans libraries that are present in connected content snaps
+    """
+
+    @staticmethod
+    def get_supported_bases() -> Tuple[str, ...]:
+        return ("core18",)
+
+    @staticmethod
+    def get_supported_confinement() -> Tuple[str, ...]:
+        return ("strict", "devmode")
+
+    def __init__(self, *, extension_name: str, yaml_data: Dict[str, Any]) -> None:
+        super().__init__(extension_name=extension_name, yaml_data=yaml_data)
+
+        base: str = yaml_data["base"]
+
+        parts = []
+        snaps = [base]
+
+        for part in yaml_data.get("parts", {}).keys():
+            parts.append(part)
+
+        for plug in yaml_data.get("plugs", {}).values():
+            if type(plug) is dict:
+                if plug.get("default-provider"):
+                    snaps.append(plug.get("default-provider"))
+
+        snaps = list(set(snaps))
+        snaps.sort()
+        self.parts = {
+            "cleanup": {
+                "after": parts,
+                "plugin": "nil",
+                "build-snaps": snaps,
+                "override-prime": _CLEAN_SCRIPT.format(snaps=" ".join(snaps)),
+            }
+        }

--- a/tests/unit/project_loader/extensions/test_cleanup.py
+++ b/tests/unit/project_loader/extensions/test_cleanup.py
@@ -1,0 +1,109 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from testtools.matchers import Equals
+
+from snapcraft.internal.project_loader._extensions.z_cleanup import ExtensionImpl
+
+from .. import ProjectLoaderBaseTest
+
+
+_CLEAN_SCRIPT = """
+set -eux
+for snap in core18; do
+    cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$SNAPCRAFT_PRIME/{}" \\;
+done
+"""
+
+_CLEAN_SCRIPT_2 = """
+set -eux
+for snap in core18 gnome-3-28-1804 gtk-common-themes; do
+    cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$SNAPCRAFT_PRIME/{}" \\;
+done
+"""
+
+
+class ExtensionTest(ProjectLoaderBaseTest):
+    def test_extension_nopart(self):
+        cleanup_extension = ExtensionImpl(
+            extension_name="cleanup", yaml_data={"base": "core18"}
+        )
+
+        self.expectThat(
+            cleanup_extension.parts,
+            Equals(
+                {
+                    "cleanup": {
+                        "after": [],
+                        "plugin": "nil",
+                        "build-snaps": ["core18"],
+                        "override-prime": _CLEAN_SCRIPT,
+                    }
+                }
+            ),
+        )
+
+    def test_extension(self):
+        cleanup_extension = ExtensionImpl(
+            extension_name="cleanup",
+            yaml_data={
+                "base": "core18",
+                "parts": {"my-part": {}, "my-second-part": {}},
+                "plugs": {
+                    "gnome-3-28-1804": {
+                        "default-provider": "gnome-3-28-1804",
+                        "interface": "content",
+                        "target": "$SNAP/gnome-platform",
+                    },
+                    "gtk-3-themes": {
+                        "default-provider": "gtk-common-themes",
+                        "interface": "content",
+                        "target": "$SNAP/data-dir/themes",
+                    },
+                    "icon-themes": {
+                        "default-provider": "gtk-common-themes",
+                        "interface": "content",
+                        "target": "$SNAP/data-dir/icons",
+                    },
+                },
+            },
+        )
+
+        self.expectThat(
+            cleanup_extension.parts,
+            Equals(
+                {
+                    "cleanup": {
+                        "after": ["my-part", "my-second-part"],
+                        "plugin": "nil",
+                        "build-snaps": [
+                            "core18",
+                            "gnome-3-28-1804",
+                            "gtk-common-themes",
+                        ],
+                        "override-prime": _CLEAN_SCRIPT_2,
+                    }
+                }
+            ),
+        )
+
+    def test_supported_bases(self):
+        self.assertThat(ExtensionImpl.get_supported_bases(), Equals(("core18",)))
+
+    def test_supported_confinement(self):
+        self.assertThat(
+            ExtensionImpl.get_supported_confinement(), Equals(("strict", "devmode"))
+        )


### PR DESCRIPTION
This PR is a proof of concept to start a discussion.

I'd like to add a "cleanup" extensions which removes all the libraries from the prime folder which are already provided by the connected content snaps and the base snap. This turns out to be very useful for reducing the snap size. As an example; the SDLPoP snap size goes down from 31MB to 1 MB and the mc-installer snap size goes from 116MB to 40MB. This works best as an extension because extensions themselves might add content snaps and parts, so the person creating the snap doesn't know yet which content snaps need to be scanned and which parts the `cleanup` part needs to depend on in order to run last.

However, this means

1. the extension needs to run last, because other extensions might add parts and content snaps.
2. the extension needs to have a way to access to the *expanded* `snapcraft.yaml` instead of the original to see the changes of other extensions.

I'm not entirely sure how to do this.

1. I solved `1` in the `apply_extensions` function by supplying extensions with the already-modified `yaml_data` instead of `original_yaml_data`. However, this way all extensions will use the already-expanded data.
2. I solved `2` by prefixing the extension name with `z`. Either I could implement a system where an extension can specify its order using a number, or implementing a "two-stage" expansion process and a way for an extension to specify it should run in the second stage.

So do you think this is a good candidate for an extension? If so, how do I solve 1 and 2?

*Note: I'm thinking of improving the removal logic but I first want to make sure I can actually turn it into an extension. The new removal logic could be that when a library is already available in the base snap, it only removes that library when the version in the snap itself is identical to the one in the base snap. This way, a snap can still override libraries in the base snap and still use this extension.*


## Which snaps would use this?

This extension would be used by a regular snap to remove any libraries from the snap which already exist in the base and content snaps it will use. It's basically an extension which adds this post-build cleanup part. The mc-installer snap, for example, would use this extension to remove any libraries which are already present in the gnome-2-28 and the core18 snaps.


## Why is this `cleanup` extension important?

* It's a really easy way to reduce your snap size. The `mc-installer` snap goes from 104MB to 39MB using this extension.
* It GREATLY improves startup time. The `mc-installer` snap goes from a cold start of 5 seconds to 1 second using this extension.

Startup time and snap size are very dependent on each other because of the [decompression time](https://forum.snapcraft.io/t/squashfs-performance-effect-on-snap-startup-time/13920) and the [resolving of dynamically linked libraries](https://forum.snapcraft.io/t/effects-of-dynamic-library-caching-on-snap-startup-performance/14454/5). If you have less libraries in your snap, there is less to decompress and less to keep the dynamic linker busy.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
