### PR TITLE
grammar: ensure all dictionary primitives are captured

### DIFF
--- a/snapcraft/internal/project_loader/grammar/_processor.py
+++ b/snapcraft/internal/project_loader/grammar/_processor.py
@@ -113,11 +113,19 @@ class GrammarProcessor:
                     call_stack=call_stack, section=section, statement=statement,
                 )
 
-                self._process_statement(
-                    statement=finalized_statement,
-                    statements=statements,
-                    primitives=primitives,
-                )
+                # Process any finalized statement (if any).
+                if finalized_statement is not None:
+                    self._process_statement(
+                        statement=finalized_statement,
+                        statements=statements,
+                        primitives=primitives,
+                    )
+
+                # If this section does not belong to a statement, it is
+                # a primitive to be recorded.
+                if statement is None:
+                    primitives.append(section)
+
             else:
                 # jsonschema should never let us get here.
                 raise GrammarSyntaxError(
@@ -219,6 +227,13 @@ class GrammarProcessor:
 
             elif _ELSE_CLAUSE_PATTERN.match(key):
                 _handle_else(statement, value)
+            else:
+                # Since this section is a dictionary, if there are no
+                # markers to indicate the start or change of statement,
+                # the current statement is complete and this section
+                # is a primitive to be collected.
+                finalized_statement = statement
+                statement = None
 
         return statement, finalized_statement
 

--- a/tests/unit/project_loader/grammar/test_processor.py
+++ b/tests/unit/project_loader/grammar/test_processor.py
@@ -56,7 +56,25 @@ class TestBasicGrammar:
                 "grammar_entry": ["foo", "bar"],
                 "host_arch": "x86_64",
                 "target_arch": "amd64",
-                "expected_packages": ["foo", "bar"],
+                "expected_results": ["foo", "bar"],
+            },
+        ),
+        (
+            "unconditional dict",
+            {
+                "grammar_entry": [{"foo": "bar"}],
+                "host_arch": "x86_64",
+                "target_arch": "amd64",
+                "expected_results": [{"foo": "bar"}],
+            },
+        ),
+        (
+            "unconditional multi-dict",
+            {
+                "grammar_entry": [{"foo": "bar"}, {"foo2": "bar2"}],
+                "host_arch": "x86_64",
+                "target_arch": "amd64",
+                "expected_results": [{"foo": "bar"}, {"foo2": "bar2"}],
             },
         ),
         (
@@ -65,7 +83,7 @@ class TestBasicGrammar:
                 "grammar_entry": ["foo", {"on i386": ["bar"]}],
                 "host_arch": "i686",
                 "target_arch": "i386",
-                "expected_packages": ["foo", "bar"],
+                "expected_results": ["foo", "bar"],
             },
         ),
         (
@@ -74,7 +92,7 @@ class TestBasicGrammar:
                 "grammar_entry": ["foo", {"on i386": ["bar"]}],
                 "host_arch": "x86_64",
                 "target_arch": "amd64",
-                "expected_packages": ["foo"],
+                "expected_results": ["foo"],
             },
         ),
         (
@@ -83,7 +101,7 @@ class TestBasicGrammar:
                 "grammar_entry": [{"on amd64": ["foo"]}, {"on i386": ["bar"]}],
                 "host_arch": "x86_64",
                 "target_arch": "amd64",
-                "expected_packages": ["foo"],
+                "expected_results": ["foo"],
             },
         ),
         (
@@ -92,7 +110,7 @@ class TestBasicGrammar:
                 "grammar_entry": [{"on amd64": ["foo"]}, {"on i386": ["bar"]}],
                 "host_arch": "i686",
                 "target_arch": "i386",
-                "expected_packages": ["bar"],
+                "expected_results": ["bar"],
             },
         ),
         (
@@ -101,7 +119,7 @@ class TestBasicGrammar:
                 "grammar_entry": [{"on amd64": ["foo"]}, {"else": ["bar"]}],
                 "host_arch": "x86_64",
                 "target_arch": "amd64",
-                "expected_packages": ["foo"],
+                "expected_results": ["foo"],
             },
         ),
         (
@@ -110,7 +128,7 @@ class TestBasicGrammar:
                 "grammar_entry": [{"on amd64": ["foo"]}, {"else": ["bar"]}],
                 "host_arch": "i686",
                 "target_arch": "i386",
-                "expected_packages": ["bar"],
+                "expected_results": ["bar"],
             },
         ),
         (
@@ -121,7 +139,18 @@ class TestBasicGrammar:
                 ],
                 "host_arch": "x86_64",
                 "target_arch": "amd64",
