### PR TITLE
cmake v2 plugin: configure with $SNAPCRAFT_PART_SRC

### DIFF
--- a/snapcraft/plugins/v2/cmake.py
+++ b/snapcraft/plugins/v2/cmake.py
@@ -62,7 +62,7 @@ class CMakePlugin(PluginV2):
         return dict()
 
     def _get_cmake_configure_command(self) -> str:
-        cmd = ["cmake", "."] + self.options.cmake_parameters
+        cmd = ["cmake", '"${SNAPCRAFT_PART_SRC}"'] + self.options.cmake_parameters
 
         return " ".join(cmd)
 

--- a/tests/unit/plugins/v2/test_cmake.py
+++ b/tests/unit/plugins/v2/test_cmake.py
@@ -63,7 +63,7 @@ class CMakePluginTest(TestCase):
             plugin.get_build_commands(),
             Equals(
                 [
-                    "cmake .",
+                    'cmake "${SNAPCRAFT_PART_SRC}"',
                     'cmake --build . -- -j"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
                     'cmake --build . --target install -- DESTDIR="${SNAPCRAFT_PART_INSTALL}"',
                 ]
@@ -85,7 +85,7 @@ class CMakePluginTest(TestCase):
             plugin.get_build_commands(),
             Equals(
                 [
-                    "cmake . "
+                    'cmake "${SNAPCRAFT_PART_SRC}" '
                     "-DVERBOSE=1 "
                     "-DCMAKE_INSTALL_PREFIX=/foo "
                     '-DCMAKE_SPACED_ARGS="foo bar" '


### PR DESCRIPTION
This avoids errors on projects that check that the source directory
does not match the build directory.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
