### PR TITLE
cli: do not require snapd deb for assertions

### DIFF
--- a/tests/unit/commands/test_create_key.py
+++ b/tests/unit/commands/test_create_key.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import fixtures
-from testtools.matchers import Contains, Equals
+from testtools.matchers import Equals
 
 from snapcraft import storeapi
 
@@ -28,18 +28,6 @@ class CreateKeyTestCase(FakeStoreCommandsBaseTestCase):
 
         self.fake_check_call = fixtures.MockPatch("subprocess.check_call")
         self.useFixture(self.fake_check_call)
-
-    def test_create_key_snapd_not_installed(self):
-        self.fake_package_installed.mock.return_value = False
-
-        raised = self.assertRaises(
-            storeapi.errors.MissingSnapdError, self.run_command, ["create-key"]
-        )
-
-        self.assertThat(str(raised), Contains("The snapd package is not installed."))
-        self.fake_package_installed.mock.assert_called_with("snapd")
-        self.fake_check_output.mock.assert_not_called()
-        self.fake_check_call.mock.assert_not_called()
 
     def test_create_key_already_exists(self):
         raised = self.assertRaises(

--- a/tests/unit/commands/test_list_keys.py
+++ b/tests/unit/commands/test_list_keys.py
@@ -17,6 +17,7 @@
 from textwrap import dedent
 
 from testtools.matchers import Contains, Equals
+import fixtures
 
 from snapcraft import storeapi
 
@@ -26,18 +27,6 @@ from . import FakeStoreCommandsBaseTestCase, get_sample_key
 class ListKeysCommandTestCase(FakeStoreCommandsBaseTestCase):
 
     command_name = "list-keys"
-
-    def test_list_keys_snapd_not_installed(self):
-        self.fake_package_installed.mock.return_value = False
-
-        raised = self.assertRaises(
-            storeapi.errors.MissingSnapdError, self.run_command, [self.command_name]
-        )
-
-        self.assertThat(str(raised), Contains("The snapd package is not installed."))
-        self.assertThat(str(raised), Contains("The snapd package is not installed."))
-        self.fake_package_installed.mock.assert_called_with("snapd")
-        self.fake_check_output.mock.assert_not_called()
 
     def test_command_without_login_must_ask(self):
         # TODO: look into why this many calls are done inside snapcraft.storeapi
@@ -83,6 +72,39 @@ class ListKeysCommandTestCase(FakeStoreCommandsBaseTestCase):
                 ).format(
                     default_sha3_384=get_sample_key("default")["sha3-384"],
                     another_sha3_384=get_sample_key("another")["sha3-384"],
+                )
+            ),
+        )
+
+    def test_list_keys_no_keys_on_system(self):
+        self.fake_store_account_info.mock.return_value = {
+            "account_id": "abcd",
+            "account_keys": [
+                {
+                    "name": "default",
+                    "public-key-sha3-384": (get_sample_key("default")["sha3-384"]),
+                }
+            ],
+        }
+
+        self.useFixture(
+            fixtures.MockPatch("subprocess.check_output", return_value="[]".encode())
+        )
+
+        result = self.run_command(
+            [self.command_name], input="user@example.com\nsecret\n"
+        )
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(
+            result.output,
+            Contains(
+                dedent(
+                    """\
+                    No keys have been created on this system.  See 'snapcraft create-key --help to create a key.
+                    The following SHA3-384 key fingerprints have been registered but are not available on this system:
+                    - vdEeQvRxmZ26npJCFaGnl-VfGz0lU2jZZkWp_s7E-RxVCNtH2_mtjcxq2NkDKkIp
+            """
                 )
             ),
         )

--- a/tests/unit/commands/test_register_key.py
+++ b/tests/unit/commands/test_register_key.py
@@ -28,17 +28,6 @@ from . import FakeStoreCommandsBaseTestCase, get_sample_key
 
 
 class RegisterKeyTestCase(FakeStoreCommandsBaseTestCase):