-                "expected_packages": ["foo"],
+                "expected_results": ["foo"],
+            },
+        ),
+        (
+            "nested amd64 dict",
+            {
+                "grammar_entry": [
+                    {"on amd64": [{"on amd64": [{"foo": "bar"}]}, {"on i386": ["bar"]}]}
+                ],
+                "host_arch": "x86_64",
+                "target_arch": "amd64",
+                "expected_results": [{"foo": "bar"}],
             },
         ),
         (
@@ -132,7 +161,7 @@ class TestBasicGrammar:
                 ],
                 "host_arch": "i686",
                 "target_arch": "i386",
-                "expected_packages": ["bar"],
+                "expected_results": ["bar"],
             },
         ),
         (
@@ -143,7 +172,7 @@ class TestBasicGrammar:
                 ],
                 "host_arch": "x86_64",
                 "target_arch": "amd64",
-                "expected_packages": ["foo"],
+                "expected_results": ["foo"],
             },
         ),
         (
@@ -154,7 +183,7 @@ class TestBasicGrammar:
                 ],
                 "host_arch": "i686",
                 "target_arch": "amd64",
-                "expected_packages": ["bar"],
+                "expected_results": ["bar"],
             },
         ),
         (
@@ -163,7 +192,7 @@ class TestBasicGrammar:
                 "grammar_entry": [{"try": ["valid"]}],
                 "host_arch": "x86_64",
                 "target_arch": "amd64",
-                "expected_packages": ["valid"],
+                "expected_results": ["valid"],
             },
         ),
         (
@@ -172,7 +201,7 @@ class TestBasicGrammar:
                 "grammar_entry": [{"try": ["invalid"]}, {"else": ["valid"]}],
                 "host_arch": "x86_64",
                 "target_arch": "amd64",
-                "expected_packages": ["valid"],
+                "expected_results": ["valid"],
             },
         ),
         (
@@ -181,7 +210,7 @@ class TestBasicGrammar:
                 "grammar_entry": [{"on amd64": [{"try": ["foo"]}, {"else": ["bar"]}]}],
                 "host_arch": "x86_64",
                 "target_arch": "amd64",
-                "expected_packages": ["foo"],
+                "expected_results": ["foo"],
             },
         ),
         (
@@ -192,7 +221,7 @@ class TestBasicGrammar:
                 ],
                 "host_arch": "i686",
                 "target_arch": "i686",
-                "expected_packages": ["bar"],
+                "expected_results": ["bar"],
             },
         ),
         (
@@ -201,7 +230,7 @@ class TestBasicGrammar:
                 "grammar_entry": ["foo", {"try": ["invalid"]}],
                 "host_arch": "i686",
                 "target_arch": "i386",
-                "expected_packages": ["foo"],
+                "expected_results": ["foo"],
             },
         ),
         (
@@ -214,7 +243,7 @@ class TestBasicGrammar:
                 ],
                 "host_arch": "x86_64",
                 "target_arch": "i386",
-                "expected_packages": ["foo", "foo2"],
+                "expected_results": ["foo", "foo2"],
             },
         ),
         (
@@ -231,7 +260,7 @@ class TestBasicGrammar:
                 ],
                 "host_arch": "x86_64",
                 "target_arch": "i386",
-                "expected_packages": [
+                "expected_results": [
                     "foo",
                     "on-foo",
                     "after-on",
@@ -241,10 +270,46 @@ class TestBasicGrammar:
                 ],
             },
         ),
