### PR TITLE
storeapi: reduce the amount of constants and their meaning

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -27,6 +27,7 @@ from datetime import datetime
 from pathlib import Path
 from subprocess import Popen
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, TextIO, Tuple
+from urllib.parse import urljoin
 
 from tabulate import tabulate
 
@@ -137,7 +138,9 @@ def _check_dev_agreement_and_namespace_statuses(store) -> None:
     except storeapi.errors.StoreAccountInformationError as e:
         if storeapi.constants.MISSING_AGREEMENT == e.error:  # type: ignore
             # A precaution if store does not return new style error.
-            url = _get_url_from_error(e) or storeapi.constants.UBUNTU_STORE_TOS_URL
+            url = _get_url_from_error(e) or urljoin(
+                storeapi.constants.STORE_DASHBOARD_URL, "/dev/tos"
+            )
             choice = echo.prompt(storeapi.constants.AGREEMENT_INPUT_MSG.format(url))
             if choice in {"y", "Y"}:
                 try:
@@ -157,7 +160,9 @@ def _check_dev_agreement_and_namespace_statuses(store) -> None:
     except storeapi.errors.StoreAccountInformationError as e:
         if storeapi.constants.MISSING_NAMESPACE in e.error:  # type: ignore
             # A precaution if store does not return new style error.
-            url = _get_url_from_error(e) or storeapi.constants.UBUNTU_STORE_ACCOUNT_URL
+            url = _get_url_from_error(e) or urljoin(
+                storeapi.constants.STORE_DASHBOARD_URL, "/dev/account"
+            )
             raise storeapi.errors.NeedTermsSignedError(
                 storeapi.constants.NAMESPACE_ERROR.format(url)
             )

--- a/snapcraft/config.py
+++ b/snapcraft/config.py
@@ -163,7 +163,7 @@ class Config(object):
     """Hold configuration options in sections.
 
     There can be two sections for the sso related credentials: production and
-    staging. This is governed by the UBUNTU_SSO_API_ROOT_URL environment
+    staging. This is governed by the UBUNTU_ONE_SSO_URL environment
     variable. Other sections are ignored but preserved.
 
     """
@@ -174,9 +174,7 @@ class Config(object):
 
     def _section_name(self) -> str:
         # The only section we care about is the host from the SSO url
