### PR TITLE
build providers: bootstrap with dirmngr

### DIFF
--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -451,7 +451,8 @@ class LXD(Provider):
         self._run(["apt-get", "update"])
 
         # First install fuse and udev, snapd requires them.
-        self._run(["apt-get", "install", "udev", "fuse", "--yes"])
+        # Snapcraft requires dirmngr
+        self._run(["apt-get", "install", "dirmngr", "udev", "fuse", "--yes"])
 
         # the system needs networking
         self._run(["systemctl", "enable", "systemd-udevd"])

--- a/tests/spread/general/package-repositories/task.yaml
+++ b/tests/spread/general/package-repositories/task.yaml
@@ -5,6 +5,7 @@ environment:
   SNAP/test_apt_key_name: test-apt-key-name
   SNAP/test_apt_keyserver: test-apt-keyserver
   SNAP/test_apt_ppa: test-apt-ppa
+  SNAPCRAFT_BUILD_ENVIRONMENT: ""
 
 systems:
   - ubuntu-16*
@@ -18,7 +19,7 @@ prepare: |
 
 restore: |
   cd "../snaps/$SNAP"
-  snapcraft clean
+  snapcraft clean --use-lxd
   rm -f ./*.snap
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
@@ -29,7 +30,7 @@ execute: |
   cd "../snaps/$SNAP"
 
   # Build what we have and verify the snap runs as expected.
-  snapcraft
+  snapcraft --use-lxd
   snap install "${SNAP}"_1.0_*.snap --dangerous
   snap_executable="${SNAP}.test-ppa"
   [ "$("${snap_executable}")" = "hello!" ]

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -688,6 +688,7 @@ class LXDInitTest(LXDBaseTest):
                         "SNAPCRAFT_HAS_TTY=False",
                         "apt-get",
                         "install",
+                        "dirmngr",
                         "udev",
                         "fuse",
                         "--yes",


### PR DESCRIPTION
core20 is missing it, ensure it is part of our bootstrapping
requirements.

Switch the package repositories to use lxd explicitly which has a
minimalist environment when compared to the one where spread runs.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
