### PR TITLE
cli: improve sudo detection with euid check for warnings/errors

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -234,7 +234,7 @@ def _sanity_check_build_provider_flags(build_provider: str, **kwargs) -> None:
             )
 
     # Check if running as sudo.
-    if os.getenv("SUDO_USER"):
+    if os.getenv("SUDO_USER") and os.geteuid() == 0:
         if build_provider in ["lxd", "multipass"]:
             raise errors.SnapcraftEnvironmentError(
                 f"'sudo' cannot be used with build provider {build_provider!r}"

--- a/snapcraft/cli/remote.py
+++ b/snapcraft/cli/remote.py
@@ -105,7 +105,7 @@ def remote_build(
         snapcraft remote-build --recover
         snapcraft remote-build --status
     """
-    if os.getenv("SUDO_USER"):
+    if os.getenv("SUDO_USER") and os.geteuid() == 0:
         raise SnapcraftEnvironmentError("'sudo' cannot be used with remote-build")
 
     if not launchpad_accept_public_upload:

--- a/tests/unit/cli/test_options.py
+++ b/tests/unit/cli/test_options.py
@@ -307,7 +307,13 @@ class TestSudo(unit.TestCase):
     def setUp(self):
         super().setUp()
 
+        self.useFixture(
+            fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT", "host")
+        )
         self.useFixture(fixtures.EnvironmentVariable("SUDO_USER", "testuser"))
+        self.fake_euid = self.useFixture(
+            fixtures.MockPatch("os.geteuid", return_value=0)
+        ).mock
 
     def test_click_error_with_sudo_for_providers(self):
         for provider in ["lxd", "multipass"]:
@@ -315,6 +321,7 @@ class TestSudo(unit.TestCase):
                 fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT", provider)
             )
 
+            self.fake_euid.return_value = 0
             self.assertRaisesRegex(
                 SnapcraftEnvironmentError,
                 f"^'sudo' cannot be used with build provider '{provider}'$",
@@ -322,14 +329,24 @@ class TestSudo(unit.TestCase):
                 provider,
             )
 
+    def test_click_no_error_with_sudo_non_root_for_providers(self):
+        for provider in ["lxd", "multipass"]:
+            self.useFixture(
+                fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT", provider)
+            )
+
+            self.fake_euid.return_value = 1000
+            options._sanity_check_build_provider_flags(provider)
+
     @mock.patch("click.echo")
     def test_click_warn_sudo_with_host(self, echo_mock):
-        self.useFixture(
-            fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_ENVIRONMENT", "host")
-        )
-
         options._sanity_check_build_provider_flags("host")
-
         echo_mock.assert_called_once_with(
             "Running with 'sudo' may cause permission errors and is discouraged. Use 'sudo' when cleaning."
         )
+
+    @mock.patch("click.echo")
+    def test_click_no_warn_sudo_non_root_with_host(self, echo_mock):
+        self.fake_euid.return_value = 1000
+        options._sanity_check_build_provider_flags("host")
+        echo_mock.assert_not_called()

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -77,8 +77,17 @@ class RemoteBuildTests(CommandBaseTestCase):
     def test_remote_build_sudo_errors(self):
         self.useFixture(fixtures.EnvironmentVariable("SUDO_USER", "testuser"))
 
+        self.useFixture(fixtures.MockPatch("os.geteuid", return_value=0))
+
         self.assertRaises(
             SnapcraftEnvironmentError,
             self.run_command,
             ["remote-build", "--launchpad-accept-public-upload"],
         )
+
+    def test_remote_build_sudo_non_root_no_errors(self):
+        self.useFixture(fixtures.EnvironmentVariable("SUDO_USER", "testuser"))
+
+        self.useFixture(fixtures.MockPatch("os.geteuid", return_value=1000))
+
+        self.run_command(["remote-build", "--launchpad-accept-public-upload"])


### PR DESCRIPTION
Some environments will `sudo` to another user.  To avoid
unnecessary warnings/errors, additionally check that the
effective user is root.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
