### PR TITLE
Revert "lxd: update connectivity check url"

### DIFF
--- a/snapcraft/internal/lxd/_containerbuild.py
+++ b/snapcraft/internal/lxd/_containerbuild.py
@@ -44,7 +44,7 @@ _NETWORK_PROBE_COMMAND = dedent(
     import urllib.request
     import sys
 
-    check_url = "http://connectivity-check.ubuntu.com/"
+    check_url = "http://start.ubuntu.com/connectivity-check.html"
     try:
         urllib.request.urlopen(check_url, timeout=5)
     except urllib.error.URLError as e:


### PR DESCRIPTION
Reverts snapcore/snapcraft#3239

Now that the former URL is restored, a quick fix for LP #1894656