### PR TITLE
packaging: use PEP-440 compliant versioning for python & snap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,22 +30,25 @@ def recursive_data_files(directory, install_directory):
     return data_files
 
 
-def get_git_describe():
-    return (
+def determine_version():
+    # Examples (git describe -> python package version):
+    # 4.1.1-0-gad012482d -> 4.1.1
+    # 4.1.1-16-g2d8943dbc -> 4.1.1.post16+g2d8943dbc
+    version, distance, commit = (
         subprocess.run(
-            ["git", "describe", "--always"], check=True, stdout=subprocess.PIPE
+            ["git", "describe", "--always", "--long"],
+            check=True,
+            stdout=subprocess.PIPE,
         )
         .stdout.decode()
         .strip()
+        .split("-")
     )
 
+    if distance == "0":
+        return version
 
-def determine_version():
-    # 4.0rc1-23-g6f6016573 -> 4.0rc1+git23.g6f6016573
-    version = get_git_describe()
-    version = version.replace("-", "+git", 1)
-    version = version.replace("-", ".")
-    return version
+    return f"{version}.post{distance}+git{commit[1:]}"
 
 
 # Common distribution data

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -88,14 +88,15 @@ parts:
         # Put snapcraftctl into its own directory that can be included in the PATH
         # without including other binaries.
         bin/snapcraftctl: bin/scriptlet-bin/snapcraftctl
-    override-pull: |
-        snapcraftctl pull
-        version="$(git describe --always | sed -e 's/-/+git/;y/-/./')"
-        [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable
-        snapcraftctl set-version "$version"
-        snapcraftctl set-grade "$grade"
     override-build: |
         snapcraftctl build
+
+        version="$(python3 setup.py --version)"
+        snapcraftctl set-version "$version"
+
+        [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable
+        snapcraftctl set-grade "$grade"
+
         $SNAPCRAFT_PROJECT_DIR/tools/snapcraft-override-build.sh
     override-prime: |
         snapcraftctl prime


### PR DESCRIPTION
If HEAD matches a tag, then version is simply the tag (e.g. 4.1.1).

If HEAD does not match a tag, then version indicating the distance to
last tag with the ".post" indicator and the git commit revision in
the local identifier (e.g. 4.1.1.post17+git92348a7eb).

Local identifiers should not be published publically, but since we only
push tagged versions to the pip index, this should not occur.

Now we can do package version comparisons, e.g.:
```
>>> from packaging import version
>>> version.parse("4.1.1") > version.parse("4.1.2")
False
>>> version.parse("4.1.1.post17+git92348a7eb") > version.parse("4.1.1")
True
```

Finally, match the snap version to the python package version to
ensure they stay in sync. Do this by querying setup.py for the
version number so only one implementation is required.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
