### PR TITLE
Fix: files starting with '.' are not organized and also not caught by filesets

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -1215,14 +1215,15 @@ def _migratable_filesets(fileset, srcdir):
     snap_files = include_files - exclude_files
     for exclude_dir in exclude_dirs:
         # TODO: Change as_posix usage to is_relative_to (Python 3.9+)
-        snap_files = {x for x in snap_files if not x.as_posix().startswith(exclude_dir.as_posix() + "/")}
+        snap_files = {
+            x
+            for x in snap_files
+            if not x.as_posix().startswith(exclude_dir.as_posix() + "/")
+        }
 
     # Separate dirs from files.
     snap_dirs = {
-        x
-        for x in snap_files
-        if (srcdir / x).is_dir()
-        and not (srcdir / x).is_symlink()
+        x for x in snap_files if (srcdir / x).is_dir() and not (srcdir / x).is_symlink()
     }
 
     # Remove snap_dirs from snap_files.
@@ -1331,14 +1332,13 @@ def _organize_filesets(part_name, fileset, base_dir, overwrite):
                     )
             if dst.is_dir() and overwrite:
                 real_dst = dst / src.name
-                if real_dst.is_dir(): 
+                if real_dst.is_dir():
                     shutil.rmtree(real_dst)
                 else:
                     with contextlib.suppress(FileNotFoundError):
                         real_dst.unlink()
-            
             # pathlib doesn't seem to care about the trailing slash
-            if fileset[key].endswith('/'):
+            if fileset[key].endswith("/"):
                 dst.mkdir(parents=True, exist_ok=True)
             shutil.move(src.as_posix(), dst)
 
@@ -1397,12 +1397,8 @@ def _generate_include_set(directory, includes):
             include_files |= set(matches)
         else:
             include_files |= {pathlib.Path(directory) / include_pattern}
-    
-    include_dirs = {
-        x for x in include_files if x.is_dir() and not x.is_symlink()
-    }
+    include_dirs = {x for x in include_files if x.is_dir() and not x.is_symlink()}
     include_files = {x.relative_to(directory) for x in include_files}
-
     # Expand includeFiles, so that an exclude like '*/*.so' will still match
     # files from an include like 'lib'
     for include_dir in include_dirs:
@@ -1424,9 +1420,7 @@ def _generate_exclude_set(directory, excludes):
         matches = pathlib.Path(directory).glob(exclude_pattern)
         exclude_files |= set(matches)
 
-    exclude_dirs = {
-        x.relative_to(directory) for x in exclude_files if x.is_dir()
-    }
+    exclude_dirs = {x.relative_to(directory) for x in exclude_files if x.is_dir()}
     exclude_files = {x.relative_to(directory) for x in exclude_files}
 
     return exclude_files, exclude_dirs

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -755,6 +755,17 @@ class TestOrganize:
                 expected_overwrite=None,
             ),
         ),
+        (
+            "*_for_hidden_files",
+            dict(
+                setup_dirs=["foo"],
+                setup_files=["foo/.hidden"],
+                organize_set={"foo/*": "foooo/"},
+                expected=[([".hidden"], "foooo")],
+                expected_message=None,
+                expected_overwrite=None
+            )
+        )
     ]
 
     def _organize_and_assert(

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -578,10 +578,11 @@ class MigratableFilesetsTestCase(unit.TestCase):
         open("install/foo/2", "w").close()
         open("install/foo/bar/3", "w").close()
         open("install/foo/bar/baz/4", "w").close()
+        open("install/.5", 'w').close()
 
     def test_migratable_filesets_everything(self):
         files, dirs = pluginhandler._migratable_filesets(["*"], "install")
-        self.assertThat(files, Equals({"1", "foo/2", "foo/bar/3", "foo/bar/baz/4"}))
+        self.assertThat(files, Equals({"1", "foo/2", "foo/bar/3", "foo/bar/baz/4", ".5"}))
         self.assertThat(dirs, Equals({"foo", "foo/bar", "foo/bar/baz"}))
 
     def test_migratable_filesets_foo(self):

--- a/tests/unit/pluginhandler/test_pluginhandler.py
+++ b/tests/unit/pluginhandler/test_pluginhandler.py
@@ -578,11 +578,13 @@ class MigratableFilesetsTestCase(unit.TestCase):
         open("install/foo/2", "w").close()
         open("install/foo/bar/3", "w").close()
         open("install/foo/bar/baz/4", "w").close()
-        open("install/.5", 'w').close()
+        open("install/.5", "w").close()
 
     def test_migratable_filesets_everything(self):
         files, dirs = pluginhandler._migratable_filesets(["*"], "install")
-        self.assertThat(files, Equals({"1", "foo/2", "foo/bar/3", "foo/bar/baz/4", ".5"}))
+        self.assertThat(
+            files, Equals({"1", "foo/2", "foo/bar/3", "foo/bar/baz/4", ".5"})
+        )
         self.assertThat(dirs, Equals({"foo", "foo/bar", "foo/bar/baz"}))
 
     def test_migratable_filesets_foo(self):
@@ -764,9 +766,9 @@ class TestOrganize:
                 organize_set={"foo/*": "foooo/"},
                 expected=[([".hidden"], "foooo")],
                 expected_message=None,
-                expected_overwrite=None
-            )
-        )
+                expected_overwrite=None,
+            ),
+        ),
     ]
 
     def _organize_and_assert(


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
### Background
`glob.iglob` considers files starting with a dot (or hidden files) to be special cases, thus doesn't count them. 

Similar issue: https://bugs.launchpad.net/snapcraft/+bug/1669854