### PR TITLE
repo: use python-apt's fetch_binary implementation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ PyYAML==5.3
 pyxdg==0.26
 requests==2.20.0
 requests_unixsocket==0.1.5
-https://launchpad.net/ubuntu/+archive/primary/+files/python-apt_1.1.0~beta1build1.tar.xz; sys_platform == 'linux'
+https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/1.6.0/python-apt_1.6.0.tar.xz; sys_platform == 'linux'
 https://launchpad.net/python-distutils-extra/trunk/2.39/+download/python-distutils-extra-2.39.tar.gz
 requests-toolbelt==0.8.0
 responses==0.5.1

--- a/tests/fixture_setup/_unittests.py
+++ b/tests/fixture_setup/_unittests.py
@@ -521,16 +521,6 @@ class FakeAptCache(fixtures.Fixture):
         for package, version in self.packages:
             self.add_package(FakeAptCachePackage(package, version))
 
-        def fetch_binary(package_candidate, destination):
-            path = os.path.join(self.path, "{}.deb".format(package_candidate.name))
-            open(path, "w").close()
-            return path
-
-        patcher = mock.patch("snapcraft.repo._deb._AptCache.fetch_binary")
-        mock_fetch_binary = patcher.start()
-        mock_fetch_binary.side_effect = fetch_binary
-        self.addCleanup(patcher.stop)
-
         # Add all the packages in the manifest.
         self.add_packages(_deb._DEFAULT_FILTERED_STAGE_PACKAGES)
 
@@ -593,6 +583,11 @@ class FakeAptCachePackage:
         self._version = version
         if version is not None:
             self.versions.update({version: self})
+
+    def fetch_binary(self, cache_dir):
+        path = os.path.join(cache_dir, f"{self.name}.deb")
+        open(path, "w").close()
+        return path
 
     def mark_install(self, *, auto_fix=True, from_user=True):
         if not self.installed:

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -46,12 +46,8 @@ class UbuntuTestCase(RepoBaseTestCase):
         self.mock_package.candidate.fetch_binary.side_effect = _fetch_binary
         self.mock_cache.return_value.get_changes.return_value = [self.mock_package]
 
-    @patch("snapcraft.internal.repo._deb._AptCache.fetch_binary")
     @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_cache_update_failed(self, mock_apt_pkg, mock_fetch_binary):
-        fake_package_path = os.path.join(self.path, "fake-package.deb")
-        open(fake_package_path, "w").close()
-        mock_fetch_binary.return_value = fake_package_path
+    def test_cache_update_failed(self, mock_apt_pkg):
         self.mock_cache().is_virtual_package.return_value = False
         self.mock_cache().update.side_effect = apt.cache.FetchFailedException()
         project_options = snapcraft.ProjectOptions()
@@ -59,12 +55,8 @@ class UbuntuTestCase(RepoBaseTestCase):
         self.assertRaises(errors.CacheUpdateFailedError, ubuntu.get, ["fake-package"])
 
     @patch("shutil.rmtree")
-    @patch("snapcraft.internal.repo._deb._AptCache.fetch_binary")
     @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_cache_hashsum_mismatch(self, mock_apt_pkg, mock_fetch_binary, mock_rmtree):
-        fake_package_path = os.path.join(self.path, "fake-package.deb")
-        open(fake_package_path, "w").close()
-        mock_fetch_binary.return_value = fake_package_path
+    def test_cache_hashsum_mismatch(self, mock_apt_pkg, mock_rmtree):
         self.mock_cache().is_virtual_package.return_value = False
         self.mock_cache().update.side_effect = [
             apt.cache.FetchFailedException(
@@ -91,12 +83,8 @@ class UbuntuTestCase(RepoBaseTestCase):
         self.assertThat(name, Equals("hello"))
         self.assertThat(version, Equals("2.10-1"))
 
-    @patch("snapcraft.internal.repo._deb._AptCache.fetch_binary")
     @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_get_package(self, mock_apt_pkg, mock_fetch_binary):
-        fake_package_path = os.path.join(self.path, "fake-package.deb")
-        open(fake_package_path, "w").close()
-        mock_fetch_binary.return_value = fake_package_path
+    def test_get_package(self, mock_apt_pkg):
         self.mock_cache().is_virtual_package.return_value = False
 
         fake_trusted_parts_path = os.path.join(self.path, "fake-trusted-parts")
@@ -154,10 +142,11 @@ class UbuntuTestCase(RepoBaseTestCase):
         )
         self.assertThat(os.listdir(trusted_parts_dir), Equals(["trusted-part.gpg"]))
 
-    @patch("snapcraft.internal.repo._deb._AptCache.fetch_binary")
     @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_get_package_fetch_error(self, mock_apt_pkg, mock_fetch_binary):
-        mock_fetch_binary.side_effect = apt.package.FetchError("foo")
+    def test_get_package_fetch_error(self, mock_apt_pkg):
+        self.mock_package.candidate.fetch_binary.side_effect = apt.package.FetchError(
+            "foo"
+        )
         self.mock_cache().is_virtual_package.return_value = False
         project_options = snapcraft.ProjectOptions()
         ubuntu = repo.Ubuntu(self.tempdir, project_options=project_options)
@@ -166,14 +155,8 @@ class UbuntuTestCase(RepoBaseTestCase):
         )
         self.assertThat(str(raised), Equals("Package fetch error: foo"))
 
-    @patch("snapcraft.internal.repo._deb._AptCache.fetch_binary")
     @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_get_package_trusted_parts_already_imported(
-        self, mock_apt_pkg, mock_fetch_binary
-    ):
-        fake_package_path = os.path.join(self.path, "fake-package.deb")
-        open(fake_package_path, "w").close()
-        mock_fetch_binary.return_value = fake_package_path
+    def test_get_package_trusted_parts_already_imported(self, mock_apt_pkg):
         self.mock_cache().is_virtual_package.return_value = False
 
         def _fake_find_file(key: str):
@@ -219,12 +202,8 @@ class UbuntuTestCase(RepoBaseTestCase):
             os.path.join(self.tempdir, "download", "fake-package.deb"), FileExists()
         )
 
-    @patch("snapcraft.internal.repo._deb._AptCache.fetch_binary")
     @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_get_multiarch_package(self, mock_apt_pkg, mock_fetch_binary):
-        fake_package_path = os.path.join(self.path, "fake-package.deb")
-        open(fake_package_path, "w").close()
-        mock_fetch_binary.return_value = fake_package_path
+    def test_get_multiarch_package(self, mock_apt_pkg):
         self.mock_cache().is_virtual_package.return_value = False
 
         fake_trusted_parts_path = os.path.join(self.path, "fake-trusted-parts")


### PR DESCRIPTION
python-apt has been updated to be less verbose, so we can
use the fetch_binary() logic that was lifted from there.

Update mocks, fixture, and tests accordingly.

Depends on https://github.com/snapcore/snapcraft/pull/2999