### PR TITLE
sources: enable git, local, and tar handlers for all platforms

### DIFF
--- a/snapcraft/internal/sources/__init__.py
+++ b/snapcraft/internal/sources/__init__.py
@@ -111,7 +111,7 @@ if sys.platform == "linux":
         "snap": Snap,
         "": Local,
     }
-elif sys.platform == "win32":
+else:
     from ._git import Git  # noqa
     from ._local import Local  # noqa
     from ._tar import Tar  # noqa


### PR DESCRIPTION
Previously it was enabled for Windows, but OS X will require
these as well for remote-build.

LP #1876326

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
