### PR TITLE
package repositories: fix case where formats is empty

### DIFF
--- a/snapcraft/internal/meta/package_repository.py
+++ b/snapcraft/internal/meta/package_repository.py
@@ -100,7 +100,7 @@ class PackageRepositoryApt(PackageRepository):
         *,
         architectures: Optional[List[str]] = None,
         components: List[str],
-        deb_types: Optional[List[str]] = None,
+        formats: Optional[List[str]] = None,
         key_id: str,
         key_server: Optional[str] = None,
         name: Optional[str] = None,
@@ -110,7 +110,7 @@ class PackageRepositoryApt(PackageRepository):
         self.type = "apt"
         self.architectures = architectures
         self.components = components
-        self.deb_types = deb_types
+        self.formats = formats
         self.key_id = key_id
         self.key_server = key_server
 
@@ -133,7 +133,7 @@ class PackageRepositoryApt(PackageRepository):
         new_sources: bool = repo.Ubuntu.install_sources(
             architectures=self.architectures,
             components=self.components,
-            deb_types=self.deb_types,
+            formats=self.formats,
             name=self.name,
             suites=self.suites,
             url=self.url,
@@ -149,8 +149,8 @@ class PackageRepositoryApt(PackageRepository):
 
         data["components"] = self.components
 
-        if self.deb_types:
-            data["formats"] = self.deb_types
+        if self.formats:
+            data["formats"] = self.formats
 
         data["key-id"] = self.key_id
 
@@ -172,7 +172,7 @@ class PackageRepositoryApt(PackageRepository):
 
         architectures = data_copy.pop("architectures", None)
         components = data_copy.pop("components", None)
-        deb_types = data_copy.pop("formats", None)
+        formats = data_copy.pop("formats", None)
         key_id = data_copy.pop("key-id", None)
         key_server = data_copy.pop("key-server", None)
         name = data_copy.pop("name", None)
@@ -200,8 +200,8 @@ class PackageRepositoryApt(PackageRepository):
                 f"invalid deb repository object: {data!r} (invalid components)"
             )
 
