### PR TITLE
store: Add ReviewQueued status

### DIFF
--- a/snapcraft/storeapi/v2/_api_schema.py
+++ b/snapcraft/storeapi/v2/_api_schema.py
@@ -115,6 +115,7 @@ RELEASES_JSONSCHEMA: Dict[str, Any] = {
                             "AutomaticallyRejected",
                             "Rejected",
                             "ReviewInProgress",
+                            "ReviewQueued",
                         ],
                         "introduced_at": 1,
                         "type": "string",


### PR DESCRIPTION
Another failure such as #3533

```
snapcraft list-revisions joplin --arch=amd64
'ReviewQueued' is not one of ['Published', 'Unpublished', 'ManualReviewPending', 'NeedsInformation', 'AutomaticallyRejected', 'Rejected', 'ReviewInProgress']

Failed validating 'enum' in schema['properties']['revisions']['items']['properties']['status']:
    {'enum': ['Published',
              'Unpublished',
              'ManualReviewPending',
              'NeedsInformation',
              'AutomaticallyRejected',
              'Rejected',
              'ReviewInProgress'],
     'introduced_at': 1,
     'type': 'string'}

On instance['revisions'][0]['status']:
    'ReviewQueued'
```

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