-    def test_register_key_snapd_not_installed(self):
-        self.fake_package_installed.mock.return_value = False
-
-        raised = self.assertRaises(
-            storeapi.errors.MissingSnapdError, self.run_command, ["register-key"]
-        )
-
-        self.expectThat(str(raised), Contains("The snapd package is not installed."))
-        self.fake_package_installed.mock.assert_called_with("snapd")
-        self.fake_check_output.mock.assert_not_called()
-
     def test_register_key(self):
         result = self.run_command(
             ["register-key", "default"], input="user@example.com\nsecret\n"

--- a/tests/unit/commands/test_sign_build.py
+++ b/tests/unit/commands/test_sign_build.py
@@ -53,26 +53,7 @@ class SignBuildTestCase(CommandBaseTestCase):
         self.snap_test = SnapTest("test-snap.snap")
         self.useFixture(self.snap_test)
 
-    @mock.patch("subprocess.check_output")
-    @mock.patch("snapcraft.internal.repo.Repo.is_package_installed")
-    def test_sign_build_snapd_not_installed(self, mock_installed, mock_check_output):
-        mock_installed.return_value = False
-
-        raised = self.assertRaises(
-            storeapi.errors.MissingSnapdError,
-            self.run_command,
-            ["sign-build", self.snap_test.snap_path, "--local"],
-        )
-
-        self.assertThat(str(raised), Contains("The snapd package is not installed."))
-        mock_installed.assert_called_with("snapd")
-        self.assertThat(mock_check_output.call_count, Equals(0))
-
-    @mock.patch("subprocess.check_output")
-    @mock.patch("snapcraft.internal.repo.Repo.is_package_installed")
-    def test_sign_build_nonexisting_snap(self, mock_installed, mock_check_output):
-        mock_installed.return_value = True
-
+    def test_sign_build_nonexisting_snap(self):
         result = self.run_command(["sign-build", "nonexisting.snap"])
 
         self.assertThat(result.exit_code, Equals(2))
@@ -82,11 +63,8 @@ class SignBuildTestCase(CommandBaseTestCase):
                 "Error: Invalid value for '<snap-file>': File 'nonexisting.snap' does not exist.\n"
             ),
         )
-        self.assertThat(mock_check_output.call_count, Equals(0))
 
-    @mock.patch("snapcraft.internal.repo.Repo.is_package_installed")
-    def test_sign_build_invalid_snap(self, mock_installed):
-        mock_installed.return_value = True
+    def test_sign_build_invalid_snap(self):
         snap_path = os.path.join(
             os.path.dirname(tests.__file__), "data", "invalid.snap"
         )
@@ -100,17 +78,10 @@ class SignBuildTestCase(CommandBaseTestCase):
         self.assertThat(str(raised), Contains("Cannot read data from snap"))
 
     @mock.patch.object(storeapi._sca_client.SCAClient, "get_account_information")
-    @mock.patch("subprocess.check_output")
     @mock.patch("snapcraft._store._get_data_from_snap_file")
-    @mock.patch("snapcraft.internal.repo.Repo.is_package_installed")
     def test_sign_build_missing_account_info(
-        self,
-        mock_installed,
-        mock_get_snap_data,
-        mock_check_output,
-        mock_get_account_info,
+        self, mock_get_snap_data, mock_get_account_info,
     ):
-        mock_installed.return_value = True
         mock_get_account_info.return_value = {"account_id": "abcd", "snaps": {}}
         mock_get_snap_data.return_value = {"name": "test-snap", "grade": "stable"}
 
@@ -128,26 +99,21 @@ class SignBuildTestCase(CommandBaseTestCase):
                 "'test-snap' for series '16'."
             ),
         )
-        self.assertThat(mock_check_output.call_count, Equals(0))
 
     @mock.patch.object(storeapi._sca_client.SCAClient, "get_account_information")
-    @mock.patch("subprocess.check_output")
     @mock.patch("snapcraft._store._get_data_from_snap_file")
