### PR TITLE
repo: restore marked-install strategy for apt-cache

### DIFF
--- a/snapcraft/internal/repo/apt_cache.py
+++ b/snapcraft/internal/repo/apt_cache.py
@@ -1,0 +1,252 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import apt
+import logging
+import os
+import re
+import shutil
+from contextlib import ContextDecorator
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+from snapcraft.internal import common, repo
+from snapcraft.internal.indicators import is_dumb_terminal
+from snapcraft.internal.repo import errors
+
+logger = logging.getLogger(__name__)
+
+
+_HASHSUM_MISMATCH_PATTERN = re.compile(r"(E:Failed to fetch.+Hash Sum mismatch)+")
+
+
+class AptCache(ContextDecorator):
+    """Transient cache for use with stage-packages, or read-only host-mode for build-packages."""
+
+    def __init__(self, *, stage_cache: Optional[Path] = None) -> None:
+        self.stage_cache = stage_cache
+
+    def __enter__(self) -> "AptCache":
+        if self.stage_cache is not None:
+            self._configure_apt()
+            self._populate_cache_dir()
+            self.cache = apt.Cache(rootdir=str(self.stage_cache), memonly=True)
+        else:
+            # There appears to be a slowdown when using `rootdir` = '/' with
+            # apt.Cache().  Do not set it for the host cache.
+            self.cache = apt.Cache()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.cache.close()
+        self.cache = None
+
+    def _configure_apt(self):
+        # Do not install recommends.
+        apt.apt_pkg.config.set("Apt::Install-Recommends", "False")
+
+        # Ensure repos are provided by trusted third-parties.
+        apt.apt_pkg.config.set("Acquire::AllowInsecureRepositories", "False")
+
+        # Methods and solvers dir for when in the SNAP.
+        snap_dir = os.getenv("SNAP")
+        if common.is_snap() and snap_dir and os.path.exists(snap_dir):
+            apt_dir = os.path.join(snap_dir, "usr", "lib", "apt")
+            apt.apt_pkg.config.set("Dir", apt_dir)
+            # yes apt is broken like that we need to append os.path.sep
+            methods_dir = os.path.join(apt_dir, "methods")
+            apt.apt_pkg.config.set("Dir::Bin::methods", methods_dir + os.path.sep)
+            solvers_dir = os.path.join(apt_dir, "solvers")
+            apt.apt_pkg.config.set("Dir::Bin::solvers::", solvers_dir + os.path.sep)
+            apt_key_path = os.path.join(snap_dir, "usr", "bin", "apt-key")
+            apt.apt_pkg.config.set("Dir::Bin::apt-key", apt_key_path)
+            gpgv_path = os.path.join(snap_dir, "usr", "bin", "gpgv")
+            apt.apt_pkg.config.set("Apt::Key::gpgvcommand", gpgv_path)
+
+        apt.apt_pkg.config.set("Dir::Etc::Trusted", "/etc/apt/trusted.gpg")
+        apt.apt_pkg.config.set("Dir::Etc::TrustedParts", "/etc/apt/trusted.gpg.d/")
+
+        # Clear up apt's Post-Invoke-Success as we are not running
+        # on the system.
+        apt.apt_pkg.config.clear("APT::Update::Post-Invoke-Success")
+
+        self.progress = apt.progress.text.AcquireProgress()
+        if is_dumb_terminal():
+            # Make output more suitable for logging.
+            self.progress.pulse = lambda owner: True
+            self.progress._width = 0
+
+    def _populate_cache_dir(self) -> None:
+        if self.stage_cache is None:
+            return
+
+        # Create /etc inside cache root, and symlink apt to host's.
+        cache_etc_apt_path = Path(self.stage_cache, "etc", "apt")
+        if not cache_etc_apt_path.exists():
+            cache_etc_apt_path.parent.mkdir(parents=True, exist_ok=True)
+            os.symlink(Path("/etc/apt"), cache_etc_apt_path)
+
+        # dpkg also needs to be in the rootdir in order to support multiarch
+        # (apt calls dpkg --print-foreign-architectures).
+        dpkg_path = shutil.which("dpkg")
+        if dpkg_path:
+            # Symlink it into place
+            destination = Path(self.stage_cache, dpkg_path[1:])
+            if not destination.exists():
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                os.symlink(dpkg_path, destination)
+        else:
+            logger.warning("Cannot find 'dpkg' command needed to support multiarch")
+
+    def _autokeep_packages(self) -> None:
+        # If the package has been installed automatically as a dependency
+        # of another package, and if no packages depend on it anymore,
+        # the package is no longer required.
+        for package in self.cache.get_changes():
+            if package.is_auto_removable:
+                package.mark_keep()
+
+    def _set_pkg_version(self, package: apt.Package, version: str) -> None:
+        # Set cadidate version to a specific version if available
+        if version in package.versions:
+            version = package.versions.get(version)
+            package.candidate = version
+        else:
+            raise errors.PackageNotFoundError("{}={}".format(package.name, version))
+
+    def _verify_marked_install(self, package: apt.Package):
+        if not package.installed and not package.marked_install:
+            broken_deps: List[str] = list()
+            for package_dependencies in package.candidate.dependencies:
+                for dep in package_dependencies:
+                    if not dep.target_versions:
+                        broken_deps.append(dep.name)
+            raise errors.PackageBrokenError(package.name, broken_deps)
+
+    def is_package_valid(self, package_name: str) -> bool:
+        return package_name in self.cache or self.cache.is_virtual_package(package_name)
+
+    def get_installed_version(self, package_name: str) -> Optional[str]:
+        if package_name in self.cache:
+            if self.cache[package_name].installed is not None:
+                return self.cache[package_name].installed.version
+        return None
+
+    def fetch_archives(self, download_path: Path) -> List[Tuple[str, str, Path]]:
+        """Fetches archives, list of (<package-name>, <package-version>, <dl-path>)."""
+        downloaded = list()
+        for package in self.cache.get_changes():
+            try:
+                dl_path = package.candidate.fetch_binary(str(download_path))
+            except apt.package.FetchError as e:
+                raise errors.PackageFetchError(str(e))
+
+            downloaded.append((package.name, package.candidate.version, Path(dl_path)))
+        return downloaded
+
+    def get_installed_packages(self) -> Dict[str, str]:
+        installed: Dict[str, str] = dict()
+        for package in self.cache:
+            if package.installed is not None:
+                installed[package.name] = str(package.installed.version)
+        return installed
+
+    def get_marked_packages(self) -> List[Tuple[str, str]]:
+        return [
+            (package.name, package.candidate.version)
+            for package in self.cache.get_changes()
+        ]
+
+    def mark_packages(self, package_names: Set[str]) -> None:
+        for name in package_names:
+            if name.endswith(":any"):
+                name = name[:-4]
+
+            if self.cache.is_virtual_package(name):
+                name = self.cache.get_providing_packages(name)[0].name
+
+            logger.debug(
+                "Marking {!r} (and its dependencies) to be fetched".format(name)
+            )
+
+            name_arch, version = repo.get_pkg_name_parts(name)
+            if name_arch not in self.cache:
+                raise errors.PackageNotFoundError(name_arch)
+
+            package = self.cache[name_arch]
+            if version is not None:
+                self._set_pkg_version(package, version)
+
+            logger.debug(f"package: {package!r}")
+
+            # Disable automatic resolving of broken packages here
+            # because if that fails it raises a SystemError and the
+            # API doesn't expose enough information about the problem.
+            # Instead we let apt-get show a verbose error message later.
+            # Also, make sure this package is marked as auto-installed,
+            # which will propagate to its dependencies.
+            package.mark_install(auto_fix=False, from_user=False)
+
+            # Now mark this package as NOT automatically installed, which
+            # will leave its dependencies marked as auto-installed, which
+            # allows us to clean them up if necessary.
+            package.mark_auto(False)
+
+            self._verify_marked_install(package)
+
+    def unmark_packages(
+        self, *, required_names: Set[str], filtered_names: Set[str]
+    ) -> None:
+        skipped_essential = set()
+        skipped_blacklisted = set()
+
+        for package in self.cache:
+            # Explicitly listed packages are never filtered.
+            if package.name in required_names:
+                continue
+
+            if package.candidate.priority == "essential":
+                # Filter 'essential' packages.
+                skipped_essential.add(package.name)
+                package.mark_keep()
+                continue
+
+            if package.name in filtered_names:
+                # Filter packages from given list.
+                skipped_blacklisted.add(package.name)
+                package.mark_keep()
+                continue
+
+        if skipped_essential:
+            logger.debug(
+                f"Skipping priority essential packages: {sorted(skipped_essential)}"
+            )
+
+        if skipped_blacklisted:
+            logger.debug(
+                f"Skipping blacklisted from manifest packages: {sorted(skipped_blacklisted)}"
+            )
+
+        # Unmark dependencies that are no longer required.
+        self._autokeep_packages()
+
+    def update(self) -> None:
+        try:
+            self.cache.update(fetch_progress=self.progress, sources_list=None)
+            self.cache.close()
+            self.cache = apt.Cache(rootdir=str(self.stage_cache), memonly=True)
+        except apt.cache.FetchFailedException as e:
+            raise errors.CacheUpdateFailedError(str(e))

