### PR TITLE
cli: introduce metrics command (CRAFT-387)

### DIFF
--- a/snapcraft/cli/_metrics.py
+++ b/snapcraft/cli/_metrics.py
@@ -1,0 +1,93 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from typing import List, Union
+
+import pkg_resources
+
+from snapcraft.storeapi import metrics as metrics_module
+
+logger = logging.getLogger(__name__)
+
+
+METRIC_NAMES_TO_SERIES_LABEL_MAPPINGS = {
+    metrics_module.MetricsNames.DAILY_DEVICE_CHANGE.value: "Devices",
+    metrics_module.MetricsNames.INSTALLED_BASE_BY_CHANNEL.value: "Channel",
+    metrics_module.MetricsNames.INSTALLED_BASE_BY_COUNTRY.value: "Country",
+    metrics_module.MetricsNames.INSTALLED_BASE_BY_OPERATING_SYSTEM.value: "OS",
+    metrics_module.MetricsNames.INSTALLED_BASE_BY_VERSION.value: "Version",
+    metrics_module.MetricsNames.WEEKLY_DEVICE_CHANGE.value: "Devices",
+    metrics_module.MetricsNames.WEEKLY_INSTALLED_BASE_BY_CHANNEL.value: "Channel",
+    metrics_module.MetricsNames.WEEKLY_INSTALLED_BASE_BY_COUNTRY.value: "Country",
+    metrics_module.MetricsNames.WEEKLY_INSTALLED_BASE_BY_OPERATING_SYSTEM.value: "OS",
+    metrics_module.MetricsNames.WEEKLY_INSTALLED_BASE_BY_VERSION.value: "Version",
+}
+
+
+def get_series_label_from_metric_name(metric_name: str) -> str:
+    """Get series label from metric name.
+
+    :returns: Label for series.
+
+    :raises KeyError: if metric name not supported.
+    """
+    return METRIC_NAMES_TO_SERIES_LABEL_MAPPINGS[metric_name]
+
+
+def convert_metrics_to_table(
+    results: metrics_module.MetricResults, *, transpose: bool = True
+) -> List[List[Union[str, int]]]:
+    rows: List[List[Union[str, int]]] = []
+
+    if results.status == metrics_module.MetricsStatus["NO DATA"]:
+        # No data available, return empty list.
+        return rows
+    elif results.status == metrics_module.MetricsStatus["FAIL"]:
+        # API docs say to consider this as data to discard, just warn the user.
+        logger.warning("No data available due to Snap Store internal failure.")
+        return rows
+
+    # Sort series sensibly, using a version sort.
+    def key_as_version(series):
+        """Key series as versions, if possible."""
+        return pkg_resources.parse_version(series.name)
+
+    series = sorted(results.series, key=key_as_version)
+
+    # Determine headers from series, taking into account whether table will be transposed.
+    if not transpose:
+        initial_column_header = "Date"
+    else:
+        initial_column_header = get_series_label_from_metric_name(results.metric_name)
+
+    header_row = [
+        initial_column_header,
+        *[s.name.capitalize() for s in series],
+    ]
+
+    # First add header row.
+    rows.append(header_row)  # type: ignore
+
+    # Add data rows.
+    for i, bucket in enumerate(results.buckets):
+        rows.append([bucket] + [s.values[i] or 0 for s in series])  # type: ignore
+
+    # Optionally transpose.
+    if transpose:
+        rows = list(zip(*rows))  # type: ignore
+
+    return rows

--- a/tests/fixture_setup/_fixtures.py
+++ b/tests/fixture_setup/_fixtures.py
@@ -144,8 +144,9 @@ class _FakeStderr(io.StringIO):
 
 
 class _FakeTerminalSize:
-    def __init__(self, columns=80):
+    def __init__(self, columns=80, lines=24):
         self.columns = columns
+        self.lines = lines
 
 
 class FakeTerminal(fixtures.Fixture):

