### PR TITLE
travis: add and ship a self-hosting build of snapcraft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,11 @@ jobs:
             - libssl-dev
             - libyaml-dev
             - python3.6-dev
-      script: snapcraft snap --destructive-mode --output "snapcraft-pr$TRAVIS_PULL_REQUEST.snap"
+      script:
+        - snapcraft snap --destructive-mode --output "snapcraft-pr$TRAVIS_PULL_REQUEST.snap"
+        - sudo snap install "snapcraft-pr$TRAVIS_PULL_REQUEST.snap" --dangerous --classic
+        - snapcraft clean --destructive-mode
+        - snapcraft snap --destructive-mode --output "snapcraft-pr$TRAVIS_PULL_REQUEST.snap"
       after_success:
         - timeout 180 /snap/bin/transfer snapcraft-pr$TRAVIS_PULL_REQUEST.snap
       after_failure:


### PR DESCRIPTION
Self-hosting snapcraft as part of the PR will help prevent a PR from
breaking the snapcraft build for subsequent builds.  Snapcraft is an
excellent test case anyways.

Do this by first building the snap from stable snap, then rebuild
snapcraft using the newly created snap.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
