### PR TITLE
python v2 plugin: default python-packages to [pip, setuptools, wheel]

### DIFF
--- a/snapcraft/plugins/v2/python.py
+++ b/snapcraft/plugins/v2/python.py
@@ -94,7 +94,7 @@ class PythonPlugin(PluginV2):
                     "type": "array",
                     "uniqueItems": True,
                     "items": {"type": "string"},
-                    "default": [],
+                    "default": ["pip", "setuptools", "wheel"],
                 },
             },
         }

--- a/tests/unit/plugins/v2/test_python.py
+++ b/tests/unit/plugins/v2/test_python.py
@@ -32,7 +32,7 @@ def test_schema():
                 "uniqueItems": True,
             },
             "python-packages": {
-                "default": [],
+                "default": ["pip", "setuptools", "wheel"],
                 "items": {"type": "string"},
                 "type": "array",
                 "uniqueItems": True,


### PR DESCRIPTION
pip has an especially ugly error when wheel is not installed.  Install
the latest pip, setuptools, and wheel to the v2 python environment.
This may be overriden if/when the user sets python-packages manually,
this just improves the out-of-the-box behavior for the majority of
projects.

LP: #1912244

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
