### PR TITLE
project: enable experimental target-arch support for core20

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -186,6 +186,13 @@ _PROVIDER_OPTIONS: List[Dict[str, Any]] = [
         envvar="SNAPCRAFT_ENABLE_EXPERIMENTAL_PACKAGE_REPOSITORIES",
         supported_providers=["host", "lxd", "managed-host", "multipass"],
     ),
+    dict(
+        param_decls="--enable-experimental-target-arch",
+        is_flag=True,
+        help="Enable experimental `--target-arch` support for core20.",
+        envvar="SNAPCRAFT_ENABLE_EXPERIMENTAL_TARGET_ARCH",
+        supported_providers=["host", "lxd", "managed-host", "multipass"],
+    ),
 ]
 
 
@@ -387,9 +394,16 @@ def apply_host_provider_flags(build_provider_flags: Dict[str, str]) -> None:
             os.environ.pop(env_name, None)
             continue
 
+    issue_build_provider_warnings(build_provider_flags)
+
+
+def issue_build_provider_warnings(build_provider_flags: Dict[str, str]) -> None:
     # Log any experimental flags in use.
     if build_provider_flags.get("SNAPCRAFT_ENABLE_EXPERIMENTAL_PACKAGE_REPOSITORIES"):
         warning("*EXPERIMENTAL* package-repositories enabled.")
 
     if build_provider_flags.get("SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS"):
         warning("*EXPERIMENTAL* extensions enabled.")
+
+    if build_provider_flags.get("SNAPCRAFT_ENABLE_EXPERIMENTAL_TARGET_ARCH"):
+        warning("*EXPERIMENTAL* --target-arch for core20 enabled.")

--- a/snapcraft/project/_sanity_checks.py
+++ b/snapcraft/project/_sanity_checks.py
@@ -62,9 +62,11 @@ def conduct_project_sanity_check(project: Project, **kwargs) -> None:
     if (
         project._get_build_base() in ["core20"]
         and kwargs.get("target_arch") is not None
+        and not os.getenv("SNAPCRAFT_ENABLE_EXPERIMENTAL_TARGET_ARCH")
     ):
         raise SnapcraftEnvironmentError(
-            "--target-arch has been deprecated and is no longer supported on core20."
+            "*EXPERIMENTAL* '--target-arch' configured, but not enabled. "
+            "Enable with '--enable-experimental-target-arch' flag."
         )
 
     # Icon should refer to project file, verify it exists.


### PR DESCRIPTION
Allow use of --target-arch with an *EXPERIMENTAL* warning.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
