### PR TITLE
build providers: hide systemd setup for LXD

### DIFF
--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -440,13 +440,16 @@ class LXD(Provider):
         self._wait_for_systemd()
 
         # Use resolv.conf managed by systemd-resolved.
-        self._run(["ln", "-sf", "/run/systemd/resolve/resolv.conf", "/etc/resolv.conf"])
+        self._run(
+            ["ln", "-sf", "/run/systemd/resolve/resolv.conf", "/etc/resolv.conf"],
+            hide_output=True,
+        )
 
-        self._run(["systemctl", "enable", "systemd-resolved"])
-        self._run(["systemctl", "enable", "systemd-networkd"])
+        self._run(["systemctl", "enable", "systemd-resolved"], hide_output=True)
+        self._run(["systemctl", "enable", "systemd-networkd"], hide_output=True)
 
-        self._run(["systemctl", "restart", "systemd-resolved"])
-        self._run(["systemctl", "restart", "systemd-networkd"])
+        self._run(["systemctl", "restart", "systemd-resolved"], hide_output=True)
+        self._run(["systemctl", "restart", "systemd-networkd"], hide_output=True)
 
         self._wait_for_network()
 
@@ -458,12 +461,12 @@ class LXD(Provider):
         self._run(["apt-get", "install", "dirmngr", "udev", "fuse", "--yes"])
 
         # the system needs networking
-        self._run(["systemctl", "enable", "systemd-udevd"])
-        self._run(["systemctl", "start", "systemd-udevd"])
+        self._run(["systemctl", "enable", "systemd-udevd"], hide_output=True)
+        self._run(["systemctl", "start", "systemd-udevd"], hide_output=True)
 
         # And only then install snapd.
         self._run(["apt-get", "install", "snapd", "sudo", "--yes"])
-        self._run(["systemctl", "start", "snapd"])
+        self._run(["systemctl", "start", "snapd"], hide_output=True)
 
     def _setup_snapcraft(self):
         self._wait_for_network()

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -38,7 +38,12 @@ class GetEnv(_base_provider.Provider):
         return ["env", "SNAPCRAFT_HAS_TTY=False"]
 
 
-class LXDTestImpl(LXD, GetEnv):
+class EnvSetup(_base_provider.Provider):
+    def _setup_environment(self):
+        pass
+
+
+class LXDTestImpl(LXD, GetEnv, EnvSetup):
     pass
 
 
@@ -217,7 +222,7 @@ class LXDInitTest(LXDBaseTest):
         container = self.fake_pylxd_client.containers.get(self.instance_name)
         container.start_mock.assert_called_once_with(wait=True)
         self.assertThat(container.save_mock.call_count, Equals(2))
