### PR TITLE
travis: set cla check as final stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,20 +30,6 @@ jobs:
         - pip3 install --user -r requirements-devel.txt
       script:
         - ./runtests.sh static
-    # CLA check, only in pull requests, not coming from the bot.
-    - stage: static
-      name:  CLA check
-      addons:
-        apt:
-          packages:
-            - git
-            - python-launchpadlib
-      if: type = pull_request AND sender != snappy-m-o
-      git:
-        depth: false
-      script:
-        - ./tools/cla_check.py
-
     - stage: unit and snap
       name: unit tests
       script:
@@ -132,3 +118,16 @@ jobs:
         - cd docker
         - docker build --no-cache -f ${RISK}.Dockerfile --tag snapcore/snapcraft:${RISK} .
         - docker run snapcore/snapcraft:${RISK} snapcraft --version
+    # CLA check, only in pull requests, not coming from the bot.
+    - stage: cla
+      name:  CLA check
+      addons:
+        apt:
+          packages:
+            - git
+            - python-launchpadlib
+      if: type = pull_request AND sender != snappy-m-o
+      git:
+        depth: false
+      script:
+        - ./tools/cla_check.py


### PR DESCRIPTION
It's useful to see test results regardless of the outcome
of the CLA checks.  This may encourage further development
of PRs while contributors work on getting their CLAs sorted out.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
