### PR TITLE
ROS 2 plugins v2 misc fixes

### DIFF
--- a/extensions/ros2/launch
+++ b/extensions/ros2/launch
@@ -14,6 +14,6 @@ function source_with_prefix() {
 original_args=("$@")
 
 source_with_prefix "$SNAP/opt/ros/$ROS_DISTRO"
-source_with_prefix "$SNAP"
+source_with_prefix "$SNAP/opt/ros/snap"
 
 exec "${original_args[@]}"

--- a/extensions/ros2/launch
+++ b/extensions/ros2/launch
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 function source_with_prefix() {
-    export COLCON_CURRENT_PREFIX="$1"
-    if [ ! -f "$COLCON_CURRENT_PREFIX/local_setup.bash" ]; then
-      echo "error: $COLCON_CURRENT_PREFIX/local_setup.bash not found"
+    export ROS_WORKSPACE_CURRENT_PREFIX="$1"
+    if [ ! -f "$ROS_WORKSPACE_CURRENT_PREFIX/local_setup.bash" ]; then
+      echo "error: $ROS_WORKSPACE_CURRENT_PREFIX/local_setup.bash not found"
       exit 1
     fi
     # shellcheck disable=SC1090
-    source "$COLCON_CURRENT_PREFIX/local_setup.bash"
+    source "$ROS_WORKSPACE_CURRENT_PREFIX/local_setup.bash"
 }
 
 # Save off parameters, the sourced setup scripts may manipulate them.

--- a/snapcraft/plugins/v2/_ros.py
+++ b/snapcraft/plugins/v2/_ros.py
@@ -103,13 +103,13 @@ class RosPlugin(PluginV2):
                     os.path.abspath(__file__),
                     "stage-runtime-dependencies",
                     "--part-src",
-                    "$SNAPCRAFT_PART_SRC",
+                    '"${SNAPCRAFT_PART_SRC}"',
                     "--part-install",
-                    "$SNAPCRAFT_PART_INSTALL",
+                    '"${SNAPCRAFT_PART_INSTALL}"',
                     "--ros-distro",
-                    "$ROS_DISTRO",
+                    '"${ROS_DISTRO}"',
                     "--target-arch",
-                    "$SNAPCRAFT_TARGET_ARCH",
+                    '"${SNAPCRAFT_TARGET_ARCH}"',
                 ]
             )
         ]
@@ -119,8 +119,8 @@ class RosPlugin(PluginV2):
             self._get_workspace_activation_commands()
             + [
                 "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep init; fi",
-                "rosdep update --include-eol-distros --rosdistro $ROS_DISTRO",
-                "rosdep install --default-yes --ignore-packages-from-source --from-paths $SNAPCRAFT_PART_SRC",
+                'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
+                'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC}"',
             ]
             + self._get_build_commands()
             + self._get_stage_runtime_dependencies_commands()

--- a/snapcraft/plugins/v2/_ros.py
+++ b/snapcraft/plugins/v2/_ros.py
@@ -49,6 +49,7 @@ class RosPlugin(PluginV2):
     def out_of_source_build(self):
         return True
 
+    @abc.abstractmethod
     def _get_workspace_activation_commands(self) -> List[str]:
         """Return a list of commands source a ROS workspace.
 
@@ -60,24 +61,6 @@ class RosPlugin(PluginV2):
         snapcraftctl can be used in the script to call out to snapcraft
         specific functionality.
         """
-
-        # There are a number of unbound vars, disable flag
-        # after saving current state to restore after.
-        return [
-            'state="$(set +o)"',
-            "set +u",
-            'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh ]; then',
-            "set -- --local",
-            "_CATKIN_SETUP_DIR={path} . {path}/setup.sh".format(
-                path='"${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO'
-            ),
-            "set -- --local --extend",
-            "else",
-            "set -- --local",
-            "fi",
-            ". /opt/ros/$ROS_DISTRO/setup.sh",
-            'eval "${state}"',
-        ]
 
     @abc.abstractmethod
     def _get_build_commands(self) -> List[str]:

--- a/snapcraft/plugins/v2/catkin.py
+++ b/snapcraft/plugins/v2/catkin.py
@@ -74,6 +74,36 @@ class CatkinPlugin(_ros.RosPlugin):
     def get_build_packages(self) -> Set[str]:
         return super().get_build_packages() | {"ros-noetic-catkin"}
 
