### PR TITLE
extensions/desktop: do not export a fixed QT_QPA_PLATFORM_THEME

### DIFF
--- a/extensions/desktop/kde-neon/launcher-specific
+++ b/extensions/desktop/kde-neon/launcher-specific
@@ -3,18 +3,6 @@
 # KDE NEON launcher specific part #
 ###################################
 
-# Ensure a sane default for QT_QPA_PLATFORMTHEME.
-if [[ -z "$QT_QPA_PLATFORMTHEME" ]]; then
-  gtk_based_desktops=("GNOME" "X-CINNAMON" "UNITY" "MATE" "XFCE" "LXDE" "Pantheon")
-  for gtk_desktop in "${gtk_based_desktops[@]}"; do
-    if [[ "$XDG_CURRENT_DESKTOP" == *"$gtk_desktop"* ]]; then
-      export QT_QPA_PLATFORMTHEME="gtk3"
-      break
-    fi
-  done
-fi
-export QT_QPA_PLATFORMTHEME=${QT_QPA_PLATFORMTHEME:-kde}
-
 # Add paths for games
 append_dir PATH "$SNAP/usr/games"
 append_dir PATH "$SNAP_DESKTOP_RUNTIME/usr/games"


### PR DESCRIPTION
Let the platform decide with what is available.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
