### PR TITLE
build_providers: pass through SNAPCRAFT_{BUILD,IMAGE}_INFO to container or VM

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import distutils.util
 import os
 import sys
 
@@ -46,16 +47,21 @@ class PromptOption(click.Option):
         )
 
 
-class SimpleBoolParamType(click.ParamType):
+class BoolParamType(click.ParamType):
     name = "boolean"
 
     def convert(self, value, param, ctx):
         """Convert option string to value.
 
-        Unlike click's BoolParamType, any non-empty string is treated
-        as True.
+        Unlike click's BoolParamType, use distutils.util.strtobool to
+        convert values.
         """
-        return bool(value)
+        if isinstance(value, bool):
+            return value
+        try:
+            return bool(distutils.util.strtobool(value))
+        except ValueError:
+            self.fail("%r is not a valid boolean" % value, param, ctx)
 
     def __repr__(self):
         return "BOOL"
@@ -142,7 +148,7 @@ _PROVIDER_OPTIONS = [
     dict(
         param_decls="--enable-manifest",
         is_flag=True,
-        type=SimpleBoolParamType(),
+        type=BoolParamType(),
         help="Generate snap manifest.",
         envvar="SNAPCRAFT_BUILD_INFO",
         supported_providers=["host", "lxd", "managed-host", "multipass"],

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -124,6 +124,22 @@ _PROVIDER_OPTIONS = [
         supported_providers=["host", "lxd", "managed-host", "multipass"],
         hidden=True,
     ),
+    dict(
+        param_decls="--generate-manifest",
+        is_flag=True,
+        help="Generate snap manifest.",
+        envvar="SNAPCRAFT_BUILD_INFO",
+        supported_providers=["host", "lxd", "managed-host", "multipass"],
+        hidden=True,
+    ),
+    dict(
+        param_decls="--manifest-image-information",
+        metavar="<json string>",
+        help="Set snap manifest image-info",
+        envvar="SNAPCRAFT_IMAGE_INFO",
+        supported_providers=["host", "lxd", "managed-host", "multipass"],
+        hidden=True,
+    ),
 ]
 
 
@@ -233,6 +249,7 @@ def get_build_provider_flags(build_provider: str, **kwargs) -> Dict[str, str]:
 
     for option in _PROVIDER_OPTIONS:
         key: str = option["param_decls"]  # type: ignore
+        is_flag: bool = option.get("is_flag", False)  # type: ignore
         envvar: Optional[str] = option.get("envvar")  # type: ignore
         supported_providers: List[str] = option["supported_providers"]  # type: ignore
 
@@ -244,8 +261,12 @@ def get_build_provider_flags(build_provider: str, **kwargs) -> Dict[str, str]:
         if build_provider not in supported_providers:
             continue
 
-        # Add build provider flag using envvar as key.
+        # Skip boolean flags that have not been set.
         key_formatted = _param_decls_to_kwarg(key)
+        if is_flag and not kwargs.get(key_formatted):
+            continue
+
+        # Add build provider flag using envvar as key.
         if envvar is not None and key_formatted in kwargs:
             build_provider_flags[envvar] = kwargs[key_formatted]
 

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -46,6 +46,21 @@ class PromptOption(click.Option):
         )
 
 
+class SimpleBoolParamType(click.ParamType):
+    name = "boolean"
+
+    def convert(self, value, param, ctx):
+        """Convert option string to value.
+
+        Unlike click's BoolParamType, any non-empty string is treated
+        as True.
+        """
+        return bool(value)
+
+    def __repr__(self):
+        return "BOOL"
+
+
 _SUPPORTED_PROVIDERS = ["host", "lxd", "multipass"]
 _HIDDEN_PROVIDERS = ["managed-host"]
 _ALL_PROVIDERS = _SUPPORTED_PROVIDERS + _HIDDEN_PROVIDERS
