### PR TITLE
Feature/meta: architectures

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -64,7 +64,7 @@ pydocstyle==6.1.1
 pyelftools==0.28
 pyflakes==2.4.0
 pyftpdlib==1.5.6
-pylint==2.14.1
+pylint==2.14.2
 pylint-fixme-info==1.0.3
 pylint-pytest==1.1.2
 pylxd==2.3.1

--- a/snapcraft/errors.py
+++ b/snapcraft/errors.py
@@ -73,5 +73,19 @@ class FilePermissionError(SnapcraftError):
         )
 
 
+class InvalidArchitecture(SnapcraftError):
+    """The machine architecture is not supported.
+
+    :param arch_name: The unsupported architecture name.
+    """
+
+    def __init__(self, arch_name: str):
+        self.arch_name = arch_name
+        super().__init__(
+            f"Architecture {arch_name!r} is not supported.",
+            resolution="Make sure the architecture name is correct.",
+        )
+
+
 class LegacyFallback(Exception):
     """Fall back to legacy snapcraft implementation."""

--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -41,37 +41,80 @@ def _verify_snap(directory: Path) -> None:
         raise errors.SnapcraftError(msg)
 
 
+def _get_directory(output: Optional[str]) -> Optional[str]:
+    """Get directory to output the snap file to.
+
+    :param output: Snap file name or directory.
+
+    :return: The directory to output the snap file to.
+      If no directory is provided, return None.
+      If directory is current working directory, return None.
+    """
+    if output:
+        output_path = Path(output)
+        output_parent = output_path.parent
+        if output_path.is_dir():
+            return str(output_path)
+        if output_parent and output_parent.resolve() != Path(".").resolve():
+            return str(output_parent)
+    return None
+
+
+def _get_filename(
+    output: Optional[str],
+    name: Optional[str] = None,
+    version: Optional[str] = None,
+    target_arch: Optional[str] = None,
+) -> Optional[str]:
+    """Get output filename of the snap file.
+
+    If output is not a file, then the filename will be <name>_<version>_<target_arch>.snap
+
+    :param output: Snap file name or directory.
+    :param name: Name of snap project.
+    :param version: Version of snap project.
+    :param target_arch: Target architecture the snap project is built to.
+
+    :return: The filename of the snap file.
+    """
+    if name is not None and version is not None and target_arch is not None:
+        output_file = name + "_" + version + "_" + target_arch + ".snap"
+    else:
+        output_file = None
+
+    if output:
+        output_path = Path(output)
+        if not output_path.is_dir():
+            output_file = output_path.name
+
+    return output_file
+
+
 def pack_snap(
-    directory: Path, *, output: Optional[str], compression: Optional[str] = None
+    directory: Path,
+    *,
+    output: Optional[str],
+    compression: Optional[str] = None,
+    name: Optional[str] = None,
+    version: Optional[str] = None,
+    target_arch: Optional[str] = None,
 ) -> None:
     """Pack snap contents.
 
     :param directory: Directory to pack.
     :param output: Snap file name or directory.
     :param compression: Compression type to use, None for defaults.
+    :param name: Name of snap project.
+    :param version: Version of snap project.
+    :param target_arch: Target architecture the snap project is built to.
     """
     emit.trace(f"pack_snap: output={output!r}, compression={compression!r}")
 
     # TODO remove workaround once LP: #1950465 is fixed
     _verify_snap(directory)
 
-    output_file = None
-    output_dir = None
-
-    if output:
-        output_path = Path(output)
-        output_parent = output_path.parent
-        if output_path.is_dir():
-            # do not define a snap name if the output is a directory
-            output_dir = str(output_path)
-        elif output_parent and output_parent.resolve() != Path(".").resolve():
-            output_dir = str(output_parent)
-            output_file = output_path.name
-        else:
-            # do not define a directory if the output parent directory is the cwd
-            output_file = output_path.name
-
     command: List[Union[str, Path]] = ["snap", "pack"]
+    output_file = _get_filename(output, name, version, target_arch)
     if output_file is not None:
         command.extend(["--filename", output_file])
 
@@ -81,6 +124,7 @@ def pack_snap(
 
     command.append(directory)
 
+    output_dir = _get_directory(output)
     if output_dir is not None:
         command.append(output_dir)
 

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -20,16 +20,22 @@ import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import craft_parts
 from craft_cli import EmitterMode, emit
-from craft_parts import ProjectInfo, StepInfo, callbacks, infos
+from craft_parts import ProjectInfo, StepInfo, callbacks
 
 from snapcraft import errors, extensions, pack, providers, utils
 from snapcraft.meta import snap_yaml
-from snapcraft.projects import GrammarAwareProject, Project
+from snapcraft.projects import (
+    Architecture,
+    ArchitectureProject,
+    GrammarAwareProject,
+    Project,
+)
 from snapcraft.providers import capture_logs_from_instance
+from snapcraft.utils import get_host_architecture, process_version
 
 from . import grammar, plugins, yaml_utils
 from .parts import PartsLifecycle
@@ -77,8 +83,17 @@ def get_snap_project() -> _SnapProject:
     )
 
 
-def apply_yaml(yaml_data: Dict[str, Any]) -> Dict[str, Any]:
-    """Apply Snapcraft logic to yaml_data."""
+def apply_yaml(
+    yaml_data: Dict[str, Any], build_on: str, build_to: str
+) -> Dict[str, Any]:
+    """Apply Snapcraft logic to yaml_data.
+
+    Extensions are applied and advanced grammar is processed.
+    The architectures data is reduced to architectures in the current build plan.
+
+    :param yaml_data: The project YAML data.
+    :param build_to: Target architecture the snap project will be built to.
+    """
     # validate project grammar
     GrammarAwareProject.validate_grammar(yaml_data)
 
@@ -88,22 +103,29 @@ def apply_yaml(yaml_data: Dict[str, Any]) -> Dict[str, Any]:
         core_part["plugin"] = "nil"
         yaml_data["parts"][_CORE_PART_NAME] = core_part
 
-    # TODO: support for target_arch
-    arch = _get_arch()
-    yaml_data = extensions.apply_extensions(yaml_data, arch=arch, target_arch=arch)
+    yaml_data = extensions.apply_extensions(
+        yaml_data, arch=build_on, target_arch=build_to
+    )
 
     if "parts" in yaml_data:
         yaml_data["parts"] = grammar.process_parts(
-            parts_yaml_data=yaml_data["parts"], arch=arch, target_arch=arch
+            parts_yaml_data=yaml_data["parts"], arch=build_on, target_arch=build_to
         )
