### PR TITLE
yaml: detect and log warning on duplicate keys in snapcraft.yaml (CRAFT-553)

### DIFF
--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -27,7 +27,9 @@ class ProjectInfo:
 
     def __init__(self, *, snapcraft_yaml_file_path) -> None:
         self.snapcraft_yaml_file_path = snapcraft_yaml_file_path
-        self.__raw_snapcraft = yaml_utils.load_yaml_file(snapcraft_yaml_file_path)
+        self.__raw_snapcraft = yaml_utils.load_yaml_file(
+            snapcraft_yaml_file_path, warn_duplicate_keys=True
+        )
 
         try:
             self.name = self.__raw_snapcraft["name"]

--- a/snapcraft/project/_project_info.py
+++ b/snapcraft/project/_project_info.py
@@ -27,9 +27,7 @@ class ProjectInfo:
 
     def __init__(self, *, snapcraft_yaml_file_path) -> None:
         self.snapcraft_yaml_file_path = snapcraft_yaml_file_path
-        self.__raw_snapcraft = yaml_utils.load_yaml_file(
-            snapcraft_yaml_file_path, warn_duplicate_keys=True
-        )
+        self.__raw_snapcraft = yaml_utils.load_yaml_file(snapcraft_yaml_file_path)
 
         try:
             self.name = self.__raw_snapcraft["name"]

--- a/snapcraft/yaml_utils/__init__.py
+++ b/snapcraft/yaml_utils/__init__.py
@@ -132,11 +132,16 @@ def _dict_representer(dumper, data):
 
 def _check_duplicate_keys(loader, node):
     mappings = set()
+
     for key_node, value_node in node.value:
-        if key_node.value in mappings:
-            logger.warning("Duplicate key in YAML detected: %r", key_node.value)
-            return
-        mappings.add(key_node.value)
+        try:
+            if key_node.value in mappings:
+                logger.warning("Duplicate key in YAML detected: %r", key_node.value)
+                return
+            mappings.add(key_node.value)
+        except TypeError:
+            # Ignore errors for malformed inputs that will be caught later.
+            pass
 
 
 def _dict_constructor(loader, node):

--- a/snapcraft/yaml_utils/__init__.py
+++ b/snapcraft/yaml_utils/__init__.py
@@ -132,8 +132,8 @@ def _check_duplicate_keys(loader, node):
         try:
             if key_node.value in mappings:
                 logger.warning("Duplicate key in YAML detected: %r", key_node.value)
-                return
-            mappings.add(key_node.value)
+            else:
+                mappings.add(key_node.value)
         except TypeError:
             # Ignore errors for malformed inputs that will be caught later.
             pass

--- a/tests/unit/yaml_utils/test_yaml_utils.py
+++ b/tests/unit/yaml_utils/test_yaml_utils.py
@@ -15,39 +15,48 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
-import os
+import pytest
 
-from testtools.matchers import Equals
 
 from snapcraft import yaml_utils
 from snapcraft.yaml_utils import YamlValidationError
-from tests import unit
 
 
-class YamlLoadTests(unit.TestCase):
-    def test_load_yaml_file(self):
-        path = os.path.join(self.path, "test.yaml")
-        with open(path, "w") as f:
-            f.write("foo: bar")
+def test_load_yaml_file(caplog, tmp_path):
+    yaml_path = tmp_path / "test.yaml"
+    yaml_path.write_text("foo: bar")
 
-        cfg = yaml_utils.load_yaml_file(path)
+    cfg = yaml_utils.load_yaml_file(str(yaml_path))
 
-        self.assertThat(cfg, Equals({"foo": "bar"}))
-
-    def test_load_yaml_file_bad_yaml(self):
-        path = os.path.join(self.path, "test.yaml")
-        with open(path, "w") as f:
-            # Note the missing newlines...
-            f.write("foo: bar")
-            f.write("a-b-c: xyz")
-
-        self.assertRaises(YamlValidationError, yaml_utils.load_yaml_file, path)
+    assert cfg == {"foo": "bar"}
+    assert [r.message for r in caplog.records] == []
 
 
-class OctIntTest(unit.TestCase):
-    def test_octint_dump(self):
-        output = io.StringIO()
-        yaml_utils.dump(dict(number=yaml_utils.OctInt(8)), stream=output)
-        output.seek(0)
+def test_load_yaml_file_bad_yaml(caplog, tmp_path):
+    yaml_path = tmp_path / "test.yaml"
+    yaml_path.write_text("foo: bara-b-c: xyz\n")
 
