### PR TITLE
build providers: fix issues running on Windows

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -297,20 +297,28 @@ class Provider(abc.ABC):
     def _install_file(self, *, path: str, content: str, permissions: str) -> None:
         basename = os.path.basename(path)
 
-        with tempfile.NamedTemporaryFile(suffix=basename) as temp_file:
+        # Push to a location that can be written to by all backends
+        # with unique files depending on path.
+        # The path should be a valid path for the target.
+        remote_file = "/var/tmp/{}".format(base64.b64encode(path.encode()).decode())
+
+        # Windows cannot open the same file twice, so write to a temporary file that
+        # would later be deleted manually.
+        with tempfile.NamedTemporaryFile(delete=False, suffix=basename) as temp_file:
             temp_file.write(content.encode())
             temp_file.flush()
-            # Push to a location that can be written to by all backends
-            # with unique files depending on path.
-            remote_file = os.path.join(
-                "/var/tmp", base64.b64encode(path.encode()).decode()
-            )
+            temp_file_path = temp_file.name
+
+        try:
             self._push_file(source=temp_file.name, destination=remote_file)
             self._run(["mv", remote_file, path])
+
             # This chown is not necessarily needed. but does keep things
             # consistent.
             self._run(["chown", "root:root", path])
             self._run(["chmod", permissions, path])
+        finally:
+            os.unlink(temp_file_path)
 
     def _get_code_name_from_build_base(self):
         build_base = self.project._get_build_base()
@@ -326,7 +334,7 @@ class Provider(abc.ABC):
         primary_mirror = os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT_PRIMARY_MIRROR", None)
 
         if primary_mirror is None:
-            if platform.machine() in ["i686", "x86_64"]:
+            if platform.machine() in ["AMD64", "i686", "x86_64"]:
                 primary_mirror = "http://archive.ubuntu.com/ubuntu"
             else:
                 primary_mirror = "http://ports.ubuntu.com/ubuntu-ports"
@@ -337,7 +345,7 @@ class Provider(abc.ABC):
         security_mirror = os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT_PRIMARY_MIRROR", None)
 
         if security_mirror is None:
-            if platform.machine() in ["i686", "x86_64"]:
+            if platform.machine() in ["AMD64", "i686", "x86_64"]:
                 security_mirror = "http://security.ubuntu.com/ubuntu"
             else:
                 security_mirror = "http://ports.ubuntu.com/ubuntu-ports"
@@ -383,7 +391,7 @@ class Provider(abc.ABC):
             path="/etc/apt/sources.list.d/default.sources",
             content=dedent(
                 """\
-                    Types: deb deb-src
+                    Types: deb
                     URIs: {primary_mirror}
                     Suites: {release} {release}-updates
                     Components: main multiverse restricted universe
@@ -399,7 +407,7 @@ class Provider(abc.ABC):
             path="/etc/apt/sources.list.d/default-security.sources",
             content=dedent(
                 """\
-                        Types: deb deb-src
+                        Types: deb
                         URIs: {security_mirror}
                         Suites: {release}-security
                         Components: main multiverse restricted universe

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -16,13 +16,18 @@
 
 import contextlib
 import os
+import platform
 import pathlib
+import tempfile
 from textwrap import dedent
 from unittest.mock import Mock, call, patch
 
 import fixtures
+import pytest
 from testtools.matchers import DirExists, EndsWith, Equals, Not
 
+from snapcraft.project import Project
+from snapcraft.internal.meta.snap import Snap
 from snapcraft.internal.build_providers import errors
 
 from . import (
@@ -237,132 +242,6 @@ class BaseProviderTest(BaseProviderBaseTest):
                 call(self.project._project_dir, "/root/project"),
                 call("/home/user/.ssh", "/root/.ssh"),
             ]
-        )
-
-    def test_setup_environment_content_amd64(self):
-        self.useFixture(fixtures.MockPatch("platform.machine", return_value="x86_64"))
-        recorded_files = dict()
-
-        @contextlib.contextmanager
-        def fake_namedtempfile(*, suffix: str, **kwargs):
-            # Usage hides the file basename in the suffix.
-            tmp_path = os.path.join(self.path, "tmpfile")
-            with open(tmp_path, "wb") as f_write:
-                yield f_write
-            with open(tmp_path, "r") as f_read:
-                recorded_files[suffix] = f_read.read()
-
-        self.useFixture(
-            fixtures.MockPatch("tempfile.NamedTemporaryFile", new=fake_namedtempfile)
-        )
-
-        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
-        provider._setup_environment()
-
-        self.expectThat(
-            recorded_files,
-            Equals(
-                {
-                    ".bashrc": '#!/bin/bash\nexport PS1="\\h \\$(/bin/_snapcraft_prompt)# "\n',
-                    "00-snapcraft": 'Apt::Install-Recommends "false";\n',
-                    "_snapcraft_prompt": dedent(
-                        """\
-                        #!/bin/bash
-                        if [[ "$PWD" =~ ^$HOME.* ]]; then
-                            path="${PWD/#$HOME/\\ ..}"
-                            if [[ "$path" == " .." ]]; then
-                                ps1=""
-                            else
-                                ps1="$path"
-                            fi
-                        else
-                            ps1="$PWD"
-                        fi
-                        echo -n $ps1
-                        """
-                    ),
-                    "default.sources": dedent(
-                        """\
-                        Types: deb deb-src
-                        URIs: http://archive.ubuntu.com/ubuntu
-                        Suites: xenial xenial-updates
-                        Components: main multiverse restricted universe
-                    """
-                    ),
-                    "default-security.sources": dedent(
-                        """\
-                        Types: deb deb-src
-                        URIs: http://security.ubuntu.com/ubuntu
-                        Suites: xenial-security
-                        Components: main multiverse restricted universe
-                    """
-                    ),
-                    "sources.list": "",
-                }
-            ),
-        )
-
-    def test_setup_environment_content_arm64(self):
-        self.useFixture(fixtures.MockPatch("platform.machine", return_value="aarch64"))
-        recorded_files = dict()
-
-        @contextlib.contextmanager
-        def fake_namedtempfile(*, suffix: str, **kwargs):
-            # Usage hides the file basename in the suffix.
-            tmp_path = os.path.join(self.path, "tmpfile")
-            with open(tmp_path, "wb") as f_write:
-                yield f_write
-            with open(tmp_path, "r") as f_read:
-                recorded_files[suffix] = f_read.read()
-
-        self.useFixture(
-            fixtures.MockPatch("tempfile.NamedTemporaryFile", new=fake_namedtempfile)
-        )
-
-        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
-        provider._setup_environment()
-
-        self.expectThat(
-            recorded_files,
-            Equals(
-                {
-                    ".bashrc": '#!/bin/bash\nexport PS1="\\h \\$(/bin/_snapcraft_prompt)# "\n',
-                    "00-snapcraft": 'Apt::Install-Recommends "false";\n',
-                    "_snapcraft_prompt": dedent(
-                        """\
-                        #!/bin/bash
-                        if [[ "$PWD" =~ ^$HOME.* ]]; then
-                            path="${PWD/#$HOME/\\ ..}"
-                            if [[ "$path" == " .." ]]; then
-                                ps1=""
-                            else
-                                ps1="$path"
-                            fi
-                        else
-                            ps1="$PWD"
-                        fi
-                        echo -n $ps1
-                        """
-                    ),
-                    "default.sources": dedent(
-                        """\
-                        Types: deb deb-src
-                        URIs: http://ports.ubuntu.com/ubuntu-ports
-                        Suites: xenial xenial-updates
-                        Components: main multiverse restricted universe
-                    """
-                    ),
-                    "default-security.sources": dedent(
-                        """\
-                        Types: deb deb-src
-                        URIs: http://ports.ubuntu.com/ubuntu-ports
-                        Suites: xenial-security
-                        Components: main multiverse restricted universe
-                    """
-                    ),
-                    "sources.list": "",
-                }
-            ),
         )
 
     def test_start_instance(self):
