### PR TITLE
commands: list-extensions and extensions alias

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -102,6 +102,7 @@ translationstring==1.4
 types-Deprecated==1.2.5
 types-PyYAML==6.0.5
 types-setuptools==57.4.11
+types-tabulate==0.8.6
 typing-utils==0.1.0
 typing_extensions==4.1.1
 urllib3==1.26.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,4 +39,4 @@ ignore = E203,E501
 # D203 1 blank line required before class docstring (reason: pep257 default)
 # D213 Multi-line docstring summary should start at the second line (reason: pep257 default)
 ignore = D107, D203, D213
-
+ignore_decorators = overrides

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ dev_requires = [
     "pytest-subprocess",
     "types-PyYAML",
     "types-setuptools",
+    "types-tabulate",
 ]
 
 if sys.platform == "win32":

--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -39,6 +39,14 @@ COMMAND_GROUPS = [
             commands.PackCommand,
         ],
     ),
+    craft_cli.CommandGroup(
+        "Extensions",
+        [
+            commands.ListExtensionsCommand,
+            # hidden command, alias to list-extensions.
+            commands.ExtensionsCommand,
+        ],
+    ),
     craft_cli.CommandGroup("Other", [commands.VersionCommand]),
 ]
 

--- a/snapcraft/commands/__init__.py
+++ b/snapcraft/commands/__init__.py
@@ -16,11 +16,23 @@
 
 """Snapcraft commands."""
 
