### PR TITLE
build providers: set snapd proxy settings prior to _setup_snapcraft()

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -153,8 +153,7 @@ class Provider(abc.ABC):
         """Mount host source directory to target mount point."""
 
     def mount_project(self) -> None:
-        """Provider steps needed to make the project available to the instance.
-        """
+        """Provider steps needed to make the project available to the instance."""
         target = (self._get_home_directory() / "project").as_posix()
         self._mount(self.project._project_dir, target)
 
@@ -180,8 +179,7 @@ class Provider(abc.ABC):
         self._mount(src, target)
 
     def expose_prime(self) -> None:
-        """Provider steps needed to expose the prime directory to the host.
-        """
+        """Provider steps needed to expose the prime directory to the host."""
         os.makedirs(self.project.prime_dir, exist_ok=True)
         if not self._mount_prime_directory():
             self._run(command=["snapcraft", "clean", "--unprime"])
@@ -254,13 +252,14 @@ class Provider(abc.ABC):
             # image, but may be required for snapcraft to function.
             self._run(["apt-get", "install", "--yes", "apt-transport-https"])
 
+        # Always update snapd proxy settings to match current http(s) proxy
+        # settings.  All providers should have installed snapd upon completion
+        # of _setup_environment().
+        self._setup_snapd_proxy()
+
         # Always setup snapcraft after a start to bring it up to speed with
         # what is on the host.
         self._setup_snapcraft()
-
-        # Always update snapd proxy settings to match current http(s) proxy
-        # settings.
-        self._setup_snapd_proxy()
 
         # Install any CA certificates requested by the user.
         certs_path = self.build_provider_flags.get("SNAPCRAFT_ADD_CA_CERTIFICATES")

--- a/snapcraft/internal/build_providers/_lxd/_lxd.py
+++ b/snapcraft/internal/build_providers/_lxd/_lxd.py
@@ -14,21 +14,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from textwrap import dedent
 import logging
 import os
 import subprocess
 import sys
 import urllib.parse
 import warnings
+from textwrap import dedent
 from time import sleep
 from typing import Dict, Optional, Sequence
 
-from .._base_provider import Provider
-from .._base_provider import errors
-from ._images import get_image_source
 from snapcraft.internal import repo
 from snapcraft.internal.errors import SnapcraftEnvironmentError
+
+from .._base_provider import Provider, errors
+from ._images import get_image_source
 
 # LXD is only supported on Linux and causes issues when imported on Windows.
 # We conditionally import it and rely on ensure_provider() to check OS before
@@ -467,6 +467,7 @@ class LXD(Provider):
         # And only then install snapd.
         self._run(["apt-get", "install", "snapd", "sudo", "--yes"])
         self._run(["systemctl", "start", "snapd"], hide_output=True)
+        self._run(["snap", "wait", "system", "seed.loaded"], hide_output=True)
 
     def _setup_snapcraft(self):
         self._wait_for_network()

--- a/tests/unit/build_providers/lxd/test_lxd.py
+++ b/tests/unit/build_providers/lxd/test_lxd.py
@@ -233,7 +233,6 @@ class LXDInitTest(LXDBaseTest):
         container = self.fake_pylxd_client.containers.get(self.instance_name)
         container.start_mock.assert_called_once_with(wait=True)
         self.assertThat(container.save_mock.call_count, Equals(2))
-        self.assertThat(self.check_output_mock.call_count, Equals(11))
 
         for args, kwargs in (
             self.check_output_mock.call_args_list + self.check_call_mock.call_args_list
@@ -256,6 +255,7 @@ class LXDInitTest(LXDBaseTest):
             ["systemctl", "enable", "systemd-udevd"],
             ["systemctl", "start", "systemd-udevd"],
             ["systemctl", "start", "snapd"],
+            ["snap", "wait", "system", "seed.loaded"],
             ["getent", "hosts", "snapcraft.io"],
         ]
 


### PR DESCRIPTION
Snaps may be installed in _setup_snapcraft(), which runs before
_setup_snapd_proxy().

It works when snaps are injected from the host, but the snapd
proxy must be configured in case the host does not provide the
required snaps.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
