### PR TITLE
repo: always use host source lists and remove those found in plugins

### DIFF
--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -191,8 +191,9 @@ class PartsConfig:
             "properties {!r}.".format(part_name, plugin_name, part_properties)
         )
 
-        sources = getattr(plugin, "PLUGIN_STAGE_SOURCES", None)
-        keyrings = getattr(plugin, "PLUGIN_STAGE_KEYRINGS", None)
+        sources = plugin.PLUGIN_STAGE_SOURCES
+        keyrings = plugin.PLUGIN_STAGE_KEYRINGS
+
         stage_packages_repo = repo.Repo(
             plugin.osrepodir,
             sources=sources,

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -26,7 +26,7 @@ import string
 import subprocess
 import sys
 import tempfile
-from typing import Dict, List, Set, Tuple  # noqa: F401
+from typing import Dict, List, Optional, Set, Tuple  # noqa: F401
 
 import apt
 
@@ -183,12 +183,9 @@ def _run_dpkg_query_s(file_path: str) -> str:
 
 
 class _AptCache:
-    def __init__(self, deb_arch, *, sources_list=None, keyrings=None):
+    def __init__(self, deb_arch, *, sources: List[str], keyrings: List[str]):
         self._deb_arch = deb_arch
-        self._sources_list = sources_list
-
-        if not keyrings:
-            keyrings = list()
+        self._sources = sources
         self._keyrings = keyrings
 
     def _setup_apt(self, cache_dir):
@@ -332,16 +329,20 @@ class _AptCache:
             self._collected_sources_list().encode(sys.getfilesystemencoding())
         ).hexdigest()
 
-    def _collected_sources_list(self):
-        if self._sources_list:
+    def _collected_sources_list(self) -> str:
+        sources = _get_local_sources_list()
+
+        # Append additionally configured repositories, if any.
+        if self._sources:
             release = os_release.OsRelease()
