### PR TITLE
godeps: set default channel to 1.15/stable

### DIFF
--- a/snapcraft/plugins/v1/godeps.py
+++ b/snapcraft/plugins/v1/godeps.py
@@ -24,10 +24,13 @@ This plugin uses the common plugin keywords as well as those for "sources".
 For more information check the 'plugins' topic for the former and the
 'sources' topic for the latter.
 
+This plugin only works with go < 1.16.  As godeps is no longer maintained,
+it is not recommended to continue using this plugin.
+
 Additionally, this plugin uses the following plugin-specific keywords:
 
     - go-channel:
-      (string, default: latest/stable)
+      (string, default: 1.15/stable)
       The Snap Store channel to install go from. If set to an empty string,
       go will be installed using the system's traditional package manager.
 
@@ -65,9 +68,10 @@ class GodepsPlugin(PluginV1):
     @classmethod
     def schema(cls):
         schema = super().schema()
+
         schema["properties"]["go-channel"] = {
             "type": "string",
-            "default": "latest/stable",
+            "default": "1.15/stable",
         }
         schema["properties"]["godeps-file"] = {
             "type": "string",

--- a/tests/spread/plugins/v1/godeps/snaps/godeps-use-build-packages-go-snap/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/godeps/snaps/godeps-use-build-packages-go-snap/snap/snapcraft.yaml
@@ -20,4 +20,4 @@ parts:
     - git
     plugin: godeps
     go-importpath: bcrypt
-    go-channel: latest/stable
+    go-channel: 1.14/stable

--- a/tests/unit/plugins/v1/test_godeps.py
+++ b/tests/unit/plugins/v1/test_godeps.py
@@ -36,7 +36,7 @@ class GodepsPluginBaseTest(PluginsV1BaseTestCase):
 
         class Options:
             source = "src"
-            go_channel = "latest/stable"
+            go_channel = "1.15/stable"
             go_importpath = "github.com/foo/bar"
             godeps_file = "dependencies.tsv"
             go_packages = []
@@ -74,9 +74,9 @@ class GoPluginPropertiesTest(unit.TestCase):
         go_channel_default = go_channel["default"]
         self.assertThat(
             go_channel_default,
-            Equals("latest/stable"),
+            Equals("1.15/stable"),
             'Expected "go-channel" "default" to be '
-            '"latest/stable", but it was "{}"'.format(go_channel_default),
+            '"1.15/stable", but it was "{}"'.format(go_channel_default),
         )
 
         # Check godeps-file
@@ -387,7 +387,7 @@ class GodepsPluginToolSetupTest(GodepsPluginBaseTest):
         plugin = godeps.GodepsPlugin("test-part", self.options, self.project)
 
         self.assertThat(plugin.build_packages, Not(Contains("golang-go")))
-        self.assertThat(plugin.build_snaps, Contains("go/latest/stable"))
+        self.assertThat(plugin.build_snaps, Contains("go/1.15/stable"))
 
     def test_build_packages(self):
         self.options.go_channel = ""
@@ -395,7 +395,7 @@ class GodepsPluginToolSetupTest(GodepsPluginBaseTest):
         plugin = godeps.GodepsPlugin("test-part", self.options, self.project)
 
         self.assertThat(plugin.build_packages, Contains("golang-go"))
-        self.assertThat(plugin.build_snaps, Not(Contains("go/latest/stable")))
+        self.assertThat(plugin.build_snaps, Not(Contains("go/1.15/stable")))
 
 
 class GodepsPluginUnsupportedBaseTest(PluginsV1BaseTestCase):
@@ -406,7 +406,7 @@ class GodepsPluginUnsupportedBaseTest(PluginsV1BaseTestCase):
 
         class Options:
             source = "dir"
-            go_channel = "latest/stable"
+            go_channel = "1.15/stable"
 
         self.options = Options()
 


### PR DESCRIPTION
The godeps plugin breaks with 1.16 due to a change of behavior
with go get (go/src/... is no longer populated as the plugin
expects).

As godeps is no longer maintained, it doesn't really make sense
to update the plugin to work with 1.16.  Simply sets the plugin's
default to the last-known working version of go, 1.15.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
