### PR TITLE
github: update workflows that to use pull_request_target

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,7 @@
 name: CI
 
-on: 
-  pull_request:
+on:
+    - pull_request_target
 
 jobs:
   publish:

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -1,6 +1,7 @@
 name: Spread Tests
 
-on: [pull_request]
+on:
+    - pull_request_target
 
 jobs:
   build:


### PR DESCRIPTION
This would force using workflows from master/main on forks, which
allows using secrets. Exposure is reduced as the workflow is executed
from a already commited code.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target