### PR TITLE
file utils: introduce get_host_tool_path() to find commands on host

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -16,26 +16,17 @@
 
 import itertools
 import logging
-import typing
 import os
-import shutil
 import subprocess
 import sys
 import time
+import typing
 from typing import List, Optional
 
 import click
 import progressbar
 
-from . import echo
-from ._command import SnapcraftProjectCommand
-from ._options import (
-    add_provider_options,
-    apply_host_provider_flags,
-    get_build_provider,
-    get_build_provider_flags,
-    get_project,
-)
+from snapcraft import file_utils
 from snapcraft.internal import (
     build_providers,
     deprecations,
@@ -46,8 +37,17 @@ from snapcraft.internal import (
     steps,
 )
 from snapcraft.project._sanity_checks import conduct_project_sanity_check
-from ._errors import TRACEBACK_MANAGED, TRACEBACK_HOST
 
+from . import echo
+from ._command import SnapcraftProjectCommand
+from ._errors import TRACEBACK_HOST, TRACEBACK_MANAGED
+from ._options import (
+    add_provider_options,
+    apply_host_provider_flags,
+    get_build_provider,
+    get_build_provider_flags,
+    get_project,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -201,11 +201,10 @@ def _run_pack(snap_command: List[str]) -> str:
 def _pack(
     directory: str, *, compression: Optional[str] = None, output: Optional[str]
 ) -> None:
-    snap_path = shutil.which("snap")
-    if snap_path is None:
-        raise errors.HostToolNotFoundError(command_name="snap", package_name="snapd")
 
-    command = [snap_path, "pack"]
+    snap_path = file_utils.get_host_tool_path(command_name="snap", package_name="snapd")
+
+    command = [str(snap_path), "pack"]
     # When None, just use snap pack's default settings.
     if compression is not None:
         if compression != "xz":

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -17,11 +17,12 @@
 import itertools
 import logging
 import os
+import pathlib
 import subprocess
 import sys
 import time
 import typing
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import click
 import progressbar
@@ -152,7 +153,7 @@ def _execute(  # noqa: C901
     return project
 
 
-def _run_pack(snap_command: List[str]) -> str:
+def _run_pack(snap_command: List[Union[str, pathlib.Path]]) -> str:
     ret = None
     stdout = ""
     stderr = ""
@@ -204,7 +205,7 @@ def _pack(
 
     snap_path = file_utils.get_host_tool_path(command_name="snap", package_name="snapd")
 
-    command = [str(snap_path), "pack"]
+    command: List[Union[str, pathlib.Path]] = [snap_path, "pack"]
     # When None, just use snap pack's default settings.
     if compression is not None:
         if compression != "xz":

--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -331,15 +331,15 @@ def calculate_hash(path: str, *, algorithm: str) -> str:
 
 
 def get_host_tool_path(*, command_name: str, package_name: str) -> pathlib.Path:
-    """Return the path command found on the host.
+    """Return the path of command_name found on the host.
 
     Using shutil.which() to find the host-provided command,
     raises SnapcraftHostMissingToolError if not found.
 
-    :param command_name: command to find
-    :param package_name: package <command> is usually found in
-    :raises SnapcraftHosterrors.ToolMissingError: if command not found.
-    :return: Path to command
+    :param command_name: name of the command to resolve a path for.
+    :param package_name: package <command_name> is usually found in.
+    :raises SnapcraftHosterrors.ToolMissingError: if command_name not found.
+    :return: Path to command.
     """
     command_path = shutil.which(command_name)
     if command_path is None:

--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -120,7 +120,7 @@ def link(source: str, destination: str, *, follow_symlinks: bool = False) -> Non
     :param str destination: The destination to be linked to source.
     :param bool follow_symlinks: Whether or not symlinks should be followed.
 
-    :raises errors.SnapcraftCopyFileNotFoundError: If source doesn't exist.
+    :raises SnapcraftCopyFileNotFoundError: If source doesn't exist.
     """
     # Note that follow_symlinks doesn't seem to work for os.link, so we'll
     # implement this logic ourselves using realpath.
@@ -151,7 +151,7 @@ def copy(source: str, destination: str, *, follow_symlinks: bool = False) -> Non
     :param str destination: Where to put the copy.
     :param bool follow_symlinks: Whether or not symlinks should be followed.
 
-    :raises errors.SnapcraftCopyFileNotFoundError: If source doesn't exist.
+    :raises SnapcraftCopyFileNotFoundError: If source doesn't exist.
     """
     # If os.link raised an I/O error, it may have left a file behind. Skip on
     # OSError in case it doesn't exist or is a directory.
@@ -357,7 +357,7 @@ def get_snap_tool_path(command_name: str) -> str:
     to resolve the command using PATH.
 
     :param command_name: the name of the command to resolve a path for.
-    :raises errors.ToolMissingError: if command_name was not found.
+    :raises ToolMissingError: if command_name was not found.
     :return: Path to command
     """
     if common.is_snap():

--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -14,27 +14,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from contextlib import contextmanager, suppress
 import errno
 import hashlib
 import logging
-import re
 import os
+import pathlib
+import re
 import shutil
 import stat
 import subprocess
 import sys
-from typing import Pattern, Callable, Generator, List, Optional, Set
+from contextlib import contextmanager, suppress
+from typing import Callable, Generator, List, Optional, Pattern, Set
 
-from snapcraft.internal import common
-from snapcraft.internal.errors import (
-    RequiredCommandFailure,
-    RequiredCommandNotFound,
-    RequiredPathDoesNotExist,
-    SnapcraftEnvironmentError,
-    SnapcraftCopyFileNotFoundError,
-    ToolMissingError,
-)
+from snapcraft.internal import common, errors
 
 if sys.version_info < (3, 6):
     import sha3  # noqa
@@ -127,7 +120,7 @@ def link(source: str, destination: str, *, follow_symlinks: bool = False) -> Non
     :param str destination: The destination to be linked to source.
     :param bool follow_symlinks: Whether or not symlinks should be followed.
 
-    :raises SnapcraftCopyFileNotFoundError: If source doesn't exist.
+    :raises errors.SnapcraftCopyFileNotFoundError: If source doesn't exist.
     """
     # Note that follow_symlinks doesn't seem to work for os.link, so we'll
     # implement this logic ourselves using realpath.
@@ -145,7 +138,7 @@ def link(source: str, destination: str, *, follow_symlinks: bool = False) -> Non
     try:
         os.link(source_path, destination, follow_symlinks=False)
     except FileNotFoundError:
-        raise SnapcraftCopyFileNotFoundError(source)
+        raise errors.SnapcraftCopyFileNotFoundError(source)
 
 
 def copy(source: str, destination: str, *, follow_symlinks: bool = False) -> None:
@@ -158,7 +151,7 @@ def copy(source: str, destination: str, *, follow_symlinks: bool = False) -> Non
     :param str destination: Where to put the copy.
     :param bool follow_symlinks: Whether or not symlinks should be followed.
 
-    :raises SnapcraftCopyFileNotFoundError: If source doesn't exist.
+    :raises errors.SnapcraftCopyFileNotFoundError: If source doesn't exist.
     """
     # If os.link raised an I/O error, it may have left a file behind. Skip on
     # OSError in case it doesn't exist or is a directory.
@@ -168,7 +161,7 @@ def copy(source: str, destination: str, *, follow_symlinks: bool = False) -> Non
     try:
         shutil.copy2(source, destination, follow_symlinks=follow_symlinks)
     except FileNotFoundError:
-        raise SnapcraftCopyFileNotFoundError(source)
+        raise errors.SnapcraftCopyFileNotFoundError(source)
     uid = os.stat(source, follow_symlinks=follow_symlinks).st_uid
     gid = os.stat(source, follow_symlinks=follow_symlinks).st_gid
     try:
@@ -200,12 +193,14 @@ def link_or_copy_tree(
     """
 
     if not os.path.isdir(source_tree):
-        raise SnapcraftEnvironmentError("{!r} is not a directory".format(source_tree))
+        raise errors.SnapcraftEnvironmentError(
+            "{!r} is not a directory".format(source_tree)
+        )
 
     if not os.path.isdir(destination_tree) and (
         os.path.exists(destination_tree) or os.path.islink(destination_tree)
     ):
-        raise SnapcraftEnvironmentError(
+        raise errors.SnapcraftEnvironmentError(
             "Cannot overwrite non-directory {!r} with directory "
             "{!r}".format(destination_tree, source_tree)
         )
@@ -294,11 +289,11 @@ def requires_command_success(
     except FileNotFoundError:
         if not_found_fmt is not None:
             kwargs["fmt"] = not_found_fmt
-        raise RequiredCommandNotFound(**kwargs)
+        raise errors.RequiredCommandNotFound(**kwargs)
     except subprocess.CalledProcessError:
         if failure_fmt is not None:
             kwargs["fmt"] = failure_fmt
-        raise RequiredCommandFailure(**kwargs)
+        raise errors.RequiredCommandFailure(**kwargs)
     yield
 
 
@@ -308,7 +303,7 @@ def requires_path_exists(path: str, error_fmt: str = None) -> Generator:
         kwargs = dict(path=path)
         if error_fmt is not None:
             kwargs["fmt"] = error_fmt
-        raise RequiredPathDoesNotExist(**kwargs)
+        raise errors.RequiredPathDoesNotExist(**kwargs)
     yield
 
 
@@ -335,6 +330,26 @@ def calculate_hash(path: str, *, algorithm: str) -> str:
     return hasher.hexdigest()
 
 
+def get_host_tool_path(*, command_name: str, package_name: str) -> pathlib.Path:
+    """Return the path command found on the host.
+
+    Using shutil.which() to find the host-provided command,
+    raises SnapcraftHostMissingToolError if not found.
+
+    :param command_name: command to find
+    :param package_name: package <command> is usually found in
+    :raises SnapcraftHosterrors.ToolMissingError: if command not found.
+    :return: Path to command
+    """
+    command_path = shutil.which(command_name)
+    if command_path is None:
+        raise errors.SnapcraftHostToolNotFoundError(
+            command_name=command_name, package_name=package_name
+        )
+
+    return pathlib.Path(command_path)
+
+
 def get_snap_tool_path(command_name: str) -> str:
     """Return the path command found in the snap.
 
@@ -342,7 +357,7 @@ def get_snap_tool_path(command_name: str) -> str:
     to resolve the command using PATH.
 
     :param command_name: the name of the command to resolve a path for.
-    :raises ToolMissingError: if command_name was not found.
+    :raises errors.ToolMissingError: if command_name was not found.
     :return: Path to command
     """
     if common.is_snap():
@@ -355,7 +370,7 @@ def get_snap_tool_path(command_name: str) -> str:
         command_path = shutil.which(command_name)
 
     if command_path is None:
-        raise ToolMissingError(command_name=command_name)
+        raise errors.ToolMissingError(command_name=command_name)
 
     return command_path
 
@@ -385,14 +400,14 @@ def get_linker_version_from_file(linker_file: str) -> str:
                             the linker from libc6 or related.
     :returns: the version extracted from the linker file.
     :rtype: string
-    :raises snapcraft.internal.errors.SnapcraftEnvironmentError:
+    :raises snapcraft.internal.errors.errors.SnapcraftEnvironmentError:
        if linker_file is not of the expected format.
     """
     m = re.search(r"ld-(?P<linker_version>[\d.]+).so$", linker_file)
     if not m:
         # This is a programmatic error, we don't want to be friendly
         # about this.
-        raise SnapcraftEnvironmentError(
+        raise errors.SnapcraftEnvironmentError(
             "The format for the linker should be of the of the form "
             "<root>/ld-<X>.<Y>.so. {!r} does not match that format. "
             "Ensure you are targeting an appropriate base".format(linker_file)

--- a/snapcraft/file_utils.py
+++ b/snapcraft/file_utils.py
@@ -333,12 +333,11 @@ def calculate_hash(path: str, *, algorithm: str) -> str:
 def get_host_tool_path(*, command_name: str, package_name: str) -> pathlib.Path:
     """Return the path of command_name found on the host.
 
-    Using shutil.which() to find the host-provided command,
-    raises SnapcraftHostMissingToolError if not found.
+    Uses shutil.which() to find the host-provided command.
 
     :param command_name: name of the command to resolve a path for.
     :param package_name: package <command_name> is usually found in.
-    :raises SnapcraftHosterrors.ToolMissingError: if command_name not found.
+    :raises SnapcraftHostToolMissingError: if command_name not found.
     :return: Path to command.
     """
     command_path = shutil.which(command_name)

--- a/snapcraft/internal/errors.py
+++ b/snapcraft/internal/errors.py
@@ -15,12 +15,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import shlex
-
 from abc import ABC, abstractmethod
+from subprocess import CalledProcessError
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
+
 from snapcraft import formatting_utils
 from snapcraft.internal import steps
-from subprocess import CalledProcessError
-from typing import Dict, List, Union, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from snapcraft.internal.pluginhandler._dirty_report import DirtyReport
@@ -755,7 +755,7 @@ class SnapcraftPluginBuildError(SnapcraftException):
         return "Check the build logs and ensure the part's configuration and sources are correct."
 
 
-class HostToolNotFoundError(SnapcraftException):
+class SnapcraftHostToolNotFoundError(SnapcraftException):
     """An exception to raise when a host tool is required, but not found."""
 
     def __init__(self, *, command_name: str, package_name: str) -> None:

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -22,10 +22,10 @@ import requests.exceptions
 from requests.packages import urllib3
 
 from snapcraft.internal import errors, pluginhandler, steps
-from snapcraft.internal.repo import errors as repo_errors
-from snapcraft.storeapi import errors as store_errors
 from snapcraft.internal.project_loader import errors as project_loader_errors
 from snapcraft.internal.project_loader.inspection import errors as inspection_errors
+from snapcraft.internal.repo import errors as repo_errors
+from snapcraft.storeapi import errors as store_errors
 
 
 def _fake_error_response(status_code):
@@ -668,9 +668,9 @@ class TestSnapcraftExceptionTests:
             },
         ),
         (
-            "HostToolNotFoundError",
+            "SnapcraftHostToolNotFoundError",
             {
-                "exception_class": errors.HostToolNotFoundError,
+                "exception_class": errors.SnapcraftHostToolNotFoundError,
                 "kwargs": {"command_name": "foo", "package_name": "foo-pkg"},
                 "expected_brief": "A tool snapcraft depends on could not be found: 'foo'",
                 "expected_resolution": "Ensure that 'foo-pkg' is installed.",

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -334,8 +334,10 @@ def test_get_host_tool_finds_command(monkeypatch):
 
 def test_get_host_tool_failure(monkeypatch):
     monkeypatch.setattr(shutil, "which", lambda x: None)
+
     with pytest.raises(errors.SnapcraftHostToolNotFoundError) as error:
         file_utils.get_host_tool_path(command_name="foo", package_name="foo-pkg")
+
         assert error.command_name == "foo"
         assert error.package_name == "foo-pkg"
 


### PR DESCRIPTION
A counterpart to get_snap_tool_path() for finding commands inside of
snapcraft snap, this finds tools required on the host.

Raises snapcraft.internal.errors.SnapcraftHostToolNotFoundError if not found.

- Renames HostToolNotFoundError -> SnapcraftHostToolNotFoundError

- Uses this new method for lifecycle finding snapd.

- Update tests (and minor refactor to import 'errors' rather
  than continue cherry-picking each exception import.)

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
