### PR TITLE
build providers: clean environment if project directory is changed

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -313,6 +313,16 @@ class Provider(abc.ABC):
             )
             return True
 
+        instance_project_dir = info.get("host-project-directory")
+        if (
+            instance_project_dir is not None
+            and self.project._project_dir != instance_project_dir
+        ):
+            self.echoer.warning(
+                f"Build environment project directory changed from {instance_project_dir!r}, cleaning first."
+            )
+            return True
+
         return False
 
     def _ensure_compatible_build_environment(self) -> None:
@@ -461,6 +471,7 @@ class Provider(abc.ABC):
             data={
                 "base": self.project._get_build_base(),
                 "created-by-snapcraft-version": snapcraft._get_version(),
+                "host-project-directory": self.project._project_dir,
             }
         )
 

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -106,7 +106,13 @@ class BaseProviderTest(BaseProviderBaseTest):
         provider.launch_mock.assert_any_call()
         provider.start_mock.assert_any_call()
         provider.save_info_mock.assert_called_once_with(
-            {"data": {"base": "core16", "created-by-snapcraft-version": "4.0"}}
+            {
+                "data": {
+                    "base": "core16",
+                    "created-by-snapcraft-version": "4.0",
+                    "host-project-directory": self.project._project_dir,
+                }
+            }
         )
 
         self.assertThat(
@@ -553,6 +559,41 @@ class TestCompatibilityClean:
             ),
         ),
         (
+            "same-project-dir-no-clean",
+            dict(
+                base="core18",
+                loaded_info={
+                    "base": "core18",
+                    "created-by-snapcraft-version": "1.0",
+                    "host-project-directory": "/fake/host/dir",
+                },
+                version="1.0",
+                expect_clean=False,
+            ),
+        ),
+        (
+            "no-project-dir-no-clean",
+            dict(
+                base="core18",
+                loaded_info={"base": "core18", "created-by-snapcraft-version": "1.0"},
+                version="1.0",
+                expect_clean=False,
+            ),
+        ),
+        (
+            "different-project-dir-clean",
+            dict(
+                base="core18",
+                loaded_info={
+                    "base": "core18",
+                    "created-by-snapcraft-version": "1.0",
+                    "host-project-directory": "/nowhere",
+                },
+                version="1.0",
+                expect_clean=True,
+            ),
+        ),
+        (
             "unspecified-base-clean",
             dict(
                 base="core20",
@@ -602,6 +643,7 @@ class TestCompatibilityClean:
     def test_scenario(
         self, monkeypatch, in_snap, base, loaded_info, version, expect_clean
     ):
+        monkeypatch.setattr("os.getcwd", lambda: "/fake/host/dir")
         monkeypatch.setenv("SNAP_VERSION", version)
 
         provider = ProviderImpl(project=get_project(), echoer=Mock())


### PR DESCRIPTION
A common issue when a user moves/copies/relocates a project directory,
or re-uses the same project name.

Save the project directory location and verify it when checking
instance compatibility.  If it doesn't match, clean the environment
prior to building.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
