### PR TITLE
projects: add project model and validation (CRAFT-763)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ docs/reference.md
 htmlcov
 .idea
 .mypy_cache
-parts
+/parts
 pip-wheel-metadata/
 prime
 *.pyc
@@ -27,7 +27,6 @@ snap/.snapcraft/
 stage
 *.swp
 target
-tests/unit/parts/
 tests/unit/snap/
 tests/unit/stage/
 .vscode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,10 @@ ensure_newline_before_comments = true
 line_length = 88
 
 [tool.pylint.messages_control]
-disable = "fixme"
+disable = "too-few-public-methods,fixme"
 
 [tool.pylint.MASTER]
+extension-pkg-allow-list = [
+    "pydantic"
+]
 load-plugins = "pylint_fixme_info,pylint_pytest"

--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 from craft_cli import BaseCommand, emit
 from overrides import overrides
 
-from snapcraft import parts
+from snapcraft.parts import lifecycle as parts_lifecycle
 
 if TYPE_CHECKING:
     import argparse
@@ -45,7 +45,7 @@ class _LifecycleCommand(BaseCommand, abc.ABC):
             raise RuntimeError("command name not specified")
 
         emit.trace(f"lifecycle command: {self.name!r}, arguments: {parsed_args!r}")
-        parts.run_lifecycle(self.name, parsed_args)
+        parts_lifecycle.run(self.name, parsed_args)
 
 
 class PullCommand(_LifecycleCommand):

--- a/snapcraft/errors.py
+++ b/snapcraft/errors.py
@@ -30,5 +30,9 @@ class FeatureNotImplemented(SnapcraftError):
         super().__init__(f"Command or feature not implemented: {msg}")
 
 
+class ProjectValidationError(SnapcraftError):
+    """Error validatiing snapcraft.yaml."""
+
+
 class LegacyFallback(Exception):
     """Fall back to legacy snapcraft implementation."""

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -24,6 +24,7 @@ import yaml.error
 from craft_cli import emit
 
 from snapcraft import errors
+from snapcraft.projects import Project
 
 if TYPE_CHECKING:
     import argparse
@@ -37,7 +38,7 @@ _PROJECT_FILES = [
 ]
 
 
