### PR TITLE
meta: add suite/component validation checks for package-repositories

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -154,7 +154,7 @@
                     "uniqueItems": true,
                     "items": {
                         "type": "string",
-                        "description": "Deb repository components to enable, e.g. 'main, multiverse, unstable'"
+                        "description": "Deb repository components to enable, e.g. 'main, multiverse, unstable'.  Must be empty if suites are paths (ending with '/')."
                     }
                 },
                 "key-id": {

--- a/snapcraft/internal/meta/package_repository.py
+++ b/snapcraft/internal/meta/package_repository.py
@@ -233,6 +233,17 @@ class PackageRepositoryApt(PackageRepository):
         if data_copy:
             raise RuntimeError(f"invalid deb repository object: {data!r} (extra keys)")
 
+        suite_is_path = any(s.endswith("/") for s in suites)
+        if suite_is_path and not all(s.endswith("/") for s in suites):
+            raise RuntimeError(
+                f"invalid deb repository object: {data!r} (mixed suites - paths ending with '/' and non-path names)"
+            )
+
+        if suite_is_path and len(components) > 0:
+            raise RuntimeError(
+                f"invalid deb repository object: {data!r} (pathed suite with components)"
+            )
+
         return cls(
             architectures=architectures,
             components=components,

--- a/specifications/package-repositories.org
+++ b/specifications/package-repositories.org
@@ -120,6 +120,8 @@ the schema is to be considered stable.
 
   May be empty, e.g.: =components: []=
 
+  _MUST_ be empty if =suites= refers to an absolute path (ends with =/=).
+
 - *Examples:*
 
   - =components: []=
@@ -177,6 +179,9 @@ the schema is to be considered stable.
     - Supports =$SNAPCRAFT_APT_RELEASE= variable for snapcraft to populate base's release name (e.g. =xenial=).
 
     - If your deb URL does not look like it has a suite defined, it is likely that the suite is =/=.
+
+    - If suite(s) refer to a path (i.e. ends with =/=), then =components= _MUST_
+      be empty (or unspecified).
 
   - *Examples:*
 

--- a/tests/unit/meta/test_package_repository.py
+++ b/tests/unit/meta/test_package_repository.py
@@ -190,6 +190,52 @@ class DebTests(unit.TestCase):
             str(error), MatchesRegex("invalid deb repository object:.*(extra keys)")
         )
 
+    def test_invalid_mixed_suites(self):
+        test_dict = {
+            "architectures": ["amd64", "i386"],
+            "components": ["main", "multiverse"],
+            "deb-types": ["deb", "deb-src"],
+            "key-id": "test-key-id",
+            "key-server": "keyserver.ubuntu.com",
+            "name": "test-name",
+            "suites": ["xenial", "/"],
+            "type": "apt",
+            "url": "http://archive.ubuntu.com/ubuntu",
+        }
+
+        error = self.assertRaises(
+            RuntimeError, PackageRepositoryApt.unmarshal, test_dict
+        )
+        self.assertThat(
+            str(error),
+            MatchesRegex(
+                "invalid deb repository object:.*(mixed suites - paths ending with '/' and non-path names)"
+            ),
+        )
+
+    def test_invalid_path_suite_with_components(self):
+        test_dict = {
+            "architectures": ["amd64", "i386"],
+            "components": ["main", "multiverse"],
+            "deb-types": ["deb", "deb-src"],
+            "key-id": "test-key-id",
+            "key-server": "keyserver.ubuntu.com",
+            "name": "test-name",
+            "suites": ["some-path/"],
+            "type": "apt",
+            "url": "http://archive.ubuntu.com/ubuntu",
+        }
+
+        error = self.assertRaises(
+            RuntimeError, PackageRepositoryApt.unmarshal, test_dict
+        )
+        self.assertThat(
+            str(error),
+            MatchesRegex(
+                "invalid deb repository object:.*(pathed suite with components)"
+            ),
+        )
+
 
 class RepoTests(unit.TestCase):
     def test_marshal_none(self):


### PR DESCRIPTION
According to apt's sources.list manpage, there are two invalid cases
that snapcraft should verify:

(1) No components must be specified if suite is a path.  Apt determines
that a suite is a path if it ends with a "/".

(2) Due to the above requirement, it follows that suite types cannot
be mixed in the same repository object.

This commit makes the following changes:

- Add these checks to package-repositories when being unmarshalled.

- Note #1 in the specification and JSON schema.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
