### PR TITLE
plugin handler: set -x for scriptlets

### DIFF
--- a/snapcraft/internal/pluginhandler/_runner.py
+++ b/snapcraft/internal/pluginhandler/_runner.py
@@ -139,6 +139,8 @@ class Runner:
 
                 {env}
 
+                set -x
+
                 {scriptlet}"""
             ).format(
                 interpreter=sys.executable,


### PR DESCRIPTION
Improve visibility for scriptlets, much like the behavior
for core20 plugins.  It's a fairly common pattern for users
to add 'set -x' in their blocks and this will just enable
it by default.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
