### PR TITLE
storeapi: log responses and registration error code

### DIFF
--- a/snapcraft/storeapi/_dashboard_api.py
+++ b/snapcraft/storeapi/_dashboard_api.py
@@ -47,7 +47,9 @@ class DashboardAPI(Requests):
 
     def _request(self, method: str, urlpath: str, **kwargs) -> requests.Response:
         url = urljoin(self._root_url, urlpath)
-        return self._auth_client.request(method, url, **kwargs)
+        response = self._auth_client.request(method, url, **kwargs)
+        logger.debug("Call to %s returned: %s", url, response.text)
+        return response
 
     def get_macaroon(
         self,

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -282,6 +282,8 @@ class StoreRegistrationError(StoreError):
 
     __FMT_INVALID = "{message}"
 
+    _FMT_CODE = "Registration failed ({code})."
+
     fmt = "Registration failed."
 
     __error_messages = {
@@ -311,13 +313,18 @@ class StoreRegistrationError(StoreError):
         if error_list is None:
             error_code = response_json.get("code")
             # we default to self.fmt in case error_code is not mapped yet.
-            fmt = self.__error_messages.get(error_code, self.fmt)
+            if error_code is not None:
+                fmt = self.__error_messages.get(error_code, self._FMT_CODE).format(
+                    **response_json
+                )
+            else:
+                fmt = self.fmt
             self._errors.append(fmt.format(**response_json))
             return
 
         # Support new style formatted errors.
         for error in error_list:
-            fmt = self.__error_messages.get(error["code"], self.fmt)
+            fmt = self.__error_messages.get(error["code"], self._FMT_CODE)
             # Augment 'error' with remaining top-level keys. Should be a
             # no-op once they are moved to their specific error record.
             error.update(response_json)

--- a/tests/fake_servers/api.py
+++ b/tests/fake_servers/api.py
@@ -798,7 +798,7 @@ class FakeStoreAPIServer(base.BaseFakeServer):
         )
 
     def _register_name_unclear_error(self):
-        payload = json.dumps({"status": 409, "code": "unexistent_error_code"}).encode()
+        payload = json.dumps({"status": 409, "code": "nonexistent_error_code"}).encode()
         response_code = 409
         content_type = "application/json"
         return response.Response(

--- a/tests/unit/store/test_store_client.py
+++ b/tests/unit/store/test_store_client.py
@@ -668,7 +668,9 @@ class RegisterTestCase(StoreTestCase):
             self.client.register,
             "snap-name-no-clear-error",
         )
-        self.assertThat(str(raised), Equals("Registration failed."))
+        self.assertThat(
+            str(raised), Equals("Registration failed (nonexistent_error_code).")
+        )
 
 
 class ValidationSetsTestCase(StoreTestCase):


### PR DESCRIPTION
All responses are now logged in debug mode (response.text) and the error
code is properly printed out on registration errors.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----

A very minimal change PR in case we need to cherry pick it to an older release