### PR TITLE
elf: extract defined symbol versions

### DIFF
--- a/tests/fixture_setup/_unittests.py
+++ b/tests/fixture_setup/_unittests.py
@@ -141,6 +141,7 @@ def _fake_elffile_extract_attributes(self):
 
         self.interp = "/lib64/ld-linux-x86-64.so.2"
         self.soname = ""
+        self.versions = set()
         self.needed = {glibc.name: glibc}
         self.execstack_set = False
         self.is_dynamic = True
@@ -153,6 +154,7 @@ def _fake_elffile_extract_attributes(self):
 
         self.interp = "/lib64/ld-linux-x86-64.so.2"
         self.soname = ""
+        self.versions = set()
         self.needed = {glibc.name: glibc}
         self.execstack_set = False
         self.is_dynamic = True
@@ -165,6 +167,7 @@ def _fake_elffile_extract_attributes(self):
 
         self.interp = "/lib64/ld-linux-x86-64.so.2"
         self.soname = ""
+        self.versions = set()
         self.needed = {glibc.name: glibc}
         self.execstack_set = False
         self.is_dynamic = True
@@ -173,6 +176,7 @@ def _fake_elffile_extract_attributes(self):
     elif name == "fake_elf-static":
         self.interp = "/lib64/ld-linux-x86-64.so.2"
         self.soname = ""
+        self.versions = set()
         self.needed = dict()
         self.execstack_set = False
         self.is_dynamic = False
@@ -184,6 +188,7 @@ def _fake_elffile_extract_attributes(self):
 
         self.interp = ""
         self.soname = "libfake_elf.so.0"
+        self.versions = set()
         self.needed = {openssl.name: openssl}
         self.execstack_set = False
         self.is_dynamic = True
@@ -195,6 +200,7 @@ def _fake_elffile_extract_attributes(self):
 
         self.interp = "/lib64/ld-linux-x86-64.so.2"
         self.soname = ""
+        self.versions = set()
         self.needed = {glibc.name: glibc}
         self.execstack_set = True
         self.is_dynamic = True
@@ -206,6 +212,7 @@ def _fake_elffile_extract_attributes(self):
 
         self.interp = "/lib64/ld-linux-x86-64.so.2"
         self.soname = ""
+        self.versions = set()
         self.needed = {glibc.name: glibc}
         self.execstack_set = True
         self.is_dynamic = True
@@ -214,6 +221,7 @@ def _fake_elffile_extract_attributes(self):
     elif name == "libc.so.6":
         self.interp = ""
         self.soname = "libc.so.6"
+        self.versions = {"libc.so.6", "GLIBC_2.2.5", "GLIBC_2.23", "GLIBC_2.26"}
         self.needed = {}
         self.execstack_set = False
         self.is_dynamic = True
@@ -222,6 +230,7 @@ def _fake_elffile_extract_attributes(self):
     elif name == "libssl.so.1.0.0":
         self.interp = ""
         self.soname = "libssl.so.1.0.0"
+        self.versions = {"libssl.so.1.0.0", "OPENSSL_1.0.0"}
         self.needed = {}
         self.execstack_set = False
         self.is_dynamic = True
@@ -230,6 +239,7 @@ def _fake_elffile_extract_attributes(self):
     else:
         self.interp = ""
         self.soname = ""
+        self.versions = set()
         self.needed = {}
         self.execstack_set = False
         self.is_dynamic = True

--- a/tests/unit/test_elf.py
+++ b/tests/unit/test_elf.py
@@ -85,8 +85,9 @@ class TestElfFileSmoketest(unit.TestCase):
         self.assertTrue(isinstance(elf_file.interp, str))
         self.assertThat(elf_file.interp, NotEquals(""))
 
-        # Python is not a shared library, so has no soname
+        # Python is not a shared library, so has no soname or defined versions
         self.assertThat(elf_file.soname, Equals(""))
+        self.assertThat(elf_file.versions, Equals(set()))
 
         # We expect that Python will be linked to libc
         for lib in elf_file.needed.values():
@@ -404,6 +405,14 @@ class TestElfFileAttrs(TestElfBase):
         openssl = elf_file.needed["libssl.so.1.0.0"]
         self.assertThat(openssl.name, Equals("libssl.so.1.0.0"))
         self.assertThat(openssl.versions, Equals({"OPENSSL_1.0.0"}))
+
+    def test_libssl(self):
+        # libssl.so.1.0.0 defines some symbol versions it provides
+        elf_file = self.fake_elf["libssl.so.1.0.0"]
+
+        self.assertThat(elf_file.interp, Equals(""))
+        self.assertThat(elf_file.soname, Equals("libssl.so.1.0.0"))
+        self.assertThat(elf_file.versions, Equals({"libssl.so.1.0.0", "OPENSSL_1.0.0"}))
 
 
 class TestPatcher(TestElfBase):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
I think it would be useful for Snapcraft to warn if a snap was missing libraries, or including duplicate libraries provided by the base snap or a content interface snap.

The current `ElfFile` class contains most of this information, in the form of the list of needed libraries together with the required symbol versions.  What is missing is a list of symbol versions defined by the library.  This PR adds that information to the class.