### PR TITLE
meta: fix content slot to set content when using source key

### DIFF
--- a/snapcraft/internal/meta/slots.py
+++ b/snapcraft/internal/meta/slots.py
@@ -166,7 +166,7 @@ class ContentSlot(Slot):
 
     @classmethod
     def from_dict(cls, *, slot_dict: Dict[str, Any], slot_name: str) -> "ContentSlot":
-        slot = ContentSlot(slot_name=slot_name)
+        slot = ContentSlot(slot_name=slot_name, content=slot_dict.get("content"))
 
         # Content directories may be nested under "source",
         # but they cannot be in both places according to snapd:
@@ -183,9 +183,6 @@ class ContentSlot(Slot):
 
         if "write" in source_data:
             slot.write = source_data["write"]
-
-        if "content" in source_data:
-            slot.content = source_data["content"]
 
         return slot
 

--- a/tests/unit/meta/test_slots.py
+++ b/tests/unit/meta/test_slots.py
@@ -117,6 +117,28 @@ class ContentSlotTests(unit.TestCase):
         self.assertRaises(errors.SlotValidationError, slot.validate)
         self.assertEqual(set(), slot.get_content_dirs(installed_path=""))
 
+    def test_explicit_content(self):
+        slot_dict = OrderedDict({"interface": "content", "content": "content-test"})
+        slot_name = "slot-test"
+
+        slot = ContentSlot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
+
+        assert slot_dict == slot.to_yaml_object()
+
+    def test_explicit_content_with_source(self):
+        slot_dict = OrderedDict(
+            {
+                "interface": "content",
+                "content": "content-test",
+                "source": {"read": "/"},
+            }
+        )
+        slot_name = "slot-test"
+
+        slot = ContentSlot.from_dict(slot_dict=slot_dict, slot_name=slot_name)
+
+        assert slot_dict == slot.to_yaml_object()
+
     def test_read_from_dict(self):
         slot_dict = OrderedDict(
             {


### PR DESCRIPTION
If using the 'source' key, the content key was lost.  Fix
and add accompanying unit tests.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
