### PR TITLE
grammar: pick from properties if attributes not in the plugin

### DIFF
--- a/snapcraft/internal/project_loader/grammar/typing.py
+++ b/snapcraft/internal/project_loader/grammar/typing.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Sequence, Union
 
-Grammar = List[Union[str, Dict[str, Any]]]
+Grammar = Sequence[Union[str, Dict[str, Any]]]
 CallStack = List["Statement"]
 
 from ._statement import Statement  # noqa: F401

--- a/snapcraft/internal/project_loader/grammar_processing/_part_grammar_processor.py
+++ b/snapcraft/internal/project_loader/grammar_processing/_part_grammar_processor.py
@@ -81,6 +81,7 @@ class PartGrammarProcessor:
         repo: "repo.Ubuntu"
     ) -> None:
         self._plugin = plugin
+        self._properties = properties
         self._project = project
         self._repo = repo
 
@@ -109,10 +110,14 @@ class PartGrammarProcessor:
                 self.__source = source_array.pop()
         return self.__source
 
+    def _get_property(self, attr: str) -> grammar.typing.Grammar:
+        prop = self._properties.get(attr, set())
+        return getattr(self._plugin, attr.replace("-", "_"), prop)
+
     def get_build_snaps(self) -> Set[str]:
         if not self.__build_snaps:
             processor = grammar.GrammarProcessor(
-                getattr(self._plugin, "build_snaps", []),
+                self._get_property("build-snaps"),
                 self._project,
                 repo.snaps.SnapPackage.is_valid_snap,
             )
@@ -123,7 +128,7 @@ class PartGrammarProcessor:
     def get_stage_snaps(self) -> Set[str]:
         if not self.__stage_snaps:
             processor = grammar.GrammarProcessor(
-                getattr(self._plugin, "stage_snaps", []),
+                self._get_property("stage-snaps"),
                 self._project,
                 repo.snaps.SnapPackage.is_valid_snap,
             )
@@ -134,7 +139,7 @@ class PartGrammarProcessor:
     def get_build_packages(self) -> Set[str]:
         if not self.__build_packages:
             processor = grammar.GrammarProcessor(
-                getattr(self._plugin, "build_packages", []),
+                self._get_property("build-packages"),
                 self._project,
                 self._repo.build_package_is_valid,
                 transformer=package_transformer,
@@ -146,7 +151,7 @@ class PartGrammarProcessor:
     def get_stage_packages(self) -> Set[str]:
         if not self.__stage_packages:
             processor = grammar.GrammarProcessor(
-                getattr(self._plugin, "stage_packages", []),
+                self._get_property("stage-packages"),
                 self._project,
                 self._repo.build_package_is_valid,
                 transformer=package_transformer,

--- a/tests/unit/project_loader/grammar_processing/test_part_grammar_processor.py
+++ b/tests/unit/project_loader/grammar_processing/test_part_grammar_processor.py
@@ -316,13 +316,44 @@ class PartGrammarBuildAndStageSnapsTestCase(unit.TestCase):
         platform_architecture_mock.return_value = ("64bit", "ELF")
 
         repo = mock.Mock()
-        plugin = mock.Mock()
-        plugin.build_snaps = self.snaps
-        plugin.stage_snaps = self.snaps
+
+        class Plugin:
+            build_snaps = self.snaps
+            stage_snaps = self.snaps
+
+        plugin = Plugin()
         expected = getattr(self, "expected_{}".format(self.target_arch))
         processor = PartGrammarProcessor(
             plugin=plugin,
-            properties={},
+            properties={
+                "build-snaps": {"plugin-preferred"},
+                "stage-snaps": "plugin-preferred",
+            },
+            project=project.Project(target_deb_arch=self.target_arch),
+            repo=repo,
+        )
+
+        self.assertThat(processor.get_build_snaps(), Equals(expected))
+        self.assertThat(processor.get_stage_snaps(), Equals(expected))
+
+    @mock.patch("platform.architecture")
+    @mock.patch("platform.machine")
+    def test_build_snaps_plugin_no_attr(
+        self, platform_machine_mock, platform_architecture_mock
+    ):
+        platform_machine_mock.return_value = self.host_arch
+        platform_architecture_mock.return_value = ("64bit", "ELF")
+
+        repo = mock.Mock()
+
+        class Plugin:
+            pass
+
+        plugin = Plugin()
+        expected = getattr(self, "expected_{}".format(self.target_arch))
+        processor = PartGrammarProcessor(
+            plugin=plugin,
+            properties={"build-snaps": self.snaps, "stage-snaps": self.snaps},
             project=project.Project(target_deb_arch=self.target_arch),
             repo=repo,
         )
@@ -405,13 +436,46 @@ class PartGrammarBuildAndStagePackagesTestCase(unit.TestCase):
         platform_architecture_mock.return_value = ("64bit", "ELF")
 
         repo = mock.Mock()
-        plugin = mock.Mock()
-        plugin.build_packages = self.packages
-        plugin.stage_packages = self.packages
+
+        class Plugin:
+            build_packages = self.packages
+            stage_packages = self.packages
+
+        plugin = Plugin()
         expected = getattr(self, "expected_{}".format(self.target_arch))
         processor = PartGrammarProcessor(
             plugin=plugin,
-            properties={},
+            properties={
+                "build-packages": {"plugin-preferred"},
+                "stage-packages": "plugin-preferred",
+            },
+            project=project.Project(target_deb_arch=self.target_arch),
+            repo=repo,
+        )
+        self.assertThat(processor.get_build_packages(), Equals(expected))
+        self.assertThat(processor.get_stage_packages(), Equals(expected))
+
+    @mock.patch("platform.architecture")
+    @mock.patch("platform.machine")
+    def test_packages_plugin_no_attr(
+        self, platform_machine_mock, platform_architecture_mock
+    ):
+        platform_machine_mock.return_value = self.host_arch
+        platform_architecture_mock.return_value = ("64bit", "ELF")
+
+        repo = mock.Mock()
+
+        class Plugin:
+            pass
+
+        plugin = Plugin()
+        expected = getattr(self, "expected_{}".format(self.target_arch))
+        processor = PartGrammarProcessor(
+            plugin=plugin,
+            properties={
+                "build-packages": self.packages,
+                "stage-packages": self.packages,
+            },
             project=project.Project(target_deb_arch=self.target_arch),
             repo=repo,
         )


### PR DESCRIPTION
This enables support for v2 which decouples user added
properties (build-packages, stage-packages, build-snaps and
stage-snaps) and the ones the plugin needs to operate.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
