### PR TITLE
sources: make submodule recursion configurable

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -983,6 +983,10 @@
                             "type": "integer",
                             "default": 0
                         },
+                        "source-recurse-submodules": {
+                            "type": "boolean",
+                            "default": true
+                        },
                         "source-subdir": {
                             "type": "string",
                             "default": ""

--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -206,6 +206,7 @@ class PluginHandler:
                 source_tag=properties["source-tag"],
                 source_depth=properties["source-depth"],
                 source_commit=properties["source-commit"],
+                source_recurse_submodules=properties["source-recurse-submodules"],
             )
 
         return source_handler

--- a/snapcraft/internal/remote_build/_worktree.py
+++ b/snapcraft/internal/remote_build/_worktree.py
@@ -99,6 +99,7 @@ class WorkTree:
             source_tag=part_config.get("source-tag"),
             source_depth=part_config.get("source-depth"),
             source_commit=part_config.get("source-commit"),
+            source_recurse_submodules=part_config.get("source-recurse-submodules"),
         )
 
     def _get_part_cache_dir(self, part_name: str, selector=None) -> str:

--- a/snapcraft/internal/sources/_7z.py
+++ b/snapcraft/internal/sources/_7z.py
@@ -33,6 +33,7 @@ class SevenZip(FileBase):
         source_branch=None,
         source_depth=None,
         source_checksum=None,
+        source_recurse_submodules=None,
     ):
         super().__init__(
             source,
@@ -42,6 +43,7 @@ class SevenZip(FileBase):
             source_branch,
             source_depth,
             source_checksum,
+            source_recurse_submodules,
             "7zip",
         )
         if source_tag:

--- a/snapcraft/internal/sources/__init__.py
+++ b/snapcraft/internal/sources/__init__.py
@@ -65,6 +65,12 @@ code for that part, and how to unpack it if necessary.
     When building, Snapcraft will set the working directory to be this
     subdirectory within the source.
 
+  - source-recurse-submodule: <boolean>
+
+    If true, snapcraft will recursively fetch submodules from the source tree.
+    If false, submodules are not fetched.
+    Default is true.
+
 Note that plugins might well define their own semantics for the 'source'
 keywords, because they handle specific build systems, and many languages
 have their own built-in packaging systems (think CPAN, PyPI, NPM). In those
@@ -147,6 +153,7 @@ __SOURCE_DEFAULTS = {
     "source-type": None,
     "source-branch": None,
     "source-subdir": None,
+    "source-recurse-submodules": None,
 }
 
 
@@ -168,6 +175,7 @@ def get(sourcedir, builddir, options):
         source_tag=getattr(options, "source_tag", None),
         source_commit=getattr(options, "source_commit", None),
         source_branch=getattr(options, "source_branch", None),
+        source_recurse_submodules=getattr(options, "source_recurse_submodules", None),
     )
 
     handler_class = get_source_handler(options.source, source_type=source_type)

--- a/snapcraft/internal/sources/_base.py
+++ b/snapcraft/internal/sources/_base.py
@@ -41,6 +41,7 @@ class Base:
         source_branch=None,
         source_depth=None,
         source_checksum=None,
+        source_recurse_submodules=None,
         command=None,
     ):
         self.source = source
@@ -50,6 +51,7 @@ class Base:
         self.source_branch = source_branch
         self.source_depth = source_depth
         self.source_checksum = source_checksum
+        self.source_recurse_submodules = source_recurse_submodules
         self.source_details = None
 
         self.command = command

--- a/snapcraft/internal/sources/_bazaar.py
+++ b/snapcraft/internal/sources/_bazaar.py
@@ -31,6 +31,7 @@ class Bazaar(Base):
         source_branch=None,
         source_depth=None,
         source_checksum=None,
+        source_recurse_submodules=None,
         silent=False,
     ):
         super().__init__(
@@ -41,6 +42,7 @@ class Bazaar(Base):
             source_branch,
             source_depth,
             source_checksum,
+            source_recurse_submodules,
             "bzr",
         )
         if source_branch:

