### PR TITLE
utils: return the userspace architecture

### DIFF
--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -54,6 +54,13 @@ ARCH_TRANSLATIONS = {
     "AMD64": "amd64",  # Windows support
 }
 
+_32BIT_USERSPACE_ARCHITECTURE = {
+    "aarch64": "armv7l",
+    "armv8l": "armv7l",
+    "ppc64le": "ppc",
+    "x86_64": "i686",
+}
+
 
 def get_os_platform(filepath=pathlib.Path("/etc/os-release")):
     """Determine a system/release combo for an OS using /etc/os-release if available."""
@@ -85,8 +92,14 @@ def get_os_platform(filepath=pathlib.Path("/etc/os-release")):
 
 def get_host_architecture():
     """Get host architecture in deb format suitable for base definition."""
-    os_platform = get_os_platform()
-    return ARCH_TRANSLATIONS.get(os_platform.machine, os_platform.machine)
+    os_platform_machine = get_os_platform().machine
+
+    if platform.architecture()[0] == "32bit":
+        userspace = _32BIT_USERSPACE_ARCHITECTURE.get(os_platform_machine)
+        if userspace:
+            os_platform_machine = userspace
+
+    return ARCH_TRANSLATIONS.get(os_platform_machine, os_platform_machine)
 
 
 def strtobool(value: str) -> bool:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -178,20 +178,25 @@ def test_get_os_platform_windows(mocker):
 
 
 @pytest.mark.parametrize(
-    "platform_arch,deb_arch",
+    "platform_machine,platform_architecture,deb_arch",
     [
-        ("AMD64", "amd64"),
-        ("aarch64", "arm64"),
-        ("armv7l", "armhf"),
-        ("ppc", "powerpc"),
-        ("ppc64le", "ppc64el"),
-        ("x86_64", "amd64"),
-        ("unknown-arch", "unknown-arch"),
+        ("AMD64", ("64bit", "ELF"), "amd64"),
+        ("aarch64", ("64bit", "ELF"), "arm64"),
+        ("aarch64", ("32bit", "ELF"), "armhf"),
+        ("armv7l", ("64bit", "ELF"), "armhf"),
+        ("ppc", ("64bit", "ELF"), "powerpc"),
+        ("ppc64le", ("64bit", "ELF"), "ppc64el"),
+        ("x86_64", ("64bit", "ELF"), "amd64"),
+        ("x86_64", ("32bit", "ELF"), "i386"),
+        ("unknown-arch", ("64bit", "ELF"), "unknown-arch"),
     ],
 )
-def test_get_host_architecture(platform_arch, mocker, deb_arch):
+def test_get_host_architecture(
+    platform_machine, platform_architecture, mocker, deb_arch
+):
     """Test all platform mappings in addition to unknown."""
-    mocker.patch("platform.machine", return_value=platform_arch)
+    mocker.patch("platform.machine", return_value=platform_machine)
+    mocker.patch("platform.architecture", return_value=platform_architecture)
 
     assert utils.get_host_architecture() == deb_arch
 


### PR DESCRIPTION
Solve the case of a 64 kernel running a 32 bit userpace

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
