### PR TITLE
plugins v2: add support for out of source tree builds

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -257,6 +257,7 @@ class PluginHandler:
         dirs = [
             self.part_source_dir,
             self.part_build_dir,
+            self.part_build_work_dir,
             self.part_install_dir,
             self.part_state_dir,
             self._project.stage_dir,

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -575,10 +575,7 @@ class PluginHandler:
     def build(self, force=False):
         self.makedirs()
 
-        if not (
-            isinstance(self.plugin, plugins.v1.PluginV1)
-            and self.plugin.out_of_source_build
-        ):
+        if not self.plugin.out_of_source_build:
             if os.path.exists(self.part_build_dir):
                 shutil.rmtree(self.part_build_dir)
 
@@ -589,10 +586,7 @@ class PluginHandler:
         self._do_build()
 
     def update_build(self):
-        if not (
-            isinstance(self.plugin, plugins.v1.PluginV1)
-            and self.plugin.out_of_source_build
-        ):
+        if not self.plugin.out_of_source_build:
             # Use the local source to update. It's important to use
             # file_utils.copy instead of link_or_copy, as the build process
             # may modify these files

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -94,7 +94,10 @@ class PluginHandler:
         # part property.
         source_sub_dir = self._part_properties.get("source-subdir", "")
         self.part_source_work_dir = os.path.join(self.part_source_dir, source_sub_dir)
-        self.part_build_work_dir = os.path.join(self.part_build_dir, source_sub_dir)
+        if self.plugin.out_of_source_build:
+            self.part_build_work_dir = self.part_build_dir
+        else:
+            self.part_build_work_dir = os.path.join(self.part_build_dir, source_sub_dir)
 
         self._pull_state: Optional[states.PullState] = None
         self._build_state: Optional[states.BuildState] = None
@@ -257,7 +260,6 @@ class PluginHandler:
         dirs = [
             self.part_source_dir,
             self.part_build_dir,
-            self.part_build_work_dir,
             self.part_install_dir,
             self.part_state_dir,
             self._project.stage_dir,

--- a/snapcraft/plugins/v2/_plugin.py
+++ b/snapcraft/plugins/v2/_plugin.py
@@ -66,3 +66,13 @@ class PluginV2(abc.ABC):
         snapcraftctl can be used in the script to call out to snapcraft
         specific functionality.
         """
+
+    @property
+    def out_of_source_build(self) -> bool:
+        """Returns True if the plugin performs out-of-source-tree builds.
+
+        In practice, this controls whether the PluginHandler code will
+        copy the source code to the build directory before invoking
+        the plugin's build commands.
+        """
+        return False

--- a/snapcraft/plugins/v2/_plugin.py
+++ b/snapcraft/plugins/v2/_plugin.py
@@ -54,6 +54,14 @@ class PluginV2(abc.ABC):
         This method is called by the PluginHandler during the "build" step.
         """
 
+    out_of_source_build = False
+    """Set to True if the plugin performs out-of-source-tree builds.
+
+    In practice, this controls whether the PluginHandler code will
+    copy the source code to the build directory before invoking the
+    plugin's build commands.
+    """
+
     @abc.abstractmethod
     def get_build_commands(self) -> List[str]:
         """
@@ -66,13 +74,3 @@ class PluginV2(abc.ABC):
         snapcraftctl can be used in the script to call out to snapcraft
         specific functionality.
         """
-
-    @property
-    def out_of_source_build(self) -> bool:
-        """Returns True if the plugin performs out-of-source-tree builds.
-
-        In practice, this controls whether the PluginHandler code will
-        copy the source code to the build directory before invoking
-        the plugin's build commands.
-        """
-        return False

--- a/snapcraft/plugins/v2/_plugin.py
+++ b/snapcraft/plugins/v2/_plugin.py
@@ -54,13 +54,15 @@ class PluginV2(abc.ABC):
         This method is called by the PluginHandler during the "build" step.
         """
 
-    out_of_source_build = False
-    """Set to True if the plugin performs out-of-source-tree builds.
+    @property
+    def out_of_source_build(self):
+        """Set to True if the plugin performs out-of-source-tree builds.
 
-    In practice, this controls whether the PluginHandler code will
-    copy the source code to the build directory before invoking the
-    plugin's build commands.
-    """
+        In practice, this controls whether the PluginHandler code will
+        copy the source code to the build directory before invoking
+        the plugin's build commands.
+        """
+        return False
 
     @abc.abstractmethod
     def get_build_commands(self) -> List[str]:

--- a/snapcraft/plugins/v2/cmake.py
+++ b/snapcraft/plugins/v2/cmake.py
@@ -88,13 +88,11 @@ class CMakePlugin(PluginV2):
 
         return " ".join(cmd)
 
+    out_of_source_build = True
+
     def get_build_commands(self) -> List[str]:
         return [
             self._get_cmake_configure_command(),
             'cmake --build . -- -j"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
             'DESTDIR="${SNAPCRAFT_PART_INSTALL}" cmake --build . --target install',
         ]
-
-    @property
-    def out_of_source_build(self) -> bool:
-        return True

--- a/snapcraft/plugins/v2/cmake.py
+++ b/snapcraft/plugins/v2/cmake.py
@@ -88,7 +88,9 @@ class CMakePlugin(PluginV2):
 
         return " ".join(cmd)
 
-    out_of_source_build = True
+    @property
+    def out_of_source_build(self):
+        return True
 
     def get_build_commands(self) -> List[str]:
         return [

--- a/snapcraft/plugins/v2/cmake.py
+++ b/snapcraft/plugins/v2/cmake.py
@@ -94,3 +94,7 @@ class CMakePlugin(PluginV2):
             'cmake --build . -- -j"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
             'DESTDIR="${SNAPCRAFT_PART_INSTALL}" cmake --build . --target install',
         ]
+
+    @property
+    def out_of_source_build(self) -> bool:
+        return True

--- a/snapcraft/plugins/v2/meson.py
+++ b/snapcraft/plugins/v2/meson.py
@@ -81,11 +81,15 @@ class MesonPlugin(PluginV2):
         meson_cmd = ["meson"]
         if self.options.meson_parameters:
             meson_cmd.append(" ".join(self.options.meson_parameters))
-        meson_cmd.append(".snapbuild")
+        meson_cmd.append('"${SNAPCRAFT_PART_SRC_WORK}"')
 
         return [
             f"/usr/bin/python3 -m pip install -U {meson_package}",
-            "[ ! -d .snapbuild ] && {}".format(" ".join(meson_cmd)),
-            "(cd .snapbuild && ninja)",
-            '(cd .snapbuild && DESTDIR="${SNAPCRAFT_PART_INSTALL}" ninja install)',
+            "[ ! -f build.ninja ] && {}".format(" ".join(meson_cmd)),
+            "ninja",
+            'DESTDIR="${SNAPCRAFT_PART_INSTALL}" ninja install',
         ]
+
+    @property
+    def out_of_source_build(self) -> bool:
+        return True

--- a/snapcraft/plugins/v2/meson.py
+++ b/snapcraft/plugins/v2/meson.py
@@ -72,7 +72,9 @@ class MesonPlugin(PluginV2):
     def get_build_environment(self) -> Dict[str, str]:
         return dict()
 
-    out_of_source_build = True
+    @property
+    def out_of_source_build(self):
+        return True
 
     def get_build_commands(self) -> List[str]:
         if self.options.meson_version:

--- a/snapcraft/plugins/v2/meson.py
+++ b/snapcraft/plugins/v2/meson.py
@@ -72,6 +72,8 @@ class MesonPlugin(PluginV2):
     def get_build_environment(self) -> Dict[str, str]:
         return dict()
 
+    out_of_source_build = True
+
     def get_build_commands(self) -> List[str]:
         if self.options.meson_version:
             meson_package = f"meson=={self.options.meson_version}"
@@ -89,7 +91,3 @@ class MesonPlugin(PluginV2):
             "ninja",
             'DESTDIR="${SNAPCRAFT_PART_INSTALL}" ninja install',
         ]
-
-    @property
-    def out_of_source_build(self) -> bool:
-        return True

--- a/tests/unit/plugins/v2/test_cmake.py
+++ b/tests/unit/plugins/v2/test_cmake.py
@@ -117,3 +117,13 @@ def test_get_build_commands_with_cmake_parameters():
         'cmake --build . -- -j"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
         'DESTDIR="${SNAPCRAFT_PART_INSTALL}" cmake --build . --target install',
     ]
+
+
+def test_out_of_source_build():
+    class Options:
+        cmake_parameters = list()
+        cmake_generator = "Unix Makefiles"
+
+    plugin = CMakePlugin(part_name="my-part", options=Options())
+
+    assert plugin.out_of_source_build is True

--- a/tests/unit/plugins/v2/test_meson.py
+++ b/tests/unit/plugins/v2/test_meson.py
@@ -78,9 +78,9 @@ class MesonPluginTest(TestCase):
             Equals(
                 [
                     "/usr/bin/python3 -m pip install -U meson",
-                    "[ ! -d .snapbuild ] && meson .snapbuild",
-                    "(cd .snapbuild && ninja)",
-                    '(cd .snapbuild && DESTDIR="${SNAPCRAFT_PART_INSTALL}" ninja install)',
+                    '[ ! -f build.ninja ] && meson "${SNAPCRAFT_PART_SRC_WORK}"',
+                    "ninja",
+                    'DESTDIR="${SNAPCRAFT_PART_INSTALL}" ninja install',
                 ]
             ),
         )
@@ -97,9 +97,14 @@ class MesonPluginTest(TestCase):
             Equals(
                 [
                     "/usr/bin/python3 -m pip install -U meson==2.2",
-                    "[ ! -d .snapbuild ] && meson --buildtype=release .snapbuild",
-                    "(cd .snapbuild && ninja)",
-                    '(cd .snapbuild && DESTDIR="${SNAPCRAFT_PART_INSTALL}" ninja install)',
+                    '[ ! -f build.ninja ] && meson --buildtype=release "${SNAPCRAFT_PART_SRC_WORK}"',
+                    "ninja",
+                    'DESTDIR="${SNAPCRAFT_PART_INSTALL}" ninja install',
                 ]
             ),
         )
+
+    def test_out_of_source_build(self):
+        plugin = MesonPlugin(part_name="my-part", options=lambda: None)
+
+        self.assertThat(plugin.out_of_source_build, Equals(True))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
This is intended as an alternative to PR #3347.  It adds an `out_of_source_build` property to `PluginV2`, which is interpreted the same way it would be on `PluginV1` implementations, in that it disables the automatic copying of a part's source code to the build directory.  The default implementation of the property is `plugin.out_of_source_build == False`.

To demonstrate that this works, I've ported the meson and cmake plugins to use this mode.  For what it is worth, the cmake plugin was already configuring the build to use the copy of the source in `part_source_dir`, ignoring the copy in `part_build_dir`.