### PR TITLE
cli: restore --target-arch with warning for LXD and Multipass

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -75,7 +75,7 @@ _PROVIDER_OPTIONS = [
         param_decls="--target-arch",
         metavar="<arch>",
         help="Target architecture to cross compile to",
-        supported_providers=["host"],
+        supported_providers=["host", "lxd", "multipass"],
     ),
     dict(
         param_decls="--debug",

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -73,7 +73,7 @@ def _execute(  # noqa: C901
     # Temporary fix to ignore target_arch.
     if "target_arch" in kwargs and build_provider in ["multipass", "lxd"]:
         echo.warning(
-            "Ignoring '--target-arch' flag.  This flag requires --destructive-mode, is unsupported, and will be removed in future versions."
+            "Ignoring '--target-arch' flag.  This flag requires --destructive-mode and is unsupported with Multipass and LXD build providers."
         )
         kwargs.pop("target_arch")
 

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -70,6 +70,13 @@ def _execute(  # noqa: C901
 
     is_managed_host = build_provider == "managed-host"
 
+    # Temporary fix to ignore target_arch.
+    if "target_arch" in kwargs and build_provider in ["multipass", "lxd"]:
+        echo.warning(
+            "Ignoring '--target-arch' flag.  This flag requires --destructive-mode, is unsupported, and will be removed in future versions."
+        )
+        kwargs.pop("target_arch")
+
     project = get_project(is_managed_host=is_managed_host, **kwargs)
     conduct_project_sanity_check(project, **kwargs)
 
@@ -315,6 +322,10 @@ def clean(ctx, parts, unprime, step, **kwargs):
     apply_host_provider_flags(build_provider_flags)
 
     is_managed_host = build_provider == "managed-host"
+
+    # Temporary fix to ignore target_arch, silently for clean.
+    if "target_arch" in kwargs and build_provider in ["multipass", "lxd"]:
+        kwargs.pop("target_arch")
 
     try:
         project = get_project(is_managed_host=is_managed_host)


### PR DESCRIPTION
Electron builder currently uses --target-arch.  Until fixes are
upstreamed, restore --target-arch availability for LXD and Multipass,
replacing the error with a warning.

Pops target_arch from kwargs to prevent usage by get_project(),
which is not aware of the build provider.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
