### PR TITLE
spread tests: set appropriate default base in snapcraft.yamls

### DIFF
--- a/tests/spread/build-providers/snaps/env-passthrough/snap/snapcraft.yaml
+++ b/tests/spread/build-providers/snaps/env-passthrough/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   Help verify environment passthrough variables are set.
 
 grade: devel
+base: core18
 confinement: devmode
 
 parts:

--- a/tests/spread/build-providers/snaps/exit1/snap/snapcraft.yaml
+++ b/tests/spread/build-providers/snaps/exit1/snap/snapcraft.yaml
@@ -8,6 +8,7 @@ description: |
   store.
 
 grade: devel
+base: core18
 confinement: devmode
 
 parts:

--- a/tests/spread/build-providers/snaps/make-hello/snap/snapcraft.yaml
+++ b/tests/spread/build-providers/snaps/make-hello/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   Make a new one.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/extensions/snaps/gtk3-hello/snap/snapcraft.yaml
+++ b/tests/spread/extensions/snaps/gtk3-hello/snap/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: test the gnome extension
 description: This is a basic gtk snap
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/general/content-interface-provider-found/snaps/provider/snap/snapcraft.yaml
+++ b/tests/spread/general/content-interface-provider-found/snaps/provider/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   listed under default-provider.
 
 grade: devel
+base: core18
 confinement: devmode
 
 plugs:

--- a/tests/spread/general/content-interface-provider-not-found/snaps/provider/snap/snapcraft.yaml
+++ b/tests/spread/general/content-interface-provider-not-found/snaps/provider/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   cannot find the snap listed under default-provider.
 
 grade: devel
+base: core18
 confinement: devmode
 
 plugs:

--- a/tests/spread/general/cwd_not_on_sys_path/snaps/sys-path-test/snap/snapcraft.yaml
+++ b/tests/spread/general/cwd_not_on_sys_path/snaps/sys-path-test/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   will clash and cause the build to fail. It should succeed.
 
 grade: stable
+base: core18
 confinement: strict
 
 parts:

--- a/tests/spread/general/dependency-check-missing-lib/snaps/missing-lib/snap/snapcraft.yaml
+++ b/tests/spread/general/dependency-check-missing-lib/snaps/missing-lib/snap/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 'test1'
 summary: test
 description: test
 grade: stable
+base: core18
 confinement: strict
 
 parts:

--- a/tests/spread/general/dependency-check-missing-none/snaps/missing-none/snap/snapcraft.yaml
+++ b/tests/spread/general/dependency-check-missing-none/snaps/missing-none/snap/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 'test1'
 summary: test
 description: test
 grade: stable
+base: core18
 confinement: strict
 
 parts:

--- a/tests/spread/general/snap_local_dir/snaps/snap-local-dir/snap/snapcraft.yaml
+++ b/tests/spread/general/snap_local_dir/snaps/snap-local-dir/snap/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: Snap to test snap/local dir
 description: Verify that the snap/local dir can be used for sources.
 
 grade: devel
+base: core18
 confinement: strict
 
 parts:

--- a/tests/spread/plugins/v1/ament/legacy-pull/task.yaml
+++ b/tests/spread/plugins/v1/ament/legacy-pull/task.yaml
@@ -7,6 +7,11 @@ priority: 100  # Run this test early so we're not waiting for it
 environment:
   SNAP_DIR: ../snaps/ros2-talker-listener
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/ament/snaps/ros2-talker-listener/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/ament/snaps/ros2-talker-listener/snap/snapcraft.yaml
@@ -4,8 +4,9 @@ summary: ROS2 Example
 description: |
   A ROS2 workspace containing a talker and a listener.
 
-grade: stable
+base: core18
 confinement: strict
+grade: stable
 
 apps:
   ros2-talker-listener:

--- a/tests/spread/plugins/v1/ant/legacy-pull/task.yaml
+++ b/tests/spread/plugins/v1/ant/legacy-pull/task.yaml
@@ -8,6 +8,11 @@ systems: [ubuntu-16*]
 environment:
   SNAP_DIR: ../snaps/legacy-ant-hello
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/ant/snaps/ant-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/ant/snaps/ant-hello/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
 
 confinement: strict
 grade: devel
+base: core18
 
 apps:
   ant-hello:

--- a/tests/spread/plugins/v1/ant/snaps/legacy-ant-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/ant/snaps/legacy-ant-hello/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
 
 confinement: strict
 grade: devel
+base: core18
 
 apps:
   ant-hello:

