### PR TITLE
project_loader, meta, formatting_utils: account for empty env

### DIFF
--- a/snapcraft/formatting_utils.py
+++ b/snapcraft/formatting_utils.py
@@ -39,15 +39,17 @@ def format_path_variable(
     :param str prepend: String to prepend to each path in the definition.
     :param str separator: String to place between each path in the definition.
     """
-
     if not paths:
         raise ValueError("Failed to format '${}': no paths supplied".format(envvar))
 
-    return '{envvar}="${envvar}{separator}{paths}"'.format(
-        envvar=envvar,
-        separator=separator,
-        paths=combine_paths(paths, prepend, separator),
-    )
+    combined_paths = combine_paths(paths, prepend, separator)
+
+    if separator.isspace():
+        formatted = f'{envvar}="${envvar}{separator}{combined_paths}"'
+    else:
+        formatted = f'{envvar}="${{{envvar}:+${envvar}{separator}}}{combined_paths}"'
+
+    return formatted
 
 
 def humanize_list(

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -431,7 +431,7 @@ class _SnapPackaging:
             ld_library_path_empty = {
                 name
                 for name, ld_env in app_environment.items()
-                if "$LD_LIBRARY_PATH" in ld_env
+                if "$LD_LIBRARY_PATH" in ld_env or "${LD_LIBRARY_PATH}" in ld_env
             }
         elif (
             root_ld_library_path is not None
@@ -577,13 +577,6 @@ class _SnapPackaging:
                 print("{}".format(assembled_env), file=f)
                 print(
                     'export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"',
-                    file=f,
-                )
-                print(
-                    'echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && '
-                    'echo "WARNING: an empty LD_LIBRARY_PATH has been set. '
-                    "CWD will be added to the library path. "
-                    'This can cause the incorrect library to be loaded."',
                     file=f,
                 )
             if cwd:

--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -111,6 +111,7 @@ def create_snap_packaging(project_config: _config.Config) -> str:
     packaging.setup_assets()
     packaging.generate_hook_wrappers()
     packaging.write_snap_directory()
+    packaging.warn_ld_library_paths()
 
     return packaging.meta_dir
 
@@ -412,6 +413,54 @@ class _SnapPackaging:
 
         self._record_manifest_and_source_snapcraft_yaml()
 
+    def warn_ld_library_paths(self) -> None:
+        root_environment = self._config_data.get("environment", dict())
+        root_ld_library_path = root_environment.get("LD_LIBRARY_PATH")
+        # Dictionary of app names with LD_LIBRARY_PATH in their environment.
+        app_environment: Dict[str, str] = dict()
+
+        for app_name, app_props in self._config_data.get("apps", dict()).items():
+            with contextlib.suppress(KeyError):
+                app_environment[app_name] = app_props["environment"]["LD_LIBRARY_PATH"]
+
+        if root_ld_library_path is None and not app_environment:
+            return
+
+        ld_library_path_empty: Set[str] = set()
+        if root_ld_library_path is None and app_environment:
+            ld_library_path_empty = {
+                name
+                for name, ld_env in app_environment.items()
+                if "$LD_LIBRARY_PATH" in ld_env
+            }
+        elif (
+            root_ld_library_path is not None
+            and "LD_LIBRARY_PATH" in root_ld_library_path
+        ):
+            ld_library_path_empty = {"."}
+
+        _EMPTY_LD_LIBRARY_PATH_ITEM_PATTERN = re.compile("^:|::|:$")
+
+        for name, ld_env in app_environment.items():
+            if _EMPTY_LD_LIBRARY_PATH_ITEM_PATTERN.findall(ld_env):
+                ld_library_path_empty.add(name)
+
+        if (
+            root_ld_library_path is not None
+            and _EMPTY_LD_LIBRARY_PATH_ITEM_PATTERN.findall(root_ld_library_path)
+        ):
+            ld_library_path_empty.add(".")
+
+        if ld_library_path_empty:
+            logger.warning(
+                "CVE-2020-27348: A potentially empty LD_LIBRARY_PATH has been set for environment "
+                "in {}. "
+                "The current working directory will be added to the library path if empty. "
+                "This can cause unexpected libraries to be loaded.".format(
+                    formatting_utils.humanize_list(sorted(ld_library_path_empty), "and")
+                )
+            )
+
     def generate_hook_wrappers(self) -> None:
         snap_hooks_dir = os.path.join(self._prime_dir, "snap", "hooks")
         hooks_dir = os.path.join(self._prime_dir, "meta", "hooks")
@@ -527,7 +576,15 @@ class _SnapPackaging:
             if assembled_env:
                 print("{}".format(assembled_env), file=f)
                 print(
-                    "export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH", file=f
+                    'export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"',
+                    file=f,
+                )
+                print(
+                    'echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && '
+                    'echo "WARNING: an empty LD_LIBRARY_PATH has been set. '
+                    "CWD will be added to the library path. "
+                    'This can cause the incorrect library to be loaded."',
+                    file=f,
                 )
             if cwd:
                 print("{}".format(cwd), file=f)

--- a/snapcraft/internal/project_loader/_config.py
+++ b/snapcraft/internal/project_loader/_config.py
@@ -301,7 +301,9 @@ class Config:
         if dependency_paths:
             # Add more specific LD_LIBRARY_PATH from the dependencies.
             env.append(
-                'LD_LIBRARY_PATH="' + ":".join(dependency_paths) + ':$LD_LIBRARY_PATH"'
+                'LD_LIBRARY_PATH="'
+                + ":".join(dependency_paths)
+                + '${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"'
             )
 
         return env

--- a/snapcraft/internal/project_loader/_env.py
+++ b/snapcraft/internal/project_loader/_env.py
@@ -25,10 +25,8 @@ def runtime_env(root: str, arch_triplet: str) -> List[str]:
 
     env.append(
         'PATH="'
-        + ":".join(
-            ["{0}/usr/sbin", "{0}/usr/bin", "{0}/sbin", "{0}/bin", "$PATH"]
-        ).format(root)
-        + '"'
+        + ":".join(["{0}/usr/sbin", "{0}/usr/bin", "{0}/sbin", "{0}/bin"]).format(root)
+        + '${PATH:+:$PATH}"'
     )
 
     # Add the default LD_LIBRARY_PATH

--- a/tests/unit/project_loader/test_environment.py
+++ b/tests/unit/project_loader/test_environment.py
@@ -26,8 +26,9 @@ from testtools.matchers import Contains, Equals, Not, StartsWith
 
 import snapcraft
 from snapcraft.internal import common
-from . import ProjectLoaderBaseTest
 from tests.fixture_setup.os_release import FakeOsRelease
+
+from . import ProjectLoaderBaseTest
 
 
 class EnvironmentTest(ProjectLoaderBaseTest):
@@ -55,10 +56,6 @@ class EnvironmentTest(ProjectLoaderBaseTest):
         lib_paths = [
             os.path.join(self.prime_dir, "lib"),
             os.path.join(self.prime_dir, "usr", "lib"),
-            os.path.join(self.prime_dir, "lib", project_config.project.arch_triplet),
-            os.path.join(
-                self.prime_dir, "usr", "lib", project_config.project.arch_triplet
-            ),
         ]
         for lib_path in lib_paths:
             os.makedirs(lib_path)
@@ -67,43 +64,25 @@ class EnvironmentTest(ProjectLoaderBaseTest):
         self.assertThat(
             environment,
             Contains(
-                'PATH="{0}/usr/sbin:{0}/usr/bin:{0}/sbin:{0}/bin:$PATH"'.format(
+                'PATH="{0}/usr/sbin:{0}/usr/bin:{0}/sbin:{0}/bin${{PATH:+:$PATH}}"'.format(
                     self.prime_dir
                 )
             ),
         )
-
-        # Ensure that LD_LIBRARY_PATH is present and it contains only the
-        # basics.
-        paths = []
-        for variable in environment:
-            if "LD_LIBRARY_PATH" in variable:
-                these_paths = variable.split("=")[1].strip()
-                paths.extend(these_paths.replace('"', "").split(":"))
-
-        self.assertTrue(len(paths) > 0, "Expected LD_LIBRARY_PATH to be in environment")
-
-        expected = (
-            os.path.join(self.prime_dir, i)
-            for i in [
-                "lib",
-                os.path.join("usr", "lib"),
-                os.path.join("lib", project_config.project.arch_triplet),
-                os.path.join("usr", "lib", project_config.project.arch_triplet),
-            ]
+        self.assertThat(
+            environment,
+            Contains(
+                'LD_LIBRARY_PATH="${{LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}}'
+                '{0}/lib:{0}/usr/lib"'.format(self.prime_dir)
+            ),
         )
-        for item in expected:
-            self.assertTrue(
-                item in paths,
-                "Expected LD_LIBRARY_PATH in {!r} to include {!r}".format(paths, item),
-            )
 
     def test_config_snap_environment_with_no_library_paths(self):
         project_config = self.make_snapcraft_project(self.snapcraft_yaml)
 
         environment = project_config.snap_env()
         self.assertTrue(
-            'PATH="{0}/usr/sbin:{0}/usr/bin:{0}/sbin:{0}/bin:$PATH"'.format(
+            'PATH="{0}/usr/sbin:{0}/usr/bin:{0}/sbin:{0}/bin${{PATH:+:$PATH}}"'.format(
                 self.prime_dir
             )
             in environment,
@@ -130,20 +109,14 @@ class EnvironmentTest(ProjectLoaderBaseTest):
 
         # Ensure that LD_LIBRARY_PATH is present and it contains the
         # extra dependency paths.
-        paths = []
-        for variable in project_config.snap_env():
-            if "LD_LIBRARY_PATH" in variable:
-                these_paths = variable.split("=")[1].strip()
-                paths.extend(these_paths.replace('"', "").split(":"))
-
-        self.assertTrue(len(paths) > 0, "Expected LD_LIBRARY_PATH to be in environment")
-
-        expected = (os.path.join(self.prime_dir, i) for i in ["lib1", "lib2"])
-        for item in expected:
-            self.assertTrue(
-                item in paths,
-                "Expected LD_LIBRARY_PATH ({!r}) to include {!r}".format(paths, item),
-            )
+        self.assertThat(
+            project_config.snap_env(),
+            Contains(
+                'LD_LIBRARY_PATH="{0}/lib1:{0}/lib2${{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}}"'.format(
+                    self.prime_dir
+                )
+            ),
+        )
 
     @mock.patch.object(
         snapcraft.internal.pluginhandler.PluginHandler, "get_primed_dependency_paths"
@@ -238,13 +211,13 @@ class EnvironmentTest(ProjectLoaderBaseTest):
                         'PATH="{0}/parts/main/install/usr/sbin:'
                         "{0}/parts/main/install/usr/bin:"
                         "{0}/parts/main/install/sbin:"
-                        '{0}/parts/main/install/bin:$PATH"'
+                        '{0}/parts/main/install/bin${{PATH:+:$PATH}}"'
                     ).format(self.path),
                     (
                         'PATH="{0}/stage/usr/sbin:'
                         "{0}/stage/usr/bin:"
                         "{0}/stage/sbin:"
-                        '{0}/stage/bin:$PATH"'
+                        '{0}/stage/bin${{PATH:+:$PATH}}"'
                     ).format(self.path),
                     'PERL5LIB="{0}/stage/usr/share/perl5/"'.format(self.path),
                     'SNAPCRAFT_ARCH_TRIPLET="{}"'.format(
@@ -361,42 +334,39 @@ class EnvironmentTest(ProjectLoaderBaseTest):
         project_config = self.make_snapcraft_project(self.snapcraft_yaml)
         environment = project_config.stage_env()
 
-        self.assertTrue(
-            'PATH="{0}/usr/sbin:{0}/usr/bin:{0}/sbin:{0}/bin:$PATH"'.format(
+        self.assertIn(
+            'PATH="{0}/usr/sbin:{0}/usr/bin:{0}/sbin:{0}/bin${{PATH:+:$PATH}}"'.format(
                 self.stage_dir
-            )
-            in environment
+            ),
+            environment,
         )
-        self.assertTrue(
-            'LD_LIBRARY_PATH="$LD_LIBRARY_PATH:{stage_dir}/lib:'
+        self.assertIn(
+            'LD_LIBRARY_PATH="${{LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}}{stage_dir}/lib:'
             "{stage_dir}/usr/lib:{stage_dir}/lib/{arch_triplet}:"
             '{stage_dir}/usr/lib/{arch_triplet}"'.format(
                 stage_dir=self.stage_dir,
                 arch_triplet=project_config.project.arch_triplet,
-            )
-            in environment,
-            "Current environment is {!r}".format(environment),
+            ),
+            environment,
         )
-        self.assertTrue(
+        self.assertIn(
             'CFLAGS="$CFLAGS -I{stage_dir}/include -I{stage_dir}/usr/include '
             "-I{stage_dir}/include/{arch_triplet} "
             '-I{stage_dir}/usr/include/{arch_triplet}"'.format(
                 stage_dir=self.stage_dir,
                 arch_triplet=project_config.project.arch_triplet,
-            )
-            in environment,
-            "Current environment is {!r}".format(environment),
+            ),
+            environment,
         )
-        self.assertTrue(
+        self.assertIn(
             'CPPFLAGS="$CPPFLAGS -I{stage_dir}/include '
             "-I{stage_dir}/usr/include "
             "-I{stage_dir}/include/{arch_triplet} "
             '-I{stage_dir}/usr/include/{arch_triplet}"'.format(
                 stage_dir=self.stage_dir,
                 arch_triplet=project_config.project.arch_triplet,
-            )
-            in environment,
-            "Current environment is {!r}".format(environment),
+            ),
+            environment,
         )
         self.assertTrue(
             'CXXFLAGS="$CXXFLAGS -I{stage_dir}/include '

--- a/tests/unit/test_formatting_utils.py
+++ b/tests/unit/test_formatting_utils.py
@@ -65,14 +65,14 @@ class FormatPathVariableTestCases(unit.TestCase):
     def test_one_path(self):
         paths = ["/bin"]
         output = formatting_utils.format_path_variable("PATH", paths, "/usr", ":")
-        self.assertThat(output, Equals('PATH="$PATH:/usr/bin"'))
+        self.assertThat(output, Equals('PATH="${PATH:+$PATH:}/usr/bin"'))
 
     def test_two_paths(self):
         paths = ["/bin", "/sbin"]
         output = formatting_utils.format_path_variable("PATH", paths, "/usr", ":")
-        self.assertThat(output, Equals('PATH="$PATH:/usr/bin:/usr/sbin"'))
+        self.assertThat(output, Equals('PATH="${PATH:+$PATH:}/usr/bin:/usr/sbin"'))
 
     def test_two_paths_other_paremeters(self):
         paths = ["/usr/bin", "/usr/sbin"]
         output = formatting_utils.format_path_variable("PATH", paths, "", ",")
-        self.assertThat(output, Equals('PATH="$PATH,/usr/bin,/usr/sbin"'))
+        self.assertThat(output, Equals('PATH="${PATH:+$PATH,}/usr/bin,/usr/sbin"'))

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -1165,7 +1165,11 @@ class GenerateHookWrappersTestCase(CreateBaseTestCase):
         expected = (
             "#!/bin/sh\n"
             "export PATH=$SNAP/foo\n"
-            "export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n"
+            'export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"\n'
+            'echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && '
+            'echo "WARNING: an empty LD_LIBRARY_PATH has been set. '
+            "CWD will be added to the library path. "
+            'This can cause the incorrect library to be loaded."\n'
             'exec "$SNAP/snap/hooks/snap-hook" "$@"\n'
         )
 
@@ -1372,8 +1376,11 @@ class WrapExeTest(BaseWrapTest):
         expected = (
             "#!/bin/sh\n"
             "PATH=$SNAP/usr/bin:$SNAP/bin\n"
-            "export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:"
-            "$LD_LIBRARY_PATH\n"
+            'export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"\n'
+            'echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && '
+            'echo "WARNING: an empty LD_LIBRARY_PATH has been set. '
+            "CWD will be added to the library path. "
+            'This can cause the incorrect library to be loaded."\n'
             'exec "$SNAP/test_relexepath" "$@"\n'
         )
 
@@ -1421,8 +1428,11 @@ class WrapExeTest(BaseWrapTest):
         expected = (
             "#!/bin/sh\n"
             "PATH=$SNAP/usr/bin:$SNAP/bin\n"
-            "export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:"
-            "$LD_LIBRARY_PATH\n"
+            'export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"\n'
+            'echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && '
+            'echo "WARNING: an empty LD_LIBRARY_PATH has been set. '
+            "CWD will be added to the library path. "
+            'This can cause the incorrect library to be loaded."\n'
             'exec "$SNAP/test_relexepath" "$@"\n'
         )
         self.assertThat(wrapper_path, FileContains(expected))
@@ -1562,6 +1572,164 @@ class WrapExeTest(BaseWrapTest):
         self.assertThat(
             snap_yaml["apps"], Equals({"app": {"command": "command-app.wrapper"}})
         )
+
+
+class TestRootEnvironmentLibraryPathWarnings(CreateBaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.config_data["grade"] = "stable"
+
+        self.fake_logger = fixtures.FakeLogger(level=logging.WARNING)
+        self.useFixture(self.fake_logger)
+
+    def assert_warnings(self):
+        self.generate_meta_yaml()
+
+        self.assertThat(
+            self.fake_logger.output,
+            Contains(
+                "CVE-2020-27348: A potentially empty LD_LIBRARY_PATH has been set for environment "
+                "in '.'. The current working directory will be added to the library path if empty. "
+                "This can cause unexpected libraries to be loaded."
+            ),
+        )
+
+    def assert_no_warnings(self):
+        self.generate_meta_yaml()
+
+        self.assertThat(
+            self.fake_logger.output,
+            Not(
+                Contains(
+                    "CVE-2020-27348: A potentially empty LD_LIBRARY_PATH has been set for environment "
+                    "in '.'. The current working directory will be added to the library path if empty. "
+                    "This can cause unexpected libraries to be loaded."
+                )
+            ),
+        )
+
+    def test_root_ld_library_path(self):
+        self.config_data["environment"] = {"LD_LIBRARY_PATH": "/foo:$LD_LIBRARY_PATH"}
+
+        self.assert_warnings()
+
+    def test_root_ld_library_path_with_colon_at_start(self):
+        self.config_data["environment"] = {"LD_LIBRARY_PATH": ":/foo:/bar"}
+
+        self.assert_warnings()
+
+    def test_root_ld_library_path_with_colon_at_end(self):
+        self.config_data["environment"] = {"LD_LIBRARY_PATH": "/foo:/bar:"}
+
+        self.assert_warnings()
+
+    def test_root_ld_library_path_with_colon_at_middle(self):
+        self.config_data["environment"] = {"LD_LIBRARY_PATH": "/foo::/bar"}
+
+        self.assert_warnings()
+
+    def test_root_ld_library_path_good(self):
+        self.config_data["environment"] = {"LD_LIBRARY_PATH": "/foo:/bar"}
+
+        self.assert_no_warnings()
+
+
+class TestAppsEnvironmentLibraryPathWarnings(CreateBaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.config_data["grade"] = "stable"
+        self.config_data["apps"] = {
+            "app1": {"command": "foo"},
+            "app2": {"command": "bar"},
+        }
+
+        _create_file(os.path.join(self.prime_dir, "foo"), executable=True)
+        _create_file(os.path.join(self.prime_dir, "bar"), executable=True)
+
+        self.fake_logger = fixtures.FakeLogger(level=logging.WARNING)
+        self.useFixture(self.fake_logger)
+
+    def assert_warnings_both(self):
+        self.generate_meta_yaml()
+
+        self.assertThat(
+            self.fake_logger.output,
+            Contains(
+                "CVE-2020-27348: A potentially empty LD_LIBRARY_PATH has been set for environment "
+                "in 'app1' and 'app2'. The current working directory will be added to the library "
+                "path if empty. "
+                "This can cause unexpected libraries to be loaded."
+            ),
+        )
+
+    def assert_warnings_app1(self):
+        self.generate_meta_yaml()
+
+        self.assertThat(
+            self.fake_logger.output,
+            Contains(
+                "CVE-2020-27348: A potentially empty LD_LIBRARY_PATH has been set for environment "
+                "in 'app1'. The current working directory will be added to the library "
+                "path if empty. "
+                "This can cause unexpected libraries to be loaded."
+            ),
+        )
+
+    def assert_no_warnings(self):
+        self.generate_meta_yaml()
+
+        self.assertThat(
+            self.fake_logger.output,
+            Not(
+                Contains(
+                    "CVE-2020-27348: A potentially empty LD_LIBRARY_PATH has been set for environment "
+                    "in 'app1' and 'app2'. The current working directory will be added to the library "
+                    "path if empty. "
+                    "This can cause unexpected libraries to be loaded."
+                )
+            ),
+        )
+
+    def test_app_ld_library_path_app1(self):
+        self.config_data["apps"]["app1"]["environment"] = {
+            "LD_LIBRARY_PATH": "/foo:$LD_LIBRARY_PATH"
+        }
+
+        self.assert_warnings_app1()
+
+    def test_app_ld_library_path_app1_app2(self):
+        self.config_data["apps"]["app1"]["environment"] = {
+            "LD_LIBRARY_PATH": "/foo:$LD_LIBRARY_PATH"
+        }
+        self.config_data["apps"]["app2"]["environment"] = {
+            "LD_LIBRARY_PATH": "/foo:$LD_LIBRARY_PATH"
+        }
+
+        self.assert_warnings_both()
+
+    def test_root_ld_library_path_set(self):
+        self.config_data["environment"] = {"LD_LIBRARY_PATH": "/foo:/bar"}
+
+        self.config_data["apps"]["app1"]["environment"] = {
+            "LD_LIBRARY_PATH": "/foo:$LD_LIBRARY_PATH"
+        }
+        self.config_data["apps"]["app2"]["environment"] = {
+            "LD_LIBRARY_PATH": "/foo:$LD_LIBRARY_PATH"
+        }
+
+        self.assert_no_warnings()
+
+    def test_app_ld_library_path_colon_middle_app1_app2(self):
+        self.config_data["apps"]["app1"]["environment"] = {
+            "LD_LIBRARY_PATH": "/foo::/bar"
+        }
+        self.config_data["apps"]["app2"]["environment"] = {
+            "LD_LIBRARY_PATH": "/foo::/bar"
+        }
+
+        self.assert_warnings_both()
 
 
 def _create_file(path, *, content="", executable=False):

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -1166,10 +1166,6 @@ class GenerateHookWrappersTestCase(CreateBaseTestCase):
             "#!/bin/sh\n"
             "export PATH=$SNAP/foo\n"
             'export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"\n'
-            'echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && '
-            'echo "WARNING: an empty LD_LIBRARY_PATH has been set. '
-            "CWD will be added to the library path. "
-            'This can cause the incorrect library to be loaded."\n'
             'exec "$SNAP/snap/hooks/snap-hook" "$@"\n'
         )
 
@@ -1377,10 +1373,6 @@ class WrapExeTest(BaseWrapTest):
             "#!/bin/sh\n"
             "PATH=$SNAP/usr/bin:$SNAP/bin\n"
             'export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"\n'
-            'echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && '
-            'echo "WARNING: an empty LD_LIBRARY_PATH has been set. '
-            "CWD will be added to the library path. "
-            'This can cause the incorrect library to be loaded."\n'
             'exec "$SNAP/test_relexepath" "$@"\n'
         )
 
@@ -1429,10 +1421,6 @@ class WrapExeTest(BaseWrapTest):
             "#!/bin/sh\n"
             "PATH=$SNAP/usr/bin:$SNAP/bin\n"
             'export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"\n'
-            'echo $LD_LIBRARY_PATH | grep -qE "::|^:|:$" && '
-            'echo "WARNING: an empty LD_LIBRARY_PATH has been set. '
-            "CWD will be added to the library path. "
-            'This can cause the incorrect library to be loaded."\n'
             'exec "$SNAP/test_relexepath" "$@"\n'
         )
         self.assertThat(wrapper_path, FileContains(expected))
@@ -1614,6 +1602,11 @@ class TestRootEnvironmentLibraryPathWarnings(CreateBaseTestCase):
 
         self.assert_warnings()
 
+    def test_root_ld_library_path_braces(self):
+        self.config_data["environment"] = {"LD_LIBRARY_PATH": "/foo:${LD_LIBRARY_PATH}"}
+
+        self.assert_warnings()
+
     def test_root_ld_library_path_with_colon_at_start(self):
         self.config_data["environment"] = {"LD_LIBRARY_PATH": ":/foo:/bar"}
 
@@ -1695,6 +1688,13 @@ class TestAppsEnvironmentLibraryPathWarnings(CreateBaseTestCase):
     def test_app_ld_library_path_app1(self):
         self.config_data["apps"]["app1"]["environment"] = {
             "LD_LIBRARY_PATH": "/foo:$LD_LIBRARY_PATH"
+        }
+
+        self.assert_warnings_app1()
+
+    def test_app_ld_library_path_app1_braces(self):
+        self.config_data["apps"]["app1"]["environment"] = {
+            "LD_LIBRARY_PATH": "/foo:${LD_LIBRARY_PATH}"
         }
 
         self.assert_warnings_app1()


### PR DESCRIPTION
Prevent library injection vulnerability on strict mode snaps built
with Snapcraft via misconfigured LD_LIBRARY_PATH:

- project_loader: do not export empty environment
- meta: do not export empty environment. Warn on empty environment.

CVE-2020-27348
LP: #1901572

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
