### PR TITLE
pluginhandler: skip plugin clean_pull for PluginV2

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -545,7 +545,8 @@ class PluginHandler:
             else:
                 shutil.rmtree(self.part_source_dir)
 
-        self.plugin.clean_pull()
+        if isinstance(self.plugin, plugins.v1.PluginV1):
+            self.plugin.clean_pull()
         self.mark_cleaned(steps.PULL)
 
     def prepare_build(self, force=False):
@@ -773,7 +774,8 @@ class PluginHandler:
         if os.path.exists(self.part_install_dir):
             shutil.rmtree(self.part_install_dir)
 
-        self.plugin.clean_build()
+        if isinstance(self.plugin, plugins.v1.PluginV1):
+            self.plugin.clean_build()
         self.mark_cleaned(steps.BUILD)
 
     def migratable_fileset_for(self, step):

--- a/snapcraft/internal/pluginhandler/_part_build_environment.py
+++ b/snapcraft/internal/pluginhandler/_part_build_environment.py
@@ -25,17 +25,25 @@ if TYPE_CHECKING:
 
 
 def get_snapcraft_global_environment(project: "Project") -> Dict[str, str]:
-    if project.info.name:
+    # The triple check is mostly for unit tests support until we completely
+    # get rid of project.info.
+    if project._snap_meta.name:
+        name = project._snap_meta.name
+    elif project.info is not None and project.info.name:
         name = project.info.name
     else:
         name = ""
 
-    if project.info.version:
+    if project._snap_meta.version:
+        version = project._snap_meta.version
+    elif project.info is not None and project.info.version:
         version = project.info.version
     else:
         version = ""
 
-    if project.info.grade:
+    if project._snap_meta.grade:
+        grade = project._snap_meta.grade
+    elif project.info is not None and project.info.grade:
         grade = project.info.grade
     else:
         grade = ""

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -277,9 +277,14 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         properties = {"plugin": plugin_name}
         if part_properties:
             properties.update(part_properties)
+        if "build-environment" not in properties:
+            properties["build-environment"] = list()
         if not project:
             project = snapcraft.project.Project()
 
+        project._snap_meta.name = "test-snap"
+        project._snap_meta.version = "1.0"
+        project._snap_meta.grade = "devel"
         project._snap_meta.type = snap_type
         project._snap_meta.confinement = confinement
         project._snap_meta.base = base

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -267,6 +267,7 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         part_properties=None,
         project=None,
         stage_packages_repo=None,
+        snap_name="test-snap",
         base="core18",
         build_base=None,
         confinement="strict",
@@ -282,7 +283,7 @@ class TestCase(testscenarios.WithScenarios, testtools.TestCase):
         if not project:
             project = snapcraft.project.Project()
 
-        project._snap_meta.name = "test-snap"
+        project._snap_meta.name = snap_name
         project._snap_meta.version = "1.0"
         project._snap_meta.grade = "devel"
         project._snap_meta.type = snap_type

--- a/tests/unit/pluginhandler/test_patcher.py
+++ b/tests/unit/pluginhandler/test_patcher.py
@@ -104,15 +104,16 @@ class StaticBasePatchingTest(unit.TestCase):
 class PrimeTypeExcludesPatchingTestCase(unit.TestCase):
 
     scenarios = (
-        ("kernel", dict(snap_type="kernel")),
-        ("gadget", dict(snap_type="gadget")),
-        ("base", dict(snap_type="base")),
-        ("os", dict(snap_type="os")),
+        ("kernel", dict(snap_type="kernel", snap_name="test-snap")),
+        ("gadget", dict(snap_type="gadget", snap_name="test-snap")),
+        ("base", dict(snap_type="base", snap_name="core18")),
+        ("os", dict(snap_type="os", snap_name="test-snap")),
     )
 
     def test_no_patcher_called(self):
         handler = self.load_part(
             "test-part",
+            snap_name=self.snap_name,
             part_properties={"source-subdir": "src"},
             snap_type=self.snap_type,
         )


### PR DESCRIPTION
This method is not there anymore. Update unit tests, but these really
need redoing.

Fixes SNAPCRAFT-1JS

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
