### PR TITLE
craftctl: add snapcraftctl compatibility wrapper

### DIFF
--- a/bin/snapcraftctl-compat
+++ b/bin/snapcraftctl-compat
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+if [ -z "$SNAPCRAFT_PROJECT_NAME" ]; then
+    echo "This utility is designed for use only in part scriptlets." >&2
+    exit 1
+fi
+
+if [ -z "$CRAFT_PROJECT_NAME" ]; then
+    # Running in legacy mode, execute legacy snapcraftctl
+    exec "$SNAP"/bin/scriptlet-bin/snapcraftctl "$@"
+    echo "Error: cannot execute legacy snapcraftctl" >&2
+    exit 1
+fi
+
+cmd="$1"
+args="$2"
+retcode=0
+
+set -e
+case "$cmd" in
+  pull|build|stage|prime)
+    if [ "${cmd^^}" = "$CRAFT_STEP_NAME" ]; then
+        echo "Warning: use 'craftctl default' to execute the default step handler" >&2
+        craftctl default
+    else
+        echo "Error: cannot execute the '${cmd}' handler from step '${CRAFT_STEP_NAME,,}'" >&2
+        retcode=1
+    fi
+    ;;
+  set-version)
+    echo "Warning: Use 'craftctl set version=<value>' to set version" >&2
+    craftctl set version="$args"
+    ;;
+  set-grade)
+    echo "Warning: Use 'craftctl set grade=<value>' to set grade" >&2
+    craftctl set grade="$args"
+    ;;
+  *)
+    echo "Error: snapcraftctl called with an invalid command" >&2
+    retcode=1
+esac
+
+cat <<EOF >&2
+
+Users are encouraged to replace 'snapcraftctl' with 'craftctl' and use
+'CRAFT_*' environment variables in scriptlets when building snaps based
+on core22. Please refer to the core22 migration guide for details.
+EOF
+
+exit $retcode

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ classifiers = [
 # snapcraftctl is not in console_scripts because we need a clean environment.
 # Only include it for Linux.
 if sys.platform == "linux":
-    scripts = ["bin/snapcraftctl"]
+    scripts = ["bin/snapcraftctl", "bin/snapcraftctl-compat"]
 else:
     scripts = []
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -121,6 +121,8 @@ parts:
         # Put snapcraftctl into its own directory that can be included in the PATH
         # without including other binaries.
         bin/snapcraftctl: bin/scriptlet-bin/snapcraftctl
+        # Also install the compatibility wrapper for core22+
+        bin/snapcraftctl-compat: libexec/snapcraft/snapcraftctl
     build-environment:
         - "CRYPTOGRAPHY_DONT_BUILD_RUST": "1"
         - "SODIUM_INSTALL": "system"

--- a/tests/spread/core22/craftctl/task.yaml
+++ b/tests/spread/core22/craftctl/task.yaml
@@ -3,6 +3,7 @@ summary: Test craftctl commands on core22
 environment:
   SNAP/test_craftctl_default: test-craftctl-default
   SNAP/test_craftctl_get_set: test-craftctl-get-set
+  SNAP/test_snapcraftctl_compat: test-craftctl-snapcraftctl-compat
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
@@ -21,10 +22,7 @@ restore: |
 
 execute: |
   cd "$SNAP"
-
-  if [ "$SPREAD_SYSTEM" = "ubuntu-20.04-64" ]; then
-      snapcraft --verbose --destructive-mode
-      TESTBIN="${SNAP##*test-}"
-      snap install craftctl-*.snap --dangerous
-      $TESTBIN | grep hello
-  fi
+  snapcraft --verbose --destructive-mode
+  TESTBIN="${SNAP##*test-}"
+  snap install craftctl-*.snap --dangerous
+  $TESTBIN | grep hello

--- a/tests/spread/core22/craftctl/test-craftctl-snapcraftctl-compat/Makefile
+++ b/tests/spread/core22/craftctl/test-craftctl-snapcraftctl-compat/Makefile
@@ -1,0 +1,19 @@
+CC = gcc
+CFLAGS = -O2 -Wall
+LD = gcc
+LDFLAGS =
+OBJS = hello.o
+BIN = hello
+
+.c.o:
+	$(CC) -c $(CFLAGS) -o$*.o $<
+
+$(BIN): $(OBJS)
+	$(LD) -o $@ $(OBJS)
+
+install:
+	mkdir -p $(DESTDIR)/usr/bin
+	install -m755 $(BIN) $(DESTDIR)/usr/bin
+
+clean:
+	rm -f $(OBJS)

--- a/tests/spread/core22/craftctl/test-craftctl-snapcraftctl-compat/hello.c
+++ b/tests/spread/core22/craftctl/test-craftctl-snapcraftctl-compat/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main()
+{
+    printf("hello\n");
+}

--- a/tests/spread/core22/craftctl/test-craftctl-snapcraftctl-compat/snap/snapcraft.yaml
+++ b/tests/spread/core22/craftctl/test-craftctl-snapcraftctl-compat/snap/snapcraft.yaml
@@ -1,0 +1,29 @@
+name: craftctl-snapcraftctl-compat
+summary: test
+description: test
+confinement: strict
+base: core22
+adopt-info: hello
+
+apps:
+  craftctl-snapcraftctl-compat:
+    command: usr/bin/hello
+
+parts:
+  hello:
+    plugin: make
+    source: .
+    override-pull: |
+      echo "This is the pull step"
+      snapcraftctl pull
+    override-build: |
+      echo "This is the build step"
+      snapcraftctl build
+      snapcraftctl set-version 1.0
+      snapcraftctl set-grade stable
+    override-stage: |
+      echo "This is the stage step"
+      snapcraftctl stage
+    override-prime: |
+      echo "This is the prime step"
+      snapcraftctl prime

--- a/tests/spread/core22/environment/test-variables/task.yaml
+++ b/tests/spread/core22/environment/test-variables/task.yaml
@@ -23,36 +23,35 @@ execute: |
 
   check_vars() {
     file="$1"
+    root="/snapcraft/tests/spread/core22/environment/test-variables"
     echo "==== $file ===="
     cat "$file"
     for exp in \
       "^CRAFT_ARCH_TRIPLET=x86_64-linux-gnu$" \
       "^CRAFT_TARGET_ARCH=amd64$" \
       "^CRAFT_PARALLEL_BUILD_COUNT=[0-9]\+$" \
-      "^CRAFT_PROJECT_DIR=/root/project$" \
+      "^CRAFT_PROJECT_DIR=${root}$" \
       "^CRAFT_PART_NAME=hello$" \
-      "^CRAFT_PART_SRC=/root/parts/hello/src$" \
-      "^CRAFT_PART_SRC_WORK=/root/parts/hello/src$" \
-      "^CRAFT_PART_BUILD=/root/parts/hello/build$" \
-      "^CRAFT_PART_BUILD_WORK=/root/parts/hello/build$" \
-      "^CRAFT_PART_INSTALL=/root/parts/hello/install$" \
-      "^CRAFT_OVERLAY=/root/overlay/overlay$" \
-      "^CRAFT_STAGE=/root/stage$" \
-      "^CRAFT_PRIME=/root/prime$"; do
+      "^CRAFT_PART_SRC=${root}/parts/hello/src$" \
+      "^CRAFT_PART_SRC_WORK=${root}/parts/hello/src$" \
+      "^CRAFT_PART_BUILD=${root}/parts/hello/build$" \
+      "^CRAFT_PART_BUILD_WORK=${root}/parts/hello/build$" \
+      "^CRAFT_PART_INSTALL=${root}/parts/hello/install$" \
+      "^CRAFT_OVERLAY=${root}/overlay/overlay$" \
+      "^CRAFT_STAGE=${root}/stage$" \
+      "^CRAFT_PRIME=${root}/prime$"; do
       grep -q "$exp" < "$file"
     done
   }
 
-  if [ "$SPREAD_SYSTEM" = "ubuntu-20.04-64" ]; then
-    snapcraft pull
-    check_vars pull.txt
+  snapcraft pull
+  check_vars pull.txt
 
-    snapcraft build
-    check_vars build.txt
+  snapcraft build
+  check_vars build.txt
 
-    snapcraft stage
-    check_vars stage.txt
+  snapcraft stage
+  check_vars stage.txt
 
-    snapcraft prime
-    check_vars prime.txt
-  fi
+  snapcraft prime
+  check_vars prime.txt

--- a/tests/spread/core22/package-repositories/task.yaml
+++ b/tests/spread/core22/package-repositories/task.yaml
@@ -16,20 +16,10 @@ restore: |
 execute: |
   cd "$SNAP"
 
-  # No jammy for this ppa yet
-  if [ "$(basename "$SNAP")" != "test-apt-ppa" ]; then
-      # Build what we have.
-      snapcraft --verbose --use-lxd
+  # Build what we have.
+  snapcraft --verbose --use-lxd
 
-      # And verify the snap runs as expected.
-      snap install "${SNAP}"_1.0_*.snap --dangerous
-      snap_executable="${SNAP}.test-ppa"
-      [ "$("${snap_executable}")" = "hello!" ]
-  fi
-
-  # Do it again in destructive mode
-  snap remove "${SNAP}"
-  snapcraft --verbose --destructive-mode
+  # And verify the snap runs as expected.
   snap install "${SNAP}"_1.0_*.snap --dangerous
   snap_executable="${SNAP}.test-ppa"
   [ "$("${snap_executable}")" = "hello!" ]

--- a/tests/spread/core22/scriptlets/task.yaml
+++ b/tests/spread/core22/scriptlets/task.yaml
@@ -19,10 +19,8 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 execute: |
-  if [ "$SPREAD_SYSTEM" = "ubuntu-20.04-64" ]; then
-      cd "$SNAP_DIR"
-      snapcraft_log="$(snapcraft build 2>&1 || true)"
+  cd "$SNAP_DIR"
+  snapcraft_log="$(snapcraft build 2>&1 || true)"
 
-      echo "${snapcraft_log}" | NOMATCH "^should have failed set-version"
-      echo "${snapcraft_log}" | NOMATCH "^should have failed build"
-  fi
+  echo "${snapcraft_log}" | NOMATCH "^should have failed set-version"
+  echo "${snapcraft_log}" | NOMATCH "^should have failed build"


### PR DESCRIPTION
Add snapcraftctl wrapper to craftctl to make the transition to core22
easier. Execution of the wrapper displays a message encouraging the
user to update to craftctl.

Also add a spread test and fix existing core22 spread tests that were
not being executed.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-965