### PR TITLE
python v2 plugin: update pip properly

### DIFF
--- a/snapcraft/plugins/v2/python.py
+++ b/snapcraft/plugins/v2/python.py
@@ -38,8 +38,12 @@ Additionally, this plugin uses the following plugin-specific keywords:
 
     - python-packages
       (list)
-      A list of dependencies to get from PyPI. If needed, pip,
-      setuptools and wheel can be upgraded here.
+      A list of dependencies to get from PyPI.
+
+    - update-pip
+      (boolean)
+      If set to true, build with the latest versions
+      of pip, wheel, and setuptools.
 
 This plugin also interprets these specific build-environment entries:
 
@@ -94,8 +98,9 @@ class PythonPlugin(PluginV2):
                     "type": "array",
                     "uniqueItems": True,
                     "items": {"type": "string"},
-                    "default": ["pip", "setuptools", "wheel"],
+                    "default": [],
                 },
+                "update-pip": {"type": "boolean", "default": True},
             },
         }
 
@@ -122,6 +127,9 @@ class PythonPlugin(PluginV2):
             '"${SNAPCRAFT_PYTHON_INTERPRETER}" -m venv ${SNAPCRAFT_PYTHON_VENV_ARGS} "${SNAPCRAFT_PART_INSTALL}"',
             'SNAPCRAFT_PYTHON_VENV_INTERP_PATH="${SNAPCRAFT_PART_INSTALL}/bin/${SNAPCRAFT_PYTHON_INTERPRETER}"',
         ]
+
+        if self.options.update_pip:
+            build_commands.append("pip install -U pip wheel setuptools")
 
         if self.options.constraints:
             constraints = " ".join(f"-c {c!r}" for c in self.options.constraints)

--- a/tests/unit/plugins/v2/test_python.py
+++ b/tests/unit/plugins/v2/test_python.py
@@ -32,7 +32,7 @@ def test_schema():
                 "uniqueItems": True,
             },
             "python-packages": {
-                "default": ["pip", "setuptools", "wheel"],
+                "default": [],
                 "items": {"type": "string"},
                 "type": "array",
                 "uniqueItems": True,
@@ -43,6 +43,7 @@ def test_schema():
                 "type": "array",
                 "uniqueItems": True,
             },
+            "update-pip": {"type": "boolean", "default": True},
         },
         "type": "object",
     }
@@ -106,6 +107,7 @@ def test_get_build_commands():
         constraints = list()
         requirements = list()
         python_packages = list()
+        update_pip = bool()
 
     plugin = PythonPlugin(part_name="my-part", options=Options())
 
@@ -125,6 +127,7 @@ def test_get_build_commands_with_all_properties():
         constraints = ["constraints.txt"]
         requirements = ["requirements.txt"]
         python_packages = ["pip", "some-pkg; sys_platform != 'win32'"]
+        update_pip = True
 
     plugin = PythonPlugin(part_name="my-part", options=Options())
 
@@ -133,6 +136,7 @@ def test_get_build_commands_with_all_properties():
         == [
             '"${SNAPCRAFT_PYTHON_INTERPRETER}" -m venv ${SNAPCRAFT_PYTHON_VENV_ARGS} "${SNAPCRAFT_PART_INSTALL}"',
             'SNAPCRAFT_PYTHON_VENV_INTERP_PATH="${SNAPCRAFT_PART_INSTALL}/bin/${SNAPCRAFT_PYTHON_INTERPRETER}"',
+            "pip install -U pip wheel setuptools",
             "pip install -c 'constraints.txt' -U pip 'some-pkg; sys_platform != '\"'\"'win32'\"'\"''",
             "pip install -c 'constraints.txt' -U -r 'requirements.txt'",
             "[ -f setup.py ] && pip install -c 'constraints.txt' -U .",


### PR DESCRIPTION
Prior to this commit, pip wouldn't be updated properly.
With this commit, pip wheel and setuptools will be updated automatically,
this behaviour can be turned off with the 'update-pip: false' attribute,
in which case the original pip (e.g, from the base) will be used.

- [Y] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [Y] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [Y] Have you successfully run `./runtests.sh static`?
- [Y] Have you successfully run `./runtests.sh tests/unit`?

-----
