### PR TITLE
repos: fix returned strings for install_stage_packages()

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -509,7 +509,7 @@ class Ubuntu(BaseRepo):
         cls.normalize(install_dir)
 
         return [
-            f"{pkg_name}={pkg_version}"
+            f"{pkg_name}={pkg_version.version}"
             for pkg_name, pkg_version in marked_packages.items()
         ]
 


### PR DESCRIPTION
Instead of returning `<package>=<version>`, it was returning
`<package>=<apt.Version>`.  Resolve the version string which
is the intended return value.

Fix unit tests to cover this. Switch to using PropertyMocks,
as the MagicMock(wraps=...) did not work as I had expected.

LP #1873349

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
