### PR TITLE
plugins: Pin pip to supported versions

### DIFF
--- a/snapcraft/plugins/_python/_pip.py
+++ b/snapcraft/plugins/_python/_pip.py
@@ -184,7 +184,12 @@ class Pip:
                 self.__python_home = os.path.join(os.path.sep, "usr")
 
                 # Using the host's pip, install our own pip
-                self.download({"pip"})
+                # pip >=21 no longer support python3.5 or python 2 and if
+                # used will result in a broken install with pip unable to
+                # install packages.
+                self.download(
+                    {'pip; python_version >= "3.6"', 'pip<21; python_version < "3.6"'}
+                )
                 self.install({"pip"}, ignore_installed=True)
             finally:
                 # Now that we have our own pip, reset the python home


### PR DESCRIPTION
pip 21 dropped support for python 3.5 and python 2.

pip >=21 no longer support python3.5 or python 2 and if used will result in a
broken install with pip unable to install packages.

* Drop support for Python 3.5 https://github.com/pypa/pip/issues/9189
* Drop support for Python 2 https://github.com/pypa/pip/issues/6148

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
