### PR TITLE
repo: fix regression in fix_symlink()

### DIFF
--- a/snapcraft/internal/repo/_base.py
+++ b/snapcraft/internal/repo/_base.py
@@ -291,18 +291,11 @@ class BaseRepo:
 
         # Use relative symlink if target is found in unpack directory.
         target_in_unpack_dir = os.path.join(unpack_dir, symlink_target[1:])
-        if os.path.exists(target_in_unpack_dir):
-            relative_target = os.path.relpath(
-                target_in_unpack_dir, os.path.dirname(symlink_path)
-            )
-
-            # Relink to relative path.
-            os.unlink(symlink_path)
-            os.symlink(relative_target, symlink_path)
-            return
-
-        # Copy the file from host, if it exists - but warn about it.
-        if os.path.isfile(resolved_path):
+        relative_target = os.path.relpath(
+            target_in_unpack_dir, os.path.dirname(symlink_path)
+        )
+        # Copy the file from host if we need it, but warn about it.
+        if not os.path.exists(target_in_unpack_dir) and os.path.isfile(resolved_path):
             logger.warning(
                 "Copying needed symlink target %r from host to satisfy %r.",
                 resolved_path,
@@ -310,6 +303,11 @@ class BaseRepo:
             )
             os.makedirs(os.path.dirname(target_in_unpack_dir), exist_ok=True)
             shutil.copyfile(resolved_path, target_in_unpack_dir)
+
+        # Relink to relative path.
+        if os.path.exists(target_in_unpack_dir):
+            os.unlink(symlink_path)
+            os.symlink(relative_target, symlink_path)
             return
 
         # Cannot find target, issue a warning.

--- a/tests/spread/general/fix-symlink-host-copy/snaps/fix-symlink-host-copy/snap/snapcraft.yaml
+++ b/tests/spread/general/fix-symlink-host-copy/snaps/fix-symlink-host-copy/snap/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: fix-symlink-host-copy
+version: "1.0"
+summary: Verify dangling symlinks are corrected with file from host
+description: Fix symlink tests
+
+base: core20
+grade: devel
+confinement: strict
+
+parts:
+  part1:
+    plugin: nil
+    build-packages: [zlib1g]
+    stage-packages: [zlib1g-dev]

--- a/tests/spread/general/fix-symlink-host-copy/task.yaml
+++ b/tests/spread/general/fix-symlink-host-copy/task.yaml
@@ -1,0 +1,25 @@
+summary: Build a snap that resorts to copying a file from host to satisfy a symlink
+systems: [ubuntu-20*]
+
+environment:
+  SNAP_DIR: snaps/fix-symlink-host-copy
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+
+prepare: |
+  apt-get install -y dpkg-dev
+  apt-mark auto dpkg-dev
+
+execute: |
+  host_arch_triplet="$(dpkg-architecture  | grep DEB_BUILD_MULTIARCH | cut -f 2 -d=)"
+
+  cd "$SNAP_DIR"
+  output="$(snapcraft prime)"
+
+  # Ensure it is logged.
+  echo "$output" | MATCH "Copying needed symlink target '/usr/lib/$host_arch_triplet/libz.so.1.2.* from host to satisfy .*/install/usr/lib/$host_arch_triplet/libz.so"
+
+  # Ensure link is correct.
+  readlink "prime/usr/lib/$host_arch_triplet/libz.so" | MATCH "^../../../lib/$host_arch_triplet/libz.so.1.2.*$"

--- a/tests/spread/general/fix-symlink-relative/snaps/fix-symlink-relative/snap/snapcraft.yaml
+++ b/tests/spread/general/fix-symlink-relative/snaps/fix-symlink-relative/snap/snapcraft.yaml
@@ -1,0 +1,13 @@
+name: fix-symlink-relative
+version: "1.0"
+summary: Verify symlink to root is re-written to relative found in snap
+description: Fix symlink tests
+
+base: core20
+grade: devel
+confinement: strict
+
+parts:
+  part1:
+    plugin: nil
+    stage-packages: [openssl]

--- a/tests/spread/general/fix-symlink-relative/task.yaml
+++ b/tests/spread/general/fix-symlink-relative/task.yaml
@@ -1,0 +1,19 @@
+summary: Build a snap that fixes absolute symlink to relative if found in install.
+systems: [ubuntu-20*]
+
+environment:
+  SNAP_DIR: snaps/fix-symlink-relative
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+
+execute: |
+  cd "$SNAP_DIR"
+  output="$(snapcraft prime)"
+
+  # Ensure we are not copying from host.
+  echo "$output" | NOMATCH "Copying needed symlink target"
+
+  # Ensure link is correct.
+  readlink "prime/usr/lib/ssl/openssl.cnf" | MATCH "^../../../etc/ssl/openssl.cnf$"


### PR DESCRIPTION
If the file was copied from host, the symlink was not updated
to point to the new file.  It was logged as being copied, but
the copy wasn't utilized without a fixed (relative) symlink.

Add spread tests to cover relative and host copy cases.