### PR TITLE
meta: dump unicode yaml data

### DIFF
--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -180,7 +180,11 @@ def write(project: Project, prime_dir: Path, *, arch: str):
 
     yaml.add_representer(str, _repr_str, Dumper=yaml.SafeDumper)
     yaml_data = snap_metadata.yaml(
-        by_alias=True, exclude_none=True, sort_keys=False, width=1000
+        by_alias=True,
+        exclude_none=True,
+        allow_unicode=True,
+        sort_keys=False,
+        width=1000,
     )
 
     snap_yaml = meta_dir / "snap.yaml"


### PR DESCRIPTION
Set yaml dumping to allow unicode. This fixes formatting of multiline
text in e.g. snap.yaml when it contains unicode characters.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
