### PR TITLE
plugins v2: use repo.Repo not repo.Ubuntu in colcon

### DIFF
--- a/snapcraft/plugins/v2/colcon.py
+++ b/snapcraft/plugins/v2/colcon.py
@@ -63,7 +63,7 @@ from typing import Any, Dict, List, Set
 import click
 from catkin_pkg import packages as catkin_packages
 
-from snapcraft.internal.repo import Ubuntu
+from snapcraft.internal.repo import Repo
 from snapcraft.plugins.v1._ros.rosdep import _parse_rosdep_resolve_dependencies
 from snapcraft.plugins.v2 import PluginV2
 
@@ -231,14 +231,14 @@ def stage_runtime_dependencies(part_install: str, ros_distro: str):
         stage_packages_path = install_path.parent / "stage_packages"
 
         click.echo(f"Fetching stage packages: {package_names!r}")
-        Ubuntu.fetch_stage_packages(
+        Repo.fetch_stage_packages(
             package_names=package_names,
             base="core20",
             stage_packages_path=stage_packages_path,
         )
 
         click.echo(f"Unpacking stage packages: {package_names!r}")
-        Ubuntu.unpack_stage_packages(
+        Repo.unpack_stage_packages(
             stage_packages_path=stage_packages_path, install_path=install_path
         )
 


### PR DESCRIPTION
References to "Ubuntu" breaks on non-Ubuntu systems.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
