### PR TITLE
ci: run spread store tests when secret is available

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -112,7 +112,7 @@ jobs:
         name: Run spread
         env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
-          SNAP_STORE_MACAROON: ${{ secrects.SNAP_STORE_MACAROON }}
+          SNAP_STORE_MACAROON: ${{ secrets.SNAP_STORE_MACAROON }}
         run: spread google:ubuntu-18.04-64:tests/spread/general/store
 
       - name: Discard spread workers

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -68,3 +68,57 @@ jobs:
           for r in .spread-reuse.*.yaml; do
             spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')"
           done
+
+  integration-spread-tests-store:
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      # FIXME: enable fail-fast mode once spread can cancel an executing job.
+      # Disable fail-fast mode as it doesn't function with spread. It seems
+      # that cancelling tasks requires short, interruptible actions and
+      # interrupting spread, notably, does not work today. As such disable
+      # fail-fast while we tackle that problem upstream.
+      fail-fast: false
+
+    steps:
+      - name: Decision to Run
+        id: decisions
+        run: |
+          # Secrets cannot be used in conditionals, so this is our dance:
+          # https://github.com/actions/runner/issues/520
+          if [[ -n "${{ secrets.SNAP_STORE_MACAROON }}" ]]; then
+            echo "::set-output name=RUN::true"
+          else
+            echo "::set-output name=RUN::"
+          fi
+
+      - if: steps.decisions.outputs.RUN == 'true'
+        name: Checkout snapcraft
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - if: steps.decisions.outputs.RUN == 'true'
+        name: Download snapcraft snap
+        uses: actions/download-artifact@v2
+        with:
+          name: snap
+
+      - if: steps.decisions.outputs.RUN == 'true'
+        name: Install spread
+        run: curl -s https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz | sudo tar xzv -C /usr/bin
+
+      - if: steps.decisions.outputs.RUN == 'true'
+        name: Run spread
+        env:
+          SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
+          SNAP_STORE_MACAROON: ${{ secrects.SNAP_STORE_MACAROON }}
+        run: spread google:ubuntu-18.04-64:tests/spread/general/store
+
+      - name: Discard spread workers
+        if: always()
+        run: |
+          shopt -s nullglob
+          for r in .spread-reuse.*.yaml; do
+            spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')"
+          done

--- a/tests/spread/general/store/task.yaml
+++ b/tests/spread/general/store/task.yaml
@@ -52,7 +52,9 @@ execute: |
   snap_name=$(grep "name: " snap/snapcraft.yaml | sed -e "s/name: \(.*$\)/\1/")
 
   # Login
+  set +x
   echo "${SNAP_STORE_MACAROON}" | snapcraft login --with -
+  set -x
 
   # Register
   snapcraft register --yes "${snap_name}"

--- a/tests/spread/general/store/task.yaml
+++ b/tests/spread/general/store/task.yaml
@@ -12,7 +12,7 @@ environment:
   STORE_DASHBOARD_URL: https://dashboard.staging.snapcraft.io/
   STORE_API_ROOT: https://api.staging.snapcraft.io/
   STORE_UPLOAD_URL: https://upload.apps.staging.ubuntu.com/
-  UBUNTU_ONE_SSO_URL: https://login.staging.ubuntu.com/api/v2/
+  UBUNTU_ONE_SSO_URL: https://login.staging.ubuntu.com/
 
 prepare: |
   # Install the review tools to make sure we do not break anything

--- a/tests/spread/general/store/task.yaml
+++ b/tests/spread/general/store/task.yaml
@@ -10,7 +10,7 @@ environment:
   SNAP: dump-hello
   SNAP_STORE_MACAROON: "$(HOST: echo ${SNAP_STORE_MACAROON})"
   STORE_DASHBOARD_URL: https://dashboard.staging.snapcraft.io/
-  STORE_API_ROOT: https://api.staging.snapcraft.io/
+  STORE_API_URL: https://api.staging.snapcraft.io/
   STORE_UPLOAD_URL: https://upload.apps.staging.ubuntu.com/
   UBUNTU_ONE_SSO_URL: https://login.staging.ubuntu.com/
 

--- a/tests/spread/general/store/task.yaml
+++ b/tests/spread/general/store/task.yaml
@@ -9,11 +9,10 @@ manual: true
 environment:
   SNAP: dump-hello
   SNAP_STORE_MACAROON: "$(HOST: echo ${SNAP_STORE_MACAROON})"
-  SNAP_STORE_DASHBOARD_ROOT_URL: https://dashboard.staging.snapcraft.io/
-  UBUNTU_STORE_API_ROOT_URL: https://dashboard.staging.snapcraft.io/dev/api/
-  UBUNTU_STORE_SEARCH_ROOT_URL: https://api.staging.snapcraft.io/
-  UBUNTU_STORE_UPLOAD_ROOT_URL: https://upload.apps.staging.ubuntu.com/
-  UBUNTU_SSO_API_ROOT_URL: https://login.staging.ubuntu.com/api/v2/
+  STORE_DASHBOARD_URL: https://dashboard.staging.snapcraft.io/
+  STORE_API_ROOT: https://api.staging.snapcraft.io/
+  STORE_UPLOAD_URL: https://upload.apps.staging.ubuntu.com/
+  UBUNTU_ONE_SSO_URL: https://login.staging.ubuntu.com/api/v2/
 
 prepare: |
   # Install the review tools to make sure we do not break anything

--- a/tools/staging_env.sh
+++ b/tools/staging_env.sh
@@ -14,7 +14,7 @@ deactivate() {
 export STORE_DASHBOARD_URL="https://dashboard.staging.snapcraft.io/"
 export STORE_API_URL="https://api.staging.snapcraft.io/"
 export STORE_UPLOAD_URL="https://upload.apps.staging.ubuntu.com/"
-export UBUNTU_ONE_SSO_URL="https://login.staging.ubuntu.com/api/v2/"
+export UBUNTU_ONE_SSO_URL="https://login.staging.ubuntu.com/"
 export TEST_STORE="staging"
 
 export ORIGINAL_PS1="$PS1"


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
