### PR TITLE
cli: add plugin help for core20

### DIFF
--- a/snapcraft/cli/help.py
+++ b/snapcraft/cli/help.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017-2018 Canonical Ltd
+# Copyright (C) 2017-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -20,8 +20,10 @@ from textwrap import dedent
 import click
 
 import snapcraft
+from snapcraft.project import errors as project_errors
 from . import echo
-from snapcraft.internal import sources
+from ._options import get_project
+from snapcraft.internal import errors, sources
 
 
 _TOPICS = {"sources": sources, "plugins": snapcraft}
@@ -38,8 +40,13 @@ def helpcli():
 @click.option(
     "--devel", is_flag=True, help="Show more details for snapcraft developers"
 )
+@click.option(
+    "--base",
+    help="Show help for specific base",
+    type=click.Choice(["core", "core16", "core18", "core20"]),
+)
 @click.pass_context
-def help_command(ctx, topic, devel):
+def help_command(ctx, topic, devel, base):
     """Obtain help for a certain topic, plugin or command.
 
     The <topic> can either be a plugin name or one of:
@@ -55,6 +62,7 @@ def help_command(ctx, topic, devel):
         snapcraft help plugins
         snapcraft help sources
         snapcraft help go
+        snapcraft help go --base core18
         snapcraft help build
     """
     if not topic:
@@ -81,7 +89,7 @@ def help_command(ctx, topic, devel):
         _topic_help(topic, devel)
     else:
         try:
-            _module_help(topic, devel)
+            _module_help(topic, devel, base)
         except ImportError:
             # 10 is the limit which determines ellipsis is needed
             if len(topic) > 10:
@@ -115,13 +123,28 @@ def _topic_help(module_name, devel):
         click.echo(_TOPICS[module_name].__doc__)
 
 
-def _module_help(module_name, devel):
+def _module_help(module_name: str, devel: bool, base: str):
+    module_name = module_name.replace("-", "_")
+
+    if base is None:
+        try:
+            if get_project()._snap_meta.get_build_base() == "core20":
+                plugin_version = "v2"
+            else:
+                plugin_version = "v1"
+        except (errors.ProjectNotFoundError, project_errors.MissingSnapcraftYamlError):
+            plugin_version = "v2"
+    elif base == "core20":
+        plugin_version = "v2"
+    elif base:
+        plugin_version = "v1"
+
     module = importlib.import_module(
-        "snapcraft.plugins.v1.{}".format(module_name.replace("-", "_"))
+        f"snapcraft.plugins.{plugin_version}.{module_name}"
     )
     if module.__doc__ and devel:
         help(module)
     elif module.__doc__:
-        click.echo(module.__doc__)
+        click.echo_via_pager(module.__doc__)
     else:
         click.echo("The plugin has no documentation")

--- a/snapcraft/cli/help.py
+++ b/snapcraft/cli/help.py
@@ -123,20 +123,18 @@ def _topic_help(module_name, devel):
         click.echo(_TOPICS[module_name].__doc__)
 
 
-def _module_help(module_name: str, devel: bool, base: str):
-    module_name = module_name.replace("-", "_")
+def _module_help(plugin_name: str, devel: bool, base: str):
+    module_name = plugin_name.replace("-", "_")
 
     if base is None:
         try:
-            if get_project()._snap_meta.get_build_base() == "core20":
-                plugin_version = "v2"
-            else:
-                plugin_version = "v1"
+            base = get_project()._snap_meta.get_build_base()
         except (errors.ProjectNotFoundError, project_errors.MissingSnapcraftYamlError):
-            plugin_version = "v2"
-    elif base == "core20":
+            base = "core20"
+
+    if base == "core20":
         plugin_version = "v2"