--- a/snapcraft/internal/sources/_deb.py
+++ b/snapcraft/internal/sources/_deb.py
@@ -34,6 +34,7 @@ class Deb(FileBase):
         source_branch=None,
         source_depth=None,
         source_checksum=None,
+        source_recurse_submodules=None,
     ):
         super().__init__(
             source,
@@ -43,6 +44,7 @@ class Deb(FileBase):
             source_branch,
             source_depth,
             source_checksum,
+            source_recurse_submodules,
         )
         if source_tag:
             raise errors.SnapcraftSourceInvalidOptionError("deb", "source-tag")

--- a/snapcraft/internal/sources/_mercurial.py
+++ b/snapcraft/internal/sources/_mercurial.py
@@ -32,6 +32,7 @@ class Mercurial(Base):
         source_depth=None,
         source_checksum=None,
         silent=False,
+        source_recurse_submodules=None,
     ):
         super().__init__(
             source,
@@ -41,6 +42,7 @@ class Mercurial(Base):
             source_branch,
             source_depth,
             source_checksum,
+            source_recurse_submodules,
             "hg",
         )
         if source_tag and source_branch:

--- a/snapcraft/internal/sources/_rpm.py
+++ b/snapcraft/internal/sources/_rpm.py
@@ -33,6 +33,7 @@ class Rpm(FileBase):
         source_branch=None,
         source_depth=None,
         source_checksum=None,
+        source_recurse_submodules=None,
     ):
         super().__init__(
             source,
@@ -42,6 +43,7 @@ class Rpm(FileBase):
             source_branch,
             source_depth,
             source_checksum,
+            source_recurse_submodules,
             "rpm2cpio",
         )
         if source_tag:

--- a/snapcraft/internal/sources/_script.py
+++ b/snapcraft/internal/sources/_script.py
@@ -30,6 +30,7 @@ class Script(FileBase):
         source_branch=None,
         source_depth=None,
         source_checksum=None,
+        source_recurse_submodules=None,
     ):
         super().__init__(
             source,
@@ -39,6 +40,7 @@ class Script(FileBase):
             source_branch,
             source_depth,
             source_checksum,
+            source_recurse_submodules,
         )
 
     def download(self, filepath: str = None) -> str:

--- a/snapcraft/internal/sources/_snap.py
+++ b/snapcraft/internal/sources/_snap.py
@@ -41,6 +41,7 @@ class Snap(FileBase):
         source_branch: str = None,
         source_depth: str = None,
         source_checksum: str = None,
+        source_recurse_submodules=None,
     ) -> None:
         super().__init__(
             source,
@@ -50,6 +51,7 @@ class Snap(FileBase):
             source_branch,
             source_depth,
             source_checksum,
+            source_recurse_submodules,
             "unsquashfs",
         )
         if source_tag:

--- a/snapcraft/internal/sources/_subversion.py
+++ b/snapcraft/internal/sources/_subversion.py
@@ -32,6 +32,7 @@ class Subversion(Base):
         source_depth=None,
         source_checksum=None,
         silent=False,
+        source_recurse_submodules=None,
     ):
         super().__init__(
             source,
@@ -41,6 +42,7 @@ class Subversion(Base):
             source_branch,
             source_depth,
             source_checksum,
+            source_recurse_submodules,
             "svn",
         )
         if source_tag:

--- a/snapcraft/internal/sources/_tar.py
+++ b/snapcraft/internal/sources/_tar.py
@@ -34,6 +34,7 @@ class Tar(FileBase):
         source_branch=None,
         source_depth=None,
         source_checksum=None,
+        source_recurse_submodules=None,
     ):
         super().__init__(
             source,
@@ -43,6 +44,7 @@ class Tar(FileBase):
             source_branch,
             source_depth,
             source_checksum,
+            source_recurse_submodules,
         )
         if source_tag:
             raise errors.SnapcraftSourceInvalidOptionError("tar", "source-tag")

--- a/snapcraft/internal/sources/_zip.py
+++ b/snapcraft/internal/sources/_zip.py
@@ -32,6 +32,7 @@ class Zip(FileBase):
         source_branch=None,
         source_depth=None,
         source_checksum=None,
