### PR TITLE
storeapi: add support for reporting status of progressive releases

### DIFF
--- a/snapcraft/cli/_channel_map.py
+++ b/snapcraft/cli/_channel_map.py
@@ -110,10 +110,10 @@ def _get_channel_lines_for_channel(  # noqa: C901
     channel_info = snap_channel_map.get_channel_info(channel_name)
 
     try:
-        progressive_mapped_channel: Optional[
-            MappedChannel
-        ] = snap_channel_map.get_mapped_channel(
-            channel_name=channel_name, architecture=architecture, progressive=True
+        progressive_mapped_channel: Optional[MappedChannel] = (
+            snap_channel_map.get_mapped_channel(
+                channel_name=channel_name, architecture=architecture, progressive=True
+            )
         )
     except ValueError:
         progressive_mapped_channel = None
@@ -123,20 +123,28 @@ def _get_channel_lines_for_channel(  # noqa: C901
             progressive_mapped_channel.revision
         )
 
+        if progressive_mapped_channel.progressive.percentage is None:
+            percentage = 0.0
+        else:
+            percentage = progressive_mapped_channel.progressive.percentage
+
+        if progressive_mapped_channel.progressive.current_percentage is None:
+            current_percentage = 0.0
+        else:
+            current_percentage = (
+                progressive_mapped_channel.progressive.current_percentage
+            )
+
         progressive_mapped_channel_line = _get_channel_line(
             mapped_channel=progressive_mapped_channel,
             revision=progressive_revision,
             channel_info=channel_info,
             hint=current_tick,
-            progress_string=f"{_HINTS.PROGRESSING_TO} {progressive_mapped_channel.progressive.percentage:.0f}%",
+            progress_string=f"{current_percentage:.0f} {_HINTS.PROGRESSING_TO} {percentage:.0f}%",
         )
-        if progressive_mapped_channel.progressive.percentage is None:
-            percentage = 0.0
-        else:
-            percentage = progressive_mapped_channel.progressive.percentage
         # Setup progress for the actually released revision, this needs to be
         # calculated. But only show it if the channel is open.
-        progress_string = "{} {:.0f}%".format(_HINTS.PROGRESSING_TO, 100 - percentage)
+        progress_string = f"{100 - current_percentage:.0f} {_HINTS.PROGRESSING_TO} {100 - percentage:.0f}%"
     else:
         progress_string = _HINTS.NO_PROGRESS
 

--- a/snapcraft/cli/_channel_map.py
+++ b/snapcraft/cli/_channel_map.py
@@ -35,6 +35,7 @@ class _HINTS:
     FOLLOWING: Final[str] = "↑"
     NO_PROGRESS: Final[str] = "-"
     PROGRESSING_TO: Final[str] = "→"
+    UNKNOWN: Final[str] = "?"
 
 
 def _get_channel_order(
@@ -124,27 +125,30 @@ def _get_channel_lines_for_channel(  # noqa: C901
         )
 
         if progressive_mapped_channel.progressive.percentage is None:
-            percentage = 0.0
+            raise RuntimeError("Unexpected null progressive percentage")
         else:
             percentage = progressive_mapped_channel.progressive.percentage
 
         if progressive_mapped_channel.progressive.current_percentage is None:
-            current_percentage = 0.0
+            current_percentage_fmt = _HINTS.UNKNOWN
+            remaining_percentage_fmt = _HINTS.UNKNOWN
         else:
             current_percentage = (
                 progressive_mapped_channel.progressive.current_percentage
             )
+            current_percentage_fmt = f"{current_percentage:.0f}"
+            remaining_percentage_fmt = f"{100 - current_percentage:.0f}"
 
         progressive_mapped_channel_line = _get_channel_line(
             mapped_channel=progressive_mapped_channel,
             revision=progressive_revision,
             channel_info=channel_info,
             hint=current_tick,
-            progress_string=f"{current_percentage:.0f} {_HINTS.PROGRESSING_TO} {percentage:.0f}%",
+            progress_string=f"{current_percentage_fmt} {_HINTS.PROGRESSING_TO} {percentage:.0f}%",
         )
         # Setup progress for the actually released revision, this needs to be
         # calculated. But only show it if the channel is open.
-        progress_string = f"{100 - current_percentage:.0f} {_HINTS.PROGRESSING_TO} {100 - percentage:.0f}%"
+        progress_string = f"{remaining_percentage_fmt} {_HINTS.PROGRESSING_TO} {100 - percentage:.0f}%"
     else:
         progress_string = _HINTS.NO_PROGRESS
 

--- a/snapcraft/storeapi/v2/_api_schema.py
+++ b/snapcraft/storeapi/v2/_api_schema.py
@@ -41,6 +41,7 @@ CHANNEL_MAP_JSONSCHEMA: Dict[str, Any] = {
                         "properties": {
                             "paused": {"type": ["boolean", "null"]},
                             "percentage": {"type": ["number", "null"]},
+                            "current-percentage": {"type": ["number", "null"]},
                         },
                         "required": ["paused", "percentage"],
                         "type": "object",

--- a/snapcraft/storeapi/v2/_api_schema.py
+++ b/snapcraft/storeapi/v2/_api_schema.py
@@ -43,7 +43,7 @@ CHANNEL_MAP_JSONSCHEMA: Dict[str, Any] = {
                             "percentage": {"type": ["number", "null"]},
                             "current-percentage": {"type": ["number", "null"]},
                         },
-                        "required": ["paused", "percentage"],
+                        "required": ["paused", "percentage", "current-percentage"],
                         "type": "object",
                     },
                     "revision": {"type": "integer"},

--- a/snapcraft/storeapi/v2/channel_map.py
+++ b/snapcraft/storeapi/v2/channel_map.py
@@ -40,17 +40,32 @@ class Progressive:
                 "progressive"
             ],
         )
-        return cls(paused=payload["paused"], percentage=payload["percentage"])
+        return cls(
+            paused=payload["paused"],
+            percentage=payload["percentage"],
+            current_percentage=payload["current-percentage"],
+        )
 
     def marshal(self) -> Dict[str, Any]:
-        return {"paused": self.paused, "percentage": self.percentage}
+        return {
+            "paused": self.paused,
+            "percentage": self.percentage,
+            "current-percentage": self.current_percentage,
+        }
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}: {self.percentage!r}>"
+        return f"<{self.__class__.__name__}: {self.current_percentage!r}=>{self.percentage!r}>"
 
