### PR TITLE
providers: use final 22.04 lxd image

### DIFF
--- a/snapcraft/providers/_lxd.py
+++ b/snapcraft/providers/_lxd.py
@@ -31,8 +31,7 @@ from ._provider import Provider, ProviderError
 
 logger = logging.getLogger(__name__)
 
-# FIXME: use final 22.04 image
-_BASE_IMAGE = {"core22": "ubuntu-daily:22.04"}
+_BASE_IMAGE = {"core22": "ubuntu:22.04"}
 
 
 class LXDProvider(Provider):


### PR DESCRIPTION
Update lxd image from daily to final 22.04.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
