### PR TITLE
Allow validation assertions to be revoked

### DIFF
--- a/snapcraft/cli/assertions.py
+++ b/snapcraft/cli/assertions.py
@@ -94,8 +94,7 @@ def sign_build(snap_file: str, key_name: str, local: bool) -> None:
 @click.argument("validations", metavar="<validation>...", nargs=-1, required=True)
 @click.option("--key-name", metavar="<key-name>")
 @click.option("--revoke/--no-revoke", default=False)
-def validate(
-        snap_name: str, validations: list, key_name: str, revoke: bool) -> None:
+def validate(snap_name: str, validations: list, key_name: str, revoke: bool) -> None:
     """Validate a gated snap.
 
     Each validation can be presented with ether syntax:

--- a/snapcraft/cli/assertions.py
+++ b/snapcraft/cli/assertions.py
@@ -93,7 +93,9 @@ def sign_build(snap_file: str, key_name: str, local: bool) -> None:
 @click.argument("snap-name", metavar="<snap-name>")
 @click.argument("validations", metavar="<validation>...", nargs=-1, required=True)
 @click.option("--key-name", metavar="<key-name>")
-def validate(snap_name: str, validations: list, key_name: str) -> None:
+@click.option("--revoke/--no-revoke", default=False)
+def validate(
+        snap_name: str, validations: list, key_name: str, revoke: bool) -> None:
     """Validate a gated snap.
 
     Each validation can be presented with ether syntax:
@@ -101,7 +103,7 @@ def validate(snap_name: str, validations: list, key_name: str) -> None:
     -  <snap-name>=<revision>
     -  <snap-id>=<revision>
     """
-    snapcraft.validate(snap_name, validations, key=key_name)
+    snapcraft.validate(snap_name, validations, revoke=revoke, key=key_name)
 
 
 @assertionscli.command()

--- a/tests/unit/commands/test_validate.py
+++ b/tests/unit/commands/test_validate.py
@@ -167,3 +167,57 @@ class ValidateCommandTestCase(StoreCommandsBaseTestCase):
             None,
             "validations",
         )
+
+    def test_validate_with_revoke(self):
+        self.fake_sign = fixtures.MockPatch(
+            "snapcraft._store._sign_assertion", return_value=b""
+        )
+        self.useFixture(self.fake_sign)
+
+        self.client.login("dummy", "test correct password")
+
+        self.run_command(["validate", "core", "test-snap=3", "--revoke"])
+
+        self.assertThat("core-test-snap-r3.assertion", FileExists())
+        self.fake_sign.mock.assert_called_once_with(
+            "test-snap=3",
+            {
+                "type": "validation",
+                "authority-id": "abcd",
+                "series": "16",
+                "snap-id": "good",
+                "approved-snap-id": "test-snap-snap-id",
+                "approved-snap-revision": "3",
+                "timestamp": mock.ANY,
+                "revoked": "true",
+            },
+            None,
+            "validations",
+        )
+
+    def test_validate_with_no_revoke(self):
+        self.fake_sign = fixtures.MockPatch(
+            "snapcraft._store._sign_assertion", return_value=b""
+        )
+        self.useFixture(self.fake_sign)
+
+        self.client.login("dummy", "test correct password")
+
+        self.run_command(["validate", "core", "test-snap=3", "--no-revoke"])
+
+        self.assertThat("core-test-snap-r3.assertion", FileExists())
+        self.fake_sign.mock.assert_called_once_with(
+            "test-snap=3",
+            {
+                "type": "validation",
+                "authority-id": "abcd",
+                "series": "16",
+                "snap-id": "good",
+                "approved-snap-id": "test-snap-snap-id",
+                "approved-snap-revision": "3",
+                "timestamp": mock.ANY,
+                "revoked": "false",
+            },
+            None,
+            "validations",
+        )


### PR DESCRIPTION
A recent customer request includes being able to revoke an already issued
validation assertion. The store backend already supported this option, but
it was needed to surface the option in the `snapcraft validate` CLI.

- [x ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