--- a/tests/unit/lifecycle/__init__.py
+++ b/tests/unit/lifecycle/__init__.py
@@ -75,6 +75,7 @@ class LifecycleTestBase(unit.TestCase):
         )
 
         self.useFixture(self.fake_storeapi_get_info)
+        self.useFixture(fixtures.MockPatch("apt.Cache"))
 
     def make_snapcraft_project(self, parts, snap_type=""):
         yaml = textwrap.dedent(

--- a/tests/unit/repo/test_apt_cache.py
+++ b/tests/unit/repo/test_apt_cache.py
@@ -1,0 +1,200 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+from unittest import mock
+from unittest.mock import call
+from pathlib import Path
+
+import fixtures
+from testtools.matchers import Equals
+
+from snapcraft.internal.repo.apt_cache import AptCache
+from tests import unit
+
+
+class TestAptStageCache(unit.TestCase):
+    # This are expensive tests, but is much more valuable than using mocks.
+    # When adding tests, consider adding it to test_stage_packages(), or
+    # create mocks.
+    @unittest.skip("hangs on google spread test with 'Error in function start'")
+    def test_stage_packages(self):
+        fetch_dir_path = Path(self.path, "debs")
+        fetch_dir_path.mkdir(exist_ok=True, parents=True)
+        stage_cache = Path(self.path, "cache")
+        stage_cache.mkdir(exist_ok=True, parents=True)
+
+        with AptCache(stage_cache=stage_cache) as apt_cache:
+            apt_cache.update()
+
+            package_names = {"pciutils"}
+            filtered_names = {"base-files", "libc6", "libkmod2", "libudev1", "zlib1g"}
+
+            apt_cache.mark_packages(package_names)
+            apt_cache.unmark_packages(
+                required_names=package_names, filtered_names=filtered_names
+            )
+
+            marked_packages = apt_cache.get_marked_packages()
+            self.assertThat(
+                sorted([name for name, _ in marked_packages]),
+                Equals(["libpci3", "pciutils"]),
+            )
+
+            names = []
+            for pkg_name, pkg_version, dl_path in apt_cache.fetch_archives(
+                fetch_dir_path
+            ):
+                names.append(pkg_name)
+                self.assertThat(dl_path.exists(), Equals(True))
+                self.assertThat(dl_path.parent, Equals(fetch_dir_path))
+                self.assertThat(isinstance(pkg_version, str), Equals(True))
+
+            self.assertThat(sorted(names), Equals(["libpci3", "pciutils"]))
+
+
+class TestMockedApt(unit.TestCase):
+    def test_stage_cache(self):
+        stage_cache = Path(self.path, "cache")
+        stage_cache.mkdir(exist_ok=True, parents=True)
+        self.fake_apt = self.useFixture(
+            fixtures.MockPatch("snapcraft.internal.repo.apt_cache.apt")
+        ).mock
+
+        with AptCache(stage_cache=stage_cache) as apt_cache:
+            apt_cache.update()
+
+        self.assertThat(
+            self.fake_apt.mock_calls,
+            Equals(
+                [
+                    call.apt_pkg.config.set("Apt::Install-Recommends", "False"),
+                    call.apt_pkg.config.set(
+                        "Acquire::AllowInsecureRepositories", "False"
+                    ),
+                    call.apt_pkg.config.set(
+                        "Dir::Etc::Trusted", "/etc/apt/trusted.gpg"
+                    ),
+                    call.apt_pkg.config.set(
+                        "Dir::Etc::TrustedParts", "/etc/apt/trusted.gpg.d/"
+                    ),
+                    call.apt_pkg.config.clear("APT::Update::Post-Invoke-Success"),
+                    call.progress.text.AcquireProgress(),
+                    call.Cache(memonly=True, rootdir=str(stage_cache)),
+                    call.Cache().update(fetch_progress=mock.ANY, sources_list=None),
+                    call.Cache().close(),
+                    call.Cache(memonly=True, rootdir=str(stage_cache)),
+                    call.Cache().close(),
+                ]
+            ),
+        )
+
+    def test_stage_cache_in_snap(self):
+        self.fake_apt = self.useFixture(
+            fixtures.MockPatch("snapcraft.internal.repo.apt_cache.apt")
+        ).mock
+
+        stage_cache = Path(self.path, "cache")
+        stage_cache.mkdir(exist_ok=True, parents=True)
+
+        snap = Path(self.path, "snap")
+        snap.mkdir(exist_ok=True, parents=True)
+
+        self.useFixture(
+            fixtures.MockPatch("snapcraft.internal.common.is_snap", return_value=True)
+        )
+        self.useFixture(fixtures.EnvironmentVariable("SNAP", str(snap)))
+
+        with AptCache(stage_cache=stage_cache) as apt_cache:
+            apt_cache.update()
+
+        self.assertThat(
+            self.fake_apt.mock_calls,
+            Equals(
+                [
+                    call.apt_pkg.config.set("Apt::Install-Recommends", "False"),
+                    call.apt_pkg.config.set(
+                        "Acquire::AllowInsecureRepositories", "False"
+                    ),
+                    call.apt_pkg.config.set("Dir", str(Path(snap, "usr/lib/apt"))),
+                    call.apt_pkg.config.set(
+                        "Dir::Bin::methods",
+                        str(Path(snap, "usr/lib/apt/methods")) + os.sep,
+                    ),
+                    call.apt_pkg.config.set(
+                        "Dir::Bin::solvers::",
+                        str(Path(snap, "usr/lib/apt/solvers")) + os.sep,
+                    ),
+                    call.apt_pkg.config.set(
+                        "Dir::Bin::apt-key", str(Path(snap, "usr/bin/apt-key"))
+                    ),
+                    call.apt_pkg.config.set(
+                        "Apt::Key::gpgvcommand", str(Path(snap, "usr/bin/gpgv"))
+                    ),
+                    call.apt_pkg.config.set(
+                        "Dir::Etc::Trusted", "/etc/apt/trusted.gpg"
+                    ),
+                    call.apt_pkg.config.set(
+                        "Dir::Etc::TrustedParts", "/etc/apt/trusted.gpg.d/"
+                    ),
+                    call.apt_pkg.config.clear("APT::Update::Post-Invoke-Success"),
+                    call.progress.text.AcquireProgress(),
+                    call.Cache(memonly=True, rootdir=str(stage_cache)),
+                    call.Cache().update(fetch_progress=mock.ANY, sources_list=None),
+                    call.Cache().close(),
+                    call.Cache(memonly=True, rootdir=str(stage_cache)),
+                    call.Cache().close(),
+                ]
+            ),
+        )
+
+    def test_host_cache_setup(self):
+        self.fake_apt = self.useFixture(
+            fixtures.MockPatch("snapcraft.internal.repo.apt_cache.apt")
+        ).mock
+
+        with AptCache() as _:
+            pass
+
+        self.assertThat(
+            self.fake_apt.mock_calls, Equals([call.Cache(), call.Cache().close()])
+        )
+
+
+class TestAptReadonlyHostCache(unit.TestCase):
+    def test_host_is_package_valid(self):
+        with AptCache() as apt_cache:
+            self.assertThat(apt_cache.is_package_valid("apt"), Equals(True))
+            self.assertThat(
+                apt_cache.is_package_valid("fake-news-bears"), Equals(False)
+            )
+
+    def test_host_get_installed_packages(self):
+        with AptCache() as apt_cache:
+            installed_packages = apt_cache.get_installed_packages()
+            self.assertThat(isinstance(installed_packages, dict), Equals(True))
+            self.assertThat("apt" in installed_packages, Equals(True))
+            self.assertThat("fake-news-bears" in installed_packages, Equals(False))
+
+    def test_host_get_installed_version(self):
+        with AptCache() as apt_cache:
+            self.assertThat(
+                isinstance(apt_cache.get_installed_version("apt"), str), Equals(True)
+            )
+            self.assertThat(
+                apt_cache.get_installed_version("fake-news-bears"), Equals(None)
+            )


### PR DESCRIPTION
Re-introduce refactored AptCache to wrap apt-cache usage.
Use it in read-only mode for working with the host cache
for use with build-packages, and use it to create a new
transient cache for use with handling stage packages. It
will symlink the host /etc/apt configuration so it matches
the host configuration, but allow for an empty cache to mark
packages and dependencies for fetching.

The strategy of marking stage packages ourselves was more
complicated than it appeared, and this achieves a far better
result with less risk of affecting existing snaps.

Additionally this fixes primed-stage-packages, which mistakenly
was using a `:` instead of `=` to split the name and version.

TODO: unit tests and a spread test for the manifest

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
