### PR TITLE
NodeJS V1 Plugin: check source-subdir for package.json if specified

### DIFF
--- a/snapcraft/plugins/v1/nodejs.py
+++ b/snapcraft/plugins/v1/nodejs.py
@@ -149,7 +149,8 @@ class NodePlugin(PluginV1):
         # install node and yarn.
         if self.options.source_subdir != None:
             self._install_node_and_yarn(
-                rootdir=os.path.join(self.options.source_subdir, self.sourcedir))
+                rootdir=os.path.join(self.options.source_subdir, self.sourcedir)
+            )
         else:
             self._install_node_and_yarn(rootdir=self.sourcedir)
 

--- a/snapcraft/plugins/v1/nodejs.py
+++ b/snapcraft/plugins/v1/nodejs.py
@@ -147,7 +147,11 @@ class NodePlugin(PluginV1):
             self._yarn_tar.download()
 
         # install node and yarn.
-        self._install_node_and_yarn(rootdir=self.sourcedir)
+        if self.options.source_subdir != None:
+            self._install_node_and_yarn(
+                rootdir=os.path.join(self.options.source_subdir, self.sourcedir))
+        else:
+            self._install_node_and_yarn(rootdir=self.sourcedir)
 
     def clean_pull(self):
         super().clean_pull()

--- a/tests/unit/plugins/v1/test_nodejs.py
+++ b/tests/unit/plugins/v1/test_nodejs.py
@@ -41,7 +41,7 @@ class NodePluginBaseTest(PluginsV1BaseTestCase):
             nodejs_version = nodejs._NODEJS_VERSION
             nodejs_package_manager = "npm"
             nodejs_yarn_version = ""
-            source = "."
+            source_subdir = "."
 
         self.options = Options()
 
@@ -74,7 +74,7 @@ class NodePluginBaseTest(PluginsV1BaseTestCase):
         single_bin=False,
         skip_package_json=False,
     ):
-        for directory in (plugin.sourcedir, plugin.builddir):
+        for directory in (os.path.join(plugin.sourcedir, plugin.options.source_subdir), plugin.builddir):
             os.makedirs(directory)
             if not skip_package_json:
                 with open(os.path.join(directory, "package.json"), "w") as json_file:
@@ -477,13 +477,13 @@ def nodejs_plugin(project, request):
         nodejs_version = nodejs._NODEJS_VERSION
         nodejs_package_manager = request.param
         nodejs_yarn_version = ""
-        source = "."
+        source_subdir = "."
 
     return nodejs.NodePlugin("test-part", Options(), project)
 
 
 def _create_assets(nodejs_plugin, mock_tar, package_name="test-nodejs"):
-    for directory in (nodejs_plugin.sourcedir, nodejs_plugin.builddir):
+    for directory in (os.path.join(nodejs_plugin.sourcedir, nodejs_plugin.options.source_subdir), nodejs_plugin.builddir):
         directory_path = pathlib.Path(directory)
         directory_path.mkdir(parents=True)
 

--- a/tests/unit/plugins/v1/test_nodejs.py
+++ b/tests/unit/plugins/v1/test_nodejs.py
@@ -74,7 +74,10 @@ class NodePluginBaseTest(PluginsV1BaseTestCase):
         single_bin=False,
         skip_package_json=False,
     ):
-        for directory in (os.path.join(plugin.sourcedir, plugin.options.source_subdir), plugin.builddir):
+        for directory in (
+            os.path.join(plugin.sourcedir, plugin.options.source_subdir),
+            plugin.builddir,
+        ):
             os.makedirs(directory)
             if not skip_package_json:
                 with open(os.path.join(directory, "package.json"), "w") as json_file:
@@ -483,7 +486,10 @@ def nodejs_plugin(project, request):
 
 
 def _create_assets(nodejs_plugin, mock_tar, package_name="test-nodejs"):
-    for directory in (os.path.join(nodejs_plugin.sourcedir, nodejs_plugin.options.source_subdir), nodejs_plugin.builddir):
+    for directory in (
+        os.path.join(nodejs_plugin.sourcedir, nodejs_plugin.options.source_subdir),
+        nodejs_plugin.builddir,
+    ):
         directory_path = pathlib.Path(directory)
         directory_path.mkdir(parents=True)
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

### Issue

`_install_node_and_yarn` doesn't check for the `source-subdir` value as expected or specified in the `NodejsPluginMissingPackageJsonError` error message - 

https://github.com/snapcore/snapcraft/blob/2a2342c69334a6b2a00dbbda21b09ea81111773f/snapcraft/plugins/v1/nodejs.py#L150
https://github.com/snapcore/snapcraft/blob/2a2342c69334a6b2a00dbbda21b09ea81111773f/snapcraft/plugins/v1/nodejs.py#L80

### Fix

Now it checks if `source-subdir` is specified or not, and checks for `package.json` accordingly.

Fixes https://bugs.launchpad.net/snapcraft/+bug/1694642