### PR TITLE
package repositories: drop $SNAPCRAFT_APT_RELEASE variable

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -172,7 +172,7 @@
                     "uniqueItems": true,
                     "items": {
                         "type": "string",
-                        "description": "Deb repository suites to enable, e.g. 'xenial-updates, xenial-security'.  Supports '$SNAPCRAFT_APT_RELEASE' variable for snapcraft to populate base's release name (e.g. 'xenial')."
+                        "description": "Deb repository suites to enable, e.g. 'xenial-updates, xenial-security')."
                     }
                 },
                 "url": {

--- a/snapcraft/internal/project_loader/_extensions/ros1_noetic.py
+++ b/snapcraft/internal/project_loader/_extensions/ros1_noetic.py
@@ -58,7 +58,7 @@ class ExtensionImpl(Extension):
                     "formats": ["deb"],
                     "key-id": "C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654",
                     "key-server": "keyserver.ubuntu.com",
-                    "suites": ["$SNAPCRAFT_APT_RELEASE"],
+                    "suites": ["focal"],
                 }
             ]
         }

--- a/snapcraft/internal/project_loader/_extensions/ros2_foxy.py
+++ b/snapcraft/internal/project_loader/_extensions/ros2_foxy.py
@@ -60,7 +60,7 @@ class ExtensionImpl(Extension):
                     "formats": ["deb"],
                     "key-id": "C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654",
                     "key-server": "keyserver.ubuntu.com",
-                    "suites": ["$SNAPCRAFT_APT_RELEASE"],
+                    "suites": ["focal"],
                 }
             ]
         }

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -660,6 +660,7 @@ class Ubuntu(BaseRepo):
     def install_ppa(cls, *, keys_path: pathlib.Path, ppa: str) -> bool:
         owner, name = cls._get_ppa_parts(ppa)
         key_id = cls._get_launchpad_ppa_key_id(ppa)
+        codename = os_release.OsRelease().version_codename()
 
         return any(
             [
@@ -668,7 +669,7 @@ class Ubuntu(BaseRepo):
                     components=["main"],
                     deb_types=["deb"],
                     name=f"ppa-{owner}_{name}",
-                    suites=["$SNAPCRAFT_APT_RELEASE"],
+                    suites=[codename],
                     url=f"http://ppa.launchpad.net/{owner}/{name}/ubuntu",
                 ),
             ]
@@ -689,10 +690,9 @@ class Ubuntu(BaseRepo):
                 deb_text = " ".join(deb_types)
                 print(f"Types: {deb_text}", file=deb822)
 
-            url_text = _format_sources_list(url)
-            print(f"URIs: {url_text}", file=deb822)
+            print(f"URIs: {url}", file=deb822)
 
-            suites_text = _format_sources_list(" ".join(suites))
+            suites_text = " ".join(suites)
             print(f"Suites: {suites_text}", file=deb822)
 
             components_text = " ".join(components)
@@ -757,9 +757,3 @@ class Ubuntu(BaseRepo):
             subprocess.check_call(["dpkg-deb", "--extract", deb_path, extract_dir])
         except subprocess.CalledProcessError:
             raise errors.UnpackError(deb_path)
-
-
-def _format_sources_list(sources_list: str):
-    release = os_release.OsRelease().version_codename()
-
-    return sources_list.replace("$SNAPCRAFT_APT_RELEASE", release)

--- a/snapcraft/plugins/v1/catkin.py
+++ b/snapcraft/plugins/v1/catkin.py
@@ -72,24 +72,24 @@ Additionally, this plugin uses the following plugin-specific keywords:
 
 import contextlib
 import glob
+import logging
 import os
 import pathlib
-import tempfile
-import logging
 import re
 import shlex
 import shutil
 import subprocess
+import tempfile
 import textwrap
-from typing import List, Set, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Set
 
-from snapcraft.plugins.v1 import PluginV1, _python, _ros
 from snapcraft import file_utils, formatting_utils
-from snapcraft.internal import common, errors, mangling, repo
+from snapcraft.internal import common, errors, mangling, os_release, repo
 from snapcraft.internal.meta.package_repository import (
     PackageRepository,
     PackageRepositoryApt,
 )
+from snapcraft.plugins.v1 import PluginV1, _python, _ros
 
 if TYPE_CHECKING:
     from snapcraft.project import Project
@@ -279,13 +279,15 @@ class CatkinPlugin(PluginV1):
 
     @classmethod
     def get_required_package_repositories(self) -> List[PackageRepository]:
+        codename = os_release.OsRelease().version_codename()
+
         return [
             PackageRepositoryApt(
                 deb_types=["deb"],
                 components=["main"],
                 key_id="C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654",
                 url="http://packages.ros.org/ros/ubuntu/",
-                suites=["$SNAPCRAFT_APT_RELEASE"],
+                suites=[codename],
             )
         ]
 

