### PR TITLE
storeapi: add classes for validation sets

### DIFF
--- a/snapcraft/storeapi/v2/_api_schema.py
+++ b/snapcraft/storeapi/v2/_api_schema.py
@@ -465,3 +465,75 @@ WHOAMI_JSONSCHEMA: Dict[str, Any] = {
     "required": ["account", "channels", "packages", "permissions"],
     "type": "object",
 }
+
+# https://dashboard.snapcraft.io/docs/v2/en/validation-sets.html
+BUILD_ASSERTION_JSONSCHEMA: Dict[str, Any] = {
+    "properties": {
+        "account-id": {
+            "description": 'The "account-id" assertion header',
+            "type": "string",
+        },
+        "authority-id": {
+            "description": 'The "authority-id" assertion header',
+            "type": "string",
+        },
+        "name": {"description": 'The "name" assertion header', "type": "string"},
+        "revision": {
+            "description": 'The "revision" assertion header',
+            "type": "string",
+        },
+        "sequence": {
+            "description": 'The "sequence" assertion header',
+            "type": "string",
+        },
+        "series": {"description": 'The "series" assertion header', "type": "string"},
+        "snaps": {
+            "items": {
+                "description": "List of snaps in a Validation Set assertion",
+                "properties": {
+                    "id": {
+                        "description": "Snap ID",
+                        "maxLength": 100,
+                        "type": "string",
+                    },
+                    "name": {
+                        "description": "Snap name",
+                        "maxLength": 100,
+                        "type": "string",
+                    },
+                    "presence": {
+                        "description": "Snap presence",
+                        "enum": ["required", "optional", "invalid"],
+                        "type": "string",
+                    },
+                    "revision": {"description": "Snap revision", "type": "string"},
+                },
+                "required": ["name"],
+                "type": "object",
+            },
+            "minItems": 1,
+            "type": "array",
+        },
+        "timestamp": {
+            "description": 'The "timestamp" assertion header',
+            "type": "string",
+        },
+        "type": {
+            "const": "validation-set",
+            "description": 'The "type" assertion header',
+            "type": "string",
+        },
+    },
+    "required": [
+        "type",
+        "authority-id",
+        "series",
+        "account-id",
+        "name",
+        "sequence",
+        # "revision",
+        "timestamp",
+        "snaps",
+    ],
+    "type": "object",
+}

--- a/snapcraft/storeapi/v2/validation_sets.py
+++ b/snapcraft/storeapi/v2/validation_sets.py
@@ -118,7 +118,6 @@ class BuildAssertion:
             self.name == other.name
             and self.account_id == other.account_id
             and self.authority_id == other.authority_id
-            and self.name == other.name
             and self.revision == other.revision
             and self.sequence == other.sequence
             and self.snaps == other.snaps