-def run_lifecycle(step_name: str, parsed_args: "argparse.Namespace") -> None:
+def run(step_name: str, parsed_args: "argparse.Namespace") -> None:
     """Run the parts lifecycle.
 
     :raises SnapcraftError: if the step name is invalid, or the project
@@ -57,14 +58,23 @@ def run_lifecycle(step_name: str, parsed_args: "argparse.Namespace") -> None:
             resolution="To start a new project, use `snapcraft init`",
         )
 
+    # only execute the new codebase from core22 onwards
     if yaml_data.get("base") != "core22":
         raise errors.LegacyFallback("base is not core22")
 
-    _run_step(step_name, parsed_args, yaml_data)
+    # TODO: apply extensions
+    # yaml_data = apply_extensions(yaml_data)
+
+    # TODO: process grammar
+    # yaml_data = process_grammar(yaml_data)
+
+    project = Project.unmarshal(yaml_data)
+
+    _run_step(step_name, project, parsed_args)
 
 
 def _run_step(
-    step_name: str, parsed_args: "argparse.Namespace", yaml_data: Dict[str, Any]
+    step_name: str, project: Project, parsed_args: "argparse.Namespace",
 ) -> None:
     raise errors.FeatureNotImplemented(f"core22 {step_name} handler")
 

--- a/snapcraft/parts/validation.py
+++ b/snapcraft/parts/validation.py
@@ -14,4 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Parts lifecycle processing."""
+"""Part schema validation."""
+
+from typing import Any, Dict
+
+
+def validate_part(data: Dict[str, Any]) -> None:  # pylint: disable=unused-argument
+    """Validate the given part data against common and plugin models."""
+    # TODO: implement after craft-parts integration

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -1,0 +1,374 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Project file definition and helpers."""
+
+import re
+
+# XXX: mypy doesn't like Literal
+from typing import Literal  # type: ignore
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+
+import pydantic
+from pydantic import conlist, constr
+
+from snapcraft.errors import ProjectValidationError
+from snapcraft.parts import validation as parts_validation
+
+
+class ProjectModel(pydantic.BaseModel):
+    """Base model for snapcraft project classes."""
+
+    class Config:  # pylint: disable=too-few-public-methods
+        """Pydantic model configuration."""
+
+        validate_assignment = True
+        # extra = "forbid"
+        allow_mutation = False
+        allow_population_by_field_name = True
+        alias_generator = lambda s: s.replace("_", "-")  # noqa: E731
+
+
+# A workaround for mypy false positives
+# see https://github.com/samuelcolvin/pydantic/issues/975#issuecomment-551147305
+# fmt: off
+if TYPE_CHECKING:
+    CommandChainStr = str
+    UniqueStrList = List[str]
+    UniqueAliasList = List[str]
+else:
+    CommandChainStr = constr(regex=r"^[A-Za-z0-9/._#:$-]*$")
+    UniqueStrList = conlist(str, unique_items=True)
+    UniqueAliasList = conlist(constr(regex=r"^[a-zA-Z0-9][-_.a-zA-Z0-9]*$"), unique_items=True)
+# fmt: on
+
+
+class App(ProjectModel):
+    """Snapcraft project app definition."""
+
+    command: str
+    autostart: Optional[str]
+    common_id: Optional[str]
+    bus_name: Optional[str]
+    desktop: Optional[str]
+    completer: Optional[str]
+    stop_command: Optional[str]
+    post_stop_command: Optional[str]
+    start_timeout: Optional[str]
+    stop_timeout: Optional[str]
+    watchdog_timeout: Optional[str]
+    reload_command: Optional[str]
+    restart_delay: Optional[str]
+    timer: Optional[str]
+    daemon: Optional[Literal["simple", "forking", "oneshot", "notify", "dbus"]]
+    after: UniqueStrList = []
+    before: UniqueStrList = []
+    refresh_mode: Optional[Literal["endure", "restart"]]
+    stop_mode: Optional[
+        Literal[
+            "sigterm",
+            "sigterm-all",
+            "sighup",
+            "sighup-all",
+            "sigusr1",
+            "sigusr1-all",
+            "sigusr2",
+            "sigusr2-all",
+        ]
+    ]
+    restart_condition: Optional[
+        Literal[
+            "on-success",
+            "on-failure",
+            "on-abnormal",
+            "on-abort",
+            "on-watchdog",
+            "always",
+            "never",
+        ]
+    ]
+    install_mode: Optional[Literal["enable", "disable"]]
+    slots: UniqueStrList = []
+    plugs: UniqueStrList = []
+    aliases: UniqueAliasList = []
+    environment: List[Dict[str, str]] = []
+    command_chain: List[CommandChainStr] = []
+    # TODO: sockets
+
+    @pydantic.validator("autostart")
+    @classmethod
+    def _validate_desktop_name(cls, name):
+        if not re.match(r"^[A-Za-z0-9. _#:$-]+\\.desktop$", name):
+            raise ValueError(
+                f"{name!r} is not a valid desktop file name (e.g. myapp.desktop)"
+            )
+
+        return name
+
+    @pydantic.validator("bus_name")
+    @classmethod
+    def _validate_bus_name(cls, name):
+        if not re.match(r"^[A-Za-z0-9/. _#:$-]*$", name):
+            raise ValueError(f"{name!r} is not a valid bus name")
+
+        return name
+
+    @pydantic.validator(
+        "start_timeout", "stop_timeout", "watchdog_timeout", "restart_delay"
+    )
+    @classmethod
+    def _validate_time(cls, timeval):
+        if not re.match(r"^[0-9]+(ns|us|ms|s|m)*$", timeval):
+            raise ValueError(f"{timeval!r} is not a valid time value")
+
+        return timeval
+
+
+class Hook(ProjectModel):
+    """Snapcraft project hook definition."""
+
+    command_chain: List[CommandChainStr] = []
+    environment: List[Dict[str, str]] = []
+    plugs: UniqueStrList = []
+    passthrough: Optional[Dict[str, Any]]
+
+
+class Architecture(ProjectModel):
+    """Snapcraft project architecture definition."""
+
+    build_on: Union[str, UniqueStrList]
+    build_to: Optional[Union[str, UniqueStrList]]
+
+
+class Project(ProjectModel):
+    """Snapcraft project definition.
+
+    See https://snapcraft.io/docs/snapcraft-yaml-reference
+
+    XXX: Not implemented in this version
+    - environment (top-level)
+    - frameworks
+    - system-usernames
+    - package-repositories
+    - version-script (deprecated)
+    """
+
+    name: constr(max_length=40)  # type: ignore
+    title: Optional[constr(max_length=40)]  # type: ignore
+    base: Optional[str]
+    build_base: Optional[str]
+    compression: Literal["lzo", "xz"] = "xz"
+    version: Optional[constr(max_length=32, strict=True)]  # type: ignore
+    contact: Optional[Union[str, UniqueStrList]]
+    donation: Optional[Union[str, UniqueStrList]]
+    issues: Optional[Union[str, UniqueStrList]]
+    source_code: Optional[str]  # XXX: should we validate as URL?
+    website: Optional[str]  # XXX: should we validate as URL?
+    summary: constr(max_length=78)  # type: ignore
+    description: str
+    type: Literal["app", "base", "gadget", "kernel", "snapd"] = "app"
+    icon: Optional[str]
+    confinement: Literal["classic", "devmode", "strict"]
+    layout: Optional[Dict[str, Dict[str, Any]]]
+    license: Optional[str]
+    grade: Literal["stable", "devel"]
+    adopt_info: Optional[str]
+    architectures: List[Architecture] = []
+    assumes: UniqueStrList = []
+    hooks: Optional[Dict[str, Hook]]
+    passthrough: Optional[Dict[str, Any]]
+    apps: Optional[Dict[str, App]]
+    plugs: Optional[Dict[str, Dict[str, str]]]  # TODO: add plug name validation
+    slots: Optional[Dict[str, Dict[str, str]]]  # TODO: add slot name validation
+    parts: Dict[str, Any]  # parts are handled by craft-parts
+    epoch: Optional[int]
+
+    @pydantic.root_validator(pre=True)
+    @classmethod
+    def _validate_mandatory_version(cls, values):
+        if "version" not in values and "adopt-info" not in values:
+            raise ValueError("Snap version is required if not using adopt-info")
+        return values
+
+    @pydantic.root_validator(pre=True)
+    @classmethod
+    def _validate_mandatory_base(cls, values):
+        snap_type = values.get("type")
+        if ("base" in values) ^ (snap_type not in ["base", "kernel", "snapd"]):
+            raise ValueError(
+                "Snap base must be declared when type is not base, kernel or snapd"
+            )
+        return values
+
+    @pydantic.validator("name")
+    @classmethod
+    def _validate_name(cls, name):
+        if not re.match(r"^[a-z0-9-]*[a-z][a-z0-9-]*$", name):
+            raise ValueError(
+                "Snap names can only use ASCII lowercase letters, numbers, and hyphens, "
+                "and must have at least one letter"
+            )
+
+        if name.startswith("-"):
+            raise ValueError("Snap names cannot start with a hyphen")
+
+        if name.endswith("-"):
+            raise ValueError("Snap names cannot end with a hyphen")
+
+        if "--" in name:
+            raise ValueError("Snap names cannot have two hyphens in a row")
+
+        return name
+
+    @pydantic.validator("version")
+    @classmethod
+    def _validate_version(cls, version):
+        if not re.match(r"^[a-zA-Z0-9](?:[a-zA-Z0-9:.+~-]*[a-zA-Z0-9+~])?$", version):
+            raise ValueError(
+                "Snap versions consist of upper- and lower-case alphanumeric characters, "
+                "as well as periods, colons, plus signs, tildes, and hyphens. They cannot "
+                "begin with a period, colon, plus sign, tilde, or hyphen. They cannot end "
+                "with a period, colon, or hyphen"
+            )
+
+        return version
+
+    @pydantic.validator("build_base", always=True)
+    @classmethod
+    def _validate_build_base(cls, build_base, values):
+        """Build-base defaults to the base value if not specified."""
+        if not build_base:
+            build_base = values.get("base")
+        return build_base
+
+    @pydantic.validator("parts", each_item=True)
+    @classmethod
+    def _validate_parts(cls, item):
+        """Verify each part (craft-parts will re-validate this)."""
+        parts_validation.validate_part(item)
+        return item
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]) -> "Project":
+        """Create and populate a new ``Project`` object from dictionary data.
+
+        The unmarshal method validates entries in the input dictionary, populating
+        the corresponding fields in the data object.
+
+        :param data: The dictionary data to unmarshal.
+
+        :return: The newly created object.
+
+        :raise TypeError: If data is not a dictionary.
+        """
+        if not isinstance(data, dict):
+            raise TypeError("part data is not a dictionary")
+
+        try:
+            project = Project(**data)
+        except pydantic.ValidationError as err:
+            raise ProjectValidationError(_format_pydantic_errors(err.errors())) from err
+
+        return project
+
+
+def _format_pydantic_errors(errors, *, file_name: str = "snapcraft.yaml"):
+    """Format errors.
+
+    Example 1: Single error.
+
+    Bad snapcraft.yaml content:
+    - field: <some field>
+      reason: <some reason>
+
+    Example 2: Multiple errors.
+
+    Bad snapcraft.yaml content:
+    - field: <some field>
+      reason: <some reason>
+    - field: <some field 2>
+      reason: <some reason 2>
+    """
+    combined = [f"Bad {file_name} content:"]
+    for error in errors:
+        formatted_loc = _format_pydantic_error_location(error["loc"])
+        formatted_msg = _format_pydantic_error_message(error["msg"])
+
+        if formatted_msg == "field required":
+            field_name, location = _printable_field_location_split(formatted_loc)
+            combined.append(
+                f"- field {field_name} required in {location} configuration"
+            )
+        elif formatted_msg == "extra fields not permitted":
+            field_name, location = _printable_field_location_split(formatted_loc)
+            combined.append(
+                f"- extra field {field_name} not permitted in {location} configuration"
+            )
+        elif formatted_loc == "__root__":
+            combined.append(f"- {formatted_msg}")
+        else:
+            combined.append(f"- {formatted_msg} (in field {formatted_loc!r})")
+
+    return "\n".join(combined)
+
+
+def _format_pydantic_error_location(loc):
+    """Format location."""
+    loc_parts = []
+    for loc_part in loc:
+        if isinstance(loc_part, str):
+            loc_parts.append(loc_part)
+        elif isinstance(loc_part, int):
+            # Integer indicates an index. Go
+            # back and fix up previous part.
+            previous_part = loc_parts.pop()
+            previous_part += f"[{loc_part}]"
+            loc_parts.append(previous_part)
+        else:
+            raise RuntimeError(f"unhandled loc: {loc_part}")
+
+    loc = ".".join(loc_parts)
+
+    # Filter out internal __root__ detail.
+    loc = loc.replace(".__root__", "")
+    return loc
+
+
+def _format_pydantic_error_message(msg):
+    """Format pydantic's error message field."""
+    # Replace shorthand "str" with "string".
+    msg = msg.replace("str type expected", "string type expected")
+    return msg
+
+
+def _printable_field_location_split(location: str) -> Tuple[str, str]:
+    """Return split field location.
+
+    If top-level, location is returned as unquoted "top-level".
+    If not top-level, location is returned as quoted location, e.g.
+
+    (1) field1[idx].foo => 'foo', 'field1[idx]'
+    (2) field2 => 'field2', top-level
+
+    :returns: Tuple of <field name>, <location> as printable representations.
+    """
+    loc_split = location.split(".")
+    field_name = repr(loc_split.pop())
+
+    if loc_split:
+        return field_name, repr(".".join(loc_split))
+
+    return field_name, "top-level"

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -37,7 +37,7 @@ from snapcraft.commands.lifecycle import (
     ],
 )
 def test_lifecycle_command(step_name, cmd_class, mocker):
