### PR TITLE
snaps: don't validate snaps before `SnapPackage.download()`

### DIFF
--- a/snapcraft/internal/repo/snaps.py
+++ b/snapcraft/internal/repo/snaps.py
@@ -275,10 +275,6 @@ def download_snaps(*, snaps_list: Sequence[str], directory: str) -> None:
     os.makedirs(directory, exist_ok=True)
     for snap in snaps_list:
         snap_pkg = SnapPackage(snap)
-        if not snap_pkg.is_valid():
-            raise errors.SnapUnavailableError(
-                snap_name=snap_pkg.name, snap_channel=snap_pkg.channel
-            )
 
         # TODO: use dependency injected echoer
         logger.info("Downloading snap {!r}".format(snap_pkg.name))

--- a/tests/fixture_setup/_unittests.py
+++ b/tests/fixture_setup/_unittests.py
@@ -387,6 +387,7 @@ class FakeSnapCommand(fixtures.Fixture):
         self.calls = []
         self.install_success = True
         self.refresh_success = True
+        self.download_side_effect = None
         self._email = "-"
 
     def _setUp(self):
@@ -446,6 +447,12 @@ class FakeSnapCommand(fixtures.Fixture):
             raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
         elif cmd == "whoami":
             return "email: {}".format(self._email).encode()
+        elif (
+            cmd == "download"
+            and self.download_side_effect is not None
+            and not self.download_side_effect.pop(0)
+        ):
+            raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
         elif cmd == "download":
             return "Downloaded  ".encode()
 

--- a/tests/unit/repo/test_snaps.py
+++ b/tests/unit/repo/test_snaps.py
@@ -505,21 +505,23 @@ class SnapPackageLifecycleTest(unit.TestCase):
     def test_download_snaps_with_invalid(self):
         self.fake_snapd.find_result = [
             {"fake-snap": {"channels": {"latest/stable": {"confinement": "strict"}}}},
-            {
-                "other-fake-snap": {
-                    "channels": {"latest/stable": {"confinement": "strict"}}
-                }
-            },
         ]
+        self.fake_snap_command.download_side_effect = [True, False]
 
         self.assertRaises(
-            errors.SnapUnavailableError,
+            errors.SnapDownloadError,
             snaps.download_snaps,
             snaps_list=["fake-snap", "other-invalid"],
             directory="fakedir",
         )
         self.assertThat(
-            self.fake_snap_command.calls, Equals([["snap", "download", "fake-snap"]])
+            self.fake_snap_command.calls,
+            Equals(
+                [
+                    ["snap", "download", "fake-snap"],
+                    ["snap", "download", "other-invalid"],
+                ]
+            ),
         )
 
     def test_refresh_to_classic(self):


### PR DESCRIPTION
Otherwise branches can't be staged (LP#1901733).

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
