### PR TITLE
extension/desktop: Prevent keeping updating when there is no user use…

### DIFF
--- a/extensions/desktop/common/init
+++ b/extensions/desktop/common/init
@@ -43,16 +43,19 @@ export XDG_CONFIG_HOME="$SNAP_USER_DATA/.config"
 ensure_dir_exists "$XDG_CONFIG_HOME"
 chmod 700 "$XDG_CONFIG_HOME"
 
-# If the user has modified their user-dirs settings, force an update
-if [[ -f "$XDG_CONFIG_HOME/user-dirs.dirs.md5sum" ]]; then
-  if [[ "$(md5sum < "$REALHOME/.config/user-dirs.dirs")" != "$(cat "$XDG_CONFIG_HOME/user-dirs.dirs.md5sum")" ||
-        ( -f "$XDG_CONFIG_HOME/user-dirs.locale.md5sum" &&
-          "$(md5sum < "$REALHOME/.config/user-dirs.locale")" != "$(cat "$XDG_CONFIG_HOME/user-dirs.locale.md5sum")" ) ]]; then
+# If there is no user user-dirs, don't check for the checksum
+if [[ -f "$REALHOME/.config/user-dirs.dirs" ]]; then
+  # If the user has modified their user-dirs settings, force an update
+  if [[ -f "$XDG_CONFIG_HOME/user-dirs.dirs.md5sum" ]]; then
+    if [[ "$(md5sum < "$REALHOME/.config/user-dirs.dirs")" != "$(cat "$XDG_CONFIG_HOME/user-dirs.dirs.md5sum")" ||
+          ( -f "$XDG_CONFIG_HOME/user-dirs.locale.md5sum" &&
+            "$(md5sum < "$REALHOME/.config/user-dirs.locale")" != "$(cat "$XDG_CONFIG_HOME/user-dirs.locale.md5sum")" ) ]]; then
+      needs_update=true
+    fi
+  else
+    # shellcheck disable=SC2034
     needs_update=true
   fi
-else
-  # shellcheck disable=SC2034
-  needs_update=true
 fi
 
 if [ "$SNAP_ARCH" = "amd64" ]; then


### PR DESCRIPTION
…r-dirs.dirs

On non real desktop (like WSL), we don’t have any service creating
HOME/.config/user-dirs.dirs.
Consequently, as the checksum file was not created on update, we were
fallbacking to always trying to update.
To prevent this, always check the original file first.

- [Y] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [Y] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
Note that CLA check will fail due to using my @ubuntu.com address and launchpad API being limited for private team.
- [Y] Have you successfully run `./runtests.sh static`?
- [Y] Have you successfully run `./runtests.sh tests/unit`?

-----
