### PR TITLE
projects: adoptable fields are optional if adopt-info used

### DIFF
--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -107,7 +107,7 @@ class SnapMetadata(YamlModel):
     hooks: Optional[Dict[str, Any]]
 
 
-def write(project: Project, prime_dir: Path, *, arch: str, version: str, grade: str):
+def write(project: Project, prime_dir: Path, *, arch: str):
     """Create a snap.yaml file."""
     meta_dir = prime_dir / "meta"
     meta_dir.mkdir(parents=True, exist_ok=True)
@@ -159,9 +159,9 @@ def write(project: Project, prime_dir: Path, *, arch: str, version: str, grade: 
     snap_metadata = SnapMetadata(
         name=project.name,
         title=project.title,
-        version=version,
+        version=project.version,
         summary=project.summary,
-        description=project.description,
+        description=project.description,  # type: ignore
         license=project.license,
         type=project.type,
         architectures=[arch],
@@ -170,7 +170,7 @@ def write(project: Project, prime_dir: Path, *, arch: str, version: str, grade: 
         epoch=project.epoch,
         apps=snap_apps,
         confinement=project.confinement,
-        grade=grade,
+        grade=project.grade,  # type: ignore
         environment=project.environment,
         plugs=project.plugs,
         hooks=project.hooks,

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, cast
 
+import pydantic
 from craft_cli import EmitterMode, emit
 from craft_parts import infos
 
@@ -169,7 +170,7 @@ def _run_command(
         adopt_info=project.adopt_info,
         project_vars={
             "version": project.version or "",
-            "grade": project.grade,
+            "grade": project.grade or "",
         },
     )
     if command_name == "clean":
@@ -181,24 +182,13 @@ def _run_command(
     # Generate snap.yaml
     project_vars = lifecycle.project_vars
     if step_name == "prime" and not part_names:
-        version = project_vars["version"]
-        if not version:
-            raise errors.SnapcraftError("snap version cannot be empty")
-
-        # FIXME: refactor craft-parts to define validators for project variables
-        grade = project_vars["grade"]
-        if grade not in ("stable", "devel"):
-            raise errors.SnapcraftError(
-                f"invalid grade {grade!r}, must be either 'stable' or 'devel'"
-            )
+        _update_project_metadata(project, project_vars)
 
         emit.progress("Generating snap metadata...")
         snap_yaml.write(
             project,
             lifecycle.prime_dir,
             arch=lifecycle.target_arch,
-            version=version,
-            grade=grade,
         )
         emit.message("Generated snap metadata", intermediate=True)
 
@@ -208,6 +198,47 @@ def _run_command(
             output=parsed_args.output,
             compression=project.compression,
         )
+
+
+def _update_project_metadata(project: Project, project_vars: Dict[str, str]) -> None:
+    """Set project fields using corresponding adopted entries.
+
+    :param project: The project to update.
+    :param project_vars: The variables updated during lifecycle execution.
+
+    :raises SnapcraftError: If project update failed.
+    """
+    # Update project variables
+    try:
+        if project_vars["version"]:
+            project.version = project_vars["version"]
+        if project_vars["grade"]:
+            project.grade = project_vars["grade"]  # type: ignore
+    except pydantic.ValidationError as err:
+        _raise_formatted_validation_error(err)
+        raise errors.SnapcraftError(f"error setting variable: {err}")
+
+    # Fields that must not end empty
+    for field in ("version", "grade", "summary", "description"):
+        if not getattr(project, field):
+            raise errors.SnapcraftError(
+                f"Field {field!r} was not adopted from metadata"
+        )
+
+def _raise_formatted_validation_error(err: pydantic.ValidationError):
+    error_list = err.errors()
+    if len(error_list) != 1:
+        return
+
+    error = error_list[0]
+    loc = error.get("loc")
+    msg = error.get("msg")
+
+    if not (loc and msg) or not isinstance(loc, tuple):
+        return
+
+    varname = ".".join((x for x in loc if isinstance(x, str)))
+    raise errors.SnapcraftError(f"error setting {varname}: {msg}")
 
 
 def _clean_provider(project: Project, parsed_args: "argparse.Namespace") -> None:

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -59,8 +59,6 @@ def test_simple_snap_yaml(simple_project, new_dir):
         simple_project,
         prime_dir=Path(new_dir),
         arch="arch",
-        version="1.30",
-        grade="stable",
     )
     yaml_file = Path("meta/snap.yaml")
     assert yaml_file.is_file()
@@ -69,7 +67,7 @@ def test_simple_snap_yaml(simple_project, new_dir):
     assert content == textwrap.dedent(
         """\
         name: mytest
-        version: '1.30'
+        version: 1.29.3
         summary: Single-line elevator pitch for your amazing snap
         description: |
           This is my-snap's description. You have a paragraph or two to tell the
@@ -188,8 +186,6 @@ def test_complex_snap_yaml(complex_project, new_dir):
         complex_project,
         prime_dir=Path(new_dir),
         arch="arch",
-        version="1.30",
-        grade="devel",
     )
     yaml_file = Path("meta/snap.yaml")
     assert yaml_file.is_file()
@@ -198,7 +194,7 @@ def test_complex_snap_yaml(complex_project, new_dir):
     assert content == textwrap.dedent(
         """\
         name: mytest
-        version: '1.30'
+        version: 1.29.3
         summary: Single-line elevator pitch for your amazing snap
         description: |
           This is my-snap's description. You have a paragraph or two to tell the
@@ -253,7 +249,7 @@ def test_complex_snap_yaml(complex_project, new_dir):
                 listen_stream: 100
                 socket_mode: 1
         confinement: strict
-        grade: devel
+        grade: stable
         environment:
           GLOBAL_VARIABLE: test-global-variable
         plugs:

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -132,17 +132,7 @@ class TestProjectDefaults:
 class TestProjectValidation:
     """Validate top-level project items."""
 
-    @pytest.mark.parametrize(
-        "field",
-        [
-            "name",
-            "summary",
-            "description",
-            "grade",
-            "confinement",
-            "parts",
-        ],
-    )
+    @pytest.mark.parametrize("field", ["name", "confinement", "parts"])
     def test_mandatory_fields(self, field, project_yaml_data):
         data = project_yaml_data()
         data.pop(field)
@@ -172,19 +162,27 @@ class TestProjectValidation:
             project = Project.unmarshal(data)
             assert project.base is None
 
-    def test_mandatory_version(self, project_yaml_data):
+    @pytest.mark.parametrize("field", ["version", "summary", "description", "grade"])
+    def test_adoptable_fields(self, field, project_yaml_data):
         data = project_yaml_data()
-        data.pop("version")
-        error = "Snap version is required if not using adopt-info"
+        data.pop(field)
+        error = f"Snap {field} is required if not using adopt-info"
         with pytest.raises(errors.ProjectValidationError, match=error):
             Project.unmarshal(data)
 
-    def test_version_not_required(self, project_yaml_data):
+    @pytest.mark.parametrize("field", ["version", "summary", "description", "grade"])
+    def test_adoptable_field_not_required(self, field, project_yaml_data):
         data = project_yaml_data()
-        data.pop("version")
+        data.pop(field)
         data["adopt-info"] = "part1"
         project = Project.unmarshal(data)
-        assert project.version is None
+        assert getattr(project, field) is None
+
+    @pytest.mark.parametrize("field", ["version", "summary", "description", "grade"])
+    def test_adoptable_field_assignment(self, field, project_yaml_data):
+        data = project_yaml_data()
+        project = Project.unmarshal(data)
+        setattr(project, field, None)
 
     @pytest.mark.parametrize(
         "name",
@@ -277,8 +275,7 @@ class TestProjectValidation:
                 Project.unmarshal(data)
 
     @pytest.mark.parametrize(
-        "confinement",
-        ["strict", "devmode", "classic", "_invalid"],
+        "confinement", ["strict", "devmode", "classic", "_invalid"]
     )
     def test_project_confinement(self, confinement, project_yaml_data):
         data = project_yaml_data(confinement=confinement)
@@ -291,10 +288,7 @@ class TestProjectValidation:
             with pytest.raises(errors.ProjectValidationError, match=error):
                 Project.unmarshal(data)
 
-    @pytest.mark.parametrize(
-        "grade",
-        ["devel", "stable", "_invalid"],
-    )
+    @pytest.mark.parametrize("grade", ["devel", "stable", "_invalid"])
     def test_project_grade(self, grade, project_yaml_data):
         data = project_yaml_data(grade=grade)
 
@@ -305,6 +299,18 @@ class TestProjectValidation:
             error = ".*unexpected value; permitted: 'stable', 'devel'"
             with pytest.raises(errors.ProjectValidationError, match=error):
                 Project.unmarshal(data)
+
+    @pytest.mark.parametrize("grade", ["devel", "stable", "_invalid"])
+    def test_project_grade_assignment(self, grade, project_yaml_data):
+        data = project_yaml_data()
+
+        project = Project.unmarshal(data)
+        if grade != "_invalid":
+            project.grade = grade
+        else:
+            error = ".*unexpected value; permitted: 'stable', 'devel'"
+            with pytest.raises(pydantic.ValidationError, match=error):
+                project.grade = grade
 
     def test_project_summary_valid(self, project_yaml_data):
         summary = "x" * 78


### PR DESCRIPTION
Project fields `version`, `summary`, `description` and `grade` are
allowed to be unspecified in project if `adopt-info` is used. The final
values of such fields are still required and expected to be adopted
from metadata, otherwise an error is raised.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
CRAFT-1031