### PR TITLE
ROS plugins v2: Exclude packages in stage snap from fetched packages during staging 

### DIFF
--- a/snapcraft/internal/repo/_deb.py
+++ b/snapcraft/internal/repo/_deb.py
@@ -450,6 +450,7 @@ class Ubuntu(BaseRepo):
         base: str,
         stage_packages_path: pathlib.Path,
         target_arch: str,
+        filters: Set[str] = set(),
     ) -> List[str]:
         logger.debug(f"Requested stage-packages: {sorted(package_names)!r}")
 
@@ -459,6 +460,8 @@ class Ubuntu(BaseRepo):
         filtered_names = _get_filtered_stage_package_names(
             base=base, package_list=package_list
         )
+
+        filtered_names.update(filters)
 
         stage_packages_path.mkdir(exist_ok=True)
         with AptCache(

--- a/tests/unit/plugins/v2/test_catkin.py
+++ b/tests/unit/plugins/v2/test_catkin.py
@@ -53,7 +53,11 @@ def test_schema():
 def test_get_build_packages():
     plugin = catkin.CatkinPlugin(part_name="my-part", options=lambda: None)
 
-    assert plugin.get_build_packages() == {"python3-rosdep", "ros-noetic-catkin"}
+    assert plugin.get_build_packages() == {
+        "python3-rosdep",
+        "rospack-tools",
+        "ros-noetic-catkin",
+    }
 
 
 def test_get_build_environment():
@@ -98,6 +102,16 @@ def test_get_build_commands(monkeypatch):
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
+        'rospack list-names | xargs rosdep resolve --rosdistro "${ROS_DISTRO}" '
+        '| grep -v "#" > "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        'rosdep keys --rosdistro "${ROS_DISTRO}" --from-paths "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" --ignore-packages-from-source '
+        '| xargs rosdep resolve --rosdistro "${ROS_DISTRO}" | grep -v "#" >> "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/snap/setup.sh" ]; then',
+        'rosdep keys --rosdistro "${ROS_DISTRO}" --from-paths "${SNAPCRAFT_PART_INSTALL}/opt/ros/snap" --ignore-packages-from-source '
+        '| xargs rosdep resolve --rosdistro "${ROS_DISTRO}" | grep -v "#" >> "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        "fi",
+        "fi",
         'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         "catkin_make_isolated --install --merge "
         '--source-space "${SNAPCRAFT_PART_SRC_WORK}" --build-space "${SNAPCRAFT_PART_BUILD}" '
@@ -151,6 +165,16 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
+        'rospack list-names | xargs rosdep resolve --rosdistro "${ROS_DISTRO}" '
+        '| grep -v "#" > "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        'rosdep keys --rosdistro "${ROS_DISTRO}" --from-paths "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" --ignore-packages-from-source '
+        '| xargs rosdep resolve --rosdistro "${ROS_DISTRO}" | grep -v "#" >> "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/snap/setup.sh" ]; then',
+        'rosdep keys --rosdistro "${ROS_DISTRO}" --from-paths "${SNAPCRAFT_PART_INSTALL}/opt/ros/snap" --ignore-packages-from-source '
+        '| xargs rosdep resolve --rosdistro "${ROS_DISTRO}" | grep -v "#" >> "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        "fi",
+        "fi",
         'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         "catkin_make_isolated --install --merge "
         '--source-space "${SNAPCRAFT_PART_SRC_WORK}" --build-space "${SNAPCRAFT_PART_BUILD}" '

--- a/tests/unit/plugins/v2/test_catkin_tools.py
+++ b/tests/unit/plugins/v2/test_catkin_tools.py
@@ -48,6 +48,7 @@ def test_get_build_packages():
 
     assert plugin.get_build_packages() == {
         "python3-rosdep",
+        "rospack-tools",
         "python3-catkin-tools",
     }
 
@@ -93,6 +94,16 @@ def test_get_build_commands(monkeypatch):
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
+        'rospack list-names | xargs rosdep resolve --rosdistro "${ROS_DISTRO}" '
+        '| grep -v "#" > "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        'rosdep keys --rosdistro "${ROS_DISTRO}" --from-paths "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" --ignore-packages-from-source '
+        '| xargs rosdep resolve --rosdistro "${ROS_DISTRO}" | grep -v "#" >> "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/snap/setup.sh" ]; then',
+        'rosdep keys --rosdistro "${ROS_DISTRO}" --from-paths "${SNAPCRAFT_PART_INSTALL}/opt/ros/snap" --ignore-packages-from-source '
+        '| xargs rosdep resolve --rosdistro "${ROS_DISTRO}" | grep -v "#" >> "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        "fi",
+        "fi",
         'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         "catkin init",
         "catkin profile add -f default",
@@ -147,6 +158,16 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
+        'rospack list-names | xargs rosdep resolve --rosdistro "${ROS_DISTRO}" '
+        '| grep -v "#" > "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        'rosdep keys --rosdistro "${ROS_DISTRO}" --from-paths "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" --ignore-packages-from-source '
+        '| xargs rosdep resolve --rosdistro "${ROS_DISTRO}" | grep -v "#" >> "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/snap/setup.sh" ]; then',
+        'rosdep keys --rosdistro "${ROS_DISTRO}" --from-paths "${SNAPCRAFT_PART_INSTALL}/opt/ros/snap" --ignore-packages-from-source '
+        '| xargs rosdep resolve --rosdistro "${ROS_DISTRO}" | grep -v "#" >> "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        "fi",
+        "fi",
         'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         "catkin init",
         "catkin profile add -f default",

--- a/tests/unit/plugins/v2/test_colcon.py
+++ b/tests/unit/plugins/v2/test_colcon.py
@@ -68,6 +68,7 @@ def test_get_build_packages():
     assert plugin.get_build_packages() == {
         "python3-colcon-common-extensions",
         "python3-rosdep",
+        "rospack-tools",
         "python3-rosinstall",
         "python3-wstool",
     }
@@ -115,6 +116,16 @@ def test_get_build_commands(monkeypatch):
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
+        'rospack list-names | xargs rosdep resolve --rosdistro "${ROS_DISTRO}" '
+        '| grep -v "#" > "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        'rosdep keys --rosdistro "${ROS_DISTRO}" --from-paths "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" --ignore-packages-from-source '
+        '| xargs rosdep resolve --rosdistro "${ROS_DISTRO}" | grep -v "#" >> "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/snap/setup.sh" ]; then',
+        'rosdep keys --rosdistro "${ROS_DISTRO}" --from-paths "${SNAPCRAFT_PART_INSTALL}/opt/ros/snap" --ignore-packages-from-source '
+        '| xargs rosdep resolve --rosdistro "${ROS_DISTRO}" | grep -v "#" >> "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        "fi",
+        "fi",
         'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         "colcon build "
         '--base-paths "${SNAPCRAFT_PART_SRC_WORK}" --build-base "${SNAPCRAFT_PART_BUILD}" '
@@ -169,6 +180,16 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
         "init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
+        'rospack list-names | xargs rosdep resolve --rosdistro "${ROS_DISTRO}" '
+        '| grep -v "#" > "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        'rosdep keys --rosdistro "${ROS_DISTRO}" --from-paths "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" --ignore-packages-from-source '
+        '| xargs rosdep resolve --rosdistro "${ROS_DISTRO}" | grep -v "#" >> "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/snap/setup.sh" ]; then',
+        'rosdep keys --rosdistro "${ROS_DISTRO}" --from-paths "${SNAPCRAFT_PART_INSTALL}/opt/ros/snap" --ignore-packages-from-source '
+        '| xargs rosdep resolve --rosdistro "${ROS_DISTRO}" | grep -v "#" >> "${SNAPCRAFT_PART_INSTALL}"/.installed_packages.txt',
+        "fi",
+        "fi",
         'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         "colcon build "
         '--base-paths "${SNAPCRAFT_PART_SRC_WORK}" --build-base "${SNAPCRAFT_PART_BUILD}" '

--- a/tests/unit/repo/test_deb.py
+++ b/tests/unit/repo/test_deb.py
@@ -178,6 +178,45 @@ class TestPackages(unit.TestCase):
             Equals(sorted(["fake-package=1.0", "fake-package-dep=2.0"])),
         )
 
