### PR TITLE
appveyor: disable artifact collection

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ test_script:
     start /wait "SNAPCRAFT INSTALLER" dist\snapcraft-installer.exe /VERYSILENT /ALLUSERS
     "%SNAPCRAFT_INSTALLED_EXE%" version
 
-artifacts:
-- path: dist\snapcraft.exe
-- path: dist\snapcraft-installer.exe
-- path: dist\snapcraft-installer.msix
+#artifacts:
+#- path: dist\snapcraft.exe
+#- path: dist\snapcraft-installer.exe
+#- path: dist\snapcraft-installer.msix


### PR DESCRIPTION
We can re-enable it in the future.  Windows support is still
unsupported at the moment anyhow.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
