### PR TITLE
storeapi: improve candid interaction errors (CRAFT-135)

### DIFF
--- a/snapcraft/storeapi/http_clients/errors.py
+++ b/snapcraft/storeapi/http_clients/errors.py
@@ -119,3 +119,18 @@ class InvalidLoginConfig(HttpClientError):
 
     def __init__(self, error):
         super().__init__(error=error)
+
+
+class TokenTimeoutError(SnapcraftError):
+    def __init__(self, *, url: str) -> None:
+        self.fmt = f"Timed out waiting for token response from {url!r}."
+
+
+class TokenKindError(SnapcraftError):
+    def __init__(self, *, url: str) -> None:
+        self.fmt = f"Empty token kind returned from {url!r}."
+
+
+class TokenValueError(SnapcraftError):
+    def __init__(self, *, url: str) -> None:
+        self.fmt = f"Empty token value returned from {url!r}."

--- a/tests/unit/store/http_client/test_errors.py
+++ b/tests/unit/store/http_client/test_errors.py
@@ -106,6 +106,32 @@ class TestSnapcraftException:
                 ),
             },
         ),
+        (
+            "TokenTimeoutError",
+            {
+                "exception_class": errors.TokenTimeoutError,
+                "kwargs": {"url": "https://foo"},
+                "expected_message": (
+                    "Timed out waiting for token response from 'https://foo'."
+                ),
+            },
+        ),
+        (
+            "TokenKindError",
+            {
+                "exception_class": errors.TokenKindError,
+                "kwargs": {"url": "https://foo"},
+                "expected_message": ("Empty token kind returned from 'https://foo'."),
+            },
+        ),
+        (
+            "TokenValueError",
+            {
+                "exception_class": errors.TokenValueError,
+                "kwargs": {"url": "https://foo"},
+                "expected_message": ("Empty token value returned from 'https://foo'."),
+            },
+        ),
     )
 
     def test_error_formatting(self, exception_class, expected_message, kwargs):


### PR DESCRIPTION
Provide distinct error classes and messages when dealing with tokens.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
