### PR TITLE
schema: add support for the daemon-scope property on apps

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -596,6 +596,9 @@
                         ],
                         "install-mode": [
                             "daemon"
+                        ],
+                        "daemon-scope": [
+                            "daemon"
                         ]
                     },
                     "additionalProperties": false,
@@ -677,6 +680,14 @@
                                 "oneshot",
                                 "notify",
                                 "dbus"
+                            ]
+                        },
+                        "daemon-scope": {
+                            "type": "string",
+                            "description": "the scope of the daemon (system or user).",
+                            "enum": [
+                                "system",
+                                "user"
                             ]
                         },
                         "after": {

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -166,6 +166,16 @@ class ValidationTest(ValidationBaseTest):
                 "daemon": "simple",
                 "install-mode": "disable",
             },
+            "service17": {
+                "command": "binary17",
+                "daemon": "simple",
+                "daemon-scope": "system",
+            },
+            "service18": {
+                "command": "binary18",
+                "daemon": "simple",
+                "daemon-scope": "user",
+            },
         }
 
         Validator(self.data).validate()
@@ -191,6 +201,26 @@ class ValidationTest(ValidationBaseTest):
                 "the required schema: 'on-tuesday' is not one of ['on-success', "
                 "'on-failure', 'on-abnormal', 'on-abort', 'on-watchdog', 'always', "
                 "'never']"
+            ),
+        )
+
+    def test_invalid_daemon_scope(self):
+        self.data["apps"] = {
+            "service1": {
+                "command": "binary1",
+                "daemon": "simple",
+                "daemon-scope": "europe",
+            }
+        }
+        raised = self.assertRaises(
+            snapcraft.yaml_utils.errors.YamlValidationError,
+            Validator(self.data).validate,
+        )
+        self.assertThat(
+            str(raised),
+            Contains(
+                "The 'apps/service1/daemon-scope' property does not match the "
+                "required schema: 'europe' is not one of ['system', 'user']"
             ),
         )
 
@@ -236,6 +266,7 @@ class ValidationTest(ValidationBaseTest):
         ("post-stop-command", "binary1 --post-stop"),
         ("before", ["service1"]),
         ("after", ["service2"]),
+        ("daemon-scope", "system"),
     ],
 )
 def test_daemon_dependency(data, option, value):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
This PR adds support for `daemon-scope` property on apps.  This syntax was introduced to snapd in https://github.com/snapcore/snapd/pull/5822, and is currently gated behind the `experimental.user-daemons` feature flag.

The `daemon-scope` property only makes sense for daemon type apps, and has a value of either `system` or `user`.  It is not an error for a daemon to omit the property: it is assumed to be a system daemon in that case.