### PR TITLE
Regenerate the GDK pixbuf loaders cache file if for whatever reason it isn't there (LP: #1863801).

### DIFF
--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -391,7 +391,7 @@ append_dir LD_LIBRARY_PATH "$SNAP/testability/$ARCH/mesa"
 # Gdk-pixbuf loaders
 export GDK_PIXBUF_MODULE_FILE="$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache"
 export GDK_PIXBUF_MODULEDIR="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders"
-if [ "$needs_update" = true ] || [ ! -f $GDK_PIXBUF_MODULE_FILE ]; then
+if [ "$needs_update" = true ] || [ ! -f "$GDK_PIXBUF_MODULE_FILE" ]; then
   rm -f "$GDK_PIXBUF_MODULE_FILE"
   if [ -f "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders" ]; then
     async_exec "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders" > "$GDK_PIXBUF_MODULE_FILE"

--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -391,7 +391,7 @@ append_dir LD_LIBRARY_PATH "$SNAP/testability/$ARCH/mesa"
 # Gdk-pixbuf loaders
 export GDK_PIXBUF_MODULE_FILE="$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache"
 export GDK_PIXBUF_MODULEDIR="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders"
-if [ "$needs_update" = true ]; then
+if [ "$needs_update" = true ] || [ ! -f $GDK_PIXBUF_MODULE_FILE ]; then
   rm -f "$GDK_PIXBUF_MODULE_FILE"
   if [ -f "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders" ]; then
     async_exec "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders" > "$GDK_PIXBUF_MODULE_FILE"


### PR DESCRIPTION
The absence of the cache file (after manual deletion) was causing the chromium snap to crash when opening a GTK file dialog.

This is a backport of the fix from the snapcraft-desktop-helpers project (https://github.com/ubuntu/snapcraft-desktop-helpers/commit/769110c9101c333c3ae6ccc3663098f094e580be).