### PR TITLE
ci: reduce amount of artifacts to upload for spread

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: snap
+          path: tests
 
       - name: Install spread
         run: curl -s https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz | sudo tar xzv -C /usr/bin
@@ -103,6 +104,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: snap
+          path: tests
 
       - if: steps.decisions.outputs.RUN == 'true'
         name: Install spread

--- a/spread.yaml
+++ b/spread.yaml
@@ -219,8 +219,8 @@ prepare: |
   # If $SNAPCRAFT_CHANNEL is defined, install snapcraft from that channel.
   # Otherwise, look for it in /snapcraft/.
   if [ -z "$SNAPCRAFT_CHANNEL" ]; then
-    if stat /snapcraft/*.snap 2>/dev/null; then
-      snap install --classic --dangerous /snapcraft/*.snap
+    if stat /snapcraft/tests/*.snap 2>/dev/null; then
+      snap install --classic --dangerous /snapcraft/tests/*.snap
     else
       echo "Expected a snap to exist in /snapcraft/. If your intention"\
            "was to install from the store, set \$SNAPCRAFT_CHANNEL."
@@ -229,6 +229,12 @@ prepare: |
   else
     snap install --classic snapcraft --channel="$SNAPCRAFT_CHANNEL"
   fi
+
+  pushd /snapcraft
+  git init
+  git add .
+  git commit -m "Testing Commit"
+  popd
 
 restore-each: |
   "$TOOLS_DIR"/restore.sh
@@ -503,3 +509,5 @@ suites:
      mv /snapcraft.bak /snapcraft/snapcraft
 
 path: /snapcraft/
+include:
+  - tests/


### PR DESCRIPTION
This reduces the payload to upload for spread to just the tests
directory. Everything is git commited to keep current reset behavior.

This work implies that when running locally, the snap to be tested
needs be copied into the test directory.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
