### PR TITLE
utils: gracefully determine host os (CRAFT-845)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ line_length = 88
 [tool.pylint.messages_control]
 disable = "too-few-public-methods,fixme"
 
+[tool.pylint.format]
+good-names = "id"
+
 [tool.pylint.MASTER]
 extension-pkg-allow-list = [
     "pydantic"

--- a/snapcraft/os_release.py
+++ b/snapcraft/os_release.py
@@ -1,0 +1,93 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""OS release information helpers."""
+
+import contextlib
+from pathlib import Path
+from typing import Dict
+
+from snapcraft import errors
+
+_ID_TO_UBUNTU_CODENAME = {
+    "17.10": "artful",
+    "17.04": "zesty",
+    "16.04": "xenial",
+    "14.04": "trusty",
+}
+
+
+class OsRelease:
+    """A class to intelligently determine the OS on which we're running."""
+
+    def __init__(self, *, os_release_file: Path = Path("/etc/os-release")) -> None:
+        """Create a new OsRelease instance.
+
+        :param str os_release_file: Path to os-release file to be parsed.
+        """
+        with contextlib.suppress(FileNotFoundError):
+            self._os_release = {}  # type: Dict[str, str]
+            with os_release_file.open(encoding="utf-8") as release_file:
+                for line in release_file:
+                    entry = line.rstrip().split("=")
+                    if len(entry) == 2:
+                        self._os_release[entry[0]] = entry[1].strip('"')
+
+    def id(self) -> str:
+        """Return the OS ID.
+
+        :raises SnapcraftError: If no ID can be determined.
+        """
+        with contextlib.suppress(KeyError):
+            return self._os_release["ID"]
+
+        raise errors.SnapcraftError("Unable to determine host OS ID")
+
+    def name(self) -> str:
+        """Return the OS name.
+
+        :raises SnapcraftError: If no name can be determined.
+        """
+        with contextlib.suppress(KeyError):
+            return self._os_release["NAME"]
+
+        raise errors.SnapcraftError("Unable to determine host OS name")
+
+    def version_id(self) -> str:
+        """Return the OS version ID.
+
+        :raises SnapcraftError: If no version ID can be determined.
+        """
+        with contextlib.suppress(KeyError):
+            return self._os_release["VERSION_ID"]
+
+        raise errors.SnapcraftError("Unable to determine host OS version ID")
+
+    def version_codename(self) -> str:
+        """Return the OS version codename.
+
+        This first tries to use the VERSION_CODENAME. If that's missing, it
+        tries to use the VERSION_ID to figure out the codename on its own.
+
+        :raises SnapcraftError: If no version codename can be determined.
+        """
+        with contextlib.suppress(KeyError):
+            return self._os_release["VERSION_CODENAME"]
+
+        with contextlib.suppress(KeyError):
+            return _ID_TO_UBUNTU_CODENAME[self._os_release["VERSION_ID"]]
+
+        raise errors.SnapcraftError("Unable to determine host OS version codename")

--- a/tests/unit/test_os_release.py
+++ b/tests/unit/test_os_release.py
@@ -1,0 +1,148 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from snapcraft import errors, os_release
+
+
+@pytest.fixture
+def _os_release(new_dir):
+    def _release_data(contents):
+        path = Path("os-release")
+        path.write_text(contents)
+        release = os_release.OsRelease(os_release_file=path)
+        return release
+
+    return _release_data
+
+
+def test_blank_lines(_os_release):
+    release = _os_release(
+        dedent(
+            """\
+            NAME="Arch Linux"
+
+            PRETTY_NAME="Arch Linux"
+            ID=arch
+            ID_LIKE=archlinux
+            VERSION_ID="foo"
+            VERSION_CODENAME="bar"
+
+            """
+        )
+    )
+
+    assert release.id() == "arch"
+    assert release.name() == "Arch Linux"
+    assert release.version_id() == "foo"
+    assert release.version_codename() == "bar"
+
+
+def test_no_id(_os_release):
+    release = _os_release(
+        dedent(
+            """\
+            NAME="Arch Linux"
+            PRETTY_NAME="Arch Linux"
+            ID_LIKE=archlinux
+            VERSION_ID="foo"
+            VERSION_CODENAME="bar"
+            """
+        )
+    )
+
+    with pytest.raises(errors.SnapcraftError) as raised:
+        release.id()
+
+    assert str(raised.value) == "Unable to determine host OS ID"
+
+
+def test_no_name(_os_release):
+    release = _os_release(
+        dedent(
+            """\
+            ID=arch
+            PRETTY_NAME="Arch Linux"
+            ID_LIKE=archlinux
+            VERSION_ID="foo"
+            VERSION_CODENAME="bar"
+            """
+        )
+    )
+
+    with pytest.raises(errors.SnapcraftError) as raised:
+        release.name()
+
+    assert str(raised.value) == "Unable to determine host OS name"
+
+
+def test_no_version_id(_os_release):
+    release = _os_release(
+        dedent(
+            """\
+            NAME="Arch Linux"
+            ID=arch
+            PRETTY_NAME="Arch Linux"
+            ID_LIKE=archlinux
+            VERSION_CODENAME="bar"
+            """
+        )
+    )
+
+    with pytest.raises(errors.SnapcraftError) as raised:
+        release.version_id()
+
+    assert str(raised.value) == "Unable to determine host OS version ID"
+
+
+def test_no_version_codename(_os_release):
+    """Test that version codename can also come from VERSION_ID"""
+    release = _os_release(
+        dedent(
+            """\
+            NAME="Ubuntu"
+            VERSION="14.04.5 LTS, Trusty Tahr"
+            ID=ubuntu
+            ID_LIKE=debian
+            PRETTY_NAME="Ubuntu 14.04.5 LTS"
+            VERSION_ID="14.04"
+            """
+        )
+    )
+
+    assert release.version_codename() == "trusty"
+
+
+def test_no_version_codename_or_version_id(_os_release):
+    release = _os_release(
+        dedent(
+            """\
+            NAME="Ubuntu"
+            ID=ubuntu
+            ID_LIKE=debian
+            PRETTY_NAME="Ubuntu 16.04.3 LTS"
+            """
+        )
+    )
+
+    with pytest.raises(errors.SnapcraftError) as raised:
+        release.version_codename()
+
+    assert str(raised.value) == "Unable to determine host OS version codename"


### PR DESCRIPTION
Create a class around parsing `/etc/os-release` so we can gracefully
fallback as appropriate when e.g. `VERSION_CODENAME` isn't set. This is
a forward port of a25cfcc (PR #1636) by Kyle Fazzari.

Co-authored-by: Kyle Fazzari <kyrofa@ubuntu.com>
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
