### PR TITLE
spread tests: improvements for python-hello-with-stage-package-dep

### DIFF
--- a/tests/spread/plugins/v2/snaps/python-hello-with-stage-package-dep/setup.py
+++ b/tests/spread/plugins/v2/snaps/python-hello-with-stage-package-dep/setup.py
@@ -8,5 +8,5 @@ setuptools.setup(
     author_email="snapcraft@lists.snapcraft.io",
     description="A simple hello world in python",
     scripts=["hello"],
-    install_requires=['appdirs'],
+    install_requires=["appdirs"],
 )

--- a/tests/spread/plugins/v2/snaps/python-hello-with-stage-package-dep/setup.py
+++ b/tests/spread/plugins/v2/snaps/python-hello-with-stage-package-dep/setup.py
@@ -8,4 +8,5 @@ setuptools.setup(
     author_email="snapcraft@lists.snapcraft.io",
     description="A simple hello world in python",
     scripts=["hello"],
+    install_requires=['appdirs'],
 )

--- a/tests/spread/plugins/v2/snaps/python-hello-with-stage-package-dep/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/python-hello-with-stage-package-dep/snap/snapcraft.yaml
@@ -22,3 +22,5 @@ parts:
       - python3-appdirs
     python-packages:
       - pip==20.0.2
+    build-environment:
+      - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$PYTHONPATH


### PR DESCRIPTION
- Add 'appdirs' to install_requires.

- Set PYTHONPATH which will incorporate the stage-packages at build-time.  Otherwise pip will fetch and install these dependencies separately.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
