### PR TITLE
python v2 plugin: filter set options to reduce output noise

### DIFF
--- a/snapcraft/plugins/v2/python.py
+++ b/snapcraft/plugins/v2/python.py
@@ -170,7 +170,7 @@ class PythonPlugin(PluginV2):
             dedent(
                 """\
             determine_link_target() {
-                opts_state="$(set +o +x)"
+                opts_state="$(set +o +x | grep xtrace)"
                 interp_dir="$(dirname "${SNAPCRAFT_PYTHON_VENV_INTERP_PATH}")"
                 target="${SNAPCRAFT_PYTHON_PATH}"
                 for dir in "${SNAPCRAFT_PART_INSTALL}" "${SNAPCRAFT_STAGE}"; do

--- a/tests/unit/plugins/v2/test_python.py
+++ b/tests/unit/plugins/v2/test_python.py
@@ -76,7 +76,7 @@ _FIXUP_BUILD_COMMANDS = [
     dedent(
         """\
             determine_link_target() {
-                opts_state="$(set +o +x)"
+                opts_state="$(set +o +x | grep xtrace)"
                 interp_dir="$(dirname "${SNAPCRAFT_PYTHON_VENV_INTERP_PATH}")"
                 target="${SNAPCRAFT_PYTHON_PATH}"
                 for dir in "${SNAPCRAFT_PART_INSTALL}" "${SNAPCRAFT_STAGE}"; do


### PR DESCRIPTION
There are 25+ bash options that end up being printed multiple
times.  Reduce noise in the output/logs by filtering in the
only option we actually care about.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
