### PR TITLE
Include SDK snap paths in ACLOCAL_PATH

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/gnome_3_38.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_38.py
@@ -141,7 +141,7 @@ class ExtensionImpl(Extension):
                     "GDK_PIXBUF_MODULE_FILE": "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gdk-pixbuf-current/loaders.cache"
                 },
                 {
-                    "ACLOCAL_PATH": "/snap/gnome-3-38-2004-sdk/current/usr/share/aclocal:$ACLOCAL_PATH"
+                    "ACLOCAL_PATH": "/snap/gnome-3-38-2004-sdk/current/usr/share/aclocal${ACLOCAL_PATH:+:$ACLOCAL_PATH}"
                 },
             ]
         }

--- a/snapcraft/internal/project_loader/_extensions/gnome_3_38.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_38.py
@@ -131,13 +131,14 @@ class ExtensionImpl(Extension):
                 {
                     "LD_LIBRARY_PATH": ":".join(
                         [
-                        "/snap/gnome-3-38-2004-sdk/current/lib/$SNAPCRAFT_ARCH_TRIPLET",
-                        "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET",
-                        "/snap/gnome-3-38-2004-sdk/current/usr/lib",
-                        "/snap/gnome-3-38-2004-sdk/current/usr/lib/vala-current",
-                        "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio",
+                            "/snap/gnome-3-38-2004-sdk/current/lib/$SNAPCRAFT_ARCH_TRIPLET",
+                            "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET",
+                            "/snap/gnome-3-38-2004-sdk/current/usr/lib",
+                            "/snap/gnome-3-38-2004-sdk/current/usr/lib/vala-current",
+                            "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio",
                         ]
-                    ) + "${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+                    )
+                    + "${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
                 },
                 {
                     "PKG_CONFIG_PATH": "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pkgconfig:/snap/gnome-3-38-2004-sdk/current/usr/lib/pkgconfig:/snap/gnome-3-38-2004-sdk/current/usr/share/pkgconfig:$PKG_CONFIG_PATH"

--- a/snapcraft/internal/project_loader/_extensions/gnome_3_38.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_38.py
@@ -129,7 +129,15 @@ class ExtensionImpl(Extension):
                     "XDG_DATA_DIRS": "$SNAPCRAFT_STAGE/usr/share:/snap/gnome-3-38-2004-sdk/current/usr/share:/usr/share:$XDG_DATA_DIRS"
                 },
                 {
-                    "LD_LIBRARY_PATH": "/snap/gnome-3-38-2004-sdk/current/lib/$SNAPCRAFT_ARCH_TRIPLET:/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:/snap/gnome-3-38-2004-sdk/current/usr/lib:/snap/gnome-3-38-2004-sdk/current/usr/lib/vala-current:/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio:$LD_LIBRARY_PATH"
+                    "LD_LIBRARY_PATH": ":".join(
+                        [
+                        "/snap/gnome-3-38-2004-sdk/current/lib/$SNAPCRAFT_ARCH_TRIPLET",
+                        "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET",
+                        "/snap/gnome-3-38-2004-sdk/current/usr/lib",
+                        "/snap/gnome-3-38-2004-sdk/current/usr/lib/vala-current",
+                        "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio",
+                        ]
+                    ) + "${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
                 },
                 {
                     "PKG_CONFIG_PATH": "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pkgconfig:/snap/gnome-3-38-2004-sdk/current/usr/lib/pkgconfig:/snap/gnome-3-38-2004-sdk/current/usr/share/pkgconfig:$PKG_CONFIG_PATH"

--- a/snapcraft/internal/project_loader/_extensions/gnome_3_38.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_38.py
@@ -129,7 +129,7 @@ class ExtensionImpl(Extension):
                     "XDG_DATA_DIRS": "$SNAPCRAFT_STAGE/usr/share:/snap/gnome-3-38-2004-sdk/current/usr/share:/usr/share:$XDG_DATA_DIRS"
                 },
                 {
-                    "LD_LIBRARY_PATH": "/snap/gnome-3-38-2004-sdk/current/lib/$SNAPCRAFT_ARCH_TRIPLET:/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:/snap/gnome-3-38-2004-sdk/current/usr/lib:/snap/gnome-3-38-2004-sdk/current/usr/lib/vala-current:$LD_LIBRARY_PATH"
+                    "LD_LIBRARY_PATH": "/snap/gnome-3-38-2004-sdk/current/lib/$SNAPCRAFT_ARCH_TRIPLET:/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:/snap/gnome-3-38-2004-sdk/current/usr/lib:/snap/gnome-3-38-2004-sdk/current/usr/lib/vala-current:/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio:$LD_LIBRARY_PATH"
                 },
                 {
                     "PKG_CONFIG_PATH": "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pkgconfig:/snap/gnome-3-38-2004-sdk/current/usr/lib/pkgconfig:/snap/gnome-3-38-2004-sdk/current/usr/share/pkgconfig:$PKG_CONFIG_PATH"
@@ -139,6 +139,9 @@ class ExtensionImpl(Extension):
                 },
                 {
                     "GDK_PIXBUF_MODULE_FILE": "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gdk-pixbuf-current/loaders.cache"
+                },
+                {
+                    "ACLOCAL_PATH": "/snap/gnome-3-38-2004-sdk/current/usr/share/aclocal:$ACLOCAL_PATH"
                 },
             ]
         }

