### PR TITLE
storeapi: set content-type and accept headers for close

### DIFF
--- a/snapcraft/storeapi/_dashboard_api.py
+++ b/snapcraft/storeapi/_dashboard_api.py
@@ -305,8 +305,9 @@ class DashboardAPI(Requests):
     def close_channels(self, snap_id, channel_names):
         url = "/dev/api/snaps/{}/close".format(snap_id)
         data = {"channels": channel_names}
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
 
-        response = self.post(url, data=json.dumps(data))
+        response = self.post(url, data=json.dumps(data), headers=headers)
         if not response.ok:
             raise errors.StoreChannelClosingError(response)
 

--- a/tests/spread/general/store/task.yaml
+++ b/tests/spread/general/store/task.yaml
@@ -79,6 +79,9 @@ execute: |
   # Progressive Release
   snapcraft release --experimental-progressive-releases --progressive 50 "${snap_name}" 1 candidate
 
+  # Close channel
+  snapcraft close "${snap_name}" candidate
+
   # List tracks
   snapcraft list-tracks "${snap_name}"
 


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
