### PR TITLE
snap: patch patchelf on riscv64 (CRAFT-566)

### DIFF
--- a/snap/local/patches/patchelf/0001-Always-use-the-ET_DYN-codepath-avoiding-shifting-loa.patch
+++ b/snap/local/patches/patchelf/0001-Always-use-the-ET_DYN-codepath-avoiding-shifting-loa.patch
@@ -1,0 +1,35 @@
+From 9734c99f47ba2365825269a1f131e98a17c7c328 Mon Sep 17 00:00:00 2001
+From: William Grant <william.grant@canonical.com>
+Date: Mon, 20 Sep 2021 19:10:15 +1000
+Subject: [PATCH 1/2] Always use the ET_DYN codepath, avoiding shifting load
+ start
+
+The executable codepath of operations like --set-rpath can cause the
+first address of a binary to move earlier, causing segfaults on startup
+of some binaries on e.g.  riscv64 where the default base address matches
+the kernel's mmap_min_addr.
+
+PIE executables, which are the great majority, already use the library
+path, so this must be pretty safe for the remaining few.
+---
+ src/patchelf.cc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/patchelf.cc b/src/patchelf.cc
+index dbe5ea7..94bb9ca 100644
+--- a/src/patchelf.cc
++++ b/src/patchelf.cc
+@@ -793,8 +793,8 @@ void ElfFile<ElfFileParamNames>::rewriteSections()
+         debug("this is a dynamic library\n");
+         rewriteSectionsLibrary();
+     } else if (rdi(hdr->e_type) == ET_EXEC) {
+-        debug("this is an executable\n");
+-        rewriteSectionsExecutable();
++        debug("this is an executable, but using library codepath to avoid shifting start forward\n");
++        rewriteSectionsLibrary();
+     } else error("unknown ELF type");
+ }
+ 
+-- 
+2.25.1
+

--- a/snap/local/patches/patchelf/0002-Fix-rewriteSectionsLibrary-to-not-assume-the-base-ad.patch
+++ b/snap/local/patches/patchelf/0002-Fix-rewriteSectionsLibrary-to-not-assume-the-base-ad.patch
@@ -1,0 +1,61 @@
+From 9edcd40f18c54bd1c92ef1b7a518abc5bc8a9290 Mon Sep 17 00:00:00 2001
+From: William Grant <william.grant@canonical.com>
+Date: Tue, 21 Sep 2021 12:48:08 +1000
+Subject: [PATCH 2/2] Fix rewriteSectionsLibrary to not assume the base address
+ is 0
+
+Also XXX some fairly bold existing assumptions.
+---
+ src/patchelf.cc | 20 ++++++++++++++++++--
+ 1 file changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/src/patchelf.cc b/src/patchelf.cc
+index 94bb9ca..1ea77c1 100644
+--- a/src/patchelf.cc
++++ b/src/patchelf.cc
+@@ -591,6 +591,17 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
+         if (thisPage > startPage) startPage = thisPage;
+     }
+ 
++    // Find file's base virtual address.
++    // XXX wgrant: Assumes that there's a PT_LOAD from the start of the file,
++    // and that the PHT falls within it.
++    Elf_Phdr *base_pt_load = NULL;
++    for (auto &phdr : phdrs)
++        if (rdi(phdr.p_type) == PT_LOAD && rdi(phdr.p_offset) == 0)
++	    base_pt_load = &phdr;
++    assert(base_pt_load != NULL);
++    Elf_Addr base_vaddr = rdi(base_pt_load->p_vaddr);
++
++    debug("base virtual address is 0x%llx\n", (unsigned long long) base_vaddr);
+     debug("last page is 0x%llx\n", (unsigned long long) startPage);
+ 
+     /* Because we're adding a new section header, we're necessarily increasing
+@@ -598,9 +609,14 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
+        to overlap the program header table in memory; we need to shift the first
+        few segments to someplace else. */
+     /* Some sections may already be replaced so account for that */
++    // XXX wgrant: We're adding a new *program* header, not section header.
++    // XXX wgrant: Is this 1 because we assume that 0 is the PT_PHDR? That
++    // seems bold.
++    // XXX wgrant: This is some awesome conflation of offsets and vaddrs.
++    // XXX wgrant: This seems to assume that sections are ordered by address?
+     unsigned int i = 1;
+     Elf_Addr pht_size = sizeof(Elf_Ehdr) + (phdrs.size() + 1)*sizeof(Elf_Phdr);
+-    while( shdrs[i].sh_addr <= pht_size && i < rdi(hdr->e_shnum) ) {
++    while( shdrs[i].sh_addr <= base_vaddr + pht_size && i < rdi(hdr->e_shnum) ) {
+         if (not haveReplacedSection(getSectionName(shdrs[i])))
+             replaceSection(getSectionName(shdrs[i]), shdrs[i].sh_size);
+         i++;
+@@ -653,7 +669,7 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
+     assert(curOff == startOffset + neededSpace);
+ 
+     /* Write out the updated program and section headers */
+-    rewriteHeaders(hdr->e_phoff);
++    rewriteHeaders(base_vaddr + rdi(hdr->e_phoff));
+ }
+ 
+ 
+-- 
+2.25.1
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,7 +53,15 @@ parts:
       - --prefix=/
     build-packages:
       - g++
+      - git
       - make
+    override-pull: |
+      snapcraftctl pull
+
+      if [ "${SNAPCRAFT_TARGET_ARCH}" = "riscv64" ]; then
+        git am apply "${SNAPCRAFT_PROJECT_DIR}/snap/local/patches/patchelf/0001-Always-use-the-ET_DYN-codepath-avoiding-shifting-loa.patch
+        git am apply "${SNAPCRAFT_PROJECT_DIR}/snap/local/patches/patchelf/0002-Fix-rewriteSectionsLibrary-to-not-assume-the-base-ad.patch
+      fi
     override-build: |
       snapcraftctl build
       make check


### PR DESCRIPTION
Conditionally patch on riscv64 to reduce the risk of breaking
currently working architectures.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

-------

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----