### PR TITLE
store: add API support for metrics (CRAFT-386)

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -47,6 +47,7 @@ from snapcraft.internal.deltas.errors import (
 )
 from snapcraft.internal.errors import SnapDataExtractionError, ToolMissingError
 from snapcraft.storeapi.constants import DEFAULT_SERIES
+from snapcraft.storeapi.metrics import MetricsFilter, MetricsResults
 
 if TYPE_CHECKING:
     from snapcraft.storeapi._status_tracker import StatusTracker
@@ -320,6 +321,12 @@ class StoreClientCLI(storeapi.StoreClient):
         self, *, snap_id: str, channel_names: List[str]
     ) -> Dict[str, Any]:
         return super().close_channels(snap_id=snap_id, channel_names=channel_names)
+
+    @_login_wrapper
+    def get_metrics(
+        self, *, filters: List[MetricsFilter], snap_name: str
+    ) -> MetricsResults:
+        return super().get_metrics(filters=filters, snap_name=snap_name)
 
     @_login_wrapper
     def get_snap_releases(self, *, snap_name: str) -> "Releases":

--- a/snapcraft/storeapi/_store_client.py
+++ b/snapcraft/storeapi/_store_client.py
@@ -22,13 +22,13 @@ from typing import Any, Dict, Iterable, List, Optional, TextIO, Union
 import requests
 
 from snapcraft.internal.indicators import download_requests_stream
-from . import _upload, errors, http_clients
+
+from . import _upload, errors, http_clients, metrics
 from ._dashboard_api import DashboardAPI
 from ._snap_api import SnapAPI
 from ._up_down_client import UpDownClient
 from .constants import DEFAULT_SERIES
 from .v2 import channel_map, releases, validation_sets, whoami
-
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +75,7 @@ class StoreClient:
             acls = [
                 "package_access",
                 "package_manage",
+                "package_metrics",
                 "package_push",
                 "package_register",
                 "package_release",
@@ -188,6 +189,11 @@ class StoreClient:
 
     def get_snap_channel_map(self, *, snap_name: str) -> channel_map.ChannelMap:
         return self.dashboard.get_snap_channel_map(snap_name=snap_name)
+
+    def get_metrics(
+        self, *, filters: List[metrics.MetricsFilter], snap_name: str,
+    ) -> metrics.MetricsResults:
+        return self.dashboard.get_metrics(filters=filters, snap_name=snap_name)
 
     def get_snap_releases(self, *, snap_name: str) -> releases.Releases:
         return self.dashboard.get_snap_releases(snap_name=snap_name)


### PR DESCRIPTION
- Add support for /dev/api/snaps/metrics endpoint.

- Add ACL token support for package_metrics.

- Add a couple of error helpers to format queries and
  error lists suited for get_details() section.  It is
  handled a few different ways through the various exceptions
  and we should probably consolidate it some in the future.

NOTE: requires re-login to gain appropriate permissions.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
