### PR TITLE
project schema tests: ensure json format checkers are loaded

### DIFF
--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -21,6 +21,8 @@ import pytest
 from testtools import TestCase
 from testtools.matchers import Contains, Equals
 
+# required for schema format checkers
+import snapcraft.internal.project_loader._config  # noqa: F401
 from snapcraft.project import errors
 from snapcraft.project._schema import Validator
 


### PR DESCRIPTION
Many of the tests would fail when not running the whole test suite.
This is because the json format checkers in project_loader._config
have not been loaded.  Ensure this module is imported, and mark the
import to ignore related warnings.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
