### PR TITLE
store: temprorarily remove support for progressive releases

### DIFF
--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -21,7 +21,7 @@ import operator
 import stat
 import sys
 from textwrap import dedent
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Union
 
 import click
 from tabulate import tabulate
@@ -219,24 +219,7 @@ def push_metadata(snap_file, force):
 @click.argument("snap-name", metavar="<snap-name>")
 @click.argument("revision", metavar="<revision>")
 @click.argument("channels", metavar="<channels>")
-@click.option(
-    "--progressive-percentage",
-    type=click.IntRange(0, 100),
-    metavar="<percentage>",
-    help="set a release progression to a certain percentage before continuing.",
-)
-@click.option(
-    "--progressive-key",
-    metavar="<key>",
-    help="the progression key to use to keep track of the --progressive-percentage to be set.",
-)
-def release(
-    snap_name,
-    revision,
-    channels,
-    progressive_percentage: Optional[int],
-    progressive_key: Optional[str],
-) -> None:
+def release(snap_name, revision, channels) -> None:
     """Release <snap-name> on <revision> to the selected store <channels>.
     <channels> is a comma separated list of valid channels on the
     store.
@@ -267,19 +250,7 @@ def release(
         snapcraft release my-snap 9 lts-channel/stable
         snapcraft release my-snap 9 lts-channel/stable/my-branch
     """
-    progressive_options = [progressive_percentage, progressive_key]
-    if any(progressive_options) and not all(progressive_options):
-        raise click.UsageError(
-            "--progressive-percentage and --progressive-key must be used together."
-        )
-
-    snapcraft.release(
-        snap_name,
-        revision,
-        channels.split(","),
-        progressive_percentage=progressive_percentage,
-        progressive_key=progressive_key,
-    )
+    snapcraft.release(snap_name, revision, channels.split(","))
 
 
 @storecli.command()

--- a/tests/unit/commands/test_release.py
+++ b/tests/unit/commands/test_release.py
@@ -122,64 +122,6 @@ class ReleaseCommandTestCase(FakeStoreCommandsBaseTestCase):
             progressive_percentage=None,
         )
 
-    def test_progressive_release(self):
-        self.fake_store_release.mock.return_value = {
-            "opened_channels": ["2.1/beta"],
-            "channel_map_tree": {
-                "2.1": {
-                    "16": {
-                        "amd64": [
-                            {"channel": "stable", "info": "none"},
-                            {"channel": "candidate", "info": "none"},
-                            {
-                                "revision": 19,
-                                "channel": "beta",
-                                "version": "0",
-                                "info": "specific",
-                            },
-                            {"channel": "edge", "info": "tracking"},
-                        ]
-                    }
-                }
-            },
-        }
-
-        result = self.run_command(
-            [
-                "release",
-                "nil-snap",
-                "19",
-                "2.1/beta",
-                "--progressive-key",
-                "progressive-key",
-                "--progressive-percentage",
-                "10",
-            ]
-        )
-
-        self.assertThat(result.exit_code, Equals(0))
-        self.assertThat(
-            result.output,
-            Contains(
-                dedent(
-                    """\
-            Track    Arch    Channel    Version    Revision    Notes
-            2.1      amd64   stable     -          -           -
-                             candidate  -          -           -
-                             beta       0          19          progressive (10%)
-                             edge       ^          ^           -
-            \x1b[0;32mThe '2.1/beta' channel is now open.\x1b[0m"""
-                )
-            ),
-        )
-        self.fake_store_release.mock.assert_called_once_with(
-            snap_name="nil-snap",
-            revision="19",
-            channels=["2.1/beta"],
-            progressive_key="progressive-key",
-            progressive_percentage=10,
-        )
-
     def test_release_snap_with_branch(self):
         self.fake_store_release.mock.return_value = {
             "opened_channels": ["stable/hotfix1"],
@@ -233,72 +175,6 @@ class ReleaseCommandTestCase(FakeStoreCommandsBaseTestCase):
             channels=["stable/hotfix1"],
             progressive_key=None,
             progressive_percentage=None,
-        )
-
-    def test_progressive_release_snap_with_branch(self):
-        self.fake_store_release.mock.return_value = {
-            "opened_channels": ["stable/hotfix1"],
-            "channel_map_tree": {
-                "latest": {
-                    "16": {
-                        "amd64": [
-                            {"channel": "stable", "info": "none"},
-                            {"channel": "candidate", "info": "none"},
-                            {
-                                "revision": 19,
-                                "channel": "beta",
-                                "version": "0",
-                                "info": "specific",
-                            },
-                            {"channel": "edge", "info": "tracking"},
-                            {
-                                "channel": "stable/hotfix1",
-                                "info": "branch",
-                                "revision": 20,
-                                "version": "1",
-                                "expires_at": "2017-05-21T18:52:14.578435",
-                            },
-                        ]
-                    }
-                }
-            },
-        }
-
-        result = self.run_command(
-            [
-                "release",
-                "nil-snap",
-                "20",
-                "stable/hotfix1",
-                "--progressive-key",
-                "progressive-key",
-                "--progressive-percentage",
-                "10",
-            ]
-        )
-
-        self.assertThat(result.exit_code, Equals(0))
-        self.assertThat(
-            result.output,
-            Contains(
-                dedent(
-                    """\
-            Track    Arch    Channel         Version    Revision    Notes              Expires at
-            latest   amd64   stable          -          -           -
-                             candidate       -          -           -
-                             beta            0          19          -
-                             edge            ^          ^           -
-                             stable/hotfix1  1          20          progressive (10%)  2017-05-21T18:52:14.578435
-            \x1b[0;32mThe 'stable/hotfix1' channel is now open.\x1b[0m"""
-                )
-            ),
-        )
-        self.fake_store_release.mock.assert_called_once_with(
-            snap_name="nil-snap",
-            revision="20",
-            channels=["stable/hotfix1"],
-            progressive_key="progressive-key",
-            progressive_percentage=10,
         )
 
     def test_release_snap_opens_more_than_one_channel(self):
@@ -433,22 +309,4 @@ class ReleaseCommandTestCase(FakeStoreCommandsBaseTestCase):
         )
         self.assertThat(
             result.output, Contains("You are required to login before continuing.")
-        )
-
-
-class ReleaseCommandProgressiveUsageTest(FakeStoreCommandsBaseTestCase):
-    scenarios = (
-        ("key and no percentage", dict(args=["--progressive-key", "pk"])),
-        ("percentage and no key", dict(args=["--progressive-percentage", "10"])),
-    )
-
-    def test_progressive_release_usage(self):
-        result = self.run_command(["release", "nil-snap", "19", "beta"] + self.args)
-
-        self.assertThat(result.exit_code, Equals(2))
-        self.assertThat(
-            result.output,
-            Contains(
-                "Error: --progressive-percentage and --progressive-key must be used together."
-            ),
         )


### PR DESCRIPTION
The exposure of the progressive key has been reassessed and will not be part of
the exposed feature.

The UX also needs reconsideration on how the table is presented when a
progressive release is triggered.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