-    def __init__(self, *, paused: Optional[bool], percentage: Optional[float]) -> None:
+    def __init__(
+        self,
+        *,
+        paused: Optional[bool],
+        percentage: Optional[float],
+        current_percentage: Optional[float],
+    ) -> None:
         self.paused = paused
         self.percentage = percentage
+        self.current_percentage = current_percentage
 
 
 class MappedChannel:

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -1135,7 +1135,11 @@ class FakeStoreAPIServer(base.BaseFakeServer):
                     "channel": "2.1/beta",
                     "expiration-date": None,
                     "revision": 1,
-                    "progressive": {"paused": None, "percentage": None},
+                    "progressive": {
+                        "paused": None,
+                        "percentage": None,
+                        "current-percentage": None,
+                    },
                     "when": "2020-02-03T20:58:37Z",
                 }
             ],

--- a/tests/unit/commands/__init__.py
+++ b/tests/unit/commands/__init__.py
@@ -224,7 +224,11 @@ class FakeStoreCommandsBaseTestCase(CommandBaseTestCase):
                         "channel": "2.1/beta",
                         "expiration-date": None,
                         "revision": 19,
-                        "progressive": {"paused": None, "percentage": None},
+                        "progressive": {
+                            "paused": None,
+                            "percentage": None,
+                            "current-percentage": None,
+                        },
                     }
                 ],
                 "revisions": [

--- a/tests/unit/commands/test_release.py
+++ b/tests/unit/commands/test_release.py
@@ -90,7 +90,7 @@ class ReleaseCommandTestCase(FakeStoreCommandsBaseTestCase):
             2.1      amd64   stable     -          -           -
                              candidate  -          -           -
                              beta       -          -           -
-                                        10         19          → 10%
+                                        10         19          0 → 10%
                              edge       ↑          ↑           -
             The '2.1/beta' channel is now open.
             """
@@ -114,7 +114,9 @@ class ReleaseCommandTestCase(FakeStoreCommandsBaseTestCase):
                 architecture="amd64",
                 expiration_date="2020-02-03T20:58:37Z",
                 revision=20,
-                progressive=Progressive(paused=None, percentage=None),
+                progressive=Progressive(
+                    paused=None, percentage=None, current_percentage=None
+                ),
             )
         )
         self.channel_map.revisions.append(
@@ -167,7 +169,9 @@ class ReleaseCommandTestCase(FakeStoreCommandsBaseTestCase):
                 architecture="amd64",
                 expiration_date="2020-02-03T20:58:37Z",
                 revision=20,
-                progressive=Progressive(paused=None, percentage=80.0),
+                progressive=Progressive(
+                    paused=None, percentage=80.0, current_percentage=None
+                ),
             )
         )
         self.channel_map.revisions.append(
@@ -204,7 +208,7 @@ class ReleaseCommandTestCase(FakeStoreCommandsBaseTestCase):
             *EXPERIMENTAL* progressive releases in use.
             Track    Arch    Channel         Version    Revision    Progress    Expires at
             2.1      amd64   stable          -          -           -
-                             stable/hotfix1  10hotfix   20          → 80%       2020-02-03T20:58:37Z
+                             stable/hotfix1  10hotfix   20          0 → 80%     2020-02-03T20:58:37Z
                              candidate       -          -           -
                              beta            10         19          -
                              edge            ↑          ↑           -

--- a/tests/unit/commands/test_status.py
+++ b/tests/unit/commands/test_status.py
@@ -293,7 +293,7 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
             2.1      amd64   stable     -          -           -
                              candidate  -          -           -
                              beta       -          -           -
-                                        10         19          0 → 10%
+                                        10         19          ? → 10%
                              edge       ↑          ↑           -
             """
                 )

