### PR TITLE
Maven plugin: improve error message when target libs are not found.

### DIFF
--- a/snapcraft/plugins/v1/maven.py
+++ b/snapcraft/plugins/v1/maven.py
@@ -80,7 +80,7 @@ class EmptyBuildTargetDirectoryError(errors.SnapcraftException):
         return textwrap.dedent(
             """\
             This could happen if your `maven-targets` points to a directory that is not the same as the one
-            in your Maven's <build><directory>target</directory></build> declaration. By default, Snap's 
+            in your Maven's <build><directory>target</directory></build> declaration. By default, Snap's
             Maven plugin won't need `maven-targets` declaration as it will work with the default Maven behavior.
             If you are not sure, try removing `maven-targets` definition and build your Snap again."""
         )
@@ -93,7 +93,7 @@ class EmptyBuildTargetDirectoryError(errors.SnapcraftException):
     def get_resolution(self) -> str:
         return textwrap.dedent(
             """\
-            `maven-targets` should point the same directory as Maven's 
+            `maven-targets` should point the same directory as Maven's
             <build><directory>target</directory></build> declaration."""
         )
 

--- a/snapcraft/plugins/v1/maven.py
+++ b/snapcraft/plugins/v1/maven.py
@@ -57,7 +57,7 @@ import os
 import shutil
 import textwrap
 from glob import glob
-from typing import Sequence
+from typing import Sequence, Optional
 from urllib.parse import urlparse
 from xml.etree import ElementTree
 
@@ -67,14 +67,38 @@ from snapcraft.plugins.v1 import PluginV1
 
 logger = logging.getLogger(__name__)
 
-
 _DEFAULT_MAVEN_VERSION = "3.5.4"
 _DEFAULT_MAVEN_CHECKSUM = "sha512/2a803f578f341e164f6753e410413d16ab60fabe31dc491d1fe35c984a5cce696bc71f57757d4538fe7738be04065a216f3ebad4ef7e0ce1bb4c51bc36d6be86"
 _MAVEN_URL = "https://archive.apache.org/dist/maven/maven-3/{version}/binaries/apache-maven-{version}-bin.tar.gz"
 
 
-class UnsupportedJDKVersionError(errors.SnapcraftError):
+class EmptyBuildTargetDirectoryError(errors.SnapcraftException):
+    def __init__(self, target_directory: str) -> None:
+        self._target_directory = target_directory
 
+    def get_details(self) -> Optional[str]:
+        return textwrap.dedent(
+            """\
+            This could happen if your `maven-targets` points to a directory that is not the same as the one
+            in your Maven's <build><directory>target</directory></build> declaration. By default, Snap's 
+            Maven plugin won't need `maven-targets` declaration as it will work with the default Maven behavior.
+            If you are not sure, try removing `maven-targets` definition and build your Snap again."""
+        )
+
+    def get_brief(self) -> str:
+        return "Could not find built jar files for part in the following directory: {!r}".format(
+            self._target_directory
+        )
+
+    def get_resolution(self) -> str:
+        return textwrap.dedent(
+            """\
+            `maven-targets` should point the same directory as Maven's 
+            <build><directory>target</directory></build> declaration."""
+        )
+
+
+class UnsupportedJDKVersionError(errors.SnapcraftError):
     fmt = (
         "The maven-openjdk-version plugin property was set to {version!r}.\n"
         "Valid values for the {base!r} base are: {valid_versions}."
@@ -224,16 +248,7 @@ class MavenPlugin(PluginV1):
             arfiles = glob(os.path.join(src, "*.[jw]ar"))
 
             if len(arfiles) == 0:
-                raise RuntimeError(
-                    textwrap.dedent(
-                        """\
-                    Could not find built jar files for part in any of the following directories: %s. This
-                    could happen if your `maven-targets` points to a directory that is not the same as the one
-                    indicated in your Maven's <build><directory>target</directory></build> declaration. Try
-                    removing `maven-targets` definition."""
-                        % arfiles
-                    )
-                )
+                raise EmptyBuildTargetDirectoryError(src)
             if len(jarfiles) > 0 and len(f) == 0:
                 basedir = "jar"
             elif len(warfiles) > 0 and len(f) == 0:

--- a/snapcraft/plugins/v1/maven.py
+++ b/snapcraft/plugins/v1/maven.py
@@ -31,7 +31,9 @@ Additionally, this plugin uses the following plugin-specific keywords:
 
     - maven-targets:
       (list of strings)
-      List of targets that were built that need
+      List of target directories where the built jars are stored.
+      It corresponds to the <build><directory>target</directory></build>
+      from the Maven's build declaration.
 
     - maven-version:
       (string)
@@ -53,6 +55,7 @@ Additionally, this plugin uses the following plugin-specific keywords:
 import logging
 import os
 import shutil
+import textwrap
 from glob import glob
 from typing import Sequence
 from urllib.parse import urlparse
@@ -221,7 +224,16 @@ class MavenPlugin(PluginV1):
             arfiles = glob(os.path.join(src, "*.[jw]ar"))
 
             if len(arfiles) == 0:
-                raise RuntimeError("Could not find any built jar files for part")
+                raise RuntimeError(
+                    textwrap.dedent(
+                        """\
+                    Could not find built jar files for part in any of the following directories: %s. This
+                    could happen if your `maven-targets` points to a directory that is not the same as the one
+                    indicated in your Maven's <build><directory>target</directory></build> declaration. Try
+                    removing `maven-targets` definition."""
+                        % arfiles
+                    )
+                )
             if len(jarfiles) > 0 and len(f) == 0:
                 basedir = "jar"
             elif len(warfiles) > 0 and len(f) == 0:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?
-----
Recently joined Canonical and tried to build a Snap out of a Java library. The error seemed a bit difficult to understand at first (have done mostly Gradle before so was not used to Maven).

I have then improved a bit the error message to explain that it could just that maven-targets declaration does not match the directory in which the Java library has been built. To help the user better understand what could be wrong the error message has been improved to add the directories in which the `arfiles` were searched and clarifying a simple scenario (the one that happened to me) that could lead to fix the situation.

What I think it would help even more is to replace to have the actual part name at this point so that we could `Could not find built jar files for part [the name of the part here] ...". But I did not knew how to get that, with some guidance I could that if that is of interest. I think it could help.