--- a/tests/spread/plugins/v1/autotools/legacy-pull/task.yaml
+++ b/tests/spread/plugins/v1/autotools/legacy-pull/task.yaml
@@ -8,6 +8,11 @@ systems: [ubuntu-*]
 environment:
   SNAP_DIR: ../snaps/autotools-hello
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/autotools/snaps/autotools-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/autotools/snaps/autotools-hello/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   Make a new one.
 
 grade: stable
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/catkin/legacy-pull/task.yaml
+++ b/tests/spread/plugins/v1/catkin/legacy-pull/task.yaml
@@ -12,8 +12,11 @@ environment:
   SNAP_DIR: ../snaps/ros-talker-listener
 
 prepare: |
-  cd "$SNAP_DIR"
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
 
+  cd "$SNAP_DIR"
   # Legacy requires the rosdistro to be specified
   echo "    rosdistro: kinetic" >> snap/snapcraft.yaml
 

--- a/tests/spread/plugins/v1/catkin/snaps/catkin-recursive-rosinstall/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/catkin/snaps/catkin-recursive-rosinstall/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   This example won't build. It's only meant for pulling.
 
 grade: devel
+base: core18
 confinement: strict
 
 parts:

--- a/tests/spread/plugins/v1/catkin/snaps/catkin-shared-ros/consumer/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/catkin/snaps/catkin-shared-ros/consumer/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   used within the Catkin plugin is properly isolated.
 
 grade: devel
+base: core18
 confinement: strict
 
 parts:

--- a/tests/spread/plugins/v1/catkin/snaps/catkin-shared-ros/producer/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/catkin/snaps/catkin-shared-ros/producer/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   Of particular note, the shared bits do not include Catkin
 
 grade: devel
+base: core18
 confinement: strict
 
 parts:

--- a/tests/spread/plugins/v1/catkin/snaps/catkin-with-python-part/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/catkin/snaps/catkin-with-python-part/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   It also ensures that Catkin's handling of rosinstall files continues to work.
 
 grade: devel
+base: core18
 confinement: strict
 
 parts:

--- a/tests/spread/plugins/v1/catkin/snaps/ros-pip/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/catkin/snaps/ros-pip/snap/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: ROS Example using pip dependencies
 description: Contains a simple pip test and a .launch file.
 confinement: strict
 grade: devel
+base: core18
 
 apps:
   ros-pip:

--- a/tests/spread/plugins/v1/catkin/snaps/ros-talker-listener/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/catkin/snaps/ros-talker-listener/snap/snapcraft.yaml
@@ -2,7 +2,10 @@ name: ros-talker-listener
 version: "1.0"
 summary: ROS Example
 description: Contains talker/listener ROS packages and a .launch file.
+
+base: core18
 confinement: strict
+grade: devel
 
 apps:
   ros-talker-listener:

--- a/tests/spread/plugins/v1/catkin/snaps/source-dependencies/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/catkin/snaps/source-dependencies/snap/snapcraft.yaml
@@ -4,6 +4,9 @@ summary: ROS example with source dependencies
 description: Contains a ROS workspace with source dependencies
 confinement: strict
 
+grade: devel
+base: core18
+
 parts:
   ros-project:
     plugin: catkin

--- a/tests/spread/plugins/v1/cmake/legacy-pull/task.yaml
+++ b/tests/spread/plugins/v1/cmake/legacy-pull/task.yaml
@@ -8,6 +8,11 @@ systems: [ubuntu-*]
 environment:
   SNAP_DIR: ../snaps/cmake-hello
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/cmake/snaps/cmake-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/cmake/snaps/cmake-hello/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   Make a new one.
 
 grade: devel
+base: core18
 confinement: strict
 
 build-packages: [gcc, libc6-dev]

--- a/tests/spread/plugins/v1/cmake/snaps/cmake-with-lib/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/cmake/snaps/cmake-with-lib/snap/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: Test cmake rebuilds
 description: Test cmake rebuilds
 
 grade: devel
+base: core18
 confinement: strict
 
 parts:

