### PR TITLE
remote-build: pass through 'source-subdir' property

### DIFF
--- a/snapcraft/internal/remote_build/_worktree.py
+++ b/snapcraft/internal/remote_build/_worktree.py
@@ -245,7 +245,7 @@ class WorkTree:
         if source_modified:
             # Strip source attributes no longer relevant.
             for key in list(part_config.keys()):
-                if key.startswith("source-"):
+                if key.startswith("source-") and key != "source-subdir":
                     part_config.pop(key)
 
             # It's now an archive, set it explicitly.


### PR DESCRIPTION
It is currently being stripped with the other source keys,
but we need to instead pass it through.

Add a test to verify source properties are passed through (or not).

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
