### PR TITLE
dependencies: missing library resolution (CRAFT-422)

### DIFF
--- a/snapcraft/internal/pluginhandler/_dependencies.py
+++ b/snapcraft/internal/pluginhandler/_dependencies.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 from typing import Sequence, Set
 
 from snapcraft.internal import repo
@@ -53,9 +52,7 @@ class MissingDependencyResolver:
     def _process(self, elf_files: Sequence[str]) -> None:
         for elf_file in elf_files:
             try:
-                stage_package = repo.Repo.get_package_for_file(
-                    file_path=os.path.join(os.path.sep, elf_file)
-                )
+                stage_package = repo.Repo.get_package_for_file(file_path=elf_file)
                 self._stage_packages_dependencies.add(stage_package)
             except repo.errors.FileProviderNotFound:
                 self._unhandled_dependencies.add(elf_file)

--- a/snapcraft/internal/repo/errors.py
+++ b/snapcraft/internal/repo/errors.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from pathlib import Path
 from typing import List, Optional, Sequence
 
 from snapcraft import formatting_utils
@@ -60,7 +61,7 @@ class FileProviderNotFound(RepoError):
 
     fmt = "{file_path} is not provided by any package."
 
-    def __init__(self, *, file_path: str) -> None:
+    def __init__(self, *, file_path: Path) -> None:
         super().__init__(file_path=file_path)
 
 

--- a/tests/unit/pluginhandler/test_missing_dependency.py
+++ b/tests/unit/pluginhandler/test_missing_dependency.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from pathlib import Path
 from unittest import mock
 
 import fixtures
@@ -35,7 +36,7 @@ class MissingDependencyTest(unit.TestCase):
             try:
                 return packages[file_path]
             except KeyError:
-                raise repo.errors.FileProviderNotFound(file_path=file_path)
+                raise repo.errors.FileProviderNotFound(file_path=Path(file_path))
 
         self.useFixture(
             fixtures.MockPatch(


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `./runtests.sh static`?
- [X] Have you successfully run `./runtests.sh tests/unit`?

-----
Improvements to resolution of missing libraries.

<div class="OutlineElement Ltr  BCX2 SCXO33065325" style="margin-left: 0px; direction: ltr;"><div class="TableContainer SCXO33065325 BCX2"><div id="{b857542e-4fa0-4221-8d46-26722fa234f7}{136}" class="WACAltTextDescribedBy SCXO33065325 BCX2" aria-hidden="true"></div>

scenario | description | examples | previous behavior | new behavior
-- | -- | -- | -- | --
1 | snapcraft resolves library path | normal usage | suggests package to stage | suggests package to stage
2 | snapcraft resolves library path with symlinks | <ul><li>`usrmerge` package installed</li><li>custom library, i.e. library package has postinst action to make symlinks</li></ul> | **dpkg error** | suggests package to stage

</div></div>

</br>

For testing, this repo exercises the new functionality: https://github.com/mr-cal/missing-dependencies-snap

</br>

Source:

- https://forum.snapcraft.io/t/several-libraries-from-stage-packages-missing-despite-proper-ld-library-path/16017
- [LP: #1934403](https://bugs.launchpad.net/snapcraft/+bug/1934403)