### PR TITLE
requirements: pin pip to 20.1.1 for devel

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -8,6 +8,7 @@ mccabe==0.6.1
 mypy==0.770
 testscenarios==0.5.0
 pexpect==4.7.0
+pip==20.1.1
 pycodestyle==2.5.0
 pyftpdlib==1.5.5
 pyramid==1.10.4


### PR DESCRIPTION
Until python-apt doesn't break on install, pin pip to the last
known working version.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
