### PR TITLE
tests: make each static test available as a make target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ jobs:
         apt:
           packages:
             - libyaml-dev
+            - make
             - python3-yaml
             - python3.6-dev
         snaps:
@@ -29,7 +30,7 @@ jobs:
         - curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && python3 /tmp/get-pip.py --user
         - pip3 install --user -r requirements-devel.txt
       script:
-        - ./runtests.sh static
+        - make tests-static
     - stage: unit and snap
       name: unit tests
       script:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: autoformat-black
+autoformat-black:
+	black .
+
+.PHONY: test-black
+test-black:
+	black --check --diff .
+
+.PHONY: test-codespell
+test-codespell:
+	codespell --quiet-level 4 --ignore-words-list keyserver --skip '*.tar,*.xz,*.zip,*.bz2,*.7z,*.gz,*.deb,*.rpm,*.snap,*.gpg,*.pyc,*.png,*.ico,*.jar,changelog,.git,.hg,.mypy_cache,.tox,.venv,_build,buck-out,__pycache__,build,dist,.vscode,parts,stage,prime,test_appstream.py,./snapcraft.spec,./.direnv'
+
+.PHONY: test-flake8
+test-flake8:
+	python3 -m flake8 .
+
+.PHONY: test-mypy
+test-mypy:
+	mypy .
+
+.PHONY: test-shellcheck
+test-shellcheck:
+# Skip third-party gradlew script.
+	find . \( -name .git -o -name gradlew \) -prune -o -print0 | xargs -0 file -N | grep shell.script | cut -f1 -d: | xargs shellcheck
+	./tools/spread-shellcheck.py spread.yaml tests/spread/
+
+.PHONY: test-units
+test-units:
+	pytest --cov-report=xml --cov=snapcraft tests/unit
+
+.PHONY: tests
+tests: tests-static test-units
+
+.PHONY: tests-static
+tests-static: test-black test-codespell test-flake8 test-mypy test-shellcheck

--- a/TESTING.md
+++ b/TESTING.md
@@ -58,58 +58,33 @@ These tests are in the `snaps_tests` directory, with the sources for the test sn
 
 In order to run these tests suites, first you will need to set up your development environment. Follow the steps in the [Hacking guide](HACKING.md) to install for development.
 
-Then, you'll need a few more dependencies:
-
-    sudo apt install squashfs-tools xdelta3 bzr git mercurial subversion shellcheck
-
 ### Running the tests
 
 To run the static tests, execute:
 
-    ./runtests.sh static
+    make tests-static
 
 To run the unit tests, execute:
 
-    ./runtests.sh tests/unit
+    make test-units
 
-To run the integration tests, execute:
+...or use pytest directly:
 
-    ./runtests.sh tests/integration
+    pytest tests/unit
 
-You can also run a subsuite of the unit or integration suites specifying the path to the directory.
+You can also run a subsuite of the unit suites specifying the path to the directory.
 For example:
 
   * To run only the unit tests for the plugins:
 
     ```
-    ./runtests.sh tests/unit/plugins
+    pytest tests/unit/plugins
     ```
 
   * To run only the integration tests for the store:
 
     ```
-    ./runtests.sh tests/integration/store
-    ```
-
-And you can also run a single test module, test case or test function using the usual python way.
-For example:
-
-  * To run only the unit tests in the test_nodejs module:
-
-    ```
-    python3 -m unittest tests.unit.plugins.test_nodejs
-    ```
-
-  * To run only the unit tests in the NodePluginTest:
-
-    ```
-    python3 -m unittest tests.unit.plugins.test_nodejs.NodePluginTest
-    ```
-
-  * To run only the unit test named test_pull
-
-    ```
-    python3 -m unittest tests.unit.plugins.test_nodejs.NodePluginTest.test_pull
+    pytest tests/integration/store
     ```
 
 The snaps tests script has more complex arguments. For an explanation of them, run:
@@ -189,20 +164,6 @@ Then, you can run them using a local LXD as the backend with:
 Or, you can run them in google if you have a `SPREAD_GOOGLE_KEY`, with:
 
     SPREAD_GOOGLE_KEY={key} ./spread -v google:
-
-## External snaps tests
-
-The idea of the external snaps tests is to clone a repository external to snapcraft that contains a `snapcraft.yaml`, and check that snapcraft can build successfully that snap. There is a script in the snapcraft repo to help with this. You can see how to use it running:
-
-    python3 -m external_snaps_tests --help
-
-We have a suite of external snaps tests that runs each night using the latest snapcraft master to build a big variety of snaps. It is located in https://github.com/elopio/snapcraft-de-noche and you can add new snaps to the suite just by adding them to the `.travis.yml` file.
-
-## Reproducible builds tests
-
-This is an experimental suite, with still some details to define. The idea is to build a snap recording a manifest of all the details of the build. Then build the snap again, but this time using the manifest instead of the source `snapcraft.yaml`, and compare that both snaps are equal.
-
-Currently, the suite is using the snaps of the integration suite to check the reproducibility. It is located in https://github.com/elopio/snapcraft-reproducible/
 
 ## Testing arm
 


### PR DESCRIPTION
Instead of an all-or-nothing runtests, break up each test
into a discrete make target.  Add `static-tests` target to
execute all static tests.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
