### PR TITLE
Autotools Plugin (v1): Fix fatal crash when running autogen.sh or bootstrap

### DIFF
--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -99,7 +99,7 @@ def _run(cmd: List[str], runner: Callable, **kwargs):
     # Finally, execute desired command.
     lines.append("#############################")
     lines.append("# Execute command:")
-    cmd_string = " ".join([shlex.quote(c) for c in cmd])
+    cmd_string = " ".join([shlex.quote(str(c)) for c in cmd])
     lines.append(f"exec {cmd_string}")
 
     # Save script executed by snapcraft.


### PR DESCRIPTION
The autotools plugin will attempt to run `autogen.sh` or `bootstrap` scripts if they are present in the part's source. However, the internal representation of these scripts is a `Path` object, not a string, so when passed to `shlex` it throws an exception stating that it was expecting a bytes-like object.

Signed-off-by: Dani Llewellyn <dani@bowlhat.net>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
