### PR TITLE
lifecycle: init with core20 (CRAFT-517)

### DIFF
--- a/snapcraft/internal/lifecycle/_init.py
+++ b/snapcraft/internal/lifecycle/_init.py
@@ -22,7 +22,7 @@ from snapcraft.internal import errors
 _TEMPLATE_YAML = dedent(
     """\
     name: my-snap-name # you probably want to 'snapcraft register <name>'
-    base: core18 # the base snap is the execution environment for this snap
+    base: core20 # the base snap is the execution environment for this snap
     version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
     summary: Single-line elevator pitch for your amazing snap # 79 char long summary
     description: |

--- a/tests/unit/commands/test_init.py
+++ b/tests/unit/commands/test_init.py
@@ -28,7 +28,7 @@ class InitCommandTestCase(CommandBaseTestCase):
         expected_yaml = dedent(
             """\
             name: my-snap-name # you probably want to 'snapcraft register <name>'
-            base: core18 # the base snap is the execution environment for this snap
+            base: core20 # the base snap is the execution environment for this snap
             version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
             summary: Single-line elevator pitch for your amazing snap # 79 char long summary
             description: |


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

-------

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----