### PR TITLE
build providers: remove over use of -i in sudo

### DIFF
--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018-2019 Canonical Ltd
+# Copyright (C) 2018-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -83,9 +83,11 @@ class Multipass(Provider):
     def _run(
         self, command: Sequence[str], hide_output: bool = False
     ) -> Optional[bytes]:
-        env_command = self._get_env_command()
+        env_command = super()._get_env_command()
 
-        cmd = ["sudo", "-i"]
+        cmd = ["sudo", "-H"]
+        if not hide_output:
+            cmd.append("-i")
         cmd.extend(env_command)
         cmd.extend(command)
         self._log_run(cmd)
@@ -225,7 +227,7 @@ class Multipass(Provider):
             self._run(command=["rm", name])
 
     def shell(self) -> None:
-        self._run(command=["/bin/bash"])
+        self._run(command=["/bin/bash", "-i"])
 
     def _get_instance_info(self):
         instance_info_raw = self._multipass_cmd.info(

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -237,9 +237,7 @@ class BaseProviderTest(BaseProviderBaseTest):
                 dedent(
                     """\
             #!/bin/bash
-            export SNAPCRAFT_BUILD_ENVIRONMENT=managed-host
             export PS1="\\h \\$(/bin/_snapcraft_prompt)# "
-            export PATH=/snap/bin:$PATH
         """
                 )
             ),
@@ -301,7 +299,18 @@ class BaseProviderTest(BaseProviderBaseTest):
 
         results = provider._get_env_command()
 
-        self.assertThat(results, Equals(["env", "SNAPCRAFT_HAS_TTY=False"]))
+        self.assertThat(
+            results,
+            Equals(
+                [
+                    "env",
+                    "SNAPCRAFT_BUILD_ENVIRONMENT=managed-host",
+                    "PATH=/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                    "HOME=/root",
+                    "SNAPCRAFT_HAS_TTY=False",
+                ]
+            ),
+        )
 
     def test_passthrough_environment_flags_non_string(self):
         # Set http_proxy to a bool even though it doesn't make sense...
@@ -312,7 +321,17 @@ class BaseProviderTest(BaseProviderBaseTest):
         results = provider._get_env_command()
 
         self.assertThat(
-            results, Equals(["env", "SNAPCRAFT_HAS_TTY=False", "http_proxy=True"])
+            results,
+            Equals(
+                [
+                    "env",
+                    "SNAPCRAFT_BUILD_ENVIRONMENT=managed-host",
+                    "PATH=/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                    "HOME=/root",
+                    "SNAPCRAFT_HAS_TTY=False",
+                    "http_proxy=True",
+                ]
+            ),
         )
 
     def test_passthrough_environment_flags_all(self):
@@ -328,6 +347,9 @@ class BaseProviderTest(BaseProviderBaseTest):
             Equals(
                 [
                     "env",
+                    "SNAPCRAFT_BUILD_ENVIRONMENT=managed-host",
+                    "PATH=/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                    "HOME=/root",
                     "SNAPCRAFT_HAS_TTY=False",
                     "http_proxy=http://127.0.0.1:8080",
                     "https_proxy=http://127.0.0.1:8080",


### PR DESCRIPTION
Using -i when stdin is set to DEVNULL causes an ioctl warning in
Multipass.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
