### PR TITLE
ROS plugins v2: respect source-subdir key

### DIFF
--- a/snapcraft/plugins/v2/_plugin.py
+++ b/snapcraft/plugins/v2/_plugin.py
@@ -35,7 +35,7 @@ class PluginV2(abc.ABC):
     @abc.abstractmethod
     def get_build_snaps(self) -> Set[str]:
         """
-        Return a set of required packages to install in the build environment.
+        Return a set of required snaps to install in the build environment.
         """
 
     @abc.abstractmethod

--- a/snapcraft/plugins/v2/_ros.py
+++ b/snapcraft/plugins/v2/_ros.py
@@ -103,7 +103,7 @@ class RosPlugin(PluginV2):
                     os.path.abspath(__file__),
                     "stage-runtime-dependencies",
                     "--part-src",
-                    '"${SNAPCRAFT_PART_SRC}"',
+                    '"${SNAPCRAFT_PART_SRC_WORK}"',
                     "--part-install",
                     '"${SNAPCRAFT_PART_INSTALL}"',
                     "--ros-version",
@@ -122,7 +122,7 @@ class RosPlugin(PluginV2):
             + [
                 "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep init; fi",
                 'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
-                'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC}"',
+                'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
             ]
             + self._get_build_commands()
             + self._get_stage_runtime_dependencies_commands()
@@ -135,7 +135,7 @@ def plugin_cli():
 
 
 @plugin_cli.command()
-@click.option("--part-src", envvar="SNAPCRAFT_PART_SRC", required=True)
+@click.option("--part-src", envvar="SNAPCRAFT_PART_SRC_WORK", required=True)
 @click.option("--part-install", envvar="SNAPCRAFT_PART_INSTALL", required=True)
 @click.option("--ros-version", envvar="ROS_VERSION", required=True)
 @click.option("--ros-distro", envvar="ROS_DISTRO", required=True)

--- a/snapcraft/plugins/v2/catkin.py
+++ b/snapcraft/plugins/v2/catkin.py
@@ -110,7 +110,7 @@ class CatkinPlugin(_ros.RosPlugin):
             "--install",
             "--merge",
             "--source-space",
-            '"${SNAPCRAFT_PART_SRC}"',
+            '"${SNAPCRAFT_PART_SRC_WORK}"',
             "--build-space",
             '"${SNAPCRAFT_PART_BUILD}"',
             "--install-space",

--- a/snapcraft/plugins/v2/catkin_tools.py
+++ b/snapcraft/plugins/v2/catkin_tools.py
@@ -62,10 +62,6 @@ class CatkinToolsPlugin(_ros.RosPlugin):
     def get_build_packages(self) -> Set[str]:
         return super().get_build_packages() | {
             "python3-catkin-tools",
-            # FIXME: Only needed because of a botched release:
-            # https://github.com/catkin/catkin_tools/issues/594#issuecomment-688149976
-            # Once fixed, remove this.
-            "python3-osrf-pycommon",
         }
 
     def _get_workspace_activation_commands(self) -> List[str]:
@@ -116,7 +112,7 @@ class CatkinToolsPlugin(_ros.RosPlugin):
             "default",
             "--install",
             "--source-space",
-            '"${SNAPCRAFT_PART_SRC}"',
+            '"${SNAPCRAFT_PART_SRC_WORK}"',
             "--build-space",
             '"${SNAPCRAFT_PART_BUILD}"',
             "--install-space",

--- a/snapcraft/plugins/v2/colcon.py
+++ b/snapcraft/plugins/v2/colcon.py
@@ -151,7 +151,7 @@ class ColconPlugin(_ros.RosPlugin):
             "colcon",
             "build",
             "--base-paths",
-            '"${SNAPCRAFT_PART_SRC}"',
+            '"${SNAPCRAFT_PART_SRC_WORK}"',
             "--build-base",
             '"${SNAPCRAFT_PART_BUILD}"',
             "--merge-install",

