### PR TITLE
plugins v2: quote python packages argument for pip

### DIFF
--- a/snapcraft/plugins/v2/python.py
+++ b/snapcraft/plugins/v2/python.py
@@ -63,6 +63,7 @@ Use of python3-<python-package> in stage-packages will force the
 inclusion of the python interpreter.
 """
 
+import shlex
 from textwrap import dedent
 from typing import Any, Dict, List, Set
 
@@ -125,7 +126,9 @@ class PythonPlugin(PluginV2):
             constraints = ""
 
         if self.options.python_packages:
-            python_packages = " ".join(self.options.python_packages)
+            python_packages = " ".join(
+                [shlex.quote(pkg) for pkg in self.options.python_packages]
+            )
             python_packages_cmd = f"pip install {constraints} -U {python_packages}"
             build_commands.append(python_packages_cmd)
 

--- a/tests/spread/plugins/v2/snaps/python-hello-with-python-package-dep/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/python-hello-with-python-package-dep/snap/snapcraft.yaml
@@ -18,4 +18,4 @@ parts:
     plugin: python
     python-packages:
       - pip==20.0.2
-      - appdirs
+      - appdirs; sys_platform == 'linux'

--- a/tests/unit/plugins/v2/test_python.py
+++ b/tests/unit/plugins/v2/test_python.py
@@ -120,7 +120,7 @@ def test_get_build_commands_with_all_properties():
     class Options:
         constraints = ["constraints.txt"]
         requirements = ["requirements.txt"]
-        python_packages = ["pip"]
+        python_packages = ["pip", "some-pkg; sys_platform != 'win32'"]
 
     plugin = PythonPlugin(part_name="my-part", options=Options())
 
@@ -129,7 +129,7 @@ def test_get_build_commands_with_all_properties():
         == [
             '"${SNAPCRAFT_PYTHON_INTERPRETER}" -m venv ${SNAPCRAFT_PYTHON_VENV_ARGS} '
             '"${SNAPCRAFT_PART_INSTALL}"',
-            "pip install -c 'constraints.txt' -U pip",
+            "pip install -c 'constraints.txt' -U pip 'some-pkg; sys_platform != '\"'\"'win32'\"'\"''",
             "pip install -c 'constraints.txt' -U -r 'requirements.txt'",
             "[ -f setup.py ] && pip install -c 'constraints.txt' -U .",
         ]


### PR DESCRIPTION
If using a python package with conditionals, e.g.:
    python-packages:
      - ibm-db-sa; platform_machine == 'x86_64'
      - ibm-db-sa; platform_machine == 'ppc64le'
      - ibm-db-sa; platform_machine == 's390x'

Then snapcraft would pass the python packages unquoted to pip,
resulting in build errors.  Ensure the packages are quoted
safely using shlex.quote() when building the command string.

Update existing python-package spread test and python-package
unit test to cover this case.

LP: #1884429

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
