### PR TITLE
colcon plugin: rewrite poco absolute library paths

### DIFF
--- a/snapcraft/plugins/colcon.py
+++ b/snapcraft/plugins/colcon.py
@@ -540,6 +540,13 @@ class ColconPlugin(snapcraft.BasePlugin):
             _rewrite_paths,
         )
 
+        file_utils.replace_in_file(
+            os.path.join(self.installdir, "usr", "lib", "cmake"),
+            re.compile(r".*.cmake$"),
+            re.compile(r'"(.*?/.*?)"'),
+            _rewrite_paths,
+        )
+
     def _finish_build(self):
         # Fix all shebangs to use the in-snap python.
         mangling.rewrite_python_shebangs(self.installdir)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

The version of poco in Ubuntu Bionic (v1.8.0.1) has a bug where it installs absolute library paths in its cmake target file. ROS Eloquent was updated to inherit those paths, and no longer builds (although Dashing still does). This PR fixes [LP: #1866723](https://bugs.launchpad.net/bugs/1866723) by re-using the existing cmake-fixing logic, but also apply it to the directory containing poco's target file (`usr/lib/cmake`).

Note that this is not as targeted as it could be. I figure this issue may not be unique, so fixing all of `usr/lib/cmake` made sense, but we could keep it to the specific file that's broken as well.