### PR TITLE
project_loader, formatting_utils: take empty env values into account

### DIFF
--- a/snapcraft/formatting_utils.py
+++ b/snapcraft/formatting_utils.py
@@ -39,15 +39,17 @@ def format_path_variable(
     :param str prepend: String to prepend to each path in the definition.
     :param str separator: String to place between each path in the definition.
     """
-
     if not paths:
         raise ValueError("Failed to format '${}': no paths supplied".format(envvar))
 
-    return '{envvar}="${envvar}{separator}{paths}"'.format(
-        envvar=envvar,
-        separator=separator,
-        paths=combine_paths(paths, prepend, separator),
-    )
+    combined_paths = combine_paths(paths, prepend, separator)
+
+    if separator.isspace():
+        formatted = f'{envvar}="${envvar}{separator}{combined_paths}"'
+    else:
+        formatted = f'{envvar}="${{{envvar}:+${envvar}{separator}}}{combined_paths}"'
+
+    return formatted
 
 
 def humanize_list(

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -471,7 +471,7 @@ class _SnapPackaging:
             ld_library_path_empty = {
                 name
                 for name, ld_env in app_environment.items()
-                if "$LD_LIBRARY_PATH" in ld_env
+                if "$LD_LIBRARY_PATH" in ld_env or "${LD_LIBRARY_PATH}" in ld_env
             }
         elif (
             root_ld_library_path is not None
@@ -570,13 +570,6 @@ class _SnapPackaging:
             env.append(
                 'export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"'
             )
-
-        env.append(
-            'echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && '
-            'echo "WARNING: an empty LD_LIBRARY_PATH has been set. '
-            "CWD will be added to the library path. This can cause "
-            'the incorrect library to be loaded."'
-        )
 
         return "\n".join(env)
 

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -92,6 +92,7 @@ def create_snap_packaging(project_config: _config.Config) -> str:
     packaging.setup_assets()
     packaging.generate_hook_wrappers()
     packaging.write_snap_directory()
+    packaging.warn_ld_library_paths()
 
     return packaging.meta_dir
 
@@ -453,6 +454,53 @@ class _SnapPackaging:
         package_snap_path = os.path.join(self.meta_dir, "snap.yaml")
         self._snap_meta.write_snap_yaml(path=package_snap_path)
 
+    def warn_ld_library_paths(self) -> None:
+        root_ld_library_path = self._snap_meta.environment.get("LD_LIBRARY_PATH")
+        # Dictionary of app names with LD_LIBRARY_PATH in their environment.
+        app_environment: Dict[str, str] = dict()
+
+        for app_name, app_props in self._config_data.get("apps", dict()).items():
+            with contextlib.suppress(KeyError):
+                app_environment[app_name] = app_props["environment"]["LD_LIBRARY_PATH"]
+
+        if root_ld_library_path is None and not app_environment:
+            return
+
+        ld_library_path_empty: Set[str] = set()
+        if root_ld_library_path is None and app_environment:
+            ld_library_path_empty = {
+                name
+                for name, ld_env in app_environment.items()
+                if "$LD_LIBRARY_PATH" in ld_env
+            }
+        elif (
+            root_ld_library_path is not None
+            and "LD_LIBRARY_PATH" in root_ld_library_path
+        ):
+            ld_library_path_empty = {"."}
+
+        _EMPTY_LD_LIBRARY_PATH_ITEM_PATTERN = re.compile("^:|::|:$")
+
+        for name, ld_env in app_environment.items():
+            if _EMPTY_LD_LIBRARY_PATH_ITEM_PATTERN.findall(ld_env):
+                ld_library_path_empty.add(name)
+
+        if (
+            root_ld_library_path is not None
+            and _EMPTY_LD_LIBRARY_PATH_ITEM_PATTERN.findall(root_ld_library_path)
+        ):
+            ld_library_path_empty.add(".")
+
+        if ld_library_path_empty:
+            logger.warning(
+                "CVE-2020-27348: A potentially empty LD_LIBRARY_PATH has been set for environment "
+                "in {}. "
+                "The current working directory will be added to the library path if empty. "
+                "This can cause unexpected libraries to be loaded.".format(
+                    formatting_utils.humanize_list(sorted(ld_library_path_empty), "and")
+                )
+            )
+
     def setup_assets(self) -> None:
         # We do _setup_from_setup first since it is legacy and let the
         # declarative items take over.
@@ -519,7 +567,16 @@ class _SnapPackaging:
             # All ELF files have had rpath and interpreter patched. Strip all LD_LIBRARY_PATH variables
             env = [e for e in env if not e.startswith("export LD_LIBRARY_PATH=")]
         else:
-            env.append('export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH"')
+            env.append(
+                'export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"'
+            )
+
+        env.append(
+            'echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && '
+            'echo "WARNING: an empty LD_LIBRARY_PATH has been set. '
+            "CWD will be added to the library path. This can cause "
+            'the incorrect library to be loaded."'
+        )
 
         return "\n".join(env)
 

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -351,7 +351,9 @@ class Config:
         if dependency_paths:
             # Add more specific LD_LIBRARY_PATH from the dependencies.
             env.append(
-                'LD_LIBRARY_PATH="' + ":".join(dependency_paths) + ':$LD_LIBRARY_PATH"'
+                'LD_LIBRARY_PATH="'
+                + ":".join(dependency_paths)
+                + '${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"'
             )
 
         return env

--- a/snapcraft/internal/project_loader/_env.py
+++ b/snapcraft/internal/project_loader/_env.py
@@ -26,10 +26,8 @@ def runtime_env(root: str, arch_triplet: str) -> List[str]:
 
     env.append(
         'PATH="'
-        + ":".join(
-            ["{0}/usr/sbin", "{0}/usr/bin", "{0}/sbin", "{0}/bin", "$PATH"]
-        ).format(root)
-        + '"'
+        + ":".join(["{0}/usr/sbin", "{0}/usr/bin", "{0}/sbin", "{0}/bin"]).format(root)
+        + '${PATH:+:$PATH}"'
     )
 
     # Add the default LD_LIBRARY_PATH

--- a/tests/unit/meta/test_meta.py
+++ b/tests/unit/meta/test_meta.py
@@ -1143,8 +1143,9 @@ class WriteSnapDirectoryTestCase(CreateBaseTestCase):
                 textwrap.dedent(
                     """\
             #!/bin/sh
-            export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
-            export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH"
+            export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin${PATH:+:$PATH}"
+            export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && echo "WARNING: an empty LD_LIBRARY_PATH has been set. CWD will be added to the library path. This can cause the incorrect library to be loaded."
             exec "$SNAP/snap/hooks/install" "$@"
             """
                 )
@@ -1261,7 +1262,8 @@ class GenerateHookWrappersTestCase(CreateBaseTestCase):
             """\
             #!/bin/sh
             export PATH=$SNAP/foo
-            export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH"
+            export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && echo "WARNING: an empty LD_LIBRARY_PATH has been set. CWD will be added to the library path. This can cause the incorrect library to be loaded."
             exec "$SNAP/snap/hooks/snap-hook" "$@"
         """
         )
@@ -1308,6 +1310,164 @@ class TestConfinement(CreateBaseTestCase):
             fake_logger.output,
             Contains("'confinement' property not specified: defaulting to 'strict'"),
         )
+
+
+class TestRootEnvironmentLibraryPathWarnings(CreateBaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.config_data["grade"] = "stable"
+
+        self.fake_logger = fixtures.FakeLogger(level=logging.WARNING)
+        self.useFixture(self.fake_logger)
+
+    def assert_warnings(self):
+        self.generate_meta_yaml()
+
+        self.assertThat(
+            self.fake_logger.output,
+            Contains(
+                "CVE-2020-27348: A potentially empty LD_LIBRARY_PATH has been set for environment "
+                "in '.'. The current working directory will be added to the library path if empty. "
+                "This can cause unexpected libraries to be loaded."
+            ),
+        )
+
+    def assert_no_warnings(self):
+        self.generate_meta_yaml()
+
+        self.assertThat(
+            self.fake_logger.output,
+            Not(
+                Contains(
+                    "CVE-2020-27348: A potentially empty LD_LIBRARY_PATH has been set for environment "
+                    "in '.'. The current working directory will be added to the library path if empty. "
+                    "This can cause unexpected libraries to be loaded."
+                )
+            ),
+        )
+
+    def test_root_ld_library_path(self):
+        self.config_data["environment"] = {"LD_LIBRARY_PATH": "/foo:$LD_LIBRARY_PATH"}
+
+        self.assert_warnings()
+
+    def test_root_ld_library_path_with_colon_at_start(self):
+        self.config_data["environment"] = {"LD_LIBRARY_PATH": ":/foo:/bar"}
+
+        self.assert_warnings()
+
+    def test_root_ld_library_path_with_colon_at_end(self):
+        self.config_data["environment"] = {"LD_LIBRARY_PATH": "/foo:/bar:"}
+
+        self.assert_warnings()
+
+    def test_root_ld_library_path_with_colon_at_middle(self):
+        self.config_data["environment"] = {"LD_LIBRARY_PATH": "/foo::/bar"}
+
+        self.assert_warnings()
+
+    def test_root_ld_library_path_good(self):
+        self.config_data["environment"] = {"LD_LIBRARY_PATH": "/foo:/bar"}
+
+        self.assert_no_warnings()
+
+
+class TestAppsEnvironmentLibraryPathWarnings(CreateBaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.config_data["grade"] = "stable"
+        self.config_data["apps"] = {
+            "app1": {"command": "foo"},
+            "app2": {"command": "bar"},
+        }
+
+        _create_file(os.path.join(self.prime_dir, "foo"), executable=True)
+        _create_file(os.path.join(self.prime_dir, "bar"), executable=True)
+
+        self.fake_logger = fixtures.FakeLogger(level=logging.WARNING)
+        self.useFixture(self.fake_logger)
+
+    def assert_warnings_both(self):
+        self.generate_meta_yaml()
+
+        self.assertThat(
+            self.fake_logger.output,
+            Contains(
+                "CVE-2020-27348: A potentially empty LD_LIBRARY_PATH has been set for environment "
+                "in 'app1' and 'app2'. The current working directory will be added to the library "
+                "path if empty. "
+                "This can cause unexpected libraries to be loaded."
+            ),
+        )
+
+    def assert_warnings_app1(self):
+        self.generate_meta_yaml()
+
+        self.assertThat(
+            self.fake_logger.output,
+            Contains(
+                "CVE-2020-27348: A potentially empty LD_LIBRARY_PATH has been set for environment "
+                "in 'app1'. The current working directory will be added to the library "
+                "path if empty. "
+                "This can cause unexpected libraries to be loaded."
+            ),
+        )
+
+    def assert_no_warnings(self):
+        self.generate_meta_yaml()
+
+        self.assertThat(
+            self.fake_logger.output,
+            Not(
+                Contains(
+                    "CVE-2020-27348: A potentially empty LD_LIBRARY_PATH has been set for environment "
+                    "in 'app1' and 'app2'. The current working directory will be added to the library "
+                    "path if empty. "
+                    "This can cause unexpected libraries to be loaded."
+                )
+            ),
+        )
+
+    def test_app_ld_library_path_app1(self):
+        self.config_data["apps"]["app1"]["environment"] = {
+            "LD_LIBRARY_PATH": "/foo:$LD_LIBRARY_PATH"
+        }
+
+        self.assert_warnings_app1()
+
+    def test_app_ld_library_path_app1_app2(self):
+        self.config_data["apps"]["app1"]["environment"] = {
+            "LD_LIBRARY_PATH": "/foo:$LD_LIBRARY_PATH"
+        }
+        self.config_data["apps"]["app2"]["environment"] = {
+            "LD_LIBRARY_PATH": "/foo:$LD_LIBRARY_PATH"
+        }
+
+        self.assert_warnings_both()
+
+    def test_root_ld_library_path_set(self):
+        self.config_data["environment"] = {"LD_LIBRARY_PATH": "/foo:/bar"}
+
+        self.config_data["apps"]["app1"]["environment"] = {
+            "LD_LIBRARY_PATH": "/foo:$LD_LIBRARY_PATH"
+        }
+        self.config_data["apps"]["app2"]["environment"] = {
+            "LD_LIBRARY_PATH": "/foo:$LD_LIBRARY_PATH"
+        }
+
+        self.assert_no_warnings()
+
+    def test_app_ld_library_path_colon_middle_app1_app2(self):
+        self.config_data["apps"]["app1"]["environment"] = {
+            "LD_LIBRARY_PATH": "/foo::/bar"
+        }
+        self.config_data["apps"]["app2"]["environment"] = {
+            "LD_LIBRARY_PATH": "/foo::/bar"
+        }
+
+        self.assert_warnings_both()
 
 
 class TestGrade(CreateBaseTestCase):

--- a/tests/unit/meta/test_meta.py
+++ b/tests/unit/meta/test_meta.py
@@ -1145,7 +1145,6 @@ class WriteSnapDirectoryTestCase(CreateBaseTestCase):
             #!/bin/sh
             export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin${PATH:+:$PATH}"
             export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-            echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && echo "WARNING: an empty LD_LIBRARY_PATH has been set. CWD will be added to the library path. This can cause the incorrect library to be loaded."
             exec "$SNAP/snap/hooks/install" "$@"
             """
                 )
