### PR TITLE
providers: integrate craft-providers support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ ensure_newline_before_comments = true
 line_length = 88
 
 [tool.pylint.messages_control]
-disable = "too-few-public-methods,fixme,use-implicit-booleaness-not-comparison"
+# duplicate-code can't be disabled locally: https://github.com/PyCQA/pylint/issues/214
+disable = "too-few-public-methods,fixme,use-implicit-booleaness-not-comparison,duplicate-code"
 
 [tool.pylint.format]
 max-attributes = 15

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -11,7 +11,8 @@ codespell==2.1.0
 coverage==6.3.2
 craft-cli==0.2.0
 craft-grammar==1.1.1
-craft-parts==1.1.2
+craft-parts==1.3.0
+craft-providers==1.0.5
 cryptography==3.4
 Deprecated==1.2.13
 distro==1.7.0
@@ -99,7 +100,7 @@ tomli==2.0.1
 translationstring==1.4
 types-Deprecated==1.2.5
 types-PyYAML==6.0.4
-types-setuptools==57.4.9
+types-setuptools==57.4.10
 typing-utils==0.1.0
 typing_extensions==4.1.1
 urllib3==1.26.8

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -12,7 +12,7 @@ coverage==6.3.2
 craft-cli==0.2.0
 craft-grammar==1.1.1
 craft-parts==1.3.0
-craft-providers==1.0.5
+craft-providers==1.1.0
 cryptography==3.4
 Deprecated==1.2.13
 distro==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ charset-normalizer==2.0.12
 click==8.0.4
 craft-cli==0.2.0
 craft-grammar==1.1.1
-craft-parts==1.1.2
+craft-parts==1.3.0
+craft-providers==1.0.5
 cryptography==3.4
 Deprecated==1.2.13
 distro==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.0.4
 craft-cli==0.2.0
 craft-grammar==1.1.1
 craft-parts==1.3.0
