### PR TITLE
github actions: bootstrap CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Snapcraft
+        uses: actions/checkout@v2
+        with:
+          # Fetch all of history so Snapcraft can determine its own version from git.
+          fetch-depth: 0
+
+      - name: Build Snapcraft
+        id: build-snapcraft
+        uses: snapcore/action-build@v1
+
+      - name: Upload Snapcraft snap
+        uses: actions/upload-artifact@v2
+        with:
+          name: snap
+          path: ${{ steps.build-snapcraft.outputs.snap }}
+
+      - name: Verify install of Snapcraft snap
+        run: |
+          sudo snap install --dangerous --classic ${{ steps.build-snapcraft.outputs.snap }}


### PR DESCRIPTION
This bootstraps a GitHub Actions CI workflow, building Snapcraft
will the official snapcore/action-build action.  This will allow
for some CI tasks that are better suited for, or require, actions.

- Build master branch and all PRs using snapcore/action-build.

- Upload the snap artifact for subsequent jobs.

- Sanity check snap by installing it.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
