### PR TITLE
cli: merge build options into provider options

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -45,33 +45,34 @@ class PromptOption(click.Option):
         )
 
 
-_BUILD_OPTIONS = [
+_SUPPORTED_PROVIDERS = ["host", "lxd", "multipass"]
+_HIDDEN_PROVIDERS = ["managed-host"]
+_ALL_PROVIDERS = _SUPPORTED_PROVIDERS + _HIDDEN_PROVIDERS
+_PROVIDER_OPTIONS = [
     dict(
         param_decls="--target-arch",
         metavar="<arch>",
         help="Target architecture to cross compile to",
+        supported_providers=["host", "lxd", "managed-host", "multipass"],
     ),
     dict(
         param_decls="--debug",
         is_flag=True,
         help="Shells into the environment if the build fails.",
+        supported_providers=["host", "lxd", "managed-host", "multipass"],
     ),
     dict(
         param_decls="--shell",
         is_flag=True,
         help="Shells into the environment in lieu of the step to run.",
+        supported_providers=["host", "lxd", "managed-host", "multipass"],
     ),
     dict(
         param_decls="--shell-after",
         is_flag=True,
         help="Shells into the environment after the step has run.",
+        supported_providers=["host", "lxd", "managed-host", "multipass"],
     ),
-]
-
-_SUPPORTED_PROVIDERS = ["host", "lxd", "multipass"]
-_HIDDEN_PROVIDERS = ["managed-host"]
-_ALL_PROVIDERS = _SUPPORTED_PROVIDERS + _HIDDEN_PROVIDERS
-_PROVIDER_OPTIONS = [
     dict(
         param_decls="--destructive-mode",
         is_flag=True,
@@ -131,13 +132,6 @@ def _add_options(options, func, hidden):
         click_option = click.option(param_decls, **option, hidden=hidden)
         func = click_option(func)
     return func
-
-
-def add_build_options(hidden=False):
-    def _add_build_options(func):
-        return _add_options(_BUILD_OPTIONS, func, hidden)
-
-    return _add_build_options
 
 
 def add_provider_options(hidden=False):

--- a/snapcraft/cli/_runner.py
+++ b/snapcraft/cli/_runner.py
@@ -37,7 +37,7 @@ from .extensions import extensioncli
 from .version import versioncli, SNAPCRAFT_VERSION_TEMPLATE
 from .ci import cicli
 from ._command_group import SnapcraftGroup
-from ._options import add_build_options, add_provider_options
+from ._options import add_provider_options
 from ._errors import exception_handler
 
 
@@ -66,7 +66,6 @@ command_groups = [
     message=SNAPCRAFT_VERSION_TEMPLATE, version=snapcraft.__version__  # type: ignore
 )
 @click.pass_context
-@add_build_options(hidden=True)
 @add_provider_options(hidden=True)
 @click.option("--debug", "-d", is_flag=True)
 @enable_snapcraft_config_file()

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -25,7 +25,6 @@ from . import echo
 from ._command import SnapcraftProjectCommand
 from ._config import enable_snapcraft_config_file
 from ._options import (
-    add_build_options,
     add_provider_options,
     apply_host_provider_flags,
     get_build_provider,
@@ -157,7 +156,6 @@ def _retrieve_provider_error(instance) -> None:
 
 
 @click.group()
-@add_build_options()
 @add_provider_options()
 @click.pass_context
 def lifecyclecli(ctx, **kwargs):
@@ -179,7 +177,6 @@ def init():
 @lifecyclecli.command(cls=SnapcraftProjectCommand)
 @enable_snapcraft_config_file()
 @click.pass_context
-@add_build_options()
 @add_provider_options()
 @click.argument("parts", nargs=-1, metavar="<part>...", required=False)
 def pull(ctx, parts, **kwargs):
@@ -196,7 +193,6 @@ def pull(ctx, parts, **kwargs):
 
 @lifecyclecli.command(cls=SnapcraftProjectCommand)
 @enable_snapcraft_config_file()
-@add_build_options()
 @add_provider_options()
 @click.argument("parts", nargs=-1, metavar="<part>...", required=False)
 def build(parts, **kwargs):
@@ -213,7 +209,6 @@ def build(parts, **kwargs):
 
 @lifecyclecli.command(cls=SnapcraftProjectCommand)
 @enable_snapcraft_config_file()
-@add_build_options()
 @add_provider_options()
 @click.argument("parts", nargs=-1, metavar="<part>...", required=False)
 def stage(parts, **kwargs):
@@ -230,7 +225,6 @@ def stage(parts, **kwargs):
 
 @lifecyclecli.command(cls=SnapcraftProjectCommand)
 @enable_snapcraft_config_file()
-@add_build_options()
 @add_provider_options()
 @click.argument("parts", nargs=-1, metavar="<part>...", required=False)
 def prime(parts, **kwargs):
@@ -247,7 +241,6 @@ def prime(parts, **kwargs):
 
 @lifecyclecli.command("try")
 @enable_snapcraft_config_file()
-@add_build_options()
 @add_provider_options()
 def try_command(**kwargs):
     """Try a snap on the host, priming if necessary.
@@ -266,7 +259,6 @@ def try_command(**kwargs):
 
 @lifecyclecli.command(cls=SnapcraftProjectCommand)
 @enable_snapcraft_config_file()
-@add_build_options()
 @add_provider_options()
 @click.argument("directory", required=False)
 @click.option("--output", "-o", help="path to the resulting snap.")


### PR DESCRIPTION
In reality these options only work with specific providers.
Merge the build options and provider option lists to simplify
the option handling code.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
