### PR TITLE
Set VDPAU_DRIVER_PATH appropriately

### DIFF
--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -86,6 +86,14 @@ export LIBGL_DRIVERS_PATH="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/dri"
 append_dir LD_LIBRARY_PATH "$LIBGL_DRIVERS_PATH"
 export LIBVA_DRIVERS_PATH="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/dri"
 
+# Set where the VDPAU drivers are located
+export VDPAU_DRIVER_PATH="/usr/lib/$ARCH/vdpau/"
+if [ -e "/var/lib/snapd/lib/gl/vdpau/libvdpau_nvidia.so" ]; then
+  export VDPAU_DRIVER_PATH="/var/lib/snapd/lib/gl/vdpau"
+  # Prevent picking VA-API (Intel/AMD) over NVIDIA VDPAU; on PRIME systems for example
+  unset LIBVA_DRIVERS_PATH
+fi
+
 # Workaround in snapd for proprietary nVidia drivers mounts the drivers in
 # /var/lib/snapd/lib/gl that needs to be in LD_LIBRARY_PATH
 # Without that OpenGL using apps do not work with the nVidia drivers.


### PR DESCRIPTION
I've been working on the snap of FFmpeg and OBS Studio and noticed that VDPAU is not working correctly. This pull request sets  `VDPAU_DRIVER_PATH` appropriately and supports NVIDIA hardware when the host has the proprietary drivers installed.
