### PR TITLE
repo: use python-apt's fetch_binary implementation

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -354,38 +354,6 @@ class _AptCache:
 
         return sources
 
-    def fetch_binary(self, *, package_candidate, destination: str) -> str:
-        # This is a workaround for the overly verbose python-apt we use.
-        # There is an unreleased patch which once released could replace
-        # this code https://salsa.debian.org/apt-team/python-apt/commit/d122f9142df614dbb5f7644112280140dc155ecc  # noqa
-        # What follows is almost a tit for tat implementation of upstream's
-        # fetch_binary logic.
-        base = os.path.basename(package_candidate._records.filename)
-        destfile = os.path.join(destination, base)
-        if apt.package._file_is_same(
-            destfile, package_candidate.size, package_candidate._records.md5_hash
-        ):
-            logging.debug("Ignoring already existing file: {}".format(destfile))
-            return os.path.abspath(destfile)
-        acq = apt.apt_pkg.Acquire(self.progress)
-        acqfile = apt.apt_pkg.AcquireFile(
-            acq,
-            package_candidate.uri,
-            package_candidate._records.md5_hash,
-            package_candidate.size,
-            base,
-            destfile=destfile,
-        )
-        acq.run()
-
-        if acqfile.status != acqfile.STAT_DONE:
-            raise apt.package.FetchError(
-                "The item %r could not be fetched: %s"
-                % (acqfile.destfile, acqfile.error_text)
-            )
-
-        return os.path.abspath(destfile)
-
 
 class Ubuntu(BaseRepo):
     @classmethod
@@ -636,29 +604,14 @@ class Ubuntu(BaseRepo):
             )
 
     def _get(self, apt_cache):
-        # Ideally we'd use apt.Cache().fetch_archives() here, but it seems to
-        # mangle some package names on disk such that we can't match it up to
-        # the archive later. We could get around this a few different ways:
-        #
-        # 1. Store each stage package in the cache named by a hash instead of
-        #    its name from the archive.
-        # 2. Download packages in a different manner.
-        #
-        # In the end, (2) was chosen for minimal overhead and a simpler cache
-        # implementation. So we're using fetch_binary() here instead.
-        # Downloading each package individually has the drawback of witholding
-        # any clue of how long the whole pulling process will take, but that's
-        # something we'll have to live with.
         pkg_list = []
         for package in apt_cache.get_changes():
             pkg_list.append(str(package.candidate))
             try:
-                source = self._apt.fetch_binary(
-                    package_candidate=package.candidate,
-                    destination=self._cache.packages_dir,
-                )
+                source = package.candidate.fetch_binary(self._cache.packages_dir)
             except apt.package.FetchError as e:
                 raise errors.PackageFetchError(str(e))
+
             destination = os.path.join(self._downloaddir, os.path.basename(source))
             with contextlib.suppress(FileNotFoundError):
                 os.remove(destination)

--- a/tests/fixture_setup/_unittests.py
+++ b/tests/fixture_setup/_unittests.py
@@ -521,16 +521,6 @@ class FakeAptCache(fixtures.Fixture):
         for package, version in self.packages:
             self.add_package(FakeAptCachePackage(package, version))
 
-        def fetch_binary(package_candidate, destination):
-            path = os.path.join(self.path, "{}.deb".format(package_candidate.name))
-            open(path, "w").close()
-            return path
-
-        patcher = mock.patch("snapcraft.repo._deb._AptCache.fetch_binary")
-        mock_fetch_binary = patcher.start()
-        mock_fetch_binary.side_effect = fetch_binary
-        self.addCleanup(patcher.stop)
-
         # Add all the packages in the manifest.
         self.add_packages(_deb._DEFAULT_FILTERED_STAGE_PACKAGES)
 
@@ -593,6 +583,11 @@ class FakeAptCachePackage:
         self._version = version
         if version is not None:
             self.versions.update({version: self})
+
+    def fetch_binary(self, cache_dir):
+        path = os.path.join(cache_dir, f"{self.name}.deb")
+        open(path, "w").close()
+        return path
 
     def mark_install(self, *, auto_fix=True, from_user=True):
         if not self.installed:

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -46,12 +46,8 @@ class UbuntuTestCase(RepoBaseTestCase):
         self.mock_package.candidate.fetch_binary.side_effect = _fetch_binary
         self.mock_cache.return_value.get_changes.return_value = [self.mock_package]
 
-    @patch("snapcraft.internal.repo._deb._AptCache.fetch_binary")
     @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_cache_update_failed(self, mock_apt_pkg, mock_fetch_binary):
