### PR TITLE
pluginhandler: move attributes to PluginHandler

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -178,7 +178,7 @@ class Library:
         soname: str,
         soname_path: str,
         search_paths: List[str],
-        core_base_path: str,
+        core_base_path: Optional[str],
         arch: ElfArchitectureTuple,
         soname_cache: SonameCache,
     ) -> None:
@@ -193,7 +193,7 @@ class Library:
         # Resolve path, if possible.
         self.path = self._crawl_for_path()
 
-        if self.path.startswith(core_base_path):
+        if core_base_path is not None and self.path.startswith(core_base_path):
             self.in_base_snap = True
         else:
             self.in_base_snap = False
@@ -396,7 +396,7 @@ class ElfFile:
     def load_dependencies(
         self,
         root_path: str,
-        core_base_path: str,
+        core_base_path: Optional[str],
         content_dirs: Set[str],
         arch_triplet: str,
         soname_cache: SonameCache = None,
@@ -419,7 +419,9 @@ class ElfFile:
 
         logger.debug("Getting dependencies for {!r}".format(self.path))
 
-        search_paths = [root_path, *content_dirs, core_base_path]
+        search_paths = [root_path, *content_dirs]
+        if core_base_path is not None:
+            search_paths.append(core_base_path)
 
         ld_library_paths: List[str] = list()
         for path in search_paths:

--- a/snapcraft/internal/pluginhandler/_patchelf.py
+++ b/snapcraft/internal/pluginhandler/_patchelf.py
@@ -19,9 +19,9 @@ import os
 from typing import FrozenSet, List
 from typing import Dict  # noqa: F401
 
-from snapcraft import ProjectOptions
 from snapcraft.internal import elf
 from snapcraft.internal import errors
+from snapcraft.project import Project
 
 
 logger = logging.getLogger(__name__)
@@ -34,41 +34,26 @@ class PartPatcher:
         self,
         *,
         elf_files: FrozenSet[elf.ElfFile],
-        project: ProjectOptions,
-        confinement: str,  # TODO remove once project has this
-        core_base: str,  # TODO remove once project has this
-        snap_base_path: str,  # TODO remove once project has this
+        project: Project,
+        snap_base_path: str,
         stage_packages: List[str],
-        stagedir: str,
-        primedir: str
     ) -> None:
         """Initialize PartPatcher.
 
         :param elf_files: the list of elf files to analyze.
         :param project: the project instance from the part.
-        :param confinement: the confinement value the snapcraft project is
-                            using (i.e.; devmode, strict, classic).
-        :param core_base: the base the snap will use during runtime
-                          (e.g.; core, core18).
         :param snap_base_path: the root path of the snap during runtime,
                                necessary when using a in-snap libc6 provided
                                as a stage-packages entry.
         :param stage_packages: the stage-packages a part is set to use.
-        :param stagedir: the general stage directory for the snapcraft project.
-                         This is used to locate an alternate patchelf binary
-                         to use.
-        :param primedir: the general prime directory for the snapcraft project.
         """
         self._elf_files = elf_files
         self._project = project
-        self._is_classic = confinement == "classic"
-        self._core_base = core_base
+        self._is_classic = project._snap_meta.confinement == "classic"
         self._snap_base_path = snap_base_path
         # If libc6 is staged, to avoid symbol mixups we will resort to
         # glibc mangling.
         self._is_libc6_staged = "libc6" in stage_packages
-        self._stagedir = stagedir
-        self._primedir = primedir
 
     def _get_glibc_compatibility(self, linker_version: str) -> Dict[str, str]:
         linker_incompat = dict()  # type: Dict[str, str]
@@ -80,7 +65,7 @@ class PartPatcher:
     def _get_preferred_patchelf_path(self):
         # TODO revisit if we need to support variations and permutations
         #  of this
-        staged_patchelf_path = os.path.join(self._stagedir, "bin", "patchelf")
+        staged_patchelf_path = os.path.join(self._project.stage_dir, "bin", "patchelf")
         if not os.path.exists(staged_patchelf_path):
             staged_patchelf_path = None
         return staged_patchelf_path
