### PR TITLE
repo: add package repository handling (CRAFT-846)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ line_length = 88
 disable = "too-few-public-methods,fixme"
 
 [tool.pylint.format]
+max-attributes = 15
 good-names = "id"
 
 [tool.pylint.MASTER]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ ensure_newline_before_comments = true
 line_length = 88
 
 [tool.pylint.messages_control]
-disable = "too-few-public-methods,fixme"
+disable = "too-few-public-methods,fixme,use-implicit-booleaness-not-comparison"
 
 [tool.pylint.format]
 max-attributes = 15
@@ -39,6 +39,7 @@ good-names = "id"
 
 [tool.pylint.MASTER]
 extension-pkg-allow-list = [
-    "pydantic"
+    "pydantic",
+    "pytest",
 ]
 load-plugins = "pylint_fixme_info,pylint_pytest"

--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -37,7 +37,7 @@ class SnapApp(YamlModel):
 
     command: str
     command_chain: List[str]
-    environment: Optional[List[Dict[str, str]]]
+    environment: Optional[Dict[str, str]]
     plugs: Optional[List[str]]
 
     class Config:  # pylint: disable=too-few-public-methods

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -47,10 +47,12 @@ class ProjectModel(pydantic.BaseModel):
 # fmt: off
 if TYPE_CHECKING:
     CommandChainStr = str
+    KeyIdStr = str
     UniqueStrList = List[str]
     UniqueAliasList = List[str]
 else:
     CommandChainStr = constr(regex=r"^[A-Za-z0-9/._#:$-]*$")
+    KeyIdStr = constr(regex=r"^[A-Z0-9]{40}$")
     UniqueStrList = conlist(str, unique_items=True)
     UniqueAliasList = conlist(constr(regex=r"^[a-zA-Z0-9][-_.a-zA-Z0-9]*$"), unique_items=True)
 # fmt: on
@@ -103,7 +105,7 @@ class App(ProjectModel):
     slots: Optional[UniqueStrList]
     plugs: Optional[UniqueStrList]
     aliases: Optional[UniqueAliasList]
-    environment: Optional[List[Dict[str, str]]]
+    environment: Optional[Dict[str, str]]
     command_chain: List[CommandChainStr] = []
     # TODO: sockets
 
@@ -152,6 +154,27 @@ class Architecture(ProjectModel):
     build_to: Optional[Union[str, UniqueStrList]]
 
 
+class AptDeb(ProjectModel):
+    """Apt package repository definition."""
+
+    type: Literal["apt"]
+    url: str
+    key_id: KeyIdStr
+    architectures: Optional[List[str]]
+    formats: Optional[List[Literal["deb", "deb-src"]]]
+    components: Optional[List[str]]
+    key_server: Optional[str]
+    path: Optional[str]
+    suites: Optional[List[str]]
+
+
+class AptPPA(ProjectModel):
+    """PPA package repository definition."""
+
+    type: Literal["apt"]
+    ppa: str
+
+
 class Project(ProjectModel):
     """Snapcraft project definition.
 
@@ -160,8 +183,10 @@ class Project(ProjectModel):
     XXX: Not implemented in this version
     - environment (top-level)
     - system-usernames
-    - package-repositories
     - adopt-info (after adding craftctl support to craft-parts)
+
+    FIXME: package-repositories needs better validation and less
+           confusing error messages
     """
 
     name: constr(max_length=40)  # type: ignore
@@ -185,6 +210,7 @@ class Project(ProjectModel):
     grade: Literal["stable", "devel"]
     architectures: List[Architecture] = []
     assumes: UniqueStrList = []
+    package_repositories: List[Union[AptDeb, AptPPA]] = []
     hooks: Optional[Dict[str, Hook]]
     passthrough: Optional[Dict[str, Any]]
     apps: Optional[Dict[str, App]]

--- a/snapcraft/repo/__init__.py
+++ b/snapcraft/repo/__init__.py
@@ -1,0 +1,23 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Package repository helpers."""
+
+from .apt_key_manager import AptKeyManager  # noqa: F401
+from .apt_sources_manager import AptSourcesManager  # noqa: F401
+from .package_repository import PackageRepository  # noqa: F401
+from .package_repository import PackageRepositoryApt  # noqa: F401
+from .package_repository import PackageRepositoryAptPPA  # noqa: F401

--- a/snapcraft/repo/__init__.py
+++ b/snapcraft/repo/__init__.py
@@ -16,8 +16,8 @@
 
 """Package repository helpers."""
 
-from .apt_key_manager import AptKeyManager  # noqa: F401
-from .apt_sources_manager import AptSourcesManager  # noqa: F401
-from .package_repository import PackageRepository  # noqa: F401
-from .package_repository import PackageRepositoryApt  # noqa: F401
-from .package_repository import PackageRepositoryAptPPA  # noqa: F401
+from .projects import validate_repository
+
+__all__ = [
+    "validate_repository",
+]

--- a/snapcraft/repo/apt_key_manager.py
+++ b/snapcraft/repo/apt_key_manager.py
@@ -1,0 +1,228 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""APT key management helpers."""
+
+import pathlib
+import subprocess
+import tempfile
+from typing import List, Optional
+
+import gnupg
+from craft_cli import emit
+
+from . import apt_ppa, errors, package_repository
+
+
+class AptKeyManager:
+    """Manage APT repository keys."""
+
+    def __init__(
+        self,
+        *,
+        gpg_keyring: pathlib.Path = pathlib.Path(
+            "/etc/apt/trusted.gpg.d/snapcraft.gpg"
+        ),
+        key_assets: pathlib.Path,
+    ) -> None:
+        self._gpg_keyring = gpg_keyring
+        self._key_assets = key_assets
+
+    def find_asset_with_key_id(self, *, key_id: str) -> Optional[pathlib.Path]:
+        """Find snap key asset matching key_id.
+
+        The key asset much be named with the last 8 characters of the key
+        identifier, in upper case.
+
+        :param key_id: Key ID to search for.
+
+        :returns: Path of key asset if match found, otherwise None.
+        """
+        key_file = key_id[-8:].upper() + ".asc"
+        key_path = self._key_assets / key_file
+
+        if key_path.exists():
+            return key_path
+
+        return None
+
+    @classmethod
+    def get_key_fingerprints(cls, *, key: str) -> List[str]:
+        """List fingerprints found in specified key.
+
+        Do this by importing the key into a temporary keyring,
+        then querying the keyring for fingerprints.
+
+        :param key: Key data (string) to parse.
+
+        :returns: List of key fingerprints/IDs.
+        """
+        with tempfile.NamedTemporaryFile(suffix="keyring") as temp_file:
+            return (
+                gnupg.GPG(keyring=temp_file.name).import_keys(key_data=key).fingerprints
+            )
+
+    @classmethod
+    def is_key_installed(cls, *, key_id: str) -> bool:
+        """Check if specified key_id is installed.
+
+        Check if key is installed by attempting to export the key.
+        Unfortunately, apt-key does not exit with error and
+        we have to do our best to parse the output.
+
+        :param key_id: Key ID to check for.
+
+        :returns: True if key is installed.
+        """
+        try:
+            proc = subprocess.run(
+                ["apt-key", "export", key_id],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=True,
+            )
+        except subprocess.CalledProcessError as error:
+            # Export shouldn't exit with failure based on testing,
+            # but assume the key is not installed and log a warning.
+            emit.message(
+                f"Unexpected apt-key failure: {error.output}", intermediate=True
+            )
+            return False
+
+        apt_key_output = proc.stdout.decode()
+
+        if "BEGIN PGP PUBLIC KEY BLOCK" in apt_key_output:
+            return True
+
+        if "nothing exported" in apt_key_output:
+            return False
+
+        # The two strings above have worked in testing, but if neither is
+        # present for whatever reason, assume the key is not installed
+        # and log a warning.
+        emit.message(f"Unexpected apt-key output: {apt_key_output}", intermediate=True)
+        return False
+
+    def install_key(self, *, key: str) -> None:
+        """Install given key.
+
+        :param key: Key to install.
+
+        :raises: AptGPGKeyInstallError if unable to install key.
+        """
+        cmd = [
+            "apt-key",
+            "--keyring",
+            str(self._gpg_keyring),
+            "add",
+            "-",
+        ]
+
+        try:
+            emit.trace(f"Executing: {cmd!r}")
+            env = {}
+            env["LANG"] = "C.UTF-8"
+            subprocess.run(
+                cmd,
+                input=key.encode(),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=True,
+                env=env,
+            )
+        except subprocess.CalledProcessError as error:
+            raise errors.AptGPGKeyInstallError(error.output.decode(), key=key)
+
+        emit.trace(f"Installed apt repository key:\n{key}")
+
+    def install_key_from_keyserver(
+        self, *, key_id: str, key_server: str = "keyserver.ubuntu.com"
+    ) -> None:
+        """Install key from specified key server.
+
+        :param key_id: Key ID to install.
+        :param key_server: Key server to query.
+
+        :raises: AptGPGKeyInstallError if unable to install key.
+        """
+        env = {}
+        env["LANG"] = "C.UTF-8"
+
+        cmd = [
+            "apt-key",
+            "--keyring",
+            str(self._gpg_keyring),
+            "adv",
+            "--keyserver",
+            key_server,
+            "--recv-keys",
+            key_id,
+        ]
+
+        try:
+            emit.trace(f"Executing: {cmd!r}")
+            subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=True,
+                env=env,
+            )
+        except subprocess.CalledProcessError as error:
+            raise errors.AptGPGKeyInstallError(
+                error.output.decode(), key_id=key_id, key_server=key_server
+            )
+
+    def install_package_repository_key(
+        self, *, package_repo: package_repository.PackageRepository
+    ) -> bool:
+        """Install required key for specified package repository.
+
+        For both PPA and other Apt package repositories:
+        1) If key is already installed, return False.
+        2) Install key from local asset, if available.
+        3) Install key from key server, if available. An unspecified
+           keyserver will default to using keyserver.ubuntu.com.
+
+        :param package_repo: Apt PackageRepository configuration.
+
+        :returns: True if key configuration was changed. False if
+            key already installed.
+
+        :raises: AptGPGKeyInstallError if unable to install key.
+        """
+        key_server: Optional[str] = None
+        if isinstance(package_repo, package_repository.PackageRepositoryAptPPA):
+            key_id = apt_ppa.get_launchpad_ppa_key_id(ppa=package_repo.ppa)
+        elif isinstance(package_repo, package_repository.PackageRepositoryApt):
+            key_id = package_repo.key_id
+            key_server = package_repo.key_server
+        else:
+            raise RuntimeError(f"unhandled package repo type: {package_repo!r}")
+
+        # Already installed, nothing to do.
+        if self.is_key_installed(key_id=key_id):
+            return False
+
+        key_path = self.find_asset_with_key_id(key_id=key_id)
+        if key_path is not None:
+            self.install_key(key=key_path.read_text())
+        else:
+            if key_server is None:
+                key_server = "keyserver.ubuntu.com"
+            self.install_key_from_keyserver(key_id=key_id, key_server=key_server)
+
+        return True

