### PR TITLE
set ROS_PYTHON_VERSION for rosdep

### DIFF
--- a/snapcraft/plugins/v1/_ros/rosdep.py
+++ b/snapcraft/plugins/v1/_ros/rosdep.py
@@ -218,6 +218,8 @@ class Rosdep:
             self._rosdep_install_path, "usr", "lib", "python2.7", "dist-packages"
         )
 
+        env["ROS_PYTHON_VERSION"] = "2"
+
         # By default, rosdep uses /etc/ros/rosdep to hold its sources list. We
         # don't want that here since we don't want to touch the host machine
         # (not to mention it would require sudo), so we can redirect it via


### PR DESCRIPTION
Sets `ROS_PYTHON_VERSION = 2` for the env used by `rosdep` to fix an harmless but annoying warning:
```terminal
WARNING: ROS_PYTHON_VERSION is unset. Defaulting to 2
```

Signed-off-by: artivis <deray.jeremie@gmail.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
