### PR TITLE
meta: add support for `kernel.yaml` for kernel snaps

### DIFF
--- a/snapcraft/internal/meta/_snap_packaging.py
+++ b/snapcraft/internal/meta/_snap_packaging.py
@@ -536,6 +536,11 @@ class _SnapPackaging:
             file_utils.link_or_copy(
                 "gadget.yaml", os.path.join(self.meta_dir, "gadget.yaml")
             )
+        if self._config_data.get("type", "") == "kernel":
+            if os.path.exists("kernel.yaml"):
+                file_utils.link_or_copy(
+                    "kernel.yaml", os.path.join(self.meta_dir, "kernel.yaml")
+                )
 
     def _assemble_runtime_environment(self) -> str:
         # Classic confinement or building on a host that does not match the target base

--- a/tests/unit/meta/test_meta.py
+++ b/tests/unit/meta/test_meta.py
@@ -206,6 +206,21 @@ class CreateTestCase(CreateBaseTestCase):
 
         self.assertRaises(errors.MissingGadgetError, self.generate_meta_yaml)
 
+    def test_create_kernel_meta_with_kernel_yaml(self):
+        kernel_yaml = "stub entry: stub value"
+        _create_file("kernel.yaml", content=kernel_yaml)
+
+        self.config_data["type"] = "kernel"
+        self.config_data["build-base"] = "core20"
+        self.config_data.pop("base")
+
+        self.generate_meta_yaml()
+
+        expected_kernel = os.path.join(self.meta_dir, "kernel.yaml")
+        self.assertTrue(os.path.exists(expected_kernel))
+
+        self.assertThat(expected_kernel, FileContains(kernel_yaml))
+
     def test_create_meta_with_declared_icon(self):
         _create_file(os.path.join(os.curdir, "my-icon.png"))
         self.config_data["icon"] = "my-icon.png"


### PR DESCRIPTION
Snapd supports the "kernel.yaml" file for kernel snaps since
some versions. The file is used to ship boot assets that are
part of the kernel.

The first PR with support can be found here:
https://github.com/snapcore/snapd/pull/9150

This commit adds support for including a `kernel.yaml` as
meta/kernel.yaml in the snap. This will help the pi-kernel
to ship their DTBs as part of the kernel snap.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x]  Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`? Yes-ish, on 20.10 but the failures were unrelated to my change
- [x] Have you successfully run `./runtests.sh tests/unit`? Yes-ish I ran python3 -m unittest tests.unit.test_meta the entire suite had unrelated failures AFAICT

-----
