### PR TITLE
meta: don't overwrite preconfigured hooks with stubs

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -635,12 +635,14 @@ class _SnapPackaging:
         if hooks_with_command_chain or hooks_in_snap_dir:
             os.makedirs(hooks_dir, exist_ok=True)
 
+        # Create stub hooks as necessary.
         for hook in hooks_with_command_chain:
             hook_path = pathlib.Path(hooks_dir) / hook.hook_name
-            with hook_path.open("w") as hook_file:
-                print("#!/bin/sh", file=hook_file)
-            hook_path.chmod(0o755)
+            if not hook_path.exists():
+                hook_path.write_text("#!/bin/sh\n")
+                hook_path.chmod(0o755)
 
+        # Write wrapper hooks as necessary.
         for hook_name in hooks_in_snap_dir:
             file_path = os.path.join(snap_hooks_dir, hook_name)
             # Make sure the hook is executable

--- a/tests/fixture_setup/_fixtures.py
+++ b/tests/fixture_setup/_fixtures.py
@@ -579,7 +579,7 @@ class WithoutSnapInstalled(fixtures.Fixture):
 
 
 class SnapcraftYaml(fixtures.Fixture):
-    def __init__(
+    def __init__(  # noqa: C901
         self,
         path,
         name="test-snap",
@@ -591,6 +591,7 @@ class SnapcraftYaml(fixtures.Fixture):
         confinement="strict",
         architectures=None,
         apps=None,
+        hooks=None,
         parts=None,
         type="app",
     ):
@@ -623,6 +624,8 @@ class SnapcraftYaml(fixtures.Fixture):
             self.data["base"] = base
         if build_base is not None:
             self.data["build-base"] = build_base
+        if hooks is not None:
+            self.data["hooks"] = hooks
 
     def update_part(self, name, data):
         part = {name: data}


### PR DESCRIPTION
If a hook stub is being generated it would overwrite a primed
hook (in meta/hooks/).  Check for existence of script before
generating the stub.

Add some unit tests to get some needed coverage here, extending
the SnapcraftYaml fixture to include support for hooks.

LP: #1905072

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
