### PR TITLE
tools: split local environment setup from environment-setup.sh

### DIFF
--- a/tools/environment-setup-local.sh
+++ b/tools/environment-setup-local.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -ex
+
+SNAPCRAFT_DIR=${SNAPCRAFT_DIR:=$( cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd )}
+SNAPCRAFT_VIRTUAL_ENV_DIR=${SNAPCRAFT_VIRTUAL_ENV_DIR:=${HOME}/.venv/snapcraft}
+
+sudo apt update
+sudo apt install --yes \
+    execstack \
+    g++ \
+    gcc \
+    libapt-pkg-dev \
+    libffi-dev \
+    libsodium-dev \
+    libssl-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    libyaml-dev \
+    make \
+    patchelf \
+    python3-dev \
+    python3-pip \
+    python3-venv \
+    rpm2cpio \
+    squashfs-tools
+
+# Create a virtual environment
+python3 -m venv "${SNAPCRAFT_VIRTUAL_ENV_DIR}"
+
+# Activate virtual environment
+# shellcheck source=/dev/null
+source "${SNAPCRAFT_VIRTUAL_ENV_DIR}/bin/activate"
+
+# Install python dependencies
+pip install --upgrade wheel
+pip install -r "${SNAPCRAFT_DIR}/requirements-devel.txt"
+pip install -r "${SNAPCRAFT_DIR}/requirements.txt"
+
+# Install the project for quick tests
+pip install --editable "${SNAPCRAFT_DIR}"
+
+# Install black to run static tests.
+sudo snap install black --beta
+
+# Install shellcheck for static tests.
+sudo snap install shellcheck
+
+echo "Virtual environment may be activated by running:"
+echo "source ${SNAPCRAFT_VIRTUAL_ENV_DIR}/bin/activate"

--- a/tools/environment-setup.sh
+++ b/tools/environment-setup.sh
@@ -1,19 +1,14 @@
-#!/bin/bash
+#!/bin/bash -e
 
-set -e
+SNAPCRAFT_DIR=${SNAPCRAFT_DIR:=$( cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd )}
 
-# Check if we are in snapcraft sources
-if [ ! -f snap/snapcraft.yaml ]; then
-    echo "This tool is meant to be run from the root of the snapcraft source tree."
-    exit 1
-fi
-
-if ! grep -q '^name: snapcraft$' snap/snapcraft.yaml; then
+# Check if SNAPCRAFT_DIR is pointing to snapcraft sources.
+if ! grep -q '^name: snapcraft$' "${SNAPCRAFT_DIR}/snap/snapcraft.yaml"; then
     echo "This is not the snapcraft.yaml for the snapcraft project"
     exit 1
 fi
 
-# Create the container
+# Create the container.
 if ! lxc info snapcraft-dev >/dev/null 2>&1; then
     lxc init ubuntu:18.04 snapcraft-dev
 fi
@@ -25,57 +20,26 @@ if ! lxc info snapcraft-dev | grep -q "Status: Running"; then
     lxc start snapcraft-dev
 fi
 
-# Wait for cloud-init before moving on
+# Wait for cloud-init before moving on.
 lxc exec snapcraft-dev -- cloud-init status --wait
 
-# Install apt dependencies
-lxc exec snapcraft-dev -- apt update
-lxc exec snapcraft-dev -- apt install --yes \
-    execstack \
-    g++ \
-    gcc \
-    libapt-pkg-dev \
-    libffi-dev \
-    libsodium-dev \
-    libssl-dev \
-    libxml2-dev \
-    libxslt1-dev \
-    libyaml-dev \
-    make \
-    patchelf \
-    python3-dev \
-    python3-pip \
-    python3-venv \
-    rpm2cpio \
-    squashfs-tools
+# First login for ubuntu user.
+lxc exec snapcraft-dev -- sudo -iu ubuntu bash -c true
 
-# Create a virtual environment and set it as default 
-lxc exec snapcraft-dev -- sudo -iu ubuntu python3 -m venv .venv/snapcraft
+# Now that /home/ubuntu has been used, add the project.
+if ! lxc config device show snapcraft-dev | grep -q snapcraft-project; then
+    lxc config device add snapcraft-dev snapcraft-project disk \
+        source="$SNAPCRAFT_DIR" path=/home/ubuntu/snapcraft
+fi
+
+# Install snapcraft and dependencies.
+lxc exec snapcraft-dev -- sudo -iu ubuntu /home/ubuntu/snapcraft/tools/environment-setup-local.sh
+
+# Set virtual environment on login.
 lxc exec snapcraft-dev -- sudo -iu ubuntu bash -c \
     "echo 'source /home/ubuntu/.venv/snapcraft/bin/activate' >> .profile"
 lxc exec snapcraft-dev -- sudo -iu ubuntu bash -c \
     "echo 'source /home/ubuntu/.venv/snapcraft/bin/activate' >> .bashrc"
-lxc exec snapcraft-dev -- sudo -iu ubuntu pip install --upgrade wheel setuptools
 
-# Now that /home/ubuntu has been used, add the project
-if ! lxc config device show snapcraft-dev | grep -q snapcraft-project; then
-    lxc config device add snapcraft-dev snapcraft-project disk \
-        source="$PWD" path=/home/ubuntu/snapcraft
-fi
-
-# Install python dependencies
-lxc exec snapcraft-dev -- sudo -iu ubuntu pip install \
-    -r snapcraft/requirements.txt \
-    -r snapcraft/requirements-devel.txt
-
-# Install the project for quick tests
-lxc exec snapcraft-dev -- sudo -iu ubuntu pip install --editable snapcraft
-
-# Install black to run static tests.
-lxc exec snapcraft-dev -- snap install black --beta
-
-# Install shellcheck for static tests.
-lxc exec snapcraft-dev -- snap install shellcheck
-
-echo "Environment ready, enter it by running: "
+echo "Container ready, enter it by running: "
 echo "lxc exec snapcraft-dev -- sudo -iu ubuntu bash"


### PR DESCRIPTION
Use script locations to find snapcraft directory so the script
may be run from anywhere.

Local virtual env setup is configurable using
SNAPCRAFT_VIRTUAL_ENV_DIR, but defaults to $HOME/.venv/snapcraft.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
