### PR TITLE
cli: allow snap-id for validate

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -1012,16 +1012,16 @@ def validate(
         # The Info API is not authed, so it cannot see private snaps.
         try:
             approved_data = store_client.cpi.get_info(gated_snap)
-            snap_id = approved_data.snap_id
+            approved_snap_id = approved_data.snap_id
         except storeapi.errors.SnapNotFoundError:
-            snap_id = gated_snap
+            approved_snap_id = gated_snap
 
         assertion_payload = {
             "type": "validation",
             "authority-id": authority_id,
             "series": DEFAULT_SERIES,
             "snap-id": snap_id,
-            "approved-snap-id": snap_id,
+            "approved-snap-id": approved_snap_id,
             "approved-snap-revision": rev,
             "timestamp": datetime.utcnow().isoformat() + "Z",
             "revoked": "false",

--- a/snapcraft/cli/assertions.py
+++ b/snapcraft/cli/assertions.py
@@ -94,7 +94,13 @@ def sign_build(snap_file: str, key_name: str, local: bool) -> None:
 @click.argument("validations", metavar="<validation>...", nargs=-1, required=True)
 @click.option("--key-name", metavar="<key-name>")
 def validate(snap_name: str, validations: list, key_name: str) -> None:
-    """Validate a gated snap."""
+    """Validate a gated snap.
+
+    Each validation can be presented with ether syntax:
+
+    -  <snap-name>=<revision>
+    -  <snap-id>=<revision>
+    """
     snapcraft.validate(snap_name, validations, key=key_name)
 
 

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -1428,7 +1428,7 @@ class FakeStoreAPIServer(base.BaseFakeServer):
 
     def put_snap_validations(self, request):
         snap_id = request.matchdict["snap_id"]
-        if snap_id == "good" or snap_id == "maybe-snap-id":
+        if snap_id == "good":
             payload = request.body
             response_code = 200
         elif snap_id == "err":

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -1428,7 +1428,7 @@ class FakeStoreAPIServer(base.BaseFakeServer):
 
     def put_snap_validations(self, request):
         snap_id = request.matchdict["snap_id"]
-        if snap_id == "good":
+        if snap_id == "good" or snap_id == "maybe-snap-id":
             payload = request.body
             response_code = 200
         elif snap_id == "err":

--- a/tests/fake_servers/search.py
+++ b/tests/fake_servers/search.py
@@ -115,18 +115,20 @@ class FakeStoreSearchServer(base.BaseFakeServer):
                     }
                 )
 
+        snap_id = f"{snap}-snap-id"
+
         return json.dumps(
             {
                 "channel-map": channel_map,
                 "snap": {
                     "name": snap,
-                    "snap-id": "good",
+                    "snap-id": snap_id,
                     "publisher": {
                         "id": snap + "-developer-id",
                         "validation": "unproven",
                     },
                 },
-                "snap-id": "good",
+                "snap-id": snap_id,
                 "name": snap,
             }
         ).encode()

--- a/tests/unit/commands/test_validate.py
+++ b/tests/unit/commands/test_validate.py
@@ -112,3 +112,8 @@ class ValidateCommandTestCase(StoreCommandsBaseTestCase):
         self.assertThat(
             result.output, Contains("You are required to login before continuing.")
         )
+
+    def test_validate_fallback_to_snap_id(self):
+        self.client.login("dummy", "test correct password")
+
+        self.run_command(["validate", "core", "maybe-snap-id=3"],)


### PR DESCRIPTION
Info API can only retrieve snap-id's for what is publicly available,
workaround the issue by allowing for using the snap-id as a fallback
to the snap-name.

LP: #1902913

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
