### PR TITLE
elf: add fallback methods to detect library dependencies

### DIFF
--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -142,7 +142,7 @@ def _determine_libraries(
 
     # Fall back to trying ldd with LD_PRELOAD explicitly loading libc.
     libc_path = _get_host_libc_path(arch_triplet)
-    if libc_path.exists():
+    if libc_path.is_file():
         with contextlib.suppress(subprocess.CalledProcessError):
             return _ldd(path, ld_library_paths, ld_preload=str(libc_path))
 

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import contextlib
-import functools
 import glob
 import logging
 import os
@@ -36,7 +35,6 @@ from snapcraft.internal import common, errors, repo
 logger = logging.getLogger(__name__)
 
 
-@functools.lru_cache()
 def _get_host_libc_path(arch_triplet: str) -> pathlib.Path:
     return pathlib.Path("/lib") / arch_triplet / "libc.so.6"
 

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -72,13 +72,15 @@ def _check_output(cmd: List[str], *, extra_env: Dict[str, str]) -> str:
 def _parse_ldd_output(output: str) -> Dict[str, str]:
     """Parse ldd output.
 
-    ldd output sample:
+    Example ldd outputs:
 
     linux-vdso.so.1 =>  (0x00007ffdc13ec000)   <== ubuntu 16.04 ldd
     linux-vdso.so.1 (0x00007ffdc13ec000)       <== newer ldd
     /lib64/ld-linux-x86-64.so.2 (0x00007fb3c5298000)
     libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fb3bef03000)
-    # libmissing.so.2 => not found
+    libmissing.so.2 => not found
+
+    :returns: Dictionary of dependencies, mapping library name to path.
     """
     libraries: Dict[str, str] = {}
     ldd_lines = output.splitlines()

--- a/snapcraft/internal/elf.py
+++ b/snapcraft/internal/elf.py
@@ -14,9 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import contextlib
+import functools
 import glob
 import logging
 import os
+import pathlib
 import re
 import shutil
 import subprocess
@@ -32,6 +34,11 @@ from snapcraft import file_utils
 from snapcraft.internal import common, errors, repo
 
 logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache()
+def _get_host_libc_path(arch_triplet: str) -> pathlib.Path:
+    return pathlib.Path("/lib") / arch_triplet / "libc.so.6"
 
 
 def _ldd_resolve(soname: str, soname_path: str) -> Tuple[str, str]:
@@ -51,33 +58,32 @@ def _ldd_resolve(soname: str, soname_path: str) -> Tuple[str, str]:
     return soname, soname
 
 
-def ldd(path: str, ld_library_paths: List[str]) -> Dict[str, str]:
-    """Return a set of resolved library mappings using specified library paths.
-
-    Returns a dictionary of mappings of soname -> soname_path.
-    If library is not resolved, the soname itself is the soname_path.
-    """
-
-    libraries: Dict[str, str] = dict()
-
+def _check_output(cmd: List[str], *, extra_env: Dict[str, str]) -> str:
     env = os.environ.copy()
-    env["LD_LIBRARY_PATH"] = ":".join(ld_library_paths)
-    logger.debug(f"invoking ldd with ld library paths: {ld_library_paths!r}")
+    env.update(extra_env)
 
-    try:
-        # ldd output sample:
-        # linux-vdso.so.1 =>  (0x00007ffdc13ec000)   <== ubuntu 16.04 ldd
-        # linux-vdso.so.1 (0x00007ffdc13ec000)       <== newer ldd
-        # /lib64/ld-linux-x86-64.so.2 (0x00007fb3c5298000)
-        # libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fb3bef03000)
-        # libmissing.so.2 => not found
-        ldd_lines = (
-            subprocess.check_output(["ldd", path], env=env).decode().splitlines()
-        )
-        logger.debug(f"ldd output:\n{ldd_lines}")
-    except subprocess.CalledProcessError:
-        logger.warning("Unable to determine library dependencies for {!r}".format(path))
-        return libraries
+    debug_cmd = [f"{k}={v}" for k, v in extra_env.items()]
+    debug_cmd += cmd
+
+    logger.debug("executing: %s", " ".join(debug_cmd))
+    output = subprocess.check_output(cmd, env=env).decode()
+
+    return output
+
+
+def _parse_ldd_output(output: str) -> Dict[str, str]:
+    """Parse ldd output.
+
+    ldd output sample:
+
+    linux-vdso.so.1 =>  (0x00007ffdc13ec000)   <== ubuntu 16.04 ldd
+    linux-vdso.so.1 (0x00007ffdc13ec000)       <== newer ldd
+    /lib64/ld-linux-x86-64.so.2 (0x00007fb3c5298000)
+    libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fb3bef03000)
+    # libmissing.so.2 => not found
+    """
+    libraries: Dict[str, str] = {}
+    ldd_lines = output.splitlines()
 
     for line in ldd_lines:
         # First match against libraries that are found.
@@ -97,8 +103,56 @@ def ldd(path: str, ld_library_paths: List[str]) -> Dict[str, str]:
         soname, soname_path = _ldd_resolve(match.group(1), match.group(2))
         libraries[soname] = soname_path
 
-    logger.debug(f"ldd results: {libraries!r}")
     return libraries
+
+
+def _ld_trace(path: str, ld_library_paths: List[str]) -> Dict[str, str]:
+    """Use LD_TRACE_LOADED_OBJECTS to determine library dependencies."""
+    env = {
+        "LD_TRACE_LOADED_OBJECTS": "1",
+        "LD_LIBRARY_PATH": ":".join(ld_library_paths),
+    }
+
+    return _parse_ldd_output(_check_output([path], extra_env=env))
+
+
+def _ldd(
+    path: str, ld_library_paths: List[str], *, ld_preload: Optional[str] = None
+) -> Dict[str, str]:
+    """Use host ldd to determine library dependencies."""
+    ldd_path = str(
+        file_utils.get_host_tool_path(command_name="ldd", package_name="libc-bin")
+    )
+    env = {
+        "LD_LIBRARY_PATH": ":".join(ld_library_paths),
+    }
+
+    if ld_preload:
+        env["LD_PRELOAD"] = ld_preload
+
+    return _parse_ldd_output(_check_output([ldd_path, path], extra_env=env))
+
+
+def _determine_libraries(
+    *, path: str, ld_library_paths: List[str], arch_triplet: str
+) -> Dict[str, str]:
+    # Try the usual method with ldd.
+    with contextlib.suppress(subprocess.CalledProcessError):
+        return _ldd(path, ld_library_paths)
+
+    # Fall back to trying ldd with LD_PRELOAD explicitly loading libc.
+    with contextlib.suppress(subprocess.CalledProcessError):
+        return _ldd(
+            path, ld_library_paths, ld_preload=str(_get_host_libc_path(arch_triplet))
+        )
+
+    # Fall back to trying ld trace method which may fail with permission error
+    # for non-executable shared objects.
+    with contextlib.suppress(PermissionError, subprocess.CalledProcessError):
+        return _ld_trace(path, ld_library_paths)
+
+    logger.warning("Unable to determine library dependencies for %r", path)
+    return {}
 
 
 class NeededLibrary:
@@ -449,7 +503,9 @@ class ElfFile:
         for path in search_paths:
             ld_library_paths.extend(common.get_library_paths(path, arch_triplet))
 
-        libraries = ldd(self.path, ld_library_paths)
+        libraries = _determine_libraries(
+            path=self.path, ld_library_paths=ld_library_paths, arch_triplet=arch_triplet
+        )
         for soname, soname_path in libraries.items():
             if self.arch is None:
                 raise RuntimeError("failed to parse architecture")
@@ -543,6 +599,7 @@ class Patcher:
 
             cmd = [self._patchelf_cmd] + patchelf_args + [temp_file.name]
             try:
+                logger.debug("executing: %s", " ".join(cmd))
                 subprocess.check_call(cmd)
             # There is no need to catch FileNotFoundError as patchelf should be
             # bundled with snapcraft which means its lack of existence is a

--- a/tests/unit/test_elf.py
+++ b/tests/unit/test_elf.py
@@ -611,11 +611,8 @@ class TestLddParsing:
     ]
 
     def test_ldd(self, ldd_output, expected, monkeypatch, fake_process):
