### PR TITLE
parts: fix long recursion when verifying dirty steps

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -6,13 +6,13 @@ certifi==2021.10.8
 cffi==1.15.0
 chardet==4.0.0
 charset-normalizer==2.0.12
-click==8.1.0
+click==8.1.2
 codespell==2.1.0
 coverage==6.3.2
-craft-cli==0.3.1
+craft-cli==0.4.0
 craft-grammar==1.1.1
-craft-parts==1.4.0
-craft-providers==1.1.0
+craft-parts==1.4.2
+craft-providers==1.1.1
 cryptography==3.4
 Deprecated==1.2.13
 dill==0.3.4
@@ -53,7 +53,7 @@ plaster-pastedeploy==0.7
 platformdirs==2.5.1
 pluggy==1.0.0
 progressbar==2.5
-protobuf==3.19.4
+protobuf==3.20.0
 psutil==5.9.0
 ptyprocess==0.7.0
 py==1.11.0
@@ -65,7 +65,7 @@ pydocstyle==6.1.1
 pyelftools==0.28
 pyflakes==2.1.1
 pyftpdlib==1.5.6
-pylint==2.13.3
+pylint==2.13.4
 pylint-fixme-info==1.0.3
 pylint-pytest==1.1.2
 pylxd==2.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@ certifi==2021.10.8
 cffi==1.15.0
 chardet==4.0.0
 charset-normalizer==2.0.12
-click==8.1.0
-craft-cli==0.3.1
+click==8.1.2
+craft-cli==0.4.0
 craft-grammar==1.1.1
-craft-parts==1.4.0
-craft-providers==1.1.0
+craft-parts==1.4.2
+craft-providers==1.1.1
 cryptography==3.4
 Deprecated==1.2.13
 distro==1.7.0
@@ -30,7 +30,7 @@ oauthlib==3.2.0
 overrides==6.1.0
 platformdirs==2.5.1
 progressbar==2.5
-protobuf==3.19.4
+protobuf==3.20.0
 psutil==5.9.0
 pycparser==2.21
 pydantic==1.9.0

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -120,7 +120,8 @@ class PartsLifecycle:
                 for action in actions:
                     message = _action_message(action)
                     emit.progress(f"Executing parts lifecycle: {message}")
-                    aex.execute(action)
+                    with emit.open_stream("Executing action") as stream:
+                        aex.execute(action, stdout=stream, stderr=stream)
 
             emit.message("Executed parts lifecycle", intermediate=True)
         except RuntimeError as err:


### PR DESCRIPTION
Update craft-parts to version 1.4.2 to fix long loops blocking the
sequencer in projects with many dependency-chained parts (such
as gnome-sdk). Fix verbosity levels in the managed containers
to display craft-parts debug messages. Pause the emitter during
execution and redirect output streams to improve output readability.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
CRAFT-975
