### PR TITLE
docker: Need to repeat ARG in every section

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,8 @@ ARG RISK=edge
 ARG UBUNTU=xenial
 
 FROM ubuntu:$UBUNTU as builder
-
+ARG RISK
+ARG UBUNTU
 RUN echo "Building snapcraft:$RISK in ubuntu:$UBUNTU"
 
 # Grab dependencies


### PR DESCRIPTION
This is a followup up #2673. I've noticed that RISK is not passed down, because ARGs are scoped.

https://docs.docker.com/engine/reference/builder/#scope

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
