### PR TITLE
cli: disable --target-arch for multipass/lxd

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -75,7 +75,7 @@ _PROVIDER_OPTIONS = [
         param_decls="--target-arch",
         metavar="<arch>",
         help="Target architecture to cross compile to",
-        supported_providers=["host", "lxd", "managed-host", "multipass"],
+        supported_providers=["host"],
     ),
     dict(
         param_decls="--debug",


### PR DESCRIPTION
It currently doesn't have any effect, so rather than imply that
it is in fact working, disable it outright.  We will be working
toward expanding "--build-on" to target other architectures without
cross-compilation that is broken in many cases (like this).

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
