### PR TITLE
tests: crystal 1.0.0 requires shard.lock

### DIFF
--- a/tests/spread/plugins/v1/crystal/snaps/crystal-hello/hello/shard.lock
+++ b/tests/spread/plugins/v1/crystal/snaps/crystal-hello/hello/shard.lock
@@ -1,0 +1,2 @@
+version: 2.0
+shards: {}


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
