### PR TITLE
extensions: add conditional for GNOME Makefile using bindtextdomain

### DIFF
--- a/extensions/desktop/gnome/Makefile
+++ b/extensions/desktop/gnome/Makefile
@@ -13,13 +13,14 @@ HW_PLATFORM          := $(shell uname --hardware-platform)
 ARCH                 := $(HW_PLATFORM)-linux-gnu
 WITH_PYTHON          := "3.6"
 
+.PHONY: clean install-$(DESTLAUNCHER) install-$(BINDTEXTDOMAIN) install-$(DEST_CONFIGURE_HOOK)
+
 build: $(DEST_LAUNCHER) $(DEST_CONFIGURE_HOOK)
 
 clean:
 	rm -f $(DEST_LAUNCHER)
-	rm -f $(FLAVOR_FILE)
 	rm -f $(DEST_CONFIGURE_HOOK)
-	rm -rf $(ARCH)
+	rm -f $(BINDTEXTDOMAIN)
 
 $(DEST_LAUNCHER):
 	@cat $(SRC_DIR)/init >> $(DEST_LAUNCHER)
@@ -27,18 +28,29 @@ $(DEST_LAUNCHER):
 	@tail -n +2 $(SRC_DIR)/desktop-exports >> $(DEST_LAUNCHER)
 	@tail -n +2 $(SRC_DIR)/launcher-specific | sed -e "s/%WITH_PYTHON%/$(WITH_PYTHON)/" >> $(DEST_LAUNCHER)
 	@tail -n +2 $(SRC_DIR)/mark-and-exec >> $(DEST_LAUNCHER)
-	mkdir -p $(ARCH)
-	gcc -Wall -O2 -o $(ARCH)/$(BINDTEXTDOMAIN) -fPIC -shared $(SRC_DIR)/../src/bindtextdomain.c -ldl
 
 $(DEST_CONFIGURE_HOOK):
 	@cat $(SRC_DIR)/fonts > $(DEST_CONFIGURE_HOOK)
 
-install: $(DEST_LAUNCHER)  $(DEST_CONFIGURE_HOOK)
+$(BINDTEXTDOMAIN):
+	gcc -Wall -O2 -o $(BINDTEXTDOMAIN) -fPIC -shared $(SRC_DIR)/../src/bindtextdomain.c -ldl
+
+install-$(DEST_LAUNCHER): $(DEST_LAUNCHER)
 	install -d $(PLATFORM_DIR)
 	install -d $(DATA_DIR)
 	install -d $(DATA_DIR)/icons
 	install -d $(DATA_DIR)/sounds
 	install -d $(DATA_DIR)/themes
 	install -D -m755 $(DEST_LAUNCHER) "$(BIN_DIR)"/$(DEST_LAUNCHER)
-	install -D -m644 $(ARCH)/$(BINDTEXTDOMAIN) "$(LIB_DIR)"/$(ARCH)/$(BINDTEXTDOMAIN)
+
+install-$(DEST_CONFIGURE_HOOK): $(DEST_CONFIGURE_HOOK)
 	install -D -m755 $(DEST_CONFIGURE_HOOK) "$(BIN_DIR)"/$(DEST_CONFIGURE_HOOK)
+
+install-$(BINDTEXTDOMAIN): $(BINDTEXTDOMAIN)
+	install -D -m644 $(BINDTEXTDOMAIN) "$(LIB_DIR)"/$(ARCH)/$(BINDTEXTDOMAIN)
+
+ifdef WITH_BINDTEXTDOMAIN
+install: install-$(DEST_LAUNCHER) install-$(DEST_CONFIGURE_HOOK) install-$(BINDTEXTDOMAIN)
+else
+install: install-$(DEST_LAUNCHER) install-$(DEST_CONFIGURE_HOOK)
+endif

--- a/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
@@ -120,6 +120,7 @@ class ExtensionImpl(Extension):
                 "source": "$SNAPCRAFT_EXTENSIONS_DIR/desktop",
                 "source-subdir": "gnome",
                 "plugin": "make",
+                "make-parameters": ["WITH_BINDTEXTDOMAIN=1"],
                 "build-packages": ["gcc", "libgtk-3-dev"],
             }
         }