--- a/tests/spread/plugins/v1/colcon/snaps/colcon-talker-listener/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/colcon/snaps/colcon-talker-listener/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   A ROS2 workspace containing a talker and a listener.
 
 grade: stable
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/conda/snaps/conda-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/conda/snaps/conda-hello/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   Leverage conda-packages to install ipython and use it to say "hello world".
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/crystal/snaps/crystal-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/crystal/snaps/crystal-hello/snap/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: Create the hello snap
 description: Create the hello snap
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/dotnet/legacy-build-run/task.yaml
+++ b/tests/spread/plugins/v1/dotnet/legacy-build-run/task.yaml
@@ -3,6 +3,11 @@ summary: Build and run a basic dotnet snap with no base
 environment:
   SNAP_DIR: ../snaps/dotnet-hello
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/dotnet/snaps/dotnet-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/dotnet/snaps/dotnet-hello/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   This is a sample dotnet 2.0.0 application
 
 grade: devel
+base: core16
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/go/legacy-build-run/task.yaml
+++ b/tests/spread/plugins/v1/go/legacy-build-run/task.yaml
@@ -5,6 +5,11 @@ environment:
 
 systems: [ubuntu-*]
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/go/snaps/go-cgo/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/go/snaps/go-cgo/snap/snapcraft.yaml
@@ -5,7 +5,10 @@ description: |
   This is a basic go snap that uses cgo to access C APIs.
   The name of the binary will be that of the directory containing it,
   just like it is seen when using `go build` or `go install`.
+
 confinement: strict
+grade: devel
+base: core18
 
 parts:
   go-cgo:

--- a/tests/spread/plugins/v1/go/snaps/go-gotty/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/go/snaps/go-gotty/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   applications.
 
 grade: devel
+base: core18
 confinement: classic
 
 parts:

--- a/tests/spread/plugins/v1/go/snaps/go-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/go/snaps/go-hello/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   possible to build a snap using local go sources.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/go/snaps/go-mod-hello-subdir/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/go/snaps/go-mod-hello-subdir/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   a version pinned go package using go.mod.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/go/snaps/go-mod-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/go/snaps/go-mod-hello/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   a version pinned go package using go.mod.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/go/snaps/go-use-build-packages/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/go/snaps/go-use-build-packages/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   possible to build a snap using local go sources with go from build-packages.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/go/snaps/go-use-specific-channel/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/go/snaps/go-use-specific-channel/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   possible to build a snap using local go sources with go from build-packages.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/go/snaps/go-with-multiple-main-packages/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/go/snaps/go-with-multiple-main-packages/snap/snapcraft.yaml
@@ -5,6 +5,9 @@ description: |
   "This tests out LP: #1599328 and verifies the mechanism to work
   in such scenarios."
 
+grade: devel
+base: core18
+
 parts:
   multiple-mains:
       source: .

--- a/tests/spread/plugins/v1/godeps/legacy-build-run/task.yaml
+++ b/tests/spread/plugins/v1/godeps/legacy-build-run/task.yaml
@@ -7,6 +7,11 @@ environment:
 
 systems: [ubuntu-*]
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/godeps/snaps/godeps-use-build-packages/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/godeps/snaps/godeps-use-build-packages/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   Proves that it is possible to build a snap using godeps.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/godeps/snaps/godeps-with-go-packages/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/godeps/snaps/godeps-with-go-packages/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   while the bcrypt in the source does not
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/godeps/snaps/godeps/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/godeps/snaps/godeps/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   Proves that it is possible to build a snap using godeps.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/gradle/snaps/gradle-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/gradle/snaps/gradle-hello/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: this is not much more than an example
 
 confinement: strict
 grade: stable
+base: core18
 
 apps:
  gradle-hello:

--- a/tests/spread/plugins/v1/gradle/snaps/gradlew-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/gradle/snaps/gradlew-hello/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: this is not much more than an example
 
 confinement: strict
 grade: devel
+base: core18
 
 apps:
  gradle-hello:

--- a/tests/spread/plugins/v1/kbuild/legacy-pull/task.yaml
+++ b/tests/spread/plugins/v1/kbuild/legacy-pull/task.yaml
@@ -8,6 +8,11 @@ systems: [ubuntu-*]
 environment:
   SNAP_DIR: ../snaps/kbuild-hello
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/kbuild/snaps/kbuild-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/kbuild/snaps/kbuild-hello/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: this is a basic snap using kbuild to build a hello-world
    example program
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/make/legacy-pull/task.yaml
+++ b/tests/spread/plugins/v1/make/legacy-pull/task.yaml
@@ -8,6 +8,11 @@ systems: [ubuntu-*]
 environment:
   SNAP_DIR: ../snaps/make-hello
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/make/snaps/make-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/make/snaps/make-hello/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   Make a new one.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/make/snaps/make-with-artifacts/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/make/snaps/make-with-artifacts/snap/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: test make with artifacts
 description: test make artifacts are correctly collected
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/make/snaps/make-with-lib/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/make/snaps/make-with-lib/snap/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: Test make rebuilds
 description: Test make rebuilds
 
 grade: devel
