### PR TITLE
snap: set PATH for snapcraft command

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,7 @@ assumes:
 apps:
   snapcraft:
     environment:
+      PATH: "/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       # https://github.com/lxc/pylxd/pull/361
       PYLXD_WARNINGS: "none"
     command: bin/snapcraft

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -474,11 +474,6 @@ class Provider(abc.ABC):
         # Tell Snapcraft it can take ownership of the host.
         env_list.append("SNAPCRAFT_BUILD_ENVIRONMENT=managed-host")
 
-        # Setup PATH so that snaps have precedence.
-        env_list.append(
-            "PATH=/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-        )
-
         # Set the HOME directory.
         env_list.append(f"HOME={self._get_home_directory().as_posix()}")
 

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -384,7 +384,6 @@ class BaseProviderTest(BaseProviderBaseTest):
                 [
                     "env",
                     "SNAPCRAFT_BUILD_ENVIRONMENT=managed-host",
-                    "PATH=/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                     "HOME=/root",
                     "SNAPCRAFT_HAS_TTY=False",
                 ]
@@ -405,7 +404,6 @@ class BaseProviderTest(BaseProviderBaseTest):
                 [
                     "env",
                     "SNAPCRAFT_BUILD_ENVIRONMENT=managed-host",
-                    "PATH=/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                     "HOME=/root",
                     "SNAPCRAFT_HAS_TTY=False",
                     "http_proxy=True",
@@ -430,7 +428,6 @@ class BaseProviderTest(BaseProviderBaseTest):
                 [
                     "env",
                     "SNAPCRAFT_BUILD_ENVIRONMENT=managed-host",
-                    "PATH=/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                     "HOME=/root",
                     "SNAPCRAFT_HAS_TTY=False",
                     "http_proxy=http://127.0.0.1:8080",


### PR DESCRIPTION
Use the fixed path setup in the build environment, this brings parity to
the launchpad buildd environment and any other --destructive-mode
instance.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
