### PR TITLE
Fix colcon v1 workspace sourcing

### DIFF
--- a/snapcraft/plugins/v1/colcon.py
+++ b/snapcraft/plugins/v1/colcon.py
@@ -438,7 +438,7 @@ class ColconPlugin(PluginV1):
         """
         ).format(
             underlay_setup=os.path.join(underlaydir, "setup.sh"),
-            overlay_setup=os.path.join(overlaydir, "setup.sh"),
+            overlay_setup=os.path.join(overlaydir, "local_setup.sh"),
         )
 
         # We need to source ROS's setup.sh at this point. However, it accepts

--- a/tests/unit/plugins/v1/test_colcon.py
+++ b/tests/unit/plugins/v1/test_colcon.py
@@ -459,7 +459,7 @@ class ColconPluginTest(ColconPluginTestBase):
             sh_mock.assert_called_with(plugin.installdir)
 
         underlay_setup = os.path.join(plugin.options.colcon_rosdistro, "setup.sh")
-        overlay_setup = os.path.join("snap", "setup.sh")
+        overlay_setup = os.path.join("snap", "local_setup.sh")
 
         # Verify that the python executables and root are set before any setup.sh is
         # sourced. Also verify that the underlay setup is sourced before the overlay.
@@ -495,7 +495,7 @@ class ColconPluginTest(ColconPluginTestBase):
         )
         underlay_setup = os.path.join(underlay, "setup.sh")
         overlay = os.path.join("test-root", "opt", "ros", "snap")
-        overlay_setup = os.path.join(overlay, "setup.sh")
+        overlay_setup = os.path.join(overlay, "local_setup.sh")
 
         # Make sure $@ is zeroed, then setup.sh sourced, then $@ is restored
         lines_of_interest = [


### PR DESCRIPTION
Currently colcon v1 sources the wrong script for the overlay workspace preventing from running twice the build. This PR fixes this by sourcing the appropriate script as per [the documentation](https://index.ros.org/doc/ros2/Tutorials/Workspace/Creating-A-Workspace/#source-the-overlay).

related LP:#1866719

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
