### PR TITLE
storeapi: import sort with isort

### DIFF
--- a/snapcraft/storeapi/__init__.py
+++ b/snapcraft/storeapi/__init__.py
@@ -18,9 +18,10 @@ import logging
 
 import pymacaroons
 
-from . import errors
-from . import channels  # noqa: F401
-from . import status  # noqa: F401
+from . import errors  # isort:skip
+from . import channels  # noqa: F401 isort:skip
+from . import status  # noqa: F401 isort:skip
+
 
 logger = logging.getLogger(__name__)
 

--- a/snapcraft/storeapi/_agent.py
+++ b/snapcraft/storeapi/_agent.py
@@ -18,8 +18,8 @@ import os
 import sys
 
 import snapcraft
-from snapcraft.internal.errors import OsReleaseNameError, OsReleaseVersionIdError
 from snapcraft.internal import os_release
+from snapcraft.internal.errors import OsReleaseNameError, OsReleaseVersionIdError
 
 
 def _is_ci_env():

--- a/snapcraft/storeapi/_client.py
+++ b/snapcraft/storeapi/_client.py
@@ -15,15 +15,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import os
+import urllib.parse
+
 import requests
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError, RetryError
 from requests.packages.urllib3.util.retry import Retry
-import urllib.parse
-import os
 
-from . import _agent
-from . import errors
+from . import _agent, errors
 
 # Set urllib3's logger to only emit errors, not warnings. Otherwise even
 # retries are printed, and they're nasty.

--- a/snapcraft/storeapi/_sca_client.py
+++ b/snapcraft/storeapi/_sca_client.py
@@ -6,13 +6,9 @@ from typing import List, Optional
 import requests
 from simplejson.scanner import JSONDecodeError
 
+from . import _macaroon_auth, _metadata, constants, errors, logger
 from ._client import Client
 from ._status_tracker import StatusTracker
-
-from . import _metadata
-from . import constants
-from . import errors
-from . import logger, _macaroon_auth
 
 
 class SCAClient(Client):

--- a/snapcraft/storeapi/_snap_index_client.py
+++ b/snapcraft/storeapi/_snap_index_client.py
@@ -18,12 +18,9 @@ import contextlib
 import os
 from typing import Dict
 
+from . import _macaroon_auth, constants, errors, logger
 from ._client import Client
 from .info import SnapInfo
-
-from . import errors
-from . import logger, _macaroon_auth
-from . import constants
 
 
 class SnapIndexClient(Client):

--- a/snapcraft/storeapi/_snap_v2_client.py
+++ b/snapcraft/storeapi/_snap_v2_client.py
@@ -18,11 +18,8 @@ import os
 
 import requests
 
+from . import _macaroon_auth, constants, errors
 from ._client import Client
-
-from . import constants
-from . import errors
-from . import _macaroon_auth
 from .v2 import channel_map, releases
 
 

--- a/snapcraft/storeapi/_sso_client.py
+++ b/snapcraft/storeapi/_sso_client.py
@@ -4,10 +4,8 @@ import os
 import requests
 from simplejson.scanner import JSONDecodeError
 
+from . import constants, errors
 from ._client import Client
-
-from . import errors
-from . import constants
 
 
 class SSOClient(Client):

--- a/snapcraft/storeapi/_status_tracker.py
+++ b/snapcraft/storeapi/_status_tracker.py
@@ -1,14 +1,12 @@
 import itertools
-from time import sleep
-from threading import Thread
 from queue import Queue
-
-from progressbar import AnimatedMarker, ProgressBar, UnknownLength
+from threading import Thread
+from time import sleep
 
 import requests
+from progressbar import AnimatedMarker, ProgressBar, UnknownLength
 
-from . import constants
-from . import errors
+from . import constants, errors
 
 
 class StatusTracker:

--- a/snapcraft/storeapi/_up_down_client.py
+++ b/snapcraft/storeapi/_up_down_client.py
@@ -1,9 +1,8 @@
 import os
 import urllib.parse
 
-from ._client import Client
-
 from . import constants
+from ._client import Client
 
 
 class UpDownClient(Client):

--- a/snapcraft/storeapi/_upload.py
+++ b/snapcraft/storeapi/_upload.py
@@ -14,15 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
 import functools
+import logging
 import os
 
 from progressbar import Bar, Percentage, ProgressBar
 from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
 
 from snapcraft.storeapi.errors import StoreUpDownError
-
 
 logger = logging.getLogger(__name__)
 

--- a/snapcraft/storeapi/assertions.py
+++ b/snapcraft/storeapi/assertions.py
@@ -18,9 +18,7 @@ import subprocess
 from copy import deepcopy
 from datetime import datetime
 
-from . import StoreClient
-from . import errors
-from . import constants
+from . import StoreClient, constants, errors
 
 
 class _BaseAssertion:

--- a/snapcraft/storeapi/channels.py
+++ b/snapcraft/storeapi/channels.py
@@ -16,7 +16,6 @@
 
 from typing import Optional, Type
 
-
 _VALID_RISKS = ["stable", "candidate", "beta", "edge"]
 
 

--- a/snapcraft/storeapi/constants.py
+++ b/snapcraft/storeapi/constants.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, unicode_literals
 
-
 # FIXME: snapcraft targets the '16' series, hardcode it until more choices
 # become available server side -- vila 2016-04-22
 DEFAULT_SERIES = "16"

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -15,16 +15,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import contextlib
-from http.client import responses
 import logging
-from requests.packages import urllib3
-from simplejson.scanner import JSONDecodeError
+from http.client import responses
 from typing import Dict, List, Optional
 
-from . import channels
-from . import status
-from snapcraft.internal.errors import SnapcraftError, SnapcraftException
+from requests.packages import urllib3
+from simplejson.scanner import JSONDecodeError
+
 from snapcraft import formatting_utils
+from snapcraft.internal.errors import SnapcraftError, SnapcraftException
+
+from . import channels, status
 
 logger = logging.getLogger(__name__)
 

--- a/snapcraft/storeapi/status.py
+++ b/snapcraft/storeapi/status.py
@@ -16,10 +16,7 @@
 
 from typing import Any, Dict, List, Optional, Set
 
-from . import channels
-from . import constants
-from . import errors
-
+from . import channels, constants, errors
 
 # FIXME Obtain link to docs
 """

--- a/snapcraft/storeapi/v2/_api_schema.py
+++ b/snapcraft/storeapi/v2/_api_schema.py
@@ -21,7 +21,6 @@
 
 from typing import Any, Dict
 
-
 # Version 14, found at: https://dashboard.snapcraft.io/docs/v2/en/snaps.html#snap-releases
 RELEASES_JSONSCHEMA: Dict[str, Any] = {
     "properties": {


### PR DESCRIPTION
Add some isort:skip statements where ordering matters in the
package's __init__.py.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
