### PR TITLE
Flutter extension: Force GDK to use GLES

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/_flutter_meta.py
+++ b/snapcraft/internal/project_loader/_extensions/_flutter_meta.py
@@ -138,7 +138,7 @@ class FlutterMetaExtension(type):
             "environment": {
                 "SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform",
                 "GDK_GL": "gles",
-                },
+            },
             "layout": {
                 "/usr/share/xml/iso-codes": {
                     "bind": "$SNAP/gnome-platform/usr/share/xml/iso-codes"

--- a/snapcraft/internal/project_loader/_extensions/_flutter_meta.py
+++ b/snapcraft/internal/project_loader/_extensions/_flutter_meta.py
@@ -135,7 +135,10 @@ class FlutterMetaExtension(type):
                     "default-provider": "gtk-common-themes",
                 },
             },
-            "environment": {"SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform"},
+            "environment": {
+                "SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform",
+                "GDK_GL": "gles",
+                },
             "layout": {
                 "/usr/share/xml/iso-codes": {
                     "bind": "$SNAP/gnome-platform/usr/share/xml/iso-codes"

--- a/tests/unit/project_loader/extensions/test_flutter.py
+++ b/tests/unit/project_loader/extensions/test_flutter.py
@@ -60,7 +60,10 @@ def test_extension(extension_class):
                 "default-provider": "gnome-3-28-1804",
             },
         },
-        "environment": {"SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform"},
+        "environment": {
+            "SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform",
+            "GDK_GL": "gles",
+        },
         "layout": {
             "/usr/share/xml/iso-codes": {
                 "bind": "$SNAP/gnome-platform/usr/share/xml/iso-codes"


### PR DESCRIPTION
Force GDK to use GLES as some drivers, like the v3d driver for RPi4, don't work with OpenGL.

- [ x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