+base: core18
 confinement: strict
 
 parts:

--- a/tests/spread/plugins/v1/make/snaps/make-with-nonstandard-makefile/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/make/snaps/make-with-nonstandard-makefile/snap/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: test the make plugin with a nonstandard makefile location
 description: test the make plugin with a nonstandard makefile location
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/maven/legacy-pull/task.yaml
+++ b/tests/spread/plugins/v1/maven/legacy-pull/task.yaml
@@ -8,6 +8,11 @@ systems: [ubuntu-16*]
 environment:
   SNAP_DIR: ../snaps/legacy-maven-hello
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/maven/snaps/legacy-maven-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/maven/snaps/legacy-maven-hello/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
 
 confinement: strict
 grade: devel
+base: core18
 
 apps:
   maven-hello:

--- a/tests/spread/plugins/v1/maven/snaps/maven-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/maven/snaps/maven-hello/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
 
 confinement: strict
 grade: devel
+base: core18
 
 apps:
   maven-hello:

--- a/tests/spread/plugins/v1/meson/legacy-build-run/task.yaml
+++ b/tests/spread/plugins/v1/meson/legacy-build-run/task.yaml
@@ -3,6 +3,11 @@ summary: Build and run a basic meson snap with no base
 environment:
   SNAP_DIR: ../snaps/legacy-meson
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/meson/snaps/legacy-meson/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/meson/snaps/legacy-meson/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   Make a new one.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/meson/snaps/meson-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/meson/snaps/meson-hello/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   Make a new one.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/nil/snaps/nil-basic/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/nil/snaps/nil-basic/snap/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: Create the empty snap
 description: Create an empty snap with nothing to pull
 
 grade: devel
+base: core18
 confinement: strict
 
 parts:

--- a/tests/spread/plugins/v1/nil/snaps/nil-with-additional-properties/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/nil/snaps/nil-with-additional-properties/snap/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: Use additional property with nil
 description: Use additional property with nil (which should error out)
 
 grade: devel
+base: core18
 confinement: strict
 
 parts:

--- a/tests/spread/plugins/v1/nodejs/snaps/hello-with-npm/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/nodejs/snaps/hello-with-npm/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   Make a new one.
 confinement: strict
 grade: devel
+base: core18
 
 apps:
   nodejs-hello:

--- a/tests/spread/plugins/v1/nodejs/snaps/hello-with-yarn/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/nodejs/snaps/hello-with-yarn/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   Make a new one.
 confinement: strict
 grade: devel
+base: core18
 
 apps:
   nodejs-hello:

--- a/tests/spread/plugins/v1/plainbox/legacy-build-run/task.yaml
+++ b/tests/spread/plugins/v1/plainbox/legacy-build-run/task.yaml
@@ -5,6 +5,11 @@ systems: [ubuntu-16*]
 environment:
   SNAP_DIR: ../snaps/checkbox
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/plainbox/snaps/checkbox/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/plainbox/snaps/checkbox/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: >
 version: "0.1"
 confinement: strict
 grade: devel
+base: core18
 
 apps:
     checkbox-cli:

--- a/tests/spread/plugins/v1/plainbox/snaps/provider-basic/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/plainbox/snaps/provider-basic/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
     then be used by a checkbox application
 confinement: strict
 grade: devel
+base: core18
 
 parts:
     checkbox-ng-dev:

--- a/tests/spread/plugins/v1/plainbox/snaps/provider-python-stage-package-mix/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/plainbox/snaps/provider-python-stage-package-mix/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   https://bugs.launchpad.net/snapcraft/+bug/1768233
 confinement: strict
 grade: devel
+base: core18
 
 parts:
   checkbox-ng-local:

--- a/tests/spread/plugins/v1/plainbox/snaps/provider-with-deps/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/plainbox/snaps/provider-with-deps/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
     child. This exercises the call of manage.py validate
 confinement: strict
 grade: devel
+base: core18
 
 parts:
     checkbox-ng-dev:

--- a/tests/spread/plugins/v1/plainbox/snaps/provider-with-stage-packages/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/plainbox/snaps/provider-with-stage-packages/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
     based plainbox-provider plugin.
 confinement: strict
 grade: devel
+base: core18
 
 parts:
     checkbox-ng-local:

