### PR TITLE
meta: split up package repository sanity checks

### DIFF
--- a/snapcraft/internal/meta/package_repository.py
+++ b/snapcraft/internal/meta/package_repository.py
@@ -123,7 +123,7 @@ class PackageRepositoryAptDeb(PackageRepository):
 
         return data
 
-    @classmethod
+    @classmethod  # noqa: C901
     def unmarshal(cls, data: Dict[str, Any]) -> "PackageRepositoryAptDeb":
         if not isinstance(data, dict):
             raise RuntimeError(f"invalid deb repository object: {data!r}")
@@ -140,33 +140,55 @@ class PackageRepositoryAptDeb(PackageRepository):
         url = data_copy.pop("url", None)
         repo_type = data_copy.pop("type", None)
 
-        if (
-            repo_type != "apt"
-            or (
-                architectures is not None
-                and (
-                    not isinstance(architectures, list)
-                    or not all(isinstance(x, str) for x in architectures)
-                )
+        if repo_type != "apt":
+            raise RuntimeError(
+                f"invalid deb repository object: {data!r} (invalid type)"
             )
-            or (
-                not isinstance(components, list)
-                or not all(isinstance(x, str) for x in components)
-            )
-            or (
-                deb_types is not None
-                and any(deb_type not in ["deb", "deb-src"] for deb_type in deb_types)
-            )
-            or not isinstance(key_id, str)
-            or (key_server is not None and not isinstance(key_server, str))
-            or not isinstance(name, str)
-            or (
-                not isinstance(suites, list)
-                or not all(isinstance(x, str) for x in suites)
-            )
-            or not isinstance(url, str)
+
+        if architectures is not None and (
+            not isinstance(architectures, list)
+            or not all(isinstance(x, str) for x in architectures)
         ):
-            raise RuntimeError(f"invalid deb repository object: {data!r}")
+            raise RuntimeError(
+                f"invalid deb repository object: {data!r} (invalid architectures)"
+            )
+
+        if not isinstance(components, list) or not all(
+            isinstance(x, str) for x in components
+        ):
+            raise RuntimeError(
+                f"invalid deb repository object: {data!r} (invalid components)"
+            )
+
+        if deb_types is not None and any(
+            deb_type not in ["deb", "deb-src"] for deb_type in deb_types
+        ):
+            raise RuntimeError(
+                f"invalid deb repository object: {data!r} (invalid deb-types)"
+            )
+
+        if not isinstance(key_id, str):
+            raise RuntimeError(
+                f"invalid deb repository object: {data!r} (invalid key-id)"
+            )
+
+        if key_server is not None and not isinstance(key_server, str):
+            raise RuntimeError(
+                f"invalid deb repository object: {data!r} (invalid key-server)"
+            )
+
+        if not isinstance(name, str):
+            raise RuntimeError(
+                f"invalid deb repository object: {data!r} (invalid name)"
+            )
+
+        if not isinstance(suites, list) or not all(isinstance(x, str) for x in suites):
+            raise RuntimeError(
+                f"invalid deb repository object: {data!r} (invalid suites)"
+            )
+
+        if not isinstance(url, str):
+            raise RuntimeError(f"invalid deb repository object: {data!r} (invalid url)")
 
         if data_copy:
             raise RuntimeError(f"invalid deb repository object: {data!r} (extra keys)")

--- a/tests/unit/meta/test_package_repository.py
+++ b/tests/unit/meta/test_package_repository.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from testtools.matchers import Equals
+from testtools.matchers import Equals, MatchesRegex
 
 from snapcraft.internal.meta.package_repository import (
     PackageRepository,
@@ -118,10 +118,7 @@ class DebTests(unit.TestCase):
             RuntimeError, PackageRepositoryAptDeb.unmarshal, test_dict
         )
         self.assertThat(
-            str(error),
-            Equals(
-                "invalid deb repository object: {'architectures': ['amd64', 'i386'], 'components': ['main', 'multiverse'], 'deb-types': ['deb', 'deb-src'], 'key-id': 'test-key-id', 'key-server': 'keyserver.ubuntu.com', 'name': 'test-name', 'suites': ['xenial', 'xenial-updates'], 'type': 'aptx', 'url': 'http://archive.ubuntu.com/ubuntu'}"
-            ),
+            str(error), MatchesRegex("invalid deb repository object:.*(invalid type)")
         )
 
     def test_invalid_key(self):
@@ -141,10 +138,7 @@ class DebTests(unit.TestCase):
             RuntimeError, PackageRepositoryAptDeb.unmarshal, test_dict
         )
         self.assertThat(
-            str(error),
-            Equals(
-                "invalid deb repository object: {'architectures': ['amd64', 'i386'], 'components': ['main', 'multiverse'], 'deb-types': ['deb', 'deb-src'], 'key-id': 'test-key-id', 'key-server': 'keyserver.ubuntu.com', 'name': 'test-name', 'suites': ['xenial', 'xenial-updates'], 'type': 'apt', 'xurl': 'http://archive.ubuntu.com/ubuntu'}"
-            ),
+            str(error), MatchesRegex("invalid deb repository object:.*(invalid url)")
         )
 
     def test_invalid_apt_extra_key(self):
@@ -165,10 +159,7 @@ class DebTests(unit.TestCase):
             RuntimeError, PackageRepositoryAptDeb.unmarshal, test_dict
         )
         self.assertThat(
-            str(error),
-            Equals(
-                "invalid deb repository object: {'architectures': ['amd64', 'i386'], 'components': ['main', 'multiverse'], 'deb-types': ['deb', 'deb-src'], 'key-id': 'test-key-id', 'key-server': 'keyserver.ubuntu.com', 'name': 'test-name', 'suites': ['xenial', 'xenial-updates'], 'type': 'apt', 'url': 'http://archive.ubuntu.com/ubuntu', 'foo': 'bar'} (extra keys)"
-            ),
+            str(error), MatchesRegex("invalid deb repository object:.*(extra keys)")
         )
 
 


### PR DESCRIPTION
These sanity checks are supposed to be covered by the schema,
but in the event the schema fails, it's difficult to diagnose.

Provide a unique RuntimeError for each unexpected case.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