-    lifecycle_run_mock = mocker.patch("snapcraft.parts.run_lifecycle")
+    lifecycle_run_mock = mocker.patch("snapcraft.parts.lifecycle.run")
     cmd = cmd_class(None)
     cmd.run(argparse.Namespace(parts=["part1", "part2"]))
     assert lifecycle_run_mock.mock_calls == [

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -1,0 +1,401 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Any, Dict
+
+import pytest
+
+from snapcraft import errors
+from snapcraft.projects import Project
+
+
+@pytest.fixture
+def yaml_data():
+    def _yaml_data(
+        *, name: str = "name", version: str = "0.1", summary: str = "summary", **kwargs
+    ) -> Dict[str, Any]:
+        return {
+            "name": name,
+            "version": version,
+            "base": "core22",
+            "summary": summary,
+            "description": "description",
+            "grade": "stable",
+            "confinement": "strict",
+            "parts": [],
+            **kwargs,
+        }
+
+    yield _yaml_data
+
+
+class TestProjectDefaults:
+    """Ensure unspecified items have the correct default value."""
+
+    def test_project_defaults(self, yaml_data):
+        project = Project.unmarshal(yaml_data())
+
+        assert project.build_base == project.base
+        assert project.compression == "xz"
+        assert project.contact is None
+        assert project.donation is None
+        assert project.issues is None
+        assert project.source_code is None
+        assert project.website is None
+        assert project.type == "app"
+        assert project.icon is None
+        assert project.layout is None
+        assert project.license is None
+        assert project.adopt_info is None
+        assert project.architectures == []
+        assert project.assumes == []
+        assert project.hooks is None
+        assert project.passthrough is None
+        assert project.apps is None
+        assert project.plugs is None
+        assert project.slots is None
+        assert project.epoch is None
+
+    def test_app_defaults(self, yaml_data):
+        data = yaml_data(apps={"app1": {"command": "/bin/true"}})
+        project = Project.unmarshal(data)
+        assert project.apps is not None
+
+        app = project.apps["app1"]
+        assert app is not None
+
+        assert app.command == "/bin/true"
+        assert app.autostart is None
+        assert app.common_id is None
+        assert app.bus_name is None
+        assert app.desktop is None
+        assert app.completer is None
+        assert app.stop_command is None
+        assert app.post_stop_command is None
+        assert app.start_timeout is None
+        assert app.stop_timeout is None
+        assert app.watchdog_timeout is None
+        assert app.reload_command is None
+        assert app.restart_delay is None
+        assert app.timer is None
+        assert app.daemon is None
+        assert app.after == []
+        assert app.before == []
+        assert app.refresh_mode is None
+        assert app.stop_mode is None
+        assert app.restart_condition is None
+        assert app.install_mode is None
+        assert app.slots == []
+        assert app.plugs == []
+        assert app.aliases == []
+        assert app.environment == []
+        assert app.command_chain == []
+
+
+class TestProjectValidation:
+    """Validate top-level project items."""
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "name",
+            "summary",
+            "description",
+            "grade",
+            "confinement",
+            "parts",
+        ],
+    )
+    def test_mandatory_fields(self, field, yaml_data):
+        data = yaml_data()
+        data.pop(field)
+        error = f"field {field!r} required in top-level configuration"
+        with pytest.raises(errors.ProjectValidationError, match=error):
+            Project.unmarshal(data)
+
+    @pytest.mark.parametrize(
+        "snap_type,requires_base",
+        [
+            ("app", True),
+            ("gadget", True),
+            ("base", False),
+            ("kernel", False),
+            ("snapd", False),
+        ],
+    )
+    def test_mandatory_base(self, snap_type, requires_base, yaml_data):
+        data = yaml_data(type=snap_type)
+        data.pop("base")
+
+        if requires_base:
+            error = "Snap base must be declared when type is not"
+            with pytest.raises(errors.ProjectValidationError, match=error):
+                Project.unmarshal(data)
+        else:
+            project = Project.unmarshal(data)
+            assert project.base is None
+
+    def test_mandatory_version(self, yaml_data):
+        data = yaml_data()
+        data.pop("version")
+        error = "Snap version is required if not using adopt-info"
+        with pytest.raises(errors.ProjectValidationError, match=error):
+            Project.unmarshal(data)
+
+    def test_version_not_required(self, yaml_data):
+        data = yaml_data()
+        data.pop("version")
+        data["adopt-info"] = "part1"
+        project = Project.unmarshal(data)
+        assert project.version is None
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "name",
+            "name-with-dashes",
+            "name0123",
+            "0123name",
+            "a234567890123456789012345678901234567890",
+        ],
+    )
+    def test_project_name_valid(self, name, yaml_data):
+        project = Project.unmarshal(yaml_data(name=name))
+        assert project.name == name
+
+    @pytest.mark.parametrize(
+        "name,error",
+        [
+            ("name_with_underscores", "Snap names can only use"),
+            ("name-with-UPPERCASE", "Snap names can only use"),
+            ("name with spaces", "Snap names can only use"),
+            ("-name-starts-with-hyphen", "Snap names cannot start with a hyphen"),
+            ("name-ends-with-hyphen-", "Snap names cannot end with a hyphen"),
+            ("name-has--two-hyphens", "Snap names cannot have two hyphens in a row"),
+            ("123456", "Snap names can only use"),
+            (
+                "a2345678901234567890123456789012345678901",
+                "ensure this value has at most 40 characters",
+            ),
+        ],
+    )
+    def test_project_name_invalid(self, name, error, yaml_data):
+        with pytest.raises(errors.ProjectValidationError, match=error):
+            Project.unmarshal(yaml_data(name=name))
+
+    @pytest.mark.parametrize(
+        "version",
+        [
+            "1",
+            "1.0",
+            "1.0.1-5.2~build0.20.04:1+1A",
+            "git",
+            "1~",
+            "1+",
+            "12345678901234567890123456789012",
+        ],
+    )
+    def test_project_version_valid(self, version, yaml_data):
+        project = Project.unmarshal(yaml_data(version=version))
+        assert project.version == version
+
+    @pytest.mark.parametrize(
+        "version,error",
+        [
+            ("1_0", "Snap versions consist of"),  # _ is an invalid character
+            ("1=1", "Snap versions consist of"),  # = is an invalid character
+            (".1", "Snap versions consist of"),  # cannot start with period
+            (":1", "Snap versions consist of"),  # cannot start with colon
+            ("+1", "Snap versions consist of"),  # cannot start with plus sign
+            ("~1", "Snap versions consist of"),  # cannot start with tilde
+            ("-1", "Snap versions consist of"),  # cannot start with hyphen
+            ("1.", "Snap versions consist of"),  # cannot end with period
+            ("1:", "Snap versions consist of"),  # cannot end with colon
+            ("1-", "Snap versions consist of"),  # cannot end with hyphen
+            (
+                "123456789012345678901234567890123",
+                "ensure this value has at most 32 characters",
+            ),  # too large
+        ],
+    )
+    def test_project_version_invalid(self, version, error, yaml_data):
+        with pytest.raises(errors.ProjectValidationError, match=error):
+            Project.unmarshal(yaml_data(version=version))
+
+    @pytest.mark.parametrize(
+        "snap_type",
+        ["app", "gadget", "kernel", "snapd", "base", "_invalid"],
+    )
+    def test_project_type(self, snap_type, yaml_data):
+        data = yaml_data(type=snap_type)
+        if snap_type in ["base", "kernel", "snapd"]:
+            data.pop("base")
+
+        if snap_type != "_invalid":
+            project = Project.unmarshal(data)
+            assert project.type == snap_type
+        else:
+            error = ".*unexpected value; permitted: 'app', 'base', 'gadget', 'kernel', 'snapd'"
+            with pytest.raises(errors.ProjectValidationError, match=error):
+                Project.unmarshal(data)
+
+    @pytest.mark.parametrize(
+        "confinement",
+        ["strict", "devmode", "classic", "_invalid"],
+    )
+    def test_project_confinement(self, confinement, yaml_data):
+        data = yaml_data(confinement=confinement)
+
+        if confinement != "_invalid":
+            project = Project.unmarshal(data)
+            assert project.confinement == confinement
+        else:
+            error = ".*unexpected value; permitted: 'classic', 'devmode', 'strict'"
+            with pytest.raises(errors.ProjectValidationError, match=error):
+                Project.unmarshal(data)
+
+    @pytest.mark.parametrize(
+        "grade",
+        ["devel", "stable", "_invalid"],
+    )
+    def test_project_grade(self, grade, yaml_data):
+        data = yaml_data(grade=grade)
+
+        if grade != "_invalid":
+            project = Project.unmarshal(data)
+            assert project.grade == grade
+        else:
+            error = ".*unexpected value; permitted: 'stable', 'devel'"
+            with pytest.raises(errors.ProjectValidationError, match=error):
+                Project.unmarshal(data)
+
+    def test_project_summary_valid(self, yaml_data):
+        summary = "x" * 78
+        project = Project.unmarshal(yaml_data(summary=summary))
+        assert project.summary == summary
+
+    def test_project_summary_invalid(self, yaml_data):
+        summary = "x" * 79
+        error = "ensure this value has at most 78 characters"
+        with pytest.raises(errors.ProjectValidationError, match=error):
+            Project.unmarshal(yaml_data(summary=summary))
+
+
+class TestAppValidation:
+    """Validate apps."""
+
+    @pytest.mark.parametrize(
+        "daemon",
+        ["simple", "forking", "oneshot", "notify", "dbus", "_invalid"],
+    )
+    def test_app_daemon(self, daemon, yaml_data):
+        data = yaml_data(apps={"app1": {"command": "/bin/true", "daemon": daemon}})
+
+        if daemon != "_invalid":
+            project = Project.unmarshal(data)
+            assert project.apps is not None
+            assert project.apps["app1"].daemon == daemon
+        else:
+            error = ".*unexpected value; permitted: 'simple', 'forking', 'oneshot'"
+            with pytest.raises(errors.ProjectValidationError, match=error):
+                Project.unmarshal(data)
+
+    @pytest.mark.parametrize("refresh_mode", ["endure", "restart", "_invalid"])
+    def test_app_refresh_mode(self, refresh_mode, yaml_data):
+        data = yaml_data(
+            apps={"app1": {"command": "/bin/true", "refresh-mode": refresh_mode}}
+        )
+
+        if refresh_mode != "_invalid":
+            project = Project.unmarshal(data)
+            assert project.apps is not None
+            assert project.apps["app1"].refresh_mode == refresh_mode
+        else:
+            error = ".*unexpected value; permitted: 'endure', 'restart'"
+            with pytest.raises(errors.ProjectValidationError, match=error):
+                Project.unmarshal(data)
+
+    @pytest.mark.parametrize(
+        "stop_mode",
+        [
+            "sigterm",
+            "sigterm-all",
+            "sighup",
+            "sighup-all",
+            "sigusr1",
+            "sigusr1-all",
+            "sigusr2",
+            "sigusr2-all",
+            "_invalid",
+        ],
+    )
+    def test_app_stop_mode(self, stop_mode, yaml_data):
+        data = yaml_data(
+            apps={"app1": {"command": "/bin/true", "stop-mode": stop_mode}}
+        )
+
+        if stop_mode != "_invalid":
+            project = Project.unmarshal(data)
+            assert project.apps is not None
+            assert project.apps["app1"].stop_mode == stop_mode
+        else:
+            error = ".*unexpected value; permitted: 'sigterm', 'sigterm-all', 'sighup'"
+            with pytest.raises(errors.ProjectValidationError, match=error):
+                Project.unmarshal(data)
+
+    @pytest.mark.parametrize(
+        "restart_condition",
+        [
+            "on-success",
+            "on-failure",
+            "on-abnormal",
+            "on-abort",
+            "on-watchdog",
+            "always",
+            "never",
+            "_invalid",
+        ],
+    )
+    def test_app_restart_condition(self, restart_condition, yaml_data):
+        data = yaml_data(
+            apps={
+                "app1": {"command": "/bin/true", "restart-condition": restart_condition}
+            }
+        )
+
+        if restart_condition != "_invalid":
+            project = Project.unmarshal(data)
+            assert project.apps is not None
+            assert project.apps["app1"].restart_condition == restart_condition
+        else:
+            error = ".*unexpected value; permitted: 'on-success', 'on-failure', 'on-abnormal'"
+            with pytest.raises(errors.ProjectValidationError, match=error):
+                Project.unmarshal(data)
+
+    @pytest.mark.parametrize("install_mode", ["enable", "disable", "_invalid"])
+    def test_app_install_mode(self, install_mode, yaml_data):
+        data = yaml_data(
+            apps={"app1": {"command": "/bin/true", "install-mode": install_mode}}
+        )
+
+        if install_mode != "_invalid":
+            project = Project.unmarshal(data)
+            assert project.apps is not None
+            assert project.apps["app1"].install_mode == install_mode
+        else:
+            error = ".*unexpected value; permitted: 'enable', 'disable'"
+            with pytest.raises(errors.ProjectValidationError, match=error):
+                Project.unmarshal(data)

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -59,7 +59,6 @@ class TestProjectDefaults:
         assert project.icon is None
         assert project.layout is None
         assert project.license is None
