### PR TITLE
extensions/desktop: use fonts from $XDG_DATA_DIRS, and remove unnecessary includes

### DIFF
--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -301,9 +301,8 @@ function make_user_fontconfig {
       echo "  <dir>${data_dirs_array[$i]}/fonts</dir>"
     fi
   done
-  # We need to include this default cachedir first so that caching
-  # works: without it, fontconfig will try to write to the real user home
-  # cachedir and be blocked by AppArmor.
+  # We need to include a user-writable cachedir first to support
+  # caching of per-user fonts.
   echo '  <cachedir prefix="xdg">fontconfig</cachedir>'
   echo "  <cachedir>$SNAP_COMMON/fontconfig</cachedir>"
   echo "</fontconfig>"

--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -296,6 +296,11 @@ function make_user_fontconfig {
   if [ -d "$REALHOME/.fonts" ]; then
     echo "  <dir>$REALHOME/.fonts</dir>"
   fi
+  for ((i = 0; i < ${#data_dirs_array[@]}; i++)); do
+    if [ -d "${data_dirs_array[$i]}/fonts" ]; then
+      echo "  <dir>${data_dirs_array[$i]}/fonts</dir>"
+    fi
+  done
   echo '  <include ignore_missing="yes">conf.d</include>'
   echo "  <include ignore_missing=\"yes\">${FONTCONFIG_FILE}</include>"
   # We need to include this default cachedir first so that caching

--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -301,8 +301,6 @@ function make_user_fontconfig {
       echo "  <dir>${data_dirs_array[$i]}/fonts</dir>"
     fi
   done
-  echo '  <include ignore_missing="yes">conf.d</include>'
-  echo "  <include ignore_missing=\"yes\">${FONTCONFIG_FILE}</include>"
   # We need to include this default cachedir first so that caching
   # works: without it, fontconfig will try to write to the real user home
   # cachedir and be blocked by AppArmor.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
This PR cleans up the generation of the user `fonts.conf` file in the desktop extension, partially reverting some of the changes in PR #3299.  Namely:

1. Use fonts from $XDG_DATA_DIRS.  In particular, this means the small number of fonts provided by the platform snap will be visible to applications.  This avoids malfunctions when no fonts are available.
2. Don't include $FONTCONFIG_FILE, since this represents an include loop.

For (1), this has only really manifested in trying to run snaps on Ubuntu Core systems where there is no `desktop` slot available to share system fonts.

For (2), it seems to be a misunderstanding of what the `$XDG_CONFIG_HOME/fontconfig/fonts.conf` file is for.  It isn't used in place of the top level `fonts.conf` file (either identified by `$FONTCONFIG_FILE` or `/etc/fonts/fonts.conf`), but instead is included by the top level config file (via `conf.d/50-user.conf`).  Deleting the spurious `<include>` directives from a configuration file generated by `desktop-launch` does not change the list of fonts reported by `fc-list` inside the sandbox.