### PR TITLE
gradle v1 plugin: add support for JDK 17

### DIFF
--- a/snapcraft/plugins/v1/gradle.py
+++ b/snapcraft/plugins/v1/gradle.py
@@ -49,8 +49,8 @@ Additionally, this plugin uses the following plugin-specific keywords:
 
     - gradle-openjdk-version:
       (string)
-      openjdk version available to the base to use. If not set the latest
-      version available to the base will be used.
+      openjdk version available to the base to use. If not set, version 11
+      will be used.
 """
 
 import logging
@@ -149,11 +149,11 @@ class GradlePlugin(PluginV1):
         self._setup_base_tools(project._get_build_base())
 
     def _setup_base_tools(self, base):
-        valid_versions = ["8", "11"]
+        valid_versions = ["8", "11", "17"]
 
         version = self.options.gradle_openjdk_version
         if not version:
-            version = valid_versions[-1]
+            version = "11"
         elif version not in valid_versions:
             raise UnsupportedJDKVersionError(
                 version=version, base=base, valid_versions=valid_versions


### PR DESCRIPTION
Allow users to choose JDK 17.

JDK 17 is available in bionic:
https://packages.ubuntu.com/search?suite=bionic&searchon=names&keywords=openjdk-17-jdk
Not having this feature causes my snap to both have JRE 11 *and* 17:
https://github.com/EduMIPS64/edumips64/issues/657

In an attempt to not inadvertently have lots of snaps build with JDK 17,
also change the default JDK to be 11, changing the default stated
behavior from auto-picking the last JDK available in the base (which was
not happening anyway) to auto-picking version 11.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
