### PR TITLE
lxd unit tests: simplify command checking pattern

### DIFF
--- a/snapcraft/cli/snapcraftctl/_runner.py
+++ b/snapcraft/cli/snapcraftctl/_runner.py
@@ -22,9 +22,8 @@ import sys
 
 import click
 
-from snapcraft.internal import errors
 from snapcraft.cli._errors import exception_handler
-from snapcraft.internal import log
+from snapcraft.internal import errors, log
 
 
 @click.group()

--- a/snapcraft/plugins/v1/catkin.py
+++ b/snapcraft/plugins/v1/catkin.py
@@ -72,24 +72,24 @@ Additionally, this plugin uses the following plugin-specific keywords:
 
 import contextlib
 import glob
+import logging
 import os
 import pathlib
-import tempfile
-import logging
 import re
 import shlex
 import shutil
 import subprocess
+import tempfile
 import textwrap
-from typing import List, Set, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Set
 
-from snapcraft.plugins.v1 import PluginV1, _python, _ros
 from snapcraft import file_utils, formatting_utils
 from snapcraft.internal import common, errors, mangling, repo
 from snapcraft.internal.meta.package_repository import (
     PackageRepository,
     PackageRepositoryApt,
 )
+from snapcraft.plugins.v1 import PluginV1, _python, _ros
 
 if TYPE_CHECKING:
     from snapcraft.project import Project