@@ -127,6 +142,7 @@ _PROVIDER_OPTIONS = [
     dict(
         param_decls="--generate-manifest",
         is_flag=True,
+        type=SimpleBoolParamType(),
         help="Generate snap manifest.",
         envvar="SNAPCRAFT_BUILD_INFO",
         supported_providers=["host", "lxd", "managed-host", "multipass"],

--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -140,7 +140,7 @@ _PROVIDER_OPTIONS = [
         hidden=True,
     ),
     dict(
-        param_decls="--generate-manifest",
+        param_decls="--enable-manifest",
         is_flag=True,
         type=SimpleBoolParamType(),
         help="Generate snap manifest.",

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -16,6 +16,7 @@
 
 import copy
 import contextlib
+import distutils.util
 import itertools
 import logging
 import os
@@ -496,7 +497,7 @@ class _SnapPackaging:
             os.unlink(manifest_file_path)
 
         # FIXME hide this functionality behind a feature flag for now
-        if os.environ.get("SNAPCRAFT_BUILD_INFO"):
+        if distutils.util.strtobool(os.environ.get("SNAPCRAFT_BUILD_INFO", "n")):
             os.makedirs(prime_snap_dir, exist_ok=True)
             shutil.copy2(self._snapcraft_yaml_path, recorded_snapcraft_yaml_path)
             annotated_snapcraft = _manifest.annotate_snapcraft(

--- a/snapcraft/internal/xattrs.py
+++ b/snapcraft/internal/xattrs.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import distutils.util
 import os
 import sys
 from typing import Optional
@@ -76,7 +77,7 @@ def read_origin_stage_package(path: str) -> Optional[str]:
         return _read_snapcraft_xattr(path, "origin_stage_package")
     except XAttributeError:
         # Ignore error if origin stage package not required.
-        if os.environ.get("SNAPCRAFT_BUILD_INFO"):
+        if distutils.util.strtobool(os.environ.get("SNAPCRAFT_BUILD_INFO", "n")):
             raise
         return None
 
@@ -87,5 +88,5 @@ def write_origin_stage_package(path: str, value: str) -> None:
         _write_snapcraft_xattr(path, "origin_stage_package", value)
     except XAttributeError:
         # Ignore error if origin stage package not required.
-        if os.environ.get("SNAPCRAFT_BUILD_INFO"):
+        if distutils.util.strtobool(os.environ.get("SNAPCRAFT_BUILD_INFO", "n")):
             raise

--- a/tests/spread/build-providers/lxd-build-info/task.yaml
+++ b/tests/spread/build-providers/lxd-build-info/task.yaml
@@ -1,0 +1,41 @@
+summary: Verify SNAPCRAFT_BUILD_INFO works with LXD
+
+environment:
+  SNAP_DIR: ../snaps/make-hello
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+
+  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host.
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
+  snapcraft clean --use-lxd
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "$SNAP_DIR"
+
+  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host.
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
+  export SNAPCRAFT_BUILD_INFO=1
+  export SNAPCRAFT_IMAGE_INFO='{"build_url":"http://example.com/"}'
+
+  snapcraft --use-lxd
+  sudo snap install make-hello_*.snap --dangerous
+
+  # Check that the snap includes build info
+  [ -f /snap/make-hello/current/snap/manifest.yaml ]
+  [ -f /snap/make-hello/current/snap/snapcraft.yaml ]
+
+  # Check that the snap manifest includes the image info
+  MATCH "build_url: http://example.com/" < /snap/make-hello/current/snap/manifest.yaml

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -339,7 +339,10 @@ class BaseProviderTest(BaseProviderBaseTest):
     def test_passthrough_environment_flags_all(self):
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
         provider.build_provider_flags = dict(
-            http_proxy="http://127.0.0.1:8080", https_proxy="http://127.0.0.1:8080"
+            http_proxy="http://127.0.0.1:8080",
+            https_proxy="http://127.0.0.1:8080",
+            SNAPCRAFT_BUILD_INFO=True,
+            SNAPCRAFT_IMAGE_INFO='{"build_url":"https://example.com"}',
         )
 
         results = provider._get_env_command()
@@ -355,6 +358,8 @@ class BaseProviderTest(BaseProviderBaseTest):
                     "SNAPCRAFT_HAS_TTY=False",
                     "http_proxy=http://127.0.0.1:8080",
                     "https_proxy=http://127.0.0.1:8080",
+                    "SNAPCRAFT_BUILD_INFO=True",
+                    'SNAPCRAFT_IMAGE_INFO={"build_url":"https://example.com"}',
                 ]
             ),
         )

--- a/tests/unit/cli/test_options.py
+++ b/tests/unit/cli/test_options.py
@@ -26,55 +26,205 @@ from tests import unit
 
 class TestProviderOptions(unit.TestCase):
     scenarios = [
-        ("host empty", dict(provider="host", kwargs=dict())),
-        ("host http proxy", dict(provider="host", kwargs=dict(http_proxy="1.1.1.1"))),
-        ("host https proxy", dict(provider="host", kwargs=dict(https_proxy="1.1.1.1"))),
+        ("host empty", dict(provider="host", kwargs=dict(), flags=dict())),
+        (
+            "host http proxy",
+            dict(
+                provider="host",
+                kwargs=dict(http_proxy="1.1.1.1"),
+                flags=dict(http_proxy="1.1.1.1"),
+            ),
+        ),
+        (
+            "host https proxy",
+            dict(
+                provider="host",
+                kwargs=dict(https_proxy="1.1.1.1"),
+                flags=dict(https_proxy="1.1.1.1"),
+            ),
+        ),
+        (
+            "host build info",
+            dict(
+                provider="host",
+                kwargs=dict(generate_manifest=True),
+                flags=dict(SNAPCRAFT_BUILD_INFO=True),
+            ),
+        ),
+        (
+            "host build info off",
+            dict(provider="host", kwargs=dict(generate_manifest=False), flags=dict()),
+        ),
+        (
+            "host image info",
+            dict(
+                provider="host",
+                kwargs=dict(manifest_image_information="{}"),
+                flags=dict(SNAPCRAFT_IMAGE_INFO="{}"),
+            ),
+        ),
         (
             "host all",
             dict(
                 provider="host",
                 kwargs=dict(http_proxy="1.1.1.1", https_proxy="1.1.1.1"),
+                flags=dict(http_proxy="1.1.1.1", https_proxy="1.1.1.1"),
             ),
         ),
-        ("lxd empty", dict(provider="lxd", kwargs=dict())),
-        ("lxd http proxy", dict(provider="lxd", kwargs=dict(http_proxy="1.1.1.1"))),
-        ("lxd https proxy", dict(provider="lxd", kwargs=dict(https_proxy="1.1.1.1"))),
+        ("lxd empty", dict(provider="lxd", kwargs=dict(), flags=dict())),
+        (
+            "lxd http proxy",
+            dict(
+                provider="lxd",
+                kwargs=dict(http_proxy="1.1.1.1"),
+                flags=dict(http_proxy="1.1.1.1"),
+            ),
+        ),
+        (
+            "lxd https proxy",
+            dict(
+                provider="lxd",
+                kwargs=dict(https_proxy="1.1.1.1"),
+                flags=dict(https_proxy="1.1.1.1"),
+            ),
+        ),
+        (
+            "lxd build info",
+            dict(
+                provider="lxd",
+                kwargs=dict(generate_manifest=True),
+                flags=dict(SNAPCRAFT_BUILD_INFO=True),
+            ),
+        ),
+        (
+            "lxd image info",
+            dict(
+                provider="lxd",
+                kwargs=dict(manifest_image_information="{}"),
+                flags=dict(SNAPCRAFT_IMAGE_INFO="{}"),
+            ),
+        ),
         (
             "lxd all",
             dict(
-                provider="lxd", kwargs=dict(http_proxy="1.1.1.1", https_proxy="1.1.1.1")
+                provider="lxd",
+                kwargs=dict(
+                    http_proxy="1.1.1.1",
+                    https_proxy="1.1.1.1",
+                    generate_manifest=True,
+                    manifest_image_information="{}",
+                ),
+                flags=dict(
+                    http_proxy="1.1.1.1",
+                    https_proxy="1.1.1.1",
+                    SNAPCRAFT_BUILD_INFO=True,
+                    SNAPCRAFT_IMAGE_INFO="{}",
+                ),
             ),
         ),
-        ("managed-host empty", dict(provider="managed-host", kwargs=dict())),
+        (
+            "managed-host empty",
+            dict(provider="managed-host", kwargs=dict(), flags=dict()),
+        ),
         (
             "managed-host http proxy",
-            dict(provider="managed-host", kwargs=dict(http_proxy="1.1.1.1")),
+            dict(
+                provider="managed-host",
+                kwargs=dict(http_proxy="1.1.1.1"),
+                flags=dict(http_proxy="1.1.1.1"),
+            ),
         ),
         (
             "managed-host https proxy",
-            dict(provider="managed-host", kwargs=dict(https_proxy="1.1.1.1")),
+            dict(
+                provider="managed-host",
+                kwargs=dict(https_proxy="1.1.1.1"),
+                flags=dict(https_proxy="1.1.1.1"),
+            ),
+        ),
+        (
+            "managed-host build info",
+            dict(
+                provider="managed-host",
+                kwargs=dict(generate_manifest=True),
+                flags=dict(SNAPCRAFT_BUILD_INFO=True),
+            ),
+        ),
+        (
+            "managed-host image info",
+            dict(
+                provider="managed-host",
+                kwargs=dict(manifest_image_information="{}"),
+                flags=dict(SNAPCRAFT_IMAGE_INFO="{}"),
+            ),
         ),
         (
             "managed-host all",
             dict(
                 provider="managed-host",
-                kwargs=dict(http_proxy="1.1.1.1", https_proxy="1.1.1.1"),
+                kwargs=dict(
+                    http_proxy="1.1.1.1",
+                    https_proxy="1.1.1.1",
+                    generate_manifest=True,
+                    manifest_image_information="{}",
+                ),
+                flags=dict(
+                    http_proxy="1.1.1.1",
+                    https_proxy="1.1.1.1",
+                    SNAPCRAFT_BUILD_INFO=True,
+                    SNAPCRAFT_IMAGE_INFO="{}",
+                ),
             ),
         ),
-        ("multipass empty", dict(provider="multipass", kwargs=dict())),
+        ("multipass empty", dict(provider="multipass", kwargs=dict(), flags=dict())),
         (
             "multipass http proxy",
-            dict(provider="multipass", kwargs=dict(http_proxy="1.1.1.1")),
+            dict(
+                provider="multipass",
+                kwargs=dict(http_proxy="1.1.1.1"),
+                flags=dict(http_proxy="1.1.1.1"),
+            ),
         ),
         (
             "multipass https proxy",
-            dict(provider="multipass", kwargs=dict(https_proxy="1.1.1.1")),
+            dict(
+                provider="multipass",
+                kwargs=dict(https_proxy="1.1.1.1"),
+                flags=dict(https_proxy="1.1.1.1"),
+            ),
+        ),
+        (
+            "multipass build info",
+            dict(
+                provider="multipass",
+                kwargs=dict(generate_manifest=True),
+                flags=dict(SNAPCRAFT_BUILD_INFO=True),
+            ),
+        ),
+        (
+            "multipass image info",
+            dict(
+                provider="multipass",
+                kwargs=dict(manifest_image_information="{}"),
+                flags=dict(SNAPCRAFT_IMAGE_INFO="{}"),
+            ),
         ),
         (
             "multipass all",
             dict(
                 provider="multipass",
-                kwargs=dict(http_proxy="1.1.1.1", https_proxy="1.1.1.1"),
+                kwargs=dict(
+                    http_proxy="1.1.1.1",
+                    https_proxy="1.1.1.1",
+                    generate_manifest=True,
+                    manifest_image_information="{}",
+                ),
+                flags=dict(
+                    http_proxy="1.1.1.1",
+                    https_proxy="1.1.1.1",
+                    SNAPCRAFT_BUILD_INFO=True,
+                    SNAPCRAFT_IMAGE_INFO="{}",
+                ),
             ),
         ),
     ]
@@ -82,7 +232,7 @@ class TestProviderOptions(unit.TestCase):
     def test_valid_flags(self):
         flags = options.get_build_provider_flags(self.provider, **self.kwargs)
 
-        self.assertThat(flags, Equals(self.kwargs))
+        self.assertThat(flags, Equals(self.flags))
 
 
 class TestInvalidBuildProviderFlags(unit.TestCase):

--- a/tests/unit/cli/test_options.py
+++ b/tests/unit/cli/test_options.py
@@ -47,13 +47,13 @@ class TestProviderOptions(unit.TestCase):
             "host build info",
             dict(
                 provider="host",
-                kwargs=dict(generate_manifest=True),
+                kwargs=dict(enable_manifest=True),
                 flags=dict(SNAPCRAFT_BUILD_INFO=True),
             ),
         ),
         (
             "host build info off",
-            dict(provider="host", kwargs=dict(generate_manifest=False), flags=dict()),
+            dict(provider="host", kwargs=dict(enable_manifest=False), flags=dict()),
         ),
         (
             "host image info",
@@ -92,7 +92,7 @@ class TestProviderOptions(unit.TestCase):
             "lxd build info",
             dict(
                 provider="lxd",
-                kwargs=dict(generate_manifest=True),
+                kwargs=dict(enable_manifest=True),
                 flags=dict(SNAPCRAFT_BUILD_INFO=True),
             ),
         ),
