### PR TITLE
Use snapd-spread gce project instead of computeengine project

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -27,7 +27,7 @@ jobs:
           sudo snap install --dangerous --classic ${{ steps.build-snapcraft.outputs.snap }}
 
   integration-spread-tests:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: build
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
@@ -54,9 +54,6 @@ jobs:
           name: snap
           path: tests
 
-      - name: Install spread
-        run: curl -s https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz | sudo tar xzv -C /usr/bin
-
       - name: Run spread
         env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
@@ -71,7 +68,7 @@ jobs:
           done
 
   integration-spread-tests-store:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: build
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
@@ -105,10 +102,6 @@ jobs:
         with:
           name: snap
           path: tests
-
-      - if: steps.decisions.outputs.RUN == 'true'
-        name: Install spread
-        run: curl -s https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz | sudo tar xzv -C /usr/bin
 
       - if: steps.decisions.outputs.RUN == 'true'
         name: Run spread

--- a/spread.yaml
+++ b/spread.yaml
@@ -36,7 +36,7 @@ backends:
       - ubuntu-18.04
       - ubuntu-20.04
   google:
-    location: computeengine/us-east1-b
+    location: snapd-spread/us-east1-b
     systems:
       - ubuntu-16.04-64:
           workers: 12

--- a/spread.yaml
+++ b/spread.yaml
@@ -36,7 +36,9 @@ backends:
       - ubuntu-18.04
       - ubuntu-20.04
   google:
+    key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
     location: snapd-spread/us-east1-b
+    halt-timeout: 2h
     systems:
       - ubuntu-16.04-64:
           workers: 12


### PR DESCRIPTION
This change updates the gce project used to run spread tests.
The computeengine project is going to be deprecated soon and the
snapd-spread project has been created to replace it under the canonical
organization.
