### PR TITLE
review-tools: add --allow-classic flag for local review

### DIFF
--- a/snapcraft/internal/review_tools/_runner.py
+++ b/snapcraft/internal/review_tools/_runner.py
@@ -30,7 +30,12 @@ def is_available() -> bool:
 
 def run(*, snap_filename: str) -> None:
     # TODO allow suppression of error and warn through project configuration.
-    command = [_REVIEW_TOOLS_PATH.as_posix(), snap_filename, "--json"]
+    command = [
+        _REVIEW_TOOLS_PATH.as_posix(),
+        snap_filename,
+        "--json",
+        "--allow-classic",
+    ]
     # Speed up the process by not doing the re-squash tests.
     env = dict(SNAP_ENFORCE_RESQUASHFS="0")
 

--- a/tests/unit/review_tools/test_runner.py
+++ b/tests/unit/review_tools/test_runner.py
@@ -35,7 +35,7 @@ class RunTest(unit.TestCase):
 
     def assert_fake_check_output_called(self):
         self.fake_check_output.mock.assert_called_once_with(
-            [self.review_tools_path, "fake.snap", "--json"],
+            [self.review_tools_path, "fake.snap", "--json", "--allow-classic"],
             env={"SNAP_ENFORCE_RESQUASHFS": "0"},
             stderr=subprocess.STDOUT,
         )
@@ -72,7 +72,7 @@ class RunTest(unit.TestCase):
 
     def test_review_errors(self):
         self.fake_check_output.mock.side_effect = subprocess.CalledProcessError(
-            cmd=[self.review_tools_path, "fake.snap", "--json"],
+            cmd=[self.review_tools_path, "fake.snap", "--json", "--allow-classic"],
             returncode=3,
             output=json.dumps(
                 {
@@ -97,7 +97,7 @@ class RunTest(unit.TestCase):
 
     def test_review_unkown_error_bubbles_up(self):
         self.fake_check_output.mock.side_effect = subprocess.CalledProcessError(
-            cmd=[self.review_tools_path, "fake.snap", "--json"],
+            cmd=[self.review_tools_path, "fake.snap", "--json", "--allow-classic"],
             returncode=4,
             output=b"unknown",
         )


### PR DESCRIPTION
Snapcraft issues the error when uploading classic snaps:

```
(NEEDS REVIEW) confinement 'classic' not allowed. If your snap needs classic confinement to function, please make a request for this snap to use classic by creating a new topic in the forum using the 'store-requests' category and detail the technical reasons why classic is required.
```

Since snapcraft doesn't know if the snap has already been approved,
allow classic during local review, and let the the store can return
the error from the upload's automatic review, which snapcraft will
handle gracefully.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
