### PR TITLE
schema: add "microk8s" to the list of allowed system users

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -519,7 +519,7 @@
             "additionalProperties": false,
             "validation-failure": "{!r} is not a valid system-username.",
             "patternProperties": {
-                "^snap_daemon$": {
+                "^snap_(daemon|microk8s)$": {
                     "oneOf": [
                         {
                             "$ref": "#/definitions/system-username-scope"

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -1180,130 +1180,43 @@ def test_invalid_command_chain(data, command_chain):
     assert expected_message in str(error.value)
 
 
-class SystemUsernamesTests(ProjectBaseTest):
-    @pytest.mark.parametrize("username", ["snap_daemon", "snap_microk8s"])
-    def test_yaml_valid_system_usernames_long(self, username):
-        self.assertValidationPasses(
-            dedent(
-                """\
-                name: test
-                base: core18
-                version: "1"
-                summary: test
-                description: nothing
-                license: MIT
-                parts:
-                  part1:
-                    plugin: nil
-                system-usernames:
-                  {}:
-                    scope: shared
-                """.format(
-                    username
-                )
-            )
-        )
+@pytest.mark.parametrize("username", ["snap_daemon", "snap_microk8s"])
+def test_yaml_valid_system_usernames_long(data, username):
+    data["system-usernames"] = {username: {"scope": "shared"}}
+    Validator(data).validate()
 
-    @pytest.mark.parametrize("username", ["snap_daemon", "snap_microk8s"])
-    def test_yaml_valid_system_usernames_short(self, username):
-        self.assertValidationPasses(
-            dedent(
-                """\
-                name: test
-                base: core18
-                version: "1"
-                summary: test
-                description: nothing
-                license: MIT
-                parts:
-                  part1:
-                    plugin: nil
-                system-usernames:
-                  {}: shared
-                """.format(
-                    username
-                )
-            )
-        )
 
-    def test_invalid_yaml_invalid_username(self):
-        raised = self.assertValidationRaises(
-            dedent(
-                """\
-            name: test
-            base: core18
-            version: "1"
-            summary: test
-            description: nothing
-            license: MIT
-            parts:
-              part1:
-                plugin: nil
-            system-usernames:
-              snap_user: shared
-            """
-            )
-        )
+@pytest.mark.parametrize("username", ["snap_daemon", "snap_microk8s"])
+def test_yaml_valid_system_usernames_short(data, username):
+    data["system-usernames"] = {username: "shared"}
+    Validator(data).validate()
 
-        self.assertThat(
-            raised.message,
-            Equals(
-                "The 'system-usernames' property does not match the required schema: 'snap_user' is not a valid system-username."
-            ),
-        )
 
-    def test_invalid_yaml_invalid_short_scope(self):
-        raised = self.assertValidationRaises(
-            dedent(
-                """\
-            name: test
-            base: core18
-            version: "1"
-            summary: test
-            description: nothing
-            license: MIT
-            parts:
-              part1:
-                plugin: nil
-            system-usernames:
-              snap_daemon: invalid-scope
-            """
-            )
-        )
+def test_invalid_yaml_invalid_username(data):
+    data["system-usernames"] = {"snap_user": "shared"}
+    with pytest.raises(snapcraft.yaml_utils.errors.YamlValidationError) as error:
+        Validator(data).validate()
 
-        self.assertThat(
-            raised.message,
-            Equals(
-                "The 'system-usernames/snap_daemon' property does not match the required schema: 'invalid-scope' is not valid under any of the given schemas"
-            ),
-        )
+    expected_message = "The 'system-usernames' property does not match the required schema: 'snap_user' is not a valid system-username."
+    assert expected_message in str(error.value)
 
-    def test_invalid_yaml_invalid_long_scope(self):
-        raised = self.assertValidationRaises(
-            dedent(
-                """\
-            name: test
-            base: core18
-            version: "1"
-            summary: test
-            description: nothing
-            license: MIT
-            parts:
-              part1:
-                plugin: nil
-            system-usernames:
-              snap_daemon:
-                scope: invalid-scope
-            """
-            )
-        )
 
-        self.assertThat(
-            raised.message,
-            Equals(
-                "The 'system-usernames/snap_daemon' property does not match the required schema: OrderedDict([('scope', 'invalid-scope')]) is not valid under any of the given schemas"
-            ),
-        )
+def test_invalid_yaml_invalid_short_scope(data):
+    data["system-usernames"] = {"snap_daemon": "invalid-scope"}
+    with pytest.raises(snapcraft.yaml_utils.errors.YamlValidationError) as error:
+        Validator(data).validate()
+
+    expected_message = "The 'system-usernames/snap_daemon' property does not match the required schema: 'invalid-scope' is not valid under any of the given schemas"
+    assert expected_message in str(error.value)
+
+
+def test_invalid_yaml_invalid_long_scope(data):
+    data["system-usernames"] = {"snap_daemon": {"scope": "invalid-scope"}}
+    with pytest.raises(snapcraft.yaml_utils.errors.YamlValidationError) as error:
+        Validator(data).validate()
+
+    expected_message = "The 'system-usernames/snap_daemon' property does not match the required schema: {'scope': 'invalid-scope'} is not valid under any of the given schemas"
+    assert expected_message in str(error.value)
 
 
 class PackageManagement(ProjectBaseTest):

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -1181,7 +1181,8 @@ def test_invalid_command_chain(data, command_chain):
 
 
 class SystemUsernamesTests(ProjectBaseTest):
-    def test_yaml_valid_system_usernames_long(self):
+    @pytest.mark.parametrize("username", ["snap_daemon", "snap_microk8s"])
+    def test_yaml_valid_system_usernames_long(self, username):
         self.assertValidationPasses(
             dedent(
                 """\
@@ -1195,13 +1196,16 @@ class SystemUsernamesTests(ProjectBaseTest):
                   part1:
                     plugin: nil
                 system-usernames:
-                  snap_daemon:
+                  {}:
                     scope: shared
-                """
+                """.format(
+                    username
+                )
             )
         )
 
-    def test_yaml_valid_system_usernames_short(self):
+    @pytest.mark.parametrize("username", ["snap_daemon", "snap_microk8s"])
+    def test_yaml_valid_system_usernames_short(self, username):
         self.assertValidationPasses(
             dedent(
                 """\
@@ -1215,8 +1219,10 @@ class SystemUsernamesTests(ProjectBaseTest):
                   part1:
                     plugin: nil
                 system-usernames:
-                  snap_daemon: shared
-                """
+                  {}: shared
+                """.format(
+                    username
+                )
             )
         )
 


### PR DESCRIPTION
The code to create this user has [recently landed](https://github.com/snapcore/snapd/pull/10375) in snapd master. It will be most likely be released in 2.52, but for the time being it can be obtained by just installing snapd from the edge channel.

- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `./runtests.sh static`?
- [X] Have you successfully run `./runtests.sh tests/unit`?
