### PR TITLE
spread: change uri for flutter's pubspec to https

### DIFF
--- a/tests/spread/plugins/v1/flutter/snaps/flutter-hello/src/pubspec.yaml
+++ b/tests/spread/plugins/v1/flutter/snaps/flutter-hello/src/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
 
   url_launcher_fde:
     git:
-      url: git://github.com/google/flutter-desktop-embedding.git
+      url: https://github.com/google/flutter-desktop-embedding.git
       path: plugins/flutter_plugins/url_launcher_fde
       ref: b0794faf2c000576515aee56ca6bb5bee64cece4
 


### PR DESCRIPTION
Github no longer support unauthenticated git

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