+    def _get_workspace_activation_commands(self) -> List[str]:
+        """Return a list of commands to source a ROS workspace.
+
+        The commands returned will be run before doing anything else.
+        They will be run in a single shell instance with the rest of
+        the build step, so these commands can affect the commands that
+        follow.
+
+        snapcraftctl can be used in the script to call out to snapcraft
+        specific functionality.
+        """
+
+        # There are a number of unbound vars, disable flag
+        # after saving current state to restore after.
+        return [
+            'state="$(set +o)"',
+            "set +u",
+            'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh ]; then',
+            "set -- --local",
+            "_CATKIN_SETUP_DIR={path} . {path}/setup.sh".format(
+                path='"${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO'
+            ),
+            "set -- --local --extend",
+            "else",
+            "set -- --local",
+            "fi",
+            ". /opt/ros/$ROS_DISTRO/setup.sh",
+            'eval "${state}"',
+        ]
+
     def _get_build_commands(self) -> List[str]:
         cmd = [
             "catkin_make_isolated",

--- a/snapcraft/plugins/v2/catkin.py
+++ b/snapcraft/plugins/v2/catkin.py
@@ -91,16 +91,16 @@ class CatkinPlugin(_ros.RosPlugin):
         return [
             'state="$(set +o)"',
             "set +u",
-            'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh ]; then',
+            'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
             "set -- --local",
-            "_CATKIN_SETUP_DIR={path} . {path}/setup.sh".format(
-                path='"${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO'
+            '_CATKIN_SETUP_DIR="{path}" . "{path}/setup.sh"'.format(
+                path="${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}"
             ),
             "set -- --local --extend",
             "else",
             "set -- --local",
             "fi",
-            ". /opt/ros/$ROS_DISTRO/setup.sh",
+            '. /opt/ros/"${ROS_DISTRO}"/setup.sh',
             'eval "${state}"',
         ]
 
@@ -110,13 +110,13 @@ class CatkinPlugin(_ros.RosPlugin):
             "--install",
             "--merge",
             "--source-space",
-            "$SNAPCRAFT_PART_SRC",
+            '"${SNAPCRAFT_PART_SRC}"',
             "--build-space",
-            "$SNAPCRAFT_PART_BUILD",
+            '"${SNAPCRAFT_PART_BUILD}"',
             "--install-space",
-            "$SNAPCRAFT_PART_INSTALL/opt/ros/$ROS_DISTRO",
+            '"${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}"',
             "-j",
-            "$SNAPCRAFT_PARALLEL_BUILD_COUNT",
+            '"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
         ]
 
         if self.options.catkin_packages:

--- a/snapcraft/plugins/v2/catkin_tools.py
+++ b/snapcraft/plugins/v2/catkin_tools.py
@@ -85,16 +85,16 @@ class CatkinToolsPlugin(_ros.RosPlugin):
         return [
             'state="$(set +o)"',
             "set +u",
-            'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh ]; then',
+            'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
             "set -- --local",
-            "_CATKIN_SETUP_DIR={path} . {path}/setup.sh".format(
-                path='"${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO'
+            '_CATKIN_SETUP_DIR="{path}" . "{path}/setup.sh"'.format(
+                path="${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}"
             ),
             "set -- --local --extend",
             "else",
             "set -- --local",
             "fi",
-            ". /opt/ros/$ROS_DISTRO/setup.sh",
+            '. /opt/ros/"${ROS_DISTRO}"/setup.sh',
             'eval "${state}"',
         ]
 
@@ -116,11 +116,11 @@ class CatkinToolsPlugin(_ros.RosPlugin):
             "default",
             "--install",
             "--source-space",
-            "$SNAPCRAFT_PART_SRC",
+            '"${SNAPCRAFT_PART_SRC}"',
             "--build-space",
-            "$SNAPCRAFT_PART_BUILD",
+            '"${SNAPCRAFT_PART_BUILD}"',
             "--install-space",
-            "$SNAPCRAFT_PART_INSTALL/opt/ros/$ROS_DISTRO",
+            '"${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}"',
         ]
 
         if self.options.catkin_tools_cmake_args:
@@ -138,7 +138,7 @@ class CatkinToolsPlugin(_ros.RosPlugin):
             "--profile",
             "default",
             "-j",
-            "$SNAPCRAFT_PARALLEL_BUILD_COUNT",
+            '"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
         ]
 
         if self.options.catkin_tools_packages:

--- a/snapcraft/plugins/v2/catkin_tools.py
+++ b/snapcraft/plugins/v2/catkin_tools.py
@@ -68,6 +68,36 @@ class CatkinToolsPlugin(_ros.RosPlugin):
             "python3-osrf-pycommon",
         }
 
+    def _get_workspace_activation_commands(self) -> List[str]:
+        """Return a list of commands to source a ROS workspace.
+
+        The commands returned will be run before doing anything else.
+        They will be run in a single shell instance with the rest of
+        the build step, so these commands can affect the commands that
+        follow.
+
+        snapcraftctl can be used in the script to call out to snapcraft
+        specific functionality.
+        """
+
+        # There are a number of unbound vars, disable flag
+        # after saving current state to restore after.
+        return [
+            'state="$(set +o)"',
+            "set +u",
+            'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh ]; then',
+            "set -- --local",
+            "_CATKIN_SETUP_DIR={path} . {path}/setup.sh".format(
+                path='"${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO'
+            ),
+            "set -- --local --extend",
+            "else",
+            "set -- --local",
+            "fi",
+            ". /opt/ros/$ROS_DISTRO/setup.sh",
+            'eval "${state}"',
+        ]
+
     def _get_build_commands(self) -> List[str]:
         # It's possible that this workspace wasn't initialized to be used with
         # catkin-tools, so initialize it first. Note that this is a noop if it

--- a/snapcraft/plugins/v2/colcon.py
+++ b/snapcraft/plugins/v2/colcon.py
@@ -174,4 +174,10 @@ class ColconPlugin(_ros.RosPlugin):
         # Specify the number of workers
         cmd.extend(["--parallel-workers", "${SNAPCRAFT_PARALLEL_BUILD_COUNT}"])
 
-        return [" ".join(cmd)]
+        return [" ".join(cmd)] + [
+            # Remove the COLCON_IGNORE marker so that, at staging,
+            # catkin can crawl the entire folder to look up for packages.
+            'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE ]; then',
+            'rm "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE',
+            "fi",
+        ]

--- a/snapcraft/plugins/v2/colcon.py
+++ b/snapcraft/plugins/v2/colcon.py
@@ -142,7 +142,7 @@ class ColconPlugin(_ros.RosPlugin):
                 path='"${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap'
             ),
             "fi",
-            ". /opt/ros/$ROS_DISTRO/local_setup.sh",
+            '. /opt/ros/"${ROS_DISTRO}"/local_setup.sh',
             'eval "${state}"',
         ]
 
@@ -151,12 +151,12 @@ class ColconPlugin(_ros.RosPlugin):
             "colcon",
             "build",
             "--base-paths",
-            "$SNAPCRAFT_PART_SRC",
+            '"${SNAPCRAFT_PART_SRC}"',
             "--build-base",
-            "$SNAPCRAFT_PART_BUILD",
+            '"${SNAPCRAFT_PART_BUILD}"',
             "--merge-install",
             "--install-base",
