### PR TITLE
parts: consider non core22 when loading yaml

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -79,10 +79,6 @@ def run(command_name: str, parsed_args: "argparse.Namespace") -> None:
     # validate project grammar
     GrammarAwareProject.validate_grammar(yaml_data)
 
-    # only execute the new codebase from core22 onwards
-    if yaml_data.get("base") != "core22":
-        raise errors.LegacyFallback("base is not core22")
-
     # argument --provider is only supported by legacy snapcraft
     if parsed_args.provider:
         raise errors.SnapcraftError("Option --provider is not supported.")

--- a/snapcraft/parts/yaml_utils.py
+++ b/snapcraft/parts/yaml_utils.py
@@ -84,9 +84,9 @@ def load(filestream: TextIO) -> Dict[str, Any]:
     except KeyError as key_error:
         raise errors.LegacyFallback("no base defined") from key_error
     except yaml.error.YAMLError as err:
-        raise errors.SnapcraftError(f"YAML parsing error: {err!s}") from err
+        raise errors.SnapcraftError(f"snapcraft.yaml parsing error: {err!s}") from err
     filestream.seek(0)
     try:
         return yaml.load(filestream, Loader=_SafeLoader)
     except yaml.error.YAMLError as err:
-        raise errors.SnapcraftError(f"YAML parsing error: {err!s}") from err
+        raise errors.SnapcraftError(f"snapcraft.yaml parsing error: {err!s}") from err

--- a/snapcraft/parts/yaml_utils.py
+++ b/snapcraft/parts/yaml_utils.py
@@ -75,7 +75,17 @@ def load(filestream: TextIO) -> Dict[str, Any]:
     :param filename: The YAML file to load.
 
     :raises SnapcraftError: if loading didn't succeed.
+    :raises LegacyFallback: if the project's base is not core22.
     """
+    try:
+        # TODO: support for build-base.
+        if yaml.safe_load(filestream)["base"] != "core22":
+            raise errors.LegacyFallback("base is not core22")
+    except KeyError as key_error:
+        raise errors.LegacyFallback("no base defined") from key_error
+    except yaml.error.YAMLError as err:
+        raise errors.SnapcraftError(f"YAML parsing error: {err!s}") from err
+    filestream.seek(0)
     try:
         return yaml.load(filestream, Loader=_SafeLoader)
     except yaml.error.YAMLError as err:

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -136,30 +136,6 @@ def test_snapcraft_yaml_load(new_dir, snapcraft_yaml, filename, mocker):
     ]
 
 
-def test_snapcraft_yaml_parse_error(new_dir, snapcraft_yaml, mocker):
-    """If snapcraft.yaml is not a valid yaml, raise an error."""
-    snapcraft_yaml(base="invalid: true")
-    run_command_mock = mocker.patch("snapcraft.parts.lifecycle._run_command")
-
-    with pytest.raises(errors.SnapcraftError) as raised:
-        parts_lifecycle.run("pull", argparse.Namespace(parts=["part1"]))
-
-    assert str(raised.value) == (
-        "YAML parsing error: mapping values are not allowed here\n"
-        '  in "snap/snapcraft.yaml", line 4, column 14'
-    )
-    assert run_command_mock.mock_calls == []
-
-
-def test_legacy_base_not_core22(new_dir, snapcraft_yaml):
-    """Only core22 is processed by the new code, use legacy otherwise."""
-    snapcraft_yaml(base="core20")
-    with pytest.raises(errors.LegacyFallback) as raised:
-        parts_lifecycle.run("pull", argparse.Namespace())
-
-    assert str(raised.value) == "base is not core22"
-
-
 @pytest.mark.parametrize("cmd", ["pull", "build", "stage", "prime", "pack"])
 def test_lifecycle_run_provider(cmd, snapcraft_yaml, new_dir, mocker):
     """Option --provider is not supported in core22."""

--- a/tests/unit/parts/test_yaml_utils.py
+++ b/tests/unit/parts/test_yaml_utils.py
@@ -66,7 +66,7 @@ def test_yaml_load_duplicates_errors():
 
     assert str(raised.value) == dedent(
         """\
-        YAML parsing error: while constructing a mapping
+        snapcraft.yaml parsing error: while constructing a mapping
         found duplicate key 'entry'
           in "<file>", line 1, column 1"""
     )
@@ -87,7 +87,7 @@ def test_yaml_load_unhashable_errors():
 
     assert str(raised.value) == dedent(
         """\
-        YAML parsing error: while constructing a mapping
+        snapcraft.yaml parsing error: while constructing a mapping
           in "<file>", line 2, column 8
         found unhashable key
           in "<file>", line 2, column 9"""

--- a/tests/unit/parts/test_yaml_utils.py
+++ b/tests/unit/parts/test_yaml_utils.py
@@ -30,6 +30,7 @@ def test_yaml_load():
             io.StringIO(
                 dedent(
                     """\
+        base: core22
         entry:
             sub-entry:
               - list1
@@ -40,6 +41,7 @@ def test_yaml_load():
             )
         )
         == {
+            "base": "core22",
             "entry": {
                 "sub-entry": ["list1", "list2"],
             },
@@ -54,6 +56,7 @@ def test_yaml_load_duplicates_errors():
             io.StringIO(
                 dedent(
                     """\
+            base: core22
             entry: value1
             entry: value2
     """
@@ -75,6 +78,7 @@ def test_yaml_load_unhashable_errors():
             io.StringIO(
                 dedent(
                     """\
+            base: core22
             entry: {{value}}
     """
                 )
@@ -84,6 +88,37 @@ def test_yaml_load_unhashable_errors():
     assert str(raised.value) == dedent(
         """\
         YAML parsing error: while constructing a mapping
+          in "<file>", line 2, column 8
         found unhashable key
-          in "<file>", line 1, column 8"""
+          in "<file>", line 2, column 9"""
     )
+
+
+def test_yaml_load_not_core22_base():
+    with pytest.raises(errors.LegacyFallback) as raised:
+        yaml_utils.load(
+            io.StringIO(
+                dedent(
+                    """\
+            base: core20
+    """
+                )
+            )
+        )
+
+    assert str(raised.value) == "base is not core22"
+
+
+def test_yaml_load_no_base():
+    with pytest.raises(errors.LegacyFallback) as raised:
+        yaml_utils.load(
+            io.StringIO(
+                dedent(
+                    """\
+            entry: foo
+    """
+                )
+            )
+        )
+
+    assert str(raised.value) == "no base defined"


### PR DESCRIPTION
The yaml loader is shared, the strategy is to load twice, once with the
plain safe loader to check for the base and raise if necessary, then
load again with Snapcraft's new custom _SafeLoader.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
