### PR TITLE
extensions: introduce flutter-master

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -780,6 +780,7 @@
                             "uniqueItems": true,
                             "items": {
                                 "enum": [
+                                    "flutter-master",
                                     "gnome-3-28",
                                     "gnome-3-34",
                                     "kde-neon"

--- a/snapcraft/internal/project_loader/_extensions/flutter_master.py
+++ b/snapcraft/internal/project_loader/_extensions/flutter_master.py
@@ -1,0 +1,131 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018-2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Import types and tell flake8 to ignore the "unused" List.
+
+import textwrap
+from typing import Any, Dict, Tuple
+
+from ._extension import Extension
+
+_PLATFORM_SNAP = dict(core18="gnome-3-28-1804")
+
+
+class ExtensionImpl(Extension):
+    """This extension eases creation of snaps that use Flutter
+
+    It tracks the master channel for flutter.
+
+    At build time it ensures the right build dependencies are setup and for
+    the runtime it ensures the application is run in an environment catered
+    for Flutter applications.
+
+    It configures each application with the following plugs:
+
+    \b
+    - GTK3 Themes.
+    - Common Icon Themes.
+    - Common Sound Themes.
+    - The GNOME runtime libraries and utilities corresponding to 3.28.
+
+    For easier desktop integration, it also configures each application
+    entry with these additional plugs:
+
+    \b
+    - desktop (https://snapcraft.io/docs/desktop-interface)
+    - desktop-legacy (https://snapcraft.io/docs/desktop-legacy-interface)
+    - gsettings (https://snapcraft.io/docs/gsettings-interface)
+    - wayland (https://snapcraft.io/docs/wayland-interface)
+    - opengl (https://snapcraft.io/docs/opengl-interface)
+    - x11 (https://snapcraft.io/docs/x11-interface)
+    """
+
+    @staticmethod
+    def get_supported_bases() -> Tuple[str, ...]:
+        return ("core18",)
+
+    @staticmethod
+    def get_supported_confinement() -> Tuple[str, ...]:
+        return ("strict", "devmode")
+
+    def __init__(self, *, extension_name: str, yaml_data: Dict[str, Any]) -> None:
+        super().__init__(extension_name=extension_name, yaml_data=yaml_data)
+
+        base: str = yaml_data["base"]
+        platform_snap = _PLATFORM_SNAP[base]
+        self.root_snippet = {
+            "plugs": {
+                "gtk-3-themes": {
+                    "interface": "content",
+                    "target": "$SNAP/data-dir/themes",
+                    "default-provider": "gtk-common-themes",
+                },
+                "icon-themes": {
+                    "interface": "content",
+                    "target": "$SNAP/data-dir/icons",
+                    "default-provider": "gtk-common-themes",
+                },
+                "sound-themes": {
+                    "interface": "content",
+                    "target": "$SNAP/data-dir/sounds",
+                    "default-provider": "gtk-common-themes",
+                },
+                platform_snap: {
+                    "interface": "content",
+                    "target": "$SNAP/gnome-platform",
+                    "default-provider": "{snap}".format(snap=platform_snap),
+                },
+            },
+            "environment": {"SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform"},
+            "layout": {
+                "/usr/share/xml/iso-codes": {
+                    "bind": "$SNAP/gnome-platform/usr/share/xml/iso-codes"
+                },
+            },
+        }
+
+        self.app_snippet = {
+            "command-chain": ["snap/command-chain/desktop-launch"],
+            "plugs": [
+                "desktop",
+                "desktop-legacy",
+                "gsettings",
+                "opengl",
+                "wayland",
+                "x11",
+            ],
+        }
+
+        self.parts = {
+            "gnome-3-28-extension": {
+                "source": "$SNAPCRAFT_EXTENSIONS_DIR/desktop",
+                "source-subdir": "gnome",
+                "plugin": "make",
+                "build-packages": ["gcc", "libgtk-3-dev"],
+            },
+            "flutter-extension": {
+                "plugin": "nil",
+                "override-pull": textwrap.dedent(
+                    """\
+                    flutter channel master
+                    flutter config --enable-linux-desktop
+                    flutter upgrade
+                    flutter doctor
+                    """
+                ),
+                "build-snaps": ["flutter/latest/stable"],
+            },
+        }

--- a/snapcraft/plugins/v1/flutter.py
+++ b/snapcraft/plugins/v1/flutter.py
@@ -22,9 +22,6 @@ For more information check the 'plugins' topic for the former and the
 
 Additionally, this plugin uses the following plugin-specific keywords:
 
-    - flutter-channel
-      (string)
-      Which Flutter channel to use for the build
     - flutter-revision
       (string)
       Which Flutter revision to use for the build. This must be a valid
@@ -32,6 +29,8 @@ Additionally, this plugin uses the following plugin-specific keywords:
     - flutter-target
       (string, default: lib/main.dart)
       The main entry-point file of the application
+
+This plugin works best with the flutter related extensions.
 """
 
 import logging
@@ -50,10 +49,6 @@ class FlutterPlugin(PluginV1):
     @classmethod
     def schema(cls) -> Dict[str, Any]:
         schema = super().schema()
-        schema["properties"]["flutter-channel"] = {
-            "type": "string",
-            "enum": ["dev", "master"],
-        }
         schema["properties"]["flutter-target"] = {
             "type": "string",
             "default": "lib/main.dart",
@@ -68,7 +63,7 @@ class FlutterPlugin(PluginV1):
 
     @classmethod
     def get_pull_properties(cls) -> List[str]:
-        return ["flutter-channel", "flutter-revision"]
+        return ["flutter-revision"]
 
     @classmethod
     def get_build_properties(cls) -> List[str]:
@@ -82,8 +77,6 @@ class FlutterPlugin(PluginV1):
                 part_name=self.name, base=project._get_build_base()
             )
 
-        self.build_snaps.extend(["flutter/latest/stable"])
-
         logger.warning(
             "The flutter plugin is currently in beta, its API may break. Use at your "
             "own risk."
@@ -93,10 +86,6 @@ class FlutterPlugin(PluginV1):
         super().pull()
 
         # Let these errors go through to get them on Sentry.
-        subprocess.run(["flutter", "channel", self.options.flutter_channel], check=True)
-        subprocess.run(["flutter", "config", "--enable-linux-desktop"], check=True)
-        subprocess.run(["flutter", "upgrade"], check=True)
-        subprocess.run(["flutter", "doctor"], check=True)
         if self.options.flutter_revision:
             subprocess.run(
                 f"yes | flutter version {self.options.flutter_revision}",

--- a/specifications/flutter-extension.org
+++ b/specifications/flutter-extension.org
@@ -1,0 +1,58 @@
+#+TITLE: Flutter Extensions
+#+AUTHOR: Sergio Schvezov <sergio.schvezov@canonical.com>
+#+DATE: [2020-07-02]
+
+* Scope
+
+This extension enables easy creation of snaps that target flutter, specifically
+the flutter desktop configuration.
+
+An extension variant per each /flutter/ channel available shall be available
+that reproduces the setup required to target a given flutter channel, these
+channels are:
+
+- flutter or flutter-stable (ideally, the default).
+- flutter-beta
+- flutter-dev
+- flutter-master
+
+Under the hood, these extensions shall setup the run time part of the extension
+leveraging the use of the gnome-3-28 extension as it is the GNOME stack that the
+flutter desktop integration currently targets.
+
+Use of the =flutter= plugin is optional, the plugin just drives the build for
+flutter project sources.
+
+* Using the extension
+
+As a Snapcraft snap author, given a snap with an application =foo=, the
+following snippet would enable use of the =flutter-master= extension:
+
+#+BEGIN_SRC yaml
+apps:
+  foo:
+    command: foo
+    extension: [flutter-master]
+#+END_SRC
+
+* Differences with the GNOME extension
+
+This extension has many similarities to the GNOME one. To reduce cognitive load
+for a flutter developer working on other platforms and wanting to create a snap,
+a new extension name was decided upon.
+
+This extension shall use the same list of plugs as used for the GNOME
+extensions.
+
+Where it is different is in the use of layouts, as the layouts related to gjs
+and webkit are not required.
+
+In addition to the command-chain generating part, a new part shall be added
+=flutter-extension= and it shall setup flutter will the following commands:
+
+#+BEGIN_SRC sh
+flutter channel master
+flutter config --enable-linux-desktop
+flutter upgrade
+flutter doctor
+#+END_SRC

--- a/tests/spread/plugins/v1/flutter/snaps/flutter-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/flutter/snaps/flutter-hello/snap/snapcraft.yaml
@@ -9,7 +9,7 @@ grade: stable
 apps:
   flutter-hello:
     command: flutter-hello
-    extensions: [gnome-3-28]
+    extensions: [flutter-master]
     plugs:
       - network
 
@@ -17,5 +17,4 @@ parts:
   flutter-hello:
     source: .
     plugin: flutter
-    flutter-channel: master
     flutter-revision: 3ce26910923b6a5e784df17a8a9a17b50598df4a

--- a/tests/unit/plugins/v1/test_flutter.py
+++ b/tests/unit/plugins/v1/test_flutter.py
@@ -30,7 +30,6 @@ def test_schema():
         "$schema": "http://json-schema.org/draft-04/schema#",
         "additionalProperties": False,
         "properties": {
-            "flutter-channel": {"enum": ["dev", "master"], "type": "string"},
             "flutter-revision": {"default": None, "type": "string"},
             "flutter-target": {"default": "lib/main.dart", "type": "string"},
         },
@@ -41,7 +40,6 @@ def test_schema():
 
 def test_get_pull_properties():
     assert flutter.FlutterPlugin.get_pull_properties() == [
-        "flutter-channel",
         "flutter-revision",
     ]
 
@@ -72,12 +70,6 @@ def test_pull(mock_subprocess_run, flutter_plugin):
     flutter_plugin.pull()
 
     assert mock_subprocess_run.mock_calls == [
-        call(
-            ["flutter", "channel", flutter_plugin.options.flutter_channel], check=True
-        ),
-        call(["flutter", "config", "--enable-linux-desktop"], check=True),
-        call(["flutter", "upgrade"], check=True),
-        call(["flutter", "doctor"], check=True),
         call(["flutter", "pub", "get"], check=True),
     ]
 
@@ -87,12 +79,6 @@ def test_pull_with_revision(mock_subprocess_run, flutter_plugin):
     flutter_plugin.pull()
 
     assert mock_subprocess_run.mock_calls == [
-        call(
-            ["flutter", "channel", flutter_plugin.options.flutter_channel], check=True
-        ),
-        call(["flutter", "config", "--enable-linux-desktop"], check=True),
-        call(["flutter", "upgrade"], check=True),
-        call(["flutter", "doctor"], check=True),
         call("yes | flutter version foo", shell=True, check=True,),
         call(["flutter", "pub", "get"], check=True),
     ]

--- a/tests/unit/project_loader/extensions/test_flutter_master.py
+++ b/tests/unit/project_loader/extensions/test_flutter_master.py
@@ -1,0 +1,116 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+
+from testtools.matchers import Equals
+
+from snapcraft.internal.project_loader._extensions.flutter_master import ExtensionImpl
+
+from .. import ProjectLoaderBaseTest
+
+
+class ExtensionTest(ProjectLoaderBaseTest):
+    def test_extension(self):
+        flutter_extension = ExtensionImpl(
+            extension_name="flutter-master", yaml_data=dict(base="core18")
+        )
+
+        self.expectThat(
+            flutter_extension.root_snippet,
+            Equals(
+                {
+                    "plugs": {
+                        "gtk-3-themes": {
+                            "interface": "content",
+                            "target": "$SNAP/data-dir/themes",
+                            "default-provider": "gtk-common-themes",
+                        },
+                        "icon-themes": {
+                            "interface": "content",
+                            "target": "$SNAP/data-dir/icons",
+                            "default-provider": "gtk-common-themes",
+                        },
+                        "sound-themes": {
+                            "interface": "content",
+                            "target": "$SNAP/data-dir/sounds",
+                            "default-provider": "gtk-common-themes",
+                        },
+                        "gnome-3-28-1804": {
+                            "interface": "content",
+                            "target": "$SNAP/gnome-platform",
+                            "default-provider": "gnome-3-28-1804",
+                        },
+                    },
+                    "environment": {"SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform"},
+                    "layout": {
+                        "/usr/share/xml/iso-codes": {
+                            "bind": "$SNAP/gnome-platform/usr/share/xml/iso-codes"
+                        },
+                    },
+                }
+            ),
+        )
+        self.expectThat(
+            flutter_extension.app_snippet,
+            Equals(
+                {
+                    "command-chain": ["snap/command-chain/desktop-launch"],
+                    "plugs": [
+                        "desktop",
+                        "desktop-legacy",
+                        "gsettings",
+                        "opengl",
+                        "wayland",
+                        "x11",
+                    ],
+                }
+            ),
+        )
+        self.expectThat(flutter_extension.part_snippet, Equals(dict()))
+        self.expectThat(
+            flutter_extension.parts,
+            Equals(
+                {
+                    "gnome-3-28-extension": {
+                        "source": "$SNAPCRAFT_EXTENSIONS_DIR/desktop",
+                        "source-subdir": "gnome",
+                        "plugin": "make",
+                        "build-packages": ["gcc", "libgtk-3-dev"],
+                    },
+                    "flutter-extension": {
+                        "plugin": "nil",
+                        "override-pull": textwrap.dedent(
+                            """\
+                            flutter channel master
+                            flutter config --enable-linux-desktop
+                            flutter upgrade
+                            flutter doctor
+                            """
+                        ),
+                        "build-snaps": ["flutter/latest/stable"],
+                    },
+                }
+            ),
+        )
+
+    def test_supported_bases(self):
+        self.assertThat(ExtensionImpl.get_supported_bases(), Equals(("core18",)))
+
+    def test_supported_confinement(self):
+        self.assertThat(
+            ExtensionImpl.get_supported_confinement(), Equals(("strict", "devmode"))
+        )

--- a/todo.org
+++ b/todo.org
@@ -42,7 +42,7 @@ CLOSED: [2020-06-24]
 - [ ] Add support for specific channel-map endpoint errors
 - [ ] Remove experimental flag
 
-*** STRT [[file:specifications/package-repositories.org][Package Repositories]] [/]
+*** STRT [[file:specifications/package-repositories.org][Package Repositories]] [6/9]
 
 - [X] System-wide APT configuration for build and stage-packages.
 - [X] Meta support for =package-repositories=: PackageRepository
@@ -53,3 +53,9 @@ CLOSED: [2020-06-24]
 - [ ] Improve error handling when schema validation fails. Nearly everything will fail with: "The =package-repositories[0] property does not match the required schema: <schemas>=
 - [ ] Add multi-arch spread test(s).
 - [ ] Finalize schema and mark stable.
+*** TODO [[file:specifications/flutter-extension.org][Flutter Extension]] [0/4]
+
+- [ ] Add extension variant for master
+- [ ] Add extension variant for dev
+- [ ] Add extension variant for beta
+- [ ] Add extension variant for stable

--- a/todo.org
+++ b/todo.org
@@ -1,6 +1,7 @@
 #+TITLE: Snapcraft Tasks
 #+STARTUP: content
 #+STARTUP: lognotestate
+#+TODO: TODO(t) STRT(s@/!) | DONE(d!) CANCELED(c@)
 
 * Specifications
 
@@ -53,9 +54,10 @@ CLOSED: [2020-06-24]
 - [ ] Improve error handling when schema validation fails. Nearly everything will fail with: "The =package-repositories[0] property does not match the required schema: <schemas>=
 - [ ] Add multi-arch spread test(s).
 - [ ] Finalize schema and mark stable.
-*** TODO [[file:specifications/flutter-extension.org][Flutter Extension]] [0/4]
 
-- [ ] Add extension variant for master
+*** STRT [[file:specifications/flutter-extension.org][Flutter Extension]] [1/4]
+
+- [X] Add extension variant for master
 - [ ] Add extension variant for dev
 - [ ] Add extension variant for beta
 - [ ] Add extension variant for stable


### PR DESCRIPTION
An extension that sets up an environment with flutter-master and is able
wraps the usage of GNOME into a dependency.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
