### PR TITLE
project loader: refactor errors to conform to SnapcraftException

### DIFF
--- a/snapcraft/cli/extensions.py
+++ b/snapcraft/cli/extensions.py
@@ -67,7 +67,7 @@ def extension(ctx, name, **kwargs):
     # Not using inspect.getdoc here since it'll fall back to the base class
     docstring = extension_cls.__doc__
     if not docstring:
-        raise project_loader.errors.ExtensionMissingDocumentationError(name)
+        raise RuntimeError(f"The {name!r} extension is missing required documentation.")
 
     formatter = ctx.make_formatter()
     formatter.write_text(inspect.cleandoc(docstring))

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -56,12 +56,12 @@ def _validate_icon(instance):
     return True
 
 
-@jsonschema.FormatChecker.cls_checks("epoch", raises=errors.InvalidEpochError)
+@jsonschema.FormatChecker.cls_checks("epoch", raises=errors.SnapcraftInvalidEpochError)
 def _validate_epoch(instance):
     str_instance = str(instance)
     pattern = re.compile("^(?:0|[1-9][0-9]*[*]?)$")
     if not pattern.match(str_instance):
-        raise errors.InvalidEpochError()
+        raise errors.SnapcraftInvalidEpochError(epoch=str_instance)
 
     return True
 

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -243,7 +243,7 @@ class Config:
             else:
                 seen.add(alias)
         if duplicates:
-            raise errors.DuplicateAliasError(aliases=duplicates)
+            raise errors.SnapcraftDuplicateAliasError(aliases=duplicates)
 
     def install_package_repositories(self) -> None:
         keys_path = self.project._get_keys_path()
@@ -394,10 +394,7 @@ def _expand_filesets_for(step, properties):
             try:
                 new_step_set.extend(filesets[item[1:]])
             except KeyError:
-                raise errors.SnapcraftLogicError(
-                    "'{}' referred to in the '{}' fileset but it is not "
-                    "in filesets".format(item, step)
-                )
+                raise errors.SnapcraftFilesetReferenceError(item=item, step=step)
         else:
             new_step_set.append(item)
 

--- a/snapcraft/internal/project_loader/_extensions/_extension.py
+++ b/snapcraft/internal/project_loader/_extensions/_extension.py
@@ -64,14 +64,16 @@ class Extension(metaclass=abc.ABCMeta):
 
         # A base is required in order to use extensions, so raise an error if not specified.
         if not base:
-            raise errors.ExtensionBaseRequiredError()
+            raise errors.SnapcraftExtensionBaseRequiredError()
 
         if base not in self.get_supported_bases():
-            raise errors.ExtensionUnsupportedBaseError(extension_name, base)
+            raise errors.SnapcraftExtensionUnsupportedBaseError(
+                extension_name=extension_name, base=base
+            )
 
         # Default to devmode if confinement is not set.
         confinement = yaml_data.get("confinement", "devmode")
         if confinement not in self.get_supported_confinement():