--- a/snapcraft/repo/apt_ppa.py
+++ b/snapcraft/repo/apt_ppa.py
@@ -1,0 +1,50 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2020-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Personal Package Archive helpers."""
+
+from typing import Tuple
+
+import lazr.restfulclient.errors
+from craft_cli import emit
+from launchpadlib.launchpad import Launchpad
+
+from . import errors
+
+
+def split_ppa_parts(*, ppa: str) -> Tuple[str, str]:
+    """Obtain user and repository components from a PPA line."""
+    ppa_split = ppa.split("/")
+    if len(ppa_split) != 2:
+        raise errors.AptPPAInstallError(ppa, "invalid PPA format")
+    return ppa_split[0], ppa_split[1]
+
+
+def get_launchpad_ppa_key_id(*, ppa: str) -> str:
+    """Query Launchpad for PPA's key ID."""
+    owner, name = split_ppa_parts(ppa=ppa)
+    launchpad = Launchpad.login_anonymously("snapcraft", "production")
+    launchpad_url = f"~{owner}/+archive/{name}"
+
+    emit.trace(f"Loading launchpad url: {launchpad_url}")
+    try:
+        key_id = launchpad.load(launchpad_url).signing_key_fingerprint
+    except lazr.restfulclient.errors.NotFound as error:
+        raise errors.AptPPAInstallError(ppa, "not found on launchpad") from error
+
+    emit.trace(f"Retrieved launchpad PPA key ID: {key_id}")
+
+    return key_id

--- a/snapcraft/repo/apt_sources_manager.py
+++ b/snapcraft/repo/apt_sources_manager.py
@@ -1,0 +1,216 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""Manage the host's apt source repository configuration."""
+
+import io
+import pathlib
+import re
+from typing import List, Optional
+
+from craft_cli import emit
+
+from snapcraft import os_release
+from snapcraft_legacy.project._project_options import ProjectOptions
+
+from . import apt_ppa, package_repository
+
+
+def _construct_deb822_source(
+    *,
+    architectures: Optional[List[str]] = None,
+    components: Optional[List[str]] = None,
+    formats: Optional[List[str]] = None,
+    suites: List[str],
+    url: str,
+) -> str:
+    """Construct deb-822 formatted sources.list config string."""
+    with io.StringIO() as deb822:
+        if formats:
+            type_text = " ".join(formats)
+        else:
+            type_text = "deb"
+
+        print(f"Types: {type_text}", file=deb822)
+
+        print(f"URIs: {url}", file=deb822)
+
+        suites_text = " ".join(suites)
+        print(f"Suites: {suites_text}", file=deb822)
+
+        if components:
+            components_text = " ".join(components)
+            print(f"Components: {components_text}", file=deb822)
+
+        if architectures:
+            arch_text = " ".join(architectures)
+        else:
+            arch_text = _get_host_arch()
+
+        print(f"Architectures: {arch_text}", file=deb822)
+
+        return deb822.getvalue()
+
+
+def _get_host_arch() -> str:
+    return ProjectOptions().deb_arch
+
+
+class AptSourcesManager:
+    """Manage apt source configuration in /etc/apt/sources.list.d.
+
+    :param sources_list_d: Path to sources.list.d directory.
+    """
+
+    # pylint: disable=too-few-public-methods
+    def __init__(
+        self,
+        *,
+        sources_list_d: pathlib.Path = pathlib.Path("/etc/apt/sources.list.d"),
+    ) -> None:
+        self._sources_list_d = sources_list_d
+
+    def _install_sources(
+        self,
+        *,
+        architectures: Optional[List[str]] = None,
+        components: Optional[List[str]] = None,
+        formats: Optional[List[str]] = None,
+        name: str,
+        suites: List[str],
+        url: str,
+    ) -> bool:
+        """Install sources list configuration.
+
+        Write config to:
+        /etc/apt/sources.list.d/snapcraft-<name>.sources
+
+        :returns: True if configuration was changed.
+        """
+        config = _construct_deb822_source(
+            architectures=architectures,
+            components=components,
+            formats=formats,
+            suites=suites,
+            url=url,
+        )
+
+        if name not in ["default", "default-security"]:
+            name = "snapcraft-" + name
+
+        config_path = self._sources_list_d / f"{name}.sources"
+        if config_path.exists() and config_path.read_text() == config:
+            # Already installed and matches, nothing to do.
+            emit.trace(f"Ignoring unchanged sources: {config_path!s}")
+            return False
+
+        config_path.write_text(config)
+        emit.trace(f"Installed sources: {config_path!s}")
+        return True
+
+    def _install_sources_apt(
+        self, *, package_repo: package_repository.PackageRepositoryApt
+    ) -> bool:
+        """Install repository configuration.
+
+        1) First check to see if package repo is implied path,
+           or "bare repository" config.  This is indicated when no
+           path, components, or suites are indicated.
+        2) If path is specified, convert path to a suite entry,
+           ending with "/".
+
+        Relatedly, this assumes all of the error-checking has been
+        done already on the package_repository object in a proper
+        fashion, but do some sanity checks here anyways.
+
+        :returns: True if source configuration was changed.
+        """
+        if (
+            not package_repo.path
+            and not package_repo.components
+            and not package_repo.suites
+        ):
+            suites = ["/"]
+        elif package_repo.path:
+            # Suites denoting exact path must end with '/'.
+            path = package_repo.path
+            if not path.endswith("/"):
+                path += "/"
+            suites = [path]
+        elif package_repo.suites:
+            suites = package_repo.suites
+            if not package_repo.components:
+                raise RuntimeError("no components with suite")
+        else:
+            raise RuntimeError("no suites or path")
+
+        if package_repo.name:
+            name = package_repo.name
+        else:
+            name = re.sub(r"\W+", "_", package_repo.url)
+
+        return self._install_sources(
+            architectures=package_repo.architectures,
+            components=package_repo.components,
+            formats=package_repo.formats,
+            name=name,
+            suites=suites,
+            url=package_repo.url,
+        )
+
+    def _install_sources_ppa(
+        self, *, package_repo: package_repository.PackageRepositoryAptPPA
+    ) -> bool:
+        """Install PPA formatted repository.
+
+        Create a sources list config by:
+        - Looking up the codename of the host OS and using it as the "suites"
+          entry.
+        - Formulate deb URL to point to PPA.
+        - Enable only "deb" formats.
+
+        :returns: True if source configuration was changed.
+        """
+        owner, name = apt_ppa.split_ppa_parts(ppa=package_repo.ppa)
+        codename = os_release.OsRelease().version_codename()
+
+        return self._install_sources(
+            components=["main"],
+            formats=["deb"],
+            name=f"ppa-{owner}_{name}",
+            suites=[codename],
+            url=f"http://ppa.launchpad.net/{owner}/{name}/ubuntu",
+        )
+
+    def install_package_repository_sources(
+        self,
+        *,
+        package_repo: package_repository.PackageRepository,
+    ) -> bool:
+        """Install configured package repositories.
+
+        :param package_repo: Repository to install the source configuration for.
+
+        :returns: True if source configuration was changed.
+        """
+        emit.trace(f"Processing repo: {package_repo!r}")
+        if isinstance(package_repo, package_repository.PackageRepositoryAptPPA):
+            return self._install_sources_ppa(package_repo=package_repo)
+
+        if isinstance(package_repo, package_repository.PackageRepositoryApt):
+            return self._install_sources_apt(package_repo=package_repo)
+
+        raise RuntimeError(f"unhandled package repository: {package_repository!r}")

--- a/snapcraft/repo/errors.py
+++ b/snapcraft/repo/errors.py
@@ -1,0 +1,101 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Package repository error definitions."""
+
+from typing import Optional
+
+from snapcraft.errors import SnapcraftError
+
+
+class PackageRepositoryValidationError(SnapcraftError):
+    """Package repository is invalid."""
+
+    def __init__(
+        self,
+        url: str,
+        brief: str,
+        details: Optional[str] = None,
+        resolution: Optional[str] = None,
+    ):
+        super().__init__(
+            f"Invalid package repository for {url!r}: {brief}",
+            details=details,
+            resolution=resolution,
+        )
+
+
+class AptPPAInstallError(SnapcraftError):
+    """Installation of a PPA repository failed."""
+
+    def __init__(self, ppa: str, reason: str):
+        super().__init__(
+            f"Failed to install PPA {ppa!r}: {reason}",
+            resolution="Verify PPA is correct and try again",
+        )
+
+
+class AptGPGKeyInstallError(SnapcraftError):
+    """Installation of GPG key failed."""
+
+    def __init__(
+        self,
+        output: str,
+        *,
+        key: Optional[str] = None,
+        key_id: Optional[str] = None,
+        key_server: Optional[str] = None,
+    ):
+        """Convert apt-key's output into a more user-friendly message."""
+        message = output.replace(
+            "Warning: apt-key output should not be parsed (stdout is not a terminal)",
+            "",
+        ).strip()
+
+        # Improve error messages that we can.
+        if (
+            "gpg: keyserver receive failed: No data" in message
+            and key_id
+            and key_server
+        ):
+            message = f"GPG key {key_id!r} not found on key server {key_server!r}"
+        elif (
+            "gpg: keyserver receive failed: Server indicated a failure" in message
+            and key_server
+        ):
+            message = f"unable to establish connection to key server {key_server!r}"
+        elif (
+            "gpg: keyserver receive failed: Connection timed out" in message
+            and key_server
+        ):
+            message = (
+                f"unable to establish connection to key server {key_server!r} "
+                f"(connection timed out)"
+            )
+
+        details = ""
+        if key:
+            details += f"GPG key:\n{key}\n"
+        if key_id:
+            details += f"GPG key ID: {key_id}\n"
+        if key_server:
+            details += f"GPG key server: {key_server}"
+
+        super().__init__(
+            f"Failed to install GPG key: {message}",
+            details=details,
+            resolution="Verify any configured GPG keys",
+        )

