### PR TITLE
cli: fix help command legacy fallback

### DIFF
--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -21,7 +21,7 @@ import os
 import sys
 
 import craft_cli
-from craft_cli import ArgumentParsingError, EmitterMode, emit
+from craft_cli import ArgumentParsingError, EmitterMode, ProvideHelpException, emit
 
 from snapcraft import __version__, errors, utils
 from snapcraft_legacy.cli import legacy
@@ -89,7 +89,7 @@ def run():
     dispatcher = craft_cli.Dispatcher(
         "snapcraft",
         COMMAND_GROUPS,
-        summary="What's the app about",
+        summary="Package, distribute, and update snaps for Linux and IoT",
         extra_global_args=GLOBAL_ARGS,
         default_command=commands.PackCommand,
     )
@@ -102,7 +102,7 @@ def run():
             dispatcher.load_command(None)
             dispatcher.run()
         emit.ended_ok()
-    except (errors.LegacyFallback, ArgumentParsingError) as err:
+    except (ProvideHelpException, errors.LegacyFallback, ArgumentParsingError) as err:
         emit.trace(f"run legacy implementation: {err!s}")
         emit.ended_ok()
         legacy.legacy_run()

--- a/tests/unit/cli/test_help.py
+++ b/tests/unit/cli/test_help.py
@@ -1,0 +1,48 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+from unittest.mock import call
+
+import pytest
+
+from snapcraft import cli
+
+
+def test_help_command(mocker):
+    mocker.patch.object(sys, "argv", ["cmd", "help"])
+    mock_dispatcher_run = mocker.patch("craft_cli.dispatcher.Dispatcher.run")
+    mock_legacy_run = mocker.patch("snapcraft_legacy.cli.legacy.legacy_run")
+
+    cli.run()
+
+    assert mock_dispatcher_run.mock_calls == []
+    assert mock_legacy_run.mock_calls == [call()]
+
+
+@pytest.mark.parametrize("arg", ["-h", "--help"])
+def test_help_option(mocker, arg):
+    mocker.patch.object(sys, "argv", ["cmd", arg])
+    mock_dispatcher_run = mocker.patch("craft_cli.dispatcher.Dispatcher.run")
+    mock_legacy_run = mocker.patch(
+        "snapcraft_legacy.cli.legacy.legacy_run", side_effect=SystemExit
+    )
+
+    with pytest.raises(SystemExit):
+        cli.run()
+
+    assert mock_dispatcher_run.mock_calls == []
+    assert mock_legacy_run.mock_calls == [call()]


### PR DESCRIPTION
Handle craft-cli's `ProvideHelpException` error to display the same
message displayed when invoked using the `--help` option.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
