### PR TITLE
plugin handler: properly handle snapcraftctl errors

### DIFF
--- a/snapcraft/cli/snapcraftctl/_runner.py
+++ b/snapcraft/cli/snapcraftctl/_runner.py
@@ -22,9 +22,8 @@ import sys
 
 import click
 
-from snapcraft.internal import errors
 from snapcraft.cli._errors import exception_handler
-from snapcraft.internal import log
+from snapcraft.internal import errors, log
 
 
 @click.group()
@@ -108,6 +107,6 @@ def _call_function(function_name, args=None):
     with open(feedback_fifo, "r") as f:
         feedback = f.readline().strip()
 
-    # Any feedback is considered a fatal error to be printed
+    # Any feedback is considered a fatal error.
     if feedback:
-        raise errors.SnapcraftctlError(feedback)
+        sys.exit(-1)

--- a/tests/spread/general/scriptlets/scriptlet-failures/snap/snapcraft.yaml
+++ b/tests/spread/general/scriptlets/scriptlet-failures/snap/snapcraft.yaml
@@ -1,0 +1,17 @@
+name: snapcraftctl-build-failure
+base: core20
+version: '0.1'
+summary: Fail on snapcraftctl build
+description: |
+  Failing with purpose.
+
+grade: devel
+confinement: strict
+
+parts:
+  my-part:
+    plugin: go
+    source: .
+    override-build: |
+      snapcraftctl set-version && echo "should have failed set-version"
+      snapcraftctl build && echo "should have failed build"

--- a/tests/spread/general/scriptlets/task.yaml
+++ b/tests/spread/general/scriptlets/task.yaml
@@ -9,20 +9,16 @@ prepare: |
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
 
 restore: |
-  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
-  . "$TOOLS_DIR/snapcraft-yaml.sh"
   cd "$SNAP_DIR"
