### PR TITLE
cmake v2 plugin: take source-subdir into account

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -89,9 +89,9 @@ class PluginHandler:
         self.part_snaps_dir = os.path.join(self.part_dir, "snaps")
         # The working directory for the build depends on the source-subdir
         # part property.
-        self.part_build_work_dir = os.path.join(
-            self.part_build_dir, self._part_properties.get("source-subdir", "")
-        )
+        source_sub_dir = self._part_properties.get("source-subdir", "")
+        self.part_source_work_dir = os.path.join(self.part_source_dir, source_sub_dir)
+        self.part_build_work_dir = os.path.join(self.part_build_dir, source_sub_dir)
 
         self._pull_state: Optional[states.PullState] = None
         self._build_state: Optional[states.BuildState] = None

--- a/snapcraft/internal/pluginhandler/_part_environment.py
+++ b/snapcraft/internal/pluginhandler/_part_environment.py
@@ -78,12 +78,16 @@ def get_snapcraft_global_environment(
 def get_snapcraft_part_directory_environment(
     part: "PluginHandler", *, step: Optional[steps.Step] = None
 ) -> Dict[str, str]:
-    env = {"SNAPCRAFT_PART_SRC": part.part_source_dir}
+    env = {
+        "SNAPCRAFT_PART_SRC": part.part_source_dir,
+        "SNAPCRAFT_PART_SRC_WORK": part.part_source_work_dir,
+    }
 
     if step is None or step == steps.BUILD:
         env.update(
             {
                 "SNAPCRAFT_PART_BUILD": part.part_build_dir,
+                "SNAPCRAFT_PART_BUILD_WORK": part.part_build_work_dir,
                 "SNAPCRAFT_PART_INSTALL": part.part_install_dir,
             }
         )

--- a/snapcraft/plugins/v2/cmake.py
+++ b/snapcraft/plugins/v2/cmake.py
@@ -62,7 +62,7 @@ class CMakePlugin(PluginV2):
         return dict()
 
     def _get_cmake_configure_command(self) -> str:
-        cmd = ["cmake", '"${SNAPCRAFT_PART_SRC}"'] + self.options.cmake_parameters
+        cmd = ["cmake", '"${SNAPCRAFT_PART_SRC_WORK}"'] + self.options.cmake_parameters
 
         return " ".join(cmd)
 

--- a/tests/spread/plugins/v2/build-and-run-hello/task.yaml
+++ b/tests/spread/plugins/v2/build-and-run-hello/task.yaml
@@ -5,6 +5,7 @@ summary: >-
 environment:
   SNAP/autotools: autotools-hello
   SNAP/cmake: cmake-hello
+  SNAP/cmake_subdir: cmake-hello-subdir
   SNAP/make: make-hello
   SNAP/python: python-hello
   SNAP/python_staged: python-hello-staged-python

--- a/tests/spread/plugins/v2/build-and-run-hello/task.yaml
+++ b/tests/spread/plugins/v2/build-and-run-hello/task.yaml
@@ -33,6 +33,7 @@ restore: |
   # Undo changes to hello
   [ -f hello ] && git checkout hello
   [ -f hello.c ] && git checkout hello.c
+  [ -f subdir/hello.c ] && git checkout subdir/hello.c
   [ -f hello.js ] && git checkout hello.js
   [ -f main.go ] && git checkout main.go
   [ -f src/main.rs ] && git checkout src/main.rs
@@ -61,6 +62,8 @@ execute: |
     modified_file=hello
   elif [ -f hello.c ]; then
     modified_file=hello.c
+  elif [ -f subdir/hello.c ]; then
+    modified_file=subdir/hello.c
   elif [ -f hello.js ]; then
     modified_file=hello.js
   elif [ -f main.go ]; then

--- a/tests/spread/plugins/v2/snaps/cmake-hello-subdir/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/cmake-hello-subdir/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: cmake-hello-subdir
+version: "1.0"
+summary: test the cmake plugin
+description: |
+  This is a basic cmake snap. It just prints a hello world.
+  If you want to add other functionalities to this snap, please don't.
+  Make a new one.
+
+grade: devel
+base: core20
+confinement: strict
+
+apps:
+  cmake-hello-subdir:
+    command: usr/bin/cmake-hello
+
+parts:
+  hello:
+    plugin: cmake
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+    source: .
+    source-subdir: subdir

--- a/tests/spread/plugins/v2/snaps/cmake-hello-subdir/subdir/CMakeLists.txt
+++ b/tests/spread/plugins/v2/snaps/cmake-hello-subdir/subdir/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.6)
+project(cmake-hello C)
+add_executable(cmake-hello hello.c)
+install(TARGETS cmake-hello RUNTIME DESTINATION bin)

