### PR TITLE
repo: normalize if stage-packages and check types (CRAFT-222)

### DIFF
--- a/snapcraft/internal/repo/_base.py
+++ b/snapcraft/internal/repo/_base.py
@@ -253,7 +253,7 @@ class BaseRepo:
                 elif os.path.exists(path):
                     _fix_filemode(path)
 
-                if path.endswith(".pc") and not os.path.islink(path):
+                if path.endswith(".pc") and os.path.isfile(path) and not os.path.islink(path):
                     fix_pkg_config(unpackdir, path)
 
     @classmethod

--- a/snapcraft/internal/repo/_base.py
+++ b/snapcraft/internal/repo/_base.py
@@ -253,7 +253,11 @@ class BaseRepo:
                 elif os.path.exists(path):
                     _fix_filemode(path)
 
-                if path.endswith(".pc") and os.path.isfile(path) and not os.path.islink(path):
+                if (
+                    path.endswith(".pc")
+                    and os.path.isfile(path)
+                    and not os.path.islink(path)
+                ):
                     fix_pkg_config(unpackdir, path)
 
     @classmethod

--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -475,7 +475,12 @@ class Ubuntu(BaseRepo):
     def unpack_stage_packages(
         cls, *, stage_packages_path: pathlib.Path, install_path: pathlib.Path
     ) -> None:
-        for pkg_path in stage_packages_path.glob("*.deb"):
+        stage_packages = stage_packages_path.glob("*.deb")
+
+        if not stage_packages:
+            return
+
+        for pkg_path in stage_packages:
             with tempfile.TemporaryDirectory(suffix="deb-extract") as extract_dir:
                 # Extract deb package.
                 cls._extract_deb(pkg_path, extract_dir)

--- a/tests/spread/general/stage-snaps-normalization/task.yaml
+++ b/tests/spread/general/stage-snaps-normalization/task.yaml
@@ -1,0 +1,39 @@
+summary: "Correct behavior for stage-snaps when used with the pc snap"
+
+systems:
+  - ubuntu-18.04-64
+  - ubuntu-18.04-amd64
+  - ubuntu-20.04-64
+  - ubuntu-20.04-amd64
+
+environment:
+  STAGE_PACKAGES/none: ""
+  STAGE_PACKAGES/hello: "hello"
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+
+  snapcraft init
+  set_base "snap/snapcraft.yaml"
+  
+  if [[ "$SPREAD_SYSTEM" =~ ubuntu-20.04 ]]; then
+    PC_TRACK="20"
+  elif [[ "$SPREAD_SYSTEM" =~ ubuntu-18.04 ]]; then
+    PC_TRACK="18"
+  else
+    exit 1
+  fi
+
+  echo "    stage-snaps: [pc/${PC_TRACK}/stable]" >> snap/snapcraft.yaml
+
+  if [ -n "${STAGE_PACKAGES}" ]; then
+    echo "    stage-packages: [$STAGE_PACKAGES]" >> snap/snapcraft.yaml
+  fi
+
+restore: |
+  snapcraft clean
+  rm -rf snap
+
+execute: |
+  snapcraft build

--- a/tests/unit/repo/test_base.py
+++ b/tests/unit/repo/test_base.py
@@ -258,6 +258,15 @@ class FixPkgConfigTestCase(RepoBaseTestCase):
 
         self.assertThat(pc_file, FileContains(expected_pc_file_content))
 
+    def test_skip_directories_matching_pc(self):
+        snap_pc_dir = os.path.join(self.tempdir, "snap.pc")
+
+        os.mkdir(snap_pc_dir)
+
+        # Verify the directory is not passed to fileinput, which would
+        # try to file copy snap.pc to snap.pc.bak for the inplace replace.
+        BaseRepo.normalize(self.tempdir)
+
 
 class TestFixSymlinks(RepoBaseTestCase):
     def assert_fix(self, src, dst):


### PR DESCRIPTION
Normalization takes place across the entire working tree for a part.
As a side effect, files that are not part of stage-packages are also
normalized, for that matter, stage-snaps, as those are unpacked first.

When considering the pc snap, Snapcraft creates a snap.pc to correctly
namespace the snaps snap directory. The .pc artifact fixes does not
filter on file type, fileinput is used for the fixup and internally
creates a .bak file as a backup which fails as snap.pc is a directory
and not a file.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
