### PR TITLE
Add gcc to the build-packages for the gnome-3-34 extension

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/gnome_3_34.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_34.py
@@ -131,5 +131,6 @@ class ExtensionImpl(Extension):
                 "source-subdir": "gnome",
                 "plugin": "make",
                 "build-snaps": ["gnome-3-34-1804-sdk/latest/stable"],
+                "build-packages": ["gcc"],
             }
         }

--- a/tests/unit/project_loader/extensions/test_gnome_3_34.py
+++ b/tests/unit/project_loader/extensions/test_gnome_3_34.py
@@ -186,6 +186,8 @@ class ExtensionTest(ProjectLoaderBaseTest, CommandBaseTestCase):
                             plugin: nil
                             build-environment: *id001
                           gnome-3-34-extension:
+                            build-packages:
+                            - gcc
                             build-snaps:
                             - gnome-3-34-1804-sdk/latest/stable
                             plugin: make

--- a/tests/unit/project_loader/extensions/test_gnome_3_34.py
+++ b/tests/unit/project_loader/extensions/test_gnome_3_34.py
@@ -120,6 +120,7 @@ class ExtensionTest(ProjectLoaderBaseTest, CommandBaseTestCase):
                         "source-subdir": "gnome",
                         "plugin": "make",
                         "build-snaps": ["gnome-3-34-1804-sdk/latest/stable"],
+                        "build-packages": ["gcc"],
                     }
                 }
             ),


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
Even though gcc is staged in the gnome-3-34-1804-sdk build snap, Ken still needs this to build firefox in docker.