+
+    # replace all architectures with the architectures in the current build plan
+    yaml_data["architectures"] = [Architecture(build_on=build_on, build_to=build_to)]
 
     return yaml_data
 
 
 def process_yaml(project_file: Path) -> Dict[str, Any]:
-    """Process the yaml from project file.
+    """Process yaml data from file into a dictionary.
+
+    :param project_file: Path to project.
 
     :raises SnapcraftError: if the project yaml file cannot be loaded.
+
+    :return: The processed YAML data.
     """
     try:
         with open(project_file, encoding="utf-8") as yaml_file:
@@ -114,7 +136,7 @@ def process_yaml(project_file: Path) -> Dict[str, Any]:
             msg = f"{msg}: {err.filename!r}."
         raise errors.SnapcraftError(msg) from err
 
-    return apply_yaml(yaml_data)
+    return yaml_data
 
 
 def _extract_parse_info(yaml_data: Dict[str, Any]) -> Dict[str, List[str]]:
@@ -145,7 +167,7 @@ def run(command_name: str, parsed_args: "argparse.Namespace") -> None:
 
     snap_project = get_snap_project()
     yaml_data = process_yaml(snap_project.project_file)
-    parse_info = _extract_parse_info(yaml_data)
+    build_plan = get_build_plan(yaml_data)
 
     if parsed_args.provider:
         raise errors.SnapcraftError("Option --provider is not supported.")
@@ -158,19 +180,23 @@ def run(command_name: str, parsed_args: "argparse.Namespace") -> None:
     build_count = utils.get_parallel_build_count()
     _expand_environment(yaml_data, parallel_build_count=build_count)
 
-    project = Project.unmarshal(yaml_data)
+    for build_on, build_to in build_plan:
+        emit.progress(f"running with build_on: {build_on} and build_to: {build_to}")
+        yaml_data_for_arch = apply_yaml(yaml_data, build_on, build_to)
+        parse_info = _extract_parse_info(yaml_data_for_arch)
+        project = Project.unmarshal(yaml_data_for_arch)
 
-    try:
-        _run_command(
-            command_name,
-            project=project,
-            parse_info=parse_info,
-            parallel_build_count=build_count,
-            assets_dir=snap_project.assets_dir,
-            parsed_args=parsed_args,
-        )
-    except PermissionError as err:
-        raise errors.FilePermissionError(err.filename, reason=err.strerror)
+        try:
+            _run_command(
+                command_name,
+                project=project,
+                parse_info=parse_info,
+                parallel_build_count=build_count,
+                assets_dir=snap_project.assets_dir,
+                parsed_args=parsed_args,
+            )
+        except PermissionError as err:
+            raise errors.FilePermissionError(err.filename, reason=err.strerror)
 
 
 def _run_command(
@@ -233,6 +259,7 @@ def _run_command(
             "grade": project.grade or "",
         },
         extra_build_snaps=_get_extra_build_snaps(project),
+        target_arch=project.get_build_to(),
     )
 
     if command_name == "clean":
@@ -271,7 +298,7 @@ def _run_command(
         snap_yaml.write(
             project,
             lifecycle.prime_dir,
-            arch=lifecycle.target_arch,
+            target_arch=lifecycle.target_arch,
             arch_triplet=lifecycle.target_arch_triplet,
         )
         emit.message("Generated snap metadata", intermediate=True)
@@ -281,6 +308,9 @@ def _run_command(
             lifecycle.prime_dir,
             output=parsed_args.output,
             compression=project.compression,
+            name=project.name,
+            version=process_version(project.version),
+            target_arch=project.get_build_to(),
         )
 
 
@@ -292,8 +322,12 @@ def _clean_provider(project: Project, parsed_args: "argparse.Namespace") -> None
     emit.trace("Clean build provider")
     provider_name = "lxd" if parsed_args.use_lxd else None
     provider = providers.get_provider(provider_name)
+
     instance_names = provider.clean_project_environments(
-        project_name=project.name, project_path=Path().absolute()
+        project_name=project.name,
+        project_path=Path().absolute(),
+        build_on=project.get_build_on(),
+        build_to=project.get_build_to(),
     )
     if instance_names:
         emit.message(f"Removed instance: {', '.join(instance_names)}")
@@ -340,6 +374,8 @@ def _run_in_provider(
         project_path=Path().absolute(),
         base=project.get_effective_base(),
         bind_ssh=parsed_args.bind_ssh,
+        build_on=project.get_build_on(),
+        build_to=project.get_build_to(),
     ) as instance:
         try:
             with emit.pause():
@@ -350,13 +386,6 @@ def _run_in_provider(
             raise providers.ProviderError(
                 f"Failed to execute {command_name} in instance."
             ) from err
-
-
-# TODO Needs exposure from craft-parts.
-def _get_arch() -> str:
-    machine = infos._get_host_architecture()  # pylint: disable=protected-access
-    # FIXME Raise the potential KeyError.
-    return infos._ARCH_TRANSLATIONS[machine]["deb"]  # pylint: disable=protected-access
 
 
 def _get_extra_build_snaps(project: Project) -> Optional[List[str]]:
@@ -431,3 +460,50 @@ def _expand_environment(
     _set_global_environment(info)
 
     craft_parts.expand_environment(snapcraft_yaml, info=info, skip=["name", "version"])
+
+
+def get_build_plan(yaml_data: Dict[str, Any]) -> List[Tuple[str, str]]:
+    """Get a list of all build_on->build_to architectures from the project file.
+
+    Additionally, check for the environment variable `SNAPCRAFT_BUILD_TO`.
+    If the environmental variable is defined, the build_plan will only
+    contain builds where `build-to` matches `SNAPCRAFT_BUILD_TO`.
+
+    :param yaml_data: The project YAML data.
+
+    :return: List of tuples of every valid build-on->build-to combination.
+    """
+    archs = ArchitectureProject.unmarshal(yaml_data).architectures
+
+    host_arch = get_host_architecture()
+    build_plan: List[Tuple[str, str]] = []
+
+    # `isinstance()` calls are for mypy type checking and should not change logic
+    for arch in [arch for arch in archs if isinstance(arch, Architecture)]:
+        for build_on in arch.build_on:
+            if build_on in host_arch and isinstance(arch.build_to, list):
+                build_plan.append((host_arch, arch.build_to[0]))
+            else:
+                emit.progress(
+                    f"skipping build-on: {build_on} build-to: {arch.build_to}"
+                    f" because build-on doesn't match host arch: {host_arch}"
+                )
+
+    # filter out builds where not matching SNAPCRAFT_BUILD_TO
+    env_build_to = os.getenv("SNAPCRAFT_BUILD_TO")
+    if env_build_to is not None:
+        build_plan = [build for build in build_plan if build[1] == env_build_to]
+
+    if len(build_plan) == 0:
+        emit.message(
+            "Could not make build plan:"
+            " build-on architectures in snapcraft.yaml"
+            f" does not match host architecture ({host_arch})."
+        )
+    else:
+        log_output = "Created build plan:"
+        for build in build_plan:
+            log_output += f"\n  build-on: {build[0]} build-to: {build[1]}"
+        emit.trace(log_output)
+
+    return build_plan

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -28,6 +28,7 @@ from xdg import BaseDirectory  # type: ignore
 
 from snapcraft import errors, repo
 from snapcraft.meta import ExtractedMetadata, extract_metadata
+from snapcraft.utils import ARCH_TRANSLATIONS_DEB_TO_PLATFORM, get_host_architecture
 
 _LIFECYCLE_STEPS = {
     "pull": Step.PULL,
@@ -65,6 +66,7 @@ class PartsLifecycle:
         project_name: str,
         project_vars: Dict[str, str],
         extra_build_snaps: Optional[List[str]] = None,
+        target_arch: str,
     ):
         self._work_dir = work_dir
         self._assets_dir = assets_dir
@@ -78,12 +80,20 @@ class PartsLifecycle:
         # set the cache dir for parts package management
         cache_dir = BaseDirectory.save_cache_path("snapcraft")
 
+        if target_arch == "all":
+            target_arch = get_host_architecture()
+
+        platform_arch = ARCH_TRANSLATIONS_DEB_TO_PLATFORM.get(target_arch)
+        if not platform_arch:
+            raise errors.InvalidArchitecture(target_arch)
+
         try:
             self._lcm = craft_parts.LifecycleManager(
                 {"parts": all_parts},
                 application_name="snapcraft",
                 work_dir=work_dir,
                 cache_dir=cache_dir,
+                arch=platform_arch,
                 base=base,
                 ignore_local_sources=["*.snap"],
                 extra_build_snaps=extra_build_snaps,

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -23,9 +23,10 @@ import pydantic
 from craft_grammar.models import GrammarSingleEntryDictList, GrammarStr, GrammarStrList
 from pydantic import conlist, constr
 
-from snapcraft import repo, utils
+from snapcraft import repo
 from snapcraft.errors import ProjectValidationError
 from snapcraft.parts import validation as parts_validation
+from snapcraft.utils import get_effective_base, get_host_architecture
 
 
 class ProjectModel(pydantic.BaseModel):
@@ -62,6 +63,99 @@ def _validate_command_chain(command_chains: Optional[List[str]]) -> Optional[Lis
                     "special characters: / . _ # : $ -"
                 )
     return command_chains
+
+
+def _validate_architectures(architectures):
+    """Expand and validate architecture data.
+
+    Validation includes:
+        - The list cannot be a combination of strings and Architecture objects.
+        - The same architecture cannot be defined in multiple `build-to` fields,
+          even if the implicit values are used to define `build-to`.
+        - Only one architecture can be defined in the `build-to` list.
+        - The `all` keyword is properly used. (see `_validate_architectures_all_keyword()`)
+
+    :raise ValueError: If architecture data is invalid.
+    """
+    # validate strings and Architecture objects are not mixed
+    if not (
+        all(isinstance(architecture, str) for architecture in architectures)
+        or all(isinstance(architecture, Architecture) for architecture in architectures)
+    ):
+        raise ValueError(
+            f"Every item must either be a string or an object for {architectures!r}"
+        )
+
+    _expand_architectures(architectures)
+
+    # validate `build-to` after expanding data
+    if any(len(architecture.build_to) > 1 for architecture in architectures):
+        raise ValueError("multiple architectures are defined for one 'build-to'")
+
+    _validate_architectures_all_keyword(architectures)
+
+    if len(architectures) > 1:
+        # validate multiple uses of the same architecture
+        unique_build_tos = set()
+        for element in architectures:
+            for architecture in element.build_to:
+                if architecture in unique_build_tos:
+                    raise ValueError(
+                        f"multiple items will build snaps that claim to run on {architecture}"
+                    )
+                unique_build_tos.add(architecture)
+
+    return architectures
+
+
+def _expand_architectures(architectures):
+    """Expand architecture data.
+
+    Expansion to fully-defined Architecture objects includes the following:
+        - strings (shortform notation) are converted to Architecture objects
+        - `build-on` and `build-to` strings are converted to single item lists
+        - Empty `build-to` fields are implicitly set to the same architecture used in `build-on`
+    """
+    for index, architecture in enumerate(architectures):
+        # convert strings into Architecture objects
+        if isinstance(architecture, str):
+            architectures[index] = Architecture(
+                build_on=[architecture], build_to=[architecture]
+            )
+        elif isinstance(architecture, Architecture):
+            # convert strings to lists
+            if isinstance(architecture.build_on, str):
+                architectures[index].build_on = [architecture.build_on]
+            if isinstance(architecture.build_to, str):
+                architectures[index].build_to = [architecture.build_to]
+            # implicitly set build_to to build_on
+            elif architecture.build_to is None:
+                architectures[index].build_to = architectures[index].build_on
+
+
+def _validate_architectures_all_keyword(architectures):
+    """Validate `all` keyword is properly used.
+
+    Validation rules:
+    - `all` cannot be used to `build-on`
+    - If `all` is used for `build-to`, no other architectures can be defined
+      for `build-to`.
+
+    :raise ValueError: if `all` keyword isn't properly used.
+    """
+    # validate use of `all` inside each build-on list
+    for architecture in architectures:
+        if "all" in architecture.build_on:
+            raise ValueError("'all' cannot be used for 'build-on'")
+
+    # validate use of `all` across all items in architecture list
+    if len(architectures) > 1:
+        if any("all" in architecture.build_to for architecture in architectures):
+            raise ValueError(
+                "one of the items has 'all' in 'build-to', but there are"
+                f" {len(architectures)} items: upon release they will conflict."
+                "'all' should only be used if there is a single item"
+            )
 
 
 class Socket(ProjectModel):
@@ -208,11 +302,11 @@ class Hook(ProjectModel):
         return plugs
 
 
-class Architecture(ProjectModel):
+class Architecture(ProjectModel, extra=pydantic.Extra.forbid):
     """Snapcraft project architecture definition."""
 
     build_on: Union[str, UniqueStrList]
-    build_to: Optional[Union[str, UniqueStrList]]
+    build_to: Optional[Union[str, UniqueStrList]] = None
 
 
 class ContentPlug(ProjectModel):
@@ -257,7 +351,7 @@ class Project(ProjectModel):
     ]
     license: Optional[str]
     grade: Optional[Literal["stable", "devel"]]
-    architectures: List[Architecture] = []
+    architectures: List[Union[str, Architecture]] = [get_host_architecture()]
     assumes: UniqueStrList = []
     package_repositories: List[Dict[str, Any]] = []  # handled by repo
     hooks: Optional[Dict[str, Hook]]
@@ -390,6 +484,12 @@ class Project(ProjectModel):
 
         return epoch
 
+    @pydantic.validator("architectures", always=True)
+    @classmethod
+    def _validate_architecture_data(cls, architectures):
+        """Validate architecture data."""
+        return _validate_architectures(architectures)
+
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]) -> "Project":
         """Create and populate a new ``Project`` object from dictionary data.
