### PR TITLE
snap: re-add xml development packages for non x86

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,6 +28,8 @@ build-packages:
   - libssl-dev
   - libsodium-dev
   - liblzma-dev
+  - libxml2-dev
+  - libxslt-dev
   - libyaml-dev
   - patch
   - sed
@@ -62,6 +64,8 @@ parts:
         - gpgv
         - libffi6
         - libsodium23
+        - libxml2
+        - libxslt1.1
         - squashfs-tools
         - xdelta3
     override-build: |

--- a/spread.yaml
+++ b/spread.yaml
@@ -386,7 +386,7 @@ suites:
      PIP_COMMAND: "/root/.local/bin/pip"
    prepare: |
      apt-get update
-     apt-get install --yes gcc g++ make python3-dev python3-pip python3-wheel libffi-dev libsodium-dev libapt-pkg-dev squashfs-tools xdelta3 bzr git mercurial subversion
+     apt-get install --yes gcc g++ make python3-dev python3-pip python3-wheel libffi-dev libsodium-dev libapt-pkg-dev squashfs-tools xdelta3 bzr git mercurial subversion libxml2-dev libxslt-dev
      pip3 install --user --upgrade pip
      $PIP_COMMAND install --user -r /snapcraft/requirements.txt -r /snapcraft/requirements-devel.txt
      # Move the snapcraft modules out of the way

--- a/spread.yaml
+++ b/spread.yaml
@@ -199,6 +199,8 @@ suites:
        libnacl-dev \
        libsodium-dev \
        libssl-dev \
+       libxml2-dev \
+       libxslt-dev \
        libyaml-dev \
        python3-venv \
        python3-yaml \
@@ -213,6 +215,8 @@ suites:
        libnacl-dev \
        libsodium-dev \
        libssl-dev \
+       libxml2-dev \
+       libxslt-dev \
        libyaml-dev \
        python3-venv \
        python3-yaml \


### PR DESCRIPTION
Binary wheels are only available for x86.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
