### PR TITLE
extensions: correctly spell the GTK_USE_PORTAL variable

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/gnome_3_34.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_34.py
@@ -87,7 +87,7 @@ class ExtensionImpl(Extension):
             },
             "environment": {
                 "SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform",
-                "GTK_USE_PORTALS": "1",
+                "GTK_USE_PORTAL": "1",
             },
             "hooks": {
                 "configure": {

--- a/tests/unit/project_loader/extensions/test_gnome_3_34.py
+++ b/tests/unit/project_loader/extensions/test_gnome_3_34.py
@@ -57,7 +57,7 @@ class ExtensionTest(ProjectLoaderBaseTest, CommandBaseTestCase):
                     },
                     "environment": {
                         "SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform",
-                        "GTK_USE_PORTALS": "1",
+                        "GTK_USE_PORTAL": "1",
                     },
                     "hooks": {
                         "configure": {


### PR DESCRIPTION
Testing something in thunderbird I checked the environment and notice that GTK_USE_PORTALS was set, sounds like the intend is to define GTK_USE_PORTAL (which was recently manually added)? The commit should fix the issue