-            raise errors.ExtensionUnsupportedConfinementError(
-                extension_name, confinement
+            raise errors.SnapcraftExtensionUnsupportedConfinementError(
+                extension_name=extension_name, confinement=confinement
             )

--- a/snapcraft/internal/project_loader/_extensions/_flutter_meta.py
+++ b/snapcraft/internal/project_loader/_extensions/_flutter_meta.py
@@ -74,16 +74,18 @@ class FlutterMetaExtension(type):
             base: Optional[str] = yaml_data.get("base")
             # A base is required in order to use extensions, so raise an error if not specified.
             if base is None:
-                raise errors.ExtensionBaseRequiredError()
+                raise errors.SnapcraftExtensionBaseRequiredError()
 
             if base not in self.get_supported_bases():
-                raise errors.ExtensionUnsupportedBaseError(extension_name, base)
+                raise errors.SnapcraftExtensionUnsupportedBaseError(
+                    extension_name=extension_name, base=base
+                )
 
             # Default to devmode if confinement is not set.
             confinement = yaml_data.get("confinement", "devmode")
             if confinement not in self.get_supported_confinement():
-                raise errors.ExtensionUnsupportedConfinementError(
-                    extension_name, confinement
+                raise errors.SnapcraftExtensionUnsupportedConfinementError(
+                    extension_name=extension_name, confinement=confinement
                 )
 
             platform_snap = _PLATFORM_SNAP[base]

--- a/snapcraft/internal/project_loader/_extensions/_utils.py
+++ b/snapcraft/internal/project_loader/_extensions/_utils.py
@@ -87,7 +87,7 @@ def find_extension(extension_name: str) -> Type[Extension]:
     :raises: errors.ExtensionNotFoundError if the extension is not found
     """
     if extension_name.startswith("_"):
-        raise errors.ExtensionNotFoundError(extension_name)
+        raise errors.SnapcraftExtensionNotFoundError(extension_name=extension_name)
 
     try:
         extension_module = importlib.import_module(
@@ -96,7 +96,7 @@ def find_extension(extension_name: str) -> Type[Extension]:
             )
         )
     except ImportError:
-        raise errors.ExtensionNotFoundError(extension_name)
+        raise errors.SnapcraftExtensionNotFoundError(extension_name=extension_name)
 
     # The extension module requires a class named ExtensionImpl.
     return getattr(extension_module, "ExtensionImpl")
@@ -165,7 +165,9 @@ def _apply_extension(
     for part_name, part_definition in extension.parts.items():
         # If a extension part name clashes with a part that already exists, error.
         if part_name in parts:
-            raise errors.ExtensionPartConflictError(extension_name, part_name)
+            raise errors.SnapcraftExtensionPartConflictError(
+                extension_name=extension_name, part_name=part_name
+            )
 
         parts[part_name] = part_definition
 

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -104,9 +104,7 @@ class PartsConfig:
                     top_part = part
                     break
             if not top_part:
-                raise errors.SnapcraftLogicError(
-                    "circular dependency chain found in parts definition"
-                )
+                raise errors.SnapcraftCircularDependencyError()
             sorted_parts = [top_part] + sorted_parts
             self.all_parts.remove(top_part)
 

--- a/snapcraft/internal/project_loader/_parts_config.py
+++ b/snapcraft/internal/project_loader/_parts_config.py
@@ -76,7 +76,9 @@ class PartsConfig:
             for dep_name in dep_names:
                 dep = self.get_part(dep_name)
                 if not dep:
-                    raise errors.SnapcraftAfterPartMissingError(part.name, dep_name)
+                    raise errors.SnapcraftAfterPartMissingError(
+                        part_name=part.name, after_part_name=dep_name
+                    )
 
                 part.deps.append(dep)
 

--- a/snapcraft/internal/project_loader/errors.py
+++ b/snapcraft/internal/project_loader/errors.py
@@ -31,6 +31,14 @@ class SnapcraftAfterPartMissingError(SnapcraftException):
         return "Ensure 'after' configuration and referenced part name is correct."
 
 
+class SnapcraftCircularDependencyError(SnapcraftException):
+    def get_brief(self) -> str:
+        return f"Circular dependency chain found in parts definition."
+
+    def get_resolution(self) -> str:
+        return "Ensure the each part's 'after' configuration is correct."
+
+
 class SnapcraftDuplicateAliasError(SnapcraftException):
     def __init__(self, *, aliases: Set[str]) -> None:
         self.aliases = ", ".join(sorted(aliases))

--- a/snapcraft/internal/project_loader/inspection/_latest_step.py
+++ b/snapcraft/internal/project_loader/inspection/_latest_step.py
@@ -43,6 +43,6 @@ def latest_step(
                 latest_timestamp = timestamp
 
     if not latest_part or not latest_step:
-        raise errors.NoStepsRunError()
+        raise errors.SnapcraftNoStepsRunError()
 
     return (latest_part, latest_step, latest_timestamp)

--- a/snapcraft/internal/project_loader/inspection/_provides.py
+++ b/snapcraft/internal/project_loader/inspection/_provides.py
@@ -34,7 +34,7 @@ def provides(
     """
     # First of all, ensure the file actually exists before doing any work
     if not os.path.exists(path):
-        raise errors.NoSuchFileError(path)
+        raise errors.SnapcraftNoSuchFileError(path=path)
 
     # Convert file path into absolute path
     absolute_file_path = os.path.abspath(path)
@@ -52,7 +52,7 @@ def provides(
             absolute_file_path, start=project.prime_dir
         )
     else:
-        raise errors.ProvidesInvalidFilePathError(path)
+        raise errors.SnapcraftProvidesInvalidFilePathError(path=path)
 
     is_dir = os.path.isdir(absolute_file_path)
     is_file = os.path.isfile(absolute_file_path)
@@ -65,7 +65,7 @@ def provides(
             providing_parts.add(part)
 
     if not providing_parts:
-        raise errors.UntrackedFileError(path)
+        raise errors.SnapcraftUntrackedFileError(path=path)
 
     return providing_parts
 

--- a/snapcraft/internal/project_loader/inspection/errors.py
+++ b/snapcraft/internal/project_loader/inspection/errors.py
@@ -14,47 +14,52 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import snapcraft.internal.errors
+from snapcraft.internal.errors import SnapcraftException
 
 
-class NoSuchFileError(snapcraft.internal.errors.SnapcraftError):
+class SnapcraftNoSuchFileError(SnapcraftException):
+    def __init__(self, *, path: str) -> None:
+        self.path = path
 
-    fmt = (
-        "Failed to find part that provided path: {path!r} does not "
-        "exist.\n"
-        "Check the file path and try again."
-    )
+    def get_brief(self) -> str:
+        return f"Failed to find part that provided path {self.path!r}: file does not exist."
 
-    def __init__(self, path):
-        super().__init__(path=path)
+    def get_resolution(self) -> str:
+        return "Check the file path and try again."
 
 
-class SnapcraftInspectError(snapcraft.internal.errors.SnapcraftError):
+class SnapcraftInspectError(SnapcraftException):
     # Use a different exit code for these errors so the orchestrating snapcraft can
     # differentiate them.
     def get_exit_code(self):
         return 3
 
 
-class ProvidesInvalidFilePathError(SnapcraftInspectError):
+class SnapcraftNoStepsRunError(SnapcraftInspectError):
+    def get_brief(self) -> str:
+        return "Failed to get latest step: no steps have run"
 
-    fmt = (
-        "Failed to find part that provides path: {path!r} is not in the "
-        "staging or priming area.\n"
-        "Ensure the path is in the staging or priming area and try again."
-    )
-
-    def __init__(self, path):
-        super().__init__(path=path)
+    def get_resolution(self) -> str:
+        return "Run 'snapcraft clean' and retry build."
 
 
-class UntrackedFileError(SnapcraftInspectError):
+class SnapcraftProvidesInvalidFilePathError(SnapcraftInspectError):
+    def __init__(self, *, path: str) -> None:
+        self.path = path
 
-    fmt = "No known parts provided {path!r}. It may have been provided by a scriptlet."
+    def get_brief(self) -> str:
+        return f"Failed to find part that provided path {self.path!r}: file is not in the staging or priming area."
 
-    def __init__(self, path):
-        super().__init__(path=path)
+    def get_resolution(self) -> str:
+        return "Ensure the path is in the staging or priming area and try again."
 
 
-class NoStepsRunError(SnapcraftInspectError):
-    fmt = "Failed to get latest step: no steps have run"
+class SnapcraftUntrackedFileError(SnapcraftInspectError):
+    def __init__(self, *, path: str) -> None:
+        self.path = path
+
+    def get_brief(self) -> str:
+        return f"Failed to find part that provided path {self.path!r}: it may have been provided by a scriplet."
+
+    def get_resolution(self) -> str:
+        return "Run 'snapcraft clean' and retry build."

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -540,6 +540,36 @@ def test_invalid_part_names(data, name):
     assert str(error.value).endswith(expected_message)
 
 
+def test_invalid_arch_build_on_all_others():
+    data = {
+        "name": "my-package-1",
+        "base": "core18",
+        "version": "1.0-snapcraft1~ppa1",
+        "summary": "my summary less that 79 chars",
+        "description": "description which can be pretty long",
+        "adopt-info": "part1",
+        "parts": {"part1": {"plugin": "project", "parse-info": ["test-metadata-file"]}},
+        "architectures": [{"build-on": ["amd64", "all"]}],
+    }
+
+    import os
+    import json
+    import jsonschema
+    from snapcraft.internal import common
+
+    schema_file = os.path.abspath(
+        os.path.join(common.get_schemadir(), "snapcraft.json")
+    )
+
+    with open(schema_file) as fp:
+        schema = json.load(fp)
+    jsonschema.validate(instance=data, schema=schema)
+
+    Validator(data).validate()
+
+    assert str(error.value) == "x"
+
+
 class TestInvalidArchitectures:
 
     scenarios = [

--- a/tests/unit/project_loader/inspection/test_errors.py
+++ b/tests/unit/project_loader/inspection/test_errors.py
@@ -1,0 +1,74 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from snapcraft.internal.project_loader.inspection import errors
+
+
+def test_SnapcraftNoSuchFileError():
+    exception = errors.SnapcraftNoSuchFileError(path="some-path")
+    assert (
+        exception.get_brief()
+        == "Failed to find part that provided path 'some-path': file does not exist."
+    )
+    assert exception.get_details() is None
+    assert exception.get_resolution() == "Check the file path and try again."
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False
+    assert exception.get_exit_code() == 2
+
+
+def test_SnapcraftInspectError():
+    exception = errors.SnapcraftInspectError()
+    assert exception.get_exit_code() == 3
+
+
+def test_SnapcraftNoStepsRunError():
+    exception = errors.SnapcraftNoStepsRunError()
+    assert exception.get_brief() == "Failed to get latest step: no steps have run"
+    assert exception.get_details() is None
+    assert exception.get_resolution() == "Run 'snapcraft clean' and retry build."
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False
+    assert exception.get_exit_code() == 3
+
+
+def test_SnapcraftProvidesInvalidFilePathError():
+    exception = errors.SnapcraftProvidesInvalidFilePathError(path="some-path")
+    assert (
+        exception.get_brief()
+        == "Failed to find part that provided path 'some-path': file is not in the staging or priming area."
+    )
+    assert exception.get_details() is None
+    assert (
+        exception.get_resolution()
+        == "Ensure the path is in the staging or priming area and try again."
+    )
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False
+    assert exception.get_exit_code() == 3
+
+
+def test_SnapcraftUntrackedFileError():
+    exception = errors.SnapcraftUntrackedFileError(path="some-path")
+    assert (
+        exception.get_brief()
+        == "Failed to find part that provided path 'some-path': it may have been provided by a scriplet."
+    )
+    assert exception.get_details() is None
+    assert exception.get_resolution() == "Run 'snapcraft clean' and retry build."
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False
+    assert exception.get_exit_code() == 3

--- a/tests/unit/project_loader/test_config.py
+++ b/tests/unit/project_loader/test_config.py
@@ -229,12 +229,9 @@ class DependenciesTest(ProjectLoaderBaseTest):
         """
         )
         raised = self.assertRaises(
-            errors.SnapcraftLogicError, self.make_snapcraft_project, snapcraft_yaml
-        )
-
-        self.assertThat(
-            raised.message,
-            Equals("circular dependency chain found in parts definition"),
+            errors.SnapcraftCircularDependencyError,
+            self.make_snapcraft_project,
+            snapcraft_yaml,
         )
 
 
@@ -260,15 +257,12 @@ class FilesetsTest(unit.TestCase):
         self.properties["stage"] = ["$3"]
 
         raised = self.assertRaises(
-            errors.SnapcraftLogicError,
+            errors.SnapcraftFilesetReferenceError,
             _config._expand_filesets_for,
             "stage",
             self.properties,
         )
 
-        self.assertThat(
-            str(raised),
-            Contains(
-                "'$3' referred to in the 'stage' fileset but it is not in filesets"
-            ),
+        assert (
+            str(raised) == "Fileset '$3' referred to in the 'stage' step was not found."
         )

--- a/tests/unit/project_loader/test_errors.py
+++ b/tests/unit/project_loader/test_errors.py
@@ -1,0 +1,152 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from snapcraft.internal.project_loader import errors
+
+
+def test_SnapcraftAfterPartMissingError():
+    exception = errors.SnapcraftAfterPartMissingError(
+        part_name="some-part", after_part_name="after-part"
+    )
+    assert (
+        exception.get_brief()
+        == "Part 'some-part' after configuration refers to unknown part 'after-part'."
+    )
+    assert exception.get_details() is None
+    assert (
+        exception.get_resolution()
+        == "Ensure 'after' configuration and referenced part name is correct."
+    )
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False
+
+
+def test_SnapcraftDuplicateAliasError_one_alias():
+    exception = errors.SnapcraftDuplicateAliasError(aliases={"alias-a"})
+    assert (
+        exception.get_brief() == "Multiple parts have the same alias defined: alias-a"
+    )
+    assert exception.get_details() is None
+    assert exception.get_resolution() == "Use each alias only once."
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False
+
+
+def test_SnapcraftDuplicateAliasError_multiple_alias():
+    exception = errors.SnapcraftDuplicateAliasError(aliases={"alias-a", "alias-b"})
+    assert (
+        exception.get_brief()
+        == "Multiple parts have the same alias defined: alias-a, alias-b"
+    )
+    assert exception.get_details() is None
+    assert exception.get_resolution() == "Use each alias only once."
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False
+
+
+def test_SnapcraftExtensionBaseRequiredError():
+    exception = errors.SnapcraftExtensionBaseRequiredError()
+    assert (
+        exception.get_brief()
+        == "Extensions can only be used if the snapcraft.yaml specifies a 'base'."
+    )
+    assert exception.get_details() is None
+    assert exception.get_resolution() == "Ensure your base configuration is correct."
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False
+
+
+def test_SnapcraftExtensionNotFoundError():
+    exception = errors.SnapcraftExtensionNotFoundError(extension_name="extension-name")
+    assert exception.get_brief() == "Failed to find extension 'extension-name'."
+    assert exception.get_details() is None
+    assert exception.get_resolution() == "Ensure the extension name is correct."
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False
+
+
+def test_SnapcraftExtensionPartConflictError():
+    exception = errors.SnapcraftExtensionPartConflictError(
+        extension_name="extension-name", part_name="part-name"
+    )
+    assert exception.get_brief() == "Failed to apply extension 'extension-name'."
+    assert (
+        exception.get_details()
+        == "This extension adds a part named 'part-name', but a part by that name already exists."
+    )
+    assert exception.get_resolution() == "Rename the 'part-name' part."
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False
+
+
+def test_SnapcraftExtensionUnsupportedBaseError():
+    exception = errors.SnapcraftExtensionUnsupportedBaseError(
+        extension_name="extension-name", base="some-base"
+    )
+    assert exception.get_brief() == "Failed to load extension 'extension-name'."
+    assert (
+        exception.get_details()
+        == "This extension does not support the 'some-base' base."
+    )
+    assert (
+        exception.get_resolution()
+        == "Either use a different extension, or use a base supported by this extension."
+    )
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False
+
+
+def test_SnapcraftExtensionUnsupportedConfinementError():
+    exception = errors.SnapcraftExtensionUnsupportedConfinementError(
+        extension_name="extension-name", confinement="some-confinement"
+    )
+    assert exception.get_brief() == "Failed to load extension 'extension-name'."
+    assert (
+        exception.get_details()
+        == "This extension does not support 'some-confinement' confinement."
+    )
+    assert (
+        exception.get_resolution()
+        == "Either use a different extension, or use a confinement supported by this extension."
+    )
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False
+
+
+def test_SnapcraftFilesetReferenceError():
+    exception = errors.SnapcraftFilesetReferenceError(
+        item="some-item", step="some-step"
+    )
+    assert (
+        exception.get_brief()
+        == "Fileset 'some-item' referred to in the 'some-step' step was not found."
+    )
+    assert exception.get_details() is None
+    assert exception.get_resolution() == "Ensure the fileset configuration is correct."
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False
+
+
+def test_SnapcraftInvalidEpochError():
+    exception = errors.SnapcraftInvalidEpochError(epoch="-1")
+    assert exception.get_brief() == "Invalid epoch format for '-1'."
+    assert exception.get_details() is None
+    assert (
+        exception.get_resolution()
+        == "Valid epochs are positive integers followed by an optional asterisk."
+    )
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False

--- a/tests/unit/project_loader/test_schema.py
+++ b/tests/unit/project_loader/test_schema.py
@@ -265,15 +265,10 @@ class AliasesTest(ProjectLoaderBaseTest):
             ("test2", dict(command="test", aliases=["testing"])),
         ]
         raised = self.assertRaises(
-            errors.DuplicateAliasError, self.make_snapcraft_project, apps
+            errors.SnapcraftDuplicateAliasError, self.make_snapcraft_project, apps
         )
 
-        self.assertThat(
-            str(raised),
-            Equals(
-                "Multiple parts have the same alias defined: {!r}".format("testing")
-            ),
-        )
+        assert str(raised) == "Multiple parts have the same alias defined: testing"
 
     def test_invalid_alias(self):
         apps = [("test", dict(command="test", aliases=[".test"]))]

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -24,8 +24,6 @@ from requests.packages import urllib3
 from snapcraft.internal import errors, pluginhandler, steps
 from snapcraft.internal.repo import errors as repo_errors
 from snapcraft.storeapi import errors as store_errors
-from snapcraft.internal.project_loader import errors as project_loader_errors
-from snapcraft.internal.project_loader.inspection import errors as inspection_errors
 
 
 def _fake_error_response(status_code):
@@ -65,20 +63,6 @@ class TestErrorFormatting:
                     "{'test-file'}. "
                     "Edit the `snapcraft.yaml` to make sure that the files "
                     "included in `prime` are also included in `stage`."
-                ),
-            },
-        ),
-        (
-            "SnapcraftAfterPartMissingError",
-            {
-                "exception_class": project_loader_errors.SnapcraftAfterPartMissingError,
-                "kwargs": {"part_name": "test-part1", "after_part_name": "test-part2"},
-                "expected_message": (
-                    "Failed to get part information: "
-                    "Cannot find the definition for part 'test-part2', required by "
-                    "part 'test-part1'.\n"
-                    "Remote parts are not supported with bases, so make sure that this "
-                    "part is defined in the `snapcraft.yaml`."
                 ),
             },
         ),
@@ -549,50 +533,6 @@ class TestErrorFormatting:
                     "A tool snapcraft depends on could not be found: 'runnable'.\n"
                     "Ensure the tool is installed and available, and try again."
                 ),
-            },
-        ),
-        (
-            "NoSuchFileError",
-            {
-                "exception_class": inspection_errors.NoSuchFileError,
-                "kwargs": {"path": "test-path"},
-                "expected_message": (
-                    "Failed to find part that provided path: 'test-path' does not "
-                    "exist.\n"
-                    "Check the file path and try again."
-                ),
-            },
-        ),
-        (
-            "ProvidesInvalidFilePathError",
-            {
-                "exception_class": inspection_errors.ProvidesInvalidFilePathError,
-                "kwargs": {"path": "test-path"},
-                "expected_message": (
-                    "Failed to find part that provides path: 'test-path' is not "
-                    "in the staging or priming area.\n"
-                    "Ensure the path is in the staging or priming area and try "
-                    "again."
-                ),
-            },
-        ),
-        (
-            "UntrackedFileError",
-            {
-                "exception_class": inspection_errors.UntrackedFileError,
-                "kwargs": {"path": "test-path"},
-                "expected_message": (
-                    "No known parts provided 'test-path'. It may have been "
-                    "provided by a scriptlet."
-                ),
-            },
-        ),
-        (
-            "NoStepsRunError",
-            {
-                "exception_class": inspection_errors.NoStepsRunError,
-                "kwargs": {},
-                "expected_message": "Failed to get latest step: no steps have run",
             },
         ),
     )


### PR DESCRIPTION
Refactor errors found in snapcraft.internal.project_loader and
snapcraft.internal.project_loader.inspection.

- Drop ExtensionMissingDocumentationError, replacing with
  a RuntimeError as it should never occur and be exposed to
  the user.

- Rebase all exceptions on SnapcraftException.

- Introduce test_errors for project loader, removing whatever
  tests existed in tests/unit/test_errors.

- Prefix all exception names with "Snapcraft".

- Minor wording/formatting changes for certain exceptions
  to better conform to SnapcraftException usage.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
