### PR TITLE
meta: migrate get_build_base to Snap

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -23,6 +23,7 @@ from typing import Dict, List, Optional
 from snapcraft.project import Project, get_snapcraft_yaml
 from snapcraft.cli.echo import confirm, prompt
 from snapcraft.internal import common, errors
+from snapcraft.internal.meta.snap import Snap
 
 
 class PromptOption(click.Option):
@@ -275,6 +276,10 @@ def get_project(*, is_managed_host: bool = False, **kwargs):
         snapcraft_yaml_file_path=snapcraft_yaml_file_path,
         is_managed_host=is_managed_host,
     )
+    # TODO: this should be automatic on get_project().
+    # This is not the complete meta parsed by the project loader.
+    project._snap_meta = Snap.from_dict(project.info.get_raw_snapcraft())
+
     return project
 
 

--- a/snapcraft/cli/remote.py
+++ b/snapcraft/cli/remote.py
@@ -115,8 +115,9 @@ def remote_build(
     project = get_project()
 
     # TODO: use project.is_legacy() when available.
-    base = project.info.get_build_base()
-    if base is None:
+    try:
+        project._get_build_base()
+    except RuntimeError:
         raise errors.BaseRequiredError()
 
     # Use a hash of current working directory to distinguish between other

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -92,21 +92,21 @@ class Provider(abc.ABC):
         self.echoer = echoer
         self._is_ephemeral = is_ephemeral
 
-        self.instance_name = "snapcraft-{}".format(project.info.name)
+        self.instance_name = "snapcraft-{}".format(project._snap_meta.name)
 
-        if project.info.version:
+        if project._snap_meta.version:
             self.snap_filename = "{}_{}_{}.snap".format(
-                project.info.name, project.info.version, project.deb_arch
+                project._snap_meta.name, project._snap_meta.version, project.deb_arch
             )
         else:
             self.snap_filename = "{}_{}.snap".format(
-                project.info.name, project.deb_arch
+                project._snap_meta.name, project.deb_arch
             )
 
         self.provider_project_dir = os.path.join(
             BaseDirectory.save_data_path("snapcraft"),
             "projects",
-            project.info.name,
+            project._snap_meta.name,
             self._get_provider_name(),
         )
 
@@ -282,10 +282,10 @@ class Provider(abc.ABC):
     def _ensure_base(self) -> None:
         info = self._load_info()
         provider_base = info["base"] if "base" in info else None
-        if self._base_has_changed(self.project.info.get_build_base(), provider_base):
+        if self._base_has_changed(self.project._get_build_base(), provider_base):
             self.echoer.warning(
                 "Project base changed from {!r} to {!r}, cleaning build instance.".format(
-                    provider_base, self.project.info.get_build_base()
+                    provider_base, self.project._get_build_base()
                 )
             )
             self.clean_project()
@@ -314,7 +314,7 @@ class Provider(abc.ABC):
                 )
 
     def _setup_snapcraft(self) -> None:
-        self._save_info(base=self.project.info.get_build_base())
+        self._save_info(base=self.project._get_build_base())
 
         registry_filepath = os.path.join(
             self.provider_project_dir, "snap-registry.yaml"
@@ -342,7 +342,7 @@ class Provider(abc.ABC):
         # Check for None as this build can be driven from a non snappy enabled
         # system, so we may find ourselves in a situation where the base is not
         # set like on OSX or Windows.
-        build_base = self.project.info.get_build_base()
+        build_base = self.project._get_build_base()
         if build_base is not None and build_base != "core":
             snap_injector.add(snap_name="snapd")
 

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -190,7 +190,7 @@ class LXD(Provider):
     def _launch(self) -> None:
         config = {
             "name": self.instance_name,
-            "source": get_image_source(base=self.project.info.get_build_base()),
+            "source": get_image_source(base=self.project._get_build_base()),
         }
 
         try:

--- a/snapcraft/internal/build_providers/_multipass/_multipass.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass.py
@@ -97,7 +97,7 @@ class Multipass(Provider):
         )
 
     def _get_disk_image(self) -> str:
-        return "snapcraft:{}".format(self.project.info.get_build_base())
+        return "snapcraft:{}".format(self.project._get_build_base())
 
     def _launch(self) -> None:
         image = self._get_disk_image()

--- a/snapcraft/internal/meta/snap.py
+++ b/snapcraft/internal/meta/snap.py
@@ -42,6 +42,7 @@ class Snap:
         architectures: Optional[Sequence[str]] = None,
         assumes: Optional[Set[str]] = None,
         base: Optional[str] = None,
+        build_base: Optional[str] = None,
         confinement: Optional[str] = None,
         description: Optional[str] = None,
         environment: Optional[Dict[str, Any]] = None,
@@ -78,6 +79,7 @@ class Snap:
             self.assumes = assumes
 
         self.base = base
+        self.build_base = build_base
         self.confinement = confinement
         self.description = description
 
@@ -148,6 +150,28 @@ class Snap:
                 return True
 
         return False
+
+    def get_build_base(self) -> str:
+        """
+        Return the base to use to create the snap.
+
+        Returns build-base if set, but if not, name is returned if the
+        snap is of type base. For all other snaps, the base is returned
+        as the build-base.
+        """
+        build_base: Optional[str] = None
+        if self.build_base is not None:
+            build_base = self.build_base
+        elif self.name is not None and self.type == "base":
+            build_base = self.name
+        else:
+            build_base = self.base
+
+        # The schema does not allow for this when loaded from snapcraft.yaml.
+        if build_base is None:
+            raise RuntimeError("'build_base' cannot be None")
+
+        return build_base
 
     def get_content_plugs(self) -> List[ContentPlug]:
         """Get list of content plugs."""
@@ -262,6 +286,7 @@ class Snap:
         assumes = set(snap_dict.pop("assumes", set()))
 
         base = snap_dict.pop("base", None)
+        build_base = snap_dict.pop("build-base", None)
         confinement = snap_dict.pop("confinement", None)
         description = snap_dict.pop("description", None)
         environment = snap_dict.pop("environment", None)
@@ -327,6 +352,7 @@ class Snap:
             apps=apps,
             assumes=assumes,
             base=base,
+            build_base=build_base,
             confinement=confinement,
             description=description,
             environment=environment,
@@ -380,6 +406,9 @@ class Snap:
 
         if self.base is not None:
             snap_dict["base"] = self.base
+
+        if self.build_base is not None:
+            snap_dict["build-base"] = self.build_base
 
         if self.confinement is not None:
             snap_dict["confinement"] = self.confinement
@@ -439,6 +468,7 @@ class Snap:
             snap_dict.pop("base")
 
         # Remove keys that are not for snap.yaml.
+        snap_dict.pop("build-base", None)
         snap_dict.pop("adopt-info", None)
 
         # Apply passthrough keys.

--- a/snapcraft/plugins/v1/ant.py
+++ b/snapcraft/plugins/v1/ant.py
@@ -155,12 +155,12 @@ class AntPlugin(PluginV1):
         super().__init__(name, options, project)
 
         self._setup_ant()
-        self._setup_base_tools(project.info.get_build_base())
+        self._setup_base_tools(project._get_build_base())
 
     def _setup_base_tools(self, base):
         if base not in ("core", "core16", "core18"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=self.project.info.get_build_base()
+                part_name=self.name, base=self.project._get_build_base()
             )
 
         if base in ("core", "core16"):
@@ -235,7 +235,7 @@ class AntPlugin(PluginV1):
         self._create_symlinks()
 
     def _create_symlinks(self):
-        base = self.project.info.get_build_base()
+        base = self.project._get_build_base()
         if base not in ("core18", "core16", "core"):
             raise errors.PluginBaseError(part_name=self.name, base=base)
 

