### PR TITLE
environment-setup-local: do not build rust

### DIFF
--- a/tools/environment-setup-local.sh
+++ b/tools/environment-setup-local.sh
@@ -33,6 +33,7 @@ python3 -m venv "${SNAPCRAFT_VIRTUAL_ENV_DIR}"
 source "${SNAPCRAFT_VIRTUAL_ENV_DIR}/bin/activate"
 
 # Install python dependencies
+export CRYPTOGRAPHY_DONT_BUILD_RUST=1
 pip install --upgrade wheel pip setuptools
 pip install -r "${SNAPCRAFT_DIR}/requirements-devel.txt"
 pip install -r "${SNAPCRAFT_DIR}/requirements.txt"


### PR DESCRIPTION
snapcraft.yaml builds cryptography without rust, local development
should match that. Currently rustc toolcahin is not installed, and
when available it may fail to build rust based cryptography 3.4 on
some architectures.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