@@ -433,7 +533,7 @@ class Project(ProjectModel):
 
     def get_effective_base(self) -> str:
         """Return the base to use to create the snap."""
-        base = utils.get_effective_base(
+        base = get_effective_base(
             base=self.base,
             build_base=self.build_base,
             project_type=self.type,
@@ -445,6 +545,26 @@ class Project(ProjectModel):
             raise RuntimeError("cannot determine build base")
 
         return base
+
+    def get_build_on(self) -> str:
+        """Get the first build_on architecture from the project."""
+        if isinstance(self.architectures[0], Architecture) and isinstance(
+            self.architectures[0].build_on, List
+        ):
+            return self.architectures[0].build_on[0]
+
+        # will not happen after schema validation
+        raise RuntimeError("cannot determine build-on architecture")
+
+    def get_build_to(self) -> str:
+        """Get the first build_to architecture from the project."""
+        if isinstance(self.architectures[0], Architecture) and isinstance(
+            self.architectures[0].build_to, List
+        ):
+            return self.architectures[0].build_to[0]
+
+        # will not happen after schema validation
+        raise RuntimeError("cannot determine build-to architecture")
 
 
 class _GrammarAwareModel(pydantic.BaseModel):
@@ -479,6 +599,41 @@ class GrammarAwareProject(_GrammarAwareModel):
             cls(**data)
         except pydantic.ValidationError as err:
             raise ProjectValidationError(_format_pydantic_errors(err.errors())) from err
+
+
+class ArchitectureProject(ProjectModel, extra=pydantic.Extra.ignore):
+    """Project definition containing only architecture data."""
+
+    architectures: List[Union[str, Architecture]] = [get_host_architecture()]
+
+    @pydantic.validator("architectures", always=True)
+    @classmethod
+    def _validate_architecture_data(cls, architectures):
+        """Validate architecture data."""
+        return _validate_architectures(architectures)
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]) -> "ArchitectureProject":
+        """Create and populate a new ``Project`` object from dictionary data.
+
+        The unmarshal method validates entries in the input dictionary, populating
+        the corresponding fields in the data object.
+
+        :param data: The dictionary data to unmarshal.
+
+        :return: The newly created object.
+
+        :raise TypeError: If data is not a dictionary.
+        """
+        if not isinstance(data, dict):
+            raise TypeError("Project data is not a dictionary")
+
+        try:
+            architectures = ArchitectureProject(**data)
+        except pydantic.ValidationError as err:
+            raise ProjectValidationError(_format_pydantic_errors(err.errors())) from err
+
+        return architectures
 
 
 def _format_pydantic_errors(errors, *, file_name: str = "snapcraft.yaml"):

