### PR TITLE
pack: check skeleton

### DIFF
--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -25,15 +25,35 @@ from craft_cli import emit
 from snapcraft import errors
 
 
+def _verify_snap(directory: Path) -> None:
+    emit.trace("pack_snap: check skeleton")
+    try:
+        subprocess.run(
+            ["snap", "pack", "--check-skeleton", directory],
+            capture_output=True,
+            check=True,
+            universal_newlines=True,
+        )
+    except subprocess.CalledProcessError as err:
+        msg = f"Cannot pack snap file: {err!s}"
+        if err.stderr:
+            msg += f" ({err.stderr.strip()!s})"
+        raise errors.SnapcraftError(msg)
+
+
 def pack_snap(
     directory: Path, *, output: Optional[str], compression: Optional[str] = None
 ) -> None:
     """Pack snap contents.
 
+    :param directory: Directory to pack.
     :param output: Snap file name or directory.
     :param compression: Compression type to use, None for defaults.
     """
     emit.trace(f"pack_snap: output={output!r}, compression={compression!r}")
+
+    # TODO remove workaround once LP: #1950465 is fixed
+    _verify_snap(directory)
 
     output_file = None
     output_dir = None

--- a/tests/unit/test_pack.py
+++ b/tests/unit/test_pack.py
@@ -27,11 +27,17 @@ def test_pack_snap(mocker, new_dir):
     pack.pack_snap(new_dir, output=None)
     assert mock_run.mock_calls == [
         call(
+            ["snap", "pack", "--check-skeleton", new_dir],
+            capture_output=True,
+            check=True,
+            universal_newlines=True,
+        ),
+        call(
             ["snap", "pack", new_dir],
             capture_output=True,
             check=True,
             universal_newlines=True,
-        )
+        ),
     ]
 
 
@@ -40,11 +46,17 @@ def test_pack_snap_compression_none(mocker, new_dir):
     pack.pack_snap(new_dir, output=None, compression=None)
     assert mock_run.mock_calls == [
         call(
+            ["snap", "pack", "--check-skeleton", new_dir],
+            capture_output=True,
+            check=True,
+            universal_newlines=True,
+        ),
+        call(
             ["snap", "pack", new_dir],
             capture_output=True,
             check=True,
             universal_newlines=True,
-        )
+        ),
     ]
 
 
@@ -53,11 +65,17 @@ def test_pack_snap_compression(mocker, new_dir):
     pack.pack_snap(new_dir, output=None, compression="zz")
     assert mock_run.mock_calls == [
         call(
+            ["snap", "pack", "--check-skeleton", new_dir],
+            capture_output=True,
+            check=True,
+            universal_newlines=True,
+        ),
+        call(
             ["snap", "pack", "--compression", "zz", new_dir],
             capture_output=True,
             check=True,
             universal_newlines=True,
-        )
+        ),
     ]
 
 
@@ -66,11 +84,17 @@ def test_pack_snap_output_file(mocker, new_dir):
     pack.pack_snap(new_dir, output="/tmp/foo")
     assert mock_run.mock_calls == [
         call(
+            ["snap", "pack", "--check-skeleton", new_dir],
+            capture_output=True,
+            check=True,
+            universal_newlines=True,
+        ),
+        call(
             ["snap", "pack", "--filename", "foo", new_dir, "/tmp"],
             capture_output=True,
             check=True,
             universal_newlines=True,
-        )
+        ),
     ]
 
 
@@ -79,11 +103,17 @@ def test_pack_snap_output_dir(mocker, new_dir):
     pack.pack_snap(new_dir, output=str(new_dir))
     assert mock_run.mock_calls == [
         call(
+            ["snap", "pack", "--check-skeleton", new_dir],
+            capture_output=True,
+            check=True,
+            universal_newlines=True,
+        ),
+        call(
             ["snap", "pack", new_dir, str(new_dir)],
             capture_output=True,
             check=True,
             universal_newlines=True,
-        )
+        ),
     ]
 
 


### PR DESCRIPTION
Run "snap pack --check-skeleton" until "snap pack" does it.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
