### PR TITLE
remote build: use channel defaults (CRAFT-568)

### DIFF
--- a/snapcraft/internal/remote_build/_launchpad.py
+++ b/snapcraft/internal/remote_build/_launchpad.py
@@ -187,14 +187,7 @@ class LaunchpadClient:
     def _issue_build_request(self, snap: Entry) -> Entry:
         dist = self._lp.distributions["ubuntu"]
         archive = dist.main_archive
-        return snap.requestBuilds(
-            archive=archive,
-            channels={
-                "core18": self._core18_channel,
-                "snapcraft": self._snapcraft_channel,
-            },
-            pocket="Updates",
-        )
+        return snap.requestBuilds(archive=archive, pocket="Updates",)
 
     def _lp_load_url(self, url: str) -> Entry:
         """Load Launchpad url with a retry in case the connection is lost."""

--- a/tests/unit/remote_build/test_launchpad.py
+++ b/tests/unit/remote_build/test_launchpad.py
@@ -318,13 +318,7 @@ class LaunchpadTestCase(unit.TestCase):
         self.assertThat(
             fake_snap.mock_calls,
             Equals(
-                [
-                    mock.call.requestBuilds(
-                        archive="main_archive",
-                        channels={"core18": "stable", "snapcraft": "stable"},
-                        pocket="Updates",
-                    )
-                ]
+                [mock.call.requestBuilds(archive="main_archive", pocket="Updates",)]
             ),
         )
 


### PR DESCRIPTION
Remove the forcing of a specific channel for snapcraft and
core18 (which is no longer relevant as snapcraft moved to core20).

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

-------

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----