### PR TITLE
Change dotnet runtime version from snapcraft.yaml

### DIFF
--- a/snapcraft/plugins/v1/dotnet.py
+++ b/snapcraft/plugins/v1/dotnet.py
@@ -43,8 +43,9 @@ from snapcraft.internal import errors
 from typing import List
 
 
-_DOTNET_RELEASE_METADATA_URL = "http://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.0/releases.json"  # noqa
+_DOTNET_RELEASE_METADATA_URL = "http://dotnetcli.blob.core.windows.net/dotnet/release-metadata/{version}/releases.json"  # noqa
 _RUNTIME_DEFAULT = "2.0.9"
+_VERSION_DEFAULT = "2.0"
 
 # TODO extend for other architectures
 _SDK_ARCH = ["amd64"]
@@ -82,6 +83,10 @@ class DotNetPlugin(snapcraft.BasePlugin):
     def schema(cls):
         schema = super().schema()
 
+        schema["properties"]["dotnet-version"] = {
+            "type": "number",
+            "default": _VERSION_DEFAULT,
+        }
         schema["properties"]["dotnet-runtime-version"] = {
             "type": "string",
             "default": _RUNTIME_DEFAULT,
@@ -94,7 +99,7 @@ class DotNetPlugin(snapcraft.BasePlugin):
     def get_pull_properties(cls):
         # Inform Snapcraft of the properties associated with pulling. If these
         # change in the YAML Snapcraft will consider the build step dirty.
-        return ["dotnet-runtime-version"]
+        return ["dotnet-runtime-version", "dotnet-version"]
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
@@ -108,12 +113,9 @@ class DotNetPlugin(snapcraft.BasePlugin):
         self._dotnet_cmd = os.path.join(self._dotnet_sdk_dir, "dotnet")
 
     def _setup_base_tools(self, base):
-        if base in ("core", "core16"):
-            self.stage_packages.extend(
-                [
+        extra_packages = [
                     "libcurl3",
                     "libcurl3-gnutls",
-                    "libicu55",
                     "liblttng-ust0",
                     "libunwind8",
                     "lldb",
@@ -122,7 +124,10 @@ class DotNetPlugin(snapcraft.BasePlugin):
                     "zlib1g",
                     "libgcc1",
                 ]
-            )
+        if base in ("core", "core16"):
+            self.stage_packages += extra_packages + ['libicu55']
+        elif base in ("core18",):
+            self.stage_packages += extra_packages + ['libicu60']
         else:
             raise errors.PluginBaseError(part_name=self.name, base=base)
 
@@ -195,7 +200,8 @@ class DotNetPlugin(snapcraft.BasePlugin):
     def _get_dotnet_release_metadata(self):
         package_metadata = []
 
-        req = urllib.request.Request(_DOTNET_RELEASE_METADATA_URL)
+        metadata_url = _DOTNET_RELEASE_METADATA_URL.format(version=self.options.dotnet_version)
+        req = urllib.request.Request(metadata_url)
         r = urllib.request.urlopen(req).read()
         package_metadata = json.loads(r.decode("utf-8"))
 

--- a/snapcraft/plugins/v1/dotnet.py
+++ b/snapcraft/plugins/v1/dotnet.py
@@ -114,20 +114,20 @@ class DotNetPlugin(snapcraft.BasePlugin):
 
     def _setup_base_tools(self, base):
         extra_packages = [
-                    "libcurl3",
-                    "libcurl3-gnutls",
-                    "liblttng-ust0",
-                    "libunwind8",
-                    "lldb",
-                    "libssl1.0.0",
-                    "libgssapi-krb5-2",
-                    "zlib1g",
-                    "libgcc1",
-                ]
+            "libcurl3",
+            "libcurl3-gnutls",
+            "liblttng-ust0",
+            "libunwind8",
+            "lldb",
+            "libssl1.0.0",
+            "libgssapi-krb5-2",
+            "zlib1g",
+            "libgcc1",
+        ]
         if base in ("core", "core16"):
-            self.stage_packages += extra_packages + ['libicu55']
+            self.stage_packages += extra_packages + ["libicu55"]
         elif base in ("core18",):
-            self.stage_packages += extra_packages + ['libicu60']
+            self.stage_packages += extra_packages + ["libicu60"]
         else:
             raise errors.PluginBaseError(part_name=self.name, base=base)
 
@@ -200,7 +200,9 @@ class DotNetPlugin(snapcraft.BasePlugin):
     def _get_dotnet_release_metadata(self):
         package_metadata = []
 
-        metadata_url = _DOTNET_RELEASE_METADATA_URL.format(version=self.options.dotnet_version)
+        metadata_url = _DOTNET_RELEASE_METADATA_URL.format(
+            version=self.options.dotnet_version
+        )
         req = urllib.request.Request(metadata_url)
         r = urllib.request.urlopen(req).read()
         package_metadata = json.loads(r.decode("utf-8"))

--- a/tests/unit/plugins/v1/test_dotnet.py
+++ b/tests/unit/plugins/v1/test_dotnet.py
@@ -24,7 +24,6 @@ from testtools.matchers import Contains, DirExists, Equals, FileExists, Not
 
 import snapcraft
 from snapcraft import file_utils
-from snapcraft.internal import errors
 from snapcraft.internal import sources
 from snapcraft.project import Project
 from snapcraft.plugins.v1 import dotnet

--- a/tests/unit/plugins/v1/test_dotnet.py
+++ b/tests/unit/plugins/v1/test_dotnet.py
@@ -272,4 +272,3 @@ class DotNetProjectBuildCommandsTest(DotNetProjectBaseTest):
                 ]
             ),
         )
-

--- a/tests/unit/plugins/v1/test_dotnet.py
+++ b/tests/unit/plugins/v1/test_dotnet.py
@@ -45,7 +45,7 @@ class DotNetPluginPropertiesTest(unit.TestCase):
         self.assertThat(schema, Contains("required"))
 
     def test_get_pull_properties(self):
-        expected_pull_properties = ["dotnet-runtime-version"]
+        expected_pull_properties = ["dotnet-runtime-version", "dotnet-version"]
         self.assertThat(
             dotnet.DotNetPlugin.get_pull_properties(), Equals(expected_pull_properties)
         )
@@ -76,6 +76,7 @@ class DotNetProjectBaseTest(unit.TestCase):
         class Options:
             build_attributes = []
             dotnet_runtime_version = dotnet._RUNTIME_DEFAULT
+            dotnet_version = dotnet._VERSION_DEFAULT
 
         self.options = Options()
 
@@ -272,32 +273,3 @@ class DotNetProjectBuildCommandsTest(DotNetProjectBaseTest):
             ),
         )
 
-
-class DotnetPluginUnsupportedBaseTest(unit.TestCase):
-    def setUp(self):
-        super().setUp()
-
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: dotnet-snap
-            base: core18
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
-
-        class Options:
-            source = "dir"
-
-        self.options = Options()
-
-    def test_unsupported_base_raises(self):
-        self.assertRaises(
-            errors.PluginBaseError,
-            dotnet.DotNetPlugin,
-            "test-part",
-            self.options,
-            self.project,
-        )


### PR DESCRIPTION
Changes:
- Add `dotnet-version` to be able to choose runtime version. Now it can be used for 3.1 version of dotnet core. Defaults to 2.0.9, nothing changed
- Update dependencies for core18
- Remove test for unsupported version core

Prereq:
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
