### PR TITLE
cli: enable config file for base snapcraft command

### DIFF
--- a/snapcraft/cli/_runner.py
+++ b/snapcraft/cli/_runner.py
@@ -24,6 +24,7 @@ import click
 import snapcraft
 from snapcraft.internal import log
 from .assertions import assertionscli
+from ._config import enable_snapcraft_config_file
 from .containers import containerscli
 from .discovery import discoverycli
 from .legacy import legacycli
@@ -68,6 +69,7 @@ command_groups = [
 @add_build_options(hidden=True)
 @add_provider_options(hidden=True)
 @click.option("--debug", "-d", is_flag=True)
+@enable_snapcraft_config_file()
 def run(ctx, debug, catch_exceptions=False, **kwargs):
     """Snapcraft is a delightful packaging tool."""
 


### PR DESCRIPTION
If using the lifecycle commands, the config file is read.  This
commit also extends it to the base `snapcraft` command, which runs
the snap lifecycle command.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
