### PR TITLE
schema/snapcraft.json: allow type: os with build-base

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -368,6 +368,7 @@
                 "base",
                 "gadget",
                 "kernel",
+                "os",
                 "snapd"
             ]
         },
@@ -1085,6 +1086,30 @@
                     "required": [
                         "build-base"
                     ]
+                },
+                {
+                    "usage": "type: os (with a build-base)",
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "os"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "required": [
+                                "build-base"
+                            ]
+                        },
+                        {
+                            "not": {
+                                "required": [
+                                    "base"
+                                ]
+                            }
+                        }
+                    ]
                 }
             ]
         },
@@ -1109,7 +1134,6 @@
         "name",
         "parts"
     ],
-
     "dependencies": {
         "license-agreement": [
             "license"


### PR DESCRIPTION
This is to build the core snap with a modern version of snapcraft.

We specifically only allow type: os with build-base required and not allowed
with base set, because the only type: os snap that should ever be built is the
core snap, which will not set a base because it is a base.

Signed-off-by: Ian Johnson <ian.johnson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

@cjp256 mentioned that there are probably some tests that need updating, not sure where those are, but probably we should have the following test cases:

- [ ] a snap with `build-base: core` and `type: os` is valid
- [ ] a snap with `base: ...` and `type: os` is invalid
- [ ] a snap with `type: os` and no `build-base` and no `base` still builds with legacy snapcraft (maybe this schema is not used for legacy snapcraft?) this is to ensure that the old snapcraft.yaml for the core snap can continue to be built
maybe there are other cases that should be tested, I can't think of any right now