### PR TITLE
schema: add missing name item in package-repositories

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -126,6 +126,9 @@
                         "apt"
                     ]
                 },
+                "name": {
+                    "type": "string"
+                },
                 "architectures": {
                     "type": "array",
                     "minItems": 1,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [?] Have you successfully run `./runtests.sh tests/unit`?

-----

To fix the error below:

```
Issues while validating snapcraft.yaml: The 'package-repositories[0]' property does not match the required schema: OrderedDict([('type', 'apt'), ('name', 'default'), ('formats', ['deb']), ('architectures', ['amd64', 'i386']), ('components', ['main', 'multiverse']), ('suites', ['$SNAPCRAFT_APT_RELEASE', '$SNAPCRAFT_APT_RELEASE-updates']), ('key-id', '...'), ('url', '...')]) is not valid under any of the given schemas
```