@@ -111,7 +111,7 @@ class TestProviderOptions(unit.TestCase):
                 kwargs=dict(
                     http_proxy="1.1.1.1",
                     https_proxy="1.1.1.1",
-                    generate_manifest=True,
+                    enable_manifest=True,
                     manifest_image_information="{}",
                 ),
                 flags=dict(
@@ -146,7 +146,7 @@ class TestProviderOptions(unit.TestCase):
             "managed-host build info",
             dict(
                 provider="managed-host",
-                kwargs=dict(generate_manifest=True),
+                kwargs=dict(enable_manifest=True),
                 flags=dict(SNAPCRAFT_BUILD_INFO=True),
             ),
         ),
@@ -165,7 +165,7 @@ class TestProviderOptions(unit.TestCase):
                 kwargs=dict(
                     http_proxy="1.1.1.1",
                     https_proxy="1.1.1.1",
-                    generate_manifest=True,
+                    enable_manifest=True,
                     manifest_image_information="{}",
                 ),
                 flags=dict(
@@ -197,7 +197,7 @@ class TestProviderOptions(unit.TestCase):
             "multipass build info",
             dict(
                 provider="multipass",
-                kwargs=dict(generate_manifest=True),
+                kwargs=dict(enable_manifest=True),
                 flags=dict(SNAPCRAFT_BUILD_INFO=True),
             ),
         ),
@@ -216,7 +216,7 @@ class TestProviderOptions(unit.TestCase):
                 kwargs=dict(
                     http_proxy="1.1.1.1",
                     https_proxy="1.1.1.1",
-                    generate_manifest=True,
+                    enable_manifest=True,
                     manifest_image_information="{}",
                 ),
                 flags=dict(


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
In order to include a `snap/manifest.yaml` in a snap, you can set the `SNAPCRAFT_BUILD_INFO` environment variable.  However, this doesn't work with build providers that perform a build within a container/VM, since the variable is not passed to the child Snapcraft instance.

This should fix [bug #1871770][1].

[1]: https://bugs.launchpad.net/snapcraft/+bug/1871770