### PR TITLE
spread: only run in LXD with the google/multipass provider for repo

### DIFF
--- a/tests/spread/general/package-repositories/task.yaml
+++ b/tests/spread/general/package-repositories/task.yaml
@@ -19,7 +19,12 @@ prepare: |
 
 restore: |
   cd "../snaps/$SNAP"
-  snapcraft clean --use-lxd
+  if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ] || [ "$SPREAD_SYSTEM" = "ubuntu-18.04-64" ] || [ "$SPREAD_SYSTEM" = "ubuntu-20.04-64" ]; then
+      snapcraft clean --use-lxd
+  else
+      snapcraft --destructive-mode --enable-experimental-package-repositories
+  fi
+
   rm -f ./*.snap
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
@@ -29,8 +34,15 @@ restore: |
 execute: |
   cd "../snaps/$SNAP"
 
-  # Build what we have and verify the snap runs as expected.
-  snapcraft --use-lxd --enable-experimental-package-repositories
+  # Build what we have.
+  # We cannot use --use-lxd for autopkgtest so we resort to --destructive-mode there.
+  if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ] || [ "$SPREAD_SYSTEM" = "ubuntu-18.04-64" ] || [ "$SPREAD_SYSTEM" = "ubuntu-20.04-64" ]; then
+      snapcraft --use-lxd --enable-experimental-package-repositories
+  else
+      snapcraft --destructive-mode --enable-experimental-package-repositories
+  fi
+
+  # And verify the snap runs as expected.
   snap install "${SNAP}"_1.0_*.snap --dangerous
   snap_executable="${SNAP}.test-ppa"
   [ "$("${snap_executable}")" = "hello!" ]


### PR DESCRIPTION
Use --destructive-mode for testing in autopkgtest until the
environment is verified to work.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
