### PR TITLE
project loader: export SNAPCRAFT_TARGET_ARCH in build environment

### DIFF
--- a/snapcraft/internal/pluginhandler/_part_environment.py
+++ b/snapcraft/internal/pluginhandler/_part_environment.py
@@ -65,14 +65,15 @@ def get_snapcraft_global_environment(
 
     return {
         "SNAPCRAFT_ARCH_TRIPLET": project.arch_triplet,
+        "SNAPCRAFT_EXTENSIONS_DIR": common.get_extensionsdir(),
         "SNAPCRAFT_PARALLEL_BUILD_COUNT": str(project.parallel_build_count),
+        "SNAPCRAFT_PRIME": project.prime_dir,
         "SNAPCRAFT_PROJECT_NAME": name,
         "SNAPCRAFT_PROJECT_VERSION": version,
         "SNAPCRAFT_PROJECT_DIR": project._project_dir,
         "SNAPCRAFT_PROJECT_GRADE": grade,
         "SNAPCRAFT_STAGE": project.stage_dir,
-        "SNAPCRAFT_PRIME": project.prime_dir,
-        "SNAPCRAFT_EXTENSIONS_DIR": common.get_extensionsdir(),
+        "SNAPCRAFT_TARGET_ARCH": project.target_arch,
     }
 
 

--- a/tests/unit/project_loader/test_environment.py
+++ b/tests/unit/project_loader/test_environment.py
@@ -240,6 +240,9 @@ class EnvironmentTest(ProjectLoaderBaseTest):
                     'SNAPCRAFT_PROJECT_NAME="test"',
                     'SNAPCRAFT_PROJECT_VERSION="1"',
                     'SNAPCRAFT_STAGE="{}/stage"'.format(self.path),
+                    'SNAPCRAFT_TARGET_ARCH="{}"'.format(
+                        project_config.project.target_arch
+                    ),
                 ]
             ),
         )


### PR DESCRIPTION
Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
