### PR TITLE
set lzo compression by default in kde-neon extension

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/kde_neon.py
+++ b/snapcraft/internal/project_loader/_extensions/kde_neon.py
@@ -77,6 +77,7 @@ class ExtensionImpl(Extension):
         info = _Info[yaml_data["base"]]
         self.root_snippet = {
             "assumes": ["snapd2.43"],  # for 'snapctl is-connected'
+            "compression": "lzo",
             "plugs": {
                 "desktop": {"mount-host-font-cache": False},
                 "icon-themes": {

--- a/tests/unit/project_loader/extensions/test_kde_neon.py
+++ b/tests/unit/project_loader/extensions/test_kde_neon.py
@@ -24,6 +24,7 @@ def test_extension_core18():
 
     assert kde_neon_extension.root_snippet == {
         "assumes": ["snapd2.43"],
+        "compression": "lzo",
         "plugs": {
             "desktop": {"mount-host-font-cache": False},
             "icon-themes": {
@@ -76,6 +77,7 @@ def test_extension_core20():
 
     assert kde_neon_extension.root_snippet == {
         "assumes": ["snapd2.43"],
+        "compression": "lzo",
         "environment": {"SNAP_DESKTOP_RUNTIME": "$SNAP/kf5"},
         "hooks": {
             "configure": {


### PR DESCRIPTION
- [x ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x ] Have you successfully run `./runtests.sh static`?
- [x ] Have you successfully run `./runtests.sh tests/unit`?

enable lzo compression in kde-neon extension by default

from chatting with ppd and post at https://forum.snapcraft.io/t/lzo-for-platform-snaps/27501

-----
