### PR TITLE
lifecycle: pass project name

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -167,6 +167,7 @@ def _run_command(
         package_repositories=project.package_repositories,
         part_names=part_names,
         adopt_info=project.adopt_info,
+        project_name=project.name,
         project_vars={
             "version": project.version or "",
             "grade": project.grade,

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -55,6 +55,7 @@ class PartsLifecycle:
         package_repositories: List[Dict[str, Any]],
         part_names: Optional[List[str]],
         adopt_info: Optional[str],
+        project_name: str,
         project_vars: Dict[str, str],
     ):
         self._assets_dir = assets_dir
@@ -79,6 +80,7 @@ class PartsLifecycle:
                 work_dir=work_dir,
                 cache_dir=cache_dir,
                 ignore_local_sources=["*.snap"],
+                project_name=project_name,
                 project_vars_part_name=adopt_info,
                 project_vars=project_vars,
             )

--- a/tests/unit/parts/test_parts.py
+++ b/tests/unit/parts/test_parts.py
@@ -38,6 +38,7 @@ def test_parts_lifecycle_run(parts_data, step_name, new_dir, emitter):
         part_names=[],
         package_repositories=[],
         adopt_info=None,
+        project_name="test-project",
         project_vars={"version": "1", "grade": "stable"},
     )
     lifecycle.run(step_name)
@@ -54,6 +55,7 @@ def test_parts_lifecycle_run_bad_step(parts_data, new_dir):
         part_names=[],
         package_repositories=[],
         adopt_info=None,
+        project_name="test-project",
         project_vars={"version": "1", "grade": "stable"},
     )
     with pytest.raises(RuntimeError) as raised:
@@ -69,6 +71,7 @@ def test_parts_lifecycle_run_internal_error(parts_data, new_dir, mocker):
         part_names=[],
         package_repositories=[],
         adopt_info=None,
+        project_name="test-project",
         project_vars={"version": "1", "grade": "stable"},
     )
     mocker.patch("craft_parts.LifecycleManager.plan", side_effect=RuntimeError("crash"))
@@ -85,6 +88,7 @@ def test_parts_lifecycle_run_parts_error(new_dir):
         part_names=[],
         package_repositories=[],
         adopt_info=None,
+        project_name="test-project",
         project_vars={"version": "1", "grade": "stable"},
     )
     with pytest.raises(errors.PartsLifecycleError) as raised:
@@ -102,6 +106,7 @@ def test_parts_lifecycle_clean(parts_data, new_dir, emitter):
         part_names=[],
         package_repositories=[],
         adopt_info=None,
+        project_name="test-project",
         project_vars={"version": "1", "grade": "stable"},
     )
     lifecycle.clean(part_names=None)
@@ -116,6 +121,7 @@ def test_parts_lifecycle_clean_parts(parts_data, new_dir, emitter):
         part_names=[],
         package_repositories=[],
         adopt_info=None,
+        project_name="test-project",
         project_vars={"version": "1", "grade": "stable"},
     )
     lifecycle.clean(part_names=["p1"])


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [X] Have you successfully run `./runtests.sh tests/unit`?

-----

Pass `project_name` to craft_parts for the [Conda plugin](https://github.com/canonical/craft-parts/pull/201).

(CRAFT-1029)