### PR TITLE
package-repositories: make 'name' optional

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -181,7 +181,6 @@
                 "type",
                 "components",
                 "key-id",
-                "name",
                 "suites",
                 "url"
             ],

--- a/snapcraft/internal/meta/package_repository.py
+++ b/snapcraft/internal/meta/package_repository.py
@@ -16,6 +16,7 @@
 
 from copy import deepcopy
 import logging
+import re
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -87,7 +88,7 @@ class PackageRepositoryAptDeb(PackageRepository):
         deb_types: Optional[List[str]] = None,
         key_id: str,
         key_server: Optional[str] = None,
-        name: str,
+        name: Optional[str] = None,
         suites: List[str],
         url: str,
     ) -> None:
@@ -97,7 +98,13 @@ class PackageRepositoryAptDeb(PackageRepository):
         self.deb_types = deb_types
         self.key_id = key_id
         self.key_server = key_server
-        self.name = name
+
+        if name is None:
+            # Default name is URL, stripping non-alphanumeric characters.
+            self.name: str = re.sub(r"\W+", "", url)
+        else:
+            self.name = name
+
         self.suites = suites
         self.url = url
 
@@ -177,7 +184,7 @@ class PackageRepositoryAptDeb(PackageRepository):
                 f"invalid deb repository object: {data!r} (invalid key-server)"
             )
 
-        if not isinstance(name, str):
+        if name is not None and not isinstance(name, str):
             raise RuntimeError(
                 f"invalid deb repository object: {data!r} (invalid name)"
             )

--- a/snapcraft/internal/meta/package_repository.py
+++ b/snapcraft/internal/meta/package_repository.py
@@ -101,7 +101,7 @@ class PackageRepositoryAptDeb(PackageRepository):
 
         if name is None:
             # Default name is URL, stripping non-alphanumeric characters.
-            self.name: str = re.sub(r"\W+", "", url)
+            self.name: str = re.sub(r"\W+", "_", url)
         else:
             self.name = name
 

--- a/tests/unit/meta/test_package_repository.py
+++ b/tests/unit/meta/test_package_repository.py
@@ -121,7 +121,7 @@ class DebTests(unit.TestCase):
                     "deb-types": ["deb", "deb-src"],
                     "key-id": "test-key-id",
                     "key-server": "keyserver.ubuntu.com",
-                    "name": "httparchiveubuntucomubuntu",
+                    "name": "http_archive_ubuntu_com_ubuntu",
                     "suites": ["xenial", "xenial-updates"],
                     "type": "apt",
                     "url": "http://archive.ubuntu.com/ubuntu",

--- a/tests/unit/meta/test_package_repository.py
+++ b/tests/unit/meta/test_package_repository.py
@@ -101,6 +101,34 @@ class DebTests(unit.TestCase):
             ),
         )
 
+    def test_valid_default_name(self):
+        repo = PackageRepositoryAptDeb(
+            architectures=["amd64", "i386"],
+            components=["main", "multiverse"],
+            deb_types=["deb", "deb-src"],
+            key_id="test-key-id",
+            key_server="keyserver.ubuntu.com",
+            suites=["xenial", "xenial-updates"],
+            url="http://archive.ubuntu.com/ubuntu",
+        )
+
+        self.assertThat(
+            repo.marshal(),
+            Equals(
+                {
+                    "architectures": ["amd64", "i386"],
+                    "components": ["main", "multiverse"],
+                    "deb-types": ["deb", "deb-src"],
+                    "key-id": "test-key-id",
+                    "key-server": "keyserver.ubuntu.com",
+                    "name": "httparchiveubuntucomubuntu",
+                    "suites": ["xenial", "xenial-updates"],
+                    "type": "apt",
+                    "url": "http://archive.ubuntu.com/ubuntu",
+                }
+            ),
+        )
+
     def test_invalid_type(self):
         test_dict = {
             "architectures": ["amd64", "i386"],

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -1983,22 +1983,6 @@ class InvalidAptConfigurations(ProjectBaseTest):
             ),
         ),
         (
-            "deb missing field: name",
-            dict(
-                packages=dedent(
-                    """\
-                    package-repositories:
-                    - type: apt
-                      components: [main, multiverse]
-                      key-id: test-key-id
-                      url: http://archive.ubuntu.com/ubuntu
-                      suites: [test, test-updates, test-security]
-                    """
-                ),
-                message_contains="The 'package-repositories[0]' property does not match the required schema:",
-            ),
-        ),
-        (
             "deb missing field: suites",
             dict(
                 packages=dedent(


### PR DESCRIPTION
Default to using the URL, stripping non-alphanumeric characters.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
