### PR TITLE
repo: minor debug log tweaks

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -447,9 +447,6 @@ class PluginHandler:
     def _install_stage_packages(self):
         stage_packages = self._grammar_processor.get_stage_packages()
         if stage_packages:
-            logger.debug(
-                f"Installing {stage_packages!r} stage-packages to {self.plugin.installdir!r}"
-            )
             try:
                 self.stage_packages = self._stage_packages_repo.install_stage_packages(
                     package_names=stage_packages, install_dir=self.plugin.installdir

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -291,8 +291,7 @@ class Ubuntu(BaseRepo):
         :raises snapcraft.repo.errors.BuildPackagesNotInstalledError:
             if installing the packages on the host failed.
         """
-        if not package_names:
-            return list()
+        logger.debug(f"Requested build-packages: {sorted(package_names)!r}")
 
         # Make sure all packages are valid and remove already installed.
         install_packages = list()
@@ -450,6 +449,8 @@ class Ubuntu(BaseRepo):
         skipped_blacklisted: Set[str] = set()
         skipped_essential: Set[str] = set()
 
+        logger.debug(f"Requested stage-packages: {sorted(package_names)!r}")
+
         # First scan all packages and set desired version, if specified.
         # We do this all at once in case it gets added as a dependency
         # along the way.
@@ -477,7 +478,7 @@ class Ubuntu(BaseRepo):
             )
 
         marked = sorted(marked_packages.keys())
-        logger.debug(f"Marked staged packages: {marked!r}")
+        logger.debug(f"Installing staged-packages {marked!r} to {install_dir!r}")
 
         if skipped_blacklisted:
             blacklisted = sorted(skipped_blacklisted)


### PR DESCRIPTION
Move one log from pluginhandler to install_stage_packages().

While here, remove unnecessary empty list check in
install_build_packages().  The function will handle
an empty list appropriately.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
