### PR TITLE
build providers: use the releases endpoint for LXD

### DIFF
--- a/snapcraft/internal/build_providers/_lxd/_images.py
+++ b/snapcraft/internal/build_providers/_lxd/_images.py
@@ -30,7 +30,7 @@ def get_image_source(*, base: str) -> Dict[str, str]:
     return dict(
         type="image",
         mode="pull",
-        server="https://cloud-images.ubuntu.com/buildd/daily",
+        server="https://cloud-images.ubuntu.com/buildd/releases",
         protocol="simplestreams",
         alias=_BASE_IMAGE[base],
     )

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -206,7 +206,7 @@ class LXDInitTest(LXDBaseTest):
                 "source": {
                     "mode": "pull",
                     "type": "image",
-                    "server": "https://cloud-images.ubuntu.com/buildd/daily",
+                    "server": "https://cloud-images.ubuntu.com/buildd/releases",
                     "protocol": "simplestreams",
                     "alias": "16.04",
                 },
@@ -546,7 +546,7 @@ class LXDInitTest(LXDBaseTest):
                 "source": {
                     "mode": "pull",
                     "type": "image",
-                    "server": "https://cloud-images.ubuntu.com/buildd/daily",
+                    "server": "https://cloud-images.ubuntu.com/buildd/releases",
                     "protocol": "simplestreams",
                     "alias": "18.04",
                 },
@@ -577,7 +577,7 @@ class LXDInitTest(LXDBaseTest):
                 "source": {
                     "mode": "pull",
                     "type": "image",
-                    "server": "https://cloud-images.ubuntu.com/buildd/daily",
+                    "server": "https://cloud-images.ubuntu.com/buildd/releases",
                     "protocol": "simplestreams",
                     "alias": "16.04",
                 },


### PR DESCRIPTION
Switch the simplestreams endpoint from daily to releases to retrieve LXD
images.

Signed-off-by: Ubuntu <ubuntu@snapcraft-dev.lxd>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
