### PR TITLE
Removed ``key`` from ``progressive`` dict following changes in the server API.

### DIFF
--- a/snapcraft/storeapi/v2/_api_schema.py
+++ b/snapcraft/storeapi/v2/_api_schema.py
@@ -39,11 +39,10 @@ CHANNEL_MAP_JSONSCHEMA: Dict[str, Any] = {
                     },
                     "progressive": {
                         "properties": {
-                            "key": {"type": ["string", "null"]},
                             "paused": {"type": ["boolean", "null"]},
                             "percentage": {"type": ["number", "null"]},
                         },
-                        "required": ["key", "paused", "percentage"],
+                        "required": ["paused", "percentage"],
                         "type": "object",
                     },
                     "revision": {"type": "integer"},

--- a/snapcraft/storeapi/v2/channel_map.py
+++ b/snapcraft/storeapi/v2/channel_map.py
@@ -42,22 +42,15 @@ class Progressive:
                 "progressive"
             ],
         )
-        return cls(
-            key=payload["key"],
-            paused=payload["paused"],
-            percentage=payload["percentage"],
-        )
+        return cls(paused=payload["paused"], percentage=payload["percentage"])
 
     def marshal(self) -> Dict[str, Any]:
-        return {"key": self.key, "paused": self.paused, "percentage": self.percentage}
+        return {"paused": self.paused, "percentage": self.percentage}
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {self.percentage!r}>"
 
-    def __init__(
-        self, *, key: Optional[str], paused: Optional[bool], percentage: Optional[float]
-    ) -> None:
-        self.key = key
+    def __init__(self, *, paused: Optional[bool], percentage: Optional[float]) -> None:
         self.paused = paused
         self.percentage = percentage
 

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -1135,7 +1135,7 @@ class FakeStoreAPIServer(base.BaseFakeServer):
                     "channel": "2.1/beta",
                     "expiration-date": None,
                     "revision": 1,
-                    "progressive": {"key": None, "paused": None, "percentage": None},
+                    "progressive": {"paused": None, "percentage": None},
                     "when": "2020-02-03T20:58:37Z",
                 }
             ],

--- a/tests/unit/commands/__init__.py
+++ b/tests/unit/commands/__init__.py
@@ -226,11 +226,7 @@ class FakeStoreCommandsBaseTestCase(CommandBaseTestCase):
                         "channel": "2.1/beta",
                         "expiration-date": None,
                         "revision": 19,
-                        "progressive": {
-                            "key": None,
-                            "paused": None,
-                            "percentage": None,
-                        },
+                        "progressive": {"paused": None, "percentage": None},
                     }
                 ],
                 "revisions": [

--- a/tests/unit/commands/test_release.py
+++ b/tests/unit/commands/test_release.py
@@ -114,7 +114,7 @@ class ReleaseCommandTestCase(FakeStoreCommandsBaseTestCase):
                 architecture="amd64",
                 expiration_date="2020-02-03T20:58:37Z",
                 revision=20,
-                progressive=Progressive(key=None, paused=None, percentage=None),
+                progressive=Progressive(paused=None, percentage=None),
             )
         )
         self.channel_map.revisions.append(
@@ -167,7 +167,7 @@ class ReleaseCommandTestCase(FakeStoreCommandsBaseTestCase):
                 architecture="amd64",
                 expiration_date="2020-02-03T20:58:37Z",
                 revision=20,
-                progressive=Progressive(key="foo", paused=None, percentage=80.0),
+                progressive=Progressive(paused=None, percentage=80.0),
             )
         )
         self.channel_map.revisions.append(

--- a/tests/unit/commands/test_status.py
+++ b/tests/unit/commands/test_status.py
@@ -99,7 +99,7 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
                 architecture="s390x",
                 expiration_date=None,
                 revision=99,
-                progressive=Progressive(key=None, paused=None, percentage=None),
+                progressive=Progressive(paused=None, percentage=None),
             )
         )
         self.channel_map.revisions.append(
@@ -131,7 +131,7 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
                 architecture="amd64",
                 expiration_date="2020-02-03T20:58:37Z",
                 revision=20,
-                progressive=Progressive(key=None, paused=None, percentage=None),
+                progressive=Progressive(paused=None, percentage=None),
             )
         )
         self.channel_map.revisions.append(
@@ -173,7 +173,7 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
                 architecture="amd64",
                 expiration_date="2020-02-03T20:58:37Z",
                 revision=20,
-                progressive=Progressive(key="foo", paused=None, percentage=20.0),
+                progressive=Progressive(paused=None, percentage=20.0),
             )
         )
         self.channel_map.revisions.append(

--- a/tests/unit/store/v2/test_channel_map.py
+++ b/tests/unit/store/v2/test_channel_map.py
@@ -22,23 +22,21 @@ from tests import unit
 
 class ProgressiveTest(unit.TestCase):
     def test_progressive(self):
-        payload = {"key": "my-key", "paused": False, "percentage": 83.3}
+        payload = {"paused": False, "percentage": 83.3}
 
         p = channel_map.Progressive.unmarshal(payload)
 
         self.expectThat(repr(p), Equals(f"<Progressive: 83.3>"))
-        self.expectThat(p.key, Equals(payload["key"]))
         self.expectThat(p.paused, Equals(payload["paused"]))
         self.expectThat(p.percentage, Equals(payload["percentage"]))
         self.expectThat(p.marshal(), Equals(payload))
 
     def test_none(self):
-        payload = {"key": None, "paused": None, "percentage": None}
+        payload = {"paused": None, "percentage": None}
 
         p = channel_map.Progressive.unmarshal(payload)
 
         self.expectThat(repr(p), Equals(f"<Progressive: None>"))
-        self.expectThat(p.key, Equals(payload["key"]))
         self.expectThat(p.paused, Equals(payload["paused"]))
         self.expectThat(p.percentage, Equals(payload["percentage"]))
         self.expectThat(p.marshal(), Equals(payload))
@@ -52,7 +50,7 @@ class MappedChannelTest(unit.TestCase):
             "architecture": "amd64",
             "channel": "latest/stable",
             "expiration-date": None,
-            "progressive": {"key": None, "paused": None, "percentage": None},
+            "progressive": {"paused": None, "percentage": None},
             "revision": 2,
         }
 
@@ -203,28 +201,28 @@ class ChannelMapTest(unit.TestCase):
                     "architecture": "amd64",
                     "channel": "latest/stable",
                     "expiration-date": None,
-                    "progressive": {"key": None, "paused": None, "percentage": None},
+                    "progressive": {"paused": None, "percentage": None},
                     "revision": 2,
                 },
                 {
                     "architecture": "amd64",
                     "channel": "latest/stable",
                     "expiration-date": None,
-                    "progressive": {"key": None, "paused": None, "percentage": 33.3},
+                    "progressive": {"paused": None, "percentage": 33.3},
                     "revision": 3,
                 },
                 {
                     "architecture": "arm64",
                     "channel": "latest/stable",
                     "expiration-date": None,
-                    "progressive": {"key": None, "paused": None, "percentage": None},
+                    "progressive": {"paused": None, "percentage": None},
                     "revision": 2,
                 },
                 {
                     "architecture": "i386",
                     "channel": "latest/stable",
                     "expiration-date": None,
-                    "progressive": {"key": None, "paused": None, "percentage": None},
+                    "progressive": {"paused": None, "percentage": None},
                     "revision": 4,
                 },
             ],


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?
