### PR TITLE
spread: remove git user config from pbr test

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -28,6 +28,10 @@ environment:
 
   TOOLS_DIR: /snapcraft/tests/spread/tools
 
+  # Git environment for commits
+  GIT_AUTHOR_NAME: "Test User"
+  GIT_AUTHOR_EMAIL: "test-user@email.com"
+
 backends:
   lxd:
     systems:

--- a/tests/spread/plugins/v1/python/pbr/task.yaml
+++ b/tests/spread/plugins/v1/python/pbr/task.yaml
@@ -17,8 +17,7 @@ prepare: |
   for python_dir in python2 python3; do
       pushd "$python_dir"
       git init
-      git config user.name "Test User"
-      git config user.email "test.user@example.com"
+      git config --global --add safe.directory "$(pwd)"
       git add .
       git commit -m "initial commit"
       popd


### PR DESCRIPTION
This is not needed for spread under google, set up git author and email
through environmnent variables for general system support (e.g.;
Multipass).

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
