### PR TITLE
repo: add initialize_snapcraft_defaults() to set default source lists

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -36,6 +36,7 @@ from snapcraft.internal import (
     errors,
     lifecycle,
     project_loader,
+    repo,
     steps,
 )
 from snapcraft.project._sanity_checks import conduct_project_sanity_check
@@ -74,6 +75,11 @@ def _execute(  # noqa: C901
     if build_provider in ["host", "managed-host"]:
         apply_host_provider_flags(build_provider_flags)
         project_config = project_loader.load_config(project)
+        if is_managed_host:
+            # Managed hosts repositories are configured with defaults
+            # set by snapcraft.
+            repo.Repo.initialize_snapcraft_defaults()
+
         lifecycle.execute(step, project_config, parts)
         if pack_project:
             _pack(project.prime_dir, output=output)

--- a/snapcraft/internal/repo/_base.py
+++ b/snapcraft/internal/repo/_base.py
@@ -183,6 +183,11 @@ class BaseRepo:
         raise errors.NoNativeBackendError()
 
     @classmethod
+    def initialize_snapcraft_defaults(cls) -> None:
+        """Initialize repository configuration."""
+        raise errors.NoNativeBackendError()
+
+    @classmethod
     def normalize(cls, unpackdir: str) -> None:
         """Normalize artifacts in unpackdir.
 

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -473,28 +473,6 @@ class TestUbuntuInstallRepo(unit.TestCase):
             errors.AptGPGKeyInstallError, repo.Ubuntu.install_gpg_key, "FAKEKEY"
         )
 
-    @mock.patch("subprocess.run")
-    @mock.patch("pathlib.Path.unlink")
-    def test_initialize_snapcraft_defaults(self, mock_unlink, mock_run):
-        def _path_exists(path_self):
-            return str(self) in [
-                "/etc/apt/sources.list",
-                "/etc/apt/sources.list.d/test.list",
-            ]
-
-        self.useFixture(fixtures.MockPatchObject(Path, "exists", _path_exists))
-
-        def _path_glob(path_self, pattern):
-            self.assertThat(str(path_self), Equals("/etc/apt/sources.list.d"))
-            self.assertThat(pattern, Equals("*"))
-            yield Path("/etc/apt/sources.list.d/test.list")
-
-        self.useFixture(fixtures.MockPatchObject(Path, "glob", _path_glob))
-
-        repo.Ubuntu.initialize_snapcraft_defaults()
-
-        # self.assertThat(mock_run.mock_calls, Equals("X"))
-
 
 class TestInitializeSnapcraftDefaults(unit.TestCase):
     def setUp(self):


### PR DESCRIPTION
For managed-hosts, these changes set the default set of apt sources and
a common apt configuration file.  We use deb822 for convenience, and it
will support upcoming repository configuration in the snapcraft.yaml.

1. Remove existing source configurations, using `unlink()` first with
   sudo rm fallback for non-root use cases:

  - /etc/apt/sources.list

  - /etc/apt/sources.list.d/*

2. Using deb822 format, install defaults to:

  - /etc/apt/sources.list.d/main.sources:

```
Types: deb deb-src
URIs: http://archive.ubuntu.com/ubuntu
Suites: ${release} ${release}-updates
Components: main multiverse restricted universe
```

  - /etc/apt/sources.list.d/security.sources:

```
Types: deb deb-src
URIs: http://security.ubuntu.com/ubuntu
Suites: ${release}-security
Components: main multiverse restricted universe
```

  - /etc/apt/apt.conf.d/00-snapcraft

```
Apt::Install-Recommends "false";
```

3. GPG keys and other APT configuration are left untouched.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
