### PR TITLE
build providers: unified provider refactoring for provider setup

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -98,19 +98,13 @@ def _execute(  # noqa: C901
             )
     else:
         build_provider_class = build_providers.get_provider_for(build_provider)
-        try:
-            build_provider_class.ensure_provider()
-        except build_providers.errors.ProviderNotFound as provider_error:
-            if provider_error.prompt_installable:
-                if echo.is_tty_connected() and echo.confirm(
-                    "Support for {!r} needs to be set up. "
-                    "Would you like to do it now?".format(provider_error.provider)
-                ):
-                    build_provider_class.setup_provider(echoer=echo)
-                else:
-                    raise provider_error
+        if not build_provider_class.is_provider_ready():
+            if echo.is_tty_connected():
+                build_provider_class.setup_provider(interactive=True, echoer=echo)
             else:
-                raise provider_error
+                echo.exit_error(
+                    brief=f"Build provider {build_provider!r} is not installed or configured."
+                )
 
         with build_provider_class(
             project=project, echoer=echo, build_provider_flags=build_provider_flags

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -96,13 +96,40 @@ class Provider(abc.ABC):
 
     @classmethod
     @abc.abstractclassmethod
-    def ensure_provider(cls) -> None:
-        """Necessary steps to ensure the provider is correctly setup."""
+    def is_provider_ready(cls) -> bool:
+        """Check if provider is accessible.
+
+        As applicable, validate that the provider is:
+        - installed
+        - configured
+        - running
+        - compatible
+
+        Used as a pre-check prior to initiating build. If False, indicates that
+        additional installation, or configuration must be performed by user, which
+        can be done with setup_provider().
+
+        If True, the provider is expected to be usable to build the project.
+
+        :returns: True if ready, False if further setup is required.
+        """
 
     @classmethod
     @abc.abstractclassmethod
-    def setup_provider(cls, *, echoer) -> None:
-        """Necessary steps to install the provider on the host."""
+    def setup_provider(cls, *, interactive: bool, echoer) -> None:
+        """Install/configure as necessary.
+
+        If interactive, prompt user for all necessary changes. If non-interactive,
+        attempt to make all necessary changes.
+
+        Once completed, the provider is expected to be usable to build the project.
+
+        :param interactive: Toggle for user input.
+        :param echoer: Echo interface for communicating with user.
+
+        :raises SnapcraftEnvironmentError: if provider has dependencies that need to be
+        installed, or configuration that must be changed, or is incompatible with host.
+        """
 
     @classmethod
     @abc.abstractclassmethod

--- a/snapcraft/internal/build_providers/_multipass/_windows.py
+++ b/snapcraft/internal/build_providers/_multipass/_windows.py
@@ -16,12 +16,13 @@
 
 import logging
 import os.path
-import requests
 import shutil
-import simplejson
 import subprocess
 import sys
 import tempfile
+
+import requests
+import simplejson
 
 from snapcraft.file_utils import calculate_sha3_384
 from snapcraft.internal.build_providers.errors import (
@@ -190,7 +191,7 @@ def _download_multipass(dl_dir: str, echoer) -> str:
     return dl_path
 
 
-def windows_install_multipass(echoer) -> None:
+def windows_install_multipass(*, echoer) -> None:
     """Download and install multipass."""
 
     assert sys.platform == "win32"

--- a/tests/unit/build_providers/__init__.py
+++ b/tests/unit/build_providers/__init__.py
@@ -18,10 +18,10 @@ import pathlib
 from typing import Dict, Optional
 from unittest import mock
 
-from snapcraft.project import Project
-from snapcraft.internal.meta.snap import Snap
-from tests import fixture_setup, unit
 from snapcraft.internal.build_providers._base_provider import Provider
+from snapcraft.internal.meta.snap import Snap
+from snapcraft.project import Project
+from tests import fixture_setup, unit
 
 
 class ProviderImpl(Provider):
@@ -80,11 +80,11 @@ class ProviderImpl(Provider):
         return "fake-instance"
 
     @classmethod
-    def ensure_provider(cls) -> None:
+    def is_provider_ready(cls) -> bool:
         """Fake provider check."""
 
     @classmethod
-    def setup_provider(cls, *, echoer=None) -> None:
+    def setup_provider(cls, *, interactive: bool, echoer=None) -> None:
         """Fake provider setup."""
 
     @classmethod


### PR DESCRIPTION
Refactoring for unified approach to checking if a provider is ready, and
performing installation.

- Adds 'is_provider_ready()' interface, replacing 'ensure_provider()'.

- Makes 'setup_provider()' responsible for all user interaction to install
and/or configure the provider, and its depdenencies.  Adds 'interactive'
parameter to allow for non-interactive installs, though not currently utilized.

- Refactored LXD checks into their own methods, adding a compatibility check to
check the LXD version is 4.0+, and removing the snap install check in favor of
just ensuring the hardcoded /snap/bin/lx[cd] paths are present.

- Moves setup code out of MultipassCommand into the Multipass provider.

- Update lifecycle CLI to utilize new interfaces.  When tty is not connected,
and setup is required, exit with error that that build provider is not
installed or configured.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
