### PR TITLE
colcon v2 plugin: don't strip environment for stage-runtime-dependencies

### DIFF
--- a/snapcraft/plugins/v2/colcon.py
+++ b/snapcraft/plugins/v2/colcon.py
@@ -157,7 +157,12 @@ class ColconPlugin(PluginV2):
     def _get_stage_runtime_dependencies_command(self):
         env = dict(LANG="C.UTF-8", LC_ALL="C.UTF-8")
 
-        for key in ["PATH", "SNAP", "SNAP_ARCH", "SNAP_NAME", "SNAP_VERSION"]:
+        for key in [
+            "SNAP",
+            "SNAP_ARCH",
+            "SNAP_NAME",
+            "SNAP_VERSION",
+        ]:
             if key in os.environ:
                 env[key] = os.environ[key]
 
@@ -165,16 +170,11 @@ class ColconPlugin(PluginV2):
         return " ".join(
             [
                 "env",
-                "-i",
                 *env_flags,
                 sys.executable,
                 "-I",
                 os.path.abspath(__file__),
                 "stage-runtime-dependencies",
-                "--part-install",
-                "$SNAPCRAFT_PART_INSTALL",
-                "--ros-distro",
-                "$ROS_DISTRO",
             ]
         )
 

--- a/tests/unit/plugins/v2/test_colcon.py
+++ b/tests/unit/plugins/v2/test_colcon.py
@@ -103,12 +103,9 @@ def test_get_build_commands(monkeypatch):
         "init; fi",
         "rosdep update --include-eol-distros --rosdistro $ROS_DISTRO",
         "rosdep install --from-paths . --default-yes --ignore-packages-from-source",
-        "colcon build --merge-install --install-base $SNAPCRAFT_PART_INSTALL "
-        "--parallel-workers ${SNAPCRAFT_PARALLEL_BUILD_COUNT}",
-        "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 /test/python3 -I "
-        "/test/colcon.py "
-        "stage-runtime-dependencies --part-install $SNAPCRAFT_PART_INSTALL "
-        "--ros-distro $ROS_DISTRO",
+        "colcon build --merge-install --install-base $SNAPCRAFT_PART_INSTALL --parallel-workers ${SNAPCRAFT_PARALLEL_BUILD_COUNT}",
+        "env LANG=C.UTF-8 LC_ALL=C.UTF-8 /test/python3 -I "
+        "/test/colcon.py stage-runtime-dependencies",
     ]
 
 
@@ -130,7 +127,6 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "environ",
         dict(
             FOO="baR",
-            PATH="/bin:/test",
             SNAP="TESTSNAP",
             SNAP_ARCH="TESTARCH",
             SNAP_NAME="TESTSNAPNAME",
@@ -148,10 +144,7 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "--packages-ignore ipackage1 ipackage2... --packages-select package1 "
         "package2... --ament-cmake-args ament args... --catkin-cmake-args catkin "
         "args... --parallel-workers ${SNAPCRAFT_PARALLEL_BUILD_COUNT}",
-        "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/bin:/test SNAP=TESTSNAP "
+        "env LANG=C.UTF-8 LC_ALL=C.UTF-8 SNAP=TESTSNAP "
         "SNAP_ARCH=TESTARCH SNAP_NAME=TESTSNAPNAME SNAP_VERSION=TESTV1 "
-        "/test/python3 -I "
-        "/test/colcon.py "
-        "stage-runtime-dependencies --part-install $SNAPCRAFT_PART_INSTALL "
-        "--ros-distro $ROS_DISTRO",
+        "/test/python3 -I /test/colcon.py stage-runtime-dependencies",
     ]


### PR DESCRIPTION
    HTTP proxy settings are being lost.
    
    - Remove the `-i` argument to `env`, there are no longer variables
      that must be filtered, allow all of the build-time environment
      variables through.  This will include http(s)_proxy once the
      run scripts include it (shipped separately).
    
    - Remove parameters to `stage-runtime-dependencies` which can just
      be picked up from the environment now, after removing `-i` from
      `env`.
    
    - Remove PATH from env list as it no longer needs to be passed
      through explicitly, it is in the run script.