### PR TITLE
pluginhandler: allow cleaning the build step

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -777,10 +777,6 @@ class PluginHandler:
         }
 
     def clean_build(self):
-        # Only relevant for PluginV1.
-        if not isinstance(self.plugin, plugins.v1.PluginV1):
-            return
-
         if self.is_clean(steps.BUILD):
             return
 

--- a/tests/spread/plugins/v1/rust/rebuild/task.yaml
+++ b/tests/spread/plugins/v1/rust/rebuild/task.yaml
@@ -43,7 +43,7 @@ execute: |
   snapcraft build
 
   # Verify the changed source is reflected
-  if ! diff src/main.rs parts/rust-hello/src/src/main.rs; then
+  if ! diff src/main.rs parts/hello/src/src/main.rs; then
     echo "The source has not changed."
     exit 1
   fi

--- a/tests/spread/plugins/v1/rust/rust-toolchain/task.yaml
+++ b/tests/spread/plugins/v1/rust/rust-toolchain/task.yaml
@@ -35,4 +35,4 @@ execute: |
 
   # Verify that nightly was used instead of the default stable
   # e.g.; MATCH 'rustc-version: rustc 1.39.0-beta.1 (968967007 2019-09-24)'
-  MATCH 'rustc-version: rustc .*-beta.*' < parts/rust-hello/state/build
+  MATCH 'rustc-version: rustc .*-beta.*' < parts/hello/state/build

--- a/tests/spread/plugins/v2/build-and-run-hello/task.yaml
+++ b/tests/spread/plugins/v2/build-and-run-hello/task.yaml
@@ -45,7 +45,11 @@ execute: |
   cd "../snaps/$SNAP"
 
   # Build what we have and verify the snap runs as expected.
-  snapcraft prime
+  snapcraft
+  snap install "${SNAP}"_1.0_*.snap --dangerous
+  [ "$($SNAP)" = "hello world" ]
+
+  # Clean the hello part, then build and run again.
   snapcraft clean hello
   snapcraft
   snap install "${SNAP}"_1.0_*.snap --dangerous

--- a/tests/spread/plugins/v2/build-and-run-hello/task.yaml
+++ b/tests/spread/plugins/v2/build-and-run-hello/task.yaml
@@ -1,4 +1,6 @@
-summary: Build, rebuild and run hello.c with different plugin configurations
+summary: >-
+  Build, clean, build, modify and rebuild, and run hello
+  with different plugin configurations
 
 environment:
   SNAP/autotools: autotools-hello
@@ -43,6 +45,8 @@ execute: |
   cd "../snaps/$SNAP"
 
   # Build what we have and verify the snap runs as expected.
+  snapcraft prime
+  snapcraft clean hello
   snapcraft
   snap install "${SNAP}"_1.0_*.snap --dangerous
   [ "$($SNAP)" = "hello world" ]

--- a/tests/spread/plugins/v2/snaps/autotools-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/autotools-hello/snap/snapcraft.yaml
@@ -15,7 +15,7 @@ apps:
     command: usr/bin/hello
 
 parts:
-  autotools-project:
+  hello:
     plugin: autotools
     source: .
     autotools-configure-parameters:

--- a/tests/spread/plugins/v2/snaps/cmake-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/cmake-hello/snap/snapcraft.yaml
@@ -15,7 +15,7 @@ apps:
     command: usr/bin/cmake-hello
 
 parts:
-  cmake-project:
+  hello:
     plugin: cmake
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr

--- a/tests/spread/plugins/v2/snaps/dump-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/dump-hello/snap/snapcraft.yaml
@@ -12,6 +12,6 @@ apps:
     command: hello
 
 parts:
-  nil-part:
+  hello:
     plugin: dump
     source: .

--- a/tests/spread/plugins/v2/snaps/go-build-tags/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/go-build-tags/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ apps:
     command: bin/go-build-tags
 
 parts:
-  go-build-tags:
+  hello:
     source: .
     plugin: go
     go-buildtags:

--- a/tests/spread/plugins/v2/snaps/go-mod-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/go-mod-hello/snap/snapcraft.yaml
@@ -14,6 +14,6 @@ apps:
     command: bin/go-mod-hello
 
 parts:
-  go-hello:
+  hello:
     source: .
     plugin: go

--- a/tests/spread/plugins/v2/snaps/make-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/make-hello/snap/snapcraft.yaml
@@ -15,7 +15,7 @@ apps:
     command: bin/hello
 
 parts:
-  make-project:
+  hello:
     plugin: make
     make-parameters:
       - HELLO=1

--- a/tests/spread/plugins/v2/snaps/meson-hello-staged-python/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/meson-hello-staged-python/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ apps:
     command: bin/hello
 
 parts:
-  meson-project:
+  hello:
     source: .
     plugin: meson
     meson-version: "0.48.0"

--- a/tests/spread/plugins/v2/snaps/meson-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/meson-hello/snap/snapcraft.yaml
@@ -15,7 +15,7 @@ apps:
     command: bin/hello
 
 parts:
-  meson-project:
+  hello:
     source: .
     plugin: meson
     meson-version: "0.48.0"

--- a/tests/spread/plugins/v2/snaps/npm-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/npm-hello/snap/snapcraft.yaml
@@ -17,7 +17,7 @@ apps:
       - network
 
 parts:
-  npm-part:
+  hello:
     source: .
     plugin: npm
     npm-node-version: "12.16.2"

--- a/tests/spread/plugins/v2/snaps/python-hello-staged-python/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/python-hello-staged-python/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ apps:
     command: bin/hello
 
 parts:
-  python-part:
+  hello:
     source: .
     plugin: python
     stage-packages:

--- a/tests/spread/plugins/v2/snaps/python-hello-with-python-package-dep/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/python-hello-with-python-package-dep/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ apps:
     command: bin/hello
 
 parts:
-  python-part:
+  hello:
     source: .
     plugin: python
     python-packages:

--- a/tests/spread/plugins/v2/snaps/python-hello-with-stage-package-dep/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/python-hello-with-stage-package-dep/snap/snapcraft.yaml
@@ -15,7 +15,7 @@ apps:
       PYTHONPATH: $SNAP/usr/lib/python3/dist-packages
 
 parts:
-  python-part:
+  hello:
     source: .
     plugin: python
     stage-packages:

--- a/tests/spread/plugins/v2/snaps/python-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/python-hello/snap/snapcraft.yaml
@@ -15,7 +15,7 @@ apps:
     command: bin/hello
 
 parts:
-  python-part:
+  hello:
     source: .
     plugin: python
     python-packages:

--- a/tests/spread/plugins/v2/snaps/rust-hello-features/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/rust-hello-features/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ apps:
     command: bin/rust-hello-features
 
 parts:
-  simple-rust:
+  hello:
     plugin: rust
     source: .
     rust-features: [conditional-feature-present]

--- a/tests/spread/plugins/v2/snaps/rust-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/rust-hello/snap/snapcraft.yaml
@@ -15,6 +15,6 @@ apps:
     command: bin/rust-hello
 
 parts:
-  rust-hello:
+  hello:
     plugin: rust
     source: .


### PR DESCRIPTION
PluginV2 based parts were not able to clean due to the improper guard
set at the start of the clean_build method.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