-        url = os.environ.get(
-            "UBUNTU_SSO_API_ROOT_URL", constants.UBUNTU_SSO_API_ROOT_URL
-        )
+        url = os.environ.get("UBUNTU_ONE_SSO_URL", constants.UBUNTU_ONE_SSO_URL)
         return urllib.parse.urlparse(url).netloc
 
     def get(

--- a/snapcraft/storeapi/_metadata.py
+++ b/snapcraft/storeapi/_metadata.py
@@ -38,7 +38,7 @@ class StoreMetadataHandler:
 
     def upload(self, metadata, force):
         """Upload the metadata to SCA."""
-        url = "snaps/" + self.snap_id + "/metadata"
+        url = f"/dev/api/snaps/{self.snap_id}/metadata"
         headers = {
             "Authorization": self.auth,
             "Content-Type": "application/json",
@@ -54,7 +54,7 @@ class StoreMetadataHandler:
 
     def _current_binary_metadata(self):
         """Get current icons and screenshots as set in the store."""
-        url = "snaps/" + self.snap_id + "/binary-metadata"
+        url = f"/dev/api/snaps/{self.snap_id}/binary-metadata"
         headers = {"Authorization": self.auth, "Accept": "application/json"}
         # get current binary metadata information
         response = self.client.request("GET", url, headers=headers)
@@ -116,7 +116,7 @@ class StoreMetadataHandler:
             # nothing to update
             return
 
-        url = "snaps/" + self.snap_id + "/binary-metadata"
+        url = f"/dev/api/snaps/{self.snap_id}/binary-metadata"
         headers = {"Authorization": self.auth, "Accept": "application/json"}
         method = "PUT" if force else "POST"
         response = self.client.request(

--- a/snapcraft/storeapi/_sca_client.py
+++ b/snapcraft/storeapi/_sca_client.py
@@ -16,10 +16,7 @@ class SCAClient(Client):
 
     def __init__(self, conf):
         super().__init__(
-            conf,
-            os.environ.get(
-                "UBUNTU_STORE_API_ROOT_URL", constants.UBUNTU_STORE_API_ROOT_URL
-            ),
+            conf, os.environ.get("STORE_DASHBOARD_URL", constants.STORE_DASHBOARD_URL),
         )
 
     def get_macaroon(self, acls, packages=None, channels=None, expires=None):
@@ -31,7 +28,7 @@ class SCAClient(Client):
         if expires is not None:
             data.update({"expires": expires})
         headers = {"Accept": "application/json"}
-        response = self.post("acl/", json=data, headers=headers)
+        response = self.post("/dev/api/acl/", json=data, headers=headers)
         if response.ok:
             return response.json()["macaroon"]
         else:
@@ -53,7 +50,7 @@ class SCAClient(Client):
     def verify_acl(self):
         auth = _macaroon_auth(self.conf)
         response = self.post(
-            "acl/verify/",
+            "/dev/api/acl/verify/",
             json={"auth_data": {"authorization": auth}},
             headers={"Accept": "application/json"},
         )
@@ -65,7 +62,8 @@ class SCAClient(Client):
     def get_account_information(self):
         auth = _macaroon_auth(self.conf)
         response = self.get(
-            "account", headers={"Authorization": auth, "Accept": "application/json"}
+            "/dev/api/account",
+            headers={"Authorization": auth, "Accept": "application/json"},
         )
         if response.ok:
             return response.json()
@@ -76,7 +74,7 @@ class SCAClient(Client):
         data = {"account_key_request": account_key_request}
         auth = _macaroon_auth(self.conf)
         response = self.post(
-            "account/account-key",
+            "/dev/api/account/account-key",
             data=json.dumps(data),
             headers={
                 "Authorization": auth,
@@ -95,7 +93,7 @@ class SCAClient(Client):
         if store_id is not None:
             data["store"] = store_id
         response = self.post(
-            "register-name/",
+            "/dev/api/register-name/",
             data=json.dumps(data),
             headers={"Authorization": auth, "Content-Type": "application/json"},
         )
@@ -106,7 +104,7 @@ class SCAClient(Client):
         data = {"name": snap_name, "dry_run": True}
         auth = _macaroon_auth(self.conf)
         response = self.post(
-            "snap-push/",
+            "/dev/api/snap-push/",
             data=json.dumps(data),
             headers={
                 "Authorization": auth,
@@ -146,7 +144,7 @@ class SCAClient(Client):
             data["channels"] = channels
         auth = _macaroon_auth(self.conf)
         response = self.post(
-            "snap-push/",
+            "/dev/api/snap-push/",
             data=json.dumps(data),
             headers={
                 "Authorization": auth,
@@ -191,7 +189,7 @@ class SCAClient(Client):
             }
         auth = _macaroon_auth(self.conf)
         response = self.post(
-            "snap-release/",
+            "/dev/api/snap-release/",
             data=json.dumps(data),
             headers={
                 "Authorization": auth,
@@ -213,7 +211,7 @@ class SCAClient(Client):
             data = {"snap_developer": assertion.decode("utf-8")}
         auth = _macaroon_auth(self.conf)
 
-        url = "snaps/{}/{}".format(snap_id, endpoint)
+        url = "/dev/api/snaps/{}/{}".format(snap_id, endpoint)
 
         # For `snap-developer`, revoking developers will require their uploads
         # to be invalidated.
@@ -248,7 +246,7 @@ class SCAClient(Client):
     def get_assertion(self, snap_id, endpoint, params=None):
         auth = _macaroon_auth(self.conf)
         response = self.get(
-            "snaps/{}/{}".format(snap_id, endpoint),
+            "/dev/api/snaps/{}/{}".format(snap_id, endpoint),
             headers={
                 "Authorization": auth,
                 "Content-Type": "application/json",
@@ -272,7 +270,7 @@ class SCAClient(Client):
         return response_json
 
     def push_snap_build(self, snap_id, snap_build):
-        url = "snaps/{}/builds".format(snap_id)
+        url = "/dev/api/snaps/{}/builds".format(snap_id)
         data = json.dumps({"assertion": snap_build})
         headers = {
             "Authorization": _macaroon_auth(self.conf),
@@ -288,7 +286,7 @@ class SCAClient(Client):
             qs["series"] = series
         if arch:
             qs["architecture"] = arch
-        url = "snaps/" + snap_id + "/state"
+        url = "/dev/api/snaps/" + snap_id + "/state"
         if qs:
             url += "?" + urllib.parse.urlencode(qs)
         auth = _macaroon_auth(self.conf)
@@ -308,7 +306,7 @@ class SCAClient(Client):
         return response_json
 
     def close_channels(self, snap_id, channel_names):
-        url = "snaps/{}/close".format(snap_id)
+        url = "/dev/api/snaps/{}/close".format(snap_id)
         data = {"channels": channel_names}
         headers = {"Authorization": _macaroon_auth(self.conf)}
         response = self.post(url, json=data, headers=headers)
@@ -331,7 +329,7 @@ class SCAClient(Client):
         auth = _macaroon_auth(self.conf)
         data = {"latest_tos_accepted": latest_tos_accepted}
         response = self.post(
-            "agreement/",
+            "/dev/api/agreement/",
             data=json.dumps(data),
             headers={
                 "Authorization": auth,

--- a/snapcraft/storeapi/_snap_index_client.py
+++ b/snapcraft/storeapi/_snap_index_client.py
@@ -36,10 +36,7 @@ class SnapIndexClient(Client):
         :type config: snapcraft.config.Config
         """
         super().__init__(
-            conf,
-            os.environ.get(
-                "UBUNTU_STORE_SEARCH_ROOT_URL", constants.UBUNTU_STORE_SEARCH_ROOT_URL
-            ),
+            conf, os.environ.get("STORE_API_URL", constants.STORE_API_URL),
         )
 
     def get_default_headers(self, api="v2"):
@@ -89,7 +86,7 @@ class SnapIndexClient(Client):
         if arch is not None:
             params["architecture"] = arch
         logger.debug("Getting information for {}".format(snap_name))
-        url = "v2/snaps/info/{}".format(snap_name)
+        url = "/v2/snaps/info/{}".format(snap_name)
         resp = self.get(url, headers=headers, params=params)
         if resp.status_code == 404:
             raise errors.SnapNotFoundError(snap_name=snap_name, arch=arch)
@@ -116,22 +113,3 @@ class SnapIndexClient(Client):
         if response.status_code != 200:
             raise errors.SnapNotFoundError(snap_id=snap_id)
         return response.json()
-
-    def get(self, url, headers=None, params=None, stream=False):
-        """Perform a GET request with the given arguments.
-
-        :param str url: URL to send the request.
-        :param dict headers: Headers to be sent along with the request.
-        :param dict params: Query parameters to be sent along with
-        the request.
-        :param bool stream: Determines if the request shouldn't be
-        automatically closed (true by default).
-
-        :return Response of the request.
-        """
-        if headers is None:
-            headers = self.get_default_headers()
-        response = self.request(
-            "GET", url, stream=stream, headers=headers, params=params
-        )
-        return response

--- a/snapcraft/storeapi/_snap_v2_client.py
+++ b/snapcraft/storeapi/_snap_v2_client.py
@@ -28,11 +28,7 @@ class SnapV2Client(Client):
 
     def __init__(self, conf):
         super().__init__(
-            conf,
-            os.environ.get(
-                "SNAP_STORE_DASHBOARD_ROOT_URL", constants.SNAP_STORE_DASHBOARD_ROOT_URL
-            )
-            + "/api/v2/snaps/",
+            conf, os.environ.get("STORE_DASHBOARD_URL", constants.STORE_DASHBOARD_URL)
         )
 
     @staticmethod
@@ -49,7 +45,7 @@ class SnapV2Client(Client):
         return response
 
     def get_snap_channel_map(self, *, snap_name: str) -> channel_map.ChannelMap:
-        url = snap_name + "/channel-map"
+        url = f"/api/v2/snaps/{snap_name}/channel-map"
         auth = _macaroon_auth(self.conf)
         response = self.get(
             url,
@@ -66,7 +62,7 @@ class SnapV2Client(Client):
         return channel_map.ChannelMap.unmarshal(response.json())
 
     def get_snap_releases(self, *, snap_name: str) -> releases.Releases:
-        url = snap_name + "/releases"
+        url = f"/api/v2/snaps/{snap_name}/releases"
         auth = _macaroon_auth(self.conf)
         response = self.get(
             url,

--- a/snapcraft/storeapi/_sso_client.py
+++ b/snapcraft/storeapi/_sso_client.py
@@ -15,10 +15,7 @@ class SSOClient(Client):
 
     def __init__(self, conf):
         super().__init__(
-            conf,
-            os.environ.get(
-                "UBUNTU_SSO_API_ROOT_URL", constants.UBUNTU_SSO_API_ROOT_URL
-            ),
+            conf, os.environ.get("UBUNTU_ONE_SSO_URL", constants.UBUNTU_ONE_SSO_URL),
         )
 
     def get_unbound_discharge(self, email, password, one_time_password, caveat_id):
@@ -26,7 +23,7 @@ class SSOClient(Client):
         if one_time_password:
             data["otp"] = one_time_password
         response = self.post(
-            "tokens/discharge",
+            "/api/v2/tokens/discharge",
             data=json.dumps(data),
             headers={"Content-Type": "application/json", "Accept": "application/json"},
         )
@@ -50,7 +47,7 @@ class SSOClient(Client):
     def refresh_unbound_discharge(self, unbound_discharge):
         data = {"discharge_macaroon": unbound_discharge}
         response = self.post(
-            "tokens/refresh",
+            "/api/v2/tokens/refresh",
             data=json.dumps(data),
             headers={"Content-Type": "application/json", "Accept": "application/json"},
         )

--- a/snapcraft/storeapi/_up_down_client.py
+++ b/snapcraft/storeapi/_up_down_client.py
@@ -1,5 +1,4 @@
 import os
-import urllib.parse
 
 from . import constants
 from ._client import Client
@@ -10,15 +9,12 @@ class UpDownClient(Client):
 
     def __init__(self, conf):
         super().__init__(
-            conf,
-            os.environ.get(
-                "UBUNTU_STORE_UPLOAD_ROOT_URL", constants.UBUNTU_STORE_UPLOAD_ROOT_URL
-            ),
+            conf, os.environ.get("STORE_UPLOAD_URL", constants.STORE_UPLOAD_URL),
         )
 
     def upload(self, monitor):
         return self.post(
-            urllib.parse.urljoin(self.root_url, "unscanned-upload/"),
+            "/unscanned-upload/",
             data=monitor,
             headers={
                 "Content-Type": monitor.content_type,

--- a/snapcraft/storeapi/constants.py
+++ b/snapcraft/storeapi/constants.py
@@ -20,13 +20,11 @@ from __future__ import absolute_import, unicode_literals
 DEFAULT_SERIES = "16"
 SCAN_STATUS_POLL_DELAY = 5
 SCAN_STATUS_POLL_RETRIES = 5
-SNAP_STORE_DASHBOARD_ROOT_URL = "https://dashboard.snapcraft.io/"
-UBUNTU_SSO_API_ROOT_URL = "https://login.ubuntu.com/api/v2/"
-UBUNTU_STORE_API_ROOT_URL = SNAP_STORE_DASHBOARD_ROOT_URL + "/dev/api/"
-UBUNTU_STORE_SEARCH_ROOT_URL = "https://api.snapcraft.io/"
-UBUNTU_STORE_UPLOAD_ROOT_URL = "https://upload.apps.ubuntu.com/"
-UBUNTU_STORE_TOS_URL = "https://dashboard.snapcraft.io/dev/tos/"
-UBUNTU_STORE_ACCOUNT_URL = "https://dashboard.snapcraft.io/dev/account/"
+
+STORE_DASHBOARD_URL = "https://dashboard.snapcraft.io/"
+STORE_API_URL = "https://api.snapcraft.io/"
+STORE_UPLOAD_URL = "https://upload.apps.ubuntu.com/"
+UBUNTU_ONE_SSO_URL = "https://login.ubuntu.com/"
 
 # Messages and warnings.
 MISSING_AGREEMENT = "Developer has not signed agreement."

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -254,7 +254,7 @@ class FakeStoreAPIServer(base.BaseFakeServer):
         permission = request.path.split("/")[-1]
         logger.debug("Handling ACL request for {}".format(permission))
         sso_host = urllib.parse.urlparse(
-            os.environ.get("UBUNTU_SSO_API_ROOT_URL", "http://localhost")
+            os.environ.get("UBUNTU_ONE_SSO_URL", "http://localhost")
         ).netloc
         macaroon = pymacaroons.Macaroon(
             caveats=[

--- a/tests/fixture_setup/_fixtures.py
+++ b/tests/fixture_setup/_fixtures.py
@@ -233,8 +233,7 @@ class FakeStore(fixtures.Fixture):
         self.useFixture(self.fake_sso_server_fixture)
         self.useFixture(
             fixtures.EnvironmentVariable(
-                "UBUNTU_SSO_API_ROOT_URL",
-                urllib.parse.urljoin(self.fake_sso_server_fixture.url, "api/v2/"),
+                "UBUNTU_ONE_SSO_URL", self.fake_sso_server_fixture.url
             )
         )
 
@@ -245,8 +244,7 @@ class FakeStore(fixtures.Fixture):
         self.useFixture(self.fake_store_upload_server_fixture)
         self.useFixture(
             fixtures.EnvironmentVariable(
-                "UBUNTU_STORE_UPLOAD_ROOT_URL",
-                self.fake_store_upload_server_fixture.url,
+                "STORE_UPLOAD_URL", self.fake_store_upload_server_fixture.url,
             )
         )
 
@@ -254,15 +252,7 @@ class FakeStore(fixtures.Fixture):
         self.useFixture(self.fake_store_api_server_fixture)
         self.useFixture(
             fixtures.EnvironmentVariable(
-                "UBUNTU_STORE_API_ROOT_URL",
-                urllib.parse.urljoin(
-                    self.fake_store_api_server_fixture.url, "dev/api/"
-                ),
-            )
-        )
-        self.useFixture(
-            fixtures.EnvironmentVariable(
-                "SNAP_STORE_DASHBOARD_ROOT_URL", self.fake_store_api_server_fixture.url
+                "STORE_DASHBOARD_URL", self.fake_store_api_server_fixture.url
             )
         )
 
@@ -270,8 +260,7 @@ class FakeStore(fixtures.Fixture):
         self.useFixture(self.fake_store_search_server_fixture)
         self.useFixture(
             fixtures.EnvironmentVariable(
-                "UBUNTU_STORE_SEARCH_ROOT_URL",
-                self.fake_store_search_server_fixture.url,
+                "STORE_API_URL", self.fake_store_search_server_fixture.url,
             )
         )
 
@@ -346,30 +335,22 @@ class StagingStore(fixtures.Fixture):
         super().setUp()
         self.useFixture(
             fixtures.EnvironmentVariable(
-                "SNAP_STORE_DASHBOARD_ROOT_URL",
-                "https://dashboard.staging.snapcraft.io/",
+                "STORE_DASHBOARD_URL", "https://dashboard.staging.snapcraft.io/",
             )
         )
         self.useFixture(
             fixtures.EnvironmentVariable(
-                "UBUNTU_STORE_API_ROOT_URL",
-                "https://dashboard.staging.snapcraft.io/dev/api/",
+                "STORE_UPLOAD_URL", "https://upload.apps.staging.ubuntu.com/",
             )
         )
         self.useFixture(
             fixtures.EnvironmentVariable(
-                "UBUNTU_STORE_UPLOAD_ROOT_URL",
-                "https://upload.apps.staging.ubuntu.com/",
+                "UBUNTU_ONE_SSO_URL", "https://login.staging.ubuntu.com/"
             )
         )
         self.useFixture(
             fixtures.EnvironmentVariable(
-                "UBUNTU_SSO_API_ROOT_URL", "https://login.staging.ubuntu.com/api/v2/"
-            )
-        )
-        self.useFixture(
-            fixtures.EnvironmentVariable(
-                "UBUNTU_STORE_SEARCH_ROOT_URL", "https://api.staging.snapcraft.io/"
+                "STORE_API_URL", "https://api.staging.snapcraft.io/"
             )
         )
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -126,7 +126,7 @@ class TestConfig(unit.TestCase):
         create_config_from_string("""[example.com]\nfoo=bar""")
         self.useFixture(
             fixtures.EnvironmentVariable(
-                "UBUNTU_SSO_API_ROOT_URL", "http://example.com/api/v2"
+                "UBUNTU_ONE_SSO_URL", "http://example.com/api/v2"
             )
         )
         conf = config.Config()
@@ -211,7 +211,7 @@ class TestLocalConfig(unit.TestCase):
     def setUp(self):
         super().setUp()
         override_sso = fixtures.EnvironmentVariable(
-            "UBUNTU_SSO_API_ROOT_URL", "http://example.com/api/v2"
+            "UBUNTU_ONE_SSO_URL", "http://example.com/api/v2"
         )
         self.useFixture(override_sso)
 

--- a/tools/staging_env.sh
+++ b/tools/staging_env.sh
@@ -1,22 +1,20 @@
 #!/bin/sh
 
 deactivate() {
-    unset SNAP_STORE_DASHBOARD_ROOT_URL
-    unset UBUNTU_STORE_API_ROOT_URL
-    unset UBUNTU_STORE_SEARCH_ROOT_URL
-    unset UBUNTU_STORE_UPLOAD_ROOT_URL
-    unset UBUNTU_SSO_API_ROOT_URL
+    unset STORE_DASHBOARD_URL
+    unset STORE_API_URL
+    unset STORE_UPLOAD_URL
+    unset UBUNTU_ONE_SSO_URL
     unset TEST_STORE
     export PS1="$ORIGINAL_PS1"
     unset ORIGINAL_PS1
     unset deactivate
 }
 
-export SNAP_STORE_DASHBOARD_ROOT_URL="https://dashboard.staging.snapcraft.io/"
-export UBUNTU_STORE_API_ROOT_URL="https://dashboard.staging.snapcraft.io/dev/api/"
-export UBUNTU_STORE_SEARCH_ROOT_URL="https://api.staging.snapcraft.io/"
-export UBUNTU_STORE_UPLOAD_ROOT_URL="https://upload.apps.staging.ubuntu.com/"
-export UBUNTU_SSO_API_ROOT_URL="https://login.staging.ubuntu.com/api/v2/"
+export STORE_DASHBOARD_URL="https://dashboard.staging.snapcraft.io/"
+export STORE_API_URL="https://api.staging.snapcraft.io/"
+export STORE_UPLOAD_URL="https://upload.apps.staging.ubuntu.com/"
+export UBUNTU_ONE_SSO_URL="https://login.staging.ubuntu.com/api/v2/"
 export TEST_STORE="staging"
 
 export ORIGINAL_PS1="$PS1"


### PR DESCRIPTION
Simplify the use of constants to root urls only, using full endpoint
paths where relevant. Rename the constants to reflect the backend
naming for clarity.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
