### PR TITLE
plugins v1: move build base test in v1 plugins to base class

### DIFF
--- a/snapcraft/plugins/v1/_plugin.py
+++ b/snapcraft/plugins/v1/_plugin.py
@@ -21,6 +21,7 @@ import shlex
 from subprocess import CalledProcessError
 from typing import List
 
+from snapcraft.project import Project
 from snapcraft.internal import common, errors
 from snapcraft.internal.meta.package_repository import PackageRepository
 
@@ -86,6 +87,15 @@ class PluginV1:
         self.options = options
 
         if project:
+            if isinstance(project, Project) and project._get_build_base() not in (
+                "core",
+                "core16",
+                "core18",
+            ):
+                raise errors.PluginBaseError(
+                    part_name=self.name, base=project._get_build_base()
+                )
+
             self.partdir = os.path.join(project.parts_dir, name)
         else:
             self.partdir = os.path.join(os.getcwd(), "parts", name)

--- a/snapcraft/plugins/v1/ant.py
+++ b/snapcraft/plugins/v1/ant.py
@@ -157,11 +157,6 @@ class AntPlugin(PluginV1):
         self._setup_base_tools(project._get_build_base())
 
     def _setup_base_tools(self, base):
-        if base not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(
-                part_name=self.name, base=self.project._get_build_base()
-            )
-
         if base in ("core", "core16"):
             valid_versions = ["8", "9"]
         elif base == "core18":

--- a/snapcraft/plugins/v1/catkin.py
+++ b/snapcraft/plugins/v1/catkin.py
@@ -307,9 +307,6 @@ class CatkinPlugin(PluginV1):
         super().__init__(name, options, project)
 
         base = self.project._get_build_base()
-        if base not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(part_name=self.name, base=base)
-
         self._rosdistro = _BASE_TO_ROS_RELEASE_MAP[base]
 
         self.build_packages.extend(["gcc", "g++", "libc6-dev", "make", "python-pip"])

--- a/snapcraft/plugins/v1/cmake.py
+++ b/snapcraft/plugins/v1/cmake.py
@@ -37,7 +37,6 @@ import logging
 import os
 from typing import List, Optional
 
-from snapcraft.internal import errors
 from snapcraft.plugins.v1 import PluginV1
 
 logger = logging.getLogger(name=__name__)
@@ -93,11 +92,6 @@ class CMakePlugin(PluginV1):
         super().__init__(name, options, project)
         self.build_packages.append("cmake")
         self.out_of_source_build = True
-
-        if project._get_build_base() not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(
-                part_name=self.name, base=project._get_build_base()
-            )
 
         if options.make_parameters:
             logger.warning("make-paramaters is deprecated, ignoring.")

--- a/snapcraft/plugins/v1/conda.py
+++ b/snapcraft/plugins/v1/conda.py
@@ -88,11 +88,6 @@ class CondaPlugin(PluginV1):
 
     def __init__(self, name, options, project) -> None:
         super().__init__(name, options, project)
-        if project._get_build_base() not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(
-                part_name=self.name, base=project._get_build_base()
-            )
-
         self._conda_home = os.path.join(self.partdir, "miniconda")
         self._miniconda_script = os.path.join(self.partdir, "miniconda.sh")
 

