### PR TITLE
cli: create new snapcraft entry point (CRAFT-729)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,10 @@ setup(
     classifiers=classifiers,
     scripts=scripts,
     entry_points=dict(
-        console_scripts=["snapcraft = snapcraft_legacy.cli.__main__:run"]
+        console_scripts=[
+            "snapcraft_legacy = snapcraft_legacy.cli.__main__:run",
+            "snapcraft = snapcraft.cli:run",
+        ]
     ),
     data_files=(
         recursive_data_files("schema", "share/snapcraft")

--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -1,0 +1,26 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Command-line application entry point."""
+
+from typing import Optional, Sequence
+
+from snapcraft_legacy.cli import legacy
+
+
+def run(argv: Optional[Sequence] = None):
+    """Run the CLI."""
+    legacy.legacy_run()

--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -16,11 +16,9 @@
 
 """Command-line application entry point."""
 
-from typing import Optional, Sequence
-
 from snapcraft_legacy.cli import legacy
 
 
-def run(argv: Optional[Sequence] = None):
+def run():
     """Run the CLI."""
     legacy.legacy_run()

--- a/snapcraft_legacy/cli/legacy.py
+++ b/snapcraft_legacy/cli/legacy.py
@@ -1,0 +1,23 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Legacy execution entry points."""
+
+from ._runner import run  # noqa: F401
+
+
+def legacy_run():
+    run()


### PR DESCRIPTION
Set a new entry point to the snapcraft application. This currently
invokes the legacy implementation in all cases (future PRs will
add logic to decide between new and legacy code execution).
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