-            "$SNAPCRAFT_PART_INSTALL/opt/ros/snap",
+            '"${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap',
         ]
 
         if self.options.colcon_packages_ignore:
@@ -172,7 +172,7 @@ class ColconPlugin(_ros.RosPlugin):
             cmd.extend(["--catkin-cmake-args", *self.options.colcon_catkin_cmake_args])
 
         # Specify the number of workers
-        cmd.extend(["--parallel-workers", "${SNAPCRAFT_PARALLEL_BUILD_COUNT}"])
+        cmd.extend(["--parallel-workers", '"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"'])
 
         return [" ".join(cmd)] + [
             # Remove the COLCON_IGNORE marker so that, at staging,

--- a/snapcraft/plugins/v2/colcon.py
+++ b/snapcraft/plugins/v2/colcon.py
@@ -156,7 +156,7 @@ class ColconPlugin(_ros.RosPlugin):
             "$SNAPCRAFT_PART_BUILD",
             "--merge-install",
             "--install-base",
-            "$SNAPCRAFT_PART_INSTALL",
+            "$SNAPCRAFT_PART_INSTALL/opt/ros/snap",
         ]
 
         if self.options.colcon_packages_ignore:

--- a/snapcraft/plugins/v2/colcon.py
+++ b/snapcraft/plugins/v2/colcon.py
@@ -119,6 +119,33 @@ class ColconPlugin(_ros.RosPlugin):
 
         return env
 
+    def _get_workspace_activation_commands(self) -> List[str]:
+        """Return a list of commands source a ROS 2 workspace.
+
+        The commands returned will be run before doing anything else.
+        They will be run in a single shell instance with the rest of
+        the build step, so these commands can affect the commands that
+        follow.
+
+        snapcraftctl can be used in the script to call out to snapcraft
+        specific functionality.
+        """
+
+        # There are a number of unbound vars, disable flag
+        # after saving current state to restore after.
+        return [
+            'state="$(set +o)"',
+            "set +u",
+            # If it exists, source the stage-snap underlay
+            'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/setup.sh ]; then',
+            "COLCON_CURRENT_PREFIX={path} . {path}/setup.sh".format(
+                path='"${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap'
+            ),
+            "fi",
+            ". /opt/ros/$ROS_DISTRO/local_setup.sh",
+            'eval "${state}"',
+        ]
+
     def _get_build_commands(self) -> List[str]:
         cmd = [
             "colcon",

--- a/tests/spread/plugins/v2/colcon-ros2-stage-snap/task.yaml
+++ b/tests/spread/plugins/v2/colcon-ros2-stage-snap/task.yaml
@@ -1,0 +1,39 @@
+summary: >-
+  Build, clean, build, and run hello
+  for ros2/colcon.
+
+kill-timeout: 180m
+
+environment:
+  SNAP/colcon_stage_snaps: colcon-stage-snaps
+  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
+
+systems:
+  - ubuntu-20.04
+  - ubuntu-20.04-64
+  - ubuntu-20.04-amd64
+  - ubuntu-20.04-arm64
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "../snaps/$SNAP/snap/snapcraft.yaml"
+
+restore: |
+  cd "../snaps/$SNAP"
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "../snaps/$SNAP"
+
+  # Build what we have and verify the snap runs as expected.
+  snapcraft
+  snap install "${SNAP}"_1.0_*.snap --dangerous
+  output=$($SNAP)
+
+  echo "$output" | MATCH "I heard:"

--- a/tests/spread/plugins/v2/snaps/colcon-stage-snaps/CMakeLists.txt
+++ b/tests/spread/plugins/v2/snaps/colcon-stage-snaps/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.5)
+project(test_minimal_subscriber)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+find_package(test_minimal_publisher REQUIRED)
+
+add_executable(${PROJECT_NAME}_node src/subscriber.cpp)
+ament_target_dependencies(
+  ${PROJECT_NAME}_node
+  test_minimal_publisher
+)
+
+install(TARGETS
+  ${PROJECT_NAME}_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(
+  DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/tests/spread/plugins/v2/snaps/colcon-stage-snaps/launch/talker_subscriber.launch.py
+++ b/tests/spread/plugins/v2/snaps/colcon-stage-snaps/launch/talker_subscriber.launch.py
@@ -1,0 +1,24 @@
+from launch import LaunchDescription
+from launch.actions import Shutdown
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            Node(
+                package="test_minimal_publisher",
+                executable="test_minimal_publisher_node",
+                name="test_minimal_publisher_node",
+            ),
+            Node(
+                package="test_minimal_subscriber",
+                executable="test_minimal_subscriber_node",
+                name="test_minimal_subscriber_node",
+                output="screen",
+                emulate_tty=True,
+                parameters=[{"exit_after_receive": True}],
+                on_exit=Shutdown(),
+            ),
+        ]
+    )

--- a/tests/spread/plugins/v2/snaps/colcon-stage-snaps/package.xml
+++ b/tests/spread/plugins/v2/snaps/colcon-stage-snaps/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>test_minimal_subscriber</name>
+  <version>0.0.0</version>
+  <description>A description</description>
+  <maintainer email="me@example.com">me</maintainer>
+  <license>GPLv3</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>test_minimal_publisher</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/tests/spread/plugins/v2/snaps/colcon-stage-snaps/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/colcon-stage-snaps/snap/snapcraft.yaml
@@ -5,57 +5,24 @@ description: Verify that ROS 2 stage-snaps are checked for dependencies.
 confinement: strict
 base: core20
 
-package-repositories:
-  - components:
-      - main
-    formats:
-      - deb
-    key-id: C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-    key-server: keyserver.ubuntu.com
-    suites:
-      - focal
-    type: apt
-    url: http://repo.ros2.org/ubuntu/main
-
 parts:
