### PR TITLE
[WIP] ros2 (colcon) extension preview

### DIFF
--- a/extensions/ros2/ros2-launch
+++ b/extensions/ros2/ros2-launch
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Save off parameters, the sourced setup scripts may manipulate them.
+original_args=("$@")
+
+export AMENT_PYTHON_EXECUTABLE="$SNAP/usr/bin/python3"
+export COLCON_PYTHON_EXECUTABLE="$SNAP/usr/bin/python3"
+export SNAP_COLCON_ROOT="$SNAP"
+
+# First, source the upstream ROS underlay, if it exists.
+if [ -f "/opt/ros/$SNAP_ROS_DISTRO/setup.sh" ]; then
+    # shellcheck source=/dev/null
+    source "/opt/ros/$SNAP_ROS_DISTRO/setup.sh"
+fi
+
+# Then source the overlay, if it exists.
+if [ -f "/opt/ros/snap/setup.sh" ]; then
+    # shellcheck source=/dev/null
+    source "/opt/ros/snap/setup.sh"
+fi
+
+exec "${original_args[@]}"

--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -660,7 +660,9 @@
                                 "enum": [
                                     "gnome-3-28",
                                     "gnome-3-34",
-                                    "kde-neon"
+                                    "kde-neon",
+                                    "ros2-dashing",
+                                    "ros2-eloquent"
                                 ]
                             }
                         }

--- a/snapcraft/internal/project_loader/_extensions/_ros2.py
+++ b/snapcraft/internal/project_loader/_extensions/_ros2.py
@@ -1,0 +1,58 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018-2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Import types and tell flake8 to ignore the "unused" List.
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Tuple
+
+from ._extension import Extension
+
+
+class Ros2Extension(Extension, ABC):
+    """This extension eases creation of snaps that integrate with ROS2."""
+
+    @staticmethod
+    def get_supported_bases() -> Tuple[str, ...]:
+        # TODO: core20
+        return ("core18",)
+
+    @staticmethod
+    def get_supported_confinement() -> Tuple[str, ...]:
+        return ("strict", "devmode")
+
+    @classmethod
+    @abstractmethod
+    def get_distro(cls) -> str:
+        ...
+
+    def __init__(self, *, extension_name: str, yaml_data: Dict[str, Any]) -> None:
+        super().__init__(extension_name=extension_name, yaml_data=yaml_data)
+
+        self.root_snippet = {"layout": {"/opt": {"bind": "$SNAP/opt"}}}
+
+        self.app_snippet = {
+            "command-chain": ["snap/command-chain/ros2-launch"],
+            "environment": {"SNAP_ROS_DISTRO": self.get_distro()},
+        }
+
+        self.parts = {
+            "ros2-extension": {
+                "source": "$SNAPCRAFT_EXTENSIONS_DIR/ros2",
+                "plugin": "nil",
+                "override-build": "snapcraftctl build && install -D -m 0755 ros2-launch $SNAPCRAFT_PART_INSTALL/snap/command-chain/ros2-launch",
+            }
+        }

--- a/snapcraft/internal/project_loader/_extensions/_ros2.py
+++ b/snapcraft/internal/project_loader/_extensions/_ros2.py
@@ -50,7 +50,7 @@ class Ros2Extension(Extension, ABC):
         }
 
         self.parts = {
-            "ros2-extension": {
+            f"ros2-{self.get_distro()}-extension": {
                 "source": "$SNAPCRAFT_EXTENSIONS_DIR/ros2",
                 "plugin": "nil",
                 "override-build": "snapcraftctl build && install -D -m 0755 ros2-launch $SNAPCRAFT_PART_INSTALL/snap/command-chain/ros2-launch",

--- a/snapcraft/internal/project_loader/_extensions/ros2_dashing.py
+++ b/snapcraft/internal/project_loader/_extensions/ros2_dashing.py
@@ -1,0 +1,27 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018-2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Import types and tell flake8 to ignore the "unused" List.
+
+from ._ros2 import Ros2Extension
+
+
+class ExtensionImpl(Ros2Extension):
+    """ros2-dashing"""
+
+    @classmethod
+    def get_distro(cls) -> str:
+        return "dashing"

--- a/snapcraft/internal/project_loader/_extensions/ros2_eloquent.py
+++ b/snapcraft/internal/project_loader/_extensions/ros2_eloquent.py
@@ -1,0 +1,27 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018-2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Import types and tell flake8 to ignore the "unused" List.
+
+from ._ros2 import Ros2Extension
+
+
+class ExtensionImpl(Ros2Extension):
+    """ros2-dashing"""
+
+    @classmethod
+    def get_distro(cls) -> str:
+        return "dashing"

--- a/snapcraft/internal/project_loader/_extensions/ros2_eloquent.py
+++ b/snapcraft/internal/project_loader/_extensions/ros2_eloquent.py
@@ -20,8 +20,8 @@ from ._ros2 import Ros2Extension
 
 
 class ExtensionImpl(Ros2Extension):
-    """ros2-dashing"""
+    """ros2-eloquent"""
 
     @classmethod
     def get_distro(cls) -> str:
-        return "dashing"
+        return "eloquent"

--- a/snapcraft/plugins/v1/colcon.py
+++ b/snapcraft/plugins/v1/colcon.py
@@ -336,7 +336,11 @@ class ColconPlugin(PluginV1):
             raise ColconWorkspaceIsRootError()
 
     def env(self, root):
-        """Runtime environment for ROS binaries and services."""
+        """Build environment for ROS binaries and services."""
+
+        # TODO: split v1 plugins `env()` -> `env()` and `runtime_env()`.
+        if root != self.installdir:
+            return []
 
         env = [
             'AMENT_PYTHON_EXECUTABLE="{}"'.format(

--- a/tests/spread/plugins/v1/colcon/snaps/colcon-talker-listener/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/colcon/snaps/colcon-talker-listener/snap/snapcraft.yaml
@@ -14,6 +14,7 @@ apps:
     plugs: [network, network-bind]
     environment:
       PYTHONUNBUFFERED: 1
+    extensions: [ros2-dashing]
 
   ros2:
     command: opt/ros/dashing/bin/ros2


### PR DESCRIPTION
Implemented on core18, but will only be required on core20.

- adds ros2-dashing and ros2-eloquent extension.

- disable's colcon modifications of runtime environment.

- updates colcon-talker-listener spread test as example.

- adds /opt layout, but it doesn't really affect much as
  we still need need to rewrite $installdir out of the prefixes.
  This is because the overlay & underlay are configured for
  $installdir/opt/<layer>, instead of /opt.

  Maybe we could link/bind /opt to $installdir/opt as part of
  the plugin's build to simplify?

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
