### PR TITLE
meta: fix snap yaml generation to match legacy

### DIFF
--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -99,7 +99,7 @@ class SnapMetadata(YamlModel):
     summary: str
     description: str
     license: Optional[str]
-    type: str
+    type: Optional[str]
     architectures: List[str]
     base: str
     assumes: Optional[List[str]]
@@ -168,9 +168,9 @@ def write(project: Project, prime_dir: Path, *, arch: str):
         type=project.type,
         architectures=[arch],
         base=cast(str, project.base),
-        assumes=["command-chain"],
+        assumes=["command-chain"] if snap_apps else None,
         epoch=project.epoch,
-        apps=snap_apps,
+        apps=snap_apps or None,
         confinement=project.confinement,
         grade=project.grade or "stable",
         environment=project.environment,

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -250,7 +250,7 @@ class Project(ProjectModel):
     website: Optional[str]
     summary: Optional[constr(max_length=78)]  # type: ignore
     description: Optional[str]
-    type: Literal["app", "base", "gadget", "kernel", "snapd"] = "app"
+    type: Optional[Literal["app", "base", "gadget", "kernel", "snapd"]]
     icon: Optional[str]
     confinement: Literal["classic", "devmode", "strict"]
     layout: Optional[Dict[str, Dict[str, Any]]]

--- a/tests/spread/core22/appstream-desktop/expected_snap.yaml
+++ b/tests/spread/core22/appstream-desktop/expected_snap.yaml
@@ -13,7 +13,6 @@ description: |-
 
 
   Test me please.
-type: app
 architectures:
 - amd64
 base: core22

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -73,7 +73,6 @@ def test_simple_snap_yaml(simple_project, new_dir):
           most important story about your snap. Keep it under 100 words though,
           we live in tweetspace and your description wants to look good in the snap
           store.
-        type: app
         architectures:
         - arch
         base: core22
@@ -97,6 +96,7 @@ def complex_project():
         name: mytest
         version: 1.29.3
         base: core22
+        type: app
         summary: Single-line elevator pitch for your amazing snap
         description: |
           This is my-snap's description. You have a paragraph or two to tell the

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -72,7 +72,7 @@ def snapcraft_yaml(new_dir):
             "website": None,
             "summary": "Just some test data",
             "description": "This is just some test data.",
-            "type": "app",
+            "type": None,
             "confinement": "strict",
             "icon": None,
             "layout": None,

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -84,7 +84,7 @@ class TestProjectDefaults:
         assert project.issues is None
         assert project.source_code is None
         assert project.website is None
-        assert project.type == "app"
+        assert project.type is None
         assert project.icon is None
         assert project.layout is None
         assert project.license is None


### PR DESCRIPTION
Fix undeclared snap type and app list if no apps defined.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
