### PR TITLE
preload bindtextdomain from the gnome content snap if it exists

### DIFF
--- a/extensions/desktop/common/init
+++ b/extensions/desktop/common/init
@@ -71,7 +71,9 @@ export SNAP_LAUNCHER_ARCH_TRIPLET="$ARCH"
 
 # Don't LD_PRELOAD bindtextdomain for classic snaps
 if ! grep -qs "^\s*confinement:\s*classic\s*" "$SNAP/meta/snap.yaml"; then
-  if [ -f "$SNAP/lib/$ARCH/bindtextdomain.so" ]; then
+  if [ -f "$SNAP/gnome-platform/lib/$ARCH/bindtextdomain.so" ]; then
+    export LD_PRELOAD="$LD_PRELOAD:$SNAP/gnome-platform/\$LIB/bindtextdomain.so"
+  elif [ -f "$SNAP/lib/$ARCH/bindtextdomain.so" ]; then
     export LD_PRELOAD="$LD_PRELOAD:$SNAP/\$LIB/bindtextdomain.so"
   fi
 fi


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

This requires an unreleased gnome-3-38-2004, which can be tracked at https://gitlab.gnome.org/Community/Ubuntu/gnome-sdk/-/merge_requests/29
-----
