### PR TITLE
tests: use lxd in clean provider test

### DIFF
--- a/tests/spread/core22/clean/task.yaml
+++ b/tests/spread/core22/clean/task.yaml
@@ -17,6 +17,9 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 execute: |
+  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host.
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
   snapcraft pack
   snapcraft clean part1
   lxc --project=snapcraft list | grep snapcraft-clean


### PR DESCRIPTION
Tests are ordinarily conducted in destructive mode, enable lxd in
provider cleaning tests.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
