### PR TITLE
go: support projects with multiple binaries when using go.mod

### DIFF
--- a/snapcraft/plugins/v1/go.py
+++ b/snapcraft/plugins/v1/go.py
@@ -262,15 +262,18 @@ class GoPlugin(snapcraft.BasePlugin):
         post_build_files = os.listdir(self._install_bin_dir)
 
         new_files = set(post_build_files) - set(pre_build_files)
-        if len(new_files) != 1:
-            raise RuntimeError(f"Expected one binary to be built, found: {new_files!r}")
-        binary_path = os.path.join(self._install_bin_dir, new_files.pop())
 
-        # Relink with system linker if executable is dynamic in order to be
-        # able to set rpath later on. This workaround can be removed after
-        # https://github.com/NixOS/patchelf/issues/146 is fixed.
-        if self._is_classic and elf.ElfFile(path=binary_path).is_dynamic:
-            self._run(relink_cmd, cwd=work_dir)
+        if len(new_files) == 0:
+            logger.warning(f"no binaries found from {build_cmd!r}")
+
+        for new_file in new_files:
+            binary_path = os.path.join(self._install_bin_dir, new_file)
+
+            # Relink with system linker if executable is dynamic in order to be
+            # able to set rpath later on. This workaround can be removed after
+            # https://github.com/NixOS/patchelf/issues/146 is fixed.
+            if self._is_classic and elf.ElfFile(path=binary_path).is_dynamic:
+                self._run(relink_cmd, cwd=work_dir)
 
     def _build_go_packages(self) -> None:
         if self.options.go_packages:

--- a/tests/spread/plugins/v1/go/multiple_mains/task.yaml
+++ b/tests/spread/plugins/v1/go/multiple_mains/task.yaml
@@ -38,6 +38,15 @@ execute: |
   [ -f stage/bin/main3 ]
   snapcraft clean
 
+  # Now run the same test, but using go.mod support.
+  go mod init io.snapcraft.maintests
+  snapcraft stage
+  [ -f stage/bin/main1 ]
+  [ -f stage/bin/main2 ]
+  [ -f stage/bin/main3 ]
+  snapcraft clean
+  rm go.mod
+
   # Now run the same test again, but with multiple go-packages
   cat << EOF >> snap/snapcraft.yaml
         go-packages:


### PR DESCRIPTION
There was a check to assert only one binary was built.

- Remove the error check. If no binaries are found, warn.

- Update logic to handle relinking multiple binaries.

- Update multiple main spread test to also build with go.mod.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
