### PR TITLE
Create an extra 'build' directory for plugins

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -84,6 +84,7 @@ class PluginHandler:
         self.part_dir = os.path.join(project.parts_dir, self.name)
         self.part_source_dir = os.path.join(self.part_dir, "src")
         self.part_build_dir = os.path.join(self.part_dir, "build")
+        self.part_build_plugin_dir = os.path.join(self.part_dir, "build_plugin")
         self.part_install_dir = os.path.join(self.part_dir, "install")
         self.part_state_dir = os.path.join(self.part_dir, "state")
         self.part_snaps_dir = os.path.join(self.part_dir, "snaps")
@@ -258,6 +259,7 @@ class PluginHandler:
         dirs = [
             self.part_source_dir,
             self.part_build_dir,
+            self.part_build_plugin_dir,
             self.part_install_dir,
             self.part_state_dir,
             self._project.stage_dir,
@@ -582,6 +584,8 @@ class PluginHandler:
         ):
             if os.path.exists(self.part_build_dir):
                 shutil.rmtree(self.part_build_dir)
+            if os.path.exists(self.part_build_plugin_dir):
+                shutil.rmtree(self.part_build_plugin_dir)
 
             # No hard-links being used here in case the build process modifies
             # these files.

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -801,6 +801,9 @@ class PluginHandler:
         if os.path.exists(self.part_build_dir):
             shutil.rmtree(self.part_build_dir)
 
+        if os.path.exists(self.part_build_plugin_dir):
+            shutil.rmtree(self.part_build_plugin_dir)
+
         if os.path.exists(self.part_install_dir):
             shutil.rmtree(self.part_install_dir)
 

--- a/snapcraft/internal/pluginhandler/_part_environment.py
+++ b/snapcraft/internal/pluginhandler/_part_environment.py
@@ -88,6 +88,7 @@ def get_snapcraft_part_directory_environment(
             {
                 "SNAPCRAFT_PART_BUILD": part.part_build_dir,
                 "SNAPCRAFT_PART_BUILD_WORK": part.part_build_work_dir,
+                "SNAPCRAFT_PART_BUILD_PLUGIN": part.part_build_plugin_dir,
                 "SNAPCRAFT_PART_INSTALL": part.part_install_dir,
             }
         )


### PR DESCRIPTION
This PR introduces an extra 'build' directory `part-name/build_plugin` (and associated env var `SNAPCRAFT_PART_BUILD_PLUGIN`) for plugins that may need it.

This comes from the need to isolate the source files root directory (`part-name/build`) from the build artifacts for the ROS plugins.

Signed-off-by: artivis <deray.jeremie@gmail.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
