### PR TITLE
spread: use absolute path to lxd

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -215,8 +215,8 @@ prepare: |
       echo "PATH=$PATH"
       echo "which lxd: $(command -v lxd)"
       stat /snap/bin/lxd
-      lxd waitready --timeout=30
-      lxd init --auto
+      /snap/bin/lxd waitready --timeout=30
+      /snap/bin/lxd init --auto
       # Add the ubuntu user to the lxd group.
       adduser ubuntu lxd
   fi


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
