### PR TITLE
autotools v2 plugin: adding cross compilation support

### DIFF
--- a/snapcraft/plugins/v2/autotools.py
+++ b/snapcraft/plugins/v2/autotools.py
@@ -77,9 +77,11 @@ class AutotoolsPlugin(PluginV2):
         return dict()
 
     def _get_configure_command(self) -> str:
-        cmd = self.options.autotools_configure_env_variables
+        cmd = ["CC=${SNAPCRAFT_ARCH_TRIPLET}-gcc"]
+        cmd += self.options.autotools_configure_env_variables
         cmd += ["./configure"]
         cmd += self.options.autotools_configure_parameters
+        cmd.append("--host=${SNAPCRAFT_ARCH_TRIPLET}")
 
         return " ".join(cmd)
 

--- a/snapcraft/plugins/v2/autotools.py
+++ b/snapcraft/plugins/v2/autotools.py
@@ -32,6 +32,11 @@ In addition, this plugin uses the following plugin-specific keywords:
       (list of strings)
       configure flags to pass to the build such as those shown by running
       './configure --help'
+
+    - autotools-configure-env-variables
+      (list of strings)
+      environment variables to set for the build such as those shown by running
+      './configure --help'
 """
 
 from typing import Any, Dict, List, Set
@@ -52,7 +57,13 @@ class AutotoolsPlugin(PluginV2):
                     "uniqueItems": True,
                     "items": {"type": "string"},
                     "default": [],
-                }
+                },
+                "autotools-configure-env-variables": {
+                    "type": "array",
+                    "uniqueItems": True,
+                    "items": {"type": "string"},
+                    "default": [],
+                },
             },
         }
 
@@ -66,7 +77,9 @@ class AutotoolsPlugin(PluginV2):
         return dict()
 
     def _get_configure_command(self) -> str:
-        cmd = ["./configure"] + self.options.autotools_configure_parameters
+        cmd = self.options.autotools_configure_env_variables
+        cmd += ["./configure"]
+        cmd += self.options.autotools_configure_parameters
 
         return " ".join(cmd)
 

--- a/snapcraft/plugins/v2/autotools.py
+++ b/snapcraft/plugins/v2/autotools.py
@@ -33,7 +33,7 @@ In addition, this plugin uses the following plugin-specific keywords:
       configure flags to pass to the build such as those shown by running
       './configure --help'
 
-    - autotools-configure-env-variables
+    - autotools-configure-environment
       (list of strings)
       environment variables to set for the build such as those shown by running
       './configure --help'
@@ -58,7 +58,7 @@ class AutotoolsPlugin(PluginV2):
                     "items": {"type": "string"},
                     "default": [],
                 },
-                "autotools-configure-env-variables": {
+                "autotools-configure-environment": {
                     "type": "array",
                     "uniqueItems": True,
                     "items": {"type": "string"},
@@ -78,7 +78,7 @@ class AutotoolsPlugin(PluginV2):
 
     def _get_configure_command(self) -> str:
         cmd = ["CC=${SNAPCRAFT_ARCH_TRIPLET}-gcc"]
-        cmd += self.options.autotools_configure_env_variables
+        cmd += self.options.autotools_configure_environment
         cmd += ["./configure"]
         cmd += self.options.autotools_configure_parameters
         cmd.append("--host=${SNAPCRAFT_ARCH_TRIPLET}")

--- a/tests/unit/plugins/v2/test_autotools.py
+++ b/tests/unit/plugins/v2/test_autotools.py
@@ -28,7 +28,7 @@ def test_schema():
                 "items": {"type": "string"},
                 "default": [],
             },
-            "autotools-configure-env-variables": {
+            "autotools-configure-environment": {
                 "type": "array",
                 "uniqueItems": True,
                 "items": {"type": "string"},
@@ -59,7 +59,7 @@ def test_get_build_environment():
 def test_get_build_commands():
     class Options:
         autotools_configure_parameters = list()
-        autotools_configure_env_variables = list()
+        autotools_configure_environment = list()
 
     plugin = AutotoolsPlugin(part_name="my-part", options=Options())
 
@@ -76,7 +76,7 @@ def test_get_build_commands():
 def test_get_build_commands_with_configure_parameters():
     class Options:
         autotools_configure_parameters = ["--with-foo=true", "--prefix=/foo"]
-        autotools_configure_env_variables = ["FOO=BAR", "BAR=FOO"]
+        autotools_configure_environment = ["FOO=BAR", "BAR=FOO"]
 
     plugin = AutotoolsPlugin(part_name="my-part", options=Options())
 

--- a/tests/unit/plugins/v2/test_autotools.py
+++ b/tests/unit/plugins/v2/test_autotools.py
@@ -27,7 +27,13 @@ def test_schema():
                 "uniqueItems": True,
                 "items": {"type": "string"},
                 "default": [],
-            }
+            },
+            "autotools-configure-env-variables": {
+                "type": "array",
+                "uniqueItems": True,
+                "items": {"type": "string"},
+                "default": [],
+            },
         },
     }
 
@@ -53,6 +59,7 @@ def test_get_build_environment():
 def test_get_build_commands():
     class Options:
         autotools_configure_parameters = list()
+        autotools_configure_env_variables = list()
 
     plugin = AutotoolsPlugin(part_name="my-part", options=Options())
 
@@ -60,7 +67,7 @@ def test_get_build_commands():
         "[ ! -f ./configure ] && [ -f ./autogen.sh ] && env NOCONFIGURE=1 ./autogen.sh",
         "[ ! -f ./configure ] && [ -f ./bootstrap ] && env NOCONFIGURE=1 ./bootstrap",
         "[ ! -f ./configure ] && autoreconf --install",
-        "./configure",
+        "CC=${SNAPCRAFT_ARCH_TRIPLET}-gcc ./configure --host=${SNAPCRAFT_ARCH_TRIPLET}",
         'make -j"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
         'make install DESTDIR="${SNAPCRAFT_PART_INSTALL}"',
     ]
@@ -69,6 +76,7 @@ def test_get_build_commands():
 def test_get_build_commands_with_configure_parameters():
     class Options:
         autotools_configure_parameters = ["--with-foo=true", "--prefix=/foo"]
+        autotools_configure_env_variables = ["FOO=BAR", "BAR=FOO"]
 
     plugin = AutotoolsPlugin(part_name="my-part", options=Options())
 
@@ -76,7 +84,7 @@ def test_get_build_commands_with_configure_parameters():
         "[ ! -f ./configure ] && [ -f ./autogen.sh ] && env NOCONFIGURE=1 ./autogen.sh",
         "[ ! -f ./configure ] && [ -f ./bootstrap ] && env NOCONFIGURE=1 ./bootstrap",
         "[ ! -f ./configure ] && autoreconf --install",
-        "./configure --with-foo=true --prefix=/foo",
+        "CC=${SNAPCRAFT_ARCH_TRIPLET}-gcc FOO=BAR BAR=FOO ./configure --with-foo=true --prefix=/foo --host=${SNAPCRAFT_ARCH_TRIPLET}",
         'make -j"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
         'make install DESTDIR="${SNAPCRAFT_PART_INSTALL}"',
     ]


### PR DESCRIPTION
Adding minimal cross compilation support for autotools v2 plugin

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
