### PR TITLE
cli: use prefix in store name registration hint

### DIFF
--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -41,7 +41,7 @@ _MESSAGE_REGISTER_PRIVATE = dedent(
     the choice of name and make sure you are confident nobody else will
     have a stronger claim to that particular name. If you are unsure
     then we suggest you prefix the name with your developer identity,
-    As ‘nessita-yoyodyne-www-site-content’."""
+    As '$username-yoyodyne-www-site-content'."""
 )
 _MESSAGE_REGISTER_CONFIRM = dedent(
     """
@@ -51,9 +51,9 @@ _MESSAGE_REGISTER_CONFIRM = dedent(
     If needed, we will rename snaps to ensure that a particular name
     reflects the software most widely expected by our community.
 
-    For example, most people would expect ‘thunderbird’ to be published by
+    For example, most people would expect 'thunderbird' to be published by
     Mozilla. They would also expect to be able to get other snaps of
-    Thunderbird as 'thunderbird-$username'.
+    Thunderbird as '$username-thunderbird'.
 
     Would you say that MOST users will expect {!r} to come from
     you, and be the software you intend to publish there?"""


### PR DESCRIPTION
Snapcraft recommended to register <snap-name>-<username> to overcome
concerns about ownership of a given name. It was agreed a while ago to
prefix the username suggestion to have a common namespace for a
publisher for ordering/listing.

Minor updates to quoting were also done.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
