### PR TITLE
extensions: use SNAP_COMMON instead of SNAP_DATA for fonts

### DIFF
--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -296,7 +296,7 @@ function make_user_fontconfig {
   # works: without it, fontconfig will try to write to the real user home
   # cachedir and be blocked by AppArmor.
   echo '  <cachedir prefix="xdg">fontconfig</cachedir>'
-  echo "  <cachedir>$SNAP_DATA/fontconfig</cachedir>"
+  echo "  <cachedir>$SNAP_COMMON/fontconfig</cachedir>"
   echo "</fontconfig>"
 }
 

--- a/extensions/desktop/common/fonts
+++ b/extensions/desktop/common/fonts
@@ -31,9 +31,9 @@ append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib"
 append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/lib"
 append_dir PATH "$SNAP_DESKTOP_RUNTIME/usr/bin"
 
-cat > "${SNAP_DATA}/fontconfig/fonts.conf" <<EOF
+cat > "${SNAP_COMMON}/fontconfig/fonts.conf" <<EOF
 <fontconfig>
-  <cachedir>${SNAP_DATA}/fontconfig</cachedir>
+  <cachedir>${SNAP_COMMON}/fontconfig</cachedir>
   <include ignore_missing="yes">/etc/fonts/fonts.conf</include>
 </fontconfig>
 EOF

--- a/extensions/desktop/common/fonts
+++ b/extensions/desktop/common/fonts
@@ -2,7 +2,7 @@
 
 set -e
 
-[ ! -d "${SNAP_DATA}/fontconfig" ] && mkdir -p "${SNAP_DATA}/fontconfig"
+[ ! -d "${SNAP_COMMON}/fontconfig" ] && mkdir -p "${SNAP_COMMON}/fontconfig"
 
 function append_dir() {
   local -n var="$1"
@@ -38,7 +38,7 @@ cat > "${SNAP_COMMON}/fontconfig/fonts.conf" <<EOF
 </fontconfig>
 EOF
 
-export FONTCONFIG_FILE="${SNAP_DATA}/fontconfig/fonts.conf"
+export FONTCONFIG_FILE="${SNAP_COMMON}/fontconfig/fonts.conf"
 
 "${SNAP_DESKTOP_RUNTIME}/usr/bin/fc-cache" --force --system-only --verbose
 


### PR DESCRIPTION
This mitigates issues with fonts breaking when snaps update in the
backround (yet to be fixed in snapd).

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
