### PR TITLE
commands: add snap command

### DIFF
--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -38,14 +38,14 @@ COMMAND_GROUPS = [
             commands.StageCommand,
             commands.PrimeCommand,
             commands.PackCommand,
+            commands.SnapCommand,  # hidden (legacy compatibility)
         ],
     ),
     craft_cli.CommandGroup(
         "Extensions",
         [
             commands.ListExtensionsCommand,
-            # hidden command, alias to list-extensions.
-            commands.ExtensionsCommand,
+            commands.ExtensionsCommand,  # hidden (alias to list-extensions)
             commands.ExpandExtensionsCommand,
         ],
     ),

--- a/snapcraft/commands/__init__.py
+++ b/snapcraft/commands/__init__.py
@@ -27,6 +27,7 @@ from .lifecycle import (
     PackCommand,
     PrimeCommand,
     PullCommand,
+    SnapCommand,
     StageCommand,
 )
 from .version import VersionCommand
@@ -38,6 +39,7 @@ __all__ = [
     "PackCommand",
     "PrimeCommand",
     "PullCommand",
+    "SnapCommand",
     "StageCommand",
     "ExtensionsCommand",
     "ListExtensionsCommand",

--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -133,8 +133,9 @@ class PackCommand(_LifecycleCommand):
     help_msg = "Create the snap package"
     overview = textwrap.dedent(
         """
-        Process parts and create a snap file containing the project payload.
-        If a directory is specified, pack its contents instead.
+        Process parts and create a snap file containing the project payload
+        with the provided metadata. If a directory is specified, pack its
+        contents instead.
         """
     )
 
@@ -171,11 +172,12 @@ class SnapCommand(_LifecycleCommand):
     """Pack the final snap payload. This is a legacy compatibility command."""
 
     name = "snap"
-    help_msg = "Build artifacts defined for a part"
+    help_msg = "Create a snap"
     hidden = True
     overview = textwrap.dedent(
         """
-        Process parts and create a snap file containing the project payload.
+        Process parts and create a snap file containing the project payload
+        with the provided metadata.
         """
     )
 

--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -127,15 +127,14 @@ class PrimeCommand(_LifecycleStepCommand):
 
 
 class PackCommand(_LifecycleCommand):
-    """Prepare the final payload for packing."""
+    """Pack the final snap payload."""
 
     name = "pack"
-    help_msg = "Build artifacts defined for a part"
+    help_msg = "Create the snap package"
     overview = textwrap.dedent(
         """
-        Prepare the final payload to be packed as a snap. If part names are
-        specified only those parts will be primed. The default is to prime
-        all parts.
+        Process parts and create a snap file containing the project payload.
+        If a directory is specified, pack its contents instead.
         """
     )
 
@@ -166,6 +165,31 @@ class PackCommand(_LifecycleCommand):
             pack.pack_snap(parsed_args.directory, output=parsed_args.output)
         else:
             super().run(parsed_args)
+
+
+class SnapCommand(_LifecycleCommand):
+    """Pack the final snap payload. This is a legacy compatibility command."""
+
+    name = "snap"
+    help_msg = "Build artifacts defined for a part"
+    hidden = True
+    overview = textwrap.dedent(
+        """
+        Process parts and create a snap file containing the project payload.
+        """
+    )
+
+    @overrides
+    def fill_parser(self, parser: "argparse.ArgumentParser") -> None:
+        """Add arguments specific to the pack command."""
+        super().fill_parser(parser)
+        parser.add_argument(
+            "-o",
+            "--output",
+            metavar="filename",
+            type=str,
+            help="Path to the resulting snap",
+        )
 
 
 class CleanCommand(_LifecycleStepCommand):

--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -33,6 +33,8 @@ def pack_snap(
     :param output: Snap file name or directory.
     :param compression: Compression type to use, None for defaults.
     """
+    emit.trace(f"pack_snap: output={output!r}, compression={compression!r}")
+
     output_file = None
     output_dir = None
 
@@ -61,6 +63,7 @@ def pack_snap(
         command.append(output_dir)
 
     emit.progress("Creating snap package...")
+    emit.trace(f"Pack command: {command}")
     try:
         subprocess.run(
             command, capture_output=True, check=True, universal_newlines=True

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -141,6 +141,11 @@ def _run_command(
             "The 'snap' command is deprecated, use 'pack' instead.", intermediate=True
         )
 
+    if parsed_args.use_lxd and providers.get_platform_default_provider() == "lxd":
+        emit.message(
+            "LXD is used by default on this platform.", intermediate=True
+        )
+
     if not managed_mode and not parsed_args.destructive_mode:
         if command_name == "clean" and not part_names:
             _clean_provider(project, parsed_args)

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -136,6 +136,11 @@ def _run_command(
     managed_mode = utils.is_managed_mode()
     part_names = getattr(parsed_args, "parts", None)
 
+    if not managed_mode and command_name == "snap":
+        emit.message(
+            "The 'snap' command is deprecated, use 'pack' instead.", intermediate=True
+        )
+
     if not managed_mode and not parsed_args.destructive_mode:
         if command_name == "clean" and not part_names:
             _clean_provider(project, parsed_args)

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -148,7 +148,7 @@ def _run_command(
     else:
         work_dir = Path.cwd()
 
-    step_name = "prime" if command_name == "pack" else command_name
+    step_name = "prime" if command_name in ("pack", "snap") else command_name
 
     lifecycle = PartsLifecycle(
         project.parts,
@@ -192,7 +192,7 @@ def _run_command(
         )
         emit.message("Generated snap metadata", intermediate=True)
 
-    if command_name == "pack":
+    if command_name in ("pack", "snap"):
         pack.pack_snap(
             lifecycle.prime_dir,
             output=parsed_args.output,
@@ -230,6 +230,9 @@ def _run_in_provider(
 
     if hasattr(parsed_args, "parts"):
         cmd.extend(parsed_args.parts)
+
+    if getattr(parsed_args, "output", None):
+        cmd.extend(["--output", parsed_args.output])
 
     if emit.get_mode() == EmitterMode.VERBOSE:
         cmd.append("--verbose")

--- a/snapcraft/providers/__init__.py
+++ b/snapcraft/providers/__init__.py
@@ -17,7 +17,7 @@
 """Build provider support."""
 
 from ._buildd import SnapcraftBuilddBaseConfiguration  # noqa: F401
-from ._get_provider import get_provider  # noqa: F401
+from ._get_provider import get_platform_default_provider, get_provider  # noqa: F401
 from ._logs import capture_logs_from_instance  # noqa: F401
 from ._lxd import LXDProvider  # noqa: F401
 from ._multipass import MultipassProvider  # noqa: F401

--- a/snapcraft/providers/_get_provider.py
+++ b/snapcraft/providers/_get_provider.py
@@ -38,7 +38,7 @@ def get_provider(provider: Optional[str] = None) -> Provider:
     :return: Provider instance.
     """
     if provider is None:
-        provider = _get_platform_default_provider()
+        provider = get_platform_default_provider()
 
     if provider == "lxd":
         return LXDProvider()
@@ -49,7 +49,11 @@ def get_provider(provider: Optional[str] = None) -> Provider:
     raise RuntimeError(f"Unsupported provider specified: {provider!r}.")
 
 
-def _get_platform_default_provider() -> str:
+def get_platform_default_provider() -> str:
+    """Obtain the default provider for the host platform.
+
+    :return: Default provider name.
+    """
     if sys.platform == "linux":
         return "lxd"
 

--- a/tests/spread/general/core22/packing/snap/snapcraft.yaml
+++ b/tests/spread/general/core22/packing/snap/snapcraft.yaml
@@ -1,0 +1,16 @@
+name: my-snap-name
+version: '0.1'
+summary: Single-line elevator pitch for your amazing snap # 79 char long summary
+description: |
+  This is my-snap's description. You have a paragraph or two to tell the
+  most important story about your snap. Keep it under 100 words though,
+  we live in tweetspace and your description wants to look good in the snap
+  store.
+base: core22
+
+grade: devel
+confinement: devmode
+
+parts:
+  my-part:
+    plugin: nil

--- a/tests/spread/general/core22/packing/task.yaml
+++ b/tests/spread/general/core22/packing/task.yaml
@@ -1,0 +1,38 @@
+summary: Validate scriptlet failures
+
+environment:
+  CMD/pack: pack
+  CMD/pack_output: pack -o output.snap
+  CMD/pack_output_subdir: pack --output subdir/output.snap
+  CMD/snap: snap
+  CMD/snap_output: snap --output output.snap
+  CMD/snap_output_subdir: snap -o subdir/output.snap
+  CMD/default: ""
+  CMD/default_output: -o output.snap
+  CMD/default_output_subdir: --output subdir/output.snap
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  # set_base "$SNAP_DIR/snap/snapcraft.yaml"
+  snap install core22 --edge
+
+restore: |
+  snapcraft clean
+  rm -Rf subdir ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  # shellcheck disable=SC2086
+  snapcraft $CMD
+
+  if echo "$CMD" | grep subdir/output; then
+    test -f subdir/output.snap
+  elif echo "$CMD" | grep output; then
+    test -f output.snap
+  else
+    test -f my-snap-name_0.1_*.snap
+  fi

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -25,6 +25,7 @@ from snapcraft.commands.lifecycle import (
     PackCommand,
     PrimeCommand,
     PullCommand,
+    SnapCommand,
     StageCommand,
 )
 
@@ -48,13 +49,43 @@ def test_lifecycle_command(cmd_name, cmd_class, mocker):
     ]
 
 
-def test_pack_command(mocker):
+@pytest.mark.parametrize(
+    "cmd_name,cmd_class",
+    [
+        ("pack", PackCommand),
+        ("snap", SnapCommand),
+    ],
+)
+def test_pack_command(mocker, cmd_name, cmd_class):
     lifecycle_run_mock = mocker.patch("snapcraft.parts.lifecycle.run")
-    cmd = PackCommand(None)
+    cmd = cmd_class(None)
     cmd.run(argparse.Namespace(directory=None, output=None, compression=None))
     assert lifecycle_run_mock.mock_calls == [
-        call("pack", argparse.Namespace(directory=None, output=None, compression=None))
+        call(
+            cmd_name, argparse.Namespace(directory=None, output=None, compression=None)
+        )
     ]
+
+
+@pytest.mark.parametrize(
+    "cmd_name,cmd_class",
+    [
+        ("pack", PackCommand),
+        ("snap", SnapCommand),
+    ],
+)
+def test_pack_command_with_output(mocker, cmd_name, cmd_class):
+    lifecycle_run_mock = mocker.patch("snapcraft.parts.lifecycle.run")
+    pack_mock = mocker.patch("snapcraft.pack.pack_snap")
+    cmd = cmd_class(None)
+    cmd.run(argparse.Namespace(directory=None, output="output", compression=None))
+    assert lifecycle_run_mock.mock_calls == [
+        call(
+            cmd_name,
+            argparse.Namespace(compression=None, directory=None, output="output"),
+        )
+    ]
+    assert pack_mock.mock_calls == []
 
 
 def test_pack_command_with_directory(mocker):

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -145,7 +145,7 @@ def test_snapcraft_yaml_load(new_dir, snapcraft_yaml, filename, mocker):
     ]
 
 