-            return _format_sources_list(
-                self._sources_list,
+            additional_sources = _format_sources_list(
+                "\n".join(self._sources),
                 deb_arch=self._deb_arch,
                 release=release.version_codename(),
             )
+            sources = "\n".join([sources, additional_sources])
 
-        return _get_local_sources_list()
+        return sources
 
     def fetch_binary(self, *, package_candidate, destination: str) -> str:
         # This is a workaround for the overly verbose python-apt we use.
@@ -556,7 +557,11 @@ class Ubuntu(BaseRepo):
         return installed_packages
 
     def __init__(
-        self, rootdir, sources=None, keyrings=None, project_options=None
+        self,
+        rootdir,
+        sources: Optional[List[str]] = None,
+        keyrings: Optional[List[str]] = None,
+        project_options=None,
     ) -> None:
         super().__init__(rootdir)
         self._downloaddir = os.path.join(rootdir, "download")
@@ -564,8 +569,14 @@ class Ubuntu(BaseRepo):
         if not project_options:
             project_options = snapcraft.ProjectOptions()
 
+        if sources is None:
+            sources = list()
+
+        if keyrings is None:
+            keyrings = list()
+
         self._apt = _AptCache(
-            project_options.deb_arch, sources_list=sources, keyrings=keyrings
+            project_options.deb_arch, sources=sources, keyrings=keyrings
         )
 
         self._cache = cache.AptStagePackageCache(

--- a/snapcraft/plugins/v1/_plugin.py
+++ b/snapcraft/plugins/v1/_plugin.py
@@ -19,6 +19,7 @@ import logging
 import os
 import shlex
 from subprocess import CalledProcessError
+from typing import List
 
 from snapcraft.internal import common, errors
 
@@ -53,14 +54,14 @@ class PluginV1:
         return []
 
     @property
-    def PLUGIN_STAGE_SOURCES(self):
-        """Define alternative sources.list."""
-        return getattr(self, "_PLUGIN_STAGE_SOURCES", [])
+    def PLUGIN_STAGE_SOURCES(self) -> List[str]:
+        """Define additional deb source lines using templates variables."""
+        return []
 
     @property
-    def PLUGIN_STAGE_KEYRINGS(self):
+    def PLUGIN_STAGE_KEYRINGS(self) -> List[str]:
         """Define additional keyrings to trust for stage-packages."""
-        return getattr(self, "_PLUGIN_STAGE_KEYRINGS", [])
+        return []
 
     @property
     def stage_packages(self):

--- a/snapcraft/plugins/v1/_ros/wstool.py
+++ b/snapcraft/plugins/v1/_ros/wstool.py
@@ -18,7 +18,7 @@ import os
 import logging
 import subprocess
 import sys
-from typing import List, Sequence
+from typing import List
 
 import snapcraft
 from snapcraft.internal import errors, repo
@@ -58,8 +58,8 @@ class Wstool:
         self,
         ros_package_path: str,
         wstool_path: str,
-        ubuntu_sources: str,
-        ubuntu_keyrings: Sequence[str],
+        ubuntu_sources: List[str],
+        ubuntu_keyrings: List[str],
         project: snapcraft.ProjectOptions,
     ) -> None:
         """Create new Wstool

--- a/snapcraft/plugins/v1/catkin.py
+++ b/snapcraft/plugins/v1/catkin.py
@@ -289,27 +289,8 @@ class CatkinPlugin(snapcraft.BasePlugin):
         return self.__pip
 
     @property
-    def PLUGIN_STAGE_SOURCES(self):
-        ros_repo = "http://packages.ros.org/ros/ubuntu/"
-        ubuntu_repo = "http://${prefix}.ubuntu.com/${suffix}/"
-        security_repo = "http://${security}.ubuntu.com/${suffix}/"
-
-        return textwrap.dedent(
-            """
-            deb {ros_repo} {codename} main
-            deb {ubuntu_repo} {codename} main universe
-            deb {ubuntu_repo} {codename}-updates main universe
-            deb {ubuntu_repo} {codename}-security main universe
-            deb {security_repo} {codename}-security main universe
-            """.format(
-                ros_repo=ros_repo,
-                ubuntu_repo=ubuntu_repo,
-                security_repo=security_repo,
-                codename=_BASE_TO_UBUNTU_RELEASE_MAP[
-                    self.project.info.get_build_base()
-                ],
-            )
-        )
+    def PLUGIN_STAGE_SOURCES(self) -> List[str]:
+        return ["deb http://packages.ros.org/ros/ubuntu/ ${release} main"]
 
     @property
     def PLUGIN_STAGE_KEYRINGS(self):

--- a/snapcraft/plugins/v1/colcon.py
+++ b/snapcraft/plugins/v1/colcon.py
@@ -237,26 +237,7 @@ class ColconPlugin(snapcraft.BasePlugin):
 
     @property
     def PLUGIN_STAGE_SOURCES(self):
-        ros_repo = "http://repo.ros2.org/ubuntu/main"
-        ubuntu_repo = "http://${prefix}.ubuntu.com/${suffix}/"
-        security_repo = "http://${security}.ubuntu.com/${suffix}/"
-
-        return textwrap.dedent(
-            """
-            deb {ros_repo} {codename} main
-            deb {ubuntu_repo} {codename} main universe
-            deb {ubuntu_repo} {codename}-updates main universe
-            deb {ubuntu_repo} {codename}-security main universe
-            deb {security_repo} {codename}-security main universe
-            """.format(
-                ros_repo=ros_repo,
-                ubuntu_repo=ubuntu_repo,
-                security_repo=security_repo,
-                codename=_BASE_TO_UBUNTU_RELEASE_MAP[
-                    self.project.info.get_build_base()
-                ],
-            )
-        )
+        return ["deb http://repo.ros2.org/ubuntu/main ${release} main"]
 
     @property
     def PLUGIN_STAGE_KEYRINGS(self):

--- a/tests/unit/plugins/v1/test_catkin.py
+++ b/tests/unit/plugins/v1/test_catkin.py
@@ -337,51 +337,6 @@ class CatkinPluginTestCase(CatkinPluginBaseTest):
         for property in expected_build_properties:
             self.assertIn(property, actual_build_properties)
 
-    def test_get_stage_sources_core(self):
-        self.project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: catkin-snap
-                    base: core
-                    """
-                )
-            )
-        )
-
-        plugin = catkin.CatkinPlugin("test-part", self.properties, self.project)
-        self.assertTrue("xenial" in plugin.PLUGIN_STAGE_SOURCES)
-
-    def test_get_stage_sources_core16(self):
-        self.project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: catkin-snap
-                    base: core16
-                    """
-                )
-            )
-        )
-
-        plugin = catkin.CatkinPlugin("test-part", self.properties, self.project)
-        self.assertTrue("xenial" in plugin.PLUGIN_STAGE_SOURCES)
-
-    def test_get_stage_sources_core18(self):
-        self.project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: catkin-snap
-                    base: core18
-                    """
-                )
-            )
-        )
-
-        plugin = catkin.CatkinPlugin("test-part", self.properties, self.project)
-        self.assertTrue("bionic" in plugin.PLUGIN_STAGE_SOURCES)
-
     def test_pull_invalid_dependency(self):
         plugin = catkin.CatkinPlugin("test-part", self.properties, self.project)
         os.makedirs(os.path.join(plugin.sourcedir, "src"))


### PR DESCRIPTION
The Ubuntu object is now responsible for ensuring that all of
the configured apt sources are merged (performed in
AptCache._collected_sources_list()).

- (Re)define plugin.PLUGIN_STAGE_SOURCES to be a list of strings of
repositories to be added.  The base plugin will return an empty
list if the plugin doesn't define it.  There was a bit of mixed
usage of str vs. list, so we make it explicit.

- Remove the redundant sources specified by the catkin and colcon
plugins, we do not support building for non-native releases.

- Update tests accordingly, removing catkin's tests for verifying
sources are formatted for cross-release build (i.e. base does
not match build environment), which is no longer supported.

- Remove unused reference to plugin._PLUGIN_STAGE_SOURCES.

- Remove unused reference to plugin._PLUGIN_STAGE_KEYRINGS.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
