### PR TITLE
cli: migrate close to use the new channel map

### DIFF
--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -343,7 +343,6 @@ from snapcraft.plugins.v1 import PluginV1 as BasePlugin  # noqa: F401
 # FIXME LP: #1662658
 from snapcraft._store import (  # noqa
     create_key,
-    close,
     download,
     revisions,
     gated,

--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -901,35 +901,6 @@ def _tabulated_channel_map_tree(channel_map_tree):
     return tabulate(data, numalign="left", headers=headers, tablefmt="plain")
 
 
-def close(snap_name, channel_names):
-    """Close one or more channels for the specific snap."""
-    store_client = StoreClientCLI()
-    account_info = store_client.get_account_information()
-
-    try:
-        snap_id = account_info["snaps"][DEFAULT_SERIES][snap_name]["snap-id"]
-    except KeyError as e:
-        raise storeapi.errors.StoreChannelClosingPermissionError(
-            snap_name, DEFAULT_SERIES
-        ) from e
-
-    closed_channels, c_m_tree = store_client.close_channels(
-        snap_id=snap_id, channel_names=channel_names
-    )
-
-    tabulated_status = _tabulated_channel_map_tree(c_m_tree)
-    print(tabulated_status)
-
-    print()
-    if len(closed_channels) == 1:
-        msg = "The {} channel is now closed.".format(closed_channels[0])
-    else:
-        msg = "The {} and {} channels are now closed.".format(
-            ", ".join(closed_channels[:-1]), closed_channels[-1]
-        )
-    logger.info(msg)
-
-
 def download(
     snap_name,
     *,

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -433,7 +433,40 @@ def close(snap_name, channels):
         snapcraft close my-snap beta
         snapcraft close my-snap beta edge
     """
-    snapcraft.close(snap_name, channels)
+    store = storeapi.StoreClient()
+    account_info = store.get_account_information()
+
+    try:
+        snap_id = account_info["snaps"][DEFAULT_SERIES][snap_name]["snap-id"]
+    except KeyError:
+        raise storeapi.errors.StoreChannelClosingPermissionError(
+            snap_name, DEFAULT_SERIES
+        )
+
+    # Returned closed_channels cannot be trusted as it returns risks.
+    store.close_channels(snap_id=snap_id, channel_names=channels)
+    if len(channels) == 1:
+        msg = "The {} channel is now closed.".format(channels[0])
+    else:
+        msg = "The {} and {} channels are now closed.".format(
+            ", ".join(channels[:-1]), channels[-1]
+        )
+
+    snap_channel_map = store.get_snap_channel_map(snap_name=snap_name)
+    if snap_channel_map.channel_map:
+        closed_tracks = {storeapi.channels.Channel(c).track for c in channels}
+        existing_architectures = snap_channel_map.get_existing_architectures()
+
+        click.echo(
+            get_tabulated_channel_map(
+                snap_channel_map,
+                architectures=existing_architectures,
+                tracks=closed_tracks,
+            )
+        )
+        click.echo()
+
+    echo.info(msg)
 
 
 @storecli.command()

--- a/tests/unit/commands/test_close.py
+++ b/tests/unit/commands/test_close.py
@@ -14,19 +14,32 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from textwrap import dedent
-from unittest import mock
 
+import fixtures
 from testtools.matchers import Contains, Equals
 
 import snapcraft.storeapi.errors
 from snapcraft import storeapi
-from . import CommandBaseTestCase
+from . import FakeStoreCommandsBaseTestCase
 
 
-class CloseCommandTestCase(CommandBaseTestCase):
-    @mock.patch.object(storeapi._sca_client.SCAClient, "get_account_information")
-    def test_close_missing_permission(self, mock_get_account_info):
-        mock_get_account_info.return_value = {"account_id": "abcd", "snaps": {}}
+class CloseCommandTestCase(FakeStoreCommandsBaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.useFixture(
+            fixtures.MockPatchObject(
+                storeapi._sca_client.SCAClient,
+                "close_channels",
+                return_value=(list(), dict()),
+            )
+        )
+
+    def test_close_missing_permission(self):
+        self.fake_store_account_info.mock.return_value = {
+            "account_id": "abcd",
+            "snaps": {},
+        }
 
         raised = self.assertRaises(
             snapcraft.storeapi.errors.StoreChannelClosingPermissionError,
@@ -43,33 +56,8 @@ class CloseCommandTestCase(CommandBaseTestCase):
             ),
         )
 
-    @mock.patch.object(storeapi._sca_client.SCAClient, "get_account_information")
-    @mock.patch.object(storeapi._sca_client.SCAClient, "close_channels")
-    def test_close_basic(self, mock_close_channels, mock_get_account_info):
-        mock_get_account_info.return_value = {
-            "snaps": {"16": {"basic": {"snap-id": "snap-id"}}}
-        }
-        closed_channels = ["beta"]
-        channel_map_tree = {
-            "latest": {
-                "16": {
-                    "amd64": [
-                        {"channel": "stable", "info": "none"},
-                        {"channel": "candidate", "info": "none"},
-                        {
-                            "channel": "beta",
-                            "info": "specific",
-                            "version": "1.1",
-                            "revision": 42,
-                        },
-                        {"channel": "edge", "info": "tracking"},
-                    ]
-                }
-            }
-        }
-        mock_close_channels.side_effect = [(closed_channels, channel_map_tree)]
-
-        result = self.run_command(["close", "basic", "beta"])
+    def test_close(self):
+        result = self.run_command(["close", "snap-test", "2.1/candidate"])
 
         self.assertThat(result.exit_code, Equals(0))
         self.assertThat(
@@ -77,44 +65,29 @@ class CloseCommandTestCase(CommandBaseTestCase):
             Contains(
                 dedent(
                     """\
-            Track    Arch    Channel    Version    Revision    Notes
-            latest   amd64   stable     -          -           -
-                             candidate  -          -           -
-                             beta       1.1        42          -
-                             edge       ^          ^           -
+            Track    Arch    Channel    Version    Revision
+            2.1      amd64   stable     -          -
+                             candidate  -          -
+                             beta       10         19
+                             edge       ↑          ↑
 
-            \x1b[0;32mThe beta channel is now closed.\x1b[0m"""
+            The 2.1/candidate channel is now closed."""
                 )
             ),
         )
 
-    @mock.patch.object(storeapi._sca_client.SCAClient, "get_account_information")
-    @mock.patch.object(storeapi._sca_client.SCAClient, "close_channels")
-    def test_close_multiple_channels(self, mock_close_channels, mock_get_account_info):
-        mock_get_account_info.return_value = {
-            "snaps": {"16": {"basic": {"snap-id": "snap-id"}}}
-        }
-        closed_channels = ["beta", "edge"]
-        channel_map_tree = {
-            "latest": {
-                "16": {
-                    "amd64": [
-                        {"channel": "stable", "info": "none"},
-                        {
-                            "channel": "candidate",
-                            "info": "specific",
-                            "version": "1.1",
-                            "revision": 42,
-                        },
-                        {"channel": "beta", "info": "tracking"},
-                        {"channel": "edge", "info": "tracking"},
-                    ]
-                }
-            }
-        }
-        mock_close_channels.side_effect = [(closed_channels, channel_map_tree)]
+    def test_close_no_revisions(self):
+        self.channel_map.channel_map = list()
 
-        result = self.run_command(["close", "basic", "beta", "edge"])
+        result = self.run_command(["close", "snap-test", "2.1/candidate"])
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(
+            result.output.strip(), Equals("The 2.1/candidate channel is now closed.")
+        )
+
+    def test_close_multiple_channels(self):
+        result = self.run_command(["close", "snap-test", "2.1/stable", "2.1/edge/test"])
 
         self.assertThat(result.exit_code, Equals(0))
         self.assertThat(
@@ -122,128 +95,13 @@ class CloseCommandTestCase(CommandBaseTestCase):
             Contains(
                 dedent(
                     """\
-            Track    Arch    Channel    Version    Revision    Notes
-            latest   amd64   stable     -          -           -
-                             candidate  1.1        42          -
-                             beta       ^          ^           -
-                             edge       ^          ^           -
+            Track    Arch    Channel    Version    Revision
+            2.1      amd64   stable     -          -
+                             candidate  -          -
+                             beta       10         19
+                             edge       ↑          ↑
 
-            \x1b[0;32mThe beta and edge channels are now closed.\x1b[0m"""
+            The 2.1/stable and 2.1/edge/test channels are now closed."""
                 )
             ),
         )
-
-    @mock.patch.object(storeapi._sca_client.SCAClient, "get_account_information")
-    @mock.patch.object(storeapi._sca_client.SCAClient, "close_channels")
-    def test_close_multiple_architectures(
-        self, mock_close_channels, mock_get_account_info
-    ):
-        mock_get_account_info.return_value = {
-            "snaps": {"16": {"basic": {"snap-id": "snap-id"}}}
-        }
-        closed_channels = ["beta"]
-        channel_map_tree = {
-            "latest": {
-                "16": {
-                    "amd64": [
-                        {"channel": "stable", "info": "none"},
-                        {"channel": "candidate", "info": "none"},
-                        {
-                            "channel": "beta",
-                            "info": "specific",
-                            "version": "1.1",
-                            "revision": 42,
-                        },
-                        {"channel": "edge", "info": "tracking"},
-                    ],
-                    "armhf": [
-                        {"channel": "stable", "info": "none"},
-                        {
-                            "channel": "beta",
-                            "info": "specific",
-                            "version": "1.2",
-                            "revision": 24,
-                        },
-                        {"channel": "beta", "info": "tracking"},
-                        {"channel": "edge", "info": "tracking"},
-                    ],
-                }
-            }
-        }
-        mock_close_channels.side_effect = [(closed_channels, channel_map_tree)]
-
-        result = self.run_command(["close", "basic", "beta"])
-
-        self.assertThat(result.exit_code, Equals(0))
-        self.assertThat(
-            result.output,
-            Contains(
-                dedent(
-                    """\
-            Track    Arch    Channel    Version    Revision    Notes
-            latest   amd64   stable     -          -           -
-                             candidate  -          -           -
-                             beta       1.1        42          -
-                             edge       ^          ^           -
-                     armhf   stable     -          -           -
-                             beta       1.2        24          -
-                             beta       ^          ^           -
-                             edge       ^          ^           -
-
-            \x1b[0;32mThe beta channel is now closed.\x1b[0m"""
-                )
-            ),
-        )
-
-    @mock.patch.object(storeapi._sca_client.SCAClient, "get_account_information")
-    @mock.patch.object(storeapi._sca_client.SCAClient, "close_channels")
-    def test_close_branches(self, mock_close_channels, mock_get_account_info):
-        mock_get_account_info.return_value = {
-            "snaps": {"16": {"basic": {"snap-id": "snap-id"}}}
-        }
-        closed_channels = ["stable/hotfix-1"]
-        channel_map_tree = {
-            "latest": {
-                "16": {
-                    "amd64": [
-                        {"channel": "stable", "info": "none"},
-                        {"channel": "candidate", "info": "none"},
-                        {
-                            "channel": "beta",
-                            "info": "specific",
-                            "version": "1.1",
-                            "revision": 42,
-                        },
-                        {"channel": "edge", "info": "tracking"},
-                        {
-                            "channel": "stable/hotfix-2",
-                            "info": "branch",
-                            "version": "1.3",
-                            "revision": 49,
-                            "expires_at": "2017-05-21T18:52:14.578435",
-                        },
-                    ]
-                }
-            }
-        }
-        mock_close_channels.side_effect = [(closed_channels, channel_map_tree)]
-
-        result = self.run_command(["close", "basic", "stable/hotfix-1"])
-
-        self.assertThat(result.exit_code, Equals(0))
-        self.assertThat(
-            result.output,
-            Contains(
-                dedent(
-                    """\
-            Track    Arch    Channel          Version    Revision    Notes    Expires at
-            latest   amd64   stable           -          -           -
-                             candidate        -          -           -
-                             beta             1.1        42          -
-                             edge             ^          ^           -
-                             stable/hotfix-2  1.3        49          -        2017-05-21T18:52:14.578435
-
-            \x1b[0;32mThe stable/hotfix-1 channel is now closed.\x1b[0m"""
-                )
-            ),
-        )  # noqa

--- a/todo.org
+++ b/todo.org
@@ -29,13 +29,14 @@
 - [ ] Replace =mksquashfs= with =snap pack=
 - [ ] Toggle compression with =snap pack=
 
-*** STRT [[file:specifications/progressive-releases.org][Progressive Releases]] [/]
+*** STRT [[file:specifications/progressive-releases.org][Progressive Releases]] [5/10]
 
 - [X] Implement channel-map endpoint
 - [X] Add support for the status command
 - [X] Add support for the release command
-- [ ] Add support for the close command
+- [X] Add support for the close command
 - [X] Add support for the promote command
+- [ ] Add support for the upload and release command
 - [ ] Migrate promote away from using the state endpoint
 - [ ] Remove the state endpoint
 - [ ] Add support for metrics


### PR DESCRIPTION
The implementation was moved to the CLI as being done for all commands.

With this, the new implementation for displaying a channel map is used,
which avoids the bug in the channel_map_tree returned in close that is
not progressive release aware and shows channels mistakenly as open.

The closed_channels API results are skipped as well as they are not
really track aware, returning mixed results for tracks in some scenarios
and plain risks for others (when latest is used, which is not allowed
when using more than one track).

The tests have been simplified to the concerns of the close CLI results
as display variants of the channel map tree are already done under test_status.

A missing todo checklist entry was added to take care of the upload logic.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
