### PR TITLE
requirements: use PyNaCl 1.3.0 and ensure is compiled on linux

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,8 @@ pycparser==2.20
 pyelftools==0.24
 pylxd==2.2.10
 pymacaroons==0.13.0
-PyNaCl==1.4.0
+PyNaCl==1.3.0; sys.platform != 'linux'
+https://files.pythonhosted.org/packages/61/ab/2ac6dea8489fa713e2b4c6c5b549cc962dd4a842b5998d9e80cf8440b7cd/PyNaCl-1.3.0.tar.gz; sys.platform == 'linux'
 pyparsing==2.4.7
 python-apt @ http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_1.6.5ubuntu0.5.tar.xz; sys_platform == 'linux'
 python-dateutil==2.8.1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -94,6 +94,7 @@ parts:
         bin/snapcraftctl: bin/scriptlet-bin/snapcraftctl
     build-environment:
         - "CRYPTOGRAPHY_DONT_BUILD_RUST": "1"
+        - "SODIUM_INSTALL": "system"
     override-build: |
         # pip 20.2 breaks python3-apt, so we pin
         # the version of pip installed before building
@@ -129,6 +130,7 @@ parts:
         - requirements.txt
     build-environment:
         - "CRYPTOGRAPHY_DONT_BUILD_RUST": "1"
+        - "SODIUM_INSTALL": "system"
     override-build: |
         snapcraftctl build
         $SNAPCRAFT_PROJECT_DIR/tools/snapcraft-override-build.sh


### PR DESCRIPTION
PyNaCl 1.4.0 has crypto related symbol issues when using the system
provided sodium.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