@@ -90,7 +75,7 @@ class PartPatcher:
 
         elf_patcher = elf.Patcher(
             dynamic_linker=dynamic_linker,
-            root_path=self._primedir,
+            root_path=self._project.prime_dir,
             preferred_patchelf_path=preferred_patchelf_path,
         )
 
@@ -112,7 +97,12 @@ class PartPatcher:
                 raise patch_error
 
     def _verify_compat(self) -> None:
-        linker_version = self._project._get_linker_version_for_base(self._core_base)
+        if self._project._snap_meta.base is None:
+            return
+
+        linker_version = self._project._get_linker_version_for_base(
+            self._project._snap_meta.base
+        )
         linker_incompat = self._get_glibc_compatibility(linker_version)
         logger.debug(
             "List of files incompatible with {!r}: {!r}".format(
@@ -122,7 +112,7 @@ class PartPatcher:
         # Even though we do this in patch, it does not hurt to check again
         if linker_incompat and not self._is_libc6_staged:
             raise errors.IncompatibleBaseError(
-                base=self._core_base,
+                base=self._project._snap_meta.base,
                 linker_version=linker_version,
                 file_list=linker_incompat,
             )
@@ -150,12 +140,17 @@ class PartPatcher:
         :raises errors.SnapcraftEnvironementError:
             if something is horribly wrong.
         """
-        # Just return if this is a static base and libc6 has not been staged.
-        if self._project.is_static_base(self._core_base) and not self._is_libc6_staged:
+        # Just return if this is None or a static base and libc6 has not been staged.
+        if self._project._snap_meta.base is None:
+            return
+        if (
+            self._project.is_static_base(self._project._snap_meta.base)
+            and not self._is_libc6_staged
+        ):
             return
         if not (
-            self._project.is_static_base(self._core_base)
-            or self._project.is_host_compatible_with_base(self._core_base)
+            self._project.is_static_base(self._project._snap_meta.base)
+            or self._project.is_host_compatible_with_base(self._project._snap_meta.base)
         ):
             logger.debug("Host is not compatible with base")
             self._verify_compat()
@@ -166,7 +161,7 @@ class PartPatcher:
 
         if self._is_libc6_staged:
             dynamic_linker = elf.find_linker(
-                root_path=self._primedir, snap_base_path=self._snap_base_path
+                root_path=self._project.prime_dir, snap_base_path=self._snap_base_path
             )
             logger.warning(
                 "libc6 has been staged into the snap: only do this if you know what "
@@ -174,7 +169,7 @@ class PartPatcher:
             )
         elif self._is_classic:
             dynamic_linker = self._project.get_core_dynamic_linker(
-                self._core_base, expand=False
+                self._project._snap_meta.base, expand=False
             )
         else:
             raise errors.SnapcraftEnvironmentError(

--- a/snapcraft/internal/pluginhandler/_patchelf.py
+++ b/snapcraft/internal/pluginhandler/_patchelf.py
@@ -140,10 +140,8 @@ class PartPatcher:
         :raises errors.SnapcraftEnvironementError:
             if something is horribly wrong.
         """
-        # Just return if this is None or a static base and libc6 has not been staged.
-        if self._project._snap_meta.base is None:
-            return
-        if (
+        # Just return if base is None or a static base and libc6 has not been staged.
+        if self._project._snap_meta.base is None or (
             self._project.is_static_base(self._project._snap_meta.base)
             and not self._is_libc6_staged
         ):

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -114,8 +114,9 @@ class PartsConfig:
 
         return sorted_parts
 
-    def get_dependencies(self, part_name, *, recursive=False):
-        # type: (str, bool) -> Set[pluginhandler.PluginHandler]
+    def get_dependencies(
+        self, part_name: str, *, recursive: bool = False
+    ) -> Set[pluginhandler.PluginHandler]:
         """Returns a set of all the parts upon which part_name depends."""
 
         dependency_names = set(self.after_requests.get(part_name, []))
@@ -131,8 +132,9 @@ class PartsConfig:
 
         return dependencies
 
-    def get_reverse_dependencies(self, part_name, *, recursive=False):
-        # type: (str, bool) -> Set[pluginhandler.PluginHandler]
+    def get_reverse_dependencies(
+        self, part_name: str, *, recursive: bool = False
+    ) -> Set[pluginhandler.PluginHandler]:
         """Returns a set of all the parts that depend upon part_name."""
 
         reverse_dependency_names = set()
@@ -199,7 +201,9 @@ class PartsConfig:
         for source in sources:
             repo.Repo.install_source(source)
 
-        stage_packages_repo = repo.Repo(plugin.osrepodir)
+        # TODO: rename with migration strategy.
+        repo_dir = path.join(self._project.parts_dir, part_name, "ubuntu")
+        stage_packages_repo = repo.Repo(repo_dir)
 
         grammar_processor = grammar_processing.PartGrammarProcessor(
             plugin=plugin,
@@ -211,15 +215,12 @@ class PartsConfig:
         part = pluginhandler.PluginHandler(
             plugin=plugin,
             part_properties=part_properties,
-            project_options=self._project,
+            project=self._project,
             part_schema=self._validator.part_schema,
             definitions_schema=self._validator.definitions_schema,
             stage_packages_repo=stage_packages_repo,
             grammar_processor=grammar_processor,
             snap_base_path=path.join("/", "snap", self._project.info.name, "current"),
-            base=self._project.info.base,
-            confinement=self._project.info.confinement,
-            snap_type=self._snap_type,
             soname_cache=self._soname_cache,
         )
 

--- a/snapcraft/plugins/v1/_plugin.py
+++ b/snapcraft/plugins/v1/_plugin.py
@@ -98,8 +98,6 @@ class PluginV1:
         self.sourcedir = os.path.join(self.partdir, "src")
         self.installdir = os.path.join(self.partdir, "install")
         self.statedir = os.path.join(self.partdir, "state")
-        self.osrepodir = os.path.join(self.partdir, "ubuntu")
-        self.snapsdir = os.path.join(self.partdir, "snaps")
 
         self.build_basedir = os.path.join(self.partdir, "build")
         source_subdir = getattr(self.options, "source_subdir", None)

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -268,6 +268,7 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         project=None,
         stage_packages_repo=None,
         base="core18",
+        build_base=None,
         confinement="strict",
         snap_type="app",
     ):
@@ -282,6 +283,8 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         project._snap_meta.type = snap_type
         project._snap_meta.confinement = confinement
         project._snap_meta.base = base
+        if build_base is not None:
+            project._snap_meta.build_base = build_base
 
         validator = _schema.Validator()
         schema = validator.part_schema
@@ -297,6 +300,7 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
 
         if not stage_packages_repo:
             stage_packages_repo = mock.Mock()
+            stage_packages_repo.rootdir = "ubuntu"
         grammar_processor = grammar_processing.PartGrammarProcessor(
             plugin=plugin,
             properties=properties,
@@ -307,15 +311,12 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         return snapcraft.internal.pluginhandler.PluginHandler(
             plugin=plugin,
             part_properties=properties,
-            project_options=project,
+            project=project,
             part_schema=schema,
             definitions_schema=definitions_schema,
             grammar_processor=grammar_processor,
             stage_packages_repo=stage_packages_repo,
             snap_base_path="/snap/fake-name/current",
-            base=base,
-            confinement=confinement,
-            snap_type=snap_type,
             soname_cache=elf.SonameCache(),
         )
 

--- a/tests/unit/pluginhandler/test_patcher.py
+++ b/tests/unit/pluginhandler/test_patcher.py
@@ -80,6 +80,27 @@ class StaticBasePatchingTest(unit.TestCase):
 
         self.fake_patchelf.mock.assert_not_called()
 
+    def test_no_base(self):
+        # The "bare" base is a static base, empty, so there is no linker loader to look for.
+        handler = self.load_part(
+            "test-part",
+            snap_type="app",
+            base=None,
+            build_base="core",
+            confinement=self.confinement,
+        )
+
+        patcher = PartPatcher(
+            elf_files=frozenset(["foo"]),
+            project=handler._project,
+            snap_base_path="/snap/test-snap/current",
+            stage_packages=[],
+        )
+
+        patcher.patch()
+
+        self.fake_patchelf.mock.assert_not_called()
+
 
 class PrimeTypeExcludesPatchingTestCase(unit.TestCase):
 

--- a/tests/unit/pluginhandler/test_patcher.py
+++ b/tests/unit/pluginhandler/test_patcher.py
@@ -18,9 +18,8 @@ from unittest import mock
 
 import fixtures
 
-from snapcraft.project import Project
 from snapcraft.internal.pluginhandler import PartPatcher
-from tests import fixture_setup, unit
+from tests import unit
 
 
 class StaticBasePatchingTest(unit.TestCase):
@@ -37,25 +36,19 @@ class StaticBasePatchingTest(unit.TestCase):
 
     def test_static_base_with_libc6_stage_packaged(self):
         # The "bare" base is a static base.
-        snapcraft_yaml = fixture_setup.SnapcraftYaml(
-            self.path, base="bare", confinement=self.confinement
-        )
-        snapcraft_yaml.update_part("part1", dict(plugin="nil"))
-        self.useFixture(snapcraft_yaml)
-
-        project = Project(
-            snapcraft_yaml_file_path=snapcraft_yaml.snapcraft_yaml_file_path
+        handler = self.load_part(
+            "test-part",
+            snap_type="app",
+            base="bare",
+            build_base="core",
+            confinement=self.confinement,
         )
 
         patcher = PartPatcher(
             elf_files=frozenset(["foo"]),
-            project=project,
-            confinement="strict",
-            core_base="bare",
+            project=handler._project,
             snap_base_path="/snap/test-snap/current",
             stage_packages=["libc6"],
-            stagedir="stage",
-            primedir="prime",
         )
 
         patcher.patch()
@@ -63,30 +56,24 @@ class StaticBasePatchingTest(unit.TestCase):
         self.fake_patchelf.mock.assert_called_once_with(
             dynamic_linker="/snap/test-snap/current/lib/x86_64-linux-gnu/ld-2.27.so",
             preferred_patchelf_path=None,
-            root_path="prime",
+            root_path=handler._project.prime_dir,
         )
 
     def test_static_base_without_libc6_stage_packaged(self):
         # The "bare" base is a static base, empty, so there is no linker loader to look for.
-        snapcraft_yaml = fixture_setup.SnapcraftYaml(
-            self.path, base="bare", confinement=self.confinement
-        )
-        snapcraft_yaml.update_part("part1", dict(plugin="nil"))
-        self.useFixture(snapcraft_yaml)
-
-        project = Project(
-            snapcraft_yaml_file_path=snapcraft_yaml.snapcraft_yaml_file_path
+        handler = self.load_part(
+            "test-part",
+            snap_type="app",
+            base="bare",
+            build_base="core",
+            confinement=self.confinement,
         )
 
         patcher = PartPatcher(
             elf_files=frozenset(["foo"]),
-            project=project,
-            confinement="strict",
-            core_base="bare",
+            project=handler._project,
             snap_base_path="/snap/test-snap/current",
             stage_packages=[],
-            stagedir="stage",
-            primedir="prime",
         )
 
         patcher.patch()
@@ -119,19 +106,18 @@ class PrimeTypeExcludesPatchingTestCase(unit.TestCase):
 class PrimeTypeAppDoesPatchingTestCase(unit.TestCase):
     def test_patcher_called(self):
         handler = self.load_part(
-            "test-part", part_properties={"source-subdir": "src"}, snap_type="app"
+            "test-part",
+            part_properties={"source-subdir": "src"},
+            snap_type="app",
+            base="core18",
         )
 
         patcher_class = "snapcraft.internal.pluginhandler.PartPatcher"
         with mock.patch(patcher_class) as patcher_mock:
             handler.prime()
             patcher_mock.assert_called_with(
-                confinement="strict",
-                core_base="core18",
                 elf_files=frozenset(),
-                primedir=self.prime_dir,
                 project=mock.ANY,
                 snap_base_path="/snap/fake-name/current",
                 stage_packages=[],
-                stagedir=self.stage_dir,
             )


### PR DESCRIPTION
Rely less on setting from the plugin and remove duplicate attributes
already held by Project and Project._snap_meta.

This involved a general cleanup.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