--- a/snapcraft/providers/_lxd.py
+++ b/snapcraft/providers/_lxd.py
@@ -52,7 +52,12 @@ class LXDProvider(Provider):
         self.lxd_remote = lxd_remote
 
     def clean_project_environments(
-        self, *, project_name: str, project_path: pathlib.Path
+        self,
+        *,
+        project_name: str,
+        project_path: pathlib.Path,
+        build_on: str,
+        build_to: str,
     ) -> List[str]:
         """Clean up any build environments created for project.
 
@@ -69,6 +74,8 @@ class LXDProvider(Provider):
         instance_name = self.get_instance_name(
             project_name=project_name,
             project_path=project_path,
+            build_on=build_on,
+            build_to=build_to,
         )
 
         try:
@@ -142,6 +149,8 @@ class LXDProvider(Provider):
         project_path: pathlib.Path,
         base: str,
         bind_ssh: bool,
+        build_on: str,
+        build_to: str,
     ) -> Generator[Executor, None, None]:
         """Launch environment for specified base.
 
@@ -154,6 +163,8 @@ class LXDProvider(Provider):
         instance_name = self.get_instance_name(
             project_name=project_name,
             project_path=project_path,
+            build_on=build_on,
+            build_to=build_to,
         )
         alias = BASE_TO_BUILDD_IMAGE_ALIAS[base]
         try:

--- a/snapcraft/providers/_multipass.py
+++ b/snapcraft/providers/_multipass.py
@@ -46,7 +46,12 @@ class MultipassProvider(Provider):
         self.multipass = instance
 
     def clean_project_environments(
-        self, *, project_name: str, project_path: pathlib.Path
+        self,
+        *,
+        project_name: str,
+        project_path: pathlib.Path,
+        build_on: str,
+        build_to: str,
     ) -> List[str]:
         """Clean up any build environments created for project.
 
@@ -133,6 +138,8 @@ class MultipassProvider(Provider):
         project_path: pathlib.Path,
         base: str,
         bind_ssh: bool,
+        build_on: str,
+        build_to: str,
     ) -> Generator[Executor, None, None]:
         """Launch environment for specified base.
 
