### PR TITLE
build providers: nice message on bad base

### DIFF
--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -186,10 +186,15 @@ class LXD(Provider):
         return output
 
     def _launch(self) -> None:
-        config = {
-            "name": self.instance_name,
-            "source": get_image_source(base=self.project._get_build_base()),
-        }
+        build_base = self.project._get_build_base()
+        try:
+            source = get_image_source(base=build_base)
+        except KeyError:
+            raise errors.ProviderInvalidBaseError(
+                provider_name=self._get_provider_name(), build_base=build_base
+            )
+
+        config = {"name": self.instance_name, "source": source}
 
         try:
             container = self._lxd_client.containers.create(config, wait=True)

--- a/snapcraft/internal/build_providers/errors.py
+++ b/snapcraft/internal/build_providers/errors.py
@@ -133,7 +133,7 @@ class ProviderInvalidBaseError(_SnapcraftException):
         self.build_base = build_base
 
     def get_brief(self) -> str:
-        return f"The {self.provider_name!r} does not have an environment setup to build for base {self.build_base!r}"
+        return f"The {self.provider_name!r} provider does not support base {self.build_base!r}"
 
     def get_resolution(self) -> str:
         return "Ensure build-base or base are correct in the snapcraft.yaml file."

--- a/snapcraft/internal/build_providers/errors.py
+++ b/snapcraft/internal/build_providers/errors.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, Optional
 from typing import Sequence  # noqa: F401
 
 from snapcraft.internal.errors import SnapcraftError as _SnapcraftError
+from snapcraft.internal.errors import SnapcraftException as _SnapcraftException
 
 
 class ProviderBaseError(_SnapcraftError):
@@ -78,7 +79,7 @@ class _GenericProviderError(ProviderBaseError):
         provider_name: str,
         action: str,
         error_message: Optional[str] = None,
-        exit_code: Optional[int] = None
+        exit_code: Optional[int] = None,
     ) -> None:
         if exit_code is not None and error_message is not None:
             fmt = self._FMT_ERROR_MESSAGE_AND_EXIT_CODE
@@ -116,7 +117,7 @@ class ProviderLaunchError(_GenericProviderError):
         *,
         provider_name: str,
         error_message: Optional[str] = None,
-        exit_code: Optional[int] = None
+        exit_code: Optional[int] = None,
     ) -> None:
         super().__init__(
             action="launch",
@@ -126,13 +127,28 @@ class ProviderLaunchError(_GenericProviderError):
         )
 
 
+class ProviderInvalidBaseError(_SnapcraftException):
+    def __init__(self, *, provider_name: str, build_base: str) -> None:
+        self.provider_name = provider_name
+        self.build_base = build_base
+
+    def get_brief(self) -> str:
+        return f"The {self.provider_name!r} does not have an environment setup to build for base {self.build_base!r}"
+
+    def get_resolution(self) -> str:
+        return "Ensure build-base or base are correct in the snapcraft.yaml file."
+
+    def get_docs_url(self) -> str:
+        return "https://snapcraft.io/docs/base-snaps"
+
+
 class ProviderStartError(_GenericProviderError):
     def __init__(
         self,
         *,
         provider_name: str,
         error_message: Optional[str] = None,
-        exit_code: Optional[int] = None
+        exit_code: Optional[int] = None,
     ) -> None:
         super().__init__(
             action="start",
@@ -148,7 +164,7 @@ class ProviderStopError(_GenericProviderError):
         *,
         provider_name: str,
         error_message: Optional[str] = None,
-        exit_code: Optional[int] = None
+        exit_code: Optional[int] = None,
     ) -> None:
         super().__init__(
             action="stop",
@@ -164,7 +180,7 @@ class ProviderDeleteError(_GenericProviderError):
         *,
         provider_name: str,
         error_message: Optional[str] = None,
-        exit_code: Optional[int] = None
+        exit_code: Optional[int] = None,
     ) -> None:
         super().__init__(
             action="delete",
@@ -187,7 +203,7 @@ class ProviderExecError(ProviderBaseError):
         provider_name: str,
         command: Sequence[str],
         exit_code: int,
-        output: Optional[bytes] = None
+        output: Optional[bytes] = None,
     ) -> None:
         command_string = " ".join(shlex.quote(i) for i in command)
         super().__init__(
@@ -205,7 +221,7 @@ class ProviderShellError(_GenericProviderError):
         *,
         provider_name: str,
         error_message: Optional[str] = None,
-        exit_code: Optional[int] = None
+        exit_code: Optional[int] = None,
     ) -> None:
         super().__init__(
             action="shell",
@@ -221,7 +237,7 @@ class ProviderMountError(_GenericProviderError):
         *,
         provider_name: str,
         error_message: Optional[str] = None,
-        exit_code: Optional[int] = None
+        exit_code: Optional[int] = None,
     ) -> None:
         super().__init__(
             action="mount",
@@ -237,7 +253,7 @@ class ProviderUnMountError(_GenericProviderError):
         *,
         provider_name: str,
         error_message: Optional[str] = None,
-        exit_code: Optional[int] = None
+        exit_code: Optional[int] = None,
     ) -> None:
         super().__init__(
             action="unmount",
@@ -253,7 +269,7 @@ class ProviderFileCopyError(_GenericProviderError):
         *,
         provider_name: str,
         error_message: Optional[str] = None,
-        exit_code: Optional[int] = None
+        exit_code: Optional[int] = None,
     ) -> None:
         super().__init__(
             action="copy files",

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -787,6 +787,13 @@ class LXDInitTest(LXDBaseTest):
             wait=True,
         )
 
