### PR TITLE
colcon v2: forward cmake args

### DIFF
--- a/snapcraft/plugins/v2/colcon.py
+++ b/snapcraft/plugins/v2/colcon.py
@@ -165,6 +165,9 @@ class ColconPlugin(_ros.RosPlugin):
         if self.options.colcon_packages:
             cmd.extend(["--packages-select", *self.options.colcon_packages])
 
+        if self.options.colcon_cmake_args:
+            cmd.extend(["--cmake-args", *self.options.colcon_cmake_args])
+
         if self.options.colcon_ament_cmake_args:
             cmd.extend(["--ament-cmake-args", *self.options.colcon_ament_cmake_args])
 

--- a/tests/unit/plugins/v2/test_colcon.py
+++ b/tests/unit/plugins/v2/test_colcon.py
@@ -174,7 +174,8 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         '--base-paths "${SNAPCRAFT_PART_SRC}" --build-base "${SNAPCRAFT_PART_BUILD}" '
         '--merge-install --install-base "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap '
         "--packages-ignore ipackage1 ipackage2... --packages-select package1 "
-        "package2... --ament-cmake-args ament args... --catkin-cmake-args catkin "
+        "package2... --cmake-args cmake args... "
+        "--ament-cmake-args ament args... --catkin-cmake-args catkin "
         'args... --parallel-workers "${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
         'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE ]; then',
         'rm "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE',


### PR DESCRIPTION
Colcon v2 plugin has a parameter, `colcon-cmake-args`, to define cmake args (for plain cmake packages). Said args were not forwarded to the build command.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
