### PR TITLE
repo: drop _AptCache and add migrate to install_stage_packages()

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -435,7 +435,7 @@ class PluginHandler:
         stage_packages = self._grammar_processor.get_stage_packages()
         if stage_packages:
             logger.debug(
-                "Installing stage-packages to {!r}".format(self.plugin.installdir)
+                f"Installing {stage_packages!r} stage-packages to {self.plugin.installdir!r}"
             )
             try:
                 self.stage_packages = self._stage_packages_repo.install_stage_packages(

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -517,10 +517,6 @@ class PluginHandler:
         if self.is_clean(steps.PULL):
             return
 
-        # Remove stage-packages cache (where stage packages are fetched)
-        if os.path.exists(self._stage_packages_repo.rootdir):
-            shutil.rmtree(self._stage_packages_repo.rootdir)
-
         # Remove snaps dir (where stage snaps are fetched)
         if os.path.exists(self.part_snaps_dir):
             shutil.rmtree(self.part_snaps_dir)

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -201,9 +201,7 @@ class PartsConfig:
         for source in sources:
             repo.Repo.install_source(source)
 
-        # TODO: rename with migration strategy.
-        repo_dir = path.join(self._project.parts_dir, part_name, "ubuntu")
-        stage_packages_repo = repo.Repo(repo_dir)
+        stage_packages_repo = repo.Repo
 
         grammar_processor = grammar_processing.PartGrammarProcessor(
             plugin=plugin,

--- a/snapcraft/internal/project_loader/grammar_processing/_part_grammar_processor.py
+++ b/snapcraft/internal/project_loader/grammar_processing/_part_grammar_processor.py
@@ -148,7 +148,7 @@ class PartGrammarProcessor:
             processor = grammar.GrammarProcessor(
                 getattr(self._plugin, "stage_packages", []),
                 self._project,
-                self._repo.is_valid,
+                self._repo.build_package_is_valid,
                 transformer=package_transformer,
             )
             self.__stage_packages = processor.process()

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -14,14 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import contextlib
+
 import functools
 import glob
-import hashlib
 import logging
 import os
 import re
-import shutil
 import string
 import subprocess
 import sys
@@ -31,9 +29,10 @@ from typing import Dict, List, Optional, Set, Tuple  # noqa: F401
 from typing_extensions import Final
 
 import apt
+from xdg import BaseDirectory
 
 from snapcraft import file_utils
-from snapcraft.internal import cache, common, os_release, repo
+from snapcraft.internal import os_release, repo
 from snapcraft.internal.indicators import is_dumb_terminal
 
 from . import errors
@@ -214,164 +213,6 @@ def _sudo_write_file(*, dst_path: Path, content: bytes) -> None:
             raise RuntimeError(f"failed to run: {command!r}")
 
 
-class _AptCache:
-    def __init__(self, *, sources: List[str], keyrings: List[str]):
-        self._sources = sources
-        self._keyrings = keyrings
-
-    def _setup_apt(self, cache_dir):
-        # Do not install recommends
-        apt.apt_pkg.config.set("Apt::Install-Recommends", "False")
-
-        # Ensure repos are provided by trusted third-parties
-        apt.apt_pkg.config.set("Acquire::AllowInsecureRepositories", "False")
-
-        # Methods and solvers dir for when in the SNAP
-        if common.is_snap():
-            snap_dir = os.getenv("SNAP")
-            apt_dir = os.path.join(snap_dir, "usr", "lib", "apt")
-            apt.apt_pkg.config.set("Dir", apt_dir)
-            # yes apt is broken like that we need to append os.path.sep
-            methods_dir = os.path.join(apt_dir, "methods")
-            apt.apt_pkg.config.set("Dir::Bin::methods", methods_dir + os.path.sep)
-            solvers_dir = os.path.join(apt_dir, "solvers")
-            apt.apt_pkg.config.set("Dir::Bin::solvers::", solvers_dir + os.path.sep)
-            apt_key_path = os.path.join(snap_dir, "usr", "bin", "apt-key")
-            apt.apt_pkg.config.set("Dir::Bin::apt-key", apt_key_path)
-            gpgv_path = os.path.join(snap_dir, "usr", "bin", "gpgv")
-            apt.apt_pkg.config.set("Apt::Key::gpgvcommand", gpgv_path)
-            apt.apt_pkg.config.set("Dir::Etc::Trusted", "/etc/apt/trusted.gpg")
-            apt.apt_pkg.config.set("Dir::Etc::TrustedParts", "/etc/apt/trusted.gpg.d/")
-
-        # Make sure we always use the system GPG configuration, even with
-        # apt.Cache(rootdir). However, we also want to be able to add keys to it
-        # without root, so symlink back to the system's, but maintain our own.
-        # We'll leave Trusted alone and just fiddle with TrustedParts (Trusted is the
-        # one modified by apt-key, so add-apt-repository should still work).
-        apt.apt_pkg.config.set(
-            "Dir::Etc::Trusted", apt.apt_pkg.config.find_file("Dir::Etc::Trusted")
-        )
-        apt_config_path = os.path.join(cache_dir, "etc", "apt", "apt.conf")
-        trusted_parts_path = apt.apt_pkg.config.find_file("Dir::Etc::TrustedParts")
-        if not trusted_parts_path.startswith(cache_dir):
-            cached_trusted_parts = os.path.join(
-                cache_dir, trusted_parts_path.lstrip("/")
-            )
-            with contextlib.suppress(FileNotFoundError):
-                shutil.rmtree(cached_trusted_parts)
-            os.makedirs(cached_trusted_parts)
-            for trusted_part in os.scandir(trusted_parts_path):
-                os.symlink(
-                    os.path.join(trusted_parts_path, trusted_part.name),
-                    os.path.join(cached_trusted_parts, trusted_part.name),
-                )
-
-            apt.apt_pkg.config.set("Dir::Etc::TrustedParts", cached_trusted_parts)
-
-            # The above config is all that is needed on bionic, but xenial
-            # requires this configuration file
-            os.makedirs(os.path.dirname(apt_config_path), exist_ok=True)
-            with open(apt_config_path, "w") as f:
-                f.write("Dir::Etc::TrustedParts {};\n".format(cached_trusted_parts))
-
-            # Now copy in any requested keyrings
-            for keyring in self._keyrings:
-                shutil.copy2(keyring, cached_trusted_parts)
-
-        # Clear up apt's Post-Invoke-Success as we are not running
-        # on the system.
-        apt.apt_pkg.config.clear("APT::Update::Post-Invoke-Success")
-
-        self.progress = apt.progress.text.AcquireProgress()
-        if is_dumb_terminal():
-            # Make output more suitable for logging.
-            self.progress.pulse = lambda owner: True
-            self.progress._width = 0
-
-        sources_list_file = os.path.join(cache_dir, "etc", "apt", "sources.list")
-
-        os.makedirs(os.path.dirname(sources_list_file), exist_ok=True)
-        with open(sources_list_file, "w") as f:
-            f.write(self._collected_sources_list())
-
-        # dpkg also needs to be in the rootdir in order to support multiarch
-        # (apt calls dpkg --print-foreign-architectures).
-        dpkg_path = shutil.which("dpkg")
-        if dpkg_path:
-            # Symlink it into place
-            destination = os.path.join(cache_dir, dpkg_path[1:])
-            if not os.path.exists(destination):
-                os.makedirs(os.path.dirname(destination), exist_ok=True)
-                os.symlink(dpkg_path, destination)
-        else:
-            logger.warning("Cannot find 'dpkg' command needed to support multiarch")
-
-        old_apt_config = os.environ.get("APT_CONFIG")
-        try:
-            # Only xenial needs this. If snapcraft changes to core18, this
-            # variable is unnecessary.
-            os.environ["APT_CONFIG"] = apt_config_path
-            return self._create_cache(cache_dir, sources_list_file)
-        finally:
-            if old_apt_config is None:
-                del os.environ["APT_CONFIG"]
-            else:
-                os.environ["APT_CONFIG"] = old_apt_config
-
-    def _create_cache(self, cache_dir: str, sources_list_file: str) -> apt.Cache:
-        apt_cache = apt.Cache(rootdir=cache_dir, memonly=True)
-        try:
-            apt_cache.update(
-                fetch_progress=self.progress, sources_list=sources_list_file
-            )
-        except apt.cache.FetchFailedException as e:
-            # In case of a hashsum mismatch, clear the index and try again.
-            # Re-raise the error if that failed.
-            if re.match(_HASHSUM_MISMATCH_PATTERN, str(e)):
-                try:
-                    index = apt.apt_pkg.config.find_dir("Dir::State::Lists")
-                    shutil.rmtree(index)
-                    apt_cache = apt.Cache(rootdir=cache_dir, memonly=True)
-                    apt_cache.update(
-                        fetch_progress=self.progress, sources_list=sources_list_file
-                    )
-                except apt.cache.FetchFailedException as retry:
-                    raise errors.CacheUpdateFailedError(str(retry))
-            else:
-                raise errors.CacheUpdateFailedError(str(e))
-        return apt_cache
-
-    @contextlib.contextmanager
-    def archive(self, cache_dir):
-        try:
-            apt_cache = self._setup_apt(cache_dir)
-            apt_cache.open()
-
-            try:
-                yield apt_cache
-            finally:
-                apt_cache.close()
-        except Exception as e:
-            logger.debug("Exception occurred: {!r}".format(e))
-            raise e
-
-    def sources_digest(self):
-        return hashlib.sha384(
-            self._collected_sources_list().encode(sys.getfilesystemencoding())
-        ).hexdigest()
-
-    def _collected_sources_list(self) -> str:
-        sources = _get_local_sources_list()
-
-        # Append additionally configured repositories, if any.
-        if self._sources:
-
-            additional_sources = _format_sources_list("\n".join(self._sources))
-            sources = "\n".join([sources, additional_sources])
-
-        return sources
-
-
 class Ubuntu(BaseRepo):
     _SNAPCRAFT_INSTALLED_GPG_KEYRING: Final[
         str
@@ -379,6 +220,21 @@ class Ubuntu(BaseRepo):
     _SNAPCRAFT_INSTALLED_SOURCES_LIST: Final[
         str
     ] = "/etc/apt/sources.list.d/snapcraft.list"
+
+    _cache_dir: str = BaseDirectory.save_cache_path("snapcraft", "download")
+    _cache: Optional[apt.Cache] = None
+
+    @classmethod
+    def _get_apt_cache(cls) -> apt.Cache:
+        if cls._cache is None:
+            cls._cache = apt.Cache()
+        return cls._cache
+
+    @classmethod
+    def _refresh_cache(cls) -> None:
+        if cls._cache is not None:
+            cls._cache.close()
+        cls._cache = apt.Cache()
 
     @classmethod
     def get_package_libraries(cls, package_name: str) -> Set[str]:
@@ -418,6 +274,8 @@ class Ubuntu(BaseRepo):
                 "failed to run apt update"
             ) from call_error
 
+        cls._refresh_cache()
+
     @classmethod
     def install_build_packages(cls, package_names: List[str]) -> List[str]:
         """Install packages on the host required to build.
@@ -433,62 +291,41 @@ class Ubuntu(BaseRepo):
         :raises snapcraft.repo.errors.BuildPackagesNotInstalledError:
             if installing the packages on the host failed.
         """
-        new_packages = []  # type: List[Tuple[str, str]]
-        with apt.Cache() as apt_cache:
-            try:
-                cls._mark_install(apt_cache, package_names)
-            except errors.PackageNotFoundError as e:
-                raise errors.BuildPackageNotFoundError(e.package_name)
-            for package in apt_cache.get_changes():
-                new_packages.append((package.name, package.candidate.version))
+        if not package_names:
+            return list()
 
-        if new_packages:
-            cls._install_new_build_packages([package[0] for package in new_packages])
-        return ["{}={}".format(package[0], package[1]) for package in new_packages]
+        # Make sure all packages are valid and remove already installed.
+        install_packages = list()
+        for name in sorted(package_names):
+            package_name, _ = repo.get_pkg_name_parts(name)
 
-    @classmethod
-    def _mark_install(cls, apt_cache: apt.Cache, package_names: List[str]) -> None:
-        for name in package_names:
-            if name.endswith(":any"):
-                name = name[:-4]
-            if apt_cache.is_virtual_package(name):
-                name = apt_cache.get_providing_packages(name)[0].name
-            logger.debug(
-                "Marking {!r} (and its dependencies) to be fetched".format(name)
-            )
-            name_arch, version = repo.get_pkg_name_parts(name)
-            try:
-                if version:
-                    _set_pkg_version(apt_cache[name_arch], version)
-                # Disable automatic resolving of broken packages here
-                # because if that fails it raises a SystemError and the
-                # API doesn't expose enough information about he problem.
-                # Instead we let apt-get show a verbose error message later.
-                # Also, make sure this package is marked as auto-installed,
-                # which will propagate to its dependencies.
-                apt_cache[name_arch].mark_install(auto_fix=False, from_user=False)
+            if not cls.build_package_is_valid(package_name):
+                raise errors.BuildPackageNotFoundError(name)
 
-                # Now mark this package as NOT automatically installed, which
-                # will leave its dependencies marked as auto-installed, which
-                # allows us to clean them up if necessary.
-                apt_cache[name_arch].mark_auto(False)
+            if not cls.is_package_installed(package_name):
+                install_packages.append(name)
 
-                cls._verify_marked_install(apt_cache[name_arch])
-            except KeyError:
-                raise errors.PackageNotFoundError(name)
+        # Install packages, if any.
+        if install_packages:
+            cls._install_packages(install_packages)
+
+        # Return installed packages with version info.
+        return [
+            f"{name}={cls._get_installed_package_version(name)}"
+            for name in install_packages
+        ]
 
     @classmethod
-    def _verify_marked_install(cls, package: apt.Package):
-        if not package.installed and not package.marked_install:
-            broken_deps = []  # type: List[str]
-            for deps in package.candidate.dependencies:
-                for dep in deps:
-                    if not dep.target_versions:
-                        broken_deps.append(dep.name)
-            raise errors.PackageBrokenError(package.name, broken_deps)
+    def _get_installed_package_version(cls, package_name: str) -> Optional[str]:
+        try:
+            package = cls._get_apt_cache()[package_name]
+        except KeyError:
+            return None
+
+        return package.installed.version if package.installed else None
 
     @classmethod
-    def _install_new_build_packages(cls, package_names: List[str]) -> None:
+    def _install_packages(cls, package_names: List[str]) -> None:
         package_names.sort()
         logger.info("Installing build dependencies: %s", " ".join(package_names))
         env = os.environ.copy()
@@ -523,27 +360,153 @@ class Ubuntu(BaseRepo):
                 "Impossible to mark packages as auto-installed: {}".format(e)
             )
 
+        cls._refresh_cache()
+
+    @classmethod
+    def _resolve_virtual_package(cls, package_name: str) -> str:
+        if cls._get_apt_cache().is_virtual_package(package_name):
+            package_name = (
+                cls._get_apt_cache().get_providing_packages(package_name)[0].name
+            )
+        return package_name
+
+    @classmethod
+    def _get_cached_package(cls, package_name: str) -> apt.package.Package:
+        # Strip ":any" that may come from dependency names.
+        if package_name.endswith(":any"):
+            package_name = package_name[:-4]
+
+        # Resolve virtual package, if it is one.
+        package_name = cls._resolve_virtual_package(package_name)
+
+        try:
+            return cls._get_apt_cache()[package_name]
+        except KeyError:
+            raise errors.PackageNotFoundError(package_name)
+
+    @classmethod
+    def _set_package_version(cls, package, version: Optional[str] = None) -> None:
+        """Set cadidate version to a specific version if available"""
+        if version in package.versions:
+            version = package.versions.get(version)
+            package.candidate = version
+        else:
+            raise errors.PackageNotFoundError("{}={}".format(package.name, version))
+
+    @classmethod
+    def _mark_package_dependencies(
+        cls,
+        *,
+        package: apt.package.Package,
+        marked_packages: Dict[str, apt.package.Version],
+        skipped_blacklisted: Set[str],
+        skipped_essential: Set[str],
+    ) -> None:
+        if package.name in marked_packages:
+            # already marked, ignore.
+            return
+
+        if cls._is_filtered_package(package.name):
+            skipped_blacklisted.add(package.name)
+            return
+
+        if package.candidate.priority == "essential":
+            skipped_essential.add(package.name)
+            return
+
+        # We have to mark it first or risk recursion depth exceeded...
+        marked_packages[package.name] = package.candidate
+
+        for pkg_dep in package.candidate.dependencies:
+            dep_pkg = pkg_dep.target_versions[0].package
+            cls._mark_package_dependencies(
+                package=dep_pkg,
+                marked_packages=marked_packages,
+                skipped_blacklisted=skipped_blacklisted,
+                skipped_essential=skipped_essential,
+            )
+
+    @classmethod
+    def install_stage_packages(
+        cls, *, package_names: List[str], install_dir: str
+    ) -> List[str]:
+        marked_packages: Dict[str, apt.package.Version] = dict()
+        skipped_blacklisted: Set[str] = set()
+        skipped_essential: Set[str] = set()
+
+        # First scan all packages and set desired version, if specified.
+        # We do this all at once in case it gets added as a dependency
+        # along the way.
+        for name in package_names:
+            name, specified_version = repo.get_pkg_name_parts(name)
+            if specified_version:
+                package = cls._get_cached_package(name)
+                cls._set_package_version(package, specified_version)
+
+        for name in package_names:
+            name, _ = repo.get_pkg_name_parts(name)
+            package = cls._get_cached_package(name)
+            cls._mark_package_dependencies(
+                package=package,
+                marked_packages=marked_packages,
+                skipped_blacklisted=skipped_blacklisted,
+                skipped_essential=skipped_essential,
+            )
+
+        marked = sorted(marked_packages.keys())
+        logger.debug(f"Marked staged packages: {marked!r}")
+
+        if skipped_blacklisted:
+            blacklisted = sorted(skipped_blacklisted)
+            logger.debug(f"Skipping blacklisted packages: {blacklisted!r}")
+
+        if skipped_essential:
+            essential = sorted(skipped_essential)
+            logger.debug(f"Skipping priority essential packages: {essential!r}")
+
+        for pkg_name, pkg_version in marked_packages.items():
+            try:
+                dl_path = pkg_version.fetch_binary(cls._cache_dir)
+            except apt.package.FetchError as e:
+                raise errors.PackageFetchError(str(e))
+
+            logger.debug(f"Extracting stage package: {pkg_name}")
+            with tempfile.TemporaryDirectory() as temp_dir:
+                # Extract deb package.
+                cls._extract_deb(dl_path, temp_dir)
+
+                # Mark source of files.
+                marked_name = f"{pkg_name}:{pkg_version.version}"
+                cls._mark_origin_stage_package(temp_dir, marked_name)
+
+                # Stage files to install_dir.
+                file_utils.link_or_copy_tree(temp_dir, install_dir)
+
+        cls.normalize(install_dir)
+
+        return [
+            f"{pkg_name}={pkg_version}"
+            for pkg_name, pkg_version in marked_packages.items()
+        ]
+
     @classmethod
     def build_package_is_valid(cls, package_name):
-        with apt.Cache() as apt_cache:
-            return package_name in apt_cache
+        return package_name in cls._get_apt_cache()
 
     @classmethod
     def is_package_installed(cls, package_name):
-        with apt.Cache() as apt_cache:
-            if package_name not in apt_cache:
-                return False
-            return apt_cache[package_name].installed
+        if package_name not in cls._get_apt_cache():
+            return False
+        return cls._get_apt_cache()[package_name].installed is not None
 
     @classmethod
-    def get_installed_packages(cls):
+    def get_installed_packages(cls) -> List[str]:
         installed_packages = []
-        with apt.Cache() as apt_cache:
-            for package in apt_cache:
-                if package.installed:
-                    installed_packages.append(
-                        "{}={}".format(package.name, package.installed.version)
-                    )
+        for package in cls._get_apt_cache():
+            if package.installed:
+                installed_packages.append(
+                    "{}={}".format(package.name, package.installed.version)
+                )
         return installed_packages
 
     @classmethod
@@ -598,99 +561,15 @@ class Ubuntu(BaseRepo):
 
         logger.debug(f"Installed apt repository {expanded_source!r}")
 
-    def __init__(
-        self,
-        rootdir,
-        sources: Optional[List[str]] = None,
-        keyrings: Optional[List[str]] = None,
-        project_options=None,
-    ) -> None:
-        super().__init__(rootdir)
-        self._downloaddir = os.path.join(rootdir, "download")
-
-        if sources is None:
-            sources = list()
-
-        if keyrings is None:
-            keyrings = list()
-
-        self._apt = _AptCache(sources=sources, keyrings=keyrings)
-
-        self._cache = cache.AptStagePackageCache(
-            sources_digest=self._apt.sources_digest()
-        )
-
-    def is_valid(self, package_name):
-        with self._apt.archive(self._cache.base_dir) as apt_cache:
-            return package_name in apt_cache
-
-    def get(self, package_names) -> List[str]:
-        with self._apt.archive(self._cache.base_dir) as apt_cache:
-            self._mark_install(apt_cache, package_names)
-            self._filter_base_packages(apt_cache, package_names)
-            self._autokeep_packages(apt_cache)
-            return self._get(apt_cache)
-
-    def _autokeep_packages(self, apt_cache):
-        for package in apt_cache.get_changes():
-            if package.is_auto_removable:
-                package.mark_keep()
-
-    def _is_filtered_package(self, package_name: str) -> bool:
+    @classmethod
+    def _is_filtered_package(cls, package_name: str) -> bool:
         # Filter out packages provided by the core snap.
         # TODO: use manifest found in core snap, if found at:
         # <core-snap>/usr/share/snappy/dpkg.list
         return package_name in _DEFAULT_FILTERED_STAGE_PACKAGES
 
-    def _filter_base_packages(self, apt_cache, package_names):
-        skipped_essential = []
-        skipped_blacklisted = []
-
-        # unmark some base packages here
-        # note that this will break the consistency check inside apt_cache
-        # (apt_cache.broken_count will be > 0)
-        # but that is ok as it was consistent before we excluded
-        # these base package
-        for pkg in apt_cache:
-            # those should be already on each system, it also prevents
-            # diving into downloading libc6
-            if pkg.candidate.priority in "essential" and pkg.name not in package_names:
-                skipped_essential.append(pkg.name)
-                pkg.mark_keep()
-                continue
-            if self._is_filtered_package(pkg.name) and pkg.name not in package_names:
-                skipped_blacklisted.append(pkg.name)
-                pkg.mark_keep()
-                continue
-
-        if skipped_essential:
-            logger.debug(
-                "Skipping priority essential packages: "
-                "{!r}".format(skipped_essential)
-            )
-        if skipped_blacklisted:
-            logger.debug(
-                "Skipping blacklisted from manifest packages: "
-                "{!r}".format(skipped_blacklisted)
-            )
-
-    def _get(self, apt_cache):
-        pkg_list = []
-        for package in apt_cache.get_changes():
-            pkg_list.append(str(package.candidate))
-            try:
-                source = package.candidate.fetch_binary(self._cache.packages_dir)
-            except apt.package.FetchError as e:
-                raise errors.PackageFetchError(str(e))
-
-            destination = os.path.join(self._downloaddir, os.path.basename(source))
-            with contextlib.suppress(FileNotFoundError):
-                os.remove(destination)
-            file_utils.link_or_copy(source, destination)
-
-        return pkg_list
-
-    def _extract_deb_name_version(self, deb_path: str) -> str:
+    @classmethod
+    def _extract_deb_name_version(cls, deb_path: str) -> str:
         try:
             output = subprocess.check_output(
                 ["dpkg-deb", "--show", "--showformat=${Package}=${Version}", deb_path]
@@ -700,22 +579,13 @@ class Ubuntu(BaseRepo):
 
         return output.decode().strip()
 
-    def _extract_deb(self, deb_path: str, extract_dir: str) -> None:
+    @classmethod
+    def _extract_deb(cls, deb_path: str, extract_dir: str) -> None:
         """Extract deb and return `<package-name>=<version>`."""
         try:
             subprocess.check_call(["dpkg-deb", "--extract", deb_path, extract_dir])
         except subprocess.CalledProcessError:
             raise errors.UnpackError(deb_path)
-
-    def unpack(self, unpackdir) -> None:
-        pkgs_abs_path = glob.glob(os.path.join(self._downloaddir, "*.deb"))
-        for pkg in pkgs_abs_path:
-            with tempfile.TemporaryDirectory() as temp_dir:
-                self._extract_deb(pkg, temp_dir)
-                deb_name = self._extract_deb_name_version(pkg)
-                self._mark_origin_stage_package(temp_dir, deb_name)
-                file_utils.link_or_copy_tree(temp_dir, unpackdir)
-        self.normalize(unpackdir)
 
 
 def _get_local_sources_list():
@@ -734,12 +604,3 @@ def _format_sources_list(sources_list: str):
     release = os_release.OsRelease().version_codename()
 
     return string.Template(sources_list).substitute({"release": release})
-
-
-def _set_pkg_version(pkg, version):
-    """Set cadidate version to a specific version if available"""
-    if version in pkg.versions:
-        version = pkg.versions.get(version)
-        pkg.candidate = version
-    else:
-        raise errors.PackageNotFoundError("{}={}".format(pkg.name, version))

--- a/snapcraft/plugins/v1/_ros/rosdep.py
+++ b/snapcraft/plugins/v1/_ros/rosdep.py
@@ -80,14 +80,10 @@ class Rosdep:
 
         # rosdep isn't necessarily a dependency of the project, so we'll unpack
         # it off to the side and use it from there.
-        logger.info("Preparing to fetch rosdep...")
-        ubuntu = repo.Ubuntu(self._rosdep_path)
-
-        logger.info("Fetching rosdep...")
-        ubuntu.get(["python-rosdep"])
-
         logger.info("Installing rosdep...")
-        ubuntu.unpack(self._rosdep_install_path)
+        repo.Ubuntu.install_stage_packages(
+            package_names=["python-rosdep"], install_dir=self._rosdep_install_path
+        )
 
         logger.info("Initializing rosdep database...")
         try:

--- a/snapcraft/plugins/v1/_ros/wstool.py
+++ b/snapcraft/plugins/v1/_ros/wstool.py
@@ -79,13 +79,10 @@ class Wstool:
 
         # wstool isn't a dependency of the project, so we'll unpack it
         # somewhere else, and use it from there.
-        logger.info("Preparing to fetch wstool...")
-        ubuntu = repo.Ubuntu(self._wstool_path)
-        logger.info("Fetching wstool...")
-        ubuntu.get(["python-wstool"])
-
         logger.info("Installing wstool...")
-        ubuntu.unpack(self._wstool_install_path)
+        repo.Ubuntu.install_stage_packages(
+            package_names=["python-wstool"], install_dir=self._wstool_install_path
+        )
 
         logger.info("Initializing workspace (if necessary)...")
         try:

--- a/snapcraft/plugins/v1/colcon.py
+++ b/snapcraft/plugins/v1/colcon.py
@@ -397,21 +397,16 @@ class ColconPlugin(PluginV1):
         self._setup_pip_dependencies(system_dependencies.get("pip"))
 
     def _setup_apt_dependencies(self, apt_dependencies):
-        if apt_dependencies:
-            ubuntudir = os.path.join(self.partdir, "ubuntu")
-            os.makedirs(ubuntudir, exist_ok=True)
+        if not apt_dependencies:
+            return
 
-            logger.info("Preparing to fetch apt dependencies...")
-            ubuntu = repo.Ubuntu(ubuntudir)
-
-            logger.info("Fetching apt dependencies...")
-            try:
-                ubuntu.get(apt_dependencies)
-            except repo.errors.PackageNotFoundError as e:
-                raise ColconAptDependencyFetchError(e.message)
-
-            logger.info("Installing apt dependencies...")
-            ubuntu.unpack(self.installdir)
+        logger.info("Installing apt dependencies...")
+        try:
+            repo.Ubuntu.install_stage_packages(
+                package_names=apt_dependencies, install_dir=self.installdir
+            )
+        except repo.errors.PackageNotFoundError as e:
+            raise ColconAptDependencyFetchError(e.message)
 
     def _setup_pip_dependencies(self, pip_dependencies):
         if pip_dependencies:

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -300,7 +300,6 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
 
         if not stage_packages_repo:
             stage_packages_repo = mock.Mock()
-            stage_packages_repo.rootdir = "ubuntu"
         grammar_processor = grammar_processing.PartGrammarProcessor(
             plugin=plugin,
             properties=properties,

--- a/tests/unit/lifecycle/test_lifecycle.py
+++ b/tests/unit/lifecycle/test_lifecycle.py
@@ -798,7 +798,7 @@ class RecordManifestTestCase(RecordManifestBaseTestCase):
         )
 
     @mock.patch(
-        "snapcraft.repo.Repo.get",
+        "snapcraft.repo.Repo.install_stage_packages",
         return_value=["test-package1=test-version1", "test-package2=test-version2"],
     )
     def test_prime_with_stage_packages(self, mock_stage_packages):

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -2867,7 +2867,9 @@ class CollisionTestCase(unit.TestCase):
 class StagePackagesTestCase(unit.TestCase):
     def test_missing_stage_package_raises_exception(self):
         fake_repo = Mock()
-        fake_repo.get.side_effect = repo.errors.PackageNotFoundError("non-existing")
+        fake_repo.install_stage_packages.side_effect = repo.errors.PackageNotFoundError(
+            "non-existing"
+        )
         part = self.load_part(
             "stage-test",
             part_properties={"stage-packages": ["non-existing"]},

--- a/tests/unit/plugins/v1/ros/test_rosdep.py
+++ b/tests/unit/plugins/v1/ros/test_rosdep.py
@@ -53,15 +53,16 @@ class RosdepTestCase(unit.TestCase):
         self.rosdep.setup()
 
         # Verify that only rosdep was installed (no other .debs)
-        self.assertThat(self.ubuntu_mock.call_count, Equals(1))
-        self.assertThat(self.ubuntu_mock.return_value.get.call_count, Equals(1))
-        self.assertThat(self.ubuntu_mock.return_value.unpack.call_count, Equals(1))
-        self.ubuntu_mock.assert_has_calls(
-            [
-                mock.call(self.rosdep._rosdep_path),
-                mock.call().get(["python-rosdep"]),
-                mock.call().unpack(self.rosdep._rosdep_install_path),
-            ]
+        self.assertThat(
+            self.ubuntu_mock.mock_calls,
+            Equals(
+                [
+                    mock.call.install_stage_packages(
+                        install_dir="rosdep_path/install",
+                        package_names=["python-rosdep"],
+                    )
+                ]
+            ),
         )
 
         # Verify that rosdep was initialized and updated

--- a/tests/unit/plugins/v1/ros/test_wstool.py
+++ b/tests/unit/plugins/v1/ros/test_wstool.py
@@ -47,14 +47,11 @@ class WstoolTestCase(unit.TestCase):
         self.wstool.setup()
 
         # Verify that only wstool was installed (no other .debs)
-        self.assertThat(self.ubuntu_mock.call_count, Equals(1))
-        self.assertThat(self.ubuntu_mock.return_value.get.call_count, Equals(1))
-        self.assertThat(self.ubuntu_mock.return_value.unpack.call_count, Equals(1))
         self.ubuntu_mock.assert_has_calls(
             [
-                mock.call(self.wstool._wstool_path),
-                mock.call().get(["python-wstool"]),
-                mock.call().unpack(self.wstool._wstool_install_path),
+                mock.call.install_stage_packages(
+                    install_dir="wstool_path/install", package_names=["python-wstool"]
+                )
             ]
         )
 

--- a/tests/unit/repo/test_base.py
+++ b/tests/unit/repo/test_base.py
@@ -21,8 +21,7 @@ from textwrap import dedent
 from testtools.matchers import Equals, FileContains, FileExists, Not
 
 from snapcraft.internal import errors
-from snapcraft.internal.repo import check_for_command
-from snapcraft.internal.repo import BaseRepo
+from snapcraft.internal.repo import BaseRepo, check_for_command, get_pkg_name_parts
 from tests import unit
 from . import RepoBaseTestCase
 
@@ -131,7 +130,7 @@ class FixXmlToolsTestCase(RepoBaseTestCase):
             with open(path, "w") as f:
                 f.write(test_file["content"])
 
-        BaseRepo("root").normalize("root")
+        BaseRepo.normalize("root")
 
         for test_file in self.files:
             self.assertThat(test_file["path"], FileContains(test_file["expected"]))
@@ -195,7 +194,7 @@ class FixShebangTestCase(RepoBaseTestCase):
         with open(self.file_path, "w") as fd:
             fd.write(self.content)
 
-        BaseRepo("root").normalize("root")
+        BaseRepo.normalize("root")
 
         with open(self.file_path, "r") as fd:
             self.assertThat(fd.read(), Equals(self.expected))
@@ -243,7 +242,7 @@ class RemoveUselessFilesTestCase(RepoBaseTestCase):
         os.makedirs(os.path.dirname(path), exist_ok=True)
         open(path, "w").close()
 
-        BaseRepo("root").normalize("root")
+        BaseRepo.normalize("root")
 
         self.assertThat(path, self.matcher)
 
@@ -271,7 +270,7 @@ class FixPkgConfigTestCase(RepoBaseTestCase):
                 )
             )
 
-        BaseRepo(self.tempdir).normalize(self.tempdir)
+        BaseRepo.normalize(self.tempdir)
 
         expected_pc_file_content = dedent(
             """\
@@ -312,7 +311,7 @@ class FixSymlinksTestCase(RepoBaseTestCase):
     def test_fix_symlinks(self):
         os.symlink(self.src, self.dst)
 
-        BaseRepo(self.tempdir).normalize(self.tempdir)
+        BaseRepo.normalize(self.tempdir)
 
         self.assertThat(os.readlink(self.dst), Equals(self.src))
 
@@ -337,6 +336,23 @@ class FixSUIDTestCase(RepoBaseTestCase):
         open(file, mode="w").close()
         os.chmod(file, self.test_mod)
 
-        BaseRepo(self.tempdir).normalize(self.tempdir)
+        BaseRepo.normalize(self.tempdir)
 
         self.assertThat(stat.S_IMODE(os.stat(file).st_mode), Equals(self.expected_mod))
+
+
+class TestPkgNameParts(unit.TestCase):
+    def test_get_pkg_name_parts_name_only(self):
+        name, version = get_pkg_name_parts("hello")
+        self.assertThat(name, Equals("hello"))
+        self.assertThat(version, Equals(None))
+
+    def test_get_pkg_name_parts_all(self):
+        name, version = get_pkg_name_parts("hello:i386=2.10-1")
+        self.assertThat(name, Equals("hello:i386"))
+        self.assertThat(version, Equals("2.10-1"))
+
+    def test_get_pkg_name_parts_no_arch(self):
+        name, version = get_pkg_name_parts("hello=2.10-1")
+        self.assertThat(name, Equals("hello"))
+        self.assertThat(version, Equals("2.10-1"))

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -15,17 +15,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import apt
-import collections
 import os
 import subprocess
 import textwrap
 from pathlib import Path
 from subprocess import CalledProcessError
 from unittest import mock
-from unittest.mock import ANY, DEFAULT, call, patch, MagicMock
+from unittest.mock import call, patch, MagicMock, PropertyMock
 
-from testtools.matchers import Contains, Equals, FileExists, Not
+from testtools.matchers import Contains, Equals
 import fixtures
+from typing import Dict, List, Optional
 
 from snapcraft.internal import repo
 from snapcraft.internal.repo import errors
@@ -33,409 +33,164 @@ from tests import unit
 from . import RepoBaseTestCase
 
 
-class FakeAptCache(fixtures.Fixture):
-    class Cache:
-        def __init__(self):
-            super().__init__()
-            self.packages = collections.OrderedDict()
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *args):
-            pass
-
-        def __setitem__(self, key, item):
-            package_parts = key.split("=")
-            package_name = package_parts[0]
-            version = package_parts[1] if len(package_parts) > 1 else item.version
-            if package_name in self.packages:
-                self.packages[package_name].version = version
-            else:
-                if version and not item.version:
-                    item.version = version
-                self.packages[package_name] = item
-
-        def __getitem__(self, key):
-            if "=" in key:
-                key = key.split("=")[0]
-            return self.packages[key]
-
-        def __contains__(self, key):
-            return key in self.packages
-
-        def __iter__(self):
-            return iter(self.packages.values())
-
-        def open(self):
-            pass
-
-        def close(self):
-            pass
-
-        def update(self, *args, **kwargs):
-            pass
-
-        def get_changes(self):
-            return [
-                self.packages[package]
-                for package in self.packages
-                if self.packages[package].marked_install
-            ]
-
-        def get_providing_packages(self, package_name):
-            providing_packages = []
-            for package in self.packages:
-                if package_name in self.packages[package].provides:
-                    providing_packages.append(self.packages[package])
-            return providing_packages
-
-        def is_virtual_package(self, package_name):
-            is_virtual = False
-            if package_name not in self.packages:
-                for package in self.packages:
-                    if package_name in self.packages[package].provides:
-                        return True
-            return is_virtual
-
-    def __init__(self, packages=None):
-        super().__init__()
-        self.packages = packages if packages else []
-
-    def setUp(self):
-        super().setUp()
-        temp_dir_fixture = fixtures.TempDir()
-        self.useFixture(temp_dir_fixture)
-        self.path = temp_dir_fixture.path
-        patcher = mock.patch("snapcraft.repo._deb.apt.Cache")
-        self.mock_apt_cache = patcher.start()
-        self.addCleanup(patcher.stop)
-
-        self.cache = self.Cache()
-        self.mock_apt_cache.return_value = self.cache
-        for package, version in self.packages:
-            self.add_package(FakeAptCachePackage(package, version))
-
-        # Add all the packages in the manifest.
-        self.add_packages(repo._deb._DEFAULT_FILTERED_STAGE_PACKAGES)
-
-    def add_package(self, package):
-        package.temp_dir = self.path
-        self.cache[package.name] = package
-
-    def add_packages(self, package_names):
-        for name in package_names:
-            self.cache[name] = FakeAptCachePackage(name)
+class FakeAptDependency:
+    def __init__(self, *, target_versions: List[MagicMock]) -> None:
+        self.target_versions = target_versions
 
 
-class FakeAptCachePackage:
+class FakeAptVersion:
     def __init__(
         self,
-        name,
-        version=None,
-        installed=None,
-        temp_dir=None,
-        provides=None,
-        priority="non-essential",
-    ):
-        super().__init__()
-        self.temp_dir = temp_dir
-        self.name = name
-        self._version = None
-        self.versions = {}
-        self.version = version
-        self.candidate = self
-        self.dependencies = []
-        self.conflicts = []
-        self.provides = provides if provides else []
-        if installed:
-            # XXX The installed attribute requires some values that the fake
-            # package also requires. The shortest path to do it that I found
-            # was to get installed to return the same fake package.
-            self.installed = self
-        else:
-            self.installed = None
+        *,
+        dependencies: List[MagicMock],
+        package: MagicMock,
+        priority: str,
+        version: str,
+    ) -> None:
+        self.dependencies = dependencies
+        self.package = package
         self.priority = priority
-        self.marked_install = False
-        self.is_auto_installed = False
+        self.version = version
 
-    def __str__(self):
-        if "=" in self.name:
-            return self.name
-        else:
-            return "{}={}".format(self.name, self.version)
-
-    @property
-    def is_auto_removable(self):
-        return self.marked_install and self.is_auto_installed
-
-    @property
-    def version(self):
-        return self._version
-
-    @version.setter
-    def version(self, version):
-        self._version = version
-        if version is not None:
-            self.versions.update({version: self})
-
-    def fetch_binary(self, cache_dir):
-        path = os.path.join(cache_dir, f"{self.name}.deb")
-        open(path, "w").close()
-        return path
-
-    def mark_install(self, *, auto_fix=True, from_user=True):
-        if not self.installed:
-            # First, verify dependencies are valid. If not, bail.
-            for or_set in self.dependencies:
-                for dep in or_set:
-                    if "broken" in dep.name:
-                        return
-
-            for or_set in self.dependencies:
-                if or_set and or_set[0].target_versions:
-                    # Install the first target version of the first OR
-                    or_set[0].target_versions[0].mark_install(
-                        auto_fix=auto_fix, from_user=from_user
-                    )
-            for conflict in self.conflicts:
-                conflict.mark_keep()
-
-            self.marked_install = True
-            self.is_auto_installed = not from_user
-
-    def mark_auto(self, auto=True):
-        self.is_auto_installed = auto
-
-    def mark_keep(self):
-        self.marked_install = False
-        self.is_auto_installed = False
-
-    def get_dependencies(self, _):
-        return []
+    def fetch_binary(self, path: str) -> str:
+        return os.path.join(path, self.package.name + ".deb")
 
 
-class FakeAptBaseDependency:
-    def __init__(self, name, target_versions):
+class FakeAptPackage:
+    def __init__(
+        self,
+        *,
+        name: str,
+        candidate: Optional[MagicMock] = None,
+        installed: Optional[MagicMock] = None,
+    ) -> None:
         self.name = name
-        self.target_versions = target_versions
+        self.candidate = candidate
+        self.installed = installed
+
+
+class FakeAptCache:
+    def __init__(self) -> None:
+        self.dependencies: Dict[str, MagicMock] = dict()
+        self.packages: Dict[str, MagicMock] = dict()
+        self.versions: Dict[str, MagicMock] = dict()
+
+    def __getitem__(self, key) -> MagicMock:
+        return self.packages[key]
+
+    def __contains__(self, key) -> bool:
+        return key in self.packages
+
+    def add_fake_package(
+        self,
+        *,
+        name: str,
+        priority: str = "normal",
+        version: str = "1.0",
+        installed: bool = False,
+        dependency_names: List[str],
+    ) -> MagicMock:
+        package = MagicMock(wraps=FakeAptPackage(name=name))
+        package_name_mock = PropertyMock(return_value=name)
+        type(package).name = package_name_mock
+
+        self.packages[name] = package
+
+        package_dependencies = [
+            self.dependencies.get(name) for name in dependency_names
+        ]
+
+        version = MagicMock(
+            wraps=FakeAptVersion(
+                version=version,
+                priority=priority,
+                package=package,
+                dependencies=package_dependencies,
+            )
+        )
+        self.versions[name] = version
+
+        # Wire up coupled package properties.
+        package.candidate = version
+        if installed:
+            package.installed = version
+        else:
+            package.installed = None
+
+        # Create matching dependency, even if unused.
+        dependency = MagicMock(wraps=FakeAptDependency(target_versions=[version]))
+        self.dependencies[name] = dependency
+
+        return package
+
+    def is_virtual_package(self, package_name):
+        return package_name.startswith("virtual-")
+
+    def get_providing_package(self, package_name):
+        return package_name.replace("virtual-", "nonvirtual-")
+
+    def close(self):
+        pass
 
 
 class UbuntuTestCase(RepoBaseTestCase):
     def setUp(self):
         super().setUp()
-        patcher = patch("snapcraft.repo._deb.apt.Cache")
-        self.mock_cache = patcher.start()
-        self.addCleanup(patcher.stop)
 
-        def _fetch_binary(download_dir, **kwargs):
-            path = os.path.join(download_dir, "fake-package.deb")
-            open(path, "w").close()
-            return path
+        self.fake_apt_cache = FakeAptCache()
+        self.fake_apt_cache.add_fake_package(name="fake-package", dependency_names=[])
 
-        self.mock_package = MagicMock()
-        self.mock_package.candidate.fetch_binary.side_effect = _fetch_binary
-        self.mock_cache.return_value.get_changes.return_value = [self.mock_package]
+        self.fake_apt_cache_mock = MagicMock(wraps=self.fake_apt_cache)
 
-    @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_cache_update_failed(self, mock_apt_pkg):
-        self.mock_cache().is_virtual_package.return_value = False
-        self.mock_cache().update.side_effect = apt.cache.FetchFailedException()
-        ubuntu = repo.Ubuntu(self.tempdir)
-        self.assertRaises(errors.CacheUpdateFailedError, ubuntu.get, ["fake-package"])
-
-    @patch("shutil.rmtree")
-    @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_cache_hashsum_mismatch(self, mock_apt_pkg, mock_rmtree):
-        self.mock_cache().is_virtual_package.return_value = False
-        self.mock_cache().update.side_effect = [
-            apt.cache.FetchFailedException(
-                "E:Failed to fetch copy:foo Hash Sum mismatch"
-            ),
-            DEFAULT,
-        ]
-        ubuntu = repo.Ubuntu(self.tempdir)
-        ubuntu.get(["fake-package"])
-
-    def test_get_pkg_name_parts_name_only(self):
-        name, version = repo.get_pkg_name_parts("hello")
-        self.assertThat(name, Equals("hello"))
-        self.assertThat(version, Equals(None))
-
-    def test_get_pkg_name_parts_all(self):
-        name, version = repo.get_pkg_name_parts("hello:i386=2.10-1")
-        self.assertThat(name, Equals("hello:i386"))
-        self.assertThat(version, Equals("2.10-1"))
-
-    def test_get_pkg_name_parts_no_arch(self):
-        name, version = repo.get_pkg_name_parts("hello=2.10-1")
-        self.assertThat(name, Equals("hello"))
-        self.assertThat(version, Equals("2.10-1"))
-
-    @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_get_package(self, mock_apt_pkg):
-        self.mock_cache().is_virtual_package.return_value = False
-
-        fake_trusted_parts_path = os.path.join(self.path, "fake-trusted-parts")
-        os.mkdir(fake_trusted_parts_path)
-        open(os.path.join(fake_trusted_parts_path, "trusted-part.gpg"), "w").close()
-
-        def _fake_find_file(key: str):
-            if key == "Dir::Etc::TrustedParts":
-                return fake_trusted_parts_path
-            else:
-                return DEFAULT
-
-        mock_apt_pkg.config.find_file.side_effect = _fake_find_file
-
-        ubuntu = repo.Ubuntu(self.tempdir)
-        ubuntu.get(["fake-package"])
-
-        mock_apt_pkg.assert_has_calls(
-            [
-                call.config.set("Apt::Install-Recommends", "False"),
-                call.config.set("Acquire::AllowInsecureRepositories", "False"),
-                call.config.find_file("Dir::Etc::Trusted"),
-                call.config.set("Dir::Etc::Trusted", ANY),
-                call.config.find_file("Dir::Etc::TrustedParts"),
-                call.config.set("Dir::Etc::TrustedParts", ANY),
-                call.config.clear("APT::Update::Post-Invoke-Success"),
-            ]
+        self.useFixture(
+            fixtures.MockPatch("apt.Cache", return_value=self.fake_apt_cache)
         )
 
-        self.mock_cache.assert_has_calls(
-            [
-                call(memonly=True, rootdir=ANY),
-                call().update(fetch_progress=ANY, sources_list=ANY),
-                call().open(),
-            ]
+        self.fake_run = self.useFixture(
+            fixtures.MockPatch("subprocess.check_call")
+        ).mock
+
+        # Override the cache directory to temp path.
+        repo.Ubuntu._cache_dir = self.path
+
+        # Ensure the cache is reset.
+        repo.Ubuntu._cache = None
+
+    def test_install_stage_package(self):
+        repo.Ubuntu.install_stage_packages(
+            package_names=["fake-package"], install_dir=self.path
         )
 
-        # __getitem__ is tricky
         self.assertThat(
-            self.mock_cache.return_value.__getitem__.call_args_list,
-            Contains(call("fake-package")),
+            self.fake_apt_cache["fake-package"].mock_calls,
+            Contains(call.candidate.fetch_binary(self.path)),
         )
 
-        # Verify that the package was actually fetched and copied into the
-        # requested location.
-        self.assertThat(
-            os.path.join(self.tempdir, "download", "fake-package.deb"), FileExists()
-        )
+    def test_get_package_fetch_error(self):
+        self.fake_apt_cache.packages[
+            "fake-package"
+        ].candidate.fetch_binary.side_effect = apt.package.FetchError("foo")
 
-        # Verify that TrustedParts were properly setup
-        trusted_parts_dir = os.path.join(
-            ubuntu._cache.base_dir,
-            os.path.join(self.path, "fake-trusted-parts").lstrip("/"),
-        )
-        self.assertThat(os.listdir(trusted_parts_dir), Equals(["trusted-part.gpg"]))
-
-    @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_get_package_fetch_error(self, mock_apt_pkg):
-        self.mock_package.candidate.fetch_binary.side_effect = apt.package.FetchError(
-            "foo"
-        )
-        self.mock_cache().is_virtual_package.return_value = False
-        ubuntu = repo.Ubuntu(self.tempdir)
         raised = self.assertRaises(
-            errors.PackageFetchError, ubuntu.get, ["fake-package"]
+            errors.PackageFetchError,
+            repo.Ubuntu.install_stage_packages,
+            package_names=["fake-package"],
+            install_dir=self.path,
         )
         self.assertThat(str(raised), Equals("Package fetch error: foo"))
 
-    @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_get_package_trusted_parts_already_imported(self, mock_apt_pkg):
-        self.mock_cache().is_virtual_package.return_value = False
-
-        def _fake_find_file(key: str):
-            if key == "Dir::Etc::TrustedParts":
-                return os.path.join(ubuntu._cache.base_dir, "trusted")
-            else:
-                return DEFAULT
-
-        mock_apt_pkg.config.find_file.side_effect = _fake_find_file
-
-        ubuntu = repo.Ubuntu(self.tempdir)
-        ubuntu.get(["fake-package"])
-
-        mock_apt_pkg.assert_has_calls(
-            [
-                call.config.set("Apt::Install-Recommends", "False"),
-                call.config.set("Acquire::AllowInsecureRepositories", "False"),
-                call.config.find_file("Dir::Etc::Trusted"),
-                call.config.set("Dir::Etc::Trusted", ANY),
-                call.config.find_file("Dir::Etc::TrustedParts"),
-                call.config.clear("APT::Update::Post-Invoke-Success"),
-            ]
+    def test_get_multiarch_package(self):
+        self.fake_apt_cache.add_fake_package(
+            name="fake-package:arch", dependency_names=[]
         )
 
-        self.mock_cache.assert_has_calls(
-            [
-                call(memonly=True, rootdir=ANY),
-                call().update(fetch_progress=ANY, sources_list=ANY),
-                call().open(),
-            ]
+        repo.Ubuntu.install_stage_packages(
+            package_names=["fake-package:arch"], install_dir=self.path
         )
 
-        # __getitem__ is tricky
         self.assertThat(
-            self.mock_cache.return_value.__getitem__.call_args_list,
-            Contains(call("fake-package")),
-        )
-
-        # Verify that the package was actually fetched and copied into the
-        # requested location.
-        self.assertThat(
-            os.path.join(self.tempdir, "download", "fake-package.deb"), FileExists()
-        )
-
-    @patch("snapcraft.internal.repo._deb.apt.apt_pkg")
-    def test_get_multiarch_package(self, mock_apt_pkg):
-        self.mock_cache().is_virtual_package.return_value = False
-
-        fake_trusted_parts_path = os.path.join(self.path, "fake-trusted-parts")
-        os.mkdir(fake_trusted_parts_path)
-        open(os.path.join(fake_trusted_parts_path, "trusted-part.gpg"), "w").close()
-
-        def _fake_find_file(key: str):
-            if key == "Dir::Etc::TrustedParts":
-                return fake_trusted_parts_path
-            else:
-                return DEFAULT
-
-        mock_apt_pkg.config.find_file.side_effect = _fake_find_file
-
-        ubuntu = repo.Ubuntu(self.tempdir)
-        ubuntu.get(["fake-package:arch"])
-
-        mock_apt_pkg.assert_has_calls(
-            [
-                call.config.set("Apt::Install-Recommends", "False"),
-                call.config.set("Acquire::AllowInsecureRepositories", "False"),
-                call.config.find_file("Dir::Etc::Trusted"),
-                call.config.set("Dir::Etc::Trusted", ANY),
-                call.config.find_file("Dir::Etc::TrustedParts"),
-                call.config.set("Dir::Etc::TrustedParts", ANY),
-                call.config.clear("APT::Update::Post-Invoke-Success"),
-            ]
-        )
-        self.mock_cache.assert_has_calls(
-            [
-                call(memonly=True, rootdir=ANY),
-                call().update(fetch_progress=ANY, sources_list=ANY),
-                call().open(),
-            ]
-        )
-
-        # __getitem__ is tricky
-        self.assertThat(
-            self.mock_cache.return_value.__getitem__.call_args_list,
-            Contains(call("fake-package:arch")),
-        )
-
-        # Verify that the package was actually fetched and copied into the
-        # requested location.
-        self.assertThat(
-            os.path.join(self.tempdir, "download", "fake-package.deb"), FileExists()
+            self.fake_apt_cache.packages["fake-package:arch"].mock_calls,
+            Contains(call.candidate.fetch_binary(self.path)),
         )
 
     @mock.patch(
@@ -460,111 +215,42 @@ class UbuntuTestCase(RepoBaseTestCase):
         self.assertThat(sources_list, Equals(expected_sources_list))
 
 
-class UbuntuTestCaseWithFakeAptCache(RepoBaseTestCase):
+class BuildPackagesTestCase(UbuntuTestCase):
     def setUp(self):
         super().setUp()
-        self.fake_apt_cache = FakeAptCache()
-        self.useFixture(self.fake_apt_cache)
 
-    def test_get_installed_packages(self):
-        for name, version, installed in (
-            ("test-installed-package", "test-installed-package-version", True),
-            ("test-not-installed-package", "dummy", False),
-        ):
-            self.fake_apt_cache.add_package(
-                FakeAptCachePackage(name, version, installed=installed)
-            )
-
-        self.assertThat(
-            repo.Repo.get_installed_packages(),
-            Equals(["test-installed-package=test-installed-package-version"]),
+        self.fake_apt_cache.add_fake_package(
+            name="package-installed",
+            priority="normal",
+            version="0.1",
+            installed=True,
+            dependency_names=[],
         )
 
-
-class AutokeepTestCase(RepoBaseTestCase):
-    def test_autokeep(self):
-        self.fake_apt_cache = FakeAptCache()
-        self.useFixture(self.fake_apt_cache)
-        self.test_packages = (
-            "main-package",
-            "dependency",
-            "sub-dependency",
-            "conflicting-dependency",
-        )
-        self.fake_apt_cache.add_packages(self.test_packages)
-        self.fake_apt_cache.cache["main-package"].dependencies = [
-            [
-                FakeAptBaseDependency(
-                    "dependency", [self.fake_apt_cache.cache["dependency"]]
-                ),
-                FakeAptBaseDependency(
-                    "conflicting-dependency",
-                    [self.fake_apt_cache.cache["conflicting-dependency"]],
-                ),
-            ]
-        ]
-        self.fake_apt_cache.cache["dependency"].dependencies = [
-            [
-                FakeAptBaseDependency(
-                    "sub-dependency", [self.fake_apt_cache.cache["sub-dependency"]]
-                )
-            ]
-        ]
-        self.fake_apt_cache.cache["conflicting-dependency"].conflicts = [
-            self.fake_apt_cache.cache["dependency"]
-        ]
-
-        ubuntu = repo.Ubuntu(self.tempdir)
-        ubuntu.get(["main-package", "conflicting-dependency"])
-
-        # Verify that the package was actually fetched and copied into the
-        # requested location.
-        self.assertThat(
-            os.path.join(self.tempdir, "download", "main-package.deb"), FileExists()
-        )
-        self.assertThat(
-            os.path.join(self.tempdir, "download", "conflicting-dependency.deb"),
-            FileExists(),
-        )
-        self.assertThat(
-            os.path.join(self.tempdir, "download", "dependency.deb"),
-            Not(FileExists()),
-            "Dependency should not have been fetched",
-        )
-        self.assertThat(
-            os.path.join(self.tempdir, "download", "sub-dependency.deb"),
-            Not(FileExists()),
-            "Sub-dependency should not have been fetched",
+        self.fake_apt_cache.add_fake_package(
+            name="package-not-installed",
+            priority="normal",
+            version="0.1",
+            installed=False,
+            dependency_names=[],
         )
 
+        self.fake_apt_cache.add_fake_package(
+            name="versioned-package",
+            priority="normal",
+            version="0.2",
+            installed=False,
+            dependency_names=[],
+        )
 
-class BuildPackagesTestCase(unit.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.fake_apt_cache = FakeAptCache()
-        self.useFixture(self.fake_apt_cache)
-        self.test_packages = (
-            "package-not-installed",
+        self.test_packages = [
             "package-installed",
-            "another-uninstalled",
-            "another-installed",
-            "repeated-package",
-            "repeated-package",
+            "package-not-installed",
             "versioned-package=0.2",
-            "versioned-package",
-        )
-        self.fake_apt_cache.add_packages(self.test_packages)
-        self.fake_apt_cache.cache["package-installed"].installed = True
-        self.fake_apt_cache.cache["another-installed"].installed = True
-        self.fake_apt_cache.cache["versioned-package"].version = "0.1"
+        ]
 
     def get_installable_packages(self, packages):
-        return [
-            "package-not-installed",
-            "another-uninstalled",
-            "repeated-package",
-            "versioned-package=0.2",
-        ]
+        return ["package-not-installed", "versioned-package=0.2"]
 
     @patch("os.environ")
     def install_test_packages(self, test_pkgs, mock_env):
@@ -648,27 +334,14 @@ class BuildPackagesTestCase(unit.TestCase):
         )
 
     @patch("subprocess.check_call")
-    def test_broken_package_requested(self, mock_check_call):
-        self.fake_apt_cache.add_packages(("package-not-installable",))
-        self.fake_apt_cache.cache["package-not-installable"].dependencies = [
-            [FakeAptBaseDependency("broken-dependency", [])]
-        ]
-        self.assertRaises(
-            errors.PackageBrokenError,
-            repo.Ubuntu.install_build_packages,
-            ["package-not-installable"],
-        )
-
-    @patch("subprocess.check_call")
     def test_broken_package_apt_install(self, mock_check_call):
         mock_check_call.side_effect = CalledProcessError(100, "apt-get")
-        self.fake_apt_cache.add_packages(("package-not-installable",))
         raised = self.assertRaises(
             errors.BuildPackagesNotInstalledError,
             repo.Ubuntu.install_build_packages,
-            ["package-not-installable"],
+            ["package-not-installed"],
         )
-        self.assertThat(raised.packages, Equals("package-not-installable"))
+        self.assertThat(raised.packages, Equals("package-not-installed"))
 
     @patch("subprocess.check_call")
     def test_refresh_buid_packages(self, mock_check_call):


### PR DESCRIPTION
This does remove the broken dependency handling... I need
a working test case to make sure that's solid.

- Move repo.get_pkg_name_parts to test_base, even though it's
  in __init__.

- Remove all instance methods from repo and Ubuntu, consolidating
  to install_stage_packages() classmethod.

- Move non-class methods in Repo into Repo class so they can be
  easily inherited.

- Remove custom _AptCache implementation.

  - Use a single instance of the system's apt cache, which should
    improve performance due to the penalty of recreating caches in
    numerous points.  It also simplifies usage without the requirement
    of copying/sharing instances for what is (now) a system-wide
    resource.

  - Remove old scheme for gathering stage packages, and simply do a scan
    ourselves for the packages and their dependencies.  Then fetch them
    using python-apt's fetch_binary().

- Rework apt tests.

- Rework of the ROS plugins to remove their current usage of Ubuntu
  and replace it with install_stage_packages().

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
