### PR TITLE
elf: add a class to check for dependency problems in a group of files

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -473,6 +473,113 @@ class ElfFile:
         return dependencies
 
 
+class DependencyChecker:
+    """DependencyChecker checks for library dependency problems in a snap."""
+
+    def __init__(self) -> None:
+        self._base_libs: Dict[Tuple[ElfArchitectureTuple, str], ElfFile] = {}
+
+    def _get_elfs(
+        self, base_path: str
+    ) -> Tuple[Dict[Tuple[ElfArchitectureTuple, str], ElfFile], List[ElfFile]]:
+        """Return the the libraries and other elf files found under base_path.
+
+        The libraries are returned as a dictionary keyed by
+        (architecture, soname), while other elf files are returned as
+        a simple sequence.
+        """
+        file_list: List[str] = []
+        for root, dirs, files in os.walk(base_path):
+            for f in files:
+                path = os.path.join(root, f)
+                if os.access(path, os.R_OK) and os.path.isfile(path):
+                    file_list.append(os.path.relpath(path, base_path))
+        libraries: Dict[Tuple[ElfArchitectureTuple, str], ElfFile] = {}
+        other: List[ElfFile] = []
+        for elf in get_elf_files(base_path, file_list):
+            if elf.soname:
+                assert elf.arch is not None
+                libraries[elf.arch, elf.soname] = elf
+            else:
+                other.append(elf)
+        return libraries, other
+
+    def add_base_libs(self, base_path: str) -> None:
+        """Add libraries provided by the base snap or a "platform" content snap.
+
+        The libraries can be used to satisfy dependencies, but it is
+        assumed that their own dependencies are already satisfied.
+        """
+        libs, _ = self._get_elfs(base_path)
+        self._base_libs.update(libs)
+
+    def check(self, snap_path: str) -> Sequence[str]:
+        """Check for dependency problems with the ELF files in a snap.
+
+        Currently this includes checks for:
+
+         1. Unused libraries, using the non-libraries as a seed for a
+            recursive search.
+         2. ELF files whose dependencies are not met by libraries in
+            the snap or its base (including symbol version checks).
+         3. Libraries in the snap that appear to duplicate those
+            provided by the base.
+        """
+        warnings: Set[str] = set()
+        libs, to_check = self._get_elfs(snap_path)
+        seen: Set[ElfFile] = set()
+        required_versions: Dict[Tuple[ElfArchitectureTuple, str], Set[str]] = {}
+        # Scan through the set of elf files referenced by executables
+        # and plugin shared libraries.
+        while len(to_check) != 0:
+            elf = to_check.pop()
+            if elf in seen:
+                continue
+            seen.add(elf)
+            assert elf.arch is not None
+            for needed in elf.needed.values():
+                required_versions.setdefault((elf.arch, needed.name), set()).update(
+                    needed.versions
+                )
+                # Is this library provided by the snap?
+                library = libs.get((elf.arch, needed.name))
+                if library is not None:
+                    to_check.append(library)
+                    if not needed.versions.issubset(library.versions):
+                        warnings.add(
+                            f"library {os.path.relpath(library.path, snap_path)} provided by snap does not provide symbol versions {needed.versions.difference(library.versions)}"
+                        )
+                    continue
+                # Is this library provided by the base snap?
+                library = self._base_libs.get((elf.arch, needed.name))
+                if library is not None:
+                    if not needed.versions.issubset(library.versions):
+                        warnings.add(
+                            f"library {library.path} provided by base does not provide symbol versions {needed.versions.difference(library.versions)}"
+                        )
+                else:
+                    warnings.add(
+                        f"library {needed.name} required by {os.path.relpath(elf.path, snap_path)} is missing"
+                    )
+
+        # Now check for library usage:
+        for library in libs.values():
+            if library in seen:
+                assert library.arch is not None
+                versions = required_versions.get((library.arch, library.soname), set())
+                base_lib = self._base_libs.get((library.arch, library.soname))
+                if base_lib is not None and versions.issubset(base_lib.versions):
+                    warnings.add(
+                        f"library {os.path.relpath(library.path, snap_path)} in snap duplicates {base_lib.path} from base snap"
+                    )
+            else:
+                warnings.add(
+                    f"library {os.path.relpath(library.path, snap_path)} in snap is unused"
+                )
+
+        return sorted(warnings)
+
+
 class Patcher:
     """Patcher holds the necessary logic to patch elf files."""
 
@@ -677,8 +784,8 @@ def get_elf_files(root: str, file_list: Sequence[str]) -> FrozenSet[ElfFile]:
             logger.warning(exception.get_brief())
             continue
 
-        # If ELF has dynamic symbols, add it.
-        if elf_file.needed:
+        # If ELF is dynamic, add it.
+        if elf_file.is_dynamic:
             elf_files.add(elf_file)
 
     return frozenset(elf_files)


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
This is still a work in progress, and somewhat duplicates the current `ldd` based dependency checking code.  It is currently not hooked up to anything, and I'm not quite sure where it would make most sense to run the check.

With a single pass over all files in the snap, it performs the following checks:

1. check for unused shared libraries, using the non-libraries as a starting point and recursively following dependencies.
2. check that all dependencies in the set of used elf files are met by either the snap itself or its base.  This includes checking that required symbol versions are defined (e.g. to catch executables requiring newer glibc).
3. check whether libraries in the snap duplicate those in the base snap.  We only generate a warning if the library from the base snap defines all the symbol versions required by the elf files in the snap.

For (1), I'm defining non-libraries as ELF files without a soname.  I intended this to cover both executables and "plugin" type shared object files.  Unfortunately my testing showed up a number of cases where plugins have sonames, so perhaps it needs to take the file path into account too.

Here is an example of the current output:

```
>>> from snapcraft.internal import elf
>>> dep = elf.DependencyChecker()
>>> dep.add_base_libs('/snap/core18/current')
>>> for w in dep.check('/snap/lxd/current'): print(w)
... 
library lib/liblxcfs.so in snap is unused
library lib/libmnl.so.0.2.0 in snap duplicates /snap/core18/current/lib/x86_64-linux-gnu/libmnl.so.0.2.0 from base snap
library lib/libseccomp.so.2.5.1 in snap duplicates /snap/core18/current/lib/x86_64-linux-gnu/libseccomp.so.2.4.3 from base snap
library lib/libsqlite3.so.0.8.6 in snap duplicates /snap/core18/current/usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6 from base snap
library lib/x86_64-linux-gnu/ceph/compressor/libceph_snappy.so.2.0.0 in snap is unused
library lib/x86_64-linux-gnu/ceph/compressor/libceph_zlib.so.2.0.0 in snap is unused
library lib/x86_64-linux-gnu/ceph/compressor/libceph_zstd.so.2.0.0 in snap is unused
library lib/x86_64-linux-gnu/ceph/crypto/libceph_crypto_isal.so.1.0.0 in snap is unused
library lib/x86_64-linux-gnu/device-mapper/libdevmapper-event-lvm2mirror.so in snap is unused
library lib/x86_64-linux-gnu/device-mapper/libdevmapper-event-lvm2raid.so in snap is unused
library lib/x86_64-linux-gnu/device-mapper/libdevmapper-event-lvm2snapshot.so in snap is unused
library lib/x86_64-linux-gnu/device-mapper/libdevmapper-event-lvm2thin.so in snap is unused
library lib/x86_64-linux-gnu/libdb-5.3.so in snap duplicates /snap/core18/current/usr/lib/x86_64-linux-gnu/libdb-5.3.so from base snap
library lib/x86_64-linux-gnu/libdevmapper-event-lvm2.so.2.02 in snap is unused
library lib/x86_64-linux-gnu/liblvm2app.so.2.2 in snap is unused
library lib/x86_64-linux-gnu/liblvm2cmd.so.2.02 in snap is unused
library lib/x86_64-linux-gnu/libsnappy.so.1.1.7 in snap is unused
library lib/x86_64-linux-gnu/libusbredirhost.so.1.0.0 in snap is unused
library lib/x86_64-linux-gnu/nss/libfreeblpriv3.so in snap is unused
library lib/x86_64-linux-gnu/nss/libsoftokn3.so in snap is unused
library libebt_802_3.so required by bin/ebtables is missing
library libebt_among.so required by bin/ebtables is missing
library libebt_arp.so required by bin/ebtables is missing
library libebt_arpreply.so required by bin/ebtables is missing
library libebt_ip.so required by bin/ebtables is missing
library libebt_ip6.so required by bin/ebtables is missing
library libebt_limit.so required by bin/ebtables is missing
library libebt_log.so required by bin/ebtables is missing
library libebt_mark.so required by bin/ebtables is missing
library libebt_mark_m.so required by bin/ebtables is missing
library libebt_nat.so required by bin/ebtables is missing
library libebt_nflog.so required by bin/ebtables is missing
library libebt_pkttype.so required by bin/ebtables is missing
library libebt_redirect.so required by bin/ebtables is missing
library libebt_standard.so required by bin/ebtables is missing
library libebt_stp.so required by bin/ebtables is missing
library libebt_ulog.so required by bin/ebtables is missing
library libebt_vlan.so required by bin/ebtables is missing
library libebtable_broute.so required by bin/ebtables is missing
library libebtable_filter.so required by bin/ebtables is missing
library libebtable_nat.so required by bin/ebtables is missing
library zfs-2.0/lib/libzfsbootenv.so.1.0.0 in snap is unused
library zfs-2.0/lib/libzpool.so.4.0.0 in snap is unused
```

While this shows up a few libraries that could be removed from the snap, there it also exposes a few problems with the checks:
 * the ceph and device-mapper plugins are listed as unused libraries, which has knock-on effects for other libraries in the snap.  They should be treated as non-libraries despite having a soname.
 * the `libebt_*.so` libraries are reported as missing.  It turns out the files exist but have no soname set so were incorrectly excluded from the library set.

So perhaps doing a path based check is a better approach for distinguishing libraries from executables/plugins.  Perhaps checking that the file's dirname ends with `/lib` or `/lib/${any_arch_triplet}` would be appropriate?