### PR TITLE
parts: run debug shell on build environment

### DIFF
--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -43,6 +43,12 @@ class _LifecycleCommand(BaseCommand, abc.ABC):
             action="store_true",
             help="Use LXD to build",
         )
+        parser.add_argument(
+            "--debug",
+            action="store_true",
+            help="Shell into the environment if the build fails",
+        )
+
         # --enable-experimental-extensions is only available in legacy
         parser.add_argument(
             "--enable-experimental-extensions",
@@ -88,6 +94,16 @@ class _LifecycleStepCommand(_LifecycleCommand):
             type=str,
             nargs="*",
             help="Optional list of parts to process",
+        )
+        parser.add_argument(
+            "--shell",
+            action="store_true",
+            help="Shell into the environment in lieu of the step to run.",
+        )
+        parser.add_argument(
+            "--shell-after",
+            action="store_true",
+            help="Shell into the environment after the step has run.",
         )
 
 

--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -95,12 +95,14 @@ class _LifecycleStepCommand(_LifecycleCommand):
             nargs="*",
             help="Optional list of parts to process",
         )
-        parser.add_argument(
+
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
             "--shell",
             action="store_true",
             help="Shell into the environment in lieu of the step to run.",
         )
-        parser.add_argument(
+        group.add_argument(
             "--shell-after",
             action="store_true",
             help="Shell into the environment after the step has run.",

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -205,7 +205,12 @@ def _run_command(
         lifecycle.clean(part_names=part_names)
         return
 
-    lifecycle.run(step_name)
+    lifecycle.run(
+        step_name,
+        debug=parsed_args.debug,
+        shell=getattr(parsed_args, "shell", False),
+        shell_after=getattr(parsed_args, "shell_after", False),
+    )
 
     # Extract metadata and generate snap.yaml
     project_vars = lifecycle.project_vars
@@ -283,6 +288,13 @@ def _run_in_provider(
         cmd.append("--quiet")
     elif emit.get_mode() == EmitterMode.TRACE:
         cmd.append("--trace")
+
+    if parsed_args.debug:
+        cmd.append("--debug")
+    if getattr(parsed_args, "shell", False):
+        cmd.append("--shell")
+    if getattr(parsed_args, "shell_after", False):
+        cmd.append("--shell-after")
 
     output_dir = utils.get_managed_environment_project_path()
 

--- a/tests/unit/cli/test_default_command.py
+++ b/tests/unit/cli/test_default_command.py
@@ -30,6 +30,7 @@ def test_default_command(mocker):
     assert mock_pack_cmd.mock_calls == [
         call(
             argparse.Namespace(
+                debug=False,
                 directory=None,
                 output=None,
                 destructive_mode=False,
@@ -53,6 +54,7 @@ def test_default_command_destructive_mode(mocker):
             argparse.Namespace(
                 directory=None,
                 output=None,
+                debug=False,
                 destructive_mode=True,
                 use_lxd=False,
                 enable_experimental_extensions=False,
@@ -74,6 +76,7 @@ def test_default_command_use_lxd(mocker):
             argparse.Namespace(
                 directory=None,
                 output=None,
+                debug=False,
                 destructive_mode=False,
                 use_lxd=True,
                 enable_experimental_extensions=False,
@@ -96,6 +99,7 @@ def test_default_command_output(mocker, option):
             argparse.Namespace(
                 directory=None,
                 output="name",
+                debug=False,
                 destructive_mode=False,
                 use_lxd=False,
                 enable_experimental_extensions=False,

--- a/tests/unit/cli/test_lifecycle.py
+++ b/tests/unit/cli/test_lifecycle.py
@@ -40,7 +40,10 @@ def test_lifecycle_command(cmd, run_method, mocker):
         call(
             argparse.Namespace(
                 parts=[],
+                debug=False,
                 destructive_mode=False,
+                shell=False,
+                shell_after=False,
                 use_lxd=False,
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
@@ -78,7 +81,10 @@ def test_lifecycle_command_arguments(cmd, run_method, mocker):
         call(
             argparse.Namespace(
                 parts=["part1", "part2"],
+                debug=False,
                 destructive_mode=False,
+                shell=False,
+                shell_after=False,
                 use_lxd=False,
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
@@ -117,7 +123,10 @@ def test_lifecycle_command_arguments_destructive_mode(cmd, run_method, mocker):
         call(
             argparse.Namespace(
                 parts=["part1", "part2"],
+                debug=False,
                 destructive_mode=True,
+                shell=False,
+                shell_after=False,
                 use_lxd=False,
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
@@ -156,8 +165,92 @@ def test_lifecycle_command_arguments_use_lxd(cmd, run_method, mocker):
         call(
             argparse.Namespace(
                 parts=["part1", "part2"],
+                debug=False,
                 destructive_mode=False,
+                shell=False,
+                shell_after=False,
                 use_lxd=True,
+                enable_experimental_extensions=False,
+                enable_developer_debug=False,
+                enable_experimental_target_arch=False,
+                target_arch=None,
+                provider=None,
+            )
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "cmd,run_method",
+    [
+        ("pull", "snapcraft.commands.lifecycle.PullCommand.run"),
+        ("build", "snapcraft.commands.lifecycle.BuildCommand.run"),
+        ("stage", "snapcraft.commands.lifecycle.StageCommand.run"),
+        ("prime", "snapcraft.commands.lifecycle.PrimeCommand.run"),
+    ],
+)
+def test_lifecycle_command_arguments_debug(cmd, run_method, mocker):
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "cmd",
+            cmd,
+            "--debug",
+        ],
+    )
+    mock_lifecycle_cmd = mocker.patch(run_method)
+    cli.run()
+    assert mock_lifecycle_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                parts=[],
+                debug=True,
+                destructive_mode=False,
+                shell=False,
+                shell_after=False,
+                use_lxd=False,
+                enable_experimental_extensions=False,
+                enable_developer_debug=False,
+                enable_experimental_target_arch=False,
+                target_arch=None,
+                provider=None,
+            )
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "cmd,run_method",
+    [
+        ("pull", "snapcraft.commands.lifecycle.PullCommand.run"),
+        ("build", "snapcraft.commands.lifecycle.BuildCommand.run"),
+        ("stage", "snapcraft.commands.lifecycle.StageCommand.run"),
+        ("prime", "snapcraft.commands.lifecycle.PrimeCommand.run"),
+    ],
+)
+def test_lifecycle_command_arguments_shell(cmd, run_method, mocker):
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "cmd",
+            cmd,
+            "--shell",
+            "--shell-after",
+        ],
+    )
+    mock_lifecycle_cmd = mocker.patch(run_method)
+    cli.run()
+    assert mock_lifecycle_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                parts=[],
+                debug=False,
+                destructive_mode=False,
+                shell=True,
+                shell_after=True,
+                use_lxd=False,
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
@@ -181,6 +274,7 @@ def test_lifecycle_command_pack(mocker):
             argparse.Namespace(
                 directory=None,
                 output=None,
+                debug=False,
                 destructive_mode=False,
                 use_lxd=False,
                 enable_experimental_extensions=False,
@@ -206,6 +300,7 @@ def test_lifecycle_command_pack_destructive_mode(mocker):
             argparse.Namespace(
                 directory=None,
                 output=None,
+                debug=False,
                 destructive_mode=True,
                 use_lxd=False,
                 enable_experimental_extensions=False,
@@ -231,8 +326,35 @@ def test_lifecycle_command_pack_use_lxd(mocker):
             argparse.Namespace(
                 directory=None,
                 output=None,
+                debug=False,
                 destructive_mode=False,
                 use_lxd=True,
+                enable_experimental_extensions=False,
+                enable_developer_debug=False,
+                enable_experimental_target_arch=False,
+                target_arch=None,
+                provider=None,
+            )
+        )
+    ]
+
+
+def test_lifecycle_command_pack_debug(mocker):
+    mocker.patch.object(
+        sys,
+        "argv",
+        ["cmd", "pack", "--debug"],
+    )
+    mock_pack_cmd = mocker.patch("snapcraft.commands.lifecycle.PackCommand.run")
+    cli.run()
+    assert mock_pack_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                directory=None,
+                output=None,
+                debug=True,
+                destructive_mode=False,
+                use_lxd=False,
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
@@ -253,6 +375,7 @@ def test_lifecycle_command_pack_output(mocker, option):
             argparse.Namespace(
                 directory=None,
                 output="name",
+                debug=False,
                 destructive_mode=False,
                 use_lxd=False,
                 enable_experimental_extensions=False,
@@ -272,9 +395,10 @@ def test_lifecycle_command_pack_directory(mocker):
     assert mock_pack_cmd.mock_calls == [
         call(
             argparse.Namespace(
+                debug=False,
+                destructive_mode=False,
                 directory="name",
                 output=None,
-                destructive_mode=False,
                 use_lxd=False,
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,

--- a/tests/unit/cli/test_lifecycle.py
+++ b/tests/unit/cli/test_lifecycle.py
@@ -237,7 +237,6 @@ def test_lifecycle_command_arguments_shell(cmd, run_method, mocker):
             "cmd",
             cmd,
             "--shell",
-            "--shell-after",
         ],
     )
     mock_lifecycle_cmd = mocker.patch(run_method)
@@ -249,6 +248,46 @@ def test_lifecycle_command_arguments_shell(cmd, run_method, mocker):
                 debug=False,
                 destructive_mode=False,
                 shell=True,
+                shell_after=False,
+                use_lxd=False,
+                enable_experimental_extensions=False,
+                enable_developer_debug=False,
+                enable_experimental_target_arch=False,
+                target_arch=None,
+                provider=None,
+            )
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "cmd,run_method",
+    [
+        ("pull", "snapcraft.commands.lifecycle.PullCommand.run"),
+        ("build", "snapcraft.commands.lifecycle.BuildCommand.run"),
+        ("stage", "snapcraft.commands.lifecycle.StageCommand.run"),
+        ("prime", "snapcraft.commands.lifecycle.PrimeCommand.run"),
+    ],
+)
+def test_lifecycle_command_arguments_shell_after(cmd, run_method, mocker):
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "cmd",
+            cmd,
+            "--shell-after",
+        ],
+    )
+    mock_lifecycle_cmd = mocker.patch(run_method)
+    cli.run()
+    assert mock_lifecycle_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                parts=[],
+                debug=False,
+                destructive_mode=False,
+                shell=False,
                 shell_after=True,
                 use_lxd=False,
                 enable_experimental_extensions=False,

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -36,6 +36,12 @@ _SNAPCRAFT_YAML_FILENAMES = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def disable_install(mocker):
+    mocker.patch("craft_parts.packages.Repository.install_packages")
+    mocker.patch("craft_parts.packages.snaps.install_snaps")
+
+
 @pytest.fixture
 def snapcraft_yaml(new_dir):
     def write_file(


### PR DESCRIPTION
Handle arguments --debug, --shell and --shell-after to run a shell
on the build environment (tipically on instance) in case of a parts
error or to replace a lifecycle step.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
CRAFT-993
