### PR TITLE
meta: generate basic snap.yaml (CRAFT-801)

### DIFF
--- a/snapcraft/meta/__init__.py
+++ b/snapcraft/meta/__init__.py
@@ -1,0 +1,17 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Snap metadata definitions and helpers."""

--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -1,0 +1,136 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Create snap.yaml metadata file."""
+
+import textwrap
+from pathlib import Path
+from typing import Dict, List, Optional, cast
+
+import yaml
+from pydantic_yaml import YamlModel
+
+from snapcraft.projects import Project
+
+
+class SnapApp(YamlModel):
+    """Snap.yaml app entry.
+
+    This is currently a partial implementation, see
+    https://snapcraft.io/docs/snap-format for details.
+
+    TODO: add missing properties, improve validation (CRAFT-802)
+    """
+
+    command: str
+    command_chain: List[str]
+    environment: Optional[List[Dict[str, str]]]
+    plugs: Optional[List[str]]
+
+    class Config:  # pylint: disable=too-few-public-methods
+        """Pydantic model configuration."""
+
+        allow_population_by_field_name = True
+        alias_generator = lambda s: s.replace("_", "-")  # noqa: E731
+
+
+class SnapMetadata(YamlModel):
+    """The snap.yaml model.
+
+    This is currently a partial implementation, see
+    https://snapcraft.io/docs/snap-format for details.
+
+    TODO: add missing properties, improve validation (CRAFT-802)
+    """
+
+    name: str
+    title: Optional[str]
+    version: str
+    summary: str
+    description: str
+    license: Optional[str]
+    type: str
+    architectures: List[str]
+    base: str
+    assumes: Optional[List[str]]
+    epoch: Optional[str]
+    apps: Optional[Dict[str, SnapApp]]
+    confinement: str
+    grade: str
+
+
+def write(project: Project, prime_dir: Path, *, arch: str):
+    """Create a snap.yaml file."""
+    meta_dir = prime_dir / "meta"
+    meta_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_snapcraft_runner(prime_dir)
+
+    snap_apps: Dict[str, SnapApp] = {}
+    if project.apps:
+        for name, app in project.apps.items():
+            snap_apps[name] = SnapApp(
+                command=app.command,
+                command_chain=["snap/command-chain/snapcraft-runner"],
+                environment=app.environment,
+                plugs=app.plugs,
+            )
+
+    # FIXME: handle adopted parameters
+    snap_metadata = SnapMetadata(
+        name=project.name,
+        title=project.title,
+        version=project.version,  # type: ignore
+        summary=project.summary,
+        description=project.description,
+        license=project.license,
+        type=project.type,
+        architectures=[arch],
+        base=cast(str, project.base),
+        assumes=["command-chain"],
+        epoch=project.epoch,
+        apps=snap_apps,
+        confinement=project.confinement,
+        grade=project.grade,
+    )
+
+    yaml.add_representer(str, _repr_str, Dumper=yaml.SafeDumper)
+    yaml_data = snap_metadata.yaml(exclude_none=True, sort_keys=False, width=1000)
+
+    snap_yaml = meta_dir / "snap.yaml"
+    snap_yaml.write_text(yaml_data)
+
+
+def _write_snapcraft_runner(prime_dir: Path):
+    content = textwrap.dedent(
+        """#!/bin/sh
+        export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+        export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+        exec "$@"
+        """
+    )
+
+    runner_path = prime_dir / "snap/command-chain/snapcraft-runner"
+    runner_path.parent.mkdir(parents=True, exist_ok=True)
+    runner_path.write_text(content)
+    runner_path.chmod(0o755)
+
+
+def _repr_str(dumper, data):
+    """Multi-line string representer for the YAML dumper."""
+    if "\n" in data:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -24,6 +24,7 @@ import yaml.error
 from craft_cli import emit
 
 from snapcraft import errors
+from snapcraft.meta import snap_yaml
 from snapcraft.parts import PartsLifecycle
 from snapcraft.projects import Project
 
