### PR TITLE
extensions: prepend the snapd glvnd path

### DIFF
--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -100,7 +100,7 @@ append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/libunity"
 append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/pulseaudio"
 
 # EGL vendor files on glvnd enabled systems
-append_dir __EGL_VENDOR_LIBRARY_DIRS "/var/lib/snapd/lib/glvnd/egl_vendor.d"
+prepend_dir __EGL_VENDOR_LIBRARY_DIRS "/var/lib/snapd/lib/glvnd/egl_vendor.d"
 append_dir __EGL_VENDOR_LIBRARY_DIRS "$SNAP_DESKTOP_RUNTIME/usr/share/glvnd/egl_vendor.d"
 
 # Tell GStreamer where to find its plugins


### PR DESCRIPTION
The system path needs precedence, as their contents are not looked through to find the highest priority one.

References:
- ubuntu/snapcraft-desktop-helpers#212
- https://github.com/NVIDIA/libglvnd/blob/master/src/EGL/icd_enumeration.md