### PR TITLE
spread tests: introduce electron-builder test

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -524,6 +524,10 @@ suites:
      sudo apt-get install git
      sudo apt-mark auto git
 
+# Electron builder tests
+ tests/spread/electron-builder/:
+   summary: electron-builder tests
+
 # Legacy tests
  tests/spread/legacy/:
    summary: legacy snapcraft tests

--- a/tests/spread/electron-builder/no-template/electron-builder-hello-world/.gitignore
+++ b/tests/spread/electron-builder/no-template/electron-builder-hello-world/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tests/spread/electron-builder/no-template/electron-builder-hello-world/electron-builder.yml
+++ b/tests/spread/electron-builder/no-template/electron-builder-hello-world/electron-builder.yml
@@ -1,0 +1,11 @@
+snap:
+ confinement: strict
+ buildPackages:
+ - jq
+ stagePackages:
+ - default
+ - jq
+ plugs:
+ - default
+ - raw-usb
+ useTemplateApp: false

--- a/tests/spread/electron-builder/no-template/electron-builder-hello-world/index.html
+++ b/tests/spread/electron-builder/no-template/electron-builder-hello-world/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'">
+    <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self'">
+    <title>Hello World!</title>
+  </head>
+  <body>
+    <h1>Hello World!</h1>
+    We are using Node.js <span id="node-version"></span>,
+    Chromium <span id="chrome-version"></span>,
+    and Electron <span id="electron-version"></span>.
+  </body>
+</html>

--- a/tests/spread/electron-builder/no-template/electron-builder-hello-world/main.js
+++ b/tests/spread/electron-builder/no-template/electron-builder-hello-world/main.js
@@ -1,0 +1,43 @@
+// Modules to control application life and create native browser window
+const {app, BrowserWindow} = require('electron')
+const path = require('path')
+
+function createWindow () {
+  // Create the browser window.
+  const mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js')
+    }
+  })
+
+  // and load the index.html of the app.
+  mainWindow.loadFile('index.html')
+
+  // Open the DevTools.
+  // mainWindow.webContents.openDevTools()
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.whenReady().then(() => {
+  createWindow()
+  
+  app.on('activate', function () {
+    // On macOS it's common to re-create a window in the app when the
+    // dock icon is clicked and there are no other windows open.
+    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+  })
+})
+
+// Quit when all windows are closed, except on macOS. There, it's common
+// for applications and their menu bar to stay active until the user quits
+// explicitly with Cmd + Q.
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit()
+})
+
+// In this file you can include the rest of your app's specific main process
+// code. You can also put them in separate files and require them here.

--- a/tests/spread/electron-builder/no-template/electron-builder-hello-world/package.json
+++ b/tests/spread/electron-builder/no-template/electron-builder-hello-world/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "electron-builder-hello-world",
+  "version": "1.0.0",
+  "description": "A minimal Electron application",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "dist": "electron-builder --linux snap"
+  },
+  "repository": "https://github.com/electron/electron-quick-start",
+  "keywords": [
+    "Electron",
+    "quick",
+    "start",
+    "tutorial",
+    "demo"
+  ],
+  "author": "GitHub",
+  "license": "CC0-1.0",
+  "devDependencies": {
+    "electron": "latest",
+    "electron-builder": "latest",
+    "electron-installer-snap": "latest"
+  }
+}

--- a/tests/spread/electron-builder/no-template/electron-builder-hello-world/preload.js
+++ b/tests/spread/electron-builder/no-template/electron-builder-hello-world/preload.js
@@ -1,0 +1,12 @@
+// All of the Node.js APIs are available in the preload process.
+// It has the same sandbox as a Chrome extension.
+window.addEventListener('DOMContentLoaded', () => {
+  const replaceText = (selector, text) => {
+    const element = document.getElementById(selector)
+    if (element) element.innerText = text
+  }
+
+  for (const type of ['chrome', 'node', 'electron']) {
+    replaceText(`${type}-version`, process.versions[type])
+  }
+})

--- a/tests/spread/electron-builder/no-template/electron-builder-hello-world/renderer.js
+++ b/tests/spread/electron-builder/no-template/electron-builder-hello-world/renderer.js
@@ -1,0 +1,6 @@
+// This file is required by the index.html file and will
+// be executed in the renderer process for that window.
+// No Node.js APIs are available in this process because
+// `nodeIntegration` is turned off. Use `preload.js` to
+// selectively enable features needed in the rendering
+// process.

