### PR TITLE
storeapi: drop arch requirement for get_channel_mapping()

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -452,7 +452,6 @@ class Provider(abc.ABC):
 
         snap_injector = SnapInjector(
             registry_filepath=registry_filepath,
-            snap_arch=self.project.deb_arch,
             runner=self._run,
             file_pusher=self._push_file,
             inject_from_host=inject_from_host,

--- a/snapcraft/internal/build_providers/_snap.py
+++ b/snapcraft/internal/build_providers/_snap.py
@@ -19,8 +19,7 @@ import enum
 import logging
 import os
 import tempfile
-from typing import Callable, List, Optional
-from typing import Any, Dict  # noqa: F401
+from typing import Any, Callable, Dict, List, Optional  # noqa: F401
 
 from snapcraft import storeapi, yaml_utils
 from snapcraft.internal import repo
@@ -57,12 +56,10 @@ class _SnapManager:
         snap_name: str,
         remote_snap_dir: str,
         latest_revision: Optional[str],
-        snap_arch: str,
         inject_from_host: bool = True
     ) -> None:
         self.snap_name = snap_name
         self._remote_snap_dir = remote_snap_dir
-        self._snap_arch = snap_arch
         self._inject_from_host = inject_from_host
 
         self._latest_revision = latest_revision
@@ -198,7 +195,7 @@ class _SnapManager:
             snap_channel = _get_snap_channel(self.snap_name)
             store_snap_info = storeapi.StoreClient().cpi.get_info(self.snap_name)
             snap_channel_map = store_snap_info.get_channel_mapping(
-                risk=snap_channel.risk, track=snap_channel.track, arch=self._snap_arch
+                risk=snap_channel.risk, track=snap_channel.track
             )
             snap_revision = snap_channel_map.revision
             if snap_channel_map.confinement == "classic":
@@ -301,7 +298,6 @@ class SnapInjector:
         self,
         *,
         registry_filepath: str,
-        snap_arch: str,
         runner: Callable[..., Optional[bytes]],
         file_pusher: Callable[..., None],
         inject_from_host: bool = True
@@ -309,7 +305,6 @@ class SnapInjector:
         """
         Initialize a SnapInjector instance.
 
-        :param str snap_arch: the snap architecture of the snaps to inject.
         :param str registry_filepath: path to where recordings of previusly installed
                                       revisions of a snap can be queried and recorded.
         :param runner: a callable which can run commands in the build environment.
@@ -320,7 +315,6 @@ class SnapInjector:
 
         self._snaps = []  # type: List[_SnapManager]
         self._registry_filepath = registry_filepath
-        self._snap_arch = snap_arch
         self._inject_from_host = inject_from_host
         self._runner = runner
         self._file_pusher = file_pusher
@@ -369,7 +363,6 @@ class SnapInjector:
                 snap_name=snap_name,
                 remote_snap_dir=self._remote_snap_dir,
                 latest_revision=self._get_latest_revision(snap_name),
-                snap_arch=self._snap_arch,
                 inject_from_host=self._inject_from_host,
             )
         )

--- a/snapcraft/storeapi/_store_client.py
+++ b/snapcraft/storeapi/_store_client.py
@@ -17,26 +17,21 @@
 import os
 import urllib.parse
 from time import sleep
-from typing import Any, Dict, Iterable, List, Optional, TextIO, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, TextIO, Union
 
 import pymacaroons
 import requests
 
-import snapcraft
 from snapcraft import config
 from snapcraft.internal.indicators import download_requests_stream
 
-from . import logger
-from . import _upload
-from . import errors
-from .constants import DEFAULT_SERIES
-
-from ._sso_client import SSOClient
-from ._snap_index_client import SnapIndexClient
+from . import _upload, errors, logger
 from ._sca_client import SCAClient
+from ._snap_index_client import SnapIndexClient
 from ._snap_v2_client import SnapV2Client
+from ._sso_client import SSOClient
 from ._up_down_client import UpDownClient
-
+from .constants import DEFAULT_SERIES
 
 if TYPE_CHECKING:
     from .v2 import snap_channel_map
@@ -280,13 +275,10 @@ class StoreClient:
         *,
         risk: str,
         download_path: str,
-        track: str = None,
-        arch: str = None,
-        except_hash=""
+        track: Optional[str] = None,
+        arch: Optional[str] = None,
+        except_hash: str = ""
     ):
-        if arch is None:
-            arch = snapcraft.ProjectOptions().deb_arch
-
         snap_info = self.cpi.get_info(snap_name)
         channel_mapping = snap_info.get_channel_mapping(
             risk=risk, track=track, arch=arch

--- a/snapcraft/storeapi/info.py
+++ b/snapcraft/storeapi/info.py
@@ -17,9 +17,9 @@
 import os
 from typing import Any, Dict, List, Optional
 
-from . import errors
 from snapcraft.file_utils import calculate_hash
 
+from . import errors
 
 """
 This module holds representations for results from the v2 info API provided by
