### PR TITLE
tests: restrict colcon / ros2-foxy test to amd64 & arm64

### DIFF
--- a/tests/spread/plugins/v2/build-and-run-hello/task.yaml
+++ b/tests/spread/plugins/v2/build-and-run-hello/task.yaml
@@ -2,15 +2,11 @@ summary: >-
   Build, clean, build, modify and rebuild, and run hello
   with different plugin configurations
 
-# ROS2/colcon takes about 15 minutes to run.
-kill-timeout: 20m
-
 environment:
   SNAP/autotools: autotools-hello
   SNAP/cmake: cmake-hello
   SNAP/cmake_ninja: cmake-hello-ninja
   SNAP/cmake_subdir: cmake-hello-subdir
-  SNAP/colcon_ros2_foxy_rlcpp_hello: colcon-ros2-foxy-rlcpp-hello
   SNAP/make: make-hello
   SNAP/local_plugin_from_base: local-plugin-from-base-hello
   SNAP/local_plugin_from_nil: local-plugin-from-nil-hello

--- a/tests/spread/plugins/v2/colcon-ros2-hello/task.yaml
+++ b/tests/spread/plugins/v2/colcon-ros2-hello/task.yaml
@@ -2,13 +2,14 @@ summary: >-
   Build, clean, build, modify and rebuild, and run hello
   for ros2/colcon.
 
-kill-timeout: 30m
+kill-timeout: 180m
 
 environment:
   SNAP/colcon_ros2_foxy_rlcpp_hello: colcon-ros2-foxy-rlcpp-hello
   SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
 systems:
+  - ubuntu-20.04-64
   - ubuntu-20.04-amd64
   - ubuntu-20.04-arm64
 

--- a/tests/spread/plugins/v2/colcon-ros2-hello/task.yaml
+++ b/tests/spread/plugins/v2/colcon-ros2-hello/task.yaml
@@ -9,6 +9,7 @@ environment:
   SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
 systems:
+  - ubuntu-20.04
   - ubuntu-20.04-64
   - ubuntu-20.04-amd64
   - ubuntu-20.04-arm64

--- a/tests/spread/plugins/v2/colcon-ros2-hello/task.yaml
+++ b/tests/spread/plugins/v2/colcon-ros2-hello/task.yaml
@@ -1,0 +1,51 @@
+summary: >-
+  Build, clean, build, modify and rebuild, and run hello
+  for ros2/colcon.
+
+kill-timeout: 30m
+
+environment:
+  SNAP/colcon_ros2_foxy_rlcpp_hello: colcon-ros2-foxy-rlcpp-hello
+  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
+
+systems:
+  - ubuntu-20.04-amd64
+  - ubuntu-20.04-arm64
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "../snaps/$SNAP/snap/snapcraft.yaml"
+
+restore: |
+  cd "../snaps/$SNAP"
+  snapcraft clean
+  rm -f ./*.snap
+
+  git checkout src/hello.cpp
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "../snaps/$SNAP"
+
+  # Build what we have and verify the snap runs as expected.
+  snapcraft
+  snap install "${SNAP}"_1.0_*.snap --dangerous
+  [ "$($SNAP)" = "hello world" ]
+
+  # Clean the hello part, then build and run again.
+  snapcraft clean hello
+  snapcraft
+  snap install "${SNAP}"_1.0_*.snap --dangerous
+  [ "$($SNAP)" = "hello world" ]
+
+  # Make sure that what we built runs with the changes applied.
+  modified_file=src/hello.cpp
+  sed -i "${modified_file}" -e 's/hello world/hello rebuilt world/'
+
+  snapcraft
+  snap install "${SNAP}"_1.0_*.snap --dangerous
+  [ "$($SNAP)" = "hello rebuilt world" ]


### PR DESCRIPTION
Requires splitting the task yaml to its own config.

Bump test time to 30m as well because the arm64 test may take
longer than the usual 15 or so minutes.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
