### PR TITLE
project loader: fix v1 plugin repository installation on host

### DIFF
--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -245,15 +245,29 @@ class Config:
         if duplicates:
             raise errors.DuplicateAliasError(aliases=duplicates)
 
-    def get_build_packages(self) -> Set[str]:
+    def install_package_repositories(self) -> None:
         keys_path = self.project._get_keys_path()
-        if any(
-            [
-                package_repo.install(keys_path=keys_path)
-                for package_repo in self.project._snap_meta.package_repositories
-            ]
-        ):
+
+        # Install repositories configured by 'package-repositories'.
+        changes = [
+            package_repo.install(keys_path=keys_path)
+            for package_repo in self.project._snap_meta.package_repositories
+        ]
+
+        # Install repositories configured by v1 plugins.
+        for part in self.all_parts:
+            if isinstance(part.plugin, plugins.v1.PluginV1):
+                changes += [
+                    package_repo.install(keys_path=keys_path)
+                    for package_repo in part.plugin.get_required_package_repositories()
+                ]
+
+        if any(changes):
             repo.Repo.refresh_build_packages()
+
+    def get_build_packages(self) -> Set[str]:
+        # Install/update configured package repositories.
+        self.install_package_repositories()
 
         build_packages = self._global_grammar_processor.get_build_packages()
         build_packages |= set(self.project.additional_build_packages)

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -26,7 +26,6 @@ from snapcraft.internal.pluginhandler._part_environment import (
     get_snapcraft_global_environment,
     get_snapcraft_part_directory_environment,
 )
-from snapcraft import plugins
 from ._env import build_env, build_env_for_stage, runtime_env
 from . import errors, grammar_processing
 
@@ -188,17 +187,6 @@ class PartsConfig:
             "Setting up part {!r} with plugin {!r} and "
             "properties {!r}.".format(part_name, plugin_name, part_properties)
         )
-
-        if isinstance(plugin, plugins.v1.PluginV1):
-            keys_path = self._project._get_keys_path()
-
-            if any(
-                [
-                    package_repo.install(keys_path=keys_path)
-                    for package_repo in plugin.get_required_package_repositories()
-                ]
-            ):
-                repo.Repo.refresh_build_packages()
 
         stage_packages_repo = repo.Repo
 


### PR DESCRIPTION
v1 plugins were unconditionally having their repositories installed
on the host when using a build environment.  Consolidate to previous
work in Config, creating a new method `install_package_repositories()`
to handle both v1 plugins and `package-repositories` configured repo
installation, when required.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