-  ros2-foxy-extension:
-      build-packages:
-        - python3-colcon-common-extensions
-        - ros-foxy-ros-core
-      override-build: install -D -m 0755 launch ${SNAPCRAFT_PART_INSTALL}/snap/command-chain/ros2-launch
-      plugin: nil
-      source: $SNAPCRAFT_EXTENSIONS_DIR/ros2
   colcon-part:
     plugin: colcon
     source: .
     build-packages: [g++, make]
     stage-packages: [ros-foxy-ros2launch]
     stage-snaps: [test-snapcraft-fake-ros2-package-core20/latest/edge]
-    build-environment:
-      - ROS_DISTRO: foxy
 
 apps:
   colcon-stage-snaps:
     command: opt/ros/foxy/bin/ros2 launch test_minimal_subscriber talker_subscriber.launch.py
     plugs: [network, network-bind]
-    command-chain:
-      - snap/command-chain/ros2-launch
-    environment:
-      PYTHONPATH: $SNAP/opt/ros/foxy/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages:${PYTHONPATH}
-      ROS_DISTRO: foxy
+    extensions: [ros2-foxy]
   subscriber:
     command: opt/ros/foxy/bin/ros2 run test_minimal_subscriber test_minimal_subscriber_node
     plugs: [network, network-bind]
-    command-chain:
-      - snap/command-chain/ros2-launch
-    environment:
-      PYTHONPATH: $SNAP/opt/ros/foxy/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages:${PYTHONPATH}
-      ROS_DISTRO: foxy
+    extensions: [ros2-foxy]
   publisher:
     command: opt/ros/foxy/bin/ros2 run test_minimal_publisher test_minimal_publisher_node
     plugs: [network, network-bind]
-    command-chain:
-      - snap/command-chain/ros2-launch
-    environment:
-      PYTHONPATH: $SNAP/opt/ros/foxy/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages:${PYTHONPATH}
-      ROS_DISTRO: foxy
+    extensions: [ros2-foxy]

--- a/tests/spread/plugins/v2/snaps/colcon-stage-snaps/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/colcon-stage-snaps/snap/snapcraft.yaml
@@ -1,0 +1,61 @@
+name: colcon-stage-snaps
+version: '1.0'
+summary: ROS 2 stage-snaps test
+description: Verify that ROS 2 stage-snaps are checked for dependencies.
+confinement: strict
+base: core20
+
+package-repositories:
+  - components:
+      - main
+    formats:
+      - deb
+    key-id: C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+    key-server: keyserver.ubuntu.com
+    suites:
+      - focal
+    type: apt
+    url: http://repo.ros2.org/ubuntu/main
+
+parts:
+  ros2-foxy-extension:
+      build-packages:
+        - python3-colcon-common-extensions
+        - ros-foxy-ros-core
+      override-build: install -D -m 0755 launch ${SNAPCRAFT_PART_INSTALL}/snap/command-chain/ros2-launch
+      plugin: nil
+      source: $SNAPCRAFT_EXTENSIONS_DIR/ros2
+  colcon-part:
+    plugin: colcon
+    source: .
+    build-packages: [g++, make]
+    stage-packages: [ros-foxy-ros2launch]
+    stage-snaps: [test-snapcraft-fake-ros2-package-core20/latest/edge]
+    build-environment:
+      - ROS_DISTRO: foxy
+
+apps:
+  colcon-stage-snaps:
+    command: opt/ros/foxy/bin/ros2 launch test_minimal_subscriber talker_subscriber.launch.py
+    plugs: [network, network-bind]
+    command-chain:
+      - snap/command-chain/ros2-launch
+    environment:
+      PYTHONPATH: $SNAP/opt/ros/foxy/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages:${PYTHONPATH}
+      ROS_DISTRO: foxy
+  subscriber:
+    command: opt/ros/foxy/bin/ros2 run test_minimal_subscriber test_minimal_subscriber_node
+    plugs: [network, network-bind]
+    command-chain:
+      - snap/command-chain/ros2-launch
+    environment:
+      PYTHONPATH: $SNAP/opt/ros/foxy/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages:${PYTHONPATH}
+      ROS_DISTRO: foxy
+  publisher:
+    command: opt/ros/foxy/bin/ros2 run test_minimal_publisher test_minimal_publisher_node
+    plugs: [network, network-bind]
+    command-chain:
+      - snap/command-chain/ros2-launch
+    environment:
+      PYTHONPATH: $SNAP/opt/ros/foxy/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages:${PYTHONPATH}
+      ROS_DISTRO: foxy