@@ -145,6 +152,8 @@ class MultipassProvider(Provider):
         instance_name = self.get_instance_name(
             project_name=project_name,
             project_path=project_path,
+            build_on=build_on,
+            build_to=build_to,
         )
 
         environment = self.get_command_environment()

--- a/snapcraft/providers/_provider.py
+++ b/snapcraft/providers/_provider.py
@@ -36,7 +36,12 @@ class Provider(ABC):
 
     @abstractmethod
     def clean_project_environments(
-        self, *, project_name: str, project_path: pathlib.Path
+        self,
+        *,
+        project_name: str,
+        project_path: pathlib.Path,
+        build_on: str,
+        build_to: str,
     ) -> List[str]:
         """Clean up any environments created for project.
 
@@ -76,6 +81,8 @@ class Provider(ABC):
         *,
         project_name: str,
         project_path: pathlib.Path,
+        build_on: str,
+        build_to: str,
     ) -> str:
         """Formulate the name for an instance using each of the given parameters.
 
@@ -86,7 +93,17 @@ class Provider(ABC):
         :param project_name: Name of the project.
         :param project_path: Directory of the project.
         """
-        return "-".join(["snapcraft", project_name, str(project_path.stat().st_ino)])
+        return "-".join(
+            [
+                "snapcraft",
+                project_name,
+                "on",
+                build_on,
+                "to",
+                build_to,
+                str(project_path.stat().st_ino),
+            ]
+        )
 
     @classmethod
     def is_base_available(cls, base: str) -> Tuple[bool, Union[str, None]]:
@@ -122,6 +139,8 @@ class Provider(ABC):
         project_path: pathlib.Path,
         base: str,
         bind_ssh: bool,
+        build_on: str,
+        build_to: str,
     ) -> Generator[Executor, None, None]:
         """Launch environment for specified base.
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -268,6 +268,13 @@ suites:
    systems:
      - ubuntu-22.04*
 
+ tests/spread/core22/architectures/:
+   summary: core22 architecture tests
+   systems:
+     - ubuntu-22.04
+     - ubuntu-22.04-64
+     - ubuntu-22.04-amd64
+
  # General, core suite
  tests/spread/general/:
    summary: tests of snapcraft core functionality

--- a/tests/spread/core22/architectures/snaps/build-on-no-match/snap/snapcraft.yaml
+++ b/tests/spread/core22/architectures/snaps/build-on-no-match/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: build-on-no-match
+version: "1.0"
+summary: test
+description: |
+  When build-on doesn't match the host architecture,
+  no snaps should be built.
+grade: devel
+confinement: strict
+base: core22
+architectures:
+  - build-on: arm64
+    build-to: arm64
+  - build-on: armhf
+    build-to: armhf
+
+parts:
+  nil:
+    plugin: nil

--- a/tests/spread/core22/architectures/snaps/build-to-all/expected-snaps.txt
+++ b/tests/spread/core22/architectures/snaps/build-to-all/expected-snaps.txt
@@ -1,0 +1,1 @@
+build-to-all_1.0_all.snap

--- a/tests/spread/core22/architectures/snaps/build-to-all/snap/snapcraft.yaml
+++ b/tests/spread/core22/architectures/snaps/build-to-all/snap/snapcraft.yaml
@@ -1,0 +1,15 @@
+name: build-to-all
+version: "1.0"
+summary: test
+description: |
+  Test building of `build-to: all`
+grade: devel
+confinement: strict
+base: core22
+architectures:
+  - build-on: amd64
+    build-to: all
+
+parts:
+  nil:
+    plugin: nil

--- a/tests/spread/core22/architectures/snaps/env-var-match/environmental-variables.txt
+++ b/tests/spread/core22/architectures/snaps/env-var-match/environmental-variables.txt
@@ -1,0 +1,1 @@
+SNAPCRAFT_BUILD_TO="arm64"

--- a/tests/spread/core22/architectures/snaps/env-var-match/expected-snaps.txt
+++ b/tests/spread/core22/architectures/snaps/env-var-match/expected-snaps.txt
@@ -1,0 +1,1 @@
+env-var-match_1.0_arm64.snap

--- a/tests/spread/core22/architectures/snaps/env-var-match/snap/snapcraft.yaml
+++ b/tests/spread/core22/architectures/snaps/env-var-match/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: env-var-match
+version: "1.0"
+summary: test
+description: |
+  Only snaps should be built where `build-to` matches the 
+  environmental variable `SNAPCRAFT_BUILD_TO`.
+grade: devel
+confinement: strict
+base: core22
+architectures:
+  - build-on: amd64
+    build-to: amd64
+  - build-on: [amd64, arm64]
+    build-to: arm64
+
+parts:
+  nil:
+    plugin: nil

--- a/tests/spread/core22/architectures/snaps/env-var-no-match/environmental-variables.txt
+++ b/tests/spread/core22/architectures/snaps/env-var-no-match/environmental-variables.txt
@@ -1,0 +1,1 @@
+SNAPCRAFT_BUILD_TO=armhf

--- a/tests/spread/core22/architectures/snaps/env-var-no-match/snap/snapcraft.yaml
+++ b/tests/spread/core22/architectures/snaps/env-var-no-match/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: env-var-no-match
+version: "1.0"
+summary: test
+description: |
+  No snaps should be built if there no `build-to`
+  matches the environmental variable `SNAPCRAFT_BUILD_TO`.
+grade: devel
+confinement: strict
+base: core22
+architectures:
+  - build-on: amd64
+    build-to: amd64
+  - build-on: [amd64, arm64]
+    build-to: arm64
+
+parts:
+  nil:
+    plugin: nil

--- a/tests/spread/core22/architectures/snaps/multiple-build-to/expected-snaps.txt
+++ b/tests/spread/core22/architectures/snaps/multiple-build-to/expected-snaps.txt
@@ -1,0 +1,2 @@
+multiple-build-to_1.0_amd64.snap
+multiple-build-to_1.0_arm64.snap