--- a/tests/spread/plugins/v1/python/legacy-build-and-run/task.yaml
+++ b/tests/spread/plugins/v1/python/legacy-build-and-run/task.yaml
@@ -5,6 +5,11 @@ systems: [ubuntu-16*]
 environment:
   SNAP_DIR: ../snaps/python-hello
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/python/snaps/pip-bzr/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/python/snaps/pip-bzr/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   plugin.
 confinement: strict
 grade: devel
+base: core18
 
 parts:
   pip-bzr:

--- a/tests/spread/plugins/v1/python/snaps/pip-python-packages/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/python/snaps/pip-python-packages/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   using pip.
 confinement: strict
 grade: devel
+base: core18
 
 parts:
   python2:

--- a/tests/spread/plugins/v1/python/snaps/pip-requirements-file/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/python/snaps/pip-requirements-file/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   that will be downloaded using pip.
 confinement: strict
 grade: devel
+base: core18
 
 parts:
   python2:

--- a/tests/spread/plugins/v1/python/snaps/pip-root-data-files/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/python/snaps/pip-root-data-files/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
     not break
 confinement: strict
 grade: devel
+base: core18
 
 parts:
   root:

--- a/tests/spread/plugins/v1/python/snaps/python-entry-point/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/python/snaps/python-entry-point/snap/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: Entry point test
 description: Test entry points with different versions of python
 confinement: strict
 grade: devel
+base: core18
 
 parts:
   python2-test:

--- a/tests/spread/plugins/v1/python/snaps/python-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/python/snaps/python-hello/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   Make a new one.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/python/snaps/python-pbr/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/python/snaps/python-pbr/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
         This is a regression test for LP: #1670852"
 confinement: strict
 grade: devel
+base: core18
 
 parts:
   python2-test:

--- a/tests/spread/plugins/v1/python/snaps/python-pyyaml/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/python/snaps/python-pyyaml/snap/snapcraft.yaml
@@ -2,7 +2,10 @@ name: python-pyyaml
 version: "0"
 summary: summary
 description: description
+
+base: core18
 confinement: strict
+grade: devel
 
 parts:
   python2:

--- a/tests/spread/plugins/v1/python/snaps/python-setuppy-with-deps/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/python/snaps/python-setuppy-with-deps/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: >
   as it may have dependencies.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/python/snaps/python-site-packages/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/python/snaps/python-site-packages/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   meant to be used during runtime as $SNAP would be snapcraft's
   which is also using the python plugin.
 grade: devel
+base: core18
 confinement: strict
 
 parts:

--- a/tests/spread/plugins/v1/python/snaps/python-with-source-subdir-dependencies/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/python/snaps/python-with-source-subdir-dependencies/snap/snapcraft.yaml
@@ -5,6 +5,10 @@ description: |
   Have two python packages in the same source, driven by source-subdir
   two prove that they can be satisfied locally.
 
+base: core18
+confinement: strict
+grade: devel
+
 parts:
   mod1:
     plugin: python

--- a/tests/spread/plugins/v1/python/snaps/python-with-source-subdir/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/python/snaps/python-with-source-subdir/snap/snapcraft.yaml
@@ -9,6 +9,7 @@ description: |
   properly handled.
 confinement: strict
 grade: devel
+base: core18
 
 apps:
   python-hello:

--- a/tests/spread/plugins/v1/python/snaps/python-with-stage-packages/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/python/snaps/python-with-stage-packages/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
     Install yamllint from pypi but use pyyaml as a stage-packages entry.
 confinement: strict
 grade: devel
+base: core18
 
 parts:
   python2:

--- a/tests/spread/plugins/v1/python/snaps/python-with-two-parts/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/python/snaps/python-with-two-parts/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   https://bugs.launchpad.net/snapcraft/+bug/1663739
 confinement: strict
 grade: devel
+base: core18
 
 parts:
   part1:

--- a/tests/spread/plugins/v1/python/snaps/stage-and-python-packages/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/python/snaps/stage-and-python-packages/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   Use a stage-package and a python-package from PyPI
 confinement: strict
 grade: devel
+base: core18
 
 parts:
   python-from-archive:

