### PR TITLE
cli,plugins: assume that core22 base wants v2 plugins.

### DIFF
--- a/snapcraft/cli/discovery.py
+++ b/snapcraft/cli/discovery.py
@@ -43,10 +43,10 @@ def _try_get_base_from_project() -> str:
 
 
 def _get_modules_iter(base: str) -> Iterable:
-    if base == "core20":
-        modules_path = snapcraft.plugins.v2.__path__  # type: ignore  # mypy issue #1422
-    else:
+    if base in ("core", "core16", "core18"):
         modules_path = snapcraft.plugins.v1.__path__  # type: ignore  # mypy issue #1422
+    else:
+        modules_path = snapcraft.plugins.v2.__path__  # type: ignore  # mypy issue #1422
 
     # TODO make this part of plugin_finder.
     return pkgutil.iter_modules(modules_path)

--- a/snapcraft/plugins/_plugin_finder.py
+++ b/snapcraft/plugins/_plugin_finder.py
@@ -93,7 +93,7 @@ def get_plugin_for_base(plugin_name: str, *, build_base: str) -> PluginTypes:
     if build_base in ( "core", "core16", "core18"):
         plugin_version = "v1"
     elif build_base == "":
-        # This should never happen if 
+        # This should never happen when using build_base from Project.
         raise RuntimeError("'build_base' cannot be unset.")
         plugin_version = "v1"
 

