### PR TITLE
parts: set up snap assets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ dev_requires = [
     "pytest-mock",
     "pytest-subprocess",
     "types-PyYAML",
+    "types-requests",
     "types-setuptools",
     "types-tabulate",
 ]

--- a/snapcraft/errors.py
+++ b/snapcraft/errors.py
@@ -49,5 +49,12 @@ class MetadataExtractionError(SnapcraftError):
         super().__init__(f"Error extracting metadata from {filename!r}: {message}")
 
 
+class DesktopFileError(SnapcraftError):
+    """Failed to create application desktop file."""
+
+    def __init__(self, filename: str, message: str) -> None:
+        super().__init__(f"Failed to generate desktop file {filename!r}: {message}")
+
+
 class LegacyFallback(Exception):
     """Fall back to legacy snapcraft implementation."""

--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -16,7 +16,6 @@
 
 """Create snap.yaml metadata file."""
 
-import textwrap
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union, cast
 
@@ -118,8 +117,6 @@ def write(project: Project, prime_dir: Path, *, arch: str):
     meta_dir = prime_dir / "meta"
     meta_dir.mkdir(parents=True, exist_ok=True)
 
-    _write_snapcraft_runner(prime_dir)
-
     snap_apps: Dict[str, SnapApp] = {}
     if project.apps:
         for name, app in project.apps.items():
@@ -189,21 +186,6 @@ def write(project: Project, prime_dir: Path, *, arch: str):
 
     snap_yaml = meta_dir / "snap.yaml"
     snap_yaml.write_text(yaml_data)
-
-
-def _write_snapcraft_runner(prime_dir: Path):
-    content = textwrap.dedent(
-        """#!/bin/sh
-        export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
-        export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
-        exec "$@"
-        """
-    )
-
-    runner_path = prime_dir / "snap/command-chain/snapcraft-runner"
-    runner_path.parent.mkdir(parents=True, exist_ok=True)
-    runner_path.write_text(content)
-    runner_path.chmod(0o755)
 
 
 def _repr_str(dumper, data):