@@ -1263,7 +1262,6 @@ class GenerateHookWrappersTestCase(CreateBaseTestCase):
             #!/bin/sh
             export PATH=$SNAP/foo
             export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-            echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && echo "WARNING: an empty LD_LIBRARY_PATH has been set. CWD will be added to the library path. This can cause the incorrect library to be loaded."
             exec "$SNAP/snap/hooks/snap-hook" "$@"
         """
         )
@@ -1352,6 +1350,11 @@ class TestRootEnvironmentLibraryPathWarnings(CreateBaseTestCase):
 
         self.assert_warnings()
 
+    def test_root_ld_library_path_braces(self):
+        self.config_data["environment"] = {"LD_LIBRARY_PATH": "/foo:${LD_LIBRARY_PATH}"}
+
+        self.assert_warnings()
+
     def test_root_ld_library_path_with_colon_at_start(self):
         self.config_data["environment"] = {"LD_LIBRARY_PATH": ":/foo:/bar"}
 
@@ -1433,6 +1436,13 @@ class TestAppsEnvironmentLibraryPathWarnings(CreateBaseTestCase):
     def test_app_ld_library_path_app1(self):
         self.config_data["apps"]["app1"]["environment"] = {
             "LD_LIBRARY_PATH": "/foo:$LD_LIBRARY_PATH"
+        }
+
+        self.assert_warnings_app1()
+
+    def test_app_ld_library_path_app1_braces(self):
+        self.config_data["apps"]["app1"]["environment"] = {
+            "LD_LIBRARY_PATH": "/foo:${LD_LIBRARY_PATH}"
         }
 
         self.assert_warnings_app1()

--- a/tests/unit/meta/test_snap_packaging.py
+++ b/tests/unit/meta/test_snap_packaging.py
@@ -71,7 +71,6 @@ class SnapPackagingRunnerTests(unit.TestCase):
             #!/bin/sh
             export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin${PATH:+:$PATH}"
             export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-            echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && echo "WARNING: an empty LD_LIBRARY_PATH has been set. CWD will be added to the library path. This can cause the incorrect library to be loaded."
             exec "$@"
             """
         ).lstrip()
