### PR TITLE
build providers: update brew installation (CRAFT-268)

### DIFF
--- a/snapcraft/internal/build_providers/_multipass/_multipass_command.py
+++ b/snapcraft/internal/build_providers/_multipass/_multipass_command.py
@@ -118,12 +118,12 @@ class MultipassCommand:
             repo.snaps.install_snaps(["multipass/latest/stable"])
         elif platform == "darwin":
             try:
-                subprocess.check_call(["brew", "cask", "install", "multipass"])
+                subprocess.check_call(["brew", "install", "multipass"])
             except subprocess.CalledProcessError:
                 raise SnapcraftEnvironmentError(
                     "Failed to install multipass using homebrew.\n"
                     "Verify your homebrew installation and try again.\n"
-                    "Alternatively, manually install multipass by running 'brew cask install multipass'."
+                    "Alternatively, manually install multipass by running 'brew install multipass'."
                 )
         elif platform == "win32":
             windows_install_multipass(echoer)

--- a/tests/unit/build_providers/multipass/test_multipass_command.py
+++ b/tests/unit/build_providers/multipass/test_multipass_command.py
@@ -129,9 +129,7 @@ class MultipassCommandSetupMultipassTest(MultipassCommandBaseTest):
     def test_darwin(self):
         MultipassCommand.setup_multipass(platform="darwin", echoer=self.echoer_mock)
 
-        self.check_call_mock.assert_called_once_with(
-            ["brew", "cask", "install", "multipass"]
-        )
+        self.check_call_mock.assert_called_once_with(["brew", "install", "multipass"])
         self.echoer_mock.wrapped.assert_called_once_with("Waiting for multipass...")
 
     def test_unkown_platform_raises(self):


### PR DESCRIPTION
"brew cask install" no longer works.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
