### PR TITLE
utils: port humanize_list from Snapcraft legacy

### DIFF
--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -21,7 +21,7 @@ import pathlib
 import platform
 import sys
 from dataclasses import dataclass
-from typing import Optional
+from typing import Iterable, Optional
 
 from craft_cli import emit
 
@@ -159,3 +159,28 @@ def confirm_with_user(prompt, default=False) -> bool:
         return False
 
     return default
+
+
+def humanize_list(
+    items: Iterable[str], conjunction: str, item_format: str = "{!r}"
+) -> str:
+    """Format a list into a human-readable string.
+
+    :param items: list to humanize.
+    :param conjunction: the conjunction used to join the final element to
+                        the rest of the list (e.g. 'and').
+    :param item_format: format string to use per item.
+    """
+    if not items:
+        return ""
+
+    quoted_items = [item_format.format(item) for item in sorted(items)]
+    if len(quoted_items) == 1:
+        return quoted_items[0]
+
+    humanized = ", ".join(quoted_items[:-1])
+
+    if len(quoted_items) > 2:
+        humanized += ","
+
+    return f"{humanized} {conjunction} {quoted_items[-1]}"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -194,3 +194,27 @@ def test_get_host_architecture(platform_arch, mocker, deb_arch):
     mocker.patch("platform.machine", return_value=platform_arch)
 
     assert utils.get_host_architecture() == deb_arch
+
+
+#################
+# Humanize List #
+#################
+
+
+@pytest.mark.parametrize(
+    "items,conjunction,expected",
+    (
+        ([], "and", ""),
+        (["foo"], "and", "'foo'"),
+        (["foo", "bar"], "and", "'bar' and 'foo'"),
+        (["foo", "bar", "baz"], "and", "'bar', 'baz', and 'foo'"),
+        (["foo", "bar", "baz", "qux"], "and", "'bar', 'baz', 'foo', and 'qux'"),
+        ([], "or", ""),
+        (["foo"], "or", "'foo'"),
+        (["foo", "bar"], "or", "'bar' or 'foo'"),
+        (["foo", "bar", "baz"], "or", "'bar', 'baz', or 'foo'"),
+        (["foo", "bar", "baz", "qux"], "or", "'bar', 'baz', 'foo', or 'qux'"),
+    ),
+)
+def test_humanize_list(items, conjunction, expected):
+    assert utils.humanize_list(items, conjunction) == expected


### PR DESCRIPTION
No functional change, tests update to pytest

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
