### PR TITLE
build providers: snap sw to channels if injecting

### DIFF
--- a/tests/fake_servers/snapd.py
+++ b/tests/fake_servers/snapd.py
@@ -72,7 +72,13 @@ class FakeSnapdRequestHandler(fake_servers.BaseHTTPRequestHandler):
                     status_code = 200
                     type_ = "sync"
                     params = {}
-                    for key in ("channel", "revision", "confinement", "id"):
+                    for key in (
+                        "channel",
+                        "revision",
+                        "confinement",
+                        "id",
+                        "tracking-channel",
+                    ):
                         if key in snap:
                             params.update({key: snap[key]})
                     break

--- a/tests/unit/build_providers/test_snap.py
+++ b/tests/unit/build_providers/test_snap.py
@@ -49,8 +49,9 @@ class SnapInjectionTest(unit.TestCase):
                 "name": "snapd",
                 "confinement": "strict",
                 "id": "2kkitQ",
-                "channel": "stable",
+                "channel": "edge",
                 "revision": "1",
+                "tracking-channel": "latest/edge",
             },
             {
                 "name": "core18",
@@ -58,6 +59,7 @@ class SnapInjectionTest(unit.TestCase):
                 "id": "2kkibb",
                 "channel": "stable",
                 "revision": "123",
+                "tracking-channel": "latest/beta",
             },
             {
                 "name": "snapcraft",
@@ -65,6 +67,7 @@ class SnapInjectionTest(unit.TestCase):
                 "id": "3lljuR",
                 "channel": "edge",
                 "revision": "345",
+                "tracking-channel": "latest/candidate",
             },
         ]
         self.get_assertion_mock.side_effect = [
@@ -124,10 +127,13 @@ class SnapInjectionTest(unit.TestCase):
                 call(["snap", "watch", "--last=auto-refresh?"]),
                 call(["snap", "ack", "/var/tmp/snapd.assert"]),
                 call(["snap", "install", "/var/tmp/snapd.snap"]),
+                call(["snap", "switch", "snapd", "--channel", "latest/edge"]),
                 call(["snap", "ack", "/var/tmp/core18.assert"]),
                 call(["snap", "install", "/var/tmp/core18.snap"]),
+                call(["snap", "switch", "core18", "--channel", "latest/beta"]),
                 call(["snap", "ack", "/var/tmp/snapcraft.assert"]),
                 call(["snap", "install", "--classic", "/var/tmp/snapcraft.snap"]),
+                call(["snap", "switch", "snapcraft", "--channel", "latest/candidate"]),
             ]
         )
         self.provider.push_file_mock.assert_has_calls(


### PR DESCRIPTION
Avoid refreshing to "latest/stable" which is set to the default channel
to track in snapd when installing a snap that has a revision assertion.

The results:

```
$ snapcraft pull --use-lxd --shell
...
snapd 2.44.3 from Canonical✓ installed
"snapd" switched to the "latest/stable" channel

core18 20200427 from Canonical✓ installed
"core18" switched to the "latest/stable" channel

snapcraft 4.0.3 installed
"snapcraft" switched to the "latest/edge" channel

ubuntu # snap list
Name       Version   Rev   Tracking       Publisher   Notes
core18     20200427  1754  latest/stable  canonical✓  base
snapcraft  4.0.3     x1    latest/edge    -           classic
snapd      2.44.3    7264  latest/stable  canonical✓  snapd
```

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
