### PR TITLE
extensions: support core22

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ exclude =
     prime
 
 [mypy]
-python_version = 3.6
+python_version = 3.8
 ignore_missing_imports = True
 follow_imports = silent
 

--- a/snapcraft/errors.py
+++ b/snapcraft/errors.py
@@ -38,5 +38,9 @@ class ProjectValidationError(SnapcraftError):
     """Error validatiing snapcraft.yaml."""
 
 
+class ExtensionError(SnapcraftError):
+    """Error during parts processing."""
+
+
 class LegacyFallback(Exception):
     """Fall back to legacy snapcraft implementation."""

--- a/snapcraft/extensions/__init__.py
+++ b/snapcraft/extensions/__init__.py
@@ -1,0 +1,30 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Extension processor and related utilities."""
+
+from ._extension import Extension
+from ._utils import apply_extensions
+from .registry import get_extension_class, get_extension_names, register, unregister
+
+__all__ = [
+    "Extension",
+    "get_extension_class",
+    "get_extension_names",
+    "apply_extensions",
+    "register",
+    "unregister",
+]

--- a/snapcraft/extensions/_extension.py
+++ b/snapcraft/extensions/_extension.py
@@ -1,0 +1,120 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2018-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import abc
+import os
+from typing import Any, Dict, Optional, Tuple, final
+
+from craft_cli import emit
+
+from snapcraft import errors
+
+
+class Extension(abc.ABC):
+    """Extension is the class from which all extensions inherit.
+
+    Extensions have the ability to add snippets to apps, parts, and indeed add new parts
+    to a given snapcraft.yaml.
+
+    :param yaml_data: Loaded snapcraft.yaml data.
+    :param arch: the host architecture.
+    :param target_arch: the target architecture.
+    """
+
+    def __init__(
+        self, *, yaml_data: Dict[str, Any], arch: str, target_arch: str
+    ) -> None:
+        """Create a new Extension."""
+        self.yaml_data = yaml_data
+        self.arch = arch
+        self.target_arch = target_arch
+
+    @staticmethod
+    @abc.abstractmethod
+    def get_supported_bases() -> Tuple[str, ...]:
+        """Return a tuple of supported bases."""
+
+    @staticmethod
+    @abc.abstractmethod
+    def get_supported_confinement() -> Tuple[str, ...]:
+        """Return a tuple of supported confinement settings."""
+
+    @staticmethod
+    @abc.abstractmethod
+    def is_experimental(base: Optional[str]) -> bool:
+        """Return whether or not this extension is unstable for given base."""
+
+    @abc.abstractmethod
+    def get_root_snippet(self) -> Dict[str, Any]:
+        """Return the root snippet to apply."""
+
+    @abc.abstractmethod
+    def get_app_snippet(self) -> Dict[str, Any]:
+        """Return the app snippet to apply."""
+
+    @abc.abstractmethod
+    def get_part_snippet(self) -> Dict[str, Any]:
+        """Return the part snippet to apply to existing parts."""
+
+    @abc.abstractmethod
+    def get_parts_snippet(self) -> Dict[str, Any]:
+        """Return the parts to add to parts."""
+
+    @final
+    def validate(self, extension_name: str):
+        """Validate that the extension can be used with the current project.
+
+        :param extension_name: the name of the extension being parsed.
+        :raises errors.ExtensionError: if the extension is incompatible with the project.
+        """
+        base: str = self.yaml_data["base"]
+        confinement: Optional[str] = self.yaml_data.get("confinement")
+
+        if self.is_experimental(base) and not os.getenv(
+            "SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS"
+        ):
+            raise errors.ExtensionError(
+                f"Extension is experimental: {extension_name!r}",
+                docs_url="https://snapcraft.io/docs/supported-extensions",
+            )
+        elif self.is_experimental(base):
+            emit.message(
+                f"*EXPERIMENTAL* extension {extension_name!r} enabled",
+                intermediate=True,
+            )
+
+        if base not in self.get_supported_bases():
+            raise errors.ExtensionError(
+                f"Extension {extension_name!r} does not support base: {base!r}"
+            )
+
+        if (
+            confinement is not None
+            and confinement not in self.get_supported_confinement()
+        ):
+            raise errors.ExtensionError(
+                f"Extension {extension_name!r} does not support confinement {confinement!r}"
+            )
+
+        invalid_parts = [
+            p
+            for p in self.get_parts_snippet()
+            if not p.startswith(f"{extension_name}/")
+        ]
+        if invalid_parts:
+            raise ValueError(
+                f"Extension has invalid part names: {invalid_parts!r}. Format is <extension-name>/<part-name>"
+            )

--- a/snapcraft/extensions/_utils.py
+++ b/snapcraft/extensions/_utils.py
@@ -1,0 +1,136 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import collections
+import contextlib
+import copy
+from typing import Any, Dict, List, Set
+
+from ._extension import Extension
+from .registry import get_extension_class
+
+
+def apply_extensions(
+    yaml_data: Dict[str, Any], *, arch: str, target_arch: str
+) -> Dict[str, Any]:
+    """Apply all extensions.
+
+    :param dict yaml_data: Loaded, unprocessed snapcraft.yaml
+    :param arch: the host architecture.
+    :param target_arch: the target architecture.
+    :returns: Modified snapcraft.yaml data with extensions applied
+    """
+    # Don't modify the dict passed in
+    yaml_data = copy.deepcopy(yaml_data)
+
+    # Mapping of extension names to set of app names to which the extension needs to be
+    # applied.
+    declared_extensions: Dict[str, Set[str]] = collections.defaultdict(set)
+
+    for app_name, app_definition in yaml_data.get("apps", dict()).items():
+        extension_names = app_definition.get("extensions", [])
+
+        for extension_name in extension_names:
+            declared_extensions[extension_name].add(app_name)
+
+        # Now that we've saved the app -> extension relationship, remove the property
+        # from this app's declaration in the YAML.
+        with contextlib.suppress(KeyError):
+            del yaml_data["apps"][app_name]["extensions"]
+
+    # Process extensions in a consistent order
+    for extension_name in sorted(declared_extensions.keys()):
+        extension_class = get_extension_class(extension_name)
+        extension = extension_class(
+            yaml_data=copy.deepcopy(yaml_data), arch=arch, target_arch=target_arch
+        )
+        extension.validate(extension_name=extension_name)
+        _apply_extension(yaml_data, declared_extensions[extension_name], extension)
+
+    return yaml_data
+
+
+def _apply_extension(
+    yaml_data: Dict[str, Any],
+    app_names: Set[str],
+    extension: Extension,
+) -> None:
+    # Apply the root components of the extension (if any)
+    root_extension = extension.get_root_snippet()
+    for property_name, property_value in root_extension.items():
+        yaml_data[property_name] = _apply_extension_property(
+            yaml_data.get(property_name), property_value
+        )
+
+    # Apply the app-specific components of the extension (if any)
+    app_extension = extension.get_app_snippet()
+    for app_name in app_names:
+        app_definition = yaml_data["apps"][app_name]
+        for property_name, property_value in app_extension.items():
+            app_definition[property_name] = _apply_extension_property(
+                app_definition.get(property_name), property_value
+            )
+
+    # Next, apply the part-specific components
+    part_extension = extension.get_part_snippet()
+    parts = yaml_data["parts"]
+    for part_name, part_definition in parts.items():
+        for property_name, property_value in part_extension.items():
+            part_definition[property_name] = _apply_extension_property(
+                part_definition.get(property_name), property_value
+            )
+
+    # Finally, add any parts specified in the extension
+    for part_name, part_definition in extension.get_parts_snippet().items():
+        parts[part_name] = part_definition
+
+
+def _apply_extension_property(existing_property: Any, extension_property: Any) -> Any:
+    if existing_property:
+        # If the property is not scalar, merge them
+        if isinstance(existing_property, list) and isinstance(extension_property, list):
+            merged = extension_property + existing_property
+
+            # If the lists are just strings, remove duplicates.
+            if all(isinstance(item, str) for item in merged):
+                return _remove_list_duplicates(merged)
+
+            return merged
+
+        elif isinstance(existing_property, dict) and isinstance(
+            extension_property, dict
+        ):
+            for key, value in extension_property.items():
+                existing_property[key] = _apply_extension_property(
+                    existing_property.get(key), value
+                )
+            return existing_property
+        return existing_property
+
+    return extension_property
+
+
+def _remove_list_duplicates(seq: List[str]) -> List[str]:
+    """De-dupe string list maintaining ordering."""
+    seen: Set[str] = set()
+    deduped: List[str] = list()
+
+    for item in seq:
+        if item not in seen:
+            seen.add(item)
+            deduped.append(item)
+
+    return deduped

--- a/snapcraft/extensions/registry.py
+++ b/snapcraft/extensions/registry.py
@@ -1,0 +1,69 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2018-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Extension registry."""
+
+from typing import Dict, List, Type
+
+from snapcraft import errors
+
+from ._extension import Extension
+
+ExtensionType = Type[Extension]
+
+_EXTENSIONS: Dict[str, ExtensionType] = {}
+
+
+def get_extension_names() -> List[str]:
+    """Obtain a extension class given the name.
+
+    :param name: The extension name.
+    :return: The list of available extensions.
+    :raises ExtensionError: If the extension name is invalid.
+    """
+    return list(_EXTENSIONS.keys())
+
+
+def get_extension_class(extension_name: str) -> ExtensionType:
+    """Obtain a extension class given the name.
+
+    :param name: The extension name.
+    :return: The extension class.
+    :raises ExtensionError: If the extension name is invalid.
+    """
+    try:
+        return _EXTENSIONS[extension_name]
+    except KeyError as key_error:
+        raise errors.ExtensionError(
+            f"Extension {extension_name!r} does not exist"
+        ) from key_error
+
+
+def register(extension_name: str, extension_class: ExtensionType) -> None:
+    """Register extension.
+
+    :param extension_name: the name to register.
+    :param extension_class: the Extension implementation.
+    """
+    _EXTENSIONS[extension_name] = extension_class
+
+
+def unregister(extension_name: str) -> None:
+    """Unregister extension_name.
+
+    :raises KeyError: if extension_name is not registered.
+    """
+    del _EXTENSIONS[extension_name]

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -25,7 +25,7 @@ import yaml.error
 from craft_cli import emit
 from craft_parts import infos
 
