### PR TITLE
plugins v2: update plugins so they have a similar behavior

### DIFF
--- a/snapcraft/plugins/v2/autotools.py
+++ b/snapcraft/plugins/v2/autotools.py
@@ -49,7 +49,6 @@ class AutotoolsPlugin(PluginV2):
             "properties": {
                 "autotools-configure-parameters": {
                     "type": "array",
-                    "minitems": 1,
                     "uniqueItems": True,
                     "items": {"type": "string"},
                     "default": [],
@@ -64,15 +63,10 @@ class AutotoolsPlugin(PluginV2):
         return {"autoconf", "automake", "autopoint", "gcc", "libtool"}
 
     def get_build_environment(self) -> Dict[str, str]:
-        return {"SNAPCRAFT_AUTOTOOLS_INSTALL_PREFIX": "/"}
+        return dict()
 
     def _get_configure_command(self) -> str:
         cmd = ["./configure"] + self.options.autotools_configure_parameters
-        if not any(
-            c.startswith("--prefix=")
-            for c in self.options.autotools_configure_parameters
-        ):
-            cmd.append('--prefix="${SNAPCRAFT_AUTOTOOLS_INSTALL_PREFIX}"')
 
         return " ".join(cmd)
 

--- a/snapcraft/plugins/v2/cmake.py
+++ b/snapcraft/plugins/v2/cmake.py
@@ -25,7 +25,7 @@ For more information check the 'plugins' topic for the former and the
 
 Additionally, this plugin uses the following plugin-specific keywords:
 
-    - cmake-parameters:
+    - cmake-parameters
       (list of strings)
       parameters to pass to the build using the common cmake semantics.
 """
@@ -45,7 +45,6 @@ class CMakePlugin(PluginV2):
             "properties": {
                 "cmake-parameters": {
                     "type": "array",
-                    "minitems": 1,
                     "uniqueItems": True,
                     "items": {"type": "string"},
                     "default": [],
@@ -60,16 +59,10 @@ class CMakePlugin(PluginV2):
         return {"gcc", "cmake"}
 
     def get_build_environment(self) -> Dict[str, str]:
-        return {"SNAPCRAFT_CMAKE_INSTALL_PREFIX": "/"}
+        return dict()
 
     def _get_cmake_configure_command(self) -> str:
         cmd = ["cmake", "."] + self.options.cmake_parameters
-
-        if not any(
-            c.startswith("-DCMAKE_INSTALL_PREFIX=")
-            for c in self.options.cmake_parameters
-        ):
-            cmd.append('-DCMAKE_INSTALL_PREFIX="${SNAPCRAFT_CMAKE_INSTALL_PREFIX}"')
 
         return " ".join(cmd)
 

--- a/snapcraft/plugins/v2/go.py
+++ b/snapcraft/plugins/v2/go.py
@@ -22,11 +22,11 @@ For more information check the 'plugins' topic for the former and the
 
 Additionally, this plugin uses the following plugin-specific keywords:
 
-    - go-channel:
+    - go-channel
       (string, default: latest/stable)
       The Snap Store channel to install go from.
 
-    - go-buildtags:
+    - go-buildtags
       (list of strings)
       Tags to use during the go build. Default is not to use any build tags.
 """
@@ -47,7 +47,6 @@ class GoPlugin(PluginV2):
                 "go-channel": {"type": "string", "default": "latest/stable"},
                 "go-buildtags": {
                     "type": "array",
-                    "minitems": 1,
                     "uniqueItems": True,
                     "items": {"type": "string"},
                     "default": [],

--- a/snapcraft/plugins/v2/make.py
+++ b/snapcraft/plugins/v2/make.py
@@ -28,7 +28,7 @@ For more information check the 'plugins' topic for the former and the
 
 Additionally, this plugin uses the following plugin-specific keywords:
 
-    - make-parameters:
+    - make-parameters
       (list of strings)
       Pass the given parameters to the make command.
 """

--- a/snapcraft/plugins/v2/meson.py
+++ b/snapcraft/plugins/v2/meson.py
@@ -23,20 +23,14 @@ This plugin leverages ninja to build and install.
 
 Additionally, this plugin uses the following plugin-specific keywords:
 
-    - meson-version:
+    - meson-version
       (string)
       The version of meson to install from PyPI.
       If unspecified, the latest released version of meson will be used.
-    - meson-parameters:
+
+    - meson-parameters
       (list of strings)
       Configure flags to pass to the build using the common meson semantics.
-
-This plugin also interprets these specific build-environment entries:
-
-    - SNAPCRAFT_MESON_BUILDTYPE
-      (default: release)
-      Use as the default --buildtype for meson when not explicitly set in
-      meson-parameters.
 """
 
 from typing import Any, Dict, List, Set
@@ -54,7 +48,6 @@ class MesonPlugin(PluginV2):
             "properties": {
                 "meson-parameters": {
                     "type": "array",
-                    "minitems": 1,
                     "uniqueItems": True,
                     "items": {"type": "string"},
                     "default": [],
@@ -77,7 +70,7 @@ class MesonPlugin(PluginV2):
         }
 
     def get_build_environment(self) -> Dict[str, str]:
-        return {"SNAPCRAFT_MESON_BUILDTYPE": "release"}
+        return dict()
 
     def get_build_commands(self) -> List[str]:
         if self.options.meson_version:
@@ -88,8 +81,6 @@ class MesonPlugin(PluginV2):
         meson_cmd = ["meson"]
         if self.options.meson_parameters:
             meson_cmd.append(" ".join(self.options.meson_parameters))
-        if not any(c.startswith("--buildtype=") for c in self.options.meson_parameters):
-            meson_cmd.append("--buildtype=${SNAPCRAFT_MESON_BUILDTYPE}")
         meson_cmd.append(".snapbuild")
 
         return [

--- a/snapcraft/plugins/v2/python.py
+++ b/snapcraft/plugins/v2/python.py
@@ -28,13 +28,15 @@ For more information check the 'plugins' topic for the former and the
 
 Additionally, this plugin uses the following plugin-specific keywords:
 
-    - requirements:
+    - requirements
       (list of strings)
       List of paths to requirements files.
-    - constraints:
+
+    - constraints
       (list of strings)
       List of paths to constraint files.
-    - python-packages:
+
+    - python-packages
       (list)
       A list of dependencies to get from PyPI. If needed, pip,
       setuptools and wheel can be upgraded here.
@@ -44,6 +46,7 @@ This plugin also interprets these specific build-environment entries:
     - SNAPCRAFT_PYTHON_INTERPRETER
       (default: python3)
       The interpreter binary to search for in PATH.
+
     - SNAPCRAFT_PYTHON_VENV_ARGS
       Additional arguments for venv.
 
@@ -76,21 +79,18 @@ class PythonPlugin(PluginV2):
             "properties": {
                 "requirements": {
                     "type": "array",
-                    "minitems": 1,
                     "uniqueItems": True,
                     "items": {"type": "string"},
                     "default": [],
                 },
                 "constraints": {
                     "type": "array",
-                    "minitems": 1,
                     "uniqueItems": True,
                     "items": {"type": "string"},
                     "default": [],
                 },
                 "python-packages": {
                     "type": "array",
-                    "minitems": 1,
                     "uniqueItems": True,
                     "items": {"type": "string"},
                     "default": [],

--- a/snapcraft/plugins/v2/rust.py
+++ b/snapcraft/plugins/v2/rust.py
@@ -59,7 +59,6 @@ class RustPlugin(PluginV2):
                 },
                 "rust-features": {
                     "type": "array",
-                    "minItems": 1,
                     "uniqueItems": True,
                     "items": {"type": "string"},
                     "default": [],

--- a/tests/unit/plugins/v2/test_autotools.py
+++ b/tests/unit/plugins/v2/test_autotools.py
@@ -33,7 +33,6 @@ class AutotoolsPluginTest(TestCase):
                     "properties": {
                         "autotools-configure-parameters": {
                             "type": "array",
-                            "minitems": 1,
                             "uniqueItems": True,
                             "items": {"type": "string"},
                             "default": [],
@@ -54,10 +53,7 @@ class AutotoolsPluginTest(TestCase):
     def test_get_build_environment(self):
         plugin = AutotoolsPlugin(part_name="my-part", options=lambda: None)
 
-        self.assertThat(
-            plugin.get_build_environment(),
-            Equals({"SNAPCRAFT_AUTOTOOLS_INSTALL_PREFIX": "/"}),
-        )
+        self.assertThat(plugin.get_build_environment(), Equals(dict()))
 
     def test_get_build_commands(self):
         class Options:
@@ -70,7 +66,7 @@ class AutotoolsPluginTest(TestCase):
             Equals(
                 [
                     "[ ! -f ./configure ] && autoreconf --install",
-                    './configure --prefix="${SNAPCRAFT_AUTOTOOLS_INSTALL_PREFIX}"',
+                    "./configure",
                     'make -j"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
                     'make install DESTDIR="${SNAPCRAFT_PART_INSTALL}"',
                 ]

--- a/tests/unit/plugins/v2/test_cmake.py
+++ b/tests/unit/plugins/v2/test_cmake.py
@@ -34,7 +34,6 @@ class CMakePluginTest(TestCase):
                     "properties": {
                         "cmake-parameters": {
                             "type": "array",
-                            "minitems": 1,
                             "uniqueItems": True,
                             "items": {"type": "string"},
                             "default": [],
@@ -52,10 +51,7 @@ class CMakePluginTest(TestCase):
     def test_get_build_environment(self):
         plugin = CMakePlugin(part_name="my-part", options=lambda: None)
 
-        self.assertThat(
-            plugin.get_build_environment(),
-            Equals({"SNAPCRAFT_CMAKE_INSTALL_PREFIX": "/"}),
-        )
+        self.assertThat(plugin.get_build_environment(), Equals(dict()))
 
     def test_get_build_commands(self):
         class Options:
@@ -67,7 +63,7 @@ class CMakePluginTest(TestCase):
             plugin.get_build_commands(),
             Equals(
                 [
-                    'cmake . -DCMAKE_INSTALL_PREFIX="${SNAPCRAFT_CMAKE_INSTALL_PREFIX}"',
+                    "cmake .",
                     'cmake --build . -- -j"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
                     'cmake --build . --target install -- DESTDIR="${SNAPCRAFT_PART_INSTALL}"',
                 ]

--- a/tests/unit/plugins/v2/test_go.py
+++ b/tests/unit/plugins/v2/test_go.py
@@ -35,7 +35,6 @@ class GoPluginTest(TestCase):
                         "go-channel": {"type": "string", "default": "latest/stable"},
                         "go-buildtags": {
                             "type": "array",
-                            "minitems": 1,
                             "uniqueItems": True,
                             "items": {"type": "string"},
                             "default": [],

--- a/tests/unit/plugins/v2/test_meson.py
+++ b/tests/unit/plugins/v2/test_meson.py
@@ -34,7 +34,6 @@ class MesonPluginTest(TestCase):
                         "meson-parameters": {
                             "default": [],
                             "items": {"type": "string"},
-                            "minitems": 1,
                             "type": "array",
                             "uniqueItems": True,
                         },
@@ -65,10 +64,7 @@ class MesonPluginTest(TestCase):
     def test_get_build_environment(self):
         plugin = MesonPlugin(part_name="my-part", options=lambda: None)
 
-        self.assertThat(
-            plugin.get_build_environment(),
-            Equals({"SNAPCRAFT_MESON_BUILDTYPE": "release"}),
-        )
+        self.assertThat(plugin.get_build_environment(), Equals(dict()))
 
     def test_get_build_commands(self):
         class Options:
@@ -82,7 +78,7 @@ class MesonPluginTest(TestCase):
             Equals(
                 [
                     "python3 -m pip install -U meson",
-                    "[ ! -d .snapbuild ] && meson --buildtype=${SNAPCRAFT_MESON_BUILDTYPE} .snapbuild",
+                    "[ ! -d .snapbuild ] && meson .snapbuild",
                     "(cd .snapbuild && ninja)",
                     '(cd .snapbuild && DESTDIR="${SNAPCRAFT_PART_INSTALL}" ninja install)',
                 ]

--- a/tests/unit/plugins/v2/test_python.py
+++ b/tests/unit/plugins/v2/test_python.py
@@ -68,21 +68,18 @@ class PythonPluginTest(TestCase):
                         "constraints": {
                             "default": [],
                             "items": {"type": "string"},
-                            "minitems": 1,
                             "type": "array",
                             "uniqueItems": True,
                         },
                         "python-packages": {
                             "default": [],
                             "items": {"type": "string"},
-                            "minitems": 1,
                             "type": "array",
                             "uniqueItems": True,
                         },
                         "requirements": {
                             "default": [],
                             "items": {"type": "string"},
-                            "minitems": 1,
                             "type": "array",
                             "uniqueItems": True,
                         },

--- a/tests/unit/plugins/v2/test_rust.py
+++ b/tests/unit/plugins/v2/test_rust.py
@@ -36,7 +36,6 @@ class RustPluginTest(TestCase):
                         "rust-features": {
                             "default": [],
                             "items": {"type": "string"},
-                            "minItems": 1,
                             "type": "array",
                             "uniqueItems": True,
                         },


### PR DESCRIPTION
- Remove invalid uses of minitems (and not minItems) in the plugin
  schemas.
- Remove use of any "prefix" setup, it is up to the developer of the
  snap to pick.
- Remove the concept of setting a default build type for plugins.
- Fixup the docstrings so they are consistent with spacing and general
  presentation.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