+        source_recurse_submodules=None,
     ):
         super().__init__(
             source,
@@ -41,6 +42,7 @@ class Zip(FileBase):
             source_branch,
             source_depth,
             source_checksum,
+            source_recurse_submodules,
         )
         if source_tag:
             raise errors.SnapcraftSourceInvalidOptionError("zip", "source-tag")

--- a/snapcraft/internal/states/_pull_state.py
+++ b/snapcraft/internal/states/_pull_state.py
@@ -30,6 +30,7 @@ def _schema_properties():
         "source-type",
         "source-branch",
         "source-subdir",
+        "source-recurse-submodules",
         "stage-packages",
     }
 

--- a/tests/spread/general/sources/snaps/git-recurse-submodules/snapcraft.yaml
+++ b/tests/spread/general/sources/snaps/git-recurse-submodules/snapcraft.yaml
@@ -1,0 +1,13 @@
+name: git-recurse-submodules
+base: core20
+version: "0.1"
+summary: Test the use of source-recurse-submodules
+description: Make sure source-recurse-submodules works
+confinement: strict
+
+parts:
+    git:
+        plugin: dump
+        source: https://github.com/snapcore/core18
+        source-type: git
+        source-recurse-submodules: true

--- a/tests/spread/general/sources/task.yaml
+++ b/tests/spread/general/sources/task.yaml
@@ -11,6 +11,7 @@ environment:
   SNAP_DIR/git_commit: snaps/git-commit
   SNAP_DIR/git_depth: snaps/git-depth
   SNAP_DIR/git_head: snaps/git-head
+  SNAP_DIR/git_recurse_submodules: snaps/git-recurse-submodules
   SNAP_DIR/local_source: snaps/local-source
   SNAP_DIR/local_source_subfolders: snaps/local-source-subfolders
   SNAP_DIR/local_source_type: snaps/local-source-type

--- a/tests/spread/plugins/v1/x-local/local-plugin-x-compat/state-pull
+++ b/tests/spread/plugins/v1/x-local/local-plugin-x-compat/state-pull
@@ -23,6 +23,7 @@ properties:
   source-subdir: ''
   source-tag: ''
   source-type: ''
+  source-recurse-submodules: False
   stage-packages: []
 schema_properties:
 - foo

--- a/tests/spread/plugins/v1/x-local/local-plugin-x-compat/state-pull
+++ b/tests/spread/plugins/v1/x-local/local-plugin-x-compat/state-pull
@@ -20,10 +20,10 @@ properties:
   source-branch: ''
   source-commit: ''
   source-depth: 0
+  source-recurse-submodules: true
   source-subdir: ''
   source-tag: ''
   source-type: ''
-  source-recurse-submodules: False
   stage-packages: []
 schema_properties:
 - foo

--- a/tests/spread/plugins/v1/x-local/local-plugin/state-pull
+++ b/tests/spread/plugins/v1/x-local/local-plugin/state-pull
@@ -23,6 +23,7 @@ properties:
   source-subdir: ''
   source-tag: ''
   source-type: ''
+  source-recurse-submodules: False
   stage-packages: []
 schema_properties:
 - foo

--- a/tests/spread/plugins/v1/x-local/local-plugin/state-pull
+++ b/tests/spread/plugins/v1/x-local/local-plugin/state-pull
@@ -20,10 +20,10 @@ properties:
   source-branch: ''
   source-commit: ''
   source-depth: 0
+  source-recurse-submodules: true
   source-subdir: ''
   source-tag: ''
   source-type: ''
-  source-recurse-submodules: False
   stage-packages: []
 schema_properties:
 - foo

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -49,6 +49,7 @@ class MockOptions:
         source_depth=None,
         source_commit=None,
         source_checksum=None,
+        source_recurse_submodules=None,
         disable_parallel=False,
     ):
         self.source = source
@@ -58,6 +59,7 @@ class MockOptions:
         self.source_commit = source_commit
         self.source_tag = source_tag
         self.source_subdir = source_subdir
