### PR TITLE
win32 installer: store artifact with tagged version (CRAFT-413)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,11 +34,16 @@ build_script:
     powershell.exe windows\generate-self-signed-cert.ps1
     "%SIGNTOOL%" sign /fd SHA256 /td SHA256 /tr "%TIMESTAMP_SERVICE%" /f test-signing.pfx /p Password1234 dist\snapcraft.exe
 
+    echo "Setting Snapcraft version..."
+    venv\Scripts\activate.bat
+    python -m tools.version set-snapcraft-iss
+    venv\Scripts\deactivate.bat
     echo "Building snapcraft inno installer..."
     "%INNOCC%" windows\snapcraft.iss
 
+    copy dist\snapcraft-installer.exe dist\snapcraft-installer-self-signed.exe
     echo "Test signing snapcraft inno installer..."
-    "%SIGNTOOL%" sign /fd SHA256 /td SHA256 /tr "%TIMESTAMP_SERVICE%" /f test-signing.pfx /p Password1234 dist\snapcraft-installer.exe
+    "%SIGNTOOL%" sign /fd SHA256 /td SHA256 /tr "%TIMESTAMP_SERVICE%" /f test-signing.pfx /p Password1234 dist\snapcraft-installer-self-signed.exe
 
     echo "Building snapcraft msix installer..."
     mkdir dist\msix
@@ -60,11 +65,11 @@ test_script:
     ..\dist\snapcraft.exe init
     cd ..
 
-    echo "Smoke testing snapcraft-installer.exe..."
-    start /wait "SNAPCRAFT INSTALLER" dist\snapcraft-installer.exe /VERYSILENT /ALLUSERS
+    echo "Smoke testing snapcraft-installer-self-signed.exe..."
+    start /wait "SNAPCRAFT INSTALLER" dist\snapcraft-installer-self-signed.exe /VERYSILENT /ALLUSERS
     "%SNAPCRAFT_INSTALLED_EXE%" version
 
-#artifacts:
+artifacts:
 #- path: dist\snapcraft.exe
-#- path: dist\snapcraft-installer.exe
+- path: dist\snapcraft-installer.exe
 #- path: dist\snapcraft-installer.msix

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import subprocess
 import sys
 
 from setuptools import find_namespace_packages, setup
+
+from tools.version import determine_version
 
 
 def recursive_data_files(directory, install_directory):
@@ -28,39 +29,6 @@ def recursive_data_files(directory, install_directory):
         file_paths = [os.path.join(root, file_name) for file_name in file_names]
         data_files.append((os.path.join(install_directory, root), file_paths))
     return data_files
-
-
-def determine_version():
-    # Examples (git describe -> python package version):
-    # 4.1.1-0-gad012482d -> 4.1.1
-    # 4.1.1-16-g2d8943dbc -> 4.1.1.post16+g2d8943dbc
-    #
-    # For shallow clones or repositories missing tags:
-    # 0ae7c04
-
-    desc = (
-        subprocess.run(
-            ["git", "describe", "--always", "--long"],
-            check=True,
-            stdout=subprocess.PIPE,
-        )
-        .stdout.decode()
-        .strip()
-    )
-
-    split_desc = desc.split("-")
-    assert (
-        len(split_desc) == 3
-    ), f"Failed to parse Snapcraft git version description {desc!r}. Confirm that git repository is present and has the required tags/history."
-
-    version = split_desc[0]
-    distance = split_desc[1]
-    commit = split_desc[2]
-
-    if distance == "0":
-        return version
-
-    return f"{version}.post{distance}+git{commit[1:]}"
 
 
 # Common distribution data

--- a/tools/version.py
+++ b/tools/version.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2021 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import fileinput
+import pathlib
+import subprocess
+import sys
+
+
+def determine_version():
+    # Examples (git describe -> python package version):
+    # 4.1.1-0-gad012482d -> 4.1.1
+    # 4.1.1-16-g2d8943dbc -> 4.1.1.post16+g2d8943dbc
+    #
+    # For shallow clones or repositories missing tags:
+    # 0ae7c04
+
+    desc = (
+        subprocess.run(
+            ["git", "describe", "--always", "--long"],
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+        .stdout.decode()
+        .strip()
+    )
+
+    split_desc = desc.split("-")
+    assert (
+        len(split_desc) == 3
+    ), f"Failed to parse Snapcraft git version description {desc!r}. Confirm that git repository is present and has the required tags/history."
+
+    version = split_desc[0]
+    distance = split_desc[1]
+    commit = split_desc[2]
+
+    if distance == "0":
+        return version
+
+    return f"{version}.post{distance}+git{commit[1:]}"
+
+
+def set_snapcraft_iss():
+    snapcraft_iss_path = pathlib.Path("windows/snapcraft.iss")
+    assert (
+        snapcraft_iss_path.exists()
+    ), f"Run from project root and ensure {snapcraft_iss_path!s} exists."
+    with fileinput.input(str(snapcraft_iss_path), inplace=True) as iss_file:
+        for line in iss_file:
+            if line.startswith("AppVersion="):
+                print(f"AppVersion={determine_version()}")
+            else:
+                print(line, end="")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2 and sys.argv[1] == "set-snapcraft-iss":
+        set_snapcraft_iss()
+    else:
+        print(determine_version())

--- a/windows/snapcraft.iss
+++ b/windows/snapcraft.iss
@@ -1,8 +1,7 @@
 [Setup]
 AppId={{05E40DED-CE0A-437E-B90C-25A32B47880F}
-AppName=Snapcraft for Windows
-AppVersion=3.7.2
-;AppVerName=Snapcraft for Windows 3.7.2
+AppName=Snapcraft (Preview) for Windows
+AppVersion=VERSION
 AppPublisher=Canonical Ltd.
 AppPublisherURL=https://snapcraft.io/
 AppSupportURL=https://snapcraft.io/


### PR DESCRIPTION
Added a simple script to call from AppVeyor to set the version correctly
on 'windows/snapcraft.iss'.

For this, 'determine_version' was extracted from 'setup.py'.

Appveyor has been reconfigured to store the non self signed
'snapcraft-installer.exe'.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
