### PR TITLE
cli: make remote-build more user-friendly

### DIFF
--- a/snapcraft/cli/remote.py
+++ b/snapcraft/cli/remote.py
@@ -50,10 +50,6 @@ def remotecli():
 @click.option(
     "--launchpad-accept-public-upload",
     is_flag=True,
-    prompt=(
-        "All data sent to remote builders will be publicly available. "
-        "Are you sure you want to continue?"
-    ),
     help="Acknowledge that uploaded code will be publicly available.",
     cls=PromptOption,
 )
@@ -110,9 +106,6 @@ def remote_build(
             "Running with 'sudo' may cause permission errors and is discouraged."
         )
 
-    if not launchpad_accept_public_upload:
-        raise errors.AcceptPublicUploadError()
-
     echo.warning(
         "snapcraft remote-build is experimental and is subject to change - use with caution."
     )
@@ -147,7 +140,11 @@ def remote_build(
         _print_status(lp)
         return
 
-    if lp.has_outstanding_build():
+    has_outstanding_build = lp.has_outstanding_build()
+    if recover and not has_outstanding_build:
+        echo.info("No build found.")
+        return
+    elif has_outstanding_build:
         echo.info("Found previously started build.")
         _print_status(lp)
 
@@ -158,6 +155,15 @@ def remote_build(
 
         # Otherwise clean running build before we start a new one.
         _clean_build(lp)
+
+    if not (
+        launchpad_accept_public_upload
+        or echo.confirm(
+            "All data sent to remote builders will be publicly available. Are you sure you want to continue?",
+            default=True,
+        )
+    ):
+        raise errors.AcceptPublicUploadError()
 
     _start_build(
         lp=lp,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Remote build currently has a few papercuts.

First of all, if there is no outstanding build, `--recover` literally means nothing: it just spins up another build as if it wasn't supplied at all, which in my experience is never what is desired. It also means there is a disconnect between how `--recover` and `--status` works. Fix that by making `--recover` function more like `--status`, and simply say that there are no builds. Harmony!

Second, one is _always_ prompted about how data being sent to the remote builders is publicly available, even when using options that don't send any meaningful data to the builders, like `--status` and (now) `--recover`. Fix that by no longer using Click to prompt, and prompting only when actually spinning up a new build.

Finally, add tests confirming this behavior.