### PR TITLE
repo: fix for multi-arch stage-package scenario

### DIFF
--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -83,11 +83,15 @@ class FakeAptCache:
         priority: str = "normal",
         version: str = "1.0",
         installed: bool = False,
+        architecture: Optional[str] = None,
         dependency_names: List[str],
     ) -> MagicMock:
+        if architecture is None:
+            architecture = repo._deb._get_host_arch()
+
         package = MagicMock(wraps=FakeAptPackage(name=name))
-        package_name_mock = PropertyMock(return_value=name)
-        type(package).name = package_name_mock
+        type(package).name = PropertyMock(return_value=name)
+        type(package).architecture = PropertyMock(return_value=architecture)
 
         self.packages[name] = package
 


### PR DESCRIPTION
When enabling multiple architectures, python-apt's BaseDependency
may yield target_versions for a package which are for the unintended
architecture when coming across a package with ':all' architecture.

For example: python3-pip has a dependency on "python3:any". On AMD64
it may point to the i386 package, when having i386 architectures
enabled:

```
>>> apt.Cache()["python3-pip"].candidate.dependencies[-1].target_versions

[
  <Version: package:'python3:i386' version:'3.6.7-1~18.04'>,
  <Version: package:'python3' version:'3.6.7-1~18.04'>,
  <Version: package:'python3:i386' version:'3.6.5-3'>,
  <Version: package:'python3' version:'3.6.5-3'>]
]
```

Instead, we'll look at python-apt's `or_dependencies` list, which is
used to calculate the allowable target_versions:

```
>>> apt.Cache()["python3-pip"].candidate.dependencies[-1].or_dependencies

<Dependency: [<BaseDependency: name:'python3:any' relation:'>=' version:'3.4~' rawtype:'Depends'>]>
```

apt.package.Dependency will provide us with the 'name', e.g.
'python3:any', and we can use this name to fetch the correct
dependencies.

To support installing the correct architecture, we now will pass
target_arch to _mark_package_dependencies() and
_get_resolved_package().  _get_resolved_package() will use the
now-introduced _get_package_for_arch() method to find the correct
package for the intended architecture:

1. First trying `<package-name>:<target-arch>`.

2. Then trying `<package-name>:all` in case it's a no-arch package.

3. Finally trying `<package-name>`, but logging a warning that
   it may be the incorrect architecture.  This shouldn't happen,
   but the warning is there just so we'll know about it if there
   is a case we didn't consider.

Update unit tests, cleaning out some old cruft left behind and
passing without purpose.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
