### PR TITLE
tests: add missing mock for rust unit tests

### DIFF
--- a/tests/unit/plugins/v1/test_rust.py
+++ b/tests/unit/plugins/v1/test_rust.py
@@ -167,7 +167,9 @@ class TestRustPluginCrossCompile:
         project._snap_meta = meta.snap.Snap(name="test-snap", base="core18")
 
         plugin = rust.RustPlugin("test-part", options, project)
-        plugin.pull()
+
+        with mock.patch("os.path.exists", return_value=False):
+            plugin.pull()
 
         assert mock_run.call_count == 4
         mock_run.assert_has_calls(


### PR DESCRIPTION
If the rustup command exists on host, the cross compilation
unit tests will fail.  Simply mock the pull() step to return
False for os.path.exists().

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
