### PR TITLE
apt cache: improve error handling when packages do not have candidates available (CRAFT-136) (CRAFT-218)

### DIFF
--- a/snapcraft/internal/repo/apt_cache.py
+++ b/snapcraft/internal/repo/apt_cache.py
@@ -265,7 +265,7 @@ class AptCache(ContextDecorator):
         skipped_essential = set()
         skipped_filtered = set()
 
-        for package in self.cache:
+        for package in self.cache.get_changes():
             if package.candidate is None:
                 raise errors.PackageNotFoundError(package.name)
 

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -16,6 +16,7 @@
 
 from typing import List, Optional, Sequence
 
+from snapcraft import formatting_utils
 from snapcraft.internal import errors
 from snapcraft.internal.errors import SnapcraftException
 from snapcraft.internal.os_release import OsRelease
@@ -115,6 +116,18 @@ class PackageNotFoundError(RepoError):
 
     def __str__(self):
         return self.message
+
+
+class PackagesNotFoundError(SnapcraftException):
+    def __init__(self, packages: List[str]) -> None:
+        self.packages = packages
+
+    def get_brief(self) -> str:
+        missing_pkgs = formatting_utils.humanize_list(self.packages, "and")
+        return f"Failed to find installation candidate for packages: {missing_pkgs}"
+
+    def get_resolution(self) -> str:
+        return "Verify APT repository configuration and package names are correct."
 
 
 class UnpackError(RepoError):

--- a/tests/spread/general/xenial-without-ua-token/snaps/xenial-test/snap/snapcraft.yaml
+++ b/tests/spread/general/xenial-without-ua-token/snaps/xenial-test/snap/snapcraft.yaml
@@ -1,0 +1,16 @@
+name: xenial-test
+version: "1.0"
+summary: Quick snap to ensure packages work in ESM
+description: Quick snap to ensure packages work in ESM
+
+base: core
+grade: devel
+confinement: strict
+
+parts:
+  part1:
+    plugin: nil
+    stage-packages:
+      - tree
+    build-packages:
+      - tree

--- a/tests/spread/general/xenial-without-ua-token/task.yaml
+++ b/tests/spread/general/xenial-without-ua-token/task.yaml
@@ -1,0 +1,33 @@
+summary: Verify latest Xenial ESM w/o token
+
+systems: [ubuntu-16*]
+
+environment:
+  SNAP_DIR: snaps/xenial-test
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+
+  cd "$SNAP_DIR"
+  set_base "snap/snapcraft.yaml"
+
+  # Install UA tools without attaching.
+  apt-get update
+  apt-get -y dist-upgrade
+  apt-get install -y ubuntu-advantage-tools
+
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "$SNAP_DIR"
+
+  snapcraft

--- a/tests/unit/repo/test_errors.py
+++ b/tests/unit/repo/test_errors.py
@@ -149,3 +149,35 @@ class TestAptGPGKeyInstallError:
         assert exception.get_details() == expected_details
         assert exception.get_docs_url() == expected_docs_url
         assert exception.get_reportable() == expected_reportable
+
+
+def test_packages_not_found_error():
+    exception = errors.PackagesNotFoundError(["foo"])
+
+    assert (
+        exception.get_brief()
+        == "Failed to find installation candidate for packages: 'foo'"
+    )
+    assert (
+        exception.get_resolution()
+        == "Verify APT repository configuration and package names are correct."
+    )
+    assert exception.get_details() is None
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False
+
+
+def test_multiple_packages_not_found_error():
+    exception = errors.PackagesNotFoundError(["foo", "foo2", "foo3"])
+
+    assert (
+        exception.get_brief()
+        == "Failed to find installation candidate for packages: 'foo', 'foo2', and 'foo3'"
+    )
+    assert (
+        exception.get_resolution()
+        == "Verify APT repository configuration and package names are correct."
+    )
+    assert exception.get_details() is None
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False


### PR DESCRIPTION
(1) Add some checks to ensure package.candidate is not None before using
it.  If it is None, when expected to not be None, raise a
PackageNotFoundError with the name of the package in question.

(2) Do not iterate over all packages when unmarking.  This is the cause of
https://forum.snapcraft.io/t/snapcraft-crash-when-esm-repositories-are-present/24587/8
where a package was being inspected that did not have an available candidate,
causing Snapcraft to fail unnecessarily.

Fixes SNAPCRAFT-2NE
Fixes SNAPCRAFT-2H2
Fixes SNAPCRAFT-2BC
Fixes SNAPCRAFT-277
Fixes SNAPCRAFT-263
Fixes SNAPCRAFT-1R4
Fixes SNAPCRAFT-1Q5
Fixes SNAPCRAFT-1DH
    
Fixes a comment in unrelated bug report: LP: #1853682

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
