### PR TITLE
project_loader: use -isystem instead of -I for system include paths

### DIFF
--- a/snapcraft/internal/project_loader/_env.py
+++ b/snapcraft/internal/project_loader/_env.py
@@ -59,7 +59,7 @@ def build_env(root: str, snap_name: str, arch_triplet: str) -> List[str]:
         for envvar in ["CPPFLAGS", "CFLAGS", "CXXFLAGS"]:
             env.append(
                 formatting_utils.format_path_variable(
-                    envvar, paths, prepend="-I", separator=" "
+                    envvar, paths, prepend="-isystem", separator=" "
                 )
             )
 

--- a/tests/unit/project_loader/test_environment.py
+++ b/tests/unit/project_loader/test_environment.py
@@ -338,9 +338,9 @@ class EnvironmentTest(ProjectLoaderBaseTest):
             "Current environment is {!r}".format(environment),
         )
         self.assertTrue(
-            'CFLAGS="$CFLAGS -I{stage_dir}/include -I{stage_dir}/usr/include '
-            "-I{stage_dir}/include/{arch_triplet} "
-            '-I{stage_dir}/usr/include/{arch_triplet}"'.format(
+            'CFLAGS="$CFLAGS -isystem{stage_dir}/include -isystem{stage_dir}/usr/include '
+            "-isystem{stage_dir}/include/{arch_triplet} "
+            '-isystem{stage_dir}/usr/include/{arch_triplet}"'.format(
                 stage_dir=self.stage_dir,
                 arch_triplet=project_config.project.arch_triplet,
             )
@@ -348,10 +348,10 @@ class EnvironmentTest(ProjectLoaderBaseTest):
             "Current environment is {!r}".format(environment),
         )
         self.assertTrue(
-            'CPPFLAGS="$CPPFLAGS -I{stage_dir}/include '
-            "-I{stage_dir}/usr/include "
-            "-I{stage_dir}/include/{arch_triplet} "
-            '-I{stage_dir}/usr/include/{arch_triplet}"'.format(
+            'CPPFLAGS="$CPPFLAGS -isystem{stage_dir}/include '
+            "-isystem{stage_dir}/usr/include "
+            "-isystem{stage_dir}/include/{arch_triplet} "
+            '-isystem{stage_dir}/usr/include/{arch_triplet}"'.format(
                 stage_dir=self.stage_dir,
                 arch_triplet=project_config.project.arch_triplet,
             )
@@ -359,10 +359,10 @@ class EnvironmentTest(ProjectLoaderBaseTest):
             "Current environment is {!r}".format(environment),
         )
         self.assertTrue(
-            'CXXFLAGS="$CXXFLAGS -I{stage_dir}/include '
-            "-I{stage_dir}/usr/include "
-            "-I{stage_dir}/include/{arch_triplet} "
-            '-I{stage_dir}/usr/include/{arch_triplet}"'.format(
+            'CXXFLAGS="$CXXFLAGS -isystem{stage_dir}/include '
+            "-isystem{stage_dir}/usr/include "
+            "-isystem{stage_dir}/include/{arch_triplet} "
+            '-isystem{stage_dir}/usr/include/{arch_triplet}"'.format(
                 stage_dir=self.stage_dir,
                 arch_triplet=project_config.project.arch_triplet,
             )
@@ -449,10 +449,10 @@ class EnvironmentTest(ProjectLoaderBaseTest):
 
         expected_cflags = (
             "-I/user-provided "
-            "-I{parts_dir}/part2/install/include -I{stage_dir}/include "
-            "-I{stage_dir}/usr/include "
-            "-I{stage_dir}/include/{arch_triplet} "
-            "-I{stage_dir}/usr/include/{arch_triplet}".format(
+            "-isystem{parts_dir}/part2/install/include -isystem{stage_dir}/include "
+            "-isystem{stage_dir}/usr/include "
+            "-isystem{stage_dir}/include/{arch_triplet} "
+            "-isystem{stage_dir}/usr/include/{arch_triplet}".format(
                 parts_dir=self.parts_dir,
                 stage_dir=self.stage_dir,
                 arch_triplet=project_config.project.arch_triplet,


### PR DESCRIPTION
project_loader: use -isystem instead of -I for system include paths

Warnings are ignored for sytem includes.  However, when a system
include gets installed to staging directory, the user may be
issued warnings (errors if -Werror) because snapcraft is adding
include paths thats include these system headers.

Use `-isystem` rather than `-I` to add system include paths to
the default compiler flags.  The other option is to use `-idirafter`,
but is more likely to affect current builds by changing the order
of the search paths.

For example:
```
In file included from /root/parts/workspace/install/usr/include/x86_64-linux-gnu/bits/fcntl.h:61:0,
from /root/parts/workspace/install/usr/include/fcntl.h:35,
from /root/parts/workspace/build/benchmark_catkin/benchmark_src-prefix/src/benchmark_src/src/sysinfo.cc:23:
/root/parts/workspace/install/usr/include/x86_64-linux-gnu/bits/fcntl-linux.h:355:27: error: ISO C++ forbids zero-size array ‘f_handle’ [-Wpedantic]
unsigned char f_handle[0];
```

See:

[1] https://gcc.gnu.org/onlinedocs/cpp/System-Headers.html

> The header files declaring interfaces to the operating system and runtime libraries often cannot be written in strictly conforming C. Therefore, GCC gives code found in system headers special treatment. All warnings, other than those generated by ‘#warning’ (see Diagnostics), are suppressed while GCC is processing a system header.

[2] https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html

> The -isystem and -idirafter options also mark the directory as a system directory, so that it gets the same special treatment that is applied to the standard system directories.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
