### PR TITLE
store: whoami schema fix

### DIFF
--- a/snapcraft/storeapi/v2/_api_schema.py
+++ b/snapcraft/storeapi/v2/_api_schema.py
@@ -402,19 +402,14 @@ WHOAMI_JSONSCHEMA: Dict[str, Any] = {
         "packages": {
             "oneOf": [
                 {
-                    "description": 'A list of packages to restrict the macaroon to. Those can be defined in two ways: 1- by name: each item in the list should be a json dict like `{"name": "the-name"}`, or 2- by snap_id: each item in the list should be a json dict like `{"snap_id": "some-snap-id-1234"}`.',
+                    "type": "array",
                     "items": {
-                        "anyOf": [{"required": ["snap_id"]}, {"required": ["name"]}],
-                        "description": "Package identifier: a dict with at least name or snap_id keys.",
-                        "properties": {
-                            "name": {"type": "string"},
-                            "snap_id": {"type": "string"},
-                        },
-                        "type": "object",
+                        "type": "string",
+                        "description": "Package identifier (snap_id).",
                     },
                     "minItems": 1,
-                    "type": "array",
                     "uniqueItems": True,
+                    "description": "A list of snap_ids to restrict the macaroon to.",
                 },
                 {"type": "null"},
             ]


### PR DESCRIPTION
The schema was incorrect, causing errors when package names were scoped
in the permissions e.g.; reproduced with something like

    snapcraft export-login --snaps <snap-name> login-creds && \
    snapcraft login --with login-creds && \
    snapcraft whoami

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
