### PR TITLE
project loader: install dirmngr prior to configuring package repositories

### DIFF
--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -248,12 +248,12 @@ class Config:
 
     def _get_required_package_repositories(self) -> List[PackageRepository]:
         package_repos = self.project._snap_meta.package_repositories.copy()
+        
         v1_plugins = [
             part.plugin
             for part in self.all_parts
             if isinstance(part.plugin, plugins.v1.PluginV1)
         ]
-
         for plugin in v1_plugins:
             package_repos.extend(plugin.get_required_package_repositories())
 

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -19,22 +19,23 @@ import logging
 import os
 import os.path
 import re
-
-import jsonschema
 from typing import List, Set
 
-from snapcraft import plugins, project, formatting_utils
+import jsonschema
+
+from snapcraft import formatting_utils, plugins, project
 from snapcraft.internal import deprecations, repo, states, steps
+from snapcraft.internal.meta.package_repository import PackageRepository
 from snapcraft.internal.meta.snap import Snap
 from snapcraft.internal.pluginhandler._part_environment import (
     get_snapcraft_global_environment,
 )
 from snapcraft.project._schema import Validator
-from ._parts_config import PartsConfig
-from ._extensions import apply_extensions
-from ._env import build_env_for_stage, runtime_env, environment_to_replacements
-from . import errors, grammar_processing, replace_attr
 
+from . import errors, grammar_processing, replace_attr
+from ._env import build_env_for_stage, environment_to_replacements, runtime_env
+from ._extensions import apply_extensions
+from ._parts_config import PartsConfig
 
 logger = logging.getLogger(__name__)
 
@@ -245,23 +246,31 @@ class Config:
         if duplicates:
             raise errors.DuplicateAliasError(aliases=duplicates)
 
-    def install_package_repositories(self) -> None:
-        keys_path = self.project._get_keys_path()
-
-        # Install repositories configured by 'package-repositories'.
-        changes = [
-            package_repo.install(keys_path=keys_path)
-            for package_repo in self.project._snap_meta.package_repositories
+    def _get_required_package_repositories(self) -> List[PackageRepository]:
+        package_repos = self.project._snap_meta.package_repositories.copy()
+        v1_plugins = [
+            part.plugin
+            for part in self.all_parts
+            if isinstance(part.plugin, plugins.v1.PluginV1)
         ]
 
-        # Install repositories configured by v1 plugins.
-        for part in self.all_parts:
-            if isinstance(part.plugin, plugins.v1.PluginV1):
-                changes += [
-                    package_repo.install(keys_path=keys_path)
-                    for package_repo in part.plugin.get_required_package_repositories()
-                ]
+        for plugin in v1_plugins:
+            package_repos.extend(plugin.get_required_package_repositories())
 
+        return package_repos
+
+    def install_package_repositories(self) -> None:
+        package_repos = self._get_required_package_repositories()
+        if not package_repos:
+            return
+
+        # Install pre-requisite packages for apt-key, if not installed.
+        repo.Repo.install_build_packages(package_names=["gnupg", "dirmngr"])
+
+        keys_path = self.project._get_keys_path()
+        changes = [
+            package_repo.install(keys_path=keys_path) for package_repo in package_repos
+        ]
         if any(changes):
             repo.Repo.refresh_build_packages()
 


### PR DESCRIPTION


This was previously addressed by installing the required packages
in the LXD provider's setup environment and Multipass images already
have the required packages installed.  However, on Launchpad,
the required package would not be installed.

Install the required packages when additional package-repositories
are configured, including 'dirmngr' and 'gnupg' using
'Repo.install_build_packages()' which accounts for already-installed
packages.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
