### PR TITLE
meson v2 plugin: ignore any staged python when installing meson

### DIFF
--- a/snapcraft/plugins/v2/meson.py
+++ b/snapcraft/plugins/v2/meson.py
@@ -84,7 +84,7 @@ class MesonPlugin(PluginV2):
         meson_cmd.append(".snapbuild")
 
         return [
-            f"python3 -m pip install -U {meson_package}",
+            f"/usr/bin/python3 -m pip install -U {meson_package}",
             "[ ! -d .snapbuild ] && {}".format(" ".join(meson_cmd)),
             "(cd .snapbuild && ninja)",
             '(cd .snapbuild && DESTDIR="${SNAPCRAFT_PART_INSTALL}" ninja install)',

--- a/tests/spread/plugins/v2/build-and-run-hello/task.yaml
+++ b/tests/spread/plugins/v2/build-and-run-hello/task.yaml
@@ -9,6 +9,7 @@ environment:
   SNAP/go_mod: go-mod-hello
   SNAP/dump: dump-hello
   SNAP/meson: meson-hello
+  SNAP/meson_staged_python: meson-hello-staged-python
   SNAP/npm: npm-hello
   SNAP/rust: rust-hello
   SNAP/rust_features: rust-hello-features

--- a/tests/spread/plugins/v2/snaps/meson-hello-staged-python/hello.c
+++ b/tests/spread/plugins/v2/snaps/meson-hello-staged-python/hello.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main()
+{
+    printf("hello world\n");
+    return 0;
+}

--- a/tests/spread/plugins/v2/snaps/meson-hello-staged-python/meson.build
+++ b/tests/spread/plugins/v2/snaps/meson-hello-staged-python/meson.build
@@ -1,0 +1,2 @@
+project('meson-hello', 'c')
+executable('hello', 'hello.c', install : true)

--- a/tests/spread/plugins/v2/snaps/meson-hello-staged-python/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/meson-hello-staged-python/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: meson-hello-staged-python
+version: "1.0"
+summary: test the meson plugin
+description: |
+  This is a basic meson snap that stages python to cause interference.
+
+grade: devel
+base: core20
+confinement: strict
+
+apps:
+  meson-hello-staged-python:
+    command: bin/hello
+
+parts:
+  meson-project:
+    source: .
+    plugin: meson
+    meson-version: "0.48.0"
+    meson-parameters:
+      - --prefix=/
+    stage-packages:
+      - python3-minimal

--- a/tests/unit/plugins/v2/test_meson.py
+++ b/tests/unit/plugins/v2/test_meson.py
@@ -77,7 +77,7 @@ class MesonPluginTest(TestCase):
             plugin.get_build_commands(),
             Equals(
                 [
-                    "python3 -m pip install -U meson",
+                    "/usr/bin/python3 -m pip install -U meson",
                     "[ ! -d .snapbuild ] && meson .snapbuild",
                     "(cd .snapbuild && ninja)",
                     '(cd .snapbuild && DESTDIR="${SNAPCRAFT_PART_INSTALL}" ninja install)',
@@ -96,7 +96,7 @@ class MesonPluginTest(TestCase):
             plugin.get_build_commands(),
             Equals(
                 [
-                    "python3 -m pip install -U meson==2.2",
+                    "/usr/bin/python3 -m pip install -U meson==2.2",
                     "[ ! -d .snapbuild ] && meson --buildtype=release .snapbuild",
                     "(cd .snapbuild && ninja)",
                     '(cd .snapbuild && DESTDIR="${SNAPCRAFT_PART_INSTALL}" ninja install)',


### PR DESCRIPTION
Fixes SNAPCRAFT-1JV

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
