### PR TITLE
package repositories: improve error handling

### DIFF
--- a/snapcraft/internal/meta/errors.py
+++ b/snapcraft/internal/meta/errors.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
+from typing import List, Optional
 
 from snapcraft import formatting_utils
 from snapcraft.internal import errors
@@ -177,6 +177,27 @@ class HookValidationError(errors.SnapcraftError):
 
     def __init__(self, *, hook_name: str, message: str) -> None:
         super().__init__(hook_name=hook_name, message=message)
+
+
+class PackageRepositoryValidationError(errors.SnapcraftException):
+    def __init__(
+        self, *, url: str, brief: str, resolution: Optional[str] = None
+    ) -> None:
+        self.url = url
+        self.brief = brief
+        self.resolution = resolution
+
+    def get_brief(self) -> str:
+        return f"Invalid package-repository for {self.url!r}: {self.brief}"
+
+    def get_resolution(self) -> str:
+        if self.resolution:
+            return self.resolution
+
+        return "You can verify package repository configuration according to the referenced documentation."
+
+    def get_docs_url(self) -> str:
+        return "https://snapcraft.io/docs/package-repositories"
 
 
 class SystemUsernamesValidationError(errors.SnapcraftException):

--- a/tests/unit/meta/test_errors.py
+++ b/tests/unit/meta/test_errors.py
@@ -197,3 +197,28 @@ class TestSnapcraftException:
         assert exception.get_details() == expected_details
         assert exception.get_docs_url() == expected_docs_url
         assert exception.get_reportable() == expected_reportable
+
+
+def test_PackageRepositoriesValidationError():
+    error = errors.PackageRepositoryValidationError(
+        url="http://foo", brief="some error", resolution="some way to fix"
+    )
+
+    assert (
+        error.get_brief() == "Invalid package-repository for 'http://foo': some error"
+    )
+    assert error.get_resolution() == "some way to fix"
+    assert error.get_details() is None
+    assert error.get_docs_url() == "https://snapcraft.io/docs/package-repositories"
+    assert error.get_reportable() is False
+
+
+def test_PackageRepositoriesValidationError_no_resolution():
+    error = errors.PackageRepositoryValidationError(
+        url="http://foo", brief="some error"
+    )
+
+    assert (
+        error.get_resolution()
+        == "You can verify package repository configuration according to the referenced documentation."
+    )

--- a/tests/unit/meta/test_package_repository.py
+++ b/tests/unit/meta/test_package_repository.py
@@ -65,7 +65,6 @@ class PpaTests(unit.TestCase):
         )
 
         assert error.brief == "Invalid keys present ('test')."
-        assert error.resolution == "You can remove the unsupported keys."
 
 
 class DebTests(unit.TestCase):
@@ -192,7 +191,6 @@ class DebTests(unit.TestCase):
         )
 
         assert error.brief == "Invalid keys present ('foo', 'foo2')."
-        assert error.resolution == "You can remove the unsupported keys."
 
 
 class RepoTests(unit.TestCase):

--- a/tests/unit/meta/test_package_repository.py
+++ b/tests/unit/meta/test_package_repository.py
@@ -14,8 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from testtools.matchers import Equals, MatchesRegex
+from testtools.matchers import Equals
 
