### PR TITLE
python v2 plugin: install wheel for build environment

### DIFF
--- a/snapcraft/plugins/v2/python.py
+++ b/snapcraft/plugins/v2/python.py
@@ -129,6 +129,9 @@ class PythonPlugin(PluginV2):
             'SNAPCRAFT_PYTHON_PATH="$(readlink -e "${SNAPCRAFT_PYTHON_PATH}")"',
             '"${SNAPCRAFT_PYTHON_PATH}" -m venv ${SNAPCRAFT_PYTHON_VENV_ARGS} "${SNAPCRAFT_PART_INSTALL}"',
             'SNAPCRAFT_PYTHON_VENV_INTERP_PATH="${SNAPCRAFT_PART_INSTALL}/bin/${SNAPCRAFT_PYTHON_INTERPRETER}"',
+            'SNAPCRAFT_PYTHON_BUILD_EXTRAS="$(readlink -f "../python-build-extras")"',
+            'export PYTHONPATH="${SNAPCRAFT_PYTHON_BUILD_EXTRAS}${PYTHONPATH:+:$PYTHONPATH}"',
+            'pip install wheel --target "${SNAPCRAFT_PYTHON_BUILD_EXTRAS}"',
         ]
 
         if self.options.constraints:

--- a/tests/unit/plugins/v2/test_python.py
+++ b/tests/unit/plugins/v2/test_python.py
@@ -114,6 +114,9 @@ def test_get_build_commands():
             'SNAPCRAFT_PYTHON_PATH="$(readlink -e "${SNAPCRAFT_PYTHON_PATH}")"',
             '"${SNAPCRAFT_PYTHON_PATH}" -m venv ${SNAPCRAFT_PYTHON_VENV_ARGS} "${SNAPCRAFT_PART_INSTALL}"',
             'SNAPCRAFT_PYTHON_VENV_INTERP_PATH="${SNAPCRAFT_PART_INSTALL}/bin/${SNAPCRAFT_PYTHON_INTERPRETER}"',
+            'SNAPCRAFT_PYTHON_BUILD_EXTRAS="$(readlink -f "../python-build-extras")"',
+            'export PYTHONPATH="${SNAPCRAFT_PYTHON_BUILD_EXTRAS}${PYTHONPATH:+:$PYTHONPATH}"',
+            'pip install wheel --target "${SNAPCRAFT_PYTHON_BUILD_EXTRAS}"',
             "[ -f setup.py ] && pip install  -U .",
         ]
         + _FIXUP_BUILD_COMMANDS
@@ -135,6 +138,9 @@ def test_get_build_commands_with_all_properties():
             'SNAPCRAFT_PYTHON_PATH="$(readlink -e "${SNAPCRAFT_PYTHON_PATH}")"',
             '"${SNAPCRAFT_PYTHON_PATH}" -m venv ${SNAPCRAFT_PYTHON_VENV_ARGS} "${SNAPCRAFT_PART_INSTALL}"',
             'SNAPCRAFT_PYTHON_VENV_INTERP_PATH="${SNAPCRAFT_PART_INSTALL}/bin/${SNAPCRAFT_PYTHON_INTERPRETER}"',
+            'SNAPCRAFT_PYTHON_BUILD_EXTRAS="$(readlink -f "../python-build-extras")"',
+            'export PYTHONPATH="${SNAPCRAFT_PYTHON_BUILD_EXTRAS}${PYTHONPATH:+:$PYTHONPATH}"',
+            'pip install wheel --target "${SNAPCRAFT_PYTHON_BUILD_EXTRAS}"',
             "pip install -c 'constraints.txt' -U pip 'some-pkg; sys_platform != '\"'\"'win32'\"'\"''",
             "pip install -c 'constraints.txt' -U -r 'requirements.txt'",
             "[ -f setup.py ] && pip install -c 'constraints.txt' -U .",


### PR DESCRIPTION
Install wheel library into `<part-dir>/python-build-extras` and
update PYTHONPATH to include libraries installed there.

This way pip will have wheel installed and available:
(1) preventing a really ugly build error
(2) not polluting the installed components

LP: #1912244

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
