### PR TITLE
snap: explicitly add setuptools-rust package to python-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,6 +33,7 @@ build-packages:
   - libxslt1-dev
   - libyaml-dev
   - patch
+  - rustc
   - sed
 
 parts:
@@ -83,6 +84,10 @@ parts:
   snapcraft:
     source: .
     plugin: python
+    python-packages:
+        # required for cryptography>3.4 and python v1 plugins
+        # setup_requires is not accounted for in v1
+        - setuptools-rust>=0.11.4
     requirements:
         - requirements.txt
     organize:
@@ -114,6 +119,10 @@ parts:
 
   legacy-snapcraft:
     plugin: python
+    python-packages:
+        # required for cryptography>3.4 and python v1 plugins
+        # setup_requires is not accounted for in v1
+        - setuptools-rust>=0.11.4
     source: https://github.com/snapcore/snapcraft.git
     source-branch: legacy
     source-depth: 1


### PR DESCRIPTION
With cryptography >= 3.4, setuptools-rust is required to build.

It is listed as part of the setup_requires [1], but this is not
accounted for in the v1 python plugin.  This is due to a discrepancy
of dependency resolution of pip download vs install with regards
to setup_requires [2].

[1] https://github.com/pyca/cryptography/blob/main/setup.py#L46
[2] https://github.com/pypa/pip/issues/5865

Work around this by simply pinning the requirement in the
snapcraft.yaml parts (as it is a Snapcraft-related issue).

Additionally add rustc to build-packages to ensure it is available
if the package is built from source.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
