### PR TITLE
extensions/desktop: preload bindtextdomain from snap first if it exists

### DIFF
--- a/extensions/desktop/common/init
+++ b/extensions/desktop/common/init
@@ -74,9 +74,9 @@ export SNAP_LAUNCHER_ARCH_TRIPLET="$ARCH"
 
 # Don't LD_PRELOAD bindtextdomain for classic snaps
 if ! grep -qs "^\s*confinement:\s*classic\s*" "$SNAP/meta/snap.yaml"; then
-  if [ -f "$SNAP/gnome-platform/lib/$ARCH/bindtextdomain.so" ]; then
-    export LD_PRELOAD="$LD_PRELOAD:$SNAP/gnome-platform/\$LIB/bindtextdomain.so"
-  elif [ -f "$SNAP/lib/$ARCH/bindtextdomain.so" ]; then
+  if [ -f "$SNAP/lib/$ARCH/bindtextdomain.so" ]; then
     export LD_PRELOAD="$LD_PRELOAD:$SNAP/\$LIB/bindtextdomain.so"
+  elif [ -f "$SNAP/gnome-platform/lib/$ARCH/bindtextdomain.so" ]; then
+    export LD_PRELOAD="$LD_PRELOAD:$SNAP/gnome-platform/\$LIB/bindtextdomain.so"
   fi
 fi


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
This fixes error caused by `desktop-launch` loading `amd64` `bindtextdomain.so` first from `gnome-platform` then `i386` from snap.
```
ERROR: ld.so: object '/snap/test/x1/gnome-platform/$LIB/bindtextdomain.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
```