### PR TITLE
Support install-mode option for apps

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -593,6 +593,9 @@
                         ],
                         "timer": [
                             "daemon"
+                        ],
+                        "install-mode": [
+                            "daemon"
                         ]
                     },
                     "additionalProperties": false,
@@ -726,6 +729,13 @@
                                 "on-watchdog",
                                 "always",
                                 "never"
+                            ]
+                        },
+                        "install-mode": {
+                            "type": "string",
+                            "enum": [
+                                "enable",
+                                "disable"
                             ]
                         },
                         "slots": {

--- a/snapcraft/internal/meta/application.py
+++ b/snapcraft/internal/meta/application.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2019 Canonical Ltd
+# Copyright (C) 2019-2021 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -47,6 +47,7 @@ class Application:
         app_properties: Dict[str, Any] = None,
         adapter: ApplicationAdapter,
         desktop: str = None,
+        install_mode: str = None,
         command_chain: List[str] = None,
         passthrough: Dict[str, Any] = None,
         commands: Dict[str, Command] = None
@@ -63,6 +64,7 @@ class Application:
 
         self.adapter = adapter
         self.desktop = desktop
+        self.install_mode = install_mode
 
         self.command_chain: List[str] = list()
         if command_chain:
@@ -159,6 +161,7 @@ class Application:
             app_properties=app_dict,
             adapter=adapter,
             desktop=app_dict.get("desktop", None),
+            install_mode=app_dict.get("install-mode", None),
             command_chain=app_dict.get("command-chain", None),
             passthrough=app_dict.get("passthrough", None),
         )
@@ -186,6 +189,9 @@ class Application:
 
         if self.command_chain:
             app_dict["command-chain"] = self.command_chain
+
+        if self.install_mode:
+            app_dict["install-mode"] = self.install_mode
 
         # Adjust socket values to formats snap.yaml accepts
         sockets = app_dict.get("sockets", dict())

--- a/tests/unit/meta/test_application.py
+++ b/tests/unit/meta/test_application.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2019 Canonical Ltd
+# Copyright (C) 2019-2021 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -43,6 +43,7 @@ class AppCommandTest(unit.TestCase):
                 "command": "test-command",
                 "stop-command": "test-stop-command",
                 "daemon": "simple",
+                "install-mode": "disable",
                 "command-chain": ["test-command-chain"],
             },
         )
@@ -56,6 +57,7 @@ class AppCommandTest(unit.TestCase):
                     "command": "test-command",
                     "stop-command": "test-stop-command",
                     "daemon": "simple",
+                    "install-mode": "disable",
                     "command-chain": ["test-command-chain"],
                 }
             ),
@@ -250,7 +252,7 @@ class DesktopFileTest(unit.TestCase):
 
 
 class AppPassthroughTests(unit.TestCase):
-    def test_no_passthroug(self):
+    def test_no_passthrough(self):
         app = application.Application(
             app_name="foo",
             adapter=application.ApplicationAdapter.NONE,

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2019 Canonical Ltd
+# Copyright (C) 2015-2021 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -156,6 +156,16 @@ class ValidationTest(ValidationBaseTest):
                 "restart-condition": "on-watchdog",
                 "watchdog-timeout": "30s",
             },
+            "service15": {
+                "command": "binary15",
+                "daemon": "simple",
+                "install-mode": "enable",
+            },
+            "service16": {
+                "command": "binary16",
+                "daemon": "simple",
+                "install-mode": "disable",
+            },
         }
 
         Validator(self.data).validate()
@@ -195,6 +205,26 @@ class ValidationTest(ValidationBaseTest):
 
         expected_message = (
             "'adopt-info' is a required property or 'summary' is a required property"
+        )
+        self.assertThat(raised.message, Equals(expected_message), message=self.data)
+
+    def test_invalid_install_mode(self):
+        self.data["apps"] = {
+            "service": {
+                "command": "binary",
+                "daemon": "simple",
+                "install-mode": "invalid",
+            }
+        }
+
+        raised = self.assertRaises(
+            snapcraft.yaml_utils.errors.YamlValidationError,
+            Validator(self.data).validate,
+        )
+
+        expected_message = (
+            "The 'apps/service/install-mode' property does not match the required schema: "
+            "'invalid' is not one of ['enable', 'disable']"
         )
         self.assertThat(raised.message, Equals(expected_message), message=self.data)
 


### PR DESCRIPTION
Add support for the "install-mode" property in snapcraft.yaml apps.

LP: #1907668

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