+    def test_create_invalid_base(self):
+        self.project._snap_meta.base = "core19"
+
+        instance = LXDTestImpl(project=self.project, echoer=self.echoer_mock)
+
+        self.assertRaises(errors.ProviderInvalidBaseError, instance.create)
+
 
 class LXDLaunchedTest(LXDBaseTest):
     def setUp(self):

--- a/tests/unit/build_providers/test_errors.py
+++ b/tests/unit/build_providers/test_errors.py
@@ -401,7 +401,7 @@ class TestSnapcraftExceptionTests:
             {
                 "exception_class": errors.ProviderInvalidBaseError,
                 "kwargs": {"provider_name": "LXD", "build_base": "core29"},
-                "expected_brief": "The 'LXD' does not have an environment setup to build for base 'core29'",
+                "expected_brief": "The 'LXD' provider does not support base 'core29'",
                 "expected_resolution": "Ensure build-base or base are correct in the snapcraft.yaml file.",
                 "expected_details": None,
                 "expected_docs_url": "https://snapcraft.io/docs/base-snaps",

--- a/tests/unit/build_providers/test_errors.py
+++ b/tests/unit/build_providers/test_errors.py
@@ -392,3 +392,38 @@ class TestErrorFormatting:
 
     def test_error_formatting(self, exception_class, kwargs, expected_message):
         assert str(exception_class(**kwargs)) == expected_message
+
+
+class TestSnapcraftExceptionTests:
+    scenarios = (
+        (
+            "ProviderInvalidBaseError",
+            {
+                "exception_class": errors.ProviderInvalidBaseError,
+                "kwargs": {"provider_name": "LXD", "build_base": "core29"},
+                "expected_brief": "The 'LXD' does not have an environment setup to build for base 'core29'",
+                "expected_resolution": "Ensure build-base or base are correct in the snapcraft.yaml file.",
+                "expected_details": None,
+                "expected_docs_url": "https://snapcraft.io/docs/base-snaps",
+                "expected_reportable": False,
+            },
+        ),
+    )
+
+    def test_snapcraft_exception_handling(
+        self,
+        exception_class,
+        expected_brief,
+        expected_details,
+        expected_docs_url,
+        expected_reportable,
+        expected_resolution,
+        kwargs,
+    ):
+        exception = exception_class(**kwargs)
+
+        assert exception.get_brief() == expected_brief
+        assert exception.get_resolution() == expected_resolution
+        assert exception.get_details() == expected_details
+        assert exception.get_docs_url() == expected_docs_url
+        assert exception.get_reportable() == expected_reportable


### PR DESCRIPTION
Create a new exception to handle bad bases being used for LXD.

Fixes SNAPCRAFT-1H2
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