-        fake_package_path = os.path.join(self.path, "fake-package.deb")
-        open(fake_package_path, "w").close()
-        mock_fetch_binary.return_value = fake_package_path
+    def test_cache_update_failed(self, mock_apt_pkg):
         self.mock_cache().is_virtual_package.return_value = False
         self.mock_cache().update.side_effect = apt.cache.FetchFailedException()
         project_options = snapcraft.ProjectOptions()
@@ -59,12 +55,8 @@ class UbuntuTestCase(RepoBaseTestCase):
         self.assertRaises(errors.CacheUpdateFailedError, ubuntu.get, ["fake-package"])
 
     @patch("shutil.rmtree")
-    @patch("snapcraft.internal.repo._deb._AptCache.fetch_binary")
     @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_cache_hashsum_mismatch(self, mock_apt_pkg, mock_fetch_binary, mock_rmtree):
-        fake_package_path = os.path.join(self.path, "fake-package.deb")
-        open(fake_package_path, "w").close()
-        mock_fetch_binary.return_value = fake_package_path
+    def test_cache_hashsum_mismatch(self, mock_apt_pkg, mock_rmtree):
         self.mock_cache().is_virtual_package.return_value = False
         self.mock_cache().update.side_effect = [
             apt.cache.FetchFailedException(
@@ -91,12 +83,8 @@ class UbuntuTestCase(RepoBaseTestCase):
         self.assertThat(name, Equals("hello"))
         self.assertThat(version, Equals("2.10-1"))
 
-    @patch("snapcraft.internal.repo._deb._AptCache.fetch_binary")
     @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_get_package(self, mock_apt_pkg, mock_fetch_binary):
-        fake_package_path = os.path.join(self.path, "fake-package.deb")
-        open(fake_package_path, "w").close()
-        mock_fetch_binary.return_value = fake_package_path
+    def test_get_package(self, mock_apt_pkg):
         self.mock_cache().is_virtual_package.return_value = False
 
         fake_trusted_parts_path = os.path.join(self.path, "fake-trusted-parts")
@@ -154,10 +142,11 @@ class UbuntuTestCase(RepoBaseTestCase):
         )
         self.assertThat(os.listdir(trusted_parts_dir), Equals(["trusted-part.gpg"]))
 
-    @patch("snapcraft.internal.repo._deb._AptCache.fetch_binary")
     @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_get_package_fetch_error(self, mock_apt_pkg, mock_fetch_binary):
-        mock_fetch_binary.side_effect = apt.package.FetchError("foo")
+    def test_get_package_fetch_error(self, mock_apt_pkg):
+        self.mock_package.candidate.fetch_binary.side_effect = apt.package.FetchError(
+            "foo"
+        )
         self.mock_cache().is_virtual_package.return_value = False
         project_options = snapcraft.ProjectOptions()
         ubuntu = repo.Ubuntu(self.tempdir, project_options=project_options)
@@ -166,14 +155,8 @@ class UbuntuTestCase(RepoBaseTestCase):
         )
         self.assertThat(str(raised), Equals("Package fetch error: foo"))
 
-    @patch("snapcraft.internal.repo._deb._AptCache.fetch_binary")
     @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_get_package_trusted_parts_already_imported(
-        self, mock_apt_pkg, mock_fetch_binary
-    ):
-        fake_package_path = os.path.join(self.path, "fake-package.deb")
-        open(fake_package_path, "w").close()
-        mock_fetch_binary.return_value = fake_package_path
+    def test_get_package_trusted_parts_already_imported(self, mock_apt_pkg):
         self.mock_cache().is_virtual_package.return_value = False
 
         def _fake_find_file(key: str):
@@ -219,12 +202,8 @@ class UbuntuTestCase(RepoBaseTestCase):
             os.path.join(self.tempdir, "download", "fake-package.deb"), FileExists()
         )
 
-    @patch("snapcraft.internal.repo._deb._AptCache.fetch_binary")
     @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_get_multiarch_package(self, mock_apt_pkg, mock_fetch_binary):
-        fake_package_path = os.path.join(self.path, "fake-package.deb")
-        open(fake_package_path, "w").close()
-        mock_fetch_binary.return_value = fake_package_path
+    def test_get_multiarch_package(self, mock_apt_pkg):
         self.mock_cache().is_virtual_package.return_value = False
 
         fake_trusted_parts_path = os.path.join(self.path, "fake-trusted-parts")


### PR DESCRIPTION
python-apt has been updated to be less verbose, so we can
use the fetch_binary() logic that was lifted from there.

Update mocks, fixture, and tests accordingly.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