--- a/snapcraft/plugins/v1/catkin.py
+++ b/snapcraft/plugins/v1/catkin.py
@@ -328,7 +328,7 @@ class CatkinPlugin(PluginV1):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        base = self.project.info.get_build_base()
+        base = self.project._get_build_base()
         if base not in ("core", "core16", "core18"):
             raise errors.PluginBaseError(part_name=self.name, base=base)
 
@@ -524,9 +524,7 @@ class CatkinPlugin(PluginV1):
             ros_distro=self._rosdistro,
             ros_package_path=self._ros_package_path,
             rosdep_path=self._rosdep_path,
-            ubuntu_distro=_BASE_TO_UBUNTU_RELEASE_MAP[
-                self.project.info.get_build_base()
-            ],
+            ubuntu_distro=_BASE_TO_UBUNTU_RELEASE_MAP[self.project._get_build_base()],
         )
         rosdep.setup()
 

--- a/snapcraft/plugins/v1/cmake.py
+++ b/snapcraft/plugins/v1/cmake.py
@@ -94,9 +94,9 @@ class CMakePlugin(PluginV1):
         self.build_packages.append("cmake")
         self.out_of_source_build = True
 
-        if project.info.get_build_base() not in ("core", "core16", "core18"):
+        if project._get_build_base() not in ("core", "core16", "core18"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=project.info.get_build_base()
+                part_name=self.name, base=project._get_build_base()
             )
 
         if options.make_parameters:

--- a/snapcraft/plugins/v1/colcon.py
+++ b/snapcraft/plugins/v1/colcon.py
@@ -276,9 +276,9 @@ class ColconPlugin(PluginV1):
         self.out_of_source_build = True
 
         self._rosdistro = options.colcon_rosdistro
-        if project.info.get_build_base() != _ROSDISTRO_TO_BASE_MAP[self._rosdistro]:
+        if project._get_build_base() != _ROSDISTRO_TO_BASE_MAP[self._rosdistro]:
             raise ColconPluginBaseError(
-                self.name, project.info.get_build_base(), self._rosdistro
+                self.name, project._get_build_base(), self._rosdistro
             )
 
         if self._rosdistro in _EOL_ROSDISTROS:
@@ -380,9 +380,7 @@ class ColconPlugin(PluginV1):
             ros_distro=self._rosdistro,
             ros_package_path=self._ros_package_path,
             rosdep_path=self._rosdep_path,
-            ubuntu_distro=_BASE_TO_UBUNTU_RELEASE_MAP[
-                self.project.info.get_build_base()
-            ],
+            ubuntu_distro=_BASE_TO_UBUNTU_RELEASE_MAP[self.project._get_build_base()],
         )
         rosdep.setup()
 

--- a/snapcraft/plugins/v1/conda.py
+++ b/snapcraft/plugins/v1/conda.py
@@ -89,9 +89,9 @@ class CondaPlugin(PluginV1):
 
     def __init__(self, name, options, project) -> None:
         super().__init__(name, options, project)
-        if project.info.get_build_base() not in ("core", "core16", "core18"):
+        if project._get_build_base() not in ("core", "core16", "core18"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=project.info.get_build_base()
+                part_name=self.name, base=project._get_build_base()
             )
 
         self._conda_home = os.path.join(self.partdir, "miniconda")