--- a/tests/spread/plugins/v2/snaps/colcon-stage-snaps/src/subscriber.cpp
+++ b/tests/spread/plugins/v2/snaps/colcon-stage-snaps/src/subscriber.cpp
@@ -1,0 +1,25 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+#include <test_minimal_publisher/subscriber.h>
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<test::MinimalSubscriber>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/tests/spread/plugins/v2/snaps/test-snapcraft-fake-ros2-package-core20/CMakeLists.txt
+++ b/tests/spread/plugins/v2/snaps/test-snapcraft-fake-ros2-package-core20/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.5)
+project(test_minimal_publisher)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+
+# This package installs libraries without exporting them.
+# Export the library path to ensure that the installed libraries are available.
+if(NOT WIN32)
+  ament_environment_hooks(
+    "${ament_cmake_package_templates_ENVIRONMENT_HOOK_LIBRARY_PATH}"
+    )
+endif()
+
+add_library(${PROJECT_NAME} src/subscriber.cpp)
+target_include_directories(${PROJECT_NAME} PUBLIC include)
+ament_target_dependencies(${PROJECT_NAME} rclcpp std_msgs)
+
+add_executable(${PROJECT_NAME}_node src/publisher.cpp)
+ament_target_dependencies(${PROJECT_NAME}_node rclcpp std_msgs)
+
+install(DIRECTORY include/
+  DESTINATION include/
+)
+
+install(TARGETS
+  ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(TARGETS
+  ${PROJECT_NAME}_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
+ament_export_dependencies(rclcpp std_msgs)
+
+ament_package()

--- a/tests/spread/plugins/v2/snaps/test-snapcraft-fake-ros2-package-core20/README.md
+++ b/tests/spread/plugins/v2/snaps/test-snapcraft-fake-ros2-package-core20/README.md
@@ -1,0 +1,6 @@
+# What is this, and why isn't it used?
+
+Spread tests do not build this snap, but spread tests (specifically
+colcon-stage-snaps) use it as a stage-snap. It's here to provide an
+understanding of what that stage-snap contains, as well as to facilitate
+updating it in the future.

--- a/tests/spread/plugins/v2/snaps/test-snapcraft-fake-ros2-package-core20/include/test_minimal_publisher/subscriber.h
+++ b/tests/spread/plugins/v2/snaps/test-snapcraft-fake-ros2-package-core20/include/test_minimal_publisher/subscriber.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+
+namespace test {
+
+class MinimalSubscriber : public rclcpp::Node
+{
+public:
+  MinimalSubscriber();
+
+private:
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
+  bool exit_after_receive_ = false;
+};
+
+} // namespace test

--- a/tests/spread/plugins/v2/snaps/test-snapcraft-fake-ros2-package-core20/package.xml
+++ b/tests/spread/plugins/v2/snaps/test-snapcraft-fake-ros2-package-core20/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>test_minimal_publisher</name>
+  <version>0.0.1</version>
+  <description>A dummy ROS 2 package for testing snapcraft</description>
+  <maintainer email="me@example.com">me</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/tests/spread/plugins/v2/snaps/test-snapcraft-fake-ros2-package-core20/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/test-snapcraft-fake-ros2-package-core20/snap/snapcraft.yaml
@@ -1,0 +1,51 @@
+name: test-snapcraft-fake-ros2-package-core20
+base: core20
+version: '0.1'
+summary: Bare-bones ROS 2 dependency for snapcraft CLI test
+description: |
+  This snap contains a single unusable ROS 2 package. This snap is not meant to
+  be used for anything other than snapcraft CLI tests.
+
+grade: stable
+confinement: strict
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+
+package-repositories:
+  - components:
+      - main
+    formats:
+      - deb
+    key-id: C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+    key-server: keyserver.ubuntu.com
+    suites:
+      - focal
+    type: apt
+    url: http://repo.ros2.org/ubuntu/main
+
+parts:
+  ros2-foxy-extension:
+    build-packages:
+      - python3-colcon-common-extensions
+      - ros-foxy-ros-core
+    stage-packages:
+      - ros-foxy-ros2run
+    override-build: install -D -m 0755 launch ${SNAPCRAFT_PART_INSTALL}/snap/command-chain/ros2-launch
+    plugin: nil
+    source: $SNAPCRAFT_EXTENSIONS_DIR/ros2
+  colcon-part:
+    plugin: colcon
+    source: .
+    build-environment:
+      - ROS_DISTRO: foxy
+
+apps:
+  test-snapcraft-fake-ros2-package-core20:
+    command: opt/ros/foxy/bin/ros2 run test_minimal_publisher test_minimal_publisher_node
+    plugs: [network, network-bind]
+    command-chain:
+      - snap/command-chain/ros2-launch
+    environment:
+      PYTHONPATH: $SNAP/opt/ros/foxy/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages:${PYTHONPATH}
+      ROS_DISTRO: foxy

--- a/tests/spread/plugins/v2/snaps/test-snapcraft-fake-ros2-package-core20/src/publisher.cpp
+++ b/tests/spread/plugins/v2/snaps/test-snapcraft-fake-ros2-package-core20/src/publisher.cpp
@@ -1,0 +1,51 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+
+using namespace std::chrono_literals;
+
+class MinimalPublisher : public rclcpp::Node
+{
+public:
+  MinimalPublisher()
+  : Node("test_minimal_publisher"), count_(0)
+  {
+    publisher_ = this->create_publisher<std_msgs::msg::String>("/test/topic", 10);
+    auto timer_callback =
+      [this]() -> void {
+        auto message = std_msgs::msg::String();
+        message.data = "Hello, world! " + std::to_string(this->count_++);
+        RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", message.data.c_str());
+        this->publisher_->publish(message);
+      };
+    timer_ = this->create_wall_timer(500ms, timer_callback);
+  }
+
+private:
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
+  size_t count_;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<MinimalPublisher>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/tests/spread/plugins/v2/snaps/test-snapcraft-fake-ros2-package-core20/src/subscriber.cpp
+++ b/tests/spread/plugins/v2/snaps/test-snapcraft-fake-ros2-package-core20/src/subscriber.cpp
@@ -1,0 +1,21 @@
+#include "test_minimal_publisher/subscriber.h"
+
+namespace test {
+
+MinimalSubscriber::MinimalSubscriber()
+: Node("test_minimal_subscriber") {
+  this->declare_parameter<bool>("exit_after_receive", exit_after_receive_);
+  this->get_parameter("exit_after_receive", exit_after_receive_);
+  subscription_ = this->create_subscription<std_msgs::msg::String>(
+    "/test/topic",
+    10,
+    [this](std_msgs::msg::String::UniquePtr msg) {
+      RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
+
+      if (exit_after_receive_) {
+        rclcpp::shutdown();
+      }
+    });
+}
+
+} // namespace test

--- a/tests/unit/plugins/v2/test_catkin.py
+++ b/tests/unit/plugins/v2/test_catkin.py
@@ -86,27 +86,27 @@ def test_get_build_commands(monkeypatch):
     assert plugin.get_build_commands() == [
         'state="$(set +o)"',
         "set +u",
-        'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh ]; then',
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
         "set -- --local",
-        '_CATKIN_SETUP_DIR="${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO . "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh',
+        '_CATKIN_SETUP_DIR="${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" . "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh"',
         "set -- --local --extend",
         "else",
         "set -- --local",
         "fi",
-        ". /opt/ros/$ROS_DISTRO/setup.sh",
+        '. /opt/ros/"${ROS_DISTRO}"/setup.sh',
         'eval "${state}"',
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
-        "rosdep update --include-eol-distros --rosdistro $ROS_DISTRO",
-        "rosdep install --default-yes --ignore-packages-from-source --from-paths $SNAPCRAFT_PART_SRC",
+        'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
+        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC}"',
         "catkin_make_isolated --install --merge "
-        "--source-space $SNAPCRAFT_PART_SRC --build-space $SNAPCRAFT_PART_BUILD "
-        "--install-space $SNAPCRAFT_PART_INSTALL/opt/ros/$ROS_DISTRO "
-        "-j $SNAPCRAFT_PARALLEL_BUILD_COUNT",
+        '--source-space "${SNAPCRAFT_PART_SRC}" --build-space "${SNAPCRAFT_PART_BUILD}" '
+        '--install-space "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" '
+        '-j "${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
         "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 /test/python3 -I "
         "/test/_ros.py "
-        "stage-runtime-dependencies --part-src $SNAPCRAFT_PART_SRC --part-install $SNAPCRAFT_PART_INSTALL "
-        "--ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
+        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
+        '--ros-distro "${ROS_DISTRO}" --target-arch "${SNAPCRAFT_TARGET_ARCH}"',
     ]
 
 
@@ -139,29 +139,29 @@ def test_get_build_commands_with_all_properties(monkeypatch):
     assert plugin.get_build_commands() == [
         'state="$(set +o)"',
         "set +u",
-        'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh ]; then',
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
         "set -- --local",
-        '_CATKIN_SETUP_DIR="${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO . "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh',
+        '_CATKIN_SETUP_DIR="${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" . "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh"',
         "set -- --local --extend",
         "else",
         "set -- --local",
         "fi",
-        ". /opt/ros/$ROS_DISTRO/setup.sh",
+        '. /opt/ros/"${ROS_DISTRO}"/setup.sh',
         'eval "${state}"',
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
-        "rosdep update --include-eol-distros --rosdistro $ROS_DISTRO",
-        "rosdep install --default-yes --ignore-packages-from-source --from-paths $SNAPCRAFT_PART_SRC",
+        'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
+        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC}"',
         "catkin_make_isolated --install --merge "
-        "--source-space $SNAPCRAFT_PART_SRC --build-space $SNAPCRAFT_PART_BUILD "
-        "--install-space $SNAPCRAFT_PART_INSTALL/opt/ros/$ROS_DISTRO "
-        "-j $SNAPCRAFT_PARALLEL_BUILD_COUNT --pkg package1 package2... "
+        '--source-space "${SNAPCRAFT_PART_SRC}" --build-space "${SNAPCRAFT_PART_BUILD}" '
+        '--install-space "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" '
+        '-j "${SNAPCRAFT_PARALLEL_BUILD_COUNT}" --pkg package1 package2... '
         "--ignore-pkg ipackage1 ipackage2... --cmake-args cmake args...",
         "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/bin:/test SNAP=TESTSNAP "
         "SNAP_ARCH=TESTARCH SNAP_NAME=TESTSNAPNAME SNAP_VERSION=TESTV1 "
         "http_proxy=http://foo https_proxy=https://bar "
         "/test/python3 -I "
         "/test/_ros.py "
-        "stage-runtime-dependencies --part-src $SNAPCRAFT_PART_SRC --part-install $SNAPCRAFT_PART_INSTALL "
-        "--ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
+        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
+        '--ros-distro "${ROS_DISTRO}" --target-arch "${SNAPCRAFT_TARGET_ARCH}"',
     ]

--- a/tests/unit/plugins/v2/test_catkin_tools.py
+++ b/tests/unit/plugins/v2/test_catkin_tools.py
@@ -82,29 +82,29 @@ def test_get_build_commands(monkeypatch):
     assert plugin.get_build_commands() == [
         'state="$(set +o)"',
         "set +u",
-        'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh ]; then',
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
         "set -- --local",
-        '_CATKIN_SETUP_DIR="${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO . "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh',
+        '_CATKIN_SETUP_DIR="${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" . "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh"',
         "set -- --local --extend",
         "else",
         "set -- --local",
         "fi",
-        ". /opt/ros/$ROS_DISTRO/setup.sh",
+        '. /opt/ros/"${ROS_DISTRO}"/setup.sh',
         'eval "${state}"',
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
-        "rosdep update --include-eol-distros --rosdistro $ROS_DISTRO",
-        "rosdep install --default-yes --ignore-packages-from-source --from-paths $SNAPCRAFT_PART_SRC",
+        'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
+        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC}"',
         "catkin init",
         "catkin profile add -f default",
         "catkin config --profile default --install "
-        "--source-space $SNAPCRAFT_PART_SRC --build-space $SNAPCRAFT_PART_BUILD "
-        "--install-space $SNAPCRAFT_PART_INSTALL/opt/ros/$ROS_DISTRO",
-        "catkin build --no-notify --profile default -j $SNAPCRAFT_PARALLEL_BUILD_COUNT",
+        '--source-space "${SNAPCRAFT_PART_SRC}" --build-space "${SNAPCRAFT_PART_BUILD}" '
+        '--install-space "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}"',
+        'catkin build --no-notify --profile default -j "${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
         "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 /test/python3 -I "
         "/test/_ros.py "
-        "stage-runtime-dependencies --part-src $SNAPCRAFT_PART_SRC --part-install $SNAPCRAFT_PART_INSTALL "
-        "--ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
+        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
+        '--ros-distro "${ROS_DISTRO}" --target-arch "${SNAPCRAFT_TARGET_ARCH}"',
     ]
 
 
