### PR TITLE
cli: rename experimental login environment variable

### DIFF
--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -672,7 +672,7 @@ def list_registered():
     "--experimental-login",
     is_flag=True,
     help="*EXPERIMENTAL* Enables login through candid.",
-    envvar="SNAPCRAFT_LOGIN",
+    envvar="SNAPCRAFT_EXPERIMENTAL_LOGIN",
 )
 def export_login(
     login_file: str,
@@ -800,7 +800,7 @@ def export_login(
     "--experimental-login",
     is_flag=True,
     help="*EXPERIMENTAL* Enables login through candid.",
-    envvar="SNAPCRAFT_LOGIN",
+    envvar="SNAPCRAFT_EXPERIMENTAL_LOGIN",
 )
 def login(login_file, experimental_login: bool):
     """Login with your Ubuntu One e-mail address and password.


### PR DESCRIPTION
It was SNAPCRAFT_LOGIN, which conflicted with commonly named
environment variables used for CI/CD.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
