### PR TITLE
repo: always use host release and arch for Ubuntu

### DIFF
--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -195,10 +195,7 @@ class PartsConfig:
         keyrings = plugin.PLUGIN_STAGE_KEYRINGS
 
         stage_packages_repo = repo.Repo(
-            plugin.osrepodir,
-            sources=sources,
-            keyrings=keyrings,
-            project_options=self._project,
+            plugin.osrepodir, sources=sources, keyrings=keyrings
         )
 
         grammar_processor = grammar_processing.PartGrammarProcessor(

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -30,7 +30,6 @@ from typing import Dict, List, Optional, Set, Tuple  # noqa: F401
 
 import apt
 
-import snapcraft
 from snapcraft import file_utils
 from snapcraft.internal import cache, common, os_release, repo
 from snapcraft.internal.indicators import is_dumb_terminal
@@ -698,20 +697,8 @@ def _get_local_sources_list():
 
 def _format_sources_list(sources_list: str):
     release = os_release.OsRelease().version_codename()
-    deb_arch = snapcraft.ProjectOptions().deb_arch
 
-    if deb_arch in ("amd64", "i386"):
-        prefix = "archive"
-        suffix = "ubuntu"
-        security = "security"
-    else:
-        prefix = "ports"
-        suffix = "ubuntu-ports"
-        security = "ports"
-
-    return string.Template(sources_list).substitute(
-        {"prefix": prefix, "release": release, "suffix": suffix, "security": security}
-    )
+    return string.Template(sources_list).substitute({"release": release})
 
 
 def _set_pkg_version(pkg, version):

--- a/snapcraft/plugins/v1/_ros/rosdep.py
+++ b/snapcraft/plugins/v1/_ros/rosdep.py
@@ -98,7 +98,6 @@ class Rosdep:
             self._rosdep_path,
             sources=self._ubuntu_sources,
             keyrings=self._ubuntu_keyrings,
-            project_options=self._project,
         )
 
         logger.info("Fetching rosdep...")

--- a/snapcraft/plugins/v1/_ros/wstool.py
+++ b/snapcraft/plugins/v1/_ros/wstool.py
@@ -92,7 +92,6 @@ class Wstool:
             self._wstool_path,
             sources=self._ubuntu_sources,
             keyrings=self._ubuntu_keyrings,
-            project_options=self._project,
         )
         logger.info("Fetching wstool...")
         ubuntu.get(["python-wstool"])

--- a/snapcraft/plugins/v1/catkin.py
+++ b/snapcraft/plugins/v1/catkin.py
@@ -549,7 +549,6 @@ class CatkinPlugin(snapcraft.BasePlugin):
                 ubuntudir,
                 sources=self.PLUGIN_STAGE_SOURCES,
                 keyrings=self.PLUGIN_STAGE_KEYRINGS,
-                project_options=self.project,
             )
 
             logger.info("Fetching apt dependencies...")
@@ -993,7 +992,6 @@ class _Catkin:
             self._catkin_path,
             sources=self._ubuntu_sources,
             keyrings=self._ubuntu_keyrings,
-            project_options=self._project,
         )
         logger.info("Fetching catkin...")
         ubuntu.get(["ros-{}-catkin".format(self._ros_distro)])

--- a/snapcraft/plugins/v1/colcon.py
+++ b/snapcraft/plugins/v1/colcon.py
@@ -383,7 +383,6 @@ class ColconPlugin(snapcraft.BasePlugin):
                 ubuntudir,
                 sources=self.PLUGIN_STAGE_SOURCES,
                 keyrings=self.PLUGIN_STAGE_KEYRINGS,
-                project_options=self.project,
             )
 
             logger.info("Fetching apt dependencies...")

--- a/tests/unit/plugins/v1/ros/test_rosdep.py
+++ b/tests/unit/plugins/v1/ros/test_rosdep.py
@@ -65,7 +65,6 @@ class RosdepTestCase(unit.TestCase):
                     self.rosdep._rosdep_path,
                     sources="sources",
                     keyrings=["keyring"],
