### PR TITLE
deb: do not filter python3 packages on core20

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -162,6 +162,51 @@ _DEFAULT_FILTERED_STAGE_PACKAGES: List[str] = [
 ]
 
 
+IGNORE_FILTERS: Dict[str, Set[str]] = {
+    "core20": {
+        "python3-attr",
+        "python3-blinker",
+        "python3-certifi",
+        "python3-cffi-backend",
+        "python3-chardet",
+        "python3-configobj",
+        "python3-cryptography",
+        # Rely on setuptools installed by plugin or found in base, unless
+        # explicitly requested.
+        # "python3-distutils"
+        "python3-idna",
+        "python3-importlib-metadata",
+        "python3-jinja2",
+        "python3-json-pointer",
+        "python3-jsonpatch",
+        "python3-jsonschema",
+        "python3-jwt",
+        "python3-lib2to3",
+        "python3-markupsafe",
+        # Provides /usr/bin/python3, don't bring in unless explicitly requested.
+        # "python3-minimal"
+        "python3-more-itertools",
+        "python3-netifaces",
+        "python3-oauthlib",
+        # Rely on version brought in by setuptools, unless explicitly requested.
+        # "python3-pkg-resources"
+        "python3-pyrsistent",
+        "python3-pyudev",
+        "python3-requests",
+        "python3-requests-unixsocket",
+        "python3-serial",
+        # Rely on version installed by plugin or found in base, unless
+        # explicitly requested.
+        # "python3-setuptools"
+        "python3-six",
+        "python3-urllib3",
+        "python3-urwid",
+        "python3-yaml",
+        "python3-zipp",
+    }
+}
+
+
 @functools.lru_cache(maxsize=256)
 def _run_dpkg_query_search(file_path: str) -> str:
     try:
