### PR TITLE
spread: introduce appstream parse-info test

### DIFF
--- a/tests/spread/general/appstream/expected_appstream-desktop.desktop
+++ b/tests/spread/general/appstream/expected_appstream-desktop.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=appstream-desktop
+Exec=appstream-desktop
+Type=Application
+Icon=${SNAP}/usr/share/icons/hicolor/scalable/apps/snapcraft.svg
+

--- a/tests/spread/general/appstream/expected_snap.yaml
+++ b/tests/spread/general/appstream/expected_snap.yaml
@@ -1,0 +1,28 @@
+name: appstream-desktop
+version: 1.0.0
+summary: Appstream Desktop test
+description: |-
+  Some description.
+
+
+  Some list:
+
+  - First item
+  - Second item
+
+
+  Test me please.
+apps:
+  appstream-desktop:
+    command: usr/bin/appstream-desktop
+    command-chain:
+    - snap/command-chain/snapcraft-runner
+    common-id: io.snapcraft.appstream
+architectures:
+- amd64
+assumes:
+- command-chain
+base: core18
+confinement: strict
+grade: devel
+title: Appstream Desktop

--- a/tests/spread/general/appstream/snaps/appstream-desktop/appstream-desktop
+++ b/tests/spread/general/appstream/snaps/appstream-desktop/appstream-desktop
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "appstream desktop"

--- a/tests/spread/general/appstream/snaps/appstream-desktop/io.snapcraft.appstream.desktop
+++ b/tests/spread/general/appstream/snaps/appstream-desktop/io.snapcraft.appstream.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=appstream-desktop
+Exec=appstream
+Type=Application
+Icon=/usr/share/icons/hicolor/scalable/apps/snapcraft.svg

--- a/tests/spread/general/appstream/snaps/appstream-desktop/io.snapcraft.appstream.metainfo.xml
+++ b/tests/spread/general/appstream/snaps/appstream-desktop/io.snapcraft.appstream.metainfo.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Some Comment -->
+<component type="desktop-application">
+  <id>io.snapcraft.appstream</id>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+  <name>Appstream Desktop</name>
+  <summary>Appstream Desktop test</summary>
+
+  <description>
+    <p>
+      Some description.
+    </p>
+    <p>Some list:</p>
+    <ul>
+      <li>First item</li>
+      <li>Second item</li>
+    </ul>
+    <p>
+      Test me please.
+    </p>
+  </description>
+
+  <icon type="local">/usr/share/icons/hicolor/scalable/apps/snapcraft.svg</icon>
+  <launchable type="desktop-id">io.snapcraft.appstream.desktop</launchable>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>snapcraft</caption>
+      <image>https://admin.insights.ubuntu.com/wp-content/uploads/3124/snapcraft_db_brandmark@4x.png</image>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">https://snapcraft.io</url>
+  <project_group>snapcraft</project_group>
+
+  <provides>
+    <binary>appstream</binary>
+  </provides>
+
+  <releases>
+    <release version="1.0.0" date="2020-01-01">
+      <description>
+        <p>Initial release.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/tests/spread/general/appstream/snaps/appstream-desktop/snap/snapcraft.yaml
+++ b/tests/spread/general/appstream/snaps/appstream-desktop/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: appstream-desktop
+base: core18
+
+grade: devel
+confinement: strict
+adopt-info: appstream-desktop
+
+apps:
+  appstream-desktop:
+    command: usr/bin/appstream-desktop
+    common-id: io.snapcraft.appstream
+    desktop: usr/share/applications/io.snapcraft.appstream.desktop
+
+parts:
+  appstream-desktop:
+    plugin: nil
+    source: .
+    build-packages: [gcc, libc6-dev]
+    parse-info: [io.snapcraft.appstream.metainfo.xml]
+    override-build: |
+      install -D -m 0644 io.snapcraft.appstream.desktop $SNAPCRAFT_PART_INSTALL/usr/share/applications/io.snapcraft.appstream.desktop
+      install -D -m 0644 snapcraft.svg $SNAPCRAFT_PART_INSTALL/usr/share/icons/hicolor/scalable/apps/snapcraft.svg
+      install -D -m 0755 appstream-desktop $SNAPCRAFT_PART_INSTALL/usr/bin/appstream-desktop

--- a/tests/spread/general/appstream/snaps/appstream-desktop/snapcraft.svg
+++ b/tests/spread/general/appstream/snaps/appstream-desktop/snapcraft.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" viewBox="0 0 37.680001 36" height="36" width="37.68" id="svg3750" version="1.1" sodipodi:docname="snapcraft-bird.svg" inkscape:version="0.92.2 (30a58d1, 2017-08-07)">
+  
+  
+  <defs id="defs3754">
+    
+  </defs>
+  <g transform="translate(-25.38,-12)" id="g3921">
+    <polygon style="fill:#82bea0" class="cls-2" points="47.06,32.14 55.37,23.83 47.06,20.14 " id="polygon3894"/>
+    <polygon style="fill:#82bea0" class="cls-2" points="31.19,48 45.85,33.34 41.38,28.9 " id="polygon3896"/>
+    <polygon style="fill:#82bea0" class="cls-2" points="25.38,12 46.35,32.84 46.35,19.58 " id="polygon3898"/>
+    <polygon style="fill:#fa6441" class="cls-3" points="59.62,19.58 47.54,19.58 63.06,26.48 " id="polygon3900"/>
+  </g>
+</svg>

--- a/tests/spread/general/appstream/task.yaml
+++ b/tests/spread/general/appstream/task.yaml
@@ -1,0 +1,34 @@
+summary: Build a snap that tests appstream settings
+
+# This test snap uses core18, and is limited to amd64 arch due to
+# architectures specified in expected_snap.yaml.
+systems:
+  - ubuntu-18.04-64
+  - ubuntu-18.04-amd64
+  - ubuntu-18.04
+
+environment:
+  SNAP_DIR: snaps/appstream-desktop
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+execute: |
+  cd "$SNAP_DIR"
+  snapcraft prime
+
+  expected_snap_yaml="$PWD/../../expected_snap.yaml"
+
+  if ! diff -U10 prime/meta/snap.yaml "$expected_snap_yaml"; then
+      echo "The formatting for snap.yaml is incorrect"
+      exit 1
+  fi
+
+  expected_desktop="$PWD/../../expected_appstream-desktop.desktop"
+
+  if ! diff -U10 prime/meta/gui/appstream-desktop.desktop "$expected_desktop"; then
+      echo "The formatting for appstream-desktop.desktop is incorrect"
+      exit 1
+  fi


### PR DESCRIPTION
- Ensure that adopt-info + parse-info is capturing the correct
  data.

- Test the desktop icon path is rewritten using ${SNAP}.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>



There does some to be some unexplained difference when running this test against local LXD.  My newlines are different in the description field... see https://github.com/snapcore/snapcraft/compare/4f3f58f0fcd40e3cc6383a278eefb7f61b1b90d3..221da1a606f2cf51d33489db0ac1fcada30519fa