### PR TITLE
repo: fix resolution of virtual build packages

### DIFF
--- a/tests/spread/general/virtual-packages/snaps/virtual-packages-test/hello
+++ b/tests/spread/general/virtual-packages/snaps/virtual-packages-test/hello
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "hi"

--- a/tests/spread/general/virtual-packages/snaps/virtual-packages-test/snapcraft.yaml
+++ b/tests/spread/general/virtual-packages/snaps/virtual-packages-test/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: virtual-packages-tests
+version: "1.0"
+summary: virtual-packages-tests
+description: virtual-packages-tests
+
+base: core18
+grade: devel
+confinement: strict
+
+parts:
+  virtual-packages-tests:
+    plugin: nil
+    source: .
+    override-build:
+      install -m 0755 hello $SNAPCRAFT_PART_INSTALL/
+    build-packages:
+      - uglifyjs
+    stage-packages:
+      - uglifyjs
+
+apps:
+  hello:
+    command: hello

--- a/tests/spread/general/virtual-packages/task.yaml
+++ b/tests/spread/general/virtual-packages/task.yaml
@@ -1,0 +1,36 @@
+summary: Build a snap that has virtual stage and build packages
+
+environment:
+  SNAP_DIR: snaps/virtual-packages-test
+
+systems:
+  - ubuntu-16*
+  - ubuntu-18*
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+execute: |
+  test_file="/usr/lib/nodejs/uglify-js/bin/uglifyjs"
+
+  if [ -f "${test_file}" ]; then
+    echo "uglifyjs already installed?"
+    exit 1
+  fi
+
+  cd "$SNAP_DIR"
+  snapcraft build
+
+  if [ ! -f "${test_file}" ]; then
+    echo "failed to install uglifyjs build package"
+    exit 1
+  fi
+
+  snapcraft prime
+
+  if [ ! -f "prime/${test_file}" ]; then
+    echo "failed to install uglifyjs stage package"
+    exit 1
+  fi


### PR DESCRIPTION
With my previous PR, virtual build packages are no longer found.
Ensure that build and stage packages are resolved the best we can,
and persist any potential versioning.

Log any build and stage packages that have been resolved so the
user can see any assumptions we're making to resolve it.

Add unit and spread test coverage.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
