### PR TITLE
schema: add environment support for hooks (CRAFT-424)

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -267,6 +267,22 @@
                 "shared"
             ],
             "validation-failure": "{!r} is not a valid user scope. Valid scopes include: 'shared'"
+        },
+        "environment": {
+            "type": "object",
+            "description": "environment entries",
+            "minItems": 1,
+            "additionalProperties": {
+                "anyOf": [
+                    {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    {
+                        "type": "number"
+                    }
+                ]
+            }
         }
     },
     "title": "snapcraft schema",
@@ -472,20 +488,8 @@
             ]
         },
         "environment": {
-            "type": "object",
             "description": "environment entries for the snap as a whole",
-            "minItems": 1,
-            "additionalProperties": {
-                "anyOf": [
-                    {
-                        "type": "string",
-                        "minLength": 1
-                    },
-                    {
-                        "type": "number"
-                    }
-                ]
-            }
+            "$ref": "#/definitions/environment"
         },
         "passthrough": {
             "type": "object",
@@ -820,20 +824,8 @@
                             }
                         },
                         "environment": {
-                            "type": "object",
                             "description": "environment entries for the specific app.",
-                            "minItems": 1,
-                            "additionalProperties": {
-                                "anyOf": [
-                                    {
-                                        "type": "string",
-                                        "minLength": 1
-                                    },
-                                    {
-                                        "type": "number"
-                                    }
-                                ]
-                            }
+                            "$ref": "#/definitions/environment"
                         },
                         "adapter": {
                             "$comment": "Full should be the default, but it requires command-chain which isn't available in snapd until 2.36, which isn't yet stable. Until 2.36 is generally available, continue with legacy as the default.",
@@ -931,6 +923,10 @@
                                 "pattern": "^[A-Za-z0-9/._#:$-]*$",
                                 "validation-failure": "{.instance!r} is not a valid command-chain entry. Command chain entries must be strings, and can only use ASCII alphanumeric characters and the following special characters: / . _ # : $ -"
                             }
+                        },
+                        "environment": {
+                            "description": "environment entries for this hook",
+                            "$ref": "#/definitions/environment"
                         },
                         "plugs": {
                             "type": "array",

--- a/snapcraft/internal/meta/hooks.py
+++ b/snapcraft/internal/meta/hooks.py
@@ -29,6 +29,7 @@ class Hook:
         *,
         hook_name: str,
         command_chain: Optional[List[str]] = None,
+        environment: Optional[Dict[str, str]] = None,
         plugs: Optional[List[str]] = None,
         passthrough: Optional[Dict[str, Any]] = None,
     ) -> None:
@@ -37,6 +38,10 @@ class Hook:
         self.command_chain: List[str] = list()
         if command_chain:
             self.command_chain = command_chain
+
+        self.environment: Dict[str, str] = dict()
+        if environment:
+            self.environment = environment
 
         self.plugs: List[str] = list()
         if plugs:
@@ -84,9 +89,15 @@ class Hook:
     def from_dict(cls, hook_dict: Dict[str, Any], hook_name: str) -> "Hook":
         """Create hook from dictionary."""
 
+        environment = hook_dict.get("environment", dict())
+        for k, v in environment.items():
+            # Ensure alll environment values are converted to string.
+            environment[k] = str(v)
+
         return Hook(
             hook_name=hook_name,
             command_chain=hook_dict.get("command-chain", None),
+            environment=environment,
             plugs=hook_dict.get("plugs", None),
             passthrough=hook_dict.get("passthrough", None),
         )
@@ -98,6 +109,9 @@ class Hook:
 
         if self.command_chain:
             hook_dict["command-chain"] = self.command_chain
+
+        if self.environment:
+            hook_dict["environment"] = self.environment
 
         if self.plugs:
             hook_dict["plugs"] = self.plugs