--- a/tests/spread/plugins/v1/qmake/legacy-pull/task.yaml
+++ b/tests/spread/plugins/v1/qmake/legacy-pull/task.yaml
@@ -8,6 +8,11 @@ systems: [ubuntu-*]
 environment:
   SNAP_DIR: ../snaps/qmake-hello
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/qmake/snaps/qmake-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/qmake/snaps/qmake-hello/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   Make a new one.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/ruby/legacy-pull/task.yaml
+++ b/tests/spread/plugins/v1/ruby/legacy-pull/task.yaml
@@ -8,6 +8,11 @@ systems: [ubuntu-*]
 environment:
   SNAP_DIR: ../snaps/ruby-hello
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/ruby/snaps/ruby-bins-exist/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/ruby/snaps/ruby-bins-exist/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   Snap to run ruby-exists test against
 
 grade: devel
+base: core18
 confinement: strict
 
 parts:

--- a/tests/spread/plugins/v1/ruby/snaps/ruby-bundle-install/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/ruby/snaps/ruby-bundle-install/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   Snap to test 'bundle install' command
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/ruby/snaps/ruby-gem-install/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/ruby/snaps/ruby-gem-install/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   Snap to test 'gem install <gem>' command
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/ruby/snaps/ruby-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/ruby/snaps/ruby-hello/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   Snap to test ruby compiled correctly, exists, and works
 
 grade: stable
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/rust/legacy-pull/task.yaml
+++ b/tests/spread/plugins/v1/rust/legacy-pull/task.yaml
@@ -18,6 +18,11 @@ systems:
 environment:
   SNAP_DIR: ../snaps/rust-hello
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/rust/snaps/rust-hello-with-cargo-lock/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/rust/snaps/rust-hello-with-cargo-lock/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   Make a new one.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/rust/snaps/rust-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/rust/snaps/rust-hello/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   Make a new one.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/rust/snaps/rust-with-conditional/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/rust/snaps/rust-with-conditional/snap/snapcraft.yaml
@@ -3,7 +3,10 @@ version: "1.0"
 summary: A simple rust project with conditional features.
 description: |
   Snap used to test conditional features in rust.
+
+base: core18
 confinement: strict
+grade: devel
 
 apps:
   rust-with-conditional:

--- a/tests/spread/plugins/v1/rust/snaps/rust-workspace-fib/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/rust/snaps/rust-workspace-fib/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   This is a basic rust snap with workspaces.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/scons/legacy-build-run/task.yaml
+++ b/tests/spread/plugins/v1/scons/legacy-build-run/task.yaml
@@ -5,6 +5,11 @@ systems: [ubuntu-*]
 environment:
   SNAP_DIR: ../snaps/scons-hello
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/scons/snaps/scons-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/scons/snaps/scons-hello/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   Make a new one.
 
 grade: devel
+base: core18
 confinement: strict
 
 apps:

--- a/tests/spread/plugins/v1/waf/legacy-build-run/task.yaml
+++ b/tests/spread/plugins/v1/waf/legacy-build-run/task.yaml
@@ -3,6 +3,11 @@ summary: Build and run a basic waf snap with no base
 environment:
   SNAP_DIR: ../snaps/waf-hello
 
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  clear_base "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/spread/plugins/v1/waf/snaps/waf-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/waf/snaps/waf-hello/snap/snapcraft.yaml
@@ -4,6 +4,8 @@ summary: test the waf plugin
 description: |
   This is a basic waf snap with configflags.
 confinement: strict
+grade: devel
+base: core18
 
 apps:
   waf-hello:

--- a/tests/spread/tools/snapcraft-yaml.sh
+++ b/tests/spread/tools/snapcraft-yaml.sh
@@ -14,8 +14,18 @@ set_base()
         exit 1
     fi
     
-    # Insert at the very top to be safe
-    sed -i "1ibase: $base"  "$snapcraft_yaml_path"
+    if grep -q "^base:" "$snapcraft_yaml_path"; then
+        sed -i "s/base:.*/base: $base/g" "$snapcraft_yaml_path"
+    else
+        # Insert at the very top to be safe
+        sed -i "1ibase: $base"  "$snapcraft_yaml_path"
+    fi
+}
+
+clear_base()
+{
+    snapcraft_yaml_path="$1"
+    sed -i '/^base:/d' "$snapcraft_yaml_path"
 }
 
 set_confinement()


### PR DESCRIPTION
Instead have spread tests replace the base with appropriate
target base.  This way we can easily build tests without having
to modify snapcraft.yaml locally.

Every snap was designated as core18 by default, except:
- ament is legacy, so no base added
- dotnet is core16 only according to spread.yaml
- all legacy tests

Added clear_base() helper for legacy tests outside of /legacy/
to specifically ensure that the base is removed when run.

This also populates grade and confinement in a couple cases
where they weren't specified explicitly, nor set with
set_confinement().

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