--- a/snapcraft/internal/project_loader/_extensions/gnome_3_34.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_34.py
@@ -147,6 +147,7 @@ class ExtensionImpl(Extension):
                 "source": "$SNAPCRAFT_EXTENSIONS_DIR/desktop",
                 "source-subdir": "gnome",
                 "plugin": "make",
+                "make-parameters": ["WITH_BINDTEXTDOMAIN=1"],
                 "build-snaps": ["gnome-3-34-1804-sdk/latest/stable"],
                 "build-packages": ["gcc"],
             }

--- a/snapcraft/plugins/v1/make.py
+++ b/snapcraft/plugins/v1/make.py
@@ -96,10 +96,10 @@ class MakePlugin(PluginV1):
         if self.options.makefile:
             command.extend(["-f", self.options.makefile])
 
-        if self.options.make_parameters:
-            command.extend(self.options.make_parameters)
-
-        self.run(command + ["-j{}".format(self.parallel_build_count)], env=env)
+        self.run(
+            command + [f"-j{self.parallel_build_count}"] + self.options.make_parameters,
+            env=env,
+        )
         if self.options.artifacts:
             for artifact in self.options.artifacts:
                 source_path = os.path.join(self.builddir, artifact)
@@ -111,13 +111,13 @@ class MakePlugin(PluginV1):
                 else:
                     snapcraft.file_utils.link_or_copy(source_path, destination_path)
         else:
-            command.append("install")
+            install_command = command + ["install"] + self.options.make_parameters
             if self.options.make_install_var:
-                command.append(
+                install_command.append(
                     "{}={}".format(self.options.make_install_var, self.installdir)
                 )
 
-            self.run(command, env=env)
+            self.run(install_command, env=env)
 
     def build(self):
         super().build()

--- a/tests/unit/plugins/v1/test_make.py
+++ b/tests/unit/plugins/v1/test_make.py
@@ -266,6 +266,26 @@ class MakePluginTest(PluginsV1BaseTestCase):
             ]
         )
 
+    @mock.patch.object(make.MakePlugin, "run")
+    def test_make_with_parameters(self, run_mock):
+        """Ensure the targets comes before the parameters."""
+        self.options.make_parameters = ["FOO=BAR"]
+        plugin = make.MakePlugin("test-part", self.options, self.project)
+        os.makedirs(plugin.sourcedir)
+
+        plugin.make()
+
+        self.assertThat(run_mock.call_count, Equals(2))
+        run_mock.assert_has_calls(
+            [
+                mock.call(["make", "-j2", "FOO=BAR"], env=None),
+                mock.call(
+                    ["make", "install", "FOO=BAR", f"DESTDIR={plugin.installdir}"],
+                    env=None,
+                ),
+            ]
+        )
+
     def test_unsupported_base(self):
         self.project._snap_meta.base = "unsupported-base"
 

--- a/tests/unit/project_loader/extensions/test_gnome_3_28.py
+++ b/tests/unit/project_loader/extensions/test_gnome_3_28.py
@@ -99,6 +99,7 @@ class ExtensionTest(ProjectLoaderBaseTest):
                         "source": "$SNAPCRAFT_EXTENSIONS_DIR/desktop",
                         "source-subdir": "gnome",
                         "plugin": "make",
+                        "make-parameters": ["WITH_BINDTEXTDOMAIN=1"],
                         "build-packages": ["gcc", "libgtk-3-dev"],
                     }
                 }

--- a/tests/unit/project_loader/extensions/test_gnome_3_34.py
+++ b/tests/unit/project_loader/extensions/test_gnome_3_34.py
@@ -129,6 +129,7 @@ class ExtensionTest(ProjectLoaderBaseTest, CommandBaseTestCase):
                         "source": "$SNAPCRAFT_EXTENSIONS_DIR/desktop",
                         "source-subdir": "gnome",
                         "plugin": "make",
+                        "make-parameters": ["WITH_BINDTEXTDOMAIN=1"],
                         "build-snaps": ["gnome-3-34-1804-sdk/latest/stable"],
                         "build-packages": ["gcc"],
                     }


### PR DESCRIPTION
Split the Makefile into smaller logical pieces and add a conditional
for bindtextdomain.so. Set bindtextdomain.so to build for GNOME 3.28
and 3.34 extensions.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
