### PR TITLE
meta: detailed warnings for resolution of commands

### DIFF
--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -19,7 +19,7 @@ import glob
 import logging
 import math
 import os
-from pathlib import Path
+import pathlib
 import shlex
 import shutil
 import subprocess
@@ -27,10 +27,10 @@ import sys
 import tempfile
 import urllib
 from contextlib import suppress
-from typing import Callable, List
+from pathlib import Path
+from typing import Callable, List, Union
 
 from snapcraft.internal import errors
-
 
 SNAPCRAFT_FILES = ["parts", "stage", "prime"]
 _DEFAULT_PLUGINDIR = os.path.join(sys.prefix, "share", "snapcraft", "plugins")
@@ -323,7 +323,7 @@ def format_output_in_columns(
     return result_output
 
 
-def get_bin_paths(*, root: str, existing_only=True) -> List[str]:
+def get_bin_paths(*, root: Union[str, pathlib.Path], existing_only=True) -> List[str]:
     paths = (os.path.join("usr", "sbin"), os.path.join("usr", "bin"), "sbin", "bin")
     rooted_paths = (os.path.join(root, p) for p in paths)
 

--- a/snapcraft/internal/meta/_utils.py
+++ b/snapcraft/internal/meta/_utils.py
@@ -15,10 +15,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import pathlib
 import stat
+from typing import Union
 
 
-def _executable_is_valid(path: str) -> bool:
+def _executable_is_valid(path: Union[str, pathlib.Path]) -> bool:
     if not os.path.isfile(path):
         return False
 

--- a/snapcraft/internal/meta/command.py
+++ b/snapcraft/internal/meta/command.py
@@ -39,7 +39,7 @@ _FMT_SNAPD_WRAPPER = (
 
 
 def _get_shebang_from_file(file_path: pathlib.Path) -> Optional[str]:
-    """Returns the shebang from file_path."""
+    """Get the shebang from specified file."""
     with open(file_path, "rb") as exefile:
         if exefile.read(2) != b"#!":
             return None
@@ -58,9 +58,8 @@ class _SnapCommandResolver:
     def _find_executable(self, command: str) -> Optional[pathlib.Path]:
         """Find executable in common binary path locations.
 
-        Returns:
-          Path to executable found, whether it is in searched
-          prime directory paths, or on host using shutil.which().
+        :return: Path to executable found, whether it is in searched
+            prime directory paths, or on host using shutil.which().
         """
         binary_paths = (
             pathlib.Path(p, command)
@@ -91,9 +90,8 @@ class _SnapCommandResolver:
         Effectively performs the job of "/usr/bin/env", ignoring
         it if used as the (initial) interpreter.
 
-        Returns:
-          Resolved and normalized interpreter path, if any.
-          Incorporate arguments found in shebang.
+        :return: Resolved and normalized interpreter path, if any.
+            Incorporate arguments found in shebang.
         """
         interpreter = self.get_command_interpreter()
         if interpreter is None:
@@ -143,8 +141,7 @@ class _SnapCommandResolver:
     def resolve_command(self) -> str:
         """Resolve the given command, searching prime directory or host if needed.
 
-        Returns:
-          Resolved and normalized command string.
+        :return: Resolved and normalized command string.
         """
         command_parts = shlex.split(self.command, posix=False)
 
@@ -176,7 +173,10 @@ class _SnapCommandResolver:
         return " ".join(command_parts)
 
     def get_command_interpreter(self) -> Optional[str]:
-        """Return interpreter (shebang) for self.command, if any."""
+        """Get interpreter (shebang) for executable pointed to by self.command.
+
+        :return: Interpreter string, else None if none found.
+        """
         command_parts = shlex.split(self.command, posix=False)
 
         command_path = pathlib.Path(self._prime_path, command_parts[0])
@@ -190,8 +190,7 @@ class _SnapCommandResolver:
         resolving ambiguous commands either relative to prime, or absolute
         to host/base.
 
-        Returns:
-          Resolved and normalized command, accounting for the interpreter,
+        :return: Resolved and normalized command, accounting for the interpreter,
           if required.
         """
         # Strip leading unneed $SNAP from command, if present.
@@ -236,13 +235,10 @@ class _SnapCommandResolver:
         """Resolve and normalize a given snap command entry, taking
         the interpreter into account, if appropriate.
 
-        Args:
-          command: command to resolve and normalize.
-          prime_path: path to prime directory.
-
-        Returns:
-          Resolved and normalized command string suitable for a snap.yaml
-          if no wrapper is required.
+        :param command: command to resolve and normalize.
+        :param prime_path: path to prime directory.
+        :return: Resolved and normalized command string suitable for a snap.yaml
+            if no wrapper is required.
         """
         # If command is absolute, nothing to resolve.
         if command.startswith("/"):

--- a/snapcraft/internal/meta/command.py
+++ b/snapcraft/internal/meta/command.py
@@ -14,26 +14,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import contextlib
 import logging
 import os
+import pathlib
 import re
 import shlex
 import shutil
-from typing import List, Optional
+from typing import Optional
+
+from snapcraft.internal import common
 
 from . import errors
 from ._utils import _executable_is_valid
-from snapcraft.internal import common
-
 
 logger = logging.getLogger(__name__)
 _COMMAND_PATTERN = re.compile("^[A-Za-z0-9. _#:$-][A-Za-z0-9/. _#:$-]*$")
-_FMT_COMMAND_SNAP_STRIP = "Stripped '$SNAP/' from command {!r}."
-_FMT_COMMAND_ROOT = (
-    "The command {!r} was not found in the prime directory, it has been "
-    "changed to {!r}."
-)
 _FMT_SNAPD_WRAPPER = (
     "A shell wrapper will be generated for command {!r} as it does not conform "
     "with the command pattern expected by the runtime. "
@@ -43,130 +38,218 @@ _FMT_SNAPD_WRAPPER = (
 )
 
 
-def _get_shebang_from_file(file_path: str) -> List[str]:
+def _get_shebang_from_file(file_path: pathlib.Path) -> Optional[str]:
     """Returns the shebang from file_path."""
-    if not os.path.exists(file_path):
-        raise errors.ShebangNotFoundError()
-
     with open(file_path, "rb") as exefile:
         if exefile.read(2) != b"#!":
-            raise errors.ShebangNotFoundError()
+            return None
         shebang_line = exefile.readline().strip().decode("utf-8")
 
-    # posix is set to False to respect the quoting of variables.
-    shebang_parts = shlex.split(shebang_line, posix=False)
-    # remove the leading /usr/bin/env.
-    if shebang_parts[0] == "/usr/bin/env":
-        shebang_parts = shebang_parts[1:]
-    # or if the shebang startswith /.
-    elif shebang_parts[0].startswith("/"):
-        raise errors.ShebangInRoot()
-
-    return shebang_parts
+    return shebang_line
 
 
-def _find_executable(*, binary: str, prime_dir: str) -> str:
-    found_path: Optional[str] = None
-    binary_paths = (
-        os.path.join(p, binary) for p in common.get_bin_paths(root=prime_dir)
-    )
-    for binary_path in binary_paths:
-        if _executable_is_valid(binary_path):
-            found_path = binary_path
-            break
-    else:
+class _SnapCommandResolver:
+    def __init__(self, *, command: str, prime_path: pathlib.Path) -> None:
+        self.original_command = command
+        self._prime_path = prime_path
+        self.interpreter: Optional[str] = None
+        self.command = command
+
+    def _find_executable(self, command: str) -> Optional[pathlib.Path]:
+        """Find executable in common binary path locations.
+
+        Returns:
+          Path to executable found, whether it is in searched
+          prime directory paths, or on host using shutil.which().
+        """
+        binary_paths = (
+            pathlib.Path(p, command)
+            for p in common.get_bin_paths(root=self._prime_path)
+        )
+        for binary_path in binary_paths:
+            if _executable_is_valid(binary_path):
+                return binary_path
+
         # Last chance to find in the prime_dir, mostly for backwards compatibility,
         # to find the executable, historical snaps like those built with the catkin
         # plugin will have roslaunch in a path like /opt/ros/bin/roslaunch.
-        for root, _, files in os.walk(prime_dir):
-            if _executable_is_valid(os.path.join(root, binary)):
-                found_path = os.path.join(root, binary)
-                break
+        for root, _, files in os.walk(self._prime_path):
+            file_path = pathlib.Path(root, command)
+            if _executable_is_valid(str(file_path)):
+                return file_path
+
+        # Finally, check if it is part of the system.
+        which_command = shutil.which(command)
+        if which_command is not None:
+            return pathlib.Path(which_command)
+
+        return None
+
+    def resolve_interpreter(self) -> Optional[str]:
+        """Resolve the interpreter to a format suitable for use in a snap.yaml.
+
+        Effectively performs the job of "/usr/bin/env", ignoring
+        it if used as the (initial) interpreter.
+
+        Returns:
+          Resolved and normalized interpreter path, if any.
+          Incorporate arguments found in shebang.
+        """
+        interpreter = self.get_command_interpreter()
+        if interpreter is None:
+            return None
+
+        # Remove the leading /usr/bin/env and resolve it now.
+        interpreter_parts = shlex.split(interpreter, posix=False)
+        if interpreter_parts[0] == "/usr/bin/env":
+            interpreter_parts = interpreter_parts[1:]
+
+        # If interpreter is absolute, ignore it.
+        if pathlib.Path(interpreter_parts[0]).is_absolute():
+            return None
+
+        # Strip leading unnecessary $SNAP from command, if present.
+        interpreter_parts[0] = re.sub(r"^\$SNAP/", "", interpreter_parts[0])
+
+        # Check if relative to prime, where it should be found.
+        if pathlib.Path(self._prime_path, interpreter_parts[0]).exists():
+            return " ".join(interpreter_parts)
+
+        # If not where it claims to be, search for backwards compatibility.
+        interpreter_path = self._find_executable(command=interpreter_parts[0])
+
+        if interpreter_path is None:
+            # Interpreter was not found, note that this is not a hard error.
+            logger.warning(
+                f"The interpreter {interpreter_parts[0]!r} for {self.original_command!r} was not found."
+            )
         else:
-            # Finally, check if it is part of the system.
-            found_path = shutil.which(binary)
+            # Interpreter was found in the prime directory, but required the
+            # legacy search, or it was found on the host.  Log a warning.
+            if self._prime_path in interpreter_path.parents:
+                resolved_interpreter = interpreter_path.relative_to(
+                    self._prime_path
+                ).as_posix()
+            else:
+                resolved_interpreter = interpreter_path.as_posix()
 
-    if found_path is None:
-        raise errors.PrimedCommandNotFoundError(binary)
+            logger.warning(
+                f"The interpreter {interpreter_parts[0]!r} for {self.original_command!r} was resolved to {resolved_interpreter!r}."
+            )
+            interpreter_parts[0] = resolved_interpreter
 
-    return found_path
+        return " ".join(interpreter_parts)
 
+    def resolve_command(self) -> str:
+        """Resolve the given command, searching prime directory or host if needed.
 
-def _get_command_path(*, command: str, prime_dir: str) -> str:
-    # Strip leading "/"
-    command = re.sub(r"^/", "", command)
-    # Strip leading "$SNAP/"
-    command = re.sub(r"^\$SNAP/", "", command)
+        Returns:
+          Resolved and normalized command string.
+        """
+        command_parts = shlex.split(self.command, posix=False)
 
-    return os.path.join(prime_dir, command)
+        # Strip leading unnecessary $SNAP from command, if present.
+        command_parts[0] = re.sub(r"^\$SNAP/", "", command_parts[0])
 
+        # Check if relative to prime, where it should be found.
+        if os.path.exists(os.path.join(self._prime_path, command_parts[0])):
+            return " ".join(command_parts)
 
-def _massage_command(*, command: str, prime_dir: str) -> str:
-    """Rewrite command to take into account interpreter and pathing.
+        # If not where it claims to be, search for backwards compatibility.
+        command_path = self._find_executable(command=command_parts[0])
 
-    (1) Interpreter: if shebang is found in file, explicitly prepend
-        the interpreter to the command string.  Fixup path of
-        command with $SNAP if required so the interpreter is able
-        to find the correct target.
-    (2) Explicit path: attempt to find the executable if path
-        is ambiguous.  If found in prime_dir, set the path relative
-        to snap.
+        if command_path is None:
+            raise errors.PrimedCommandNotFoundError(self.original_command)
 
-    Returns massaged command."""
+        # Command was found in the prime directory, but it required the
+        # legacy search or was found on the host.  Log a warning.
+        if self._prime_path in command_path.parents:
+            resolved_command = command_path.relative_to(self._prime_path).as_posix()
+        else:
+            resolved_command = command_path.as_posix()
 
-    # If command starts with "/" we have no option but to use a wrapper.
-    if command.startswith("/"):
-        return command
+        logger.warning(
+            f"The command {command_parts[0]!r} for {self.original_command!r} was resolved to {resolved_command!r}."
+        )
+        command_parts[0] = resolved_command
 
-    # command_parts holds the lexical split of a command entry.
-    # posix is set to False to respect the quoting of variables.
-    command_parts = shlex.split(command, posix=False)
-    # Make a note now that $SNAP if found this path will not make it into the
-    # resulting command entry.
-    if command_parts[0].startswith("$SNAP/"):
-        logger.warning(_FMT_COMMAND_SNAP_STRIP.format(command))
-    # command_path is the absolute path to the real command (command_parts[0]),
-    # used to verify that the executable is valid and potentially extract a
-    # shebang.
-    command_path = _get_command_path(command=command_parts[0], prime_dir=prime_dir)
+        return " ".join(command_parts)
 
-    # Extract shebang, if the shebang is not root bound it will be inserted at the
-    # beginning of command_parts. If the shebang is not found we will ignore it
-    # for backwards compatibility (this might be part of a content interfaced
-    # snap).
-    # If a shebang is found, command_path is rewritten to point to the shebang.
-    with contextlib.suppress(errors.ShebangNotFoundError, errors.ShebangInRoot):
-        shebang_parts = _get_shebang_from_file(command_path)
-        # Add the shebang (interpreter) to the front of the command.
-        command_parts = shebang_parts + command_parts
-        # And make sure the original command is prepended with $SNAP so it is
-        # found and not already set.
-        if not command_parts[1].startswith("$SNAP"):
-            command_parts[1] = os.path.join("$SNAP", command_parts[1])
-        command_path = _get_command_path(command=shebang_parts[0], prime_dir=prime_dir)
+    def get_command_interpreter(self) -> Optional[str]:
+        """Return interpreter (shebang) for self.command, if any."""
+        command_parts = shlex.split(self.command, posix=False)
 
-    # If the command is part of the snap (starts with $SNAP) it NEEDS to exist
-    # within the prime directory.
-    if not os.path.exists(command_path) and command_parts[0].startswith("$SNAP/"):
-        raise errors.PrimedCommandNotFoundError(command_parts[0])
-    # if the command is "pathless", make an attempt to find the executable within
-    # the prime directory and as a last resort (for backwards compatibility),
-    # at the root of the filesystem.
-    elif not os.path.exists(command_path):
-        command_path = _find_executable(binary=command_parts[0], prime_dir=prime_dir)
+        command_path = pathlib.Path(self._prime_path, command_parts[0])
+        if not command_path.exists():
+            return None
 
-    # A command found within the prime directory will have a command_path that
-    # starts with the prime directory leading the path. Make it relative to
-    # this prime directory before replacing the original command.
-    if command_path.startswith(prime_dir):
-        command_parts[0] = os.path.relpath(command_path, prime_dir)
-    # If not in the prime directory, add as is as it is pointing to the root
-    # (most likely part of the base for this snap).
-    else:
-        logger.warning(_FMT_COMMAND_ROOT.format(command, command_path))
-        command_parts[0] = command_path
+        return _get_shebang_from_file(command_path)
 
-    return " ".join(command_parts)
+    def resolve(self) -> str:
+        """Resolve command to take into account interpreter and pathing,
+        resolving ambiguous commands either relative to prime, or absolute
+        to host/base.
+
+        Returns:
+          Resolved and normalized command, accounting for the interpreter,
+          if required.
+        """
+        # Strip leading unneed $SNAP from command, if present.
+        self.command = re.sub(r"^\$SNAP/", "", self.command)
+
+        # Resolve interpreter, if any.
+        self.interpreter = self.resolve_interpreter()
+
+        # Resolve command.
+        self.command = self.resolve_command()
+
+        # Format interpreter and command for snap.yaml.
+        if self.interpreter is not None:
+            finalized_command = " ".join(
+                [self.interpreter, pathlib.Path("$SNAP", self.command).as_posix()]
+            )
+        else:
+            finalized_command = self.command
+
+        # Issue final warnings for any changes.
+        if finalized_command != self.original_command:
+            if self.original_command.startswith("$SNAP/"):
+                logger.warning(
+                    f"Found unneeded '$SNAP/' in command {self.original_command!r}."
+                )
+
+            if self.interpreter is not None:
+                logger.warning(
+                    f"The command {self.original_command!r} has been changed to {finalized_command!r} to safely account for the interpreter."
+                )
+            else:
+                logger.warning(
+                    f"The command {self.original_command!r} has been changed to {finalized_command!r}."
+                )
+
+        return finalized_command
+
+    @classmethod
+    def resolve_snap_command_entry(
+        cls, *, command: str, prime_path: pathlib.Path
+    ) -> str:
+        """Resolve and normalize a given snap command entry, taking
+        the interpreter into account, if appropriate.
+
+        Args:
+          command: command to resolve and normalize.
+          prime_path: path to prime directory.
+
+        Returns:
+          Resolved and normalized command string suitable for a snap.yaml
+          if no wrapper is required.
+        """
+        # If command is absolute, nothing to resolve.
+        if command.startswith("/"):
+            return command
+        else:
+            resolver = cls(command=command, prime_path=prime_path)
+            return resolver.resolve()
 
 
 class Command:
@@ -204,14 +287,16 @@ class Command:
         )
 
     def prime_command(
-        self, *, can_use_wrapper: bool, massage_command: bool = True, prime_dir: str
+        self, *, can_use_wrapper: bool, massage_command: bool = True, prime_dir: str,
     ) -> str:
         """Finalize and prime command, massaging as necessary.
 
         Check if command is in prime_dir and raise exception if not valid."""
 
         if massage_command:
-            self.command = _massage_command(command=self.command, prime_dir=prime_dir)
+            self.command = _SnapCommandResolver.resolve_snap_command_entry(
+                command=self.command, prime_path=pathlib.Path(prime_dir)
+            )
 
         if self.requires_wrapper:
             if not can_use_wrapper:

--- a/snapcraft/internal/meta/command.py
+++ b/snapcraft/internal/meta/command.py
@@ -65,9 +65,21 @@ class _SnapCommandResolver:
             pathlib.Path(p, command)
             for p in common.get_bin_paths(root=self._prime_path)
         )
-        for binary_path in binary_paths:
-            if _executable_is_valid(binary_path):
-                return binary_path
+
+        # Final all potential hits, sorting to ensure consistent behavior.
+        primed_binary_paths = sorted(
+            [p for p in binary_paths if _executable_is_valid(p)]
+        )
+
+        # Warn if we have multiple potential hits.
+        if len(primed_binary_paths) > 1:
+            logger.warning(
+                f"Multiple binaries matching for ambiguous command {command!r}, using {primed_binary_paths[0]!r}."
+            )
+
+        # Return first hit, if any.
+        if primed_binary_paths:
+            return primed_binary_paths[0]
 
         # Last chance to find in the prime_dir, mostly for backwards compatibility,
         # to find the executable, historical snaps like those built with the catkin

--- a/snapcraft/internal/meta/command.py
+++ b/snapcraft/internal/meta/command.py
@@ -72,13 +72,14 @@ class _SnapCommandResolver:
         )
 
         # Warn if we have multiple potential hits.
-        if len(primed_binary_paths) > 1:
-            logger.warning(
-                f"Multiple binaries matching for ambiguous command {command!r}, using {primed_binary_paths[0]!r}."
-            )
-
-        # Return first hit, if any.
-        if primed_binary_paths:
+        if len(primed_binary_paths) > 0:
+            if len(primed_binary_paths) > 1:
+                matches = [
+                    str(p.relative_to(self._prime_path)) for p in primed_binary_paths
+                ]
+                logger.warning(
+                    f"Multiple binaries matching for ambiguous command {command!r}: {matches!r}"
+                )
             return primed_binary_paths[0]
 
         # Last chance to find in the prime_dir, mostly for backwards compatibility,

--- a/snapcraft/internal/meta/errors.py
+++ b/snapcraft/internal/meta/errors.py
@@ -171,14 +171,6 @@ class PrimedCommandNotFoundError(errors.SnapcraftError):
         super().__init__(command=command)
 
 
-class ShebangNotFoundError(Exception):
-    """Internal exception for when a shebang is not found."""
-
-
-class ShebangInRoot(Exception):
-    """Internal exception for when a shebang is part of the root."""
-
-
 class SlotValidationError(errors.SnapcraftError):
     fmt = "failed to validate slot={slot_name}: {message}"
 

--- a/tests/unit/meta/test_command.py
+++ b/tests/unit/meta/test_command.py
@@ -16,17 +16,20 @@
 
 import logging
 import os
+import shutil
 
 import fixtures
-from testtools.matchers import Equals, Is, FileContains, FileExists
+from testtools.matchers import Equals, FileContains, FileExists, Is
 
 from snapcraft.internal.meta import command, errors
 from tests import unit
 
 
-def _create_file(file_path: str, *, mode=0o755) -> None:
+def _create_file(file_path: str, *, mode=0o755, contents="") -> None:
     os.makedirs(os.path.dirname(file_path), exist_ok=True)
-    open(file_path, "w").close()
+    with open(file_path, "w") as f:
+        if contents:
+            f.write(contents)
     os.chmod(file_path, mode)
 
 
@@ -47,7 +50,7 @@ class CommandWithoutWrapperAllowedTest(unit.TestCase):
         cmd = command.Command(app_name="foo", command_name="command", command="foo")
 
         cmd.prime_command(
-            can_use_wrapper=False, massage_command=True, prime_dir=self.path
+            can_use_wrapper=False, massage_command=True, prime_dir=self.path,
         )
 
         self.assertThat(cmd.command, Equals("foo"))
@@ -58,10 +61,52 @@ class CommandWithoutWrapperAllowedTest(unit.TestCase):
             app_name="foo", command_name="command", command="foo bar -baz"
         )
         cmd.prime_command(
-            can_use_wrapper=False, massage_command=True, prime_dir=self.path
+            can_use_wrapper=False, massage_command=True, prime_dir=self.path,
         )
 
         self.assertThat(cmd.command, Equals("foo bar -baz"))
