### PR TITLE
repo: revert logic to get deb_arch

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -34,6 +34,7 @@ from launchpadlib.launchpad import Launchpad
 from xdg import BaseDirectory
 
 from snapcraft import file_utils
+from snapcraft.project._project_options import ProjectOptions
 from snapcraft.internal import os_release, repo
 from snapcraft.internal.indicators import is_dumb_terminal
 
@@ -194,23 +195,8 @@ def _run_dpkg_query_list_files(package_name: str) -> Set[str]:
     return {i for i in output if ("lib" in i and os.path.isfile(i))}
 
 
-@functools.lru_cache(maxsize=256)
-def _run_dpkg_architecture_query(deb_property: str) -> str:
-
-    return (
-        subprocess.run(
-            ["dpkg-architecture", "-q", deb_property],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            check=True,
-        )
-        .stdout.decode()
-        .strip()
-    )
-
-
-def _get_host_arch():
-    return _run_dpkg_architecture_query("DEB_HOST_ARCH")
+def _get_host_arch() -> str:
+    return ProjectOptions().deb_arch
 
 
 def _sudo_write_file(*, dst_path: Path, content: bytes) -> None:


### PR DESCRIPTION
dpkg-architecture is not installed on all systems and the code path
is run from the host before entering build environments.

Fixes SNAPCRAFT-1K1

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
