### PR TITLE
plugin handler: debug build commands if developer debug enabled

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -17,6 +17,7 @@
 import collections
 import contextlib
 import copy
+import distutils
 import filecmp
 import io
 import logging
@@ -627,6 +628,12 @@ class PluginHandler:
         # Create the script.
         with io.StringIO() as run_environment:
             print("#!/bin/sh", file=run_environment)
+
+            if distutils.util.strtobool(
+                os.environ.get("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", "n")
+            ):
+                print("set -x", file=run_environment)
+
             print("set -e", file=run_environment)
 
             print("# Environment", file=run_environment)


### PR DESCRIPTION
Include `set -x` in build script if user enables developer debug.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
