### PR TITLE
spread tests: default base for local plugin tests

### DIFF
--- a/tests/spread/plugins/v1/x-local/snaps/from-baseplugin/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/x-local/snaps/from-baseplugin/snap/snapcraft.yaml
@@ -1,4 +1,5 @@
 name: test-local-plugins
+base: core18
 version: "0.1"
 summary: local plugin in snap/plugins
 description: Tests if local plugins load and can build

--- a/tests/spread/plugins/v1/x-local/snaps/from-nilplugin/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/x-local/snaps/from-nilplugin/snap/snapcraft.yaml
@@ -1,4 +1,5 @@
 name: test-local-plugins
+base: core18
 version: "0.1"
 summary: local plugin in snap/plugins that inherits from nil
 description: Tests if local plugins load and can build


### PR DESCRIPTION
Follow the pattern applied in commit
feb2672d28c6198515f55601a16ec3b2001ce1e9

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