+
+
+def test_interpretered_command_from_host(monkeypatch, tmp_path):
+    monkeypatch.setattr(shutil, "which", lambda x: "/bin/python3")
+
+    _create_file(os.path.join(tmp_path, "foo"), contents="#!/usr/bin/env python3\n")
+    cmd = command.Command(
+        app_name="foo", command_name="command", command="foo bar -baz"
+    )
+    cmd.prime_command(
+        can_use_wrapper=True, massage_command=True, prime_dir=tmp_path.as_posix(),
+    )
+
+    assert cmd.command == "command-foo.wrapper"
+    assert cmd.wrapped_command == "/bin/python3 $SNAP/foo bar -baz"
+
+
+def test_interpretered_command_from_prime(tmp_path):
+    _create_file(os.path.join(tmp_path, "bin", "python3"))
+    _create_file(os.path.join(tmp_path, "foo"), contents="#!/usr/bin/env python3\n")
+
+    cmd = command.Command(
+        app_name="foo", command_name="command", command="foo bar -baz"
+    )
+    cmd.prime_command(
+        can_use_wrapper=True, massage_command=True, prime_dir=tmp_path.as_posix(),
+    )
+
+    assert cmd.command == "bin/python3 $SNAP/foo bar -baz"
+
+
+def test_interpretered_command_from_root(tmp_path):
+    _create_file(os.path.join(tmp_path, "foo"), contents="#!/bin/sh\n")
+
+    cmd = command.Command(
+        app_name="foo", command_name="command", command="foo bar -baz"
+    )
+    cmd.prime_command(
+        can_use_wrapper=True, massage_command=True, prime_dir=tmp_path.as_posix(),
+    )
+
+    assert cmd.command == "foo bar -baz"
 
 
 class CommandWithoutWrapperAllowedTestErrors(unit.TestCase):