@@ -135,7 +135,7 @@ class CondaPlugin(PluginV1):
 
         # conda needs to rewrite the prefixes in the python shebangs and binaries
         conda_target_prefix = os.path.join(
-            os.path.sep, "snap", self.project.info.name, "current"
+            os.path.sep, "snap", self.project._snap_meta.name, "current"
         )
 
         subprocess.check_call(

--- a/snapcraft/plugins/v1/crystal.py
+++ b/snapcraft/plugins/v1/crystal.py
@@ -73,9 +73,9 @@ class CrystalPlugin(PluginV1):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        if project.info.get_build_base() not in ("core", "core16", "core18"):
+        if project._get_build_base() not in ("core", "core16", "core18"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=project.info.get_build_base()
+                part_name=self.name, base=project._get_build_base()
             )
 
         self.build_snaps.append("crystal/{}".format(self.options.crystal_channel))
@@ -122,7 +122,7 @@ class CrystalPlugin(PluginV1):
             elf_dependencies_path = elf_file.load_dependencies(
                 root_path=self.installdir,
                 core_base_path=common.get_installed_snap_path(
-                    self.project.info.get_build_base()
+                    self.project._get_build_base()
                 ),
                 arch_triplet=self.project.arch_triplet,
                 content_dirs=self.project._get_provider_content_dirs(),

--- a/snapcraft/plugins/v1/dotnet.py
+++ b/snapcraft/plugins/v1/dotnet.py
@@ -107,7 +107,7 @@ class DotNetPlugin(PluginV1):
         self._dotnet_dir = os.path.join(self.partdir, "dotnet")
         self._dotnet_sdk_dir = os.path.join(self._dotnet_dir, "sdk")
 
-        self._setup_base_tools(project.info.get_build_base())
+        self._setup_base_tools(project._get_build_base())
 
         self._sdk = self._get_sdk()
         self._dotnet_cmd = os.path.join(self._dotnet_sdk_dir, "dotnet")

--- a/snapcraft/plugins/v1/go.py
+++ b/snapcraft/plugins/v1/go.py
@@ -140,8 +140,8 @@ class GoPlugin(PluginV1):
     def __init__(self, name: str, options, project: "Project") -> None:
         super().__init__(name, options, project)
 
-        self._setup_base_tools(options.go_channel, project.info.get_build_base())
-        self._is_classic = project.info.confinement == "classic"
+        self._setup_base_tools(options.go_channel, project._get_build_base())
+        self._is_classic = project._snap_meta.confinement == "classic"
 
         self._install_bin_dir = os.path.join(self.installdir, "bin")
 

--- a/snapcraft/plugins/v1/godeps.py
+++ b/snapcraft/plugins/v1/godeps.py
@@ -103,7 +103,7 @@ class GodepsPlugin(PluginV1):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        self._setup_base_tools(options.go_channel, project.info.get_build_base())
+        self._setup_base_tools(options.go_channel, project._get_build_base())
 
         self._gopath = os.path.join(self.partdir, "go")
         self._gopath_src = os.path.join(self._gopath, "src")

--- a/snapcraft/plugins/v1/gradle.py
+++ b/snapcraft/plugins/v1/gradle.py
@@ -146,12 +146,12 @@ class GradlePlugin(PluginV1):
         super().__init__(name, options, project)
 
         self._setup_gradle()
-        self._setup_base_tools(project.info.get_build_base())
+        self._setup_base_tools(project._get_build_base())
 
     def _setup_base_tools(self, base):
         if base not in ("core", "core16", "core18"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=self.project.info.get_build_base()
+                part_name=self.name, base=self.project._get_build_base()
             )
 
         if base in ("core", "core16"):
@@ -234,9 +234,9 @@ class GradlePlugin(PluginV1):
         self._create_symlinks()
 
     def _create_symlinks(self):
-        if self.project.info.get_build_base() not in ("core18", "core16", "core"):
+        if self.project._get_build_base() not in ("core18", "core16", "core"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=self.project.info.get_build_base()
+                part_name=self.name, base=self.project._get_build_base()
             )
 
         os.makedirs(os.path.join(self.installdir, "bin"), exist_ok=True)

--- a/snapcraft/plugins/v1/kbuild.py
+++ b/snapcraft/plugins/v1/kbuild.py
@@ -103,9 +103,9 @@ class KBuildPlugin(PluginV1):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        if project.info.get_build_base() not in ("core", "core16", "core18"):
+        if project._get_build_base() not in ("core", "core16", "core18"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=project.info.get_build_base()
+                part_name=self.name, base=project._get_build_base()
             )
 
         self.build_packages.extend(["bc", "gcc", "make"])

--- a/snapcraft/plugins/v1/make.py
+++ b/snapcraft/plugins/v1/make.py
@@ -89,9 +89,9 @@ class MakePlugin(PluginV1):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        if project.info.get_build_base() not in ("core", "core16", "core18", "core20"):
+        if project._get_build_base() not in ("core", "core16", "core18", "core20"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=project.info.get_build_base()
+                part_name=self.name, base=project._get_build_base()
             )
 
         self.build_packages.append("make")

--- a/snapcraft/plugins/v1/maven.py
+++ b/snapcraft/plugins/v1/maven.py
@@ -149,12 +149,12 @@ class MavenPlugin(PluginV1):
         super().__init__(name, options, project)
 
         self._setup_maven()
-        self._setup_base_tools(project.info.get_build_base())
+        self._setup_base_tools(project._get_build_base())
 
     def _setup_base_tools(self, base):
         if base not in ("core", "core16", "core18"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=self.project.info.get_build_base()
+                part_name=self.name, base=self.project._get_build_base()
             )
 
         if base in ("core", "core16"):
@@ -242,9 +242,9 @@ class MavenPlugin(PluginV1):
         self._create_symlinks()
 
     def _create_symlinks(self):
-        if self.project.info.get_build_base() not in ("core18", "core16", "core"):
+        if self.project._get_build_base() not in ("core18", "core16", "core"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=self.project.info.get_build_base()
+                part_name=self.name, base=self.project._get_build_base()
             )
 
         os.makedirs(os.path.join(self.installdir, "bin"), exist_ok=True)

--- a/snapcraft/plugins/v1/meson.py
+++ b/snapcraft/plugins/v1/meson.py
@@ -68,7 +68,7 @@ class MesonPlugin(PluginV1):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        self._setup_base_tools(project.info.get_build_base())
+        self._setup_base_tools(project._get_build_base())
 
         self.snapbuildname = "snapbuild"
         self.mesonbuilddir = os.path.join(self.builddir, self.snapbuildname)

--- a/snapcraft/plugins/v1/plainbox_provider.py
+++ b/snapcraft/plugins/v1/plainbox_provider.py
@@ -46,7 +46,7 @@ class PlainboxProviderPlugin(PluginV1):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        self._setup_base_tools(project.info.get_build_base())
+        self._setup_base_tools(project._get_build_base())
 
     def _setup_base_tools(self, base):
         if base in ("core", "core16", "core18"):

--- a/snapcraft/plugins/v1/python.py
+++ b/snapcraft/plugins/v1/python.py
@@ -147,12 +147,12 @@ class PythonPlugin(PluginV1):
         elif self.options.python_version == "python3":
             python_base = "python3"
 
-        if self.project.info.get_build_base() in ("core", "core16", "core18"):
+        if self.project._get_build_base() in ("core", "core16", "core18"):
             stage_packages = [python_base]
         else:
             stage_packages = []
 
-        if self.project.info.get_build_base() == "core18" and python_base == "python3":
+        if self.project._get_build_base() == "core18" and python_base == "python3":
             stage_packages.append("{}-distutils".format(python_base))
 
         return stage_packages
@@ -185,7 +185,7 @@ class PythonPlugin(PluginV1):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        self._setup_base_tools(project.info.get_build_base())
+        self._setup_base_tools(project._get_build_base())
 
         self._manifest = collections.OrderedDict()
 

--- a/snapcraft/plugins/v1/qmake.py
+++ b/snapcraft/plugins/v1/qmake.py
@@ -85,9 +85,9 @@ class QmakePlugin(PluginV1):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        if project.info.get_build_base() not in ("core", "core16", "core18"):
+        if project._get_build_base() not in ("core", "core16", "core18"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=project.info.get_build_base()
+                part_name=self.name, base=project._get_build_base()
             )
 
         self.build_packages.append("make")

--- a/snapcraft/plugins/v1/ruby.py
+++ b/snapcraft/plugins/v1/ruby.py
@@ -74,9 +74,9 @@ class RubyPlugin(PluginV1):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        if project.info.get_build_base() not in ("core", "core16", "core18"):
+        if project._get_build_base() not in ("core", "core16", "core18"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=project.info.get_build_base()
+                part_name=self.name, base=project._get_build_base()
             )
 
         # Beta Warning

--- a/snapcraft/plugins/v1/rust.py
+++ b/snapcraft/plugins/v1/rust.py
@@ -91,9 +91,9 @@ class RustPlugin(PluginV1):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        if project.info.get_build_base() not in ("core", "core16", "core18"):
+        if project._get_build_base() not in ("core", "core16", "core18"):
             raise errors.PluginBaseError(
-                part_name=self.name, base=project.info.get_build_base()
+                part_name=self.name, base=project._get_build_base()
             )
 
         self.build_packages.extend(["gcc", "git", "curl", "file"])

--- a/snapcraft/plugins/v1/scons.py
+++ b/snapcraft/plugins/v1/scons.py
@@ -57,7 +57,7 @@ class SconsPlugin(PluginV1):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
-        self._setup_base_tools(project.info.get_build_base())
+        self._setup_base_tools(project._get_build_base())
 
     def _setup_base_tools(self, base):
         if base in ("core", "core16", "core18"):

--- a/snapcraft/plugins/v1/waf.py
+++ b/snapcraft/plugins/v1/waf.py
@@ -56,7 +56,7 @@ class WafPlugin(PluginV1):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        self._setup_base_tools(project.info.get_build_base())
+        self._setup_base_tools(project._get_build_base())
 
     def _setup_base_tools(self, base):
         if base in ("core", "core16", "core18"):

--- a/snapcraft/project/_project.py
+++ b/snapcraft/project/_project.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018-2019 Canonical Ltd
+# Copyright (C) 2018-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -66,6 +66,12 @@ class Project(ProjectOptions):
         # Ideally everywhere wold converge to operating on snap_meta, and ww
         # would only need to initialize it once (properly).
         self._snap_meta = Snap()
+
+    def _get_build_base(self) -> str:
+        """
+        Return name for type base or the base otherwise build-base is set
+        """
+        return self._snap_meta.get_build_base()
 
     def _get_project_directory_hash(self) -> str:
         m = hashlib.sha1()

--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from copy import deepcopy
-from typing import Optional
 
 from snapcraft import yaml_utils
 from . import _schema
@@ -48,17 +47,6 @@ class ProjectInfo:
     def validate_raw_snapcraft(self):
         """Validate the snapcraft.yaml for this project."""
         _schema.Validator(self.__raw_snapcraft).validate()
-
-    def get_build_base(self) -> Optional[str]:
-        """
-        Return name for type base or the base otherwise build-base is set
-        """
-        if self.build_base:
-            return self.build_base
-        elif self.type == "base":
-            return self.name
-        else:
-            return self.base
 
     def get_raw_snapcraft(self):
         # TODO this should be a MappingProxyType, but ordered writing

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -19,7 +19,7 @@ from typing import Optional
 from unittest import mock
 
 from snapcraft.project import Project
-
+from snapcraft.internal.meta.snap import Snap
 from tests import fixture_setup, unit
 from snapcraft.internal.build_providers._base_provider import Provider
 
@@ -124,11 +124,11 @@ class ProviderImpl(Provider):
 
 
 def get_project(base: str = "core16") -> Project:
-    with open("snapcraft.yaml", "w") as snapcraft_file:
-        print("name: project-name", file=snapcraft_file)
-        print("base: {}".format(base), file=snapcraft_file)
-
-    return Project(snapcraft_yaml_file_path="snapcraft.yaml")
+    project = Project()
+    project._snap_meta = Snap(
+        name="project-name", base=base, version="1.0", confinement="strict"
+    )
+    return project
 
 
 class BaseProviderBaseTest(unit.TestCase):

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -313,9 +313,9 @@ class LXDInitTest(LXDBaseTest):
         instance.destroy()
 
     def test_create_for_type_base(self):
-        self.project.info.name = "core18"
-        self.project.info.type = "base"
-        self.project.info.base = None
+        self.project._snap_meta.name = "core18"
+        self.project._snap_meta.type = "base"
+        self.project._snap_meta.base = None
 
         instance = LXDTestImpl(project=self.project, echoer=self.echoer_mock)
 

--- a/tests/unit/build_providers/multipass/test_multipass.py
+++ b/tests/unit/build_providers/multipass/test_multipass.py
@@ -184,9 +184,9 @@ class MultipassTest(BaseProviderBaseTest):
         )
 
     def test_launch_for_type_base(self):
-        self.project.info.name = "core18"
-        self.project.info.type = "base"
-        self.project.info.base = None
+        self.project._snap_meta.name = "core18"
+        self.project._snap_meta.type = "base"
+        self.project._snap_meta.base = None
 
         instance = MultipassTestImpl(project=self.project, echoer=self.echoer_mock)
         self.useFixture(

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -40,7 +40,7 @@ class BaseProviderTest(BaseProviderBaseTest):
         )
         self.assertThat(
             provider.snap_filename,
-            Equals("project-name_{}.snap".format(self.project.deb_arch)),
+            Equals("project-name_1.0_{}.snap".format(self.project.deb_arch)),
         )
 
     def test_context(self):
@@ -73,7 +73,7 @@ class BaseProviderTest(BaseProviderBaseTest):
         destroy_mock.assert_called_once_with("destroy bad")
 
     def test_initialize_snap_filename_with_version(self):
-        self.project.info.version = "test-version"
+        self.project._snap_meta.version = "test-version"
 
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
 
@@ -152,7 +152,7 @@ class BaseProviderTest(BaseProviderBaseTest):
 
     def test_ensure_base_same_base(self):
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
-        provider.project.info.base = "core16"
+        provider.project._snap_meta.base = "core16"
 
         # Provider and project have the same base
         patcher = patch(
@@ -167,7 +167,7 @@ class BaseProviderTest(BaseProviderBaseTest):
 
     def test_ensure_base_new_base(self):
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
-        provider.project.info.base = "core16"
+        provider.project._snap_meta.base = "core16"
 
         # Provider and project have different bases
         patcher = patch(
@@ -182,7 +182,7 @@ class BaseProviderTest(BaseProviderBaseTest):
 
     def test_ensure_base_no_base_clean(self):
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
-        provider.project.info.base = "core16"
+        provider.project._snap_meta.base = "core16"
 
         # Provider has no base, project has base that's not core18
         # (assume provider has core18 for backward compatibility)
@@ -199,7 +199,7 @@ class BaseProviderTest(BaseProviderBaseTest):
     def test_ensure_base_no_base_keep(self):
 
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
-        provider.project.info.base = "core18"
+        provider.project._snap_meta.base = "core18"
 
         # Provider has no base, project has base core18
         # (assume provider has core18 for backward compatibility)
@@ -410,8 +410,8 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
         self.snap_injector_mock().apply.assert_called_once_with()
 
     def test_setup_snapcraft_with_core(self):
-        self.project.info.base = "core"
-        self.project.info.confinement = "classic"
+        self.project._snap_meta.base = "core"
+        self.project._snap_meta.confinement = "classic"
 
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
         provider._setup_snapcraft()
@@ -427,8 +427,8 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
         self.snap_injector_mock().apply.assert_called_once_with()
 
     def test_setup_snapcraft_for_classic_build(self):
-        self.project.info.base = "core18"
-        self.project.info.confinement = "classic"
+        self.project._snap_meta.base = "core18"
+        self.project._snap_meta.confinement = "classic"
 
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
         provider._setup_snapcraft()
@@ -446,7 +446,7 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
 
 class MacProviderProvisionSnapcraftTest(MacBaseProviderWithBasesBaseTest):
     def test_setup_snapcraft_with_base(self):
-        self.project.info.base = "core18"
+        self.project._snap_meta.base = "core18"
 
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
         provider._setup_snapcraft()
@@ -470,30 +470,9 @@ class MacProviderProvisionSnapcraftTest(MacBaseProviderWithBasesBaseTest):
         self.assertThat(self.snap_injector_mock().add.call_count, Equals(3))
         self.snap_injector_mock().apply.assert_called_once_with()
 
-    def test_setup_snapcraft_with_no_base(self):
-        self.project.info.base = None
-
-        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
-        provider._setup_snapcraft()
-
-        self.snap_injector_mock.assert_called_once_with(
-            registry_filepath=os.path.join(
-                provider.provider_project_dir, "snap-registry.yaml"
-            ),
-            snap_arch=self.project.deb_arch,
-            runner=provider._run,
-            file_pusher=provider._push_file,
-            inject_from_host=False,
-        )
-        self.snap_injector_mock().add.assert_has_calls(
-            [call(snap_name="core18"), call(snap_name="snapcraft")]
-        )
-        self.assertThat(self.snap_injector_mock().add.call_count, Equals(2))
-        self.snap_injector_mock().apply.assert_called_once_with()
-
     def test_setup_snapcraft_for_classic_build(self):
-        self.project.info.base = "core18"
-        self.project.info.confinement = "classic"
+        self.project._snap_meta.base = "core18"
+        self.project._snap_meta.confinement = "classic"
 
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
         provider._setup_snapcraft()

--- a/tests/unit/plugins/v1/__init__.py
+++ b/tests/unit/plugins/v1/__init__.py
@@ -1,0 +1,29 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from snapcraft.internal.meta.snap import Snap
+from snapcraft.project import Project
+from tests import unit
+
+
+class PluginsV1BaseTestCase(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.project = Project()
+        self.project._snap_meta = Snap(
+            name="test-snap", base="core18", confinement="strict"
+        )

--- a/tests/unit/plugins/v1/test_ant.py
+++ b/tests/unit/plugins/v1/test_ant.py
@@ -16,7 +16,6 @@
 
 import os
 import tarfile
-from textwrap import dedent
 from unittest import mock
 
 import fixtures
@@ -24,8 +23,8 @@ from testtools.matchers import Contains, Equals, HasLength
 
 from snapcraft.internal import errors
 from snapcraft.plugins.v1 import ant
-from snapcraft.project import Project
 from tests import unit
+from . import PluginsV1BaseTestCase
 
 
 class AntPluginPropertiesTest(unit.TestCase):
@@ -86,7 +85,7 @@ class AntPluginPropertiesTest(unit.TestCase):
             self.assertIn(property, resulting_build_properties)
 
 
-class AntPluginBaseTest(unit.TestCase):
+class AntPluginBaseTest(PluginsV1BaseTestCase):
     scenarios = (
         (
             "core java version 8 ",
@@ -129,16 +128,7 @@ class AntPluginBaseTest(unit.TestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: test-snap
-            base: {base}
-        """
-            ).format(base=self.base)
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = self.base
 
         class Options:
             ant_properties = {}
@@ -292,20 +282,9 @@ class AntPluginBaseTest(unit.TestCase):
         )
 
 
-class AntPluginSnapTest(unit.TestCase):
+class AntPluginSnapTest(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
-
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-                name: test-snap
-                base: core18
-                """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
 
         class Options:
             ant_properties = {}
@@ -380,20 +359,11 @@ class AntPluginSnapTest(unit.TestCase):
         self.assertEqual(plugin.build_snaps, ["ant/other/channel"])
 
 
-class AntPluginUnsupportedBase(unit.TestCase):
+class AntPluginUnsupportedBase(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: ant-snap
-            base: unsupported-base
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = "unsupported-base"
 
         class Options:
             ant_properties = {}
@@ -415,7 +385,7 @@ class AntPluginUnsupportedBase(unit.TestCase):
         )
 
 
-class UnsupportedJDKVersionErrorTest(unit.TestCase):
+class UnsupportedJDKVersionErrorTest(PluginsV1BaseTestCase):
 
     scenarios = (
         (
@@ -456,18 +426,7 @@ class UnsupportedJDKVersionErrorTest(unit.TestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: ant-snap
-            base: {base}
-        """.format(
-                    base=self.base
-                )
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = self.base
 
         class Options:
             ant_properties = {}

--- a/tests/unit/plugins/v1/test_catkin.py
+++ b/tests/unit/plugins/v1/test_catkin.py
@@ -41,6 +41,7 @@ from snapcraft import repo
 from snapcraft.internal import errors
 from snapcraft.plugins.v1 import catkin, _ros
 from tests import unit
+from . import PluginsV1BaseTestCase
 
 
 class _CompareContainers:
@@ -65,9 +66,12 @@ class _CompareContainers:
         return True
 
 
-class CatkinPluginBaseTest(unit.TestCase):
+class CatkinPluginBaseTest(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
+
+        # Most Catkin test use core.
+        self.project._snap_meta.base = "core"
 
         class props:
             catkin_packages = ["my_package"]
@@ -85,17 +89,6 @@ class CatkinPluginBaseTest(unit.TestCase):
         self.properties = props()
         self.ros_distro = "kinetic"
         self.ubuntu_distro = "xenial"
-
-        self.project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: catkin-snap
-                    base: core16
-                    """
-                )
-            )
-        )
 
         patcher = mock.patch("snapcraft.repo.Ubuntu")
         self.ubuntu_mock = patcher.start()

--- a/tests/unit/plugins/v1/test_catkin_tools.py
+++ b/tests/unit/plugins/v1/test_catkin_tools.py
@@ -16,17 +16,15 @@
 import os
 import os.path
 import re
-import textwrap
 
 from unittest import mock
 from testtools.matchers import Contains, Equals
 
-import snapcraft
 from snapcraft.plugins.v1 import catkin_tools
-from tests import unit
+from . import PluginsV1BaseTestCase
 
 
-class CatkinToolsPluginBaseTest(unit.TestCase):
+class CatkinToolsPluginBaseTest(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
@@ -43,16 +41,6 @@ class CatkinToolsPluginBaseTest(unit.TestCase):
             build_attributes = []
 
         self.properties = props()
-        self.project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: catkin-snap
-                    base: core16
-                    """
-                )
-            )
-        )
 
         patcher = mock.patch("snapcraft.plugins.v1._python.Pip")
         self.pip_mock = patcher.start()

--- a/tests/unit/plugins/v1/test_cmake.py
+++ b/tests/unit/plugins/v1/test_cmake.py
@@ -15,19 +15,18 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import textwrap
 
 from unittest import mock
 from testtools.matchers import Equals, HasLength
 
-import snapcraft
 from snapcraft.internal import errors
 from snapcraft.plugins.v1 import cmake
 from tests import fixture_setup, unit
 from typing import Any, Dict, List, Tuple
+from . import PluginsV1BaseTestCase
 
 
-class CMakeBaseTest(unit.TestCase):
+class CMakeBaseTest(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
@@ -40,17 +39,6 @@ class CMakeBaseTest(unit.TestCase):
             build_snaps = []
 
         self.options = Options()
-
-        self.project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: make-snap
-                    base: core16
-                    """
-                )
-            )
-        )
 
         patcher = mock.patch("snapcraft.internal.common.run")
         self.run_mock = patcher.start()
@@ -174,23 +162,14 @@ class CMakeTest(CMakeBaseTest):
                 )
 
     def test_unsupported_base(self):
-        project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: cmake-snap
-                    base: unsupported-base
-                    """
-                )
-            )
-        )
+        self.project._snap_meta.base = "unsupported-base"
 
         raised = self.assertRaises(
             errors.PluginBaseError,
             cmake.CMakePlugin,
             "test-part",
             self.options,
-            project,
+            self.project,
         )
 
         self.assertThat(raised.part_name, Equals("test-part"))

--- a/tests/unit/plugins/v1/test_colcon.py
+++ b/tests/unit/plugins/v1/test_colcon.py
@@ -18,7 +18,6 @@ import logging
 import os
 import os.path
 import re
-import textwrap
 
 import fixtures
 from unittest import mock
@@ -33,11 +32,11 @@ from testtools.matchers import (
     Not,
 )
 
-import snapcraft
 from snapcraft import repo
 from snapcraft.plugins.v1 import colcon
 from snapcraft.plugins.v1 import _ros
 from tests import unit
+from . import PluginsV1BaseTestCase
 
 
 class _CompareContainers:
@@ -62,7 +61,7 @@ class _CompareContainers:
         return True
 
 
-class ColconPluginTestBase(unit.TestCase):
+class ColconPluginTestBase(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
@@ -80,17 +79,6 @@ class ColconPluginTestBase(unit.TestCase):
 
         self.properties = props()
         self.ubuntu_distro = "bionic"
-
-        self.project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: colcon-snap
-                    base: core18
-                    """
-                )
-            )
-        )
 
         self.ubuntu_mock = self.useFixture(
             fixtures.MockPatch("snapcraft.repo.Ubuntu")
@@ -157,23 +145,14 @@ class ColconPluginTest(ColconPluginTestBase):
             self.assertThat(properties, Contains(prop))
 
     def test_unsupported_base(self):
-        project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: cmake-snap
-                    base: unsupported-base
-                    """
-                )
-            )
-        )
+        self.project._snap_meta.base = "unsupported-base"
 
         raised = self.assertRaises(
             colcon.ColconPluginBaseError,
             colcon.ColconPlugin,
             "test-part",
             self.properties,
-            project,
+            self.project,
         )
 
         self.assertThat(raised.part_name, Equals("test-part"))

--- a/tests/unit/plugins/v1/test_conda.py
+++ b/tests/unit/plugins/v1/test_conda.py
@@ -15,40 +15,28 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from textwrap import dedent
 from unittest import mock
 
 from testtools.matchers import DirExists, Equals, HasLength, Not
 import fixtures
 
 from snapcraft.internal import errors
-from snapcraft.project import Project
 from snapcraft.plugins.v1 import conda
 from tests import unit
+from . import PluginsV1BaseTestCase
 
 
-class CondaPluginBaseTest(unit.TestCase):
+class CondaPluginBaseTest(PluginsV1BaseTestCase):
 
     deb_arch = None
 
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: conda-snap
-            base: core18
-        """
-            )
-        )
-
-        self.project = Project(
-            target_deb_arch=self.deb_arch, snapcraft_yaml_file_path=snapcraft_yaml_path
-        )
-
         if self.project.deb_arch != "amd64":
             self.skipTest("architecture is not supported by conda plugin")
