### PR TITLE
spread tests: fix classic patchelf linker regex to match all arches

### DIFF
--- a/tests/spread/general/classic-patchelf/task.yaml
+++ b/tests/spread/general/classic-patchelf/task.yaml
@@ -32,15 +32,15 @@ execute: |
   arch_triplet="$(dpkg-architecture -q DEB_HOST_MULTIARCH)"
 
   # Verify typical binary.
-  patchelf --print-interpreter prime/bin/hello-classic | MATCH "^/snap/$base/current/lib.*ld-linux-.*.so.*"
+  patchelf --print-interpreter prime/bin/hello-classic | MATCH "^/snap/$base/current/lib.*ld.*.so.*"
   patchelf --print-rpath prime/bin/hello-classic | MATCH "^/snap/$base/current/lib/$arch_triplet:/snap/$base/current/usr/lib/$arch_triplet"
 
   # Verify binary w/ existing rpath.
-  patchelf --print-interpreter prime/bin/hello-classic-existing-rpath | MATCH "^/snap/$base/current/lib.*ld-linux-.*.so.*"
+  patchelf --print-interpreter prime/bin/hello-classic-existing-rpath | MATCH "^/snap/$base/current/lib.*ld.*.so.*"
   patchelf --print-rpath prime/bin/hello-classic-existing-rpath | MATCH "^\\\$ORIGIN/../fake-lib:/snap/$base/current/lib/$arch_triplet:/snap/$base/current/usr/lib/$arch_triplet"
 
   # Verify untouched no-patchelf.
-  patchelf --print-interpreter prime/bin/hello-classic-no-patchelf | MATCH "^/lib.*ld-linux.*.so.*"
+  patchelf --print-interpreter prime/bin/hello-classic-no-patchelf | MATCH "^/lib.*ld.*.so.*"
   rpath="$(patchelf --print-rpath prime/bin/hello-classic-no-patchelf)"
   if [[ -n "${rpath}" ]]; then
      echo "found rpath with no-patchelf: ${rpath}"


### PR DESCRIPTION
ppc64el and others may not follow the `ld-linux` convention, e.g.:
/snap/core18/current/lib64/ld64.so.2

Fix by broadening the match to ld.*.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
