### PR TITLE
project: support system-usernames

### DIFF
--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -112,6 +112,13 @@ class SnapMetadata(YamlModel):
     plugs: Optional[Dict[str, Any]]
     hooks: Optional[Dict[str, Any]]
     layout: Optional[Dict[str, Dict[str, str]]]
+    system_usernames: Optional[Dict[str, Any]]
+
+    class Config:  # pylint: disable=too-few-public-methods
+        """Pydantic model configuration."""
+
+        allow_population_by_field_name = True
+        alias_generator = lambda s: s.replace("_", "-")  # noqa: E731
 
 
 def write(project: Project, prime_dir: Path, *, arch: str):
@@ -179,6 +186,7 @@ def write(project: Project, prime_dir: Path, *, arch: str):
         plugs=project.plugs,
         hooks=project.hooks,
         layout=project.layout,
+        system_usernames=project.system_usernames,
     )
 
     yaml.add_representer(str, _repr_str, Dumper=yaml.SafeDumper)

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -269,6 +269,7 @@ class Project(ProjectModel):
     parts: Dict[str, Any]  # parts are handled by craft-parts
     epoch: Optional[str]
     adopt_info: Optional[str]
+    system_usernames: Optional[Dict[str, Any]]
     environment: Optional[Dict[str, str]]
 
     @pydantic.validator("plugs")

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -175,6 +175,11 @@ def complex_project():
             environment:
               environment-var-1: "test"
 
+        system-usernames:
+          snap_daemon:
+            scope: shared
+          snap_microk8s: shared
+
         layout:
           /usr/share/libdrm:
             bind: $SNAP/gnome-platform/usr/share/libdrm
@@ -290,5 +295,9 @@ def test_complex_snap_yaml(complex_project, new_dir):
             bind: $SNAP/gnome-platform/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0
           /usr/share/xml/iso-codes:
             bind: $SNAP/gnome-platform/usr/share/xml/iso-codes
+        system-usernames:
+          snap_daemon:
+            scope: shared
+          snap_microk8s: shared
         """
     )

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -1134,3 +1134,28 @@ class TestGrammarValidation:
         error = r".*- syntax error in 'on' selector"
         with pytest.raises(errors.ProjectValidationError, match=error):
             GrammarAwareProject.validate_grammar(data)
+
+    @pytest.mark.parametrize(
+        "system_username",
+        [
+            {"snap_daemon": {"scope": "shared"}},
+            {"snap_microk8s": {"scope": "shared"}},
+            {"snap_daemon": "shared"},
+            {"snap_microk8s": "shared"},
+        ],
+    )
+    def test_project_system_usernames_valid(self, system_username, project_yaml_data):
+        project = Project.unmarshal(project_yaml_data(system_usernames=system_username))
+        assert project.system_usernames == system_username
+
+    @pytest.mark.parametrize(
+        "system_username",
+        [
+            0,
+            "string",
+        ],
+    )
+    def test_project_system_usernames_invalid(self, system_username, project_yaml_data):
+        error = "- value is not a valid dict"
+        with pytest.raises(errors.ProjectValidationError, match=error):
+            Project.unmarshal(project_yaml_data(system_usernames=system_username))


### PR DESCRIPTION
Contrary to what was done for legacy, make the system-usernames much more lax.

More strict errors should be raised by "snap pack".

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1083