### PR TITLE
storeapi: reset account_id on store login

### DIFF
--- a/snapcraft/storeapi/_store_client.py
+++ b/snapcraft/storeapi/_store_client.py
@@ -87,6 +87,8 @@ class StoreClient:
             unbound_discharge = self.sso.get_unbound_discharge(
                 email, password, one_time_password, caveat_id
             )
+            # Clear any old data before setting.
+            self.conf.clear()
             # The macaroon has been discharged, save it in the config
             self.conf.set("macaroon", macaroon)
             self.conf.set("unbound_discharge", unbound_discharge)

--- a/tests/unit/store/test_store_client.py
+++ b/tests/unit/store/test_store_client.py
@@ -164,6 +164,18 @@ class LoginTestCase(StoreTestCase):
 
         self.assertTrue(config.Config().is_empty())
 
+    def test_login_account_id_wiped_on_relogin(self):
+        self.client.login("dummy email", "test correct password")
+        self.assertIsNotNone(self.client.conf.get("macaroon"))
+        self.assertIsNotNone(self.client.conf.get("unbound_discharge"))
+        self.assertIsNone(self.client.conf.get("account_id"))
+        self.client.whoami()
+        self.assertIsNotNone(self.client.conf.get("account_id"))
+
+        # A new login should wipe account_id.
+        self.client.login("dummy email", "test correct password")
+        self.assertIsNone(self.client.conf.get("account_id"))
+
 
 class DownloadTestCase(StoreTestCase):
 


### PR DESCRIPTION
LP: #1879679

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