-craft-providers==1.0.5
+craft-providers==1.1.0
 cryptography==3.4
 Deprecated==1.2.13
 distro==1.7.0

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ install_requires = [
     "craft-cli",
     "craft-grammar",
     "craft-parts",
+    "craft-providers",
     "cryptography==3.4",
     "gnupg",
     "jsonschema==2.5.1",

--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -23,7 +23,7 @@ import sys
 import craft_cli
 from craft_cli import ArgumentParsingError, EmitterMode, emit
 
-from snapcraft import __version__, errors
+from snapcraft import __version__, errors, utils
 from snapcraft_legacy.cli import legacy
 
 from . import commands
@@ -65,7 +65,17 @@ def run():
         logger = logging.getLogger(lib_name)
         logger.setLevel(logging.DEBUG)
 
-    emit.init(EmitterMode.NORMAL, "snapcraft", f"Starting Snapcraft {__version__}")
+    emit_args = {
+        "mode": EmitterMode.NORMAL,
+        "appname": "snapcraft",
+        "greeting": f"Starting Snapcraft {__version__}",
+    }
+
+    if utils.is_managed_mode():
+        emit_args["log_filepath"] = utils.get_managed_environment_log_path()
+
+    emit.init(**emit_args)
+
     dispatcher = craft_cli.Dispatcher(
         "snapcraft",
         COMMAND_GROUPS,
@@ -88,3 +98,4 @@ def run():
         legacy.legacy_run()
     except errors.SnapcraftError as err:
         emit.error(err)
+        sys.exit(1)

--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -61,8 +61,7 @@ def run():
         legacy.legacy_run()
 
     # set lib loggers to debug level so that all messages are sent to Emitter
-    # TODO: add craft_providers
-    for lib_name in ("craft_parts",):
+    for lib_name in ("craft_parts", "craft_providers"):
         logger = logging.getLogger(lib_name)
         logger.setLevel(logging.DEBUG)
 

--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -17,8 +17,8 @@
 """Snapcraft lifecycle commands."""
 
 import abc
+import argparse
 import textwrap
-from typing import TYPE_CHECKING
 
 from craft_cli import BaseCommand, emit
 from overrides import overrides
@@ -26,30 +26,25 @@ from overrides import overrides
 from snapcraft import pack
 from snapcraft.parts import lifecycle as parts_lifecycle
 
-if TYPE_CHECKING:
-    import argparse
-
 
 class _LifecycleCommand(BaseCommand, abc.ABC):
     """Run lifecycle-related commands."""
 
     @overrides
     def fill_parser(self, parser: "argparse.ArgumentParser") -> None:
-        parser.add_argument(
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
             "--destructive-mode",
             action="store_true",
-            help="Build in the current host (implies `--provider=host`)",
+            help="Build in the current host",
         )
-        parser.add_argument(
-            "--provider",
-            choices=["host", "lxd", "multipass"],
-            help="The build provider to use",
-        )
-        parser.add_argument(
+        group.add_argument(
             "--use-lxd",
             action="store_true",
-            help="Use LXD to build (implies `--provider=lxd`)",
+            help="Use LXD to build",
         )
+        # --provider is only available in legacy
+        parser.add_argument("--provider", help=argparse.SUPPRESS)
 
     @overrides
     def run(self, parsed_args):

--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -35,8 +35,21 @@ class _LifecycleCommand(BaseCommand, abc.ABC):
 
     @overrides
     def fill_parser(self, parser: "argparse.ArgumentParser") -> None:
-        # TODO: add arguments for all step commands and pack
-        pass
+        parser.add_argument(
+            "--destructive-mode",
+            action="store_true",
+            help="Build in the current host (implies `--provider=host`)",
+        )
+        parser.add_argument(
+            "--provider",
+            choices=["host", "lxd", "multipass"],
+            help="The build provider to use",
+        )
+        parser.add_argument(
+            "--use-lxd",
+            action="store_true",
+            help="Use LXD to build (implies `--provider=lxd`)",
+        )
 
     @overrides
     def run(self, parsed_args):

--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -62,7 +62,13 @@ def pack_snap(
 
     emit.progress("Creating snap package...")
     try:
-        subprocess.run(command, capture_output=True, check=True)  # type: ignore
+        subprocess.run(
+            command, capture_output=True, check=True, universal_newlines=True
+        )  # type: ignore
     except subprocess.CalledProcessError as err:
-        raise errors.SnapcraftError(f"Cannot pack snap file: {err!s}")
+        msg = f"Cannot pack snap file: {err!s}"
+        if err.stderr:
+            msg += f" ({err.stderr.strip()!s})"
+        raise errors.SnapcraftError(msg)
+
     emit.message("Created snap package", intermediate=True)

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -112,7 +112,7 @@ def _run_command(
     if managed_mode:
         work_dir = utils.get_managed_environment_home_path()
     else:
-        work_dir = Path("work").absolute()
+        work_dir = Path.cwd()
 
     step_name = "prime" if command_name == "pack" else command_name
 

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -177,9 +177,7 @@ def _run_in_provider(project: Project, command_name: str, parsed_args: "argparse
     ) as instance:
         try:
             emit.message("Launched instance", intermediate=True)
-            instance.execute_run(
-                cmd, check=True, cwd=output_dir,
-            )
+            instance.execute_run(cmd, check=True, cwd=output_dir)
         except subprocess.CalledProcessError as err:
             capture_logs_from_instance(instance)
             raise providers.ProviderError(

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -157,7 +157,7 @@ def _run_in_provider(project: Project, command_name: str, parsed_args: "argparse
     """Pack image in provider instance."""
     provider = "lxd" if parsed_args.use_lxd else parsed_args.provider
 
-    emit.progress("Checking build provider availability")
+    emit.trace("Checking build provider availability")
     provider = providers.get_provider(provider)
     provider.ensure_provider_is_available()
 

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -170,11 +170,13 @@ def _run_in_provider(project: Project, command_name: str, parsed_args: "argparse
 
     output_dir = utils.get_managed_environment_project_path()
 
-    emit.progress("Launching build provider")
+    # FIXME: pause emitter when executing instance (needs craft-cli support)
+    emit.progress("Launching instance...")
     with provider.launched_environment(
         project_name=project.name, project_path=Path().absolute(), base=cast(str, project.base)
     ) as instance:
         try:
+            emit.message("Launched instance", intermediate=True)
             instance.execute_run(
                 cmd, check=True, cwd=output_dir,
             )

--- a/snapcraft/providers/__init__.py
+++ b/snapcraft/providers/__init__.py
@@ -1,0 +1,25 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021-2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Build provider support."""
+
+from ._buildd import SnapcraftBuilddBaseConfiguration  # noqa: F401
+from ._get_provider import get_provider  # noqa: F401
+from ._logs import capture_logs_from_instance  # noqa: F401
+from ._lxd import LXDProvider  # noqa: F401
+from ._multipass import MultipassProvider  # noqa: F401
+from ._provider import Provider  # noqa: F401
+from ._provider import ProviderError  # noqa: F401

--- a/snapcraft/providers/_buildd.py
+++ b/snapcraft/providers/_buildd.py
@@ -1,0 +1,118 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Buildd-related helpers for Snapcraft."""
+
+import enum
+import sys
+from typing import Optional
+
+from craft_providers import Executor, bases
+from craft_providers.actions import snap_installer
+
+from snapcraft import utils
+
+
+# FIXME: update in craft-providers
+class _BuilddBaseAlias(enum.Enum):
+    """Mappings for supported buildd images."""
+
+    JAMMY = "22.04"
+
+
+BASE_TO_BUILDD_IMAGE_ALIAS = {
+    # "core22": bases.BuilddBaseAlias.JAMMY,
+    "core22": _BuilddBaseAlias.JAMMY,
+}
+
+
+class SnapcraftBuilddBaseConfiguration(bases.BuilddBase):
+    """Base configuration for Snapcraft.
+
+    :cvar compatibility_tag: Tag/Version for variant of build configuration and
+        setup.  Any change to this version would indicate that prior [versioned]
+        instances are incompatible and must be cleaned.  As such, any new value
+        should be unique to old values (e.g. incrementing).  Snapcraft extends
+        the buildd tag to include its own version indicator (.0) and namespace
+        ("snapcraft").
+    """
+
+    compatibility_tag: str = f"snapcraft-{bases.BuilddBase.compatibility_tag}.0"
+
+    @staticmethod
+    def _setup_snapcraft(*, executor: Executor) -> None:
+        """Install Snapcraft in target environment.
+
+        On Linux, the default behavior is to inject the host snap into the target
+        environment.
+
+        On other platforms, the Snapcraft snap is installed from the Snap Store.
+
+        When installing the snap from the Store, we check if the user specifies a
+        channel, using SNAPCRAFT_INSTALL_SNAP_CHANNEL=<channel>.  If unspecified,
+        we use the "stable" channel on the default track.
+
+        On Linux, the user may specify this environment variable to force Snapcraft
+        to install the snap from the Store rather than inject the host snap.
+
+        :raises BaseConfigurationError: on error.
+        """
+        snap_channel = utils.get_managed_environment_snap_channel()
+        if snap_channel is None and sys.platform != "linux":
+            snap_channel = "stable"
+
+        if snap_channel:
+            try:
+                snap_installer.install_from_store(
+                    executor=executor,
+                    snap_name="snapcraft",
+                    channel=snap_channel,
+                    classic=True,
+                )
+            except snap_installer.SnapInstallationError as error:
+                raise bases.BaseConfigurationError(
+                    "Failed to install snapcraft snap from store channel "
+                    f"{snap_channel!r} into target environment."
+                ) from error
+        else:
+            try:
+                snap_installer.inject_from_host(
+                    executor=executor, snap_name="snapcraft", classic=True
+                )
+            except snap_installer.SnapInstallationError as error:
+                raise bases.BaseConfigurationError(
+                    "Failed to inject host snapcraft snap into target environment."
+                ) from error
+
+    def setup(
+        self,
+        *,
+        executor: Executor,
+        retry_wait: float = 0.25,
+        timeout: Optional[float] = None,
+    ) -> None:
+        """Prepare base instance for use by the application.
+
+        :param executor: Executor for target container.
+        :param retry_wait: Duration to sleep() between status checks (if
+            required).
+        :param timeout: Timeout in seconds.
+
+        :raises BaseCompatibilityError: if instance is incompatible.
+        :raises BaseConfigurationError: on other unexpected error.
+        """
+        super().setup(executor=executor, retry_wait=retry_wait, timeout=timeout)
+        self._setup_snapcraft(executor=executor)

--- a/snapcraft/providers/_buildd.py
+++ b/snapcraft/providers/_buildd.py
@@ -16,7 +16,6 @@
 
 """Buildd-related helpers for Snapcraft."""
 
-import enum
 import sys
 from typing import Optional
 
@@ -25,17 +24,8 @@ from craft_providers.actions import snap_installer
 
 from snapcraft import utils
 
-
-# FIXME: update in craft-providers
-class _BuilddBaseAlias(enum.Enum):
-    """Mappings for supported buildd images."""
-
-    JAMMY = "22.04"
-
-
 BASE_TO_BUILDD_IMAGE_ALIAS = {
-    # "core22": bases.BuilddBaseAlias.JAMMY,
-    "core22": _BuilddBaseAlias.JAMMY,
+    "core22": bases.BuilddBaseAlias.JAMMY,
 }
 
 
@@ -73,6 +63,9 @@ class SnapcraftBuilddBaseConfiguration(bases.BuilddBase):
         snap_channel = utils.get_managed_environment_snap_channel()
         if snap_channel is None and sys.platform != "linux":
             snap_channel = "stable"
+
+        # FIXME: don't reinstall snapcraft if already installed.
+        #        See https://github.com/canonical/craft-providers/issues/91
 
         if snap_channel:
             try:

--- a/snapcraft/providers/_get_provider.py
+++ b/snapcraft/providers/_get_provider.py
@@ -1,0 +1,56 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Build environment provider support for snapcraft."""
+
+import sys
+from typing import Optional
+
+from ._lxd import LXDProvider
+from ._multipass import MultipassProvider
+from ._provider import Provider
+
+
+def get_provider(provider: Optional[str] = None) -> Provider:
+    """Get the configured or appropriate provider for the host OS.
+
+    If platform is not Linux, use Multipass.
+
+    If platform is Linux:
+    (1) use provider specified in the function argument,
+    (2) use provider specified with snap configuration if running
+        as snap,
+    (3) default to platform default (LXD on Linux).
+
+    :return: Provider instance.
+    """
+    if provider is None:
+        provider = _get_platform_default_provider()
+
+    if provider == "lxd":
+        return LXDProvider()
+
+    if provider == "multipass":
+        return MultipassProvider()
+
+    raise RuntimeError(f"Unsupported provider specified: {provider!r}.")
+
+
+def _get_platform_default_provider() -> str:
+    if sys.platform == "linux":
+        return "lxd"
+
+    return "multipass"

--- a/snapcraft/providers/_logs.py
+++ b/snapcraft/providers/_logs.py
@@ -1,0 +1,51 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Build environment provider support for snapcraft."""
+
+import pathlib
+import tempfile
+
+from craft_cli import emit
+from craft_providers import Executor
+
+from snapcraft.utils import get_managed_environment_log_path
+
+
+def capture_logs_from_instance(instance: Executor) -> None:
+    """Retrieve logs from instance.
+
+    :param instance: Instance to retrieve logs from.
+
+    :returns: String of logs.
+    """
+    # Get a temporary file path.
+    with tempfile.NamedTemporaryFile(delete=False, prefix="snapcraft-") as tmp_file:
+        local_log_path = pathlib.Path(tmp_file.name)
+
+    instance_log_path = get_managed_environment_log_path()
+
+    try:
+        instance.pull_file(source=instance_log_path, destination=local_log_path)
+    except FileNotFoundError:
+        emit.trace("No logs found in instance.")
+        return
+
+    emit.trace("Logs captured from managed instance:")
+    with local_log_path.open("rt", encoding="utf8") as logfile:
+        for line in logfile:
+            emit.trace(":: " + line.rstrip())
+    local_log_path.unlink()

--- a/snapcraft/providers/_lxd.py
+++ b/snapcraft/providers/_lxd.py
@@ -1,0 +1,206 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""LXD build environment provider support for Snapcraft."""
+
+import contextlib
+import logging
+import os
+import pathlib
+from typing import Generator, List
+
+from craft_providers import Executor, bases, lxd
+
+from snapcraft.utils import confirm_with_user, get_managed_environment_project_path
+
+from ._buildd import BASE_TO_BUILDD_IMAGE_ALIAS, SnapcraftBuilddBaseConfiguration
+from ._provider import Provider, ProviderError
+
+logger = logging.getLogger(__name__)
+
+# FIXME: use final 22.04 image
+_BASE_IMAGE = {"core22": "ubuntu-daily:22.04"}
+
+
+class LXDProvider(Provider):
+    """LXD build environment provider.
+
+    :param lxc: Optional lxc client to use.
+    :param lxd_project: LXD project to use (default is snapcraft).
+    :param lxd_remote: LXD remote to use (default is local).
+    """
+
+    def __init__(
+        self,
+        *,
+        lxc: lxd.LXC = lxd.LXC(),
+        lxd_project: str = "snapcraft",
+        lxd_remote: str = "local",
+    ) -> None:
+        self.lxc = lxc
+        self.lxd_project = lxd_project
+        self.lxd_remote = lxd_remote
+
+    def clean_project_environments(
+        self, *, project_name: str, project_path: pathlib.Path
+    ) -> List[str]:
+        """Clean up any build environments created for project.
+
+        :param project_name: Name of project.
+
+        :returns: List of containers deleted.
+        """
+        deleted: List[str] = []
+
+        # Nothing to do if provider is not installed.
+        if not self.is_provider_available():
+            return deleted
+
+        inode = str(project_path.stat().st_ino)
+
+        try:
+            names = self.lxc.list_names(
+                project=self.lxd_project, remote=self.lxd_remote
+            )
+        except lxd.LXDError as error:
+            raise ProviderError(str(error)) from error
+
+        for name in names:
+            if name == f"snapcraft-{project_name}-{inode}":
+                logger.debug("Deleting container %r.", name)
+                try:
+                    self.lxc.delete(
+                        instance_name=name,
+                        force=True,
+                        project=self.lxd_project,
+                        remote=self.lxd_remote,
+                    )
+                except lxd.LXDError as error:
+                    raise ProviderError(str(error)) from error
+                deleted.append(name)
+            else:
+                logger.debug("Not deleting container %r.", name)
+
+        return deleted
+
+    @classmethod
+    def ensure_provider_is_available(cls) -> None:
+        """Ensure provider is available, prompting the user to install it if required.
+
+        :raises ProviderError: if provider is not available.
+        """
+        if not lxd.is_installed():
+            if confirm_with_user(
+                "LXD is required, but not installed. Do you wish to install LXD "
+                "and configure it with the defaults?",
+                default=False,
+            ):
+                try:
+                    lxd.install()
+                except lxd.LXDInstallationError as error:
+                    raise ProviderError(
+                        "Failed to install LXD. Visit https://snapcraft.io/lxd for "
+                        "instructions on how to install the LXD snap for your distribution",
+                    ) from error
+            else:
+                raise ProviderError(
+                    "LXD is required, but not installed. Visit https://snapcraft.io/lxd "
+                    "for instructions on how to install the LXD snap for your distribution",
+                )
+
+        try:
+            lxd.ensure_lxd_is_ready()
+        except lxd.LXDError as error:
+            raise ProviderError(str(error)) from error
+
+    @classmethod
+    def is_provider_available(cls) -> bool:
+        """Check if provider is installed and available for use.
+
+        :returns: True if installed.
+        """
+        return lxd.is_installed()
+
+    @contextlib.contextmanager
+    def launched_environment(
+        self,
+        *,
+        project_name: str,
+        project_path: pathlib.Path,
+        base: str,
+    ) -> Generator[Executor, None, None]:
+        """Launch environment for specified base.
+
+        :param project_name: Name of project.
+        :param project_path: Path to project.
+        :param base: Base to create.
+        """
+        alias = BASE_TO_BUILDD_IMAGE_ALIAS[base]
+
+        instance_name = self.get_instance_name(
+            project_name=project_name,
+            project_path=project_path,
+        )
+
+        base_image = _BASE_IMAGE[base]
+        if ":" in base_image:
+            image_remote, image_name = base_image.split(":", 1)
+        else:
+            try:
+                image_remote = lxd.configure_buildd_image_remote()
+                image_name = base_image
+            except lxd.LXDError as error:
+                raise ProviderError(str(error)) from error
+
+        environment = self.get_command_environment()
+
+        base_configuration = SnapcraftBuilddBaseConfiguration(
+            alias=alias,  # type: ignore
+            environment=environment,
+            hostname=instance_name,
+        )
+
+        try:
+            instance = lxd.launch(
+                name=instance_name,
+                base_configuration=base_configuration,
+                image_name=image_name,
+                image_remote=image_remote,
+                auto_clean=True,
+                auto_create_project=True,
+                map_user_uid=True,
+                uid=os.stat(project_path).st_uid,
+                use_snapshots=True,
+                project=self.lxd_project,
+                remote=self.lxd_remote,
+            )
+        except (bases.BaseConfigurationError, lxd.LXDError) as error:
+            raise ProviderError(str(error)) from error
+
+        # Mount project.
+        instance.mount(
+            host_source=project_path, target=get_managed_environment_project_path()
+        )
+
+        try:
+            yield instance
+        finally:
+            # Ensure to unmount everything and stop instance upon completion.
+            try:
+                instance.unmount_all()
+                instance.stop()
+            except lxd.LXDError as error:
+                raise ProviderError(str(error)) from error

--- a/snapcraft/providers/_multipass.py
+++ b/snapcraft/providers/_multipass.py
@@ -1,0 +1,182 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Multipass build environment provider for Snapcraft."""
+
+import contextlib
+import logging
+import pathlib
+from typing import Generator, List
+
+from craft_providers import Executor, bases, multipass
+from craft_providers.multipass.errors import MultipassError
+
+from snapcraft.utils import confirm_with_user, get_managed_environment_project_path
+
+from ._buildd import BASE_TO_BUILDD_IMAGE_ALIAS, SnapcraftBuilddBaseConfiguration
+from ._provider import Provider, ProviderError
+
+logger = logging.getLogger(__name__)
+
+
+class MultipassProvider(Provider):
+    """Multipass build environment provider.
+
+    :param multipass: Optional Multipass client to use.
+    """
+
+    def __init__(
+        self,
+        instance: multipass.Multipass = multipass.Multipass(),
+    ) -> None:
+        self.multipass = instance
+
+    def clean_project_environments(
+        self, *, project_name: str, project_path: pathlib.Path
+    ) -> List[str]:
+        """Clean up any build environments created for project.
+
+        :param project_name: Name of the project.
+        :param project_path: Directory of the project.
+
+        :returns: List of containers deleted.
+        """
+        deleted: List[str] = []
+
+        # Nothing to do if provider is not installed.
+        if not self.is_provider_available():
+            return deleted
+
+        inode = project_path.stat().st_ino
+
+        try:
+            names = self.multipass.list()
+        except multipass.MultipassError as error:
+            raise ProviderError(str(error)) from error
+
+        for name in names:
+            if name == f"snapcraft-{project_name}-{inode}":
+                logger.debug("Deleting Multipass VM %r.", name)
+                try:
+                    self.multipass.delete(
+                        instance_name=name,
+                        purge=True,
+                    )
+                except multipass.MultipassError as error:
+                    raise ProviderError(str(error)) from error
+
+                deleted.append(name)
+            else:
+                logger.debug("Not deleting Multipass VM %r.", name)
+
+        return deleted
+
+    @classmethod
+    def ensure_provider_is_available(cls) -> None:
+        """Ensure provider is available, prompting the user to install it if required.
+
+        :raises ProviderError: if provider is not available.
+        """
+        if not multipass.is_installed():
+            if confirm_with_user(
+                "Multipass is required, but not installed. Do you wish to install Multipass "
+                "and configure it with the defaults?",
+                default=False,
+            ):
+                try:
+                    multipass.install()
+                except multipass.MultipassInstallationError as error:
+                    raise ProviderError(
+                        "Failed to install Multipass. Visit https://multipass.run/ for "
+                        "instructions on installing Multipass for your operating system.",
+                    ) from error
+            else:
+                raise ProviderError(
+                    "Multipass is required, but not installed. Visit https://multipass.run/ for "
+                    "instructions on installing Multipass for your operating system.",
+                )
+
+        try:
+            multipass.ensure_multipass_is_ready()
+        except multipass.MultipassError as error:
+            raise ProviderError(str(error)) from error
+
+    @classmethod
+    def is_provider_available(cls) -> bool:
+        """Check if provider is installed and available for use.
+
+        :returns: True if installed.
+        """
+        return multipass.is_installed()
+
+    @contextlib.contextmanager
+    def launched_environment(
+        self,
+        *,
+        project_name: str,
+        project_path: pathlib.Path,
+        base: str,
+    ) -> Generator[Executor, None, None]:
+        """Launch environment for specified base.
+
+        :param project_name: Name of the project.
+        :param project_path: Path to project.
+        :param base: Base to create.
+        """
+        alias = BASE_TO_BUILDD_IMAGE_ALIAS[base]
+
+        instance_name = self.get_instance_name(
+            project_name=project_name,
+            project_path=project_path,
+        )
+
+        environment = self.get_command_environment()
+        base_configuration = SnapcraftBuilddBaseConfiguration(
+            alias=alias,  # type: ignore
+            environment=environment,
+            hostname=instance_name,
+        )
+
+        try:
+            instance = multipass.launch(
+                name=instance_name,
+                base_configuration=base_configuration,
+                image_name=f"snapcraft:{base}",
+                cpus=2,
+                disk_gb=64,
+                mem_gb=2,
+                auto_clean=True,
+            )
+        except (bases.BaseConfigurationError, MultipassError) as error:
+            raise ProviderError(str(error)) from error
+
+        try:
+            # Mount project.
+            instance.mount(
+                host_source=project_path, target=get_managed_environment_project_path()
+            )
+        except MultipassError as error:
+            raise ProviderError(str(error)) from error
+
+        try:
+            yield instance
+        finally:
+            # Ensure to unmount everything and stop instance upon completion.
+            try:
+                instance.unmount_all()
+                instance.stop()
+            except MultipassError as error:
+                raise ProviderError(str(error)) from error

--- a/snapcraft/providers/_provider.py
+++ b/snapcraft/providers/_provider.py
@@ -1,0 +1,125 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Build environment provider support for snapcraft."""
+
+import contextlib
+import os
+import pathlib
+from abc import ABC, abstractmethod
+from typing import Dict, Generator, List, Optional, Tuple, Union
+
+from craft_providers import Executor, bases
+
+from snapcraft.errors import SnapcraftError
+
+
+class ProviderError(SnapcraftError):
+    """Error in provider operation."""
+
+
+class Provider(ABC):
+    """Snapcraft's build environment provider."""
+
+    @abstractmethod
+    def clean_project_environments(
+        self, *, project_name: str, project_path: pathlib.Path
+    ) -> List[str]:
+        """Clean up any environments created for project.
+
+        :param project_name: Name of project.
+
+        :returns: List of containers deleted.
+        """
+
+    @classmethod
+    @abstractmethod
+    def ensure_provider_is_available(cls) -> None:
+        """Ensure provider is available, prompting the user to install it if required.
+
+        :raises ProviderError: if provider is not available.
+        """
+
+    @staticmethod
+    def get_command_environment() -> Dict[str, Optional[str]]:
+        """Construct the required environment."""
+        env = bases.buildd.default_command_environment()
+        env["SNAPCRAFT_MANAGED_MODE"] = "1"
+
+        # Pass-through host environment that target may need.
+        for env_key in ["http_proxy", "https_proxy", "no_proxy"]:
+            if env_key in os.environ:
+                env[env_key] = os.environ[env_key]
+
+        return env
+
+    @staticmethod
+    def get_instance_name(
+        *,
+        project_name: str,
+        project_path: pathlib.Path,
+    ) -> str:
+        """Formulate the name for an instance using each of the given parameters.
+
+        Incorporate each of the parameters into the name to come up with a
+        predictable naming schema that avoids name collisions across multiple
+        projects.
+
+        :param project_name: Name of the project.
+        :param project_path: Directory of the project.
+        """
+        return "-".join(["snapcraft", project_name, str(project_path.stat().st_ino)])
+
+    @classmethod
+    def is_base_available(cls, base: str) -> Tuple[bool, Union[str, None]]:
+        """Check if provider can provide an environment matching given base.
+
+        :param base: Base to check.
+
+        :returns: Tuple of bool indicating whether it is a match, with optional
+                reason if not a match.
+        """
+        if base not in ["ubuntu:18.04", "ubuntu:20.04"]:
+            return (
+                False,
+                f"Base {base!r} is not supported (must be 'ubuntu:18.04' or 'ubuntu:20.04')",
+            )
+
+        return True, None
+
+    @classmethod
+    @abstractmethod
+    def is_provider_available(cls) -> bool:
+        """Check if provider is installed and available for use.
+
+        :returns: True if installed.
+        """
+
+    @abstractmethod
+    @contextlib.contextmanager
+    def launched_environment(
+        self,
+        *,
+        project_name: str,
+        project_path: pathlib.Path,
+        base: str,
+    ) -> Generator[Executor, None, None]:
+        """Launch environment for specified base.
+
+        :param project_name: Name of the project.
+        :param project_path: Path to the project.
+        :param base: Base to create.
+        """

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -1,0 +1,87 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utilities for snapcraft."""
+
+import distutils.util
+import logging
+import os
+import pathlib
+import sys
+from collections import namedtuple
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+OSPlatform = namedtuple("OSPlatform", "system release machine")
+
+
+def is_managed_mode():
+    """Check if snapcraft is running in a managed environment."""
+    managed_flag = os.getenv("SNAPCRAFT_MANAGED_MODE", "n")
+    return distutils.util.strtobool(managed_flag) == 1
+
+
+def get_managed_environment_home_path():
+    """Path for home when running in managed environment."""
+    return pathlib.Path("/root")
+
+
+def get_managed_environment_project_path():
+    """Path for project when running in managed environment."""
+    return get_managed_environment_home_path() / "project"
+
+
+def get_managed_environment_log_path():
+    """Path for log when running in managed environment."""
+    return pathlib.Path("/tmp/snapcraft.log")
+
+
+def get_managed_environment_snap_channel() -> Optional[str]:
+    """User-specified channel to use when installing Snapcraft snap from Snap Store.
+
+    :returns: Channel string if specified, else None.
+    """
+    return os.getenv("SNAPCRAFT_INSTALL_SNAP_CHANNEL")
+
+
+def confirm_with_user(prompt, default=False) -> bool:
+    """Query user for yes/no answer.
+
+    If stdin is not a tty, the default value is returned.
+
+    If user returns an empty answer, the default value is returned.
+    returns default value.
+
+    :returns: True if answer starts with [yY], False if answer starts with [nN],
+        otherwise the default.
+    """
+    if is_managed_mode():
+        raise RuntimeError("confirmation not yet supported in managed-mode")
+
+    if not sys.stdin.isatty():
+        return default
+
+    choices = " [Y/n]: " if default else " [y/N]: "
+
+    reply = str(input(prompt + choices)).lower().strip()
+    if reply and reply[0] == "y":
+        return True
+
+    if reply and reply[0] == "n":
+        return False
+
+    return default

--- a/tests/spread/general/core22/task.yaml
+++ b/tests/spread/general/core22/task.yaml
@@ -25,11 +25,21 @@ restore: |
 execute: |
   cd "$SNAP"
 
-  # Build what we have.
   if [ "$SPREAD_SYSTEM" = "ubuntu-20.04-64" ]; then
-      snapcraft --verbose
+      # No jammy for this ppa yet
+      if [ "$(basename "$SNAP")" != "test-apt-ppa" ]; then
+          # Build what we have.
+          snapcraft --verbose --use-lxd
 
-      # And verify the snap runs as expected.
+          # And verify the snap runs as expected.
+          snap install "${SNAP}"_1.0_*.snap --dangerous
+          snap_executable="${SNAP}.test-ppa"
+          [ "$("${snap_executable}")" = "hello!" ]
+      fi
+
+      # Do it again in destructive mode
+      snap remove "${SNAP}"
+      snapcraft --verbose --destructive-mode
       snap install "${SNAP}"_1.0_*.snap --dangerous
       snap_executable="${SNAP}.test-ppa"
       [ "$("${snap_executable}")" = "hello!" ]

--- a/tests/spread/plugins/v1/flutter/snaps/flutter-hello/src/pubspec.yaml
+++ b/tests/spread/plugins/v1/flutter/snaps/flutter-hello/src/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
 
   url_launcher_fde:
     git:
-      url: git://github.com/google/flutter-desktop-embedding.git
+      url: https://github.com/google/flutter-desktop-embedding.git
       path: plugins/flutter_plugins/url_launcher_fde
       ref: b0794faf2c000576515aee56ca6bb5bee64cece4
 

--- a/tests/unit/cli/test_default_command.py
+++ b/tests/unit/cli/test_default_command.py
@@ -28,7 +28,34 @@ def test_default_command(mocker):
     mock_pack_cmd = mocker.patch("snapcraft.commands.lifecycle.PackCommand.run")
     cli.run()
     assert mock_pack_cmd.mock_calls == [
-        call(argparse.Namespace(directory=None, output=None))
+        call(
+            argparse.Namespace(
+                directory=None,
+                output=None,
+                destructive_mode=False,
+                use_lxd=False,
+                provider=None,
+            )
+        )
+    ]
+
+
+def test_default_command_parameters(mocker):
+    mocker.patch.object(
+        sys, "argv", ["cmd", "--destructive-mode", "--use-lxd", "--provider=lxd"]
+    )
+    mock_pack_cmd = mocker.patch("snapcraft.commands.lifecycle.PackCommand.run")
+    cli.run()
+    assert mock_pack_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                directory=None,
+                output=None,
+                destructive_mode=True,
+                use_lxd=True,
+                provider="lxd",
+            )
+        )
     ]
 
 
@@ -38,5 +65,13 @@ def test_default_command_output(mocker, option):
     mock_pack_cmd = mocker.patch("snapcraft.commands.lifecycle.PackCommand.run")
     cli.run()
     assert mock_pack_cmd.mock_calls == [
-        call(argparse.Namespace(directory=None, output="name"))
+        call(
+            argparse.Namespace(
+                directory=None,
+                output="name",
+                destructive_mode=False,
+                use_lxd=False,
+                provider=None,
+            )
+        )
     ]

--- a/tests/unit/cli/test_default_command.py
+++ b/tests/unit/cli/test_default_command.py
@@ -40,10 +40,8 @@ def test_default_command(mocker):
     ]
 
 
-def test_default_command_parameters(mocker):
-    mocker.patch.object(
-        sys, "argv", ["cmd", "--destructive-mode", "--use-lxd", "--provider=lxd"]
-    )
+def test_default_command_destructive_mode(mocker):
+    mocker.patch.object(sys, "argv", ["cmd", "--destructive-mode"])
     mock_pack_cmd = mocker.patch("snapcraft.commands.lifecycle.PackCommand.run")
     cli.run()
     assert mock_pack_cmd.mock_calls == [
@@ -52,8 +50,25 @@ def test_default_command_parameters(mocker):
                 directory=None,
                 output=None,
                 destructive_mode=True,
+                use_lxd=False,
+                provider=None,
+            )
+        )
+    ]
+
+
+def test_default_command_use_lxd(mocker):
+    mocker.patch.object(sys, "argv", ["cmd", "--use-lxd"])
+    mock_pack_cmd = mocker.patch("snapcraft.commands.lifecycle.PackCommand.run")
+    cli.run()
+    assert mock_pack_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                directory=None,
+                output=None,
+                destructive_mode=False,
                 use_lxd=True,
-                provider="lxd",
+                provider=None,
             )
         )
     ]

--- a/tests/unit/cli/test_lifecycle.py
+++ b/tests/unit/cli/test_lifecycle.py
@@ -61,9 +61,41 @@ def test_lifecycle_command_arguments(cmd, run_method, mocker):
         [
             "cmd",
             cmd,
+            "part1",
+            "part2",
+        ],
+    )
+    mock_lifecycle_cmd = mocker.patch(run_method)
+    cli.run()
+    assert mock_lifecycle_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                parts=["part1", "part2"],
+                destructive_mode=False,
+                use_lxd=False,
+                provider=None,
+            )
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "cmd,run_method",
+    [
+        ("pull", "snapcraft.commands.lifecycle.PullCommand.run"),
+        ("build", "snapcraft.commands.lifecycle.BuildCommand.run"),
+        ("stage", "snapcraft.commands.lifecycle.StageCommand.run"),
+        ("prime", "snapcraft.commands.lifecycle.PrimeCommand.run"),
+    ],
+)
+def test_lifecycle_command_arguments_destructive_mode(cmd, run_method, mocker):
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "cmd",
+            cmd,
             "--destructive-mode",
-            "--use-lxd",
-            "--provider=lxd",
             "part1",
             "part2",
         ],
@@ -75,16 +107,54 @@ def test_lifecycle_command_arguments(cmd, run_method, mocker):
             argparse.Namespace(
                 parts=["part1", "part2"],
                 destructive_mode=True,
-                use_lxd=True,
-                provider="lxd",
+                use_lxd=False,
+                provider=None,
             )
         )
     ]
 
 
-@pytest.mark.parametrize("provider", ["host", "lxd", "multipass"])
-def test_lifecycle_command_provider(mocker, provider):
-    mocker.patch.object(sys, "argv", ["cmd", "pack", "--provider=" + provider])
+@pytest.mark.parametrize(
+    "cmd,run_method",
+    [
+        ("pull", "snapcraft.commands.lifecycle.PullCommand.run"),
+        ("build", "snapcraft.commands.lifecycle.BuildCommand.run"),
+        ("stage", "snapcraft.commands.lifecycle.StageCommand.run"),
+        ("prime", "snapcraft.commands.lifecycle.PrimeCommand.run"),
+    ],
+)
+def test_lifecycle_command_arguments_use_lxd(cmd, run_method, mocker):
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "cmd",
+            cmd,
+            "--use-lxd",
+            "part1",
+            "part2",
+        ],
+    )
+    mock_lifecycle_cmd = mocker.patch(run_method)
+    cli.run()
+    assert mock_lifecycle_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                parts=["part1", "part2"],
+                destructive_mode=False,
+                use_lxd=True,
+                provider=None,
+            )
+        )
+    ]
+
+
+def test_lifecycle_command_pack(mocker):
+    mocker.patch.object(
+        sys,
+        "argv",
+        ["cmd", "pack"],
+    )
     mock_pack_cmd = mocker.patch("snapcraft.commands.lifecycle.PackCommand.run")
     cli.run()
     assert mock_pack_cmd.mock_calls == [
@@ -94,23 +164,17 @@ def test_lifecycle_command_provider(mocker, provider):
                 output=None,
                 destructive_mode=False,
                 use_lxd=False,
-                provider=provider,
+                provider=None,
             )
         )
     ]
 
 
-def test_lifecycle_command_provider_invalid(mocker):
-    mocker.patch.object(sys, "argv", ["cmd", "pack", "--provider=foo"])
-    mock_pack_cmd = mocker.patch("snapcraft.commands.lifecycle.PackCommand.run")
-    assert mock_pack_cmd.mock_calls == []
-
-
-def test_lifecycle_command_pack(mocker):
+def test_lifecycle_command_pack_destructive_mode(mocker):
     mocker.patch.object(
         sys,
         "argv",
-        ["cmd", "pack", "--destructive-mode", "--use-lxd", "--provider=lxd"],
+        ["cmd", "pack", "--destructive-mode"],
     )
     mock_pack_cmd = mocker.patch("snapcraft.commands.lifecycle.PackCommand.run")
     cli.run()
@@ -120,8 +184,29 @@ def test_lifecycle_command_pack(mocker):
                 directory=None,
                 output=None,
                 destructive_mode=True,
+                use_lxd=False,
+                provider=None,
+            )
+        )
+    ]
+
+
+def test_lifecycle_command_pack_use_lxd(mocker):
+    mocker.patch.object(
+        sys,
+        "argv",
+        ["cmd", "pack", "--use-lxd"],
+    )
+    mock_pack_cmd = mocker.patch("snapcraft.commands.lifecycle.PackCommand.run")
+    cli.run()
+    assert mock_pack_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                directory=None,
+                output=None,
+                destructive_mode=False,
                 use_lxd=True,
-                provider="lxd",
+                provider=None,
             )
         )
     ]

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -124,7 +124,7 @@ def test_snapcraft_yaml_load(new_dir, snapcraft_yaml, filename, mocker):
             "pull",
             project=project,
             assets_dir=assets_dir,
-            parsed_args=argparse.Namespace(parts=["part1"])
+            parsed_args=argparse.Namespace(parts=["part1"]),
         ),
     ]
 
@@ -169,7 +169,12 @@ def test_lifecycle_run_command_step(cmd, step, snapcraft_yaml, new_dir, mocker):
     pack_mock = mocker.patch("snapcraft.pack.pack_snap")
 
     parts_lifecycle._run_command(
-        cmd, project=project, assets_dir=Path(), parsed_args=argparse.Namespace()
+        cmd,
+        project=project,
+        assets_dir=Path(),
+        parsed_args=argparse.Namespace(
+            destructive_mode=True, use_lxd=False, provider=None
+        ),
     )
 
     assert run_mock.mock_calls == [call(step)]
@@ -186,10 +191,115 @@ def test_lifecycle_run_command_pack(snapcraft_yaml, new_dir, mocker):
         "pack",
         project=project,
         assets_dir=Path(),
-        parsed_args=argparse.Namespace(directory=None, output=None),
+        parsed_args=argparse.Namespace(
+            directory=None,
+            output=None,
+            destructive_mode=True,
+            use_lxd=False,
+            provider=None,
+        ),
     )
 
     assert run_mock.mock_calls == [call("prime")]
     assert pack_mock.mock_calls == [
         call(new_dir / "work/prime", output=None, compression="xz")
+    ]
+
+
+def test_lifecycle_pack_destructive_mode(snapcraft_yaml, new_dir, mocker):
+    project = Project.unmarshal(snapcraft_yaml(base="core22"))
+    run_in_provider_mock = mocker.patch("snapcraft.parts.lifecycle._run_in_provider")
+    run_mock = mocker.patch("snapcraft.parts.PartsLifecycle.run")
+    pack_mock = mocker.patch("snapcraft.pack.pack_snap")
+    mocker.patch("snapcraft.meta.snap_yaml.write")
+    mocker.patch("snapcraft.utils.is_managed_mode", return_value=True)
+    mocker.patch(
+        "snapcraft.utils.get_managed_environment_home_path",
+        return_value=new_dir / "home",
+    )
+
+    parts_lifecycle._run_command(
+        "pack",
+        project=project,
+        assets_dir=Path(),
+        parsed_args=argparse.Namespace(
+            directory=None,
+            output=None,
+            destructive_mode=True,
+            use_lxd=False,
+            provider=None,
+        ),
+    )
+
+    assert run_in_provider_mock.mock_calls == []
+    assert run_mock.mock_calls == [call("prime")]
+    assert pack_mock.mock_calls == [
+        call(new_dir / "home/prime", output=None, compression="xz")
+    ]
+
+
+def test_lifecycle_pack_managed(snapcraft_yaml, new_dir, mocker):
+    project = Project.unmarshal(snapcraft_yaml(base="core22"))
+    run_in_provider_mock = mocker.patch("snapcraft.parts.lifecycle._run_in_provider")
+    run_mock = mocker.patch("snapcraft.parts.PartsLifecycle.run")
+    pack_mock = mocker.patch("snapcraft.pack.pack_snap")
+    mocker.patch("snapcraft.meta.snap_yaml.write")
+    mocker.patch("snapcraft.utils.is_managed_mode", return_value=True)
+    mocker.patch(
+        "snapcraft.utils.get_managed_environment_home_path",
+        return_value=new_dir / "home",
+    )
+
+    parts_lifecycle._run_command(
+        "pack",
+        project=project,
+        assets_dir=Path(),
+        parsed_args=argparse.Namespace(
+            directory=None,
+            output=None,
+            destructive_mode=False,
+            use_lxd=False,
+            provider=None,
+        ),
+    )
+
+    assert run_in_provider_mock.mock_calls == []
+    assert run_mock.mock_calls == [call("prime")]
+    assert pack_mock.mock_calls == [
+        call(new_dir / "home/prime", output=None, compression="xz")
+    ]
+
+
+def test_lifecycle_pack_not_managed(snapcraft_yaml, new_dir, mocker):
+    project = Project.unmarshal(snapcraft_yaml(base="core22"))
+    run_in_provider_mock = mocker.patch("snapcraft.parts.lifecycle._run_in_provider")
+    run_mock = mocker.patch("snapcraft.parts.PartsLifecycle.run")
+    mocker.patch("snapcraft.utils.is_managed_mode", return_value=False)
+
+    parts_lifecycle._run_command(
+        "pack",
+        project=project,
+        assets_dir=Path(),
+        parsed_args=argparse.Namespace(
+            directory=None,
+            output=None,
+            destructive_mode=False,
+            use_lxd=False,
+            provider=None,
+        ),
+    )
+
+    assert run_mock.mock_calls == []
+    assert run_in_provider_mock.mock_calls == [
+        call(
+            project,
+            "pack",
+            argparse.Namespace(
+                directory=None,
+                output=None,
+                destructive_mode=False,
+                use_lxd=False,
+                provider=None,
+            ),
+        )
     ]

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -202,7 +202,7 @@ def test_lifecycle_run_command_pack(snapcraft_yaml, new_dir, mocker):
 
     assert run_mock.mock_calls == [call("prime")]
     assert pack_mock.mock_calls == [
-        call(new_dir / "work/prime", output=None, compression="xz")
+        call(new_dir / "prime", output=None, compression="xz")
     ]
 
 

--- a/tests/unit/test_pack.py
+++ b/tests/unit/test_pack.py
@@ -26,7 +26,12 @@ def test_pack_snap(mocker, new_dir):
     mock_run = mocker.patch("subprocess.run")
     pack.pack_snap(new_dir, output=None)
     assert mock_run.mock_calls == [
-        call(["snap", "pack", new_dir], capture_output=True, check=True)
+        call(
+            ["snap", "pack", new_dir],
+            capture_output=True,
+            check=True,
+            universal_newlines=True,
+        )
     ]
 
 
@@ -34,7 +39,12 @@ def test_pack_snap_compression_none(mocker, new_dir):
     mock_run = mocker.patch("subprocess.run")
     pack.pack_snap(new_dir, output=None, compression=None)
     assert mock_run.mock_calls == [
-        call(["snap", "pack", new_dir], capture_output=True, check=True)
+        call(
+            ["snap", "pack", new_dir],
+            capture_output=True,
+            check=True,
+            universal_newlines=True,
+        )
     ]
 
 
@@ -46,6 +56,7 @@ def test_pack_snap_compression(mocker, new_dir):
             ["snap", "pack", "--compression", "zz", new_dir],
             capture_output=True,
             check=True,
+            universal_newlines=True,
         )
     ]
 
@@ -58,6 +69,7 @@ def test_pack_snap_output_file(mocker, new_dir):
             ["snap", "pack", "--filename", "foo", new_dir, "/tmp"],
             capture_output=True,
             check=True,
+            universal_newlines=True,
         )
     ]
 
@@ -70,6 +82,7 @@ def test_pack_snap_output_dir(mocker, new_dir):
             ["snap", "pack", new_dir, str(new_dir)],
             capture_output=True,
             check=True,
+            universal_newlines=True,
         )
     ]
 


### PR DESCRIPTION
Run lifecycle commands inside a build provider using lxd or multipass.
Craft-providers glue code based on Chris Patterson's implementation for
Charmcraft. Note: multipass images for multipass will be fixed when base
devel is implemented.

Co-authored-by: Chris Patterson <chris.patterson@canonical.com>
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
