### PR TITLE
cli: support snap --output <directory>

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -231,7 +231,7 @@ def _pack(
             )
         command.extend(["--compression", compression])
 
-    if output_file:
+    if output_file is not None:
         command.extend(["--filename", output_file])
 
     command.append(directory)

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -202,6 +202,23 @@ def _run_pack(snap_command: List[Union[str, pathlib.Path]]) -> str:
 def _pack(
     directory: str, *, compression: Optional[str] = None, output: Optional[str]
 ) -> None:
+    output_file = None
+    output_dir = None
+
+    # Output may be:
+    # (1) a directory path to output snaps to
+    # (2) an explicit file path to output snap to
+    # (3) unspecified (None), output to current directory (project directory)
+    if output:
+        output_path = pathlib.Path(output)
+        output_parent = output_path.parent
+        if output_path.is_dir():
+            output_dir = str(output_path)
+        elif output_parent and output_parent != pathlib.Path("."):
+            output_dir = str(output_parent)
+            output_file = output_path.name
+        else:
+            output_file = output
 
     snap_path = file_utils.get_host_tool_path(command_name="snap", package_name="snapd")
 
@@ -213,10 +230,16 @@ def _pack(
                 f"EXPERIMENTAL: Setting the squash FS compression to {compression!r}."
             )
         command.extend(["--compression", compression])
-    if output is not None:
-        command.extend(["--filename", output])
+
+    if output_file:
+        command.extend(["--filename", output_file])
+
     command.append(directory)
 
+    if output_dir:
+        command.append(output_dir)
+
+    logger.debug(f"Running pack command: {command}")
     snap_filename = _run_pack(command)
     echo.info(f"Snapped {snap_filename}")
 

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -236,7 +236,7 @@ def _pack(
 
     command.append(directory)
 
-    if output_dir:
+    if output_dir is not None:
         command.append(output_dir)
 
     logger.debug(f"Running pack command: {command}")

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -203,6 +203,7 @@ def _pack(
     directory: str, *, compression: Optional[str] = None, output: Optional[str]
 ) -> None:
     """Pack a snap.
+
     :param directory: directory to snap
     :param compression: compression type to use, None for defaults
     :param output: Output may either be:

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -202,13 +202,18 @@ def _run_pack(snap_command: List[Union[str, pathlib.Path]]) -> str:
 def _pack(
     directory: str, *, compression: Optional[str] = None, output: Optional[str]
 ) -> None:
+    """Pack a snap.
+    
+    :param directory: directory to snap
+    :param compression: compression type to use, None for defaults
+    :param output: Output may either be:
+        (1) a directory path to output snaps to
+        (2) an explicit file path to output snap to
+        (3) unpsecified/None to output to current (project) directory
+    """
     output_file = None
     output_dir = None
 
-    # Output may be:
-    # (1) a directory path to output snaps to
-    # (2) an explicit file path to output snap to
-    # (3) unspecified (None), output to current directory (project directory)
     if output:
         output_path = pathlib.Path(output)
         output_parent = output_path.parent

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -203,7 +203,6 @@ def _pack(
     directory: str, *, compression: Optional[str] = None, output: Optional[str]
 ) -> None:
     """Pack a snap.
-    
     :param directory: directory to snap
     :param compression: compression type to use, None for defaults
     :param output: Output may either be:

--- a/tests/unit/cli/test_lifecycle.py
+++ b/tests/unit/cli/test_lifecycle.py
@@ -1,0 +1,57 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import mock
+
+import pytest
+
+from snapcraft.cli import lifecycle
+
+
+@pytest.mark.parametrize(
+    "output,pack_name,pack_dir",
+    [
+        ("/tmp/output.snap", "output.snap", "/tmp"),
+        ("/tmp", None, "/tmp"),
+        ("output.snap", "output.snap", None),
+    ],
+)
+@pytest.mark.parametrize(
+    "compression", ["xz", "lzo", None],
+)
+@mock.patch("snapcraft.file_utils.get_host_tool_path", return_value="/bin/snap")
+@mock.patch("snapcraft.cli.lifecycle._run_pack", return_value="ignore.snap")
+def test_pack(mock_run_pack, mock_host_tool, compression, output, pack_name, pack_dir):
+    lifecycle._pack(directory="/my/snap", compression=compression, output=output)
+
+    assert mock_host_tool.mock_calls == [
+        mock.call(command_name="snap", package_name="snapd")
+    ]
+
+    pack_command = ["/bin/snap", "pack"]
+
+    if compression:
+        pack_command.extend(["--compression", compression])
+
+    if pack_name:
+        pack_command.extend(["--filename", pack_name])
+
+    pack_command.append("/my/snap")
+
+    if pack_dir:
+        pack_command.append(pack_dir)
+
+    assert mock_run_pack.mock_calls == [mock.call(pack_command)]

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -21,6 +21,7 @@ from unittest import mock
 from testtools.matchers import Contains, Equals
 
 from snapcraft.internal import steps
+
 from . import LifecycleCommandsBaseTestCase
 
 
@@ -52,6 +53,13 @@ class TestSnap(LifecycleCommandsBaseTestCase):
         self.assertThat(result.exit_code, Equals(0))
         self.fake_get_provider_for.mock.assert_called_once_with("multipass")
         self.assert_build_provider_calls(output="foo.snap")
+
+    def test_output_using_defaults_with_dir(self):
+        result = self.run_command(["snap", "--output", "/tmp"])
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.fake_get_provider_for.mock.assert_called_once_with("multipass")
+        self.assert_build_provider_calls(output="/tmp")
 
     def test_shell_using_defaults(self):
         result = self.run_command(["snap", "--shell"])
@@ -100,6 +108,18 @@ class TestSnap(LifecycleCommandsBaseTestCase):
         )
         self.fake_pack.mock.assert_called_once_with(
             os.path.join(self.path, "prime"), compression=None, output="foo.snap"
+        )
+
+    def test_output_using_destructive_mode_with_directory(self):
+        result = self.run_command(["snap", "--destructive-mode", "--output", "/tmp"])
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.fake_get_provider_for.mock.assert_not_called()
+        self.fake_lifecycle_execute.mock.assert_called_once_with(
+            steps.PRIME, mock.ANY, tuple()
+        )
+        self.fake_pack.mock.assert_called_once_with(
+            os.path.join(self.path, "prime"), compression=None, output="/tmp"
         )
 
     def test_deprecated_snap_dir(self):


### PR DESCRIPTION
Currently one may only specify an explicit path to output snap
in the case of destructive mode.  For LXD/Multipass, one may only
specify the name of the snap within the project directory, otherwise
it gets "lost" in the container and is not retrieved.

This change allows output to point to an output directory, rather
than a snap file name.  This will help providers that may ship
multiple snaps, or users that want the snapcraft-provided name,
but rather have it shipped into a different directory.

NOTE that this change does not fix the still-broken case where
LXD/Multipass users specify a path outside of the project. This
should be addressed in upcoming work.

- Update _pack() to support the three uses of 'output'
- Introduce test coverage for _pack()

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
