### PR TITLE
snap: use python3-apt stage-package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ PyYAML==5.3
 pyxdg==0.26
 requests==2.20.0
 requests_unixsocket==0.1.5
-http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_1.6.5ubuntu0.2.tar.xz; sys_platform == 'linux'
 https://launchpad.net/python-distutils-extra/trunk/2.39/+download/python-distutils-extra-2.39.tar.gz
 requests-toolbelt==0.8.0
 responses==0.5.1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -85,6 +85,8 @@ parts:
     plugin: python
     requirements:
         - requirements.txt
+    stage-packages:
+        - python3-apt
     organize:
         # Put snapcraftctl into its own directory that can be included in the PATH
         # without including other binaries.

--- a/spread.yaml
+++ b/spread.yaml
@@ -260,6 +260,7 @@ suites:
        libxml2-dev \
        libxslt-dev \
        libyaml-dev \
+       python3-apt \
        python3-venv \
        python3-yaml \
        python3.6-dev \
@@ -286,6 +287,14 @@ suites:
      # shellcheck source=/dev/null
      source "$HOME/venv/snapcraft/bin/activate"
      pip install --upgrade pip wheel setuptools
+
+     # Install python-apt using pip 20.1, last known working version.
+     # https://github.com/pypa/pip/issues/8654
+     pip install --upgrade pip==20.1
+     pip install http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_1.6.5ubuntu0.2.tar.xz
+     pip install --upgrade pip
+
+     # Install remaining snapcraft dependencies.
      cd /snapcraft
      pip install -r requirements.txt -r requirements-devel.txt codecov
      pip install -e .
@@ -542,7 +551,7 @@ suites:
      SNAPCRAFT_PACKAGE_TYPE: "snap"
    prepare: |
      apt-get update
-     apt-get install --yes gcc g++ make python3-dev python3-pip python3-wheel libffi-dev libsodium-dev libapt-pkg-dev squashfs-tools xdelta3 bzr git mercurial subversion libxml2-dev libxslt-dev
+     apt-get install --yes gcc g++ make python3-apt python3-dev python3-pip python3-wheel libffi-dev libsodium-dev libapt-pkg-dev squashfs-tools xdelta3 bzr git mercurial subversion libxml2-dev libxslt-dev
      pip3 install --user --upgrade pip
      $PIP_COMMAND install --user --upgrade wheel setuptools
      $PIP_COMMAND install --user -r /snapcraft/requirements.txt -r /snapcraft/requirements-devel.txt

--- a/tools/environment-setup.sh
+++ b/tools/environment-setup.sh
@@ -43,6 +43,7 @@ lxc exec snapcraft-dev -- apt install --yes \
     libyaml-dev \
     make \
     patchelf \
+    python3-apt \
     python3-dev \
     python3-pip \
     python3-venv \


### PR DESCRIPTION
Currently python3-apt package is not installable with pip without
a patch.  Switch to the stage-package, which has the benefit
of matching the base (and up-to-date).

https://github.com/pypa/pip/issues/8654

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
