### PR TITLE
legacy: plugins: convert paths to strings for commands

### DIFF
--- a/snapcraft_legacy/plugins/v1/_plugin.py
+++ b/snapcraft_legacy/plugins/v1/_plugin.py
@@ -187,7 +187,7 @@ class PluginV1:
     def run(self, cmd, cwd=None, **kwargs):
         if not cwd:
             cwd = self.builddir
-        cmd_string = " ".join([shlex.quote(c) for c in cmd])
+        cmd_string = " ".join([shlex.quote(str(c)) for c in cmd])
         print(cmd_string)
         os.makedirs(cwd, exist_ok=True)
         try:

--- a/tests/legacy/unit/plugins/v1/test_base.py
+++ b/tests/legacy/unit/plugins/v1/test_base.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from pathlib import Path
 import unittest.mock
 
 from testtools.matchers import Equals
@@ -65,6 +66,20 @@ class TestBasePlugin(unit.TestCase):
         plugin.run(["ls"], cwd=plugin.sourcedir)
 
         mock_run.assert_called_once_with(["ls"], cwd=plugin.sourcedir)
+
+    @unittest.mock.patch("snapcraft_legacy.internal.common.run")
+    def test_run_with_string(self, mock_run):
+        plugin = snapcraft_legacy.BasePlugin("test/part", options=None)
+        plugin.run(["ls", "/test"], cwd=plugin.sourcedir)
+
+        mock_run.assert_called_once_with(["ls", "/test"], cwd=plugin.sourcedir)
+
+    @unittest.mock.patch("snapcraft_legacy.internal.common.run")
+    def test_run_with_path(self, mock_run):
+        plugin = snapcraft_legacy.BasePlugin("test/part", options=None)
+        plugin.run(["ls", Path("/test")], cwd=plugin.sourcedir)
+
+        mock_run.assert_called_once_with(["ls", Path("/test")], cwd=plugin.sourcedir)
 
     @unittest.mock.patch("snapcraft_legacy.internal.common.run_output")
     def test_run_output_without_specifying_cwd(self, mock_run):


### PR DESCRIPTION
Signed-off-by: Callahan Kovacs <callahan.kovacs@canonical.com>

- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
Convert `Path` to `string` for commands in legacy v1 plugins.  Add regression tests.

Bug was exposed when https://github.com/snapcore/snapcraft/pull/3601/files started using `pathlib` for `autotools`.  
@diddledani partially fixed the issue https://github.com/snapcore/snapcraft/pull/3628, but this PR should wrap up the issue.