-        assert project.adopt_info is None
         assert project.architectures == []
         assert project.assumes == []
         assert project.hooks is None
@@ -81,7 +80,6 @@ class TestProjectDefaults:
         assert app.autostart is None
         assert app.common_id is None
         assert app.bus_name is None
-        assert app.desktop is None
         assert app.completer is None
         assert app.stop_command is None
         assert app.post_stop_command is None
@@ -292,6 +290,37 @@ class TestProjectValidation:
         error = "ensure this value has at most 78 characters"
         with pytest.raises(errors.ProjectValidationError, match=error):
             Project.unmarshal(yaml_data(summary=summary))
+
+    @pytest.mark.parametrize(
+        "epoch",
+        [
+            "0",
+            "1",
+            "1*",
+            "12345",
+            "12345*",
+        ],
+    )
+    def test_project_epoch_valid(self, epoch, yaml_data):
+        project = Project.unmarshal(yaml_data(epoch=epoch))
+        assert project.epoch == epoch
+
+    @pytest.mark.parametrize(
+        "epoch",
+        [
+            "",
+            "invalid",
+            "0*",
+            "012345",
+            "-1",
+            "*1",
+            "1**",
+        ],
+    )
+    def test_project_epoch_invalid(self, epoch, yaml_data):
+        error = "Epoch is a positive integer followed by an optional asterisk"
+        with pytest.raises(errors.ProjectValidationError, match=error):
+            Project.unmarshal(yaml_data(epoch=epoch))
 
 
 class TestAppValidation:


### PR DESCRIPTION
Add pydantic model and validators for the snapcraft.yaml project file,
based on legacy schema and public documentation.

Package layout was slightly changed to prevent cyclic imports during
test execution. The layout may be further changed during the integration
of craft-parts. Additional validation and tests will be added as more features are
implemented.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
