### PR TITLE
autotools v1 plugin: fix fatal crash when running autogen.sh or bootstrap

### DIFF
--- a/snapcraft/plugins/v1/_plugin.py
+++ b/snapcraft/plugins/v1/_plugin.py
@@ -187,7 +187,7 @@ class PluginV1:
     def run(self, cmd, cwd=None, **kwargs):
         if not cwd:
             cwd = self.builddir
-        cmd_string = " ".join([shlex.quote(c) for c in cmd])
+        cmd_string = " ".join([shlex.quote(str(c)) for c in cmd])
         print(cmd_string)
         os.makedirs(cwd, exist_ok=True)
         try:


### PR DESCRIPTION
Adapt the fix applied in 916965432b37f30e480fee50a019bc4ab4f91970 to the autotools v1 plugin.

Signed-off-by: Mike Miller <mtmiller@debian.org>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
