### PR TITLE
python v2 plugin: reduce noise by replacing for-loop with xargs

### DIFF
--- a/snapcraft/plugins/v2/python.py
+++ b/snapcraft/plugins/v2/python.py
@@ -156,11 +156,9 @@ class PythonPlugin(PluginV2):
         build_commands.append(
             dedent(
                 """\
-            for e in $(find "${SNAPCRAFT_PART_INSTALL}" -type f -executable)
-            do
-                sed -i "1 s|^#\\!${SNAPCRAFT_PYTHON_VENV_INTERP_PATH}.*$|#\\!/usr/bin/env ${SNAPCRAFT_PYTHON_INTERPRETER}|" "${e}"
-            done
-        """
+            find "${SNAPCRAFT_PART_INSTALL}" -type f -executable -print0 | xargs -0 \
+                sed -i "1 s|^#\\!${SNAPCRAFT_PYTHON_VENV_INTERP_PATH}.*$|#\\!/usr/bin/env ${SNAPCRAFT_PYTHON_INTERPRETER}|"
+            """
             )
         )
 

--- a/tests/unit/plugins/v2/test_python.py
+++ b/tests/unit/plugins/v2/test_python.py
@@ -67,11 +67,9 @@ def test_get_build_environment():
 _FIXUP_BUILD_COMMANDS = [
     dedent(
         """\
-            for e in $(find "${SNAPCRAFT_PART_INSTALL}" -type f -executable)
-            do
-                sed -i "1 s|^#\\!${SNAPCRAFT_PYTHON_VENV_INTERP_PATH}.*$|#\\!/usr/bin/env ${SNAPCRAFT_PYTHON_INTERPRETER}|" "${e}"
-            done
-        """
+            find "${SNAPCRAFT_PART_INSTALL}" -type f -executable -print0 | xargs -0 \
+                sed -i "1 s|^#\\!${SNAPCRAFT_PYTHON_VENV_INTERP_PATH}.*$|#\\!/usr/bin/env ${SNAPCRAFT_PYTHON_INTERPRETER}|"
+            """
     ),
     dedent(
         """\


### PR DESCRIPTION
If the snap is large, there is extra noise iterating over all
executable files.  Replace this loop with xargs to reduce the
output noise.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