--- a/tests/unit/cli/test_metrics.py
+++ b/tests/unit/cli/test_metrics.py
@@ -1,0 +1,118 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from snapcraft.cli._metrics import (
+    convert_metrics_to_table,
+    get_series_label_from_metric_name,
+)
+from snapcraft.storeapi import metrics
+
+
+def test_get_series_label_from_metric_name():
+    mappings = {
+        n.value: get_series_label_from_metric_name(n.value)
+        for n in metrics.MetricsNames
+    }
+
+    assert mappings == {
+        "daily_device_change": "Devices",
+        "installed_base_by_channel": "Channel",
+        "installed_base_by_country": "Country",
+        "installed_base_by_operating_system": "OS",
+        "installed_base_by_version": "Version",
+        "weekly_device_change": "Devices",
+        "weekly_installed_base_by_channel": "Channel",
+        "weekly_installed_base_by_country": "Country",
+        "weekly_installed_base_by_operating_system": "OS",
+        "weekly_installed_base_by_version": "Version",
+    }
+
+
+@pytest.mark.parametrize("metric_name", [n.value for n in metrics.MetricsNames])
+def test_convert_metrics_to_table_no_data(caplog, metric_name):
+    results = metrics.MetricResults(
+        status=metrics.MetricsStatus["NO DATA"],
+        snap_id="foo",
+        metric_name=metric_name,
+        buckets=[],
+        series=[],
+    )
+
+    assert convert_metrics_to_table(results) == []
+    assert [rec.message for rec in caplog.records] == []
+
+
+@pytest.mark.parametrize("metric_name", [n.value for n in metrics.MetricsNames])
+def test_convert_metrics_to_table_store_failure_no_data(caplog, metric_name):
+    results = metrics.MetricResults(
+        status=metrics.MetricsStatus["FAIL"],
+        snap_id="foo",
+        metric_name=metric_name,
+        buckets=[],
+        series=[],
+    )
+
+    assert convert_metrics_to_table(results) == []
+    assert [rec.message for rec in caplog.records] == [
+        "No data available due to Snap Store internal failure."
+    ]
+
+
+@pytest.mark.parametrize("metric_name", [n.value for n in metrics.MetricsNames])
+def test_convert_metrics_to_table_store_one_bucket(caplog, metric_name):
+    results = metrics.MetricResults(
+        status=metrics.MetricsStatus["OK"],
+        snap_id="test-snap-id",
+        metric_name=metric_name,
+        buckets=["2021-01-01"],
+        series=[metrics.Series(name="blah", values=[1], currently_released=None)],
+    )
+
+    assert convert_metrics_to_table(results) == [
+        (get_series_label_from_metric_name(metric_name), "2021-01-01"),
+        ("Blah", 1),
+    ]
+    assert [rec.message for rec in caplog.records] == []
+
+
+@pytest.mark.parametrize("metric_name", [n.value for n in metrics.MetricsNames])
+def test_convert_metrics_to_table_store_multiple_buckets(caplog, metric_name):
+    results = metrics.MetricResults(
+        status=metrics.MetricsStatus["OK"],
+        snap_id="test-snap-id",
+        metric_name=metric_name,
+        buckets=["2021-01-01", "2021-01-02", "2021-01-03"],
+        series=[
+            metrics.Series(name="blah", values=[1, 2, 3], currently_released=None),
+            metrics.Series(name="blahh", values=[4, 5, 6], currently_released=None),
+            metrics.Series(name="blahhh", values=[7, 8, 9], currently_released=None),
+        ],
+    )
+
+    assert convert_metrics_to_table(results) == [
+        (
+            get_series_label_from_metric_name(metric_name),
+            "2021-01-01",
+            "2021-01-02",
+            "2021-01-03",
+        ),
+        ("Blah", 1, 2, 3),
+        ("Blahh", 4, 5, 6),
+        ("Blahhh", 7, 8, 9),
+    ]
+    assert [rec.message for rec in caplog.records] == []

--- a/tests/unit/commands/test_metrics.py
+++ b/tests/unit/commands/test_metrics.py
@@ -1,0 +1,143 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from textwrap import dedent
+
+import pytest
+
+from snapcraft import storeapi
+
+from . import FakeStoreCommandsBaseTestCase
+
+
+class MetricsCommandTestCase(FakeStoreCommandsBaseTestCase):
+    def test_metrics_without_snap_raises_exception(self):
+        result = self.run_command(
+            ["metrics", "--name", "daily_device_change", "--format", "table"]
+        )
+
+        assert result.exit_code == 2
+        assert "Usage:" in result.output
+
+    def test_metrics_without_name_raises_exception(self):
+        result = self.run_command(["metrics", "snap-test", "--format", "table"])
+
+        assert result.exit_code == 2
+        assert "Usage:" in result.output
+
+    def test_metrics_without_format_raises_exception(self):
+        result = self.run_command(
+            ["metrics", "snap-test", "--name", "daily_device_change"]
+        )
+
+        assert result.exit_code == 2
+        assert "Usage:" in result.output
+
+    @pytest.mark.skip("needs more work")
+    def test_status_without_login_must_ask(self):
+        self.fake_store_account_info.mock.side_effect = [
+            storeapi.http_clients.errors.InvalidCredentialsError("error"),
+            self.fake_store_account_info_data,
+        ]
+
+        result = self.run_command(
+            [
+                "metrics",
+                "snap-test",
+                "--name",
+                "daily_device_change",
+                "--format",
+                "table",
+            ],
+            input="user@example.com\nsecret\n",
+        )
+        assert "You are required to login before continuing." in result.output
+
+    def test_status_table_format(self):
+        result = self.run_command(
+            [
+                "metrics",
+                "snap-test",
+                "--name",
+                "daily_device_change",
+                "--format",
+                "table",
+            ]
+        )
+
+        assert result.output == dedent(
+            """\
+               Devices    2021-01-01  2021-01-02  2021-01-03
+               Continued  10          11          12
+               Lost       1           2           3
+               New        2           3           4
+            """
+        )
+        assert result.exit_code == 0
+
+    def test_status_table_json(self):
+        result = self.run_command(
+            [
+                "metrics",
+                "snap-test",
+                "--name",
+                "daily_device_change",
+                "--format",
+                "json",
+            ]
+        )
+
+        assert result.output == dedent(
+            """\
+                {
+                  "buckets": [
+                    "2021-01-01",
+                    "2021-01-02",
+                    "2021-01-03"
+                  ],
+                  "metric_name": "daily_device_change",
+                  "series": [
+                    {
+                      "name": "continued",
+                      "values": [
+                        10,
+                        11,
+                        12
+                      ]
+                    },
+                    {
+                      "name": "lost",
+                      "values": [
+                        1,
+                        2,
+                        3
+                      ]
+                    },
+                    {
+                      "name": "new",
+                      "values": [
+                        2,
+                        3,
+                        4
+                      ]
+                    }
+                  ],
+                  "snap_id": "test-snap-id",
+                  "status": "OK"
+                }
+            """
+        )
+        assert result.exit_code == 0


### PR DESCRIPTION
- Add metrics command with:

-- required args for name and format.
-- optional args for start and end dates
-- JSON and table format options

- Update fake terminal fixture to support lines

Future work is still required to re-auth if needed, the user
must relogin to get credentials if they don't already have
the package_metrics ACL token.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
