### PR TITLE
lxd: enable security.syscalls.intercept.mknod if supported to allow snaps to create some device nodes

### DIFF
--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -207,6 +207,12 @@ class LXD(Provider):
 
         self._start()
 
+    def _supports_syscall_interception(self) -> bool:
+        # syscall interception relies on the seccomp_listener kernel feature
+        environment = self._lxd_client.host_info.get("environment", {})
+        kernel_features = environment.get("kernel_features", {})
+        return kernel_features.get("seccomp_listener", "false") == "true"
+
     def _start(self):
         if not self._lxd_client.containers.exists(self.instance_name):
             raise errors.ProviderInstanceNotFoundError(instance_name=self.instance_name)
@@ -221,9 +227,10 @@ class LXD(Provider):
         self._container.config["raw.idmap"] = "both {!s} 0".format(
             os.stat(self.project._project_dir).st_uid
         )
-        # Allow container to make safe mknod calls, as documented at
+        # If possible, allow container to make safe mknod calls. Documented at
         # https://linuxcontainers.org/lxd/docs/master/syscall-interception
-        self._container.config["security.syscalls.intercept.mknod"] = "true"
+        if self._supports_syscall_interception():
+            self._container.config["security.syscalls.intercept.mknod"] = "true"
         self._container.save(wait=True)
 
         if self._container.status.lower() != "running":

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -221,6 +221,9 @@ class LXD(Provider):
         self._container.config["raw.idmap"] = "both {!s} 0".format(
             os.stat(self.project._project_dir).st_uid
         )
+        # Allow container to make safe mknod calls, as documented at
+        # https://linuxcontainers.org/lxd/docs/master/syscall-interception
+        self._container.config["security.syscalls.intercept.mknod"] = "true"
         self._container.save(wait=True)
 
         if self._container.status.lower() != "running":

--- a/tests/spread/build-providers/lxd-mknod/task.yaml
+++ b/tests/spread/build-providers/lxd-mknod/task.yaml
@@ -1,5 +1,8 @@
 summary: Verify LXD builds can make (some) device nodes
 
+systems:
+  - -ubuntu-16.04*    # kernel does not support syscall interception
+
 environment:
   SNAP_DIR: ../snaps/devices
 

--- a/tests/spread/build-providers/lxd-mknod/task.yaml
+++ b/tests/spread/build-providers/lxd-mknod/task.yaml
@@ -1,0 +1,37 @@
+summary: Verify LXD builds can make (some) device nodes
+
+environment:
+  SNAP_DIR: ../snaps/devices
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+
+  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host.
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
+  snapcraft clean --use-lxd
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "$SNAP_DIR"
+
+  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host.
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
+  snapcraft --use-lxd
+  sudo snap install devices_*.snap --dangerous
+
+  # Check that the snap includes the expected character device files
+  [ -c /snap/devices/current/dev/null ]
+  [ -c /snap/devices/current/dev/zero ]
+  [ -c /snap/devices/current/dev/random ]
+  [ -c /snap/devices/current/dev/urandom ]

--- a/tests/spread/build-providers/snaps/devices/snap/snapcraft.yaml
+++ b/tests/spread/build-providers/snaps/devices/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: devices
+version: '0.1'
+summary: Help verify (some) device files can be created in LXD builds
+description: ...
+
+grade: devel
+base: core18
+confinement: strict
+
+parts:
+  test:
+    plugin: nil
+    build-packages:
+      - coreutils
+    override-build: |
+      mkdir -p $SNAPCRAFT_PART_INSTALL/dev
+      mknod $SNAPCRAFT_PART_INSTALL/dev/null c 1 3
+      mknod $SNAPCRAFT_PART_INSTALL/dev/zero c 1 5
+      mknod $SNAPCRAFT_PART_INSTALL/dev/random c 1 8
+      mknod $SNAPCRAFT_PART_INSTALL/dev/urandom c 1 9

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -200,6 +200,7 @@ class LXDInitTest(LXDBaseTest):
             config={
                 "name": "snapcraft-project-name",
                 "raw.idmap": f"both {os.getuid()} 0",
+                "security.syscalls.intercept.mknod": "true",
                 "source": {
                     "mode": "pull",
                     "type": "image",
@@ -776,6 +777,7 @@ class LXDInitTest(LXDBaseTest):
             config={
                 "name": "snapcraft-core18",
                 "raw.idmap": f"both {os.getuid()} 0",
+                "security.syscalls.intercept.mknod": "true",
                 "source": {
                     "mode": "pull",
                     "type": "image",

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -143,6 +143,9 @@ class FakeContainers:
 class FakePyLXDClient:
     def __init__(self) -> None:
         self.containers = FakeContainers()
+        self.host_info = {
+            "environment": {"kernel_features": {"seccomp_listener": "true"}}
+        }
 
 
 class LXDBaseTest(BaseProviderBaseTest):
@@ -795,6 +798,30 @@ class LXDInitTest(LXDBaseTest):
         instance = LXDTestImpl(project=self.project, echoer=self.echoer_mock)
 
         self.assertRaises(errors.ProviderInvalidBaseError, instance.create)
+
+    def test_create_without_syscall_intercept(self):
+        self.fake_pylxd_client.host_info["environment"]["kernel_features"][
+            "seccomp_listener"
+        ] = "false"
+
+        instance = LXDTestImpl(project=self.project, echoer=self.echoer_mock)
+
+        instance.create()
+
+        self.fake_pylxd_client.containers.create_mock.assert_called_once_with(
+            config={
+                "name": "snapcraft-project-name",
+                "raw.idmap": f"both {os.getuid()} 0",
+                "source": {
+                    "mode": "pull",
+                    "type": "image",
+                    "server": "https://cloud-images.ubuntu.com/buildd/daily",
+                    "protocol": "simplestreams",
+                    "alias": "16.04",
+                },
+            },
+            wait=True,
+        )
 
 
 class LXDLaunchedTest(LXDBaseTest):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
When building a bootable base snap, it is common to include a few device files in `/dev` for the benefit of anything running in early boot before udev/devtmpfs is available.

However, trying to build such a snap with the LXD build provider fails because the `mknod` syscall is blocked by default for unprivileged containers.  LXD does provide a way to give unprivileged containers limited access to the syscall for device nodes it considers safe:

https://linuxcontainers.org/lxd/docs/master/syscall-interception#mknod-mknodat

This safe set of devices includes all of the ones included in the `core18` and `core20` snaps, so enabling it should allow bases like that to be built under LXD.