### PR TITLE
cli: fix following hints in channel status

### DIFF
--- a/tests/unit/commands/test_status.py
+++ b/tests/unit/commands/test_status.py
@@ -67,6 +67,38 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
             ),
         )
 
+    def test_status_following(self):
+        self.channel_map.channel_map = [
+            MappedChannel(
+                channel="2.1/stable",
+                architecture="amd64",
+                expiration_date="2020-02-03T20:58:37Z",
+                revision=20,
+                progressive=Progressive(paused=None, percentage=None),
+            )
+        ]
+        self.channel_map.revisions.append(
+            Revision(architectures=["amd64"], revision=20, version="10")
+        )
+
+        result = self.run_command(["status", "snap-test"])
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(
+            result.output,
+            Equals(
+                dedent(
+                    """\
+            Track    Arch    Channel    Version    Revision
+            2.1      amd64   stable     10         20
+                             candidate  ↑          ↑
+                             beta       ↑          ↑
+                             edge       ↑          ↑
+            """
+                )
+            ),
+        )
+
     def test_progressive_status(self):
         self.channel_map.channel_map[0].progressive.percentage = 10.0
 


### PR DESCRIPTION
Following logic was not considering previous states so all channels
were marked as closed instead of as following.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
