### PR TITLE
pluginhandler: do not search installdir or stagedir for dependencies

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -927,9 +927,9 @@ class PluginHandler:
         _clean_migrated_files(primed_files, primed_directories, shared_directory)
 
     def _calculate_dependency_paths(
-        self, split_depencies: Dict[str, Set[str]]
+        self, split_dependencies: Dict[str, Set[str]]
     ) -> Set[str]:
-        part_dependencies: Set[str] = split_depencies.get(self.primedir, set())
+        part_dependencies = split_dependencies.get(self.primedir, set())
         return {os.path.dirname(d) for d in part_dependencies}
 
     def _warn_missing_dependencies(self, split_dependencies: Dict[str, Set[str]]):

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -65,7 +65,7 @@ class PluginHandler:
         base,
         confinement,
         snap_type,
-        soname_cache
+        soname_cache,
     ) -> None:
         self.valid = False
         self.plugin = plugin
@@ -827,7 +827,7 @@ class PluginHandler:
 
     def _handle_elf(self, snap_files: Sequence[str]) -> Set[str]:
         elf_files = elf.get_elf_files(self.primedir, snap_files)
-        all_dependencies = set()
+        all_dependencies: Set[str] = set()
         core_path = common.get_installed_snap_path(self._base)
 
         # Clear the cache of all libs that aren't already in the primedir
@@ -847,9 +847,14 @@ class PluginHandler:
                 )
             )
 
-        dependency_paths = self._handle_dependencies(
-            all_dependencies=all_dependencies, content_dirs=content_dirs
-        )
+        # Split the necessary dependencies into their corresponding location.
+        search_paths = [self.primedir, core_path, *content_dirs]
+        split_dependencies = _split_dependencies(all_dependencies, search_paths)
+
+        logger.debug(f"_handle_elf: search_paths={search_paths!r}")
+        logger.debug(f"_handle_elf: split_dependencies={split_dependencies!r}")
+
+        self._warn_missing_dependencies(split_dependencies)
 
         if not self._build_attributes.keep_execstack():
             clear_execstack(elf_files=elf_files)
@@ -873,7 +878,7 @@ class PluginHandler:
             )
             part_patcher.patch()
 
