### PR TITLE
yaml: detect and log warning on duplicate keys in snapcraft.yaml

### DIFF
--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -27,7 +27,9 @@ class ProjectInfo:
 
     def __init__(self, *, snapcraft_yaml_file_path) -> None:
         self.snapcraft_yaml_file_path = snapcraft_yaml_file_path
-        self.__raw_snapcraft = yaml_utils.load_yaml_file(snapcraft_yaml_file_path)
+        self.__raw_snapcraft = yaml_utils.load_yaml_file(
+            snapcraft_yaml_file_path, warn_duplicate_keys=True
+        )
 
         try:
             self.name = self.__raw_snapcraft["name"]

--- a/snapcraft/yaml_utils/__init__.py
+++ b/snapcraft/yaml_utils/__init__.py
@@ -16,11 +16,14 @@
 
 import codecs
 import collections
+import logging
 from typing import Any, Dict, Optional, TextIO, Union
 
 import yaml
 
 from snapcraft.yaml_utils.errors import YamlValidationError
+
+logger = logging.getLogger(__name__)
 
 try:
     # The C-based loaders/dumpers aren't available everywhere, but they're much faster.
@@ -31,7 +34,9 @@ except ImportError:
     raise RuntimeError("Snapcraft requires PyYAML to be built with libyaml bindings")
 
 
-def load_yaml_file(yaml_file_path: str) -> collections.OrderedDict:
+def load_yaml_file(
+    yaml_file_path: str, *, warn_duplicate_keys: bool = False
+) -> collections.OrderedDict:
     """Load YAML with wrapped YamlValidationError."""
     with open(yaml_file_path, "rb") as fp:
         bs = fp.read(2)
@@ -43,7 +48,7 @@ def load_yaml_file(yaml_file_path: str) -> collections.OrderedDict:
 
     try:
         with open(yaml_file_path, encoding=encoding) as fp:  # type: ignore
-            yaml_contents = load(fp)  # type: ignore
+            yaml_contents = load(fp, warn_duplicate_keys=warn_duplicate_keys)  # type: ignore
     except yaml.MarkedYAMLError as e:
         raise YamlValidationError(
             "{} on line {}, column {}".format(
@@ -67,9 +72,14 @@ def load_yaml_file(yaml_file_path: str) -> collections.OrderedDict:
     return yaml_contents
 
 
-def load(stream: Union[TextIO, str]) -> Any:
+def load(stream: Union[TextIO, str], *, warn_duplicate_keys: bool = False) -> Any:
     """Safely load YAML in ordered manner."""
-    return yaml.load(stream, Loader=_SafeOrderedLoader)
+
+    class YamlLoader(_SafeOrderedLoader):
+        pass
+
+    YamlLoader.warn_duplicate_keys = warn_duplicate_keys
+    return yaml.load(stream, Loader=YamlLoader)
 
 
 def dump(
@@ -90,8 +100,11 @@ def dump(
 
 
 class _SafeOrderedLoader(CSafeLoader):
+    warn_duplicate_keys: bool = False
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
         self.add_constructor(
             yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _dict_constructor
         )
@@ -117,7 +130,20 @@ def _dict_representer(dumper, data):
     return dumper.represent_dict(data.items())
 
 
+def _check_duplicate_keys(loader, node):
+    mappings = set()
+    print(node)
+    for key_node, value_node in node.value:
+        if key_node.value in mappings:
+            logger.warning("Duplicate key in YAML detected: %r", key_node.value)
+            return
+        mappings.add(key_node.value)
+
+
 def _dict_constructor(loader, node):
+    if loader.warn_duplicate_keys:
+        _check_duplicate_keys(loader, node)
+
     # Necessary in order to make yaml merge tags work
     loader.flatten_mapping(node)
     value = loader.construct_pairs(node)

--- a/tests/unit/yaml_utils/test_yaml_utils.py
+++ b/tests/unit/yaml_utils/test_yaml_utils.py
@@ -15,39 +15,48 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
-import os
+import pytest
 
-from testtools.matchers import Equals
 
 from snapcraft import yaml_utils
 from snapcraft.yaml_utils import YamlValidationError
-from tests import unit
 
 
-class YamlLoadTests(unit.TestCase):
-    def test_load_yaml_file(self):
-        path = os.path.join(self.path, "test.yaml")
-        with open(path, "w") as f:
-            f.write("foo: bar")
+def test_load_yaml_file(caplog, tmp_path):
+    yaml_path = tmp_path / "test.yaml"
+    yaml_path.write_text("foo: bar")
 
-        cfg = yaml_utils.load_yaml_file(path)
+    cfg = yaml_utils.load_yaml_file(str(yaml_path))
 
-        self.assertThat(cfg, Equals({"foo": "bar"}))
-
-    def test_load_yaml_file_bad_yaml(self):
-        path = os.path.join(self.path, "test.yaml")
-        with open(path, "w") as f:
-            # Note the missing newlines...
-            f.write("foo: bar")
-            f.write("a-b-c: xyz")
-
-        self.assertRaises(YamlValidationError, yaml_utils.load_yaml_file, path)
+    assert cfg == {"foo": "bar"}
+    assert [r.message for r in caplog.records] == []
 
 
-class OctIntTest(unit.TestCase):
-    def test_octint_dump(self):
-        output = io.StringIO()
-        yaml_utils.dump(dict(number=yaml_utils.OctInt(8)), stream=output)
-        output.seek(0)
+def test_load_yaml_file_bad_yaml(caplog, tmp_path):
+    yaml_path = tmp_path / "test.yaml"
+    yaml_path.write_text("foo: bara-b-c: xyz\n")
 
-        self.assertThat(output.read().strip(), Equals("number: 0010"))
+    with pytest.raises(YamlValidationError):
+        yaml_utils.load_yaml_file(str(yaml_path))
+
+    assert [r.message for r in caplog.records] == []
+
+
+def test_load_yaml_file_with_duplicate_warnings(caplog, tmp_path):
+    yaml_path = tmp_path / "test.yaml"
+    yaml_path.write_text("foo: bar\nfoo: bar2")
+
+    cfg = yaml_utils.load_yaml_file(str(yaml_path), warn_duplicate_keys=True)
+
+    assert cfg == {"foo": "bar2"}
+    assert [r.message for r in caplog.records] == [
+        "Duplicate key in YAML detected: 'foo'"
+    ]
+
+
+def test_dump_octint(tmp_path):
+    output = io.StringIO()
+    yaml_utils.dump(dict(number=yaml_utils.OctInt(8)), stream=output)
+    output.seek(0)
+
+    assert output.read().strip() == "number: 0010"


### PR DESCRIPTION
A very primitive check to warn if duplicate keys are found in
the snapcraft.yaml.  At the moment the file is loaded multiple
times which may result in duplicate warnings (ha ha) which we
need to address in future work.  Given that there shouldn't be
duplicates in YAML files, the extra verbosity should be OK.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
