### PR TITLE
Go: unable to build snap when using `go mod` and main package is not in the root

### DIFF
--- a/snapcraft/plugins/go.py
+++ b/snapcraft/plugins/go.py
@@ -250,8 +250,8 @@ class GoPlugin(snapcraft.BasePlugin):
 
         if self._is_using_go_mod(self.builddir) and not package:
             work_dir = self.builddir
-            build_cmd.extend(["-o", self._install_bin_dir])
-            relink_cmd.extend(["-o", self._install_bin_dir])
+            build_cmd.extend(["-o", self._install_bin_dir, "./..."])
+            relink_cmd.extend(["-o", self._install_bin_dir, "./..."])
         else:
             work_dir = self._install_bin_dir
             build_cmd.append(package)

--- a/tests/spread/plugins/go/run-go-mod-subdir/task.yaml
+++ b/tests/spread/plugins/go/run-go-mod-subdir/task.yaml
@@ -1,0 +1,37 @@
+summary: Build and run a basic Go snap using go.mod
+
+environment:
+  SNAP_DIR: ../snaps/go-mod-hello-subdir
+  LANG: C.UTF-8
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+  restore_yaml snap/snapcraft.yaml
+
+execute: |
+  cd "$SNAP_DIR"
+
+  snapcraft
+
+  if ! snap list go; then
+    echo "The go snap from the Snap Store should have been installed."
+    exit 1
+  fi
+
+  # This only works on ubuntu
+  if dpkg -s golang-go; then
+    echo "The go deb for the system repositories should not have been installed."
+    exit 1
+  fi
+
+  sudo snap install go-mod-hello-subdir_*.snap --dangerous
+  [ "$(go-mod-hello-subdir)" = "Ahoy, world!" ]

--- a/tests/spread/plugins/go/run-go-mod-subdir/task.yaml
+++ b/tests/spread/plugins/go/run-go-mod-subdir/task.yaml
@@ -1,4 +1,4 @@
-summary: Build and run a basic Go snap using go.mod
+summary: Build and run a basic Go snap using go.mod with main package in a subdir
 
 environment:
   SNAP_DIR: ../snaps/go-mod-hello-subdir

--- a/tests/spread/plugins/go/snaps/go-mod-hello-subdir/go-hello/main.go
+++ b/tests/spread/plugins/go/snaps/go-mod-hello-subdir/go-hello/main.go
@@ -1,0 +1,33 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"rsc.io/quote"
+)
+
+func hello() string {
+	return quote.Hello()
+}
+
+func main() {
+	fmt.Println(hello())
+}

--- a/tests/spread/plugins/go/snaps/go-mod-hello-subdir/go.mod
+++ b/tests/spread/plugins/go/snaps/go-mod-hello-subdir/go.mod
@@ -1,0 +1,5 @@
+module github.com/snapcore/snapcraft/tests/spread/plugins/go/snaps/go-mod-hello-subdir
+
+go 1.13
+
+require rsc.io/quote v1.5.2

--- a/tests/spread/plugins/go/snaps/go-mod-hello-subdir/go.sum
+++ b/tests/spread/plugins/go/snaps/go-mod-hello-subdir/go.sum
@@ -1,0 +1,6 @@
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c h1:qgOY6WgZOaTkIIMiVjBQcw93ERBE4m30iBm00nkL0i8=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+rsc.io/quote v1.5.2 h1:w5fcysjrx7yqtD/aO+QwRjYZOKnaM9Uh2b40tElTs3Y=
+rsc.io/quote v1.5.2/go.mod h1:LzX7hefJvL54yjefDEDHNONDjII0t9xZLPXsUe+TKr0=
+rsc.io/sampler v1.3.0 h1:7uVkIFmeBqHfdjD+gZwtXXI+RODJ2Wc4O7MPEh/QiW4=
+rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/tests/spread/plugins/go/snaps/go-mod-hello-subdir/snap/snapcraft.yaml
+++ b/tests/spread/plugins/go/snaps/go-mod-hello-subdir/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: go-mod-hello-subdir
+version: "0.1"
+summary: A simple go project using go.mod
+description: |
+  This is a basic go snap. It just prints a hello world brought in from
+  a version pinned go package using go.mod.
+
+grade: devel
+confinement: strict
+
+apps:
+  go-mod-hello-subdir:
+    command: go-hello
+
+parts:
+  go-hello:
+    source: .
+    plugin: go

--- a/tests/unit/plugins/test_go.py
+++ b/tests/unit/plugins/test_go.py
@@ -645,7 +645,7 @@ class GoPluginTest(GoPluginBaseTest):
             ["go", "version"], cwd=mock.ANY, env=mock.ANY
         )
         self.run_mock.assert_called_once_with(
-            ["go", "build", "-o", plugin._install_bin_dir],
+            ["go", "build", "-o", plugin._install_bin_dir, "./..."],
             cwd=plugin.builddir,
             env=mock.ANY,
         )
@@ -723,7 +723,7 @@ class GoPluginTest(GoPluginBaseTest):
         self.run_mock.assert_has_calls(
             [
                 mock.call(
-                    ["go", "build", "-o", plugin._install_bin_dir],
+                    ["go", "build", "-o", plugin._install_bin_dir, "./..."],
                     cwd=plugin.builddir,
                     env=mock.ANY,
                 ),
@@ -735,6 +735,7 @@ class GoPluginTest(GoPluginBaseTest):
                         "-linkmode=external",
                         "-o",
                         plugin._install_bin_dir,
+                        "./...",
                     ],
                     cwd=plugin.builddir,
                     env=mock.ANY,


### PR DESCRIPTION
When using go modules, `go build -o <path>` will pick up main package only if it's in the root of repository.

Steps to reproduce:

0. Given a go module, where [main](https://github.com/pavel-d/snaptest/blob/master/cli/main.go) package is located in `./cli` subdirectory
1. Clone https://github.com/pavel-d/snaptest
2. `cd snaptest`
2. Run `snapcraft build --use-lxd --debug`

Result:
```
snapcraft --use-lxd  --debug
The LXD provider is offered as a technology preview for early adopters.
The command line interface, container names or lifecycle handling may change in upcoming releases.
Launching a container.
Waiting for container to be ready
......................
status: done
snapd 2.43.3 from Canonical✓ refreshed
Skipping pull snaptest (already ran)
Building snaptest 
go build -o /root/parts/snaptest/install/bin
go build: no main packages to build
Failed to run 'go build -o /root/parts/snaptest/install/bin' for 'snaptest': Exited with code 1.
Verify that the part is using the correct parameters and try again.
snapcraft-snaptest # snapcraft --version
snapcraft, version 3.10.1
```

The `./...` pattern matches all the packages within the current module and `go build` will automatically build main packages in subdirectories.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