+
+        self.project._snap_meta.name = "conda-snap"
 
         self.fake_check_call = fixtures.MockPatch("subprocess.check_call")
         self.useFixture(self.fake_check_call)
@@ -373,20 +361,11 @@ class CondaPluginTest(CondaPluginBaseTest):
         self.assertThat(plugin._conda_home, DirExists())
 
 
-class CondaPluginUnsupportedBase(unit.TestCase):
+class CondaPluginUnsupportedBase(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: conda-snap
-            base: unsupported-base
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = "unsupported-base"
 
         class Options:
             pass

--- a/tests/unit/plugins/v1/test_crystal.py
+++ b/tests/unit/plugins/v1/test_crystal.py
@@ -15,14 +15,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from textwrap import dedent
 from unittest import mock
 
 from testtools.matchers import Equals, FileExists, HasLength
 import fixtures
 
 from snapcraft.internal import errors
-from snapcraft.project import Project
 from snapcraft.plugins.v1 import crystal
 from tests import unit
 from . import PluginsV1BaseTestCase

--- a/tests/unit/plugins/v1/test_crystal.py
+++ b/tests/unit/plugins/v1/test_crystal.py
@@ -25,27 +25,12 @@ from snapcraft.internal import errors
 from snapcraft.project import Project
 from snapcraft.plugins.v1 import crystal
 from tests import unit
+from . import PluginsV1BaseTestCase
 
 
-class CrystalPluginBaseTest(unit.TestCase):
-
-    deb_arch = None
-
+class CrystalPluginBaseTest(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
-
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: crystal-snap
-            base: core18
-        """
-            )
-        )
-
-        self.project = Project(
-            target_deb_arch=self.deb_arch, snapcraft_yaml_file_path=snapcraft_yaml_path
-        )
 
         self.fake_run = fixtures.MockPatch("snapcraft.internal.common.run")
         self.useFixture(self.fake_run)

--- a/tests/unit/plugins/v1/test_crystal.py
+++ b/tests/unit/plugins/v1/test_crystal.py
@@ -224,20 +224,11 @@ class CrystalPluginTest(CrystalPluginBaseTest):
         self.assertRaises(errors.SnapcraftEnvironmentError, plugin.build)
 
 
-class CrystalPluginUnsupportedBase(unit.TestCase):
+class CrystalPluginUnsupportedBase(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: crystal-snap
-            base: unsupported-base
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = "unsupported-base"
 
         class Options:
             source = "dir"

--- a/tests/unit/plugins/v1/test_dotnet.py
+++ b/tests/unit/plugins/v1/test_dotnet.py
@@ -17,7 +17,6 @@
 import json
 import os
 import tarfile
-from textwrap import dedent
 from unittest import mock
 
 from testtools.matchers import Contains, DirExists, Equals, FileExists, Not
@@ -25,9 +24,9 @@ from testtools.matchers import Contains, DirExists, Equals, FileExists, Not
 import snapcraft
 from snapcraft import file_utils
 from snapcraft.internal import sources
-from snapcraft.project import Project
 from snapcraft.plugins.v1 import dotnet
 from tests import unit
+from . import PluginsV1BaseTestCase
 
 
 def _setup_dirs(plugin):
@@ -57,20 +56,9 @@ class DotNetPluginPropertiesTest(unit.TestCase):
         )
 
 
-class DotNetProjectBaseTest(unit.TestCase):
+class DotNetProjectBaseTest(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
-
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: dotnet-snap
-            base: core16
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
 
         class Options:
             build_attributes = []

--- a/tests/unit/plugins/v1/test_godeps.py
+++ b/tests/unit/plugins/v1/test_godeps.py
@@ -15,31 +15,19 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from textwrap import dedent
 
 from unittest import mock
 from testtools.matchers import Contains, Equals, HasLength, Not
 
 from snapcraft.internal import errors
-from snapcraft.project import Project
 from snapcraft.plugins.v1 import godeps
 from tests import unit
+from . import PluginsV1BaseTestCase
 
 
-class GodepsPluginBaseTest(unit.TestCase):
+class GodepsPluginBaseTest(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
-
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: godeps-snap
-            base: core18
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
 
         patcher = mock.patch("snapcraft.internal.common.run")
         self.run_mock = patcher.start()
@@ -392,20 +380,11 @@ class GodepsPluginToolSetupTest(GodepsPluginBaseTest):
         self.assertThat(plugin.build_snaps, Not(Contains("go/latest/stable")))
 
 
-class GodepsPluginUnsupportedBaseTest(unit.TestCase):
+class GodepsPluginUnsupportedBaseTest(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: go-snap
-            base: unsupported-base
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = "unsupported-base"
 
         class Options:
             source = "dir"

--- a/tests/unit/plugins/v1/test_gradle.py
+++ b/tests/unit/plugins/v1/test_gradle.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from textwrap import dedent
 from unittest import mock
 
 import fixtures
@@ -23,11 +22,11 @@ from testtools.matchers import Equals, HasLength
 
 from snapcraft.internal import errors
 from snapcraft.plugins.v1 import gradle
-from snapcraft.project import Project
 from tests import unit
+from . import PluginsV1BaseTestCase
 
 
-class GradlePluginBaseTest(unit.TestCase):
+class GradlePluginBaseTest(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
@@ -194,16 +193,7 @@ class GradlePluginTest(GradlePluginBaseTest):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: gradle-snap
-            base: {base}
-        """
-            ).format(base=self.base)
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = self.base
 
         class Options:
             gradle_options = []
@@ -377,17 +367,6 @@ class GradleProxyTestCase(GradlePluginBaseTest):
 
         self.useFixture(fixtures.EnvironmentVariable(*self.env_var))
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: gradle-snap
-            base: core18
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
-
         class Options:
             gradle_options = []
             gradle_output_dir = "build/libs"
@@ -436,20 +415,11 @@ class GradleProxyTestCase(GradlePluginBaseTest):
         )
 
 
