### PR TITLE
meta: remove snapd workaround for classic for core20 onwards

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016-2019 Canonical Ltd
+# Copyright (C) 2016-2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -470,6 +470,14 @@ class _SnapPackaging:
 
         # If there are no apps, or type is snapd, no need to create a runner.
         if not self._snap_meta.apps or self._config_data.get("type") == "snapd":
+            return None
+
+        # No more command-chain for core20 and classic confinement.
+        # This was a workaround for LP: #1860369.
+        if (
+            self._snap_meta.base not in ("core", "core16", "core18", None)
+            and self._snap_meta.confinement == "classic"
+        ):
             return None
 
         assembled_env = self._assemble_runtime_environment()


### PR DESCRIPTION
Keep the command-chain workaround for core, core16, core18 and the
case of no base (when used with build-base).

All other bases should follow user instruction and have no
command-chain if not specifically requested when using classic
confinement.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
