### PR TITLE
snap-packaging: remove broken host-compatibility check for runner

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -333,9 +333,6 @@ class _SnapPackaging:
         self._parts_dir = project_config.project.parts_dir
 
         self._arch_triplet = project_config.project.arch_triplet
-        self._is_host_compatible_with_base = (
-            project_config.project.is_host_compatible_with_base
-        )
         self.meta_dir = os.path.join(self._prime_dir, "meta")
         self.meta_gui_dir = os.path.join(self.meta_dir, "gui")
         self._config_data = project_config.data.copy()
@@ -438,10 +435,7 @@ class _SnapPackaging:
     def _assemble_runtime_environment(self) -> str:
         # Classic confinement or building on a host that does not match the target base
         # means we cannot setup an environment that will work.
-        if (
-            self._config_data["confinement"] == "classic"
-            or not self._is_host_compatible_with_base
-        ):
+        if self._config_data["confinement"] == "classic":
             # Temporary workaround for snapd bug not expanding PATH:
             # We generate an empty runner which addresses the issue.
             # https://bugs.launchpad.net/snapd/+bug/1860369


### PR DESCRIPTION
The check is incorrect as-is because is_host_compatible points to a
function, not a bool, effectively evaluating to true (always).

Just remove the check and generate the environment as is currently
being done anyways.  Even if the host were incompatible, the
environment will be more correct that omitting it.  Building on
an incompatible host is user-beware and this is one of the risks.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
