### PR TITLE
build providers: check revision before switching

### DIFF
--- a/snapcraft/internal/build_providers/_snap.py
+++ b/snapcraft/internal/build_providers/_snap.py
@@ -164,7 +164,7 @@ class _SnapManager:
             snap_revision = host_snap_info["revision"]
             snap_channel = host_snap_info.get("tracking-channel")
 
-            if snap_channel:
+            if not snap_revision.startswith("x") and snap_channel:
                 switch_cmd = [
                     "snap",
                     "switch",

--- a/tests/unit/build_providers/test_snap.py
+++ b/tests/unit/build_providers/test_snap.py
@@ -211,7 +211,12 @@ class SnapInjectionTest(unit.TestCase):
                 "channel": "stable",
                 "revision": "123",
             },
-            {"name": "snapcraft", "confinement": "classic", "revision": "x20", "tracking-channel": "latest/stable"},
+            {
+                "name": "snapcraft",
+                "confinement": "classic",
+                "revision": "x20",
+                "tracking-channel": "latest/stable",
+            },
         ]
         self.get_assertion_mock.side_effect = [
             b"fake-assertion-account-store",

--- a/tests/unit/build_providers/test_snap.py
+++ b/tests/unit/build_providers/test_snap.py
@@ -20,7 +20,7 @@ from textwrap import dedent
 from unittest.mock import call, patch, ANY
 
 import fixtures
-from testtools.matchers import Contains, Equals, FileContains, HasLength, Not
+from testtools.matchers import Contains, Equals, FileContains, Not
 
 from . import ProviderImpl, get_project
 from snapcraft.internal.build_providers._snap import (

--- a/tests/unit/build_providers/test_snap.py
+++ b/tests/unit/build_providers/test_snap.py
@@ -20,7 +20,7 @@ from textwrap import dedent
 from unittest.mock import call, patch, ANY
 
 import fixtures
-from testtools.matchers import Contains, Equals, FileContains, Not
+from testtools.matchers import Contains, Equals, FileContains, HasLength, Not
 
 from . import ProviderImpl, get_project
 from snapcraft.internal.build_providers._snap import (
@@ -211,7 +211,7 @@ class SnapInjectionTest(unit.TestCase):
                 "channel": "stable",
                 "revision": "123",
             },
-            {"name": "snapcraft", "confinement": "classic", "revision": "x20"},
+            {"name": "snapcraft", "confinement": "classic", "revision": "x20", "tracking-channel": "latest/stable"},
         ]
         self.get_assertion_mock.side_effect = [
             b"fake-assertion-account-store",
@@ -240,6 +240,8 @@ class SnapInjectionTest(unit.TestCase):
             call(["snap-revision", "snap-revision=123", "snap-id=2kkitQ"]),
         ]
         self.get_assertion_mock.assert_has_calls(get_assertion_calls)
+        # Check the call count to ensure the snap switch command does not sneak in.
+        self.assertThat(self.provider.run_mock.call_count, Equals(6))
         self.provider.run_mock.assert_has_calls(
             [
                 call(["snap", "set", "system", ANY]),


### PR DESCRIPTION
Snapcraft was switching channels on the availability of a tracking
channel, it may be that this was incorrectly implemented or that snapd
now switched to always report a tracking-channel when installing a snap
with --dangerous after previously having installed a revision from the
Snap Store.

An additional check for revision is now enforced before setting the
switch.

LP: #1884576
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
