### PR TITLE
cli: disable --target-arch support on core20

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -71,7 +71,7 @@ def _execute(  # noqa: C901
     is_managed_host = build_provider == "managed-host"
 
     project = get_project(is_managed_host=is_managed_host, **kwargs)
-    conduct_project_sanity_check(project)
+    conduct_project_sanity_check(project, **kwargs)
 
     if build_provider in ["host", "managed-host"]:
         project_config = project_loader.load_config(project)

--- a/snapcraft/project/_project.py
+++ b/snapcraft/project/_project.py
@@ -74,10 +74,11 @@ class Project(ProjectOptions):
         """
 
         # In case snap_meta is not yet populated, lookup base in info.
-        if self.info.build_base:
-            return self.info.build_base
-        elif self.info.base:
-            return self.info.base
+        if self.info:
+            if self.info.build_base:
+                return self.info.build_base
+            if self.info.base:
+                return self.info.base
 
         return self._snap_meta.get_build_base()
 

--- a/snapcraft/project/_project.py
+++ b/snapcraft/project/_project.py
@@ -72,6 +72,13 @@ class Project(ProjectOptions):
         """
         Return name for type base or the base otherwise build-base is set
         """
+
+        # In case snap_meta is not yet populated, lookup base in info.
+        if self.info.build_base:
+            return self.info.build_base
+        elif self.info.base:
+            return self.info.base
+
         return self._snap_meta.get_build_base()
 
     def _get_project_directory_hash(self) -> str:

--- a/snapcraft/project/_sanity_checks.py
+++ b/snapcraft/project/_sanity_checks.py
@@ -35,7 +35,7 @@ _EXPECTED_SNAP_DIR_PATTERNS = {
 }
 
 
-def conduct_project_sanity_check(project: Project) -> None:
+def conduct_project_sanity_check(project: Project, **kwargs) -> None:
     """Sanity check the project itself before continuing.
 
     The checks done here are meant to be light, and not rely on the build environment.
@@ -57,6 +57,11 @@ def conduct_project_sanity_check(project: Project) -> None:
         raise SnapcraftEnvironmentError(
             "*EXPERIMENTAL* 'package-repositories' configured, but not enabled. "
             "Enable with '--enable-experimental-package-repositories' flag."
+        )
+
+    if project._get_build_base() in ["core20"] and "target_arch" in kwargs:
+        raise SnapcraftEnvironmentError(
+            "--target-arch has been deprecated and is no longer supported on core20."
         )
 
 

--- a/snapcraft/project/_sanity_checks.py
+++ b/snapcraft/project/_sanity_checks.py
@@ -59,7 +59,10 @@ def conduct_project_sanity_check(project: Project, **kwargs) -> None:
             "Enable with '--enable-experimental-package-repositories' flag."
         )
 
-    if project._get_build_base() in ["core20"] and "target_arch" in kwargs:
+    if (
+        project._get_build_base() in ["core20"]
+        and kwargs.get("target_arch") is not None
+    ):
         raise SnapcraftEnvironmentError(
             "--target-arch has been deprecated and is no longer supported on core20."
         )


### PR DESCRIPTION
Rather than cross-compiling, which has numerous limitations,
this commit disables --target-arch. We need to work on expanding
support for --build-on to create an environment to target the
correct architecture.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
