### PR TITLE
cli: introduce echo.echo_with_pager_if_needed() (CRAFT-380)

### DIFF
--- a/snapcraft/cli/echo.py
+++ b/snapcraft/cli/echo.py
@@ -20,6 +20,7 @@ click.echo adding the corresponding color codes for each level.
 """
 import distutils.util
 import os
+import shutil
 import sys
 from typing import Any, Optional
 
@@ -68,6 +69,21 @@ def error(msg: str) -> None:
     If the terminal supports color the output will be red.
     """
     click.echo("\033[0;31m{}\033[0m".format(msg), err=True)
+
+
+def echo_with_pager_if_needed(msg: str) -> None:
+    """Output msg to stdout using pager if output is too large for terminal."""
+    term_size = shutil.get_terminal_size()
+    split_output = msg.splitlines()
+
+    # Account for final newline when checking row counts.
+    output_lines = len(split_output) + 1
+    if output_lines > term_size.lines or any(
+        len(l) > term_size.columns for l in split_output
+    ):
+        click.echo_via_pager(msg)
+    else:
+        click.echo(msg)
 
 
 def exit_error(


### PR DESCRIPTION
Determine if output string is too large for current terminal and
use a pager to echo information using click.echo_via_pager() if so.

If output looks small enough to fit in terminal, use click.echo().

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
