### PR TITLE
repo: respect http proxy for apt update

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -325,7 +325,7 @@ class Ubuntu(BaseRepo):
     @classmethod
     def refresh_build_packages(cls) -> None:
         try:
-            subprocess.check_call(["sudo", "apt", "update"])
+            subprocess.check_call(["sudo", "--preserve-env", "apt-get", "update"])
         except subprocess.CalledProcessError as call_error:
             raise errors.CacheUpdateFailedError(
                 "failed to run apt update"

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -571,18 +571,24 @@ class BuildPackagesTestCase(unit.TestCase):
     def test_refresh_buid_packages(self, mock_check_call):
         repo.Ubuntu.refresh_build_packages()
 
-        mock_check_call.assert_called_once_with(["sudo", "apt", "update"])
+        mock_check_call.assert_called_once_with(
+            ["sudo", "--preserve-env", "apt-get", "update"]
+        )
 
     @patch(
         "subprocess.check_call",
-        side_effect=CalledProcessError(returncode=1, cmd=["sudo", "apt", "update"]),
+        side_effect=CalledProcessError(
+            returncode=1, cmd=["sudo", "--preserve-env", "apt-get", "update"]
+        ),
     )
     def test_refresh_buid_packages_fails(self, mock_check_call):
         self.assertRaises(
             errors.CacheUpdateFailedError, repo.Ubuntu.refresh_build_packages
         )
 
-        mock_check_call.assert_called_once_with(["sudo", "apt", "update"])
+        mock_check_call.assert_called_once_with(
+            ["sudo", "--preserve-env", "apt-get", "update"]
+        )
 
 
 class PackageForFileTest(unit.TestCase):


### PR DESCRIPTION
Use `--preserve-env` as used for `apt-get install`.

Switch to `apt-get` for updating packages as well for
consistency.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
