### PR TITLE
spread: move core22 to stable

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -248,9 +248,6 @@ prepare: |
   git commit -m "Testing Commit"
   popd
 
-  # TODO remove once core22 is stable
-  snap install core22 --edge
-
 restore-each: |
   "$TOOLS_DIR"/restore.sh
 

--- a/tests/spread/core22/clean/task.yaml
+++ b/tests/spread/core22/clean/task.yaml
@@ -6,7 +6,6 @@ prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   # set_base "$SNAP/snap/snapcraft.yaml"
-  snap install core22 --edge
 
 restore: |
   rm -f ./*.snap

--- a/tests/spread/core22/craftctl/task.yaml
+++ b/tests/spread/core22/craftctl/task.yaml
@@ -9,7 +9,6 @@ prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   # set_base "$SNAP/snap/snapcraft.yaml"
-  snap install core22 --edge
 
 restore: |
   cd "$SNAP"

--- a/tests/spread/core22/environment/paths/task.yaml
+++ b/tests/spread/core22/environment/paths/task.yaml
@@ -9,7 +9,6 @@ prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "../snaps/$SNAP/snap/snapcraft.yaml"
-  snap install core22 --edge
 
 restore: |
   cd "../snaps/$SNAP"

--- a/tests/spread/core22/environment/test-variables/task.yaml
+++ b/tests/spread/core22/environment/test-variables/task.yaml
@@ -7,7 +7,6 @@ prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "../snaps/$SNAP/snap/snapcraft.yaml"
-  snap install core22 --edge
 
 restore: |
   cd "../snaps/$SNAP"
@@ -23,7 +22,7 @@ execute: |
 
   check_vars() {
     file="$1"
-    root="/snapcraft/tests/spread/core22/environment/test-variables"
+    root="/snapcraft/tests/spread/core22/environment/snaps/test-variables"
     echo "==== $file ===="
     cat "$file"
     for exp in \

--- a/tests/spread/core22/packing/task.yaml
+++ b/tests/spread/core22/packing/task.yaml
@@ -15,7 +15,6 @@ prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   # set_base "$SNAP_DIR/snap/snapcraft.yaml"
-  snap install core22 --edge
 
 restore: |
   snapcraft clean

--- a/tests/spread/core22/scriptlets/task.yaml
+++ b/tests/spread/core22/scriptlets/task.yaml
@@ -7,7 +7,6 @@ prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   # set_base "$SNAP_DIR/snap/snapcraft.yaml"
-  snap install core22 --edge
 
 restore: |
   cd "$SNAP_DIR"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
`core22 latest/edge` now depends on `snapd 2.55.5`, which is not easily available to the github runners.  This is preventing spread tests from running.

Error:
```
+ snap install core22 --edge
error: cannot install "core22": snap "core22" assumes unsupported features:
       snapd2.55.5 (try to refresh snapd)
```

Source: https://github.com/snapcore/core-base/commit/ed8f06c2ed30dc6084fc11591372744d67e2e4bb#diff-e68b9afd67bb77dec8eda77796d3e0b784c7011203114996383eed6533be0cefR11


