### PR TITLE
schema: minor tweaks/fixes for package-repositories

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -128,7 +128,7 @@
                 },
                 "architectures": {
                     "type": "array",
-                    "minItems": 0,
+                    "minItems": 1,
                     "uniqueItems": true,
                     "items": {
                         "type": "string",
@@ -138,7 +138,7 @@
                 "deb-types": {
                     "type": "array",
                     "description": "deb types to enable.  Defaults to [deb, deb-src].",
-                    "minItems": 0,
+                    "minItems": 1,
                     "uniqueItems": true,
                     "items": {
                         "type": "string",
@@ -177,7 +177,7 @@
                     "uniqueItems": true,
                     "items": {
                         "type": "string",
-                        "description": "Deb repository suites to enable, e.g. 'xenial-updates, xenial-security'.  Supports '$SNAPCRAFT_APT_RELEASE' variable for snapcraft to populate base release name (e.g. 'xenial')."
+                        "description": "Deb repository suites to enable, e.g. 'xenial-updates, xenial-security'.  Supports '$SNAPCRAFT_APT_RELEASE' variable for snapcraft to populate base's release name (e.g. 'xenial')."
                     }
                 },
                 "url": {

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -1906,7 +1906,6 @@ class PackageManagement(ProjectBaseTest):
                     url: http://archive.ubuntu.com/ubuntu
                     suites: [test, test-updates, test-security]
                   - type: apt
-                    name: test-name2
                     components: [main, multiverse]
                     key-id: test-key-id
                     url: http://archive.ubuntu.com/ubuntu
@@ -2026,6 +2025,7 @@ class InvalidAptConfigurations(ProjectBaseTest):
                       name: test-name
                       key-id: test-key-id
                       suites: [test, test-updates, test-security]
+                      url: http://test-url.com/ubuntu
                     """
                 ),
                 message_contains="The 'package-repositories[0]' property does not match the required schema:",
@@ -2042,6 +2042,7 @@ class InvalidAptConfigurations(ProjectBaseTest):
                       name: ../foo
                       key-id: test-key-id
                       suites: [test, test-updates, test-security]
+                      url: http://test-url.com/ubuntu
                     """
                 ),
                 message_contains="The 'package-repositories[0]' property does not match the required schema:",
@@ -2058,6 +2059,58 @@ class InvalidAptConfigurations(ProjectBaseTest):
                       name: test-name
                       key-id: \\*\\*
                       suites: [test, test-updates, test-security]
+                      url: http://test-url.com/ubuntu
+                    """
+                ),
+                message_contains="The 'package-repositories[0]' property does not match the required schema:",
+            ),
+        ),
+        (
+            "deb empty architectures",
+            dict(
+                packages=dedent(
+                    """\
+                    package-repositories:
+                    - type: apt
+                      components: [main, multiverse]
+                      name: test-name
+                      key-id: test-key-id
+                      suites: [test, test-updates, test-security]
+                      architectures: []
+                      url: http://test-url.com/ubuntu
+                    """
+                ),
+                message_contains="The 'package-repositories[0]' property does not match the required schema:",
+            ),
+        ),
+        (
+            "deb empty components",
+            dict(
+                packages=dedent(
+                    """\
+                    package-repositories:
+                    - type: apt
+                      components: []
+                      name: test-name
+                      key-id: test-key-id
+                      suites: [test, test-updates, test-security]
+                      url: http://test-url.com/ubuntu
+                    """
+                ),
+                message_contains="The 'package-repositories[0]' property does not match the required schema:",
+            ),
+        ),
+        (
+            "deb empty suites",
+            dict(
+                packages=dedent(
+                    """\
+                    package-repositories:
+                    - type: apt
+                      components: [main]
+                      key-id: test-key-id
+                      suites: []
+                      url: http://test-url.com/ubuntu
                     """
                 ),
                 message_contains="The 'package-repositories[0]' property does not match the required schema:",


### PR DESCRIPTION
- Grammar fixes.

- Add test coverage for empty architectures, suites, and components.

- Correct tests that were passing for incorrect reasons (missing url).
  Requires better error detection handling than what we can do wih the
  schema.

- Remove name from one of the validity checks, it is no longer required.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
