### PR TITLE
Fix/core20 ros plugin build failure should stop snapcraft

### DIFF
--- a/snapcraft_legacy/plugins/v2/catkin.py
+++ b/snapcraft_legacy/plugins/v2/catkin.py
@@ -89,7 +89,7 @@ class CatkinPlugin(_ros.RosPlugin):
         # There are a number of unbound vars, disable flag
         # after saving current state to restore after.
         return [
-            'state="$(set +o)"',
+            'state="$(set +o); set -$-"',
             "set +u",
             'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
             "set -- --local",

--- a/snapcraft_legacy/plugins/v2/catkin_tools.py
+++ b/snapcraft_legacy/plugins/v2/catkin_tools.py
@@ -79,7 +79,7 @@ class CatkinToolsPlugin(_ros.RosPlugin):
         # There are a number of unbound vars, disable flag
         # after saving current state to restore after.
         return [
-            'state="$(set +o)"',
+            'state="$(set +o); set -$-"',
             "set +u",
             'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
             "set -- --local",

--- a/snapcraft_legacy/plugins/v2/colcon.py
+++ b/snapcraft_legacy/plugins/v2/colcon.py
@@ -134,7 +134,7 @@ class ColconPlugin(_ros.RosPlugin):
         # There are a number of unbound vars, disable flag
         # after saving current state to restore after.
         return [
-            'state="$(set +o)"',
+            'state="$(set +o); set -$-"',
             "set +u",
             # If it exists, source the stage-snap underlay
             'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/setup.sh ]; then',

--- a/tests/legacy/unit/plugins/v2/test_catkin.py
+++ b/tests/legacy/unit/plugins/v2/test_catkin.py
@@ -84,7 +84,7 @@ def test_get_build_commands(monkeypatch):
     monkeypatch.setattr(os, "environ", dict())
 
     assert plugin.get_build_commands() == [
-        'state="$(set +o)"',
+        'state="$(set +o); set -$-"',
         "set +u",
         'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
         "set -- --local",
@@ -137,7 +137,7 @@ def test_get_build_commands_with_all_properties(monkeypatch):
     )
 
     assert plugin.get_build_commands() == [
-        'state="$(set +o)"',
+        'state="$(set +o); set -$-"',
         "set +u",
         'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
         "set -- --local",

--- a/tests/legacy/unit/plugins/v2/test_catkin_tools.py
+++ b/tests/legacy/unit/plugins/v2/test_catkin_tools.py
@@ -79,7 +79,7 @@ def test_get_build_commands(monkeypatch):
     monkeypatch.setattr(os, "environ", dict())
 
     assert plugin.get_build_commands() == [
-        'state="$(set +o)"',
+        'state="$(set +o); set -$-"',
         "set +u",
         'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
         "set -- --local",
@@ -133,7 +133,7 @@ def test_get_build_commands_with_all_properties(monkeypatch):
     )
 
     assert plugin.get_build_commands() == [
-        'state="$(set +o)"',
+        'state="$(set +o); set -$-"',
         "set +u",
         'if [ -f "${SNAPCRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/setup.sh" ]; then',
         "set -- --local",

--- a/tests/legacy/unit/plugins/v2/test_colcon.py
+++ b/tests/legacy/unit/plugins/v2/test_colcon.py
@@ -105,7 +105,7 @@ def test_get_build_commands(monkeypatch):
     monkeypatch.setattr(os, "environ", dict())
 
     assert plugin.get_build_commands() == [
-        'state="$(set +o)"',
+        'state="$(set +o); set -$-"',
         "set +u",
         'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/setup.sh ]; then',
         'COLCON_CURRENT_PREFIX="${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap . "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/setup.sh',
@@ -159,7 +159,7 @@ def test_get_build_commands_with_all_properties(monkeypatch):
     )
 
     assert plugin.get_build_commands() == [
-        'state="$(set +o)"',
+        'state="$(set +o); set -$-"',
         "set +u",
         'if [ -f "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/setup.sh ]; then',
         'COLCON_CURRENT_PREFIX="${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap . "${SNAPCRAFT_PART_INSTALL}"/opt/ros/snap/setup.sh',

--- a/tests/spread/plugins/v2/ros-plugins-error-code/task.yaml
+++ b/tests/spread/plugins/v2/ros-plugins-error-code/task.yaml
@@ -1,0 +1,51 @@
+summary: >-
+  Make sure snapcraft fails when a ROS command returns an exit code
+
+kill-timeout: 180m
+
+environment:
+  SNAP/catkin_noetic_hello: catkin-noetic-hello
+  SNAP/catkin_tools_noetic_hello: catkin-tools-noetic-hello
+  SNAP/colcon_ros2_foxy_rlcpp_hello: colcon-ros2-foxy-rlcpp-hello
+  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
+
+systems:
+  - ubuntu-20.04
+  - ubuntu-20.04-64
+  - ubuntu-20.04-amd64
+  - ubuntu-20.04-arm64
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "../snaps/$SNAP/snap/snapcraft.yaml"
+
+restore: |
+  cd "../snaps/$SNAP"
+  snapcraft clean
+  rm -f ./*.snap
+
+  # ROS1 packages
+  [ -f src/snapcraft_hello/package.xml ] && git checkout src/snapcraft_hello/package.xml
+
+  # ROS2 packages
+  [ -f package.xml ] && git checkout package.xml
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "../snaps/$SNAP"
+
+  # ROS1 packages
+  [ -f src/snapcraft_hello/package.xml ] && sed -i '/<buildtool_depend>catkin<\/buildtool_depend>/a <build_depend>IDoNotExist<\/build_depend>' src/snapcraft_hello/package.xml
+
+  # ROS2 packages
+  [ -f package.xml ] && sed -i '/<build_depend>std_msgs<\/build_depend>/a <build_depend>IDoNotExist<\/build_depend>' package.xml
+
+  # Build what we have and verify that snapcraft failed
+  if snapcraft build; then
+    echo "Because of the non-existing dependency snapcraft should fail"
+    exit 1
+  fi


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
ROS plugin-v2 (colcon/catkin/catkin-tools) build error were not stopping snapcraft.
Bash turns off the `errexit` option in command substitutions, so we have to explicitly save the option in the saved state.

Added tests checking that it properly fails