### PR TITLE
meta: parse environment variables (CRAFT-835)

### DIFF
--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -18,7 +18,7 @@
 
 import textwrap
 from pathlib import Path
-from typing import Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, cast
 
 import yaml
 from pydantic_yaml import YamlModel
@@ -37,7 +37,7 @@ class SnapApp(YamlModel):
 
     command: str
     command_chain: List[str]
-    environment: Optional[Dict[str, str]]
+    environment: Optional[Dict[str, Any]]
     plugs: Optional[List[str]]
 
     class Config:  # pylint: disable=too-few-public-methods
@@ -70,6 +70,7 @@ class SnapMetadata(YamlModel):
     apps: Optional[Dict[str, SnapApp]]
     confinement: str
     grade: str
+    environment: Optional[Dict[str, Any]]
 
 
 def write(project: Project, prime_dir: Path, *, arch: str):
@@ -105,6 +106,7 @@ def write(project: Project, prime_dir: Path, *, arch: str):
         apps=snap_apps,
         confinement=project.confinement,
         grade=project.grade,
+        environment=project.environment,
     )
 
     yaml.add_representer(str, _repr_str, Dumper=yaml.SafeDumper)

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -104,7 +104,7 @@ class App(ProjectModel):
     slots: Optional[UniqueStrList]
     plugs: Optional[UniqueStrList]
     aliases: Optional[UniqueAliasList]
-    environment: Optional[Dict[str, str]]
+    environment: Optional[Dict[str, Any]]
     command_chain: List[CommandChainStr] = []
     # TODO: sockets
 
@@ -159,7 +159,6 @@ class Project(ProjectModel):
     See https://snapcraft.io/docs/snapcraft-yaml-reference
 
     XXX: Not implemented in this version
-    - environment (top-level)
     - system-usernames
     - adopt-info (after adding craftctl support to craft-parts)
     """
@@ -193,6 +192,7 @@ class Project(ProjectModel):
     slots: Optional[Dict[str, Dict[str, str]]]  # TODO: add slot name validation
     parts: Dict[str, Any]  # parts are handled by craft-parts
     epoch: Optional[str]
+    environment: Optional[Dict[str, Any]]
 
     @pydantic.root_validator(pre=True)
     @classmethod

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -41,6 +41,9 @@ def simple_project():
         grade: stable
         confinement: strict
 
+        environment:
+          GLOBAL_VARIABLE: "my-global-variable"
+
         parts:
           part1:
             plugin: nil
@@ -48,6 +51,8 @@ def simple_project():
         apps:
           app1:
             command: bin/mytest
+            environment:
+              APP_VARIABLE: "my-app-variable"
         """
     )
     data = yaml.safe_load(snapcraft_yaml)
@@ -81,7 +86,11 @@ def test_snap_yaml(simple_project, new_dir):
             command: bin/mytest
             command_chain:
             - snap/command-chain/snapcraft-runner
+            environment:
+              APP_VARIABLE: my-app-variable
         confinement: strict
         grade: stable
+        environment:
+          GLOBAL_VARIABLE: my-global-variable
         """
     )


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `./runtests.sh static`?
- [X] Have you successfully run `./runtests.sh tests/unit`?

-----

Parse `environment` dictionary in snapcraft.yaml, both for apps and at the root level.