@@ -136,30 +136,30 @@ def test_get_build_commands_with_all_properties(monkeypatch):
     assert plugin.get_build_commands() == [
         'state="$(set +o)"',
         "set +u",
-        'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh ]; then',
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
         "set -- --local",
-        '_CATKIN_SETUP_DIR="${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO . "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh',
+        '_CATKIN_SETUP_DIR="${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" . "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh"',
         "set -- --local --extend",
         "else",
         "set -- --local",
         "fi",
-        ". /opt/ros/$ROS_DISTRO/setup.sh",
+        '. /opt/ros/"${ROS_DISTRO}"/setup.sh',
         'eval "${state}"',
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
-        "rosdep update --include-eol-distros --rosdistro $ROS_DISTRO",
-        "rosdep install --default-yes --ignore-packages-from-source --from-paths $SNAPCRAFT_PART_SRC",
+        'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
+        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC}"',
         "catkin init",
         "catkin profile add -f default",
         "catkin config --profile default --install "
-        "--source-space $SNAPCRAFT_PART_SRC --build-space $SNAPCRAFT_PART_BUILD "
-        "--install-space $SNAPCRAFT_PART_INSTALL/opt/ros/$ROS_DISTRO --cmake-args cmake args...",
-        "catkin build --no-notify --profile default -j $SNAPCRAFT_PARALLEL_BUILD_COUNT package1 package2...",
+        '--source-space "${SNAPCRAFT_PART_SRC}" --build-space "${SNAPCRAFT_PART_BUILD}" '
+        '--install-space "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" --cmake-args cmake args...',
+        'catkin build --no-notify --profile default -j "${SNAPCRAFT_PARALLEL_BUILD_COUNT}" package1 package2...',
         "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/bin:/test SNAP=TESTSNAP "
         "SNAP_ARCH=TESTARCH SNAP_NAME=TESTSNAPNAME SNAP_VERSION=TESTV1 "
         "http_proxy=http://foo https_proxy=https://bar "
         "/test/python3 -I "
         "/test/_ros.py "
