### PR TITLE
cli: provide option to install ca certs into build environment

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -131,6 +131,16 @@ _PROVIDER_OPTIONS: List[Dict[str, Any]] = [
         supported_providers=["host", "lxd", "managed-host", "multipass"],
     ),
     dict(
+        param_decls="--add-ca-certificates",
+        metavar="<certificate-path>",
+        help="File or directory containing CA certificates to install into build environments.",
+        envvar="SNAPCRAFT_ADD_CA_CERTIFICATES",
+        supported_providers=["lxd", "multipass"],
+        type=click.Path(
+            exists=True, file_okay=True, dir_okay=True, readable=True, resolve_path=True
+        ),
+    ),
+    dict(
         param_decls="--bind-ssh",
         is_flag=True,
         help="Bind ~/.ssh directory to locally-run build environments.",

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -275,13 +275,13 @@ class Provider(abc.ABC):
         if certs_path.is_file():
             certificate_files = [certs_path]
         elif certs_path.is_dir():
-            certificate_files = sorted([x for x in certs_path.iterdir() if x.is_file()])
+            certificate_files = [x for x in certs_path.iterdir() if x.is_file()]
         else:
             raise RuntimeError(
                 f"Unable to read CA certificates: {certs_path!r} (unhandled file type)"
             )
 
-        for certificate_file in certificate_files:
+        for certificate_file in sorted(certificate_files):
             logger.info(f"Installing CA certificate: {certificate_file}")
             dst_path = "/usr/local/share/ca-certificates/" + certificate_file.name
             self._push_file(source=str(certificate_file), destination=dst_path)

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -275,7 +275,7 @@ class Provider(abc.ABC):
         if certs_path.is_file():
             certificate_files = [certs_path]
         elif certs_path.is_dir():
-            certificate_files = [x for x in certs_path.iterdir() if x.is_file()]
+            certificate_files = sorted([x for x in certs_path.iterdir() if x.is_file()])
         else:
             raise RuntimeError(
                 f"Unable to read CA certificates: {certs_path!r} (unhandled file type)"

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -208,6 +208,58 @@ class BaseProviderTest(BaseProviderBaseTest):
             ]
         )
 
+    def test_launch_instance_with_cert_file(self):
+        test_certs = pathlib.Path(self.path, "certs")
+        test_certs.mkdir()
+        test_cert1 = pathlib.Path(test_certs, "1.crt")
+        test_cert1.write_text("")
+
+        provider = ProviderImpl(
+            project=self.project,
+            echoer=self.echoer_mock,
+            build_provider_flags={"SNAPCRAFT_ADD_CA_CERTIFICATES": str(test_cert1)},
+        )
+        provider.launch_instance()
+
+        provider.push_file_mock.assert_has_calls(
+            [
+                call(
+                    destination="/usr/local/share/ca-certificates/1.crt",
+                    source=str(test_cert1),
+                )
+            ]
+        )
+        provider.run_mock.assert_has_calls([call(["update-ca-certificates"])])
+
+    def test_launch_instance_with_cert_dir_files(self):
+        test_certs = pathlib.Path(self.path, "certs")
+        test_certs.mkdir()
+        test_cert1 = pathlib.Path(test_certs, "1.crt")
+        test_cert1.write_text("")
+        test_cert2 = pathlib.Path(test_certs, "2.crt")
+        test_cert2.write_text("")
+
+        provider = ProviderImpl(
+            project=self.project,
+            echoer=self.echoer_mock,
+            build_provider_flags={"SNAPCRAFT_ADD_CA_CERTIFICATES": str(test_certs)},
+        )
+        provider.launch_instance()
+
+        provider.push_file_mock.assert_has_calls(
+            [
+                call(
+                    destination="/usr/local/share/ca-certificates/1.crt",
+                    source=str(test_cert1),
+                ),
+                call(
+                    destination="/usr/local/share/ca-certificates/2.crt",
+                    source=str(test_cert2),
+                ),
+            ]
+        )
+        provider.run_mock.assert_has_calls([call(["update-ca-certificates"])])
+
     def test_expose_prime(self):
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
         provider.expose_prime()


### PR DESCRIPTION
Allow user to specify a specific CA file, or directory of CA files,
to install into LXD or Multipass build environment.

- Adds `--install-ca-certificates <certs-path>` CLI option.

- Implement certification installation in base provider using
_push_file() and running `update-ca-certificates` on every launch.

- Update unit tests.

LP: #1807988

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
