### PR TITLE
build providers: snapcraft's new base is core20 (CRAFT-544)

### DIFF
--- a/snapcraft/internal/build_providers/_base_provider.py
+++ b/snapcraft/internal/build_providers/_base_provider.py
@@ -496,13 +496,13 @@ class Provider(abc.ABC):
 
         snap_injector.add(snap_name="snapd")
 
-        # Prevent injecting core18 twice.
+        # Prevent injecting core20 twice (Snapcraft's base).
         build_base = self.project._get_build_base()
-        if build_base != "core18":
+        if build_base != "core20":
             snap_injector.add(snap_name=build_base)
 
-        # Inject snapcraft
-        snap_injector.add(snap_name="core18")
+        # Inject snapcraft and its base.
+        snap_injector.add(snap_name="core20")
         snap_injector.add(snap_name="snapcraft")
 
         snap_injector.apply()

--- a/tests/spread/tools/restore.sh
+++ b/tests/spread/tools/restore.sh
@@ -13,7 +13,7 @@ apt-get autoremove --purge -y
 snaps="$(snap list | awk '{if (NR!=1) {print $1}}')"
 for snap in $snaps; do
 	case "$snap" in
-		"core" | "core18" | "core20" | "snapcraft" | "multipass" | "lxd" | "snapd")
+		"bare" | "core" | "core18" | "core20" | "snapcraft" | "multipass" | "lxd" | "snapd")
 			# Do not or cannot remove these
 			;;
 		*)

--- a/tests/unit/build_providers/test_base_provider.py
+++ b/tests/unit/build_providers/test_base_provider.py
@@ -437,11 +437,10 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
             [
                 call(snap_name="snapd"),
                 call(snap_name="core20"),
-                call(snap_name="core18"),
                 call(snap_name="snapcraft"),
             ]
         )
-        self.assertThat(self.snap_injector_mock().add.call_count, Equals(4))
+        self.assertThat(self.snap_injector_mock().add.call_count, Equals(3))
         self.snap_injector_mock().apply.assert_called_once_with()
 
     def test_ephemeral_setup_snapcraft(self):
@@ -462,11 +461,10 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
             [
                 call(snap_name="snapd"),
                 call(snap_name="core20"),
-                call(snap_name="core18"),
                 call(snap_name="snapcraft"),
             ]
         )
-        self.assertThat(self.snap_injector_mock().add.call_count, Equals(4))
+        self.assertThat(self.snap_injector_mock().add.call_count, Equals(3))
         self.snap_injector_mock().apply.assert_called_once_with()
 
     def test_setup_snapcraft_for_classic_build(self):
@@ -480,10 +478,11 @@ class BaseProviderProvisionSnapcraftTest(BaseProviderBaseTest):
             [
                 call(snap_name="snapd"),
                 call(snap_name="core18"),
+                call(snap_name="core20"),
                 call(snap_name="snapcraft"),
             ]
         )
-        self.assertThat(self.snap_injector_mock().add.call_count, Equals(3))
+        self.assertThat(self.snap_injector_mock().add.call_count, Equals(4))
         self.snap_injector_mock().apply.assert_called_once_with()
 
 
@@ -506,10 +505,11 @@ class MacProviderProvisionSnapcraftTest(MacBaseProviderWithBasesBaseTest):
             [
                 call(snap_name="snapd"),
                 call(snap_name="core18"),
+                call(snap_name="core20"),
                 call(snap_name="snapcraft"),
             ]
         )
-        self.assertThat(self.snap_injector_mock().add.call_count, Equals(3))
+        self.assertThat(self.snap_injector_mock().add.call_count, Equals(4))
         self.snap_injector_mock().apply.assert_called_once_with()
 
     def test_setup_snapcraft_for_classic_build(self):
@@ -531,10 +531,11 @@ class MacProviderProvisionSnapcraftTest(MacBaseProviderWithBasesBaseTest):
             [
                 call(snap_name="snapd"),
                 call(snap_name="core18"),
+                call(snap_name="core20"),
                 call(snap_name="snapcraft"),
             ]
         )
-        self.assertThat(self.snap_injector_mock().add.call_count, Equals(3))
+        self.assertThat(self.snap_injector_mock().add.call_count, Equals(4))
         self.snap_injector_mock().apply.assert_called_once_with()
 
 


### PR DESCRIPTION
Stop injecting core18.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

-------

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----