### PR TITLE
requirements: rely on host's python3-apt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ PyYAML==5.3
 pyxdg==0.26
 requests==2.20.0
 requests_unixsocket==0.1.5
-http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_1.6.5ubuntu0.2.tar.xz; sys_platform == 'linux'
 https://launchpad.net/python-distutils-extra/trunk/2.39/+download/python-distutils-extra-2.39.tar.gz
 requests-toolbelt==0.8.0
 responses==0.5.1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,7 +18,7 @@ apps:
       PATH: "/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       # https://github.com/lxc/pylxd/pull/361
       PYLXD_WARNINGS: "none"
-    command: bin/snapcraft
+    command: usr/bin/python3 $SNAP/bin/snapcraft
     completer: snapcraft-completion
 
 build-packages:
@@ -79,6 +79,12 @@ parts:
       # Remove so the link can be recreated on re-builds
       rm -f "$TRIPLET_PATH/libsodium.so"
       ln -s "$LIBSODIUM" "$TRIPLET_PATH/libsodium.so"
+
+      # We don't use stage-packages to prevent other dependencies from getting
+      # automatically pulled (such as an incomplete python3, which Snapcraft
+      # will attempt to use and break the build).
+      apt download python3-apt
+      dpkg -x python3-apt_*.deb $SNAPCRAFT_PART_INSTALL/
 
   snapcraft:
     source: .

--- a/tools/environment-setup-local.sh
+++ b/tools/environment-setup-local.sh
@@ -17,14 +17,15 @@ sudo apt install --yes \
     libyaml-dev \
     make \
     patchelf \
+    python3-apt \
     python3-dev \
     python3-pip \
     python3-venv \
     rpm2cpio \
     squashfs-tools
 
-# Create a virtual environment
-python3 -m venv "${SNAPCRAFT_VIRTUAL_ENV_DIR}"
+# Create a virtual environment enabling system packages (for python3-apt).
+python3 -m venv "${SNAPCRAFT_VIRTUAL_ENV_DIR}" --system-site-packages
 
 # Activate virtual environment
 # shellcheck source=/dev/null


### PR DESCRIPTION
The python apt package must match the host.  The current
requirements.txt basically assumes the host is Ubuntu 18.04.

- Update snap to include python3-apt stage package, working
  around a snapcraft issue which attempts to use staged
  python, whether or not it is desired.

- Update environment-setup-local script to install python3-apt
  and enable system site packages in constructed venv.

- Remove python3-apt from requirements package.

While here, fix the app command entry in the snap to address
Snapcraft's warning about rewriting the command.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
