### PR TITLE
plugins: add crystal v2 plugin

### DIFF
--- a/snapcraft/internal/pluginhandler/_part_environment.py
+++ b/snapcraft/internal/pluginhandler/_part_environment.py
@@ -63,6 +63,14 @@ def get_snapcraft_global_environment(
     else:
         grade = ""
 
+    content_dirs = project._get_provider_content_dirs()
+    if content_dirs:
+        content_dirs_envvar = formatting_utils.combine_paths(
+            content_dirs, prepend="", separator=":"
+        )
+    else:
+        content_dirs_envvar = ""
+
     return {
         "SNAPCRAFT_ARCH_TRIPLET": project.arch_triplet,
         "SNAPCRAFT_EXTENSIONS_DIR": common.get_extensionsdir(),
@@ -74,6 +82,7 @@ def get_snapcraft_global_environment(
         "SNAPCRAFT_PROJECT_GRADE": grade,
         "SNAPCRAFT_STAGE": project.stage_dir,
         "SNAPCRAFT_TARGET_ARCH": project.target_arch,
+        "SNAPCRAFT_CONTENT_DIRS": content_dirs_envvar,
     }
 
 

--- a/snapcraft/plugins/_plugin_finder.py
+++ b/snapcraft/plugins/_plugin_finder.py
@@ -63,6 +63,7 @@ if sys.platform == "linux" or TYPE_CHECKING:
             "cmake": v2.CMakePlugin,
             "colcon": v2.ColconPlugin,
             "conda": v2.CondaPlugin,
+            "crystal": v2.CrystalPlugin,
             "dump": v2.DumpPlugin,
             "go": v2.GoPlugin,
             "make": v2.MakePlugin,

--- a/snapcraft/plugins/v2/__init__.py
+++ b/snapcraft/plugins/v2/__init__.py
@@ -26,6 +26,7 @@ if sys.platform == "linux":
     from .cmake import CMakePlugin  # noqa: F401
     from .colcon import ColconPlugin  # noqa: F401
     from .conda import CondaPlugin  # noqa: F401
+    from .crystal import CrystalPlugin  # noqa: F401
     from .dump import DumpPlugin  # noqa: F401
     from .go import GoPlugin  # noqa: F401
     from .make import MakePlugin  # noqa: F401

--- a/snapcraft/plugins/v2/crystal.py
+++ b/snapcraft/plugins/v2/crystal.py
@@ -1,0 +1,187 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Manas.Tech
+# License granted by Canonical Limited
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The Crystal plugin can be used for Crystal projects using `shards`.
+
+This plugin uses the common plugin keywords as well as those for "sources".
+For more information check the 'plugins' topic for the former and the
+'sources' topic for the latter.
+
+Additionally, this plugin uses the following plugin-specific keywords:
+
+    - crystal-channel:
+      (string, default: latest/stable)
+      The Snap Store channel to install Crystal from.
+
+    - crystal-build-options
+      (list of strings, default: '[]')
+      These options are passed to `shards build`.
+"""
+import os
+import shlex
+import shutil
+import sys
+from typing import Any, Dict, List, Set
+
+import click
+
+from snapcraft import file_utils
+from snapcraft.internal import common, elf, errors
+
+from snapcraft.plugins.v2 import PluginV2
+
+_CRYSTAL_CHANNEL = "latest/stable"
+
+
+class CrystalPlugin(PluginV2):
+    @classmethod
+    def get_schema(cls) -> Dict[str, Any]:
+        return {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "crystal-channel": {"type": "string", "default": _CRYSTAL_CHANNEL},
+                "crystal-build-options": {
+                    "type": "array",
+                    "uniqueItems": True,
+                    "items": {"type": "string"},
+                    "default": [],
+                },
+            },
+            "required": ["source"],
+        }
+
+    def get_build_snaps(self) -> Set[str]:
+        return {f"crystal/{self.options.crystal_channel}"}
+
+    def get_build_packages(self) -> Set[str]:
+        # See https://github.com/crystal-lang/distribution-scripts/blob/8bc01e26291dc518390129e15df8f757d687871c/docker/ubuntu.Dockerfile#L9
+        return {
+            "git",
+            "make",
+            "gcc",
+            "pkg-config",
+            "libssl-dev",
+            "libxml2-dev",
+            "libyaml-dev",
+            "libgmp-dev",
+            "libpcre3-dev",
+            "libevent-dev",
+            "libz-dev",
+        }
+
+    def get_build_environment(self) -> Dict[str, str]:
+        return dict()
+
+    def get_build_commands(self) -> List[str]:
+        if self.options.crystal_build_options:
+            build_options = " ".join(
+                [shlex.quote(option) for option in self.options.crystal_build_options]
+            )
+        else:
+            build_options = ""
+
+        env = dict(LANG="C.UTF-8", LC_ALL="C.UTF-8")
+        env_flags = [f"{key}={value}" for key, value in env.items()]
+
+        return [
+            f"shards build --without-development {build_options}",
+            'cp -r ./bin "${SNAPCRAFT_PART_INSTALL}"/bin',
+            " ".join(
+                [
+                    "env",
+                    "-i",
+                    *env_flags,
+                    sys.executable,
+                    "-I",
+                    os.path.abspath(__file__),
+                    "stage-runtime-dependencies",
+                    "--part-src",
+                    '"${SNAPCRAFT_PART_SRC}"',
+                    "--part-install",
+                    '"${SNAPCRAFT_PART_INSTALL}"',
+                    "--part-build",
+                    '"${SNAPCRAFT_PART_BUILD}"',
+                    "--arch-triplet",
+                    '"${SNAPCRAFT_ARCH_TRIPLET}"',
+                    "--content-dirs",
+                    '"${SNAPCRAFT_CONTENT_DIRS}"',
+                ]
+            ),
+        ]
+
+
+@click.group()
+def plugin_cli():
+    pass
+
+
+@plugin_cli.command()
+@click.option("--part-src", envvar="SNAPCRAFT_PART_SRC", required=True)
+@click.option("--part-install", envvar="SNAPCRAFT_PART_INSTALL", required=True)
+@click.option("--part-build", envvar="SNAPCRAFT_PART_BUILD", required=True)
+@click.option("--arch-triplet", envvar="SNAPCRAFT_ARCH_TRIPLET", required=True)
+@click.option("--content-dirs", envvar="SNAPCRAFT_CONTENT_DIRS", required=True)
+def stage_runtime_dependencies(
+    part_src: str,
+    part_install: str,
+    part_build: str,
+    arch_triplet: str,
+    content_dirs: str,
+):
+    build_path = os.path.join(part_build, "bin")
+    install_path = os.path.join(part_install, "bin")
+
+    if not os.path.exists(build_path):
+        raise errors.SnapcraftEnvironmentError(
+            "No binaries were built. Ensure the shards.yaml contains valid targets."
+        )
+
+    bin_paths = (os.path.join(build_path, b) for b in os.listdir(build_path))
+    elf_files = (elf.ElfFile(path=b) for b in bin_paths if elf.ElfFile.is_elf(b))
+    os.makedirs(install_path, exist_ok=True)
+
+    # convert colon-delimited paths into a set
+    if content_dirs == "":
+        content_dirs_set = set()
+    else:
+        content_dirs_set = set(content_dirs.split(":"))
+
+    for elf_file in elf_files:
+        shutil.copy2(
+            elf_file.path, os.path.join(install_path, os.path.basename(elf_file.path)),
+        )
+
+        elf_dependencies_path = elf_file.load_dependencies(
+            root_path=part_install,
+            core_base_path=common.get_installed_snap_path("core20"),
+            arch_triplet=arch_triplet,
+            content_dirs=content_dirs_set,
+        )
+
+        for elf_dependency_path in elf_dependencies_path:
+            lib_install_path = os.path.join(part_install, elf_dependency_path[1:])
+            os.makedirs(os.path.dirname(lib_install_path), exist_ok=True)
+            if not os.path.exists(lib_install_path):
+                file_utils.link_or_copy(
+                    elf_dependency_path, lib_install_path, follow_symlinks=True
+                )
+
+
+if __name__ == "__main__":
+    plugin_cli()

--- a/tests/spread/plugins/v2/build-and-run-hello/task.yaml
+++ b/tests/spread/plugins/v2/build-and-run-hello/task.yaml
@@ -9,6 +9,7 @@ environment:
   SNAP/cmake_ninja: cmake-hello-ninja
   SNAP/cmake_subdir: cmake-hello-subdir
   SNAP/conda: conda-hello
+  SNAP/crystal: crystal-hello
   SNAP/make: make-hello
   SNAP/local_plugin_from_base: local-plugin-from-base-hello
   SNAP/local_plugin_from_nil: local-plugin-from-nil-hello
@@ -51,6 +52,7 @@ restore: |
   [ -f src/hello.cpp ] && git checkout src/hello.cpp
   [ -f src/main.rs ] && git checkout src/main.rs
   [ -f lib/src/lib.rs ] && git checkout lib/src/lib.rs
+  [ -f hello.cr ] && git checkout hello.cr
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
@@ -87,6 +89,8 @@ execute: |
     modified_file=src/main.rs
   elif [ -f say/src/lib.rs ]; then
     modified_file=say/src/lib.rs
+  elif [ -f hello.cr ]; then
+    modified_file=hello.cr
   else
     FATAL "Cannot setup ${SNAP} for rebuilding"
   fi

--- a/tests/spread/plugins/v2/snaps/crystal-hello/hello.cr
+++ b/tests/spread/plugins/v2/snaps/crystal-hello/hello.cr
@@ -1,0 +1,1 @@
+puts "hello world"

--- a/tests/spread/plugins/v2/snaps/crystal-hello/shard.lock
+++ b/tests/spread/plugins/v2/snaps/crystal-hello/shard.lock
@@ -1,0 +1,2 @@
+version: 2.0
+shards: {}

--- a/tests/spread/plugins/v2/snaps/crystal-hello/shard.yml
+++ b/tests/spread/plugins/v2/snaps/crystal-hello/shard.yml
@@ -1,0 +1,6 @@
+name: hello
+version: 0.1.0
+
+targets:
+  hello:
+    main: hello.cr

--- a/tests/spread/plugins/v2/snaps/crystal-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/crystal-hello/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: crystal-hello
+version: "1.0"
+summary: test the crystal plugin
+description: |
+  This is a basic crystal snap. It just prints a hello world.
+  If you want to add other functionalities to this snap, please don't.
+  Make a new one.
+
+grade: devel
+base: core20
+confinement: strict
+
+apps:
+  crystal-hello:
+    command: bin/hello
+
+parts:
+  hello:
+    plugin: crystal
+    source: .

--- a/tests/unit/plugins/v2/test_crystal.py
+++ b/tests/unit/plugins/v2/test_crystal.py
@@ -1,0 +1,140 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2020 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+
+from testtools import TestCase
+from testtools.matchers import Equals
+
+import snapcraft.plugins.v2.crystal as crystal
+from snapcraft.plugins.v2.crystal import CrystalPlugin
+
+
+class CrystalPluginTest(TestCase):
+    def test_schema(self):
+        self.assertThat(
+            CrystalPlugin.get_schema(),
+            Equals(
+                {
+                    "$schema": "http://json-schema.org/draft-04/schema#",
+                    "additionalProperties": False,
+                    "type": "object",
+                    "properties": {
+                        "crystal-channel": {
+                            "type": "string",
+                            "default": "latest/stable",
+                        },
+                        "crystal-build-options": {
+                            "type": "array",
+                            "uniqueItems": True,
+                            "items": {"type": "string"},
+                            "default": [],
+                        },
+                    },
+                    "required": ["source"],
+                }
+            ),
+        )
+
+    def test_get_build_snaps(self):
+        class Options:
+            crystal_channel = "latest/edge"
+
+        self.assertThat(
+            CrystalPlugin(part_name="my-part", options=Options()).get_build_snaps(),
+            Equals({"crystal/latest/edge"}),
+        )
+
+    def test_get_build_packages(self):
+        self.assertThat(
+            CrystalPlugin(
+                part_name="my-part", options=lambda: None
+            ).get_build_packages(),
+            Equals(
+                {
+                    "git",
+                    "make",
+                    "gcc",
+                    "pkg-config",
+                    "libssl-dev",
+                    "libxml2-dev",
+                    "libyaml-dev",
+                    "libgmp-dev",
+                    "libpcre3-dev",
+                    "libevent-dev",
+                    "libz-dev",
+                }
+            ),
+        )
+
+    def test_get_build_environment(self):
+        self.assertThat(
+            CrystalPlugin(
+                part_name="my-part", options=lambda: None
+            ).get_build_environment(),
+            Equals(dict()),
+        )
+
+
+def test_get_build_commands(monkeypatch):
+    class Options:
+        crystal_channel = "latest/stable"
+        crystal_build_options = []
+
+    monkeypatch.setattr(sys, "path", ["", "/test"])
+    monkeypatch.setattr(sys, "executable", "/test/python3")
+    monkeypatch.setattr(crystal, "__file__", "/test/crystal.py")
+    monkeypatch.setattr(os, "environ", dict())
+
+    plugin = CrystalPlugin(part_name="my-part", options=Options())
+
+    assert plugin.get_build_commands() == [
+        "shards build --without-development ",
+        'cp -r ./bin "${SNAPCRAFT_PART_INSTALL}"/bin',
+        "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 /test/python3 -I /test/crystal.py "
+        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC}" --part-install '
+        '"${SNAPCRAFT_PART_INSTALL}" --part-build "${SNAPCRAFT_PART_BUILD}" '
+        '--arch-triplet "${SNAPCRAFT_ARCH_TRIPLET}" --content-dirs '
+        '"${SNAPCRAFT_CONTENT_DIRS}"',
+    ]
+
+
+def test_get_build_commands_with_build_options(monkeypatch):
+    class Options:
+        crystal_channel = "latest/stable"
+        crystal_build_options = [
+            "--release",
+            "--static",
+            "--link-flags=-s -wl,-z,relro,-z,now",
+        ]
+
+    monkeypatch.setattr(sys, "path", ["", "/test"])
+    monkeypatch.setattr(sys, "executable", "/test/python3")
+    monkeypatch.setattr(crystal, "__file__", "/test/crystal.py")
+    monkeypatch.setattr(os, "environ", dict())
+
+    plugin = CrystalPlugin(part_name="my-part", options=Options())
+
+    assert plugin.get_build_commands() == [
+        "shards build --without-development --release --static '--link-flags=-s -wl,-z,relro,-z,now'",
+        'cp -r ./bin "${SNAPCRAFT_PART_INSTALL}"/bin',
+        "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 /test/python3 -I /test/crystal.py "
+        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC}" --part-install '
+        '"${SNAPCRAFT_PART_INSTALL}" --part-build "${SNAPCRAFT_PART_BUILD}" '
+        '--arch-triplet "${SNAPCRAFT_ARCH_TRIPLET}" --content-dirs '
+        '"${SNAPCRAFT_CONTENT_DIRS}"',
+    ]

--- a/tests/unit/project_loader/test_environment.py
+++ b/tests/unit/project_loader/test_environment.py
@@ -225,6 +225,7 @@ class EnvironmentTest(ProjectLoaderBaseTest):
                     'SNAPCRAFT_ARCH_TRIPLET="{}"'.format(
                         project_config.project.arch_triplet
                     ),
+                    'SNAPCRAFT_CONTENT_DIRS=""',
                     'SNAPCRAFT_EXTENSIONS_DIR="{}"'.format(common.get_extensionsdir()),
                     'SNAPCRAFT_PARALLEL_BUILD_COUNT="2"',
                     'SNAPCRAFT_PART_BUILD="{}/parts/main/build"'.format(self.path),
@@ -437,6 +438,20 @@ class EnvironmentTest(ProjectLoaderBaseTest):
         project_config = self.make_snapcraft_project(self.snapcraft_yaml)
         env = project_config.parts.build_env_for_part(project_config.parts.all_parts[0])
         self.assertThat(env, Contains('SNAPCRAFT_PROJECT_DIR="{}"'.format(self.path)))
+
+    def test_content_dirs_default(self):
+        project_config = self.make_snapcraft_project(self.snapcraft_yaml)
+        env = project_config.parts.build_env_for_part(project_config.parts.all_parts[0])
+        self.assertThat(env, Contains('SNAPCRAFT_CONTENT_DIRS=""'))
+
+    @mock.patch(
+        "snapcraft.project._project.Project._get_provider_content_dirs",
+        return_value=sorted({"/tmp/test1", "/tmp/test2"}),
+    )
+    def test_content_dirs(self, mock_get_content_dirs):
+        project_config = self.make_snapcraft_project(self.snapcraft_yaml)
+        env = project_config.parts.build_env_for_part(project_config.parts.all_parts[0])
+        self.assertThat(env, Contains('SNAPCRAFT_CONTENT_DIRS="/tmp/test1:/tmp/test2"'))
 
     def test_build_environment(self):
         self.useFixture(FakeOsRelease())


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Initial implementation of a v2 Crystal plugin.  Manually tested by loading in the changes as a local plugin and build a Crystal shard via snap.

> **NOTE:** You'll need to name the local plugin `PluginImpl` instead of `CrystalPlugin`

@mamantoha If you could test with your project that would be 💯.

Some things that still need handled:

- [ ] I'm not sure how to replicate the [elf](https://github.com/snapcore/snapcraft/blob/master/snapcraft/plugins/v1/crystal.py#L111-L133) stuff in the v1 plugin given there isn't a place to run arbitrary code like that after build?  Maybe @bcardiff would have an idea?
- [x] Is there a better way to move the built binaries than just `cp`?
  * Ideally we update it once https://github.com/crystal-lang/shards/issues/518 is implemented/released
- [x] Do I need to write a `spread` test for the v2 plugin?  I didn't see one for `go` or `rust` so I didn't bother...

(CRAFT-823)