### PR TITLE
meta: Snap to_dict() cleanup

### DIFF
--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -379,6 +379,9 @@ class Snap:
         if self.description is not None:
             snap_dict["description"] = self.description
 
+        if self.adopt_info is not None:
+            snap_dict["adopt-info"] = self.adopt_info
+
         if self.apps:
             snap_dict["apps"] = OrderedDict()
             for name, app in sorted(self.apps.items()):
@@ -416,6 +419,9 @@ class Snap:
         if self.license is not None:
             snap_dict["license"] = self.license
 
+        if self.passthrough:
+            snap_dict["passthrough"] = deepcopy(self.passthrough)
+
         if self.plugs:
             snap_dict["plugs"] = OrderedDict()
             for name, plug in sorted(self.plugs.items()):
@@ -437,18 +443,28 @@ class Snap:
         if self.type is not None:
             snap_dict["type"] = self.type
 
-        # Apply passthrough keys.
-        snap_dict.update(deepcopy(self.passthrough))
         return snap_dict
 
-    def write_snap_yaml(self, path: str) -> None:
-        """Write snap.yaml contents to specified path."""
+    def to_snap_yaml_dict(self) -> OrderedDict:
         snap_dict = self.to_dict()
 
         # If the base is core in snapcraft.yaml we do not set it in
         # snap.yaml LP: #1819290
         if self.base == "core":
             snap_dict.pop("base")
+
+        # Remove keys that are not for snap.yaml.
+        snap_dict.pop("adopt-info", None)
+
+        # Apply passthrough keys.
+        passthrough = snap_dict.pop("passthrough", dict())
+        snap_dict.update(passthrough)
+
+        return snap_dict
+
+    def write_snap_yaml(self, path: str) -> None:
+        """Write snap.yaml contents to specified path."""
+        snap_dict = self.to_snap_yaml_dict()
 
         with open(path, "w") as f:
             yaml_utils.dump(snap_dict, stream=f)

--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -367,55 +367,75 @@ class Snap:
         # Ensure command-chain is in assumes, if required.
         self._ensure_command_chain_assumption()
 
-        for key in _MANDATORY_PACKAGE_KEYS + _OPTIONAL_PACKAGE_KEYS:
-            if key != "system-usernames" and self.__dict__[key] is None:
-                continue
+        if self.name is not None:
+            snap_dict["name"] = self.name
 
-            # Skip fields that are empty lists/dicts.
-            if (
-                key
-                in [
-                    "apps",
-                    "architectures",
-                    "assumes",
-                    "environment",
-                    "hooks",
-                    "layout",
-                    "plugs",
-                    "slots",
-                ]
-                and not self.__dict__[key]
-            ):
-                continue
+        if self.version is not None:
+            snap_dict["version"] = self.version
 
