### PR TITLE
cli: support getting snap status by track

### DIFF
--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -497,13 +497,16 @@ def close(snap_name, channels):
 @click.option(
     "--arch", metavar="<arch>", help="The snap architecture to get the status for"
 )
+@click.option("--track", metavar="<track>", help="The snap track to get the status for")
 @click.argument("snap-name", metavar="<snap-name>")
-def status(snap_name, arch, experimental_progressive_releases):
+def status(snap_name, arch, track, experimental_progressive_releases):
     """Get the status on the store for <snap-name>.
 
     \b
     Examples:
         snapcraft status my-snap
+        snapcraft status --track 20 my-snap
+        snapcraft status --arch amd64 my-snap
     """
     if experimental_progressive_releases:
         os.environ["SNAPCRAFT_EXPERIMENTAL_PROGRESSIVE_RELEASES"] = "Y"
@@ -521,8 +524,13 @@ def status(snap_name, arch, experimental_progressive_releases):
             architectures = (arch,)
         else:
             architectures = existing_architectures
+        tracks = None
+        if track:
+            tracks = (track,)
         click.echo(
-            get_tabulated_channel_map(snap_channel_map, architectures=architectures)
+            get_tabulated_channel_map(
+                snap_channel_map, architectures=architectures, tracks=tracks
+            )
         )
 
 

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -495,11 +495,21 @@ def close(snap_name, channels):
     envvar="SNAPCRAFT_EXPERIMENTAL_PROGRESSIVE_RELEASES",
 )
 @click.option(
-    "--arch", metavar="<arch>", help="The snap architecture to get the status for"
+    "architectures",
+    "--arch",
+    metavar="<arch>",
+    multiple=True,
+    help="Limit status to these architectures (can specify multiple times)",
 )
-@click.option("--track", metavar="<track>", help="The snap track to get the status for")
+@click.option(
+    "tracks",
+    "--track",
+    multiple=True,
+    metavar="<track>",
+    help="Limit status to these tracks (can specify multiple times)",
+)
 @click.argument("snap-name", metavar="<snap-name>")