@@ -96,8 +141,8 @@ class CommandWithoutWrapperAllowedTestErrors(unit.TestCase):
         self.assertThat(
             self.fake_logger.output.strip(),
             Equals(
-                "The command 'sh' was not found in the prime directory, it has "
-                "been changed to '/bin/sh'."
+                "The command 'sh' for 'sh' was resolved to '/bin/sh'.\n"
+                "The command 'sh' has been changed to '/bin/sh'."
             ),
         )
 
@@ -141,7 +186,7 @@ class CommandWithWrapperTest(unit.TestCase):
         _create_file(os.path.join(self.path, "foo"))
         cmd = command.Command(app_name="foo", command_name="command", command="foo")
         cmd.prime_command(
-            can_use_wrapper=True, massage_command=True, prime_dir=self.path
+            can_use_wrapper=True, massage_command=True, prime_dir=self.path,
         )
 
         self.assertThat(cmd.command, Equals("foo"))
@@ -153,15 +198,15 @@ class CommandWithWrapperTest(unit.TestCase):
             app_name="foo", command_name="command", command="$SNAP/foo !option"
         )
         cmd.prime_command(
-            can_use_wrapper=True, massage_command=True, prime_dir=self.path
+            can_use_wrapper=True, massage_command=True, prime_dir=self.path,
         )
 
         self.assertThat(cmd.command, Equals("command-foo.wrapper"))
         self.assertThat(
             self.fake_logger.output.strip(),
             Equals(
-                "Stripped '$SNAP/' from command '$SNAP/foo !option'."
-                "\n"
+                "Found unneeded '$SNAP/' in command '$SNAP/foo !option'.\n"
+                "The command '$SNAP/foo !option' has been changed to 'foo !option'.\n"
                 "A shell wrapper will be generated for command 'foo !option' "
                 "as it does not conform with the command pattern expected "
                 "by the runtime. Commands must be relative to the prime "
@@ -177,7 +222,7 @@ class CommandWithWrapperTest(unit.TestCase):
         )
 
         cmd.prime_command(
-            can_use_wrapper=True, massage_command=True, prime_dir=self.path
+            can_use_wrapper=True, massage_command=True, prime_dir=self.path,
         )
         wrapper_path = cmd.write_wrapper(prime_dir=self.path)
 
@@ -192,7 +237,7 @@ class CommandWithWrapperTest(unit.TestCase):
         )
 
         cmd.prime_command(
-            can_use_wrapper=True, massage_command=True, prime_dir=self.path
+            can_use_wrapper=True, massage_command=True, prime_dir=self.path,
         )
         wrapper_path = cmd.write_wrapper(prime_dir=self.path)
 