-        "stage-runtime-dependencies --part-src $SNAPCRAFT_PART_SRC --part-install $SNAPCRAFT_PART_INSTALL "
-        "--ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
+        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
+        '--ros-distro "${ROS_DISTRO}" --target-arch "${SNAPCRAFT_TARGET_ARCH}"',
     ]

--- a/tests/unit/plugins/v2/test_colcon.py
+++ b/tests/unit/plugins/v2/test_colcon.py
@@ -110,23 +110,23 @@ def test_get_build_commands(monkeypatch):
         'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/setup.sh ]; then',
         'COLCON_CURRENT_PREFIX="${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap . "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/setup.sh',
         "fi",
-        ". /opt/ros/$ROS_DISTRO/local_setup.sh",
+        '. /opt/ros/"${ROS_DISTRO}"/local_setup.sh',
         'eval "${state}"',
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
-        "rosdep update --include-eol-distros --rosdistro $ROS_DISTRO",
-        "rosdep install --default-yes --ignore-packages-from-source --from-paths $SNAPCRAFT_PART_SRC",
+        'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
+        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC}"',
         "colcon build "
-        "--base-paths $SNAPCRAFT_PART_SRC --build-base $SNAPCRAFT_PART_BUILD "
-        "--merge-install --install-base $SNAPCRAFT_PART_INSTALL/opt/ros/snap "
-        "--parallel-workers ${SNAPCRAFT_PARALLEL_BUILD_COUNT}",
+        '--base-paths "${SNAPCRAFT_PART_SRC}" --build-base "${SNAPCRAFT_PART_BUILD}" '
+        '--merge-install --install-base "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap '
+        '--parallel-workers "${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
         'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE ]; then',
         'rm "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE',
         "fi",
         "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 /test/python3 -I "
         "/test/_ros.py "
-        "stage-runtime-dependencies --part-src $SNAPCRAFT_PART_SRC --part-install $SNAPCRAFT_PART_INSTALL "
-        "--ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
+        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
+        '--ros-distro "${ROS_DISTRO}" --target-arch "${SNAPCRAFT_TARGET_ARCH}"',
     ]
 
 
@@ -164,18 +164,18 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/setup.sh ]; then',
         'COLCON_CURRENT_PREFIX="${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap . "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/setup.sh',
         "fi",
-        ". /opt/ros/$ROS_DISTRO/local_setup.sh",
+        '. /opt/ros/"${ROS_DISTRO}"/local_setup.sh',
         'eval "${state}"',
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
-        "rosdep update --include-eol-distros --rosdistro $ROS_DISTRO",
-        "rosdep install --default-yes --ignore-packages-from-source --from-paths $SNAPCRAFT_PART_SRC",
+        'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
+        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC}"',
         "colcon build "
-        "--base-paths $SNAPCRAFT_PART_SRC --build-base $SNAPCRAFT_PART_BUILD "
-        "--merge-install --install-base $SNAPCRAFT_PART_INSTALL/opt/ros/snap "
+        '--base-paths "${SNAPCRAFT_PART_SRC}" --build-base "${SNAPCRAFT_PART_BUILD}" '
+        '--merge-install --install-base "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap '
         "--packages-ignore ipackage1 ipackage2... --packages-select package1 "
         "package2... --ament-cmake-args ament args... --catkin-cmake-args catkin "
-        "args... --parallel-workers ${SNAPCRAFT_PARALLEL_BUILD_COUNT}",
+        'args... --parallel-workers "${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
         'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE ]; then',
         'rm "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE',
         "fi",
