### PR TITLE
build providers: use LXD-provided DNS by default

### DIFF
--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -17,7 +17,6 @@
 from textwrap import dedent
 import logging
 import os
-import pathlib
 import subprocess
 import sys
 import urllib.parse
@@ -41,21 +40,6 @@ logger = logging.getLogger(__name__)
 # Filter out attribute setting warnings for properties that exist in LXD operations
 # but are unhandled in pylxd.
 warnings.filterwarnings("ignore", module="pylxd.models.operation")
-
-
-def _get_resolv_conf_content(
-    resolv_conf_path: pathlib.Path = pathlib.Path("/run/systemd/resolve/resolv.conf"),
-) -> str:
-    environment_nameserver = os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT_NAMESERVER")
-    if environment_nameserver is not None:
-        resolv_conf_content = f"nameserver {environment_nameserver}"
-    elif resolv_conf_path.exists():
-        with resolv_conf_path.open() as resolv_conf_file:
-            resolv_conf_content = resolv_conf_file.read(-1)
-    else:
-        resolv_conf_content = "nameserver 1.1.1.1"
-
-    return resolv_conf_content
 
 
 class LXD(Provider):
@@ -438,18 +422,16 @@ class LXD(Provider):
             path="/etc/hostname", content=self.instance_name, permissions="0644"
         )
 
-        self._install_file(
-            path="/etc/resolv.conf",
-            content=_get_resolv_conf_content(),
-            permissions="0644",
-        )
-
-        self._container.restart(wait=True)
         self._wait_for_systemd()
 
-        # the system needs networking
+        # Use resolv.conf managed by systemd-resolved.
+        self._run(["ln", "-sf", "/run/systemd/resolve/resolv.conf", "/etc/resolv.conf"])
+
+        self._run(["systemctl", "enable", "systemd-resolved"])
         self._run(["systemctl", "enable", "systemd-networkd"])
-        self._run(["systemctl", "start", "systemd-networkd"])
+
+        self._run(["systemctl", "restart", "systemd-resolved"])
+        self._run(["systemctl", "restart", "systemd-networkd"])
 
         self._wait_for_network()
 

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import pathlib
 import os
 import subprocess
 import sys
@@ -22,14 +21,11 @@ from typing import Any, Dict
 from unittest import mock
 from unittest.mock import call
 
-import fixtures
-from testtools import TestCase
 from testtools.matchers import Equals, FileContains, FileExists
 
 from snapcraft.internal.errors import SnapcraftEnvironmentError
 from snapcraft.internal.build_providers import _base_provider, errors
 from snapcraft.internal.build_providers._lxd import LXD
-from snapcraft.internal.build_providers._lxd._lxd import _get_resolv_conf_content
 from snapcraft.internal.repo.errors import SnapdConnectionError
 from tests.unit.build_providers import BaseProviderBaseTest
 
@@ -147,49 +143,6 @@ class FakeContainers:
 class FakePyLXDClient:
     def __init__(self) -> None:
         self.containers = FakeContainers()
-
-
-class ResolvConfTest(TestCase):
-    def setUp(self):
-        super().setUp()
-        temp_dir = fixtures.TempDir()
-        self.useFixture(temp_dir)
-        self.temp_dir = pathlib.Path(temp_dir.path)
-
-    def test_get_resolv_conf_file(self):
-        resolv_conf_content = "nameserver 1.2.3.4"
-        resolv_conf_path = self.temp_dir / "fake-resolv.conf"
-        with resolv_conf_path.open("w") as resolv_conf_file:
-            print(resolv_conf_content, file=resolv_conf_file, end="")
-
-        self.assertThat(
-            _get_resolv_conf_content(resolv_conf_path), Equals(resolv_conf_content)
-        )
-
-    def test_get_resolv_conf_file_default_nameserver(self):
-        resolv_conf_path = self.temp_dir / "fake-resolv.conf"
-
-        self.assertThat(
-            _get_resolv_conf_content(resolv_conf_path), Equals("nameserver 1.1.1.1")
-        )
-
-    def test_get_resolv_conf_file_from_environment_preferred(self):
-        self.useFixture(
-            fixtures.EnvironmentVariable(
-                "SNAPCRAFT_BUILD_ENVIRONMENT_NAMESERVER", "9.9.9.9"
-            )
-        )
-
-        resolv_conf_content = "nameserver 1.2.3.4"
-        resolv_conf_path = self.temp_dir / "fake-resolv.conf"
-        with resolv_conf_path.open("w") as resolv_conf_file:
-            print(resolv_conf_content, file=resolv_conf_file, end="")
-
-        resolv_conf_path = self.temp_dir / "fake-resolv.conf"
-
-        self.assertThat(
-            _get_resolv_conf_content(resolv_conf_path), Equals("nameserver 9.9.9.9")
-        )
 
 
 class LXDBaseTest(BaseProviderBaseTest):
@@ -616,8 +569,9 @@ class LXDInitTest(LXDBaseTest):
                         "--",
                         "env",
                         "SNAPCRAFT_HAS_TTY=False",
-                        "mv",
-                        "/var/tmp/L2V0Yy9yZXNvbHYuY29uZg==",
+                        "ln",
+                        "-sf",
+                        "/run/systemd/resolve/resolv.conf",
                         "/etc/resolv.conf",
                     ]
                 ),
@@ -629,22 +583,9 @@ class LXDInitTest(LXDBaseTest):
                         "--",
                         "env",
                         "SNAPCRAFT_HAS_TTY=False",
-                        "chown",
-                        "root:root",
-                        "/etc/resolv.conf",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "chmod",
-                        "0644",
-                        "/etc/resolv.conf",
+                        "systemctl",
+                        "enable",
+                        "systemd-resolved",
                     ]
                 ),
                 call(
@@ -669,7 +610,20 @@ class LXDInitTest(LXDBaseTest):
                         "env",
                         "SNAPCRAFT_HAS_TTY=False",
                         "systemctl",
-                        "start",
+                        "restart",
+                        "systemd-resolved",
+                    ]
+                ),
+                call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "systemctl",
+                        "restart",
                         "systemd-networkd",
                     ]
                 ),


### PR DESCRIPTION
A DNS server is provided by LXD, we just need to configure
the host to use systemd-resolved for name resolution.

After installing these files, there is no need to restart
the container, just restart networkd.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
