### PR TITLE
ROS V2 plugins: resolve conditional dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test-black:
 
 .PHONY: test-codespell
 test-codespell:
-	codespell --quiet-level 4 --ignore-words-list crate,keyserver --skip '*.tar,*.xz,*.zip,*.bz2,*.7z,*.gz,*.deb,*.rpm,*.snap,*.gpg,*.pyc,*.png,*.ico,*.jar,changelog,.git,.hg,.mypy_cache,.tox,.venv,_build,buck-out,__pycache__,build,dist,.vscode,parts,stage,prime,test_appstream.py,./snapcraft.spec,./.direnv'
+	codespell --quiet-level 4 --ignore-words-list crate,keyserver --skip '*.tar,*.xz,*.zip,*.bz2,*.7z,*.gz,*.deb,*.rpm,*.snap,*.gpg,*.pyc,*.png,*.ico,*.jar,changelog,.git,.hg,.mypy_cache,.tox,.venv,_build,buck-out,__pycache__,build,dist,.vscode,parts,stage,prime,test_appstream.py,./snapcraft.spec,./.direnv,./.pytest_cache'
 
 .PHONY: test-flake8
 test-flake8:

--- a/snapcraft/internal/project_loader/_extensions/ros1_noetic.py
+++ b/snapcraft/internal/project_loader/_extensions/ros1_noetic.py
@@ -26,6 +26,7 @@ from ._extension import Extension
 class ExtensionImpl(Extension):
     """Setup a ROS 1 build and runtime environment suitable for a snap."""
 
+    ROS_VERSION: Final[str] = "1"
     ROS_DISTRO: Final[str] = "noetic"
 
     @staticmethod
@@ -66,12 +67,18 @@ class ExtensionImpl(Extension):
         self.app_snippet = {
             "command-chain": ["snap/command-chain/ros1-launch"],
             "environment": {
+                "ROS_VERSION": self.ROS_VERSION,
                 "ROS_DISTRO": self.ROS_DISTRO,
                 "PYTHONPATH": ":".join(python_paths),
             },
         }
 