--- a/snapcraft/repo/errors.py
+++ b/snapcraft/repo/errors.py
@@ -21,7 +21,11 @@ from typing import Optional
 from snapcraft.errors import SnapcraftError
 
 
-class PackageRepositoryValidationError(SnapcraftError):
+class PackageRepositoryError(SnapcraftError):
+    """Package repository error base."""
+
+
+class PackageRepositoryValidationError(PackageRepositoryError):
     """Package repository is invalid."""
 
     def __init__(
@@ -38,7 +42,7 @@ class PackageRepositoryValidationError(SnapcraftError):
         )
 
 
-class AptPPAInstallError(SnapcraftError):
+class AptPPAInstallError(PackageRepositoryError):
     """Installation of a PPA repository failed."""
 
     def __init__(self, ppa: str, reason: str):
@@ -48,7 +52,7 @@ class AptPPAInstallError(SnapcraftError):
         )
 
 
-class AptGPGKeyInstallError(SnapcraftError):
+class AptGPGKeyInstallError(PackageRepositoryError):
     """Installation of GPG key failed."""
 
     def __init__(

--- a/snapcraft/repo/package_repository.py
+++ b/snapcraft/repo/package_repository.py
@@ -1,0 +1,513 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2019-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Package repository definitions."""
+
+import abc
+import re
+from copy import deepcopy
+from typing import Any, Dict, List, Optional
+
+from overrides import overrides
+
+from . import errors
+
+
+class PackageRepository(abc.ABC):
+    """The base class for package repositories."""
+
+    @abc.abstractmethod
+    def marshal(self) -> Dict[str, Any]:
+        """Return the package repository data as a dictionary."""
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, str]) -> "PackageRepository":
+        """Create a package repository object from the given data."""
+        if not isinstance(data, dict):
+            raise errors.PackageRepositoryValidationError(
+                url=str(data),
+                brief="invalid object.",
+                details="Package repository must be a valid dictionary object.",
+                resolution=(
+                    "Verify repository configuration and ensure that the "
+                    "correct syntax is used."
+                ),
+            )
+
+        if "ppa" in data:
+            return PackageRepositoryAptPPA.unmarshal(data)
+
+        return PackageRepositoryApt.unmarshal(data)
+
+    @classmethod
+    def unmarshal_package_repositories(cls, data: Any) -> List["PackageRepository"]:
+        """Create multiple package repositories from the given data."""
+        repositories = []
+
+        if data is not None:
+            if not isinstance(data, list):
+                raise errors.PackageRepositoryValidationError(
+                    url=str(data),
+                    brief="invalid list object.",
+                    details="Package repositories must be a list of objects.",
+                    resolution=(
+                        "Verify 'package-repositories' configuration and ensure "
+                        "that the correct syntax is used."
+                    ),
+                )
+
+            for repository in data:
+                package_repo = cls.unmarshal(repository)
+                repositories.append(package_repo)
+
+        return repositories
+
+
+class PackageRepositoryAptPPA(PackageRepository):
+    """A PPA package repository."""
+
+    def __init__(self, *, ppa: str) -> None:
+        self.type = "apt"
+        self.ppa = ppa
+
+        self.validate()
+
+    @overrides
+    def marshal(self) -> Dict[str, Any]:
+        """Return the package repository data as a dictionary."""
+        data: Dict[str, Any] = {"type": "apt"}
+        data["ppa"] = self.ppa
+        return data
+
+    def validate(self) -> None:
+        """Ensure the current repository data is valid."""
+        if not self.ppa:
+            raise errors.PackageRepositoryValidationError(
+                url=self.ppa,
+                brief="invalid PPA.",
+                details="PPAs must be non-empty strings.",
+                resolution=(
+                    "Verify repository configuration and ensure that "
+                    "'ppa' is correctly specified."
+                ),
+            )
+
+    @classmethod
+    @overrides
+    def unmarshal(cls, data: Dict[str, str]) -> "PackageRepositoryAptPPA":
+        """Create a package repository object from the given data."""
+        if not isinstance(data, dict):
+            raise errors.PackageRepositoryValidationError(
+                url=str(data),
+                brief="invalid object.",
+                details="Package repository must be a valid dictionary object.",
+                resolution=(
+                    "Verify repository configuration and ensure that the correct "
+                    "syntax is used."
+                ),
+            )
+
+        data_copy = deepcopy(data)
+
+        ppa = data_copy.pop("ppa", "")
+        repo_type = data_copy.pop("type", None)
+
+        if repo_type != "apt":
+            raise errors.PackageRepositoryValidationError(
+                url=ppa,
+                brief=f"unsupported type {repo_type!r}.",
+                details="The only currently supported type is 'apt'.",
+                resolution=(
+                    "Verify repository configuration and ensure that 'type' "
+                    "is correctly specified."
+                ),
+            )
+
+        if not isinstance(ppa, str):
+            raise errors.PackageRepositoryValidationError(
+                url=ppa,
+                brief=f"Invalid PPA {ppa!r}.",
+                details="PPA must be a valid string.",
+                resolution=(
+                    "Verify repository configuration and ensure that 'ppa' "
+                    "is correctly specified."
+                ),
+            )
+
+        if data_copy:
+            keys = ", ".join([repr(k) for k in data_copy.keys()])
+            raise errors.PackageRepositoryValidationError(
+                url=ppa,
+                brief=f"unsupported properties {keys}.",
+                resolution=(
+                    "Verify repository configuration and ensure that it is correct."
+                ),
+            )
+
+        return cls(ppa=ppa)
+
+
+class PackageRepositoryApt(PackageRepository):
+    """An APT package repository."""
+
+    def __init__(
+        self,
+        *,
+        architectures: Optional[List[str]] = None,
+        components: Optional[List[str]] = None,
+        formats: Optional[List[str]] = None,
+        key_id: str,
+        key_server: Optional[str] = None,
+        name: Optional[str] = None,
+        path: Optional[str] = None,
+        suites: Optional[List[str]] = None,
+        url: str,
+    ) -> None:
+        self.type = "apt"
+        self.architectures = architectures
+        self.components = components
+        self.formats = formats
+        self.key_id = key_id
+        self.key_server = key_server
+
+        if name is None:
+            # Default name is URL, stripping non-alphanumeric characters.
+            self.name: str = re.sub(r"\W+", "_", url)
+        else:
+            self.name = name
+
+        self.path = path
+        self.suites = suites
+        self.url = url
+
+        self.validate()
+
+    @overrides
+    def marshal(self) -> Dict[str, Any]:
+        """Return the package repository data as a dictionary."""
+        data: Dict[str, Any] = {"type": "apt"}
+
+        if self.architectures:
+            data["architectures"] = self.architectures
+
+        if self.components:
+            data["components"] = self.components
+
+        if self.formats:
+            data["formats"] = self.formats
+
+        data["key-id"] = self.key_id
+
+        if self.key_server:
+            data["key-server"] = self.key_server
+
+        data["name"] = self.name
+
+        if self.path:
+            data["path"] = self.path
+
+        if self.suites:
+            data["suites"] = self.suites
+
+        data["url"] = self.url
+
+        return data
+
+    # pylint: disable=too-many-branches
+
+    def validate(self) -> None:  # noqa: C901
+        """Ensure the current repository data is valid."""
+        if self.formats is not None:
+            for repo_format in self.formats:
+                if repo_format not in ["deb", "deb-src"]:
+                    raise errors.PackageRepositoryValidationError(
+                        url=self.url,
+                        brief=f"invalid format {repo_format!r}.",
+                        details="Valid formats include: deb and deb-src.",
+                        resolution=(
+                            "Verify the repository configuration and ensure that "
+                            "'formats' is correctly specified."
+                        ),
+                    )
+
+        if not self.key_id or not re.match(r"^[0-9A-F]{40}$", self.key_id):
+            raise errors.PackageRepositoryValidationError(
+                url=self.url,
+                brief=f"invalid key identifier {self.key_id!r}.",
+                details="Key IDs must be 40 upper-case hex characters.",
+                resolution=(
+                    "Verify the repository configuration and ensure that 'key-id' "
+                    "is correctly specified."
+                ),
+            )
+
+        if not self.url:
+            raise errors.PackageRepositoryValidationError(
+                url=self.url,
+                brief="invalid URL.",
+                details="URLs must be non-empty strings.",
+                resolution=(
+                    "Verify the repository configuration and ensure that 'url' "
+                    "is correctly specified."
+                ),
+            )
+
+        if self.suites:
+            for suite in self.suites:
+                if suite.endswith("/"):
+                    raise errors.PackageRepositoryValidationError(
+                        url=self.url,
+                        brief=f"invalid suite {suite!r}.",
+                        details="Suites must not end with a '/'.",
+                        resolution=(
+                            "Verify the repository configuration and remove the "
+                            "trailing '/' from suites or use the 'path' property "
+                            "to define a path."
+                        ),
+                    )
+
+        if self.path is not None and self.path == "":
+            raise errors.PackageRepositoryValidationError(
+                url=self.url,
+                brief=f"invalid path {self.path!r}.",
+                details="Paths must be non-empty strings.",
+                resolution=(
+                    "Verify the repository configuration and ensure that 'path' "
+                    "is a non-empty string such as '/'."
+                ),
+            )
+
+        if self.path and self.components:
+            raise errors.PackageRepositoryValidationError(
+                url=self.url,
+                brief=(
+                    f"components {self.components!r} cannot be combined with "
+                    f"path {self.path!r}."
+                ),
+                details="Path and components are incomptiable options.",
+                resolution=(
+                    "Verify the repository configuration and remove 'path' "
+                    "or 'components'."
+                ),
+            )
+
+        if self.path and self.suites:
+            raise errors.PackageRepositoryValidationError(
+                url=self.url,
+                brief=(
+                    f"suites {self.suites!r} cannot be combined with "
+                    f"path {self.path!r}."
+                ),
+                details="Path and suites are incomptiable options.",
+                resolution=(
+                    "Verify the repository configuration and remove 'path' or 'suites'."
+                ),
+            )
+
+        if self.suites and not self.components:
+            raise errors.PackageRepositoryValidationError(
+                url=self.url,
+                brief="no components specified.",
+                details="Components are required when using suites.",
+                resolution=(
+                    "Verify the repository configuration and ensure that 'components' "
+                    "is correctly specified."
+                ),
+            )
+
+        if self.components and not self.suites:
+            raise errors.PackageRepositoryValidationError(
+                url=self.url,
+                brief="no suites specified.",
+                details="Suites are required when using components.",
+                resolution=(
+                    "Verify the repository configuration and ensure that 'suites' "
+                    "is correctly specified."
+                ),
+            )
+
+    # pylint: enable=too-many-branches
+
+    @classmethod  # noqa: C901
+    @overrides
+    def unmarshal(cls, data: Dict[str, Any]) -> "PackageRepositoryApt":  # noqa: C901
+        """Create a package repository object from the given data."""
+        if not isinstance(data, dict):
+            raise errors.PackageRepositoryValidationError(
+                url=str(data),
+                brief="invalid object.",
+                details="Package repository must be a valid dictionary object.",
+                resolution=(
+                    "Verify repository configuration and ensure that the "
+                    "correct syntax is used."
+                ),
+            )
+
+        data_copy = deepcopy(data)
+
+        architectures = data_copy.pop("architectures", None)
+        components = data_copy.pop("components", None)
+        formats = data_copy.pop("formats", None)
+        key_id = data_copy.pop("key-id", None)
+        key_server = data_copy.pop("key-server", None)
+        name = data_copy.pop("name", None)
+        path = data_copy.pop("path", None)
+        suites = data_copy.pop("suites", None)
+        url = data_copy.pop("url", "")
+        repo_type = data_copy.pop("type", None)
+
+        if repo_type != "apt":
+            raise errors.PackageRepositoryValidationError(
+                url=url,
+                brief=f"unsupported type {repo_type!r}.",
+                details="The only currently supported type is 'apt'.",
+                resolution=(
+                    "Verify repository configuration and ensure that 'type' "
+                    "is correctly specified."
+                ),
+            )
+
+        if architectures is not None and (
+            not isinstance(architectures, list)
+            or not all(isinstance(x, str) for x in architectures)
+        ):
+            raise errors.PackageRepositoryValidationError(
+                url=url,
+                brief=f"invalid architectures {architectures!r}.",
+                details="Architectures must be a list of valid architecture strings.",
+                resolution=(
+                    "Verify repository configuration and ensure that 'architectures' "
+                    "is correctly specified."
+                ),
+            )
+
+        if components is not None and (
+            not isinstance(components, list)
+            or not all(isinstance(x, str) for x in components)
+            or not components
+        ):
+            raise errors.PackageRepositoryValidationError(
+                url=url,
+                brief=f"invalid components {components!r}.",
+                details="Components must be a list of strings.",
+                resolution=(
+                    "Verify repository configuration and ensure that 'components' "
+                    "is correctly specified."
+                ),
+            )
+
+        if formats is not None and (
+            not isinstance(formats, list)
+            or not all(isinstance(x, str) for x in formats)
+        ):
+            raise errors.PackageRepositoryValidationError(
+                url=url,
+                brief=f"invalid formats {formats!r}.",
+                details="Formats must be a list of strings.",
+                resolution=(
+                    "Verify repository configuration and ensure that 'formats' "
+                    "is correctly specified."
+                ),
+            )
+
+        if not isinstance(key_id, str):
+            raise errors.PackageRepositoryValidationError(
+                url=url,
+                brief=f"invalid key identifier {key_id!r}.",
+                details="Key identifiers must be a valid string.",
+                resolution=(
+                    "Verify repository configuration and ensure that 'key-id' "
+                    "is correctly specified."
+                ),
+            )
+
+        if key_server is not None and not isinstance(key_server, str):
+            raise errors.PackageRepositoryValidationError(
+                url=url,
+                brief=f"invalid key server {key_server!r}.",
+                details="Key servers must be a valid string.",
+                resolution=(
+                    "Verify repository configuration and ensure that 'key-server' "
+                    "is correctly specified."
+                ),
+            )
+
+        if name is not None and not isinstance(name, str):
+            raise errors.PackageRepositoryValidationError(
+                url=url,
+                brief=f"invalid name {name!r}.",
+                details="Names must be a valid string.",
+                resolution=(
+                    "Verify repository configuration and ensure that 'name' "
+                    "is correctly specified."
+                ),
+            )
+
+        if path is not None and not isinstance(path, str):
+            raise errors.PackageRepositoryValidationError(
+                url=url,
+                brief=f"invalid path {path!r}.",
+                details="Paths must be a valid string.",
+                resolution=(
+                    "Verify repository configuration and ensure that 'path' "
+                    "is correctly specified."
+                ),
+            )
+
+        if suites is not None and (
+            not isinstance(suites, list)
+            or not all(isinstance(x, str) for x in suites)
+            or not suites
+        ):
+            raise errors.PackageRepositoryValidationError(
+                url=url,
+                brief=f"invalid suites {suites!r}.",
+                details="Suites must be a list of strings.",
+                resolution=(
+                    "Verify repository configuration and ensure that 'suites' "
+                    "is correctly specified."
+                ),
+            )
+
+        if not isinstance(url, str):
+            raise errors.PackageRepositoryValidationError(
+                url=url,
+                brief="invalid URL.",
+                details="URLs must be a valid string.",
+                resolution=(
+                    "Verify repository configuration and ensure that 'url' "
+                    "is correctly specified."
+                ),
+            )
+
+        if data_copy:
+            keys = ", ".join([repr(k) for k in data_copy.keys()])
+            raise errors.PackageRepositoryValidationError(
+                url=url,
+                brief=f"unsupported properties {keys}.",
+                resolution="Verify repository configuration and ensure it is correct.",
+            )
+
+        return cls(
+            architectures=architectures,
+            components=components,
+            formats=formats,
+            key_id=key_id,
+            key_server=key_server,
+            name=name,
+            suites=suites,
+            url=url,
+        )

--- a/snapcraft/repo/projects.py
+++ b/snapcraft/repo/projects.py
@@ -1,0 +1,91 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2019-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Project model definitions and helpers."""
+
+from typing import Literal  # type: ignore
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+import pydantic
+from pydantic import constr
+
+# Workaround for mypy
+# see https://github.com/samuelcolvin/pydantic/issues/975#issuecomment-551147305
+if TYPE_CHECKING:
+    KeyIdStr = str
+else:
+    KeyIdStr = constr(regex=r"^[A-Z0-9]{40}$")
+
+
+class ProjectModel(pydantic.BaseModel):
+    """Base model for project repository classes."""
+
+    class Config:  # pylint: disable=too-few-public-methods
+        """Pydantic model configuration."""
+
+        validate_assignment = True
+        allow_mutation = False
+        allow_population_by_field_name = True
+        alias_generator = lambda s: s.replace("_", "-")  # noqa: E731
+        extra = "forbid"
+
+
+class AptDeb(ProjectModel):
+    """Apt package repository definition."""
+
+    type: Literal["apt"]
+    url: str
+    key_id: KeyIdStr
+    architectures: Optional[List[str]]
+    formats: Optional[List[Literal["deb", "deb-src"]]]
+    components: Optional[List[str]]
+    key_server: Optional[str]
+    path: Optional[str]
+    suites: Optional[List[str]]
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]) -> "AptDeb":
+        """Create an AptDeb object from dictionary data."""
+        return cls(**data)
+
+
+class AptPPA(ProjectModel):
+    """PPA package repository definition."""
+
+    type: Literal["apt"]
+    ppa: str
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]) -> "AptPPA":
+        """Create an AptPPA object from dictionary data."""
+        return cls(**data)
+
+
+def validate_repository(data: Dict[str, Any]):
+    """Validate a package repository.
+
+    :param data: The repository data to validate.
+    """
+    if not isinstance(data, dict):
+        raise TypeError("value must be a dictionary")
+
+    try:
+        AptPPA(**data)
+        return
+    except pydantic.ValidationError:
+        pass
+
+    AptDeb(**data)

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -77,7 +77,6 @@ def snapcraft_yaml():
             "layout": None,
             "license": None,
             "grade": "stable",
