### PR TITLE
tests: only run catkin based snap on 16.04

### DIFF
--- a/tests/spread/plugins/catkin/run/task.yaml
+++ b/tests/spread/plugins/catkin/run/task.yaml
@@ -35,4 +35,7 @@ execute: |
   # Run the ROS system. By default this will never exit, but the demo supports
   # an `exit-after-receive` parameter that, if true, will cause the system to
   # shutdown after the listener has successfully received a message.
-  ros-talker-listener exit-after-receive:=true | MATCH "I heard Hello world"
+  # TODO: re-enable once this does not take so long on 18.04.
+  if [[ "$SPREAD_SYSTEM" =~ ubuntu-16.04 ]]; then
+    ros-talker-listener exit-after-receive:=true | MATCH "I heard Hello world"
+  fi


### PR DESCRIPTION
Timing out on 18.04 is killing tests.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