-    elif base:
+    else:
         plugin_version = "v1"
 
     module = importlib.import_module(
@@ -145,6 +143,9 @@ def _module_help(module_name: str, devel: bool, base: str):
     if module.__doc__ and devel:
         help(module)
     elif module.__doc__:
-        click.echo_via_pager(module.__doc__)
+        click.echo_via_pager(
+            f"Displaying help for the {plugin_name!r} plugin for {base!r}.\n\n"
+            + module.__doc__
+        )
     else:
         click.echo("The plugin has no documentation")

--- a/snapcraft/plugins/v2/nil.py
+++ b/snapcraft/plugins/v2/nil.py
@@ -14,6 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+"""The nil plugin is useful for parts with no source.
+
+Using this, parts can be defined purely by utilizing properties automatically
+included by Snapcraft, e.g. stage-packages.
+"""
+
 from typing import Any, Dict, List, Set
 
 from snapcraft.plugins.v2 import PluginV2

--- a/snapcraft/plugins/v2/python.py
+++ b/snapcraft/plugins/v2/python.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""The python plugin can be used for python 2 or 3 based parts.
+"""The python plugin can be used for 3 based parts.
 
 It can be used for python projects where you would want to do:
 

--- a/tests/unit/commands/test_help.py
+++ b/tests/unit/commands/test_help.py
@@ -62,7 +62,7 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
     def test_print_module_help_for_valid_plugin_default_base(self):
         result = self.run_command(["help", "nil"])
 
-        expected = "The nil plugin is"
+        expected = "Displaying help for the 'nil' plugin for 'core20'."
         output = result.output[: len(expected)]
         self.assertThat(
             output,
@@ -75,7 +75,7 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
         for base in ("core", "core18", "core20"):
             result = self.run_command(["help", "nil", "--base", base])
 
-            expected = "The nil plugin is"
+            expected = f"Displaying help for the 'nil' plugin for {base!r}."
             output = result.output[: len(expected)]
             self.expectThat(
                 output,
@@ -94,7 +94,10 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
         )
         result = self.run_command(["help", "python", "--base", "core18"])
 
-        expected = "The python plugin can be used for python 2 or 3 based parts"
+        expected = (
+            "Displaying help for the 'python' plugin for 'core18'.\n\n"
+            "The python plugin can be used for"
+        )
         output = result.output[: len(expected)]
         self.assertThat(
             output,
@@ -106,7 +109,7 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
     def test_print_module_named_with_dashes_help_for_valid_plugin(self):
         result = self.run_command(["help", "plainbox-provider", "--base", "core18"])
 
-        expected = " Create parts"
+        expected = "Displaying help for the 'plainbox-provider' plugin for 'core18'."
         self.assertThat(result.output, StartsWith(expected))
 
     def test_show_module_help_with_devel_for_valid_plugin(self):

--- a/tests/unit/commands/test_help.py
+++ b/tests/unit/commands/test_help.py
@@ -24,6 +24,7 @@ from testtools.matchers import Contains, Equals, StartsWith
 from snapcraft.cli.help import _TOPICS
 from snapcraft.cli._runner import run
 
+from tests import fixture_setup
 from . import CommandBaseTestCase
 
 
@@ -58,7 +59,7 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
         self.assertThat(result.exit_code, Equals(1))
         self.assertThat(result.output, Contains("1234567890..."))
 
-    def test_print_module_help_for_valid_plugin(self):
+    def test_print_module_help_for_valid_plugin_default_base(self):
         result = self.run_command(["help", "nil"])
 
         expected = "The nil plugin is"
@@ -70,8 +71,40 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
             "{!r} instead".format(expected, output),
         )
 
+    def test_print_module_help_for_valid_plugin_with_base(self):
+        for base in ("core", "core18", "core20"):
+            result = self.run_command(["help", "nil", "--base", base])
+
+            expected = "The nil plugin is"
+            output = result.output[: len(expected)]
+            self.expectThat(
+                output,
+                Equals(expected),
+                "The help message does not start with {!r} but with "
+                "{!r} instead".format(expected, output),
+            )
+
+    def test_print_module_help_for_valid_plugin_snapcraft_yaml(self):
+        self.useFixture(
+            fixture_setup.SnapcraftYaml(
+                self.path,
+                base="core18",
+                parts={"part1": {"source": ".", "plugin": "nil"}},
+            )
+        )
+        result = self.run_command(["help", "python", "--base", "core18"])
+
+        expected = "The python plugin can be used for python 2 or 3 based parts"
+        output = result.output[: len(expected)]
+        self.assertThat(
+            output,
+            Equals(expected),
+            "The help message does not start with {!r} but with "
+            "{!r} instead".format(expected, output),
+        )
+
     def test_print_module_named_with_dashes_help_for_valid_plugin(self):
-        result = self.run_command(["help", "plainbox-provider"])
+        result = self.run_command(["help", "plainbox-provider", "--base", "core18"])
 
         expected = " Create parts"
         self.assertThat(result.output, StartsWith(expected))
@@ -79,7 +112,7 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
     def test_show_module_help_with_devel_for_valid_plugin(self):
         result = self.run_command(["help", "nil", "--devel"])
 
-        expected = "Help on module snapcraft.plugins.v1.nil in snapcraft.plugins"
+        expected = "Help on module snapcraft.plugins.v2.nil in snapcraft.plugins"
         output = result.output[: len(expected)]
 
         self.assertThat(

--- a/todo.org
+++ b/todo.org
@@ -4,7 +4,7 @@
 
 * Specifications
 ** 2020
-*** STRT [[file:specifications/20200304-core20-plugins.org][Snapcraft Core20 Plugins]] [/]
+*** STRT [[file:specifications/20200304-core20-plugins.org][Snapcraft Core20 Plugins]] [6/11]
 - [X] Move =BasePlugin= to a v1 import path
 - [X] Add backwards compatibility for =BasePlugin=
 - [X] Rework in-tree plugin importing into a map
@@ -12,7 +12,7 @@
 - [X] Add =PluginHandler= logic for the =core20= plugin
 - [ ] Plugin manifest generation.
 - [ ] Detection of property changes for rebuilds.
-- [ ] Add CLI support for =help=
+- [X] Add CLI support for =help=
 - [ ] Add CLI support for =list-plugins=
 - [ ] Add CLI support for =expand-plugins=
 - [ ] Introduce new custom plugin loading logic for =core20=


### PR DESCRIPTION
- Use click pager by default (it does the right thing).
- Fix the python and nil plugin help for v2.
- Load base from project or default to core20 if --base is not passed.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