-            # Sort where possible for consistency.
-            if key == "apps":
-                snap_dict[key] = dict()
-                for name, app in sorted(self.apps.items()):
-                    snap_dict[key][name] = app.to_dict()
-            elif key == "assumes":
-                snap_dict[key] = sorted(set(self.assumes))
-            elif key == "hooks":
-                snap_dict[key] = dict()
-                for name, hook in sorted(self.hooks.items()):
-                    snap_dict[key][name] = hook.to_dict()
-            elif key == "plugs":
-                snap_dict[key] = dict()
-                for name, plug in sorted(self.plugs.items()):
-                    snap_dict[key][name] = plug.to_yaml_object()
-            elif key == "slots":
-                snap_dict[key] = dict()
-                for name, slot in sorted(self.slots.items()):
-                    snap_dict[key][name] = slot.to_yaml_object()
-            elif key == "system-usernames":
-                if not self.system_usernames:
-                    continue
-                snap_dict["system-usernames"] = OrderedDict()
-                for name in sorted(self.system_usernames.keys()):
-                    user = self.system_usernames[name]
-                    snap_dict["system-usernames"][name] = deepcopy(user.to_dict())
-            else:
-                snap_dict[key] = deepcopy(self.__dict__[key])
+        if self.summary is not None:
+            snap_dict["summary"] = self.summary
+
+        if self.description is not None:
+            snap_dict["description"] = self.description
+
+        if self.apps:
+            snap_dict["apps"] = OrderedDict()
+            for name, app in sorted(self.apps.items()):
+                snap_dict["apps"][name] = deepcopy(app.to_dict())
+
+        if self.architectures:
+            snap_dict["architectures"] = deepcopy(self.architectures)
+
+        if self.assumes:
+            snap_dict["assumes"] = sorted(set(deepcopy(self.assumes)))
+
+        if self.base is not None:
+            snap_dict["base"] = self.base
+
+        if self.confinement is not None:
+            snap_dict["confinement"] = self.confinement
+
+        if self.environment:
+            snap_dict["environment"] = self.environment
+
+        if self.epoch is not None:
+            snap_dict["epoch"] = self.epoch
+
+        if self.grade is not None:
+            snap_dict["grade"] = self.grade
+
+        if self.hooks:
+            snap_dict["hooks"] = OrderedDict()
+            for name, hook in sorted(self.hooks.items()):
+                snap_dict["hooks"][name] = deepcopy(hook.to_dict())
+
+        if self.layout:
+            snap_dict["layout"] = deepcopy(self.layout)
+
+        if self.license is not None:
+            snap_dict["license"] = self.license
+
+        if self.plugs:
+            snap_dict["plugs"] = OrderedDict()
+            for name, plug in sorted(self.plugs.items()):
+                snap_dict["plugs"][name] = deepcopy(plug.to_yaml_object())
+
+        if self.slots:
+            snap_dict["slots"] = OrderedDict()
+            for name, slot in sorted(self.slots.items()):
+                snap_dict["slots"][name] = deepcopy(slot.to_yaml_object())
+
+        if self.system_usernames:
+            snap_dict["system-usernames"] = OrderedDict()
+            for name, user in sorted(self.system_usernames.items()):
+                snap_dict["system-usernames"][name] = deepcopy(user.to_dict())
+
+        if self.title is not None:
+            snap_dict["title"] = self.title
+
+        if self.type is not None:
+            snap_dict["type"] = self.type
 
         # Apply passthrough keys.
         snap_dict.update(deepcopy(self.passthrough))

--- a/tests/unit/meta/test_snap.py
+++ b/tests/unit/meta/test_snap.py
@@ -97,7 +97,7 @@ class SnapTests(unit.TestCase):
         self.assertEqual(snap_dict["summary"], snap.summary)
         self.assertEqual(snap_dict["description"], snap.description)
 
