### PR TITLE
extensions/kde-neon: use platform snap as plug name

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/kde_neon.py
+++ b/snapcraft/internal/project_loader/_extensions/kde_neon.py
@@ -95,7 +95,7 @@ class ExtensionImpl(Extension):
                     "target": "$SNAP/data-dir/sounds",
                     "default-provider": "gtk-common-themes",
                 },
-                "kde-frameworks-5-plug": {
+                info.provider: {
                     "content": info.content,
                     "interface": "content",
                     "default-provider": info.provider,
@@ -126,7 +126,7 @@ class ExtensionImpl(Extension):
                 "source": "$SNAPCRAFT_EXTENSIONS_DIR/desktop",
                 "source-subdir": "kde-neon",
                 "plugin": "make",
-                "make-parameters": ["PLATFORM_PLUG=kde-frameworks-5-plug"],
+                "make-parameters": [f"PLATFORM_PLUG={info.provider}"],
                 "build-packages": ["g++"],
                 "build-snaps": info.build_snaps,
             }

--- a/tests/spread/extensions/kde-neon/task.yaml
+++ b/tests/spread/extensions/kde-neon/task.yaml
@@ -38,13 +38,11 @@ execute: |
 
   if [[ "$SPREAD_SYSTEM" =~ ubuntu-20.04 ]]; then
     output="$(snapcraft --enable-experimental-extensions)"
-    snap install neon-hello_*.snap --dangerous
-    # This snap requires manual connection
-    snap connect neon-hello:kde-frameworks-5-plug kde-frameworks-5-qt-5-15-3-core20:kde-frameworks-5-qt-5-15-3-core20-slot
   else
     output="$(snapcraft)"
-    snap install neon-hello_*.snap --dangerous
   fi
+  
+  snap install neon-hello_*.snap --dangerous
 
   [ "$(neon-hello)" = "hello world" ]
 

--- a/tests/unit/project_loader/extensions/test_kde_neon.py
+++ b/tests/unit/project_loader/extensions/test_kde_neon.py
@@ -36,7 +36,7 @@ def test_extension_core18():
                 "target": "$SNAP/data-dir/sounds",
                 "default-provider": "gtk-common-themes",
             },
-            "kde-frameworks-5-plug": {
+            "kde-frameworks-5-core18": {
                 "content": "kde-frameworks-5-core18-all",
                 "interface": "content",
                 "target": "$SNAP/kf5",
@@ -61,7 +61,7 @@ def test_extension_core18():
             "source": "$SNAPCRAFT_EXTENSIONS_DIR/desktop",
             "source-subdir": "kde-neon",
             "plugin": "make",
-            "make-parameters": ["PLATFORM_PLUG=kde-frameworks-5-plug"],
+            "make-parameters": ["PLATFORM_PLUG=kde-frameworks-5-core18"],
             "build-packages": ["g++"],
             "build-snaps": ["kde-frameworks-5-core18-sdk/latest/stable"],
         }
@@ -89,7 +89,7 @@ def test_extension_core20():
                 "interface": "content",
                 "target": "$SNAP/data-dir/icons",
             },
-            "kde-frameworks-5-plug": {
+            "kde-frameworks-5-qt-5-15-3-core20": {
                 "content": "kde-frameworks-5-qt-5-15-3-core20-all",
                 "default-provider": "kde-frameworks-5-qt-5-15-3-core20",
                 "interface": "content",
@@ -117,7 +117,7 @@ def test_extension_core20():
         "kde-neon-extension": {
             "build-packages": ["g++"],
             "build-snaps": ["kde-frameworks-5-qt-5-15-3-core20-sdk/latest/candidate"],
-            "make-parameters": ["PLATFORM_PLUG=kde-frameworks-5-plug"],
+            "make-parameters": ["PLATFORM_PLUG=kde-frameworks-5-qt-5-15-3-core20"],
             "plugin": "make",
             "source": "$SNAPCRAFT_EXTENSIONS_DIR/desktop",
             "source-subdir": "kde-neon",


### PR DESCRIPTION
Using the same plug name "kde-frameworks-5-plug"
for all providers leads to problems when an
application updates its base or changes its default
provider because a new framework snap gets published
for the same base.

In that case, snapd will keep the old framework snap
connected and will happily connect the new framework
snap in addition to the old one.
This breaks applications because they won't find the correct
framework snap mounted at $SNAP/kf5.

Prevent this by using the same strategy that the gnome
extensions use: plug name = content snap name

See https://forum.snapcraft.io/t/snap-accumulates-content-interface-connections-to-multiple-platform-snaps/27523/8

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit/project_loader/extensions`?

-----

I built a snap (anki-ppd) with this change and everything works as expected. Also CC @jriddell.
I'm not sure about the subsystem prefix; it seemed more complete than just "extensions".