### PR TITLE
cli & providers: pass part names for lifecycle commands (CRAFT-481)

### DIFF
--- a/snapcraft/cli/lifecycle.py
+++ b/snapcraft/cli/lifecycle.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 import time
 import typing
-from typing import List, Optional, Union
+from typing import List, Optional, Sequence, Union
 
 import click
 import progressbar
@@ -60,7 +60,7 @@ if typing.TYPE_CHECKING:
 # TODO: when snap is a real step we can simplify the arguments here.
 def _execute(  # noqa: C901
     step: steps.Step,
-    parts: str,
+    parts: Sequence[str],
     pack_project: bool = False,
     output: Optional[str] = None,
     shell: bool = False,
@@ -138,14 +138,14 @@ def _execute(  # noqa: C901
                         previous_step = step.previous_step()
                     # steps.PULL is the first step, so we would directly shell into it.
                     if previous_step:
-                        instance.execute_step(previous_step)
+                        instance.execute_step(previous_step, part_names=parts)
                 elif pack_project:
                     instance.pack_project(output=output)
                 elif setup_prime_try:
                     instance.expose_prime()
-                    instance.execute_step(step)
+                    instance.execute_step(step, part_names=parts)
                 else:
-                    instance.execute_step(step)
+                    instance.execute_step(step, part_names=parts)
             except Exception:
                 _retrieve_provider_error(instance)
                 if project.debug:

--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -184,8 +184,14 @@ class Provider(abc.ABC):
         if not self._mount_prime_directory():
             self._run(command=["snapcraft", "clean", "--unprime"])
 
-    def execute_step(self, step: steps.Step) -> None:
-        self._run(command=["snapcraft", step.name])
+    def execute_step(
+        self, step: steps.Step, part_names: Optional[Sequence[str]] = None
+    ) -> None:
+        command = ["snapcraft", step.name]
+        if part_names:
+            command += list(part_names)
+
+        self._run(command=command)
 
     def clean_parts(self, part_names: Sequence[str]) -> None:
         self._run(command=["snapcraft", "clean"] + list(part_names))

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -26,6 +26,7 @@ import fixtures
 import pytest
 from testtools.matchers import DirExists, EndsWith, Equals, Not
 
+from snapcraft.internal import steps
 from snapcraft.internal.build_providers import errors
 from snapcraft.internal.meta.snap import Snap
 from snapcraft.project import Project
@@ -334,6 +335,22 @@ class BaseProviderTest(BaseProviderBaseTest):
 
         provider.run_mock.assert_called_once_with(
             ["snapcraft", "clean", "part1", "part2"]
+        )
+
+    def test_execute_step(self):
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+
+        provider.execute_step(step=steps.PULL)
+
+        provider.run_mock.assert_called_once_with(["snapcraft", "pull"])
+
+    def test_execute_step_with_parts(self):
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+
+        provider.execute_step(step=steps.PULL, part_names=("part1", "part2"))
+
+        provider.run_mock.assert_called_once_with(
+            ["snapcraft", "pull", "part1", "part2"]
         )
 
     def test_passthrough_environment_flags_empty(self):

--- a/tests/unit/commands/test_pull_build_stage_prime.py
+++ b/tests/unit/commands/test_pull_build_stage_prime.py
@@ -24,12 +24,17 @@ from . import LifecycleCommandsBaseTestCase
 
 
 class TestPullBuildStagePrimeCommand(LifecycleCommandsBaseTestCase):
-    def assert_build_provider_calls(self, step: steps.Step):
+    def assert_build_provider_calls(self, step: steps.Step, part_names=None):
+        if part_names is None:
+            part_names = tuple()
+
         self.fake_lifecycle_execute.mock.assert_not_called()
         if step is None:
             self.provider_mock.execute_step.assert_not_called()
         else:
-            self.provider_mock.execute_step.assert_called_once_with(step)
+            self.provider_mock.execute_step.assert_called_once_with(
+                step, part_names=part_names
+            )
         self.assert_clean_not_called()
 
     def run_test_using_defaults(self, step):
@@ -45,7 +50,7 @@ class TestPullBuildStagePrimeCommand(LifecycleCommandsBaseTestCase):
 
         self.assertThat(result.exit_code, Equals(0))
         self.fake_get_provider_for.mock.assert_called_once_with("multipass")
-        self.assert_build_provider_calls(step)
+        self.assert_build_provider_calls(step, part_names=("part0", "part1", "part2"))
         self.provider_mock.shell.assert_not_called()
 
     def run_test_shell_using_defaults(self, step, previous_step):
@@ -77,7 +82,7 @@ class TestPullBuildStagePrimeCommand(LifecycleCommandsBaseTestCase):
 
         self.assertThat(result.exit_code, Equals(0))
         self.fake_get_provider_for.mock.assert_called_once_with("lxd")
-        self.assert_build_provider_calls(step)
+        self.assert_build_provider_calls(step, part_names=("part0", "part1", "part2"))
         self.provider_mock.shell.assert_not_called()
 
     def run_test_using_destructive_mode(self, step):

--- a/tests/unit/commands/test_snap.py
+++ b/tests/unit/commands/test_snap.py
@@ -66,7 +66,9 @@ class TestSnap(LifecycleCommandsBaseTestCase):
         self.assertThat(result.exit_code, Equals(0))
         self.fake_get_provider_for.mock.assert_called_once_with("multipass")
         self.assert_build_provider_calls(shell=True)
-        self.provider_mock.execute_step.assert_called_once_with(steps.PRIME)
+        self.provider_mock.execute_step.assert_called_once_with(
+            steps.PRIME, part_names=()
+        )
 
     def test_shell_after_using_defaults(self):
         result = self.run_command(["snap", "--shell-after"])


### PR DESCRIPTION
Executing lifecycle commands with part names will result
in the parts being dropped when executing snapcraft in the
provided environment.

- Pass these part names along to managed snapcraft.
- Fix type annotation for 'parts' in lifecycle's execute().

LP: #1897337

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
