### PR TITLE
repo: format $SNAPCRAFT_APT_RELEASE instead of ${release} for suites

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -130,7 +130,7 @@
                     "type": "array",
                     "items": {
                         "type": "string",
-                        "description": "Architectures to enable, or restrict to, for this repository.  Defaults to host architecture."
+                        "description": "Architectures to enable, or restrict to, for this repository.  Supports '$SNAPCRAFT_APT_HOST_ARCH' variable.  Defaults to host architecture."
                     }
                 },
                 "deb-types": {
@@ -169,12 +169,12 @@
                     "type": "array",
                     "items": {
                         "type": "string",
-                        "description": "Deb repository suites to enable, e.g. 'xenial-updates, xenial-security'.  Supports '$release' variable for snapcraft to populate base release name (e.g. 'xenial')."
+                        "description": "Deb repository suites to enable, e.g. 'xenial-updates, xenial-security'.  Supports '$SNAPCRAFT_APT_RELEASE' variable for snapcraft to populate base release name (e.g. 'xenial')."
                     }
                 },
                 "url": {
                     "type": "string",
-                    "description": "Deb repository URL, e.g. 'http://archive.canonical.com/ubuntu'"
+                    "description": "Deb repository URL, e.g. 'http://archive.canonical.com/ubuntu'."
                 }
             },
             "required": [

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -20,7 +20,6 @@ import glob
 import logging
 import os
 import re
-import string
 import subprocess
 import sys
 import tempfile
@@ -581,7 +580,7 @@ class Ubuntu(BaseRepo):
 
     @classmethod
     def install_source(cls, *, name: str, source: str) -> None:
-        """Add deb source line. Supports formatting tag for ${release}."""
+        """Add deb source line. Supports $SNAPCRAFT_APT_RELEASE."""
         expanded_source = _format_sources_list(source)
 
         sources = cls._get_snapcraft_installed_sources()
@@ -634,4 +633,4 @@ def _get_local_sources_list():
 def _format_sources_list(sources_list: str):
     release = os_release.OsRelease().version_codename()
 
-    return string.Template(sources_list).substitute({"release": release})
+    return sources_list.replace("$SNAPCRAFT_APT_RELEASE", release)

--- a/snapcraft/plugins/v1/catkin.py
+++ b/snapcraft/plugins/v1/catkin.py
@@ -307,7 +307,9 @@ class CatkinPlugin(PluginV1):
 
     @classmethod
     def get_required_repo_sources(self) -> Dict[str, str]:
-        return dict(ros1="deb http://packages.ros.org/ros/ubuntu/ ${release} main")
+        return dict(
+            ros1="deb http://packages.ros.org/ros/ubuntu/ $SNAPCRAFT_APT_RELEASE main"
+        )
 
     @classmethod
     def get_required_repo_gpg_keys(self) -> Dict[str, str]:

--- a/snapcraft/plugins/v1/colcon.py
+++ b/snapcraft/plugins/v1/colcon.py
@@ -254,7 +254,9 @@ class ColconPlugin(PluginV1):
 
     @classmethod
     def get_required_repo_sources(self) -> Dict[str, str]:
-        return dict(ros2="deb http://repo.ros2.org/ubuntu/main ${release} main")
+        return dict(
+            ros2="deb http://repo.ros2.org/ubuntu/main $SNAPCRAFT_APT_RELEASE main"
+        )
 
     @classmethod
     def get_required_repo_gpg_keys(self):

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -1910,7 +1910,7 @@ class PackageManagement(ProjectBaseTest):
                     components: [main, multiverse]
                     key-id: test-key-id
                     url: http://archive.ubuntu.com/ubuntu
-                    suites: [$release, $release-updates]
+                    suites: [$SNAPCRAFT_APT_RELEASE, $SNAPCRAFT_APT_RELEASE-updates]
                 """
             )
         )

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -224,8 +224,8 @@ class UbuntuTestCase(RepoBaseTestCase):
     def test_sources_formatting(self, mock_version_codename):
         sources_list = textwrap.dedent(
             """
-            deb http://archive.ubuntu.com/ubuntu ${release} main restricted
-            deb http://archive.ubuntu.com/ubuntu ${release}-updates main restricted
+            deb http://archive.ubuntu.com/ubuntu $SNAPCRAFT_APT_RELEASE main restricted
+            deb http://archive.ubuntu.com/ubuntu $SNAPCRAFT_APT_RELEASE-updates main restricted
             """
         )
 


### PR DESCRIPTION
Change schema reference of $host_arch to $SNAPCRAFT_APT_HOST_ARCH as well,
but that's not implemented just yet.

Depends on #3055