-        if deb_types is not None and any(
-            deb_type not in ["deb", "deb-src"] for deb_type in deb_types
+        if formats is not None and any(
+            format not in ["deb", "deb-src"] for format in formats
         ):
             raise RuntimeError(
                 f"invalid deb repository object: {data!r} (invalid formats)"
@@ -236,7 +236,7 @@ class PackageRepositoryApt(PackageRepository):
         return cls(
             architectures=architectures,
             components=components,
-            deb_types=deb_types,
+            formats=formats,
             key_id=key_id,
             key_server=key_server,
             name=name,

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -667,7 +667,7 @@ class Ubuntu(BaseRepo):
                 cls.install_gpg_key_id(keys_path=keys_path, key_id=key_id),
                 cls.install_sources(
                     components=["main"],
-                    deb_types=["deb"],
+                    formats=["deb"],
                     name=f"ppa-{owner}_{name}",
                     suites=[codename],
                     url=f"http://ppa.launchpad.net/{owner}/{name}/ubuntu",
@@ -681,14 +681,17 @@ class Ubuntu(BaseRepo):
         *,
         architectures: Optional[List[str]] = None,
         components: List[str],
-        deb_types: Optional[List[str]] = None,
+        formats: Optional[List[str]] = None,
         suites: List[str],
         url: str,
     ) -> str:
         with io.StringIO() as deb822:
-            if deb_types:
-                deb_text = " ".join(deb_types)
-                print(f"Types: {deb_text}", file=deb822)
+            if formats:
+                type_text = " ".join(formats)
+            else:
+                type_text = "deb"
+
+            print(f"Types: {type_text}", file=deb822)
 
             print(f"URIs: {url}", file=deb822)
 
@@ -713,7 +716,7 @@ class Ubuntu(BaseRepo):
         *,
         architectures: Optional[List[str]] = None,
         components: List[str],
-        deb_types: Optional[List[str]] = None,
+        formats: Optional[List[str]] = None,
         name: str,
         suites: List[str],
         url: str,
@@ -721,7 +724,7 @@ class Ubuntu(BaseRepo):
         config = cls._construct_deb822_source(
             architectures=architectures,
             components=components,
-            deb_types=deb_types,
+            formats=formats,
             suites=suites,
             url=url,
         )

--- a/snapcraft/plugins/v1/catkin.py
+++ b/snapcraft/plugins/v1/catkin.py
@@ -283,7 +283,7 @@ class CatkinPlugin(PluginV1):
 
         return [
             PackageRepositoryApt(
-                deb_types=["deb"],
+                formats=["deb"],
                 components=["main"],
                 key_id="C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654",
                 url="http://packages.ros.org/ros/ubuntu/",

--- a/snapcraft/plugins/v1/colcon.py
+++ b/snapcraft/plugins/v1/colcon.py
@@ -230,7 +230,7 @@ class ColconPlugin(PluginV1):
         codename = os_release.OsRelease().version_codename()
         return [
             PackageRepositoryApt(
-                deb_types=["deb"],
+                formats=["deb"],
                 components=["main"],
                 key_id="C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654",
                 url="http://packages.ros.org/ros2/ubuntu",

--- a/tests/unit/meta/test_package_repository.py
+++ b/tests/unit/meta/test_package_repository.py
@@ -76,7 +76,7 @@ class DebTests(unit.TestCase):
         repo = PackageRepositoryApt(
             architectures=["amd64", "i386"],
             components=["main", "multiverse"],
-            deb_types=["deb", "deb-src"],
+            formats=["deb", "deb-src"],
             key_id="test-key-id",
             key_server="keyserver.ubuntu.com",
             name="test-name",
@@ -105,7 +105,7 @@ class DebTests(unit.TestCase):
         repo = PackageRepositoryApt(
             architectures=["amd64", "i386"],
             components=["main", "multiverse"],
-            deb_types=["deb", "deb-src"],
+            formats=["deb", "deb-src"],
             key_id="test-key-id",
             key_server="keyserver.ubuntu.com",
             suites=["xenial", "xenial-updates"],

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -559,7 +559,7 @@ class TestUbuntuInstallRepo(unit.TestCase):
         new_sources = repo.Ubuntu.install_sources(
             architectures=["amd64", "arm64"],
             components=["test-component"],
-            deb_types=["deb", "deb-src"],
+            formats=["deb", "deb-src"],
             name="test-name",
             suites=["test-suite1", "test-suite2"],
             url="http://test.url/ubuntu",
@@ -571,6 +571,33 @@ class TestUbuntuInstallRepo(unit.TestCase):
                 [
                     call(
                         content=b"Types: deb deb-src\nURIs: http://test.url/ubuntu\nSuites: test-suite1 test-suite2\nComponents: test-component\nArchitectures: amd64 arm64\n",
+                        dst_path=Path(
+                            "/etc/apt/sources.list.d/snapcraft-test-name.sources"
+                        ),
+                    )
+                ]
+            ),
+        )
+
+        self.assertThat(new_sources, Equals(True))
+
+    @mock.patch("snapcraft.internal.repo._deb._sudo_write_file")
+    def test_install_sources_no_format(self, mock_write):
+        new_sources = repo.Ubuntu.install_sources(
+            architectures=["amd64", "arm64"],
+            components=["test-component"],
+            formats=None,
+            name="test-name",
+            suites=["test-suite1", "test-suite2"],
+            url="http://test.url/ubuntu",
+        )
+
+        self.assertThat(
+            mock_write.mock_calls,
+            Equals(
+                [
+                    call(
+                        content=b"Types: deb\nURIs: http://test.url/ubuntu\nSuites: test-suite1 test-suite2\nComponents: test-component\nArchitectures: amd64 arm64\n",
                         dst_path=Path(
                             "/etc/apt/sources.list.d/snapcraft-test-name.sources"
                         ),
@@ -626,7 +653,7 @@ class TestUbuntuInstallRepo(unit.TestCase):
                 [
                     call(
                         components=["main"],
-                        deb_types=["deb"],
+                        formats=["deb"],
                         name="ppa-test_ppa",
                         suites=["testy"],
                         url="http://ppa.launchpad.net/test/ppa/ubuntu",


### PR DESCRIPTION
It should assume "deb" if the list is empty or unspecified,
otherwise apt will complain.

Also rename remaining use of "deb_type" to "format" for
consistency.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
