### PR TITLE
storeapi: move http client and auth to http_clients package

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -190,7 +190,7 @@ def _try_login(
         if not config_fd:
             print()
             echo.wrapped(storeapi.constants.TWO_FACTOR_WARNING)
-    except storeapi.errors.StoreTwoFactorAuthenticationRequired:
+    except storeapi.http_clients.errors.StoreTwoFactorAuthenticationRequired:
         one_time_password = echo.prompt("Second-factor auth")
         store.login(
             email=email,
@@ -258,7 +258,7 @@ def _login_wrapper(method):
     def login_decorator(self, *args, **kwargs):
         try:
             return method(self, *args, **kwargs)
-        except storeapi.errors.InvalidCredentialsError:
+        except storeapi.http_clients.errors.InvalidCredentialsError:
             print("You are required to login before continuing.")
             login(store=self)
             return method(self, *args, **kwargs)
@@ -518,7 +518,7 @@ def create_key(name):
         enabled_names = {
             account_key["name"] for account_key in account_info["account_keys"]
         }
-    except storeapi.errors.InvalidCredentialsError:
+    except storeapi.http_clients.errors.InvalidCredentialsError:
         # Don't require a login here; if they don't have valid credentials,
         # then they probably also don't have a key registered with the store
         # yet.
@@ -795,7 +795,7 @@ def _upload_delta(
             raise storeapi.errors.StoreDeltaApplicationError(str(e))
         else:
             raise
-    except storeapi.errors.StoreServerError as e:
+    except storeapi.http_clients.errors.StoreServerError as e:
         raise storeapi.errors.StoreUploadError(snap_name, e.response)
     finally:
         if os.path.isfile(delta_filename):

--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -26,7 +26,8 @@ import click
 from tabulate import tabulate
 
 import snapcraft
-from snapcraft import config, formatting_utils, storeapi
+from snapcraft import formatting_utils, storeapi
+from snapcraft.storeapi.http_clients._ubuntu_sso_client import UbuntuOneSSOConfig
 from snapcraft._store import StoreClientCLI
 from snapcraft.storeapi.constants import DEFAULT_SERIES
 
@@ -796,7 +797,7 @@ def logout():
 def whoami():
     """Returns your login information relevant to the store."""
     # TODO: workaround until bakery client is added.
-    conf = config.Config()
+    conf = UbuntuOneSSOConfig()
     email = conf.get("email")
     if email is None:
         email = "unknown"

--- a/snapcraft/config.py
+++ b/snapcraft/config.py
@@ -14,22 +14,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import base64
 import configparser
 import enum
-import io
 import logging
 import os
-import sys
-import urllib.parse
-from typing import Optional, TextIO
+from typing import Optional
 
 from xdg import BaseDirectory
 
 from snapcraft.internal.errors import SnapcraftInvalidCLIConfigError
-from snapcraft.storeapi import constants, errors
 
-LOCAL_CONFIG_FILENAME = ".snapcraft/snapcraft.cfg"
 
 logger = logging.getLogger(__name__)
 
@@ -157,122 +151,3 @@ class CLIConfig:
         else:
             # Clean by default
             return OutdatedStepAction.CLEAN
-
-
-class Config(object):
-    """Hold configuration options in sections.
-
-    There can be two sections for the sso related credentials: production and
-    staging. This is governed by the UBUNTU_ONE_SSO_URL environment
-    variable. Other sections are ignored but preserved.
-
-    """
-
-    def __init__(self) -> None:
-        self.parser = configparser.ConfigParser()
-        self.load()
-
-    def _section_name(self) -> str:
-        # The only section we care about is the host from the SSO url
-        url = os.environ.get("UBUNTU_ONE_SSO_URL", constants.UBUNTU_ONE_SSO_URL)
-        return urllib.parse.urlparse(url).netloc
-
-    def get(
-        self, option_name: str, section_name: Optional[str] = None
-    ) -> Optional[str]:
-        if not section_name:
-            section_name = self._section_name()
-        try:
-            return self.parser.get(section_name, option_name)
-        except (configparser.NoSectionError, configparser.NoOptionError, KeyError):
-            return None
-
-    def set(
-        self, option_name: str, value: str, section_name: Optional[str] = None
-    ) -> None:
-        if not section_name:
-            section_name = self._section_name()
-        if not self.parser.has_section(section_name):
-            self.parser.add_section(section_name)
-        self.parser.set(section_name, option_name, value)
-
-    def is_empty(self) -> bool:
-        # Only check the current section
-        section_name = self._section_name()
-        if self.parser.has_section(section_name):
-            if self.parser.options(section_name):
-                return False
-        return True
-
-    def load(self, *, config_fd: TextIO = None) -> None:
-        config = ""
-        if config_fd:
-            config = config_fd.read()
-        else:
-            # Local configurations (per project) are supposed to be static.
-            # That's why it's only checked for 'loading' and never written to.
-            # Essentially, all authentication-related changes, like
-            # login/logout or macaroon-refresh, will not be persisted for the
-            # next runs.
-            file_path = ""
-            if os.path.exists(LOCAL_CONFIG_FILENAME):
-                file_path = LOCAL_CONFIG_FILENAME
-
-                # FIXME: We don't know this for sure when loading the config.
-                # Need a better separation of concerns.
-                logger.warning(
-                    "Using local configuration ({!r}), changes will not be "
-                    "persisted.".format(file_path)
-                )
-            else:
-                file_path = BaseDirectory.load_first_config(
-                    "snapcraft", "snapcraft.cfg"
-                )
-            if file_path and os.path.exists(file_path):
-                with open(file_path, "r") as f:
-                    config = f.read()
-
-        if config:
-            _load_potentially_base64_config(self.parser, config)
-
-    @staticmethod
-    def save_path() -> str:
-        return os.path.join(
-            BaseDirectory.save_config_path("snapcraft"), "snapcraft.cfg"
-        )
-
-    def save(self, *, config_fd: Optional[TextIO] = None, encode: bool = False) -> None:
-        with io.StringIO() as config_buffer:
-            self.parser.write(config_buffer)
-            config = config_buffer.getvalue()
-            if encode:
-                # Encode config using base64
-                config = base64.b64encode(
-                    config.encode(sys.getfilesystemencoding())
-                ).decode(sys.getfilesystemencoding())
-
-            if config_fd:
-                config_fd.write(config)
-            else:
-                with open(self.save_path(), "w") as f:
-                    f.write(config)
-
-    def clear(self) -> None:
-        self.parser.remove_section(self._section_name())
-
-
-def _load_potentially_base64_config(parser, config):
-    try:
-        parser.read_string(config)
-    except configparser.Error as e:
-        # The config may be base64-encoded, try decoding it
-        try:
-            config = base64.b64decode(config).decode(sys.getfilesystemencoding())
-        except base64.binascii.Error:  # type: ignore
-            # It wasn't base64, so use the original error
-            raise errors.InvalidLoginConfig(e) from e
-
-        try:
-            parser.read_string(config)
-        except configparser.Error as e:
-            raise errors.InvalidLoginConfig(e) from e

--- a/snapcraft/storeapi/_dashboard_api.py
+++ b/snapcraft/storeapi/_dashboard_api.py
@@ -64,7 +64,7 @@ class DashboardAPI(Requests):
         if response.ok:
             return response.json()["macaroon"]
         else:
-            raise errors.StoreAuthenticationError("Failed to get macaroon", response)
+            raise errors.GeneralStoreError("Failed to get macaroon", response)
 
     def verify_acl(self):
         response = self.post(

--- a/snapcraft/storeapi/_store_client.py
+++ b/snapcraft/storeapi/_store_client.py
@@ -22,11 +22,10 @@ from typing import Any, Dict, Iterable, List, Optional, TextIO, Union
 import requests
 
 from snapcraft.internal.indicators import download_requests_stream
-from . import _upload, errors
+from . import _upload, errors, http_clients
 from ._dashboard_api import DashboardAPI
 from ._snap_api import SnapAPI
 from ._up_down_client import UpDownClient
-from ._ubuntu_sso_client import Client, UbuntuOneAuthClient
 from .constants import DEFAULT_SERIES
 from .v2 import channel_map, releases
 
@@ -40,8 +39,8 @@ class StoreClient:
     def __init__(self) -> None:
         super().__init__()
 
-        self.client = Client()
-        self.auth_client = UbuntuOneAuthClient()
+        self.client = http_clients.Client()
+        self.auth_client = http_clients.UbuntuOneAuthClient()
 
         self.snap = SnapAPI(self.client)
         self.dashboard = DashboardAPI(self.auth_client)

--- a/snapcraft/storeapi/constants.py
+++ b/snapcraft/storeapi/constants.py
@@ -24,7 +24,6 @@ SCAN_STATUS_POLL_RETRIES = 5
 STORE_DASHBOARD_URL = "https://dashboard.snapcraft.io/"
 STORE_API_URL = "https://api.snapcraft.io/"
 STORE_UPLOAD_URL = "https://upload.apps.ubuntu.com/"
-UBUNTU_ONE_SSO_URL = "https://login.ubuntu.com/"
 
 # Messages and warnings.
 MISSING_AGREEMENT = "Developer has not signed agreement."

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -16,10 +16,8 @@
 
 import contextlib
 import logging
-from http.client import responses
 from typing import Dict, List, Optional
 
-from requests.packages import urllib3
 from simplejson.scanner import JSONDecodeError
 
 from snapcraft import formatting_utils
@@ -29,7 +27,6 @@ from . import channels, status
 
 logger = logging.getLogger(__name__)
 
-_STORE_STATUS_URL = "https://status.snapcraft.io/"
 _FORUM_URL = "https://forum.snapcraft.io/c/store"
 
 
@@ -44,6 +41,27 @@ class StoreError(SnapcraftError):
         with contextlib.suppress(KeyError, AttributeError):
             logger.debug("Store error response: {}".format(kwargs["response"].__dict__))
         super().__init__(**kwargs)
+
+
+class GeneralStoreError(StoreError):
+
+    fmt = "Store Error: {message}"
+
+    def __init__(self, message, response=None):
+        # Unfortunately the store doesn't give us a consistent error response,
+        # so we'll check the ones of which we're aware.
+        with contextlib.suppress(AttributeError, JSONDecodeError):
+            response_json = response.json()
+            extra_error_message = ""
+            if "error_message" in response_json:
+                extra_error_message = response_json["error_message"]
+            elif "message" in response_json:
+                extra_error_message = response_json["message"]
+
+            if extra_error_message:
+                message += ": {}".format(extra_error_message)
+
+        super().__init__(response=response, message=message)
 
 
 class StoreErrorList:
@@ -74,31 +92,6 @@ class StoreErrorList:
 
     def __init__(self, error_list: List[Dict[str, str]]) -> None:
         self._error_list = error_list
-
-
-class InvalidCredentialsError(StoreError):
-
-    fmt = "Invalid credentials: {message}. " 'Have you run "snapcraft login"?'
-
-    def __init__(self, message):
-        super().__init__(message=message)
-
-
-class StoreNetworkError(StoreError):
-
-    fmt = "There seems to be a network error: {message}"
-
-    def __init__(self, exception):
-        message = str(exception)
-        with contextlib.suppress(IndexError):
-            underlying_exception = exception.args[0]
-            if isinstance(underlying_exception, urllib3.exceptions.MaxRetryError):
-                message = (
-                    "maximum retries exceeded trying to reach the store.\n"
-                    "Check your network connection, and check the store "
-                    "status at {}".format(_STORE_STATUS_URL)
-                )
-        super().__init__(message=message)
 
 
 class SnapNotFoundError(SnapcraftException):
@@ -192,32 +185,6 @@ class SHAMismatchError(StoreDownloadError):
 
     def __init__(self, *, path: str, expected: str, calculated: str) -> None:
         super().__init__(path=path, expected=expected, calculated=calculated)
-
-
-class StoreAuthenticationError(StoreError):
-
-    fmt = "Authentication error: {message}"
-
-    def __init__(self, message, response=None):
-        # Unfortunately the store doesn't give us a consistent error response,
-        # so we'll check the ones of which we're aware.
-        with contextlib.suppress(AttributeError, JSONDecodeError):
-            response_json = response.json()
-            extra_error_message = ""
-            if "error_message" in response_json:
-                extra_error_message = response_json["error_message"]
-            elif "message" in response_json:
-                extra_error_message = response_json["message"]
-
-            if extra_error_message:
-                message += ": {}".format(extra_error_message)
-
-        super().__init__(response=response, message=message)
-
-
-class StoreTwoFactorAuthenticationRequired(StoreAuthenticationError):
-    def __init__(self):
-        super().__init__("Two-factor authentication required.")
 
 
 class DeveloperAgreementSignError(StoreError):
@@ -447,28 +414,6 @@ class StoreReviewError(StoreError):
             self.fmt += "\n{additional}"
         self.code = result["code"]
         super().__init__()
-
-
-class StoreServerError(StoreError):
-
-    fmt = "{what}: {error_text} (code {error_code}).\n{action}"
-
-    def __init__(self, response):
-        what = "The Snap Store encountered an error while processing your request"
-        error_code = response.status_code
-        error_text = responses[error_code].lower()
-        action = "The operational status of the Snap Store can be checked at {}".format(
-            _STORE_STATUS_URL
-        )
-        self.response = response
-
-        super().__init__(
-            response=response,
-            what=what,
-            error_text=error_text,
-            error_code=error_code,
-            action=action,
-        )
 
 
 class StoreReleaseError(StoreError):
@@ -794,14 +739,6 @@ class SignBuildAssertionError(StoreError):
 
     def __init__(self, snap_name):
         super().__init__(snap_name=snap_name)
-
-
-class InvalidLoginConfig(StoreError):
-
-    fmt = "Invalid login config: {error}"
-
-    def __init__(self, error):
-        super().__init__(error=error)
 
 
 def _error_list_to_message(response_json):

--- a/snapcraft/storeapi/http_clients/__init__.py
+++ b/snapcraft/storeapi/http_clients/__init__.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2016-2017, 2020-2021 Canonical Ltd
+# Copyright 2021 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,14 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
-
-from . import errors  # noqa: F401 isort:skip
-from . import channels  # noqa: F401 isort:skip
-from . import status  # noqa: F401 isort:skip
-from . import http_clients  # noqa: F401 isort: skip
-
-logger = logging.getLogger(__name__)
-
-
-from ._store_client import StoreClient  # noqa
+from . import errors  # noqa: F401
+from ._ubuntu_sso_client import UbuntuOneAuthClient  # noqa: F401
+from ._http_client import Client  # noqa: F401

--- a/snapcraft/storeapi/http_clients/_config.py
+++ b/snapcraft/storeapi/http_clients/_config.py
@@ -1,0 +1,116 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import abc
+import base64
+import io
+import pathlib
+from typing import Optional, TextIO
+
+import configparser
+
+from . import errors
+
+
+class Config(abc.ABC):
+    def __init__(self) -> None:
+        self.parser = configparser.ConfigParser()
+        self.load()
+
+    @abc.abstractmethod
+    def _get_section_name(self) -> str:
+        """Return section name."""
+
+    @abc.abstractmethod
+    def _get_config_path(self) -> pathlib.Path:
+        """Return Path to configuration file."""
+
+    def get(
+        self, option_name: str, section_name: Optional[str] = None
+    ) -> Optional[str]:
+        """Return content of section_name/option_name or None if not found."""
+        if section_name is None:
+            section_name = self._get_section_name()
+        try:
+            return self.parser.get(section_name, option_name)
+        except (configparser.NoSectionError, configparser.NoOptionError, KeyError):
+            return None
+
+    def set(
+        self, option_name: str, value: str, section_name: Optional[str] = None
+    ) -> None:
+        """Set value to section_name/option_name."""
+        if not section_name:
+            section_name = self._get_section_name()
+        if not self.parser.has_section(section_name):
+            self.parser.add_section(section_name)
+        self.parser.set(section_name, option_name, value)
+
+    def is_section_empty(self, section_name: Optional[str] = None) -> bool:
+        """Check if section_name is empty."""
+        if section_name is None:
+            section_name = self._get_section_name()
+
+        if self.parser.has_section(section_name):
+            if self.parser.options(section_name):
+                return False
+        return True
+
+    def _load_potentially_base64_config(self, config_content: str) -> None:
+        try:
+            self.parser.read_string(config_content)
+        except configparser.Error as parser_error:
+            # The config may be base64-encoded, try decoding it
+            try:
+                decoded_config_content = base64.b64decode(config_content).decode()
+            except base64.binascii.Error:  # type: ignore
+                # It wasn't base64, so use the original error
+                raise errors.InvalidLoginConfig(parser_error)
+
+            try:
+                self.parser.read_string(decoded_config_content)
+            except configparser.Error as parser_error:
+                raise errors.InvalidLoginConfig(parser_error)
+
+    def load(self, *, config_fd: TextIO = None) -> None:
+        if config_fd is not None:
+            config_content = config_fd.read()
+        elif self._get_config_path().exists():
+            with self._get_config_path().open() as config_file:
+                config_content = config_file.read()
+        else:
+            return
+
+        self._load_potentially_base64_config(config_content)
+
+    def save(self, *, config_fd: Optional[TextIO] = None, encode: bool = False) -> None:
+        with io.StringIO() as config_buffer:
+            self.parser.write(config_buffer)
+            config_content = config_buffer.getvalue()
+            if encode:
+                config_content = base64.b64encode(config_content.encode()).decode()
+
+            if config_fd:
+                print(config_content, file=config_fd)
+            else:
+                with self._get_config_path().open("w") as config_file:
+                    print(config_content, file=config_file)
+
+    def clear(self, section_name: Optional[str] = None) -> None:
+        if section_name is None:
+            section_name = self._get_section_name()
+
+        self.parser.remove_section(self._get_section_name())

--- a/snapcraft/storeapi/http_clients/_http_client.py
+++ b/snapcraft/storeapi/http_clients/_http_client.py
@@ -1,0 +1,88 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import logging
+
+import requests
+
+from requests.adapters import HTTPAdapter
+from requests.exceptions import ConnectionError, RetryError
+from requests.packages.urllib3.util.retry import Retry
+
+from . import agent, errors
+
+
+# Set urllib3's logger to only emit errors, not warnings. Otherwise even
+# retries are printed, and they're nasty.
+logging.getLogger(requests.packages.urllib3.__package__).setLevel(logging.ERROR)
+logger = logging.getLogger(__name__)
+
+
+class Client:
+    """Generic Client to talk to the *Store."""
+
+    def __init__(self, *, user_agent: str = agent.get_user_agent()) -> None:
+        self.session = requests.Session()
+        self._user_agent = user_agent
+
+        # Setup max retries for all store URLs and the CDN
+        retries = Retry(
+            total=int(os.environ.get("STORE_RETRIES", 5)),
+            backoff_factor=int(os.environ.get("STORE_BACKOFF", 2)),
+            status_forcelist=[104, 500, 502, 503, 504],
+        )
+        self.session.mount("http://", HTTPAdapter(max_retries=retries))
+        self.session.mount("https://", HTTPAdapter(max_retries=retries))
+
+    def request(
+        self, method, url, params=None, headers=None, **kwargs
+    ) -> requests.Response:
+        """Send a request to url relative to the root url.
+
+        :param str method: Method used for the request.
+        :param str url: URL to request with method.
+        :param list params: Query parameters to be sent along with the request.
+        :param list headers: Headers to be sent along with the request.
+
+        :return Response of the request.
+        """
+        if headers:
+            headers["User-Agent"] = self._user_agent
+        else:
+            headers = {"User-Agent": self._user_agent}
+
+        debug_headers = headers.copy()
+        if "Authorization" in debug_headers:
+            debug_headers["Authorization"] = "<macaroon>"
+        logger.debug(
+            "Calling {} with params {} and headers {}".format(
+                url, params, debug_headers
+            )
+        )
+        try:
+            response = self.session.request(
+                method, url, headers=headers, params=params, **kwargs
+            )
+        except (ConnectionError, RetryError) as e:
+            raise errors.StoreNetworkError(e) from e
+
+        # Handle 5XX responses generically right here, so the callers don't
+        # need to worry about it.
+        if response.status_code >= 500:
+            raise errors.StoreServerError(response)
+
+        return response

--- a/snapcraft/storeapi/http_clients/_ubuntu_sso_client.py
+++ b/snapcraft/storeapi/http_clients/_ubuntu_sso_client.py
@@ -18,7 +18,7 @@ import logging
 import json
 import os
 import pathlib
-from typing import Final, Optional, TextIO
+from typing import Optional, TextIO
 from urllib.parse import urljoin, urlparse
 
 import pymacaroons
@@ -29,7 +29,7 @@ from xdg import BaseDirectory
 from . import agent, _config, errors, _http_client
 
 
-UBUNTU_ONE_SSO_URL: Final = "https://login.ubuntu.com/"
+UBUNTU_ONE_SSO_URL = "https://login.ubuntu.com/"
 
 
 logger = logging.getLogger(__name__)

--- a/snapcraft/storeapi/http_clients/agent.py
+++ b/snapcraft/storeapi/http_clients/agent.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2017,2020 Canonical Ltd
+# Copyright (C) 2017,2020-2021 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/snapcraft/storeapi/http_clients/errors.py
+++ b/snapcraft/storeapi/http_clients/errors.py
@@ -18,14 +18,13 @@ import contextlib
 import logging
 import urllib3
 from simplejson.scanner import JSONDecodeError
-from typing import Final
 
 from snapcraft.internal.errors import SnapcraftError
 
 logger = logging.getLogger(__name__)
 
 
-_STORE_STATUS_URL: Final = "https://status.snapcraft.io/"
+_STORE_STATUS_URL = "https://status.snapcraft.io/"
 
 
 # TODO: migrate to storeapi private exception to ready craft-store.

--- a/snapcraft/storeapi/http_clients/errors.py
+++ b/snapcraft/storeapi/http_clients/errors.py
@@ -1,0 +1,122 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import contextlib
+import logging
+import urllib3
+from simplejson.scanner import JSONDecodeError
+from typing import Final
+
+from snapcraft.internal.errors import SnapcraftError
+
+logger = logging.getLogger(__name__)
+
+
+_STORE_STATUS_URL: Final = "https://status.snapcraft.io/"
+
+
+# TODO: migrate to storeapi private exception to ready craft-store.
+class HttpClientError(SnapcraftError):
+    """Base class http client errors.
+
+    :cvar fmt: A format string that daughter classes override
+    """
+
+    def __init__(self, **kwargs):
+        with contextlib.suppress(KeyError, AttributeError):
+            logger.debug("Store error response: {}".format(kwargs["response"].__dict__))
+        super().__init__(**kwargs)
+
+
+class StoreServerError(HttpClientError):
+
+    fmt = "{what}: {error_text} (code {error_code}).\n{action}"
+
+    def __init__(self, response):
+        what = "The Snap Store encountered an error while processing your request"
+        error_code = response.status_code
+        error_text = response.reason
+        action = "The operational status of the Snap Store can be checked at {}".format(
+            _STORE_STATUS_URL
+        )
+        self.response = response
+
+        super().__init__(
+            response=response,
+            what=what,
+            error_text=error_text,
+            error_code=error_code,
+            action=action,
+        )
+
+
+class StoreNetworkError(HttpClientError):
+
+    fmt = "There seems to be a network error: {message}"
+
+    def __init__(self, exception):
+        message = str(exception)
+        with contextlib.suppress(IndexError):
+            underlying_exception = exception.args[0]
+            if isinstance(underlying_exception, urllib3.exceptions.MaxRetryError):
+                message = (
+                    "maximum retries exceeded trying to reach the store.\n"
+                    "Check your network connection, and check the store "
+                    "status at {}".format(_STORE_STATUS_URL)
+                )
+        super().__init__(message=message)
+
+
+class InvalidCredentialsError(HttpClientError):
+
+    fmt = 'Invalid credentials: {message}. Have you run "snapcraft login"?'
+
+    def __init__(self, message):
+        super().__init__(message=message)
+
+
+class StoreAuthenticationError(HttpClientError):
+
+    fmt = "Authentication error: {message}"
+
+    def __init__(self, message, response=None):
+        # Unfortunately the store doesn't give us a consistent error response,
+        # so we'll check the ones of which we're aware.
+        with contextlib.suppress(AttributeError, JSONDecodeError):
+            response_json = response.json()
+            extra_error_message = ""
+            if "error_message" in response_json:
+                extra_error_message = response_json["error_message"]
+            elif "message" in response_json:
+                extra_error_message = response_json["message"]
+
+            if extra_error_message:
+                message += ": {}".format(extra_error_message)
+
+        super().__init__(response=response, message=message)
+
+
+class StoreTwoFactorAuthenticationRequired(StoreAuthenticationError):
+    def __init__(self):
+        super().__init__("Two-factor authentication required.")
+
+
+class InvalidLoginConfig(HttpClientError):
+
+    fmt = "Invalid login config: {error}"
+
+    def __init__(self, error):
+        super().__init__(error=error)

--- a/tests/unit/commands/test_export_login.py
+++ b/tests/unit/commands/test_export_login.py
@@ -157,7 +157,7 @@ class ExportLoginCommandTestCase(FakeStoreCommandsBaseTestCase):
 
     def test_successful_login_with_2fa(self):
         self.fake_store_login.mock.side_effect = [
-            storeapi.errors.StoreTwoFactorAuthenticationRequired(),
+            storeapi.http_clients.errors.StoreTwoFactorAuthenticationRequired(),
             None,
         ]
 
@@ -211,7 +211,7 @@ class ExportLoginCommandTestCase(FakeStoreCommandsBaseTestCase):
         )
 
     def test_failed_login_with_invalid_credentials(self):
-        self.fake_store_login.mock.side_effect = storeapi.errors.InvalidCredentialsError(
+        self.fake_store_login.mock.side_effect = storeapi.http_clients.errors.InvalidCredentialsError(
             "error"
         )
 

--- a/tests/unit/commands/test_export_login.py
+++ b/tests/unit/commands/test_export_login.py
@@ -215,7 +215,9 @@ class ExportLoginCommandTestCase(FakeStoreCommandsBaseTestCase):
             "error"
         )
 
-        with pytest.raises(storeapi.errors.InvalidCredentialsError) as exc_info:
+        with pytest.raises(
+            storeapi.http_clients.errors.InvalidCredentialsError
+        ) as exc_info:
             self.run_command(
                 ["export-login", "exported"],
                 input="bad-user@example.com\nbad-password\n",

--- a/tests/unit/commands/test_list.py
+++ b/tests/unit/commands/test_list.py
@@ -30,7 +30,7 @@ class ListTest(FakeStoreCommandsBaseTestCase):
     def test_command_without_login_must_ask(self):
         # TODO: look into why this many calls are done inside snapcraft.storeapi
         self.fake_store_account_info.mock.side_effect = [
-            storeapi.errors.InvalidCredentialsError("error"),
+            storeapi.http_clients.errors.InvalidCredentialsError("error"),
             {"account_id": "abcd", "snaps": dict()},
             {"account_id": "abcd", "snaps": dict()},
             {"account_id": "abcd", "snaps": dict()},

--- a/tests/unit/commands/test_list_keys.py
+++ b/tests/unit/commands/test_list_keys.py
@@ -31,7 +31,7 @@ class ListKeysCommandTestCase(FakeStoreCommandsBaseTestCase):
     def test_command_without_login_must_ask(self):
         # TODO: look into why this many calls are done inside snapcraft.storeapi
         self.fake_store_account_info.mock.side_effect = [
-            storeapi.errors.InvalidCredentialsError("error"),
+            storeapi.http_clients.errors.InvalidCredentialsError("error"),
             {"account_id": "abcd", "account_keys": list()},
             {"account_id": "abcd", "account_keys": list()},
             {"account_id": "abcd", "account_keys": list()},

--- a/tests/unit/commands/test_list_revisions.py
+++ b/tests/unit/commands/test_list_revisions.py
@@ -37,7 +37,7 @@ class RevisionsCommandTestCase(FakeStoreCommandsBaseTestCase):
 
     def test_revisions_without_login_must_ask(self):
         self.fake_store_get_releases.mock.side_effect = [
-            storeapi.errors.InvalidCredentialsError("error"),
+            storeapi.http_clients.errors.InvalidCredentialsError("error"),
             self.releases,
         ]
 

--- a/tests/unit/commands/test_list_tracks.py
+++ b/tests/unit/commands/test_list_tracks.py
@@ -32,7 +32,7 @@ class ListTracksCommandTestCase(FakeStoreCommandsBaseTestCase):
 
     def test_list_tracks_without_login_must_ask(self):
         self.fake_store_get_snap_channel_map.mock.side_effect = [
-            storeapi.errors.InvalidCredentialsError("error"),
+            storeapi.http_clients.errors.InvalidCredentialsError("error"),
             self.channel_map,
         ]
 

--- a/tests/unit/commands/test_login.py
+++ b/tests/unit/commands/test_login.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pathlib
 import re
 from unittest import mock
 
@@ -22,7 +23,7 @@ import pytest
 from simplejson.scanner import JSONDecodeError
 from testtools.matchers import Contains, Equals, MatchesRegex, Not
 
-from snapcraft import config, storeapi
+from snapcraft import storeapi
 
 from . import FakeStoreCommandsBaseTestCase
 
@@ -50,7 +51,7 @@ class LoginCommandTestCase(FakeStoreCommandsBaseTestCase):
 
     def test_login_with_2fa(self):
         self.fake_store_login.mock.side_effect = [
-            storeapi.errors.StoreTwoFactorAuthenticationRequired(),
+            storeapi.http_clients.errors.StoreTwoFactorAuthenticationRequired(),
             None,
         ]
 
@@ -105,12 +106,7 @@ class LoginCommandTestCase(FakeStoreCommandsBaseTestCase):
         )
         self.fake_store_login.mock.side_effect = None
 
-        conf = config.Config()
-        conf.set("macaroon", "test-macaroon")
-        conf.set("unbound_discharge", "test-unbound-discharge")
-        with open("exported-login", "w") as f:
-            conf.save(config_fd=f)
-            f.flush()
+        pathlib.Path("exported-login").touch()
 
         result = self.run_command(["login", "--with", "exported-login"])
 
@@ -141,7 +137,7 @@ class LoginCommandTestCase(FakeStoreCommandsBaseTestCase):
         )
 
     def test_login_failed_with_invalid_credentials(self):
-        self.fake_store_login.mock.side_effect = storeapi.errors.InvalidCredentialsError(
+        self.fake_store_login.mock.side_effect = storeapi.http_clients.errors.InvalidCredentialsError(
             "error"
         )
 
@@ -154,12 +150,12 @@ class LoginCommandTestCase(FakeStoreCommandsBaseTestCase):
         )
 
     def test_login_failed_with_store_authentication_error(self):
-        self.fake_store_login.mock.side_effect = storeapi.errors.StoreAuthenticationError(
+        self.fake_store_login.mock.side_effect = storeapi.http_clients.errors.StoreAuthenticationError(
             "error"
         )
 
         raised = self.assertRaises(
-            storeapi.errors.StoreAuthenticationError,
+            storeapi.http_clients.errors.StoreAuthenticationError,
             self.run_command,
             ["login"],
             input="user@example.com\nbad-secret\n",

--- a/tests/unit/commands/test_login.py
+++ b/tests/unit/commands/test_login.py
@@ -141,7 +141,9 @@ class LoginCommandTestCase(FakeStoreCommandsBaseTestCase):
             "error"
         )
 
-        with pytest.raises(storeapi.errors.InvalidCredentialsError) as exc_info:
+        with pytest.raises(
+            storeapi.http_clients.errors.InvalidCredentialsError
+        ) as exc_info:
             self.run_command(["login"], input="user@example.com\nbadsecret\n")
 
         assert (

--- a/tests/unit/commands/test_logout.py
+++ b/tests/unit/commands/test_logout.py
@@ -18,14 +18,14 @@ from unittest import mock
 
 from testtools.matchers import Equals, MatchesRegex
 
-from snapcraft import config
+from snapcraft.storeapi import StoreClient
 
 from . import CommandBaseTestCase
 
 
 class LogoutCommandTestCase(CommandBaseTestCase):
-    @mock.patch.object(config.Config, "clear")
-    def test_logout_clears_config(self, mock_clear):
+    @mock.patch.object(StoreClient, "logout")
+    def test_logout_clears_config(self, mock_logout):
         result = self.run_command(["logout"])
 
         self.assertThat(result.exit_code, Equals(0))

--- a/tests/unit/commands/test_register.py
+++ b/tests/unit/commands/test_register.py
@@ -33,7 +33,7 @@ class RegisterTestCase(FakeStoreCommandsBaseTestCase):
 
     def test_register_without_login_must_ask(self):
         self.fake_store_register.mock.side_effect = [
-            storeapi.errors.InvalidCredentialsError("error"),
+            storeapi.http_clients.errors.InvalidCredentialsError("error"),
             None,
         ]
 

--- a/tests/unit/commands/test_register_key.py
+++ b/tests/unit/commands/test_register_key.py
@@ -84,12 +84,12 @@ class RegisterKeyTestCase(FakeStoreCommandsBaseTestCase):
         )
 
     def test_register_key_login_failed(self):
-        self.fake_store_login.mock.side_effect = storeapi.errors.InvalidCredentialsError(
+        self.fake_store_login.mock.side_effect = storeapi.http_clients.errors.InvalidCredentialsError(
             "error"
         )
 
         raised = self.assertRaises(
-            storeapi.errors.InvalidCredentialsError,
+            storeapi.http_clients.errors.InvalidCredentialsError,
             self.run_command,
             ["register-key", "default"],
             input="user@example.com\nsecret\n",

--- a/tests/unit/commands/test_release.py
+++ b/tests/unit/commands/test_release.py
@@ -269,7 +269,7 @@ class ReleaseCommandTestCase(FakeStoreCommandsBaseTestCase):
 
     def test_release_without_login_must_ask(self):
         self.fake_store_release.mock.side_effect = [
-            storeapi.errors.InvalidCredentialsError("error"),
+            storeapi.http_clients.errors.InvalidCredentialsError("error"),
             {"opened_channels": ["beta"]},
         ]
 

--- a/tests/unit/commands/test_set_default_track.py
+++ b/tests/unit/commands/test_set_default_track.py
@@ -40,7 +40,7 @@ class SetDefaultTrackCommandTestCase(FakeStoreCommandsBaseTestCase):
 
     def test_set_default_track_without_login_must_ask(self):
         self.fake_metadata.mock.side_effect = [
-            storeapi.errors.InvalidCredentialsError("error"),
+            storeapi.http_clients.errors.InvalidCredentialsError("error"),
             None,
         ]
 

--- a/tests/unit/commands/test_status.py
+++ b/tests/unit/commands/test_status.py
@@ -38,7 +38,7 @@ class StatusCommandTestCase(FakeStoreCommandsBaseTestCase):
 
     def test_status_without_login_must_ask(self):
         self.fake_store_get_snap_channel_map.mock.side_effect = [
-            storeapi.errors.InvalidCredentialsError("error"),
+            storeapi.http_clients.errors.InvalidCredentialsError("error"),
             self.channel_map,
         ]
 

--- a/tests/unit/commands/test_upload.py
+++ b/tests/unit/commands/test_upload.py
@@ -157,7 +157,7 @@ class UploadCommandTestCase(UploadCommandBaseTestCase):
 
     def test_upload_without_login_must_ask(self):
         self.fake_store_upload_precheck.mock.side_effect = [
-            storeapi.errors.InvalidCredentialsError("error"),
+            storeapi.http_clients.errors.InvalidCredentialsError("error"),
             None,
         ]
 
@@ -459,6 +459,7 @@ class UploadCommandDeltasTestCase(UploadCommandBaseTestCase):
 
         class _FakeResponse:
             status_code = 501
+            reason = "disabled"
 
             def json(self):
                 return {
@@ -471,7 +472,7 @@ class UploadCommandDeltasTestCase(UploadCommandBaseTestCase):
                 }
 
         self.fake_store_upload.mock.side_effect = [
-            storeapi.errors.StoreServerError(_FakeResponse()),
+            storeapi.http_clients.errors.StoreServerError(_FakeResponse()),
             self.mock_tracker,
         ]
 

--- a/tests/unit/commands/test_upload_metadata.py
+++ b/tests/unit/commands/test_upload_metadata.py
@@ -162,7 +162,7 @@ class UploadMetadataCommandTestCase(CommandBaseTestCase):
         self.useFixture(self.fake_store_account_info)
 
         self.fake_metadata.mock.side_effect = [
-            storeapi.errors.InvalidCredentialsError("error"),
+            storeapi.http_clients.errors.InvalidCredentialsError("error"),
             None,
         ]
 

--- a/tests/unit/store/http_client/test_agent.py
+++ b/tests/unit/store/http_client/test_agent.py
@@ -21,7 +21,7 @@ from testtools.matchers import Equals
 
 from snapcraft import ProjectOptions
 from snapcraft import __version__ as snapcraft_version
-from snapcraft import storeapi
+from snapcraft.storeapi.http_clients import agent
 from tests import unit
 from tests.fixture_setup.os_release import FakeOsRelease
 
@@ -33,7 +33,7 @@ class UserAgentTestCase(unit.TestCase):
         arch = ProjectOptions().deb_arch
         expected = f"snapcraft/{snapcraft_version} Ubuntu/16.04 ({arch})"
 
-        self.expectThat(storeapi._agent.get_user_agent("linux"), Equals(expected))
+        self.expectThat(agent.get_user_agent("linux"), Equals(expected))
 
     def test_user_agent_linux_unknown(self):
         self.useFixture(FakeOsRelease(name=None, version_id=None))
@@ -41,33 +41,29 @@ class UserAgentTestCase(unit.TestCase):
         arch = ProjectOptions().deb_arch
         expected = f"snapcraft/{snapcraft_version} Unknown/Unknown Version ({arch})"
 
-        self.expectThat(storeapi._agent.get_user_agent("linux"), Equals(expected))
+        self.expectThat(agent.get_user_agent("linux"), Equals(expected))
 
     def test_user_agent_windows(self):
         arch = ProjectOptions().deb_arch
         expected = f"snapcraft/{snapcraft_version} Windows ({arch})"
 
-        self.expectThat(
-            storeapi._agent.get_user_agent(platform="windows"), Equals(expected)
-        )
+        self.expectThat(agent.get_user_agent(platform="windows"), Equals(expected))
 
     def test_user_agent_darwin(self):
         arch = ProjectOptions().deb_arch
         expected = f"snapcraft/{snapcraft_version} Darwin ({arch})"
 
-        self.expectThat(
-            storeapi._agent.get_user_agent(platform="darwin"), Equals(expected)
-        )
+        self.expectThat(agent.get_user_agent(platform="darwin"), Equals(expected))
 
     def test_in_travis_ci_env(self):
         self.useFixture(fixtures.EnvironmentVariable("TRAVIS_TESTING", "1"))
 
-        self.assertTrue(storeapi._agent._is_ci_env())
+        self.assertTrue(agent._is_ci_env())
 
     def test_in_autopkgtest_ci_env(self):
         self.useFixture(fixtures.EnvironmentVariable("AUTOPKGTEST_TMP", "1"))
 
-        self.assertTrue(storeapi._agent._is_ci_env())
+        self.assertTrue(agent._is_ci_env())
 
     def test_not_in_ci_env(self):
         # unset any known testing environment vars
@@ -81,4 +77,4 @@ class UserAgentTestCase(unit.TestCase):
         for var in vars_to_unset:
             self.useFixture(fixtures.EnvironmentVariable(var, None))
 
-        self.assertFalse(storeapi._agent._is_ci_env())
+        self.assertFalse(agent._is_ci_env())

--- a/tests/unit/store/http_client/test_config.py
+++ b/tests/unit/store/http_client/test_config.py
@@ -1,0 +1,112 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pathlib
+
+import pytest
+
+from snapcraft.storeapi.http_clients import errors
+from snapcraft.storeapi.http_clients._config import Config
+
+
+class ConfigImpl(Config):
+    def _get_section_name(self) -> str:
+        return "test-section"
+
+    def _get_config_path(self) -> pathlib.Path:
+        return pathlib.Path("config.cfg")
+
+
+@pytest.fixture
+def conf(tmp_work_path):
+    conf = ConfigImpl()
+    yield conf
+
+
+def test_non_existing_file_succeeds(conf):
+    assert conf.parser.sections() == []
+    assert conf.is_section_empty() is True
+
+
+def test_existing_file(conf):
+    conf.set("foo", "bar")
+    conf.save()
+
+    conf.load()
+
+    assert conf.get("foo") == "bar"
+    assert conf.is_section_empty() is False
+
+
+def test_irrelevant_sections_are_ignored(conf):
+    with conf._get_config_path().open("w") as config_file:
+        print("[example.com]", file=config_file)
+        print("foo=bar", file=config_file)
+
+    conf.load()
+
+    assert conf.get("foo") is None
+
+
+def test_clear_preserver_other_sections(conf):
+    with conf._get_config_path().open("w") as config_file:
+        print("[keep_me]", file=config_file)
+        print("foo=bar", file=config_file)
+
+    conf.load()
+    conf.set("bar", "baz")
+
+    assert conf.get("bar") == "baz"
+
+    conf.clear()
+    conf.save()
+    conf.load()
+
+    assert conf.get("bar") is None
+    assert conf.get("foo", "keep_me") == "bar"
+    assert conf.is_section_empty() is True
+
+
+def test_save_encoded(conf):
+    conf.set("bar", "baz")
+    conf.save(encode=True)
+    conf.load()
+
+    assert conf.get("bar") == "baz"
+    with conf._get_config_path().open() as config_file:
+        assert config_file.read() == "W3Rlc3Qtc2VjdGlvbl0KYmFyID0gYmF6Cgo=\n"
+
+
+def test_save_encoded_other_config_file(conf):
+    conf.set("bar", "baz")
+    test_config_file = pathlib.Path("test-config")
+    with test_config_file.open("w") as config_fd:
+        conf.save(config_fd=config_fd, encode=True)
+        config_fd.flush()
+
+    with test_config_file.open() as config_file:
+        assert config_file.read() == "W3Rlc3Qtc2VjdGlvbl0KYmFyID0gYmF6Cgo=\n"
+
+
+def test_load_invalid_config(conf):
+    test_config_file = pathlib.Path("test-config")
+    with test_config_file.open("w") as config_fd:
+        print("invalid config", file=config_fd)
+        config_fd.flush()
+
+    with test_config_file.open() as config_fd:
+        with pytest.raises(errors.InvalidLoginConfig):
+            conf.load(config_fd=config_fd)

--- a/tests/unit/store/http_client/test_errors.py
+++ b/tests/unit/store/http_client/test_errors.py
@@ -21,9 +21,10 @@ from unittest import mock
 from snapcraft.storeapi.http_clients import errors
 
 
-def _fake_error_response(status_code):
+def _fake_error_response(status_code, reason):
     response = mock.Mock()
     response.status_code = status_code
+    response.reason = reason
     return response
 
 
@@ -81,7 +82,9 @@ class TestSnapcraftException:
             "StoreServerError 500",
             {
                 "exception_class": errors.StoreServerError,
-                "kwargs": {"response": _fake_error_response(500)},
+                "kwargs": {
+                    "response": _fake_error_response(500, "internal server error")
+                },
                 "expected_message": (
                     "The Snap Store encountered an error while processing your "
                     "request: internal server error (code 500).\nThe operational "
@@ -94,7 +97,7 @@ class TestSnapcraftException:
             "StoreServerError 501",
             {
                 "exception_class": errors.StoreServerError,
-                "kwargs": {"response": _fake_error_response(501)},
+                "kwargs": {"response": _fake_error_response(501, "not implemented")},
                 "expected_message": (
                     "The Snap Store encountered an error while processing your "
                     "request: not implemented (code 501).\nThe operational "

--- a/tests/unit/store/http_client/test_errors.py
+++ b/tests/unit/store/http_client/test_errors.py
@@ -1,0 +1,109 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import requests
+import urllib3
+from unittest import mock
+
+from snapcraft.storeapi.http_clients import errors
+
+
+def _fake_error_response(status_code):
+    response = mock.Mock()
+    response.status_code = status_code
+    return response
+
+
+class TestSnapcraftException:
+    scenarios = (
+        (
+            "InvalidCredentialsError",
+            {
+                "exception_class": errors.InvalidCredentialsError,
+                "kwargs": {"message": "macaroon expired"},
+                "expected_message": (
+                    "Invalid credentials: macaroon expired. "
+                    'Have you run "snapcraft login"?'
+                ),
+            },
+        ),
+        (
+            "StoreAuthenticationError",
+            {
+                "exception_class": errors.StoreAuthenticationError,
+                "kwargs": {"message": "invalid password"},
+                "expected_message": ("Authentication error: invalid password"),
+            },
+        ),
+        (
+            "StoreNetworkError generic error",
+            {
+                "exception_class": errors.StoreNetworkError,
+                "kwargs": {
+                    "exception": requests.exceptions.ConnectionError("bad error")
+                },
+                "expected_message": "There seems to be a network error: bad error",
+            },
+        ),
+        (
+            "StoreNetworkError max retry error",
+            {
+                "exception_class": errors.StoreNetworkError,
+                "kwargs": {
+                    "exception": requests.exceptions.ConnectionError(
+                        urllib3.exceptions.MaxRetryError(
+                            pool="test-pool", url="test-url"
+                        )
+                    )
+                },
+                "expected_message": (
+                    "There seems to be a network error: maximum retries exceeded "
+                    "trying to reach the store.\n"
+                    "Check your network connection, and check the store status at "
+                    "https://status.snapcraft.io/"
+                ),
+            },
+        ),
+        (
+            "StoreServerError 500",
+            {
+                "exception_class": errors.StoreServerError,
+                "kwargs": {"response": _fake_error_response(500)},
+                "expected_message": (
+                    "The Snap Store encountered an error while processing your "
+                    "request: internal server error (code 500).\nThe operational "
+                    "status of the Snap Store can be checked at "
+                    "https://status.snapcraft.io/"
+                ),
+            },
+        ),
+        (
+            "StoreServerError 501",
+            {
+                "exception_class": errors.StoreServerError,
+                "kwargs": {"response": _fake_error_response(501)},
+                "expected_message": (
+                    "The Snap Store encountered an error while processing your "
+                    "request: not implemented (code 501).\nThe operational "
+                    "status of the Snap Store can be checked at "
+                    "https://status.snapcraft.io/"
+                ),
+            },
+        ),
+    )
+
+    def test_error_formatting(self, exception_class, expected_message, kwargs):
+        assert str(exception_class(**kwargs)) == expected_message

--- a/tests/unit/store/http_client/test_ubuntu_one_auth_client.py
+++ b/tests/unit/store/http_client/test_ubuntu_one_auth_client.py
@@ -1,0 +1,48 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pathlib
+
+import pymacaroons
+import pytest
+
+from snapcraft.storeapi import http_clients
+
+
+def test_invalid_macaroon_root_raises_exception(tmp_work_path):
+    with pathlib.Path("conf").open("w") as config_fd:
+        print("[login.ubuntu.com]", file=config_fd)
+        print("macaroon=inval'id", file=config_fd)
+        config_fd.flush()
+
+    client = http_clients.UbuntuOneAuthClient()
+    with pathlib.Path("conf").open() as config_fd:
+        with pytest.raises(http_clients.errors.InvalidCredentialsError):
+            client.login(config_fd=config_fd)
+
+
+def test_invalid_discharge_raises_exception():
+    with pathlib.Path("conf").open("w") as config_fd:
+        print("[login.ubuntu.com]", file=config_fd)
+        print("macaroon={}".format(pymacaroons.Macaroon().serialize()), file=config_fd)
+        print("unbound_discharge=inval'id", file=config_fd)
+        config_fd.flush()
+
+    client = http_clients.UbuntuOneAuthClient()
+
+    with pathlib.Path("conf").open() as config_fd:
+        with pytest.raises(http_clients.errors.InvalidCredentialsError):
+            client.login(config_fd=config_fd)

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -16,22 +16,11 @@
 
 from subprocess import CalledProcessError
 from typing import List
-from unittest import mock
-
-import requests.exceptions
-from requests.packages import urllib3
 
 from snapcraft.internal import errors, pluginhandler, steps
 from snapcraft.internal.project_loader import errors as project_loader_errors
 from snapcraft.internal.project_loader.inspection import errors as inspection_errors
 from snapcraft.internal.repo import errors as repo_errors
-from snapcraft.storeapi import errors as store_errors
-
-
-def _fake_error_response(status_code):
-    response = mock.Mock()
-    response.status_code = status_code
-    return response
 
 
 class TestErrorFormatting:
@@ -405,35 +394,6 @@ class TestErrorFormatting:
             },
         ),
         (
-            "StoreNetworkError generic error",
-            {
-                "exception_class": store_errors.StoreNetworkError,
-                "kwargs": {
-                    "exception": requests.exceptions.ConnectionError("bad error")
-                },
-                "expected_message": "There seems to be a network error: bad error",
-            },
-        ),
-        (
-            "StoreNetworkError max retry error",
-            {
-                "exception_class": store_errors.StoreNetworkError,
-                "kwargs": {
-                    "exception": requests.exceptions.ConnectionError(
-                        urllib3.exceptions.MaxRetryError(
-                            pool="test-pool", url="test-url"
-                        )
-                    )
-                },
-                "expected_message": (
-                    "There seems to be a network error: maximum retries exceeded "
-                    "trying to reach the store.\n"
-                    "Check your network connection, and check the store status at "
-                    "https://status.snapcraft.io/"
-                ),
-            },
-        ),
-        (
             "SnapcraftCopyFileNotFoundError",
             {
                 "exception_class": errors.SnapcraftCopyFileNotFoundError,
@@ -441,32 +401,6 @@ class TestErrorFormatting:
                 "expected_message": (
                     "Failed to copy 'test-path': no such file or directory.\n"
                     "Check the path and try again."
-                ),
-            },
-        ),
-        (
-            "StoreServerError 500",
-            {
-                "exception_class": store_errors.StoreServerError,
-                "kwargs": {"response": _fake_error_response(500)},
-                "expected_message": (
-                    "The Snap Store encountered an error while processing your "
-                    "request: internal server error (code 500).\nThe operational "
-                    "status of the Snap Store can be checked at "
-                    "https://status.snapcraft.io/"
-                ),
-            },
-        ),
-        (
-            "StoreServerError 501",
-            {
-                "exception_class": store_errors.StoreServerError,
-                "kwargs": {"response": _fake_error_response(501)},
-                "expected_message": (
-                    "The Snap Store encountered an error while processing your "
-                    "request: not implemented (code 501).\nThe operational "
-                    "status of the Snap Store can be checked at "
-                    "https://status.snapcraft.io/"
                 ),
             },
         ),


### PR DESCRIPTION
Move the existing http clients (UbuntuOneAuthClient and Client)
together with the agent logic into its own http_clients.

Corresponding errors (which still need redoing with a cetralized
strategy around the final request) to this package too.

Additionally, migrate snapcraft.config.Config to this package in the
form of a Abstract Base Class with a specific implementation for the
UbuntuOneAuthClient class.

While migrating config, the "local credentials" implementation was
removed as it was a feature brought in from the click_toolbelt days
and we never really exposed in Snapcraft.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