-@pytest.mark.parametrize("cmd", ["pull", "build", "stage", "prime", "pack", "clean"])
+@pytest.mark.parametrize("cmd", ["pull", "build", "stage", "prime", "pack", "snap", "clean"])
 def test_lifecycle_run_provider(cmd, snapcraft_yaml, new_dir, mocker):
     """Option --provider is not supported in core22."""
     snapcraft_yaml(base="core22")
@@ -165,7 +165,7 @@ def test_lifecycle_run_provider(cmd, snapcraft_yaml, new_dir, mocker):
     assert str(raised.value) == "Option --provider is not supported."
 
 
-@pytest.mark.parametrize("cmd", ["pull", "build", "stage", "prime", "clean"])
+@pytest.mark.parametrize("cmd", ["pull", "build", "stage", "prime", "snap", "clean"])
 def test_lifecycle_legacy_run_provider(cmd, snapcraft_yaml, new_dir, mocker):
     """Option --provider is supported by legacy."""
     snapcraft_yaml(base="core20")
@@ -213,14 +213,15 @@ def test_lifecycle_run_command_step(
     assert pack_mock.mock_calls == []
 
 
-def test_lifecycle_run_command_pack(snapcraft_yaml, project_vars, new_dir, mocker):
+@pytest.mark.parametrize("cmd", ["pack", "snap"])
+def test_lifecycle_run_command_pack(cmd, snapcraft_yaml, project_vars, new_dir, mocker):
     project = Project.unmarshal(snapcraft_yaml(base="core22"))
     run_mock = mocker.patch("snapcraft.parts.PartsLifecycle.run")
     mocker.patch("snapcraft.meta.snap_yaml.write")
     pack_mock = mocker.patch("snapcraft.pack.pack_snap")
 
     parts_lifecycle._run_command(
-        "pack",
+        cmd,
         project=project,
         assets_dir=Path(),
         parsed_args=argparse.Namespace(
@@ -238,7 +239,8 @@ def test_lifecycle_run_command_pack(snapcraft_yaml, project_vars, new_dir, mocke
     ]
 
 
-def test_lifecycle_pack_destructive_mode(snapcraft_yaml, project_vars, new_dir, mocker):
+@pytest.mark.parametrize("cmd", ["pack", "snap"])
+def test_lifecycle_pack_destructive_mode(cmd, snapcraft_yaml, project_vars, new_dir, mocker):
     project = Project.unmarshal(snapcraft_yaml(base="core22"))
     run_in_provider_mock = mocker.patch("snapcraft.parts.lifecycle._run_in_provider")
     run_mock = mocker.patch("snapcraft.parts.PartsLifecycle.run")
@@ -251,7 +253,7 @@ def test_lifecycle_pack_destructive_mode(snapcraft_yaml, project_vars, new_dir, 
     )
 
     parts_lifecycle._run_command(
-        "pack",
+        cmd,
         project=project,
         assets_dir=Path(),
         parsed_args=argparse.Namespace(
@@ -270,7 +272,8 @@ def test_lifecycle_pack_destructive_mode(snapcraft_yaml, project_vars, new_dir, 
     ]
 
 
-def test_lifecycle_pack_managed(snapcraft_yaml, project_vars, new_dir, mocker):
+@pytest.mark.parametrize("cmd", ["pack", "snap"])
+def test_lifecycle_pack_managed(cmd, snapcraft_yaml, project_vars, new_dir, mocker):
     project = Project.unmarshal(snapcraft_yaml(base="core22"))
     run_in_provider_mock = mocker.patch("snapcraft.parts.lifecycle._run_in_provider")
     run_mock = mocker.patch("snapcraft.parts.PartsLifecycle.run")
@@ -283,7 +286,7 @@ def test_lifecycle_pack_managed(snapcraft_yaml, project_vars, new_dir, mocker):
     )
 
     parts_lifecycle._run_command(
-        "pack",
+        cmd,
         project=project,
         assets_dir=Path(),
         parsed_args=argparse.Namespace(
@@ -302,14 +305,15 @@ def test_lifecycle_pack_managed(snapcraft_yaml, project_vars, new_dir, mocker):
     ]
 
 
-def test_lifecycle_pack_not_managed(snapcraft_yaml, new_dir, mocker):
+@pytest.mark.parametrize("cmd", ["pack", "snap"])
+def test_lifecycle_pack_not_managed(cmd, snapcraft_yaml, new_dir, mocker):
     project = Project.unmarshal(snapcraft_yaml(base="core22"))
     run_in_provider_mock = mocker.patch("snapcraft.parts.lifecycle._run_in_provider")
     run_mock = mocker.patch("snapcraft.parts.PartsLifecycle.run")
     mocker.patch("snapcraft.utils.is_managed_mode", return_value=False)
 
     parts_lifecycle._run_command(
-        "pack",
+        cmd,
         project=project,
         assets_dir=Path(),
         parsed_args=argparse.Namespace(
@@ -325,7 +329,7 @@ def test_lifecycle_pack_not_managed(snapcraft_yaml, new_dir, mocker):
     assert run_in_provider_mock.mock_calls == [
         call(
             project,
-            "pack",
+            cmd,
             argparse.Namespace(
                 directory=None,
                 output=None,


### PR DESCRIPTION
Allow usage of the legacy command `snap` to create a snap package, and
fix passing the output parameter to the managed instance.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
CRAFT-984