### PR TITLE
unit tests: fix runtests.sh not filtering tests when passed a subdirectory

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -56,7 +56,7 @@ run_snapcraft_tests(){
 
     if [[ "$test_suite" == "tests/unit"* ]]; then
         # Run with coverage results, if available.
-        pytest --cov-report=xml --cov=snapcraft tests/unit/
+        pytest --cov-report=xml --cov=snapcraft "$test_suite"
     else
         python3 -m unittest discover -b -v -s "$test_suite" -t .
     fi


### PR DESCRIPTION
Instructions in `TESTING.md` for testing a subsuite don't work as expected: it just runs the whole suite.

Before:
```sh
$ ./runtests.sh tests/unit/commands
...
collected 3842 items                                                                                                                                                                                                                                        
...
```
After:
```sh
$ ./runtests.sh tests/unit/commands
...
collected 295 items                                                                                                                                                                                                                                         
...
```

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`? 
  - `shellcheck` throws a bunch of warnings, but I believe these are not related with this change at all.
- [ ] Have you successfully run `./runtests.sh tests/unit`?
  - 3 tests fail out of 3842 but, again, it must be a local setup issue:
```
FAILED tests/unit/test_config.py::TestConfig::test_save_encoded_to_file
FAILED tests/unit/commands/test_whoami.py::WhoamiCommandBaseTestCase::test_unknown_email_must_suggest_logout_and_login
FAILED tests/unit/commands/test_whoami.py::WhoamiCommandBaseTestCase::test_whoami_must_print_email_and_developer_id
```

-----
