### PR TITLE
spread: fix python-hello

### DIFF
--- a/tests/spread/plugins/v2/snaps/python-hello-multiple-parts-staged/setup.py
+++ b/tests/spread/plugins/v2/snaps/python-hello-multiple-parts-staged/setup.py
@@ -7,4 +7,5 @@ setuptools.setup(
     author_email="snapcraft@lists.snapcraft.io",
     description="A simple hello world in python",
     scripts=["hello"],
+    py_modules=["hello"],
 )

--- a/tests/spread/plugins/v2/snaps/python-hello-multiple-parts/setup.py
+++ b/tests/spread/plugins/v2/snaps/python-hello-multiple-parts/setup.py
@@ -7,4 +7,5 @@ setuptools.setup(
     author_email="snapcraft@lists.snapcraft.io",
     description="A simple hello world in python",
     scripts=["hello"],
+    py_modules=["hello"],
 )


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `./runtests.sh static`?
- [X] Have you successfully run `./runtests.sh tests/unit`?

-----

[`setuptools-61.1.0`](https://setuptools.pypa.io/en/latest/history.html#breaking-changes) broke two spread tests:
- `tests/spread/plugins/v2/build-and-run-hello:python_multiple_parts`
- `tests/spread/plugins/v2/build-and-run-hello:python_multiple_parts_staged`

The following error is produced:
```
Successfully installed pip-22.0.4 setuptools-61.0.0 wheel-0.37.1
+ '[' -f setup.py ']'
+ pip install -U .
Processing /root/parts/hello/build
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [14 lines of output]
      error: Multiple top-level packages discovered in a flat-layout: ['snap', 'empty'].

      To avoid accidental inclusion of unwanted files or directories,
      setuptools will not proceed with this build.

      If you are trying to create a single distribution with multiple packages
      on purpose, you should not rely on automatic discovery.
      Instead, consider the following options:

      1. set up custom discovery (`find` directive with `include` or `exclude`)
      2. use a `src-layout`
      3. explicitly set `py_modules` or `packages` with a list of names

      To find more information, look for "package discovery" on setuptools docs.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
Failed to build 'hello'.

Recommended resolution:
Check the build logs and ensure the part's configuration and sources are correct.
Run the same command again with --debug to shell into the environment if you wish to introspect this failure.
```

source: https://github.com/pypa/setuptools/pull/2894