### PR TITLE
db: introduce generalized datastore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ mypy-extensions==0.4.3
 gnupg==2.3.1
 catkin-pkg==0.4.20
 rosdep==0.19.0
+tinydb==4.1.1

--- a/snapcraft/internal/db/datastore.py
+++ b/snapcraft/internal/db/datastore.py
@@ -1,0 +1,112 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import pathlib
+from typing import Any, Dict, List, Type
+
+import tinydb
+import yaml
+
+from . import errors, migration
+
+logger = logging.getLogger()
+
+
+class _YAMLStorage(tinydb.Storage):
+    """Provide YAML-backed storage for TinyDB."""
+
+    def __init__(self, path: str):
+        self.path = pathlib.Path(path)
+
+    def read(self) -> Dict[Any, Any]:
+        """Read database from file."""
+        try:
+            text_data = self.path.read_text()
+        except FileNotFoundError:
+            return dict()
+
+        return yaml.safe_load(text_data)
+
+    def write(self, data) -> None:
+        """Write database (data) to file."""
+        logger.debug(f"saving datstore: {self.path} {data}")
+        self.path.write_text(yaml.dump(data))
+
+    def close(self):
+        """Nothing to do since we do not keep <path> open."""
+
+
+class _YAMLStorageReadOnly(_YAMLStorage):
+    def write(self, data) -> None:
+        """Ignore any writes in read-only mode."""
+
+
+class Datastore:
+    """Datastore class, providing context manager for TinyDB.
+
+    Manages migrations and storage requirements.  If migrations
+    do not indicate support for current datastore version,
+    SnapcraftDatastoreVersionUnsupported will be raised. In that
+    event, some basic fallback mode can be utilized by re-opening
+    datastore in read-only mode."""
+
+    def __init__(
+        self,
+        *,
+        path: pathlib.Path,
+        migrations: List[Type[migration.Migration]],
+        read_only: bool = False,
+    ) -> None:
+        self.path = path
+
+        if read_only:
+            storage_class = _YAMLStorageReadOnly
+        else:
+            storage_class = _YAMLStorage
+
+        self.db = tinydb.TinyDB(str(path), storage=storage_class)
+
+        logger.debug(f"opened datstore: {self.path} read_only: {read_only}")
+
+        # Nothing left to do if opening in read-only mode.
+        if read_only:
+            return
+
+        current_version: int = 0
+        supported_version: int = 0
+
+        for migration_class in migrations:
+            current_version = migration_class(self.db).apply()
+            supported_version = migration_class.SCHEMA_VERSION
+
+        if current_version > supported_version:
+            raise errors.SnapcraftDatastoreVersionUnsupported(
+                path=self.path,
+                current_version=current_version,
+                supported_version=supported_version,
+            )
+
+    def __enter__(self) -> tinydb.TinyDB:
+        return self.db
+
+    def __exit__(self, exc_value, exc_type, exc_traceback) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close database."""
+        self.db.close()
+        logger.debug(f"closed datastore: {self.path}")

--- a/snapcraft/internal/db/datastore.py
+++ b/snapcraft/internal/db/datastore.py
@@ -39,7 +39,7 @@ class _YAMLStorage(tinydb.Storage):
         """Read database from file."""
         logger.debug(f"_YAMLStorage read: {self.path}")
         try:
-            with open(self.path, "r") as fd:
+            with self.path.open() as fd:
                 db_data = yaml.safe_load(fd)
         except FileNotFoundError:
             return dict()

--- a/snapcraft/internal/db/errors.py
+++ b/snapcraft/internal/db/errors.py
@@ -1,0 +1,34 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pathlib
+
+from snapcraft.internal.errors import SnapcraftException
+
+
+class SnapcraftDatastoreVersionUnsupported(SnapcraftException):
+    def __init__(
+        self, *, path: pathlib.Path, current_version: int, supported_version: int
+    ) -> None:
+        self.path = path
+        self.current_version = current_version
+        self.supported_version = supported_version
+
+    def get_brief(self) -> str:
+        return f"This version of snapcraft does not support version {self.current_version!r} of the {self.path} datastore."
+
+    def get_resolution(self) -> str:
+        return "Use 'snap revert' or 'snap refresh' to install previously used version of snapcraft (or newer)."

--- a/snapcraft/internal/db/migration.py
+++ b/snapcraft/internal/db/migration.py
@@ -61,7 +61,7 @@ class Migration(metaclass=abc.ABCMeta):
             {
                 "schema_version": self.SCHEMA_VERSION,
                 "snapcraft_version": self._snapcraft_version,
-                "timestamp": str(datetime.now(tz=None)),
+                "timestamp": datetime.utcnow().isoformat() + "Z",
             }
         )
 

--- a/snapcraft/internal/db/migration.py
+++ b/snapcraft/internal/db/migration.py
@@ -1,0 +1,116 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import abc
+import logging
+from datetime import datetime
+from typing import Any, ClassVar, Dict
+
+import tinydb
+
+import snapcraft
+
+logger = logging.getLogger()
+
+
+def get_snapcraft_version() -> str:
+    return snapcraft.__version__
+
+
+class Migration(metaclass=abc.ABCMeta):
+    """Migrates schema from <SCHEMA_VERSION-1> to <SCHEMA_VERSION>."""
+
+    SCHEMA_VERSION: ClassVar[int] = 0
+
+    def __init__(self, db: tinydb.TinyDB) -> None:
+        self.db = db
+
+    def _query_control_record(self) -> Dict[str, Any]:
+        """Query control record (single document in 'control' table)."""
+        control_table = self.db.table("control")
+        control_records = control_table.all()
+
+        if len(control_records) == 0:
+            return dict(schema_version=0)
+        elif len(control_records) == 1:
+            return control_records[0]
+
+        raise RuntimeError(f"Invalid control records: {control_records!r}")
+
+    def _update_control_schema_version(self) -> None:
+        """Update 'control' table record to SCHEMA_VERSION."""
+        control_record = self._query_control_record()
+        control_record["schema_version"] = self.SCHEMA_VERSION
+
+        control_table = self.db.table("control")
+        control_table.truncate()
+        control_table.insert(control_record)
+
+    def _record_migration(self) -> None:
+        """Record migration in 'migration' table."""
+        migration_table = self.db.table("migration")
+        migration_table.insert(
+            {
+                "schema_version": self.SCHEMA_VERSION,
+                "snapcraft_version": get_snapcraft_version(),
+                "timestamp": str(datetime.now(tz=None)),
+            }
+        )
+
+    @abc.abstractmethod
+    def _migrate(self) -> None:
+        """Per-migration implementation."""
+        ...
+
+    def apply(self) -> int:
+        """Apply migration, if determined to be necessary.
+
+        Returns current schema version."""
+        control_record = self._query_control_record()
+        current_schema_version = control_record["schema_version"]
+
+        if self.SCHEMA_VERSION <= current_schema_version:
+            logger.debug(
+                f"migration {self.SCHEMA_VERSION} already applied, ignoring..."
+            )
+            return current_schema_version
+
+        logger.debug(
+            f"applying migration for {self.SCHEMA_VERSION} for {control_record}"
+        )
+        self._migrate()
+        self._record_migration()
+        self._update_control_schema_version()
+        return self.SCHEMA_VERSION
+
+
+class MigrationV1(Migration):
+    """Default (Initial) Migration to v1."""
+
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    def _migrate_control(self) -> None:
+        control_table = self.db.table("control")
+        control_table.insert(
+            {
+                "created_with_snapcraft_version": get_snapcraft_version(),
+                "schema_version": self.SCHEMA_VERSION,
+            }
+        )
+
+    def _migrate(self) -> None:
+        """Per-migration implementation."""
+        self._migrate_control()

--- a/tests/unit/db/test_datastore.py
+++ b/tests/unit/db/test_datastore.py
@@ -27,7 +27,7 @@ from snapcraft.internal.db import datastore, errors, migration
 @pytest.fixture(autouse=True)
 def mock_datetime(monkeypatch):
     datetime_mock = Mock(wraps=datetime.datetime)
-    datetime_mock.now.return_value = datetime.datetime(2020, 1, 2, 3, 4, 5, 6)
+    datetime_mock.utcnow.return_value = datetime.datetime(2020, 1, 2, 3, 4, 5, 6)
     monkeypatch.setattr(migration, "datetime", datetime_mock)
 
 
@@ -80,7 +80,7 @@ def test_create_default_migration(tmp_path):
           '1':
             schema_version: 1
             snapcraft_version: '42'
-            timestamp: '2020-01-02 03:04:05.000006'
+            timestamp: '2020-01-02T03:04:05.000006Z'
         test:
           '1':
             foo: bar

--- a/tests/unit/db/test_datastore.py
+++ b/tests/unit/db/test_datastore.py
@@ -1,0 +1,102 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+import textwrap
+from unittest.mock import Mock
+
+import pytest
+import tinydb
+
+from snapcraft.internal.db import datastore, errors, migration
+
+
+@pytest.fixture(autouse=True)
+def mock_snapcraft_version(monkeypatch):
+    monkeypatch.setattr(migration.snapcraft, "__version__", 42)
+
+
+@pytest.fixture(autouse=True)
+def mock_datetime(monkeypatch):
+    datetime_mock = Mock(wraps=datetime.datetime)
+    datetime_mock.now.return_value = datetime.datetime(2020, 1, 2, 3, 4, 5, 6)
+    monkeypatch.setattr(migration, "datetime", datetime_mock)
+
+
+def test_get_snapcraft_version(monkeypatch):
+    assert migration.get_snapcraft_version() == 42
+
+
+def test_create_no_migration(tmp_path):
+    db_path = tmp_path / "db.yaml"
+    with datastore.Datastore(path=db_path, migrations=[]) as db:
+        assert isinstance(db, tinydb.TinyDB) is True
+        db.table("test").insert({"foo": "bar"})
+
+    assert db_path.read_text() == textwrap.dedent(
+        """\
+        test:
+          '1':
+            foo: bar
+        """
+    )
+
+
+def test_create_default_migration(tmp_path):
+    db_path = tmp_path / "db.yaml"
+    with datastore.Datastore(path=db_path, migrations=[migration.MigrationV1]) as db:
+        assert isinstance(db, tinydb.TinyDB) is True
+        db.table("test").insert({"foo": "bar"})
+
+    assert db_path.read_text() == textwrap.dedent(
+        """\
+        control:
+          '1':
+            created_with_snapcraft_version: 42
+            schema_version: 1
+        migration:
+          '1':
+            schema_version: 1
+            snapcraft_version: 42
+            timestamp: '2020-01-02 03:04:05.000006'
+        test:
+          '1':
+            foo: bar
+        """
+    )
+
+
+def test_unknown_version(tmp_path):
+    db_path = tmp_path / "db.yaml"
+    control_record = {"created_with_snapcraft_version": 42, "schema_version": 3}
+
+    # Populate test db with schema version greater than 1.
+    with datastore.Datastore(path=db_path, migrations=[]) as db:
+        assert isinstance(db, tinydb.TinyDB) is True
+        db.table("control").insert(control_record)
+
+    # Re-open db, should raise version unsupported error.
+    with pytest.raises(errors.SnapcraftDatastoreVersionUnsupported):
+        with datastore.Datastore(
+            path=db_path, migrations=[migration.MigrationV1]
+        ) as db:
+            assert False
+
+    # Verify we are able to open unsupported version in read-only.
+    with datastore.Datastore(
+        path=db_path, migrations=[migration.MigrationV1], read_only=True
+    ) as db:
+        assert db.table("control").all() == [control_record]

--- a/tests/unit/db/test_errors.py
+++ b/tests/unit/db/test_errors.py
@@ -1,0 +1,38 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pathlib
+
+from snapcraft.internal.db import errors
+
+
+def test_SnapcraftDatastoreVersionUnsupported():
+    error = errors.SnapcraftDatastoreVersionUnsupported(
+        path=pathlib.Path("/tmp/foo.yaml"), current_version=5, supported_version=4
+    )
+
+    assert (
+        error.get_brief()
+        == "This version of snapcraft does not support version 5 of the /tmp/foo.yaml datastore."
+    )
+    assert error.get_details() is None
+    assert (
+        error.get_resolution()
+        == "Use 'snap revert' or 'snap refresh' to install previously used version of snapcraft (or newer)."
+    )
+    assert error.get_docs_url() is None
+    assert error.get_reportable() is False
+    assert error.get_exit_code() == 2

--- a/tests/unit/db/test_migration.py
+++ b/tests/unit/db/test_migration.py
@@ -30,32 +30,23 @@ def test_db():
 
 
 @pytest.fixture(autouse=True)
-def mock_snapcraft_version(monkeypatch):
-    monkeypatch.setattr(migration.snapcraft, "__version__", 42)
-
-
-@pytest.fixture(autouse=True)
 def mock_datetime(monkeypatch):
     datetime_mock = Mock(wraps=datetime.datetime)
     datetime_mock.now.return_value = datetime.datetime(2020, 1, 2, 3, 4, 5, 6)
     monkeypatch.setattr(migration, "datetime", datetime_mock)
 
 
-def test_get_snapcraft_version(monkeypatch):
-    assert migration.get_snapcraft_version() == 42
-
-
 def test_migration_on_empty_db(test_db):
-    m = migration.MigrationV1(test_db)
+    m = migration.MigrationV1(db=test_db, snapcraft_version="42")
     m.apply()
 
     assert test_db.table("control").all() == [
-        {"created_with_snapcraft_version": 42, "schema_version": 1}
+        {"created_with_snapcraft_version": "42", "schema_version": 1}
     ]
     assert test_db.table("migration").all() == [
         {
             "schema_version": 1,
-            "snapcraft_version": 42,
+            "snapcraft_version": "42",
             "timestamp": "2020-01-02 03:04:05.000006",
         }
     ]
@@ -63,27 +54,27 @@ def test_migration_on_empty_db(test_db):
 
 def test_no_migration_on_v1_db(test_db):
     test_db.table("control").insert(
-        {"created_with_snapcraft_version": 42, "schema_version": 1}
+        {"created_with_snapcraft_version": "42", "schema_version": 1}
     )
 
-    m = migration.MigrationV1(test_db)
+    m = migration.MigrationV1(db=test_db, snapcraft_version="42")
     m.apply()
 
     assert test_db.table("control").all() == [
-        {"created_with_snapcraft_version": 42, "schema_version": 1}
+        {"created_with_snapcraft_version": "42", "schema_version": 1}
     ]
     assert test_db.table("migration").all() == []
 
 
 def test_no_migration_on_v2_db(test_db):
     test_db.table("control").insert(
-        {"created_with_snapcraft_version": 42, "schema_version": 2}
+        {"created_with_snapcraft_version": "42", "schema_version": 2}
     )
 
-    m = migration.MigrationV1(test_db)
+    m = migration.MigrationV1(db=test_db, snapcraft_version="42")
     m.apply()
 
     assert test_db.table("control").all() == [
-        {"created_with_snapcraft_version": 42, "schema_version": 2}
+        {"created_with_snapcraft_version": "42", "schema_version": 2}
     ]
     assert test_db.table("migration").all() == []

--- a/tests/unit/db/test_migration.py
+++ b/tests/unit/db/test_migration.py
@@ -32,7 +32,7 @@ def test_db():
 @pytest.fixture(autouse=True)
 def mock_datetime(monkeypatch):
     datetime_mock = Mock(wraps=datetime.datetime)
-    datetime_mock.now.return_value = datetime.datetime(2020, 1, 2, 3, 4, 5, 6)
+    datetime_mock.utcnow.return_value = datetime.datetime(2020, 1, 2, 3, 4, 5, 6)
     monkeypatch.setattr(migration, "datetime", datetime_mock)
 
 
@@ -47,7 +47,7 @@ def test_migration_on_empty_db(test_db):
         {
             "schema_version": 1,
             "snapcraft_version": "42",
-            "timestamp": "2020-01-02 03:04:05.000006",
+            "timestamp": "2020-01-02T03:04:05.000006Z",
         }
     ]
 

--- a/tests/unit/db/test_migration.py
+++ b/tests/unit/db/test_migration.py
@@ -1,0 +1,89 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+from unittest.mock import Mock
+
+import pytest
+import tinydb
+
+from snapcraft.internal.db import migration
+
+
+@pytest.fixture
+def test_db():
+    db = tinydb.TinyDB(storage=tinydb.storages.MemoryStorage)
+    return Mock(wraps=db)
+
+
+@pytest.fixture(autouse=True)
+def mock_snapcraft_version(monkeypatch):
+    monkeypatch.setattr(migration.snapcraft, "__version__", 42)
+
+
+@pytest.fixture(autouse=True)
+def mock_datetime(monkeypatch):
+    datetime_mock = Mock(wraps=datetime.datetime)
+    datetime_mock.now.return_value = datetime.datetime(2020, 1, 2, 3, 4, 5, 6)
+    monkeypatch.setattr(migration, "datetime", datetime_mock)
+
+
+def test_get_snapcraft_version(monkeypatch):
+    assert migration.get_snapcraft_version() == 42
+
+
+def test_migration_on_empty_db(test_db):
+    m = migration.MigrationV1(test_db)
+    m.apply()
+
+    assert test_db.table("control").all() == [
+        {"created_with_snapcraft_version": 42, "schema_version": 1}
+    ]
+    assert test_db.table("migration").all() == [
+        {
+            "schema_version": 1,
+            "snapcraft_version": 42,
+            "timestamp": "2020-01-02 03:04:05.000006",
+        }
+    ]
+
+
+def test_no_migration_on_v1_db(test_db):
+    test_db.table("control").insert(
+        {"created_with_snapcraft_version": 42, "schema_version": 1}
+    )
+
+    m = migration.MigrationV1(test_db)
+    m.apply()
+
+    assert test_db.table("control").all() == [
+        {"created_with_snapcraft_version": 42, "schema_version": 1}
+    ]
+    assert test_db.table("migration").all() == []
+
+
+def test_no_migration_on_v2_db(test_db):
+    test_db.table("control").insert(
+        {"created_with_snapcraft_version": 42, "schema_version": 2}
+    )
+
+    m = migration.MigrationV1(test_db)
+    m.apply()
+
+    assert test_db.table("control").all() == [
+        {"created_with_snapcraft_version": 42, "schema_version": 2}
+    ]
+    assert test_db.table("migration").all() == []


### PR DESCRIPTION
Provides a generalized datastore for snapcraft components that
need persistent storage.  This datastore provides:

- a TinyDB-based storage system with YAML file-backed storage

- schema versioning with migration support

Initial use will be the environment manager datastore, allowing
snapcraft to better track all snapcraft-created build environments.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
