### PR TITLE
catkin plugins: remove bash workaround for catkin cmake args

### DIFF
--- a/snapcraft/plugins/catkin_tools.py
+++ b/snapcraft/plugins/catkin_tools.py
@@ -63,17 +63,17 @@ class CatkinToolsPlugin(snapcraft.plugins.catkin.CatkinPlugin):
         # It's possible that this workspace wasn't initialized to be used with
         # catkin-tools, so initialize it first. Note that this is a noop if it
         # was already initialized.
-        self._run_in_bash(["catkin", "init"])
+        self.run(["catkin", "init"])
 
         # Clean to prevent conflicts with externally built packages.
-        self._run_in_bash(["catkin", "clean", "-y"])
+        self.run(["catkin", "clean", "-y"])
 
     def _add_catkin_profile(self):
         # Overwrite the default catkin profile to ensure builds
         # aren't affected by profile changes.
         catkincmd = ["catkin", "profile", "add", "-f", "default"]
 
-        self._run_in_bash(catkincmd)
+        self.run(catkincmd)
 
     def _configure_catkin_profile(self):
         # Use catkin config to set all configurations before running build.
@@ -99,9 +99,9 @@ class CatkinToolsPlugin(snapcraft.plugins.catkin.CatkinPlugin):
             build_type = "Debug"
         catkincmd.append("-DCMAKE_BUILD_TYPE={}".format(build_type))
 
-        catkincmd.extend(self.options.catkin_cmake_args)
+        catkincmd.extend(self._parse_cmake_args())
 
-        self._run_in_bash(catkincmd)
+        self.run(catkincmd)
 
     def _build_catkin_packages(self):
         # Nothing to do if no packages were specified
@@ -120,6 +120,4 @@ class CatkinToolsPlugin(snapcraft.plugins.catkin.CatkinPlugin):
         if self.catkin_packages:
             catkincmd.extend(self.catkin_packages)
 
-        # This command must run in bash due to a bug in Catkin that causes it
-        # to explode if there are spaces in the cmake args (which there are).
-        self._run_in_bash(catkincmd)
+        self.run(catkincmd)

--- a/tests/spread/plugins/catkin/snaps/ros-talker-listener/snap/snapcraft.yaml
+++ b/tests/spread/plugins/catkin/snaps/ros-talker-listener/snap/snapcraft.yaml
@@ -13,3 +13,7 @@ parts:
   ros-project:
     plugin: catkin
     source: .
+    catkin-cmake-args:
+      - -DCMAKE_BUILD_TYPE=Debug
+      - -DCMAKE_CXX_COMPILER="/usr/bin/g++"
+      - -DCMAKE_CXX_FLAGS="-Wall -Werror -I\"/tmp/dir x\" -DIGNORE_ME_IM_JUST_TESTING_SPACES"

--- a/tests/unit/plugins/test_catkin.py
+++ b/tests/unit/plugins/test_catkin.py
@@ -542,17 +542,11 @@ class CatkinPluginTestCase(CatkinPluginBaseTest):
         )
 
     @mock.patch.object(catkin.CatkinPlugin, "run")
-    @mock.patch.object(catkin.CatkinPlugin, "_run_in_bash")
     @mock.patch.object(catkin.CatkinPlugin, "run_output", return_value="foo")
     @mock.patch.object(catkin.CatkinPlugin, "_prepare_build")
     @mock.patch.object(catkin.CatkinPlugin, "_finish_build")
     def test_build_multiple(
-        self,
-        finish_build_mock,
-        prepare_build_mock,
-        run_output_mock,
-        bashrun_mock,
-        run_mock,
+        self, finish_build_mock, prepare_build_mock, run_output_mock, run_mock
     ):
         self.properties.catkin_packages.append("package_2")
 
@@ -572,7 +566,7 @@ class CatkinPluginTestCase(CatkinPluginBaseTest):
                 self.test.assertIn("package_2", packages)
                 return True
 
-        bashrun_mock.assert_called_with(check_pkg_arguments(self))
+        run_mock.assert_called_with(check_pkg_arguments(self))
 
         self.assertFalse(
             self.dependencies_mock.called,
@@ -580,18 +574,6 @@ class CatkinPluginTestCase(CatkinPluginBaseTest):
         )
 
         finish_build_mock.assert_called_once_with()
-
-    @mock.patch.object(catkin.CatkinPlugin, "run")
-    @mock.patch.object(catkin.CatkinPlugin, "run_output", return_value="foo")
-    def test_build_runs_in_bash(self, run_output_mock, run_mock):
-        plugin = catkin.CatkinPlugin("test-part", self.properties, self.project)
-        os.makedirs(os.path.join(plugin.sourcedir, "src"))
-
-        plugin.build()
-
-        run_mock.assert_has_calls(
-            [mock.call(["/bin/bash", mock.ANY], cwd=mock.ANY, env=mock.ANY)]
-        )
 
     def test_use_in_snap_python_rewrites_shebangs(self):
         plugin = catkin.CatkinPlugin("test-part", self.properties, self.project)