-class GradlePluginUnsupportedBase(unit.TestCase):
+class GradlePluginUnsupportedBase(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: gradle-snap
-            base: unsupported-base
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = "unsupported-base"
 
         class Options:
             gradle_options = []
@@ -470,7 +440,7 @@ class GradlePluginUnsupportedBase(unit.TestCase):
         )
 
 
-class UnsupportedJDKVersionErrorTest(unit.TestCase):
+class UnsupportedJDKVersionErrorTest(PluginsV1BaseTestCase):
 
     scenarios = (
         (
@@ -511,18 +481,7 @@ class UnsupportedJDKVersionErrorTest(unit.TestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: gradle-snap
-            base: {base}
-        """.format(
-                    base=self.base
-                )
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = self.base
 
         class Options:
             gradle_options = []

--- a/tests/unit/plugins/v1/test_make.py
+++ b/tests/unit/plugins/v1/test_make.py
@@ -15,18 +15,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import textwrap
 
 from unittest import mock
 from testtools.matchers import Equals, HasLength
 
-import snapcraft
 from snapcraft.internal import errors
 from snapcraft.plugins.v1 import make
-from tests import unit
+from . import PluginsV1BaseTestCase
 
 
-class MakePluginTestCase(unit.TestCase):
+class MakePluginTest(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
@@ -38,16 +36,6 @@ class MakePluginTestCase(unit.TestCase):
             artifacts = []
 
         self.options = Options()
-        self.project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: make-snap
-                    base: core16
-                    """
-                )
-            )
-        )
 
     def test_schema(self):
         schema = make.MakePlugin.schema()
