### PR TITLE
schema: add support for activates-on app property to schema

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -616,6 +616,9 @@
                         "bus-name": [
                             "daemon"
                         ],
+                        "activates-on": [
+                            "daemon"
+                        ],
                         "refresh-mode": [
                             "daemon"
                         ],
@@ -673,9 +676,18 @@
                         },
                         "bus-name": {
                             "type": "string",
-                            "description": "D-Bus name this service is reachable as (mandatory if daemon=dbus)",
+                            "description": "D-Bus name this service is reachable as",
                             "pattern": "^[A-Za-z0-9/. _#:$-]*$",
                             "validation-failure": "{.instance!r} is not a valid bus name."
+                        },
+                        "activates-on": {
+                            "type": "array",
+                            "description": "dbus interface slots this service activates on",
+                            "minitems": 1,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
                         },
                         "desktop": {
                             "type": "string",

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -166,6 +166,11 @@ class ValidationTest(ValidationBaseTest):
                 "daemon": "simple",
                 "install-mode": "disable",
             },
+            "service17": {
+                "command": "binary17",
+                "daemon": "simple",
+                "activates-on": ["slot1", "slot2"],
+            },
         }
 
         Validator(self.data).validate()
@@ -191,6 +196,25 @@ class ValidationTest(ValidationBaseTest):
                 "the required schema: 'on-tuesday' is not one of ['on-success', "
                 "'on-failure', 'on-abnormal', 'on-abort', 'on-watchdog', 'always', "
                 "'never']"
+            ),
+        )
+
+    def test_invalid_activates_on(self):
+        self.data["apps"] = {
+            "service1": {
+                "command": "binary1",
+                "daemon": "simple",
+                "activates-on": ["slot1", "slot1"],
+            },
+        }
+        raised = self.assertRaises(
+            snapcraft.yaml_utils.errors.YamlValidationError,
+            Validator(self.data).validate,
+        )
+        self.assertThat(
+            str(raised),
+            Contains(
+                "The 'apps/service1/activates-on' property does not match the required schema: ['slot1', 'slot1'] has non-unique elements"
             ),
         )
 
@@ -236,6 +260,7 @@ class ValidationTest(ValidationBaseTest):
         ("post-stop-command", "binary1 --post-stop"),
         ("before", ["service1"]),
         ("after", ["service2"]),
+        ("activates-on", ["slot1"]),
     ],
 )
 def test_daemon_dependency(data, option, value):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
This PR adds schema support for the `activates-on` property of apps.  The property holds a list of slot names representing D-Bus bus names the service activates on.  The property only makes sense when used with `daemon` type apps.

Like PR #3129, support for this feature is currently gated behind a snapd experimental feature flag (`experimental.dbus-activation` in this case).  So merging it might need to wait until the feature is turned on by default.