--- a/tests/spread/core22/architectures/snaps/multiple-build-to/snap/snapcraft.yaml
+++ b/tests/spread/core22/architectures/snaps/multiple-build-to/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: multiple-build-to
+version: "1.0"
+summary: test
+description: |
+  Building on amd64 should produce 2 snaps,
+  one snap for amd64 and one snap for arm64.
+grade: devel
+confinement: strict
+base: core22
+architectures:
+  - build-on: amd64
+    build-to: amd64
+  - build-on: [amd64, arm64]
+    build-to: arm64
+
+parts:
+  nil:
+    plugin: nil

--- a/tests/spread/core22/architectures/snaps/single-arch/expected-snaps.txt
+++ b/tests/spread/core22/architectures/snaps/single-arch/expected-snaps.txt
@@ -1,0 +1,1 @@
+single-arch_1.0_amd64.snap

--- a/tests/spread/core22/architectures/snaps/single-arch/snap/snapcraft.yaml
+++ b/tests/spread/core22/architectures/snaps/single-arch/snap/snapcraft.yaml
@@ -1,0 +1,15 @@
+name: single-arch
+version: "1.0"
+summary: test
+description: |
+  A single architecture should create a single snap file.
+grade: devel
+confinement: strict
+base: core22
+architectures:
+  - build-on: amd64
+    build-to: amd64
+
+parts:
+  nil:
+    plugin: nil

--- a/tests/spread/core22/architectures/task.yaml
+++ b/tests/spread/core22/architectures/task.yaml
@@ -1,0 +1,50 @@
+summary: Build snaps that test the build-on/build-to architecture logic in snapcraft.
+
+environment:
+  SNAP/single_arch: single-arch
+  SNAP/multiple_build_to: multiple-build-to
+  SNAP/build_on_no_match: build-on-no-match
+  SNAP/env_var_match: env-var-match
+  SNAP/env_var_no_match: env-var-no-match
+  SNAP/build_to_all: build-to-all
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "./snaps/$SNAP/snap/snapcraft.yaml"
+
+restore: |
+  cd "./snaps/$SNAP"
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "./snaps/$SNAP"
+
+  # if the environmental variable file exists, then call snapcraft with the environmental variables
+  if [[ -e "environmental-variables.txt" ]]; then
+    # shellcheck disable=SC2046
+    eval $(cat "environmental-variables.txt") snapcraft pack --destructive-mode
+  else
+    snapcraft pack --destructive-mode
+  fi
+
+  # confirm the snaps with the expected architectures were built
+  while read -r expected_snap; do
+    if [[ ! -e $expected_snap ]]; then
+      echo "Could not find snap '$expected_snap'"
+      exit 1
+    fi
+  done < "expected-snaps.txt"
+
+  # confirm no other snaps were built
+  expected_number_of_snaps=$(wc -l < "expected-snaps.txt")
+  actual_number_of_snaps=$(find . -wholename "./*.snap" | wc -l)
+  if [[ $expected_number_of_snaps -ne $actual_number_of_snaps ]]; then
+    echo "Expected $expected_number_of_snaps to be built, but $actual_number_of_snaps were built."
+    exit 1
+  fi

--- a/tests/unit/commands/test_expand_extensions.py
+++ b/tests/unit/commands/test_expand_extensions.py
@@ -21,6 +21,7 @@ from textwrap import dedent
 import pytest
 
 from snapcraft.commands import ExpandExtensionsCommand
+from snapcraft.utils import get_host_architecture
 
 
 @pytest.mark.usefixtures("fake_extension")
@@ -34,10 +35,13 @@ def test_command(new_dir, emitter):
             summary: testing extensions
             description: expand a fake extension
             base: core22
+            confinement: strict
+            grade: stable
 
             apps:
                 app1:
                     command: app1
+                    command-chain: [fake-command]
                     extensions: [fake-extension]
 
             parts:
@@ -52,17 +56,32 @@ def test_command(new_dir, emitter):
     cmd.run(Namespace())
     emitter.assert_message(
         dedent(
-            """\
+            f"""\
         name: test-name
+        base: core22
+        build-base: core22
+        compression: xz
         version: '0.1'
         summary: testing extensions
         description: expand a fake extension
-        base: core22
+        confinement: strict
+        grade: stable
+        architectures:
+        -   build-on:
+            - {get_host_architecture()}
+            build-to:
+            - {get_host_architecture()}
+        assumes: []
+        package-repositories: []
         apps:
             app1:
                 command: app1
+                after: []
+                before: []
                 plugs:
                 - fake-plug
+                command-chain:
+                - fake-command
         parts:
             part1:
                 plugin: nil
@@ -70,7 +89,6 @@ def test_command(new_dir, emitter):
                 - fake-extension/fake-part
             fake-extension/fake-part:
                 plugin: nil
-        grade: fake-grade
         """
         )
     )

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -55,7 +55,7 @@ def test_simple_snap_yaml(simple_project, new_dir):
     snap_yaml.write(
         simple_project(),
         prime_dir=Path(new_dir),
-        arch="amd64",
+        target_arch="amd64",
         arch_triplet="x86_64-linux-gnu",
     )
     yaml_file = Path("meta/snap.yaml")
@@ -100,6 +100,8 @@ def complex_project():
 
         grade: devel
         confinement: strict
+        architectures:
+          - arch
 
         environment:
           GLOBAL_VARIABLE: test-global-variable
@@ -202,7 +204,7 @@ def test_complex_snap_yaml(complex_project, new_dir):
     snap_yaml.write(
         complex_project,
         prime_dir=Path(new_dir),
-        arch="amd64",
+        target_arch="amd64",
         arch_triplet="x86_64-linux-gnu",
     )
     yaml_file = Path("meta/snap.yaml")
@@ -331,7 +333,7 @@ def test_hook_command_chain_assumes(simple_project, new_dir):
     snap_yaml.write(
         simple_project(hooks=hooks),
         prime_dir=Path(new_dir),
-        arch="amd64",
+        target_arch="amd64",
         arch_triplet="x86_64-linux-gnu",
     )
     yaml_file = Path("meta/snap.yaml")
@@ -374,7 +376,7 @@ def test_project_environment_ld_library_path_and_path_defined(simple_project, ne
     snap_yaml.write(
         simple_project(environment=environment),
         prime_dir=Path(new_dir),
-        arch="amd64",
+        target_arch="amd64",
         arch_triplet="x86_64-linux-gnu",
     )
     yaml_file = Path("meta/snap.yaml")
@@ -409,7 +411,7 @@ def test_project_environment_ld_library_path_defined(simple_project, new_dir):
     snap_yaml.write(
         simple_project(environment=environment),
         prime_dir=Path(new_dir),
-        arch="amd64",
+        target_arch="amd64",
         arch_triplet="x86_64-linux-gnu",
     )
     yaml_file = Path("meta/snap.yaml")
@@ -443,7 +445,7 @@ def test_project_environment_path_defined(simple_project, new_dir):
     snap_yaml.write(
         simple_project(environment=environment),
         prime_dir=Path(new_dir),
-        arch="amd64",
+        target_arch="amd64",
         arch_triplet="x86_64-linux-gnu",
     )
     yaml_file = Path("meta/snap.yaml")
@@ -477,7 +479,7 @@ def test_project_environment_ld_library_path_null(simple_project, new_dir):
     snap_yaml.write(
         simple_project(environment=environment),
         prime_dir=Path(new_dir),
-        arch="amd64",
+        target_arch="amd64",
         arch_triplet="x86_64-linux-gnu",
     )
     yaml_file = Path("meta/snap.yaml")
@@ -514,7 +516,7 @@ def test_version_git(simple_project, new_dir, mocker):
     snap_yaml.write(
         simple_project(version="git"),
         prime_dir=Path(new_dir),
-        arch="amd64",
+        target_arch="amd64",
         arch_triplet="x86_64-linux-gnu",
     )
 

--- a/tests/unit/parts/test_parts.py
+++ b/tests/unit/parts/test_parts.py
@@ -48,6 +48,7 @@ def test_parts_lifecycle_run(mocker, parts_data, step_name, new_dir, emitter):
         parse_info={},
         project_vars={"version": "1", "grade": "stable"},
         extra_build_snaps=["core22"],
+        target_arch="amd64",
     )
     lifecycle.run(step_name)
     assert lifecycle.prime_dir == Path(new_dir, "prime")
@@ -58,6 +59,7 @@ def test_parts_lifecycle_run(mocker, parts_data, step_name, new_dir, emitter):
             application_name="snapcraft",
             work_dir=ANY,
             cache_dir=ANY,
+            arch="x86_64",
             base="core22",
             ignore_local_sources=["*.snap"],
             extra_build_snaps=["core22"],
@@ -83,6 +85,7 @@ def test_parts_lifecycle_run_bad_step(parts_data, new_dir):
         parse_info={},
         project_name="test-project",
         project_vars={"version": "1", "grade": "stable"},
+        target_arch="amd64",
     )
     with pytest.raises(RuntimeError) as raised:
         lifecycle.run("invalid")
@@ -102,6 +105,7 @@ def test_parts_lifecycle_run_internal_error(parts_data, new_dir, mocker):
         project_name="test-project",
         parse_info={},
         project_vars={"version": "1", "grade": "stable"},
+        target_arch="amd64",
     )
     mocker.patch("craft_parts.LifecycleManager.plan", side_effect=RuntimeError("crash"))
     with pytest.raises(RuntimeError) as raised:
@@ -122,6 +126,7 @@ def test_parts_lifecycle_run_parts_error(new_dir):
         project_name="test-project",
         parse_info={},
         project_vars={"version": "1", "grade": "stable"},
+        target_arch="amd64",
     )
     with pytest.raises(errors.PartsLifecycleError) as raised:
         lifecycle.run("prime")
@@ -143,6 +148,7 @@ def test_parts_lifecycle_clean(parts_data, new_dir, emitter):
         project_name="test-project",
         parse_info={},
         project_vars={"version": "1", "grade": "stable"},
+        target_arch="amd64",
     )
     lifecycle.clean(part_names=None)
     emitter.assert_message("Cleaning all parts", intermediate=True)
@@ -161,6 +167,7 @@ def test_parts_lifecycle_clean_parts(parts_data, new_dir, emitter):
         project_name="test-project",
         parse_info={},
         project_vars={"version": "1", "grade": "stable"},
+        target_arch="amd64",
     )
     lifecycle.clean(part_names=["p1"])
     emitter.assert_message("Cleaning parts: p1", intermediate=True)
@@ -204,6 +211,7 @@ def test_parts_lifecycle_initialize_with_package_repositories_deps_not_installed
         parse_info={},
         project_vars={"version": "1", "grade": "stable"},
         extra_build_snaps=["core22"],
+        target_arch="amd64",
     )
 
     parts_lifecycle._install_package_repositories()
@@ -251,8 +259,68 @@ def test_parts_lifecycle_initialize_with_package_repositories_deps_installed(
         parse_info={},
         project_vars={"version": "1", "grade": "stable"},
         extra_build_snaps=["core22"],
+        target_arch="amd64",
     )
 
     parts_lifecycle._install_package_repositories()
 
     assert install_packages_mock.mock_calls == []
+
+
+def test_parts_lifecycle_bad_architecture(parts_data, new_dir):
+    with pytest.raises(errors.InvalidArchitecture) as raised:
+        PartsLifecycle(
+            parts_data,
+            work_dir=new_dir,
+            assets_dir=new_dir,
+            base="core22",
+            parallel_build_count=8,
+            part_names=[],
+            package_repositories=[],
+            adopt_info=None,
+            parse_info={},
+            project_name="test-project",
+            project_vars={"version": "1", "grade": "stable"},
+            target_arch="bad-arch",
+        )
+
+    assert str(raised.value) == "Architecture 'bad-arch' is not supported."
+
+
+def test_parts_lifecycle_run_with_all_architecture(mocker, parts_data, new_dir):
+    """`target_arch=all` should use the host architecture."""
+
+    mocker.patch("craft_parts.executor.executor.Executor._install_build_snaps")
+    lcm_spy = mocker.spy(craft_parts, "LifecycleManager")
+    lifecycle = PartsLifecycle(
+        parts_data,
+        work_dir=new_dir,
+        assets_dir=new_dir,
+        base="core22",
+        parallel_build_count=8,
+        part_names=[],
+        package_repositories=[],
+        adopt_info=None,
+        parse_info={},
+        project_name="test-project",
+        project_vars={"version": "1", "grade": "stable"},
+        target_arch="amd64",
+    )
+    lifecycle.run("prime")
+
+    assert lcm_spy.mock_calls == [
+        call(
+            {"parts": {"p1": {"plugin": "nil"}}},
+            application_name="snapcraft",
+            work_dir=ANY,
+            cache_dir=ANY,
+            arch="x86_64",
+            base="core22",
+            ignore_local_sources=["*.snap"],
+            extra_build_snaps=None,
+            parallel_build_count=8,
+            project_name="test-project",
+            project_vars_part_name=None,
+            project_vars={"version": "1", "grade": "stable"},
+        )
+    ]

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -44,7 +44,12 @@ class TestLxdLaunchedEnvironment:
         prov = providers.LXDProvider()
 
         with prov.launched_environment(
-            project_name="test", project_path=new_dir, base="core22", bind_ssh=False
+            project_name="test",
+            project_path=new_dir,
+            base="core22",
+            bind_ssh=False,
+            build_on="test",
+            build_to="test",
         ):
             assert lxd_instance_mock.mount.mock_calls == [
                 call(host_source=new_dir, target=Path("/root/project")),
@@ -58,7 +63,12 @@ class TestLxdLaunchedEnvironment:
         prov = providers.LXDProvider()
 
         with prov.launched_environment(
-            project_name="test", project_path=new_dir, base="core22", bind_ssh=True
+            project_name="test",
+            project_path=new_dir,
+            base="core22",
+            bind_ssh=True,
+            build_on="test",
+            build_to="test",
         ):
             assert lxd_instance_mock.mount.mock_calls == [
                 call(host_source=new_dir, target=Path("/root/project")),

--- a/tests/unit/providers/test_multipass.py
+++ b/tests/unit/providers/test_multipass.py
@@ -41,7 +41,12 @@ class TestMultipassLaunchedEnvironment:
         prov = providers.MultipassProvider()
 
         with prov.launched_environment(
-            project_name="test", project_path=new_dir, base="core22", bind_ssh=False
+            project_name="test",
+            project_path=new_dir,
+            base="core22",
+            bind_ssh=False,
+            build_on="test",
+            build_to="test",
         ):
             assert multipass_instance_mock.mount.mock_calls == [
                 call(host_source=new_dir, target=Path("/root/project")),
@@ -56,7 +61,12 @@ class TestMultipassLaunchedEnvironment:
         prov = providers.MultipassProvider()
 
         with prov.launched_environment(
-            project_name="test", project_path=new_dir, base="core22", bind_ssh=True
+            project_name="test",
+            project_path=new_dir,
+            base="core22",
+            bind_ssh=True,
+            build_on="test",
+            build_to="test",
         ):
             assert multipass_instance_mock.mount.mock_calls == [
                 call(host_source=new_dir, target=Path("/root/project")),

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -301,3 +301,29 @@ def test_get_ld_library_paths(tmp_path, lib_dirs, expected_env):
         f"${{SNAP_LIBRARY_PATH}}${{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}}:{expected_env}"
     )
     assert utils.get_ld_library_paths(tmp_path, "i286-none-none") == expected_env
+
+
+###################
+# Process Version #
+###################
+
+
+def test_process_version_empty(mocker):
+    """``version:None`` raises an error."""
+    with pytest.raises(ValueError):
+        utils.process_version(None)
+
+
+def test_process_version_dirty(mocker):
+    """A version string should be returned unmodified."""
+    assert utils.process_version("1.2.3") == "1.2.3"
+
+
+def test_process_version_git(mocker):
+    """``version:git`` must be correctly handled."""
+    mocker.patch(
+        "craft_parts.sources.git_source.GitSource.generate_version",
+        return_value="1.2.3-dirty",
+    )
+
+    assert utils.process_version("git") == "1.2.3-dirty"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----

- Add support for `build-on` and `build-to` for `core22` snaps.
- Add environmental variable `SNAPCRAFT_BUILD_TO` to limit which snaps are built

Note: For `core22` snaps, `run-on` has been replaced with `build-to`.

### Examples
These example `snapcraft.yaml` snippets show how to use architectures.

#### Single architecture
Building on `amd64` will produce 1 snap for `amd64`.
```
architectures:
  - build-on: amd64
    build-to: amd64
```

#### Single architecture, shorthand
This is the same as the previous example, but in a shorthand format.
```
architectures:
  - amd64
```

#### Multiple architectures
- Building on `amd64` will produce 1 snap for `amd64`.
- Building on `arm64` will produce 1 snap for `arm64`.
```
architectures:
  - build-on: amd64
    build-to: amd64
  - build-on: arm64
    build-to: arm64
```

#### Multiple architectures, shorthand
This is the same as the previous example, but in a shorthand format.
```
architectures:
  - amd64
  - arm64
```

#### Multiple architecture, cross-compiling
- Building on `amd64` will produce 2 snaps, 1 snap for `amd64` and 1 snap for `arm64`.
- Building on `arm64` will produce 1 snap for `arm64`.
```
architectures:
  - build-on: amd64
    build-to: amd64
  - build-on: [amd64, arm64]
    build-to: arm64
```

#### Architecture independent
For snaps that can run on any architecture (e.g. python or shell scripts), use `build-to: all`.
```
architectures:
  - build-on: amd64
    build-to: all
```

#### Limiting builds with environmental variable
The environmental variable `SNAPCRAFT_BUILD_TO` can be used so that only 1 snap package is produced.
- Running `snapcraft` on `amd64` will produce 2 snaps, 1 snap for `amd64` and 1 snap for `arm64`.
- Running `SNAPCRAFT_BUILD_TO=arm64 snapcraft` will produce 1 snap for `arm64`.
```
architectures:
  - build-on: amd64
    build-to: amd64
  - build-on: amd64
    build-to: arm64
```

### Pull Requests
This pull request (1,300+ lines of code) is being broken into multiple smaller bits:
1. [architectures: add schema support](https://github.com/snapcore/snapcraft/pull/3812)
2. [lint: bump pylint](https://github.com/snapcore/snapcraft/pull/3813)
3. [extensions: use pydantic to validate yaml before expanding](https://github.com/snapcore/snapcraft/pull/3814)
4. [utils: move process_version to utils.py](https://github.com/snapcore/snapcraft/pull/3815)

The first 4 PRs are standalone.  They can be merged in any order.
Subsequent PRs will not be standalone and will have to depend on previous PRs.

(CRAFT-954)