### PR TITLE
review tools: link or copy snap to snap common

### DIFF
--- a/snapcraft/internal/review_tools/_runner.py
+++ b/snapcraft/internal/review_tools/_runner.py
@@ -18,16 +18,41 @@ import json
 import pathlib
 import subprocess
 
+from snapcraft import file_utils
 from . import errors
 
 
 _REVIEW_TOOLS_PATH = pathlib.Path("/snap/bin/review-tools.snap-review")
+_REVIEW_TOOLS_SNAP_USER_COMMON = pathlib.Path("~/snap/review-tools/common")
 
 
 def is_available() -> bool:
     return _REVIEW_TOOLS_PATH.exists()
 
 
+def _get_review_tools_user_common() -> pathlib.Path:
+    return _REVIEW_TOOLS_SNAP_USER_COMMON
+
+
+def _snap_in_review_tools_common(method):
+    def common_decorator(*, snap_filename: str) -> None:
+        snap_filename_common_path = (
+            _get_review_tools_user_common() / pathlib.Path(snap_filename).name
+        )
+        # Create the directory tree for the cases where the review-tools have not run before.
+        snap_filename_common_path.parent.mkdir(parents=True)
+        file_utils.link_or_copy(snap_filename, str(snap_filename_common_path))
+
+        try:
+            method(snap_filename=snap_filename_common_path)
+        finally:
+            if snap_filename_common_path.exists():
+                snap_filename_common_path.unlink()
+
+    return common_decorator
+
+
+@_snap_in_review_tools_common
 def run(*, snap_filename: str) -> None:
     # TODO allow suppression of error and warn through project configuration.
     command = [

--- a/tests/unit/review_tools/test_runner.py
+++ b/tests/unit/review_tools/test_runner.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
+import pathlib
 import subprocess
 
 import fixtures
@@ -33,9 +34,25 @@ class RunTest(unit.TestCase):
         )
         self.useFixture(self.fake_check_output)
 
+        self.user_common_path = pathlib.Path(self.path) / "common"
+        self.useFixture(
+            fixtures.MockPatch(
+                "snapcraft.internal.review_tools._runner._get_review_tools_user_common",
+                return_value=self.user_common_path,
+            )
+        )
+
+        self.fake_snap_path = pathlib.Path("fake.snap")
+        self.fake_snap_path.touch()
+
     def assert_fake_check_output_called(self):
         self.fake_check_output.mock.assert_called_once_with(
-            [self.review_tools_path, "fake.snap", "--json", "--allow-classic"],
+            [
+                self.review_tools_path,
+                self.user_common_path / self.fake_snap_path,
+                "--json",
+                "--allow-classic",
+            ],
             env={"SNAP_ENFORCE_RESQUASHFS": "0"},
             stderr=subprocess.STDOUT,
         )


### PR DESCRIPTION
Attempt to link and then copy the snap to review into the review-tools'
SNAP_USER_COMMON area to support the cases where the snap created in an
area the review tools cannot read from or the broader case of having the
"home" interface disconnected.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
