### PR TITLE
repo: fix decoding of CalledProcessError output

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -128,7 +128,7 @@
                 },
                 "architectures": {
                     "type": "array",
-                    "minItems": 0,
+                    "minItems": 1,
                     "uniqueItems": true,
                     "items": {
                         "type": "string",
@@ -177,7 +177,7 @@
                     "uniqueItems": true,
                     "items": {
                         "type": "string",
-                        "description": "Deb repository suites to enable, e.g. 'xenial-updates, xenial-security'.  Supports '$SNAPCRAFT_APT_RELEASE' variable for snapcraft to populate base release name (e.g. 'xenial')."
+                        "description": "Deb repository suites to enable, e.g. 'xenial-updates, xenial-security'.  Supports '$SNAPCRAFT_APT_RELEASE' variable for snapcraft to populate base's release name (e.g. 'xenial')."
                     }
                 },
                 "url": {

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -607,7 +607,7 @@ class Ubuntu(BaseRepo):
                 env=env,
             )
         except subprocess.CalledProcessError as error:
-            raise errors.AptGPGKeyInstallError(output=error.output, key=key)
+            raise errors.AptGPGKeyInstallError(output=error.output.decode(), key=key)
 
         logger.debug(f"Installed apt repository key:\n{key}")
 
@@ -628,6 +628,9 @@ class Ubuntu(BaseRepo):
         if key_server is None:
             key_server = "keyserver.ubuntu.com"
 
+        env = os.environ.copy()
+        env["LANG"] = "C.UTF-8"
+
         cmd = [
             "sudo",
             "apt-key",
@@ -643,11 +646,15 @@ class Ubuntu(BaseRepo):
         try:
             logger.debug(f"Executing: {cmd!r}")
             subprocess.run(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=True,
+                env=env,
             )
         except subprocess.CalledProcessError as error:
             raise errors.AptGPGKeyInstallError(
-                output=error.output, key_id=key_id, key_server=key_server
+                output=error.output.decode(), key_id=key_id, key_server=key_server
             )
 
     @classmethod


### PR DESCRIPTION
CalledProcessError.output is a bytes object that must
be decoded, not a string.

- Set LANG in _install_gpg_key_id_from_keyserver() as
  done for _install_gpg_key().

- Fix unit test coverage for CalledProcessError.output.

- Add test coverage for install_gpg_key_id().

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
