### PR TITLE
project: always set target arch even if not cross compiling

### DIFF
--- a/snapcraft/project/_project_options.py
+++ b/snapcraft/project/_project_options.py
@@ -348,13 +348,19 @@ class ProjectOptions:
 
     def _set_machine(self, target_deb_arch):
         self.__platform_arch = _get_platform_architecture()
-        self.__target_arch = target_deb_arch
         if not target_deb_arch:
             self.__target_machine = self.__platform_arch
         else:
             self.__target_machine = _find_machine(target_deb_arch)
             logger.info("Setting target machine to {!r}".format(target_deb_arch))
+
         self.__machine_info = _ARCH_TRANSLATIONS[self.__target_machine]
+
+        # Set target arch to match the host if unspecified.
+        if target_deb_arch is None:
+            self.__target_arch = self.__machine_info.get("deb")
+        else:
+            self.__target_arch = target_deb_arch
 
 
 def _get_deb_arch(machine):


### PR DESCRIPTION
Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