--- a/tests/unit/store/v2/test_channel_map.py
+++ b/tests/unit/store/v2/test_channel_map.py
@@ -24,23 +24,25 @@ from tests import unit
 
 class ProgressiveTest(unit.TestCase):
     def test_progressive(self):
-        payload = {"paused": False, "percentage": 83.3}
+        payload = {"paused": False, "percentage": 83.3, "current-percentage": 32.1}
 
         p = channel_map.Progressive.unmarshal(payload)
 
-        self.expectThat(repr(p), Equals(f"<Progressive: 83.3>"))
+        self.expectThat(repr(p), Equals(f"<Progressive: 32.1=>83.3>"))
         self.expectThat(p.paused, Equals(payload["paused"]))
         self.expectThat(p.percentage, Equals(payload["percentage"]))
+        self.expectThat(p.current_percentage, Equals(payload["current-percentage"]))
         self.expectThat(p.marshal(), Equals(payload))
 
     def test_none(self):
-        payload = {"paused": None, "percentage": None}
+        payload = {"paused": None, "percentage": None, "current-percentage": None}
 
         p = channel_map.Progressive.unmarshal(payload)
 
-        self.expectThat(repr(p), Equals(f"<Progressive: None>"))
+        self.expectThat(repr(p), Equals(f"<Progressive: None=>None>"))
         self.expectThat(p.paused, Equals(payload["paused"]))
         self.expectThat(p.percentage, Equals(payload["percentage"]))
+        self.expectThat(p.current_percentage, Equals(payload["current-percentage"]))
         self.expectThat(p.marshal(), Equals(payload))
 
 
@@ -52,7 +54,11 @@ class MappedChannelTest(unit.TestCase):
             "architecture": "amd64",
             "channel": "latest/stable",
             "expiration-date": None,
-            "progressive": {"paused": None, "percentage": None},
+            "progressive": {
+                "paused": None,
+                "percentage": None,
+                "current-percentage": None,
+            },
             "revision": 2,
         }
 
@@ -245,28 +251,44 @@ class ChannelMapTest(unit.TestCase):
                     "architecture": "amd64",
                     "channel": "latest/stable",
                     "expiration-date": None,
-                    "progressive": {"paused": None, "percentage": None},
+                    "progressive": {
+                        "paused": None,
+                        "percentage": None,
+                        "current-percentage": None,
+                    },
                     "revision": 2,
                 },
                 {
                     "architecture": "amd64",
                     "channel": "latest/stable",
                     "expiration-date": None,
-                    "progressive": {"paused": None, "percentage": 33.3},
+                    "progressive": {
+                        "paused": None,
+                        "percentage": 33.3,
+                        "current-percentage": 12.3,
+                    },
                     "revision": 3,
                 },
                 {
                     "architecture": "arm64",
                     "channel": "latest/stable",
                     "expiration-date": None,
-                    "progressive": {"paused": None, "percentage": None},
+                    "progressive": {
+                        "paused": None,
+                        "percentage": None,
+                        "current-percentage": None,
+                    },
                     "revision": 2,
                 },
                 {
                     "architecture": "i386",
                     "channel": "latest/stable",
                     "expiration-date": None,
-                    "progressive": {"paused": None, "percentage": None},
+                    "progressive": {
+                        "paused": None,
+                        "percentage": None,
+                        "current-percentage": None,
+                    },
                     "revision": 4,
                 },
             ],


### PR DESCRIPTION
Parse the [`"current-percentage"` Snap Store API field](https://dashboard.staging.snapcraft.io/docs/api/snap.html#about-progressive-releases) and show the current status of progressive releases on CLI.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
  - `shellcheck` throws a bunch of warnings, but I believe these are not related with this at all.
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