-        self.part_snippet = {"build-environment": [{"ROS_DISTRO": self.ROS_DISTRO}]}
+        self.part_snippet = {
+            "build-environment": [
+                {"ROS_VERSION": self.ROS_VERSION},
+                {"ROS_DISTRO": self.ROS_DISTRO},
+            ],
+        }
 
         self.parts = {
             f"ros1-{self.ROS_DISTRO}-extension": {

--- a/snapcraft/internal/project_loader/_extensions/ros2_foxy.py
+++ b/snapcraft/internal/project_loader/_extensions/ros2_foxy.py
@@ -28,6 +28,7 @@ _PLATFORM_SNAP = dict(core18="gnome-3-34-1804")
 class ExtensionImpl(Extension):
     """Drives ROS 2 build and runtime environment for snap."""
 
+    ROS_VERSION: Final[str] = "2"
     ROS_DISTRO: Final[str] = "foxy"
 
     @staticmethod
@@ -68,12 +69,18 @@ class ExtensionImpl(Extension):
         self.app_snippet = {
             "command-chain": ["snap/command-chain/ros2-launch"],
             "environment": {
+                "ROS_VERSION": self.ROS_VERSION,
                 "ROS_DISTRO": self.ROS_DISTRO,
                 "PYTHONPATH": ":".join(python_paths),
             },
         }
 
-        self.part_snippet = {"build-environment": [{"ROS_DISTRO": self.ROS_DISTRO}]}
+        self.part_snippet = {
+            "build-environment": [
+                {"ROS_VERSION": self.ROS_VERSION},
+                {"ROS_DISTRO": self.ROS_DISTRO},
+            ],
+        }
 
         self.parts = {
             f"ros2-{self.ROS_DISTRO}-extension": {

--- a/snapcraft/plugins/v2/_ros.py
+++ b/snapcraft/plugins/v2/_ros.py
@@ -123,6 +123,8 @@ class RosPlugin(PluginV2):
                     "$SNAPCRAFT_PART_SRC",
                     "--part-install",
                     "$SNAPCRAFT_PART_INSTALL",
+                    "--ros-version",
+                    "$ROS_VERSION",
                     "--ros-distro",
                     "$ROS_DISTRO",
                     "--target-arch",
@@ -152,10 +154,15 @@ def plugin_cli():
 @plugin_cli.command()
 @click.option("--part-src", envvar="SNAPCRAFT_PART_SRC", required=True)
 @click.option("--part-install", envvar="SNAPCRAFT_PART_INSTALL", required=True)
+@click.option("--ros-version", envvar="ROS_VERSION", required=True)
 @click.option("--ros-distro", envvar="ROS_DISTRO", required=True)
 @click.option("--target-arch", envvar="SNAPCRAFT_TARGET_ARCH", required=True)
 def stage_runtime_dependencies(
-    part_src: str, part_install: str, ros_distro: str, target_arch: str
+    part_src: str,
+    part_install: str,
+    ros_version: str,
+    ros_distro: str,
+    target_arch: str,
 ):
     click.echo("Staging runtime dependencies...")
     # TODO: support python packages (only apt currently supported)
@@ -163,7 +170,18 @@ def stage_runtime_dependencies(
 
     installed_pkgs = catkin_packages.find_packages(part_install).values()
     for pkg in catkin_packages.find_packages(part_src).values():
-        for dep in pkg.exec_depends:
+        # Evaluate the conditions of all dependencies
+        pkg.evaluate_conditions(
+            {
+                "ROS_VERSION": ros_version,
+                "ROS_DISTRO": ros_distro,
+                "ROS_PYTHON_VERSION": "3",
+            }
+        )
+        # Retrieve only the 'exec_depends' which condition are true
+        for dep in (
+            exec_dep for exec_dep in pkg.exec_depends if exec_dep.evaluated_condition
+        ):
             # No need to resolve this dependency if we know it's local
             if any(p for p in installed_pkgs if p.name == dep.name):
                 continue

--- a/tests/spread/plugins/v2/snaps/catkin-noetic-hello/src/snapcraft_hello/package.xml
+++ b/tests/spread/plugins/v2/snaps/catkin-noetic-hello/src/snapcraft_hello/package.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>snapcraft_hello</name>
   <version>0.0.1</version>
   <description>snapcraft test for roscpp</description>
   <maintainer email="me@example.com">me</maintainer>
   <license>GPLv3</license>
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <build_export_depend>roscpp</build_export_depend>
-  <exec_depend>roscpp</exec_depend>
+  <build_depend condition="$ROS_VERSION == 1">roscpp</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">fake_package_that_does_not_exists</build_depend>
+  <build_export_depend condition="$ROS_VERSION == 1">roscpp</build_export_depend>
+  <exec_depend condition="$ROS_VERSION == 1">roscpp</exec_depend>
 </package>

--- a/tests/spread/plugins/v2/snaps/catkin-tools-noetic-hello/src/snapcraft_hello/package.xml
+++ b/tests/spread/plugins/v2/snaps/catkin-tools-noetic-hello/src/snapcraft_hello/package.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>snapcraft_hello</name>
   <version>0.0.1</version>
   <description>snapcraft test for roscpp</description>
   <maintainer email="me@example.com">me</maintainer>
   <license>GPLv3</license>
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <build_export_depend>roscpp</build_export_depend>
-  <exec_depend>roscpp</exec_depend>
+  <build_depend condition="$ROS_VERSION == 1">roscpp</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">fake_package_that_does_not_exists</build_depend>
+  <build_export_depend condition="$ROS_VERSION == 1">roscpp</build_export_depend>
+  <exec_depend condition="$ROS_VERSION == 1">roscpp</exec_depend>
 </package>

--- a/tests/spread/plugins/v2/snaps/colcon-ros2-foxy-rlcpp-hello/package.xml
+++ b/tests/spread/plugins/v2/snaps/colcon-ros2-foxy-rlcpp-hello/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<package format="3">
   <name>colcon_ros2_rlcpp_hello</name>
   <version>0.0.1</version>
   <description>snapcraft test for rlcpp</description>
@@ -9,11 +9,12 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>rclcpp</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">fake_package_that_does_not_exists</build_depend>
 
-  <exec_depend>rclcpp</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 

--- a/tests/unit/plugins/v2/test_catkin.py
+++ b/tests/unit/plugins/v2/test_catkin.py
@@ -106,7 +106,7 @@ def test_get_build_commands(monkeypatch):
         "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 /test/python3 -I "
         "/test/_ros.py "
         "stage-runtime-dependencies --part-src $SNAPCRAFT_PART_SRC --part-install $SNAPCRAFT_PART_INSTALL "
-        "--ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
+        "--ros-version $ROS_VERSION --ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
     ]
 
 
@@ -163,5 +163,5 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "/test/python3 -I "
         "/test/_ros.py "
         "stage-runtime-dependencies --part-src $SNAPCRAFT_PART_SRC --part-install $SNAPCRAFT_PART_INSTALL "
-        "--ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
+        "--ros-version $ROS_VERSION --ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
     ]

--- a/tests/unit/plugins/v2/test_catkin_tools.py
+++ b/tests/unit/plugins/v2/test_catkin_tools.py
@@ -104,7 +104,7 @@ def test_get_build_commands(monkeypatch):
         "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 /test/python3 -I "
         "/test/_ros.py "
         "stage-runtime-dependencies --part-src $SNAPCRAFT_PART_SRC --part-install $SNAPCRAFT_PART_INSTALL "
-        "--ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
+        "--ros-version $ROS_VERSION --ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
     ]
 
 
@@ -161,5 +161,5 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "/test/python3 -I "
         "/test/_ros.py "
         "stage-runtime-dependencies --part-src $SNAPCRAFT_PART_SRC --part-install $SNAPCRAFT_PART_INSTALL "
-        "--ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
+        "--ros-version $ROS_VERSION --ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
     ]

--- a/tests/unit/plugins/v2/test_colcon.py
+++ b/tests/unit/plugins/v2/test_colcon.py
@@ -127,7 +127,7 @@ def test_get_build_commands(monkeypatch):
         "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 /test/python3 -I "
         "/test/_ros.py "
         "stage-runtime-dependencies --part-src $SNAPCRAFT_PART_SRC --part-install $SNAPCRAFT_PART_INSTALL "
-        "--ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
+        "--ros-version $ROS_VERSION --ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
     ]
 
 
