### PR TITLE
repo: always refresh cache when build packages are required

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -269,18 +269,6 @@ class SnapcraftOrganizeError(SnapcraftError):
         super().__init__(part_name=part_name, message=message)
 
 
-class MissingCommandError(SnapcraftError):
-
-    fmt = (
-        "Failed to run command: "
-        "One or more packages are missing, please install:"
-        " {required_commands!r}"
-    )
-
-    def __init__(self, required_commands):
-        super().__init__(required_commands=required_commands)
-
-
 class InvalidWikiEntryError(SnapcraftError):
 
     fmt = (

--- a/snapcraft/internal/repo/__init__.py
+++ b/snapcraft/internal/repo/__init__.py
@@ -16,10 +16,6 @@
 
 """Operations with platform specific package repositories."""
 
-import contextlib
-import shutil
-
-from snapcraft.internal.errors import MissingCommandError
 from . import errors  # noqa
 from . import snaps  # noqa
 from . import _platform
@@ -31,19 +27,3 @@ if _platform._is_deb_based():
     from ._deb import Ubuntu  # noqa
 
 Repo = _platform._get_repo_for_platform()
-
-
-def check_for_command(command):
-    if not shutil.which(command):
-        raise MissingCommandError(command)
-
-
-def get_pkg_name_parts(pkg_name):
-    """Break package name into base parts"""
-
-    name = pkg_name
-    version = None
-    with contextlib.suppress(ValueError):
-        name, version = pkg_name.split("=")
-
-    return name, version

--- a/snapcraft/internal/repo/_base.py
+++ b/snapcraft/internal/repo/_base.py
@@ -330,3 +330,14 @@ def _fix_filemode(path: str) -> None:
     if mode & 0o4000 or mode & 0o2000:
         logger.warning("Removing suid/guid from {}".format(path))
         os.chmod(path, mode & 0o1777)
+
+
+def get_pkg_name_parts(pkg_name):
+    """Break package name into base parts"""
+
+    name = pkg_name
+    version = None
+    with contextlib.suppress(ValueError):
+        name, version = pkg_name.split("=")
+
+    return name, version

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -302,10 +302,15 @@ class Ubuntu(BaseRepo):
 
     @classmethod
     def _check_if_all_packages_installed(cls, package_names: List[str]) -> bool:
-        # If any requested package is not installed, return False. Will check
-        # versions if using <pkg_name>=<pkg_version> syntax parsed by
-        # get_pkg_name_parts().  Used as an optimization to skip installation
-        # and cache refresh if dependencies are already satisfied.
+        """Check if all given packages are installed.
+
+        Will check versions if using <pkg_name>=<pkg_version> syntax parsed by
+        get_pkg_name_parts().  Used as an optimization to skip installation
+        and cache refresh if dependencies are already satisfied.
+
+        :return True if _all_ packages are installed (with correct versions).
+        """
+
         with AptCache() as apt_cache:
             for package in package_names:
                 pkg_name, pkg_version = get_pkg_name_parts(package)

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -39,7 +39,7 @@ from snapcraft.internal.indicators import is_dumb_terminal
 
 from . import errors
 from .apt_cache import AptCache
-from ._base import BaseRepo
+from ._base import BaseRepo, get_pkg_name_parts
 
 
 logger = logging.getLogger(__name__)
@@ -301,6 +301,34 @@ class Ubuntu(BaseRepo):
             ) from call_error
 
     @classmethod
+    def _check_if_all_packages_installed(cls, package_names: List[str]) -> bool:
+        # If any requested package is not installed, return False. Will check
+        # versions if using <pkg_name>=<pkg_version> syntax parsed by
+        # get_pkg_name_parts().  Used as an optimization to skip installation
+        # and cache refresh if dependencies are already satisfied.
+        with AptCache() as apt_cache:
+            for package in package_names:
+                pkg_name, pkg_version = get_pkg_name_parts(package)
+                installed_version = apt_cache.get_installed_version(pkg_name)
+
+                if installed_version is None or (
+                    pkg_version is not None and installed_version != pkg_version
+                ):
+                    return False
+
+        return True
+
+    @classmethod
+    def _get_marked_packages(cls, package_names: List[str]) -> List[Tuple[str, str]]:
+        with AptCache() as apt_cache:
+            try:
+                apt_cache.mark_packages(set(package_names))
+            except errors.PackageNotFoundError as error:
+                raise errors.BuildPackageNotFoundError(error.package_name)
+
+            return apt_cache.get_marked_packages()
+
+    @classmethod
     def install_build_packages(cls, package_names: List[str]) -> List[str]:
         """Install packages on the host required to build.
 
@@ -317,29 +345,27 @@ class Ubuntu(BaseRepo):
         """
         logger.debug(f"Requested build-packages: {sorted(package_names)!r}")
 
