### PR TITLE
Revert "repo: account for arch & version when filtering stage packages (#3461)"

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -32,7 +32,6 @@ from snapcraft.internal.indicators import is_dumb_terminal
 
 from . import errors
 from ._base import BaseRepo, get_pkg_name_parts
-from .deb_package import DebPackage
 
 if sys.platform == "linux":
     # Ensure importing works on non-Linux.
@@ -203,20 +202,10 @@ def _get_dpkg_list_path(base: str) -> pathlib.Path:
     return pathlib.Path(f"/snap/{base}/current/usr/share/snappy/dpkg.list")
 
 
-def _get_filtered_stage_package_names(
-    *, base: str, package_list: List[DebPackage]
-) -> Set[str]:
-    """Get filtered packages by name only - no version or architectures."""
-    manifest_packages = [p.name for p in get_packages_in_base(base=base)]
-    stage_packages = [p.name for p in package_list]
-
-    return set(manifest_packages) - set(stage_packages)
-
-
-def get_packages_in_base(*, base: str) -> List[DebPackage]:
+def get_packages_in_base(*, base: str) -> List[str]:
     # We do not want to break what we already have.
     if base in ("core", "core16", "core18"):
-        return [DebPackage.from_unparsed(p) for p in _DEFAULT_FILTERED_STAGE_PACKAGES]
+        return _DEFAULT_FILTERED_STAGE_PACKAGES
 
     base_package_list_path = _get_dpkg_list_path(base)
     if not base_package_list_path.exists():
@@ -229,9 +218,9 @@ def get_packages_in_base(*, base: str) -> List[DebPackage]:
         for line in fp:
             if not line.startswith("ii "):
                 continue
-            package = DebPackage.from_unparsed(line.split()[1])
-            package_list.append(package)
+            package_list.append(line.split()[1])
 
+    # format of package_list is <package_name>[:<architecture>]
     return package_list
 
 
@@ -401,18 +390,16 @@ class Ubuntu(BaseRepo):
 
         installed: Set[str] = set()
 
-        package_list = [DebPackage.from_unparsed(name) for name in package_names]
-        filtered_names = _get_filtered_stage_package_names(
-            base=base, package_list=package_list
-        )
-
         stage_packages_path.mkdir(exist_ok=True)
         with AptCache(
             stage_cache=_STAGE_CACHE_DIR, stage_cache_arch=target_arch
         ) as apt_cache:
+            filter_packages = set(get_packages_in_base(base=base))
             apt_cache.update()
             apt_cache.mark_packages(set(package_names))
-            apt_cache.unmark_packages(filtered_names)
+            apt_cache.unmark_packages(
+                required_names=set(package_names), filtered_names=filter_packages
+            )
             for pkg_name, pkg_version, dl_path in apt_cache.fetch_archives(
                 _DEB_CACHE_DIR
             ):

--- a/tests/spread/cross-compile/stage-packages/snap/snapcraft.yaml
+++ b/tests/spread/cross-compile/stage-packages/snap/snapcraft.yaml
@@ -13,13 +13,3 @@ parts:
     plugin: nil
     stage-packages:
     - jq
-    - to amd64:
-      - tar:amd64
-      - xxd
-    - to armhf:
-      - tar:armhf
-      - xxd
-    - on amd64:
-      - grep
-    - else:
-      - grep

--- a/tests/spread/cross-compile/stage-packages/task.yaml
+++ b/tests/spread/cross-compile/stage-packages/task.yaml
@@ -60,11 +60,7 @@ execute: |
 
   [ -f cross-compile-stage-package-test_0.1_armhf.snap ]
   [ -f prime/usr/lib/arm-linux-gnueabihf/libjq.so.1 ]
-  [ -f prime/bin/grep ]
-  [ -f prime/bin/tar ]
-  [ -f prime/usr/bin/jq ]
-  [ -f prime/usr/bin/xxd ]
-  [ "$(find prime/usr/lib -mindepth 1 -maxdepth 1 -name '*-linux-*')" == prime/usr/lib/arm-linux-gnueabihf ]
+  [ "$(ls prime/usr/lib/)" == "arm-linux-gnueabihf" ]
   rm cross-compile-stage-package-test_0.1_armhf.snap
 
   # Re-spin as native.
@@ -72,11 +68,7 @@ execute: |
 
   [ -f "cross-compile-stage-package-test_0.1_$host_arch.snap" ]
   [ -f "prime/usr/lib/$host_arch_triplet/libjq.so.1" ]
-  [ -f prime/bin/grep ]
-  [ -f prime/bin/tar ]
-  [ -f prime/usr/bin/jq ]
-  [ -f prime/usr/bin/xxd ]
-  [ "$(find prime/usr/lib -mindepth 1 -maxdepth 1 -name '*-linux-*')" == prime/usr/lib/"$host_arch_triplet" ]
+  [ "$(ls prime/usr/lib/)" == "$host_arch_triplet" ]
   rm "cross-compile-stage-package-test_0.1_$host_arch.snap"
 
   # Re-build for armhf.
@@ -84,9 +76,5 @@ execute: |
 
   [ -f cross-compile-stage-package-test_0.1_armhf.snap ]
   [ -f prime/usr/lib/arm-linux-gnueabihf/libjq.so.1 ]
-  [ -f prime/bin/grep ]
-  [ -f prime/bin/tar ]
-  [ -f prime/usr/bin/jq ]
-  [ -f prime/usr/bin/xxd ]
-  [ "$(find prime/usr/lib -mindepth 1 -maxdepth 1 -name '*-linux-*')" == prime/usr/lib/arm-linux-gnueabihf ]
+  [ "$(ls prime/usr/lib/)" == "arm-linux-gnueabihf" ]
   rm cross-compile-stage-package-test_0.1_armhf.snap

--- a/tests/unit/repo/test_apt_cache.py
+++ b/tests/unit/repo/test_apt_cache.py
@@ -45,7 +45,9 @@ class TestAptStageCache(unit.TestCase):
             filtered_names = {"base-files", "libc6", "libkmod2", "libudev1", "zlib1g"}
 
             apt_cache.mark_packages(package_names)
-            apt_cache.unmark_packages(unmark_names=filtered_names)
+            apt_cache.unmark_packages(
+                required_names=package_names, filtered_names=filtered_names
+            )
 
             marked_packages = apt_cache.get_packages_marked_for_installation()
             self.assertThat(


### PR DESCRIPTION
This reverts commit 0bf7a2e6619b0037a50caeb49d28788c021d0921.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