-        self.assertThat(output.read().strip(), Equals("number: 0010"))
+    with pytest.raises(YamlValidationError):
+        yaml_utils.load_yaml_file(str(yaml_path))
+
+    assert [r.message for r in caplog.records] == []
+
+
+def test_load_yaml_file_with_duplicate_warnings(caplog, tmp_path):
+    yaml_path = tmp_path / "test.yaml"
+    yaml_path.write_text("foo: bar\nfoo: bar2")
+
+    cfg = yaml_utils.load_yaml_file(str(yaml_path), warn_duplicate_keys=True)
+
+    assert cfg == {"foo": "bar2"}
+    assert [r.message for r in caplog.records] == [
+        "Duplicate key in YAML detected: 'foo'"
+    ]
+
+
+def test_dump_octint(tmp_path):
+    output = io.StringIO()
+    yaml_utils.dump(dict(number=yaml_utils.OctInt(8)), stream=output)
+    output.seek(0)
+
+    assert output.read().strip() == "number: 0010"

--- a/tests/unit/yaml_utils/test_yaml_utils.py
+++ b/tests/unit/yaml_utils/test_yaml_utils.py
@@ -54,7 +54,20 @@ def test_load_yaml_file_with_duplicate_warnings(caplog, tmp_path):
     ]
 
 
-def test_load_yaml_file_with_nested_duplicates(caplog, tmp_path):
+def test_load_yaml_file_multiple_duplicates(caplog, tmp_path):
+    yaml_path = tmp_path / "test.yaml"
+    yaml_path.write_text("foo: bar\nfoo: bar2\nbaz: bar3\nbaz: bar4")
+
+    cfg = yaml_utils.load_yaml_file(str(yaml_path))
+
+    assert cfg == {"foo": "bar2", "baz": "bar4"}
+    assert [r.message for r in caplog.records] == [
+        "Duplicate key in YAML detected: 'foo'",
+        "Duplicate key in YAML detected: 'baz'",
+    ]
+
+
+def test_load_yaml_file_nested_duplicates(caplog, tmp_path):
     yaml_path = tmp_path / "test.yaml"
     yaml_path.write_text("foo: bar\nnest:\n  foo: bar2\n  baz: bar3\n  baz: bar4")
 

--- a/tests/unit/yaml_utils/test_yaml_utils.py
+++ b/tests/unit/yaml_utils/test_yaml_utils.py
@@ -54,6 +54,18 @@ def test_load_yaml_file_with_duplicate_warnings(caplog, tmp_path):
     ]
 
 
+def test_load_yaml_file_with_nested_duplicates(caplog, tmp_path):
+    yaml_path = tmp_path / "test.yaml"
+    yaml_path.write_text("foo: bar\nnest:\n  foo: bar2\n  baz: bar3\n  baz: bar4")
+
+    cfg = yaml_utils.load_yaml_file(str(yaml_path))
+
+    assert cfg == {"foo": "bar", "nest": {"foo": "bar2", "baz": "bar4"}}
+    assert [r.message for r in caplog.records] == [
+        "Duplicate key in YAML detected: 'baz'"
+    ]
+
+
 def test_dump_octint(tmp_path):
     output = io.StringIO()
     yaml_utils.dump(dict(number=yaml_utils.OctInt(8)), stream=output)

--- a/tests/unit/yaml_utils/test_yaml_utils.py
+++ b/tests/unit/yaml_utils/test_yaml_utils.py
@@ -46,7 +46,7 @@ def test_load_yaml_file_with_duplicate_warnings(caplog, tmp_path):
     yaml_path = tmp_path / "test.yaml"
     yaml_path.write_text("foo: bar\nfoo: bar2")
 
-    cfg = yaml_utils.load_yaml_file(str(yaml_path), warn_duplicate_keys=True)
+    cfg = yaml_utils.load_yaml_file(str(yaml_path))
 
     assert cfg == {"foo": "bar2"}
     assert [r.message for r in caplog.records] == [


### PR DESCRIPTION
A very primitive check to warn if duplicate keys are found in
the snapcraft.yaml.  At the moment the file is loaded multiple
times which may result in duplicate warnings (ha ha) which we
need to address in future work.  Given that there shouldn't be
duplicates in YAML files, the extra verbosity should be OK.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