@@ -216,7 +261,7 @@ class CommandWithWrapperTest(unit.TestCase):
         cmd = command.Command(app_name="foo", command_name="command", command="/foo")
 
         cmd.prime_command(
-            can_use_wrapper=True, massage_command=True, prime_dir=self.path
+            can_use_wrapper=True, massage_command=True, prime_dir=self.path,
         )
         wrapper_path = cmd.write_wrapper(prime_dir=self.path)
 
@@ -238,7 +283,7 @@ class CommandWithWrapperTest(unit.TestCase):
         cmd = command.Command(app_name="foo", command_name="command", command="sh")
 
         cmd.prime_command(
-            can_use_wrapper=True, massage_command=True, prime_dir=self.path
+            can_use_wrapper=True, massage_command=True, prime_dir=self.path,
         )
         wrapper_path = cmd.write_wrapper(prime_dir=self.path)
 
@@ -248,9 +293,8 @@ class CommandWithWrapperTest(unit.TestCase):
         self.assertThat(
             self.fake_logger.output.strip(),
             Equals(
-                "The command 'sh' was not found in the prime directory, it has "
-                "been changed to '/bin/sh'."
-                "\n"
+                "The command 'sh' for 'sh' was resolved to '/bin/sh'.\n"
+                "The command 'sh' has been changed to '/bin/sh'.\n"
                 "A shell wrapper will be generated for command '/bin/sh' "
                 "as it does not conform with the command pattern expected "
                 "by the runtime. Commands must be relative to the prime "

--- a/tests/unit/meta/test_command_mangle.py
+++ b/tests/unit/meta/test_command_mangle.py
@@ -29,7 +29,7 @@ class TestCommandMangle:
                 command_path="foo",
                 command_value="foo bar",
                 expected_command="foo bar",
-                expected_log=None,
+                expected_logs=[],
                 shebang="",
                 interpreter_path=None,
             ),
@@ -40,7 +40,7 @@ class TestCommandMangle:
                 command_path="bin/foo",
                 command_value="bin/foo bar",
                 expected_command="bin/foo bar",
-                expected_log=None,
+                expected_logs=[],
                 shebang="",
                 interpreter_path=None,
             ),