--- a/snapcraft/plugins/v1/colcon.py
+++ b/snapcraft/plugins/v1/colcon.py
@@ -56,23 +56,23 @@ Additionally, this plugin uses the following plugin-specific keywords:
       quoting each argument with a leading space.
 """
 
-import contextlib
 import collections
+import contextlib
+import logging
 import os
 import pathlib
-import logging
 import re
 import shutil
 import textwrap
 from typing import List
 
-from snapcraft.plugins.v1 import PluginV1, _python, _ros
 from snapcraft import file_utils
-from snapcraft.internal import errors, mangling, repo
+from snapcraft.internal import errors, mangling, os_release, repo
 from snapcraft.internal.meta.package_repository import (
     PackageRepository,
     PackageRepositoryApt,
 )
+from snapcraft.plugins.v1 import PluginV1, _python, _ros
 
 logger = logging.getLogger(__name__)
 
@@ -226,14 +226,15 @@ class ColconPlugin(PluginV1):
         ]
 
     @classmethod
-    def get_required_package_repositories(self) -> List[PackageRepository]:
+    def get_required_package_repositories(cls) -> List[PackageRepository]:
+        codename = os_release.OsRelease().version_codename()
         return [
             PackageRepositoryApt(
                 deb_types=["deb"],
                 components=["main"],
                 key_id="C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654",
                 url="http://packages.ros.org/ros2/ubuntu",
-                suites=["$SNAPCRAFT_APT_RELEASE"],
+                suites=[codename],
             )
         ]
 

--- a/specifications/package-repositories.org
+++ b/specifications/package-repositories.org
@@ -171,8 +171,6 @@ the schema is to be considered stable.
 
   - *Notes:*
 
-    - Supports =$SNAPCRAFT_APT_RELEASE= variable for snapcraft to populate base's release name (e.g. =xenial=).
-
     - If your deb URL does not look like it has a suite defined, it is likely that the suite is =/=.
 
   - *Examples:*
@@ -182,8 +180,6 @@ the schema is to be considered stable.
     - =suites: [xenial]=
 
     - =suites: [xenial, xenial-updates]=
-
-    - =suites: [$SNAPCRAFT_APT_RELEASE, $SNAPCRAFT_APT_RELEASE-security]=
 
 ** Property: url (required)
 
@@ -212,7 +208,7 @@ package-repositories:
   - type: apt
     formats: [deb, deb-src]
     components: [main]
-    suites: [$SNAPCRAFT_APT_RELEASE]
+    suites: [xenial]
     key-id: 78E1918602959B9C59103100F1831DDAFC42E99D
     url: http://ppa.launchpad.net/snappy-dev/snapcraft-daily/ubuntu
 
@@ -240,7 +236,7 @@ package-repositories:
     name: default
     formats: [deb, deb-src]
     components: [main, multiverse, restricted, universe]
-    suites: [$SNAPCRAFT_APT_RELEASE, $SNAPCRAFT_APT_RELEASE-updates]
+    suites: [xenial, xenial-updates]
     key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
     url: http://archive.ubuntu.com/ubuntu
 
@@ -248,7 +244,7 @@ package-repositories:
     name: default-security
     formats: [deb, deb-src]
     components: [main, multiverse, restricted, universe]
-    suites: [$SNAPCRAFT_APT_RELEASE-security]
+    suites: [xenial-security]
     key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
     url: http://security.ubuntu.com/ubuntu
 #+END_SRC

--- a/tests/spread/general/snaps/test-apt-key-fingerprint/snap/snapcraft.yaml
+++ b/tests/spread/general/snaps/test-apt-key-fingerprint/snap/snapcraft.yaml
@@ -20,6 +20,6 @@ package-repositories:
   - type: apt
     formats: [deb, deb-src]
     components: [main]
-    suites: [$SNAPCRAFT_APT_RELEASE]
+    suites: [bionic]
     key-id: 78E1918602959B9C59103100F1831DDAFC42E99D
     url: http://ppa.launchpad.net/snappy-dev/snapcraft-daily/ubuntu

--- a/tests/spread/general/snaps/test-apt-key-name/snap/snapcraft.yaml
+++ b/tests/spread/general/snaps/test-apt-key-name/snap/snapcraft.yaml
@@ -20,6 +20,6 @@ package-repositories:
   - type: apt
     formats: [deb, deb-src]
     components: [main]
-    suites: [$SNAPCRAFT_APT_RELEASE]
+    suites: [bionic]
     key-id: snapcraft-daily
     url: http://ppa.launchpad.net/snappy-dev/snapcraft-daily/ubuntu

--- a/tests/spread/general/snaps/test-apt-keyserver/snap/snapcraft.yaml
+++ b/tests/spread/general/snaps/test-apt-keyserver/snap/snapcraft.yaml
@@ -20,6 +20,6 @@ package-repositories:
   - type: apt
     formats: [deb, deb-src]
     components: [main]
-    suites: [$SNAPCRAFT_APT_RELEASE]
+    suites: [bionic]
     key-id: f1831ddafc42e99d
     url: http://ppa.launchpad.net/snappy-dev/snapcraft-daily/ubuntu

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -1291,7 +1291,7 @@ class PackageManagement(ProjectBaseTest):
                     components: []
                     key-id: test-key-id
                     url: http://archive.ubuntu.com/ubuntu
-                    suites: [$SNAPCRAFT_APT_RELEASE, $SNAPCRAFT_APT_RELEASE-updates]
+                    suites: [bionic, bionic-updates]
                 """
             )
         )

--- a/tests/unit/project_loader/extensions/test_ros2_foxy.py
+++ b/tests/unit/project_loader/extensions/test_ros2_foxy.py
@@ -38,7 +38,7 @@ def test_extension(extension_class):
                 "formats": ["deb"],
                 "key-id": "C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654",
                 "key-server": "keyserver.ubuntu.com",
-                "suites": ["$SNAPCRAFT_APT_RELEASE"],
+                "suites": ["focal"],
                 "type": "apt",
                 "url": "http://repo.ros2.org/ubuntu/main",
             }


### PR DESCRIPTION
Remove prior to stabilization of package-repositories. We
can revisit in the future if required.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
