### PR TITLE
Fix rosdep ROS_PYTHON_VERSION

### DIFF
--- a/snapcraft/plugins/v1/_ros/rosdep.py
+++ b/snapcraft/plugins/v1/_ros/rosdep.py
@@ -218,7 +218,10 @@ class Rosdep:
             self._rosdep_install_path, "usr", "lib", "python2.7", "dist-packages"
         )
 
-        env["ROS_PYTHON_VERSION"] = "2"
+        if self._ros_version == "2":
+            env["ROS_PYTHON_VERSION"] = "3"
+        else:
+            env["ROS_PYTHON_VERSION"] = "2"
 
         # By default, rosdep uses /etc/ros/rosdep to hold its sources list. We
         # don't want that here since we don't want to touch the host machine


### PR DESCRIPTION
Sets `ROS_PYTHON_VERSION=3` if `Rosdep` used for ROS 2 (colcon plugin V1).

Signed-off-by: artivis <deray.jeremie@gmail.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