@@ -183,6 +183,6 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "SNAP_ARCH=TESTARCH SNAP_NAME=TESTSNAPNAME SNAP_VERSION=TESTV1 "
         "http_proxy=http://foo https_proxy=https://bar "
         "/test/python3 -I /test/_ros.py "
-        "stage-runtime-dependencies --part-src $SNAPCRAFT_PART_SRC --part-install $SNAPCRAFT_PART_INSTALL "
-        "--ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
+        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
+        '--ros-distro "${ROS_DISTRO}" --target-arch "${SNAPCRAFT_TARGET_ARCH}"',
     ]

--- a/tests/unit/plugins/v2/test_colcon.py
+++ b/tests/unit/plugins/v2/test_colcon.py
@@ -107,14 +107,10 @@ def test_get_build_commands(monkeypatch):
     assert plugin.get_build_commands() == [
         'state="$(set +o)"',
         "set +u",
-        'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh ]; then',
-        "set -- --local",
-        '_CATKIN_SETUP_DIR="${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO . "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh',
-        "set -- --local --extend",
-        "else",
-        "set -- --local",
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/setup.sh ]; then',
+        'COLCON_CURRENT_PREFIX="${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap . "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/setup.sh',
         "fi",
-        ". /opt/ros/$ROS_DISTRO/setup.sh",
+        ". /opt/ros/$ROS_DISTRO/local_setup.sh",
         'eval "${state}"',
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
@@ -122,8 +118,11 @@ def test_get_build_commands(monkeypatch):
         "rosdep install --default-yes --ignore-packages-from-source --from-paths $SNAPCRAFT_PART_SRC",
         "colcon build "
         "--base-paths $SNAPCRAFT_PART_SRC --build-base $SNAPCRAFT_PART_BUILD "
-        "--merge-install --install-base $SNAPCRAFT_PART_INSTALL "
+        "--merge-install --install-base $SNAPCRAFT_PART_INSTALL/opt/ros/snap "
         "--parallel-workers ${SNAPCRAFT_PARALLEL_BUILD_COUNT}",
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE ]; then',
+        'rm "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE',
+        "fi",
         "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 /test/python3 -I "
         "/test/_ros.py "
         "stage-runtime-dependencies --part-src $SNAPCRAFT_PART_SRC --part-install $SNAPCRAFT_PART_INSTALL "
@@ -162,14 +161,10 @@ def test_get_build_commands_with_all_properties(monkeypatch):
     assert plugin.get_build_commands() == [
         'state="$(set +o)"',
         "set +u",
-        'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh ]; then',
-        "set -- --local",
-        '_CATKIN_SETUP_DIR="${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO . "${SNAPCRAFT_PART_INSTALL}"/opt/ros/$ROS_DISTRO/setup.sh',
-        "set -- --local --extend",
-        "else",
-        "set -- --local",
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/setup.sh ]; then',
+        'COLCON_CURRENT_PREFIX="${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap . "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/setup.sh',
         "fi",
-        ". /opt/ros/$ROS_DISTRO/setup.sh",
+        ". /opt/ros/$ROS_DISTRO/local_setup.sh",
         'eval "${state}"',
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
@@ -177,10 +172,13 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "rosdep install --default-yes --ignore-packages-from-source --from-paths $SNAPCRAFT_PART_SRC",
         "colcon build "
         "--base-paths $SNAPCRAFT_PART_SRC --build-base $SNAPCRAFT_PART_BUILD "
-        "--merge-install --install-base $SNAPCRAFT_PART_INSTALL "
+        "--merge-install --install-base $SNAPCRAFT_PART_INSTALL/opt/ros/snap "
         "--packages-ignore ipackage1 ipackage2... --packages-select package1 "
         "package2... --ament-cmake-args ament args... --catkin-cmake-args catkin "
         "args... --parallel-workers ${SNAPCRAFT_PARALLEL_BUILD_COUNT}",
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE ]; then',
+        'rm "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE',
+        "fi",
         "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/bin:/test SNAP=TESTSNAP "
         "SNAP_ARCH=TESTARCH SNAP_NAME=TESTSNAPNAME SNAP_VERSION=TESTV1 "
         "http_proxy=http://foo https_proxy=https://bar "


### PR DESCRIPTION
This PR is a follow-up on #3536 and essentially fixes the same issues for ROS 2 plugins v2.

This PR most notably,

- changes the colcon install path from `$SNAPCRAFT_PART_INSTALL` to `$SNAPCRAFT_PART_INSTALL/opt/ros/snap` for a cleaner separation of ROS 2 workspaces (similar to what's in the v1 plugin).
- looks for ROS 2 packages in `$SNAPCRAFT_PART_INSTALL/opt/ros/snap` in case the workspace exists (e.g. provided by a stage-snap) during the build step
- does not `rosdep resolve` packages that are available locally in `$SNAPCRAFT_PART_INSTALL` during stage step. Such locally available package may be part of the built sources or provided by a stage-snap. Furthermore, it fixes the following current issue; if the source contains packages `foo` & `bar` - two packages that are not released in the rosdistro database - where `foo` depends on `bar`, staging fails as it tries to `rosdep resolve` the `bar` key (which does not exists since it is not released). With this fix, it finds `bar` locally and thus does not try to resolve it. This issue is fixed by deleting the `${SNAPCRAFT_PART_INSTALL}/opt/ros/snap/COLCON_IGNORE` marker file - if it exists - right after the actual build command. This marker file prevents catkin from crawling the directory while looking for packages during staging.
- adds `test-snapcraft-fake-ros2-package-core20` snap and `colcon-stage-snaps` snap/spread test to test the above bullet points.

Note:

- I own the `test-snapcraft-fake-ros2-package-core20` snap that's used in the new spread test, I imagine we should transfer ownership.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
