### PR TITLE
extensions/kde-neon: declare non-experimental for core20

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/kde_neon.py
+++ b/snapcraft/internal/project_loader/_extensions/kde_neon.py
@@ -17,7 +17,7 @@
 # Import types and tell flake8 to ignore the "unused" List.
 
 from collections import namedtuple
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 from ._extension import Extension
 
@@ -35,7 +35,7 @@ _Info = dict(
         cmake_args="-DCMAKE_FIND_ROOT_PATH=/snap/kde-frameworks-5-qt-5-15-3-core20-sdk/current",
         content="kde-frameworks-5-qt-5-15-3-core20-all",
         provider="kde-frameworks-5-qt-5-15-3-core20",
-        build_snaps=["kde-frameworks-5-qt-5-15-3-core20-sdk/latest/candidate"],
+        build_snaps=["kde-frameworks-5-qt-5-15-3-core20-sdk/latest/stable"],
     ),
 )
 
@@ -63,11 +63,6 @@ class ExtensionImpl(Extension):
     - wayland (https://snapcraft.io/docs/wayland-interface)
     - x11 (https://snapcraft.io/docs/x11-interface)
     """
-
-    @staticmethod
-    def is_experimental(base: Optional[str]) -> bool:
-        # TODO: remove experimental once sdk is on stable
-        return base == "core20"
 
     @staticmethod
     def get_supported_bases() -> Tuple[str, ...]:

--- a/tests/spread/extensions/kde-neon/task.yaml
+++ b/tests/spread/extensions/kde-neon/task.yaml
@@ -35,13 +35,7 @@ restore: |
 
 execute: |
   cd "$SNAP_DIR"
-
-  if [[ "$SPREAD_SYSTEM" =~ ubuntu-20.04 ]]; then
-    output="$(snapcraft --enable-experimental-extensions)"
-  else
-    output="$(snapcraft)"
-  fi
-  
+  output="$(snapcraft)"
   snap install neon-hello_*.snap --dangerous
 
   [ "$(neon-hello)" = "hello world" ]

--- a/tests/unit/project_loader/extensions/test_kde_neon.py
+++ b/tests/unit/project_loader/extensions/test_kde_neon.py
@@ -116,7 +116,7 @@ def test_extension_core20():
     assert kde_neon_extension.parts == {
         "kde-neon-extension": {
             "build-packages": ["g++"],
-            "build-snaps": ["kde-frameworks-5-qt-5-15-3-core20-sdk/latest/candidate"],
+            "build-snaps": ["kde-frameworks-5-qt-5-15-3-core20-sdk/latest/stable"],
             "make-parameters": ["PLATFORM_PLUG=kde-frameworks-5-qt-5-15-3-core20"],
             "plugin": "make",
             "source": "$SNAPCRAFT_EXTENSIONS_DIR/desktop",
@@ -137,7 +137,7 @@ def test_experimental_core20():
     kde_neon_extension = ExtensionImpl(
         extension_name="kde-neon", yaml_data=dict(base="core20")
     )
-    assert kde_neon_extension.is_experimental(base="core20") is True
+    assert kde_neon_extension.is_experimental(base="core20") is False
 
 
 def test_experimental_core18():


### PR DESCRIPTION
From the removed TODO comment:
"remove experimental once sdk is on stable"

As the SDK snap kde-frameworks-5-qt-5-15-3-core20-sdk has
a stable revision now, the experimental flag can
be removed, and the build snap can be pulled from the
stable channel.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

~~Includes https://github.com/snapcore/snapcraft/pull/3596, but I can remove that if necessary and rebase later.~~
This is also significant because launchpad build jobs cannot be configured to enable experimental extensions at the moment, which prevents many snaps from using this extension.
