### PR TITLE
repo: consider virtual pkgs for cache invalidation

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -316,13 +316,9 @@ class Ubuntu(BaseRepo):
         with AptCache() as apt_cache:
             for package in package_names:
                 pkg_name, pkg_version = get_pkg_name_parts(package)
-                installed_version = apt_cache.get_installed_version(pkg_name)
 
-                if installed_version is None or (
-                    pkg_version is not None and installed_version != pkg_version
-                ):
+                if not apt_cache.is_package_installed(pkg_name, pkg_version):
                     return False
-
         return True
 
     @classmethod

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -316,9 +316,15 @@ class Ubuntu(BaseRepo):
         with AptCache() as apt_cache:
             for package in package_names:
                 pkg_name, pkg_version = get_pkg_name_parts(package)
+                installed_version = apt_cache.get_installed_version(
+                    pkg_name, resolve_virtual_packages=True
+                )
 
-                if not apt_cache.is_package_installed(pkg_name, pkg_version):
+                if installed_version is None or (
+                    pkg_version is not None and installed_version != pkg_version
+                ):
                     return False
+
         return True
 
     @classmethod

--- a/snapcraft/internal/repo/apt_cache.py
+++ b/snapcraft/internal/repo/apt_cache.py
@@ -140,24 +140,19 @@ class AptCache(ContextDecorator):
     def is_package_valid(self, package_name: str) -> bool:
         return package_name in self.cache or self.cache.is_virtual_package(package_name)
 
-    def is_package_installed(self, package_name: str, package_version: str) -> bool:
-        if self.cache.is_virtual_package(package_name):
+    def get_installed_version(
+        self, package_name: str, *, resolve_virtual_packages: bool = False
+    ) -> Optional[str]:
+        if resolve_virtual_packages and self.cache.is_virtual_package(package_name):
             logger.warning(
                 f"{package_name!r} is a virtual package, use non virtual packages for deterministic results."
             )
-            return self.is_package_installed(
-                self.cache.get_providing_packages(package_name)[0].name, package_version
+            # Recusrse until a "real" package is found.
+            return self.get_installed_version(
+                self.cache.get_providing_packages(package_name)[0].name,
+                resolve_virtual_packages=resolve_virtual_packages,
             )
 
-        installed_version = self.get_installed_version(package_name)
-        if installed_version is None or (
-            package_version is not None and installed_version != package_version
-        ):
-            return False
-
-        return True
-
-    def get_installed_version(self, package_name: str) -> Optional[str]:
         if package_name in self.cache:
             if self.cache[package_name].installed is not None:
                 return self.cache[package_name].installed.version

--- a/tests/spread/general/virtual-packages/task.yaml
+++ b/tests/spread/general/virtual-packages/task.yaml
@@ -21,7 +21,7 @@ execute: |
   fi
 
   cd "$SNAP_DIR"
-  snapcraft build
+  snapcraft build | MATCH "is a virtual package"
 
   if [ ! -f "${test_file}" ]; then
     echo "failed to install uglifyjs build package"

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -183,11 +183,11 @@ class BuildPackagesTestCase(unit.TestCase):
             fixtures.MockPatch("subprocess.check_call")
         ).mock
 
-        def get_installed_version(package_name):
-            return "1.0" if "installed" in package_name else None
-
-        self.fake_apt_cache.return_value.__enter__.return_value.get_installed_version.side_effect = (
-            get_installed_version
+        self.fake_apt_cache.return_value.__enter__.return_value.is_package_installed.side_effect = (
+            lambda package_name, package_version: True
+            if "installed" in package_name
+            and (package_version == "1.0" or package_version is None)
+            else False
         )
 
         self.useFixture(fixtures.MockPatch("os.environ.copy", return_value={}))

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -183,11 +183,11 @@ class BuildPackagesTestCase(unit.TestCase):
             fixtures.MockPatch("subprocess.check_call")
         ).mock
 
-        self.fake_apt_cache.return_value.__enter__.return_value.is_package_installed.side_effect = (
-            lambda package_name, package_version: True
-            if "installed" in package_name
-            and (package_version == "1.0" or package_version is None)
-            else False
+        def get_installed_version(package_name, resolve_virtual_packages=False):
+            return "1.0" if "installed" in package_name else None
+
+        self.fake_apt_cache.return_value.__enter__.return_value.get_installed_version.side_effect = (
+            get_installed_version
         )
 
         self.useFixture(fixtures.MockPatch("os.environ.copy", return_value={}))


### PR DESCRIPTION
Virtual packages were not considered when checking if all build-packages
are satisfied between runs. Check and resolve with a warning to avoid
use of virtual packages for deterministic results.

Logic has shifted a bit to avoid exposing more functionality from
AptCache and have a nicer separation of concerns.

LP: #1883546
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
