### PR TITLE
spread: run cross compile tests on amd64 only

### DIFF
--- a/tests/spread/cross-compile/stage-packages/task.yaml
+++ b/tests/spread/cross-compile/stage-packages/task.yaml
@@ -1,7 +1,9 @@
 summary: Cross-compiliation stage-package test
 
 systems:
-  - ubuntu-20.04*
+  - ubuntu-20.04
+  - ubuntu-20.04-64
+  - ubuntu-20.04-amd64
 
 environment:
   SNAP_DIR: .


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