@@ -687,3 +566,89 @@ class TestCompatibilityClean:
             provider.clean_project_mock.assert_called_once_with()
         else:
             provider.clean_project_mock.assert_not_called()
+
+
+_ARCHIVES = {
+    "x86": {
+        "main": "http://archive.ubuntu.com/ubuntu",
+        "security": "http://security.ubuntu.com/ubuntu",
+    },
+    "ports": {
+        "main": "http://ports.ubuntu.com/ubuntu-ports",
+        "security": "http://ports.ubuntu.com/ubuntu-ports",
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "machine_platform",
+    [
+        ("x86_64", _ARCHIVES["x86"]),
+        ("AMD64", _ARCHIVES["x86"]),
+        ("aarch64", _ARCHIVES["ports"]),
+    ],
+)
+@pytest.mark.parametrize(
+    "distro", [("core", "xenial"), ("core18", "bionic"), ("core20", "focal")]
+)
+def test_setup_environment_content_x86(
+    tmp_work_path, monkeypatch, machine_platform, distro
+):
+    snapcraft_project = Project()
+    snapcraft_project._snap_meta = Snap(name="test-snap", base=distro[0])
+
+    monkeypatch.setattr(platform, "machine", lambda: machine_platform[0])
+
+    recorded_files = dict()
+
+    @contextlib.contextmanager
+    def fake_namedtempfile(*, suffix: str, **kwargs):
+        # Usage hides the file basename in the suffix.
+        tmp_path = os.path.join("tmpfile")
+        with open(tmp_path, "wb") as f_write:
+            yield f_write
+        with open(tmp_path, "r") as f_read:
+            recorded_files[suffix] = f_read.read()
+
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", fake_namedtempfile)
+
+    provider = ProviderImpl(project=snapcraft_project, echoer=Mock())
+    provider._setup_environment()
+
+    assert recorded_files == {
+        ".bashrc": '#!/bin/bash\nexport PS1="\\h \\$(/bin/_snapcraft_prompt)# "\n',
+        "00-snapcraft": 'Apt::Install-Recommends "false";\n',
+        "_snapcraft_prompt": dedent(
+            """\
+            #!/bin/bash
+            if [[ "$PWD" =~ ^$HOME.* ]]; then
+                path="${PWD/#$HOME/\\ ..}"
+                if [[ "$path" == " .." ]]; then
+                    ps1=""
+                else
+                    ps1="$path"
+                fi
+            else
+                ps1="$PWD"
+            fi
+            echo -n $ps1
+            """
+        ),
+        "default.sources": dedent(
+            f"""\
+                Types: deb
+                URIs: {machine_platform[1]["main"]}
+                Suites: {distro[1]} {distro[1]}-updates
+                Components: main multiverse restricted universe
+            """
+        ),
+        "default-security.sources": dedent(
+            f"""\
+                Types: deb
+                URIs: {machine_platform[1]["security"]}
+                Suites: {distro[1]}-security
+                Components: main multiverse restricted universe
+            """
+        ),
+        "sources.list": "",
+    }


### PR DESCRIPTION
Changed tempfile management when pushing assets to the build
environment as transfer opens the tempfile which caused issues on
Windows.

Fixed the path used on destination (os.path.join created a half breed
of Unix and Windows based paths).

Repository setup takes into account the platform.machine value
returned by Windows.

Lastly, and this affects all setups, deb-src was removed from the
default list as it is not default in most installations and should be
managed by package repositories if needed (Snapcraft has no apt source
semantics).

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