-        self.assertThat(self.check_output_mock.call_count, Equals(3))
+        self.assertThat(self.check_output_mock.call_count, Equals(11))
 
         for args, kwargs in (
             self.check_output_mock.call_args_list + self.check_call_mock.call_args_list
@@ -231,7 +236,7 @@ class LXDInitTest(LXDBaseTest):
 
         self.check_output_mock.assert_has_calls(
             [
-                mock.call(
+                call(
                     [
                         "/snap/bin/lxc",
                         "exec",
@@ -243,7 +248,125 @@ class LXDInitTest(LXDBaseTest):
                         "is-system-running",
                     ]
                 ),
-                mock.call(
+                call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "ln",
+                        "-sf",
+                        "/run/systemd/resolve/resolv.conf",
+                        "/etc/resolv.conf",
+                    ]
+                ),
+                call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "systemctl",
+                        "enable",
+                        "systemd-resolved",
+                    ]
+                ),
+                call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "systemctl",
+                        "enable",
+                        "systemd-networkd",
+                    ]
+                ),
+                call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "systemctl",
+                        "restart",
+                        "systemd-resolved",
+                    ]
+                ),
+                call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "systemctl",
+                        "restart",
+                        "systemd-networkd",
+                    ]
+                ),
+                call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "getent",
+                        "hosts",
+                        "snapcraft.io",
+                    ]
+                ),
+                call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "systemctl",
+                        "enable",
+                        "systemd-udevd",
+                    ]
+                ),
+                call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "systemctl",
+                        "start",
+                        "systemd-udevd",
+                    ]
+                ),
+                call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "systemctl",
+                        "start",
+                        "snapd",
+                    ]
+                ),
+                call(
                     [
                         "/snap/bin/lxc",
                         "exec",
@@ -347,72 +470,6 @@ class LXDInitTest(LXDBaseTest):
                         "--",
                         "env",
                         "SNAPCRAFT_HAS_TTY=False",
-                        "ln",
-                        "-sf",
-                        "/run/systemd/resolve/resolv.conf",
-                        "/etc/resolv.conf",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "enable",
-                        "systemd-resolved",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "enable",
-                        "systemd-networkd",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "restart",
-                        "systemd-resolved",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "restart",
-                        "systemd-networkd",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
                         "apt-get",
                         "update",
                     ]
@@ -441,32 +498,6 @@ class LXDInitTest(LXDBaseTest):
                         "--",
                         "env",
                         "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "enable",
-                        "systemd-udevd",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "start",
-                        "systemd-udevd",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
                         "apt-get",
                         "install",
                         "snapd",
@@ -482,9 +513,63 @@ class LXDInitTest(LXDBaseTest):
                         "--",
                         "env",
                         "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "start",
-                        "snapd",
+                        "apt-get",
+                        "update",
+                    ]
+                ),
+                call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "apt-get",
+                        "dist-upgrade",
+                        "--yes",
+                    ]
+                ),
+                call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "apt-get",
+                        "install",
+                        "--yes",
+                        "apt-transport-https",
+                    ]
+                ),
+                call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "snap",
+                        "unset",
+                        "system",
+                        "proxy.http",
+                    ]
+                ),
+                call(
+                    [
+                        "/snap/bin/lxc",
+                        "exec",
+                        "snapcraft-project-name",
+                        "--",
+                        "env",
+                        "SNAPCRAFT_HAS_TTY=False",
+                        "snap",
+                        "unset",
+                        "system",
+                        "proxy.https",
                     ]
                 ),
             ]
@@ -671,39 +756,6 @@ class LXDLaunchedTest(LXDBaseTest):
         )
         self.assertThat(self.fake_container.sync_mock.call_count, Equals(1))
         self.fake_container.save_mock.assert_called_once_with(wait=True)
-        self.assertThat(self.check_output_mock.call_count, Equals(3))
-        self.check_output_mock.assert_has_calls(
-            [
-                mock.call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "is-system-running",
-                    ]
-                )
-            ]
-            + [
-                mock.call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "getent",
-                        "hosts",
-                        "snapcraft.io",
-                    ]
-                )
-            ]
-            * 2
-        )
 
     def test_mount_prime_directory(self):
         self.check_output_mock.return_value = b"/root"
@@ -724,39 +776,6 @@ class LXDLaunchedTest(LXDBaseTest):
         )
         self.assertThat(self.fake_container.sync_mock.call_count, Equals(1))
         self.fake_container.save_mock.assert_called_once_with(wait=True)
-        self.assertThat(self.check_output_mock.call_count, Equals(3))
-        self.check_output_mock.assert_has_calls(
-            [
-                mock.call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "is-system-running",
-                    ]
-                )
-            ]
-            + [
-                mock.call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "getent",
-                        "hosts",
-                        "snapcraft.io",
-                    ]
-                )
-            ]
-            * 2
-        )
 
     def test_run(self):
         self.instance._run(["ls", "/root/project"])


### PR DESCRIPTION
The LXD setup is overly verbose. This is a first pass to hide some of
the many unnecessary things show by default (snapcraft's internal debug
still shows them).

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
