### PR TITLE
extensions: introduce flutter-master

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -780,6 +780,7 @@
                             "uniqueItems": true,
                             "items": {
                                 "enum": [
+                                    "flutter-master",
                                     "gnome-3-28",
                                     "gnome-3-34",
                                     "kde-neon"

--- a/snapcraft/internal/project_loader/_extensions/flutter_master.py
+++ b/snapcraft/internal/project_loader/_extensions/flutter_master.py
@@ -1,0 +1,135 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018-2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Import types and tell flake8 to ignore the "unused" List.
+
+import textwrap
+from typing import Any, Dict, Tuple
+
+from ._extension import Extension
+
+_PLATFORM_SNAP = dict(core18="gnome-3-28-1804")
+
+
+class ExtensionImpl(Extension):
+    """This extension eases creation of snaps that use Flutter
+
+    It tracks the master channel for flutter.
+
+    At build time it ensures the right build dependencies are setup and for
+    the runtime it ensures the application is run in an environment catered
+    for Flutter applications.
+
+    It configures each application with the following plugs:
+
+    \b
+    - GTK3 Themes.
+    - Common Icon Themes.
+    - Common Sound Themes.
+    - The GNOME runtime libraries and utilities corresponding to 3.28.
+
+    For easier desktop integration, it also configures each application
+    entry with these additional plugs:
+
+    \b
+    - desktop (https://snapcraft.io/docs/desktop-interface)
+    - desktop-legacy (https://snapcraft.io/docs/desktop-legacy-interface)
+    - gsettings (https://snapcraft.io/docs/gsettings-interface)
+    - wayland (https://snapcraft.io/docs/wayland-interface)
+    - opengl (https://snapcraft.io/docs/opengl-interface)
+    - x11 (https://snapcraft.io/docs/x11-interface)
+    """
+
+    @staticmethod
+    def get_supported_bases() -> Tuple[str, ...]:
+        return ("core18",)
+
+    @staticmethod
+    def get_supported_confinement() -> Tuple[str, ...]:
+        return ("strict", "devmode")
+
+    def __init__(self, *, extension_name: str, yaml_data: Dict[str, Any]) -> None:
+        super().__init__(extension_name=extension_name, yaml_data=yaml_data)
+
+        base: str = yaml_data["base"]
+        platform_snap = _PLATFORM_SNAP[base]
+        self.root_snippet = {
+            "plugs": {
+                "gtk-3-themes": {
+                    "interface": "content",
+                    "target": "$SNAP/data-dir/themes",
+                    "default-provider": "gtk-common-themes",
+                },
+                "icon-themes": {
+                    "interface": "content",
+                    "target": "$SNAP/data-dir/icons",
+                    "default-provider": "gtk-common-themes",
+                },
+                "sound-themes": {
+                    "interface": "content",
+                    "target": "$SNAP/data-dir/sounds",
+                    "default-provider": "gtk-common-themes",
+                },
+                platform_snap: {
+                    "interface": "content",
+                    "target": "$SNAP/gnome-platform",
+                    "default-provider": "{snap}".format(snap=platform_snap),
+                },
+            },
+            "environment": {"SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform"},
+            "layout": {
+                "/usr/bin/gjs": {"symlink": "$SNAP/gnome-platform/usr/bin/gjs"},
+                "/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.0": {
+                    "bind": "$SNAP/gnome-platform/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.0"
+                },
+                "/usr/share/xml/iso-codes": {
+                    "bind": "$SNAP/gnome-platform/usr/share/xml/iso-codes"
+                },
+            },
+        }
+
+        self.app_snippet = {
+            "command-chain": ["snap/command-chain/desktop-launch"],
+            "plugs": [
+                "desktop",
+                "desktop-legacy",
+                "gsettings",
+                "opengl",
+                "wayland",
+                "x11",
+            ],
+        }
+
+        self.parts = {
+            "gnome-3-28-extension": {
+                "source": "$SNAPCRAFT_EXTENSIONS_DIR/desktop",
+                "source-subdir": "gnome",
+                "plugin": "make",
+                "build-packages": ["gcc", "libgtk-3-dev"],
+            },
+            "flutter": {
+                "plugin": "nil",
+                "override-pull": textwrap.dedent(
+                    """\
+                    flutter channel master
+                    flutter config --enable-linux-desktop
+                    flutter upgrade
+                    flutter doctor
+                    """
+                ),
+                "build-snaps": ["flutter/latest/stable"]
+            }
+        }

--- a/tests/unit/project_loader/extensions/test_flutter_master.py
+++ b/tests/unit/project_loader/extensions/test_flutter_master.py
@@ -1,0 +1,120 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+
+from testtools.matchers import Equals
+
+from snapcraft.internal.project_loader._extensions.flutter_master import ExtensionImpl
+
+from .. import ProjectLoaderBaseTest
+
+
+class ExtensionTest(ProjectLoaderBaseTest):
+    def test_extension(self):
+        flutter_extension = ExtensionImpl(
+            extension_name="flutter-master", yaml_data=dict(base="core18")
+        )
+
+        self.expectThat(
+            flutter_extension.root_snippet,
+            Equals(
+                {
+                    "plugs": {
+                        "gtk-3-themes": {
+                            "interface": "content",
+                            "target": "$SNAP/data-dir/themes",
+                            "default-provider": "gtk-common-themes",
+                        },
+                        "icon-themes": {
+                            "interface": "content",
+                            "target": "$SNAP/data-dir/icons",
+                            "default-provider": "gtk-common-themes",
+                        },
+                        "sound-themes": {
+                            "interface": "content",
+                            "target": "$SNAP/data-dir/sounds",
+                            "default-provider": "gtk-common-themes",
+                        },
+                        "gnome-3-28-1804": {
+                            "interface": "content",
+                            "target": "$SNAP/gnome-platform",
+                            "default-provider": "gnome-3-28-1804",
+                        },
+                    },
+                    "environment": {"SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform"},
+                    "layout": {
+                        "/usr/bin/gjs": {"symlink": "$SNAP/gnome-platform/usr/bin/gjs"},
+                        "/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.0": {
+                            "bind": "$SNAP/gnome-platform/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.0"
+                        },
+                        "/usr/share/xml/iso-codes": {
+                            "bind": "$SNAP/gnome-platform/usr/share/xml/iso-codes"
+                        },
+                    },
+                }
+            ),
+        )
+        self.expectThat(
+            flutter_extension.app_snippet,
+            Equals(
+                {
+                    "command-chain": ["snap/command-chain/desktop-launch"],
+                    "plugs": [
+                        "desktop",
+                        "desktop-legacy",
+                        "gsettings",
+                        "opengl",
+                        "wayland",
+                        "x11",
+                    ],
+                }
+            ),
+        )
+        self.expectThat(flutter_extension.part_snippet, Equals(dict()))
+        self.expectThat(
+            flutter_extension.parts,
+            Equals(
+                {
+                    "gnome-3-28-extension": {
+                        "source": "$SNAPCRAFT_EXTENSIONS_DIR/desktop",
+                        "source-subdir": "gnome",
+                        "plugin": "make",
+                        "build-packages": ["gcc", "libgtk-3-dev"],
+                    },
+                    "flutter-extension": {
+                        "plugin": "nil",
+                        "override-pull": textwrap.dedent(
+                            """\
+                            flutter channel master
+                            flutter config --enable-linux-desktop
+                            flutter upgrade
+                            flutter doctor
+                            """
+                        ),
+                        "build-snaps": ["flutter/latest/stable"],
+                    },
+                }
+            ),
+        )
+
+    def test_supported_bases(self):
+        self.assertThat(ExtensionImpl.get_supported_bases(), Equals(("core18",)))
+
+    def test_supported_confinement(self):
+        self.assertThat(
+            ExtensionImpl.get_supported_confinement(), Equals(("strict", "devmode"))
+        )


### PR DESCRIPTION
An extension that sets up an environment with flutter-master and is able
wraps the usage of GNOME into a dependency.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