@@ -148,7 +147,6 @@ class SnapPackagingRunnerTests(unit.TestCase):
             """
             export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin${PATH:+:$PATH}"
             export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-            echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && echo "WARNING: an empty LD_LIBRARY_PATH has been set. CWD will be added to the library path. This can cause the incorrect library to be loaded."
             """
         ).strip()
 
@@ -168,7 +166,6 @@ class SnapPackagingRunnerTests(unit.TestCase):
         expected_env = textwrap.dedent(
             """
             export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin${PATH:+:$PATH}"
-            echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && echo "WARNING: an empty LD_LIBRARY_PATH has been set. CWD will be added to the library path. This can cause the incorrect library to be loaded."
             """
         ).strip()
 

--- a/tests/unit/meta/test_snap_packaging.py
+++ b/tests/unit/meta/test_snap_packaging.py
@@ -69,8 +69,9 @@ class SnapPackagingRunnerTests(unit.TestCase):
         expected_runner = textwrap.dedent(
             """
             #!/bin/sh
-            export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
-            export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH"
+            export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin${PATH:+:$PATH}"
+            export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && echo "WARNING: an empty LD_LIBRARY_PATH has been set. CWD will be added to the library path. This can cause the incorrect library to be loaded."
             exec "$@"
             """
         ).lstrip()
