### PR TITLE
project: add fallbacks for os.sched_getaffinity

### DIFF
--- a/snapcraft/project/_project_options.py
+++ b/snapcraft/project/_project_options.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import multiprocessing
 import os
 import platform
 import sys
@@ -131,7 +132,19 @@ def _get_platform_architecture():
 class ProjectOptions:
     @property
     def parallel_build_count(self) -> int:
-        return len(os.sched_getaffinity(0))
+        try:
+            build_count = len(os.sched_getaffinity(0))
+        except AttributeError:
+            # Fall back to multiprocessing.cpu_count()...
+            try:
+                build_count = multiprocessing.cpu_count()
+            except NotImplementedError:
+                logger.warning(
+                    "Unable to determine CPU count; disabling parallel builds"
+                )
+                build_count = 1
+
+        return build_count
 
     @property
     def is_cross_compiling(self):

--- a/tests/unit/project_loader/test_environment.py
+++ b/tests/unit/project_loader/test_environment.py
@@ -515,7 +515,7 @@ class EnvironmentTest(ProjectLoaderBaseTest):
 
     @mock.patch("os.sched_getaffinity", side_effect=AttributeError)
     @mock.patch("multiprocessing.cpu_count", side_effect=NotImplementedError)
-    def test_parts_build_env_contains_parallel_build_count_no_getaffinity(
+    def test_parts_build_env_contains_parallel_build_count_no_cpucount(
         self, affinity_mock, cpu_mock
     ):
         project_config = self.make_snapcraft_project(self.snapcraft_yaml)

--- a/tests/unit/project_loader/test_environment.py
+++ b/tests/unit/project_loader/test_environment.py
@@ -501,6 +501,30 @@ class EnvironmentTest(ProjectLoaderBaseTest):
         env = project_config.parts.build_env_for_part(part1)
         self.assertThat(env, Contains('SNAPCRAFT_PARALLEL_BUILD_COUNT="42"'))
 
+    @mock.patch("os.sched_getaffinity", side_effect=AttributeError)
+    @mock.patch("multiprocessing.cpu_count", return_value=42)
+    def test_parts_build_env_contains_parallel_build_count_no_getaffinity(
+        self, affinity_mock, cpu_mock
+    ):
+        project_config = self.make_snapcraft_project(self.snapcraft_yaml)
+        part1 = [
+            part for part in project_config.parts.all_parts if part.name == "part1"
+        ][0]
+        env = project_config.parts.build_env_for_part(part1)
+        self.assertThat(env, Contains('SNAPCRAFT_PARALLEL_BUILD_COUNT="42"'))
+
+    @mock.patch("os.sched_getaffinity", side_effect=AttributeError)
+    @mock.patch("multiprocessing.cpu_count", side_effect=NotImplementedError)
+    def test_parts_build_env_contains_parallel_build_count_no_getaffinity(
+        self, affinity_mock, cpu_mock
+    ):
+        project_config = self.make_snapcraft_project(self.snapcraft_yaml)
+        part1 = [
+            part for part in project_config.parts.all_parts if part.name == "part1"
+        ][0]
+        env = project_config.parts.build_env_for_part(part1)
+        self.assertThat(env, Contains('SNAPCRAFT_PARALLEL_BUILD_COUNT="1"'))
+
     def test_extension_dir(self):
         common.set_extensionsdir("/foo")
         project_config = self.make_snapcraft_project(self.snapcraft_yaml)


### PR DESCRIPTION
Project was recently updated [1] to use os.sched_getaffinity()
to get a more accurate view of how many threads are available
for use.

However, OSX does not implement os.sched_getaffinity(), failing
with AttributeError.

Fall back to multiprocessing.cpu_count if os.sched_getaffinity()
does not exist.

Failing that, return 1.

Add a couple of unit tests for coverage.

[1] 332df0f97e93ac7ecc325f929faacb79ae55ddd1

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
