### PR TITLE
repo: get host architecture using non-legacy code

### DIFF
--- a/snapcraft/repo/apt_sources_manager.py
+++ b/snapcraft/repo/apt_sources_manager.py
@@ -23,8 +23,7 @@ from typing import List, Optional
 
 from craft_cli import emit
 
-from snapcraft import os_release
-from snapcraft_legacy.project._project_options import ProjectOptions
+from snapcraft import os_release, utils
 
 from . import apt_ppa, package_repository
 
@@ -58,15 +57,11 @@ def _construct_deb822_source(
         if architectures:
             arch_text = " ".join(architectures)
         else:
-            arch_text = _get_host_arch()
+            arch_text = utils.get_host_architecture()
 
         print(f"Architectures: {arch_text}", file=deb822)
 
         return deb822.getvalue()
-
-
-def _get_host_arch() -> str:
-    return ProjectOptions().deb_arch
 
 
 class AptSourcesManager:

--- a/tests/unit/repo/test_apt_sources_manager.py
+++ b/tests/unit/repo/test_apt_sources_manager.py
@@ -42,8 +42,8 @@ def mock_environ_copy(mocker):
 
 @pytest.fixture(autouse=True)
 def mock_host_arch(mocker):
-    m = mocker.patch("snapcraft.repo.apt_sources_manager.ProjectOptions")
-    m.return_value.deb_arch = "FAKE-HOST-ARCH"
+    m = mocker.patch("snapcraft.utils.get_host_architecture")
+    m.return_value = "FAKE-HOST-ARCH"
 
     yield m
 


### PR DESCRIPTION
Remove legacy hook to obtain host architecture, use OsPlatform instead.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