--- a/snapcraft/parts/desktop_file.py
+++ b/snapcraft/parts/desktop_file.py
@@ -1,0 +1,128 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Desktop file parser."""
+
+import configparser
+import os
+import shlex
+from pathlib import Path
+from typing import Optional
+
+from craft_cli import emit
+
+from snapcraft import errors
+
+
+class DesktopFile:
+    """Parse and process a .desktop file.
+
+    :param snap_name: The snap package name.
+    :param app_name: The name of the app using the desktop file.
+    :param filename: The desktop file name.
+    :param prime_dir: The prime directory path.
+
+    :raises DesktopFileError: If the desktop file does not exist.
+    """
+
+    def __init__(
+        self, *, snap_name: str, app_name: str, filename: str, prime_dir: Path
+    ) -> None:
+        self._snap_name = snap_name
+        self._app_name = app_name
+        self._filename = filename
+        self._prime_dir = prime_dir
+
+        file_path = prime_dir / filename
+        if not file_path.is_file():
+            raise errors.DesktopFileError(
+                filename, f"file does not exist (defined in app {app_name!r})"
+            )
+
+        self._parser = configparser.ConfigParser(interpolation=None)
+        # mypy type checking ignored, see https://github.com/python/mypy/issues/506
+        self._parser.optionxform = str  # type: ignore
+        self._parser.read(file_path, encoding="utf-8")
+
+    def _parse_and_reformat_section_exec(self, section):
+        exec_value = self._parser[section]["Exec"]
+        exec_split = shlex.split(exec_value, posix=False)
+
+        # Ensure command is invoked correctly.
+        if self._app_name == self._snap_name:
+            exec_split[0] = self._app_name
+        else:
+            exec_split[0] = f"{self._snap_name}.{self._app_name}"
+
+        self._parser[section]["Exec"] = " ".join(exec_split)
+
+    def _parse_and_reformat_section(self, *, section, icon_path: Optional[str] = None):
+        if "Exec" not in self._parser[section]:
+            raise errors.DesktopFileError(self._filename, "missing 'Exec' key")
+
+        self._parse_and_reformat_section_exec(section)
+
+        if "Icon" in self._parser[section]:
+            icon = self._parser[section]["Icon"]
+
+            if icon_path is not None:
+                icon = icon_path
+
+            # Strip any leading slash.
+            icon = icon[1:] if icon.startswith("/") else icon
+
+            # Strip any leading ${SNAP}.
+            icon = icon[8:] if icon.startswith("${SNAP}") else icon
+
+            # With everything stripped, check to see if the icon is there.
+            # if it is, add "${SNAP}" back and set the icon
+            if (self._prime_dir / icon).is_file():
+                self._parser[section]["Icon"] = os.path.join("${SNAP}", icon)
+            else:
+                emit.message(
+                    f"Icon {icon!r} specified in desktop file {self._filename!r} "
+                    f"not found in prime directory."
+                )
+
+    def _parse_and_reformat(self, *, icon_path: Optional[str] = None) -> None:
+        if "Desktop Entry" not in self._parser.sections():
+            raise errors.DesktopFileError(
+                self._filename, "missing 'Desktop Entry' section"
+            )
+
+        for section in self._parser.sections():
+            self._parse_and_reformat_section(section=section, icon_path=icon_path)
+
+    def write(self, *, gui_dir: Path, icon_path: Optional[str] = None) -> None:
+        """Write the desktop file.
+
+        :param gui_dir: The desktop file destination directory.
+        :param icon_path: The icon corresponding to this desktop file.
+        """
+        self._parse_and_reformat(icon_path=icon_path)
+
+        gui_dir.mkdir(parents=True, exist_ok=True)
+
+        # Rename the desktop file to match the app name. This will help
+        # unity8 associate them (https://launchpad.net/bugs/1659330).
+        target = gui_dir / f"{self._app_name}.desktop"
+
+        if target.exists():
+            # Unlikely. A desktop file in meta/gui/ already existed for
+            # this app. Let's pretend it wasn't there and overwrite it.
+            target.unlink()
+        with target.open("w", encoding="utf-8") as target_file:
+            self._parser.write(target_file, space_around_delimiters=False)

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -31,6 +31,7 @@ from snapcraft.projects import GrammarAwareProject, Project
 from snapcraft.providers import capture_logs_from_instance
 
 from . import grammar, yaml_utils
+from .setup_assets import setup_assets
 from .update_metadata import update_project_metadata
 
 if TYPE_CHECKING:
@@ -202,6 +203,7 @@ def _run_command(
     # Extract metadata and generate snap.yaml
     project_vars = lifecycle.project_vars
     if step_name == "prime" and not part_names:
+        emit.progress("Extracting and updating metadata...")
         metadata_list = lifecycle.extract_metadata()
         update_project_metadata(
             project,
@@ -211,7 +213,12 @@ def _run_command(
             prime_dir=lifecycle.prime_dir,
         )
 
-        # TODO: copy meta/gui assets
+        emit.progress("Copying snap assets...")
+        setup_assets(
+            project,
+            assets_dir=assets_dir,
+            prime_dir=lifecycle.prime_dir,
+        )
 
         emit.progress("Generating snap metadata...")
         snap_yaml.write(

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -187,7 +187,7 @@ class PartsLifecycle:
             emit.trace(f"extract metadata: parse info from {metadata_file}")
 
             for location in locations:
-                if pathlib.Path(location, metadata_file).is_file():
+                if pathlib.Path(location, metadata_file.lstrip("/")).is_file():
                     metadata = extract_metadata(metadata_file, workdir=str(location))
                     if metadata:
                         metadata_list.append(metadata)

--- a/snapcraft/parts/setup_assets.py
+++ b/snapcraft/parts/setup_assets.py
@@ -1,0 +1,215 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Copy assets to their final locations."""
+
+import itertools
+import os
+import shutil
+import stat
+import textwrap
+import urllib.parse
+from pathlib import Path
+from typing import List, Optional
+
+import requests
+from craft_cli import emit
+
+from snapcraft import errors
+from snapcraft.projects import Project
+
+from .desktop_file import DesktopFile
+
+
+def setup_assets(project: Project, *, assets_dir: Path, prime_dir: Path) -> None:
+    """Copy gui assets to the appropriate location in the snap filesystem.
+
+    :param project: The snap project file.
+    :param assets_dir: The directory containing snap project assets.
+    :param prime_dir: The directory containing the content to be snapped.
+    """
+    meta_dir = prime_dir / "meta"
+    gui_dir = meta_dir / "gui"
+    gui_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_snap_directory(assets_dir=assets_dir, prime_dir=prime_dir, meta_dir=meta_dir)
+    _write_snapcraft_runner(prime_dir=prime_dir)
+    # TODO: write snapcraft
+
+    if not project.apps:
+        return
+
+    icon_path = _finalize_icon(
+        project.icon, assets_dir=assets_dir, gui_dir=gui_dir, prime_dir=prime_dir
+    )
+    relative_icon_path: Optional[str] = None
+
+    if icon_path is not None:
+        if prime_dir in icon_path.parents:
+            icon_path = icon_path.relative_to(prime_dir)
+        relative_icon_path = str(icon_path)
+
+    for app_name, app in project.apps.items():
+        if not app.desktop:
+            continue
+
+        desktop_file = DesktopFile(
+            snap_name=project.name,
+            app_name=app_name,
+            filename=app.desktop,
+            prime_dir=prime_dir,
+        )
+        desktop_file.write(gui_dir=gui_dir, icon_path=relative_icon_path)
+
+        _validate_command_chain(
+            app.command_chain, app_name=app_name, prime_dir=prime_dir
+        )
+
+    # TODO: copy gadget and kernel assets
+
+
+def _finalize_icon(
+    icon: Optional[str], *, assets_dir: Path, gui_dir: Path, prime_dir: Path
+) -> Optional[Path]:
+    """Ensure sure icon is properly configured and installed.
+
+    Fetch from a remote URL, if required, and place in the meta/gui
+    directory.
+    """
+    # Nothing to do if no icon is configured, search for existing icon.
+    if icon is None:
+        return _find_icon_file(assets_dir)
+
+    # Extracted appstream icon paths will either:
+    # (1) point to a file relative to prime
+    # (2) point to a remote http(s) url
+    #
+    # The 'icon' specified in the snapcraft.yaml has the same
+    # constraint as (2) and would have already been validated
+    # as existing by the schema.  So we can treat it the same
+    # at this point, regardless of the source of the icon.
+    parsed_url = urllib.parse.urlparse(icon)
+    parsed_path = Path(parsed_url.path)
+    icon_ext = parsed_path.suffix[1:]
+    target_icon_path = Path(gui_dir, f"icon.{icon_ext}")
+
+    target_icon_path.parent.mkdir(parents=True, exist_ok=True)
+    if parsed_url.scheme in ["http", "https"]:
+        # Remote - fetch URL and write to target.
+        emit.progress(f"Fetching icon from {icon!r}")
+        icon_data = requests.get(icon).content
+        target_icon_path.write_bytes(icon_data)
+    elif parsed_url.scheme == "":
+        source_path = Path(
+            prime_dir,
+            parsed_path.relative_to("/") if parsed_path.is_absolute() else parsed_path,
+        )
+        if source_path.exists():
+            # Local with path relative to prime.
+            shutil.copy(source_path, target_icon_path)
+        elif parsed_path.exists():
+            # Local with path relative to project.
+            shutil.copy(parsed_path, target_icon_path)
+        else:
+            # No icon found, fall back to searching for existing icon.
+            return _find_icon_file(assets_dir)
+    else:
+        raise RuntimeError(f"Unexpected icon path: {parsed_url!r}")
+
+    return target_icon_path
+
+
+def _find_icon_file(assets_dir: Path) -> Optional[Path]:
+    for icon_path in (assets_dir / "gui/icon.png", assets_dir / "gui/icon.svg"):
+        if icon_path.is_file():
+            return icon_path
+    return None
+
+
+def _validate_command_chain(
+    command_chain: List[str], *, app_name: str, prime_dir: Path
+) -> None:
+    """Verify if each item in the command chain is executble."""
+    for item in command_chain:
+        executable_path = prime_dir / item
+
+        # command-chain entries must always be relative to the root of
+        # the snap, i.e. PATH is not used.
+        if not _is_executable(executable_path):
+            raise errors.SnapcraftError(
+                f"Failed to generate snap metadata: The command-chain item {item!r} "
+                f"defined in the app {app_name!r} does not exist or is not executable.",
+                resolution=f"Ensure that {item!r} is relative to the prime directory.",
+            )
+
+
+def _is_executable(path: Path) -> bool:
+    """Verify if the given path corresponds to an executable file."""
+    if not path.is_file():
+        return False
+
+    mode = path.stat().st_mode
+    return bool(mode & stat.S_IXUSR or mode & stat.S_IXGRP or mode & stat.S_IXOTH)
+
+
+def _write_snapcraft_runner(*, prime_dir: Path):
+    content = textwrap.dedent(
+        """#!/bin/sh
+        export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+        export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+        exec "$@"
+        """
+    )
+
+    runner_path = prime_dir / "snap/command-chain/snapcraft-runner"
+    runner_path.parent.mkdir(parents=True, exist_ok=True)
+    runner_path.write_text(content)
+    runner_path.chmod(0o755)
+
+
+def _write_snap_directory(*, assets_dir: Path, prime_dir: Path, meta_dir: Path) -> None:
+    """Record manifest and copy assets found under the assets directory.
+
+    These assets have priority over any code generated assets and include:
+    - hooks
+    - gui
+    """
+    prime_snap_dir = prime_dir / "snap"
+
+    snap_dir_iter = itertools.product([prime_snap_dir], ["hooks", "gui"])
+    meta_dir_iter = itertools.product([meta_dir], ["hooks", "gui"])
+
+    for origin in itertools.chain(snap_dir_iter, meta_dir_iter):
+        src_dir = assets_dir / origin[1]
+        dst_dir = origin[0] / origin[1]
+
+        if src_dir.is_dir():
+            dst_dir.mkdir(parents=True, exist_ok=True)
+            for asset in os.listdir(src_dir):
+                source = src_dir / asset
+                destination = dst_dir / asset
+
+                destination.unlink(missing_ok=True)
+
+                shutil.copy(source, destination, follow_symlinks=True)
+
+                # Ensure that the hook is executable in meta/hooks, this is a moot
+                # point considering the prior link_or_copy call, but is technically
+                # correct and allows for this operation to take place only once.
+                if origin[0] == meta_dir and origin[1] == "hooks":
+                    destination.chmod(0o755)
+
+    # TODO: record manifest and source snapcraft.yaml

