### PR TITLE
upgrade base image to ubuntu:bionic (18.04)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 RUN apt-get update && \
   apt-get dist-upgrade --yes && \


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
This is the new base image to build the snapcraft image. Main reason is, the python version v3.5.x is too old. 

For example, I can't re-use original image (which built from ubuntu:xenial), if I need install package `boto3`, it need python 3.6 at least.

I also try to upgrade it to ubuntu:focal (20.04), but with some unknown reason,  it stuck at "Checking connectivity with the snap store"

![image](https://user-images.githubusercontent.com/8954908/150675044-cd8fe9eb-b15b-48a1-bd59-7be04ba1cabf.png)
