### PR TITLE
snap: specify 'libxslt1-dev' than virtual 'libxslt-dev' build-package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,7 +30,7 @@ build-packages:
   - libsodium-dev
   - liblzma-dev
   - libxml2-dev
-  - libxslt-dev
+  - libxslt1-dev
   - libyaml-dev
   - patch
   - sed


### PR DESCRIPTION
Follow the advice of our own warning :)

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