@@ -278,19 +266,14 @@ class MakePluginTestCase(unit.TestCase):
         )
 
     def test_unsupported_base(self):
-        project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: make-snap
-                    base: unsupported-base
-                    """
-                )
-            )
-        )
+        self.project._snap_meta.base = "unsupported-base"
 
         raised = self.assertRaises(
-            errors.PluginBaseError, make.MakePlugin, "test-part", self.options, project
+            errors.PluginBaseError,
+            make.MakePlugin,
+            "test-part",
+            self.options,
+            self.project,
         )
 
         self.assertThat(raised.part_name, Equals("test-part"))

--- a/tests/unit/plugins/v1/test_maven.py
+++ b/tests/unit/plugins/v1/test_maven.py
@@ -26,8 +26,8 @@ from testtools.matchers import Equals, FileExists, HasLength
 
 from snapcraft.internal import errors
 from snapcraft.plugins.v1 import maven
-from snapcraft.project import Project
 from tests import unit
+from . import PluginsV1BaseTestCase
 
 
 class MavenPluginPropertiesTest(unit.TestCase):
@@ -131,7 +131,7 @@ class MavenPluginPropertiesTest(unit.TestCase):
             self.assertIn(property, resulting_build_properties)
 
 
-class MavenPluginTest(unit.TestCase):
+class MavenPluginTest(PluginsV1BaseTestCase):
 
     scenarios = (
         (
@@ -175,16 +175,7 @@ class MavenPluginTest(unit.TestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: maven-snap
-            base: {base}
-        """
-            ).format(base=self.base)
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = self.base
 
         class Options:
             maven_options = []
