### PR TITLE
npm plugin: allow running as root

### DIFF
--- a/snapcraft/plugins/v2/npm.py
+++ b/snapcraft/plugins/v2/npm.py
@@ -102,5 +102,6 @@ class NpmPlugin(PluginV2):
     def get_build_commands(self) -> List[str]:
         return [
             self._get_node_command(),
+            "npm config set unsafe-perm true",
             'npm install -g --prefix "${SNAPCRAFT_PART_INSTALL}" $(npm pack . | tail -1)',
         ]

--- a/tests/unit/plugins/v2/test_npm.py
+++ b/tests/unit/plugins/v2/test_npm.py
@@ -96,6 +96,7 @@ class NpmPluginTest(TestCase):
                     fi
                     """
                     ),
+                    "npm config set unsafe-perm true",
                     'npm install -g --prefix "${SNAPCRAFT_PART_INSTALL}" $(npm pack . | tail -1)',
                 ]
             ),


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

Since snapcraft in lxd/multipass is run as root user, there can be cases where the installation of npm packages fails with "permission denied". This issue has been lurking around for a long time and there isn't really a workaround apart from not using the npm plugin and shipping npm in a custom part.

The reason for that is that npm plugin's `get_build_commands` method downloads npm from upstream and then in the next command calls `npm install` and `npm pack`, leaving no way for the developers to configure npm at all.

Here is one related issue https://forum.snapcraft.io/t/issue-with-nodejs-plugin-when-using-base-keyword/11109/14
