### PR TITLE
build providers: set HOME environment variable using posix format

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -475,7 +475,7 @@ class Provider(abc.ABC):
         )
 
         # Set the HOME directory.
-        env_list.append(f"HOME={self._get_home_directory()}")
+        env_list.append(f"HOME={self._get_home_directory().as_posix()}")
 
         # Configure SNAPCRAFT_HAS_TTY.
         has_tty = str(sys.stdout.isatty())


### PR DESCRIPTION
Windows was interpreting HOME as \root which caused various failures.
When reading home, make sure we use the posix-formatted string.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
