### PR TITLE
Fix a few licenses in ros-related test files

### DIFF
--- a/tests/spread/plugins/v2/snaps/catkin-catkin-packages-ignore/src/package1/package.xml
+++ b/tests/spread/plugins/v2/snaps/catkin-catkin-packages-ignore/src/package1/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.1</version>
   <description>snapcraft test</description>
   <maintainer email="me@example.com">me</maintainer>
-  <license>Apache License 2.0</license>
+  <license>GPLv3</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_export_depend>roscpp</build_export_depend>

--- a/tests/spread/plugins/v2/snaps/catkin-catkin-packages-ignore/src/package2/package.xml
+++ b/tests/spread/plugins/v2/snaps/catkin-catkin-packages-ignore/src/package2/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.1</version>
   <description>snapcraft test</description>
   <maintainer email="me@example.com">me</maintainer>
-  <license>Apache License 2.0</license>
+  <license>GPLv3</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_export_depend>roscpp</build_export_depend>

--- a/tests/spread/plugins/v2/snaps/catkin-cmake-args/src/customizable_message/package.xml
+++ b/tests/spread/plugins/v2/snaps/catkin-cmake-args/src/customizable_message/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.1</version>
   <description>snapcraft test</description>
   <maintainer email="me@example.com">me</maintainer>
-  <license>Apache License 2.0</license>
+  <license>GPLv3</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_export_depend>roscpp</build_export_depend>

--- a/tests/spread/plugins/v2/snaps/catkin-noetic-hello/src/snapcraft_hello/package.xml
+++ b/tests/spread/plugins/v2/snaps/catkin-noetic-hello/src/snapcraft_hello/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.1</version>
   <description>snapcraft test for roscpp</description>
   <maintainer email="me@example.com">me</maintainer>
-  <license>Apache License 2.0</license>
+  <license>GPLv3</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_export_depend>roscpp</build_export_depend>

--- a/tests/spread/plugins/v2/snaps/catkin-noetic-in-source-hello/package.xml
+++ b/tests/spread/plugins/v2/snaps/catkin-noetic-in-source-hello/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.1</version>
   <description>snapcraft test for roscpp</description>
   <maintainer email="me@example.com">me</maintainer>
-  <license>Apache License 2.0</license>
+  <license>GPLv3</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_export_depend>roscpp</build_export_depend>

--- a/tests/spread/plugins/v2/snaps/catkin-specific-packages/src/package1/package.xml
+++ b/tests/spread/plugins/v2/snaps/catkin-specific-packages/src/package1/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.1</version>
   <description>snapcraft test</description>
   <maintainer email="me@example.com">me</maintainer>
-  <license>Apache License 2.0</license>
+  <license>GPLv3</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_export_depend>roscpp</build_export_depend>

--- a/tests/spread/plugins/v2/snaps/catkin-specific-packages/src/package2/package.xml
+++ b/tests/spread/plugins/v2/snaps/catkin-specific-packages/src/package2/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.1</version>
   <description>snapcraft test</description>
   <maintainer email="me@example.com">me</maintainer>
-  <license>Apache License 2.0</license>
+  <license>GPLv3</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_export_depend>roscpp</build_export_depend>

--- a/tests/spread/plugins/v2/snaps/catkin-tools-cmake-args/src/customizable_message/package.xml
+++ b/tests/spread/plugins/v2/snaps/catkin-tools-cmake-args/src/customizable_message/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.1</version>
   <description>snapcraft test</description>
   <maintainer email="me@example.com">me</maintainer>
-  <license>Apache License 2.0</license>
+  <license>GPLv3</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_export_depend>roscpp</build_export_depend>

--- a/tests/spread/plugins/v2/snaps/catkin-tools-noetic-hello/src/snapcraft_hello/package.xml
+++ b/tests/spread/plugins/v2/snaps/catkin-tools-noetic-hello/src/snapcraft_hello/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.1</version>
   <description>snapcraft test for roscpp</description>
   <maintainer email="me@example.com">me</maintainer>
-  <license>Apache License 2.0</license>
+  <license>GPLv3</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_export_depend>roscpp</build_export_depend>

--- a/tests/spread/plugins/v2/snaps/catkin-tools-noetic-in-source-hello/package.xml
+++ b/tests/spread/plugins/v2/snaps/catkin-tools-noetic-in-source-hello/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.1</version>
   <description>snapcraft test for roscpp</description>
   <maintainer email="me@example.com">me</maintainer>
-  <license>Apache License 2.0</license>
+  <license>GPLv3</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_export_depend>roscpp</build_export_depend>

--- a/tests/spread/plugins/v2/snaps/catkin-tools-specific-packages/src/package1/package.xml
+++ b/tests/spread/plugins/v2/snaps/catkin-tools-specific-packages/src/package1/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.1</version>
   <description>snapcraft test</description>
   <maintainer email="me@example.com">me</maintainer>
-  <license>Apache License 2.0</license>
+  <license>GPLv3</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_export_depend>roscpp</build_export_depend>

--- a/tests/spread/plugins/v2/snaps/catkin-tools-specific-packages/src/package2/package.xml
+++ b/tests/spread/plugins/v2/snaps/catkin-tools-specific-packages/src/package2/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.1</version>
   <description>snapcraft test</description>
   <maintainer email="me@example.com">me</maintainer>
-  <license>Apache License 2.0</license>
+  <license>GPLv3</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_export_depend>roscpp</build_export_depend>


### PR DESCRIPTION
Here is the follow-up PR to https://github.com/snapcore/snapcraft/pull/3405 fixing a few licenses in ROS-related test files. The license declared in a few `package.xml` did not match those in sources.

See [this discussion](https://github.com/snapcore/snapcraft/pull/3405#discussion_r554162049) for reference.

Signed-off-by: artivis <deray.jeremie@gmail.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
