### PR TITLE
cli: don't warn about --target-arch if target_arch is None

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -71,7 +71,7 @@ def _execute(  # noqa: C901
     is_managed_host = build_provider == "managed-host"
 
     # Temporary fix to ignore target_arch.
-    if "target_arch" in kwargs and build_provider in ["multipass", "lxd"]:
+    if kwargs.get("target_arch") is not None and build_provider in ["multipass", "lxd"]:
         echo.warning(
             "Ignoring '--target-arch' flag.  This flag requires --destructive-mode and is unsupported with Multipass and LXD build providers."
         )


### PR DESCRIPTION
Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