@@ -186,5 +186,5 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "http_proxy=http://foo https_proxy=https://bar "
         "/test/python3 -I /test/_ros.py "
         "stage-runtime-dependencies --part-src $SNAPCRAFT_PART_SRC --part-install $SNAPCRAFT_PART_INSTALL "
-        "--ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
+        "--ros-version $ROS_VERSION --ros-distro $ROS_DISTRO --target-arch $SNAPCRAFT_TARGET_ARCH",
     ]

--- a/tests/unit/project_loader/extensions/test_ros1_noetic.py
+++ b/tests/unit/project_loader/extensions/test_ros1_noetic.py
@@ -1,0 +1,77 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2021 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from snapcraft.internal.project_loader._extensions.ros1_noetic import (
+    ExtensionImpl as Ros1NoeticExtension,
+)
+
+
+@pytest.fixture(params=[Ros1NoeticExtension])
+def extension_class(request):
+    return request.param
+
+
+def test_extension(extension_class):
+    ros1_extension = extension_class(
+        extension_name="ros1-noetic", yaml_data=dict(base="core20")
+    )
+
+    assert ros1_extension.root_snippet == {
+        "package-repositories": [
+            {
+                "components": ["main"],
+                "formats": ["deb"],
+                "key-id": "C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654",
+                "key-server": "keyserver.ubuntu.com",
+                "suites": ["focal"],
+                "type": "apt",
+                "url": "http://packages.ros.org/ros/ubuntu",
+            }
+        ]
+    }
+
+    assert ros1_extension.app_snippet == {
+        "command-chain": ["snap/command-chain/ros1-launch"],
+        "environment": {
+            "PYTHONPATH": "$SNAP/opt/ros/noetic/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages:${PYTHONPATH}",
+            "ROS_VERSION": "1",
+            "ROS_DISTRO": "noetic",
+        },
+    }
+
+    assert ros1_extension.part_snippet == {
+        "build-environment": [{"ROS_VERSION": "1"}, {"ROS_DISTRO": "noetic"}]
+    }
+
+    assert ros1_extension.parts == {
+        "ros1-noetic-extension": {
+            "build-packages": ["ros-noetic-catkin"],
+            "override-build": "install -D -m 0755 launch "
+            "${SNAPCRAFT_PART_INSTALL}/snap/command-chain/ros1-launch",
+            "plugin": "nil",
+            "source": "$SNAPCRAFT_EXTENSIONS_DIR/ros1",
+        }
+    }
+
+
+def test_supported_bases(extension_class):
+    assert extension_class.get_supported_bases() == ("core20",)
+
+
+def test_supported_confinement(extension_class):
+    extension_class.get_supported_confinement() == ("strict", "devmode")

--- a/tests/unit/project_loader/extensions/test_ros2_foxy.py
+++ b/tests/unit/project_loader/extensions/test_ros2_foxy.py
@@ -49,12 +49,13 @@ def test_extension(extension_class):
         "command-chain": ["snap/command-chain/ros2-launch"],
         "environment": {
             "PYTHONPATH": "$SNAP/opt/ros/foxy/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages:${PYTHONPATH}",
+            "ROS_VERSION": "2",
             "ROS_DISTRO": "foxy",
         },
     }
 
     assert ros2_extension.part_snippet == {
-        "build-environment": [{"ROS_DISTRO": "foxy"}]
+        "build-environment": [{"ROS_VERSION": "2"}, {"ROS_DISTRO": "foxy"}],
     }
 
     assert ros2_extension.parts == {


### PR DESCRIPTION
This PR enables ROS conditional dependencies in `package.xml` such as e.g.

```xml
<build_depend condition="$ROS_VERSION == 1">roscpp</build_depend>
<build_depend condition="$ROS_VERSION == 2">rclcpp</build_depend>
```

It only enables conditions based on "ROS_VERSION", "ROS_DISTRO" and "ROS_PYTHON_VERSION" which are the most commonly encountered.

This is the plugin V2 equivalent of #3313.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
