### PR TITLE
Use `pylxd` instead of `lxc exec`

### DIFF
--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -160,7 +160,8 @@ class LXD(Provider):
     ) -> Optional[bytes]:
         self._ensure_container_running()
 
-        cmd = super()._get_env_command()
+        cmd = []
+        cmd.extend(super()._get_env_command())
         cmd.extend(command)
         logger.debug(f"Executing in {self.instance_name}: {cmd}")
         (exit_code, stdout, stderr) = self._container.execute()

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -167,7 +167,7 @@ class LXD(Provider):
         cmd = list(super()._get_env_command())
         cmd.extend(command)
         logger.debug(f"Executing in {self.instance_name}: {cmd}")
-        (exit_code, stdout, stderr) = self._container.execute()
+        (exit_code, stdout, stderr) = self._container.execute(cmd)
 
         output = stdout + "\n\nSTDERR: " + stderr
 

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -164,7 +164,7 @@ class LXD(Provider):
         cmd.extend(command)
         logger.debug(f"Executing in {self.instance_name}: {cmd}")
         (exit_code, stdout, stderr) = self._container.execute()
-        
+
         if not hide_output:
             print(stdout)
             print(stderr)

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -165,15 +165,16 @@ class LXD(Provider):
         logger.debug(f"Executing in {self.instance_name}: {cmd}")
         (exit_code, stdout, stderr) = self._container.execute()
 
+        output = stdout + "\n\nSTDERR: " + stderr
+        
         if not hide_output:
-            print(stdout)
-            print(stderr)
+            print(output)
         if exit_code:
             raise errors.ProviderExecError(
                 provider_name=self._get_provider_name(),
                 command=command,
                 exit_code=exit_code,
-                output=stdout + stderr,
+                output=output,
             )
 
         return output

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -166,7 +166,7 @@ class LXD(Provider):
         (exit_code, stdout, stderr) = self._container.execute()
 
         output = stdout + "\n\nSTDERR: " + stderr
-        
+
         if not hide_output:
             print(output)
         if exit_code:

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -164,7 +164,7 @@ class LXD(Provider):
 
         self._ensure_container_running()
 
-        cmd = []
+        cmd: List[str] = []
         cmd.extend(super()._get_env_command())
         cmd.extend(command)
         logger.debug(f"Executing in {self.instance_name}: {cmd}")

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -158,6 +158,10 @@ class LXD(Provider):
     def _run(
         self, command: Sequence[str], hide_output: bool = False
     ) -> Optional[bytes]:
+        # Sanity check - developer error if container not initialized.
+        if self._container is None:
+            raise RuntimeError("Attempted to use container before starting.")
+
         self._ensure_container_running()
 
         cmd = []

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -164,8 +164,7 @@ class LXD(Provider):
 
         self._ensure_container_running()
 
-        cmd: List[str] = []
-        cmd.extend(super()._get_env_command())
+        cmd = list(super()._get_env_command())
         cmd.extend(command)
         logger.debug(f"Executing in {self.instance_name}: {cmd}")
         (exit_code, stdout, stderr) = self._container.execute()


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

`pylxd` ignores default LXD remote, but `lxc exec` does not. This is untested attempt to remove the todo and fix `--use-lxd` failure if default LXD remote is not local.

https://forum.snapcraft.io/t/use-lxd-doesnt-work-with-non-local-remote/17775