### PR TITLE
python v2 plugin: set path to the interpreter

### DIFF
--- a/snapcraft/plugins/v2/python.py
+++ b/snapcraft/plugins/v2/python.py
@@ -106,14 +106,17 @@ class PythonPlugin(PluginV2):
 
     def get_build_environment(self) -> Dict[str, str]:
         return {
+            # Add PATH to the python interpreter we always intend to use with
+            # this plugin. It can be user overridden, but that is an explicit
+            # choice made by a user.
+            "PATH": "${SNAPCRAFT_PART_INSTALL}/bin:${PATH}",
             "SNAPCRAFT_PYTHON_INTERPRETER": "python3",
             "SNAPCRAFT_PYTHON_VENV_ARGS": "",
         }
 
     def get_build_commands(self) -> List[str]:
         build_commands = [
-            '"${SNAPCRAFT_PYTHON_INTERPRETER}" -m venv ${SNAPCRAFT_PYTHON_VENV_ARGS} "${SNAPCRAFT_PART_INSTALL}"',
-            '. "${SNAPCRAFT_PART_INSTALL}/bin/activate"',
+            '"${SNAPCRAFT_PYTHON_INTERPRETER}" -m venv ${SNAPCRAFT_PYTHON_VENV_ARGS} "${SNAPCRAFT_PART_INSTALL}"'
         ]
 
         if self.options.constraints:

--- a/tests/unit/plugins/v2/test_python.py
+++ b/tests/unit/plugins/v2/test_python.py
@@ -104,6 +104,7 @@ class PythonPluginTest(TestCase):
             plugin.get_build_environment(),
             Equals(
                 {
+                    "PATH": "${SNAPCRAFT_PART_INSTALL}/bin:${PATH}",
                     "SNAPCRAFT_PYTHON_INTERPRETER": "python3",
                     "SNAPCRAFT_PYTHON_VENV_ARGS": "",
                 }


### PR DESCRIPTION
Add the path to the interpreter instead of activating. From
Snapcraft's point of view this is essentially the only thing done by
activation.

LP: #1876162

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
