### PR TITLE
repo: only install build packages marked for installation

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -325,14 +325,16 @@ class Ubuntu(BaseRepo):
         return True
 
     @classmethod
-    def _get_marked_packages(cls, package_names: List[str]) -> List[Tuple[str, str]]:
+    def _get_packages_marked_for_installation(
+        cls, package_names: List[str]
+    ) -> List[Tuple[str, str]]:
         with AptCache() as apt_cache:
             try:
                 apt_cache.mark_packages(set(package_names))
             except errors.PackageNotFoundError as error:
                 raise errors.BuildPackageNotFoundError(error.package_name)
 
-            return apt_cache.get_marked_packages()
+            return apt_cache.get_packages_marked_for_installation()
 
     @classmethod
     def install_build_packages(cls, package_names: List[str]) -> List[str]:
@@ -360,7 +362,7 @@ class Ubuntu(BaseRepo):
             install_required = True
             cls.refresh_build_packages()
 
-        marked_packages = cls._get_marked_packages(package_names)
+        marked_packages = cls._get_packages_marked_for_installation(package_names)
         packages = [f"{name}={version}" for name, version in sorted(marked_packages)]
 
         if install_required:

--- a/snapcraft/internal/repo/apt_cache.py
+++ b/snapcraft/internal/repo/apt_cache.py
@@ -178,10 +178,11 @@ class AptCache(ContextDecorator):
                 installed[package.name] = str(package.installed.version)
         return installed
 
-    def get_marked_packages(self) -> List[Tuple[str, str]]:
+    def get_packages_marked_for_installation(self) -> List[Tuple[str, str]]:
         return [
             (package.name, package.candidate.version)
             for package in self.cache.get_changes()
+            if package.marked_install
         ]
 
     def mark_packages(self, package_names: Set[str]) -> None:

--- a/tests/unit/repo/test_apt_cache.py
+++ b/tests/unit/repo/test_apt_cache.py
@@ -49,7 +49,7 @@ class TestAptStageCache(unit.TestCase):
                 required_names=package_names, filtered_names=filtered_names
             )
 
-            marked_packages = apt_cache.get_marked_packages()
+            marked_packages = apt_cache.get_packages_marked_for_installation()
             self.assertThat(
                 sorted([name for name, _ in marked_packages]),
                 Equals(["libpci3", "pciutils"]),

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -180,7 +180,7 @@ class BuildPackagesTestCase(unit.TestCase):
         ).mock
 
     def test_install_build_package(self):
-        self.fake_apt_cache.return_value.__enter__.return_value.get_marked_packages.return_value = [
+        self.fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
             ("package", "1.0"),
             ("package-installed", "1.0"),
             ("versioned-package", "2.0"),
@@ -248,7 +248,7 @@ class BuildPackagesTestCase(unit.TestCase):
         )
 
     def test_already_installed_no_specified_version(self):
-        self.fake_apt_cache.return_value.__enter__.return_value.get_marked_packages.return_value = [
+        self.fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
             ("package-installed", "1.0")
         ]
 
@@ -258,7 +258,7 @@ class BuildPackagesTestCase(unit.TestCase):
         self.assertThat(self.fake_run.mock_calls, Equals([]))
 
     def test_already_installed_with_specified_version(self):
-        self.fake_apt_cache.return_value.__enter__.return_value.get_marked_packages.return_value = [
+        self.fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
             ("package-installed", "1.0")
         ]
 
@@ -268,7 +268,7 @@ class BuildPackagesTestCase(unit.TestCase):
         self.assertThat(self.fake_run.mock_calls, Equals([]))
 
     def test_already_installed_with_different_version(self):
-        self.fake_apt_cache.return_value.__enter__.return_value.get_marked_packages.return_value = [
+        self.fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
             ("package-installed", "3.0")
         ]
 
@@ -310,7 +310,7 @@ class BuildPackagesTestCase(unit.TestCase):
         )
 
     def test_install_virtual_build_package(self):
-        self.fake_apt_cache.return_value.__enter__.return_value.get_marked_packages.return_value = [
+        self.fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
             ("package", "1.0")
         ]
 
@@ -353,7 +353,7 @@ class BuildPackagesTestCase(unit.TestCase):
 
     def test_smart_terminal(self):
         self.fake_is_dumb_terminal.return_value = False
-        self.fake_apt_cache.return_value.__enter__.return_value.get_marked_packages.return_value = [
+        self.fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
             ("package", "1.0")
         ]
 
@@ -407,7 +407,7 @@ class BuildPackagesTestCase(unit.TestCase):
         )
 
     def test_broken_package_apt_install(self):
-        self.fake_apt_cache.return_value.__enter__.return_value.get_marked_packages.return_value = [
+        self.fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
             ("package", "1.0")
         ]
         self.useFixture(


### PR DESCRIPTION
Ubuntu usage of apt_cache.get_marked_packages() assumes any
marked package is marked for installation.  However, it may
contain packages marked for deletion.

Modify get_marked_packages() to get_packages_marked_for_installation()
to accurately capture the required build packages to install. Apt
will handle deletion as necessary.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
