### PR TITLE
errors: introduce HostToolNotFoundError exception

### DIFF
--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -753,3 +753,17 @@ class SnapcraftPluginBuildError(SnapcraftException):
 
     def get_resolution(self) -> str:
         return "Check the build logs and ensure the part's configuration and sources are correct."
+
+
+class HostToolNotFoundError(SnapcraftException):
+    """An exception to raise when a host tool is required, but not found."""
+
+    def __init__(self, *, command_name: str, package_name: str) -> None:
+        self._command_name = command_name
+        self._package_name = package_name
+
+    def get_brief(self) -> str:
+        return f"A tool snapcraft depends on could not be found: {self._command_name!r}"
+
+    def get_resolution(self) -> str:
+        return f"Ensure that {self._package_name!r} is installed."

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -668,6 +668,18 @@ class TestSnapcraftExceptionTests:
             },
         ),
         (
+            "HostToolNotFoundError",
+            {
+                "exception_class": errors.HostToolNotFoundError,
+                "kwargs": {"command_name": "foo", "package_name": "foo-pkg"},
+                "expected_brief": "A tool snapcraft depends on could not be found: 'foo'",
+                "expected_resolution": "Ensure that 'foo-pkg' is installed.",
+                "expected_details": None,
+                "expected_docs_url": None,
+                "expected_reportable": False,
+            },
+        ),
+        (
             "MissingStateCleanError",
             {
                 "exception_class": errors.MissingStateCleanError,


### PR DESCRIPTION
If a tool on the host is required, this exception
would be thrown if not found.

This differentiates from the ToolMissingError which
would be scoped to tools that are packaged with the
snapcraft snap.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
