### PR TITLE
snapcraftctl: add checks for empty string for set-version & set-grade

### DIFF
--- a/snapcraft/cli/snapcraftctl/_runner.py
+++ b/snapcraft/cli/snapcraftctl/_runner.py
@@ -67,15 +67,27 @@ def prime():
     _call_function("prime")
 
 
+def validate_version(ctx, param, value):
+    if not value:
+        raise click.BadParameter(f"Version must be a non-empty string.")
+    return value
+
+
 @run.command("set-version")
-@click.argument("version")
+@click.argument("version", callback=validate_version)
 def set_version(version):
     """Set the version of the snap"""
     _call_function("set-version", {"version": version})
 
 
+def validate_grade(ctx, param, value):
+    if value not in ["stable", "devel"]:
+        raise click.BadParameter(f"Grade must be 'stable' or 'devel'.")
+    return value
+
+
 @run.command("set-grade")
-@click.argument("grade")
+@click.argument("grade", callback=validate_grade)
 def set_grade(grade):
     """Set the grade of the snap"""
     _call_function("set-grade", {"grade": grade})

--- a/tests/unit/commands/snapcraftctl/test_set_grade.py
+++ b/tests/unit/commands/snapcraftctl/test_set_grade.py
@@ -25,17 +25,23 @@ from . import CommandBaseNoFifoTestCase, CommandBaseTestCase
 
 class SetGradeCommandTestCase(CommandBaseTestCase):
     def test_set_grade(self):
-        self.run_command(["set-grade", "test-grade"])
-        self.assertThat(self.call_fifo, FileExists())
+        for grade in ["stable", "devel"]:
+            self.run_command(["set-grade", grade])
+            self.assertThat(self.call_fifo, FileExists())
 
-        with open(self.call_fifo, "r") as f:
-            data = json.loads(f.read())
+            with open(self.call_fifo, "r") as f:
+                data = json.loads(f.read())
 
-        self.assertThat(data, Contains("function"))
-        self.assertThat(data, Contains("args"))
+            self.assertThat(data, Contains("function"))
+            self.assertThat(data, Contains("args"))
 
-        self.assertThat(data["function"], Equals("set-grade"))
-        self.assertThat(data["args"], Equals({"grade": "test-grade"}))
+            self.assertThat(data["function"], Equals("set-grade"))
+            self.assertThat(data["args"], Equals({"grade": grade}))
+
+    def test_invalid_grades(self):
+        for grade in ["", "invalid-grade"]:
+            result = self.run_command(["set-grade", ""])
+            assert result != 0
 
     def test_set_grade_error(self):
         # If there is a string in the feedback, it should be considered an
@@ -43,15 +49,13 @@ class SetGradeCommandTestCase(CommandBaseTestCase):
         with open(self.feedback_fifo, "w") as f:
             f.write("this is an error\n")
 
-        assert self.run_command(["set-grade", "test-grade"]).exit_code == -1
+        assert self.run_command(["set-grade", "stable"]).exit_code == -1
 
 
 class SetGradeCommandWithoutFifoTestCase(CommandBaseNoFifoTestCase):
     def test_set_grade_without_fifo(self):
         raised = self.assertRaises(
-            errors.SnapcraftEnvironmentError,
-            self.run_command,
-            ["set-grade", "test-grade"],
+            errors.SnapcraftEnvironmentError, self.run_command, ["set-grade", "stable"],
         )
 
         self.assertThat(

--- a/tests/unit/commands/snapcraftctl/test_set_version.py
+++ b/tests/unit/commands/snapcraftctl/test_set_version.py
@@ -37,6 +37,10 @@ class SetVersionCommandTestCase(CommandBaseTestCase):
         self.assertThat(data["function"], Equals("set-version"))
         self.assertThat(data["args"], Equals({"version": "test-version"}))
 
+    def test_set_empty_version(self):
+        result = self.run_command(["set-version", ""])
+        assert result != 0
+
     def test_set_version_error(self):
         # If there is a string in the feedback, it should be considered an
         # error


### PR DESCRIPTION
It's a pretty common mistake for scriplets to end up setting "" in
set-version, leading the the following error:
`Failed to generate snap metadata: 'adopt-info' refers to part <part>,
but that part is lacking the 'parse-info' property.`

Setting an empty grade effectively just ignores the invalid value,
relying on the default grade later.

Explicitly error out with helpful messages when invalid options
are used.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