--- a/snapcraft/storeapi/v2/validation_sets.py
+++ b/snapcraft/storeapi/v2/validation_sets.py
@@ -1,0 +1,175 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2021 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Any, Dict, List, Optional
+
+import jsonschema
+
+from ._api_schema import BUILD_ASSERTION_JSONSCHEMA
+
+
+class Snap:
+    """Represent a Snap in a Validation Set."""
+
+    @classmethod
+    def unmarshal(cls, payload: Dict[str, Any]) -> "Snap":
+        jsonschema.validate(
+            payload, BUILD_ASSERTION_JSONSCHEMA["properties"]["snaps"]["items"]
+        )
+
+        return cls(
+            name=payload["name"],
+            snap_id=payload.get("id"),
+            presence=payload.get("presence"),
+            revision=payload.get("revision"),
+        )
+
+    def marshal(self) -> Dict[str, Any]:
+        payload = {"name": self.name}
+
+        if self.snap_id is not None:
+            payload["id"] = self.snap_id
+
+        if self.presence is not None:
+            payload["presence"] = self.presence
+
+        if self.revision is not None:
+            payload["revision"] = self.revision
+
+        return payload
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Snap):
+            return False
+
+        return (
+            self.name == other.name
+            and self.snap_id == other.snap_id
+            and self.presence == other.presence
+            and self.revision == other.revision
+        )
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: {self.name!r}>"
+
+    def __init__(
+        self,
+        name: str,
+        snap_id: Optional[str] = None,
+        presence: Optional[str] = None,
+        revision: Optional[str] = None,
+    ):
+        self.name = name
+        self.snap_id = snap_id
+        self.presence = presence
+        self.revision = revision
+
+
+class BuildAssertion:
+    """Represent Validation Set assertion headers ready local signing."""
+
+    @classmethod
+    def unmarshal(cls, payload: Dict[str, Any]) -> "BuildAssertion":
+        jsonschema.validate(payload, BUILD_ASSERTION_JSONSCHEMA)
+
+        return cls(
+            account_id=payload["account-id"],
+            authority_id=payload["authority-id"],
+            name=payload["name"],
+            revision=payload.get("revision", "0"),
+            sequence=payload["sequence"],
+            series=payload["series"],
+            snaps=[Snap.unmarshal(s) for s in payload["snaps"]],
+            timestamp=payload["timestamp"],
+            assertion_type=payload["type"],
+        )
+
+    def marshal(self) -> Dict[str, Any]:
+        return {
+            "account-id": self.account_id,
+            "authority-id": self.authority_id,
+            "name": self.name,
+            "revision": self.revision,
+            "sequence": self.sequence,
+            "snaps": [s.marshal() for s in self.snaps],
+            "timestamp": self.timestamp,
+            "type": self.assertion_type,
+            "series": self.series,
+        }
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, BuildAssertion):
+            return False
+
+        return (
+            self.name == other.name
+            and self.account_id == other.account_id
+            and self.authority_id == other.authority_id
+            and self.name == other.name
+            and self.revision == other.revision
+            and self.sequence == other.sequence
+            and self.snaps == other.snaps
+            and self.timestamp == other.timestamp
+            and self.assertion_type == other.assertion_type
+            and self.series == other.series
+        )
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: {self.name!r}>"
+
+    def __init__(
+        self,
+        *,
+        account_id: str,
+        authority_id: str,
+        name: str,
+        revision: str,
+        sequence: str,
+        snaps: List[Snap],
+        timestamp: str,
+        assertion_type: str,
+        series: str = "16",
+    ):
+        self.account_id = account_id
+        self.authority_id = authority_id
+        self.name = name
+        self.revision = revision
+        self.sequence = sequence
+        self.snaps = snaps
+        self.series = series
+        self.timestamp = timestamp
+        self.assertion_type = assertion_type
+
+
+class ValidationSets:
+    @classmethod
+    def unmarshal(cls, payload: Dict[str, Any]) -> "ValidationSets":
+        return cls(
+            assertions=[
+                BuildAssertion.unmarshal(a["headers"])
+                for a in payload.get("assertions", list())
+            ]
+        )
+
+    def marshal(self) -> Dict[str, Any]:
+        return {"assertions": [{"headers": a.marshal()} for a in self.assertions]}
+
+    def __repr__(self) -> str:
+        assertion_count = len(self.assertions)
+        return f"<{self.__class__.__name__}: assertions {assertion_count!r}>"
+
+    def __init__(self, assertions: List[BuildAssertion]) -> None:
+        self.assertions = assertions