--- a/tests/unit/project_loader/extensions/test_gnome_3_38.py
+++ b/tests/unit/project_loader/extensions/test_gnome_3_38.py
@@ -115,7 +115,7 @@ class ExtensionTest(ProjectLoaderBaseTest, CommandBaseTestCase):
                             "GDK_PIXBUF_MODULE_FILE": "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gdk-pixbuf-current/loaders.cache"
                         },
                         {
-                            "ACLOCAL_PATH": "/snap/gnome-3-38-2004-sdk/current/usr/share/aclocal:$ACLOCAL_PATH"
+                            "ACLOCAL_PATH": "/snap/gnome-3-38-2004-sdk/current/usr/share/aclocal${ACLOCAL_PATH:+:$ACLOCAL_PATH}"
                         },
                     ]
                 }

--- a/tests/unit/project_loader/extensions/test_gnome_3_38.py
+++ b/tests/unit/project_loader/extensions/test_gnome_3_38.py
@@ -103,7 +103,7 @@ class ExtensionTest(ProjectLoaderBaseTest, CommandBaseTestCase):
                             "XDG_DATA_DIRS": "$SNAPCRAFT_STAGE/usr/share:/snap/gnome-3-38-2004-sdk/current/usr/share:/usr/share:$XDG_DATA_DIRS"
                         },
                         {
-                            "LD_LIBRARY_PATH": "/snap/gnome-3-38-2004-sdk/current/lib/$SNAPCRAFT_ARCH_TRIPLET:/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:/snap/gnome-3-38-2004-sdk/current/usr/lib:/snap/gnome-3-38-2004-sdk/current/usr/lib/vala-current:$LD_LIBRARY_PATH"
+                            "LD_LIBRARY_PATH": "/snap/gnome-3-38-2004-sdk/current/lib/$SNAPCRAFT_ARCH_TRIPLET:/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:/snap/gnome-3-38-2004-sdk/current/usr/lib:/snap/gnome-3-38-2004-sdk/current/usr/lib/vala-current:/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio:$LD_LIBRARY_PATH"
                         },
                         {
                             "PKG_CONFIG_PATH": "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pkgconfig:/snap/gnome-3-38-2004-sdk/current/usr/lib/pkgconfig:/snap/gnome-3-38-2004-sdk/current/usr/share/pkgconfig:$PKG_CONFIG_PATH"
@@ -113,6 +113,9 @@ class ExtensionTest(ProjectLoaderBaseTest, CommandBaseTestCase):
                         },
                         {
                             "GDK_PIXBUF_MODULE_FILE": "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gdk-pixbuf-current/loaders.cache"
+                        },
+                        {
+                            "ACLOCAL_PATH": "/snap/gnome-3-38-2004-sdk/current/usr/share/aclocal:$ACLOCAL_PATH"
                         },
                     ]
                 }

--- a/tests/unit/project_loader/extensions/test_gnome_3_38.py
+++ b/tests/unit/project_loader/extensions/test_gnome_3_38.py
@@ -103,7 +103,16 @@ class ExtensionTest(ProjectLoaderBaseTest, CommandBaseTestCase):
                             "XDG_DATA_DIRS": "$SNAPCRAFT_STAGE/usr/share:/snap/gnome-3-38-2004-sdk/current/usr/share:/usr/share:$XDG_DATA_DIRS"
                         },
                         {
-                            "LD_LIBRARY_PATH": "/snap/gnome-3-38-2004-sdk/current/lib/$SNAPCRAFT_ARCH_TRIPLET:/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:/snap/gnome-3-38-2004-sdk/current/usr/lib:/snap/gnome-3-38-2004-sdk/current/usr/lib/vala-current:/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio:$LD_LIBRARY_PATH"
+                            "LD_LIBRARY_PATH": ":".join(
+                                [
+                                    "/snap/gnome-3-38-2004-sdk/current/lib/$SNAPCRAFT_ARCH_TRIPLET",
+                                    "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET",
+                                    "/snap/gnome-3-38-2004-sdk/current/usr/lib",
+                                    "/snap/gnome-3-38-2004-sdk/current/usr/lib/vala-current",
+                                    "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio",
+                                ]
+                            )
+                            + "${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
                         },
                         {
                             "PKG_CONFIG_PATH": "/snap/gnome-3-38-2004-sdk/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pkgconfig:/snap/gnome-3-38-2004-sdk/current/usr/lib/pkgconfig:/snap/gnome-3-38-2004-sdk/current/usr/share/pkgconfig:$PKG_CONFIG_PATH"


### PR DESCRIPTION
Ensure pulse libs can be found during linking and set ACLOCAL_PATH to include build snap paths

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