@@ -227,7 +227,7 @@ class SnapInfo:
         return self._payload["snap-id"]
 
     def get_channel_mapping(
-        self, *, risk: str, arch: str, track: Optional[str] = None
+        self, *, risk: str, arch: Optional[str] = None, track: Optional[str] = None
     ) -> SnapChannelMapping:
         if track is None:
             track_filter = "latest"
@@ -235,7 +235,9 @@ class SnapInfo:
             track_filter = track
 
         arch_match = (
-            c for c in self.channel_map if c.channel_details.architecture == arch
+            c
+            for c in self.channel_map
+            if arch is None or c.channel_details.architecture == arch
         )
         track_match = (c for c in arch_match if c.channel_details.track == track_filter)
         risk_match = [c for c in track_match if c.channel_details.risk == risk]

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -16,8 +16,8 @@
 
 import contextlib
 import os
-import platform
 import pathlib
+import platform
 import tempfile
 from textwrap import dedent
 from unittest.mock import Mock, call, patch
@@ -26,9 +26,9 @@ import fixtures
 import pytest
 from testtools.matchers import DirExists, EndsWith, Equals, Not
 
-from snapcraft.project import Project
-from snapcraft.internal.meta.snap import Snap
 from snapcraft.internal.build_providers import errors
+from snapcraft.internal.meta.snap import Snap
+from snapcraft.project import Project
 
 from . import (
     BaseProviderBaseTest,
@@ -354,7 +354,6 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
             registry_filepath=os.path.join(
                 provider.provider_project_dir, "snap-registry.yaml"
             ),
-            snap_arch=self.project.deb_arch,
             runner=provider._run,
             file_pusher=provider._push_file,
             inject_from_host=True,
@@ -380,7 +379,6 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
             registry_filepath=os.path.join(
                 provider.provider_project_dir, "snap-registry.yaml"
             ),
-            snap_arch=self.project.deb_arch,
             runner=provider._run,
             file_pusher=provider._push_file,
             inject_from_host=True,
@@ -442,7 +440,6 @@ class MacProviderProvisionSnapcraftTest(MacBaseProviderWithBasesBaseTest):
             registry_filepath=os.path.join(
                 provider.provider_project_dir, "snap-registry.yaml"
             ),
-            snap_arch=self.project.deb_arch,
             runner=provider._run,
             file_pusher=provider._push_file,
             inject_from_host=False,
@@ -468,7 +465,6 @@ class MacProviderProvisionSnapcraftTest(MacBaseProviderWithBasesBaseTest):
             registry_filepath=os.path.join(
                 provider.provider_project_dir, "snap-registry.yaml"
             ),
-            snap_arch=self.project.deb_arch,
             runner=provider._run,
             file_pusher=provider._push_file,
             inject_from_host=False,

--- a/tests/unit/build_providers/test_snap.py
+++ b/tests/unit/build_providers/test_snap.py
@@ -17,18 +17,19 @@
 import logging
 import os
 from textwrap import dedent
-from unittest.mock import call, patch, ANY
+from unittest.mock import ANY, call, patch
 
 import fixtures
 from testtools.matchers import Contains, Equals, FileContains, Not
 
-from . import ProviderImpl, get_project
 from snapcraft.internal.build_providers._snap import (
     SnapInjector,
-    repo,
     _get_snap_channel,
+    repo,
 )
 from tests import fixture_setup, unit
+
+from . import ProviderImpl, get_project
 
 
 class SnapInjectionTest(unit.TestCase):
@@ -84,7 +85,6 @@ class SnapInjectionTest(unit.TestCase):
 
         snap_injector = SnapInjector(
             registry_filepath=self.registry_filepath,
-            snap_arch="amd64",
             runner=self.provider._run,
             file_pusher=self.provider._push_file,
         )
@@ -167,7 +167,6 @@ class SnapInjectionTest(unit.TestCase):
 
         snap_injector = SnapInjector(
             registry_filepath=self.registry_filepath,
-            snap_arch="amd64",
             runner=self.provider._run,
             file_pusher=self.provider._push_file,
             inject_from_host=False,
@@ -226,7 +225,6 @@ class SnapInjectionTest(unit.TestCase):
 
         snap_injector = SnapInjector(
             registry_filepath=self.registry_filepath,
-            snap_arch="amd64",
             runner=self.provider._run,
             file_pusher=self.provider._push_file,
         )
@@ -292,7 +290,6 @@ class SnapInjectionTest(unit.TestCase):
 
         snap_injector = SnapInjector(
             registry_filepath=self.registry_filepath,
-            snap_arch="amd64",
             runner=self.provider._run,
             file_pusher=self.provider._push_file,
         )
@@ -336,7 +333,6 @@ class SnapInjectionTest(unit.TestCase):
 
         snap_injector = SnapInjector(
             registry_filepath=self.registry_filepath,
-            snap_arch="amd64",
             runner=self.provider._run,
             file_pusher=self.provider._push_file,
         )
@@ -375,7 +371,6 @@ class SnapInjectionTest(unit.TestCase):
 
         snap_injector = SnapInjector(
             registry_filepath=None,
-            snap_arch="amd64",
             runner=self.provider._run,
             file_pusher=self.provider._push_file,
         )
@@ -397,7 +392,6 @@ class SnapInjectionTest(unit.TestCase):
 
         snap_injector = SnapInjector(
             registry_filepath=self.registry_filepath,
-            snap_arch="amd64",
             runner=self.provider._run,
             file_pusher=self.provider._push_file,
         )
@@ -444,7 +438,6 @@ class SnapInjectionTest(unit.TestCase):
 
         snap_injector = SnapInjector(
             registry_filepath=self.registry_filepath,
-            snap_arch="amd64",
             runner=self.provider._run,
             file_pusher=self.provider._push_file,
         )
@@ -455,7 +448,6 @@ class SnapInjectionTest(unit.TestCase):
 
         snap_injector = SnapInjector(
             registry_filepath=self.registry_filepath,
-            snap_arch="amd64",
             runner=self.provider._run,
             file_pusher=self.provider._push_file,
         )
@@ -470,7 +462,6 @@ class SnapInjectionTest(unit.TestCase):
 
         snap_injector = SnapInjector(
             registry_filepath=self.registry_filepath,
-            snap_arch="amd64",
             runner=self.provider._run,
             file_pusher=self.provider._push_file,
         )
@@ -481,7 +472,6 @@ class SnapInjectionTest(unit.TestCase):
 
         snap_injector = SnapInjector(
             registry_filepath=self.registry_filepath,
-            snap_arch="amd64",
             runner=self.provider._run,
             file_pusher=self.provider._push_file,
         )
@@ -505,7 +495,6 @@ class SnapInjectionTest(unit.TestCase):
 
         snap_injector = SnapInjector(
             registry_filepath=self.registry_filepath,
-            snap_arch="amd64",
             runner=self.provider._run,
             file_pusher=self.provider._push_file,
         )


### PR DESCRIPTION
The base build provider and SnapInjector() specifies the architecture of the
snap to download/install, which causes unnecessary coupling of the host <->
build provider architecture. While this could trivially determined, it appears
to be unnecessary as Snapd assumes the correct architecture to match the runtime
environment.

To preserve the functionality for potential usage in the future, this change
makes the arch field optional in get_channel_mapping() and download() store
APIs.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
