### PR TITLE
npm plugin: extract node archive without preserving ownership

### DIFF
--- a/snapcraft/plugins/v2/npm.py
+++ b/snapcraft/plugins/v2/npm.py
@@ -91,7 +91,7 @@ class NpmPlugin(PluginV2):
         return dedent(
             f"""\
         if [ ! -f "${{SNAPCRAFT_PART_INSTALL}}/bin/node" ]; then
-            curl -s "{node_uri}" | tar xzf - -C "${{SNAPCRAFT_PART_INSTALL}}/" --strip-components=1
+            curl -s "{node_uri}" | tar xzf - -C "${{SNAPCRAFT_PART_INSTALL}}/" --no-same-owner --strip-components=1
         fi
         """
         )

--- a/tests/unit/plugins/v2/test_npm.py
+++ b/tests/unit/plugins/v2/test_npm.py
@@ -92,7 +92,7 @@ class NpmPluginTest(TestCase):
                     dedent(
                         """\
                     if [ ! -f "${SNAPCRAFT_PART_INSTALL}/bin/node" ]; then
-                        curl -s "https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-x64.tar.gz" | tar xzf - -C "${SNAPCRAFT_PART_INSTALL}/" --strip-components=1
+                        curl -s "https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-x64.tar.gz" | tar xzf - -C "${SNAPCRAFT_PART_INSTALL}/" --no-same-owner --strip-components=1
                     fi
                     """
                     ),


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
It seems the changes that landed via https://github.com/snapcore/snapcraft/commit/52c6c7d9ce7db66a6575845d88e73067229ec2d9 weren't enough, there is another fundamental issue lurking. The node archive that is downloaded from upstream, when extracted, are owned by user `1001`, this is causing the case where installation would fail with permission denied (npm surprise!). The proposed change does actually fix the issue as I have verified it.