### PR TITLE
npm v2 plugin: always include $SNAPCRAFT_PART_INSTALL/bin in $PATH

### DIFF
--- a/snapcraft/plugins/v2/npm.py
+++ b/snapcraft/plugins/v2/npm.py
@@ -92,13 +92,12 @@ class NpmPlugin(PluginV2):
             f"""\
         if [ ! -f "${{SNAPCRAFT_PART_INSTALL}}/bin/node" ]; then
             curl -s "{node_uri}" | tar xzf - -C "${{SNAPCRAFT_PART_INSTALL}}/" --strip-components=1
-            export PATH="${{SNAPCRAFT_PART_INSTALL}}/bin:${{PATH}}"
         fi
         """
         )
 
     def get_build_environment(self) -> Dict[str, str]:
-        return dict()
+        return dict(PATH="${SNAPCRAFT_PART_INSTALL}/bin:${PATH}")
 
     def get_build_commands(self) -> List[str]:
         return [

--- a/tests/unit/plugins/v2/test_npm.py
+++ b/tests/unit/plugins/v2/test_npm.py
@@ -48,7 +48,10 @@ class NpmPluginTest(TestCase):
     def test_get_build_environment(self):
         plugin = NpmPlugin(part_name="my-part", options=lambda: None)
 
-        self.assertThat(plugin.get_build_environment(), Equals(dict()))
+        self.assertThat(
+            plugin.get_build_environment(),
+            Equals({"PATH": "${SNAPCRAFT_PART_INSTALL}/bin:${PATH}"}),
+        )
 
     def test_get_architecture_from_snap_arch(self):
         for snap_arch, node_arch in [
@@ -90,7 +93,6 @@ class NpmPluginTest(TestCase):
                         """\
                     if [ ! -f "${SNAPCRAFT_PART_INSTALL}/bin/node" ]; then
                         curl -s "https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-x64.tar.gz" | tar xzf - -C "${SNAPCRAFT_PART_INSTALL}/" --strip-components=1
-                        export PATH="${SNAPCRAFT_PART_INSTALL}/bin:${PATH}"
                     fi
                     """
                     ),


### PR DESCRIPTION
That's where we are unpacking node to anyways, always include it.
If node is already in ${SNAPCRAFT_PART_INSTALL}/bin, then the PATH
never gets updated, breaking the build.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
