### PR TITLE
cli: error/warn when using sudo

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -233,6 +233,18 @@ def _sanity_check_build_provider_flags(build_provider: str, **kwargs) -> None:
                 f"{key} cannot be used with build provider {build_provider!r}"
             )
 
+    # Check if running as sudo.
+    if os.getenv("SUDO_USER"):
+        if build_provider in ["lxd", "multipass"]:
+            raise errors.SnapcraftEnvironmentError(
+                f"'sudo' cannot be used with build provider {build_provider!r}"
+            )
+
+        if build_provider in ["host"]:
+            click.echo(
+                "Running with 'sudo' may cause permission errors and is discouraged. Use 'sudo' when cleaning."
+            )
+
 
 def get_build_provider(skip_sanity_checks: bool = False, **kwargs) -> str:
     """Get build provider and determine if running as managed instance."""

--- a/snapcraft/cli/remote.py
+++ b/snapcraft/cli/remote.py
@@ -15,9 +15,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import click
+import os
 import time
 
 from snapcraft.project import Project
+from snapcraft.internal.errors import SnapcraftEnvironmentError
 from snapcraft.internal.remote_build import WorkTree, LaunchpadClient, errors
 from snapcraft.formatting_utils import humanize_list
 from typing import List
@@ -103,6 +105,9 @@ def remote_build(
         snapcraft remote-build --recover
         snapcraft remote-build --status
     """
+    if os.getenv("SUDO_USER"):
+        raise SnapcraftEnvironmentError("'sudo' cannot be used with remote-build")
+
     if not launchpad_accept_public_upload:
         raise errors.AcceptPublicUploadError()
 

--- a/tests/spread/build-providers/lxd-prime-then-try/task.yaml
+++ b/tests/spread/build-providers/lxd-prime-then-try/task.yaml
@@ -11,12 +11,14 @@ prepare: |
   chown ubuntu "$SNAP_DIR"
 
 restore: |
+  SUDO_CMD="sudo -iu ubuntu env -i PATH=$PATH"
+
   # export the full path for sudo to work
   SNAP_DIR="$(realpath "$SNAP_DIR")"
   export SNAP_DIR
   cd "$SNAP_DIR"
 
-  sudo -iu ubuntu env -i bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
+  $SUDO_CMD bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
   rm -f ./*.snap
 
   chown root "$SNAP_DIR"
@@ -26,19 +28,21 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 execute: |
+  SUDO_CMD="sudo -iu ubuntu env -i PATH=$PATH"
+
   # export the full path for sudo to work
   SNAP_DIR="$(realpath "$SNAP_DIR")"
   export SNAP_DIR
   cd "$SNAP_DIR"
 
   # lxd mounting as root is just not going to work.
-  sudo -iu ubuntu env -i bash -c "cd $SNAP_DIR && snapcraft prime --use-lxd"
+  $SUDO_CMD bash -c "cd $SNAP_DIR && snapcraft prime --use-lxd"
   if [ -d prime ]; then
       echo "The prime directory should not be exposed"
       exit 1
   fi
 
-  sudo -iu ubuntu env -i bash -c "cd $SNAP_DIR && snapcraft try --use-lxd"
+  $SUDO_CMD bash -c "cd $SNAP_DIR && snapcraft try --use-lxd"
   snap try prime
   [ "$(make-hello)" = "hello world" ]
 

--- a/tests/spread/build-providers/lxd-prime-then-try/task.yaml
+++ b/tests/spread/build-providers/lxd-prime-then-try/task.yaml
@@ -16,7 +16,7 @@ restore: |
   export SNAP_DIR
   cd "$SNAP_DIR"
 
-  sudo -iu ubuntu bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
+  sudo -iu ubuntu env -i bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
   rm -f ./*.snap
 
   chown root "$SNAP_DIR"
@@ -32,13 +32,13 @@ execute: |
   cd "$SNAP_DIR"
 
   # lxd mounting as root is just not going to work.
-  sudo -iu ubuntu bash -c "cd $SNAP_DIR && snapcraft prime --use-lxd"
+  sudo -iu ubuntu env -i bash -c "cd $SNAP_DIR && snapcraft prime --use-lxd"
   if [ -d prime ]; then
       echo "The prime directory should not be exposed"
       exit 1
   fi
 
-  sudo -iu ubuntu bash -c "cd $SNAP_DIR && snapcraft try --use-lxd"
+  sudo -iu ubuntu env -i bash -c "cd $SNAP_DIR && snapcraft try --use-lxd"
   snap try prime
   [ "$(make-hello)" = "hello world" ]
 

--- a/tests/spread/build-providers/lxd-try/task.yaml
+++ b/tests/spread/build-providers/lxd-try/task.yaml
@@ -16,7 +16,7 @@ restore: |
   export SNAP_DIR
   cd "$SNAP_DIR"
 
-  sudo -iu ubuntu bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
+  sudo -iu ubuntu env -i bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
   rm -f ./*.snap
 
   chown root "$SNAP_DIR"
@@ -32,12 +32,12 @@ execute: |
   cd "$SNAP_DIR"
 
   # lxd mounting as root is just not going to work.
-  sudo -iu ubuntu bash -c "cd $SNAP_DIR && snapcraft try --use-lxd"
+  sudo -iu ubuntu env -i bash -c "cd $SNAP_DIR && snapcraft try --use-lxd"
   snap try prime
   [ "$(make-hello)" = "hello world" ]
 
   # snapcraft clean when trying keeps the dir
-  sudo -iu ubuntu bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
+  sudo -iu ubuntu env -i bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
   if [ ! -d prime ]; then
       echo "The prime directory should not have been removed while trying"
       exit 1
@@ -45,7 +45,7 @@ execute: |
 
   # Remove the snap try and clean again
   snap remove make-hello
-  sudo -iu ubuntu bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
+  sudo -iu ubuntu env -i bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
   if [ -d prime ]; then
       echo "The prime directory should have been removed"
       exit 1

--- a/tests/spread/build-providers/lxd-try/task.yaml
+++ b/tests/spread/build-providers/lxd-try/task.yaml
@@ -11,12 +11,14 @@ prepare: |
   chown ubuntu "$SNAP_DIR"
 
 restore: |
+  SUDO_CMD="sudo -iu ubuntu env -i PATH=$PATH"
+
   # export the full path for sudo to work
   SNAP_DIR="$(realpath "$SNAP_DIR")"
   export SNAP_DIR
   cd "$SNAP_DIR"
 
-  sudo -iu ubuntu env -i bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
+  $SUDO_CMD bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
   rm -f ./*.snap
 
   chown root "$SNAP_DIR"
@@ -26,18 +28,20 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 execute: |
+  SUDO_CMD="sudo -iu ubuntu env -i PATH=$PATH"
+
   # export the full path for sudo to work
   SNAP_DIR="$(realpath "$SNAP_DIR")"
   export SNAP_DIR
   cd "$SNAP_DIR"
 
   # lxd mounting as root is just not going to work.
-  sudo -iu ubuntu env -i bash -c "cd $SNAP_DIR && snapcraft try --use-lxd"
+  $SUDO_CMD bash -c "cd $SNAP_DIR && snapcraft try --use-lxd"
   snap try prime
   [ "$(make-hello)" = "hello world" ]
 
   # snapcraft clean when trying keeps the dir
-  sudo -iu ubuntu env -i bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
+  $SUDO_CMD bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
   if [ ! -d prime ]; then
       echo "The prime directory should not have been removed while trying"
       exit 1
@@ -45,7 +49,7 @@ execute: |
 
   # Remove the snap try and clean again
   snap remove make-hello
-  sudo -iu ubuntu env -i bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
+  $SUDO_CMD bash -c "cd $SNAP_DIR && snapcraft clean --use-lxd"
   if [ -d prime ]; then
       echo "The prime directory should have been removed"
       exit 1

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -20,6 +20,7 @@ import fixtures
 from testtools.matchers import Contains, Equals
 
 import snapcraft.internal.remote_build.errors as errors
+from snapcraft.internal.errors import SnapcraftEnvironmentError
 from . import CommandBaseTestCase
 from tests import fixture_setup
 
@@ -72,3 +73,12 @@ class RemoteBuildTests(CommandBaseTestCase):
 
         self.mock_lc.start_build.assert_not_called()
         self.mock_lc.cleanup.assert_not_called()
+
+    def test_remote_build_sudo_errors(self):
+        self.useFixture(fixtures.EnvironmentVariable("SUDO_USER", "testuser"))
+
+        self.assertRaises(
+            SnapcraftEnvironmentError,
+            self.run_command,
+            ["remote-build", "--launchpad-accept-public-upload"],
+        )


### PR DESCRIPTION
Sentry is filled with bug reports resulting from permission
errors due to mixed usage of sudo in different environments.
By checking for use of sudo, we can prevent most of these
errors from occurring.

- For lxd, multipass & remote-build users, exit with an error
if user is using sudo.

- For host (destructive-mode) users, warn if sudo is detected,
suggesting that the user also use sudo when cleaning.

Update spread tests to use `env -i` when using sudo.