+        self.source_recurse_submodules = source_recurse_submodules
         self.disable_parallel = disable_parallel
 
 

--- a/tests/unit/pluginhandler/test_state.py
+++ b/tests/unit/pluginhandler/test_state.py
@@ -113,7 +113,7 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(state, "Expected pull to save state YAML")
         self.assertTrue(type(state) is states.PullState)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertThat(len(state.properties), Equals(11))
+        self.assertThat(len(state.properties), Equals(12))
         for expected in [
             "source",
             "source-branch",
@@ -122,6 +122,7 @@ class StateTestCase(StateBaseTestCase):
             "source-subdir",
             "source-tag",
             "source-type",
+            "source-recurse-submodules",
             "plugin",
             "stage-packages",
             "parse-info",
@@ -167,7 +168,7 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(state, "Expected pull to save state YAML")
         self.assertTrue(type(state) is states.PullState)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertThat(len(state.properties), Equals(11))
+        self.assertThat(len(state.properties), Equals(12))
         for expected in [
             "source",
             "source-branch",
@@ -176,6 +177,7 @@ class StateTestCase(StateBaseTestCase):
             "source-subdir",
             "source-tag",
             "source-type",
+            "source-recurse-submodules",
             "plugin",
             "stage-packages",
             "parse-info",
@@ -224,7 +226,7 @@ class StateTestCase(StateBaseTestCase):
         self.assertTrue(state, "Expected pull to save state YAML")
         self.assertTrue(type(state) is states.PullState)
         self.assertTrue(type(state.properties) is OrderedDict)
-        self.assertThat(len(state.properties), Equals(11))
+        self.assertThat(len(state.properties), Equals(12))
         for expected in [
             "source",
             "source-branch",
@@ -233,6 +235,7 @@ class StateTestCase(StateBaseTestCase):
             "source-subdir",
             "source-tag",
             "source-type",
+            "source-recurse-submodules",
             "plugin",
             "stage-packages",
             "parse-info",

--- a/tests/unit/remote_build/test_worktree.py
+++ b/tests/unit/remote_build/test_worktree.py
@@ -204,6 +204,7 @@ class WorkTreeTestCase(unit.TestCase):
                 "source-subdir": "test-sub-dir",
                 "source-tag": "strip-me",
                 "source-type": "local",
+                "source-recurse-submodules": "strip-me",
             },
         )
 

--- a/tests/unit/sources/test_git.py
+++ b/tests/unit/sources/test_git.py
@@ -270,6 +270,37 @@ class TestGit(unit.sources.SourceTestCase):  # type: ignore
             ]
         )
 
+    def test_pull_with_recurse_submodules_default(self):
+        git = sources.Git("git://my-source", "source_dir")
+
+        git.pull()
+
+        self.mock_run.assert_called_once_with(
+            ["git", "clone", "--recursive", "git://my-source", "source_dir"]
+        )
+
+    def test_pull_with_recurse_submodules_true(self):
+        git = sources.Git(
+            "git://my-source", "source_dir", source_recurse_submodules=True
+        )
+
+        git.pull()
+
+        self.mock_run.assert_called_once_with(
+            ["git", "clone", "--recursive", "git://my-source", "source_dir"]
+        )
+
+    def test_pull_with_recurse_submodules_false(self):
+        git = sources.Git(
+            "git://my-source", "source_dir", source_recurse_submodules=False
+        )
+
+        git.pull()
+
+        self.mock_run.assert_called_once_with(
+            ["git", "clone", "git://my-source", "source_dir"]
+        )
+
     def test_pull_existing(self):
         self.mock_path_exists.return_value = True
 
@@ -424,6 +455,95 @@ class TestGit(unit.sources.SourceTestCase):  # type: ignore
                         "--recursive",
                         "--force",
                     ]