@@ -145,8 +146,9 @@ class SnapPackagingRunnerTests(unit.TestCase):
 
         expected_env = textwrap.dedent(
             """
-            export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
-            export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH"
+            export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin${PATH:+:$PATH}"
+            export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && echo "WARNING: an empty LD_LIBRARY_PATH has been set. CWD will be added to the library path. This can cause the incorrect library to be loaded."
             """
         ).strip()
 
@@ -165,7 +167,8 @@ class SnapPackagingRunnerTests(unit.TestCase):
         # Verify that, since all parts are using patchelf, no LD_LIBRARY_PATH is set
         expected_env = textwrap.dedent(
             """
-            export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+            export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin${PATH:+:$PATH}"
+            echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && echo "WARNING: an empty LD_LIBRARY_PATH has been set. CWD will be added to the library path. This can cause the incorrect library to be loaded."
             """
         ).strip()
 

--- a/tests/unit/test_formatting_utils.py
+++ b/tests/unit/test_formatting_utils.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pytest
 from testtools.matchers import Equals
 
 from snapcraft import formatting_utils
@@ -56,23 +57,27 @@ class HumanizeListTestCases(unit.TestCase):
         self.assertThat(output, Equals("'bar', 'baz', 'foo', or 'qux'"))
 
 