-    @mock.patch("snapcraft.internal.repo.Repo.is_package_installed")
     def test_sign_build_no_usable_keys(
-        self,
-        mock_installed,
-        mock_get_snap_data,
-        mock_check_output,
-        mock_get_account_info,
+        self, mock_get_snap_data, mock_get_account_info,
     ):
-        mock_installed.return_value = True
         mock_get_account_info.return_value = {
             "account_id": "abcd",
             "snaps": {"16": {"test-snap": {"snap-id": "snap-id"}}},
         }
         mock_get_snap_data.return_value = {"name": "test-snap", "grade": "stable"}
-        mock_check_output.side_effect = ["[]"]
+
+        self.useFixture(
+            fixtures.MockPatch("subprocess.check_output", return_value="[]".encode())
+        )
 
         raised = self.assertRaises(
             storeapi.errors.NoKeysError,
@@ -167,23 +133,20 @@ class SignBuildTestCase(CommandBaseTestCase):
         self.assertThat(snap_build_path, Not(FileExists()))
 
     @mock.patch.object(storeapi._sca_client.SCAClient, "get_account_information")
-    @mock.patch("subprocess.check_output")
     @mock.patch("snapcraft._store._get_data_from_snap_file")
-    @mock.patch("snapcraft.internal.repo.Repo.is_package_installed")
     def test_sign_build_no_usable_named_key(
-        self,
-        mock_installed,
-        mock_get_snap_data,
-        mock_check_output,
-        mock_get_account_info,
+        self, mock_get_snap_data, mock_get_account_info,
     ):
-        mock_installed.return_value = True
         mock_get_account_info.return_value = {
             "account_id": "abcd",
             "snaps": {"16": {"test-snap": {"snap-id": "snap-id"}}},
         }
         mock_get_snap_data.return_value = {"name": "test-snap", "grade": "stable"}
-        mock_check_output.side_effect = ['[{"name": "default"}]']
+        self.useFixture(
+            fixtures.MockPatch(
+                "subprocess.check_output", return_value='[{"name": "default"}]'.encode()
+            )
+        )
 
         raised = self.assertRaises(
             storeapi.errors.NoSuchKeyError,
@@ -201,24 +164,22 @@ class SignBuildTestCase(CommandBaseTestCase):
         self.assertThat(snap_build_path, Not(FileExists()))
 
     @mock.patch.object(storeapi._sca_client.SCAClient, "get_account_information")
-    @mock.patch("subprocess.check_output")
     @mock.patch("snapcraft._store._get_data_from_snap_file")
-    @mock.patch("snapcraft.internal.repo.Repo.is_package_installed")
     def test_sign_build_unregistered_key(
-        self,
-        mock_installed,
-        mock_get_snap_data,
-        mock_check_output,
-        mock_get_account_info,
+        self, mock_get_snap_data, mock_get_account_info,
     ):
-        mock_installed.return_value = True
         mock_get_account_info.return_value = {
             "account_id": "abcd",
             "account_keys": [{"public-key-sha3-384": "another_hash"}],
             "snaps": {"16": {"test-snap": {"snap-id": "snap-id"}}},
         }
         mock_get_snap_data.return_value = {"name": "test-snap", "grade": "stable"}
-        mock_check_output.side_effect = ['[{"name": "default", "sha3-384": "a_hash"}]']
+        self.useFixture(
+            fixtures.MockPatch(
+                "subprocess.check_output",
+                return_value='[{"name": "default", "sha3-384": "a_hash"}]'.encode(),
+            )
+        )
 
         raised = self.assertRaises(
             storeapi.errors.KeyNotRegisteredError,
@@ -240,27 +201,25 @@ class SignBuildTestCase(CommandBaseTestCase):
         self.assertThat(snap_build_path, Not(FileExists()))
 
     @mock.patch.object(storeapi._sca_client.SCAClient, "get_account_information")
-    @mock.patch("subprocess.check_output")
     @mock.patch("snapcraft._store._get_data_from_snap_file")
-    @mock.patch("snapcraft.internal.repo.Repo.is_package_installed")
     def test_sign_build_snapd_failure(
-        self,
-        mock_installed,
-        mock_get_snap_data,
-        mock_check_output,
-        mock_get_account_info,
+        self, mock_get_snap_data, mock_get_account_info,
     ):
-        mock_installed.return_value = True
         mock_get_account_info.return_value = {
             "account_id": "abcd",
             "account_keys": [{"public-key-sha3-384": "a_hash"}],
             "snaps": {"16": {"test-snap": {"snap-id": "snap-id"}}},
         }
         mock_get_snap_data.return_value = {"name": "test-snap", "grade": "stable"}
-        mock_check_output.side_effect = [
-            '[{"name": "default", "sha3-384": "a_hash"}]',
-            subprocess.CalledProcessError(1, ["a", "b"]),
-        ]
+        self.useFixture(
+            fixtures.MockPatch(
+                "subprocess.check_output",
+                side_effect=[
+                    '[{"name": "default", "sha3-384": "a_hash"}]'.encode(),
+                    subprocess.CalledProcessError(1, ["a", "b"]),
+                ],
+            )
+        )
 
         raised = self.assertRaises(
             storeapi.errors.SignBuildAssertionError,
@@ -280,23 +239,20 @@ class SignBuildTestCase(CommandBaseTestCase):
         self.assertThat(snap_build_path, Not(FileExists()))
 
     @mock.patch.object(storeapi._sca_client.SCAClient, "get_account_information")
-    @mock.patch("subprocess.check_output")
     @mock.patch("snapcraft._store._get_data_from_snap_file")
-    @mock.patch("snapcraft.internal.repo.Repo.is_package_installed")
     def test_sign_build_locally_successfully(
-        self,
-        mock_installed,
-        mock_get_snap_data,
-        mock_check_output,
-        mock_get_account_info,
+        self, mock_get_snap_data, mock_get_account_info,
     ):
-        mock_installed.return_value = True
         mock_get_account_info.return_value = {
             "account_id": "abcd",
             "snaps": {"16": {"test-snap": {"snap-id": "snap-id"}}},
         }
         mock_get_snap_data.return_value = {"name": "test-snap", "grade": "stable"}
-        mock_check_output.side_effect = ['[{"name": "default"}]', b"Mocked assertion"]
+        fake_check_output = fixtures.MockPatch(
+            "subprocess.check_output",
+            side_effect=['[{"name": "default"}]'.encode(), b"Mocked assertion"],
+        )
+        self.useFixture(fake_check_output)
 
         result = self.run_command(["sign-build", self.snap_test.snap_path, "--local"])
 
@@ -307,9 +263,9 @@ class SignBuildTestCase(CommandBaseTestCase):
             Contains("Build assertion {} saved to disk.".format(snap_build_path)),
         )
         self.assertThat(snap_build_path, FileExists())
-        mock_check_output.assert_called_with(
+        fake_check_output.mock.assert_called_with(
             [
-                "snap",
+                mock.ANY,
                 "sign-build",
                 "--developer-id=abcd",
                 "--snap-id=snap-id",
@@ -321,27 +277,21 @@ class SignBuildTestCase(CommandBaseTestCase):
         )
 
     @mock.patch.object(storeapi._sca_client.SCAClient, "get_account_information")
-    @mock.patch("subprocess.check_output")
     @mock.patch("snapcraft._store._get_data_from_snap_file")
-    @mock.patch("snapcraft.internal.repo.Repo.is_package_installed")
     def test_sign_build_missing_grade(
-        self,
-        mock_installed,
-        mock_get_snap_data,
-        mock_check_output,
-        mock_get_account_info,
+        self, mock_get_snap_data, mock_get_account_info,
     ):
-        mock_installed.return_value = True
         mock_get_account_info.return_value = {
             "account_id": "abcd",
             "account_keys": [{"public-key-sha3-384": "a_hash"}],
             "snaps": {"16": {"test-snap": {"snap-id": "snap-id"}}},
         }
         mock_get_snap_data.return_value = {"name": "test-snap"}
-        mock_check_output.side_effect = [
-            '[{"name": "default", "sha3-384": "a_hash"}]',
-            b"Mocked assertion",
-        ]
+        fake_check_output = fixtures.MockPatch(
+            "subprocess.check_output",
+            side_effect=['[{"name": "default"}]'.encode(), b"Mocked assertion"],
+        )
+        self.useFixture(fake_check_output)
 
         result = self.run_command(["sign-build", self.snap_test.snap_path, "--local"])
 
@@ -352,9 +302,9 @@ class SignBuildTestCase(CommandBaseTestCase):
             Contains("Build assertion {} saved to disk.".format(snap_build_path)),
         )
         self.assertThat(snap_build_path, FileExists())
-        mock_check_output.assert_called_with(
+        fake_check_output.mock.assert_called_with(
             [
-                "snap",
+                mock.ANY,
                 "sign-build",
                 "--developer-id=abcd",
                 "--snap-id=snap-id",
@@ -367,28 +317,24 @@ class SignBuildTestCase(CommandBaseTestCase):
 
     @mock.patch.object(storeapi._sca_client.SCAClient, "push_snap_build")
     @mock.patch.object(storeapi._sca_client.SCAClient, "get_account_information")
-    @mock.patch("subprocess.check_output")
     @mock.patch("snapcraft._store._get_data_from_snap_file")
-    @mock.patch("snapcraft.internal.repo.Repo.is_package_installed")
     def test_sign_build_upload_successfully(
-        self,
-        mock_installed,
-        mock_get_snap_data,
-        mock_check_output,
-        mock_get_account_info,
-        mock_push_snap_build,
+        self, mock_get_snap_data, mock_get_account_info, mock_push_snap_build,
     ):
-        mock_installed.return_value = True
         mock_get_account_info.return_value = {
             "account_id": "abcd",
             "account_keys": [{"public-key-sha3-384": "a_hash"}],
             "snaps": {"16": {"test-snap": {"snap-id": "snap-id"}}},
         }
         mock_get_snap_data.return_value = {"name": "test-snap", "grade": "stable"}
-        mock_check_output.side_effect = [
-            '[{"name": "default", "sha3-384": "a_hash"}]',
-            b"Mocked assertion",
-        ]
+        fake_check_output = fixtures.MockPatch(
+            "subprocess.check_output",
+            side_effect=[
+                '[{"name": "default", "sha3-384": "a_hash"}]'.encode(),
+                b"Mocked assertion",
+            ],
+        )
+        self.useFixture(fake_check_output)
 
         result = self.run_command(["sign-build", self.snap_test.snap_path])
 
@@ -405,9 +351,9 @@ class SignBuildTestCase(CommandBaseTestCase):
             ),
         )
         self.assertThat(snap_build_path, FileExists())
-        mock_check_output.assert_called_with(
+        fake_check_output.mock.assert_called_with(
             [
-                "snap",
+                mock.ANY,
                 "sign-build",
                 "--developer-id=abcd",
                 "--snap-id=snap-id",
@@ -422,15 +368,9 @@ class SignBuildTestCase(CommandBaseTestCase):
     @mock.patch.object(storeapi._sca_client.SCAClient, "push_snap_build")
     @mock.patch.object(storeapi._sca_client.SCAClient, "get_account_information")
     @mock.patch("snapcraft._store._get_data_from_snap_file")
-    @mock.patch("snapcraft.internal.repo.Repo.is_package_installed")
     def test_sign_build_upload_existing(
-        self,
-        mock_installed,
-        mock_get_snap_data,
-        mock_get_account_info,
-        mock_push_snap_build,
+        self, mock_get_snap_data, mock_get_account_info, mock_push_snap_build,
     ):
-        mock_installed.return_value = True
         mock_get_account_info.return_value = {
             "account_id": "abcd",
             "snaps": {"16": {"test-snap": {"snap-id": "snap-id"}}},


### PR DESCRIPTION
Assertion commands do not require snapd to be installed through the
deb, it just needs to be available for most commands.

LP: #1906506

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
