### PR TITLE
pyproject: add isort with black-compatible configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,12 @@ exclude = '''
   | prime
 )/
 '''
+
+[tool.isort]
+# black-compatible isort configuration
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 88

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -3,6 +3,7 @@ coverage==4.5.4
 flake8==3.7.9
 pyflakes==2.1.1
 fixtures==3.0.0
+isort==5.6.4
 mccabe==0.6.1
 mypy==0.770
 testscenarios==0.5.0


### PR DESCRIPTION
Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
