### PR TITLE
parts: raise error when duplicate keys are used

### DIFF
--- a/snapcraft/parts/yaml_utils.py
+++ b/snapcraft/parts/yaml_utils.py
@@ -1,0 +1,82 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""YAML utilities for Snapcraft."""
+
+from typing import Any, Dict, TextIO
+
+import yaml
+import yaml.error
+
+from snapcraft import errors
+
+
+def _check_duplicate_keys(node):
+    mappings = set()
+
+    for key_node, _ in node.value:
+        try:
+            if key_node.value in mappings:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    f"found duplicate key {key_node.value!r}",
+                    node.start_mark,
+                )
+            mappings.add(key_node.value)
+        except TypeError:
+            # Ignore errors for malformed inputs that will be caught later.
+            pass
+
+
+def _dict_constructor(loader, node):
+    _check_duplicate_keys(node)
+
+    # Necessary in order to make yaml merge tags work
+    loader.flatten_mapping(node)
+    value = loader.construct_pairs(node)
+
+    try:
+        return dict(value)
+    except TypeError as type_error:
+        raise yaml.constructor.ConstructorError(
+            "while constructing a mapping",
+            node.start_mark,
+            "found unhashable key",
+            node.start_mark,
+        ) from type_error
+
+
+class _SafeLoader(yaml.SafeLoader):  # pylint: disable=too-many-ancestors
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.add_constructor(
+            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _dict_constructor
+        )
+
+
+def load(filestream: TextIO) -> Dict[str, Any]:
+    """Load and parse a YAML-formatted file.
+
+    :param filename: The YAML file to load.
+
+    :raises SnapcraftError: if loading didn't succeed.
+    """
+    try:
+        return yaml.load(filestream, Loader=_SafeLoader)
+    except yaml.error.YAMLError as err:
+        raise errors.SnapcraftError(f"YAML parsing error: {err!s}") from err

--- a/tests/unit/parts/test_yaml_utils.py
+++ b/tests/unit/parts/test_yaml_utils.py
@@ -1,0 +1,89 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import io
+from textwrap import dedent
+
+import pytest
+
+from snapcraft import errors
+from snapcraft.parts import yaml_utils
+
+
+def test_yaml_load():
+    assert (
+        yaml_utils.load(
+            io.StringIO(
+                dedent(
+                    """\
+        entry:
+            sub-entry:
+              - list1
+              - list2
+        scalar: scalar-value
+    """
+                )
+            )
+        )
+        == {
+            "entry": {
+                "sub-entry": ["list1", "list2"],
+            },
+            "scalar": "scalar-value",
+        }
+    )
+
+
+def test_yaml_load_duplicates_errors():
+    with pytest.raises(errors.SnapcraftError) as raised:
+        yaml_utils.load(
+            io.StringIO(
+                dedent(
+                    """\
+            entry: value1
+            entry: value2
+    """
+                )
+            )
+        )
+
+    assert str(raised.value) == dedent(
+        """\
+        YAML parsing error: while constructing a mapping
+        found duplicate key 'entry'
+          in "<file>", line 1, column 1"""
+    )
+
+
+def test_yaml_load_unhashable_errors():
+    with pytest.raises(errors.SnapcraftError) as raised:
+        yaml_utils.load(
+            io.StringIO(
+                dedent(
+                    """\
+            entry: {{value}}
+    """
+                )
+            )
+        )
+
+    assert str(raised.value) == dedent(
+        """\
+        YAML parsing error: while constructing a mapping
+        found unhashable key
+          in "<file>", line 1, column 8"""
+    )


### PR DESCRIPTION
- Move yaml loading to a new module in the part package: yaml_utils
- Forward port the safe loading implementation from legacy

LP: #1942217

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
CRAFT-829