### PR TITLE
build providers: don't show an error if there are no auto-refresh changes

### DIFF
--- a/snapcraft/internal/build_providers/_snap.py
+++ b/snapcraft/internal/build_providers/_snap.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import contextlib
 import datetime
 import enum
 import logging
@@ -23,7 +22,6 @@ import tempfile
 from typing import Callable, List, Optional
 from typing import Any, Dict  # noqa: F401
 
-from . import errors
 from snapcraft import storeapi, yaml_utils
 from snapcraft.internal import repo
 
@@ -321,8 +319,7 @@ class SnapInjector:
 
         # Auto refresh may have kicked in while setting the hold.
         logger.debug("Waiting for pending snap auto refreshes.")
-        with contextlib.suppress(errors.ProviderExecError):
-            self._runner(["snap", "watch", "--last=auto-refresh"], hide_output=True)
+        self._runner(["snap", "watch", "--last=auto-refresh?"], hide_output=True)
 
     def _enable_snapd_snap(self) -> None:
         # Required to not install the core snap when building using

--- a/tests/unit/build_providers/test_snap.py
+++ b/tests/unit/build_providers/test_snap.py
@@ -121,7 +121,7 @@ class SnapInjectionTest(unit.TestCase):
             [
                 call(["snap", "set", "system", "experimental.snapd-snap=true"]),
                 call(["snap", "set", "system", ANY]),
-                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "watch", "--last=auto-refresh?"]),
                 call(["snap", "ack", "/var/tmp/snapd.assert"]),
                 call(["snap", "install", "/var/tmp/snapd.snap"]),
                 call(["snap", "ack", "/var/tmp/core18.assert"]),
@@ -174,7 +174,7 @@ class SnapInjectionTest(unit.TestCase):
         self.provider.run_mock.assert_has_calls(
             [
                 call(["snap", "set", "system", ANY]),
-                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "watch", "--last=auto-refresh?"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
                 call(
                     ["snap", "install", "--classic", "--channel", "stable", "snapcraft"]
@@ -237,7 +237,7 @@ class SnapInjectionTest(unit.TestCase):
         self.provider.run_mock.assert_has_calls(
             [
                 call(["snap", "set", "system", ANY]),
-                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "watch", "--last=auto-refresh?"]),
                 call(["snap", "ack", "/var/tmp/core.assert"]),
                 call(["snap", "install", "/var/tmp/core.snap"]),
                 call(["snap", "ack", "/var/tmp/snapcraft.assert"]),
@@ -291,7 +291,7 @@ class SnapInjectionTest(unit.TestCase):
         self.provider.run_mock.assert_has_calls(
             [
                 call(["snap", "set", "system", ANY]),
-                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "watch", "--last=auto-refresh?"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
                 call(
                     ["snap", "install", "--classic", "--channel", "stable", "snapcraft"]
@@ -335,7 +335,7 @@ class SnapInjectionTest(unit.TestCase):
         self.provider.run_mock.assert_has_calls(
             [
                 call(["snap", "set", "system", ANY]),
-                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "watch", "--last=auto-refresh?"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
                 call(
                     ["snap", "install", "--classic", "--channel", "edge", "snapcraft"]
@@ -373,7 +373,7 @@ class SnapInjectionTest(unit.TestCase):
         self.provider.run_mock.assert_has_calls(
             [
                 call(["snap", "set", "system", ANY]),
-                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "watch", "--last=auto-refresh?"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
                 call(
                     ["snap", "install", "--classic", "--channel", "stable", "snapcraft"]
@@ -395,7 +395,7 @@ class SnapInjectionTest(unit.TestCase):
         self.provider.run_mock.assert_has_calls(
             [
                 call(["snap", "set", "system", ANY]),
-                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "watch", "--last=auto-refresh?"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
                 call(
                     ["snap", "install", "--classic", "--channel", "stable", "snapcraft"]
@@ -479,7 +479,7 @@ class SnapInjectionTest(unit.TestCase):
         self.provider.run_mock.assert_has_calls(
             [
                 call(["snap", "set", "system", ANY]),
-                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "watch", "--last=auto-refresh?"]),
                 call(["snap", "refresh", "--channel", "stable", "core"]),
                 call(
                     ["snap", "refresh", "--classic", "--channel", "stable", "snapcraft"]
@@ -509,7 +509,7 @@ class SnapInjectionTest(unit.TestCase):
         self.provider.run_mock.assert_has_calls(
             [
                 call(["snap", "set", "system", ANY]),
-                call(["snap", "watch", "--last=auto-refresh"]),
+                call(["snap", "watch", "--last=auto-refresh?"]),
                 call(["snap", "install", "--channel", "stable", "core"]),
                 call(
                     ["snap", "install", "--classic", "--channel", "stable", "snapcraft"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
This was prompted by the following post on the forums:

https://forum.snapcraft.io/t/error-no-changes-of-type-auto-refresh-found/17562

The error message comes from the `snap watch` call when no auto-refresh changes exist in the log.   We can suppress this error by adding a question mark to the change type, which also causes `snap watch` to return a success error code in this case.