### PR TITLE
snap: get legacy branch from local

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -113,10 +113,10 @@ parts:
     after: [snapcraft-libs]
 
   legacy-snapcraft:
-    plugin: python
-    source: https://github.com/snapcore/snapcraft.git
+    source: .
+    source-type: git
     source-branch: legacy
-    source-depth: 1
+    plugin: python
     requirements:
         - requirements.txt
     override-build: |


### PR DESCRIPTION
This should speed things up!

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
