### PR TITLE
remote-build: remove artifact sanity check

### DIFF
--- a/snapcraft/internal/remote_build/_launchpad.py
+++ b/snapcraft/internal/remote_build/_launchpad.py
@@ -159,7 +159,7 @@ class LaunchpadClient:
 
         logger.debug("Downloading artifacts...")
         for build in builds:
-            self._download_snap(build)
+            self._download_build_artifacts(build)
             self._download_log(build)
 
     def _get_builds_collection_entry(self, snap: Entry) -> Optional[Entry]:
@@ -409,7 +409,7 @@ class LaunchpadClient:
         except urllib.error.HTTPError as e:
             logger.error(f"Error downloading {url}: {e.reason}")
 
-    def _download_snap(self, build: Dict[str, Any]) -> None:
+    def _download_build_artifacts(self, build: Dict[str, Any]) -> None:
         arch = build["arch_tag"]
         snap_build = self._lp_load_url(build["self_link"])
         urls = snap_build.getFileUrls()
@@ -419,15 +419,14 @@ class LaunchpadClient:
             return
 
         for url in urls:
-            snap_name = _get_url_basename(url)
+            file_name = _get_url_basename(url)
 
-            # Sanity check file name.
-            if not snap_name.endswith("_{}.snap".format(arch)):
-                logger.info("Skipping unknown artifact: {url}")
-                continue
+            self._download_file(url=url, dst=file_name)
 
-            self._download_file(url=url, dst=snap_name)
-            logger.info("Snapped {}".format(snap_name))
+            if file_name.endswith(".snap"):
+                logger.info(f"Snapped {file_name}")
+            else:
+                logger.info(f"Fetched {file_name}")
 
     def _gitify_repository(self, repo_dir: str) -> Git:
         """Git-ify source repository tree.


### PR DESCRIPTION
A snapcraft.yaml may have a configuration of `build-on` that allows
Launchpad to pick from a set of architectures that will run on
multiple architectures.

This will fail our sanity check which assumes the arch, which may
in fact end up as `multi`.  There isn't really any need to sanity
check the artifacts anyhow, so we'll remove this check and download
whatever Launchpad provides.

LP: #1870730

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
