### PR TITLE
pluginhandler: export SNAPCRAFT_BUILD_BASE to build environment

### DIFF
--- a/snapcraft/internal/pluginhandler/_part_build_environment.py
+++ b/snapcraft/internal/pluginhandler/_part_build_environment.py
@@ -50,6 +50,7 @@ def get_snapcraft_global_environment(project: "Project") -> Dict[str, str]:
 
     return {
         "SNAPCRAFT_ARCH_TRIPLET": project.arch_triplet,
+        "SNAPCRAFT_BUILD_BASE": project._get_build_base(),
         "SNAPCRAFT_PARALLEL_BUILD_COUNT": str(project.parallel_build_count),
         "SNAPCRAFT_PROJECT_NAME": name,
         "SNAPCRAFT_PROJECT_VERSION": version,

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -207,6 +207,7 @@ class Config:
 
         snapcraft_yaml = self._expand_filesets(snapcraft_yaml)
 
+        project._snap_meta = Snap.from_dict(snapcraft_yaml)
         self.data = self._expand_env(snapcraft_yaml)
 
         self.data["architectures"] = _process_architectures(

--- a/tests/unit/project_loader/test_environment.py
+++ b/tests/unit/project_loader/test_environment.py
@@ -252,6 +252,9 @@ class EnvironmentTest(ProjectLoaderBaseTest):
                     'SNAPCRAFT_ARCH_TRIPLET="{}"'.format(
                         project_config.project.arch_triplet
                     ),
+                    'SNAPCRAFT_BUILD_BASE="{}"'.format(
+                        project_config.project._get_build_base()
+                    ),
                     'SNAPCRAFT_EXTENSIONS_DIR="{}"'.format(common.get_extensionsdir()),
                     'SNAPCRAFT_PARALLEL_BUILD_COUNT="2"',
                     'SNAPCRAFT_PART_BUILD="{}/parts/main/build"'.format(self.path),


### PR DESCRIPTION
Add refresh to snap_meta before expand_env() - it will fail
because build-base has not yet been populated.  Future work
should consolidate instantiation.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
