### PR TITLE
repo: use host state for apt cache (CRAFT-488)

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -457,7 +457,6 @@ class Ubuntu(BaseRepo):
         with AptCache(
             stage_cache=_STAGE_CACHE_DIR, stage_cache_arch=target_arch
         ) as apt_cache:
-            apt_cache.update()
             apt_cache.mark_packages(set(package_names))
             apt_cache.unmark_packages(filtered_names)
             for pkg_name, pkg_version, dl_path in apt_cache.fetch_archives(

--- a/snapcraft/internal/repo/apt_cache.py
+++ b/snapcraft/internal/repo/apt_cache.py
@@ -85,6 +85,7 @@ class AptCache(ContextDecorator):
 
         apt.apt_pkg.config.set("Dir::Etc::Trusted", "/etc/apt/trusted.gpg")
         apt.apt_pkg.config.set("Dir::Etc::TrustedParts", "/etc/apt/trusted.gpg.d/")
+        apt.apt_pkg.config.set("Dir::State", "/var/lib/apt")
 
         # Clear up apt's Post-Invoke-Success as we are not running
         # on the system.
@@ -294,11 +295,3 @@ class AptCache(ContextDecorator):
 
         # Unmark dependencies that are no longer required.
         self._autokeep_packages()
-
-    def update(self) -> None:
-        try:
-            self.cache.update(fetch_progress=self.progress, sources_list=None)
-            self.cache.close()
-            self.cache = apt.Cache(rootdir=str(self.stage_cache), memonly=True)
-        except apt.cache.FetchFailedException as e:
-            raise errors.CacheUpdateFailedError(str(e))

--- a/tests/unit/repo/test_apt_cache.py
+++ b/tests/unit/repo/test_apt_cache.py
@@ -17,7 +17,6 @@
 import os
 import unittest
 from pathlib import Path
-from unittest import mock
 from unittest.mock import call
 
 import fixtures
@@ -39,8 +38,6 @@ class TestAptStageCache(unit.TestCase):
         stage_cache.mkdir(exist_ok=True, parents=True)
 
         with AptCache(stage_cache=stage_cache) as apt_cache:
-            apt_cache.update()
-
             package_names = {"pciutils"}
             filtered_names = {"base-files", "libc6", "libkmod2", "libudev1", "zlib1g"}
 
@@ -73,8 +70,8 @@ class TestMockedApt(unit.TestCase):
             fixtures.MockPatch("snapcraft.internal.repo.apt_cache.apt")
         ).mock
 
-        with AptCache(stage_cache=stage_cache) as apt_cache:
-            apt_cache.update()
+        with AptCache(stage_cache=stage_cache):
+            pass
 
         self.assertThat(
             self.fake_apt.mock_calls,
@@ -90,11 +87,9 @@ class TestMockedApt(unit.TestCase):
                     call.apt_pkg.config.set(
                         "Dir::Etc::TrustedParts", "/etc/apt/trusted.gpg.d/"
                     ),
+                    call.apt_pkg.config.set("Dir::State", "/var/lib/apt"),
                     call.apt_pkg.config.clear("APT::Update::Post-Invoke-Success"),
                     call.progress.text.AcquireProgress(),
-                    call.Cache(memonly=True, rootdir=str(stage_cache)),
-                    call.Cache().update(fetch_progress=mock.ANY, sources_list=None),
-                    call.Cache().close(),
                     call.Cache(memonly=True, rootdir=str(stage_cache)),
                     call.Cache().close(),
                 ]
@@ -117,8 +112,8 @@ class TestMockedApt(unit.TestCase):
         )
         self.useFixture(fixtures.EnvironmentVariable("SNAP", str(snap)))
 
-        with AptCache(stage_cache=stage_cache) as apt_cache:
-            apt_cache.update()
+        with AptCache(stage_cache=stage_cache):
+            pass
 
         self.assertThat(
             self.fake_apt.mock_calls,
@@ -149,11 +144,9 @@ class TestMockedApt(unit.TestCase):
                     call.apt_pkg.config.set(
                         "Dir::Etc::TrustedParts", "/etc/apt/trusted.gpg.d/"
                     ),
+                    call.apt_pkg.config.set("Dir::State", "/var/lib/apt"),
                     call.apt_pkg.config.clear("APT::Update::Post-Invoke-Success"),
                     call.progress.text.AcquireProgress(),
-                    call.Cache(memonly=True, rootdir=str(stage_cache)),
-                    call.Cache().update(fetch_progress=mock.ANY, sources_list=None),
-                    call.Cache().close(),
                     call.Cache(memonly=True, rootdir=str(stage_cache)),
                     call.Cache().close(),
                 ]

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -94,7 +94,6 @@ class TestPackages(unit.TestCase):
             [
                 call(stage_cache=self.stage_cache_path, stage_cache_arch="amd64"),
                 call().__enter__(),
-                call().__enter__().update(),
                 call().__enter__().mark_packages({"fake-package"}),
                 call()
                 .__enter__()
@@ -133,7 +132,6 @@ class TestPackages(unit.TestCase):
             [
                 call(stage_cache=self.stage_cache_path, stage_cache_arch="amd64"),
                 call().__enter__(),
-                call().__enter__().update(),
                 call().__enter__().mark_packages(set(package_names)),
                 call().__enter__().unmark_packages({"filtered-pkg-4"}),
                 call().__enter__().fetch_archives(self.debs_path),


### PR DESCRIPTION
Instead of having a split state for stage cache, rely on the
host's cache by setting the state directory to /var/lib/apt.

Co-authored-by: Chris Patterson <chris.patterson@canonical.com>
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