-from .lifecycle import (  # noqa: F401
+from .extensions import ExtensionsCommand, ListExtensionsCommand
+from .lifecycle import (
     BuildCommand,
     PackCommand,
     PrimeCommand,
     PullCommand,
     StageCommand,
 )
-from .version import VersionCommand  # noqa: F401
+from .version import VersionCommand
+
+__all__ = [
+    "BuildCommand",
+    "PackCommand",
+    "PrimeCommand",
+    "PullCommand",
+    "StageCommand",
+    "ExtensionsCommand",
+    "ListExtensionsCommand",
+    "VersionCommand",
+]

--- a/snapcraft/commands/extensions.py
+++ b/snapcraft/commands/extensions.py
@@ -1,0 +1,95 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Snapcraft lifecycle commands."""
+
+import abc
+import textwrap
+from typing import Dict, List
+
+import tabulate
+from craft_cli import BaseCommand, emit
+from overrides import overrides
+from pydantic import BaseModel
+
+from snapcraft import extensions
+from snapcraft_legacy.internal.project_loader import (
+    find_extension,
+    supported_extension_names,
+)
+
+
+class ExtensionModel(BaseModel):
+    """Extension model for presentation."""
+
+    name: str
+    bases: List[str]
+
+    def marshal(self) -> Dict[str, str]:
+        """Marshal model into a dictionary for presentation."""
+        return {
+            "Extension name": self.name,
+            "Supported bases": ", ".join(sorted(self.bases)),
+        }
+
+
+class ListExtensionsCommand(BaseCommand, abc.ABC):
+    """A command to list the available extensions."""
+
+    name = "list-extensions"
+    help_msg = "List available extensions"
+    overview = textwrap.dedent(
+        """
+        List the available extensions and the bases it can work on.
+        """
+    )
+
+    @overrides
+    def run(self, parsed_args):
+        extension_presentation: Dict[str, ExtensionModel] = {}
+
+        # New extensions.
+        for extension_name in extensions.registry.get_extension_names():
+            extension_class = extensions.registry.get_extension_class(extension_name)
+            extension_bases = list(extension_class.get_supported_bases())
+            extension_presentation[extension_name] = ExtensionModel(
+                name=extension_name, bases=extension_bases
+            )
+
+        # Extensions from snapcraft_legacy.
+        for extension_name in supported_extension_names():
+            extension_class = find_extension(extension_name)
+            extension_name = extension_name.replace("_", "-")
+            extension_bases = list(extension_class.get_supported_bases())
+            if extension_name in extension_presentation:
+                extension_presentation[extension_name].bases += extension_bases
+            else:
+                extension_presentation[extension_name] = ExtensionModel(
+                    name=extension_name, bases=extension_bases
+                )
+
+        printable_extensions = sorted(
+            [v.marshal() for v in extension_presentation.values()],
+            key=lambda d: d["Extension name"],
+        )
+        emit.message(tabulate.tabulate(printable_extensions, headers="keys"))
+
+
+class ExtensionsCommand(ListExtensionsCommand, abc.ABC):
+    """A command alias to list the available extensions."""
+
+    name = "extensions"
+    hidden = True

--- a/tests/unit/commands/test_list_extensions.py
+++ b/tests/unit/commands/test_list_extensions.py
@@ -1,0 +1,75 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from argparse import Namespace
+from textwrap import dedent
+
+import pytest
+
+from snapcraft.commands import ExtensionsCommand, ListExtensionsCommand
+
+
+@pytest.mark.usefixtures("fake_extension")
+@pytest.mark.parametrize("command", [ListExtensionsCommand, ExtensionsCommand])
+def test_command(emitter, command):
+    cmd = command(None)
+    cmd.run(Namespace())
+    emitter.assert_recorded(
+        [
+            dedent(
+                """\
+            Extension name    Supported bases
+            ----------------  -----------------
+            fake-extension    core22
+            flutter-beta      core18
+            flutter-dev       core18
+            flutter-master    core18
+            flutter-stable    core18
+            gnome-3-28        core18
+            gnome-3-34        core18
+            gnome-3-38        core20
+            kde-neon          core18, core20
+            ros1-noetic       core20
+            ros2-foxy         core20"""
+            )
+        ]
+    )
+
+
+@pytest.mark.usefixtures("fake_extension_name_from_legacy")
+@pytest.mark.parametrize("command", [ListExtensionsCommand, ExtensionsCommand])
+def test_command_extension_dups(emitter, command):
+    cmd = command(None)
+    cmd.run(Namespace())
+    emitter.assert_recorded(
+        [
+            dedent(
+                """\
+            Extension name    Supported bases
+            ----------------  -----------------
+            flutter-beta      core18
+            flutter-dev       core18
+            flutter-master    core18
+            flutter-stable    core18
+            gnome-3-28        core18
+            gnome-3-34        core18
+            gnome-3-38        core20
+            kde-neon          core18, core20
+            ros1-noetic       core20
+            ros2-foxy         core20, core22"""
+            )
+        ]
+    )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -17,9 +17,12 @@
 import os
 import tempfile
 from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
 
 import pytest
 from craft_cli import messages
+
+from snapcraft import extensions
 
 
 # XXX: This can be removed once testing fixtures are provided by craft-cli.
@@ -98,3 +101,181 @@ def emitter(monkeypatch):
     monkeypatch.setattr(messages.emit, "trace", lambda text: rec.record("trace", text))
 
     return rec
+
+
+@pytest.fixture
+def fake_extension():
+    """Basic extension."""
+
+    class ExtensionImpl(extensions.Extension):
+        """The test extension implementation."""
+
+        @staticmethod
+        def get_supported_bases() -> Tuple[str, ...]:
+            return ("core22",)
+
+        @staticmethod
+        def get_supported_confinement() -> Tuple[str, ...]:
+            return ("strict",)
+
+        @staticmethod
+        def is_experimental(base: Optional[str] = None) -> bool:
+            return False
+
+        def get_root_snippet(self) -> Dict[str, Any]:
+            return {"grade": "fake-grade"}
+
+        def get_app_snippet(self) -> Dict[str, Any]:
+            return {"plugs": ["fake-plug"]}
+
+        def get_part_snippet(self) -> Dict[str, Any]:
+            return {"after": ["fake-extension/fake-part"]}
+
+        def get_parts_snippet(self) -> Dict[str, Any]:
+            return {"fake-extension/fake-part": {"plugin": "nil"}}
+
+    extensions.register("fake-extension", ExtensionImpl)
+    yield ExtensionImpl
+    extensions.unregister("fake-extension")
+
+
+@pytest.fixture
+def fake_extension_extra():
+    """A variation of fake_extension with some conflicts and new code."""
+
+    class ExtensionImpl(extensions.Extension):
+        """The test extension implementation."""
+
+        @staticmethod
+        def get_supported_bases() -> Tuple[str, ...]:
+            return ("core22",)
+
+        @staticmethod
+        def get_supported_confinement() -> Tuple[str, ...]:
+            return ("strict",)
+
+        @staticmethod
+        def is_experimental(base: Optional[str] = None) -> bool:
+            return False
+
+        def get_root_snippet(self) -> Dict[str, Any]:
+            return {}
+
+        def get_app_snippet(self) -> Dict[str, Any]:
+            return {"plugs": ["fake-plug", "fake-plug-extra"]}
+
+        def get_part_snippet(self) -> Dict[str, Any]:
+            return {"after": ["fake-extension-extra/fake-part"]}
+
+        def get_parts_snippet(self) -> Dict[str, Any]:
+            return {"fake-extension-extra/fake-part": {"plugin": "nil"}}
+
+    extensions.register("fake-extension-extra", ExtensionImpl)
+    yield ExtensionImpl
+    extensions.unregister("fake-extension-extra")
+
+
+@pytest.fixture
+def fake_extension_invalid_parts():
+    class ExtensionImpl(extensions.Extension):
+        """The test extension implementation."""
+
+        @staticmethod
+        def get_supported_bases() -> Tuple[str, ...]:
+            return ("core22",)
+
+        @staticmethod
+        def get_supported_confinement() -> Tuple[str, ...]:
+            return ("strict",)
+
+        @staticmethod
+        def is_experimental(base: Optional[str] = None) -> bool:
+            return False
+
+        def get_root_snippet(self) -> Dict[str, Any]:
+            return {"grade": "fake-grade"}
+
+        def get_app_snippet(self) -> Dict[str, Any]:
+            return {"plugs": ["fake-plug"]}
+
+        def get_part_snippet(self) -> Dict[str, Any]:
+            return {"after": ["fake-extension/fake-part"]}
+
+        def get_parts_snippet(self) -> Dict[str, Any]:
+            return {"fake-part": {"plugin": "nil"}, "fake-part-2": {"plugin": "nil"}}
+
+    extensions.register("fake-extension-invalid-parts", ExtensionImpl)
+    yield ExtensionImpl
+    extensions.unregister("fake-extension-invalid-parts")
+
+
+@pytest.fixture
+def fake_extension_experimental():
+    """Basic extension."""
+
+    class ExtensionImpl(extensions.Extension):
+        """The test extension implementation."""
+
+        @staticmethod
+        def get_supported_bases() -> Tuple[str, ...]:
+            return ("core22",)
+
+        @staticmethod
+        def get_supported_confinement() -> Tuple[str, ...]:
+            return ("strict",)
+
+        @staticmethod
+        def is_experimental(base: Optional[str] = None) -> bool:
+            return True
+
+        def get_root_snippet(self) -> Dict[str, Any]:
+            return {}
+
+        def get_app_snippet(self) -> Dict[str, Any]:
+            return {}
+
+        def get_part_snippet(self) -> Dict[str, Any]:
+            return {}
+
+        def get_parts_snippet(self) -> Dict[str, Any]:
+            return {}
+
+    extensions.register("fake-extension-experimental", ExtensionImpl)
+    yield ExtensionImpl
+    extensions.unregister("fake-extension-experimental")
+
+
+@pytest.fixture
+def fake_extension_name_from_legacy():
+    """A fake_extension variant with a name collision with legacy."""
+
+    class ExtensionImpl(extensions.Extension):
+        """The test extension implementation."""
+
+        @staticmethod
+        def get_supported_bases() -> Tuple[str, ...]:
+            return ("core22",)
+
+        @staticmethod
+        def get_supported_confinement() -> Tuple[str, ...]:
+            return ("strict",)
+
+        @staticmethod
+        def is_experimental(base: Optional[str] = None) -> bool:
+            return False
+
+        def get_root_snippet(self) -> Dict[str, Any]:
+            return {}
+
+        def get_app_snippet(self) -> Dict[str, Any]:
+            return {"plugs": ["fake-plug", "fake-plug-extra"]}
+
+        def get_part_snippet(self) -> Dict[str, Any]:
+            return {"after": ["fake-extension-extra/fake-part"]}
+
+        def get_parts_snippet(self) -> Dict[str, Any]:
+            return {"fake-extension-extra/fake-part": {"plugin": "nil"}}
+
+    extensions.register("ros2-foxy", ExtensionImpl)
+    yield ExtensionImpl
+    extensions.unregister("ros2-foxy")


### PR DESCRIPTION
Bring in the extensions available from the new code base and then mesh
them with the ones from legacy.

Use inheritance to support the alias of extensions to list-extensions.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
CRAFT-947