--- a/tests/unit/store/v2/test_validation_sets.py
+++ b/tests/unit/store/v2/test_validation_sets.py
@@ -1,0 +1,145 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2021 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from snapcraft.storeapi.v2 import validation_sets
+
+
+@pytest.mark.parametrize("snap_id", (None, "snap_id"))
+@pytest.mark.parametrize("presence", (None, "required", "optional", "invalid"))
+@pytest.mark.parametrize("revision", ("42", None))
+def test_snap(snap_id, presence, revision):
+    payload = {
+        "name": "set-1",
+    }
+
+    if presence is not None:
+        payload["presence"] = presence
+
+    if snap_id is not None:
+        payload["id"] = snap_id
+
+    if revision is not None:
+        payload["revision"] = revision
+
+    s = validation_sets.Snap.unmarshal(payload)
+
+    assert repr(s) == "<Snap: 'set-1'>"
+    assert s.name == payload["name"]
+    assert s.snap_id == payload.get("id")
+    assert s.presence == payload.get("presence")
+    assert s.revision == payload.get("revision")
+    assert s.marshal() == payload
+
+
+@pytest.mark.parametrize("revision", ("42", None))
+def test_build_assertion(revision):
+    payload = {
+        "account-id": "account-id-1",
+        "authority-id": "authority-id-1",
+        "name": "validation-set-1",
+        "sequence": "1",
+        "series": "16",
+        "snaps": [validation_sets.Snap(name="snap-name").marshal()],
+        "timestamp": "2020-10-29T16:36:56Z",
+        "type": "validation-set",
+    }
+
+    if revision is not None:
+        payload["revision"] = revision
+
+    s = validation_sets.BuildAssertion.unmarshal(payload)
+
+    assert repr(s) == "<BuildAssertion: 'validation-set-1'>"
+    assert s.account_id == payload["account-id"]
+    assert s.authority_id == payload["authority-id"]
+    assert s.name == payload["name"]
+    assert s.sequence == payload.get("sequence")
+    assert s.series == payload.get("series")
+    assert s.snaps == [validation_sets.Snap(name="snap-name")]
+    assert s.timestamp == "2020-10-29T16:36:56Z"
+
+    if revision is None:
+        payload["revision"] = "0"
+
+    assert s.marshal() == payload
+
+
+def test_validation_sets():
+    payload = {
+        "assertions": [
+            {
+                "headers": {
+                    "account-id": "account-id-1",
+                    "authority-id": "authority-id-1",
+                    "name": "validation-set-1",
+                    "revision": "1",
+                    "sequence": "1",
+                    "series": "16",
+                    "snaps": [validation_sets.Snap(name="snap-name-1").marshal()],
+                    "timestamp": "2020-10-29T16:36:56Z",
+                    "type": "validation-set",
+                }
+            },
+            {
+                "headers": {
+                    "account-id": "account-id-1",
+                    "authority-id": "authority-id-1",
+                    "name": "validation-set-1",
+                    "revision": "3",
+                    "sequence": "1",
+                    "series": "16",
+                    "snaps": [validation_sets.Snap(name="snap-name-2").marshal()],
+                    "timestamp": "2020-10-29T16:36:56Z",
+                    "type": "validation-set",
+                },
+            },
+        ]
+    }
+
+    s = validation_sets.ValidationSets.unmarshal(payload)
+
+    assert repr(s) == "<ValidationSets: assertions 2>"
+    assert s.assertions[0] == validation_sets.BuildAssertion.unmarshal(
+        {
+            "account-id": "account-id-1",
+            "authority-id": "authority-id-1",
+            "name": "validation-set-1",
+            "revision": "1",
+            "sequence": "1",
+            "series": "16",
+            "snaps": [validation_sets.Snap(name="snap-name-1").marshal()],
+            "timestamp": "2020-10-29T16:36:56Z",
+            "type": "validation-set",
+        },
+    )
+
+    assert s.assertions[1] == validation_sets.BuildAssertion.unmarshal(
+        {
+            "account-id": "account-id-1",
+            "authority-id": "authority-id-1",
+            "name": "validation-set-1",
+            "revision": "3",
+            "sequence": "1",
+            "series": "16",
+            "snaps": [validation_sets.Snap(name="snap-name-2").marshal()],
+            "timestamp": "2020-10-29T16:36:56Z",
+            "type": "validation-set",
+        }
+    )
+
+    assert s.marshal() == payload


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
Full set of changes https://github.com/snapcore/snapcraft/compare/validation-sets