### PR TITLE
cli: nicer message for status with no releases

### DIFF
--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -460,7 +460,10 @@ def status(snap_name, arch, experimental_progressive_releases):
 
     snap_channel_map = StoreClientCLI().get_snap_channel_map(snap_name=snap_name)
     existing_architectures = snap_channel_map.get_existing_architectures()
-    if arch and arch not in existing_architectures:
+
+    if not snap_channel_map.channel_map:
+        echo.warning("This snap has no released revisions.")
+    elif arch and arch not in existing_architectures:
         echo.warning(f"No revisions for architecture {arch!r}.")
     else:
         if arch:

--- a/tests/unit/commands/test_status.py
+++ b/tests/unit/commands/test_status.py
@@ -99,6 +99,16 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
             ),
         )
 
+    def test_status_no_releases(self):
+        self.channel_map.channel_map = []
+
+        result = self.run_command(["status", "snap-test"])
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(
+            result.output.strip(), Equals("This snap has no released revisions.")
+        )
+
     def test_progressive_status(self):
         self.channel_map.channel_map[0].progressive.percentage = 10.0
 


### PR DESCRIPTION
Print a nicer message than the table headers with nothing in them.

LP: #1695241

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