--- a/snapcraft/plugins/v1/crystal.py
+++ b/snapcraft/plugins/v1/crystal.py
@@ -73,11 +73,6 @@ class CrystalPlugin(PluginV1):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        if project._get_build_base() not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(
-                part_name=self.name, base=project._get_build_base()
-            )
-
         self.build_snaps.append("crystal/{}".format(self.options.crystal_channel))
         self.build_packages.extend(
             [

--- a/snapcraft/plugins/v1/flutter.py
+++ b/snapcraft/plugins/v1/flutter.py
@@ -39,7 +39,6 @@ import subprocess
 from typing import Any, Dict, List
 
 from snapcraft import file_utils
-from snapcraft.internal import errors
 from snapcraft.plugins.v1 import PluginV1
 
 logger = logging.getLogger(__name__)
@@ -68,11 +67,6 @@ class FlutterPlugin(PluginV1):
 
     def __init__(self, name, options, project) -> None:
         super().__init__(name, options, project)
-
-        if project._get_build_base() not in ("core", "core18"):
-            raise errors.PluginBaseError(
-                part_name=self.name, base=project._get_build_base()
-            )
 
         logger.warning(
             "The flutter plugin is currently in beta, its API may break. Use at your "

--- a/snapcraft/plugins/v1/godeps.py
+++ b/snapcraft/plugins/v1/godeps.py
@@ -56,7 +56,6 @@ import os
 import shutil
 
 from snapcraft import common
-from snapcraft.internal import errors
 from snapcraft.plugins.v1 import PluginV1
 
 logger = logging.getLogger(__name__)
@@ -103,20 +102,18 @@ class GodepsPlugin(PluginV1):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        self._setup_base_tools(options.go_channel, project._get_build_base())
+        self._setup_base_tools(options.go_channel)
 
         self._gopath = os.path.join(self.partdir, "go")
         self._gopath_src = os.path.join(self._gopath, "src")
         self._gopath_bin = os.path.join(self._gopath, "bin")
         self._gopath_pkg = os.path.join(self._gopath, "pkg")
 
-    def _setup_base_tools(self, go_channel, base):
+    def _setup_base_tools(self, go_channel):
         if go_channel:
             self.build_snaps.append("go/{}".format(go_channel))
-        elif base in ("core", "core16", "core18"):
-            self.build_packages.append("golang-go")
         else:
-            raise errors.PluginBaseError(part_name=self.name, base=base)
+            self.build_packages.append("golang-go")
 
     def _install_godeps(self) -> None:
         env = self._build_environment()

--- a/snapcraft/plugins/v1/gradle.py
+++ b/snapcraft/plugins/v1/gradle.py
@@ -149,11 +149,6 @@ class GradlePlugin(PluginV1):
         self._setup_base_tools(project._get_build_base())
 
     def _setup_base_tools(self, base):
-        if base not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(
-                part_name=self.name, base=self.project._get_build_base()
-            )
-
         if base in ("core", "core16"):
             valid_versions = ["8", "9"]
         elif base == "core18":

--- a/snapcraft/plugins/v1/kbuild.py
+++ b/snapcraft/plugins/v1/kbuild.py
@@ -66,7 +66,6 @@ import re
 import subprocess
 
 from snapcraft import file_utils
-from snapcraft.internal import errors
 from snapcraft.plugins.v1 import PluginV1
 
 logger = logging.getLogger(__name__)
@@ -102,12 +101,6 @@ class KBuildPlugin(PluginV1):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
-
-        if project._get_build_base() not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(
-                part_name=self.name, base=project._get_build_base()
-            )
-
         self.build_packages.extend(["bc", "gcc", "make"])
 
         self.make_targets = []

--- a/snapcraft/plugins/v1/make.py
+++ b/snapcraft/plugins/v1/make.py
@@ -50,7 +50,6 @@ Additionally, this plugin uses the following plugin-specific keywords:
 import os
 
 import snapcraft.common
-from snapcraft.internal import errors
 from snapcraft.plugins.v1 import PluginV1
 
 
@@ -89,12 +88,6 @@ class MakePlugin(PluginV1):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
-
-        if project._get_build_base() not in ("core", "core16", "core18", "core20"):
-            raise errors.PluginBaseError(
-                part_name=self.name, base=project._get_build_base()
-            )
-
         self.build_packages.append("make")
 
     def make(self, env=None):

--- a/snapcraft/plugins/v1/maven.py
+++ b/snapcraft/plugins/v1/maven.py
@@ -179,11 +179,6 @@ class MavenPlugin(PluginV1):
         self._setup_base_tools(project._get_build_base())
 
     def _setup_base_tools(self, base):
-        if base not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(
-                part_name=self.name, base=self.project._get_build_base()
-            )
-
         if base in ("core", "core16"):
             valid_versions = ["8", "9"]
         elif base == "core18":

--- a/snapcraft/plugins/v1/meson.py
+++ b/snapcraft/plugins/v1/meson.py
@@ -74,13 +74,11 @@ class MesonPlugin(PluginV1):
         self.mesonbuilddir = os.path.join(self.builddir, self.snapbuildname)
 
     def _setup_base_tools(self, base):
-        if base in ("core", "core16", "core18"):
-            self.build_packages.append("python3-pip")
-            self.build_packages.append("python3-setuptools")
-            self.build_packages.append("python3-wheel")
-            self.build_packages.append("ninja-build")
-        else:
-            raise errors.PluginBaseError(part_name=self.name, base=base)
+        self.build_packages.append("python3-pip")
+        self.build_packages.append("python3-setuptools")
+        self.build_packages.append("python3-wheel")
+        self.build_packages.append("ninja-build")
+
         if base == "core18":
             self.build_packages.append("python3-distutils")
 

--- a/snapcraft/plugins/v1/plainbox_provider.py
+++ b/snapcraft/plugins/v1/plainbox_provider.py
@@ -31,7 +31,7 @@ For more information check the 'plugins' topic for the former and the
 
 import os
 
-from snapcraft.internal import errors, mangling
+from snapcraft.internal import mangling
 from snapcraft.plugins.v1 import PluginV1
 
 
@@ -44,17 +44,13 @@ class PlainboxProviderPlugin(PluginV1):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
+        self._setup_base_tools()
 
-        self._setup_base_tools(project._get_build_base())
-
-    def _setup_base_tools(self, base):
-        if base in ("core", "core16", "core18"):
-            self.stage_packages.extend(
-                ["python3-pip", "python3-wheel", "python3-setuptools"]
-            )
-            self.build_packages.append("intltool")
-        else:
-            raise errors.PluginBaseError(part_name=self.name, base=base)
+    def _setup_base_tools(self):
+        self.stage_packages.extend(
+            ["python3-pip", "python3-wheel", "python3-setuptools"]
+        )
+        self.build_packages.append("intltool")
 
     def build(self):
         super().build()

--- a/snapcraft/plugins/v1/python.py
+++ b/snapcraft/plugins/v1/python.py
@@ -147,10 +147,7 @@ class PythonPlugin(PluginV1):
         elif self.options.python_version == "python3":
             python_base = "python3"
 
-        if self.project._get_build_base() in ("core", "core16", "core18"):
-            stage_packages = [python_base]
-        else:
-            stage_packages = []
+        stage_packages = [python_base]
 
         if self.project._get_build_base() == "core18" and python_base == "python3":
             stage_packages.append("{}-distutils".format(python_base))
@@ -185,7 +182,7 @@ class PythonPlugin(PluginV1):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        self._setup_base_tools(project._get_build_base())
+        self._setup_base_tools()
 
         self._manifest = collections.OrderedDict()
 
@@ -200,29 +197,26 @@ class PythonPlugin(PluginV1):
         self._python_major_version = match.group("major_version")
         self.__pip = None
 
-    def _setup_base_tools(self, base):
+    def _setup_base_tools(self):
         # NOTE: stage-packages are lazily loaded.
-        if base in ("core", "core16", "core18"):
-            if self.options.python_version == "python3":
-                self.build_packages.extend(
-                    [
-                        "python3-dev",
-                        "python3-pip",
-                        "python3-pkg-resources",
-                        "python3-setuptools",
-                    ]
-                )
-            elif self.options.python_version == "python2":
-                self.build_packages.extend(
-                    [
-                        "python-dev",
-                        "python-pip",
-                        "python-pkg-resources",
-                        "python-setuptools",
-                    ]
-                )
-        else:
-            raise errors.PluginBaseError(part_name=self.name, base=base)
+        if self.options.python_version == "python3":
+            self.build_packages.extend(
+                [
+                    "python3-dev",
+                    "python3-pip",
+                    "python3-pkg-resources",
+                    "python3-setuptools",
+                ]
+            )
+        elif self.options.python_version == "python2":
+            self.build_packages.extend(
+                [
+                    "python-dev",
+                    "python-pip",
+                    "python-pkg-resources",
+                    "python-setuptools",
+                ]
+            )
 
     def pull(self):
         super().pull()

--- a/snapcraft/plugins/v1/qmake.py
+++ b/snapcraft/plugins/v1/qmake.py
@@ -38,7 +38,6 @@ Additionally, this plugin uses the following plugin-specific keywords:
 import os
 
 from snapcraft import common
-from snapcraft.internal import errors
 from snapcraft.plugins.v1 import PluginV1
 
 
@@ -84,11 +83,6 @@ class QmakePlugin(PluginV1):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
-
-        if project._get_build_base() not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(
-                part_name=self.name, base=project._get_build_base()
-            )
 
         self.build_packages.append("make")
         if self.options.qt_version == "qt5":

--- a/snapcraft/plugins/v1/ruby.py
+++ b/snapcraft/plugins/v1/ruby.py
@@ -74,11 +74,6 @@ class RubyPlugin(PluginV1):
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
 
-        if project._get_build_base() not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(
-                part_name=self.name, base=project._get_build_base()
-            )
-
         # Beta Warning
         # Remove this comment and warning once ruby plugin is stable.
         logger.warning(

--- a/snapcraft/plugins/v1/rust.py
+++ b/snapcraft/plugins/v1/rust.py
@@ -89,12 +89,6 @@ class RustPlugin(PluginV1):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
-
-        if project._get_build_base() not in ("core", "core16", "core18"):
-            raise errors.PluginBaseError(
-                part_name=self.name, base=project._get_build_base()
-            )
-
         self.build_packages.extend(["gcc", "git", "curl", "file"])
         self._rustup_dir = os.path.expanduser(os.path.join("~", ".rustup"))
         self._cargo_dir = os.path.expanduser(os.path.join("~", ".cargo"))

--- a/snapcraft/plugins/v1/scons.py
+++ b/snapcraft/plugins/v1/scons.py
@@ -31,7 +31,6 @@ Additionally, this plugin uses the following plugin-specific keywords:
 
 import os
 
-from snapcraft.internal import errors
 from snapcraft.plugins.v1 import PluginV1
 
 
@@ -57,13 +56,10 @@ class SconsPlugin(PluginV1):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
-        self._setup_base_tools(project._get_build_base())
+        self._setup_base_tools()
 
-    def _setup_base_tools(self, base):
-        if base in ("core", "core16", "core18"):
-            self.build_packages.append("scons")
-        else:
-            raise errors.PluginBaseError(part_name=self.name, base=base)
+    def _setup_base_tools(self):
+        self.build_packages.append("scons")
 
     def build(self):
         super().build()

--- a/snapcraft/plugins/v1/waf.py
+++ b/snapcraft/plugins/v1/waf.py
@@ -32,7 +32,6 @@ In addition, this plugin uses the following plugin-specific keywords:
       ./waf --help
 """
 
-from snapcraft.internal import errors
 from snapcraft.plugins.v1 import PluginV1
 
 
@@ -55,14 +54,10 @@ class WafPlugin(PluginV1):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
+        self._setup_base_tools()
 
-        self._setup_base_tools(project._get_build_base())
-
-    def _setup_base_tools(self, base):
-        if base in ("core", "core16", "core18"):
-            self.build_packages.append("python-dev:native")
-        else:
-            raise errors.PluginBaseError(part_name=self.name, base=base)
+    def _setup_base_tools(self):
+        self.build_packages.append("python-dev:native")
 
     @classmethod
     def get_build_properties(cls):

--- a/tests/unit/plugins/v1/test_colcon.py
+++ b/tests/unit/plugins/v1/test_colcon.py
@@ -25,6 +25,7 @@ from testscenarios import multiply_scenarios
 from testtools.matchers import Contains, Equals, FileExists, HasLength, LessThan, Not
 
 from snapcraft import repo
+from snapcraft.internal import errors
 from snapcraft.plugins.v1 import _ros, colcon
 from tests import unit
 
@@ -123,7 +124,7 @@ class ColconPluginTest(ColconPluginTestBase):
         self.project._snap_meta.base = "unsupported-base"
 
         raised = self.assertRaises(
-            colcon.ColconPluginBaseError,
+            errors.PluginBaseError,
             colcon.ColconPlugin,
             "test-part",
             self.properties,
@@ -132,6 +133,20 @@ class ColconPluginTest(ColconPluginTestBase):
 
         self.assertThat(raised.part_name, Equals("test-part"))
         self.assertThat(raised.base, Equals("unsupported-base"))
+
+    def test_unsupported_base_and_rosdistro(self):
+        self.project._snap_meta.base = "core"
+
+        raised = self.assertRaises(
+            colcon.ColconPluginBaseError,
+            colcon.ColconPlugin,
+            "test-part",
+            self.properties,
+            self.project,
+        )
+
+        self.assertThat(raised.part_name, Equals("test-part"))
+        self.assertThat(raised.base, Equals("core"))
         self.assertThat(raised.rosdistro, Equals("crystal"))
 
     def test_schema_colcon_rosdistro(self):

--- a/tests/unit/plugins/v1/test_go.py
+++ b/tests/unit/plugins/v1/test_go.py
@@ -878,10 +878,9 @@ class GoPluginUnsupportedBase(PluginsV1BaseTestCase):
         self.options = Options()
 
     def test_unsupported_base_using_snap(self):
-        plugin = go.GoPlugin("test-part", self.options, self.project)
-
-        self.assertThat(plugin.build_packages, Not(Contains("golang-go")))
-        self.assertThat(plugin.build_snaps, Contains("go/latest/stable"))
+        self.assertRaises(
+            errors.PluginBaseError, go.GoPlugin, "test-part", self.options, self.project
+        )
 
     def test_unsupported_base_using_without_snap_raises(self):
         self.options.go_channel = ""

--- a/tests/unit/plugins/v1/test_godeps.py
+++ b/tests/unit/plugins/v1/test_godeps.py
@@ -411,10 +411,13 @@ class GodepsPluginUnsupportedBaseTest(PluginsV1BaseTestCase):
         self.options = Options()
 
     def test_unsupported_base_using_snap(self):
-        plugin = godeps.GodepsPlugin("test-part", self.options, self.project)
-
-        self.assertThat(plugin.build_packages, Not(Contains("golang-go")))
-        self.assertThat(plugin.build_snaps, Contains("go/latest/stable"))
+        self.assertRaises(
+            errors.PluginBaseError,
+            godeps.GodepsPlugin,
+            "test-part",
+            self.options,
+            self.project,
+        )
 
     def test_unsupported_base_using_without_snap_raises(self):
         self.options.go_channel = ""


### PR DESCRIPTION
V1 plugins can be used only if the build base is core, core16 or
core18. As an additional sanity check, each plugin tests for base
consistency. To clean that up, move the base check from each
individual plugin to the V1 plugin base class constructor.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