--- a/tests/spread/plugins/v2/snaps/cmake-hello-subdir/subdir/hello.c
+++ b/tests/spread/plugins/v2/snaps/cmake-hello-subdir/subdir/hello.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main()
+{
+    printf("hello world\n");
+    return 0;
+}

--- a/tests/unit/lifecycle/test_lifecycle.py
+++ b/tests/unit/lifecycle/test_lifecycle.py
@@ -51,7 +51,9 @@ class ExecutionTestCase(LifecycleTestBase):
             def __init__(self):
                 self.plugin = Plugin()
                 self.part_source_dir = "/tmp"
+                self.part_source_work_dir = "/tmp"
                 self.part_build_dir = "/tmp"
+                self.part_build_work_dir = "/tmp"
                 self.part_install_dir = "/tmp"
 
         part = Part()

--- a/tests/unit/plugins/v2/test_cmake.py
+++ b/tests/unit/plugins/v2/test_cmake.py
@@ -63,7 +63,7 @@ class CMakePluginTest(TestCase):
             plugin.get_build_commands(),
             Equals(
                 [
-                    'cmake "${SNAPCRAFT_PART_SRC}"',
+                    'cmake "${SNAPCRAFT_PART_SRC_WORK}"',
                     'cmake --build . -- -j"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
                     'cmake --build . --target install -- DESTDIR="${SNAPCRAFT_PART_INSTALL}"',
                 ]
@@ -85,7 +85,7 @@ class CMakePluginTest(TestCase):
             plugin.get_build_commands(),
             Equals(
                 [
-                    'cmake "${SNAPCRAFT_PART_SRC}" '
+                    'cmake "${SNAPCRAFT_PART_SRC_WORK}" '
                     "-DVERBOSE=1 "
                     "-DCMAKE_INSTALL_PREFIX=/foo "
                     '-DCMAKE_SPACED_ARGS="foo bar" '

--- a/tests/unit/project_loader/test_environment.py
+++ b/tests/unit/project_loader/test_environment.py
@@ -255,8 +255,12 @@ class EnvironmentTest(ProjectLoaderBaseTest):
                     'SNAPCRAFT_EXTENSIONS_DIR="{}"'.format(common.get_extensionsdir()),
                     'SNAPCRAFT_PARALLEL_BUILD_COUNT="2"',
                     'SNAPCRAFT_PART_BUILD="{}/parts/main/build"'.format(self.path),
+                    'SNAPCRAFT_PART_BUILD_WORK="{}/parts/main/build/"'.format(
+                        self.path
+                    ),
                     'SNAPCRAFT_PART_INSTALL="{}/parts/main/install"'.format(self.path),
                     'SNAPCRAFT_PART_SRC="{}/parts/main/src"'.format(self.path),
+                    'SNAPCRAFT_PART_SRC_WORK="{}/parts/main/src/"'.format(self.path),
                     'SNAPCRAFT_PRIME="{}/prime"'.format(self.path),
                     'SNAPCRAFT_PROJECT_DIR="{}"'.format(self.path),
                     'SNAPCRAFT_PROJECT_GRADE="stable"',


### PR DESCRIPTION
Setup 2 _WORK variables, for the pull and build step, use
SNAPCRAFT_PART_SOURCE_WORK from get_build_commands instead of
SNAPCRAFT_PART_SOURCE.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
