### PR TITLE
meta: remove remaining `__dict__` and key list usage in snap

### DIFF
--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -32,27 +32,6 @@ from snapcraft.internal.meta.system_user import SystemUser
 logger = logging.getLogger(__name__)
 
 
-_MANDATORY_PACKAGE_KEYS = ["name", "version", "summary", "description"]
-_OPTIONAL_PACKAGE_KEYS = [
-    "apps",
-    "architectures",
-    "assumes",
-    "base",
-    "confinement",
-    "environment",
-    "epoch",
-    "grade",
-    "hooks",
-    "layout",
-    "license",
-    "plugs",
-    "slots",
-    "system-usernames",
-    "title",
-    "type",
-]
-
-
 class Snap:
     """Representation of snap meta object, writes snap.yaml."""
 

--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -206,12 +206,18 @@ class Snap:
     def _validate_required_keys(self) -> None:
         """Verify that all mandatory keys have been satisfied."""
         missing_keys: List[str] = []
-        for key in _MANDATORY_PACKAGE_KEYS:
-            if key == "version" and self.adopt_info:
-                continue
 
-            if not self.__dict__[key]:
-                missing_keys.append(key)
+        if not self.name:
+            missing_keys.append("name")
+
+        if not self.version and not self.adopt_info:
+            missing_keys.append("version")
+
+        if not self.summary:
+            missing_keys.append("summary")
+
+        if not self.description:
+            missing_keys.append("description")
 
         if missing_keys:
             raise errors.MissingSnapcraftYamlKeysError(keys=missing_keys)

--- a/tests/unit/meta/test_snap.py
+++ b/tests/unit/meta/test_snap.py
@@ -29,11 +29,6 @@ from tests import integration, unit
 
 
 class SnapTests(unit.TestCase):
-    """ Test the snaps.  Note that the ordering of ordereddicts must align
-    with Snap's use of _MANDATORY_PACKAGE_KEYS + _OPTIONAL_PACKAGE_KEYS.
-
-    This applies even for verifying YAMLs, which are (now) ordered."""
-
     def test_empty(self):
         snap_dict = OrderedDict()
 


### PR DESCRIPTION
also fix a c901 label for python 3.8 while I'm in the vicinity.