### PR TITLE
extensions: kde-neon: use gtk3 platform theme on gtk-based DE's

### DIFF
--- a/extensions/desktop/kde-neon/launcher-specific
+++ b/extensions/desktop/kde-neon/launcher-specific
@@ -4,6 +4,15 @@
 ###################################
 
 # Ensure a sane default for QT_QPA_PLATFORMTHEME.
+if [[ -z "$QT_QPA_PLATFORMTHEME" ]]; then
+  gtk_based_desktops=("GNOME" "X-CINNAMON" "UNITY" "MATE" "XFCE" "LXDE" "Pantheon")
+  for gtk_desktop in "${gtk_based_desktops[@]}"; do
+    if [[ "$XDG_CURRENT_DESKTOP" == *"$gtk_desktop"* ]]; then
+      export QT_QPA_PLATFORMTHEME="gtk3"
+      break
+    fi
+  done
+fi
 export QT_QPA_PLATFORMTHEME=${QT_QPA_PLATFORMTHEME:-kde}
 
 # Add paths for games


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

This PR makes the KDE neon extension default to using the `gtk3` platform theme on GTK based desktops. This also enables the file chooser portal on those desktops, providing a completely native file chooser for the apps which support it.

The `kde-frameworks-*` platform snaps currently do not ship the `gtk3` platform theme or `QGnomePlatform`. This is not an issue, however, because Qt will fallback to `QGnomeTheme`, which is a builtin theme and is always available.

> Note: `QGnomeTheme` will use Xorg and XWayland to get theme info, so there are no additional connections required for snaps using it.

I'm still trying to figure out what the best way is to provide the `gtk3` platform themes to the snaps. Either I add them to the KDE-frameworks platform snaps, or I create a separate snap which is only installed on GTK3-based desktops (maybe `snapd-desktop-integration` could play a role here?).

Even without that, however, this PR is still very useful because the builtin `QGnomeTheme` already looks a lot more native on GTK-based desktops, the use of desktop portals further increase the native look and snaps which manually ship one of the `gtk3` themes gain the full benefits of it.