-            "adopt-info": None,
             "architectures": [],
             "assumes": [],
             "hooks": None,

--- a/tests/unit/repo/test_apt_key_manager.py
+++ b/tests/unit/repo/test_apt_key_manager.py
@@ -1,0 +1,318 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2020-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import subprocess
+from unittest import mock
+from unittest.mock import call
+
+import gnupg
+import pytest
+
+from snapcraft.repo import apt_ppa, errors
+from snapcraft.repo.apt_key_manager import AptKeyManager
+from snapcraft.repo.package_repository import (
+    PackageRepositoryApt,
+    PackageRepositoryAptPPA,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_environ_copy(mocker):
+    yield mocker.patch("os.environ.copy")
+
+
+@pytest.fixture(autouse=True)
+def mock_gnupg(tmp_path, mocker):
+    m = mocker.patch("gnupg.GPG", spec=gnupg.GPG)
+    m.return_value.import_keys.return_value.fingerprints = ["FAKE-KEY-ID-FROM-GNUPG"]
+    yield m
+
+
+@pytest.fixture(autouse=True)
+def mock_run(mocker):
+    yield mocker.patch("subprocess.run", spec=subprocess.run)
+
+
+@pytest.fixture(autouse=True)
+def mock_apt_ppa_get_signing_key(mocker):
+    yield mocker.patch(
+        "snapcraft.repo.apt_ppa.get_launchpad_ppa_key_id",
+        spec=apt_ppa.get_launchpad_ppa_key_id,
+        return_value="FAKE-PPA-SIGNING-KEY",
+    )
+
+
+@pytest.fixture
+def key_assets(tmp_path):
+    assets = tmp_path / "key-assets"
+    assets.mkdir(parents=True)
+    yield assets
+
+
+@pytest.fixture
+def gpg_keyring(tmp_path):
+    yield tmp_path / "keyring.gpg"
+
+
+@pytest.fixture
+def apt_gpg(key_assets, gpg_keyring):
+    yield AptKeyManager(
+        gpg_keyring=gpg_keyring,
+        key_assets=key_assets,
+    )
+
+
+def test_find_asset(
+    apt_gpg,
+    key_assets,
+):
+    key_id = "8" * 40
+    expected_key_path = key_assets / ("8" * 8 + ".asc")
+    expected_key_path.write_text("key")
+
+    key_path = apt_gpg.find_asset_with_key_id(key_id=key_id)
+
+    assert key_path == expected_key_path
+
+
+def test_find_asset_none(
+    apt_gpg,
+):
+    key_path = apt_gpg.find_asset_with_key_id(key_id="foo")
+
+    assert key_path is None
+
+
+def test_get_key_fingerprints(
+    apt_gpg,
+    mock_gnupg,
+):
+    with mock.patch("tempfile.NamedTemporaryFile") as m:
+        m.return_value.__enter__.return_value.name = "/tmp/foo"
+        ids = apt_gpg.get_key_fingerprints(key="8" * 40)
+
+    assert ids == ["FAKE-KEY-ID-FROM-GNUPG"]
+    assert mock_gnupg.mock_calls == [
+        call(keyring="/tmp/foo"),
+        call().import_keys(key_data="8888888888888888888888888888888888888888"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "stdout,expected",
+    [
+        (b"nothing exported", False),
+        (b"BEGIN PGP PUBLIC KEY BLOCK", True),
+        (b"invalid", False),
+    ],
+)
+def test_is_key_installed(
+    stdout,
+    expected,
+    apt_gpg,
+    mock_run,
+):
+    mock_run.return_value.stdout = stdout
+
+    is_installed = apt_gpg.is_key_installed(key_id="foo")
+
+    assert is_installed is expected
+    assert mock_run.mock_calls == [
+        call(
+            ["apt-key", "export", "foo"],
+            check=True,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+        )
+    ]
+
+
+def test_is_key_installed_with_apt_key_failure(
+    apt_gpg,
+    mock_run,
+):
+    mock_run.side_effect = subprocess.CalledProcessError(
+        cmd=["apt-key"], returncode=1, output=b"some error"
+    )
+
+    is_installed = apt_gpg.is_key_installed(key_id="foo")
+
+    assert is_installed is False
+
+
+def test_install_key(
+    apt_gpg,
+    gpg_keyring,
+    mock_run,
+):
+    key = "some-fake-key"
+    apt_gpg.install_key(key=key)
+
+    assert mock_run.mock_calls == [
+        call(
+            ["apt-key", "--keyring", str(gpg_keyring), "add", "-"],
+            check=True,
+            env={"LANG": "C.UTF-8"},
+            input=b"some-fake-key",
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+        )
+    ]
+
+
+def test_install_key_with_apt_key_failure(apt_gpg, mock_run):
+    mock_run.side_effect = subprocess.CalledProcessError(
+        cmd=["foo"], returncode=1, output=b"some error"
+    )
+
+    with pytest.raises(errors.AptGPGKeyInstallError) as raised:
+        apt_gpg.install_key(key="FAKEKEY")
+
+    assert str(raised.value) == "Failed to install GPG key: some error"
+
+
+def test_install_key_from_keyserver(apt_gpg, gpg_keyring, mock_run):
+    apt_gpg.install_key_from_keyserver(key_id="FAKE_KEYID", key_server="key.server")
+
+    assert mock_run.mock_calls == [
+        call(
+            [
+                "apt-key",
+                "--keyring",
+                str(gpg_keyring),
+                "adv",
+                "--keyserver",
+                "key.server",
+                "--recv-keys",
+                "FAKE_KEYID",
+            ],
+            check=True,
+            env={"LANG": "C.UTF-8"},
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+        )
+    ]
+
+
+def test_install_key_from_keyserver_with_apt_key_failure(
+    apt_gpg, gpg_keyring, mock_run
+):
+    mock_run.side_effect = subprocess.CalledProcessError(
+        cmd=["apt-key"], returncode=1, output=b"some error"
+    )
+
+    with pytest.raises(errors.AptGPGKeyInstallError) as raised:
+        apt_gpg.install_key_from_keyserver(
+            key_id="fake-key-id", key_server="fake-server"
+        )
+
+    assert str(raised.value) == "Failed to install GPG key: some error"
+
+
+@pytest.mark.parametrize(
+    "is_installed",
+    [True, False],
+)
+def test_install_package_repository_key_already_installed(
+    is_installed, apt_gpg, mocker
+):
+    mocker.patch(
+        "snapcraft.repo.apt_key_manager.AptKeyManager.is_key_installed",
+        return_value=is_installed,
+    )
+    package_repo = PackageRepositoryApt(
+        components=["main", "multiverse"],
+        key_id="8" * 40,
+        key_server="xkeyserver.com",
+        suites=["xenial"],
+        url="http://archive.ubuntu.com/ubuntu",
+    )
+
+    updated = apt_gpg.install_package_repository_key(package_repo=package_repo)
+
+    assert updated is not is_installed
+
+
+def test_install_package_repository_key_from_asset(apt_gpg, key_assets, mocker):
+    mocker.patch(
+        "snapcraft.repo.apt_key_manager.AptKeyManager.is_key_installed",
+        return_value=False,
+    )
+    mock_install_key = mocker.patch(
+        "snapcraft.repo.apt_key_manager.AptKeyManager.install_key"
+    )
+
+    key_id = "123456789012345678901234567890123456AABB"
+    expected_key_path = key_assets / "3456AABB.asc"
+    expected_key_path.write_text("key-data")
+
+    package_repo = PackageRepositoryApt(
+        components=["main", "multiverse"],
+        key_id=key_id,
+        suites=["xenial"],
+        url="http://archive.ubuntu.com/ubuntu",
+    )
+
+    updated = apt_gpg.install_package_repository_key(package_repo=package_repo)
+
+    assert updated is True
+    assert mock_install_key.mock_calls == [call(key="key-data")]
+
+
+def test_install_package_repository_key_apt_from_keyserver(apt_gpg, mocker):
+    mock_install_key_from_keyserver = mocker.patch(
+        "snapcraft.repo.apt_key_manager.AptKeyManager.install_key_from_keyserver"
+    )
+    mocker.patch(
+        "snapcraft.repo.apt_key_manager.AptKeyManager.is_key_installed",
+        return_value=False,
+    )
+
+    key_id = "8" * 40
+
+    package_repo = PackageRepositoryApt(
+        components=["main", "multiverse"],
+        key_id=key_id,
+        key_server="key.server",
+        suites=["xenial"],
+        url="http://archive.ubuntu.com/ubuntu",
+    )
+
+    updated = apt_gpg.install_package_repository_key(package_repo=package_repo)
+
+    assert updated is True
+    assert mock_install_key_from_keyserver.mock_calls == [
+        call(key_id=key_id, key_server="key.server")
+    ]
+
+
+def test_install_package_repository_key_ppa_from_keyserver(apt_gpg, mocker):
+    mock_install_key_from_keyserver = mocker.patch(
+        "snapcraft.repo.apt_key_manager.AptKeyManager.install_key_from_keyserver"
+    )
+    mocker.patch(
+        "snapcraft.repo.apt_key_manager.AptKeyManager.is_key_installed",
+        return_value=False,
+    )
+
+    package_repo = PackageRepositoryAptPPA(ppa="test/ppa")
+    updated = apt_gpg.install_package_repository_key(package_repo=package_repo)
+
+    assert updated is True
+    assert mock_install_key_from_keyserver.mock_calls == [
+        call(key_id="FAKE-PPA-SIGNING-KEY", key_server="keyserver.ubuntu.com")
+    ]

--- a/tests/unit/repo/test_apt_ppa.py
+++ b/tests/unit/repo/test_apt_ppa.py
@@ -1,0 +1,62 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2020-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from unittest.mock import call
+
+import launchpadlib
+import pytest
+
+from snapcraft.repo import apt_ppa, errors
+
+
+@pytest.fixture(autouse=True)
+def mock_launchpad(mocker):
+    m = mocker.patch(
+        "snapcraft.repo.apt_ppa.Launchpad", spec=launchpadlib.launchpad.Launchpad
+    )
+    m.login_anonymously.return_value.load.return_value.signing_key_fingerprint = (
+        "FAKE-PPA-SIGNING-KEY"
+    )
+    yield m
+
+
+def test_split_ppa_parts():
+    owner, name = apt_ppa.split_ppa_parts(ppa="test-owner/test-name")
+
+    assert owner == "test-owner"
+    assert name == "test-name"
+
+
+def test_split_ppa_parts_invalid():
+    with pytest.raises(errors.AptPPAInstallError) as raised:
+        apt_ppa.split_ppa_parts(ppa="ppa-missing-slash")
+
+    assert str(raised.value) == (
+        "Failed to install PPA 'ppa-missing-slash': invalid PPA format"
+    )
+
+
+def test_get_launchpad_ppa_key_id(
+    mock_launchpad,
+):
+    key_id = apt_ppa.get_launchpad_ppa_key_id(ppa="ppa-owner/ppa-name")
+
+    assert key_id == "FAKE-PPA-SIGNING-KEY"
+    assert mock_launchpad.mock_calls == [
+        call.login_anonymously("snapcraft", "production"),
+        call.login_anonymously().load("~ppa-owner/+archive/ppa-name"),
+    ]

--- a/tests/unit/repo/test_apt_sources_manager.py
+++ b/tests/unit/repo/test_apt_sources_manager.py
@@ -1,0 +1,192 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from textwrap import dedent
+
+import pytest
+
+from snapcraft.repo import apt_ppa, apt_sources_manager, errors
+from snapcraft.repo.package_repository import (
+    PackageRepositoryApt,
+    PackageRepositoryAptPPA,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_apt_ppa_get_signing_key(mocker):
+    yield mocker.patch(
+        "snapcraft.repo.apt_ppa.get_launchpad_ppa_key_id",
+        spec=apt_ppa.get_launchpad_ppa_key_id,
+        return_value="FAKE-PPA-SIGNING-KEY",
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_environ_copy(mocker):
+    yield mocker.patch("os.environ.copy")
+
+
+@pytest.fixture(autouse=True)
+def mock_host_arch(mocker):
+    m = mocker.patch("snapcraft.repo.apt_sources_manager.ProjectOptions")
+    m.return_value.deb_arch = "FAKE-HOST-ARCH"
+
+    yield m
+
+
+@pytest.fixture(autouse=True)
+def mock_run(mocker):
+    yield mocker.patch("subprocess.run")
+
+
+@pytest.fixture(autouse=True)
+def mock_version_codename(mocker):
+    yield mocker.patch(
+        "snapcraft.os_release.OsRelease.version_codename",
+        return_value="FAKE-CODENAME",
+    )
+
+
+@pytest.fixture
+def apt_sources_mgr(tmp_path):
+    sources_list_d = tmp_path / "sources.list.d"
+    sources_list_d.mkdir(parents=True)
+
+    yield apt_sources_manager.AptSourcesManager(
+        sources_list_d=sources_list_d,
+    )
+
+
+@pytest.mark.parametrize(
+    "package_repo,name,content",
+    [
+        (
+            PackageRepositoryApt(
+                architectures=["amd64", "arm64"],
+                components=["test-component"],
+                formats=["deb", "deb-src"],
+                key_id="A" * 40,
+                suites=["test-suite1", "test-suite2"],
+                url="http://test.url/ubuntu",
+            ),
+            "snapcraft-http_test_url_ubuntu.sources",
+            dedent(
+                """\
+                Types: deb deb-src
+                URIs: http://test.url/ubuntu
+                Suites: test-suite1 test-suite2
+                Components: test-component
+                Architectures: amd64 arm64
+                """
+            ).encode(),
+        ),
+        (
+            PackageRepositoryApt(
+                architectures=["amd64", "arm64"],
+                components=["test-component"],
+                key_id="A" * 40,
+                name="NO-FORMAT",
+                suites=["test-suite1", "test-suite2"],
+                url="http://test.url/ubuntu",
+            ),
+            "snapcraft-NO-FORMAT.sources",
+            dedent(
+                """\
+                Types: deb
+                URIs: http://test.url/ubuntu
+                Suites: test-suite1 test-suite2
+                Components: test-component
+                Architectures: amd64 arm64
+                """
+            ).encode(),
+        ),
+        (
+            PackageRepositoryApt(
+                key_id="A" * 40,
+                name="WITH-PATH",
+                path="some-path",
+                url="http://test.url/ubuntu",
+            ),
+            "snapcraft-WITH-PATH.sources",
+            dedent(
+                """\
+                Types: deb
+                URIs: http://test.url/ubuntu
+                Suites: some-path/
+                Architectures: FAKE-HOST-ARCH
+                """
+            ).encode(),
+        ),
+        (
+            PackageRepositoryApt(
+                key_id="A" * 40,
+                name="IMPLIED-PATH",
+                url="http://test.url/ubuntu",
+            ),
+            "snapcraft-IMPLIED-PATH.sources",
+            dedent(
+                """\
+                Types: deb
+                URIs: http://test.url/ubuntu
+                Suites: /
+                Architectures: FAKE-HOST-ARCH
+                """
+            ).encode(),
+        ),
+        (
+            PackageRepositoryAptPPA(ppa="test/ppa"),
+            "snapcraft-ppa-test_ppa.sources",
+            dedent(
+                """\
+                Types: deb
+                URIs: http://ppa.launchpad.net/test/ppa/ubuntu
+                Suites: FAKE-CODENAME
+                Components: main
+                Architectures: FAKE-HOST-ARCH
+                """
+            ).encode(),
+        ),
+    ],
+)
+def test_install(package_repo, name, content, apt_sources_mgr):
+    sources_path = apt_sources_mgr._sources_list_d / name
+
+    changed = apt_sources_mgr.install_package_repository_sources(
+        package_repo=package_repo
+    )
+
+    assert changed is True
+    assert sources_path.read_bytes() == content
+
+    # Verify a second-run does not incur any changes.
+    changed = apt_sources_mgr.install_package_repository_sources(
+        package_repo=package_repo
+    )
+
+    assert changed is False
+    assert sources_path.read_bytes() == content
+
+
+def test_install_ppa_invalid(apt_sources_mgr):
+    repo = PackageRepositoryAptPPA(ppa="ppa-missing-slash")
+
+    with pytest.raises(errors.AptPPAInstallError) as raised:
+        apt_sources_mgr.install_package_repository_sources(package_repo=repo)
+
+    assert str(raised.value) == (
+        "Failed to install PPA 'ppa-missing-slash': invalid PPA format"
+    )

--- a/tests/unit/repo/test_package_repository.py
+++ b/tests/unit/repo/test_package_repository.py
@@ -1,0 +1,426 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2019-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import pytest
+
+from snapcraft.repo import errors
+from snapcraft.repo.package_repository import (
+    PackageRepository,
+    PackageRepositoryApt,
+    PackageRepositoryAptPPA,
+)
+
+
+def test_apt_name():
+    repo = PackageRepositoryApt(
+        architectures=["amd64", "i386"],
+        components=["main", "multiverse"],
+        formats=["deb", "deb-src"],
+        key_id="A" * 40,
+        key_server="keyserver.ubuntu.com",
+        suites=["xenial", "xenial-updates"],
+        url="http://archive.ubuntu.com/ubuntu",
+    )
+
+    assert repo.name == "http_archive_ubuntu_com_ubuntu"
+
+
+@pytest.mark.parametrize(
+    "arch", ["amd64", "armhf", "arm64", "i386", "ppc64el", "riscv", "s390x"]
+)
+def test_apt_valid_architectures(arch):
+    package_repo = PackageRepositoryApt(
+        key_id="A" * 40, url="http://test", architectures=[arch]
+    )
+
+    assert package_repo.architectures == [arch]
+
+
+def test_apt_invalid_url():
+    with pytest.raises(errors.PackageRepositoryValidationError) as raised:
+        PackageRepositoryApt(
+            key_id="A" * 40,
+            url="",
+        )
+
+    err = raised.value
+    assert str(err) == "Invalid package repository for '': invalid URL."
+    assert err.details == "URLs must be non-empty strings."
+    assert err.resolution == (
+        "Verify the repository configuration and ensure that 'url' "
+        "is correctly specified."
+    )
+
+
+def test_apt_invalid_path():
+    with pytest.raises(errors.PackageRepositoryValidationError) as raised:
+        PackageRepositoryApt(
+            key_id="A" * 40,
+            path="",
+            url="http://archive.ubuntu.com/ubuntu",
+        )
+
+    err = raised.value
+    assert str(err) == (
+        "Invalid package repository for 'http://archive.ubuntu.com/ubuntu': "
+        "invalid path ''."
+    )
+    assert err.details == "Paths must be non-empty strings."
+    assert err.resolution == (
+        "Verify the repository configuration and ensure that 'path' "
+        "is a non-empty string such as '/'."
+    )
+
+
+def test_apt_invalid_path_with_suites():
+    with pytest.raises(errors.PackageRepositoryValidationError) as raised:
+        PackageRepositoryApt(
+            key_id="A" * 40,
+            path="/",
+            suites=["xenial", "xenial-updates"],
+            url="http://archive.ubuntu.com/ubuntu",
+        )
+
+    err = raised.value
+    assert str(err) == (
+        "Invalid package repository for 'http://archive.ubuntu.com/ubuntu': "
+        "suites ['xenial', 'xenial-updates'] cannot be combined with path '/'."
+    )
+    assert err.details == "Path and suites are incomptiable options."
+    assert err.resolution == (
+        "Verify the repository configuration and remove 'path' or 'suites'."
+    )
+
+
+def test_apt_invalid_path_with_components():
+    with pytest.raises(errors.PackageRepositoryValidationError) as raised:
+        PackageRepositoryApt(
+            key_id="A" * 40,
+            path="/",
+            components=["main"],
+            url="http://archive.ubuntu.com/ubuntu",
+        )
+
+    err = raised.value
+    assert str(err) == (
+        "Invalid package repository for 'http://archive.ubuntu.com/ubuntu': "
+        "components ['main'] cannot be combined with path '/'."
+    )
+    assert err.details == "Path and components are incomptiable options."
+    assert err.resolution == (
+        "Verify the repository configuration and remove 'path' or 'components'."
+    )
+
+
+def test_apt_invalid_missing_components():
+    with pytest.raises(errors.PackageRepositoryValidationError) as raised:
+        PackageRepositoryApt(
+            key_id="A" * 40,
+            suites=["xenial", "xenial-updates"],
+            url="http://archive.ubuntu.com/ubuntu",
+        )
+
+    err = raised.value
+    assert str(err) == (
+        "Invalid package repository for 'http://archive.ubuntu.com/ubuntu': "
+        "no components specified."
+    )
+    assert err.details == "Components are required when using suites."
+    assert err.resolution == (
+        "Verify the repository configuration and ensure that 'components' "
+        "is correctly specified."
+    )
+
+
+def test_apt_invalid_missing_suites():
+    with pytest.raises(errors.PackageRepositoryValidationError) as raised:
+        PackageRepositoryApt(
+            key_id="A" * 40,
+            components=["main"],
+            url="http://archive.ubuntu.com/ubuntu",
+        )
+
+    err = raised.value
+    assert str(err) == (
+        "Invalid package repository for 'http://archive.ubuntu.com/ubuntu': "
+        "no suites specified."
+    )
+    assert err.details == "Suites are required when using components."
+    assert err.resolution == (
+        "Verify the repository configuration and ensure that 'suites' "
+        "is correctly specified."
+    )
+
+
+def test_apt_invalid_suites_as_path():
+    with pytest.raises(errors.PackageRepositoryValidationError) as raised:
+        PackageRepositoryApt(
+            key_id="A" * 40,
+            suites=["my-suite/"],
+            url="http://archive.ubuntu.com/ubuntu",
+        )
+
+    err = raised.value
+    assert str(err) == (
+        "Invalid package repository for 'http://archive.ubuntu.com/ubuntu': "
+        "invalid suite 'my-suite/'."
+    )
+    assert err.details == "Suites must not end with a '/'."
+    assert err.resolution == (
+        "Verify the repository configuration and remove the trailing '/' "
+        "from suites or use the 'path' property to define a path."
+    )
+
+
+def test_apt_marshal():
+    repo = PackageRepositoryApt(
+        architectures=["amd64", "i386"],
+        components=["main", "multiverse"],
+        formats=["deb", "deb-src"],
+        key_id="A" * 40,
+        key_server="xkeyserver.ubuntu.com",
+        name="test-name",
+        suites=["xenial", "xenial-updates"],
+        url="http://archive.ubuntu.com/ubuntu",
+    )
+
+    assert repo.marshal() == {
+        "architectures": ["amd64", "i386"],
+        "components": ["main", "multiverse"],
+        "formats": ["deb", "deb-src"],
+        "key-id": "A" * 40,
+        "key-server": "xkeyserver.ubuntu.com",
+        "name": "test-name",
+        "suites": ["xenial", "xenial-updates"],
+        "type": "apt",
+        "url": "http://archive.ubuntu.com/ubuntu",
+    }
+
+
+def test_apt_unmarshal_invalid_extra_keys():
+    test_dict = {
+        "architectures": ["amd64", "i386"],
+        "components": ["main", "multiverse"],
+        "formats": ["deb", "deb-src"],
+        "key-id": "A" * 40,
+        "key-server": "keyserver.ubuntu.com",
+        "name": "test-name",
+        "suites": ["xenial", "xenial-updates"],
+        "type": "apt",
+        "url": "http://archive.ubuntu.com/ubuntu",
+        "foo": "bar",
+        "foo2": "bar",
+    }
+
+    with pytest.raises(errors.PackageRepositoryValidationError) as raised:
+        PackageRepositoryApt.unmarshal(test_dict)
+
+    err = raised.value
+    assert str(err) == (
+        "Invalid package repository for 'http://archive.ubuntu.com/ubuntu': "
+        "unsupported properties 'foo', 'foo2'."
+    )
+    assert err.details is None
+    assert err.resolution == "Verify repository configuration and ensure it is correct."
+
+
+def test_apt_unmarshal_invalid_data():
+    test_dict = "not-a-dict"
+
+    with pytest.raises(errors.PackageRepositoryValidationError) as raised:
+        PackageRepositoryApt.unmarshal(test_dict)  # type: ignore
+
+    err = raised.value
+    assert str(err) == "Invalid package repository for 'not-a-dict': invalid object."
+    assert err.details == "Package repository must be a valid dictionary object."
+    assert err.resolution == (
+        "Verify repository configuration and ensure that the correct syntax is used."
+    )
+
+
+def test_apt_unmarshal_invalid_type():
+    test_dict = {
+        "architectures": ["amd64", "i386"],
+        "components": ["main", "multiverse"],
+        "formats": ["deb", "deb-src"],
+        "key-id": "A" * 40,
+        "key-server": "keyserver.ubuntu.com",
+        "name": "test-name",
+        "suites": ["xenial", "xenial-updates"],
+        "type": "aptx",
+        "url": "http://archive.ubuntu.com/ubuntu",
+    }
+
+    with pytest.raises(errors.PackageRepositoryValidationError) as raised:
+        PackageRepositoryApt.unmarshal(test_dict)
+
+    err = raised.value
+    assert str(err) == (
+        "Invalid package repository for 'http://archive.ubuntu.com/ubuntu': "
+        "unsupported type 'aptx'."
+    )
+    assert err.details == "The only currently supported type is 'apt'."
+    assert err.resolution == (
+        "Verify repository configuration and ensure that 'type' is correctly specified."
+    )
+
+
+def test_ppa_marshal():
+    repo = PackageRepositoryAptPPA(ppa="test/ppa")
+
+    assert repo.marshal() == {"type": "apt", "ppa": "test/ppa"}
+
+
+def test_ppa_invalid_ppa():
+    with pytest.raises(errors.PackageRepositoryValidationError) as raised:
+        PackageRepositoryAptPPA(ppa="")
+
+    err = raised.value
+    assert str(err) == "Invalid package repository for '': invalid PPA."
+    assert err.details == "PPAs must be non-empty strings."
+    assert err.resolution == (
+        "Verify repository configuration and ensure that 'ppa' is correctly specified."
+    )
+
+
+def test_ppa_unmarshal_invalid_data():
+    test_dict = "not-a-dict"
+
+    with pytest.raises(errors.PackageRepositoryValidationError) as raised:
+        PackageRepositoryAptPPA.unmarshal(test_dict)  # type: ignore
+
+    err = raised.value
+    assert str(err) == "Invalid package repository for 'not-a-dict': invalid object."
+    assert err.details == "Package repository must be a valid dictionary object."
+    assert err.resolution == (
+        "Verify repository configuration and ensure that the correct syntax is used."
+    )
+
+
+def test_ppa_unmarshal_invalid_apt_ppa_type():
+    test_dict = {"type": "aptx", "ppa": "test/ppa"}
+
+    with pytest.raises(errors.PackageRepositoryValidationError) as raised:
+        PackageRepositoryAptPPA.unmarshal(test_dict)
+
+    err = raised.value
+    assert str(err) == (
+        "Invalid package repository for 'test/ppa': unsupported type 'aptx'."
+    )
+    assert err.details == "The only currently supported type is 'apt'."
+    assert err.resolution == (
+        "Verify repository configuration and ensure that 'type' is correctly specified."
+    )
+
+
+def test_ppa_unmarshal_invalid_apt_ppa_extra_keys():
+    test_dict = {"type": "apt", "ppa": "test/ppa", "test": "foo"}
+
+    with pytest.raises(errors.PackageRepositoryValidationError) as raised:
+        PackageRepositoryAptPPA.unmarshal(test_dict)
+
+    err = raised.value
+    assert str(err) == (
+        "Invalid package repository for 'test/ppa': unsupported properties 'test'."
+    )
+    assert err.details is None
+    assert err.resolution == (
+        "Verify repository configuration and ensure that it is correct."
+    )
+
+
+def test_unmarshal_package_repositories_list_none():
+    assert PackageRepository.unmarshal_package_repositories(None) == []
+
+
+def test_unmarshal_package_repositories_list_empty():
+    assert PackageRepository.unmarshal_package_repositories([]) == []
+
+
+def test_unmarshal_package_repositories_list_ppa():
+    test_dict = {"type": "apt", "ppa": "test/foo"}
+    test_list = [test_dict]
+
+    unmarshalled_list = [
+        repo.marshal()
+        for repo in PackageRepository.unmarshal_package_repositories(test_list)
+    ]
+
+    assert unmarshalled_list == test_list
+
+
+def test_unmarshal_package_repositories_list_apt():
+    test_dict = {
+        "architectures": ["amd64", "i386"],
+        "components": ["main", "multiverse"],
+        "formats": ["deb", "deb-src"],
+        "key-id": "A" * 40,
+        "key-server": "keyserver.ubuntu.com",
+        "name": "test-name",
+        "suites": ["xenial", "xenial-updates"],
+        "type": "apt",
+        "url": "http://archive.ubuntu.com/ubuntu",
+    }
+
+    test_list = [test_dict]
+
+    unmarshalled_list = [
+        repo.marshal()
+        for repo in PackageRepository.unmarshal_package_repositories(test_list)
+    ]
+
+    assert unmarshalled_list == test_list
+
+
+def test_unmarshal_package_repositories_list_all():
+    test_ppa = {"type": "apt", "ppa": "test/foo"}
+
+    test_deb = {
+        "architectures": ["amd64", "i386"],
+        "components": ["main", "multiverse"],
+        "formats": ["deb", "deb-src"],
+        "key-id": "A" * 40,
+        "key-server": "keyserver.ubuntu.com",
+        "name": "test-name",
+        "suites": ["xenial", "xenial-updates"],
+        "type": "apt",
+        "url": "http://archive.ubuntu.com/ubuntu",
+    }
+
+    test_list = [test_ppa, test_deb]
+
+    unmarshalled_list = [
+        repo.marshal()
+        for repo in PackageRepository.unmarshal_package_repositories(test_list)
+    ]
+
+    assert unmarshalled_list == test_list
+
+
+def test_unmarshal_package_repositories_invalid_data():
+    with pytest.raises(errors.PackageRepositoryValidationError) as raised:
+        PackageRepository.unmarshal_package_repositories("not-a-list")
+
+    err = raised.value
+    assert str(err) == (
+        "Invalid package repository for 'not-a-list': invalid list object."
+    )
+    assert err.details == "Package repositories must be a list of objects."
+    assert err.resolution == (
+        "Verify 'package-repositories' configuration and ensure that "
+        "the correct syntax is used."
+    )

--- a/tests/unit/repo/test_projects.py
+++ b/tests/unit/repo/test_projects.py
@@ -1,0 +1,134 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pydantic
+import pytest
+
+from snapcraft.repo.projects import AptDeb, AptPPA
+
+
+class TestAptPPAValidation:
+    """AptPPA field validation."""
+
+    def test_apt_ppa_valid(self):
+        repo = {
+            "type": "apt",
+            "ppa": "test/somerepo",
+        }
+        apt_ppa = AptPPA.unmarshal(repo)
+        assert apt_ppa.type == "apt"
+        assert apt_ppa.ppa == "test/somerepo"
+
+    def test_apt_ppa_repository_invalid(self):
+        repo = {
+            "ppa": "test/somerepo",
+        }
+        error = r"type\s+field required"
+        with pytest.raises(pydantic.ValidationError, match=error):
+            AptPPA.unmarshal(repo)
+
+    def test_project_package_ppa_repository_bad_type(self):
+        repo = {
+            "type": "invalid",
+            "ppa": "test/somerepo",
+        }
+        error = "unexpected value; permitted: 'apt'"
+        with pytest.raises(pydantic.ValidationError, match=error):
+            AptPPA.unmarshal(repo)
+
+
+class TestAptDebValidation:
+    """AptDeb field validation."""
+
+    @pytest.mark.parametrize(
+        "repo",
+        [
+            {
+                "type": "apt",
+                "url": "https://some/url",
+                "key_id": "KEYID12345" * 4,
+            },
+            {
+                "type": "apt",
+                "url": "https://some/url",
+                "key_id": "KEYID12345" * 4,
+                "formats": ["deb"],
+                "components": ["some", "components"],
+                "key-server": "my-key-server",
+                "path": "my/path",
+                "suites": ["some", "suites"],
+            },
+        ],
+    )
+    def test_apt_deb_valid(self, repo):
+        apt_deb = AptDeb.unmarshal(repo)
+        assert apt_deb.type == "apt"
+        assert apt_deb.url == "https://some/url"
+        assert apt_deb.key_id == "KEYID12345" * 4
+        assert apt_deb.formats == (["deb"] if "formats" in repo else None)
+        assert apt_deb.components == (
+            ["some", "components"] if "components" in repo else None
+        )
+        assert apt_deb.key_server == ("my-key-server" if "key-server" in repo else None)
+        assert apt_deb.path == ("my/path" if "path" in repo else None)
+        assert apt_deb.suites == (["some", "suites"] if "suites" in repo else None)
+
+    @pytest.mark.parametrize(
+        "key_id,error",
+        [
+            ("KEYID12345" * 4, None),
+            ("KEYID12345", "string does not match regex"),
+            ("keyid12345" * 4, "string does not match regex"),
+        ],
+    )
+    def test_apt_deb_key_id(self, key_id, error):
+        repo = {
+            "type": "apt",
+            "url": "https://some/url",
+            "key-id": key_id,
+        }
+
+        if not error:
+            apt_deb = AptDeb.unmarshal(repo)
+            assert apt_deb.key_id == key_id
+        else:
+            with pytest.raises(pydantic.ValidationError, match=error):
+                AptDeb.unmarshal(repo)
+
+    @pytest.mark.parametrize(
+        "formats",
+        [
+            ["deb"],
+            ["deb-src"],
+            ["deb", "deb-src"],
+            ["_invalid"],
+        ],
+    )
+    def test_apt_deb_formats(self, formats):
+        repo = {
+            "type": "apt",
+            "url": "https://some/url",
+            "key-id": "KEYID12345" * 4,
+            "formats": formats,
+        }
+
+        if formats != ["_invalid"]:
+            apt_deb = AptDeb.unmarshal(repo)
+            assert apt_deb.formats == formats
+        else:
+            error = ".*unexpected value; permitted: 'deb', 'deb-src'"
+            with pytest.raises(pydantic.ValidationError, match=error):
+                AptDeb.unmarshal(repo)

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -18,7 +18,7 @@ from typing import Any, Dict
 
 import pytest
 
-from snapcraft import errors
+from snapcraft import errors, projects
 from snapcraft.projects import Project
 
 
@@ -60,6 +60,7 @@ class TestProjectDefaults:
         assert project.layout is None
         assert project.license is None
         assert project.architectures == []
+        assert project.package_repositories == []
         assert project.assumes == []
         assert project.hooks is None
         assert project.passthrough is None
@@ -322,6 +323,24 @@ class TestProjectValidation:
         with pytest.raises(errors.ProjectValidationError, match=error):
             Project.unmarshal(yaml_data(epoch=epoch))
 
+    def test_project_package_repository(self, yaml_data):
+        repos = [
+            {
+                "type": "apt",
+                "ppa": "test/somerepo",
+            },
+            {
+                "type": "apt",
+                "url": "https://some/url",
+                "key_id": "KEYID12345" * 4,
+            },
+        ]
+        project = Project.unmarshal(yaml_data(package_repositories=repos))
+        assert project.package_repositories == [
+            projects.AptPPA(**repos[0]),  # type: ignore
+            projects.AptDeb(**repos[1]),  # type: ignore
+        ]
+
 
 class TestAppValidation:
     """Validate apps."""
@@ -426,5 +445,120 @@ class TestAppValidation:
             assert project.apps["app1"].install_mode == install_mode
         else:
             error = ".*unexpected value; permitted: 'enable', 'disable'"
+            with pytest.raises(errors.ProjectValidationError, match=error):
+                Project.unmarshal(data)
+
+
+class TestAptPPAValidation:
+    """AptPPA field validation."""
+
+    def test_apt_ppa_valid(self, yaml_data):
+        repos = [
+            {
+                "type": "apt",
+                "ppa": "test/somerepo",
+            },
+        ]
+        project = Project.unmarshal(yaml_data(package_repositories=repos))
+        assert project.package_repositories == [
+            projects.AptPPA(**x) for x in repos  # type: ignore
+        ]
+
+    def test_apt_ppa_repository_invalid(self, yaml_data):
+        repos = [
+            {
+                "ppa": "test/somerepo",
+            },
+        ]
+        error = "field 'type' required"
+        with pytest.raises(errors.ProjectValidationError, match=error):
+            Project.unmarshal(yaml_data(package_repositories=repos))
+
+    def test_project_package_ppa_repository_bad_type(self, yaml_data):
+        repos = [
+            {
+                "type": "invalid",
+                "ppa": "test/somerepo",
+            },
+        ]
+        error = "unexpected value; permitted: 'apt'"
+        with pytest.raises(errors.ProjectValidationError, match=error):
+            Project.unmarshal(yaml_data(package_repositories=repos))
+
+
+class TestAptDebValidation:
+    """AptDeb field validation."""
+
+    @pytest.mark.parametrize(
+        "repo",
+        [
+            {
+                "type": "apt",
+                "url": "https://some/url",
+                "key_id": "KEYID12345" * 4,
+            },
+            {
+                "type": "apt",
+                "url": "https://some/url",
+                "key_id": "KEYID12345" * 4,
+                "formats": ["deb"],
+                "components": ["some", "components"],
+                "keyserver": "my-key-server",
+                "path": "my/path",
+                "suites": ["some", "suites"],
+            },
+        ],
+    )
+    def test_apt_deb_valid(self, yaml_data, repo):
+        project = Project.unmarshal(yaml_data(package_repositories=[repo]))
+        assert project.package_repositories == [projects.AptDeb(**repo)]
+
+    @pytest.mark.parametrize(
+        "key_id,error",
+        [
+            ("KEYID12345" * 4, None),
+            ("KEYID12345", "string does not match regex"),
+            ("keyid12345" * 4, "string does not match regex"),
+        ],
+    )
+    def test_apt_deb_key_id(self, yaml_data, key_id, error):
+        repo = {
+            "type": "apt",
+            "url": "https://some/url",
+            "key_id": key_id,
+        }
+
+        data = yaml_data(package_repositories=[repo])
+
+        if not error:
+            project = Project.unmarshal(data)
+            assert project.package_repositories == [projects.AptDeb(**repo)]
+        else:
+            with pytest.raises(errors.ProjectValidationError, match=error):
+                Project.unmarshal(data)
+
+    @pytest.mark.parametrize(
+        "formats",
+        [
+            ["deb"],
+            ["deb-src"],
+            ["deb", "deb-src"],
+            ["_invalid"],
+        ],
+    )
+    def test_apt_deb_formats(self, formats, yaml_data):
+        repo = {
+            "type": "apt",
+            "url": "https://some/url",
+            "key_id": "KEYID12345" * 4,
+            "formats": formats,
+        }
+        data = yaml_data(package_repositories=[repo])
+
+        if formats != ["_invalid"]:
+            project = Project.unmarshal(data)
+            assert project.package_repositories == [projects.AptDeb(**repo)]
+        else:
+            error = ".*unexpected value; permitted: 'deb', 'deb-src'"
             with pytest.raises(errors.ProjectValidationError, match=error):
                 Project.unmarshal(data)


### PR DESCRIPTION
Port definitions and helpers to add apt repositories and PPAs. Original
code from PRs #2911, #3341, #3359, #3363.
    
Co-authored-by: Chris Patterson <chris.patterson@canonical.com>
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
