### PR TITLE
spread: capture developer debug information

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -24,6 +24,9 @@ environment:
   # Disable all Sentry error reporting
   SNAPCRAFT_ENABLE_ERROR_REPORTING: "no"
 
+  # Print potentially useful debugging info
+  SNAPCRAFT_ENABLE_DEVELOPER_DEBUG: "yes"
+
   # Ensure that we have the right debian configuration for legacy
   DEBIAN_FRONTEND: noninteractive
   DEBIAN_PRIORITY: critical

--- a/tests/spread/legacy/command-define/task.yaml
+++ b/tests/spread/legacy/command-define/task.yaml
@@ -2,6 +2,9 @@ summary: Ensure the define command outputs correctly
 
 systems: [ubuntu-16*]
 
+environment:
+  SNAPCRAFT_ENABLE_DEVELOPER_DEBUG: "no"
+
 restore: |
   rm -rf ./parts
   rm -f ./define.txt

--- a/tests/spread/legacy_python/general/task.yaml
+++ b/tests/spread/legacy_python/general/task.yaml
@@ -1,5 +1,8 @@
 summary: Run the python driven general tests
 
+environment:
+  SNAPCRAFT_ENABLE_DEVELOPER_DEBUG: "no"
+
 execute: |
   cd /snapcraft
   ./runtests.sh tests/integration/general

--- a/tests/spread/legacy_python/lifecycle/task.yaml
+++ b/tests/spread/legacy_python/lifecycle/task.yaml
@@ -1,5 +1,8 @@
 summary: Run the python driven lifecycle tests
 
+environment:
+  SNAPCRAFT_ENABLE_DEVELOPER_DEBUG: "no"
+
 execute: |
   cd /snapcraft
   ./runtests.sh tests/integration/lifecycle


### PR DESCRIPTION
This information can often be useful to diagnose what is wrong.
Since spread only spits out the output on failure, it shouldn't
clutter up typical logs.

Sets SNAPCRAFT_ENABLE_DEVELOPER_DEBUG=yes in the spread env.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
