### PR TITLE
rosdep: include EOL ROS distros

### DIFF
--- a/snapcraft/plugins/_ros/rosdep.py
+++ b/snapcraft/plugins/_ros/rosdep.py
@@ -118,7 +118,7 @@ class Rosdep:
 
         logger.info("Updating rosdep database...")
         try:
-            self._run(["update"])
+            self._run(["update", "--include-eol-distros"])
         except subprocess.CalledProcessError as e:
             output = e.output.decode(sys.getfilesystemencoding()).strip()
             raise RosdepInitializationError(

--- a/snapcraft/plugins/colcon.py
+++ b/snapcraft/plugins/colcon.py
@@ -80,6 +80,12 @@ _ROSDISTRO_TO_BASE_MAP = {
     "eloquent": "core18",
 }
 
+# Snaps can still be built with ROS distros that are end-of-life, but such
+# things are not supported. Maintain a list so we can warn about such things.
+# This really should be using rosdistro to automatically detect the support
+# status, but that's a larger feature than we want to implement at this time.
+_EOL_ROSDISTROS = ["bouncy", "crystal"]
+
 # Map bases to Ubuntu releases. Every base in _ROSDISTRO_TO_BASE_MAP needs to be
 # specified here.
 _BASE_TO_UBUNTU_RELEASE_MAP = {"core18": "bionic"}
@@ -264,6 +270,13 @@ class ColconPlugin(snapcraft.BasePlugin):
         if project.info.get_build_base() != _ROSDISTRO_TO_BASE_MAP[self._rosdistro]:
             raise ColconPluginBaseError(
                 self.name, project.info.get_build_base(), self._rosdistro
+            )
+
+        if self._rosdistro in _EOL_ROSDISTROS:
+            logger.warning(
+                "The {!r} ROS distro has reached end-of-life and is no longer supported. Use at your own risk.".format(
+                    self._rosdistro
+                )
             )
 
         # Beta warning. Remove this comment and warning once plugin is stable.

--- a/tests/unit/plugins/ros/test_rosdep.py
+++ b/tests/unit/plugins/ros/test_rosdep.py
@@ -77,7 +77,7 @@ class RosdepTestCase(unit.TestCase):
         self.check_output_mock.assert_has_calls(
             [
                 mock.call(["rosdep", "init"], env=mock.ANY),
-                mock.call(["rosdep", "update"], env=mock.ANY),
+                mock.call(["rosdep", "update", "--include-eol-distros"], env=mock.ANY),
             ]
         )
 
@@ -107,7 +107,7 @@ class RosdepTestCase(unit.TestCase):
 
     def test_setup_update_failure(self):
         def run(args, **kwargs):
-            if args == ["rosdep", "update"]:
+            if args == ["rosdep", "update", "--include-eol-distros"]:
                 raise subprocess.CalledProcessError(1, "foo", b"bar")
 
             return mock.DEFAULT

--- a/tests/unit/plugins/test_colcon.py
+++ b/tests/unit/plugins/test_colcon.py
@@ -14,11 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import os
 import os.path
 import re
 import textwrap
 
+import fixtures
 from unittest import mock
 from testscenarios import multiply_scenarios
 from testtools.matchers import (
@@ -289,6 +291,19 @@ class ColconPluginTest(ColconPluginTestBase):
         self.assertTrue(colcon_packages_ignore["uniqueItems"])
         self.assertThat(colcon_packages_ignore["items"], Contains("type"))
         self.assertThat(colcon_packages_ignore["items"]["type"], Equals("string"))
+
+    def test_eol_ros_distro_warning(self):
+        self.properties.colcon_rosdistro = "crystal"
+
+        fake_logger = fixtures.FakeLogger(level=logging.WARNING)
+        self.useFixture(fake_logger)
+        colcon.ColconPlugin("test-part", self.properties, self.project)
+        self.assertThat(
+            fake_logger.output,
+            Contains(
+                "The 'crystal' ROS distro has reached end-of-life and is no longer supported. Use at your own risk."
+            ),
+        )
 
     def test_get_pull_properties(self):
         expected_pull_properties = [


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

Snapcraft has support for a number of ROS distributions that are actually end-of-life upstream. Once they go end-of-life, such snaps suddenly stop building. This PR fixes this by letting them continue to work, but adding a warning to let users know that it's officially EOL and no longer supported.