-class FormatPathVariableTestCases(unit.TestCase):
-    def test_no_paths(self):
-        self.assertRaises(
-            ValueError, formatting_utils.format_path_variable, "PATH", None, "/usr", ":"
-        )
+def test_no_paths():
+    with pytest.raises(ValueError):
+        formatting_utils.format_path_variable("PATH", list(), "/usr", ":")
 
-    def test_one_path(self):
-        paths = ["/bin"]
-        output = formatting_utils.format_path_variable("PATH", paths, "/usr", ":")
-        self.assertThat(output, Equals('PATH="$PATH:/usr/bin"'))
 
-    def test_two_paths(self):
-        paths = ["/bin", "/sbin"]
-        output = formatting_utils.format_path_variable("PATH", paths, "/usr", ":")
-        self.assertThat(output, Equals('PATH="$PATH:/usr/bin:/usr/sbin"'))
+def test_one_path():
+    paths = ["/bin"]
+    output = formatting_utils.format_path_variable("PATH", paths, "/usr", ":")
 
-    def test_two_paths_other_paremeters(self):
-        paths = ["/usr/bin", "/usr/sbin"]
-        output = formatting_utils.format_path_variable("PATH", paths, "", ",")
-        self.assertThat(output, Equals('PATH="$PATH,/usr/bin,/usr/sbin"'))
+    assert output == 'PATH="${PATH:+$PATH:}/usr/bin"'
+
+
+def test_two_paths():
+    paths = ["/bin", "/sbin"]
+    output = formatting_utils.format_path_variable("PATH", paths, "/usr", ":")
+
+    assert output == 'PATH="${PATH:+$PATH:}/usr/bin:/usr/sbin"'
+
+
+def test_two_paths_other_paremeters():
+    paths = ["/usr/bin", "/usr/sbin"]
+    output = formatting_utils.format_path_variable("PATH", paths, "", ",")
+
+    assert output == 'PATH="${PATH:+$PATH,}/usr/bin,/usr/sbin"'


### PR DESCRIPTION
A general solution for a specific problem with LD_LIBRARY_PATH and
PATH where the env can contain two successive colons and that being
interpreted as the CWD.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
