### PR TITLE
slots: allow lists

### DIFF
--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -265,7 +265,7 @@ class Project(ProjectModel):
     passthrough: Optional[Dict[str, Any]]
     apps: Optional[Dict[str, App]]
     plugs: Optional[Dict[str, Union[ContentPlug, Any]]]
-    slots: Optional[Dict[str, Dict[str, str]]]  # TODO: add slot name validation
+    slots: Optional[Dict[str, Dict[str, Any]]]  # TODO: add slot name validation
     parts: Dict[str, Any]  # parts are handled by craft-parts
     epoch: Optional[str]
     adopt_info: Optional[str]

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -509,6 +509,23 @@ class TestProjectValidation:
         with pytest.raises(errors.ProjectValidationError, match=error):
             Project.unmarshal(project_yaml_data(layout={"foo": {"invalid": "bar"}}))
 
+    @pytest.mark.parametrize(
+        "slots",
+        [
+            {"test-slot": {"interface": "some-value"}},
+            {
+                "db-socket": {
+                    "interface": "content",
+                    "content": "db-socket",
+                    "write": ["$SNAP_COMMON/postgres/sockets"],
+                },
+            },
+        ],
+    )
+    def test_slot_valid(self, slots, project_yaml_data):
+        project = Project.unmarshal(project_yaml_data(slots=slots))
+        assert project.slots == slots
+
 
 class TestHookValidation:
     """Validate hooks."""


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Allow for other data types in slot sub-fields in core22, similar to core20 behavior.

The TODO for slot validation (casting and validating ContentSlots, DbusSlots) is still left open, as this is a much larger effort.

(CRAFT-1084)