-        def fake_abspath(path):
-            return path
-
         monkeypatch.setattr(os.path, "exists", lambda f: True)
-        monkeypatch.setattr(os.path, "abspath", fake_abspath)
+        monkeypatch.setattr(os.path, "abspath", lambda p: p)
 
         fake_process.register_subprocess(
             ["/usr/bin/ldd", "/bin/foo"], stdout=ldd_output.encode()
@@ -679,7 +676,7 @@ def test_ld_trace_os_error_for_wrong_arch(monkeypatch, fake_process, tmp_path):
 
     fake_process.register_subprocess(["/usr/bin/ldd", "/bin/foo"], returncode=1)
 
-    def raise_os_error(args, **kwargs):
+    def raise_os_error(*args, **kwargs):
         raise OSError(8, "Exec format error:", "does-not-exist")
 
     fake_process.register_subprocess(["/bin/foo"], callback=raise_os_error)


### PR DESCRIPTION
libc6 may mismatch with the paths provided to ldd in LD_LIBRARY_PATH.

This may be avoided if invoking the binary directory and using
LD_TRACE_LOADED_OBJECTS, but this method is limited to executable
files.

This updates the library dependency search to try three variants:
(1) use ldd as today.  if ldd fails..
(2) use ldd with LD_PRELOAD to specify libc6 from host. if ldd fails...
(3) use ld trace method. if ldd trace fails...
(4) warn as before.

For #2, libc6 is expected as /lib/<arch-triplet>/libc.so.6.  This likely
will need to be more robust in the future.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
