### PR TITLE
colcon: use packages.ros.org/ros2 repository

### DIFF
--- a/snapcraft/plugins/v1/colcon.py
+++ b/snapcraft/plugins/v1/colcon.py
@@ -231,7 +231,7 @@ class ColconPlugin(PluginV1):
                 deb_types=["deb"],
                 components=["main"],
                 key_id="C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654",
-                url="http://repo.ros2.org/ubuntu/main",
+                url="http://packages.ros.org/ros2/ubuntu",
                 suites=["$SNAPCRAFT_APT_RELEASE"],
             )
         ]


### PR DESCRIPTION
repo.ros2.org has uninstallable catkin-pkg due to a depdencency
on "python2" rather than "python".  The installation directions
now suggest using packages.ros.org/ros2 as the apt repository,
so we will switch to that since it is still working.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
