### PR TITLE
repo: introduce install_source() and install_gpg_key() to Ubuntu

### DIFF
--- a/tests/unit/repo/test_errors.py
+++ b/tests/unit/repo/test_errors.py
@@ -39,3 +39,44 @@ class ErrorFormattingTestCase(unit.TestCase):
         self.assertThat(
             str(self.exception(**self.kwargs)), Equals(self.expected_message)
         )
+
+
+class AptGPGKeyInstallErrorTests(unit.TestCase):
+
+    scenarios = [
+        (
+            "AptGPGKeyInstallError basic",
+            {
+                "exception": errors.AptGPGKeyInstallError,
+                "kwargs": {"output": "some error", "gpg_key": "fake key"},
+                "expected_brief": "Failed to install GPG key: some error",
+                "expected_resolution": "Verify any configured GPG keys.",
+                "expected_details": "GPG key:\nfake key",
+                "expected_docs_url": None,
+                "expected_reportable": False,
+            },
+        ),
+        (
+            "AptGPGKeyInstallError basic with warning",
+            {
+                "exception": errors.AptGPGKeyInstallError,
+                "kwargs": {
+                    "output": "Warning: apt-key output should not be parsed (stdout is not a terminal)\nsome error",
+                    "gpg_key": "fake key",
+                },
+                "expected_brief": "Failed to install GPG key: some error",
+                "expected_resolution": "Verify any configured GPG keys.",
+                "expected_details": "GPG key:\nfake key",
+                "expected_docs_url": None,
+                "expected_reportable": False,
+            },
+        ),
+    ]
+
+    def test_snapcraft_exception_handling(self):
+        exception = self.exception(**self.kwargs)
+        self.assertThat(exception.get_brief(), Equals(self.expected_brief))
+        self.assertThat(exception.get_resolution(), Equals(self.expected_resolution))
+        self.assertThat(exception.get_details(), Equals(self.expected_details))
+        self.assertThat(exception.get_docs_url(), Equals(self.expected_docs_url))
+        self.assertThat(exception.get_reportable(), Equals(self.expected_reportable))


### PR DESCRIPTION
Allow system-wide installation of trusted GPG keys and deb sources
for apt.

- GPG keys are installed to: /etc/apt/trusted.gpg.d/snapcraft.gpg

  - Installed using apt-key with sudo.

- Introduce AptGPGKeyInstallError to help format apt-key errors.
  This will expand as we incorporate more cases of apt-key.

- Deb sources are installed to: /etc/apt/sources.list.d/snapcraft.list

  - Installed using a helper to write the file with sudo.

- Add tests for coverage.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