+from snapcraft.internal.meta import errors
 from snapcraft.internal.meta.package_repository import (
     PackageRepository,
     PackageRepositoryApt,
@@ -34,41 +35,37 @@ class PpaTests(unit.TestCase):
         test_dict = {"type": "aptx", "ppa": "test/ppa"}
 
         error = self.assertRaises(
-            RuntimeError, PackageRepositoryAptPpa.unmarshal, test_dict
+            errors.PackageRepositoryValidationError,
+            PackageRepositoryAptPpa.unmarshal,
+            test_dict,
         )
-        self.assertThat(
-            str(error),
-            Equals(
-                "invalid ppa repository object {'type': 'aptx', 'ppa': 'test/ppa'} (type invalid)"
-            ),
-        )
+
+        assert error.brief == "Unsupported type 'aptx'."
+        assert error.resolution == "You can use type 'apt'."
 
     def test_invalid_apt_ppa(self):
-        test_dict = {"type": "apt", "ppx": "test/ppa"}
+        test_dict = {"type": "apt", "ppa": ""}
 
         error = self.assertRaises(
-            RuntimeError, PackageRepositoryAptPpa.unmarshal, test_dict
+            errors.PackageRepositoryValidationError,
+            PackageRepositoryAptPpa.unmarshal,
+            test_dict,
         )
-        self.assertThat(
-            str(error),
-            Equals(
-                "invalid ppa repository object {'type': 'apt', 'ppx': 'test/ppa'} (ppa missing)"
-            ),
-        )
+
+        assert error.brief == "Invalid PPA ''."
+        assert error.resolution == "You can update 'ppa' to a non-empty string."
 
     def test_invalid_apt_ppa_extras(self):
         test_dict = {"type": "apt", "ppa": "test/ppa", "test": "foo"}
 
         error = self.assertRaises(
-            RuntimeError, PackageRepositoryAptPpa.unmarshal, test_dict
+            errors.PackageRepositoryValidationError,
+            PackageRepositoryAptPpa.unmarshal,
+            test_dict,
         )
 
-        self.assertThat(
-            str(error),
-            Equals(
-                "invalid ppa repository object {'type': 'apt', 'ppa': 'test/ppa', 'test': 'foo'} (extra keys)"
-            ),
-        )
+        assert error.brief == "Invalid keys present ('test')."
+        assert error.resolution == "You can remove the unsupported keys."
 
 
 class DebTests(unit.TestCase):
@@ -143,13 +140,15 @@ class DebTests(unit.TestCase):
         }
 
         error = self.assertRaises(
-            RuntimeError, PackageRepositoryApt.unmarshal, test_dict
-        )
-        self.assertThat(
-            str(error), MatchesRegex("invalid deb repository object:.*(invalid type)")
+            errors.PackageRepositoryValidationError,
+            PackageRepositoryApt.unmarshal,
+            test_dict,
         )
 
-    def test_invalid_key(self):
+        assert error.brief == "Unsupported type 'aptx'."
+        assert error.resolution == "You can use type 'apt'."
+
+    def test_invalid_url(self):
         test_dict = {
             "architectures": ["amd64", "i386"],
             "components": ["main", "multiverse"],
@@ -159,15 +158,17 @@ class DebTests(unit.TestCase):
             "name": "test-name",
             "suites": ["xenial", "xenial-updates"],
             "type": "apt",
-            "xurl": "http://archive.ubuntu.com/ubuntu",
+            "url": "",
         }
 
         error = self.assertRaises(
-            RuntimeError, PackageRepositoryApt.unmarshal, test_dict
+            errors.PackageRepositoryValidationError,
+            PackageRepositoryApt.unmarshal,
+            test_dict,
         )
-        self.assertThat(
-            str(error), MatchesRegex("invalid deb repository object:.*(invalid url)")
-        )
+
+        assert error.brief == "Invalid URL ''."
+        assert error.resolution == "You can update 'url' to a non-empty string."
 
     def test_invalid_apt_extra_key(self):
         test_dict = {
@@ -181,14 +182,17 @@ class DebTests(unit.TestCase):
             "type": "apt",
             "url": "http://archive.ubuntu.com/ubuntu",
             "foo": "bar",
+            "foo2": "bar",
         }
 
         error = self.assertRaises(
-            RuntimeError, PackageRepositoryApt.unmarshal, test_dict
+            errors.PackageRepositoryValidationError,
+            PackageRepositoryApt.unmarshal,
+            test_dict,
         )
-        self.assertThat(
-            str(error), MatchesRegex("invalid deb repository object:.*(extra keys)")
-        )
+
+        assert error.brief == "Invalid keys present ('foo', 'foo2')."
+        assert error.resolution == "You can remove the unsupported keys."
 
 
 class RepoTests(unit.TestCase):


### PR DESCRIPTION
- Create PackageRepositoriesValidationError for errors
  pointing user to documentation page for package-repositories.

- Convert all validation RuntimeErrors to
  PackageRepositoriesValidationError.

- Add some trivial checks/handling for empty string url and ppa.

- Add trivial check for empty suites/components.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
