### PR TITLE
cli: formalize developer debug as hidden build option

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -114,6 +114,14 @@ _PROVIDER_OPTIONS = [
         envvar="SNAPCRAFT_BIND_SSH",
         supported_providers=["lxd", "multipass"],
     ),
+    dict(
+        param_decls="--enable-developer-debug",
+        is_flag=True,
+        help="Enable developer debug logging.",
+        envvar="SNAPCRAFT_ENABLE_DEVELOPER_DEBUG",
+        supported_providers=["host", "lxd", "managed-host", "multipass"],
+        hidden=True,
+    ),
 ]
 
 
@@ -128,7 +136,8 @@ def _add_options(options, func, hidden):
         if "supported_providers" in option:
             option.pop("supported_providers")
 
-        click_option = click.option(param_decls, **option, hidden=hidden)
+        hidden_override = option.pop("hidden", hidden)
+        click_option = click.option(param_decls, **option, hidden=hidden_override)
         func = click_option(func)
     return func
 

--- a/snapcraft/cli/_runner.py
+++ b/snapcraft/cli/_runner.py
@@ -17,7 +17,6 @@ import functools
 import logging
 import os
 import sys
-from distutils import util
 
 import click
 
@@ -73,13 +72,7 @@ command_groups = [
 def run(ctx, debug, catch_exceptions=False, **kwargs):
     """Snapcraft is a delightful packaging tool."""
 
-    # Debugging snapcraft itself is not tied to debugging a snapcraft project.
-    try:
-        is_snapcraft_developer_debug = util.strtobool(
-            os.getenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", "n")
-        )
-    except ValueError:
-        is_snapcraft_developer_debug = False
+    is_snapcraft_developer_debug = kwargs["enable_developer_debug"]
     if is_snapcraft_developer_debug:
         log_level = logging.DEBUG
         click.echo(


### PR DESCRIPTION
It will now be handled in the same manner as other build
provider options.  If it is set, it will automatically get
passed through to build environment if used on host with LXD
or Multipass providers.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
