### PR TITLE
update kde neon extension to use the newer content snap with qt-5-15-3

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/kde_neon.py
+++ b/snapcraft/internal/project_loader/_extensions/kde_neon.py
@@ -32,10 +32,10 @@ _Info = dict(
         build_snaps=["kde-frameworks-5-core18-sdk/latest/stable"],
     ),
     core20=_ExtensionInfo(
-        cmake_args="-DCMAKE_FIND_ROOT_PATH=/snap/kde-frameworks-5-qt-5-15-core20-sdk/current",
-        content="kde-frameworks-5-qt-5-15-core20-all",
-        provider="kde-frameworks-5-qt-5-15-core20",
-        build_snaps=["kde-frameworks-5-qt-5-15-core20-sdk/latest/candidate"],
+        cmake_args="-DCMAKE_FIND_ROOT_PATH=/snap/kde-frameworks-5-qt-5-15-3-core20-sdk/current",
+        content="kde-frameworks-5-qt-5-15-3-core20-all",
+        provider="kde-frameworks-5-qt-5-15-3-core20",
+        build_snaps=["kde-frameworks-5-qt-5-15-3-core20-sdk/latest/candidate"],
     ),
 )
 

--- a/tests/spread/extensions/kde-neon/task.yaml
+++ b/tests/spread/extensions/kde-neon/task.yaml
@@ -40,7 +40,7 @@ execute: |
     output="$(snapcraft --enable-experimental-extensions)"
     snap install neon-hello_*.snap --dangerous
     # This snap requires manual connection
-    snap connect neon-hello:kde-frameworks-5-plug kde-frameworks-5-qt-5-15-core20:kde-frameworks-5-qt-5-15-core20-slot
+    snap connect neon-hello:kde-frameworks-5-plug kde-frameworks-5-qt-5-15-3-core20:kde-frameworks-5-qt-5-15-3-core20-slot
   else
     output="$(snapcraft)"
     snap install neon-hello_*.snap --dangerous

--- a/tests/unit/project_loader/extensions/test_kde_neon.py
+++ b/tests/unit/project_loader/extensions/test_kde_neon.py
@@ -90,8 +90,8 @@ def test_extension_core20():
                 "target": "$SNAP/data-dir/icons",
             },
             "kde-frameworks-5-plug": {
-                "content": "kde-frameworks-5-qt-5-15-core20-all",
-                "default-provider": "kde-frameworks-5-qt-5-15-core20",
+                "content": "kde-frameworks-5-qt-5-15-3-core20-all",
+                "default-provider": "kde-frameworks-5-qt-5-15-3-core20",
                 "interface": "content",
                 "target": "$SNAP/kf5",
             },
@@ -109,14 +109,14 @@ def test_extension_core20():
     assert kde_neon_extension.part_snippet == {
         "build-environment": [
             {
-                "SNAPCRAFT_CMAKE_ARGS": "-DCMAKE_FIND_ROOT_PATH=/snap/kde-frameworks-5-qt-5-15-core20-sdk/current"
+                "SNAPCRAFT_CMAKE_ARGS": "-DCMAKE_FIND_ROOT_PATH=/snap/kde-frameworks-5-qt-5-15-3-core20-sdk/current"
             }
         ]
     }
     assert kde_neon_extension.parts == {
         "kde-neon-extension": {
             "build-packages": ["g++"],
-            "build-snaps": ["kde-frameworks-5-qt-5-15-core20-sdk/latest/candidate"],
+            "build-snaps": ["kde-frameworks-5-qt-5-15-3-core20-sdk/latest/candidate"],
             "make-parameters": ["PLATFORM_PLUG=kde-frameworks-5-plug"],
             "plugin": "make",
             "source": "$SNAPCRAFT_EXTENSIONS_DIR/desktop",


### PR DESCRIPTION
- [ X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ X] Have you successfully run `./runtests.sh static`?
- [ X] Have you successfully run `./runtests.sh tests/unit`?

-----

I created a new kde neon content snap because we updated the version of Qt we use and Qt is very fussy about using the same version everywhere.  