@@ -210,7 +255,9 @@ def _get_filtered_stage_package_names(
     manifest_packages = [p.name for p in get_packages_in_base(base=base)]
     stage_packages = [p.name for p in package_list]
 
-    return set(manifest_packages) - set(stage_packages)
+    return (
+        set(manifest_packages) - set(stage_packages) - IGNORE_FILTERS.get(base, set())
+    )
 
 
 def get_packages_in_base(*, base: str) -> List[DebPackage]:

--- a/tests/spread/plugins/v2/build-and-run-hello/task.yaml
+++ b/tests/spread/plugins/v2/build-and-run-hello/task.yaml
@@ -16,6 +16,7 @@ environment:
   SNAP/python_multiple_parts: python-hello-multiple-parts
   SNAP/python_multiple_parts_staged: python-hello-multiple-parts-staged
   SNAP/python_staged: python-hello-staged-python
+  SNAP/python_with_stage_package_in_base: python-with-stage-package-in-base
   SNAP/python_with_python_package_dep: python-hello-with-python-package-dep
   SNAP/python_with_stage_package_dep: python-hello-with-stage-package-dep
   SNAP/go_mod: go-mod-hello

--- a/tests/spread/plugins/v2/snaps/python-with-stage-package-in-base/hello
+++ b/tests/spread/plugins/v2/snaps/python-with-stage-package-in-base/hello
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+import yaml
+
+obj = yaml.load("msg: hello world", Loader=yaml.Loader)
+
+print(obj["msg"])

--- a/tests/spread/plugins/v2/snaps/python-with-stage-package-in-base/setup.py
+++ b/tests/spread/plugins/v2/snaps/python-with-stage-package-in-base/setup.py
@@ -1,0 +1,11 @@
+import setuptools
+
+setuptools.setup(
+    name="hello-world",
+    version="0.0.1",
+    author="Canonical LTD",
+    author_email="snapcraft@lists.snapcraft.io",
+    description="A simple hello world in python",
+    scripts=["hello"],
+    install_requires=["appdirs"],
+)

--- a/tests/spread/plugins/v2/snaps/python-with-stage-package-in-base/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/python-with-stage-package-in-base/snap/snapcraft.yaml
@@ -1,0 +1,28 @@
+name: python-with-stage-package-in-base
+version: "1.0"
+summary: A simple hello world in python
+description: |
+  This is a basic python snap that relies on a stage-package dep found
+  in the base.  This validates the stage package dep was not filtered
+  and can be found without requiring PYTHONPATH pointing to base.
+
+grade: devel
+base: core20
+confinement: strict
+
+apps:
+  python-with-stage-package-in-base:
+    command: bin/hello
+    environment:
+      PYTHONPATH: $SNAP/usr/lib/python3/dist-packages
+
+parts:
+  hello:
+    source: .
+    plugin: python
+    stage-packages:
+      - python3-yaml
+    python-packages:
+      - pip==20.0.2
+    build-environment:
+      - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$PYTHONPATH

--- a/tests/spread/tools/snapcraft-yaml.sh
+++ b/tests/spread/tools/snapcraft-yaml.sh
@@ -24,7 +24,7 @@ set_base()
     fi
 
     if grep -q "^base:" "$snapcraft_yaml_path"; then
-        sed -i "s/base:.*/base: $base/g" "$snapcraft_yaml_path"
+        sed -i "s/^base:.*/base: $base/g" "$snapcraft_yaml_path"
     else
         # Insert at the very top to be safe
         sed -i "1ibase: $base"  "$snapcraft_yaml_path"

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -583,3 +583,62 @@ class TestGetPackagesInBase(testtools.TestCase):
         mock_dpkg_list_path.return_value = dpkg_list_path
 
         self.expectThat(repo._deb.get_packages_in_base(base="core22"), Equals(list()))
+
+
+@mock.patch.object(repo._deb, "get_packages_in_base")
+def test_get_filtered_stage_package_restricts_core20_ignore_filter(
+    mock_get_packages_in_base,
+):
+    mock_get_packages_in_base.return_value = [
+        DebPackage(name="foo"),
+        DebPackage(name="foo2"),
+        DebPackage(name="python3-attr"),
+        DebPackage(name="python3-blinker"),
+        DebPackage(name="python3-certifi"),
+        DebPackage(name="python3-cffi-backend"),
+        DebPackage(name="python3-chardet"),
+        DebPackage(name="python3-configobj"),
+        DebPackage(name="python3-cryptography"),
+        DebPackage(name="python3-idna"),
+        DebPackage(name="python3-importlib-metadata"),
+        DebPackage(name="python3-jinja2"),
+        DebPackage(name="python3-json-pointer"),
+        DebPackage(name="python3-jsonpatch"),
+        DebPackage(name="python3-jsonschema"),
+        DebPackage(name="python3-jwt"),
+        DebPackage(name="python3-lib2to3"),
+        DebPackage(name="python3-markupsafe"),
+        DebPackage(name="python3-more-itertools"),
+        DebPackage(name="python3-netifaces"),
+        DebPackage(name="python3-oauthlib"),
+        DebPackage(name="python3-pyrsistent"),
+        DebPackage(name="python3-pyudev"),
+        DebPackage(name="python3-requests"),
+        DebPackage(name="python3-requests-unixsocket"),
+        DebPackage(name="python3-serial"),
+        DebPackage(name="python3-six"),
+        DebPackage(name="python3-urllib3"),
+        DebPackage(name="python3-urwid"),
+        DebPackage(name="python3-yaml"),
+        DebPackage(name="python3-zipp"),
+    ]
+
+    filtered_names = repo._deb._get_filtered_stage_package_names(
+        base="core20", package_list=[]
+    )
+
+    assert filtered_names == {"foo", "foo2"}
+
+
+@mock.patch.object(repo._deb, "get_packages_in_base")
+def test_get_filtered_stage_package_empty_ignore_filter(mock_get_packages_in_base):
+    mock_get_packages_in_base.return_value = [
+        DebPackage(name="some-base-pkg"),
+        DebPackage(name="some-other-base-pkg"),
+    ]
+
+    filtered_names = repo._deb._get_filtered_stage_package_names(
+        base="core00", package_list=[]
+    )
+
+    assert filtered_names == {"some-base-pkg", "some-other-base-pkg"}


### PR DESCRIPTION
To make it easier on users, do not filter python3 packages found
in the core20 base.  Snapcraft will now stage them so that they
can be found in-snap alongside python3 staged packages that are
not found in the base for consistency.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
