### PR TITLE
python v2 plugin: fix typo restoring shell state

### DIFF
--- a/snapcraft/plugins/v2/python.py
+++ b/snapcraft/plugins/v2/python.py
@@ -181,7 +181,7 @@ class PythonPlugin(PluginV2):
                     fi
                 done
                 echo "${target}"
-                eval "$(opts_state)"
+                eval "${opts_state}"
             }
 
             target="$(determine_link_target)"

--- a/tests/unit/plugins/v2/test_python.py
+++ b/tests/unit/plugins/v2/test_python.py
@@ -87,7 +87,7 @@ _FIXUP_BUILD_COMMANDS = [
                     fi
                 done
                 echo "${target}"
-                eval "$(opts_state)"
+                eval "${opts_state}"
             }
 
             target="$(determine_link_target)"


### PR DESCRIPTION
Typo resulted in "opts_state command not found", though unlikely
to cause any real behavioral issues.

Use curly braces, not parenthesis.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
