### PR TITLE
Add core20 to various /Dockerfile/s

### DIFF
--- a/docker/beta.Dockerfile
+++ b/docker/beta.Dockerfile
@@ -20,6 +20,12 @@ RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/sna
 RUN mkdir -p /snap/core18
 RUN unsquashfs -d /snap/core18/current core18.snap
 
+# Grab the core20 snap (which snapcraft uses as a base) from the stable channel
+# and unpack it in the proper place.
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core20' | jq '.download_url' -r) --output core20.snap
+RUN mkdir -p /snap/core20
+RUN unsquashfs -d /snap/core20/current core20.snap
+
 # Grab the snapcraft snap from the beta channel and unpack it in the proper
 # place.
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=beta' | jq '.download_url' -r) --output snapcraft.snap
@@ -39,6 +45,7 @@ RUN chmod +x /snap/bin/snapcraft
 FROM ubuntu:xenial
 COPY --from=builder /snap/core /snap/core
 COPY --from=builder /snap/core18 /snap/core18
+COPY --from=builder /snap/core20 /snap/core20
 COPY --from=builder /snap/snapcraft /snap/snapcraft
 COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
 

--- a/docker/candidate.Dockerfile
+++ b/docker/candidate.Dockerfile
@@ -20,6 +20,12 @@ RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/sna
 RUN mkdir -p /snap/core18
 RUN unsquashfs -d /snap/core18/current core18.snap
 
+# Grab the core20 snap (which snapcraft uses as a base) from the stable channel
+# and unpack it in the proper place.
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core20' | jq '.download_url' -r) --output core20.snap
+RUN mkdir -p /snap/core20
+RUN unsquashfs -d /snap/core20/current core20.snap
+
 # Grab the snapcraft snap from the candidate channel and unpack it in the proper
 # place.
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=candidate' | jq '.download_url' -r) --output snapcraft.snap
@@ -39,6 +45,7 @@ RUN chmod +x /snap/bin/snapcraft
 FROM ubuntu:xenial
 COPY --from=builder /snap/core /snap/core
 COPY --from=builder /snap/core18 /snap/core18
+COPY --from=builder /snap/core20 /snap/core20
 COPY --from=builder /snap/snapcraft /snap/snapcraft
 COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
 

--- a/docker/edge.Dockerfile
+++ b/docker/edge.Dockerfile
@@ -20,6 +20,12 @@ RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/sna
 RUN mkdir -p /snap/core18
 RUN unsquashfs -d /snap/core18/current core18.snap
 
+# Grab the core20 snap (which snapcraft uses as a base) from the stable channel
+# and unpack it in the proper place.
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core20' | jq '.download_url' -r) --output core20.snap
+RUN mkdir -p /snap/core20
+RUN unsquashfs -d /snap/core20/current core20.snap
+
 # Grab the snapcraft snap from the edge channel and unpack it in the proper
 # place.
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=edge' | jq '.download_url' -r) --output snapcraft.snap
@@ -39,6 +45,7 @@ RUN chmod +x /snap/bin/snapcraft
 FROM ubuntu:xenial
 COPY --from=builder /snap/core /snap/core
 COPY --from=builder /snap/core18 /snap/core18
+COPY --from=builder /snap/core20 /snap/core20
 COPY --from=builder /snap/snapcraft /snap/snapcraft
 COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
 

--- a/docker/stable.Dockerfile
+++ b/docker/stable.Dockerfile
@@ -20,6 +20,12 @@ RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/sna
 RUN mkdir -p /snap/core18
 RUN unsquashfs -d /snap/core18/current core18.snap
 
+# Grab the core20 snap (which snapcraft uses as a base) from the stable channel
+# and unpack it in the proper place.
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core20' | jq '.download_url' -r) --output core20.snap
+RUN mkdir -p /snap/core20
+RUN unsquashfs -d /snap/core20/current core20.snap
+
 # Grab the snapcraft snap from the stable channel and unpack it in the proper
 # place.
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=stable' | jq '.download_url' -r) --output snapcraft.snap
@@ -39,6 +45,7 @@ RUN chmod +x /snap/bin/snapcraft
 FROM ubuntu:xenial
 COPY --from=builder /snap/core /snap/core
 COPY --from=builder /snap/core18 /snap/core18
+COPY --from=builder /snap/core20 /snap/core20
 COPY --from=builder /snap/snapcraft /snap/snapcraft
 COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
 


### PR DESCRIPTION
With the docker additions, snapcraft can be used with `base: core20`. For googlability, this PR prevents errors such as:

```
Cannot find the linker to use for the target base 'core20'.
Please verify that the linker exists at the expected path '/snap/core20/current/lib64/ld-linux-x86-64.so.2' and try again. If the linker does not exist contact the author of the base (run `snap info core20` to get information for this base).
```

-----------

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

I don't know what to fill in at "Please add the Canonical Project Manager or contact"

- [x] Have you successfully run `./runtests.sh static`?

```
15 files would be reformatted, 655 files would be left unchanged.
```

but I didn't touch those files

- [ ] Have you successfully run `./runtests.sh tests/unit`?

Tried to make a Python env, but `pip install -r requirements.txt` failed with:

```
    ERROR: Command errored out with exit status 1:
     command: /home/martijn/code/snapcraft/env/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-uweji1s9/libnacl/setup.py'"'"'; __file__='"'"'/tmp/pip-install-uweji1s9/libnacl/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-uweji1s9/libnacl/pip-egg-info
         cwd: /tmp/pip-install-uweji1s9/libnacl/
    Complete output (20 lines):
    Traceback (most recent call last):
      File "/tmp/pip-install-uweji1s9/libnacl/libnacl/__init__.py", line 62, in _get_nacl
        return ctypes.cdll.LoadLibrary('tweetnacl.so')
      File "/usr/lib/python3.8/ctypes/__init__.py", line 451, in LoadLibrary
        return self._dlltype(name)
      File "/usr/lib/python3.8/ctypes/__init__.py", line 373, in __init__
        self._handle = _dlopen(self._name, mode)
    OSError: tweetnacl.so: cannot open shared object file: No such file or directory
```

I believe the tests aren't really relevant to this change though.