### PR TITLE
ci: only run docker builds for cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,25 +146,29 @@ jobs:
         - SNAPCRAFT_PACKAGE_TYPE=snap ./runtests.sh tests/integration/store
 
     - stage: docker
+      if type = cron
       env:
         RISK: "stable"
       script:
         - cd docker
         - docker build --no-cache -f ${RISK}.Dockerfile --tag snapcore/snapcraft:${RISK} .
         - docker run snapcore/snapcraft:${RISK} snapcraft --version
-    - env:
+    - if type = cron
+      env:
         RISK: "edge"
       script:
         - cd docker
         - docker build --no-cache -f ${RISK}.Dockerfile --tag snapcore/snapcraft:${RISK} .
         - docker run snapcore/snapcraft:${RISK} snapcraft --version
-    - env:
+    - if type = cron
+      env:
         RISK: "beta"
       script:
         - cd docker
         - docker build --no-cache -f ${RISK}.Dockerfile --tag snapcore/snapcraft:${RISK} .
         - docker run snapcore/snapcraft:${RISK} snapcraft --version
-    - env:
+    - if type = cron
+      env:
         RISK: "candidate"
       script:
         - cd docker


### PR DESCRIPTION
It does not make sense to test build the docker images for every PR
as what they build is seldom based out of the snapcraft built in this
source.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
