### PR TITLE
repo: account for arch & version when filtering stage packages

### DIFF
--- a/snapcraft/internal/repo/apt_cache.py
+++ b/snapcraft/internal/repo/apt_cache.py
@@ -248,26 +248,20 @@ class AptCache(ContextDecorator):
 
             self._verify_marked_install(package)
 
-    def unmark_packages(
-        self, *, required_names: Set[str], filtered_names: Set[str]
-    ) -> None:
+    def unmark_packages(self, unmark_names: Set[str]) -> None:
         skipped_essential = set()
-        skipped_blacklisted = set()
+        skipped_filtered = set()
 
         for package in self.cache:
-            # Explicitly listed packages are never filtered.
-            if package.name in required_names:
-                continue
-
             if package.candidate.priority == "essential":
                 # Filter 'essential' packages.
                 skipped_essential.add(package.name)
                 package.mark_keep()
                 continue
 
-            if package.name in filtered_names:
+            if package.name in unmark_names:
                 # Filter packages from given list.
-                skipped_blacklisted.add(package.name)
+                skipped_filtered.add(package.name)
                 package.mark_keep()
                 continue
 
@@ -276,9 +270,9 @@ class AptCache(ContextDecorator):
                 f"Skipping priority essential packages: {sorted(skipped_essential)}"
             )
 
-        if skipped_blacklisted:
+        if skipped_filtered:
             logger.debug(
-                f"Skipping blacklisted from manifest packages: {sorted(skipped_blacklisted)}"
+                f"Skipping filtered manifest packages: {sorted(skipped_filtered)}"
             )
 
         # Unmark dependencies that are no longer required.

--- a/tests/unit/repo/test_apt_cache.py
+++ b/tests/unit/repo/test_apt_cache.py
@@ -45,9 +45,7 @@ class TestAptStageCache(unit.TestCase):
             filtered_names = {"base-files", "libc6", "libkmod2", "libudev1", "zlib1g"}
 
             apt_cache.mark_packages(package_names)
-            apt_cache.unmark_packages(
-                required_names=package_names, filtered_names=filtered_names
-            )
+            apt_cache.unmark_packages(unmark_names=filtered_names)
 
             marked_packages = apt_cache.get_packages_marked_for_installation()
             self.assertThat(


### PR DESCRIPTION
The filter should only contain package names, not including the
optional [:arch] or [=version] fields.

Move the filter/no-filter logic out of apt_cache and introduce
a _get_filtered_stage_packages() helper in _deb to handle the
processing.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