--- a/snapcraft/plugins/_plugin_finder.py
+++ b/snapcraft/plugins/_plugin_finder.py
@@ -26,7 +26,7 @@ PluginTypes = Union[Type[v1.PluginV1], Type[v2.PluginV2]]
 # TODO: segregate into base specific plugins.
 if sys.platform == "linux" or TYPE_CHECKING:
     _PLUGINS: Dict[str, Dict[str, PluginTypes]] = {
-        "legacy": {
+        "v1": {
             "ant": v1.AntPlugin,
             "autotools": v1.AutotoolsPlugin,
             "catkin": v1.CatkinPlugin,
@@ -56,7 +56,7 @@ if sys.platform == "linux" or TYPE_CHECKING:
             "scons": v1.SconsPlugin,
             "waf": v1.WafPlugin,
         },
-        "core20": {
+        "v2": {
             "autotools": v2.AutotoolsPlugin,
             "catkin": v2.CatkinPlugin,
             "catkin-tools": v2.CatkinToolsPlugin,
@@ -74,7 +74,7 @@ if sys.platform == "linux" or TYPE_CHECKING:
     }
 else:
     # We cannot import the plugins on anything but linux.
-    _PLUGINS = {"legacy": {}}
+    _PLUGINS = {"v1": {}, "v2": {}}
 
 
 def get_plugin_for_base(plugin_name: str, *, build_base: str) -> PluginTypes:
@@ -86,12 +86,15 @@ def get_plugin_for_base(plugin_name: str, *, build_base: str) -> PluginTypes:
     """
     # TODO: segregate this more and remove the checks UnsupportedBase checks
     # from the plugins
-    if build_base in ("core", "core16", "core18"):
-        build_base = "legacy"
-    if build_base not in ("legacy", "core20"):
-        build_base = "core20"
+
+    # Default for unknown, and core20
+    plugin_version = "v2"
+    # Others use v1
+    if build_base in ("", "legacy", "core", "core16", "core18"):
+        plugin_version = "v1"
+
     try:
-        plugin_classes = _PLUGINS[build_base]
+        plugin_classes = _PLUGINS[plugin_version]
         return plugin_classes[plugin_name]
     except KeyError:
         raise errors.PluginError(f"unknown plugin: {plugin_name!r}")

--- a/snapcraft/plugins/_plugin_finder.py
+++ b/snapcraft/plugins/_plugin_finder.py
@@ -88,6 +88,8 @@ def get_plugin_for_base(plugin_name: str, *, build_base: str) -> PluginTypes:
     # from the plugins
     if build_base in ("core", "core16", "core18"):
         build_base = "legacy"
+    if build_base not in ("legacy", "core20"):
+        build_base = "core20"
     try:
         plugin_classes = _PLUGINS[build_base]
         return plugin_classes[plugin_name]

--- a/snapcraft/plugins/_plugin_finder.py
+++ b/snapcraft/plugins/_plugin_finder.py
@@ -90,7 +90,11 @@ def get_plugin_for_base(plugin_name: str, *, build_base: str) -> PluginTypes:
     # Default for unknown, and core20
     plugin_version = "v2"
     # Others use v1
-    if build_base in ("", "legacy", "core", "core16", "core18"):
+    if build_base in ( "core", "core16", "core18"):
+        plugin_version = "v1"
+    elif build_base == "":
+        # This should never happen if 
+        raise RuntimeError("'build_base' cannot be unset.")
         plugin_version = "v1"
 
     try:

--- a/snapcraft/plugins/_plugin_finder.py
+++ b/snapcraft/plugins/_plugin_finder.py
@@ -90,7 +90,7 @@ def get_plugin_for_base(plugin_name: str, *, build_base: str) -> PluginTypes:
     # Default for unknown, and core20
     plugin_version = "v2"
     # Others use v1
-    if build_base in ( "core", "core16", "core18"):
+    if build_base in ("core", "core16", "core18"):
         plugin_version = "v1"
     elif build_base == "":
         # This should never happen when using build_base from Project.

--- a/tests/unit/commands/test_list_plugins.py
+++ b/tests/unit/commands/test_list_plugins.py
@@ -118,7 +118,7 @@ class ListPluginsCommandTestCase(CommandBaseTestCase):
         )
 
     def test_core2y_list(self):
-        # Note that core2y is some future core, _not_ allowed to be used from cmdline
+        # Note that core2y is some future base, _not_ allowed to be used from cmdline
         # This tests that addition of the next base will use the latest version of plugins
         snapcraft.cli.discovery.list_plugins.callback("core2y")
         self.fake_iter_modules.mock.assert_called_once_with(

--- a/tests/unit/commands/test_list_plugins.py
+++ b/tests/unit/commands/test_list_plugins.py
@@ -118,13 +118,9 @@ class ListPluginsCommandTestCase(CommandBaseTestCase):
         )
 
     def test_core2y_list(self):
-        result = self.run_command([self.command_name, "--base", "core2y"])
-
-        self.assertThat(result.exit_code, Equals(0))
-        self.assertThat(
-            result.output, Contains("Displaying plugins available for 'core2y")
-        )
-
+        # Note that core2y is some future core, _not_ allowed to be used from cmdline
+        # This tests that addition of the next base will use the latest version of plugins
+        snapcraft.cli.discovery.list_plugins.callback("core2y")
         self.fake_iter_modules.mock.assert_called_once_with(
             snapcraft.plugins.v2.__path__
         )

--- a/tests/unit/commands/test_list_plugins.py
+++ b/tests/unit/commands/test_list_plugins.py
@@ -117,6 +117,18 @@ class ListPluginsCommandTestCase(CommandBaseTestCase):
             snapcraft.plugins.v2.__path__
         )
 
+    def test_core2y_list(self):
+        result = self.run_command([self.command_name, "--base", "core2y"])
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(
+            result.output, Contains("Displaying plugins available for 'core2y")
+        )
+
+        self.fake_iter_modules.mock.assert_called_once_with(
+            snapcraft.plugins.v2.__path__
+        )
+
     def test_list_plugins_non_tty(self):
         fake_terminal = fixture_setup.FakeTerminal(isatty=False)
         self.useFixture(fake_terminal)

--- a/tests/unit/pluginhandler/test_plugin_loader.py
+++ b/tests/unit/pluginhandler/test_plugin_loader.py
@@ -70,7 +70,7 @@ class InTreePluginsTest(unit.TestCase):
             )
             self.expectThat(plugin_handler.plugin, IsInstance(PluginV1))
 
-    def test_all_core20_v2(self):
+    def test_all_v2(self):
         self.useFixture(fixtures.MockPatch("jsonschema.validate"))
         for plugin_name in _PLUGINS["v2"]:
             plugin_handler = self.load_part(

--- a/tests/unit/pluginhandler/test_plugin_loader.py
+++ b/tests/unit/pluginhandler/test_plugin_loader.py
@@ -61,7 +61,7 @@ class NonLocalTest(unit.TestCase):
 
 
 class InTreePluginsTest(unit.TestCase):
-    def test_all_known_core18_v1(self):
+    def test_all_known_v1(self):
         # We don't want validation to take place here.
         self.useFixture(fixtures.MockPatch("jsonschema.validate"))
         for plugin_name in _PLUGINS["v1"]:

--- a/tests/unit/pluginhandler/test_plugin_loader.py
+++ b/tests/unit/pluginhandler/test_plugin_loader.py
@@ -61,18 +61,18 @@ class NonLocalTest(unit.TestCase):
 
 
 class InTreePluginsTest(unit.TestCase):
-    def test_all_known_legacy(self):
+    def test_all_known_core18_v1(self):
         # We don't want validation to take place here.
         self.useFixture(fixtures.MockPatch("jsonschema.validate"))
-        for plugin_name in _PLUGINS["legacy"]:
+        for plugin_name in _PLUGINS["v1"]:
             plugin_handler = self.load_part(
                 "test-part", plugin_name=plugin_name, base="core18"
             )
             self.expectThat(plugin_handler.plugin, IsInstance(PluginV1))
 
-    def test_all_core20(self):
+    def test_all_core20_v2(self):
         self.useFixture(fixtures.MockPatch("jsonschema.validate"))
-        for plugin_name in _PLUGINS["core20"]:
+        for plugin_name in _PLUGINS["v2"]:
             plugin_handler = self.load_part(
                 "test-part", plugin_name=plugin_name, base="core20"
             )


### PR DESCRIPTION
When trying to use build-base core22, some portions of cli/plugins
defaulted to legacy/v1 plugins, instead of v2.

Use a list of old cores, and assume anything new to be modern/v2.

Add a test for a "future core2y" to use v2 plugins.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
   - no, fails on groovy with new pyflakes?
- [x] Have you successfully run `./runtests.sh tests/unit`?
   - no, fails on groovy, as it's trying to run pytest (python2) not pytest-3 (python3)?