@@ -1276,17 +1258,11 @@ class BuildTestCase(CatkinPluginBaseTest):
             self.properties.disable_parallel = self.disable_parallel
 
     @mock.patch.object(catkin.CatkinPlugin, "run")
-    @mock.patch.object(catkin.CatkinPlugin, "_run_in_bash")
     @mock.patch.object(catkin.CatkinPlugin, "run_output", return_value="foo")
     @mock.patch.object(catkin.CatkinPlugin, "_prepare_build")
     @mock.patch.object(catkin.CatkinPlugin, "_finish_build")
     def test_build(
-        self,
-        finish_build_mock,
-        prepare_build_mock,
-        run_output_mock,
-        bashrun_mock,
-        run_mock,
+        self, finish_build_mock, prepare_build_mock, run_output_mock, run_mock
     ):
         plugin = catkin.CatkinPlugin("test-part", self.properties, self.project)
         os.makedirs(os.path.join(plugin.sourcedir, "src"))
@@ -1339,7 +1315,7 @@ class BuildTestCase(CatkinPluginBaseTest):
                     and args_parallel_build_count
                 )
 
-        bashrun_mock.assert_called_with(check_build_command())
+        run_mock.assert_called_with(check_build_command())
 
         self.assertFalse(
             self.dependencies_mock.called,
@@ -1349,17 +1325,11 @@ class BuildTestCase(CatkinPluginBaseTest):
         finish_build_mock.assert_called_once_with()
 
     @mock.patch.object(catkin.CatkinPlugin, "run")
-    @mock.patch.object(catkin.CatkinPlugin, "_run_in_bash")
     @mock.patch.object(catkin.CatkinPlugin, "run_output", return_value="foo")
     @mock.patch.object(catkin.CatkinPlugin, "_prepare_build")
     @mock.patch.object(catkin.CatkinPlugin, "_finish_build")
     def test_build_all_packages(
-        self,
-        finish_build_mock,
-        prepare_build_mock,
-        run_output_mock,
-        bashrun_mock,
-        run_mock,
+        self, finish_build_mock, prepare_build_mock, run_output_mock, run_mock
     ):
         self.properties.catkin_packages = None
         plugin = catkin.CatkinPlugin("test-part", self.properties, self.project)
@@ -1404,7 +1374,7 @@ class BuildTestCase(CatkinPluginBaseTest):
                     in command
                 )
 
-        bashrun_mock.assert_called_with(check_build_command())
+        run_mock.assert_called_with(check_build_command())
 
         self.assertFalse(
             self.dependencies_mock.called,
@@ -1868,4 +1838,61 @@ class CatkinFindTestCase(unit.TestCase):
         positional_args = self.check_output_mock.call_args[0][0]
         self.assertThat(
             " ".join(positional_args), Contains("catkin_find --first-only foo")
+        )
+
+
+class CatkinCmakeArgTests(unit.TestCase):
+    scenarios = [
+        (
+            "no quote",
+            dict(input_string="-DCMAKE_FOO=BAR", expected_string="-DCMAKE_FOO=BAR"),
+        ),
+        (
+            "no quote multiple",
+            dict(
+                input_string="-DCMAKE_C_FLAGS=-Wall -Werror",
+                expected_string="-DCMAKE_C_FLAGS=-Wall -Werror",
+            ),
+        ),
+        (
+            "single quote",
+            dict(input_string="-DCMAKE_FOO='BAR'", expected_string="-DCMAKE_FOO=BAR"),
+        ),
+        (
+            "single quote multiple",
+            dict(
+                input_string="-DCMAKE_C_FLAGS='-Wall -Werror'",
+                expected_string="-DCMAKE_C_FLAGS=-Wall -Werror",
+            ),
+        ),
+        (
+            "double quote",
+            dict(input_string='-DCMAKE_FOO="BAR"', expected_string="-DCMAKE_FOO=BAR"),
+        ),
+        (
+            "double quote multiple",
+            dict(
+                input_string='-DCMAKE_C_FLAGS="-Wall -Werror"',
+                expected_string="-DCMAKE_C_FLAGS=-Wall -Werror",
+            ),
+        ),
+        (
+            "nested double quote",
+            dict(
+                input_string='-DCMAKE_C_FLAGS="-Wall -Werror -DTEXT=\\"Hello Friend\\""',
+                expected_string='-DCMAKE_C_FLAGS=-Wall -Werror -DTEXT="Hello Friend"',
+            ),
+        ),
+        (
+            "nested single quote",
+            dict(
+                input_string="-DCMAKE_C_FLAGS=\"-Wall -Werror -DTEXT='Hello Friend'\"",
+                expected_string="-DCMAKE_C_FLAGS=-Wall -Werror -DTEXT='Hello Friend'",
+            ),
+        ),
+    ]
+
+    def test_arg(self):
+        self.assertThat(
+            catkin._parse_cmake_arg(self.input_string), Equals(self.expected_string)
         )

--- a/tests/unit/plugins/test_catkin_tools.py
+++ b/tests/unit/plugins/test_catkin_tools.py
@@ -73,17 +73,11 @@ class CatkinToolsPluginTestCase(CatkinToolsPluginBaseTest):
         self.addCleanup(patcher.stop)
 
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "run")
-    @mock.patch.object(catkin_tools.CatkinToolsPlugin, "_run_in_bash")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "run_output", return_value="foo")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "_prepare_build")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "_finish_build")
     def test_build_multiple(
-        self,
-        finish_build_mock,
-        prepare_build_mock,
-        run_output_mock,
-        bashrun_mock,
-        run_mock,
+        self, finish_build_mock, prepare_build_mock, run_output_mock, run_mock
     ):
         self.properties.catkin_packages.append("package_2")
 
