### PR TITLE
elf: search dynamic tags within sections, not segment

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -321,15 +321,22 @@ class ElfFile:
                 elf.header.e_machine,
             )
 
-            for segment in elf.iter_segments():
-                if isinstance(segment, elftools.elf.dynamic.DynamicSegment):
-                    self.is_dynamic = True
-                    for tag in segment.iter_tags("DT_NEEDED"):
+            # Gather attributes from dynamic sections.
+            for section in elf.iter_sections():
+                if not isinstance(section, elftools.elf.dynamic.DynamicSection):
+                    continue
+
+                self.is_dynamic = True
+
+                for tag in section.iter_tags():
+                    if tag.entry.d_tag == "DT_NEEDED":
                         needed = _ensure_str(tag.needed)
                         self.needed[needed] = NeededLibrary(name=needed)
-                    for tag in segment.iter_tags("DT_SONAME"):
+                    elif tag.entry.d_tag == "DT_SONAME":
                         self.soname = _ensure_str(tag.soname)
-                elif segment["p_type"] == "PT_GNU_STACK":
+
+            for segment in elf.iter_segments():
+                if segment["p_type"] == "PT_GNU_STACK":
                     # p_flags holds the bit mask for this segment.
                     # See `man 5 elf`.
                     mode = segment["p_flags"]


### PR DESCRIPTION
Due to yet more patchelf mangling, snapcraft was tripping on
invalid tag data.  We can avoid this by iteration over the
dynamic sections.

LP: 1879519

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