@@ -51,7 +51,10 @@ class TestCommandMangle:
                 command_path="foo",
                 command_value="$SNAP/foo bar",
                 expected_command="foo bar",
-                expected_log="Stripped '$SNAP/' from command '$SNAP/foo bar'.",
+                expected_logs=[
+                    "Found unneeded '$SNAP/' in command '$SNAP/foo bar'.",
+                    "The command '$SNAP/foo bar' has been changed to 'foo bar'.",
+                ],
                 shebang="",
                 interpreter_path=None,
             ),
@@ -62,7 +65,7 @@ class TestCommandMangle:
                 command_path="foo",
                 command_value='foo "$bar"',
                 expected_command='foo "$bar"',
-                expected_log=None,
+                expected_logs=[],
                 shebang="",
                 interpreter_path=None,
             ),
@@ -73,7 +76,10 @@ class TestCommandMangle:
                 command_path="bin/foo",
                 command_value="$SNAP/bin/foo bar",
                 expected_command="bin/foo bar",
-                expected_log="Stripped '$SNAP/' from command '$SNAP/bin/foo bar'.",
+                expected_logs=[
+                    "Found unneeded '$SNAP/' in command '$SNAP/bin/foo bar'.",
+                    "The command '$SNAP/bin/foo bar' has been changed to 'bin/foo bar'.",
+                ],
                 shebang="",
                 interpreter_path=None,
             ),