-    def test_passthrough(self):
+    def test_snap_yaml_passthrough(self):
         snap_dict = OrderedDict(
             {
                 "name": "snap-test",
@@ -116,7 +116,7 @@ class SnapTests(unit.TestCase):
         passthrough = transformed_dict.pop("passthrough")
         transformed_dict.update(passthrough)
 
-        self.assertEqual(transformed_dict, snap.to_dict())
+        self.assertEqual(transformed_dict, snap.to_snap_yaml_dict())
         self.assertEqual(True, snap.is_passthrough_enabled)
         self.assertEqual(passthrough, snap.passthrough)
         self.assertEqual(snap_dict["name"], snap.name)
@@ -124,63 +124,74 @@ class SnapTests(unit.TestCase):
         self.assertEqual(snap_dict["summary"], snap.summary)
         self.assertEqual(snap_dict["description"], snap.description)
 
+    def test_snap_yaml_all_keys(self):
+        snap_dict = {
+            "name": "snap-test",
+            "version": "test-version",
+            "summary": "test-summary",
+            "description": "test-description",
+            "adopt-info": "some-part",
+            "apps": {"test-app": {"command": "test-app"}},
+            "architectures": ["all"],
+            "assumes": ["command-chain"],
+            "base": "core",
+            "confinement": "strict",
+            "environment": {"TESTING": "1"},
+            "epoch": 0,
+            "grade": "devel",
+            "hooks": {"test-hook": {"command-chain": ["cmd1"], "plugs": ["network"]}},
+            "layout": {"/target": {"bind": "$SNAP/foo"}},
+            "license": "GPL",
+            "passthrough": {"test": "value"},
+            "plugs": {"test-plug": {"interface": "some-value"}},
+            "slots": {"test-slot": {"interface": "some-value"}},
+            "system-usernames": {"snap_daemon": {"scope": "shared"}},
+            "title": "test-title",
+            "type": "base",
+        }
+
+        snap = Snap.from_dict(snap_dict=snap_dict)
+        snap.validate()
+
+        expected_dict = snap_dict.copy()
+        expected_dict.pop("adopt-info")
+        expected_dict.pop("base")
+        expected_dict.update(expected_dict.pop("passthrough"))
+
+        self.assertEqual(expected_dict, snap.to_snap_yaml_dict())
+        self.assertEqual(True, snap.is_passthrough_enabled)
+
     def test_all_keys(self):
-        snap_dict = OrderedDict(
-            {
-                "name": "snap-test",
-                "version": "test-version",
-                "summary": "test-summary",
-                "description": "test-description",
-                "apps": {"test-app": {"command": "test-app"}},
-                "architectures": ["all"],
-                "assumes": ["command-chain"],
-                "base": "core",
-                "confinement": "strict",
-                "environment": {"TESTING": "1"},
-                "epoch": 0,
-                "grade": "devel",
-                "hooks": {
-                    "test-hook": {"command-chain": ["cmd1"], "plugs": ["network"]}
-                },
-                "layout": {"/target": {"bind": "$SNAP/foo"}},
-                "license": "GPL",
-                "plugs": {"test-plug": OrderedDict({"interface": "some-value"})},
-                "slots": {"test-slot": OrderedDict({"interface": "some-value"})},
-                "system-usernames": OrderedDict(
-                    {"snap_daemon": OrderedDict({"scope": "shared"})}
-                ),
-                "title": "test-title",
-                "type": "base",
-            }
-        )
+        snap_dict = {
+            "name": "snap-test",
+            "version": "test-version",
+            "summary": "test-summary",
+            "description": "test-description",
+            "adopt-info": "some-part",
+            "apps": {"test-app": {"command": "test-app"}},
+            "architectures": ["all"],
+            "assumes": ["command-chain"],
+            "base": "core",
+            "confinement": "strict",
+            "environment": {"TESTING": "1"},
+            "epoch": 0,
+            "grade": "devel",
+            "hooks": {"test-hook": {"command-chain": ["cmd1"], "plugs": ["network"]}},
+            "layout": {"/target": {"bind": "$SNAP/foo"}},
+            "license": "GPL",
+            "passthrough": {"test": "value"},
+            "plugs": {"test-plug": {"interface": "some-value"}},
+            "slots": {"test-slot": {"interface": "some-value"}},
+            "system-usernames": {"snap_daemon": {"scope": "shared"}},
+            "title": "test-title",
+            "type": "base",
+        }
 
         snap = Snap.from_dict(snap_dict=snap_dict)
         snap.validate()
 
         self.assertEqual(snap_dict, snap.to_dict())
-        self.assertEqual(False, snap.is_passthrough_enabled)
-        self.assertEqual(snap_dict["name"], snap.name)
-        self.assertEqual(snap_dict["version"], snap.version)
-        self.assertEqual(snap_dict["summary"], snap.summary)
-        self.assertEqual(snap_dict["description"], snap.description)
-        self.assertEqual(snap_dict["apps"]["test-app"], snap.apps["test-app"].to_dict())
-        self.assertEqual(snap_dict["architectures"], snap.architectures)
-        self.assertEqual(set(snap_dict["assumes"]), snap.assumes)
-        self.assertEqual(snap_dict["base"], snap.base)
-        self.assertEqual(snap_dict["environment"], snap.environment)
-        self.assertEqual(
-            snap_dict["hooks"]["test-hook"], snap.hooks["test-hook"].to_dict()
-        )
-        self.assertEqual(snap_dict["license"], snap.license)
-        self.assertEqual(
-            snap_dict["plugs"]["test-plug"], snap.plugs["test-plug"].to_yaml_object()
-        )
-        self.assertEqual(
-            snap_dict["slots"]["test-slot"], snap.slots["test-slot"].to_yaml_object()
-        )
-        self.assertEqual(snap_dict["confinement"], snap.confinement)
-        self.assertEqual(snap_dict["title"], snap.title)
-        self.assertEqual(snap_dict["type"], snap.type)
+        self.assertEqual(True, snap.is_passthrough_enabled)
 
     def test_system_usernames_shortform_scope(self):
         snap_dict = OrderedDict(


### PR DESCRIPTION
- remove `__dict__` usage and detail each property
- remove snap.yaml-isms from to_dict, into newly added to_snap_yaml_dict()