-
   snapcraft clean
   rm -f ./*.snap
 
-  restore_yaml "snap/snapcraft.yaml"
-
-execute: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
-  cd "$SNAP_DIR"
+  restore_yaml "snap/snapcraft.yaml"
 
+execute: |x
+  cd "$SNAP_DIR"
   snapcraft_log="$(snapcraft build 2>&1 || true)"
 
   echo "${snapcraft_log}" | NOMATCH "^should have failed set-version"

--- a/tests/spread/general/scriptlets/task.yaml
+++ b/tests/spread/general/scriptlets/task.yaml
@@ -23,7 +23,6 @@ execute: |
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   cd "$SNAP_DIR"
 
-
   snapcraft_log="$(snapcraft build 2>&1 || true)"
 
   echo "${snapcraft_log}" | NOMATCH "^should have failed set-version"

--- a/tests/spread/general/scriptlets/task.yaml
+++ b/tests/spread/general/scriptlets/task.yaml
@@ -17,7 +17,7 @@ restore: |
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   restore_yaml "snap/snapcraft.yaml"
 
-execute: |x
+execute: |
   cd "$SNAP_DIR"
   snapcraft_log="$(snapcraft build 2>&1 || true)"
 

--- a/tests/spread/general/scriptlets/task.yaml
+++ b/tests/spread/general/scriptlets/task.yaml
@@ -1,0 +1,30 @@
+summary: Validate scriptlet failures
+
+environment:
+  SNAP_DIR: scriptlet-failures
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  cd "$SNAP_DIR"
+
+  snapcraft clean
+  rm -f ./*.snap
+
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  cd "$SNAP_DIR"
+
+
+  snapcraft_log="$(snapcraft build 2>&1 || true)"
+
+  echo "${snapcraft_log}" | NOMATCH "^should have failed set-version"
+  echo "${snapcraft_log}" | NOMATCH "^should have failed build"

--- a/tests/unit/commands/snapcraftctl/test_build.py
+++ b/tests/unit/commands/snapcraftctl/test_build.py
@@ -20,7 +20,7 @@ from testtools.matchers import Contains, Equals, FileExists
 
 from snapcraft.internal import errors
 
-from . import CommandBaseTestCase, CommandBaseNoFifoTestCase
+from . import CommandBaseNoFifoTestCase, CommandBaseTestCase
 
 
 class BuildCommandTestCase(CommandBaseTestCase):
@@ -43,11 +43,7 @@ class BuildCommandTestCase(CommandBaseTestCase):
         with open(self.feedback_fifo, "w") as f:
             f.write("this is an error\n")
 
-        raised = self.assertRaises(
-            errors.SnapcraftctlError, self.run_command, ["build"]
-        )
-
-        self.assertThat(str(raised), Equals("this is an error"))
+        assert self.run_command(["build"]).exit_code == -1
 
 
 class BuildCommandWithoutFifoTestCase(CommandBaseNoFifoTestCase):

--- a/tests/unit/commands/snapcraftctl/test_set_grade.py
+++ b/tests/unit/commands/snapcraftctl/test_set_grade.py
@@ -20,7 +20,7 @@ from testtools.matchers import Contains, Equals, FileExists
 
 from snapcraft.internal import errors
 
-from . import CommandBaseTestCase, CommandBaseNoFifoTestCase
+from . import CommandBaseNoFifoTestCase, CommandBaseTestCase
 
 
 class SetGradeCommandTestCase(CommandBaseTestCase):
@@ -43,11 +43,7 @@ class SetGradeCommandTestCase(CommandBaseTestCase):
         with open(self.feedback_fifo, "w") as f:
             f.write("this is an error\n")
 
-        raised = self.assertRaises(
-            errors.SnapcraftctlError, self.run_command, ["set-grade", "test-grade"]
-        )
-
-        self.assertThat(str(raised), Equals("this is an error"))
+        assert self.run_command(["set-grade", "test-grade"]).exit_code == -1
 
 
 class SetGradeCommandWithoutFifoTestCase(CommandBaseNoFifoTestCase):

--- a/tests/unit/commands/snapcraftctl/test_set_version.py
+++ b/tests/unit/commands/snapcraftctl/test_set_version.py
@@ -20,7 +20,7 @@ from testtools.matchers import Contains, Equals, FileExists
 
 from snapcraft.internal import errors
 
-from . import CommandBaseTestCase, CommandBaseNoFifoTestCase
+from . import CommandBaseNoFifoTestCase, CommandBaseTestCase
 
 
 class SetVersionCommandTestCase(CommandBaseTestCase):
@@ -43,11 +43,7 @@ class SetVersionCommandTestCase(CommandBaseTestCase):
         with open(self.feedback_fifo, "w") as f:
             f.write("this is an error\n")
 
-        raised = self.assertRaises(
-            errors.SnapcraftctlError, self.run_command, ["set-version", "test-version"]
-        )
-
-        self.assertThat(str(raised), Equals("this is an error"))
+        assert self.run_command(["set-version", "test-version"]).exit_code == -1
 
 
 class SetVersionCommandWithoutFifoTestCase(CommandBaseNoFifoTestCase):

--- a/tests/unit/pluginhandler/test_runner.py
+++ b/tests/unit/pluginhandler/test_runner.py
@@ -18,8 +18,8 @@ import functools
 import os
 import subprocess
 from textwrap import dedent
-
 from unittest import mock
+
 from testtools.matchers import Contains, FileContains, FileExists
 
 from snapcraft.internal import errors
@@ -315,4 +315,4 @@ class RunnerFailureTestCase(unit.TestCase):
         )
 
         with mock.patch("subprocess.Popen", wraps=silent_popen):
-            self.assertRaises(errors.ScriptletRunError, runner.prime)
+            self.assertRaises(_TestException, runner.prime)

--- a/tests/unit/pluginhandler/test_scriptlets.py
+++ b/tests/unit/pluginhandler/test_scriptlets.py
@@ -18,16 +18,15 @@ import functools
 import os
 import subprocess
 import textwrap
+from unittest import mock
 
 import fixtures
 import testtools
-from testtools.matchers import Equals
 from testscenarios.scenarios import multiply_scenarios
-from unittest import mock
+from testtools.matchers import Equals
 
-from snapcraft.internal import errors
 from snapcraft import yaml_utils
-
+from snapcraft.internal import errors
 from tests import unit
 from tests.unit.commands import CommandBaseTestCase
 
@@ -272,7 +271,7 @@ class TestScriptletMultipleSettersError:
 
         handler = unit.load_part("test_part", part_properties=part_properties)
 
-        with testtools.ExpectedException(errors.ScriptletRunError):
+        with testtools.ExpectedException(errors.ScriptletDuplicateFieldError):
             silent_popen = functools.partial(
                 subprocess.Popen, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
             )


### PR DESCRIPTION
Address issues including:

- snapcraftctl operations always exiting with 0, even for failure
  cases.

- snapcraft override scripts continue to run even after
  parent snapcraft process fails.  This is because `set -e` does
  not catch the error when snapcraftctl returns 0, and nothing
  is otherwise done to terminate the script.

Given the nature of these symptoms, this is likely the cause of
a number of other seemingly unrelated issues.

These issues occur because _handle_builtin_function() only
catches exceptions of type errors.ScriptletBaseError,
ignoring other cases that may result from the build/pull operations,
such as NodejsPluginMissingPackageJsonError, or
SnapcraftPluginBuildError.

Instead of trying to manage exceptions in _handle_builtin_function(),
catch _any_ unhandled exception in _run_scriplet()'s try block. This
simplifies the more complex return value and feedback handling.

Don't print an error from the feedback channel in snapcraftctl,
the parent process will take care of it.  This is necessary
because the error that is now seen by snapcraftctl would lead
to redundant output.  Just exit with -1 when an error is
read from the feedback fifo.

LP: #1898922

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
