### PR TITLE
utils: in-house strtobool implementation

### DIFF
--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -16,7 +16,6 @@
 
 """Utilities for snapcraft."""
 
-import distutils.util
 import logging
 import os
 import pathlib
@@ -29,10 +28,27 @@ logger = logging.getLogger(__name__)
 OSPlatform = namedtuple("OSPlatform", "system release machine")
 
 
-def is_managed_mode():
+def strtobool(value: str) -> bool:
+    """Convert a string representation of truth to true (1) or false (0).
+
+    :param value: a True value of 'y', 'yes', 't', 'true', 'on', and '1'
+        or a False value of 'n', 'no', 'f', 'false', 'off', and '0'.
+    :raises ValueError: if `value` is not a valid boolean value.
+    """
+    parsed_value = value.lower()
+
+    if parsed_value in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    if parsed_value in ("n", "no", "f", "false", "off", "0"):
+        return False
+
+    raise ValueError(f"Invalid boolean value of {value!r}")
+
+
+def is_managed_mode() -> bool:
     """Check if snapcraft is running in a managed environment."""
     managed_flag = os.getenv("SNAPCRAFT_MANAGED_MODE", "n")
-    return distutils.util.strtobool(managed_flag) == 1
+    return strtobool(managed_flag)
 
 
 def get_managed_environment_home_path():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,83 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import pytest
+
+from snapcraft import utils
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "y",
+        "Y",
+        "yes",
+        "YES",
+        "Yes",
+        "t",
+        "T",
+        "true",
+        "TRUE",
+        "True",
+        "On",
+        "ON",
+        "oN",
+        "1",
+    ],
+)
+def test_strtobool_true(value: str):
+    assert utils.strtobool(value) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "n",
+        "N",
+        "no",
+        "NO",
+        "No",
+        "f",
+        "F",
+        "false",
+        "FALSE",
+        "False",
+        "off",
+        "OFF",
+        "oFF",
+        "0",
+    ],
+)
+def test_strtobool_false(value: str):
+    assert utils.strtobool(value) is False
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "not",
+        "yup",
+        "negative",
+        "positive",
+        "whatever",
+        "2",
+        "3",
+    ],
+)
+def test_strtobool_value_error(value: str):
+    with pytest.raises(ValueError):
+        utils.strtobool(value)


### PR DESCRIPTION
distutils is mostly going away in Python 3.12

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
