### PR TITLE
extensions: pre/append_dir: support rpath tokens by not using eval

### DIFF
--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -3,19 +3,23 @@
 # Launcher common exports for any desktop app #
 ###############################################
 
+# Note: We avoid using `eval` because we don't want to expand variable names
+#       in paths. For example: LD_LIBRARY_PATH paths might contain `$LIB`.
 function prepend_dir() {
-  local var="$1"
+  local -n var="$1"
   local dir="$2"
-  if [ -d "$dir" ]; then
-    eval "export $var=\"\$dir\${$var:+:\$$var}\""
+  # We can't check if the dir exists when the dir contains variables
+  if [[ "$dir" == *"\$"*  || -d "$dir" ]]; then
+    export "${!var}=${dir}${var:+:$var}"
   fi
 }
 
 function append_dir() {
-  local var="$1"
+  local -n var="$1"
   local dir="$2"
-  if [ -d "$dir" ]; then
-    eval "export $var=\"\${$var:+\$$var:}\$dir\""
+  # We can't check if the dir exists when the dir contains variables
+  if [[ "$dir" == *"\$"*  || -d "$dir" ]]; then
+    export "${!var}=${var:+$var:}${dir}"
   fi
 }
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

This commit changes the `prepend_dir` and `append_dir` functions to not use `eval` and to not check whether the directory exists when the path contains tokens. This makes it possible to use rpath tokens in the `LD_LIBRARY_PATH`. These tokens are useful to create paths which support multi-arch apps.

More info about rpath tokens: [ld.so man page](http://man7.org/linux/man-pages/man8/ld.so.8.html), [Using LD_PRELOAD mixed 64bit/32bit environment in Linux](https://stackoverflow.com/a/38253231/1588555).

*These versions of `pre/append_dir` and rpath tokens are already used in the [sommelier-core](https://github.com/snapcrafters/sommelier-core/blob/master/scripts/sommelier#L279) script to support Wine, which uses both 32-bit and 64-bit libraries when it runs 32-bit windows apps. The [PhotoScape](https://github.com/snapcrafters/photoscape) snap is built using sommelier-core.*

## Note about compatibility

This PR makes sure we don't break things when _earlier_ scripts in the command-chain use rpath tokens in `LD_LIBRARY_PATH`.  

However, we can't yet use rpath tokens in `LD_LIBRARY_PATH` in `desktop-helpers` itself, because _later_ scripts in the command-chain might still use the old `pre/append_dir` functions. At least [one](https://github.com/Taiko2k/TauonMusicBox/blob/master/snapcraft.yaml) snap on GitHub uses the old functions together with a gnome extension.

Using rpath tokens in desktop-helpers will thus break backwards compatibility; we can only use it for new extensions and/or new bases.

*Note: This PR is [another](https://github.com/snapcore/snapcraft/pull/3127) small step towards having better tooling to support 32-bit desktop apps in snapcraft.*