@@ -608,20 +599,11 @@ class MavenPluginTest(unit.TestCase):
         self.assertSettingsEqual(expected_content, settings_path)
 
 
-class MavenPluginUnsupportedBase(unit.TestCase):
+class MavenPluginUnsupportedBase(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: maven-snap
-            base: unsupported-base
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = "unsupported-base"
 
         class Options:
             source = "dir"
@@ -641,7 +623,7 @@ class MavenPluginUnsupportedBase(unit.TestCase):
         )
 
 
-class UnsupportedJDKVersionErrorTest(unit.TestCase):
+class UnsupportedJDKVersionErrorTest(PluginsV1BaseTestCase):
 
     scenarios = (
         (
@@ -682,18 +664,7 @@ class UnsupportedJDKVersionErrorTest(unit.TestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: maven-snap
-            base: {base}
-        """.format(
-                    base=self.base
-                )
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = self.base
 
         class Options:
             maven_options = []

--- a/tests/unit/plugins/v1/test_meson.py
+++ b/tests/unit/plugins/v1/test_meson.py
@@ -182,20 +182,11 @@ class MesonPluginBaseTest(PluginsV1BaseTestCase):
         )
 
 
-class MesonPluginUnsupportedBase(unit.TestCase):
+class MesonPluginUnsupportedBase(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: meson-snap
-            base: unsupported-base
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = "unsupported-base"
 
         class Options:
             source = "dir"

--- a/tests/unit/plugins/v1/test_meson.py
+++ b/tests/unit/plugins/v1/test_meson.py
@@ -25,6 +25,7 @@ from snapcraft.internal import errors
 from snapcraft.project import Project
 from snapcraft.plugins.v1 import meson
 from tests import unit
+from . import PluginsV1BaseTestCase
 
 
 class MesonPluginPropertiesTest(unit.TestCase):
@@ -95,20 +96,9 @@ class MesonPluginPropertiesTest(unit.TestCase):
             self.assertIn(property, resulting_build_properties)
 
 
-class MesonPluginBaseTest(unit.TestCase):
+class MesonPluginBaseTest(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
-
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: meson-snap
-            base: core18
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
 
         class Options:
             """Internal Options Class matching the Meson plugin"""

--- a/tests/unit/plugins/v1/test_meson.py
+++ b/tests/unit/plugins/v1/test_meson.py
@@ -16,13 +16,11 @@
 
 import os
 import subprocess
-from textwrap import dedent
 
 from unittest import mock
 from testtools.matchers import Equals, HasLength
 
 from snapcraft.internal import errors
-from snapcraft.project import Project
 from snapcraft.plugins.v1 import meson
 from tests import unit
 from . import PluginsV1BaseTestCase

--- a/tests/unit/plugins/v1/test_nodejs.py
+++ b/tests/unit/plugins/v1/test_nodejs.py
@@ -18,7 +18,6 @@ import collections
 import json
 import os
 import tarfile
-from textwrap import dedent
 from unittest import mock
 
 import fixtures
@@ -27,24 +26,13 @@ from testtools.matchers import Equals, HasLength, FileExists
 
 from snapcraft.plugins.v1 import nodejs
 from snapcraft.internal import errors
-from snapcraft.project import Project
 from tests import fixture_setup, unit
+from . import PluginsV1BaseTestCase
 
 
-class NodePluginBaseTest(unit.TestCase):
+class NodePluginBaseTest(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
-
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: go-snap
-            base: core18
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
 
         class Options:
             source = "."

--- a/tests/unit/plugins/v1/test_plainbox_provider.py
+++ b/tests/unit/plugins/v1/test_plainbox_provider.py
@@ -24,6 +24,7 @@ from snapcraft.internal import errors
 from snapcraft.plugins.v1 import plainbox_provider
 from snapcraft.project import Project
 from tests import fixture_setup, unit
+from . import PluginsV1BaseTestCase
 
 
 class PlainboxProviderPluginPropertiesTest(unit.TestCase):
@@ -62,20 +63,9 @@ class PlainboxProviderPluginPropertiesTest(unit.TestCase):
             self.assertIn(property, resulting_build_properties)
 
 
-class PlainboxProviderPluginTest(unit.TestCase):
+class PlainboxProviderPluginTest(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
-
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: plainbox-snap
-            base: core18
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
 
         class Options:
             source = "."

--- a/tests/unit/plugins/v1/test_plainbox_provider.py
+++ b/tests/unit/plugins/v1/test_plainbox_provider.py
@@ -15,14 +15,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from textwrap import dedent
 from unittest import mock
 
 from testtools.matchers import Equals, HasLength
 
 from snapcraft.internal import errors
 from snapcraft.plugins.v1 import plainbox_provider
-from snapcraft.project import Project
 from tests import fixture_setup, unit
 from . import PluginsV1BaseTestCase
 

--- a/tests/unit/plugins/v1/test_plainbox_provider.py
+++ b/tests/unit/plugins/v1/test_plainbox_provider.py
@@ -220,20 +220,11 @@ class PlainboxProviderPluginTest(PluginsV1BaseTestCase):
         self.assertListEqual(expected_fileset, fileset)
 
 
-class PlainboxProviderPluginUnsupportedBaseTest(unit.TestCase):
+class PlainboxProviderPluginUnsupportedBaseTest(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: plainbox-snap
-            base: unsupported-base
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = "unsupported-base"
 
         class Options:
             source = "dir"

--- a/tests/unit/plugins/v1/test_python.py
+++ b/tests/unit/plugins/v1/test_python.py
@@ -17,15 +17,14 @@
 import collections
 import jsonschema
 import os
-from textwrap import dedent
 from unittest import mock
 
 from testtools.matchers import Equals, HasLength
 
 from snapcraft.internal import errors
-from snapcraft.project import Project
 from snapcraft.plugins.v1 import python
 from tests import fixture_setup, unit
+from . import PluginsV1BaseTestCase
 
 
 def setup_directories(plugin, python_version, create_setup_py=True):
@@ -56,20 +55,9 @@ def setup_directories(plugin, python_version, create_setup_py=True):
         )
 
 
-class PythonPluginBaseTest(unit.TestCase):
+class PythonPluginBaseTest(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
-
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: python-snap
-            base: core18
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
 
         class Options:
             source = "."
@@ -578,16 +566,7 @@ class PythonCore16Test(PythonPluginBaseTest):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: python-snap
-            base: {base}
-        """
-            ).format(base=self.base)
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = self.base
 
     def test_plugin_stage_packages_python2(self):
         self.options.python_version = "python2"
@@ -650,20 +629,11 @@ class PythonPluginWithURLTestCase(
         )
 
 
-class PythonPluginUnsupportedBase(unit.TestCase):
+class PythonPluginUnsupportedBase(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: python-snap
-            base: unsupported-base
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = "unsupported-base"
 
         class Options:
             source = "dir"

--- a/tests/unit/plugins/v1/test_qmake.py
+++ b/tests/unit/plugins/v1/test_qmake.py
@@ -15,31 +15,18 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import textwrap
 
 from unittest import mock
 from testtools.matchers import Equals, HasLength
 
-import snapcraft
 from snapcraft.internal import errors
 from snapcraft.plugins.v1 import qmake
-from tests import unit
+from . import PluginsV1BaseTestCase
 
 
-class QMakeTestCase(unit.TestCase):
+class QMakeTestCase(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
-
-        self.project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: test-snap
-                    base: core16
-                    """
-                )
-            )
-        )
 
         patcher = mock.patch("snapcraft.internal.common.run")
         self.run_mock = patcher.start()
@@ -370,23 +357,14 @@ class QMakeTestCase(unit.TestCase):
         )
 
     def test_unsupported_base(self):
-        project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: test-snap
-                    base: unsupported-base
-                    """
-                )
-            )
-        )
+        self.project._snap_meta.base = "unsupported-base"
 
         raised = self.assertRaises(
             errors.PluginBaseError,
             qmake.QmakePlugin,
             "test-part",
             self.options,
-            project,
+            self.project,
         )
 
         self.assertThat(raised.part_name, Equals("test-part"))

--- a/tests/unit/plugins/v1/test_ruby.py
+++ b/tests/unit/plugins/v1/test_ruby.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import textwrap
 from unittest import mock
 
 from testtools.matchers import Equals, HasLength
@@ -23,10 +22,10 @@ from testtools.matchers import Equals, HasLength
 import snapcraft
 from snapcraft.plugins.v1 import ruby
 from snapcraft.internal import errors
-from tests import unit
+from . import PluginsV1BaseTestCase
 
 
-class RubyPluginTestCase(unit.TestCase):
+class RubyPluginTestCase(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
@@ -37,16 +36,6 @@ class RubyPluginTestCase(unit.TestCase):
             use_bundler = False
 
         self.options = Options()
-        self.project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: ruby-snap
-                    base: core16
-                    """
-                )
-            )
-        )
 
     def test_schema(self):
         schema = ruby.RubyPlugin.schema()
@@ -72,19 +61,14 @@ class RubyPluginTestCase(unit.TestCase):
         self.assertDictEqual(expected_gems, schema["properties"]["gems"])
 
     def test_unsupported_base(self):
-        project = snapcraft.project.Project(
-            snapcraft_yaml_file_path=self.make_snapcraft_yaml(
-                textwrap.dedent(
-                    """\
-                    name: ruby-snap
-                    base: unsupported-base
-                    """
-                )
-            )
-        )
+        self.project._snap_meta.base = "unsupported-base"
 
         raised = self.assertRaises(
-            errors.PluginBaseError, ruby.RubyPlugin, "test-part", self.options, project
+            errors.PluginBaseError,
+            ruby.RubyPlugin,
+            "test-part",
+            self.options,
+            self.project,
         )
 
         self.assertThat(raised.part_name, Equals("test-part"))

--- a/tests/unit/plugins/v1/test_scons.py
+++ b/tests/unit/plugins/v1/test_scons.py
@@ -24,6 +24,7 @@ from snapcraft.internal import errors
 from snapcraft.project import Project
 from snapcraft.plugins.v1 import scons
 from tests import unit
+from . import PluginsV1BaseTestCase
 
 
 class SconsPluginPropertiesTest(unit.TestCase):
@@ -93,22 +94,11 @@ class SconsPluginPropertiesTest(unit.TestCase):
             self.assertIn(property, resulting_build_properties)
 
 
-class SconsPluginTest(unit.TestCase):
+class SconsPluginTest(PluginsV1BaseTestCase):
     """Plugin to provide snapcraft support for the scons build system"""
 
     def setUp(self):
         super().setUp()
-
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: scons-snap
-            base: core18
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
 
         class Options:
             """Internal Options Class matching the Scons plugin"""

--- a/tests/unit/plugins/v1/test_scons.py
+++ b/tests/unit/plugins/v1/test_scons.py
@@ -130,20 +130,11 @@ class SconsPluginTest(PluginsV1BaseTestCase):
         )
 
 
-class SconsPluginUnsupportedBaseTest(unit.TestCase):
+class SconsPluginUnsupportedBaseTest(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: scons-snap
-            base: unsupported-base
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = "unsupported-base"
 
         class Options:
             source = "dir"

--- a/tests/unit/plugins/v1/test_scons.py
+++ b/tests/unit/plugins/v1/test_scons.py
@@ -15,13 +15,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from textwrap import dedent
 
 from unittest import mock
 from testtools.matchers import Equals, HasLength
 
 from snapcraft.internal import errors
-from snapcraft.project import Project
 from snapcraft.plugins.v1 import scons
 from tests import unit
 from . import PluginsV1BaseTestCase

--- a/tests/unit/plugins/v1/test_waf.py
+++ b/tests/unit/plugins/v1/test_waf.py
@@ -15,37 +15,22 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from textwrap import dedent
 
 from unittest import mock
 from testtools.matchers import Equals, HasLength
 
-from snapcraft.internal import errors
+from snapcraft.internal import errors, meta
 from snapcraft.plugins.v1 import waf
 from snapcraft.project import Project
 from tests import unit
+from . import PluginsV1BaseTestCase
 
 
-class WafPluginBaseTest(unit.TestCase):
+class WafPluginBaseTest(PluginsV1BaseTestCase):
     """Plugin to provide snapcraft support for the waf build system"""
-
-    deb_arch = None
 
     def setUp(self):
         super().setUp()
-
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: waf-snap
-            base: core18
-        """
-            )
-        )
-
-        self.project = Project(
-            target_deb_arch=self.deb_arch, snapcraft_yaml_file_path=snapcraft_yaml_path
-        )
 
         class Options:
             """Internal Options Class matching the Waf plugin"""
