### PR TITLE
snap: pin cryptography to 3.4

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -85,7 +85,7 @@ parts:
     plugin: python
     python-packages:
         # Lock down cryptography to 3.4 to override the rust dependency.
-        - cryptography<3.5
+        - cryptography==3.4
     requirements:
         - requirements.txt
     organize:
@@ -121,7 +121,7 @@ parts:
     plugin: python
     python-packages:
         # Lock down cryptography to 3.4 to override the rust dependency.
-        - cryptography<3.5
+        - cryptography==3.4
     source: https://github.com/snapcore/snapcraft.git
     source-branch: legacy
     source-depth: 1


### PR DESCRIPTION
Latest version that works with Snapcraft on all architectures with
current requirements.

E.g. on s390x with 3.4.1 it runs into an issue with pip:

```
Collecting PyYAML==5.3
  Downloading PyYAML-5.3.tar.gz (268 kB)
ERROR: Exception:
Traceback (most recent call last):
  File "/build/snapcraft-snapcraft-b7d60c/parts/snapcraft/install/lib/python3.6/site-packages/pip/_vendor/resolvelib/resolvers.py", line 171, in _merge_into_criterion
    crit = self.state.criteria[name]
KeyError: 'pyyaml'
```

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
