### PR TITLE
tests: add LXD spread test

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -415,7 +415,7 @@ suites:
    systems:
    - ubuntu-18.04-64
    manual: true
-   summary: externals snaps
+   summary: external snaps
    prepare: |
      sudo apt-get install git
      sudo apt-mark auto git

--- a/tests/spread/snaps/lxd/task.yaml
+++ b/tests/spread/snaps/lxd/task.yaml
@@ -1,0 +1,28 @@
+summary: Build lxd using LXD and on host
+kill-timeout: 90m
+
+environment:
+  SNAP_REPO: https://github.com/lxc/lxd-pkg-snap
+  PROVIDER_OPTION/lxd: "--use-lxd"
+  PROVIDER_OPTION/destructive: "--destructive-mode"
+
+prepare: |
+  git clone "$SNAP_REPO" repo
+
+restore: |
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
+  pushd repo
+  snapcraft clean "$PROVIDER_OPTION"
+  popd
+
+  rm -rf repo
+
+execute: |
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
+  cd repo
+  snapcraft "$PROVIDER_OPTION"
+
+  # TODO LXD is a special snow flake. Enabling this needs removal on restore.
+  # snap install --dangerous lxd_*.snap


### PR DESCRIPTION
Test that LXD builds fine and installs. Instrumenting the
installation comes later.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

2020-03-17 18:00:05 Restoring multipass:ubuntu-18.04-64:tests/spread/snaps/lxd:destructive...
2020-03-17 18:00:55 Discarding multipass:ubuntu-18.04-64...
2020-03-17 18:01:31 Successful tasks: 2
2020-03-17 18:01:31 Aborted tasks: 0
