### PR TITLE
repo: move apt ppa helpers into apt_ppa module

### DIFF
--- a/snapcraft/internal/repo/apt_ppa.py
+++ b/snapcraft/internal/repo/apt_ppa.py
@@ -1,0 +1,50 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from typing import Tuple
+
+import lazr.restfulclient.errors
+from launchpadlib.launchpad import Launchpad
+
+from . import errors
+
+logger = logging.getLogger(__name__)
+
+
+def split_ppa_parts(*, ppa: str) -> Tuple[str, str]:
+    ppa_split = ppa.split("/")
+    if len(ppa_split) != 2:
+        raise errors.AptPPAInstallError(ppa=ppa, reason="invalid PPA format")
+    return ppa_split[0], ppa_split[1]
+
+
+def get_launchpad_ppa_key_id(*, ppa: str) -> str:
+    """Query Launchpad for PPA's key ID."""
+    owner, name = split_ppa_parts(ppa=ppa)
+    launchpad = Launchpad.login_anonymously("snapcraft", "production")
+    launchpad_url = f"~{owner}/+archive/{name}"
+
+    logger.debug(f"Loading launchpad url: {launchpad_url}")
+    try:
+        key_id = launchpad.load(launchpad_url).signing_key_fingerprint
+    except lazr.restfulclient.errors.NotFound as error:
+        raise errors.AptPPAInstallError(
+            ppa=ppa, reason="not found on launchpad"
+        ) from error
+
+    logger.debug(f"Retrieved launchpad PPA key ID: {key_id}")
+    return key_id

--- a/tests/unit/repo/test_apt_ppa.py
+++ b/tests/unit/repo/test_apt_ppa.py
@@ -1,0 +1,60 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from unittest import mock
+from unittest.mock import call
+
+import launchpadlib
+import pytest
+
+from snapcraft.internal.repo import apt_ppa, errors
+
+
+@pytest.fixture
+def mock_launchpad(autouse=True):
+    with mock.patch(
+        "snapcraft.internal.repo.apt_ppa.Launchpad",
+        spec=launchpadlib.launchpad.Launchpad,
+    ) as m:
+        m.login_anonymously.return_value.load.return_value.signing_key_fingerprint = (
+            "FAKE-PPA-SIGNING-KEY"
+        )
+        yield m
+
+
+def test_split_ppa_parts():
+    owner, name = apt_ppa.split_ppa_parts(ppa="test-owner/test-name")
+
+    assert owner == "test-owner"
+    assert name == "test-name"
+
+
+def test_split_ppa_parts_invalid():
+    with pytest.raises(errors.AptPPAInstallError) as exc_info:
+        apt_ppa.split_ppa_parts(ppa="ppa-missing-slash")
+
+    assert exc_info.value._ppa == "ppa-missing-slash"
+
+
+def test_get_launchpad_ppa_key_id(mock_launchpad,):
+    key_id = apt_ppa.get_launchpad_ppa_key_id(ppa="ppa-owner/ppa-name")
+
+    assert key_id == "FAKE-PPA-SIGNING-KEY"
+    assert mock_launchpad.mock_calls == [
+        call.login_anonymously("snapcraft", "production"),
+        call.login_anonymously().load("~ppa-owner/+archive/ppa-name"),
+    ]

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -609,7 +609,10 @@ class TestUbuntuInstallRepo(unit.TestCase):
         self.assertThat(new_sources, Equals(True))
 
     @mock.patch("subprocess.run")
-    @mock.patch("snapcraft.internal.repo._deb.Launchpad")
+    @mock.patch(
+        "snapcraft.internal.repo.apt_ppa.get_launchpad_ppa_key_id",
+        return_value="FAKE-PPA-KEY-ID",
+    )
     @mock.patch("snapcraft.internal.repo._deb.Ubuntu.install_sources")
     @mock.patch(
         "snapcraft.internal.os_release.OsRelease.version_codename", return_value="testy"
@@ -617,9 +620,6 @@ class TestUbuntuInstallRepo(unit.TestCase):
     def test_install_ppa(
         self, os_release, mock_install_sources, mock_launchpad, mock_run
     ):
-        mock_launchpad.login_anonymously.return_value.load.return_value.signing_key_fingerprint = (
-            "FAKE-SIGNING-KEY"
-        )
         repo.Ubuntu.install_ppa(keys_path=Path(self.path), ppa="test/ppa")
 
         env = os.environ.copy()
@@ -637,7 +637,7 @@ class TestUbuntuInstallRepo(unit.TestCase):
                         "--keyserver",
                         "keyserver.ubuntu.com",
                         "--recv-keys",
-                        "FAKE-SIGNING-KEY",
+                        "FAKE-PPA-KEY-ID",
                     ],
                     check=True,
                     stdout=subprocess.PIPE,
@@ -661,16 +661,6 @@ class TestUbuntuInstallRepo(unit.TestCase):
                 ]
             ),
         )
-
-    def test_install_ppa_invalid(self):
-        raised = self.assertRaises(
-            errors.AptPPAInstallError,
-            repo.Ubuntu.install_ppa,
-            keys_path=Path(self.path),
-            ppa="testppa",
-        )
-
-        self.assertThat(raised._ppa, Equals("testppa"))
 
     @mock.patch("subprocess.run")
     def test_apt_key_failure(self, mock_run):


### PR DESCRIPTION
This decouples the apt ppa helpers from the _deb module and
improves test coverage of the specific ppa helper functions.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
