### PR TITLE
sentry: don't report tool missing errors

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -304,7 +304,7 @@ class PluginOutdatedError(SnapcraftError):
         super().__init__(message=message)
 
 
-class ToolMissingError(SnapcraftReportableError):
+class ToolMissingError(SnapcraftError):
 
     fmt = (
         "A tool snapcraft depends on could not be found: {command_name!r}.\n"


### PR DESCRIPTION
Spread tests should capture any missing tools from the snap,
should we make that mistake.  If the host is missing the tool,
do not offer to report it to sentry.

Fixes SNAPCRAFT-1V7

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