@@ -84,7 +90,10 @@ class TestCommandMangle:
                 command_path="bin/foo",
                 command_value="foo bar",
                 expected_command="bin/foo bar",
-                expected_log=None,
+                expected_logs=[
+                    "The command 'foo' for 'foo bar' was resolved to 'bin/foo'.",
+                    "The command 'foo bar' has been changed to 'bin/foo bar'.",
+                ],
                 shebang="",
                 interpreter_path=None,
             ),
@@ -95,7 +104,10 @@ class TestCommandMangle:
                 command_path="sbin/foo",
                 command_value="foo bar",
                 expected_command="sbin/foo bar",
-                expected_log=None,
+                expected_logs=[
+                    "The command 'foo' for 'foo bar' was resolved to 'sbin/foo'.",
+                    "The command 'foo bar' has been changed to 'sbin/foo bar'.",
+                ],
                 shebang="",
                 interpreter_path=None,
             ),
@@ -106,7 +118,10 @@ class TestCommandMangle:
                 command_path="usr/bin/foo",
                 command_value="foo bar",
                 expected_command="usr/bin/foo bar",
-                expected_log=None,
+                expected_logs=[
+                    "The command 'foo' for 'foo bar' was resolved to 'usr/bin/foo'.",
+                    "The command 'foo bar' has been changed to 'usr/bin/foo bar'.",
+                ],
                 shebang="",
                 interpreter_path=None,
             ),
