### PR TITLE
lint: apply autoformat-black to source files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SOURCES=setup.py snapcraft tests/*.py tests/unit
 
 .PHONY: autoformat-black
 autoformat-black:
-	black .
+	black $(SOURCES)
 
 .PHONY: freeze-requirements
 freeze-requirements:


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `./runtests.sh static`?
- [X] Have you successfully run `./runtests.sh tests/unit`?

-----

`autoformat-black` should only apply to source files, matching `test-black`.