### PR TITLE
static: ignore direnv created artifacts

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,6 +10,7 @@ ignore =
 max-complexity = 10
 exclude =
     # No need to traverse our git directory
+    .direnv,
     .git,
     .hg,
     .mypy_cache,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 exclude = '''
 /(
     \.git
+  | \.direnv
   | \.hg
   | \.mypy_cache
   | \.tox


### PR DESCRIPTION
direnv creates a .direnv when using a pyenv layout that holds python's
standard libraries which black modifies and flake8 fails on.
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
