### PR TITLE
go v1 plugin: go.mod support for 1.11 and 1.12

### DIFF
--- a/snapcraft/plugins/v1/go.py
+++ b/snapcraft/plugins/v1/go.py
@@ -17,7 +17,7 @@
 """The go plugin can be used for go projects.
 
 The plugin supports Go Modules if a go.mod definition is found in the
-sources out of the box if the Go version used is 1.13 or greater.
+root of the part's source the Go version used is 1.13 or greater.
 
 If using 1.11 or 1.12, enabling through environment flags is required.
 Read more about this at https://github.com/golang/go/wiki/Modules and
@@ -206,7 +206,7 @@ class GoPlugin(PluginV1):
             _GO_MOD_ENV_FLAG_REQUIRED_GO_VERSION
         ):
             logger.warning(
-                "Ensure Go Module support is correct for this version of Go. "
+                "Ensure build environment configuration is correct for this version of Go. "
                 "Read more about it at "
                 "https://github.com/golang/go/wiki/Modules#how-to-install-and-activate-module-support"
             )

--- a/tests/spread/plugins/v1/go/run-go-mod/task.yaml
+++ b/tests/spread/plugins/v1/go/run-go-mod/task.yaml
@@ -1,24 +1,25 @@
 summary: Build and run a basic Go snap using go.mod
 
 environment:
-  SNAP_DIR: ../snaps/go-mod-hello
+  SNAP/supported_go: go-mod-hello
+  SNAP/supported_go_with_env: go-mod-hello-with-env
   LANG: C.UTF-8
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
-  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+  set_base "../snaps/${SNAP}/snap/snapcraft.yaml"
 
 restore: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
-  cd "$SNAP_DIR"
+  cd "../snaps/${SNAP}"
   snapcraft clean
   rm -f ./*.snap
   restore_yaml snap/snapcraft.yaml
 
 execute: |
-  cd "$SNAP_DIR"
+  cd "../snaps/${SNAP}"
 
   snapcraft
 
@@ -33,5 +34,5 @@ execute: |
     exit 1
   fi
 
-  sudo snap install go-mod-hello_*.snap --dangerous
-  [ "$(go-mod-hello)" = "hello world" ]
+  snap install "${SNAP}"_1.0_*.snap --dangerous
+  [ "$(${SNAP})" = "hello world" ]

--- a/tests/spread/plugins/v1/go/snaps/go-mod-hello-with-env/go.mod
+++ b/tests/spread/plugins/v1/go/snaps/go-mod-hello-with-env/go.mod
@@ -1,0 +1,5 @@
+module github.com/snapcore/snapcraft/tests/spread/plugins/go/snaps/go-mod-hello
+
+go 1.11
+
+require rsc.io/quote v1.5.2

--- a/tests/spread/plugins/v1/go/snaps/go-mod-hello-with-env/go.sum
+++ b/tests/spread/plugins/v1/go/snaps/go-mod-hello-with-env/go.sum
@@ -1,0 +1,6 @@
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c h1:qgOY6WgZOaTkIIMiVjBQcw93ERBE4m30iBm00nkL0i8=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+rsc.io/quote v1.5.2 h1:w5fcysjrx7yqtD/aO+QwRjYZOKnaM9Uh2b40tElTs3Y=
+rsc.io/quote v1.5.2/go.mod h1:LzX7hefJvL54yjefDEDHNONDjII0t9xZLPXsUe+TKr0=
+rsc.io/sampler v1.3.0 h1:7uVkIFmeBqHfdjD+gZwtXXI+RODJ2Wc4O7MPEh/QiW4=
+rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/tests/spread/plugins/v1/go/snaps/go-mod-hello-with-env/main.go
+++ b/tests/spread/plugins/v1/go/snaps/go-mod-hello-with-env/main.go
@@ -1,0 +1,34 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	// imported to just kick the go.mod tires.
+	"rsc.io/quote"
+)
+
+func hello() string {
+	return quote.Hello()
+}
+
+func main() {
+	fmt.Println("hello world")
+}

--- a/tests/spread/plugins/v1/go/snaps/go-mod-hello-with-env/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/go/snaps/go-mod-hello-with-env/snap/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: go-mod-hello-with-env
+version: "1.0"
+summary: A simple go project using go.mod
+description: |
+  This is a basic go snap. It just prints a hello world brought in from
+  a version pinned go package using go.mod.
+
+grade: devel
+base: core18
+confinement: strict
+
+apps:
+  go-mod-hello-with-env:
+    command: bin/go-mod-hello
+
+parts:
+  hello:
+    source: .
+    plugin: go
+    go-channel: 1.11/stable
+    build-environment:
+      - GO111MODULE: "on"
+    build-packages:
+      - git

--- a/tests/unit/plugins/v1/test_go.py
+++ b/tests/unit/plugins/v1/test_go.py
@@ -340,7 +340,7 @@ class GoPluginTest(GoPluginBaseTest):
         self.assertThat(
             fake_logger.output.strip(),
             Equals(
-                "Ensure Go Module support is correct for this version of Go. "
+                "Ensure build environment configuration is correct for this version of Go. "
                 "Read more about it at "
                 "https://github.com/golang/go/wiki/Modules#how-to-install-and-activate-module-support"
             ),
@@ -708,7 +708,7 @@ class GoPluginTest(GoPluginBaseTest):
         self.assertThat(
             fake_logger.output.strip(),
             Equals(
-                "Ensure Go Module support is correct for this version of Go. "
+                "Ensure build environment configuration is correct for this version of Go. "
                 "Read more about it at "
                 "https://github.com/golang/go/wiki/Modules#how-to-install-and-activate-module-support"
             ),

--- a/tests/unit/plugins/v1/test_go.py
+++ b/tests/unit/plugins/v1/test_go.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import os
 import jsonschema
 from unittest import mock
@@ -34,9 +35,10 @@ class GoPluginBaseTest(PluginsV1BaseTestCase):
 
         def fake_go_build(command, cwd, *args, **kwargs):
             if command[0] == "go" and command[1] == "build" and "-o" in command:
-                open(
-                    os.path.join(command[command.index("-o") + 1], "binary"), "w"
-                ).close()
+                output = command[command.index("-o") + 1]
+                if os.path.basename(output) != "module":
+                    output = os.path.join(output, "binary")
+                open(output, "w").close()
             elif command[0] == "go" and command[1] == "build" and "-o" not in command:
                 # the package is -1
                 open(os.path.join(cwd, os.path.basename(command[-1])), "w").close()
@@ -289,7 +291,7 @@ class GoPluginTest(GoPluginBaseTest):
             go_packages = []
             go_importpath = ""
 
-        self.run_output_mock.return_value = "go version go13 linux/amd64"
+        self.run_output_mock.return_value = "go version go1.13 linux/amd64"
 
         plugin = go.GoPlugin("test-part", Options(), self.project)
 
@@ -303,6 +305,45 @@ class GoPluginTest(GoPluginBaseTest):
         )
         self.run_mock.assert_called_once_with(
             ["go", "mod", "download"], cwd=plugin.sourcedir, env=mock.ANY
+        )
+
+    def test_pull_go_mod_with_older_go_version(self):
+        class Options:
+            source = "dir"
+            go_channel = "latest/stable"
+            go_packages = []
+            go_importpath = "foo"
+            go_buildtags = ""
+
+        fake_logger = fixtures.FakeLogger(level=logging.INFO)
+        self.useFixture(fake_logger)
+
+        self.run_output_mock.return_value = "go version go1.11 linux/amd64"
+
+        plugin = go.GoPlugin("test-part", Options(), self.project)
+
+        os.makedirs(plugin.sourcedir)
+        open(os.path.join(plugin.sourcedir, "go.mod"), "w").close()
+
+        plugin.pull()
+
+        self.run_output_mock.assert_called_once_with(
+            ["go", "version"], cwd=mock.ANY, env=mock.ANY
+        )
+        self.run_mock.assert_called_once_with(
+            ["go", "mod", "download"], cwd=plugin.sourcedir, env=mock.ANY
+        )
+
+        # Call pull again and ensure nothing new is logged.
+        plugin.pull()
+
+        self.assertThat(
+            fake_logger.output.strip(),
+            Equals(
+                "Ensure Go Module support is correct for this version of Go. "
+                "Read more about it at "
+                "https://github.com/golang/go/wiki/Modules#how-to-install-and-activate-module-support"
+            ),
         )
 
     def test_go_mod_requires_newer_go_version(self):
@@ -615,7 +656,7 @@ class GoPluginTest(GoPluginBaseTest):
             go_importpath = ""
             go_buildtags = ""
 
-        self.run_output_mock.return_value = "go version go13 linux/amd64"
+        self.run_output_mock.return_value = "go version go1.13 linux/amd64"
 
         plugin = go.GoPlugin("test-part", Options(), self.project)
 
@@ -631,6 +672,46 @@ class GoPluginTest(GoPluginBaseTest):
             ["go", "build", "-o", plugin._install_bin_dir, "./..."],
             cwd=plugin.builddir,
             env=mock.ANY,
+        )
+
+    def test_build_go_mod_with_older_go_version(self):
+        class Options:
+            source = "dir"
+            go_channel = "latest/stable"
+            go_packages = []
+            go_importpath = ""
+            go_buildtags = ""
+
+        fake_logger = fixtures.FakeLogger(level=logging.INFO)
+        self.useFixture(fake_logger)
+
+        self.run_output_mock.return_value = "go version go1.11 linux/amd64"
+
+        plugin = go.GoPlugin("test-part", Options(), self.project)
+
+        os.makedirs(plugin.builddir)
+        with open(os.path.join(plugin.builddir, "go.mod"), "w") as go_mod_file:
+            print("module github.com/foo/bar/module", file=go_mod_file)
+            print("go 1.11", file=go_mod_file)
+
+        plugin.build()
+
+        self.run_output_mock.assert_called_once_with(
+            ["go", "version"], cwd=mock.ANY, env=mock.ANY
+        )
+        self.run_mock.assert_called_once_with(
+            ["go", "build", "-o", f"{plugin._install_bin_dir}/module"],
+            cwd=plugin.builddir,
+            env=mock.ANY,
+        )
+
+        self.assertThat(
+            fake_logger.output.strip(),
+            Equals(
+                "Ensure Go Module support is correct for this version of Go. "
+                "Read more about it at "
+                "https://github.com/golang/go/wiki/Modules#how-to-install-and-activate-module-support"
+            ),
         )
 
     @mock.patch("snapcraft.internal.elf.ElfFile")


### PR DESCRIPTION
Add limited support for using Go Modules for 1.11 and 1.12 of Go.

The limitation when using 1.11 and 1.12 is that only the main module is
installed. This is due to limitations in "go build" in those versions,
to find the correct target, a new method "_get_module" is introduced.

A warning is issued when using 1.11 and 1.12 with a link on how to
enable support for Go Modules with precautions to only print the warning
once per execution.

Some general cleanup in GoPluing._build took place to remove repetition
of "domain" specific flag settings for when building and relinking.

LP: #1879315

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
