### PR TITLE
sources: enable 7z, bzr, hg, svn, zip for non-linux

### DIFF
--- a/snapcraft/internal/sources/__init__.py
+++ b/snapcraft/internal/sources/__init__.py
@@ -112,11 +112,28 @@ if sys.platform == "linux":
         "": Local,
     }
 else:
+    from ._7z import SevenZip  # noqa
+    from ._bazaar import Bazaar  # noqa
     from ._git import Git  # noqa
     from ._local import Local  # noqa
+    from ._mercurial import Mercurial  # noqa
+    from ._subversion import Subversion  # noqa
     from ._tar import Tar  # noqa
+    from ._zip import Zip  # noqa
 
-    _source_handler = {"git": Git, "local": Local, "tar": Tar, "": Local}
+    _source_handler = {
+        "7z": SevenZip,
+        "bzr": Bazaar,
+        "git": Git,
+        "local": Local,
+        "hg": Mercurial,
+        "mercurial": Mercurial,
+        "subversion": Subversion,
+        "svn": Subversion,
+        "tar": Tar,
+        "zip": Zip,
+        "": Local,
+    }
 
 logging.getLogger("urllib3").setLevel(logging.CRITICAL)
 


### PR DESCRIPTION
Zip uses the python zipfile implementation.

The remainder will fail if the equivalent tools are not in the
user's path on the host. That error should be more obvious
than the "KeyError" uses are currently getting when using
remote-build.  Future work should update these source handlers
to use file_utils.get_host_tool_path() to perform this check
prior to executing the command.

LP: #1898877

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
