### PR TITLE
go plugin: do not remove install /bin directory before build

### DIFF
--- a/snapcraft/plugins/go.py
+++ b/snapcraft/plugins/go.py
@@ -284,9 +284,7 @@ class GoPlugin(snapcraft.BasePlugin):
     def build(self) -> None:
         super().build()
 
-        # Clear the installation before continuing.
-        if os.path.exists(self._install_bin_dir):
-            shutil.rmtree(self._install_bin_dir)
+        # Ensure install directory exists.
         os.makedirs(self._install_bin_dir)
 
         if self._is_using_go_mod(cwd=self.builddir):

--- a/snapcraft/plugins/go.py
+++ b/snapcraft/plugins/go.py
@@ -285,7 +285,7 @@ class GoPlugin(snapcraft.BasePlugin):
         super().build()
 
         # Ensure install directory exists.
-        os.makedirs(self._install_bin_dir)
+        os.makedirs(self._install_bin_dir, exist_ok=True)
 
         if self._is_using_go_mod(cwd=self.builddir):
             self._build()

--- a/tests/spread/plugins/go/snaps/go-use-stage-packages/go-hello/main.go
+++ b/tests/spread/plugins/go/snaps/go-use-stage-packages/go-hello/main.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2020 Canonical Ltd
+ * Copyright (C) 2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/tests/spread/plugins/go/snaps/go-use-stage-packages/go-hello/main.go
+++ b/tests/spread/plugins/go/snaps/go-use-stage-packages/go-hello/main.go
@@ -1,0 +1,26 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("hello world")
+}

--- a/tests/spread/plugins/go/snaps/go-use-stage-packages/snap/snapcraft.yaml
+++ b/tests/spread/plugins/go/snaps/go-use-stage-packages/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: go-hello
+version: "0.1"
+summary: A simple go project
+description: |
+  Test to ensure stage packages ship in the final snap.
+
+grade: devel
+confinement: strict
+base: core18
+
+apps:
+  go-hello:
+    command: go-hello
+
+parts:
+  go-hello:
+    plugin: go
+    go-channel: ""
+    source: go-hello
+    stage-packages: [grep]

--- a/tests/spread/plugins/go/use-stage-packages/task.yaml
+++ b/tests/spread/plugins/go/use-stage-packages/task.yaml
@@ -1,0 +1,32 @@
+summary: Build part of a go snap using stage packages
+
+environment:
+  SNAP_DIR: ../snaps/go-use-stage-packages
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+  restore_yaml snap/snapcraft.yaml
+
+execute: |
+  cd "$SNAP_DIR"
+
+  snapcraft prime
+
+  if [[ ! -f "prime/bin/go-hello" ]]; then
+    echo "Go-hello not installed into /bin."
+    exit 1
+  fi
+
+  if [[ ! -f "prime/bin/grep" ]]; then
+    echo "Missing stage package files."
+    exit 1
+  fi


### PR DESCRIPTION
Packages configured in a part's stage-packages are installed prior
to build and installed to $SNAPCRAFT_PART_INSTALL.  Cleaning
$SNAPCRAFT_PART_INSTALL/bin will purge any files that may have been
installed there.

Running go build should overwrite any previously installed files,
which will be OK for incremental builds.  However, as the go plugin
does not enable out_of_source_build, the entire build directory is
purged on every build anyways.

Add spread test for coverage.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

Reported by @stgraber 