### PR TITLE
plainbox spread tests: set tasks to manual

### DIFF
--- a/tests/spread/plugins/v1/plainbox/legacy-build-run/task.yaml
+++ b/tests/spread/plugins/v1/plainbox/legacy-build-run/task.yaml
@@ -1,3 +1,4 @@
+manual: true
 summary: Build and run a basic checkbox snap with no base
 
 systems: [ubuntu-16*]

--- a/tests/spread/plugins/v1/plainbox/provider-basic/task.yaml
+++ b/tests/spread/plugins/v1/plainbox/provider-basic/task.yaml
@@ -1,3 +1,4 @@
+manual: true
 summary: Ensure a basic provider works
 
 environment:

--- a/tests/spread/plugins/v1/plainbox/provider-python-stage-package-mix/task.yaml
+++ b/tests/spread/plugins/v1/plainbox/provider-python-stage-package-mix/task.yaml
@@ -1,3 +1,4 @@
+manual: true
 summary: "Ensure stage-packages can be used with plainbox LP: #1768233"
 
 environment:

--- a/tests/spread/plugins/v1/plainbox/provider-with-deps/task.yaml
+++ b/tests/spread/plugins/v1/plainbox/provider-with-deps/task.yaml
@@ -1,3 +1,4 @@
+manual: true
 summary: Ensure a provider with dependencies can be staged
 
 environment:

--- a/tests/spread/plugins/v1/plainbox/provider-with-stage-packages/task.yaml
+++ b/tests/spread/plugins/v1/plainbox/provider-with-stage-packages/task.yaml
@@ -1,3 +1,4 @@
+manual: true
 summary: Ensure a basic provider using stage-packages works
 
 environment:

--- a/tests/spread/plugins/v1/plainbox/run/task.yaml
+++ b/tests/spread/plugins/v1/plainbox/run/task.yaml
@@ -1,3 +1,4 @@
+manual: true
 summary: Build and run a basic checkbox snap
 
 environment:


### PR DESCRIPTION
They intermittently fail and these failures do not appear to be
Snapcraft-specific.  Until the issue is resolved, set the tasks
to manual.

Failure log:
```
python3 manage.py validate
error: ???: Cannot load '/snapcraft/tests/spread/plugins/v1/plainbox/snaps/provider-with-deps/parts/parent-plainbox-provider/build/units/parent.pxu': (chardet 4.0.0 (/snapcraft/tests/spread/plugins/v1/plainbox/snaps/provider-with-deps/stage/lib/python3.6/site-packages), Requirement.parse('chardet<3.1.0,>=3.0.2'), {'requests'})
NOTE: subsequent units from problematic files are ignored
Validation of provider plainbox-provider-parent has failed
```

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
