### PR TITLE
Add prebuilt-wheel-dir to python plugin

### DIFF
--- a/snapcraft/plugins/v1/_python/_pip.py
+++ b/snapcraft/plugins/v1/_python/_pip.py
@@ -280,6 +280,8 @@ class Pip:
                 "--disable-pip-version-check",
                 "--dest",
                 self._python_package_dir,
+                "--find-links",
+                self._python_package_dir,
             ]
             + args
             + package_args,

--- a/tests/unit/plugins/v1/python/test_pip.py
+++ b/tests/unit/plugins/v1/python/test_pip.py
@@ -457,7 +457,14 @@ class PipDownloadTest(PipCommandBaseTestCase):
     ]
 
     def _assert_mock_run_with(self, *args, **kwargs):
-        common_args = ["download", "--disable-pip-version-check", "--dest", mock.ANY]
+        common_args = [
+            "download",
+            "--disable-pip-version-check",
+            "--dest",
+            mock.ANY,
+            "--find-links",
+            mock.ANY,
+        ]
         common_args.extend(*args)
         self.mock_run.assert_called_once_with(common_args, **kwargs)
 

--- a/tests/unit/plugins/v1/test_python.py
+++ b/tests/unit/plugins/v1/test_python.py
@@ -67,6 +67,7 @@ class PythonPluginBaseTest(PluginsV1BaseTestCase):
             python_version = "python3"
             python_packages = []
             process_dependency_links = False
+            prebuilt_wheel_dir = ""
 
         self.options = Options()
 
@@ -109,6 +110,7 @@ class PythonPluginPropertiesTest(unit.TestCase):
             "default": "python3",
             "enum": ["python2", "python3"],
         }
+        expected_prebuilt_wheel_dir = {"type": "string", "default": ""}
 
         self.assertDictEqual(
             expected_requirements, schema["properties"]["requirements"]
@@ -124,6 +126,9 @@ class PythonPluginPropertiesTest(unit.TestCase):
         self.assertDictEqual(
             expected_python_version, schema["properties"]["python-version"]
         )
+        self.assertDictEqual(
+            expected_prebuilt_wheel_dir, schema["properties"]["prebuilt-wheel-dir"]
+        )
 
     def test_get_pull_properties(self):
         expected_pull_properties = [
@@ -132,6 +137,7 @@ class PythonPluginPropertiesTest(unit.TestCase):
             "python-packages",
             "process-dependency-links",
             "python-version",
+            "prebuilt-wheel-dir",
         ]
         resulting_pull_properties = python.PythonPlugin.get_pull_properties()
 

--- a/tools/environment-setup.sh
+++ b/tools/environment-setup.sh
@@ -44,9 +44,12 @@ lxc exec snapcraft-dev -- apt install --yes \
     python3-pip \
     python3-venv \
     rpm2cpio \
-    squashfs-tools
+    squashfs-tools \
+    libssl-dev \
+    libxml2-dev \
+    libxslt1-dev
 
-# Create a virtual environment and set it as default 
+# Create a virtual environment and set it as default
 lxc exec snapcraft-dev -- sudo -iu ubuntu pyvenv .venv/snapcraft
 lxc exec snapcraft-dev -- sudo -iu ubuntu bash -c \
     "echo 'source /home/ubuntu/.venv/snapcraft/bin/activate' >> .profile"
@@ -59,6 +62,10 @@ if ! lxc config device show snapcraft-dev | grep -q snapcraft-project; then
     lxc config device add snapcraft-dev snapcraft-project disk \
         source="$PWD" path=/home/ubuntu/snapcraft
 fi
+
+# Update setuptools and wheel
+lxc exec snapcraft-dev -- sudo -iu ubuntu pip install -U setuptools
+lxc exec snapcraft-dev -- sudo -iu ubuntu pip install -U wheel
 
 # Install python dependencies
 lxc exec snapcraft-dev -- sudo -iu ubuntu pip install \


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
*have not run unit tests as some dependencies are not installing / getting a lot of `Cannot find snapcraft's data files` errors. But have successfully build my snap with a local plugin based on this same changes.

This pr adds a `prebuilt-wheel-dir` property to the python plugin which allows users to copy prebuilt `.whl` files into `<partdir>/python-packages`. This would allow the user to manually build wheels when complex to do so inside snapcraft e.g. numpy is very difficult to build from source in snapcraft as some paths for the build are hardcoded in the setup script.

It also adds the flag `--find-links` to the download call to pip as to prioritise prebuilt wheels over source wheels in remote repos or the pip cache.

It solves things like [this](https://forum.snapcraft.io/t/python-add-a-build-package-from-local-whl-file/6447) and [this](https://forum.snapcraft.io/t/how-do-i-correctly-install-a-custom-python-version-and-a-local-wheel-package/12040).

I'm happy to add to the documentation if instructed on how to do so.