### PR TITLE
store: use whoami dashboard endpoint for cli

### DIFF
--- a/snapcraft/cli/store.py
+++ b/snapcraft/cli/store.py
@@ -27,7 +27,6 @@ from tabulate import tabulate
 
 import snapcraft
 from snapcraft import formatting_utils, storeapi
-from snapcraft.storeapi.http_clients._ubuntu_sso_client import UbuntuOneSSOConfig
 from snapcraft._store import StoreClientCLI
 from snapcraft.storeapi.constants import DEFAULT_SERIES
 
@@ -838,20 +837,13 @@ def logout():
 @storecli.command()
 def whoami():
     """Returns your login information relevant to the store."""
-    # TODO: workaround until bakery client is added.
-    conf = UbuntuOneSSOConfig()
-    email = conf.get("email")
-    if email is None:
-        email = "unknown"
-
-    account_info = StoreClientCLI().get_account_information()
-    account_id = account_info["account_id"]
+    account = StoreClientCLI().whoami().account
 
     click.echo(
         dedent(
             f"""\
-        email:        {email}
-        developer-id: {account_id}"""
+        email:        {account.email}
+        developer-id: {account.account_id}"""
         )
     )
 

--- a/snapcraft/storeapi/_dashboard_api.py
+++ b/snapcraft/storeapi/_dashboard_api.py
@@ -26,7 +26,7 @@ from simplejson.scanner import JSONDecodeError
 from . import _metadata, constants, errors, http_clients
 from ._requests import Requests
 from ._status_tracker import StatusTracker
-from .v2 import channel_map, releases
+from .v2 import channel_map, releases, whoami
 
 
 logger = logging.getLogger(__name__)
@@ -356,3 +356,14 @@ class DashboardAPI(Requests):
             raise errors.StoreSnapChannelMapError(snap_name=snap_name)
 
         return releases.Releases.unmarshal(response.json())
+
+    def whoami(self) -> whoami.WhoAmI:
+        response = self.get(
+            "/api/v2/tokens/whoami",
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+        )
+
+        if not response.ok:
+            raise errors.GeneralStoreError(message="whoami failed.", response=response)
+
+        return whoami.WhoAmI.unmarshal(response.json())

--- a/snapcraft/storeapi/_store_client.py
+++ b/snapcraft/storeapi/_store_client.py
@@ -27,7 +27,7 @@ from ._dashboard_api import DashboardAPI
 from ._snap_api import SnapAPI
 from ._up_down_client import UpDownClient
 from .constants import DEFAULT_SERIES
-from .v2 import channel_map, releases
+from .v2 import channel_map, releases, whoami
 
 
 logger = logging.getLogger(__name__)
@@ -92,9 +92,9 @@ class StoreClient:
     def logout(self):
         self.auth_client.logout()
 
-    def whoami(self) -> Dict[str, str]:
+    def whoami(self) -> whoami.WhoAmI:
         """Return user relevant login information."""
-        return self.get_account_information()
+        return self.dashboard.whoami()
 
     def acl(self) -> Dict[str, Any]:
         """Return permissions for the logged-in user."""

--- a/snapcraft/storeapi/v2/_api_schema.py
+++ b/snapcraft/storeapi/v2/_api_schema.py
@@ -144,7 +144,6 @@ RELEASES_JSONSCHEMA: Dict[str, Any] = {
 
 
 CHANNEL_MAP_JSONSCHEMA: Dict[str, Any] = {
-    "additionalProperties": False,
     "properties": {
         "channel-map": {
             "items": {
@@ -337,5 +336,132 @@ CHANNEL_MAP_JSONSCHEMA: Dict[str, Any] = {
         },
     },
     "required": ["channel-map", "revisions", "snap"],
+    "type": "object",
+}
+
+# Version 27, found at https://dashboard.snapcraft.io/docs/v2/en/tokens.html#api-tokens-whoami
+WHOAMI_JSONSCHEMA: Dict[str, Any] = {
+    "properties": {
+        "account": {
+            "properties": {
+                "email": {
+                    "description": "The primary email for the user",
+                    "type": "string",
+                },
+                "id": {
+                    "description": "The store account ID for the user",
+                    "type": "string",
+                },
+                "name": {
+                    "description": "The display name for the user",
+                    "type": "string",
+                },
+                "username": {
+                    "description": "The store username for the user",
+                    "type": "string",
+                },
+            },
+            "required": ["email", "id", "name", "username"],
+            "type": "object",
+        },
+        "channels": {
+            "oneOf": [
+                {
+                    "description": "A list of channels to restrict the macaroon to, allows wildcards in the fnmatch format (https://docs.python.org/3/library/fnmatch.html)",
+                    "items": {"description": "Valid channel name.", "type": "string"},
+                    "minItems": 1,
+                    "type": "array",
+                    "uniqueItems": True,
+                },
+                {"type": "null"},
+            ]
+        },
+        "errors": {
+            "items": {
+                "properties": {
+                    "code": {"type": "string"},
+                    "extra": {"additionalProperties": True, "type": "object"},
+                    "message": {"type": "string"},
+                },
+                "required": ["code", "message", "extra"],
+                "type": "object",
+            },
+            "type": "array",
+        },
+        "expires": {
+            "oneOf": [
+                {
+                    "description": "A timestamp (string formatted per ISO8601) after which the macaroon should not be valid",
+                    "format": "date-time",
+                    "type": "string",
+                },
+                {"type": "null"},
+            ]
+        },
+        "packages": {
+            "oneOf": [
+                {
+                    "description": 'A list of packages to restrict the macaroon to. Those can be defined in two ways: 1- by name: each item in the list should be a json dict like `{"name": "the-name"}`, or 2- by snap_id: each item in the list should be a json dict like `{"snap_id": "some-snap-id-1234"}`.',
+                    "items": {
+                        "anyOf": [{"required": ["snap_id"]}, {"required": ["name"]}],
+                        "description": "Package identifier: a dict with at least name or snap_id keys.",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "snap_id": {"type": "string"},
+                        },
+                        "type": "object",
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                    "uniqueItems": True,
+                },
+                {"type": "null"},
+            ]
+        },
+        "permissions": {
+            "oneOf": [
+                {
+                    "description": "A list of permissions to restrict the macaroon to",
+                    "items": {
+                        "description": "A valid token permission.",
+                        "enum": [
+                            "edit_account",
+                            "modify_account_key",
+                            "package_access",
+                            "package_manage",
+                            "package_metrics",
+                            "package_purchase",
+                            "package_push",
+                            "package_register",
+                            "package_release",
+                            "package_update",
+                            "package_upload",
+                            "package_upload_request",
+                            "store_admin",
+                            "store_review",
+                        ],
+                        "type": "string",
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                    "uniqueItems": True,
+                },
+                {"type": "null"},
+            ]
+        },
+        "store_ids": {
+            "oneOf": [
+                {
+                    "description": "A list of store IDs to restrict the macaroon to",
+                    "items": {"description": "A store ID.", "type": "string"},
+                    "minItems": 1,
+                    "type": "array",
+                    "uniqueItems": True,
+                },
+                {"type": "null"},
+            ]
+        },
+    },
+    "required": ["account", "channels", "packages", "permissions"],
     "type": "object",
 }

--- a/snapcraft/storeapi/v2/whoami.py
+++ b/snapcraft/storeapi/v2/whoami.py
@@ -68,9 +68,6 @@ class WhoAmI:
     @classmethod
     def unmarshal(cls, payload: Dict[str, Any]) -> "WhoAmI":
         jsonschema.validate(payload, WHOAMI_JSONSCHEMA)
-        import pprint
-
-        pprint.pprint(payload)
         return cls(account=Account.unmarshal(payload["account"]))
 
     def marshal(self) -> Dict[str, Any]:

--- a/snapcraft/storeapi/v2/whoami.py
+++ b/snapcraft/storeapi/v2/whoami.py
@@ -1,0 +1,85 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Any, Dict
+
+import jsonschema
+
+from ._api_schema import WHOAMI_JSONSCHEMA
+
+"""
+This module holds representations for results for the v2 whoami
+API endpoint provided by the Snap Store.
+
+The full API is documented on
+https://dashboard.snapcraft.io/docs/v2/en/tokens.html#api-tokens-whoami
+"""
+
+
+class Account:
+    """Represent Account information for a whoami response."""
+
+    @classmethod
+    def unmarshal(cls, payload: Dict[str, Any]) -> "Account":
+        jsonschema.validate(payload, WHOAMI_JSONSCHEMA["properties"]["account"])
+        return cls(
+            email=payload["email"],
+            account_id=payload["id"],
+            name=payload["name"],
+            username=payload["username"],
+        )
+
+    def marshal(self) -> Dict[str, Any]:
+        return {
+            "email": self.email,
+            "id": self.account_id,
+            "name": self.name,
+            "username": self.username,
+        }
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: {self.email!r}>"
+
+    def __init__(
+        self, *, email: str, account_id: str, name: str, username: str
+    ) -> None:
+        self.email = email
+        self.account_id = account_id
+        self.name = name
+        self.username = username
+
+
+class WhoAmI:
+    """Represent the data returned from the whoami Snap Store endpoint."""
+
+    @classmethod
+    def unmarshal(cls, payload: Dict[str, Any]) -> "WhoAmI":
+        jsonschema.validate(payload, WHOAMI_JSONSCHEMA)
+        import pprint
+
+        pprint.pprint(payload)
+        return cls(account=Account.unmarshal(payload["account"]))
+
+    def marshal(self) -> Dict[str, Any]:
+        return {
+            "account": self.account.marshal(),
+        }
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: {self.account.email!r}>"
+
+    def __init__(self, *, account: Account) -> None:
+        self.account = account

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -159,6 +159,12 @@ class FakeStoreAPIServer(base.BaseFakeServer):
         configurator.add_view(self.snap_releases, route_name="snap_releases")
 
         configurator.add_route(
+            "whoami", "/api/v2/tokens/whoami", request_method="GET",
+        )
+
+        configurator.add_view(self.whoami, route_name="whoami")
+
+        configurator.add_route(
             "snap_validations",
             urllib.parse.urljoin(self._DEV_API_PATH, "snaps/{snap_id}/validations"),
             request_method="GET",
@@ -1495,4 +1501,28 @@ class FakeStoreAPIServer(base.BaseFakeServer):
         content_type = "application/json"
         return response.Response(
             payload, response_code, [("Content-Type", content_type)]
+        )
+
+    def whoami(self, request):
+        if self.fake_store.needs_refresh:
+            return self._refresh_error()
+        logger.debug("Handling whoami request")
+        payload = {
+            "account": {
+                "email": "foo@bar.baz",
+                "id": "1234567890",
+                "name": "Foo from Bar",
+                "username": "baz",
+            },
+            "channels": None,
+            "packages": None,
+            "permissions": None,
+        }
+
+        response_code = 200
+        content_type = "application/json"
+        return response.Response(
+            json.dumps(payload).encode(),
+            response_code,
+            [("Content-Type", content_type)],
         )

--- a/tests/spread/general/store/task.yaml
+++ b/tests/spread/general/store/task.yaml
@@ -61,6 +61,9 @@ execute: |
     snapcraft login --with login
   fi
 
+  # Who Am I?
+  snapcraft whoami
+
   # Register
   snapcraft register --yes "${snap_name}"
 

--- a/tests/unit/commands/conftest.py
+++ b/tests/unit/commands/conftest.py
@@ -1,0 +1,33 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017-2021 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import List
+
+import pytest
+from click.testing import CliRunner
+
+from snapcraft.cli._runner import run
+
+
+@pytest.fixture
+def click_run():
+    """Run commands using Click's testing backend."""
+    cli = CliRunner()
+
+    def runner(args: List[str]):
+        return cli.invoke(run, args)
+
+    return runner

--- a/tests/unit/store/test_store_client.py
+++ b/tests/unit/store/test_store_client.py
@@ -28,7 +28,7 @@ from testtools.matchers import Contains, Equals, FileExists, Is, IsInstance, Not
 import tests
 from snapcraft import storeapi
 from snapcraft.storeapi import errors, http_clients
-from snapcraft.storeapi.v2 import channel_map, releases
+from snapcraft.storeapi.v2 import channel_map, releases, whoami
 from tests import fixture_setup, unit
 
 
@@ -1347,6 +1347,14 @@ class SnapReleasesTest(StoreTestCase):
         self.assertThat(
             self.client.get_snap_releases(snap_name="basic"),
             IsInstance(releases.Releases),
+        )
+
+
+class WhoAmITest(StoreTestCase):
+    def test_whoami(self):
+        self.client.login(email="dummy", password="test correct password")
+        self.assertThat(
+            self.client.whoami(), IsInstance(whoami.WhoAmI),
         )
 
 

--- a/tests/unit/store/v2/test_whoami.py
+++ b/tests/unit/store/v2/test_whoami.py
@@ -1,0 +1,71 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+from jsonschema.exceptions import ValidationError
+
+from snapcraft.storeapi.v2 import whoami
+
+
+@pytest.fixture
+def whoami_account_payload():
+    return {
+        "email": "foo@bar.baz",
+        "id": "1234567890",
+        "name": "Foo from Bar",
+        "username": "foo",
+    }
+
+
+@pytest.fixture
+def whoami_payload(whoami_account_payload):
+    return {
+        "account": whoami_account_payload,
+        "channels": None,
+        "packages": None,
+        "permissions": None,
+    }
+
+
+def test_account(whoami_account_payload):
+    w = whoami.Account.unmarshal(whoami_account_payload)
+
+    assert repr(w) == "<Account: 'foo@bar.baz'>"
+    assert w.email == whoami_account_payload["email"]
+    assert w.account_id == whoami_account_payload["id"]
+    assert w.name == whoami_account_payload["name"]
+    assert w.username == whoami_account_payload["username"]
+    assert w.marshal() == whoami_account_payload
+
+
+@pytest.mark.parametrize("missing", ("email", "id", "name", "username"))
+def test_account_missing_data(missing, whoami_account_payload):
+    whoami_account_payload.pop(missing)
+
+    with pytest.raises(ValidationError):
+        whoami.Account.unmarshal(whoami_account_payload)
+
+
+def test_whoami(whoami_payload):
+    a = whoami.WhoAmI.unmarshal(whoami_payload)
+
+    assert repr(a) == "<WhoAmI: 'foo@bar.baz'>"
+    assert a.account.email == whoami_payload["account"]["email"]
+    assert a.account.account_id == whoami_payload["account"]["id"]
+    assert a.account.name == whoami_payload["account"]["name"]
+    assert a.account.username == whoami_payload["account"]["username"]
+    # TODO: implement fully to migrate away from account_info.
+    assert a.marshal()["account"] == whoami_payload["account"]


### PR DESCRIPTION
Add the MVP support for the whoami endpoint to the Store APIs under
Dashboard to serve as a replacement for using the account information
endpoint to serve as the backend to the whoami command.

Caching was removed from the command as the existing caching was too
strict (over caching).

"whoami" command test was rewritten in pure pytest.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
