### PR TITLE
pluginhandler: run plugin commands in isolation

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -744,6 +744,7 @@ class SnapcraftPluginAssertionError(SnapcraftException):
 
 class SnapcraftPluginBuildError(SnapcraftException):
     """An exception to raise when the PluginV2 build fails at runtime."""
+
     def __init__(self, *, part_name: str) -> None:
         self._part_name = part_name
 

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -740,3 +740,15 @@ class SnapcraftPluginAssertionError(SnapcraftException):
 
     def get_resolution(self) -> str:
         return "Ensure the part's configuration and sources are correct."
+
+
+class SnapcraftPluginBuildError(SnapcraftException):
+    """An exception to raise when the PluginV2 build fails at runtime."""
+    def __init__(self, *, part_name: str) -> None:
+        self._part_name = part_name
+
+    def get_brief(self) -> str:
+        return f"Failed to build {self._part_name!r}."
+
+    def get_resolution(self) -> str:
+        return "Check the build logs and ensure the part's configuration and sources are correct."

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -658,24 +658,25 @@ class PluginHandler:
         # TODO expand this in Runner.
         with build_script_path.open("w") as run_file:
             print(self._generate_part_env(steps.BUILD), file=run_file)
-            print('exec "$@"', file=run_file)
+            print("set -x", file=run_file)
+
+            for build_command in plugin_build_commands:
+                print(build_command, file=run_file)
+
             run_file.flush()
 
         build_script_path.chmod(0o755)
 
-        for build_command in plugin_build_commands:
-            try:
-                subprocess.run(
-                    [build_script_path, build_command],
-                    check=True,
-                    cwd=self.part_build_work_dir,
-                )
-            except subprocess.CalledProcessError as process_error:
-                raise errors.SnapcraftPluginCommandError(
-                    command=build_command,
-                    part_name=self.name,
-                    exit_code=process_error.returncode,
-                ) from process_error
+        try:
+            subprocess.run(
+                [build_script_path],
+                check=True,
+                cwd=self.part_build_work_dir,
+            )
+        except subprocess.CalledProcessError as process_error:
+            raise errors.SnapcraftPluginBuildError(
+                part_name=self.name,
+            ) from process_error
 
     def _do_build(self, *, update=False):
         self._do_runner_step(steps.BUILD)

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -669,13 +669,11 @@ class PluginHandler:
 
         try:
             subprocess.run(
-                [build_script_path],
-                check=True,
-                cwd=self.part_build_work_dir,
+                [build_script_path], check=True, cwd=self.part_build_work_dir
             )
         except subprocess.CalledProcessError as process_error:
             raise errors.SnapcraftPluginBuildError(
-                part_name=self.name,
+                part_name=self.name
             ) from process_error
 
     def _do_build(self, *, update=False):

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -665,10 +665,16 @@ class PluginHandler:
 
         for build_command in plugin_build_commands:
             try:
-                subprocess.run([build_script_path, build_command], check=True, cwd=self.part_build_work_dir)
+                subprocess.run(
+                    [build_script_path, build_command],
+                    check=True,
+                    cwd=self.part_build_work_dir,
+                )
             except subprocess.CalledProcessError as process_error:
                 raise errors.SnapcraftPluginCommandError(
-                    command=build_command, part_name=self.name, exit_code=process_error.returncode
+                    command=build_command,
+                    part_name=self.name,
+                    exit_code=process_error.returncode,
                 ) from process_error
 
     def _do_build(self, *, update=False):

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -887,8 +887,8 @@ class SnapcraftExceptionTests(unit.TestCase):
                 "expected_details": None,
                 "expected_docs_url": None,
                 "expected_reportable": False,
-            }
-        )
+            },
+        ),
     )
 
     def test_snapcraft_exception_handling(self):

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -877,6 +877,18 @@ class SnapcraftExceptionTests(unit.TestCase):
                 "expected_reportable": True,
             },
         ),
+        (
+            "SnapcraftPluginBuildError",
+            {
+                "exception": errors.SnapcraftPluginBuildError,
+                "kwargs": {"part_name": "foo"},
+                "expected_brief": "Failed to build 'foo'.",
+                "expected_resolution": "Check the build logs and ensure the part's configuration and sources are correct.",
+                "expected_details": None,
+                "expected_docs_url": None,
+                "expected_reportable": False,
+            }
+        )
     )
 
     def test_snapcraft_exception_handling(self):


### PR DESCRIPTION
Iterate over plugin commands and run them in isolation. This allows
clearer error reporting. The same exception as in PluginV1 is raised on
command execution.

Fixes SNAPCRAFT-1NQ

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
