### PR TITLE
project: validate snapcraft yaml before using it

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -369,6 +369,11 @@ def get_project(*, is_managed_host: bool = False, **kwargs):
         snapcraft_yaml_file_path=snapcraft_yaml_file_path,
         is_managed_host=is_managed_host,
     )
+
+    # Validate yaml info from schema prior to consumption.
+    if project.info is not None:
+        project.info.validate_raw_snapcraft()
+
     # TODO: this should be automatic on get_project().
     # This is not the complete meta parsed by the project loader.
     project._snap_meta = Snap.from_dict(project.info.get_raw_snapcraft())


### PR DESCRIPTION
Multiple places utilize the yaml before it gets checked by
conduct_project_sanity_check().  Instead of requiring the
sanity check, verify it before returning the Project object
in get_project().  The sanity checks can occur later as well.

(1) Config may use it to apply extensions on broken yaml.

(2) Snap meta assumptions may break when unmarshaling
    because the JSON schema check hasn't yet happened.

LP: 1853682
CRAFT-55

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
