### PR TITLE
pyinstaller: workaround pkg_resources issue

### DIFF
--- a/snapcraft.spec
+++ b/snapcraft.spec
@@ -22,6 +22,8 @@ a = Analysis(
         "click",
         "configparser",
         "pkg_resources",
+         # Workaround PyInstaller & SetupTools, https://github.com/pypa/setuptools/issues/1963
+        "pkg_resources.py2_warn",
         "pymacaroons",
         "responses",
     ],


### PR DESCRIPTION
Workaround PyInstaller & SetupTools pypa/setuptools#1963

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
