### PR TITLE
git: always fetch specified source-commit before using

### DIFF
--- a/snapcraft/internal/sources/_git.py
+++ b/snapcraft/internal/sources/_git.py
@@ -150,6 +150,19 @@ class Git(Base):
                 output=error.output.decode(),
             )
 
+    def _fetch_origin_commit(self):
+        self._run(
+            [
+                self.command,
+                "-C",
+                self.source_dir,
+                "fetch",
+                "origin",
+                self.source_commit,
+            ],
+            **self._call_kwargs
+        )
+
     def _pull_existing(self):
         refspec = "HEAD"
         if self.source_branch:
@@ -158,6 +171,7 @@ class Git(Base):
             refspec = "refs/tags/" + self.source_tag
         elif self.source_commit:
             refspec = self.source_commit
+            self._fetch_origin_commit()
 
         reset_spec = refspec if refspec != "HEAD" else "origin/master"
 
@@ -201,6 +215,8 @@ class Git(Base):
         self._run(command + [self.source, self.source_dir], **self._call_kwargs)
 
         if self.source_commit:
+            self._fetch_origin_commit()
+
             self._run(
                 [self.command, "-C", self.source_dir, "checkout", self.source_commit],
                 **self._call_kwargs

--- a/tests/unit/sources/test_git.py
+++ b/tests/unit/sources/test_git.py
@@ -253,6 +253,16 @@ class TestGit(unit.sources.SourceTestCase):  # type: ignore
                         "git",
                         "-C",
                         "source_dir",
+                        "fetch",
+                        "origin",
+                        "2514f9533ec9b45d07883e10a561b248497a8e3c",
+                    ]
+                ),
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
                         "checkout",
                         "2514f9533ec9b45d07883e10a561b248497a8e3c",
                     ]


### PR DESCRIPTION
Two cases where git will fail on specified source-commit:

- commit ID is not in specified branch history (or master, if no branch
  is specified).

- source-depth is used which doesn't contain neccessary commit ID.

This commit changes the git module to fetch the reference from origin
before attempting to use it.

LP: #1817907

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