--- a/tests/spread/plugins/v2/colcon-ros2-hello/task.yaml
+++ b/tests/spread/plugins/v2/colcon-ros2-hello/task.yaml
@@ -6,6 +6,7 @@ kill-timeout: 180m
 
 environment:
   SNAP/colcon_ros2_foxy_rlcpp_hello: colcon-ros2-foxy-rlcpp-hello
+  SNAP/colcon_subdir: colcon-subdir
   SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
 systems:
@@ -24,7 +25,8 @@ restore: |
   snapcraft clean
   rm -f ./*.snap
 
-  git checkout src/hello.cpp
+  [ -f src/hello ] && git checkout src/hello.cpp
+  [ -f colcon-ros2-foxy-rlcpp-hello/hello.cpp ] && git checkout colcon-ros2-foxy-rlcpp-hello/hello.cpp
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
@@ -45,7 +47,14 @@ execute: |
   [ "$($SNAP)" = "hello world" ]
 
   # Make sure that what we built runs with the changes applied.
-  modified_file=src/hello.cpp
+  if [ -f src/hello.cpp ]; then
+    modified_file=src/hello.cpp
+  elif [ -f colcon-ros2-foxy-rlcpp-hello/hello.cpp ]; then
+    modified_file=colcon-ros2-foxy-rlcpp-hello/hello.cpp
+  else
+    FATAL "Cannot setup ${SNAP} for rebuilding"
+  fi
+
   sed -i "${modified_file}" -e 's/hello world/hello rebuilt world/'
 
   snapcraft

--- a/tests/spread/plugins/v2/ros1-hello/task.yaml
+++ b/tests/spread/plugins/v2/ros1-hello/task.yaml
@@ -6,7 +6,9 @@ kill-timeout: 180m
 
 environment:
   SNAP/catkin_noetic_hello: catkin-noetic-hello
+  SNAP/catkin_noetic_subdir: catkin-noetic-subdir
   SNAP/catkin_tools_noetic_hello: catkin-tools-noetic-hello
+  SNAP/catkin_tools_noetic_subdir: catkin-tools-noetic-subdir
   SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
 systems:
@@ -25,7 +27,8 @@ restore: |
   snapcraft clean
   rm -f ./*.snap
 
-  git checkout src/snapcraft_hello/src/hello.cpp
+  [ -f src/snapcraft_hello/src/hello.cpp ] && git checkout src/snapcraft_hello/src/hello.cpp
+  [ -f subdir/src/snapcraft_hello/src/hello.cpp ] && git checkout subdir/src/snapcraft_hello/src/hello.cpp
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
@@ -46,7 +49,14 @@ execute: |
   [ "$($SNAP)" = "hello world" ]
 
   # Make sure that what we built runs with the changes applied.
-  modified_file=src/snapcraft_hello/src/hello.cpp
+  if [ -f src/snapcraft_hello/src/hello.cpp ]; then
+    modified_file=src/snapcraft_hello/src/hello.cpp
+  elif [ -f subdir/src/snapcraft_hello/src/hello.cpp ]; then
+    modified_file=subdir/src/snapcraft_hello/src/hello.cpp
+  else
+    FATAL "Cannot setup ${SNAP} for rebuilding"
+  fi
+
   sed -i "${modified_file}" -e 's/hello world/hello rebuilt world/'
 
   snapcraft

--- a/tests/spread/plugins/v2/snaps/catkin-noetic-subdir/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/catkin-noetic-subdir/snap/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: catkin-noetic-subdir
+version: "1.0"
+summary: hello world
+description: |
+  A ROS 1 roscpp-based workspace.
+
+grade: stable
+confinement: strict
+base: core20
+
+apps:
+  catkin-noetic-subdir:
+    command: opt/ros/noetic/lib/snapcraft_hello/snapcraft_hello
+    plugs: [network, network-bind]
+    extensions: [ros1-noetic]
+
+parts:
+  hello:
+    plugin: catkin
+    source: .
+    source-subdir: subdir
+    build-packages: [g++, make]

--- a/tests/spread/plugins/v2/snaps/catkin-noetic-subdir/subdir/src/snapcraft_hello/CMakeLists.txt
+++ b/tests/spread/plugins/v2/snaps/catkin-noetic-subdir/subdir/src/snapcraft_hello/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(snapcraft_hello)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+)
+
+catkin_package()
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(${PROJECT_NAME} src/hello.cpp)
+
+target_link_libraries(${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+)
+
+install(TARGETS ${PROJECT_NAME}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/tests/spread/plugins/v2/snaps/catkin-noetic-subdir/subdir/src/snapcraft_hello/package.xml
+++ b/tests/spread/plugins/v2/snaps/catkin-noetic-subdir/subdir/src/snapcraft_hello/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>snapcraft_hello</name>
+  <version>0.0.1</version>
+  <description>snapcraft test for roscpp</description>
+  <maintainer email="me@example.com">me</maintainer>
+  <license>GPLv3</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend condition="$ROS_VERSION == 1">roscpp</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">fake_package_that_does_not_exists</build_depend>
+  <build_export_depend condition="$ROS_VERSION == 1">roscpp</build_export_depend>
+  <exec_depend condition="$ROS_VERSION == 1">roscpp</exec_depend>
+</package>

--- a/tests/spread/plugins/v2/snaps/catkin-noetic-subdir/subdir/src/snapcraft_hello/src/hello.cpp
+++ b/tests/spread/plugins/v2/snaps/catkin-noetic-subdir/subdir/src/snapcraft_hello/src/hello.cpp
@@ -1,0 +1,24 @@
+// Copyright (C) 2022 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <iostream>
+#include <ros/ros.h>
+
+int main(int argc, char * argv[])
+{
+    ros::init(argc, argv, "snapcraft_hello");
+    std::cout << "hello world" << std::endl;
+    ros::shutdown();
+    return 0;
+}

--- a/tests/spread/plugins/v2/snaps/catkin-tools-noetic-subdir/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/catkin-tools-noetic-subdir/snap/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: catkin-tools-noetic-subdir
+version: "1.0"
+summary: hello world
+description: |
+  A ROS 1 roscpp-based workspace.
+
+grade: stable
+confinement: strict
+base: core20
+
+apps:
+  catkin-tools-noetic-subdir:
+    command: opt/ros/noetic/lib/snapcraft_hello/snapcraft_hello
+    plugs: [network, network-bind]
+    extensions: [ros1-noetic]
+
+parts:
+  hello:
+    plugin: catkin-tools
+    source: .
+    build-packages: [g++, make]

--- a/tests/spread/plugins/v2/snaps/catkin-tools-noetic-subdir/subdir/src/snapcraft_hello/CMakeLists.txt
+++ b/tests/spread/plugins/v2/snaps/catkin-tools-noetic-subdir/subdir/src/snapcraft_hello/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(snapcraft_hello)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+)
+
+catkin_package()
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(${PROJECT_NAME} src/hello.cpp)
+
+target_link_libraries(${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+)
+
+install(TARGETS ${PROJECT_NAME}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/tests/spread/plugins/v2/snaps/catkin-tools-noetic-subdir/subdir/src/snapcraft_hello/package.xml
+++ b/tests/spread/plugins/v2/snaps/catkin-tools-noetic-subdir/subdir/src/snapcraft_hello/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>snapcraft_hello</name>
+  <version>0.0.1</version>
+  <description>snapcraft test for roscpp</description>
+  <maintainer email="me@example.com">me</maintainer>
+  <license>GPLv3</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend condition="$ROS_VERSION == 1">roscpp</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">fake_package_that_does_not_exists</build_depend>
+  <build_export_depend condition="$ROS_VERSION == 1">roscpp</build_export_depend>
+  <exec_depend condition="$ROS_VERSION == 1">roscpp</exec_depend>
+</package>

--- a/tests/spread/plugins/v2/snaps/catkin-tools-noetic-subdir/subdir/src/snapcraft_hello/src/hello.cpp
+++ b/tests/spread/plugins/v2/snaps/catkin-tools-noetic-subdir/subdir/src/snapcraft_hello/src/hello.cpp
@@ -1,0 +1,24 @@
+// Copyright (C) 2022 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <iostream>
+#include <ros/ros.h>
+
+int main(int argc, char * argv[])
+{
+    ros::init(argc, argv, "snapcraft_hello");
+    std::cout << "hello world" << std::endl;
+    ros::shutdown();
+    return 0;
+}

--- a/tests/spread/plugins/v2/snaps/colcon-subdir/colcon-ros2-foxy-rlcpp-hello/CMakeLists.txt
+++ b/tests/spread/plugins/v2/snaps/colcon-subdir/colcon-ros2-foxy-rlcpp-hello/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.5)
+project(colcon_ros2_rlcpp_hello)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(std_msgs REQUIRED)
+
+# This package installs libraries without exporting them.
+# Export the library path to ensure that the installed libraries are available.
+if(NOT WIN32)
+  ament_environment_hooks(
+    "${ament_cmake_package_templates_ENVIRONMENT_HOOK_LIBRARY_PATH}"
+    )
+endif()
+
+add_executable(colcon_ros2_rlcpp_hello hello.cpp)
+target_link_libraries(colcon_ros2_rlcpp_hello)
+ament_target_dependencies(colcon_ros2_rlcpp_hello rclcpp class_loader)
+
+install(TARGETS
+  colcon_ros2_rlcpp_hello
+  DESTINATION lib/${PROJECT_NAME})
+
+ament_package()

--- a/tests/spread/plugins/v2/snaps/colcon-subdir/colcon-ros2-foxy-rlcpp-hello/hello.cpp
+++ b/tests/spread/plugins/v2/snaps/colcon-subdir/colcon-ros2-foxy-rlcpp-hello/hello.cpp
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <memory>
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::executors::SingleThreadedExecutor exec;
+  rclcpp::NodeOptions options;
+
+  printf("hello world");
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/tests/spread/plugins/v2/snaps/colcon-subdir/colcon-ros2-foxy-rlcpp-hello/package.xml
+++ b/tests/spread/plugins/v2/snaps/colcon-subdir/colcon-ros2-foxy-rlcpp-hello/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>colcon_ros2_rlcpp_hello</name>
+  <version>0.0.1</version>
+  <description>snapcraft test for rlcpp</description>
+  <maintainer email="me@example.com">me</maintainer>
+  <license>GPLv3</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend condition="$ROS_VERSION == 2">rclcpp</build_depend>
+  <build_depend>rclcpp_components</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">fake_package_that_does_not_exists</build_depend>
+
+  <exec_depend condition="$ROS_VERSION == 2">rclcpp</exec_depend>
+  <exec_depend>rclcpp_components</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/tests/spread/plugins/v2/snaps/colcon-subdir/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v2/snaps/colcon-subdir/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: colcon-subdir
+version: "1.0"
+summary: hello world
+description: |
+  A ROS2 rlcpp-based workspace.
+
+grade: stable
+confinement: strict
+base: core20
+
+apps:
+  colcon-subdir:
+    command: opt/ros/foxy/bin/ros2 run colcon_ros2_rlcpp_hello colcon_ros2_rlcpp_hello
+    plugs: [network, network-bind]
+    extensions: [ros2-foxy]
+
+parts:
+  hello:
+    plugin: colcon
+    source: .
+    source-subdir: colcon-ros2-foxy-rlcpp-hello
+    build-packages: [g++, make]
+    stage-packages: [ros-foxy-ros2run]

--- a/tests/spread/plugins/v2/snaps/colcon-subdir/this-package-should-not-be-compiled/CMakeLists.txt
+++ b/tests/spread/plugins/v2/snaps/colcon-subdir/this-package-should-not-be-compiled/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.5)
+project(this_package_should_not_be_compiled)
+
+find_package(ament_cmake REQUIRED)
+find_package(this_dependency_does_not_exist REQUIRED)
+
+add_executable(NonCompiledTarget this-file-does-not-exist.cpp)
+
+install(TARGETS
+  NonCompiledTarget
+  DESTINATION lib/${PROJECT_NAME})
+
+ament_package()

--- a/tests/spread/plugins/v2/snaps/colcon-subdir/this-package-should-not-be-compiled/package.xml
+++ b/tests/spread/plugins/v2/snaps/colcon-subdir/this-package-should-not-be-compiled/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>this_package_should_not_be_compiled</name>
+  <version>0.0.1</version>
+  <description>this package should not be compiled</description>
+  <maintainer email="me@example.com">me</maintainer>
+  <license>GPLv3</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>this_dependency_does_not_exist</build_depend>
+
+  <exec_depend>this_dependency_does_not_exist</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/tests/unit/plugins/v2/test_catkin.py
+++ b/tests/unit/plugins/v2/test_catkin.py
@@ -98,14 +98,14 @@ def test_get_build_commands(monkeypatch):
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
-        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC}"',
+        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         "catkin_make_isolated --install --merge "
-        '--source-space "${SNAPCRAFT_PART_SRC}" --build-space "${SNAPCRAFT_PART_BUILD}" '
+        '--source-space "${SNAPCRAFT_PART_SRC_WORK}" --build-space "${SNAPCRAFT_PART_BUILD}" '
         '--install-space "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" '
         '-j "${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
         "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 /test/python3 -I "
         "/test/_ros.py "
-        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
+        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC_WORK}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
         '--ros-version "${ROS_VERSION}" --ros-distro "${ROS_DISTRO}" --target-arch "${SNAPCRAFT_TARGET_ARCH}"',
     ]
 
@@ -151,9 +151,9 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
-        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC}"',
+        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         "catkin_make_isolated --install --merge "
-        '--source-space "${SNAPCRAFT_PART_SRC}" --build-space "${SNAPCRAFT_PART_BUILD}" '
+        '--source-space "${SNAPCRAFT_PART_SRC_WORK}" --build-space "${SNAPCRAFT_PART_BUILD}" '
         '--install-space "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" '
         '-j "${SNAPCRAFT_PARALLEL_BUILD_COUNT}" --pkg package1 package2... '
         "--ignore-pkg ipackage1 ipackage2... --cmake-args cmake args...",
@@ -162,6 +162,6 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "http_proxy=http://foo https_proxy=https://bar "
         "/test/python3 -I "
         "/test/_ros.py "
-        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
+        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC_WORK}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
         '--ros-version "${ROS_VERSION}" --ros-distro "${ROS_DISTRO}" --target-arch "${SNAPCRAFT_TARGET_ARCH}"',
     ]

--- a/tests/unit/plugins/v2/test_catkin_tools.py
+++ b/tests/unit/plugins/v2/test_catkin_tools.py
@@ -49,7 +49,6 @@ def test_get_build_packages():
     assert plugin.get_build_packages() == {
         "python3-rosdep",
         "python3-catkin-tools",
-        "python3-osrf-pycommon",
     }
 
 
@@ -94,16 +93,16 @@ def test_get_build_commands(monkeypatch):
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
-        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC}"',
+        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         "catkin init",
         "catkin profile add -f default",
         "catkin config --profile default --install "
-        '--source-space "${SNAPCRAFT_PART_SRC}" --build-space "${SNAPCRAFT_PART_BUILD}" '
+        '--source-space "${SNAPCRAFT_PART_SRC_WORK}" --build-space "${SNAPCRAFT_PART_BUILD}" '
         '--install-space "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}"',
         'catkin build --no-notify --profile default -j "${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
         "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 /test/python3 -I "
         "/test/_ros.py "
-        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
+        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC_WORK}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
         '--ros-version "${ROS_VERSION}" --ros-distro "${ROS_DISTRO}" --target-arch "${SNAPCRAFT_TARGET_ARCH}"',
     ]
 
@@ -148,11 +147,11 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
-        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC}"',
+        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         "catkin init",
         "catkin profile add -f default",
         "catkin config --profile default --install "
-        '--source-space "${SNAPCRAFT_PART_SRC}" --build-space "${SNAPCRAFT_PART_BUILD}" '
+        '--source-space "${SNAPCRAFT_PART_SRC_WORK}" --build-space "${SNAPCRAFT_PART_BUILD}" '
         '--install-space "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" --cmake-args cmake args...',
         'catkin build --no-notify --profile default -j "${SNAPCRAFT_PARALLEL_BUILD_COUNT}" package1 package2...',
         "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/bin:/test SNAP=TESTSNAP "
@@ -160,6 +159,6 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "http_proxy=http://foo https_proxy=https://bar "
         "/test/python3 -I "
         "/test/_ros.py "
-        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
+        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC_WORK}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
         '--ros-version "${ROS_VERSION}" --ros-distro "${ROS_DISTRO}" --target-arch "${SNAPCRAFT_TARGET_ARCH}"',
     ]

--- a/tests/unit/plugins/v2/test_colcon.py
+++ b/tests/unit/plugins/v2/test_colcon.py
@@ -115,9 +115,9 @@ def test_get_build_commands(monkeypatch):
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
-        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC}"',
+        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         "colcon build "
-        '--base-paths "${SNAPCRAFT_PART_SRC}" --build-base "${SNAPCRAFT_PART_BUILD}" '
+        '--base-paths "${SNAPCRAFT_PART_SRC_WORK}" --build-base "${SNAPCRAFT_PART_BUILD}" '
         '--merge-install --install-base "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap '
         '--parallel-workers "${SNAPCRAFT_PARALLEL_BUILD_COUNT}"',
         'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE ]; then',
@@ -125,7 +125,7 @@ def test_get_build_commands(monkeypatch):
         "fi",
         "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 /test/python3 -I "
         "/test/_ros.py "
-        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
+        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC_WORK}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
         '--ros-version "${ROS_VERSION}" --ros-distro "${ROS_DISTRO}" --target-arch "${SNAPCRAFT_TARGET_ARCH}"',
     ]
 
@@ -169,9 +169,9 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
-        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC}"',
+        'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         "colcon build "
-        '--base-paths "${SNAPCRAFT_PART_SRC}" --build-base "${SNAPCRAFT_PART_BUILD}" '
+        '--base-paths "${SNAPCRAFT_PART_SRC_WORK}" --build-base "${SNAPCRAFT_PART_BUILD}" '
         '--merge-install --install-base "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap '
         "--packages-ignore ipackage1 ipackage2... --packages-select package1 "
         "package2... --cmake-args cmake args... "
@@ -184,6 +184,6 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "SNAP_ARCH=TESTARCH SNAP_NAME=TESTSNAPNAME SNAP_VERSION=TESTV1 "
         "http_proxy=http://foo https_proxy=https://bar "
         "/test/python3 -I /test/_ros.py "
-        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
+        'stage-runtime-dependencies --part-src "${SNAPCRAFT_PART_SRC_WORK}" --part-install "${SNAPCRAFT_PART_INSTALL}" '
         '--ros-version "${ROS_VERSION}" --ros-distro "${ROS_DISTRO}" --target-arch "${SNAPCRAFT_TARGET_ARCH}"',
     ]


### PR DESCRIPTION
Update comment

Remove useless dependency in catkin_tools.
Now python3-osrf-pycommon is an explicit dependency of
python3-catkin-tools
see:
http://packages.ros.org/ros/ubuntu/dists/focal/main/binary-amd64/Packages

Use source-subdir for rosdeps dependencies pull

Use source-subdir for ROS plugins v2

Adapt test to match new ROS tools v2 source-subdir use

Add test for Colcon V2 subdir usage

Add tests for catkin/catkin-tools V2 subdir usage

- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `./runtests.sh static`?
- [X] Have you successfully run `./runtests.sh tests/unit`?

-----