@@ -117,7 +132,10 @@ class TestCommandMangle:
                 command_path="usr/sbin/foo",
                 command_value="foo bar",
                 expected_command="usr/sbin/foo bar",
-                expected_log=None,
+                expected_logs=[
+                    "The command 'foo' for 'foo bar' was resolved to 'usr/sbin/foo'.",
+                    "The command 'foo bar' has been changed to 'usr/sbin/foo bar'.",
+                ],
                 shebang="",
                 interpreter_path=None,
             ),
@@ -128,10 +146,10 @@ class TestCommandMangle:
                 command_path=None,
                 command_value="sh bar",
                 expected_command="/bin/sh bar",
-                expected_log=(
-                    "The command 'sh bar' was not found in the prime directory, "
-                    "it has been changed to '/bin/sh'."
-                ),
+                expected_logs=[
+                    "The command 'sh' for 'sh bar' was resolved to '/bin/sh'.",
+                    "The command 'sh bar' has been changed to '/bin/sh bar'.",
+                ],
                 shebang="",
                 interpreter_path=None,
             ),
@@ -142,7 +160,10 @@ class TestCommandMangle:
                 command_path="bar/foo",
                 command_value="foo bar",
                 expected_command="bar/foo bar",
-                expected_log=None,
+                expected_logs=[
+                    "The command 'foo' for 'foo bar' was resolved to 'bar/foo'.",
+                    "The command 'foo bar' has been changed to 'bar/foo bar'.",
+                ],
                 shebang="",
                 interpreter_path=None,
             ),
@@ -153,7 +174,10 @@ class TestCommandMangle:
                 command_path="bar/sh",
                 command_value="sh bar",
                 expected_command="bar/sh bar",
-                expected_log=None,
+                expected_logs=[
+                    "The command 'sh' for 'sh bar' was resolved to 'bar/sh'.",
+                    "The command 'sh bar' has been changed to 'bar/sh bar'.",
+                ],
                 shebang="",
                 interpreter_path=None,
             ),
@@ -164,7 +188,9 @@ class TestCommandMangle:
                 command_path="foo",
                 command_value="foo bar",
                 expected_command="bin/python $SNAP/foo bar",
-                expected_log=None,
+                expected_logs=[
+                    "The command 'foo bar' has been changed to 'bin/python $SNAP/foo bar' to safely account for the interpreter.",
+                ],
                 shebang="#!/usr/bin/env $SNAP/bin/python",
                 interpreter_path="bin/python",
             ),
@@ -175,7 +201,7 @@ class TestCommandMangle:
                 command_path="bin/foo",
                 command_value="bin/foo bar",
                 expected_command="bin/foo bar",
-                expected_log=None,
+                expected_logs=[],
                 shebang="/bin/python",
                 interpreter_path="/bin/python",
             ),
@@ -186,7 +212,10 @@ class TestCommandMangle:
                 command_path="bin/foo",
                 command_value="bin/foo bar",
                 expected_command="bin/python $SNAP/bin/foo bar",