+    @mock.patch("snapcraft.internal.repo._deb._DEFAULT_FILTERED_STAGE_PACKAGES", {})
+    def test_fetch_stage_package_with_deps_with_filters(self):
+        fake_package = self.debs_path / "fake-package_1.0_all.deb"
+        fake_package.touch()
+        fake_package_dep = self.debs_path / "fake-package-dep_1.0_all.deb"
+        fake_package_dep.touch()
+        other_fake_package = self.debs_path / "other-fake-package_1.0_all.deb"
+        other_fake_package.touch()
+        self.fake_apt_cache.return_value.__enter__.return_value.fetch_archives.return_value = [
+            ("fake-package", "1.0", fake_package),
+            ("fake-package-dep", "2.0", fake_package_dep),
+            ("other-fake-package", "1.0", other_fake_package),
+        ]
+
+        package_names=["fake-package", "other-fake-package"]
+
+        fetched_packages = repo.Ubuntu.fetch_stage_packages(
+            package_names=package_names,
+            stage_packages_path=self.stage_packages_path,
+            base="core18",
+            target_arch="amd64",
+            filters=["fake-package-dep", "other-fake-package"],
+        )
+
+        self.fake_apt_cache.assert_has_calls(
+            [
+                call(stage_cache=self.stage_cache_path, stage_cache_arch="amd64"),
+                call().__enter__(),
+                call().__enter__().mark_packages(set(package_names)),
+                call().__enter__().unmark_packages({"fake-package-dep", "other-fake-package"}),
+                call().__enter__().fetch_archives(self.debs_path),
+            ]
+        )
+
+        self.assertThat(
+            fetched_packages,
+            Equals(sorted(["fake-package=1.0"])),
+        )
+
     def test_get_package_fetch_error(self):
         self.fake_apt_cache.return_value.__enter__.return_value.fetch_archives.side_effect = errors.PackageFetchError(
             "foo"


### PR DESCRIPTION
This PR introduces a ROS-specific workaround that prevents from fetching debs already contained in a stage-snap during staging.

Assuming the following dependency chain `foo -> bar -> baz` and a stage snap containing package `baz`. Snapping a ROS app `foo` means that at staging the package `bar` will be fetched (as it should) together with its dependency `baz`. However, `baz` being already provided by a stage snap we would like to avoid fetching it again, potentially shadowing a desired specific `baz` version or custom changes. Afaik, there is no mechanisms at the moment to handle this case.

This PR, somewhat akin to [get_packages_in_base](https://github.com/snapcore/snapcraft/blob/0224b48ea0e1cc7378e1ad392b41466f005ae3e6/snapcraft/internal/repo/_deb.py#L261) for ROS stage snaps, proposes a workaround.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`? -> Some unrelated `black` errors
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
