### PR TITLE
pluginhandler: do not walk symlinks for include filesets

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -1397,7 +1397,9 @@ def _generate_include_set(directory, includes):
         else:
             include_files |= set([os.path.join(directory, include)])
 
-    include_dirs = [x for x in include_files if os.path.isdir(x)]
+    include_dirs = [
+        x for x in include_files if os.path.isdir(x) and not os.path.islink(x)
+    ]
     include_files = set([os.path.relpath(x, directory) for x in include_files])
 
     # Expand includeFiles, so that an exclude like '*/*.so' will still match

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -226,6 +226,27 @@ class PluginTestCase(unit.TestCase):
             "Expected migrated 'sym-a' to be a symlink.",
         )
 
+    def test_migrate_files_no_follow_symlinks(self):
+        os.makedirs("install/usr/bin")
+        os.makedirs("stage")
+
+        with open(os.path.join("install", "usr", "bin", "foo"), "w") as f:
+            f.write("installed")
+
+        os.symlink("usr/bin", os.path.join("install", "bin"))
+
+        files, dirs = pluginhandler._migratable_filesets(["-usr"], "install")
+        pluginhandler._migrate_files(files, dirs, "install", "stage")
+
+        # Verify that the symlinks were preserved
+        assert files == {"bin"}
+        assert dirs == set()
+
+        self.assertTrue(
+            os.path.islink(os.path.join("stage", "bin")),
+            "Expected migrated 'bin' to be a symlink.",
+        )
+
     def test_migrate_files_preserves_symlink_nested_file(self):
         os.makedirs(os.path.join("install", "a"))
         os.makedirs("stage")


### PR DESCRIPTION
When generating the include file set, snapcraft will walk through
symlinks.  This effectively results in being unable to filter out
anything that itself, or parent is pointed to by an external symlink.

e.g. bin -> usr/bin  will prevent filtering anything under usr/bin.

This is because snapcraft will include 'bin/foo' even though 'bin'
is a symlink.  Subsequently, it will then preserve 'usr/bin/foo'.

Avoid this by simply checking if target is a link before walking
it.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