-def status(snap_name, arch, track, experimental_progressive_releases):
+def status(snap_name, architectures, tracks, experimental_progressive_releases):
     """Get the status on the store for <snap-name>.
 
     \b
@@ -517,16 +527,37 @@ def status(snap_name, arch, track, experimental_progressive_releases):
 
     if not snap_channel_map.channel_map:
         echo.warning("This snap has no released revisions.")
-    elif arch and arch not in existing_architectures:
-        echo.warning(f"No revisions for architecture {arch!r}.")
     else:
-        if arch:
-            architectures = (arch,)
+        if architectures:
+            architectures = set(architectures)
+            for architecture in architectures.copy():
+                if architecture not in existing_architectures:
+                    echo.warning(f"No revisions for architecture {architecture!r}.")
+                    architectures.remove(architecture)
+
+            # If we have no revisions for any of the architectures requested, there's
+            # nothing to do here.
+            if not architectures:
+                return
         else:
             architectures = existing_architectures
-        tracks = None
-        if track:
-            tracks = (track,)
+
+        if tracks:
+            tracks = set(tracks)
+            existing_tracks = {
+                s.track for s in snap_channel_map.snap.channels if s.track in tracks
+            }
+            for track in tracks - existing_tracks:
+                echo.warning(f"No revisions in track {track!r}.")
+            tracks = existing_tracks
+
+            # If we have no revisions in any of the tracks requested, there's
+            # nothing to do here.
+            if not tracks:
+                return
+        else:
+            tracks = None
+
         click.echo(
             get_tabulated_channel_map(
                 snap_channel_map, architectures=architectures, tracks=tracks

--- a/tests/unit/commands/__init__.py
+++ b/tests/unit/commands/__init__.py
@@ -225,10 +225,22 @@ class FakeStoreCommandsBaseTestCase(CommandBaseTestCase):
                             "percentage": None,
                             "current-percentage": None,
                         },
-                    }
+                    },
+                    {
+                        "architecture": "amd64",
+                        "channel": "2.0/beta",
+                        "expiration-date": None,
+                        "revision": 18,
+                        "progressive": {
+                            "paused": None,
+                            "percentage": None,
+                            "current-percentage": None,
+                        },
+                    },
                 ],
                 "revisions": [
-                    {"architectures": ["amd64"], "revision": 19, "version": "10"}
+                    {"architectures": ["amd64"], "revision": 19, "version": "10"},
+                    {"architectures": ["amd64"], "revision": 18, "version": "10"},
                 ],
                 "snap": {
                     "name": "snap-test",
@@ -260,6 +272,34 @@ class FakeStoreCommandsBaseTestCase(CommandBaseTestCase):
                             "name": "2.1/edge",
                             "risk": "edge",
                             "track": "2.1",
+                        },
+                        {
+                            "branch": None,
+                            "fallback": None,
+                            "name": "2.0/stable",
+                            "risk": "stable",
+                            "track": "2.0",
+                        },
+                        {
+                            "branch": None,
+                            "fallback": "2.0/stable",
+                            "name": "2.0/candidate",
+                            "risk": "candidate",
+                            "track": "2.0",
+                        },
+                        {
+                            "branch": None,
+                            "fallback": "2.0/candidate",
+                            "name": "2.0/beta",
+                            "risk": "beta",
+                            "track": "2.0",
+                        },
+                        {
+                            "branch": None,
+                            "fallback": "2.0/beta",
+                            "name": "2.0/edge",
+                            "risk": "edge",
+                            "track": "2.0",
                         },
                     ],
                     "default-track": "2.1",

--- a/tests/unit/commands/test_status.py
+++ b/tests/unit/commands/test_status.py
@@ -192,6 +192,60 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
             ),
         )
 
+    def test_status_by_multiple_arch(self):
+        self.channel_map.channel_map.append(
+            MappedChannel(
+                channel="2.1/beta",
+                architecture="s390x",
+                expiration_date=None,
+                revision=98,
+                progressive=Progressive(
+                    paused=None, percentage=None, current_percentage=None
+                ),
+            )
+        )
+        self.channel_map.channel_map.append(
+            MappedChannel(
+                channel="2.1/beta",
+                architecture="arm64",
+                expiration_date=None,
+                revision=99,
+                progressive=Progressive(
+                    paused=None, percentage=None, current_percentage=None
+                ),
+            )
+        )
+        self.channel_map.revisions.append(
+            Revision(architectures=["s390x"], revision=98, version="10")
+        )
+        self.channel_map.revisions.append(
+            Revision(architectures=["arm64"], revision=99, version="10")
+        )
+
+        result = self.run_command(
+            ["status", "snap-test", "--arch=s390x", "--arch=arm64"]
+        )
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(
+            result.output,
+            Equals(
+                dedent(
+                    """\
+            Track    Arch    Channel    Version    Revision
+            2.1      arm64   stable     -          -
+                             candidate  -          -
+                             beta       10         99
+                             edge       ↑          ↑
+                     s390x   stable     -          -
+                             candidate  -          -
+                             beta       10         98
+                             edge       ↑          ↑
+            """
+                )
+            ),
+        )
+
     def test_status_by_track(self):
         result = self.run_command(["status", "snap-test", "--track=2.0"])
 
@@ -202,6 +256,29 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
                 dedent(
                     """\
             Track    Arch    Channel    Version    Revision
+            2.0      amd64   stable     -          -
+                             candidate  -          -
+                             beta       10         18
+                             edge       ↑          ↑
+            """
+                )
+            ),
+        )
+
+    def test_status_by_multiple_track(self):
+        result = self.run_command(["status", "snap-test", "--track=2.0", "--track=2.1"])
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(
+            result.output,
+            Equals(
+                dedent(
+                    """\
+            Track    Arch    Channel    Version    Revision
+            2.1      amd64   stable     -          -
+                             candidate  -          -
+                             beta       10         19
+                             edge       ↑          ↑
             2.0      amd64   stable     -          -
                              candidate  -          -
                              beta       10         18