-from snapcraft import errors, pack, providers, utils
+from snapcraft import errors, extensions, pack, providers, utils
 from snapcraft.meta import snap_yaml
 from snapcraft.parts import PartsLifecycle
 from snapcraft.projects import GrammarAwareProject, Project
@@ -82,11 +82,10 @@ def run(command_name: str, parsed_args: "argparse.Namespace") -> None:
     if parsed_args.provider:
         raise errors.SnapcraftError("Option --provider is not supported.")
 
-    # TODO: apply extensions
-    # yaml_data = apply_extensions(yaml_data)
-
     # TODO: support for target_arch
     arch = _get_arch()
+    yaml_data = extensions.apply_extensions(yaml_data, arch=arch, target_arch=arch)
+
     if "parts" in yaml_data:
         yaml_data["parts"] = grammar.process_parts(
             parts_yaml_data=yaml_data["parts"], arch=arch, target_arch=arch

--- a/tests/unit/extensions/__init__.py
+++ b/tests/unit/extensions/__init__.py
@@ -1,0 +1,15 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/unit/extensions/conftest.py
+++ b/tests/unit/extensions/conftest.py
@@ -1,0 +1,156 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from typing import Any, Dict, Optional, Tuple
+
+import pytest
+
+from snapcraft import extensions
+
+
+@pytest.fixture
+def fake_extension():
+    """Basic extension."""
+
+    class ExtensionImpl(extensions.Extension):
+        @staticmethod
+        def get_supported_bases() -> Tuple[str, ...]:
+            return ("core22",)
+
+        @staticmethod
+        def get_supported_confinement() -> Tuple[str, ...]:
+            return ("strict",)
+
+        @staticmethod
+        def is_experimental(base: Optional[str] = None) -> bool:
+            return False
+
+        def get_root_snippet(self) -> Dict[str, Any]:
+            return {"grade": "fake-grade"}
+
+        def get_app_snippet(self) -> Dict[str, Any]:
+            return {"plugs": ["fake-plug"]}
+
+        def get_part_snippet(self) -> Dict[str, Any]:
+            return {"after": ["fake-extension/fake-part"]}
+
+        def get_parts_snippet(self) -> Dict[str, Any]:
+            return {"fake-extension/fake-part": {"plugin": "nil"}}
+
+    extensions.register("fake-extension", ExtensionImpl)
+    yield ExtensionImpl
+    extensions.unregister("fake-extension")
+
+
+@pytest.fixture
+def fake_extension_extra():
+    """A variation of fake_extension with some conflicts and new code."""
+
+    class ExtensionImpl(extensions.Extension):
+        @staticmethod
+        def get_supported_bases() -> Tuple[str, ...]:
+            return ("core22",)
+
+        @staticmethod
+        def get_supported_confinement() -> Tuple[str, ...]:
+            return ("strict",)
+
+        @staticmethod
+        def is_experimental(base: Optional[str] = None) -> bool:
+            return False
+
+        def get_root_snippet(self) -> Dict[str, Any]:
+            return {}
+
+        def get_app_snippet(self) -> Dict[str, Any]:
+            return {"plugs": ["fake-plug", "fake-plug-extra"]}
+
+        def get_part_snippet(self) -> Dict[str, Any]:
+            return {"after": ["fake-extension-extra/fake-part"]}
+
+        def get_parts_snippet(self) -> Dict[str, Any]:
+            return {"fake-extension-extra/fake-part": {"plugin": "nil"}}
+
+    extensions.register("fake-extension-extra", ExtensionImpl)
+    yield ExtensionImpl
+    extensions.unregister("fake-extension-extra")
+
+
+@pytest.fixture
+def fake_extension_invalid_parts():
+    class ExtensionImpl(extensions.Extension):
+        @staticmethod
+        def get_supported_bases() -> Tuple[str, ...]:
+            return ("core22",)
+
+        @staticmethod
+        def get_supported_confinement() -> Tuple[str, ...]:
+            return ("strict",)
+
+        @staticmethod
+        def is_experimental(base: Optional[str] = None) -> bool:
+            return False
+
+        def get_root_snippet(self) -> Dict[str, Any]:
+            return {"grade": "fake-grade"}
+
+        def get_app_snippet(self) -> Dict[str, Any]:
+            return {"plugs": ["fake-plug"]}
+
+        def get_part_snippet(self) -> Dict[str, Any]:
+            return {"after": ["fake-extension/fake-part"]}
+
+        def get_parts_snippet(self) -> Dict[str, Any]:
+            return {"fake-part": {"plugin": "nil"}, "fake-part-2": {"plugin": "nil"}}
+
+    extensions.register("fake-extension-invalid-parts", ExtensionImpl)
+    yield ExtensionImpl
+    extensions.unregister("fake-extension-invalid-parts")
+
+
+@pytest.fixture
+def fake_extension_experimental():
+    """Basic extension."""
+
+    class ExtensionImpl(extensions.Extension):
+        @staticmethod
+        def get_supported_bases() -> Tuple[str, ...]:
+            return ("core22",)
+
+        @staticmethod
+        def get_supported_confinement() -> Tuple[str, ...]:
+            return ("strict",)
+
+        @staticmethod
+        def is_experimental(base: Optional[str] = None) -> bool:
+            return True
+
+        def get_root_snippet(self) -> Dict[str, Any]:
+            return {}
+
+        def get_app_snippet(self) -> Dict[str, Any]:
+            return {}
+
+        def get_part_snippet(self) -> Dict[str, Any]:
+            return {}
+
+        def get_parts_snippet(self) -> Dict[str, Any]:
+            return {}
+
+    extensions.register("fake-extension-experimental", ExtensionImpl)
+    yield ExtensionImpl
+    extensions.unregister("fake-extension-experimental")

--- a/tests/unit/extensions/test_extensions.py
+++ b/tests/unit/extensions/test_extensions.py
@@ -1,0 +1,224 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import pytest
+
+from snapcraft import errors, extensions
+
+
+@pytest.mark.usefixtures("fake_extension")
+def test_apply_extension():
+    yaml_data = {
+        "name": "fake-snap",
+        "summary": "fake summary",
+        "description": "fake description",
+        "base": "core22",
+        "apps": {
+            "fake-command": {
+                "command": "bin/fake-command",
+                "plugs": ["my-fake-plug"],
+                "extensions": ["fake-extension"],
+            }
+        },
+        "parts": {"fake-part": {"source": ".", "plugin": "dump"}},
+    }
+
+    assert extensions.apply_extensions(
+        yaml_data, arch="amd64", target_arch="amd64"
+    ) == {
+        "name": "fake-snap",
+        "summary": "fake summary",
+        "description": "fake description",
+        "base": "core22",
+        "grade": "fake-grade",
+        "apps": {
+            "fake-command": {
+                "command": "bin/fake-command",
+                "plugs": ["fake-plug", "my-fake-plug"],
+            }
+        },
+        "parts": {
+            "fake-part": {
+                "source": ".",
+                "plugin": "dump",
+                "after": ["fake-extension/fake-part"],
+            },
+            "fake-extension/fake-part": {"plugin": "nil"},
+        },
+    }
+
+
+@pytest.mark.usefixtures("fake_extension")
+@pytest.mark.usefixtures("fake_extension_extra")
+def test_apply_multiple_extensions():
+    yaml_data = {
+        "name": "fake-snap",
+        "summary": "fake summary",
+        "description": "fake description",
+        "base": "core22",
+        "apps": {
+            "fake-command": {
+                "command": "bin/fake-command",
+                "plugs": ["my-fake-plug"],
+                "extensions": ["fake-extension", "fake-extension-extra"],
+            }
+        },
+        "parts": {"fake-part": {"source": ".", "plugin": "dump"}},
+    }
+
+    assert extensions.apply_extensions(
+        yaml_data, arch="amd64", target_arch="amd64"
+    ) == {
+        "name": "fake-snap",
+        "summary": "fake summary",
+        "description": "fake description",
+        "base": "core22",
+        "grade": "fake-grade",
+        "apps": {
+            "fake-command": {
+                "command": "bin/fake-command",
+                "plugs": ["fake-plug", "fake-plug-extra", "my-fake-plug"],
+            }
+        },
+        "parts": {
+            "fake-part": {
+                "source": ".",
+                "plugin": "dump",
+                "after": ["fake-extension-extra/fake-part", "fake-extension/fake-part"],
+            },
+            "fake-extension/fake-part": {
+                "plugin": "nil",
+                "after": ["fake-extension-extra/fake-part"],
+            },
+            "fake-extension-extra/fake-part": {"plugin": "nil"},
+        },
+    }
+
+
+@pytest.mark.usefixtures("fake_extension")
+def test_apply_extension_wrong_base():
+    yaml_data = {
+        "base": "core20",
+        "apps": {
+            "fake-command": {
+                "command": "bin/fake-command",
+                "extensions": ["fake-extension"],
+            }
+        },
+    }
+
+    with pytest.raises(errors.ExtensionError) as raised:
+        extensions.apply_extensions(yaml_data, arch="amd64", target_arch="amd64")
+
+    assert (
+        str(raised.value)
+        == "Extension 'fake-extension' does not support base: 'core20'"
+    )
+
+
+@pytest.mark.usefixtures("fake_extension")
+def test_apply_extension_wrong_confinement():
+    yaml_data = {
+        "base": "core22",
+        "confinement": "classic",
+        "apps": {
+            "fake-command": {
+                "command": "bin/fake-command",
+                "extensions": ["fake-extension"],
+            }
+        },
+    }
+
+    with pytest.raises(errors.ExtensionError) as raised:
+        extensions.apply_extensions(yaml_data, arch="amd64", target_arch="amd64")
+
+    assert (
+        str(raised.value)
+        == "Extension 'fake-extension' does not support confinement 'classic'"
+    )
+
+
+@pytest.mark.usefixtures("fake_extension_invalid_parts")
+def test_apply_extension_invalid_parts():
+    # This is a Snapcraft developer error.
+    yaml_data = {
+        "base": "core22",
+        "apps": {
+            "fake-command": {
+                "command": "bin/fake-command",
+                "extensions": ["fake-extension-invalid-parts"],
+            }
+        },
+    }
+
+    with pytest.raises(ValueError) as raised:
+        extensions.apply_extensions(yaml_data, arch="amd64", target_arch="amd64")
+
+    assert (
+        str(raised.value)
+        == "Extension has invalid part names: ['fake-part', 'fake-part-2']. Format is <extension-name>/<part-name>"
+    )
+
+
+@pytest.mark.usefixtures("fake_extension_experimental")
+def test_apply_extension_experimental():
+    yaml_data = {
+        "base": "core22",
+        "apps": {
+            "fake-command": {
+                "command": "bin/fake-command",
+                "extensions": ["fake-extension-experimental"],
+            }
+        },
+    }
+
+    with pytest.raises(errors.ExtensionError) as raised:
+        extensions.apply_extensions(yaml_data, arch="amd64", target_arch="amd64")
+
+    assert (
+        str(raised.value) == "Extension is experimental: 'fake-extension-experimental'"
+    )
+    assert raised.value.docs_url == "https://snapcraft.io/docs/supported-extensions"
+
+
+@pytest.mark.usefixtures("fake_extension_experimental")
+def test_apply_extension_experimental_with_environment(emitter, monkeypatch):
+    monkeypatch.setenv("SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS", "1")
+
+    yaml_data = {
+        "base": "core22",
+        "apps": {
+            "fake-command": {
+                "command": "bin/fake-command",
+                "extensions": ["fake-extension-experimental"],
+            }
+        },
+        "parts": {
+            "fake-part": {
+                "source": ".",
+                "plugin": "dump",
+                "after": ["fake-extension-extra/fake-part", "fake-extension/fake-part"],
+            },
+        },
+    }
+
+    # Should not raise.
+    extensions.apply_extensions(yaml_data, arch="amd64", target_arch="amd64")
+
+    emitter.assert_recorded(
+        ["*EXPERIMENTAL* extension 'fake-extension-experimental' enabled"]
+    )

--- a/tests/unit/extensions/test_registry.py
+++ b/tests/unit/extensions/test_registry.py
@@ -1,0 +1,42 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from snapcraft import errors, extensions
+
+
+@pytest.mark.usefixtures("fake_extension")
+@pytest.mark.usefixtures("fake_extension_extra")
+@pytest.mark.usefixtures("fake_extension_experimental")
+def test_get_extension_names():
+    assert extensions.get_extension_names() == [
+        "fake-extension-experimental",
+        "fake-extension-extra",
+        "fake-extension",
+    ]
+
+
+def test_get_extension_class(fake_extension):
+    assert extensions.get_extension_class("fake-extension") == fake_extension
+
+
+def test_get_extesion_class_not_found():
+    # This is a developer error.
+    with pytest.raises(errors.ExtensionError) as raised:
+        extensions.get_extension_class("fake-extension-not-found")
+
+    assert str(raised.value) == "Extension 'fake-extension-not-found' does not exist"

--- a/tests/unit/extensions/test_utils.py
+++ b/tests/unit/extensions/test_utils.py
@@ -1,0 +1,82 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import pytest
+
+from snapcraft.extensions._utils import _apply_extension_property
+
+
+@pytest.mark.parametrize(
+    "existing_property,extension_property,expected_value",
+    [
+        # prepend
+        (
+            ["item3", "item4", "item5"],
+            ["item1", "item2"],
+            ["item1", "item2", "item3", "item4", "item5"],
+        ),
+        # empty extension
+        (["item3", "item4", "item5"], [], ["item3", "item4", "item5"]),
+        # empty property
+        ([], ["item1", "item2"], ["item1", "item2"]),
+        # duplicate items keeps first found
+        (
+            ["item3", "item4", "item1"],
+            ["item1", "item2"],
+            ["item1", "item2", "item3", "item4"],
+        ),
+        # non scalar
+        (
+            [{"k2": "v2"}],
+            [{"k1": "v1"}],
+            [{"k1": "v1"}, {"k2": "v2"}],
+        ),
+    ],
+)
+def test_apply_property_list(existing_property, extension_property, expected_value):
+    assert (
+        _apply_extension_property(existing_property, extension_property)
+        == expected_value
+    )
+
+
+@pytest.mark.parametrize(
+    "existing_property,extension_property,expected_value",
+    [
+        # add
+        (
+            {"k1": "v1", "k2": "v2", "k3": "v3"},
+            {"k4": "v4", "k5": "v5"},
+            {"k1": "v1", "k2": "v2", "k3": "v3", "k4": "v4", "k5": "v5"},
+        ),
+        # conflicts keeps existing property
+        (
+            {"k1": "v1", "k2": "v2", "k3": "v3"},
+            {"k3": "nv3", "k4": "v4"},
+            {"k1": "v1", "k2": "v2", "k3": "v3", "k4": "v4"},
+        ),
+        # empty property
+        ({}, {"k4": "v4", "k5": "v5"}, {"k4": "v4", "k5": "v5"}),
+    ],
+)
+def test_apply_property_dictionary(
+    existing_property, extension_property, expected_value
+):
+    assert (
+        _apply_extension_property(existing_property, extension_property)
+        == expected_value
+    )


### PR DESCRIPTION
This adds some variations to the API and changes where things are
processed when compared to the original implementation.

For integration it is rather hard to test until there is an extension
implementation to test with, so the current code only makes sure that
use of apply_extensions does not break the current implementation.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
CRAFT-861