### PR TITLE
cmake v2 plugin: add stage to CMAKE_PREFIX_PATH

### DIFF
--- a/snapcraft/plugins/v2/cmake.py
+++ b/snapcraft/plugins/v2/cmake.py
@@ -59,7 +59,9 @@ class CMakePlugin(PluginV2):
         return {"gcc", "cmake"}
 
     def get_build_environment(self) -> Dict[str, str]:
-        return dict()
+        return {
+            "CMAKE_PREFIX_PATH": "${SNAPCRAFT_STAGE}",
+        }
 
     def _get_cmake_configure_command(self) -> str:
         cmd = ["cmake", '"${SNAPCRAFT_PART_SRC_WORK}"'] + self.options.cmake_parameters

--- a/tests/unit/plugins/v2/test_cmake.py
+++ b/tests/unit/plugins/v2/test_cmake.py
@@ -14,84 +14,67 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from testtools.matchers import Equals
-from testtools import TestCase
-
 from snapcraft.plugins.v2.cmake import CMakePlugin
 
 
-class CMakePluginTest(TestCase):
-    def test_schema(self):
-        schema = CMakePlugin.get_schema()
+def test_schema():
+    assert CMakePlugin.get_schema() == {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "cmake-parameters": {
+                "type": "array",
+                "uniqueItems": True,
+                "items": {"type": "string"},
+                "default": [],
+            }
+        },
+    }
 
-        self.assertThat(
-            schema,
-            Equals(
-                {
-                    "$schema": "http://json-schema.org/draft-04/schema#",
-                    "type": "object",
-                    "additionalProperties": False,
-                    "properties": {
-                        "cmake-parameters": {
-                            "type": "array",
-                            "uniqueItems": True,
-                            "items": {"type": "string"},
-                            "default": [],
-                        }
-                    },
-                }
-            ),
-        )
 
-    def test_get_build_packages(self):
-        plugin = CMakePlugin(part_name="my-part", options=lambda: None)
+def test_get_build_packages():
+    plugin = CMakePlugin(part_name="my-part", options=lambda: None)
 
-        self.assertThat(plugin.get_build_packages(), Equals({"gcc", "cmake"}))
+    assert plugin.get_build_packages() == {"gcc", "cmake"}
 
-    def test_get_build_environment(self):
-        plugin = CMakePlugin(part_name="my-part", options=lambda: None)
 
-        self.assertThat(plugin.get_build_environment(), Equals(dict()))
+def test_get_build_environment():
+    plugin = CMakePlugin(part_name="my-part", options=lambda: None)
 
-    def test_get_build_commands(self):
-        class Options:
-            cmake_parameters = list()
+    assert plugin.get_build_environment() == {"CMAKE_PREFIX_PATH": "${SNAPCRAFT_STAGE}"}
 
-        plugin = CMakePlugin(part_name="my-part", options=Options())
 
-        self.assertThat(
-            plugin.get_build_commands(),
-            Equals(
-                [
-                    'cmake "${SNAPCRAFT_PART_SRC_WORK}"',
-                    'cmake --build . -- -j"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
-                    'cmake --build . --target install -- DESTDIR="${SNAPCRAFT_PART_INSTALL}"',
-                ]
-            ),
-        )
+def test_get_build_commands():
+    class Options:
+        cmake_parameters = list()
 
-    def test_get_build_commands_with_cmake_parameters(self):
-        class Options:
-            cmake_parameters = [
-                "-DVERBOSE=1",
-                "-DCMAKE_INSTALL_PREFIX=/foo",
-                '-DCMAKE_SPACED_ARGS="foo bar"',
-                '-DCMAKE_USING_ENV="$SNAPCRAFT_PART_INSTALL"/bar',
-            ]
+    plugin = CMakePlugin(part_name="my-part", options=Options())
 
-        plugin = CMakePlugin(part_name="my-part", options=Options())
+    assert plugin.get_build_commands() == [
+        'cmake "${SNAPCRAFT_PART_SRC_WORK}"',
+        'cmake --build . -- -j"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
+        'cmake --build . --target install -- DESTDIR="${SNAPCRAFT_PART_INSTALL}"',
+    ]
 
-        self.assertThat(
-            plugin.get_build_commands(),
-            Equals(
-                [
-                    'cmake "${SNAPCRAFT_PART_SRC_WORK}" '
-                    "-DVERBOSE=1 "
-                    "-DCMAKE_INSTALL_PREFIX=/foo "
-                    '-DCMAKE_SPACED_ARGS="foo bar" '
-                    '-DCMAKE_USING_ENV="$SNAPCRAFT_PART_INSTALL"/bar',
-                    'cmake --build . -- -j"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
-                    'cmake --build . --target install -- DESTDIR="${SNAPCRAFT_PART_INSTALL}"',
-                ]
-            ),
-        )
+
+def test_get_build_commands_with_cmake_parameters():
+    class Options:
+        cmake_parameters = [
+            "-DVERBOSE=1",
+            "-DCMAKE_INSTALL_PREFIX=/foo",
+            '-DCMAKE_SPACED_ARGS="foo bar"',
+            '-DCMAKE_USING_ENV="$SNAPCRAFT_PART_INSTALL"/bar',
+        ]
+
+    plugin = CMakePlugin(part_name="my-part", options=Options())
+
+    assert plugin.get_build_commands() == [
+        'cmake "${SNAPCRAFT_PART_SRC_WORK}" '
+        "-DVERBOSE=1 "
+        "-DCMAKE_INSTALL_PREFIX=/foo "
+        '-DCMAKE_SPACED_ARGS="foo bar" '
+        '-DCMAKE_USING_ENV="$SNAPCRAFT_PART_INSTALL"/bar',
+        'cmake --build . -- -j"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
+        'cmake --build . --target install -- DESTDIR="${SNAPCRAFT_PART_INSTALL}"',
+    ]


### PR DESCRIPTION
Also update the unit tests to use pytest.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
Done as noted on https://forum.snapcraft.io/t/porting-cmake-based-core18-snap-to-core20-snap-fails/18647/5 by @jhenstridge 