--- a/tests/spread/general/environment/expected_snap.yaml
+++ b/tests/spread/general/environment/expected_snap.yaml
@@ -22,3 +22,7 @@ environment:
   c: foo
   b: foo
 grade: devel
+hooks:
+  configure:
+    environment:
+      CONFIGURE_ENV: foo

--- a/tests/spread/general/environment/snaps/environment-tests/snapcraft.yaml
+++ b/tests/spread/general/environment/snaps/environment-tests/snapcraft.yaml
@@ -22,6 +22,11 @@ apps:
       c: foo
       b: foo
 
+hooks:
+  configure:
+    environment:
+      CONFIGURE_ENV: foo
+
 environment:
   a: foo
   c: foo

--- a/tests/unit/meta/test_hook.py
+++ b/tests/unit/meta/test_hook.py
@@ -90,3 +90,13 @@ class GenericHookTests(unit.TestCase):
                 "failed to validate hook=hook-test: '&/foo/bar' is not a valid command-chain command."
             ),
         )
+
+    def test_environment(self):
+        hook_dict = OrderedDict({"environment": {"FOO": "BAR"}})
+        hook_name = "hook-test"
+
+        hook = Hook.from_dict(hook_dict=hook_dict, hook_name=hook_name)
+        hook.validate()
+
+        self.assertEqual(hook.to_dict(), hook_dict)
+        self.assertEqual(hook.hook_name, hook_name)

--- a/tests/unit/meta/test_snap.py
+++ b/tests/unit/meta/test_snap.py
@@ -134,7 +134,13 @@ class SnapTests(unit.TestCase):
             "environment": {"TESTING": "1"},
             "epoch": 0,
             "grade": "devel",
-            "hooks": {"test-hook": {"command-chain": ["cmd1"], "plugs": ["network"]}},
+            "hooks": {
+                "test-hook": {
+                    "command-chain": ["cmd1"],
+                    "environment": {"FOO": "BAR"},
+                    "plugs": ["network"],
+                }
+            },
             "layout": {"/target": {"bind": "$SNAP/foo"}},
             "license": "GPL",
             "links": {
@@ -232,7 +238,13 @@ class SnapTests(unit.TestCase):
             "environment": {"TESTING": "1"},
             "epoch": 0,
             "grade": "devel",
-            "hooks": {"test-hook": {"command-chain": ["cmd1"], "plugs": ["network"]}},
+            "hooks": {
+                "test-hook": {
+                    "command-chain": ["cmd1"],
+                    "environment": {"FOO": "BAR"},
+                    "plugs": ["network"],
+                }
+            },
             "layout": {"/target": {"bind": "$SNAP/foo"}},
             "license": "GPL",
             "passthrough": {"test": "value"},

--- a/tests/unit/project/test_schema.py
+++ b/tests/unit/project/test_schema.py
@@ -950,6 +950,12 @@ class EnvironmentTest(ProjectBaseTest):
                   LOCALE: C
                   PLUGIN_PATH: $SNAP_USER_DATA/plugins
 
+            hooks:
+              configure:
+                environment:
+                  CONFIGURE_ENV: FOOBAR
+                  CONFIGURE_ENV_INT: 1
+
             parts:
               main:
                 plugin: nil
@@ -965,6 +971,10 @@ class EnvironmentTest(ProjectBaseTest):
         self.assertThat(
             snapcraft_yaml["apps"]["app1"]["environment"],
             Equals(dict(LOCALE="C", PLUGIN_PATH="$SNAP_USER_DATA/plugins")),
+        )
+        self.assertThat(
+            snapcraft_yaml["hooks"]["configure"]["environment"],
+            Equals(dict(CONFIGURE_ENV="FOOBAR", CONFIGURE_ENV_INT=1)),
         )
 
     def test_invalid_environment(self):


### PR DESCRIPTION
- Consolidate definition of environment in the schema and use it for
  global, apps, and now hooks.

- Update meta to support processing hooks.

- Add unit and spread test coverage.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