-        return dependency_paths
+        return self._calculate_dependency_paths(split_dependencies)
 
     def mark_prime_done(
         self, snap_files, snap_dirs, dependency_paths, primed_stage_packages
@@ -921,38 +926,22 @@ class PluginHandler:
         # part.
         _clean_migrated_files(primed_files, primed_directories, shared_directory)
 
-    def _handle_dependencies(
-        self, *, all_dependencies: Set[str], content_dirs: Set[str]
-    ):
-        # Split the necessary dependencies into their corresponding location.
-        # We'll only track the part and staged dependencies, since they should have
-        # already been primed by other means, and migrating them again could
-        # potentially override the `stage` or `snap` filtering.
-        dirs = [self.plugin.installdir, self.stagedir, self.primedir, *content_dirs]
+    def _calculate_dependency_paths(
+        self, split_depencies: Dict[str, Set[str]]
+    ) -> Set[str]:
+        part_dependencies: Set[str] = split_depencies.get(self.primedir, set())
+        return {os.path.dirname(d) for d in part_dependencies}
 
-        dependencies = _split_dependencies(all_dependencies, dirs)
-        dependency_paths: Set[str] = set()
+    def _warn_missing_dependencies(self, split_dependencies: Dict[str, Set[str]]):
+        # Anything that is determined to be found on host ("/") is missing.
+        missing_list: List[str] = sorted(split_dependencies.get("/", set()))
 
-        part_dependencies: Set[str] = dependencies.get(self.plugin.installdir, set())
-        part_dependency_paths = {os.path.dirname(d) for d in part_dependencies}
-
-        stage_dependencies = dependencies.get(self.stagedir, set())
-        staged_dependency_paths: Set[str] = {
-            os.path.dirname(d) for d in stage_dependencies
-        }
-
-        dependency_paths = part_dependency_paths | staged_dependency_paths
-
-        missing_set: Set[str] = dependencies.get("/", set())
-        missing_list: List[str] = sorted(list(missing_set))
         resolver = MissingDependencyResolver(elf_files=missing_list)
         resolver.print_resolutions(
             part_name=self.name,
             stage_packages_exist=self._part_properties.get("stage-packages"),
             echoer=logger,
         )
-
-        return dependency_paths
 
     def get_primed_dependency_paths(self):
         dependency_paths = set()

--- a/tests/spread/general/dependency-check-missing-lib/snaps/missing-lib/snap/snapcraft.yaml
+++ b/tests/spread/general/dependency-check-missing-lib/snaps/missing-lib/snap/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: missing-lib
+version: 'test1'
+summary: test
+description: test
+grade: stable
+confinement: strict
+
+parts:
+  pciutils:
+    plugin: nil
+    stage-packages:
+      - pciutils
+    stage:
+      - -usr/lib
+      - -lib
+
+apps:
+  lspci:
+    command: usr/bin/lspci

--- a/tests/spread/general/dependency-check-missing-lib/snaps/missing-lib/snap/snapcraft.yaml
+++ b/tests/spread/general/dependency-check-missing-lib/snaps/missing-lib/snap/snapcraft.yaml
@@ -8,11 +8,11 @@ confinement: strict
 parts:
   pciutils:
     plugin: nil
-    stage-packages:
+    build-packages:
       - pciutils
-    stage:
-      - -usr/lib
-      - -lib
+    override-build: |
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/bin
+      install -m 0755 /usr/bin/lspci $SNAPCRAFT_PART_INSTALL/usr/bin
 
 apps:
   lspci:

--- a/tests/spread/general/dependency-check-missing-lib/snaps/missing-lib/snap/snapcraft.yaml
+++ b/tests/spread/general/dependency-check-missing-lib/snaps/missing-lib/snap/snapcraft.yaml
@@ -11,8 +11,7 @@ parts:
     build-packages:
       - pciutils
     override-build: |
-      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/bin
-      install -m 0755 /usr/bin/lspci $SNAPCRAFT_PART_INSTALL/usr/bin
+      install -D -m 0755 /usr/bin/lspci $SNAPCRAFT_PART_INSTALL/usr/bin
 
 apps:
   lspci:

--- a/tests/spread/general/dependency-check-missing-lib/snaps/missing-lib/snap/snapcraft.yaml
+++ b/tests/spread/general/dependency-check-missing-lib/snaps/missing-lib/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ parts:
     build-packages:
       - pciutils
     override-build: |
-      install -D -m 0755 /usr/bin/lspci $SNAPCRAFT_PART_INSTALL/usr/bin
+      install -D -m 0755 /usr/bin/lspci $SNAPCRAFT_PART_INSTALL/usr/bin/lspci
 
 apps:
   lspci:

--- a/tests/spread/general/dependency-check-missing-lib/task.yaml
+++ b/tests/spread/general/dependency-check-missing-lib/task.yaml
@@ -1,4 +1,4 @@
-summary: Build a snap that tests adapter settings
+summary: Build a snap that is missing a library dependency
 
 systems: [ubuntu-*]
 
@@ -23,5 +23,5 @@ execute: |
   cd "$SNAP_DIR"
   output="$(snapcraft)"
 
-  echo "$output" | MATCH "part is missing libraries that are not included in the snap or base. They can be satisfied by adding the following entries to the existing stage-packages for this part:"
+  echo "$output" | MATCH "The 'pciutils' part is missing libraries that are not included in the snap or base."
   echo "$output" | MATCH -- "- libpci3"

--- a/tests/spread/general/dependency-check-missing-lib/task.yaml
+++ b/tests/spread/general/dependency-check-missing-lib/task.yaml
@@ -1,0 +1,27 @@
+summary: Build a snap that tests adapter settings
+
+systems: [ubuntu-*]
+
+environment:
+  SNAP_DIR: snaps/missing-lib
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "$SNAP_DIR"
+  output="$(snapcraft)"
+
+  echo "$output" | MATCH "part is missing libraries that are not included in the snap or base. They can be satisfied by adding the following entries to the existing stage-packages for this part:"
+  echo "$output" | MATCH -- "- libpci3"

--- a/tests/spread/general/dependency-check-missing-none/snaps/missing-none/snap/snapcraft.yaml
+++ b/tests/spread/general/dependency-check-missing-none/snaps/missing-none/snap/snapcraft.yaml
@@ -1,0 +1,16 @@
+name: missing-none
+version: 'test1'
+summary: test
+description: test
+grade: stable
+confinement: strict
+
+parts:
+  pciutils:
+    plugin: nil
+    stage-packages:
+      - pciutils
+
+apps:
+  lspci:
+    command: usr/bin/lspci

--- a/tests/spread/general/dependency-check-missing-none/task.yaml
+++ b/tests/spread/general/dependency-check-missing-none/task.yaml
@@ -1,0 +1,27 @@
+summary: Build a snap that stages an application w/ required library.
+
+systems: [ubuntu-*]
+
+environment:
+  SNAP_DIR: snaps/missing-none
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "$SNAP_DIR"
+  output="$(snapcraft)"
+
+  echo "$output" | MATCH -v "part is missing libraries"
+  echo "$output" | MATCH -v -- "- libpci.so."


### PR DESCRIPTION
The search paths already include primedir which has all of the primed
and staged files at this point.  The installdir and stagedir may
contain files that are not shipped in the final snap, so limit search
to primedir as it should be fully populated.

- Replace _handle_dependencies() with a simpler _warn_missing_dependencies()
and _calculate_dependency_paths() called from _handle_elf().

- Add a couple useful debug prints.

- Add two tests to cover the case where the dependency is found, and
another where the dependency is missing.  For the latter, the lib is
removed using `stage` configuration.

This last test would have previously failed, because the dependency
was found in installdir, and ignored by the missing dependency resolver.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
