### PR TITLE
build providers: do not print network test output for LXD

### DIFF
--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -382,7 +382,7 @@ class LXD(Provider):
         self.echoer.wrapped("Waiting for network to be ready...")
         for i in range(40):
             try:
-                self._run(["getent", "hosts", "snapcraft.io"])
+                self._run(["getent", "hosts", "snapcraft.io"], hide_output=True)
                 break
             except errors.ProviderExecError:
                 sleep(0.5)

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -189,8 +189,9 @@ class LXDInitTest(LXDBaseTest):
         self.assertThat(container.save_mock.call_count, Equals(2))
         self.assertThat(container.sync_mock.call_count, Equals(36))
         self.assertThat(self.check_output_mock.call_count, Equals(2))
-        self.check_output_mock.assert_has_calls([
-            mock.call(
+        self.check_output_mock.assert_has_calls(
+            [
+                mock.call(
                     [
                         "/snap/bin/lxc",
                         "exec",
@@ -202,8 +203,9 @@ class LXDInitTest(LXDBaseTest):
                         "hosts",
                         "snapcraft.io",
                     ]
-                ),
-        ])
+                )
+            ]
+        )
         self.assertThat(self.check_call_mock.call_count, Equals(27))
         self.check_call_mock.assert_has_calls(
             [
@@ -707,8 +709,9 @@ class LXDLaunchedTest(LXDBaseTest):
         self.assertThat(self.fake_container.sync_mock.call_count, Equals(1))
         self.fake_container.save_mock.assert_called_once_with(wait=True)
         self.assertThat(self.check_output_mock.call_count, Equals(2))
-        self.check_output_mock.assert_has_calls([
-            mock.call(
+        self.check_output_mock.assert_has_calls(
+            [
+                mock.call(
                     [
                         "/snap/bin/lxc",
                         "exec",
@@ -720,8 +723,9 @@ class LXDLaunchedTest(LXDBaseTest):
                         "hosts",
                         "snapcraft.io",
                     ]
-                ),
-        ])
+                )
+            ]
+        )
 
     def test_mount_prime_directory(self):
         self.check_output_mock.return_value = b"/root"
@@ -743,8 +747,9 @@ class LXDLaunchedTest(LXDBaseTest):
         self.assertThat(self.fake_container.sync_mock.call_count, Equals(1))
         self.fake_container.save_mock.assert_called_once_with(wait=True)
         self.assertThat(self.check_output_mock.call_count, Equals(2))
-        self.check_output_mock.assert_has_calls([
-            mock.call(
+        self.check_output_mock.assert_has_calls(
+            [
+                mock.call(
                     [
                         "/snap/bin/lxc",
                         "exec",
@@ -756,8 +761,9 @@ class LXDLaunchedTest(LXDBaseTest):
                         "hosts",
                         "snapcraft.io",
                     ]
-                ),
-        ])
+                )
+            ]
+        )
 
     def test_run(self):
         self.instance._run(["ls", "/root/project"])

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -188,7 +188,23 @@ class LXDInitTest(LXDBaseTest):
         container.start_mock.assert_called_once_with(wait=True)
         self.assertThat(container.save_mock.call_count, Equals(2))
         self.assertThat(container.sync_mock.call_count, Equals(36))
-        self.assertThat(self.check_call_mock.call_count, Equals(29))
+        self.assertThat(self.check_output_mock.call_count, Equals(2))
+        self.check_output_mock.assert_has_calls([
+            mock.call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "getent",
+                        "hosts",
+                        "snapcraft.io",
+                    ]
+                ),
+        ])
+        self.assertThat(self.check_call_mock.call_count, Equals(27))
         self.check_call_mock.assert_has_calls(
             [
                 mock.call(
@@ -381,19 +397,6 @@ class LXDInitTest(LXDBaseTest):
                         "--",
                         "env",
                         "SNAPCRAFT_HAS_TTY=False",
-                        "getent",
-                        "hosts",
-                        "snapcraft.io",
-                    ]
-                ),
-                mock.call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
                         "apt-get",
                         "update",
                     ]
@@ -543,19 +546,6 @@ class LXDInitTest(LXDBaseTest):
                         "chmod",
                         "0755",
                         "/bin/_snapcraft_prompt",
-                    ]
-                ),
-                mock.call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "getent",
-                        "hosts",
-                        "snapcraft.io",
                     ]
                 ),
                 mock.call(
@@ -716,7 +706,22 @@ class LXDLaunchedTest(LXDBaseTest):
         )
         self.assertThat(self.fake_container.sync_mock.call_count, Equals(1))
         self.fake_container.save_mock.assert_called_once_with(wait=True)
-        self.check_output_mock.assert_not_called()
+        self.assertThat(self.check_output_mock.call_count, Equals(2))
+        self.check_output_mock.assert_has_calls([
+            mock.call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "getent",
+                        "hosts",
+                        "snapcraft.io",
+                    ]
+                ),
+        ])
 
     def test_mount_prime_directory(self):
         self.check_output_mock.return_value = b"/root"
@@ -737,7 +742,22 @@ class LXDLaunchedTest(LXDBaseTest):
         )
         self.assertThat(self.fake_container.sync_mock.call_count, Equals(1))
         self.fake_container.save_mock.assert_called_once_with(wait=True)
-        self.check_output_mock.assert_not_called()
+        self.assertThat(self.check_output_mock.call_count, Equals(2))
+        self.check_output_mock.assert_has_calls([
+            mock.call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "getent",
+                        "hosts",
+                        "snapcraft.io",
+                    ]
+                ),
+        ])
 
     def test_run(self):
         self.instance._run(["ls", "/root/project"])

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -205,6 +205,7 @@ class LXDInitTest(LXDBaseTest):
                     ]
                 )
             ]
+            * 2
         )
         self.assertThat(self.check_call_mock.call_count, Equals(27))
         self.check_call_mock.assert_has_calls(
@@ -725,6 +726,7 @@ class LXDLaunchedTest(LXDBaseTest):
                     ]
                 )
             ]
+            * 2
         )
 
     def test_mount_prime_directory(self):
@@ -763,6 +765,7 @@ class LXDLaunchedTest(LXDBaseTest):
                     ]
                 )
             ]
+            * 2
         )
 
     def test_run(self):


### PR DESCRIPTION
Do not print out the output of "getent hosts snapcraft.io" which run
during environment setup.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
