### PR TITLE
plugins: fix loading of catkin-tools

### DIFF
--- a/snapcraft/plugins/_plugin_finder.py
+++ b/snapcraft/plugins/_plugin_finder.py
@@ -29,7 +29,7 @@ if sys.platform == "linux" or TYPE_CHECKING:
             "ant": v1.AntPlugin,
             "autotools": v1.AutotoolsPlugin,
             "catkin": v1.CatkinPlugin,
-            "catkin_tools": v1.CatkinToolsPlugin,
+            "catkin-tools": v1.CatkinToolsPlugin,
             "cmake": v1.CMakePlugin,
             "colcon": v1.ColconPlugin,
             "conda": v1.CondaPlugin,


### PR DESCRIPTION
Typo "catkin_tools" should be "catkin-tools".

We need a spread test for this plugin.

LP: #1882996

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