--- a/snapcraft/parts/update_metadata.py
+++ b/snapcraft/parts/update_metadata.py
@@ -108,7 +108,7 @@ def _update_project_icon(
         if Path(icon_file).is_file():
             break
     else:
-        if metadata.icon and Path(prime_dir, metadata.icon).is_file():
+        if metadata.icon and Path(prime_dir, metadata.icon.lstrip("/")).is_file():
             project.icon = metadata.icon
 
 
@@ -145,7 +145,7 @@ def _update_project_app_desktop_file(
 
         if metadata.desktop_file_paths:
             for filename in metadata.desktop_file_paths:
-                if Path(prime_dir, filename).is_file():
+                if Path(prime_dir, filename.lstrip("/")).is_file():
                     project.apps[app_name].desktop = filename
                     emit.trace(f"use desktop file {filename!r}")
                     break

--- a/tests/spread/general/core22/appstream-desktop/snaps/appstream-desktop/snap/snapcraft.yaml
+++ b/tests/spread/general/core22/appstream-desktop/snaps/appstream-desktop/snap/snapcraft.yaml
@@ -15,7 +15,6 @@ parts:
   appstream-desktop:
     plugin: nil
     source: .
-    build-packages: [gcc, libc6-dev]
     parse-info: [usr/share/metainfo/io.snapcraft.appstream.metainfo.xml]
     override-build: |
       install -D -m 0644 io.snapcraft.appstream.desktop $CRAFT_PART_INSTALL/usr/share/applications/io.snapcraft.appstream.desktop

--- a/tests/spread/general/core22/appstream-desktop/task.yaml
+++ b/tests/spread/general/core22/appstream-desktop/task.yaml
@@ -26,11 +26,9 @@ execute: |
       exit 1
   fi
 
-  # Enable after installing assets
-  #
-  # expected_desktop="$PWD/../../appstream-desktop/expected_appstream-desktop.desktop"
-  #
-  # if ! diff -U10 prime/meta/gui/appstream-desktop.desktop "$expected_desktop"; then
-  #     echo "The formatting for appstream-desktop.desktop is incorrect"
-  #     exit 1
-  # fi
+  expected_desktop="../../expected_appstream-desktop.desktop"
+
+  if ! diff -U10 prime/meta/gui/appstream-desktop.desktop "$expected_desktop"; then
+      echo "The formatting for appstream-desktop.desktop is incorrect"
+      exit 1
+  fi

--- a/tests/unit/parts/test_desktop_file.py
+++ b/tests/unit/parts/test_desktop_file.py
@@ -1,0 +1,236 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2019-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from snapcraft import errors
+from snapcraft.parts.desktop_file import DesktopFile
+
+
+class TestDesktopExec:
+    """Exec entry rewriting."""
+
+    @pytest.mark.parametrize(
+        "app_name,app_args,expected_exec",
+        [
+            # snap name == app name
+            ("foo", "", "foo"),
+            ("foo", "--arg", "foo --arg"),
+            ("foo", "--arg %U", "foo --arg %U"),
+            ("foo", "%U", "foo %U"),
+
+            # snap name != app name
+            ("bar", "", "foo.bar"),
+            ("bar", "--arg", "foo.bar --arg"),
+        ]
+    )
+    def test_generate_desktop_file(
+        self, new_dir, app_name, app_args, expected_exec
+    ):
+        snap_name = "foo"
+
+        desktop_file_path = new_dir / "app.desktop"
+        with desktop_file_path.open("w") as desktop_file:
+            print("[Desktop Entry]", file=desktop_file)
+            print(
+                f"Exec={' '.join(['in-snap-exe', app_args])}", file=desktop_file
+            )
+
+        d = DesktopFile(
+            snap_name=snap_name,
+            app_name=app_name,
+            filename=desktop_file_path,
+            prime_dir=new_dir.as_posix(),
+        )
+        d.write(gui_dir=Path())
+
+        expected_desktop_file = new_dir / f"{app_name}.desktop"
+        assert expected_desktop_file.exists()
+        with expected_desktop_file.open() as desktop_file:
+            assert desktop_file.read() == dedent(
+                f"""\
+                [Desktop Entry]
+                Exec={expected_exec}
+
+                """
+            )
+
+
+class TestDesktopIcon:
+    """Icon entry rewriting."""
+
+    @pytest.mark.parametrize(
+        "icon,icon_path,expected_icon",
+        [
+            # icon_path preferred
+            ("other.png", "foo.png", "${SNAP}/foo.png"),
+
+            # icon_path with / preferred
+            ("/foo.png", "foo.png", "${SNAP}/foo.png"),
+
+            # icon path with ${SNAP}
+            ("${SNAP}/foo.png", None, "${SNAP}/foo.png"),
+
+            # icon name
+            ("foo", None, "foo"),
+        ]
+    )
+    def test_generate_desktop_file(self, new_dir, icon, icon_path, expected_icon):
+        snap_name = app_name = "foo"
+
+        desktop_file_path = new_dir / "app.desktop"
+        with desktop_file_path.open("w") as desktop_file:
+            print("[Desktop Entry]", file=desktop_file)
+            print("Exec=in-snap-exe", file=desktop_file)
+            print(f"Icon={icon}", file=desktop_file)
+
+        if icon_path is not None:
+            (new_dir / icon_path).touch()
+
+        d = DesktopFile(
+            snap_name=snap_name,
+            app_name=app_name,
+            filename=desktop_file_path,
+            prime_dir=new_dir,
+        )
+        d.write(gui_dir=Path())
+
+        if icon_path is not None:
+            d.write(icon_path=icon_path, gui_dir=Path())
+        else:
+            d.write(gui_dir=Path())
+
+        expected_desktop_file = new_dir / f"{app_name}.desktop"
+        assert expected_desktop_file.exists()
+        with expected_desktop_file.open() as desktop_file:
+            assert (
+                desktop_file.read()
+                == dedent(
+                    """\
+            [Desktop Entry]
+            Exec=foo
+            Icon={}
+
+        """
+                ).format(expected_icon)
+            )
+
+    @pytest.mark.parametrize(
+        "icon,icon_path,expected_icon",
+        [
+            # icon_path preferred
+            ("other.png", "foo.png", "${SNAP}/foo.png"),
+
+            # icon_path with / preferred
+            ("/foo.png", "foo.png", "${SNAP}/foo.png"),
+
+            # icon path with ${SNAP}
+            ("${SNAP}/foo.png", None, "${SNAP}/foo.png"),
+
+            # icon name
+            ("foo", None, "foo"),
+        ]
+    )
+    def test_generate_desktop_file_multisection(
+        self, new_dir, icon, icon_path, expected_icon
+    ):
+        snap_name = app_name = "foo"
+
+        desktop_file_path = new_dir / "app.desktop"
+        with desktop_file_path.open("w") as desktop_file:
+            print("[Desktop Entry]", file=desktop_file)
+            print("Exec=in-snap-exe", file=desktop_file)
+            print(f"Icon={icon}", file=desktop_file)
+            print("[Desktop Entry Two]", file=desktop_file)
+            print("Exec=in-snap-exe2", file=desktop_file)
+            print(f"Icon={icon}", file=desktop_file)
+
+        if icon_path is not None:
+            (new_dir / icon_path).touch()
+
+        d = DesktopFile(
+            snap_name=snap_name,
+            app_name=app_name,
+            filename=desktop_file_path,
+            prime_dir=new_dir,
+        )
+
+        if icon_path is not None:
+            d.write(icon_path=icon_path, gui_dir=Path())
+        else:
+            d.write(gui_dir=Path())
+
+        expected_desktop_file = new_dir / f"{app_name}.desktop"
+        assert expected_desktop_file.exists()
+        with expected_desktop_file.open() as desktop_file:
+            assert desktop_file.read() == dedent(
+                f"""\
+                [Desktop Entry]
+                Exec=foo
+                Icon={expected_icon}
+
+                [Desktop Entry Two]
+                Exec=foo
+                Icon={expected_icon}
+
+                """
+            )
+
+
+def test_not_found(new_dir):
+    with pytest.raises(errors.DesktopFileError):
+        DesktopFile(
+            snap_name="foo",
+            app_name="foo",
+            filename="desktop-file-not-found",
+            prime_dir=new_dir,
+        )
+
+
+def test_no_desktop_section(new_dir):
+    with open("foo.desktop", "w") as desktop_file:
+        print("[Random Entry]", file=desktop_file)
+        print("Exec=foo", file=desktop_file)
+        print("Icon=foo", file=desktop_file)
+
+    d = DesktopFile(
+        snap_name="foo",
+        app_name="foo",
+        filename="foo.desktop",
+        prime_dir=new_dir,
+    )
+
+    with pytest.raises(errors.DesktopFileError):
+        d.write(gui_dir=new_dir)
+
+
+def test_missing_exec_entry(new_dir):
+    with open("foo.desktop", "w") as desktop_file:
+        print("[Desktop Entry]", file=desktop_file)
+        print("Icon=foo", file=desktop_file)
+
+    d = DesktopFile(
+        snap_name="foo",
+        app_name="foo",
+        filename="foo.desktop",
+        prime_dir=new_dir,
+    )
+
+    with pytest.raises(errors.DesktopFileError):
+        d.write(gui_dir=new_dir)

--- a/tests/unit/parts/test_setup_assets.py
+++ b/tests/unit/parts/test_setup_assets.py
@@ -1,0 +1,249 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import textwrap
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from snapcraft import errors
+from snapcraft.parts.setup_assets import _validate_command_chain, setup_assets
+from snapcraft.projects import Project
+
+
+@pytest.fixture
+def desktop_file():
+    def _write_file(filename: str):
+        Path(filename).write_text(
+            textwrap.dedent(
+                """\
+                [Desktop Entry]
+                Name=appstream-desktop
+                Exec=appstream
+                Type=Application
+                Icon=/usr/share/icons/my-icon.svg"""
+            )
+        )
+
+    yield _write_file
+
+
+@pytest.fixture
+def yaml_data():
+    def _yaml_data(extra_data: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "name": "test-project",
+            "base": "core22",
+            "confinement": "strict",
+            "parts": {},
+            **extra_data,
+        }
+
+    yield _yaml_data
+
+
+class TestSetupAssets:
+    """Check copied assets and desktop entries."""
+
+    @pytest.fixture(autouse=True)
+    def setup_method_fixture(self, new_dir):
+        # create prime tree
+        Path("prime").mkdir()
+        Path("prime/test.sh").touch()
+        Path("prime/test.sh").chmod(0o755)
+
+        # create assets dir
+        Path("snap").mkdir()
+
+    def test_setup_assets_happy(self, desktop_file, yaml_data, new_dir):
+        desktop_file("prime/test.desktop")
+        Path("prime/usr/share/icons").mkdir(parents=True)
+        Path("prime/usr/share/icons/my-icon.svg").touch()
+
+        # define project
+        project = Project.unmarshal(
+            yaml_data(
+                {
+                    "adopt-info": "part",
+                    "apps": {
+                        "app1": {
+                            "command": "test.sh",
+                            "common-id": "my-test",
+                            "desktop": "test.desktop",
+                        },
+                    },
+                },
+            )
+        )
+
+        setup_assets(project, assets_dir=Path("snap"), prime_dir=Path("prime"))
+
+        # desktop file should be in meta/gui and named after app
+        desktop_path = Path("prime/meta/gui/app1.desktop")
+        assert desktop_path.is_file()
+
+        # desktop file content should make icon relative to ${SNAP}
+        content = desktop_path.read_text()
+        assert content == textwrap.dedent(
+            """\
+            [Desktop Entry]
+            Name=appstream-desktop
+            Exec=test-project.app1
+            Type=Application
+            Icon=${SNAP}/usr/share/icons/my-icon.svg
+
+            """
+        )
+
+    def test_setup_assets_icon_in_assets_dir(self, desktop_file, yaml_data, new_dir):
+        desktop_file("prime/test.desktop")
+        Path("snap/gui").mkdir(parents=True)
+        Path("snap/gui/icon.svg").touch()
+
+        # define project
+        project = Project.unmarshal(
+            yaml_data(
+                {
+                    "adopt-info": "part",
+                    "apps": {
+                        "app1": {
+                            "command": "test.sh",
+                            "common-id": "my-test",
+                            "desktop": "test.desktop",
+                        },
+                    },
+                },
+            )
+        )
+
+        setup_assets(project, assets_dir=Path("snap"), prime_dir=Path("prime"))
+
+        # desktop file should be in meta/gui and named after app
+        desktop_path = Path("prime/meta/gui/app1.desktop")
+        assert desktop_path.is_file()
+
+        # desktop file content should make icon relative to ${SNAP}
+        content = desktop_path.read_text()
+        assert content == textwrap.dedent(
+            """\
+            [Desktop Entry]
+            Name=appstream-desktop
+            Exec=test-project.app1
+            Type=Application
+            Icon=${SNAP}/snap/gui/icon.svg
+
+            """
+        )
+
+        # icon file exists
+        Path("prime/snap/gui/icon.svg").is_file()
+
+    def test_setup_assets_no_apps(self, desktop_file, yaml_data, new_dir):
+        desktop_file("prime/test.desktop")
+        Path("prime/usr/share/icons").mkdir(parents=True)
+        Path("prime/usr/share/icons/icon.svg").touch()
+        Path("snap/gui").mkdir()
+
+        # define project
+        project = Project.unmarshal(yaml_data({"adopt-info": "part"}))
+
+        # setting up assets does not crash
+        setup_assets(project, assets_dir=Path("snap"), prime_dir=Path("prime"))
+
+        assert os.listdir("prime/meta/gui") == []
+
+    def test_setup_assets_remote_icon(self, desktop_file, yaml_data, new_dir):
+        # create primed tree (no icon)
+        desktop_file("prime/test.desktop")
+
+        # define project
+        # pylint: disable=line-too-long
+        project = Project.unmarshal(
+            yaml_data(
+                {
+                    "adopt-info": "part",
+                    "icon": "https://dashboard.snapcraft.io/site_media/appmedia/2018/04/Snapcraft-logo-bird.png",
+                    "apps": {
+                        "app1": {
+                            "command": "test.sh",
+                            "common-id": "my-test",
+                            "desktop": "test.desktop",
+                        },
+                    },
+                },
+            )
+        )
+        # pylint: enable=line-too-long
+
+        setup_assets(project, assets_dir=Path("snap"), prime_dir=Path("prime"))
+
+        # desktop file should be in meta/gui and named after app
+        desktop_path = Path("prime/meta/gui/app1.desktop")
+        assert desktop_path.is_file()
+
+        # desktop file content should make icon relative to ${SNAP}
+        content = desktop_path.read_text()
+        assert content == textwrap.dedent(
+            """\
+            [Desktop Entry]
+            Name=appstream-desktop
+            Exec=test-project.app1
+            Type=Application
+            Icon=${SNAP}/meta/gui/icon.png
+
+            """
+        )
+
+        # icon was downloaded
+        icon_path = Path("prime/meta/gui/icon.png")
+        assert icon_path.is_file()
+        assert icon_path.stat().st_size > 0
+
+
+class TestCommandChain:
+    """Command chain items are valid."""
+
+    def test_command_chain_path_not_found(self, new_dir):
+
+        with pytest.raises(errors.SnapcraftError) as raised:
+            _validate_command_chain(
+                ["file-not-found"], app_name="foo", prime_dir=new_dir
+            )
+
+        assert str(raised.value) == (
+            "Failed to generate snap metadata: The command-chain item 'file-not-found' "
+            "defined in the app 'foo' does not exist or is not executable."
+        )
+
+    def test_command_chain_path_not_executable(self, new_dir):
+        Path("file-executable").touch()
+        Path("file-executable").chmod(0o755)
+
+        Path("file-not-executable").touch()
+
+        with pytest.raises(errors.SnapcraftError) as raised:
+            _validate_command_chain(
+                ["file-executable", "file-not-executable"],
+                app_name="foo",
+                prime_dir=new_dir,
+            )
+
+        assert str(raised.value) == (
+            "Failed to generate snap metadata: The command-chain item 'file-not-executable' "
+            "defined in the app 'foo' does not exist or is not executable."
+        )


### PR DESCRIPTION
Copy icon and desktop files to the snap payload and edit entries in
the desktop file to point to the correct executables and icon files.

Co-authored-by: Leo Arias <leo.arias@canonical.com>
Co-authored-by: Chris Patterson <chris.patterson@canonical.com>
Co-authored-by: Sergio Schvezov <sergio.schvezov@canonical.com>
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
CRAFT-1039