### PR TITLE
cli: enable SNAPCRAFT_TARGET_ARCH envvar matching --target-arch

### DIFF
--- a/snapcraft/cli/_options.py
+++ b/snapcraft/cli/_options.py
@@ -73,6 +73,7 @@ _ALL_PROVIDERS = _SUPPORTED_PROVIDERS + _HIDDEN_PROVIDERS
 _PROVIDER_OPTIONS: List[Dict[str, Any]] = [
     dict(
         param_decls="--target-arch",
+        envvar="SNAPCRAFT_TARGET_ARCH",
         metavar="<arch>",
         help="Target architecture to cross compile to",
         supported_providers=["host", "lxd", "multipass"],
@@ -332,6 +333,11 @@ def get_build_provider_flags(build_provider: str, **kwargs) -> Dict[str, str]:
         # Add build provider flag using envvar as key.
         if envvar is not None and key_formatted in kwargs:
             build_provider_flags[envvar] = kwargs[key_formatted]
+
+    # Ensure target arch is scrubbed from build provider flags to prevent
+    # a change of behavior.
+    if build_provider in ["multipass", "lxd"]:
+        build_provider_flags.pop("SNAPCRAFT_TARGET_ARCH", None)
 
     return build_provider_flags
 

--- a/tests/unit/cli/test_options.py
+++ b/tests/unit/cli/test_options.py
@@ -64,11 +64,25 @@ class TestProviderOptions:
             ),
         ),
         (
+            "host target arch",
+            dict(
+                provider="host",
+                kwargs=dict(target_arch="somearch"),
+                flags=dict(SNAPCRAFT_TARGET_ARCH="somearch"),
+            ),
+        ),
+        (
             "host all",
             dict(
                 provider="host",
-                kwargs=dict(http_proxy="1.1.1.1", https_proxy="1.1.1.1"),
-                flags=dict(http_proxy="1.1.1.1", https_proxy="1.1.1.1"),
+                kwargs=dict(
+                    http_proxy="1.1.1.1", https_proxy="1.1.1.1", target_arch="somearch"
+                ),
+                flags=dict(
+                    http_proxy="1.1.1.1",
+                    https_proxy="1.1.1.1",
+                    SNAPCRAFT_TARGET_ARCH="somearch",
+                ),
             ),
         ),
         ("lxd empty", dict(provider="lxd", kwargs=dict(), flags=dict())),
@@ -105,6 +119,10 @@ class TestProviderOptions:
             ),
         ),
         (
+            "lxd target arch",
+            dict(provider="lxd", kwargs=dict(target_arch="somearch"), flags=dict(),),
+        ),
+        (
             "lxd all",
             dict(
                 provider="lxd",
@@ -113,6 +131,7 @@ class TestProviderOptions:
                     https_proxy="1.1.1.1",
                     enable_manifest=True,
                     manifest_image_information="{}",
+                    target_arch="somearch",
                 ),
                 flags=dict(
                     http_proxy="1.1.1.1",
@@ -210,6 +229,12 @@ class TestProviderOptions:
             ),
         ),
         (
+            "multipass target arch",
+            dict(
+                provider="multipass", kwargs=dict(target_arch="somearch"), flags=dict(),
+            ),
+        ),
+        (
             "multipass all",
             dict(
                 provider="multipass",
@@ -218,6 +243,7 @@ class TestProviderOptions:
                     https_proxy="1.1.1.1",
                     enable_manifest=True,
                     manifest_image_information="{}",
+                    target_arch="somearch",
                 ),
                 flags=dict(
                     http_proxy="1.1.1.1",


### PR DESCRIPTION
But ensure it is scrubbed from build provider flags so
that it doesn't get passed into target environment and
cause behavior changes.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
