### PR TITLE
grammar: fix the case of disappearing statements

### DIFF
--- a/snapcraft/internal/project_loader/grammar/_processor.py
+++ b/snapcraft/internal/project_loader/grammar/_processor.py
@@ -134,6 +134,9 @@ class GrammarProcessor:
             if on_to_clause_match:
                 # We've come across the beginning of a compound statement
                 # with both 'on' and 'to'.
+                # The first time through this may be None, but the
+                # collection will ignore it.
+                statements.add(statement)
 
                 # First, extract each statement's part of the string
                 on, to = on_to_clause_match.groups()

--- a/snapcraft/internal/project_loader/grammar/_processor.py
+++ b/snapcraft/internal/project_loader/grammar/_processor.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from snapcraft import project
 
@@ -44,7 +44,7 @@ class GrammarProcessor:
         project: project.Project,
         checker: Callable[[str], bool],
         *,
-        transformer: Callable[[List[Statement], str, project.Project], str] = None
+        transformer: Callable[[List[Statement], str, project.Project], str] = None,
     ) -> None:
         """Create a new GrammarProcessor.
 
@@ -100,7 +100,11 @@ class GrammarProcessor:
                 else:
                     primitives.add(self._transformer(call_stack, section, self.project))
             elif isinstance(section, dict):
-                statement = self._parse_dict(section, statement, statements, call_stack)
+                statement, finalized_statement = self._parse_section_dictionary(
+                    section=section, statement=statement, call_stack=call_stack,
+                )
+                if finalized_statement is not None:
+                    statements.add(finalized_statement)
             else:
                 # jsonschema should never let us get here.
                 raise GrammarSyntaxError(
@@ -114,13 +118,14 @@ class GrammarProcessor:
 
         return primitives
 
-    def _parse_dict(
+    def _parse_section_dictionary(
         self,
+        *,
         section: Dict[str, Any],
         statement: Optional[Statement],
-        statements: "_StatementCollection",
         call_stack: typing.CallStack,
-    ):
+    ) -> Tuple[Optional[Statement], Optional[Statement]]:
+        finalized_statement: Optional[Statement] = None
         for key, value in section.items():
             # Grammar is always written as a list of selectors but the value
             # can be a list or a string. In the latter case we wrap it so no
@@ -134,9 +139,7 @@ class GrammarProcessor:
             if on_to_clause_match:
                 # We've come across the beginning of a compound statement
                 # with both 'on' and 'to'.
-                # The first time through this may be None, but the
-                # collection will ignore it.
-                statements.add(statement)
+                finalized_statement = statement
 
                 # First, extract each statement's part of the string
                 on, to = on_to_clause_match.groups()
@@ -162,9 +165,7 @@ class GrammarProcessor:
             elif on_clause_match:
                 # We've come across the beginning of an 'on' statement.
                 # That means any previous statement we found is complete.
-                # The first time through this may be None, but the
-                # collection will ignore it.
-                statements.add(statement)
+                finalized_statement = statement
 
                 statement = OnStatement(
                     on=key, body=value, processor=self, call_stack=call_stack
@@ -173,9 +174,7 @@ class GrammarProcessor:
             elif _TO_CLAUSE_PATTERN.match(key):
                 # We've come across the beginning of a 'to' statement.
                 # That means any previous statement we found is complete.
-                # The first time through this may be None, but the
-                # collection will ignore it.
-                statements.add(statement)
+                finalized_statement = statement
 
                 statement = ToStatement(
                     to=key, body=value, processor=self, call_stack=call_stack
@@ -184,9 +183,7 @@ class GrammarProcessor:
             elif _TRY_CLAUSE_PATTERN.match(key):
                 # We've come across the beginning of a 'try' statement.
                 # That means any previous statement we found is complete.
-                # The first time through this may be None, but the
-                # collection will ignore it.
-                statements.add(statement)
+                finalized_statement = statement
 
                 statement = TryStatement(
                     body=value, processor=self, call_stack=call_stack
@@ -195,7 +192,7 @@ class GrammarProcessor:
             elif _ELSE_CLAUSE_PATTERN.match(key):
                 _handle_else(statement, value)
 
-        return statement
+        return statement, finalized_statement
 
 
 def _handle_else(statement: Optional[Statement], else_body: Optional[typing.Grammar]):

--- a/tests/unit/project_loader/grammar/test_processor.py
+++ b/tests/unit/project_loader/grammar/test_processor.py
@@ -55,6 +55,7 @@ class TestBasicGrammar:
             {
                 "grammar_entry": ["foo", "bar"],
                 "host_arch": "x86_64",
+                "target_arch": "amd64",
                 "expected_packages": {"foo", "bar"},
             },
         ),
@@ -63,6 +64,7 @@ class TestBasicGrammar:
             {
                 "grammar_entry": ["foo", {"on i386": ["bar"]}],
                 "host_arch": "i686",
+                "target_arch": "i386",
                 "expected_packages": {"foo", "bar"},
             },
         ),
@@ -71,6 +73,7 @@ class TestBasicGrammar:
             {
                 "grammar_entry": ["foo", {"on i386": ["bar"]}],
                 "host_arch": "x86_64",
+                "target_arch": "amd64",
                 "expected_packages": {"foo"},
             },
         ),
@@ -79,6 +82,7 @@ class TestBasicGrammar:
             {
                 "grammar_entry": [{"on amd64": ["foo"]}, {"on i386": ["bar"]}],
                 "host_arch": "x86_64",
+                "target_arch": "amd64",
                 "expected_packages": {"foo"},
             },
         ),
@@ -87,6 +91,7 @@ class TestBasicGrammar:
             {
                 "grammar_entry": [{"on amd64": ["foo"]}, {"on i386": ["bar"]}],
                 "host_arch": "i686",
+                "target_arch": "i386",
                 "expected_packages": {"bar"},
             },
         ),
@@ -95,6 +100,7 @@ class TestBasicGrammar:
             {
                 "grammar_entry": [{"on amd64": ["foo"]}, {"else": ["bar"]}],
                 "host_arch": "x86_64",
+                "target_arch": "amd64",
                 "expected_packages": {"foo"},
             },
         ),
@@ -103,6 +109,7 @@ class TestBasicGrammar:
             {
                 "grammar_entry": [{"on amd64": ["foo"]}, {"else": ["bar"]}],
                 "host_arch": "i686",
+                "target_arch": "i386",
                 "expected_packages": {"bar"},
             },
         ),
@@ -113,6 +120,7 @@ class TestBasicGrammar:
                     {"on amd64": [{"on amd64": ["foo"]}, {"on i386": ["bar"]}]}
                 ],
                 "host_arch": "x86_64",
+                "target_arch": "amd64",
                 "expected_packages": {"foo"},
             },
         ),
@@ -123,6 +131,7 @@ class TestBasicGrammar:
                     {"on i386": [{"on amd64": ["foo"]}, {"on i386": ["bar"]}]}
                 ],
                 "host_arch": "i686",
+                "target_arch": "i386",
                 "expected_packages": {"bar"},
             },
         ),
@@ -133,6 +142,7 @@ class TestBasicGrammar:
                     {"on amd64": [{"on amd64": ["foo"]}, {"else": ["bar"]}]}
                 ],
                 "host_arch": "x86_64",
+                "target_arch": "amd64",
                 "expected_packages": {"foo"},
             },
         ),
@@ -143,6 +153,7 @@ class TestBasicGrammar:
                     {"on i386": [{"on amd64": ["foo"]}, {"else": ["bar"]}]}
                 ],
                 "host_arch": "i686",
+                "target_arch": "amd64",
                 "expected_packages": {"bar"},
             },
         ),
@@ -151,6 +162,7 @@ class TestBasicGrammar:
             {
                 "grammar_entry": [{"try": ["valid"]}],
                 "host_arch": "x86_64",
+                "target_arch": "amd64",
                 "expected_packages": {"valid"},
             },
         ),
@@ -159,6 +171,7 @@ class TestBasicGrammar:
             {
                 "grammar_entry": [{"try": ["invalid"]}, {"else": ["valid"]}],
                 "host_arch": "x86_64",
+                "target_arch": "amd64",
                 "expected_packages": {"valid"},
             },
         ),
@@ -167,6 +180,7 @@ class TestBasicGrammar:
             {
                 "grammar_entry": [{"on amd64": [{"try": ["foo"]}, {"else": ["bar"]}]}],
                 "host_arch": "x86_64",
+                "target_arch": "amd64",
                 "expected_packages": {"foo"},
             },
         ),
@@ -177,6 +191,7 @@ class TestBasicGrammar:
                     {"on i386": [{"try": ["invalid"]}, {"else": ["bar"]}]}
                 ],
                 "host_arch": "i686",
+                "target_arch": "i686",
                 "expected_packages": {"bar"},
             },
         ),
@@ -185,19 +200,35 @@ class TestBasicGrammar:
             {
                 "grammar_entry": ["foo", {"try": ["invalid"]}],
                 "host_arch": "i686",
+                "target_arch": "i386",
                 "expected_packages": {"foo"},
+            },
+        ),
+        (
+            "multi",
+            {
+                "grammar_entry": [
+                    "foo",
+                    {"on amd64": ["foo2"]},
+                    {"on amd64 to arm64": ["foo3"]},
+                ],
+                "host_arch": "x86_64",
+                "target_arch": "i386",
+                "expected_packages": {"foo", "foo2"},
             },
         ),
     ]
 
     def test_basic_grammar(
-        self, monkeypatch, grammar_entry, host_arch, expected_packages
+        self, monkeypatch, grammar_entry, host_arch, target_arch, expected_packages
     ):
         monkeypatch.setattr(platform, "machine", lambda: host_arch)
         monkeypatch.setattr(platform, "architecture", lambda: ("64bit", "ELF"))
 
+        project = snapcraft.ProjectOptions(target_deb_arch=target_arch)
+
         processor = grammar.GrammarProcessor(
-            grammar_entry, snapcraft.ProjectOptions(), lambda x: "invalid" not in x
+            grammar_entry, project, lambda x: "invalid" not in x
         )
         assert processor.process() == expected_packages
 


### PR DESCRIPTION
Any statement prior to an 'on.. to..' clause vanishes into
the abyss.

E.g.:

```
stage-packages:
  - on amd64 to arm64:
    - foo
  - on amd64 to i386:
    - foo2
``` 

In this case `foo` will never be added to the package list.

When starting to process an on/to statement, ensure the previous
one is added to the statement collection.

Add a test to cover this case and update the basic grammar tests
to explicitly declare the target (deb) arch.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
