### PR TITLE
extension: compose and deadkeys for neon

### DIFF
--- a/snapcraft/internal/project_loader/_extensions/kde_neon.py
+++ b/snapcraft/internal/project_loader/_extensions/kde_neon.py
@@ -21,7 +21,6 @@ from typing import Any, Dict, Tuple
 
 from ._extension import Extension
 
-
 _ExtensionInfo = namedtuple("ExtensionInfo", "cmake_args content provider build_snaps")
 
 _Info = dict(
@@ -104,6 +103,7 @@ class ExtensionImpl(Extension):
                     "command-chain": ["snap/command-chain/hooks-configure-desktop"],
                 }
             },
+            "layout": {"/usr/share/X11": {"symlink": "$SNAP/kf5/usr/share/X11"}},
         }
 
         if info.cmake_args is not None:

--- a/tests/unit/project_loader/extensions/test_kde_neon.py
+++ b/tests/unit/project_loader/extensions/test_kde_neon.py
@@ -50,6 +50,7 @@ def test_extension_core18():
                 "command-chain": ["snap/command-chain/hooks-configure-desktop"],
             }
         },
+        "layout": {"/usr/share/X11": {"symlink": "$SNAP/kf5/usr/share/X11"}},
     }
     assert kde_neon_extension.app_snippet == {
         "command-chain": ["snap/command-chain/desktop-launch"],
@@ -82,6 +83,7 @@ def test_extension_core20():
                 "plugs": ["desktop"],
             }
         },
+        "layout": {"/usr/share/X11": {"symlink": "$SNAP/kf5/usr/share/X11"}},
         "plugs": {
             "desktop": {"mount-host-font-cache": False},
             "icon-themes": {


### PR DESCRIPTION
Add a layout for KF5 to find the information it requires.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
