### PR TITLE
packaging: use git-based versioning for python package

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ environment:
   matrix:
   - PYTHON: C:\Python37-x64
 
-clone_depth: 1
 cache:
 - '%LOCALAPPDATA%\pip\Cache\http'
 - '%LOCALAPPDATA%\pip\Cache\wheels'

--- a/setup.py
+++ b/setup.py
@@ -33,30 +33,18 @@ def recursive_data_files(directory, install_directory):
 def get_git_describe():
     return (
         subprocess.run(
-            ["git", "describe", "--dirty"], check=True, stdout=subprocess.PIPE
+            ["git", "describe", "--always"], check=True, stdout=subprocess.PIPE
         )
         .stdout.decode()
         .strip()
     )
 
 
-def is_git_clean():
-    return (
-        len(
-            subprocess.run(
-                ["git", "status", "--porcelain"], check=True, stdout=subprocess.PIPE
-            )
-            .stdout.decode()
-            .strip()
-        )
-        == 0
-    )
-
-
 def determine_version():
+    # 4.0rc1-23-g6f6016573 -> 4.0rc1+git23.g6f6016573
     version = get_git_describe()
-    if "dirty" not in version and not is_git_clean():
-        version += "-dirty"
+    version = version.replace("-", "+git", 1)
+    version = version.replace("-", ".")
     return version
 
 

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import codecs
 import os
-import re
+import subprocess
 import sys
 
 from setuptools import setup, find_namespace_packages
@@ -31,9 +30,38 @@ def recursive_data_files(directory, install_directory):
     return data_files
 
 
+def get_git_describe():
+    return (
+        subprocess.run(
+            ["git", "describe", "--dirty"], check=True, stdout=subprocess.PIPE
+        )
+        .stdout.decode()
+        .strip()
+    )
+
+
+def is_git_clean():
+    return (
+        len(
+            subprocess.run(
+                ["git", "status", "--porcelain"], check=True, stdout=subprocess.PIPE
+            )
+            .stdout.decode()
+            .strip()
+        )
+        == 0
+    )
+
+
+def determine_version():
+    version = get_git_describe()
+    if "dirty" not in version and not is_git_clean():
+        version += "-dirty"
+    return version
+
+
 # Common distribution data
 name = "snapcraft"
-version = "devel"
 description = "Publish your app for Linux users for desktop, cloud, and IoT."
 author_email = "snapcraft@lists.snapcraft.io"
 url = "https://github.com/snapcore/snapcraft"
@@ -52,15 +80,6 @@ classifiers = [
     "Topic :: System :: Software Distribution",
 ]
 
-# look/set what version we have
-changelog = "debian/changelog"
-if os.path.exists(changelog):
-    head = codecs.open(changelog, encoding="utf-8").readline()
-    match = re.compile(r".*\((.*)\).*").match(head)
-    if match:
-        version = match.group(1)
-
-
 # snapcraftctl is not in console_scripts because we need a clean environment.
 # Only include it for Linux.
 if sys.platform == "linux":
@@ -70,7 +89,7 @@ else:
 
 setup(
     name=name,
-    version=version,
+    version=determine_version(),
     description=description,
     author_email=author_email,
     url=url,


### PR DESCRIPTION
The current versioning is gathered from debian/changelog which
is no longer maintained.  Use git-describe, with an additional
check to label the package -dirty if the tree is not porcelain.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
