### PR TITLE
projects: field grade is not mandatory

### DIFF
--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -161,7 +161,6 @@ def write(project: Project, prime_dir: Path, *, arch: str):
                 sockets=app_sockets if app_sockets else None,
             )
 
-    # FIXME: handle adopted parameters
     snap_metadata = SnapMetadata(
         name=project.name,
         title=project.title,
@@ -176,7 +175,7 @@ def write(project: Project, prime_dir: Path, *, arch: str):
         epoch=project.epoch,
         apps=snap_apps,
         confinement=project.confinement,
-        grade=project.grade,  # type: ignore
+        grade=project.grade or "stable",
         environment=project.environment,
         plugs=project.plugs,
         hooks=project.hooks,

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -225,7 +225,7 @@ class ContentPlug(ProjectModel):
     default_provider: Optional[str]
 
 
-MANDATORY_ADOPTABLE_FIELDS = ("version", "summary", "description", "grade")
+MANDATORY_ADOPTABLE_FIELDS = ("version", "summary", "description")
 
 
 class Project(ProjectModel):

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -38,7 +38,6 @@ def simple_project():
           we live in tweetspace and your description wants to look good in the snap
           store.
 
-        grade: stable
         confinement: strict
 
         parts:
@@ -105,7 +104,7 @@ def complex_project():
           we live in tweetspace and your description wants to look good in the snap
           store.
 
-        grade: stable
+        grade: devel
         confinement: strict
 
         environment:
@@ -249,7 +248,7 @@ def test_complex_snap_yaml(complex_project, new_dir):
                 listen-stream: 100
                 socket-mode: 1
         confinement: strict
-        grade: stable
+        grade: devel
         environment:
           GLOBAL_VARIABLE: test-global-variable
         plugs:

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -173,7 +173,6 @@ class TestProjectValidation:
             "version",
             "summary",
             "description",
-            "grade",
         )
 
     @pytest.mark.parametrize("field", MANDATORY_ADOPTABLE_FIELDS)


### PR DESCRIPTION
Grade is an optional field and assumed as stable if not explicitly
set in project or adopted metadata.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
