### PR TITLE
cli: ignore sudo warning when using multipass

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -240,8 +240,14 @@ def _sanity_check_build_provider_flags(build_provider: str, **kwargs) -> None:
                 f"{key} cannot be used with build provider {build_provider!r}"
             )
 
-    # Check if running as sudo.
-    if os.getenv("SUDO_USER") and os.geteuid() == 0:
+    # Check if running as sudo but only if the host is not managed-host where Snapcraft
+    # runs as root already. This effectively avoids the warning when using the default
+    # build provider (Multipass) that uses "sudo" to get "root".
+    if (
+        build_provider != "managed-host"
+        and os.getenv("SUDO_USER")
+        and os.geteuid() == 0
+    ):
         warning(
             "Running with 'sudo' may cause permission errors and is discouraged. Use 'sudo' when cleaning."
         )


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
