### PR TITLE
extensions: don't expose host system fontconfig cache

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_28.py
@@ -65,6 +65,7 @@ class ExtensionImpl(Extension):
         self.root_snippet = {
             "assumes": ["snapd2.43"],  # for 'snapctl is-connected'
             "plugs": {
+                "desktop": {"mount-host-font-cache": False},
                 "gtk-3-themes": {
                     "interface": "content",
                     "target": "$SNAP/data-dir/themes",

--- a/snapcraft/internal/project_loader/_extensions/gnome_3_34.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_34.py
@@ -66,6 +66,7 @@ class ExtensionImpl(Extension):
         self.root_snippet = {
             "assumes": ["snapd2.43"],  # for 'snapctl is-connected'
             "plugs": {
+                "desktop": {"mount-host-font-cache": False},
                 "gtk-3-themes": {
                     "interface": "content",
                     "target": "$SNAP/data-dir/themes",

--- a/snapcraft/internal/project_loader/_extensions/gnome_3_38.py
+++ b/snapcraft/internal/project_loader/_extensions/gnome_3_38.py
@@ -66,6 +66,7 @@ class ExtensionImpl(Extension):
         self.root_snippet = {
             "assumes": ["snapd2.43"],  # for 'snapctl is-connected'
             "plugs": {
+                "desktop": {"mount-host-font-cache": False},
                 "gtk-3-themes": {
                     "interface": "content",
                     "target": "$SNAP/data-dir/themes",

--- a/snapcraft/internal/project_loader/_extensions/kde_neon.py
+++ b/snapcraft/internal/project_loader/_extensions/kde_neon.py
@@ -84,6 +84,7 @@ class ExtensionImpl(Extension):
         self.root_snippet = {
             "assumes": ["snapd2.43"],  # for 'snapctl is-connected'
             "plugs": {
+                "desktop": {"mount-host-font-cache": False},
                 "icon-themes": {
                     "interface": "content",
                     "target": "$SNAP/data-dir/icons",

--- a/tests/unit/project_loader/extensions/test_gnome_3_28.py
+++ b/tests/unit/project_loader/extensions/test_gnome_3_28.py
@@ -33,6 +33,7 @@ class ExtensionTest(ProjectLoaderBaseTest):
                 {
                     "assumes": ["snapd2.43"],
                     "plugs": {
+                        "desktop": {"mount-host-font-cache": False},
                         "gtk-3-themes": {
                             "interface": "content",
                             "target": "$SNAP/data-dir/themes",

--- a/tests/unit/project_loader/extensions/test_gnome_3_34.py
+++ b/tests/unit/project_loader/extensions/test_gnome_3_34.py
@@ -34,6 +34,7 @@ class ExtensionTest(ProjectLoaderBaseTest, CommandBaseTestCase):
                 {
                     "assumes": ["snapd2.43"],
                     "plugs": {
+                        "desktop": {"mount-host-font-cache": False},
                         "gtk-3-themes": {
                             "interface": "content",
                             "target": "$SNAP/data-dir/themes",

--- a/tests/unit/project_loader/extensions/test_gnome_3_38.py
+++ b/tests/unit/project_loader/extensions/test_gnome_3_38.py
@@ -34,6 +34,7 @@ class ExtensionTest(ProjectLoaderBaseTest, CommandBaseTestCase):
                 {
                     "assumes": ["snapd2.43"],
                     "plugs": {
+                        "desktop": {"mount-host-font-cache": False},
                         "gtk-3-themes": {
                             "interface": "content",
                             "target": "$SNAP/data-dir/themes",

--- a/tests/unit/project_loader/extensions/test_kde_neon.py
+++ b/tests/unit/project_loader/extensions/test_kde_neon.py
@@ -25,6 +25,7 @@ def test_extension_core18():
     assert kde_neon_extension.root_snippet == {
         "assumes": ["snapd2.43"],
         "plugs": {
+            "desktop": {"mount-host-font-cache": False},
             "icon-themes": {
                 "interface": "content",
                 "target": "$SNAP/data-dir/icons",
@@ -82,6 +83,7 @@ def test_extension_core20():
             }
         },
         "plugs": {
+            "desktop": {"mount-host-font-cache": False},
             "icon-themes": {
                 "default-provider": "gtk-common-themes",
                 "interface": "content",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
This PR updates the GNOME and KDE extensions to configure their desktop plug to set the `mount-host-font-cache: false` interface attribute.  In snapd 2.50, this will instruct the interface not to mount `/var/cache/fontconfig` into the sandbox mount namespace, ensuring that cache files found in that directory cannot be used.  More details can be found in https://github.com/snapcore/snapd/pull/9805.

All of these extensions include code to build a private version of the fontconfig cache, so the host cache can only be a source of problems.

Snapd versions prior to 2.50 do not support this interface attribute, so will ignore it and behave as before.  So there is no need to delay merging this until it is released or update the `assumes` setting.