### PR TITLE
requirements: uprev click to 7.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click~=7.0
+click==7.1.1
 click-config-file==0.5.0
 configparser==3.5.0
 jsonschema==2.5.1

--- a/tests/unit/commands/test_enable_ci.py
+++ b/tests/unit/commands/test_enable_ci.py
@@ -29,7 +29,7 @@ class EnableCITestCase(CommandBaseTestCase):
         self.assertThat(
             result.output,
             Contains(
-                'Error: Missing argument "<ci-system>".  Choose from:\n\ttravis.\n'
+                "Error: Missing argument '<ci-system>'.  Choose from:\n\ttravis.\n"
             ),
         )
 

--- a/tests/unit/commands/test_sign_build.py
+++ b/tests/unit/commands/test_sign_build.py
@@ -78,7 +78,7 @@ class SignBuildTestCase(CommandBaseTestCase):
         self.assertThat(
             result.output,
             Contains(
-                'Error: Invalid value for "<snap-file>": File "nonexisting.snap" does not exist.\n'
+                "Error: Invalid value for '<snap-file>': File 'nonexisting.snap' does not exist.\n"
             ),
         )
         self.assertThat(mock_check_output.call_count, Equals(0))


### PR DESCRIPTION
Lock in the version so it doesn't uprev itself to a "compatible version"
as it did here.  This uprev changed the quoting used for click errors
when failing to provide a required parameter.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
