### PR TITLE
dotnet plugin: use https for release metadata url

### DIFF
--- a/snapcraft/plugins/v1/dotnet.py
+++ b/snapcraft/plugins/v1/dotnet.py
@@ -41,7 +41,7 @@ from snapcraft import formatting_utils, sources
 from snapcraft.internal import errors
 from snapcraft.plugins.v1 import PluginV1
 
-_DOTNET_RELEASE_METADATA_URL = "http://dotnetcli.blob.core.windows.net/dotnet/release-metadata/{version}/releases.json"  # noqa
+_DOTNET_RELEASE_METADATA_URL = "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/{version}/releases.json"  # noqa
 _RUNTIME_DEFAULT = "2.0.9"
 _VERSION_DEFAULT = "2.0"
 


### PR DESCRIPTION
HTTP is no longer accessible.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