-                expected_log=None,
+                expected_logs=[
+                    "The interpreter 'python' for 'bin/foo bar' was resolved to 'bin/python'.",
+                    "The command 'bin/foo bar' has been changed to 'bin/python $SNAP/bin/foo bar' to safely account for the interpreter.",
+                ],
                 shebang="#!/usr/bin/env python",
                 interpreter_path="bin/python",
             ),
@@ -197,7 +226,11 @@ class TestCommandMangle:
                 command_path="bin/foo",
                 command_value="$SNAP/bin/foo bar",
                 expected_command="bin/python $SNAP/bin/foo bar",
-                expected_log="Stripped '$SNAP/' from command '$SNAP/bin/foo bar'.",
+                expected_logs=[
+                    "The interpreter 'python' for '$SNAP/bin/foo bar' was resolved to 'bin/python'.",
+                    "Found unneeded '$SNAP/' in command '$SNAP/bin/foo bar'.",
+                    "The command '$SNAP/bin/foo bar' has been changed to 'bin/python $SNAP/bin/foo bar' to safely account for the interpreter.",
+                ],
                 shebang="#!/usr/bin/env python",
                 interpreter_path="bin/python",
             ),
@@ -208,7 +241,7 @@ class TestCommandMangle:
                 command_path="bin/foo",
                 command_value="bin/foo bar $SNAP_DATA",
                 expected_command="bin/foo bar $SNAP_DATA",
-                expected_log=None,
+                expected_logs=[],
                 shebang="",
                 interpreter_path=None,
             ),
@@ -219,7 +252,7 @@ class TestCommandMangle:
                 command_path="bin/foo",
                 command_value="bin/foo bar '$SNAP_DATA'",
                 expected_command="bin/foo bar '$SNAP_DATA'",
-                expected_log=None,
+                expected_logs=[],
                 shebang="",
                 interpreter_path=None,
             ),
@@ -233,7 +266,7 @@ class TestCommandMangle:
         command_path,
         command_value,
         expected_command,
-        expected_log,
+        expected_logs,
         shebang,
         interpreter_path,
     ):
@@ -253,21 +286,21 @@ class TestCommandMangle:
             interpreter_path.chmod(0o755)
 
         assert (
-            command._massage_command(
-                command=command_value, prime_dir=tmp_work_path.as_posix()
+            command._SnapCommandResolver.resolve_snap_command_entry(
+                command=command_value, prime_path=tmp_work_path
             )
             == expected_command
         )
 
-        if expected_log is not None:
-            assert caplog.records[0].message == expected_log
-        else:
-            assert len(caplog.records) == 0
+        log_messages = [r.message for r in caplog.records]
+        assert log_messages == expected_logs
 
 
 def test_find_binary_not_found(tmp_path):
     with pytest.raises(errors.PrimedCommandNotFoundError):
-        command._massage_command(command="not-found", prime_dir=tmp_path.as_posix())
+        command._SnapCommandResolver.resolve_snap_command_entry(
+            command="not-found", prime_path=tmp_path
+        )
 
 
 def test_binary_not_executable(tmp_work_path):
@@ -276,6 +309,6 @@ def test_binary_not_executable(tmp_work_path):
     exec_path.touch()
 
     with pytest.raises(errors.PrimedCommandNotFoundError):
-        command._massage_command(
-            command="not-executable", prime_dir=tmp_work_path.as_posix()
+        command._SnapCommandResolver.resolve_snap_command_entry(
+            command="not-executable", prime_path=tmp_work_path
         )

--- a/tests/unit/meta/test_command_mangle.py
+++ b/tests/unit/meta/test_command_mangle.py
@@ -303,6 +303,29 @@ def test_find_binary_not_found(tmp_path):
         )
 
 
+def test_find_ambigious_command_multiple_targets(tmp_work_path, caplog):
+    caplog.set_level(logging.INFO)
+    command_paths = [tmp_work_path / "bin/xc", tmp_work_path / "usr/bin/xc"]
+    for command_path in command_paths:
+        command_path.parent.mkdir(parents=True, exist_ok=True)
+        command_path.touch()
+        command_path.chmod(0o755)
+
+    assert (
+        command._SnapCommandResolver.resolve_snap_command_entry(
+            command="xc", prime_path=tmp_work_path
+        )
+        == "bin/xc"
+    )
+
+    log_messages = [r.message for r in caplog.records]
+    assert log_messages == [
+        "Multiple binaries matching for ambiguous command 'xc': ['bin/xc', 'usr/bin/xc']",
+        "The command 'xc' for 'xc' was resolved to 'bin/xc'.",
+        "The command 'xc' has been changed to 'bin/xc'.",
+    ]
+
+
 def test_binary_not_executable(tmp_work_path):
     exec_path = tmp_work_path / "bin" / "not-executable"
     exec_path.parent.mkdir()


### PR DESCRIPTION
Better detail what command changes are happening and indicate why.
A little refactoring to make this possible in a fairly clean way.

Other than logging, there shouldn't be functional changes.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
