### PR TITLE
ci: don't publish snap on push to master

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,8 +2,6 @@ name: CI
 
 on: 
   pull_request:
-  push:
-    branches: [master]
 
 jobs:
   publish:
@@ -18,8 +16,6 @@ jobs:
             echo "::set-output name=PUBLISH::true"
             if [[ ${{ github.event_name }} == 'pull_request' ]]; then
               echo "::set-output name=PUBLISH_BRANCH::edge/pr-${{ github.event.number }}"
-            elif [[ "${GITHUB_REF##*/}" == "master" ]]; then
-              echo "::set-output name=PUBLISH_BRANCH::edge"
             else
               echo "::set-output name=PUBLISH_BRANCH::"
             fi


### PR DESCRIPTION
This process happens externally (for all architectures).

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