--- a/tests/spread/electron-builder/no-template/expected_snap.yaml
+++ b/tests/spread/electron-builder/no-template/expected_snap.yaml
@@ -1,0 +1,49 @@
+name: electron-builder-hello-world
+version: 1.0.0
+summary: electron-builder-hello-world
+description: A minimal Electron application
+apps:
+  electron-builder-hello-world:
+    command: command.sh
+    plugs:
+    - desktop
+    - desktop-legacy
+    - home
+    - x11
+    - wayland
+    - unity7
+    - browser-support
+    - network
+    - gsettings
+    - audio-playback
+    - pulseaudio
+    - opengl
+    - raw-usb
+    environment:
+      DISABLE_WAYLAND: '1'
+      TMPDIR: $XDG_RUNTIME_DIR
+      PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
+      SNAP_DESKTOP_RUNTIME: $SNAP/gnome-platform
+      LD_LIBRARY_PATH: $SNAP_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu
+architectures:
+- amd64
+base: core18
+confinement: strict
+grade: stable
+plugs:
+  gnome-3-28-1804:
+    interface: content
+    target: $SNAP/gnome-platform
+    default-provider: gnome-3-28-1804
+  gtk-3-themes:
+    interface: content
+    target: $SNAP/data-dir/themes
+    default-provider: gtk-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes

--- a/tests/spread/electron-builder/no-template/expected_snapcraft.yaml
+++ b/tests/spread/electron-builder/no-template/expected_snapcraft.yaml
@@ -1,0 +1,173 @@
+base: core18
+grade: stable
+confinement: strict
+parts:
+  launch-scripts:
+    plugin: dump
+    source: scripts
+  gnome-platform-empty-dirs:
+    plugin: nil
+    override-build: |
+      mkdir -p "$SNAPCRAFT_PART_INSTALL/data-dir/themes" mkdir -p "$SNAPCRAFT_PART_INSTALL/data-dir/icons" mkdir -p "$SNAPCRAFT_PART_INSTALL/data-dir/sounds" mkdir $SNAPCRAFT_PART_INSTALL/gnome-platform
+  app-files:
+    plugin: dump
+    source: app
+    organize:
+      '*': app/
+    stage:
+      - '-app/chrome-sandbox'
+      - '-LICENSES.chromium.html'
+  app:
+    plugin: nil
+    stage:
+      - '-usr/lib/python*'
+      - '-usr/bin/python*'
+      - '-var/lib/ucf'
+      - '-usr/include'
+      - '-usr/lib/X11'
+      - '-usr/share'
+      - '-usr/sbin'
+      - '-usr/bin'
+      - '-usr/lib/*/libicudata.*'
+      - '-usr/lib/*/libicui18n.*'
+      - '-usr/lib/*/libgtk-*'
+      - '-usr/lib/*/libgdk-*'
+      - '-usr/lib/*/glib-*'
+      - '-usr/lib/*/gtk-*'
+      - '-usr/lib/*/gdk-*'
+      - '-usr/lib/*/krb5'
+      - '-usr/lib/systemd'
+      - '-usr/lib/glib-networking'
+      - '-usr/lib/dconf'
+      - '-usr/lib/*/avahi'
+      - '-usr/lib/*/gio'
+      - '-usr/lib/*/libatk*'
+      - '-usr/lib/*/libatspi*'
+      - '-usr/lib/*/libavahi*'
+      - '-usr/lib/*/libcairo*'
+      - '-usr/lib/*/libcolordprivate*'
+      - '-usr/lib/*/libcolord*'
+      - '-usr/lib/*/libcroco*'
+      - '-usr/lib/*/libcups*'
+      - '-usr/lib/*/libdatrie*'
+      - '-usr/lib/*/libdconf*'
+      - '-usr/lib/*/libepoxy*'
+      - '-usr/lib/*/libexpatw*'
+      - '-usr/lib/*/libffi*'
+      - '-usr/lib/*/libfontconfig*'
+      - '-usr/lib/*/libfreetype*'
+      - '-usr/lib/*/libgdk_pixbuf*'
+      - '-usr/lib/*/libgdk_pixbuf_xlib*'
+      - '-usr/lib/*/libgio*'
+      - '-usr/lib/*/libglib*'
+      - '-usr/lib/*/libgmodule*'
+      - '-usr/lib/*/libgmp*'
+      - '-usr/lib/*/libgnutls*'
+      - '-usr/lib/*/libgobject*'
+      - '-usr/lib/*/libgraphite2*'
+      - '-usr/lib/*/libgssapi_krb5*'
+      - '-usr/lib/*/libgthread*'
+      - '-usr/lib/*/libharfbuzz*'
+      - '-usr/lib/*/libhogweed*'
+      - '-usr/lib/*/libicuio*'
+      - '-usr/lib/*/libicutest*'
+      - '-usr/lib/*/libicutu*'
+      - '-usr/lib/*/libicuuc*'
+      - '-usr/lib/*/libidn2*'
+      - '-usr/lib/*/libjbig*'
+      - '-usr/lib/*/libjpeg*'
+      - '-usr/lib/*/libjson*'
+      - '-usr/lib/*/libk5crypto*'
+      - '-usr/lib/*/libkrb5*'
+      - '-usr/lib/*/libkrb5support*'
+      - '-usr/lib/*/liblcms2*'
+      - '-usr/lib/*/libnettle*'
+      - '-usr/lib/*/libp11*'
+      - '-usr/lib/*/libpango*'
+      - '-usr/lib/*/libpangocairo*'
+      - '-usr/lib/*/libpangoft2*'
+      - '-usr/lib/*/libpixman*'
+      - '-usr/lib/*/libpng16*'
+      - '-usr/lib/*/libproxy*'
+      - '-usr/lib/*/librest*'
+      - '-usr/lib/*/librsvg*'
+      - '-usr/lib/*/libsecret*'
+      - '-usr/lib/*/libsoup*'
+      - '-usr/lib/*/libsqlite3*'
+      - '-usr/lib/*/libtasn1*'
+      - '-usr/lib/*/libthai*'
+      - '-usr/lib/*/libtiff*'
+      - '-usr/lib/*/libunistring*'
+      - '-usr/lib/*/libwayland*'
+      - '-usr/lib/*/libX11*'
+      - '-usr/lib/*/libXau*'
+      - '-usr/lib/*/libxcb*'
+      - '-usr/lib/*/libXcomposite*'
+      - '-usr/lib/*/libXcursor*'
+      - '-usr/lib/*/libXdamage*'
+      - '-usr/lib/*/libXdmcp*'
+      - '-usr/lib/*/libXext*'
+      - '-usr/lib/*/libXfixes*'
+      - '-usr/lib/*/libXinerama*'
+      - '-usr/lib/*/libXi*'
+      - '-usr/lib/*/libxkbcommon*'
+      - '-usr/lib/*/libxml2*'
+      - '-usr/lib/*/libXrandr*'
+      - '-usr/lib/*/libXrender*'
+    stage-packages:
+      - libnspr4
+      - libnss3
+      - libxss1
+      - libappindicator3-1
+      - libsecret-1-0
+      - jq
+    build-packages:
+      - jq
+plugs:
+  gnome-3-28-1804:
+    interface: content
+    target: $SNAP/gnome-platform
+    default-provider: gnome-3-28-1804
+  gtk-3-themes:
+    interface: content
+    target: $SNAP/data-dir/themes
+    default-provider: gtk-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes
+name: electron-builder-hello-world
+version: 1.0.0
+summary: electron-builder-hello-world
+description: A minimal Electron application
+architectures:
+  - amd64
+apps:
+  electron-builder-hello-world:
+    command: command.sh
+    plugs:
+      - desktop
+      - desktop-legacy
+      - home
+      - x11
+      - wayland
+      - unity7
+      - browser-support
+      - network
+      - gsettings
+      - audio-playback
+      - pulseaudio
+      - opengl
+      - raw-usb
+    adapter: none
+    environment:
+      DISABLE_WAYLAND: '1'
+      TMPDIR: $XDG_RUNTIME_DIR
+      PATH: '$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH'
+      SNAP_DESKTOP_RUNTIME: $SNAP/gnome-platform
+      LD_LIBRARY_PATH: '$SNAP_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu'
+icon: snap/gui/icon.png