@@ -85,6 +86,8 @@ def _run_step(
 
     lifecycle = PartsLifecycle(project.parts, work_dir=work_dir)
     lifecycle.run(step_name)
+
+    snap_yaml.write(project, lifecycle.prime_dir, arch=lifecycle.target_arch)
 
 
 def _load_yaml(filename: Path) -> Dict[str, Any]:

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -68,6 +68,11 @@ class PartsLifecycle:
         """Return the parts prime directory path."""
         return self._lcm.project_info.prime_dir
 
+    @property
+    def target_arch(self) -> str:
+        """Return the parts project target architecture."""
+        return self._lcm.project_info.target_arch
+
     def run(self, step_name: str) -> None:
         """Run the parts lifecycle.
 

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -100,10 +100,10 @@ class App(ProjectModel):
         ]
     ]
     install_mode: Optional[Literal["enable", "disable"]]
-    slots: UniqueStrList = []
-    plugs: UniqueStrList = []
-    aliases: UniqueAliasList = []
-    environment: List[Dict[str, str]] = []
+    slots: Optional[UniqueStrList]
+    plugs: Optional[UniqueStrList]
+    aliases: Optional[UniqueAliasList]
+    environment: Optional[List[Dict[str, str]]]
     command_chain: List[CommandChainStr] = []
     # TODO: sockets
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,12 +39,12 @@ def temp_xdg(tmpdir, mocker):
 
 
 @pytest.fixture
-def new_dir(tmpdir):
+def new_dir(tmp_path):
     """Change to a new temporary directory."""
 
     cwd = os.getcwd()
-    os.chdir(tmpdir)
+    os.chdir(tmp_path)
 
-    yield tmpdir
+    yield tmp_path
 
     os.chdir(cwd)

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -1,0 +1,87 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+from snapcraft.meta import snap_yaml
+from snapcraft.projects import Project
+
+
+@pytest.fixture
+def simple_project():
+    snapcraft_yaml = textwrap.dedent(
+        """\
+        name: mytest
+        version: 1.29.3
+        base: core22
+        summary: Single-line elevator pitch for your amazing snap
+        description: |
+          This is my-snap's description. You have a paragraph or two to tell the
+          most important story about your snap. Keep it under 100 words though,
+          we live in tweetspace and your description wants to look good in the snap
+          store.
+
+        grade: stable
+        confinement: strict
+
+        parts:
+          part1:
+            plugin: nil
+
+        apps:
+          app1:
+            command: bin/mytest
+        """
+    )
+    data = yaml.safe_load(snapcraft_yaml)
+    yield Project.unmarshal(data)
+
+
+def test_snap_yaml(simple_project, new_dir):
+    snap_yaml.write(simple_project, prime_dir=Path(new_dir), arch="arch")
+    yaml_file = Path("meta/snap.yaml")
+    assert yaml_file.is_file()
+
+    content = yaml_file.read_text()
+    assert content == textwrap.dedent(
+        """\
+        name: mytest
+        version: 1.29.3
+        summary: Single-line elevator pitch for your amazing snap
+        description: |
+          This is my-snap's description. You have a paragraph or two to tell the
+          most important story about your snap. Keep it under 100 words though,
+          we live in tweetspace and your description wants to look good in the snap
+          store.
+        type: app
+        architectures:
+        - arch
+        base: core22
+        assumes:
+        - command-chain
+        apps:
+          app1:
+            command: bin/mytest
+            command_chain:
+            - snap/command-chain/snapcraft-runner
+        confinement: strict
+        grade: stable
+        """
+    )

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -96,10 +96,10 @@ class TestProjectDefaults:
         assert app.stop_mode is None
         assert app.restart_condition is None
         assert app.install_mode is None
-        assert app.slots == []
-        assert app.plugs == []
-        assert app.aliases == []
-        assert app.environment == []
+        assert app.slots is None
+        assert app.plugs is None
+        assert app.aliases is None
+        assert app.environment is None
         assert app.command_chain == []
 
 


### PR DESCRIPTION
Create a minimal snap.yaml metadata file from data we already have
available to enable snap packing.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
