### PR TITLE
build providers: prevent snap refreshing in build environment

### DIFF
--- a/snapcraft/internal/build_providers/_snap.py
+++ b/snapcraft/internal/build_providers/_snap.py
@@ -311,14 +311,14 @@ class SnapInjector:
         self._remote_snap_dir = "/var/tmp"
 
     def _disable_and_wait_for_refreshes(self) -> None:
-        # Disable autorefresh for 15 minutes,
-        # https://github.com/snapcore/snapd/pull/5436/files
-        now_plus_15 = datetime.datetime.now() + datetime.timedelta(minutes=15)
+        # Disable autorefresh for 1 day.
+        hold_time = datetime.datetime.now() + datetime.timedelta(days=1)
         logger.debug("Holding refreshes for snaps.")
         self._runner(
-            ["snap", "set", "core", "refresh.hold={}Z".format(now_plus_15.isoformat())],
+            ["snap", "set", "system", "refresh.hold={}Z".format(hold_time.isoformat())],
             hide_output=True,
         )
+
         # Auto refresh may have kicked in while setting the hold.
         logger.debug("Waiting for pending snap auto refreshes.")
         with contextlib.suppress(errors.ProviderExecError):

--- a/tests/unit/build_providers/test_snap.py
+++ b/tests/unit/build_providers/test_snap.py
@@ -120,7 +120,7 @@ class SnapInjectionTest(unit.TestCase):
         self.provider.run_mock.assert_has_calls(
             [
                 call(["snap", "set", "system", "experimental.snapd-snap=true"]),
-                call(["snap", "set", "core", ANY]),
+                call(["snap", "set", "system", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "ack", "/var/tmp/snapd.assert"]),
                 call(["snap", "install", "/var/tmp/snapd.snap"]),
@@ -173,7 +173,7 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_not_called()
         self.provider.run_mock.assert_has_calls(
             [
-                call(["snap", "set", "core", ANY]),
+                call(["snap", "set", "system", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
                 call(
@@ -236,7 +236,7 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_has_calls(get_assertion_calls)
         self.provider.run_mock.assert_has_calls(
             [
-                call(["snap", "set", "core", ANY]),
+                call(["snap", "set", "system", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "ack", "/var/tmp/core.assert"]),
                 call(["snap", "install", "/var/tmp/core.snap"]),
@@ -290,7 +290,7 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_not_called()
         self.provider.run_mock.assert_has_calls(
             [
-                call(["snap", "set", "core", ANY]),
+                call(["snap", "set", "system", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
                 call(
@@ -334,7 +334,7 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_not_called()
         self.provider.run_mock.assert_has_calls(
             [
-                call(["snap", "set", "core", ANY]),
+                call(["snap", "set", "system", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
                 call(
@@ -372,7 +372,7 @@ class SnapInjectionTest(unit.TestCase):
 
         self.provider.run_mock.assert_has_calls(
             [
-                call(["snap", "set", "core", ANY]),
+                call(["snap", "set", "system", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
                 call(
@@ -394,7 +394,7 @@ class SnapInjectionTest(unit.TestCase):
 
         self.provider.run_mock.assert_has_calls(
             [
-                call(["snap", "set", "core", ANY]),
+                call(["snap", "set", "system", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
                 call(
@@ -478,7 +478,7 @@ class SnapInjectionTest(unit.TestCase):
 
         self.provider.run_mock.assert_has_calls(
             [
-                call(["snap", "set", "core", ANY]),
+                call(["snap", "set", "system", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "refresh", "--channel", "stable", "core"]),
                 call(
@@ -508,7 +508,7 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_not_called()
         self.provider.run_mock.assert_has_calls(
             [
-                call(["snap", "set", "core", ANY]),
+                call(["snap", "set", "system", ANY]),
                 call(["snap", "watch", "--last=auto-refresh"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
                 call(


### PR DESCRIPTION
hold refresh for 1 day for installed snaps