+                ),
+            ]
+        )
+
+    def test_pull_existing_with_recurse_submodule_default(self):
+        self.mock_path_exists.return_value = True
+
+        git = sources.Git("git://my-source", "source_dir")
+        git.pull()
+
+        self.mock_run.assert_has_calls(
+            [
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
+                        "fetch",
+                        "--prune",
+                        "--recurse-submodules=yes",
+                    ]
+                ),
+                mock.call(
+                    ["git", "-C", "source_dir", "reset", "--hard", "origin/master"]
+                ),
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
+                        "submodule",
+                        "update",
+                        "--recursive",
+                        "--force",
+                    ]
+                ),
+            ]
+        )
+
+    def test_pull_existing_with_recurse_submodule_true(self):
+        self.mock_path_exists.return_value = True
+
+        git = sources.Git(
+            "git://my-source", "source_dir", source_recurse_submodules=True
+        )
+        git.pull()
+
+        self.mock_run.assert_has_calls(
+            [
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
+                        "fetch",
+                        "--prune",
+                        "--recurse-submodules=yes",
+                    ]
+                ),
+                mock.call(
+                    ["git", "-C", "source_dir", "reset", "--hard", "origin/master"]
+                ),
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
+                        "submodule",
+                        "update",
+                        "--recursive",
+                        "--force",
+                    ]
+                ),
+            ]
+        )
+
+    def test_pull_existing_with_recurse_submodule_false(self):
+        self.mock_path_exists.return_value = True
+
+        git = sources.Git(
+            "git://my-source", "source_dir", source_recurse_submodules=False
+        )
+        git.pull()
+
+        self.mock_run.assert_has_calls(
+            [
+                mock.call(["git", "-C", "source_dir", "fetch", "--prune"]),
+                mock.call(
+                    ["git", "-C", "source_dir", "reset", "--hard", "origin/master"]
                 ),
             ]
         )

--- a/tests/unit/states/test_pull.py
+++ b/tests/unit/states/test_pull.py
@@ -78,11 +78,12 @@ class PullStateTestCase(PullStateBaseTestCase):
                 "source-type": "test-source-type",
                 "source-branch": "test-source-branch",
                 "source-subdir": "test-source-subdir",
+                "source-recurse-submodules": "test-source-recurse-submodules",
             }
         )
 
         properties = self.state.properties_of_interest(self.part_properties)
-        self.assertThat(len(properties), Equals(12))
+        self.assertThat(len(properties), Equals(13))
         self.assertThat(properties["foo"], Equals("bar"))
         self.assertThat(properties["override-pull"], Equals("touch override-pull"))
         self.assertThat(properties["plugin"], Equals("test-plugin"))
@@ -95,6 +96,7 @@ class PullStateTestCase(PullStateBaseTestCase):
         self.assertThat(properties["source-type"], Equals("test-source-type"))
         self.assertThat(properties["source-branch"], Equals("test-source-branch"))
         self.assertThat(properties["source-subdir"], Equals("test-source-subdir"))
+        self.assertThat(properties["source-recurse-submodules"], Equals("test-source-recurse-submodules"))
 
     def test_project_options_of_interest(self):
         options = self.state.project_options_of_interest(self.project)

--- a/tests/unit/states/test_pull.py
+++ b/tests/unit/states/test_pull.py
@@ -96,7 +96,10 @@ class PullStateTestCase(PullStateBaseTestCase):
         self.assertThat(properties["source-type"], Equals("test-source-type"))
         self.assertThat(properties["source-branch"], Equals("test-source-branch"))
         self.assertThat(properties["source-subdir"], Equals("test-source-subdir"))
-        self.assertThat(properties["source-recurse-submodules"], Equals("test-source-recurse-submodules"))
+        self.assertThat(
+            properties["source-recurse-submodules"],
+            Equals("test-source-recurse-submodules"),
+        )
 
     def test_project_options_of_interest(self):
         options = self.state.project_options_of_interest(self.project)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `./runtests.sh static`?
- [X] Have you successfully run `./runtests.sh tests/unit`?

-----
https://bugs.launchpad.net/snapcraft/+bug/1957767

Add new parameter `source_recurse_submodules`

Example snapcraft.yaml:
```
parts:
    git:
        source: https://github.com/snapcore/snapcraft
        source-type: git
        source-commit: "HEAD"
        source-recurse-submodules: False
```