-        # Make sure all packages are valid and remove already installed.
-        with AptCache() as apt_cache:
-            try:
-                apt_cache.mark_packages(set(package_names))
-            except errors.PackageNotFoundError as error:
-                raise errors.BuildPackageNotFoundError(error.package_name)
+        if cls._check_if_all_packages_installed(package_names):
+            # To get the version list required to return, we mark the installed
+            # packages, but no refresh is required.
+            marked_packages = cls._get_marked_packages(package_names)
+        else:
+            # Ensure we have an up-to-date cache first.
+            cls.refresh_build_packages()
 
-            marked_packages = apt_cache.get_marked_packages()
+            marked_packages = cls._get_marked_packages(package_names)
 
             # TODO: this matches prior behavior, but the version is not
             # being passed along to apt-get install, even if prescribed
             # by the user.  We should specify it upon user request.
             install_packages = sorted([name for name, _ in marked_packages])
 
-            # Install packages, if any.
-            if install_packages:
-                cls._install_packages(install_packages)
+            cls._install_packages(install_packages)
 
         return sorted([f"{name}={version}" for name, version in marked_packages])
 
     @classmethod
     def _install_packages(cls, package_names: List[str]) -> None:
-        package_names.sort()
         logger.info("Installing build dependencies: %s", " ".join(package_names))
         env = os.environ.copy()
         env.update(

--- a/snapcraft/internal/repo/apt_cache.py
+++ b/snapcraft/internal/repo/apt_cache.py
@@ -23,9 +23,10 @@ from contextlib import ContextDecorator
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
-from snapcraft.internal import common, repo
+from snapcraft.internal import common
 from snapcraft.internal.indicators import is_dumb_terminal
 from snapcraft.internal.repo import errors
+from snapcraft.internal.repo._base import get_pkg_name_parts
 
 logger = logging.getLogger(__name__)
 
@@ -182,7 +183,7 @@ class AptCache(ContextDecorator):
                 "Marking {!r} (and its dependencies) to be fetched".format(name)
             )
 
-            name_arch, version = repo.get_pkg_name_parts(name)
+            name_arch, version = get_pkg_name_parts(name)
             if name_arch not in self.cache:
                 raise errors.PackageNotFoundError(name_arch)
 

--- a/tests/unit/repo/test_base.py
+++ b/tests/unit/repo/test_base.py
@@ -20,20 +20,9 @@ from textwrap import dedent
 
 from testtools.matchers import Equals, FileContains, FileExists, Not
 
-from snapcraft.internal import errors
-from snapcraft.internal.repo import BaseRepo, check_for_command, get_pkg_name_parts
+from snapcraft.internal.repo._base import BaseRepo, get_pkg_name_parts
 from tests import unit
 from . import RepoBaseTestCase
-
-
-class CommandCheckTestCase(unit.TestCase):
-    def test_check_for_command_not_installed(self):
-        self.assertRaises(
-            errors.MissingCommandError, check_for_command, "missing-command"
-        )
-
-    def test_check_for_command_installed(self):
-        check_for_command("sh")
 
 
 class FixXmlToolsTestCase(RepoBaseTestCase):

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -129,18 +129,6 @@ class ErrorFormattingTestCase(unit.TestCase):
             },
         ),
         (
-            "MissingCommandError",
-            {
-                "exception": errors.MissingCommandError,
-                "kwargs": {"required_commands": ["test-command1", "test-command2"]},
-                "expected_message": (
-                    "Failed to run command: "
-                    "One or more packages are missing, please install:"
-                    " ['test-command1', 'test-command2']"
-                ),
-            },
-        ),
-        (
             "InvalidWikiEntryError",
             {
                 "exception": errors.InvalidWikiEntryError,


### PR DESCRIPTION
Make sure cache is up to date by refreshing whenever a package
being requested is not already installed.
