### PR TITLE
meta: add layout to snap.yaml

### DIFF
--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -111,6 +111,7 @@ class SnapMetadata(YamlModel):
     environment: Optional[Dict[str, Any]]
     plugs: Optional[Dict[str, Any]]
     hooks: Optional[Dict[str, Any]]
+    layout: Optional[Dict[str, Dict[str, str]]]
 
 
 def write(project: Project, prime_dir: Path, *, arch: str):
@@ -177,6 +178,7 @@ def write(project: Project, prime_dir: Path, *, arch: str):
         environment=project.environment,
         plugs=project.plugs,
         hooks=project.hooks,
+        layout=project.layout,
     )
 
     yaml.add_representer(str, _repr_str, Dumper=yaml.SafeDumper)

--- a/snapcraft/parts/setup_assets.py
+++ b/snapcraft/parts/setup_assets.py
@@ -169,7 +169,7 @@ def _write_snapcraft_runner(*, prime_dir: Path):
     content = textwrap.dedent(
         """#!/bin/sh
         export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
-        export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+        export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH"
         exec "$@"
         """
     )

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -35,7 +35,7 @@ class ProjectModel(pydantic.BaseModel):
         """Pydantic model configuration."""
 
         validate_assignment = True
-        extra = "allow"  # FIXME: change to 'forbid' after model complete
+        extra = "forbid"
         allow_mutation = True  # project is updated with adopted metadata
         allow_population_by_field_name = True
         alias_generator = lambda s: s.replace("_", "-")  # noqa: E731
@@ -135,7 +135,7 @@ class App(ProjectModel):
     slots: Optional[UniqueStrList]
     plugs: Optional[UniqueStrList]
     aliases: Optional[UniqueStrList]
-    environment: Optional[Dict[str, Any]]
+    environment: Optional[Dict[str, str]]
     adapter: Optional[Literal["none", "full"]]
     command_chain: List[str] = []
     sockets: Optional[Dict[str, Socket]]
@@ -192,7 +192,7 @@ class Hook(ProjectModel):
     """Snapcraft project hook definition."""
 
     command_chain: Optional[List[str]]
-    environment: Optional[Dict[str, Any]]
+    environment: Optional[Dict[str, str]]
     plugs: Optional[UniqueStrList]
     passthrough: Optional[Dict[str, Any]]
 
@@ -253,7 +253,9 @@ class Project(ProjectModel):
     type: Optional[Literal["app", "base", "gadget", "kernel", "snapd"]]
     icon: Optional[str]
     confinement: Literal["classic", "devmode", "strict"]
-    layout: Optional[Dict[str, Dict[str, Any]]]
+    layout: Optional[
+        Dict[str, Dict[Literal["symlink", "bind", "bind-file", "type"], str]]
+    ]
     license: Optional[str]
     grade: Optional[Literal["stable", "devel"]]
     architectures: List[Architecture] = []
@@ -267,7 +269,7 @@ class Project(ProjectModel):
     parts: Dict[str, Any]  # parts are handled by craft-parts
     epoch: Optional[str]
     adopt_info: Optional[str]
-    environment: Optional[Dict[str, Any]]
+    environment: Optional[Dict[str, str]]
 
     @pydantic.validator("plugs")
     @classmethod

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -174,6 +174,14 @@ def complex_project():
           install:
             environment:
               environment-var-1: "test"
+
+        layout:
+          /usr/share/libdrm:
+            bind: $SNAP/gnome-platform/usr/share/libdrm
+          /usr/lib/x86_64-linux-gnu/webkit2gtk-4.0:
+            bind: $SNAP/gnome-platform/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0
+          /usr/share/xml/iso-codes:
+            bind: $SNAP/gnome-platform/usr/share/xml/iso-codes
         """
     )
     data = yaml.safe_load(snapcraft_yaml)
@@ -275,5 +283,12 @@ def test_complex_snap_yaml(complex_project, new_dir):
           install:
             environment:
               environment-var-1: test
+        layout:
+          /usr/share/libdrm:
+            bind: $SNAP/gnome-platform/usr/share/libdrm
+          /usr/lib/x86_64-linux-gnu/webkit2gtk-4.0:
+            bind: $SNAP/gnome-platform/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0
+          /usr/share/xml/iso-codes:
+            bind: $SNAP/gnome-platform/usr/share/xml/iso-codes
         """
     )

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -493,6 +493,22 @@ class TestProjectValidation:
         project = Project.unmarshal(project_yaml_data(plugs=content_plug_data))
         assert project.get_content_snaps() == ["test-provider"]
 
+    @pytest.mark.parametrize("decl_type", ["symlink", "bind", "bind-file", "type"])
+    def test_project_layout(self, decl_type, project_yaml_data):
+        project = Project.unmarshal(
+            project_yaml_data(layout={"foo": {decl_type: "bar"}})
+        )
+        assert project.layout is not None
+        assert project.layout["foo"][decl_type] == "bar"
+
+    def test_project_layout_invalid(self, project_yaml_data):
+        error = (
+            "Bad snapcraft.yaml content:\n"
+            "- unexpected value; permitted: 'symlink', 'bind', 'bind-file', 'type'"
+        )
+        with pytest.raises(errors.ProjectValidationError, match=error):
+            Project.unmarshal(project_yaml_data(layout={"foo": {"invalid": "bar"}}))
+
 
 class TestHookValidation:
     """Validate hooks."""
@@ -504,7 +520,7 @@ class TestHookValidation:
             {
                 "configure": {
                     "command-chain": ["test-1", "test-2"],
-                    "build-environment": {
+                    "environment": {
                         "FIRST_VARIABLE": "test-3",
                         "SECOND_VARIABLE": "test-4",
                     },


### PR DESCRIPTION
Improve project layout validation and add layout definition to
snap.yaml. Also change project definition to not allow extra fields,
and fix toplevel and part environment field type.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `./runtests.sh static`?
- [ ] Have you successfully run `./runtests.sh tests/unit`?

-----
