### PR TITLE
extensions: suppress realpath noise on headless systems

### DIFF
--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -211,8 +211,8 @@ fi
 # Create links for user-dirs.dirs
 if [ "$needs_xdg_links" = true ]; then
   for ((i = 0; i < ${#XDG_SPECIAL_DIRS_PATHS[@]}; i++)); do
-    b="$(realpath "${XDG_SPECIAL_DIRS_PATHS[$i]}" --relative-to="$HOME")"
-    if [[ "$b" != "." && -e "$REALHOME/$b" ]]; then
+    b="$(realpath "${XDG_SPECIAL_DIRS_PATHS[$i]}" --relative-to="$HOME" 2>/dev/null)"
+    if [[ -n "$b" && "$b" != "." && -e "$REALHOME/$b" ]]; then
       [ -d "$HOME/$b" ] && rmdir "$HOME/$b" 2> /dev/null
       [ ! -e "$HOME/$b" ] && ln -s "$REALHOME/$b" "$HOME/$b"
     fi


### PR DESCRIPTION
When using extensions on systems where a desktop session has never run,
desktop-launch will create noise complaining that paths cannot be found.
Simply redirect the error messages to /dev/null.

E.G, running over SSH in Multipass, using snaps in a CLI environment.

Additionally, prevent behaviour where `rmdir $HOME` would be called
by ensuring the variable is not empty.
This is unlikely to have caused problems as rmdir would not delete directories
that have content, but it's better to not rely on semantics here.

- [Y] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [Y] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [Y] Have you successfully run `./runtests.sh static`?
- [Partial] Have you successfully run `./runtests.sh tests/unit`?
(Tests were run but this is my first contribution and the tests are noisy, I suspect they do not relate to this commit)
-----