@@ -158,20 +143,11 @@ class WafPluginTest(WafPluginBaseTest):
         )
 
 
-class WafPluginUnsupportedBase(unit.TestCase):
+class WafPluginUnsupportedBase(PluginsV1BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        snapcraft_yaml_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: waf-snap
-            base: unsupported-base
-        """
-            )
-        )
-
-        self.project = Project(snapcraft_yaml_file_path=snapcraft_yaml_path)
+        self.project._snap_meta.base = "unsupported-base"
 
         class Options:
             configflags = []
@@ -200,6 +176,9 @@ class WafCrossCompilePluginTestCase(WafPluginBaseTest):
 
     def setUp(self):
         super().setUp()
+
+        self.project = Project(target_deb_arch=self.deb_arch)
+        self.project._snap_meta = meta.snap.Snap(name="test-snap", base="core18")
 
         patcher = mock.patch("snapcraft.internal.common.run")
         self.run_mock = patcher.start()

--- a/tests/unit/project/test_project_info.py
+++ b/tests/unit/project/test_project_info.py
@@ -144,49 +144,6 @@ class ProjectInfoTest(unit.TestCase):
         raw_snapcraft = info.get_raw_snapcraft()
         self.assertThat(raw_snapcraft.get("name"), Equals("foo"))
 
-    def test_get_build_base_for_defined_base(self):
-        snapcraft_yaml_file_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: test
-            base: core20
-        """
-            )
-        )
-
-        info = ProjectInfo(snapcraft_yaml_file_path=snapcraft_yaml_file_path)
-
-        self.assertThat(info.get_build_base(), Equals("core20"))
-
-    def test_get_build_base_for_defined_type_base(self):
-        snapcraft_yaml_file_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: core20
-            type: base
-        """
-            )
-        )
-
-        info = ProjectInfo(snapcraft_yaml_file_path=snapcraft_yaml_file_path)
-
-        self.assertThat(info.get_build_base(), Equals("core20"))
-
-    def test_get_build_base_build_base_overrides(self):
-        snapcraft_yaml_file_path = self.make_snapcraft_yaml(
-            dedent(
-                """\
-            name: core20
-            type: base
-            build-base: core
-        """
-            )
-        )
-
-        info = ProjectInfo(snapcraft_yaml_file_path=snapcraft_yaml_file_path)
-
-        self.assertThat(info.get_build_base(), Equals("core"))
-
 
 class InvalidYamlTest(unit.TestCase):
     def test_tab_in_yaml(self):


### PR DESCRIPTION
Migrate away from its implementation in Projectinfo.

The required test changes introduce a simpler fixture by use of
Snap to provide the metadata, which removes the every in-Snapcraft
plugin's dependency away from self.project.info.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
