### PR TITLE
lint: disable new shellcheck warnings (CRAFT-482)

### DIFF
--- a/extensions/ros2/launch
+++ b/extensions/ros2/launch
@@ -6,7 +6,7 @@ function source_with_prefix() {
       echo "error: $COLCON_CURRENT_PREFIX/local_setup.bash not found"
       exit 1
     fi
-    # shellcheck disable=SC1090
+    # shellcheck disable=SC1090,SC1091
     source "$COLCON_CURRENT_PREFIX/local_setup.bash"
 }
 

--- a/tools/freeze-requirements.sh
+++ b/tools/freeze-requirements.sh
@@ -33,7 +33,7 @@ venv_dir="$(mktemp -d)"
 # Enable system-site-packages to find python3-apt.
 python3 -m venv "$venv_dir"
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 source "$venv_dir/bin/activate"
 
 pip install -U setuptools pip wheel


### PR DESCRIPTION
Newer shellcheck issues new errors:
```
In ./tools/freeze-requirements.sh line 37:
source "$venv_dir/bin/activate"
       ^----------------------^ SC1091: Not following: ./bin/activate was not specified as input (see shellcheck -x).

In ./extensions/ros2/launch line 10:
    source "$COLCON_CURRENT_PREFIX/local_setup.bash"
           ^-- SC1091: Not following: ./local_setup.bash was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./bin/activate was...
```

Disable these errors for these lines similar to SC1090.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
