### PR TITLE
storeapi: remove unused MissingSnapdError

### DIFF
--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -756,17 +756,6 @@ class StoreAssertionError(StoreError):
     fmt = "Error signing {endpoint} assertion for {snap_name}: {error!s}"
 
 
-class MissingSnapdError(StoreError):
-
-    fmt = (
-        "The snapd package is not installed. In order to use {command!r}, "
-        "you must run 'apt install snapd'."
-    )
-
-    def __init__(self, command):
-        super().__init__(command=command)
-
-
 class KeyAlreadyRegisteredError(StoreError):
 
     fmt = "You have already registered a key named {key_name!r}"


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