--- a/tests/spread/electron-builder/no-template/task.yaml
+++ b/tests/spread/electron-builder/no-template/task.yaml
@@ -1,0 +1,46 @@
+summary: Build a snap using electron-builder
+
+# This test snap uses core18, and is limited to amd64 arch due to
+# architectures specified in expected_snap.yaml.
+systems:
+  - ubuntu-18.04-64
+  - ubuntu-18.04-amd64
+  - ubuntu-18.04
+
+environment:
+  SNAP_DIR: electron-builder-hello-world
+  SNAPCRAFT_BUILD_INFO: "1"
+
+prepare: |
+  sudo snap install node --classic
+
+restore: |
+  sudo snap remove node
+
+  cd "$SNAP_DIR"
+  rm -rf dist node_modules package-lock.json
+
+execute: |
+  expected_snap_yaml="$(readlink -e expected_snap.yaml)"
+  expected_snapcraft_yaml="$(readlink -e expected_snapcraft.yaml)"
+
+  cd "$SNAP_DIR"
+  npm install
+  npm run dist
+
+  sudo snap install dist/electron-builder-hello-world_1.0.0_amd64.snap --dangerous
+
+  actual_snap_yaml="$(readlink -e /snap/electron-builder-hello-world/current/meta/snap.yaml)"
+  actual_snapcraft_yaml="$(readlink -e /snap/electron-builder-hello-world/current/snap/snapcraft.yaml)"
+
+  if ! diff -U10 "$actual_snap_yaml" "$expected_snap_yaml"; then
+      echo "snap.yaml does not match expected:"
+      cat "$actual_snap_yaml"
+      exit 1
+  fi
+
+  if ! diff -U10 "$actual_snapcraft_yaml" "$expected_snapcraft_yaml"; then
+      echo "snapcraft.yaml does not match expected:"
+      cat "$actual_snapcraft_yaml"
+      exit 1
+  fi


### PR DESCRIPTION
Add test case for electron builder with `useTemplate: false`.
This scenario will invoke snapcraft for the build rather than
using their pre-canned snap template.

Compare the generated snapcraft.yaml and meta/snap.yaml.  These
will have to be updated as upstream changes, but this test is
most valuable to track the latest electron.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