@@ -105,36 +99,16 @@ class CatkinToolsPluginTestCase(CatkinToolsPluginBaseTest):
                 self.test.assertIn("package_2", packages)
                 return True
 
-        bashrun_mock.assert_called_with(check_pkg_arguments(self))
+        run_mock.assert_called_with(check_pkg_arguments(self))
 
         finish_build_mock.assert_called_once_with()
 
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "run")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "run_output", return_value="foo")
-    def test_build_runs_in_bash(self, run_output_mock, run_mock):
-        plugin = catkin_tools.CatkinToolsPlugin(
-            "test-part", self.properties, self.project
-        )
-        os.makedirs(os.path.join(plugin.sourcedir, "src"))
-
-        plugin.build()
-
-        run_mock.assert_has_calls(
-            [mock.call(["/bin/bash", mock.ANY], cwd=mock.ANY, env=mock.ANY)]
-        )
-
-    @mock.patch.object(catkin_tools.CatkinToolsPlugin, "run")
-    @mock.patch.object(catkin_tools.CatkinToolsPlugin, "_run_in_bash")
-    @mock.patch.object(catkin_tools.CatkinToolsPlugin, "run_output", return_value="foo")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "_prepare_build")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "_finish_build")
     def test_build(
-        self,
-        finish_build_mock,
-        prepare_build_mock,
-        run_output_mock,
-        bashrun_mock,
-        run_mock,
+        self, finish_build_mock, prepare_build_mock, run_output_mock, run_mock
     ):
         plugin = catkin_tools.CatkinToolsPlugin(
             "test-part", self.properties, self.project
@@ -154,7 +128,7 @@ class CatkinToolsPluginTestCase(CatkinToolsPluginBaseTest):
                     and "my_package" in command
                 )
 
-        bashrun_mock.assert_called_with(check_build_command())
+        run_mock.assert_called_with(check_build_command())
 
         finish_build_mock.assert_called_once_with()
 
@@ -186,9 +160,9 @@ class PrepareBuildTestCase(CatkinToolsPluginBaseTest):
         self.properties.build_attributes.extend(self.build_attributes)
         self.properties.catkin_cmake_args = self.catkin_cmake_args
 
-    @mock.patch.object(catkin_tools.CatkinToolsPlugin, "_run_in_bash")
+    @mock.patch.object(catkin_tools.CatkinToolsPlugin, "run")
     @mock.patch.object(catkin_tools.CatkinToolsPlugin, "_use_in_snap_python")
-    def test_prepare_build(self, use_python_mock, bashrun_mock):
+    def test_prepare_build(self, use_python_mock, run_mock):
         plugin = catkin_tools.CatkinToolsPlugin(
             "test-part", self.properties, self.project
         )
@@ -201,19 +175,19 @@ class PrepareBuildTestCase(CatkinToolsPluginBaseTest):
 
         self.assertTrue(use_python_mock.called)
 
-        confArgs = bashrun_mock.mock_calls[0][1][0]
+        confArgs = run_mock.mock_calls[0][1][0]
         command = " ".join(confArgs)
         self.assertThat(command, Contains("catkin init"))
 
-        confArgs = bashrun_mock.mock_calls[1][1][0]
+        confArgs = run_mock.mock_calls[1][1][0]
         command = " ".join(confArgs)
         self.assertThat(command, Contains("catkin clean -y"))
 
-        confArgs = bashrun_mock.mock_calls[2][1][0]
+        confArgs = run_mock.mock_calls[2][1][0]
         command = " ".join(confArgs)
         self.assertThat(command, Contains("catkin profile add -f default"))
 
-        confArgs = bashrun_mock.mock_calls[3][1][0]
+        confArgs = run_mock.mock_calls[3][1][0]
         self.assertThat(confArgs[0], Equals("catkin"))
         self.assertThat(confArgs[1], Equals("config"))
 


### PR DESCRIPTION

    Parse the args like bash would using shlex.split().
    
    This parsing should match the behavior currently performed by
    pumping it all out to bash and executing it there.
    
    While I think any approach here is a bit fragile, we demonstrate
    various test cases with some unit tests and add a few cmake arg
    variants to ros-talker-listener:
    - no quotes
    - basic quotes
    - nested quotes using inner-escaped
    
    For the spread test, we don't really need to validate the variables,
    just that it managed to build.
