### PR TITLE
tests: pass proper type to run for version

### DIFF
--- a/tests/unit/commands/test_version.py
+++ b/tests/unit/commands/test_version.py
@@ -14,11 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from argparse import Namespace
+
 from snapcraft import __version__
 from snapcraft.commands.version import VersionCommand
 
 
 def test_version_command(emitter):
     cmd = VersionCommand(None)
-    cmd.run([])
+    cmd.run(Namespace())
     emitter.assert_recorded([f"snapcraft {__version__}"])


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