-                    project_options=self.project,
                 ),
                 mock.call().get(["python-rosdep"]),
                 mock.call().unpack(self.rosdep._rosdep_install_path),

--- a/tests/unit/plugins/v1/ros/test_rosdep.py
+++ b/tests/unit/plugins/v1/ros/test_rosdep.py
@@ -62,9 +62,7 @@ class RosdepTestCase(unit.TestCase):
         self.ubuntu_mock.assert_has_calls(
             [
                 mock.call(
-                    self.rosdep._rosdep_path,
-                    sources="sources",
-                    keyrings=["keyring"],
+                    self.rosdep._rosdep_path, sources="sources", keyrings=["keyring"]
                 ),
                 mock.call().get(["python-rosdep"]),
                 mock.call().unpack(self.rosdep._rosdep_install_path),

--- a/tests/unit/plugins/v1/ros/test_wstool.py
+++ b/tests/unit/plugins/v1/ros/test_wstool.py
@@ -58,7 +58,6 @@ class WstoolTestCase(unit.TestCase):
                     self.wstool._wstool_path,
                     sources="sources",
                     keyrings=["keyring"],
-                    project_options=self.project,
                 ),
                 mock.call().get(["python-wstool"]),
                 mock.call().unpack(self.wstool._wstool_install_path),

--- a/tests/unit/plugins/v1/ros/test_wstool.py
+++ b/tests/unit/plugins/v1/ros/test_wstool.py
@@ -55,9 +55,7 @@ class WstoolTestCase(unit.TestCase):
         self.ubuntu_mock.assert_has_calls(
             [
                 mock.call(
-                    self.wstool._wstool_path,
-                    sources="sources",
-                    keyrings=["keyring"],
+                    self.wstool._wstool_path, sources="sources", keyrings=["keyring"]
                 ),
                 mock.call().get(["python-wstool"]),
                 mock.call().unpack(self.wstool._wstool_install_path),

--- a/tests/unit/plugins/v1/test_catkin.py
+++ b/tests/unit/plugins/v1/test_catkin.py
@@ -1741,10 +1741,7 @@ class CatkinFindTestCase(unit.TestCase):
         self.ubuntu_mock.assert_has_calls(
             [
                 mock.call(
-                    self.catkin._catkin_path,
-                    sources="sources",
-                    keyrings=["keyring"],
-                    project_options=self.project,
+                    self.catkin._catkin_path, sources="sources", keyrings=["keyring"]
                 ),
                 mock.call().get(["ros-kinetic-catkin"]),
                 mock.call().unpack(self.catkin._catkin_install_path),

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -269,75 +269,22 @@ class UbuntuTestCase(RepoBaseTestCase):
         )
 
     @mock.patch(
-        "snapcraft.internal.os_release.OsRelease.version_codename", return_value="vivid"
+        "snapcraft.internal.os_release.OsRelease.version_codename", return_value="testy"
     )
-    @mock.patch("snapcraft.ProjectOptions.deb_arch", new="amd64")
-    def test_sources_amd64_vivid(self, mock_version_codename):
-        self.maxDiff = None
-        sources_list = textwrap.dedent(
-            """
-            deb http://${prefix}.ubuntu.com/${suffix}/ ${release} main restricted
-            deb http://${prefix}.ubuntu.com/${suffix}/ ${release}-updates main restricted
-            deb http://${prefix}.ubuntu.com/${suffix}/ ${release} universe
-            deb http://${prefix}.ubuntu.com/${suffix}/ ${release}-updates universe
-            deb http://${prefix}.ubuntu.com/${suffix}/ ${release} multiverse
-            deb http://${prefix}.ubuntu.com/${suffix}/ ${release}-updates multiverse
-            deb http://${security}.ubuntu.com/${suffix} ${release}-security main restricted
-            deb http://${security}.ubuntu.com/${suffix} ${release}-security universe
-            deb http://${security}.ubuntu.com/${suffix} ${release}-security multiverse
-            """
-        )
-
-        sources_list = repo._deb._format_sources_list(sources_list)
-
-        expected_sources_list = textwrap.dedent(
-            """
-            deb http://archive.ubuntu.com/ubuntu/ vivid main restricted
-            deb http://archive.ubuntu.com/ubuntu/ vivid-updates main restricted
-            deb http://archive.ubuntu.com/ubuntu/ vivid universe
-            deb http://archive.ubuntu.com/ubuntu/ vivid-updates universe
-            deb http://archive.ubuntu.com/ubuntu/ vivid multiverse
-            deb http://archive.ubuntu.com/ubuntu/ vivid-updates multiverse
-            deb http://security.ubuntu.com/ubuntu vivid-security main restricted
-            deb http://security.ubuntu.com/ubuntu vivid-security universe
-            deb http://security.ubuntu.com/ubuntu vivid-security multiverse
-            """
-        )
-        self.assertThat(sources_list, Equals(expected_sources_list))
-
-    @mock.patch(
-        "snapcraft.internal.os_release.OsRelease.version_codename",
-        return_value="trusty",
-    )
-    @mock.patch("snapcraft.ProjectOptions.deb_arch", new="armhf")
     def test_sources_armhf_trusty(self, mock_version_codename):
         sources_list = textwrap.dedent(
             """
-            deb http://${prefix}.ubuntu.com/${suffix}/ ${release} main restricted
-            deb http://${prefix}.ubuntu.com/${suffix}/ ${release}-updates main restricted
-            deb http://${prefix}.ubuntu.com/${suffix}/ ${release} universe
-            deb http://${prefix}.ubuntu.com/${suffix}/ ${release}-updates universe
-            deb http://${prefix}.ubuntu.com/${suffix}/ ${release} multiverse
-            deb http://${prefix}.ubuntu.com/${suffix}/ ${release}-updates multiverse
-            deb http://${security}.ubuntu.com/${suffix} ${release}-security main restricted
-            deb http://${security}.ubuntu.com/${suffix} ${release}-security universe
-            deb http://${security}.ubuntu.com/${suffix} ${release}-security multiverse
-        """
+            deb http://archive.ubuntu.com/ubuntu ${release} main restricted
+            deb http://archive.ubuntu.com/ubuntu ${release}-updates main restricted
+            """
         )
 
         sources_list = repo._deb._format_sources_list(sources_list)
 
         expected_sources_list = textwrap.dedent(
             """
-            deb http://ports.ubuntu.com/ubuntu-ports/ trusty main restricted
-            deb http://ports.ubuntu.com/ubuntu-ports/ trusty-updates main restricted
-            deb http://ports.ubuntu.com/ubuntu-ports/ trusty universe
-            deb http://ports.ubuntu.com/ubuntu-ports/ trusty-updates universe
-            deb http://ports.ubuntu.com/ubuntu-ports/ trusty multiverse
-            deb http://ports.ubuntu.com/ubuntu-ports/ trusty-updates multiverse
-            deb http://ports.ubuntu.com/ubuntu-ports trusty-security main restricted
-            deb http://ports.ubuntu.com/ubuntu-ports trusty-security universe
-            deb http://ports.ubuntu.com/ubuntu-ports trusty-security multiverse
+            deb http://archive.ubuntu.com/ubuntu testy main restricted
+            deb http://archive.ubuntu.com/ubuntu testy-updates main restricted
             """
         )
         self.assertThat(sources_list, Equals(expected_sources_list))

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -271,7 +271,7 @@ class UbuntuTestCase(RepoBaseTestCase):
     @mock.patch(
         "snapcraft.internal.os_release.OsRelease.version_codename", return_value="testy"
     )
-    def test_sources_armhf_trusty(self, mock_version_codename):
+    def test_sources_formatting(self, mock_version_codename):
         sources_list = textwrap.dedent(
             """
             deb http://archive.ubuntu.com/ubuntu ${release} main restricted


### PR DESCRIPTION
- Remove dependency of ProjectOptions parameter.

- Update format_sources_list() tp query release arch/release
  separately.

Update tests accordingly.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