+        (
+            "complex nested dicts",
+            {
+                "grammar_entry": [
+                    {"yes1": "yes1"},
+                    {
+                        "on amd64": [
+                            {"yes2": "yes2"},
+                            {"on amd64": [{"yes3": "yes3"}]},
+                            {"yes4": "yes4"},
+                            {"on i386": [{"no1": "no1"}]},
+                            {"else": [{"yes5": "yes5"}]},
+                            {"yes6": "yes6"},
+                        ],
+                    },
+                    {"else": [{"no2": "no2"}]},
+                    {"yes7": "yes7"},
+                    {"on i386": [{"no3": "no3"}]},
+                    {"else": [{"yes8": "yes8"}]},
+                    {"yes9": "yes9"},
+                ],
+                "host_arch": "x86_64",
+                "target_arch": "amd64",
+                "expected_results": [
+                    {"yes1": "yes1"},
+                    {"yes2": "yes2"},
+                    {"yes3": "yes3"},
+                    {"yes4": "yes4"},
+                    {"yes5": "yes5"},
+                    {"yes6": "yes6"},
+                    {"yes7": "yes7"},
+                    {"yes8": "yes8"},
+                    {"yes9": "yes9"},
+                ],
+            },
+        ),
     ]
 
     def test_basic_grammar(
-        self, monkeypatch, grammar_entry, host_arch, target_arch, expected_packages
+        self, monkeypatch, grammar_entry, host_arch, target_arch, expected_results
     ):
         monkeypatch.setattr(platform, "machine", lambda: host_arch)
         monkeypatch.setattr(platform, "architecture", lambda: ("64bit", "ELF"))
@@ -254,7 +319,7 @@ class TestBasicGrammar:
         processor = grammar.GrammarProcessor(
             grammar_entry, project, lambda x: "invalid" not in x
         )
-        assert processor.process() == expected_packages
+        assert processor.process() == expected_results
 
 
 class TestTransformerGrammar:
@@ -265,7 +330,7 @@ class TestTransformerGrammar:
             {
                 "grammar_entry": ["foo", "bar"],
                 "host_arch": "x86_64",
-                "expected_packages": ["foo", "bar"],
+                "expected_results": ["foo", "bar"],
             },
         ),
         (
@@ -273,7 +338,7 @@ class TestTransformerGrammar:
             {
                 "grammar_entry": ["foo", {"on i386": ["bar"]}],
                 "host_arch": "i686",
-                "expected_packages": ["foo", "bar"],
+                "expected_results": ["foo", "bar"],
             },
         ),
         (
@@ -281,7 +346,7 @@ class TestTransformerGrammar:
             {
                 "grammar_entry": ["foo", {"on i386": ["bar"]}],
                 "host_arch": "x86_64",
-                "expected_packages": ["foo"],
+                "expected_results": ["foo"],
             },
         ),
         (
@@ -289,7 +354,7 @@ class TestTransformerGrammar:
             {
                 "grammar_entry": [{"to i386": ["foo"]}],
                 "host_arch": "x86_64",
-                "expected_packages": ["foo:i386"],
+                "expected_results": ["foo:i386"],
             },
         ),
         (
@@ -297,7 +362,7 @@ class TestTransformerGrammar:
             {
                 "grammar_entry": [{"to i386": [{"on amd64": ["foo"]}]}],
                 "host_arch": "x86_64",
-                "expected_packages": ["foo:i386"],
+                "expected_results": ["foo:i386"],
             },
         ),
         (
@@ -305,13 +370,13 @@ class TestTransformerGrammar:
             {
                 "grammar_entry": [{"to amd64": ["foo"]}, {"else": ["bar"]}],
                 "host_arch": "x86_64",
-                "expected_packages": ["bar"],
+                "expected_results": ["bar"],
             },
         ),
     ]
 
     def test_grammar_with_transformer(
-        self, monkeypatch, grammar_entry, host_arch, expected_packages
+        self, monkeypatch, grammar_entry, host_arch, expected_results
     ):
         monkeypatch.setattr(platform, "machine", lambda: host_arch)
         monkeypatch.setattr(platform, "architecture", lambda: ("64bit", "ELF"))
@@ -331,7 +396,7 @@ class TestTransformerGrammar:
             transformer=_transformer,
         )
 
-        assert processor.process() == expected_packages
+        assert processor.process() == expected_results
 
 
 class TestInvalidGrammar:


### PR DESCRIPTION
There is no impact for current projects because there is
no supported usage until build-environment is enabled.

Improve test coverage of dicts and rename "expected_packages"
to "expected_results" as not all test cases imply packages.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