--- a/tests/unit/commands/test_status.py
+++ b/tests/unit/commands/test_status.py
@@ -63,6 +63,10 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
                              candidate  -          -
                              beta       10         19
                              edge       ↑          ↑
+            2.0      amd64   stable     -          -
+                             candidate  -          -
+                             beta       10         18
+                             edge       ↑          ↑
             """
                 )
             ),
@@ -145,6 +149,10 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
                              beta       10         19          93→90%
                                         11         20          7→10%
                              edge       ↑          ↑           -
+            2.0      amd64   stable     -          -           -
+                             candidate  -          -           -
+                             beta       10         18          -
+                             edge       ↑          ↑           -
             """
                 )
             ),
@@ -178,6 +186,75 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
             2.1      s390x   stable     -          -
                              candidate  -          -
                              beta       10         99
+                             edge       ↑          ↑
+            """
+                )
+            ),
+        )
+
+    def test_status_by_track(self):
+        result = self.run_command(["status", "snap-test", "--track=2.0"])
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(
+            result.output,
+            Equals(
+                dedent(
+                    """\
+            Track    Arch    Channel    Version    Revision
+            2.0      amd64   stable     -          -
+                             candidate  -          -
+                             beta       10         18
+                             edge       ↑          ↑
+            """
+                )
+            ),
+        )
+
+    def test_status_by_track_and_arch(self):
+        self.channel_map.channel_map.append(
+            MappedChannel(
+                channel="2.1/beta",
+                architecture="s390x",
+                expiration_date=None,
+                revision=99,
+                progressive=Progressive(
+                    paused=None, percentage=None, current_percentage=None
+                ),
+            )
+        )
+        self.channel_map.channel_map.append(
+            MappedChannel(
+                channel="2.0/beta",
+                architecture="s390x",
+                expiration_date=None,
+                revision=98,
+                progressive=Progressive(
+                    paused=None, percentage=None, current_percentage=None
+                ),
+            )
+        )
+        self.channel_map.revisions.append(
+            Revision(architectures=["s390x"], revision=99, version="10")
+        )
+        self.channel_map.revisions.append(
+            Revision(architectures=["s390x"], revision=98, version="10")
+        )
+
+        result = self.run_command(
+            ["status", "snap-test", "--arch=s390x", "--track=2.0"]
+        )
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(
+            result.output,
+            Equals(
+                dedent(
+                    """\
+            Track    Arch    Channel    Version    Revision
+            2.0      s390x   stable     -          -
+                             candidate  -          -
+                             beta       10         98
                              edge       ↑          ↑
             """
                 )
@@ -222,6 +299,10 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
                              stable/hotfix1  10hotfix   20          2020-02-03T20:58:37Z
                              candidate       -          -
                              beta            10         19
+                             edge            ↑          ↑
+            2.0      amd64   stable          -          -
+                             candidate       -          -
+                             beta            10         18
                              edge            ↑          ↑
             """
                 )
@@ -270,6 +351,10 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
                              candidate       -          -           -
                              beta            10         19          -
                              edge            ↑          ↑           -
+            2.0      amd64   stable          -          -           -
+                             candidate       -          -           -
+                             beta            10         18          -
+                             edge            ↑          ↑           -
             """
                 )
             ),
@@ -295,6 +380,10 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
                              candidate  -          -           -
                              beta       -          -           -
                                         10         19          ?→10%
+                             edge       ↑          ↑           -
+            2.0      amd64   stable     -          -           -
+                             candidate  -          -           -
+                             beta       10         18          -
                              edge       ↑          ↑           -
             """
                 )


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Currently snapcraft supports getting the status by architecture. Add support for getting the status by track as well.