### PR TITLE
travis: use stable channel for building snapcraft snap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
       addons:
         snaps:
           - name: snapcraft
-            channel: edge
+            channel: stable
             classic: true
           - name: transfer
           - name: http


### PR DESCRIPTION
Bootstrap snapcraft snap building using stable channel.  Upcoming
commit will install this snap and use it to rebuild snapcraft using
the PR.  This will prevent against a PR from breaking snapcraft's
own builds in the future.