--- a/snapcraft/plugins/v1/colcon.py
+++ b/snapcraft/plugins/v1/colcon.py
@@ -56,23 +56,23 @@ Additionally, this plugin uses the following plugin-specific keywords:
       quoting each argument with a leading space.
 """
 
-import contextlib
 import collections
+import contextlib
+import logging
 import os
 import pathlib
-import logging
 import re
 import shutil
 import textwrap
 from typing import List
 
-from snapcraft.plugins.v1 import PluginV1, _python, _ros
 from snapcraft import file_utils
 from snapcraft.internal import errors, mangling, repo
 from snapcraft.internal.meta.package_repository import (
     PackageRepository,
     PackageRepositoryApt,
 )
+from snapcraft.plugins.v1 import PluginV1, _python, _ros
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -31,16 +31,22 @@ from tests.unit.build_providers import BaseProviderBaseTest
 if sys.platform == "linux":
     import pylxd
 
+LXD_RUN_ENV_COMMAND = [
+    "env",
+    "SNAPCRAFT_HAS_TTY=False",
+]
+
 LXD_RUN_COMMAND_PREFIX = [
     "/snap/bin/lxc",
     "exec",
     "snapcraft-project-name",
     "--",
-    "env",
-    "SNAPCRAFT_BUILD_ENVIRONMENT=managed-host",
-    "HOME=/root",
-    "SNAPCRAFT_HAS_TTY=False",
-]
+] + LXD_RUN_ENV_COMMAND
+
+
+class GetEnv(_base_provider.Provider):
+    def _get_env_command(self):
+        return LXD_RUN_ENV_COMMAND.copy()
 
 
 class EnvSetup(_base_provider.Provider):
@@ -48,7 +54,7 @@ class EnvSetup(_base_provider.Provider):
         pass
 
 
-class LXDTestImpl(LXD, EnvSetup):
+class LXDTestImpl(LXD, GetEnv, EnvSetup):
     pass
 
 

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -19,7 +19,6 @@ import subprocess
 import sys
 from typing import Any, Dict
 from unittest import mock
-from unittest.mock import call
 
 from testtools.matchers import Equals, FileContains, FileExists
 
@@ -32,10 +31,16 @@ from tests.unit.build_providers import BaseProviderBaseTest
 if sys.platform == "linux":
     import pylxd
 
-
-class GetEnv(_base_provider.Provider):
-    def _get_env_command(self):
-        return ["env", "SNAPCRAFT_HAS_TTY=False"]
+LXD_RUN_COMMAND_PREFIX = [
+    "/snap/bin/lxc",
+    "exec",
+    "snapcraft-project-name",
+    "--",
+    "env",
+    "SNAPCRAFT_BUILD_ENVIRONMENT=managed-host",
+    "HOME=/root",
+    "SNAPCRAFT_HAS_TTY=False",
+]
 
 
 class EnvSetup(_base_provider.Provider):
@@ -43,7 +48,7 @@ class EnvSetup(_base_provider.Provider):
         pass
 
 
-class LXDTestImpl(LXD, GetEnv, EnvSetup):
+class LXDTestImpl(LXD, EnvSetup):
     pass
 
 
@@ -227,353 +232,52 @@ class LXDInitTest(LXDBaseTest):
         for args, kwargs in (
             self.check_output_mock.call_args_list + self.check_call_mock.call_args_list
         ):
-            assert args[0][0:4] == [
-                "/snap/bin/lxc",
-                "exec",
-                "snapcraft-project-name",
-                "--",
-            ]
+            assert args[0][0 : len(LXD_RUN_COMMAND_PREFIX)] == LXD_RUN_COMMAND_PREFIX
 
-        self.check_output_mock.assert_has_calls(
-            [
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "is-system-running",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "ln",
-                        "-sf",
-                        "/run/systemd/resolve/resolv.conf",
-                        "/etc/resolv.conf",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "enable",
-                        "systemd-resolved",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "enable",
-                        "systemd-networkd",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "restart",
-                        "systemd-resolved",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "restart",
-                        "systemd-networkd",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "getent",
-                        "hosts",
-                        "snapcraft.io",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "enable",
-                        "systemd-udevd",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "start",
-                        "systemd-udevd",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "systemctl",
-                        "start",
-                        "snapd",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "getent",
-                        "hosts",
-                        "snapcraft.io",
-                    ]
-                ),
-            ]
-        )
+        check_output_calls = [
+            args[0][len(LXD_RUN_COMMAND_PREFIX) :]
+            for args, kwargs in self.check_output_mock.call_args_list
+        ]
 
-        self.check_call_mock.assert_has_calls(
+        assert check_output_calls == [
+            ["systemctl", "is-system-running"],
+            ["ln", "-sf", "/run/systemd/resolve/resolv.conf", "/etc/resolv.conf"],
+            ["systemctl", "enable", "systemd-resolved"],
+            ["systemctl", "enable", "systemd-networkd"],
+            ["systemctl", "restart", "systemd-resolved"],
+            ["systemctl", "restart", "systemd-networkd"],
+            ["getent", "hosts", "snapcraft.io"],
+            ["systemctl", "enable", "systemd-udevd"],
+            ["systemctl", "start", "systemd-udevd"],
+            ["systemctl", "start", "snapd"],
+            ["getent", "hosts", "snapcraft.io"],
+        ]
+
+        check_call_calls = [
+            args[0][len(LXD_RUN_COMMAND_PREFIX) :]
+            for args, kwargs in self.check_call_mock.call_args_list
+        ]
+
+        assert check_call_calls == [
             [
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "mv",
-                        "/var/tmp/L2V0Yy9zeXN0ZW1kL25ldHdvcmsvMTAtZXRoMC5uZXR3b3Jr",
-                        "/etc/systemd/network/10-eth0.network",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "chown",
-                        "root:root",
-                        "/etc/systemd/network/10-eth0.network",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "chmod",
-                        "0644",
-                        "/etc/systemd/network/10-eth0.network",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "mv",
-                        "/var/tmp/L2V0Yy9ob3N0bmFtZQ==",
-                        "/etc/hostname",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "chown",
-                        "root:root",
-                        "/etc/hostname",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "chmod",
-                        "0644",
-                        "/etc/hostname",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "apt-get",
-                        "update",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "apt-get",
-                        "install",
-                        "dirmngr",
-                        "udev",
-                        "fuse",
-                        "--yes",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "apt-get",
-                        "install",
-                        "snapd",
-                        "sudo",
-                        "--yes",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "apt-get",
-                        "update",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "apt-get",
-                        "dist-upgrade",
-                        "--yes",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "apt-get",
-                        "install",
-                        "--yes",
-                        "apt-transport-https",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "snap",
-                        "unset",
-                        "system",
-                        "proxy.http",
-                    ]
-                ),
-                call(
-                    [
-                        "/snap/bin/lxc",
-                        "exec",
-                        "snapcraft-project-name",
-                        "--",
-                        "env",
-                        "SNAPCRAFT_HAS_TTY=False",
-                        "snap",
-                        "unset",
-                        "system",
-                        "proxy.https",
-                    ]
-                ),
-            ]
-        )
+                "mv",
+                "/var/tmp/L2V0Yy9zeXN0ZW1kL25ldHdvcmsvMTAtZXRoMC5uZXR3b3Jr",
+                "/etc/systemd/network/10-eth0.network",
+            ],
+            ["chown", "root:root", "/etc/systemd/network/10-eth0.network"],
+            ["chmod", "0644", "/etc/systemd/network/10-eth0.network"],
+            ["mv", "/var/tmp/L2V0Yy9ob3N0bmFtZQ==", "/etc/hostname"],
+            ["chown", "root:root", "/etc/hostname"],
+            ["chmod", "0644", "/etc/hostname"],
+            ["apt-get", "update"],
+            ["apt-get", "install", "dirmngr", "udev", "fuse", "--yes"],
+            ["apt-get", "install", "snapd", "sudo", "--yes"],
+            ["apt-get", "update"],
+            ["apt-get", "dist-upgrade", "--yes"],
+            ["apt-get", "install", "--yes", "apt-transport-https"],
+            ["snap", "unset", "system", "proxy.http"],
+            ["snap", "unset", "system", "proxy.https"],
+        ]
 
     def test_clean_project(self):
         instance = LXDTestImpl(project=self.project, echoer=self.echoer_mock)
@@ -730,15 +434,7 @@ class LXDLaunchedTest(LXDBaseTest):
         self.instance.shell()
 
         self.check_call_mock.assert_called_once_with(
-            [
-                "/snap/bin/lxc",
-                "exec",
-                "snapcraft-project-name",
-                "--",
-                "env",
-                "SNAPCRAFT_HAS_TTY=False",
-                "/bin/bash",
-            ]
+            [*LXD_RUN_COMMAND_PREFIX, "/bin/bash"]
         )
 
     def test_mount_project(self):
@@ -781,16 +477,7 @@ class LXDLaunchedTest(LXDBaseTest):
         self.instance._run(["ls", "/root/project"])
 
         self.check_call_mock.assert_called_once_with(
-            [
-                "/snap/bin/lxc",
-                "exec",
-                "snapcraft-project-name",
-                "--",
-                "env",
-                "SNAPCRAFT_HAS_TTY=False",
-                "ls",
-                "/root/project",
-            ]
+            [*LXD_RUN_COMMAND_PREFIX, "ls", "/root/project"]
         )
 
 

--- a/tests/unit/commands/snapcraftctl/test_build.py
+++ b/tests/unit/commands/snapcraftctl/test_build.py
@@ -20,7 +20,7 @@ from testtools.matchers import Contains, Equals, FileExists
 
 from snapcraft.internal import errors
 
-from . import CommandBaseTestCase, CommandBaseNoFifoTestCase
+from . import CommandBaseNoFifoTestCase, CommandBaseTestCase
 
 
 class BuildCommandTestCase(CommandBaseTestCase):

--- a/tests/unit/commands/snapcraftctl/test_set_grade.py
+++ b/tests/unit/commands/snapcraftctl/test_set_grade.py
@@ -20,7 +20,7 @@ from testtools.matchers import Contains, Equals, FileExists
 
 from snapcraft.internal import errors
 
-from . import CommandBaseTestCase, CommandBaseNoFifoTestCase
+from . import CommandBaseNoFifoTestCase, CommandBaseTestCase
 
 
 class SetGradeCommandTestCase(CommandBaseTestCase):

--- a/tests/unit/commands/snapcraftctl/test_set_version.py
+++ b/tests/unit/commands/snapcraftctl/test_set_version.py
@@ -20,7 +20,7 @@ from testtools.matchers import Contains, Equals, FileExists
 
 from snapcraft.internal import errors
 
-from . import CommandBaseTestCase, CommandBaseNoFifoTestCase
+from . import CommandBaseNoFifoTestCase, CommandBaseTestCase
 
 
 class SetVersionCommandTestCase(CommandBaseTestCase):

--- a/tests/unit/pluginhandler/test_runner.py
+++ b/tests/unit/pluginhandler/test_runner.py
@@ -18,8 +18,8 @@ import functools
 import os
 import subprocess
 from textwrap import dedent
-
 from unittest import mock
+
 from testtools.matchers import Contains, FileContains, FileExists
 
 from snapcraft.internal import errors

--- a/tests/unit/pluginhandler/test_scriptlets.py
+++ b/tests/unit/pluginhandler/test_scriptlets.py
@@ -18,16 +18,15 @@ import functools
 import os
 import subprocess
 import textwrap
+from unittest import mock
 
 import fixtures
 import testtools
-from testtools.matchers import Equals
 from testscenarios.scenarios import multiply_scenarios
-from unittest import mock
+from testtools.matchers import Equals
 
-from snapcraft.internal import errors
 from snapcraft import yaml_utils
-
+from snapcraft.internal import errors
 from tests import unit
 from tests.unit.commands import CommandBaseTestCase
 

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -23,9 +23,9 @@ from subprocess import CalledProcessError
 from unittest import mock
 from unittest.mock import call
 
+import fixtures
 import testtools
 from testtools.matchers import Equals
-import fixtures
 
 from snapcraft.internal import repo
 from snapcraft.internal.repo import errors


### PR DESCRIPTION
- Add common prefix args with defaults to be shared by all
  tests in `LXD_RUN_COMMAND_PREFIX`.

- Remove mock to fake the environment args to capture all
  flags relevant to LXD build provider.

- Make command checks much more concise using list
  comprehension to filter out the prefix args and/or
  using `LXD_RUN_COMMAND_PREFIX`.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
