### PR TITLE
providers: match build provider flag keys to envvar

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -18,7 +18,7 @@ import os
 import sys
 
 import click
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from snapcraft.project import Project, get_snapcraft_yaml
 from snapcraft.cli.echo import confirm, prompt
@@ -229,6 +229,7 @@ def get_build_provider_flags(build_provider: str, **kwargs) -> Dict[str, str]:
 
     for option in _PROVIDER_OPTIONS:
         key: str = option["param_decls"]  # type: ignore
+        envvar: Optional[str] = option.get("envvar")  # type: ignore
         supported_providers: List[str] = option["supported_providers"]  # type: ignore
 
         # Skip --provider option.
@@ -239,10 +240,10 @@ def get_build_provider_flags(build_provider: str, **kwargs) -> Dict[str, str]:
         if build_provider not in supported_providers:
             continue
 
-        # Add option, if set.
+        # Add build provider flag using envvar as key.
         key_formatted = _param_decls_to_kwarg(key)
-        if key_formatted in kwargs:
-            build_provider_flags[key_formatted] = kwargs[key_formatted]
+        if envvar is not None and key_formatted in kwargs:
+            build_provider_flags[envvar] = kwargs[key_formatted]
 
     return build_provider_flags
 

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -190,7 +190,7 @@ class Provider(abc.ABC):
         target = (self._get_home_directory() / "project").as_posix()
         self._mount(self.project._project_dir, target)
 
-        if self.build_provider_flags.get("bind_ssh"):
+        if self.build_provider_flags.get("SNAPCRAFT_BIND_SSH"):
             self._mount_ssh()
 
     def _mount_prime_directory(self) -> bool:
@@ -377,8 +377,7 @@ class Provider(abc.ABC):
         env_list.append(f"SNAPCRAFT_HAS_TTY={has_tty}")
 
         # Pass through configurable environment variables.
-        for key in ["http_proxy", "https_proxy"]:
-            value = self.build_provider_flags.get(key)
+        for key, value in self.build_provider_flags.items():
             if not value:
                 continue
 

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -127,7 +127,7 @@ class BaseProviderTest(BaseProviderBaseTest):
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
 
         # False.
-        provider.build_provider_flags = dict(bind_ssh=False)
+        provider.build_provider_flags = dict(SNAPCRAFT_BIND_SSH=False)
         provider.mount_project()
         provider.mount_mock.assert_has_calls(
             [call(self.project._project_dir, "/root/project")]
@@ -141,7 +141,7 @@ class BaseProviderTest(BaseProviderBaseTest):
         )
 
         # True.
-        provider.build_provider_flags = dict(bind_ssh=True)
+        provider.build_provider_flags = dict(SNAPCRAFT_BIND_SSH=True)
         provider.mount_project()
         provider.mount_mock.assert_has_calls(
             [


### PR DESCRIPTION
Currently the approach translates them to a formatted version of
the kwarg used to pass around to functions.  Instead of performing
that translation, just match the envvar used.

cmd arg       -> kwarg parameter -> environment variable
--------------------------------------
--http-proxy  -> http_proxy      -> http_proxy
--https-proxy -> https_proxy     -> https_proxy
--bind-ssh    -> bind_ssh        -> SNAPCRAFT_BIND_SSH

Since apply_host_provider_flags() sets the flags in the environment
for all build provider options, internal functions can lookup settings
using os.getenv() without the kwarg translation.  They can simply
used the defined interface name (e.g. http_proxy, SNAPCRAFT_BIND_SSH).

This will improve consistency as their use is expanded for future
options.  The kwarg version should remain an internal detail
of click usage.  This wasn't really an issue with the original
implementation because "http(s)_proxy" matched the environment
variable and bind_ssh (SNAPCRAFT_BIND_SSH) was not passed through
to the target environment.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
