### PR TITLE
tests: fix local plugin spread test to be multi-arch aware

### DIFF
--- a/tests/spread/plugins/v1/x-local/local-plugin/state-pull
+++ b/tests/spread/plugins/v1/x-local/local-plugin/state-pull
@@ -10,7 +10,7 @@ extracted_metadata:
     _data: {}
     common_id_list: []
 project_options:
-  deb_arch: amd64
+  deb_arch: @EXPECTED_ARCHITECTURE@
 properties:
   foo: null
   override-pull: snapcraftctl pull

--- a/tests/spread/plugins/v1/x-local/local-plugin/task.yaml
+++ b/tests/spread/plugins/v1/x-local/local-plugin/task.yaml
@@ -9,7 +9,12 @@ prepare: |
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
 
+  deb_arch=$(dpkg --print-architecture)
+  sed -i state-pull -e"s/\(.*deb_arch:\) @EXPECTED_ARCHITECTURE@$/\1 $deb_arch/"
+
 restore: |
+  git checkout state-pull
+
   cd "$SNAP_DIR"
   snapcraft clean
   rm -f ./*.snap

--- a/tests/spread/plugins/v1/x-local/local-plugin/task.yaml
+++ b/tests/spread/plugins/v1/x-local/local-plugin/task.yaml
@@ -13,7 +13,7 @@ prepare: |
   sed -i state-pull -e"s/\(.*deb_arch:\) @EXPECTED_ARCHITECTURE@$/\1 $deb_arch/"
 
 restore: |
-  git checkout state-pull
+  expected_pull_state="$(pwd)/state-pull"
 
   cd "$SNAP_DIR"
   snapcraft clean
@@ -22,6 +22,8 @@ restore: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   restore_yaml "snap/snapcraft.yaml"
+
+  git checkout "${expected_pull_state}"
 
 execute: |
   expected_pull_state="$(pwd)/state-pull"


### PR DESCRIPTION
This is to allow for the autopkgtests, which run on more than amd64 to
pass.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
