### PR TITLE
cli: enable SNAPCRAFT_TARGET_ARCH envvar matching --target-arch

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -73,9 +73,10 @@ _ALL_PROVIDERS = _SUPPORTED_PROVIDERS + _HIDDEN_PROVIDERS
 _PROVIDER_OPTIONS: List[Dict[str, Any]] = [
     dict(
         param_decls="--target-arch",
+        envvar="SNAPCRAFT_TARGET_ARCH",
         metavar="<arch>",
         help="Target architecture to cross compile to",
-        supported_providers=["host", "lxd", "multipass"],
+        supported_providers=["host", "lxd", "managed-host", "multipass"],
     ),
     dict(
         param_decls="--debug",

--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -78,11 +78,16 @@ def _execute(  # noqa: C901
     is_managed_host = build_provider == "managed-host"
 
     # Temporary fix to ignore target_arch.
-    if kwargs.get("target_arch") is not None and build_provider in ["multipass", "lxd"]:
-        echo.warning(
-            "Ignoring '--target-arch' flag.  This flag requires --destructive-mode and is unsupported with Multipass and LXD build providers."
-        )
-        kwargs.pop("target_arch")
+
+    if build_provider in ["multipass", "lxd"]:
+        if kwargs.get("target_arch") is not None:
+            echo.warning(
+                "Ignoring '--target-arch' flag.  This flag requires --destructive-mode and is unsupported with Multipass and LXD build providers."
+            )
+            kwargs.pop("target_arch")
+
+        # Ensure it is scrubbed from build provider flags.
+        build_provider_flags.pop("SNAPCRAFT_TARGET_ARCH", None)
 
     project = get_project(is_managed_host=is_managed_host, **kwargs)
     conduct_project_sanity_check(project, **kwargs)

--- a/tests/unit/cli/test_options.py
+++ b/tests/unit/cli/test_options.py
@@ -64,11 +64,25 @@ class TestProviderOptions:
             ),
         ),
         (
+            "host target arch",
+            dict(
+                provider="host",
+                kwargs=dict(target_arch="somearch"),
+                flags=dict(SNAPCRAFT_TARGET_ARCH="somearch"),
+            ),
+        ),
+        (
             "host all",
             dict(
                 provider="host",
-                kwargs=dict(http_proxy="1.1.1.1", https_proxy="1.1.1.1"),
-                flags=dict(http_proxy="1.1.1.1", https_proxy="1.1.1.1"),
+                kwargs=dict(
+                    http_proxy="1.1.1.1", https_proxy="1.1.1.1", target_arch="somearch"
+                ),
+                flags=dict(
+                    http_proxy="1.1.1.1",
+                    https_proxy="1.1.1.1",
+                    SNAPCRAFT_TARGET_ARCH="somearch",
+                ),
             ),
         ),
         ("lxd empty", dict(provider="lxd", kwargs=dict(), flags=dict())),
@@ -105,6 +119,14 @@ class TestProviderOptions:
             ),
         ),
         (
+            "lxd target arch",
+            dict(
+                provider="lxd",
+                kwargs=dict(target_arch="somearch"),
+                flags=dict(SNAPCRAFT_TARGET_ARCH="somearch"),
+            ),
+        ),
+        (
             "lxd all",
             dict(
                 provider="lxd",
@@ -113,12 +135,14 @@ class TestProviderOptions:
                     https_proxy="1.1.1.1",
                     enable_manifest=True,
                     manifest_image_information="{}",
+                    target_arch="somearch",
                 ),
                 flags=dict(
                     http_proxy="1.1.1.1",
                     https_proxy="1.1.1.1",
                     SNAPCRAFT_BUILD_INFO=True,
                     SNAPCRAFT_IMAGE_INFO="{}",
+                    SNAPCRAFT_TARGET_ARCH="somearch",
                 ),
             ),
         ),
@@ -159,6 +183,14 @@ class TestProviderOptions:
             ),
         ),
         (
+            "managed-host target arch",
+            dict(
+                provider="managed-host",
+                kwargs=dict(target_arch="somearch"),
+                flags=dict(SNAPCRAFT_TARGET_ARCH="somearch"),
+            ),
+        ),
+        (
             "managed-host all",
             dict(
                 provider="managed-host",
@@ -167,12 +199,14 @@ class TestProviderOptions:
                     https_proxy="1.1.1.1",
                     enable_manifest=True,
                     manifest_image_information="{}",
+                    target_arch="somearch",
                 ),
                 flags=dict(
                     http_proxy="1.1.1.1",
                     https_proxy="1.1.1.1",
                     SNAPCRAFT_BUILD_INFO=True,
                     SNAPCRAFT_IMAGE_INFO="{}",
+                    SNAPCRAFT_TARGET_ARCH="somearch",
                 ),
             ),
         ),
@@ -210,6 +244,14 @@ class TestProviderOptions:
             ),
         ),
         (
+            "multipass target arch",
+            dict(
+                provider="multipass",
+                kwargs=dict(target_arch="somearch"),
+                flags=dict(SNAPCRAFT_TARGET_ARCH="somearch"),
+            ),
+        ),
+        (
             "multipass all",
             dict(
                 provider="multipass",
@@ -218,12 +260,14 @@ class TestProviderOptions:
                     https_proxy="1.1.1.1",
                     enable_manifest=True,
                     manifest_image_information="{}",
+                    target_arch="somearch",
                 ),
                 flags=dict(
                     http_proxy="1.1.1.1",
                     https_proxy="1.1.1.1",
                     SNAPCRAFT_BUILD_INFO=True,
                     SNAPCRAFT_IMAGE_INFO="{}",
+                    SNAPCRAFT_TARGET_ARCH="somearch",
                 ),
             ),
         ),


### PR DESCRIPTION
But ensure it is scrubbed from build provider flags so
that it doesn't get passed into target environment.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
