### PR TITLE
environment: get LD_LIBRARY_PATH

### DIFF
--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -16,6 +16,9 @@
 
 """Create snap.yaml metadata file."""
 
+import glob
+import os
+import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Union, cast
 
@@ -23,6 +26,17 @@ import yaml
 from pydantic_yaml import YamlModel
 
 from snapcraft.projects import Project
+
+_ARCH_TO_TRIPLET: Dict[str, str] = {
+    "arm64": "aarch64-linux-gnu",
+    "armhf": "arm-linux-gnueabihf",
+    "i386": "i386-linux-gnu",
+    "powerpc": "powerpc-linux-gnu",
+    "ppc64el": "powerpc64le-linux-gnu",
+    "riscv64": "riscv64-linux-gnu",
+    "s390x": "s390x-linux-gnu",
+    "amd64": "x86_64-linux-gnu",
+}
 
 
 class Socket(YamlModel):
@@ -188,7 +202,7 @@ def write(project: Project, prime_dir: Path, *, arch: str):
         apps=snap_apps or None,
         confinement=project.confinement,
         grade=project.grade or "stable",
-        environment=project.environment,
+        environment=_populate_environment(project.environment, prime_dir, arch),
         plugs=project.plugs,
         slots=project.slots,
         hooks=project.hooks,
@@ -214,3 +228,107 @@ def _repr_str(dumper, data):
     if "\n" in data:
         return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
     return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+def _populate_environment(environment, prime_dir, arch):
+    """Populate default app environmental variables.
+
+    Three cases for LD_LIBRARY_PATH and PATH variables:
+        - If LD_LIBRARY_PATH or PATH are defined, keep user-defined values.
+        - If LD_LIBRARY_PATH or PATH are not defined, set to default values.
+        - If LD_LIBRARY_PATH or PATH are null, do not use default values.
+    """
+    if environment is None:
+        return {
+            "LD_LIBRARY_PATH": _get_ld_library_path(prime_dir, arch),
+            "PATH": "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH",
+        }
+
+    try:
+        if not environment["LD_LIBRARY_PATH"]:
+            environment.pop("LD_LIBRARY_PATH")
+    except KeyError:
+        environment["LD_LIBRARY_PATH"] = _get_ld_library_path(prime_dir, arch)
+
+    try:
+        if not environment["PATH"]:
+            environment.pop("PATH")
+    except KeyError:
+        environment["PATH"] = "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+
+    if len(environment):
+        return environment
+
+    # if the environment only contained a null LD_LIBRARY_PATH and a null PATH, return None
+    return None
+
+
+def _get_ld_library_path(prime_dir, arch) -> str:
+    """Get LD_LIBRARY_PATH variable."""
+    paths = ["${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"]
+    # Add the default LD_LIBRARY_PATH
+    paths += _get_common_ld_library_paths(prime_dir, arch)
+    # Add more specific LD_LIBRARY_PATH from staged packages if necessary
+    paths += _get_configured_ld_library_paths(prime_dir)
+
+    ld_library_path = ":".join(paths)
+
+    return re.sub(str(prime_dir), "$SNAP", ld_library_path)
+
+
+def _get_common_ld_library_paths(prime_dir, arch) -> List[str]:
+    """Return common library paths for a snap.
+
+    If existing_only is set the paths returned must exist for
+    the root that was set.
+    """
+    triplet = _ARCH_TO_TRIPLET[arch]
+    paths = [
+        os.path.join(prime_dir, "lib"),
+        os.path.join(prime_dir, "usr", "lib"),
+        os.path.join(prime_dir, "lib", triplet),
+        os.path.join(prime_dir, "usr", "lib", triplet),
+    ]
+
+    return [p for p in paths if os.path.exists(p)]
+
+
+def _get_configured_ld_library_paths(prime_dir: str) -> List[str]:
+    """Determine additional library paths needed for the linker loader.
+
+    This is a workaround until full library searching is implemented which
+    works by searching for ld.so.conf in specific hard coded locations
+    within root.
+
+    :param prime_dir str: the directory to search for specific ld.so.conf
+                          entries.
+    :returns: a list of strings of library paths where relevant libraries
+              can be found within prime_dir.
+    """
+    # If more ld.so.conf files need to be supported, add them here.
+    ld_config_globs = {f"{prime_dir}/usr/lib/*/mesa*/ld.so.conf"}
+
+    ld_library_paths = []
+    for this_glob in ld_config_globs:
+        for ld_conf_file in glob.glob(this_glob):
+            ld_library_paths.extend(_extract_ld_library_paths(ld_conf_file))
+
+    return [prime_dir + path for path in ld_library_paths]
+
+
+def _extract_ld_library_paths(ld_conf_file: str) -> List[str]:
+    # From the ldconfig manpage, paths can be colon-, space-, tab-, newline-,
+    # or comma-separated.
+    path_delimiters = re.compile(r"[:\s,]")
+    comments = re.compile(r"#.*$")
+
+    paths = []
+    with open(ld_conf_file, "r", encoding="utf-8") as ld_config:
+        for line in ld_config:
+            # Remove comments from line
+            line = comments.sub("", line).strip()
+
+            if line:
+                paths.extend(path_delimiters.split(line))
+
+    return paths

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -251,6 +251,7 @@ def _run_command(
             project,
             lifecycle.prime_dir,
             arch=lifecycle.target_arch,
+            arch_triplet=lifecycle.target_arch_triplet,
         )
         emit.message("Generated snap metadata", intermediate=True)
 
@@ -378,7 +379,9 @@ def _set_step_environment(step_info: StepInfo) -> bool:
     return True
 
 
-def _expand_environment(snapcraft_yaml: Dict[str, Any], *, parallel_build_count: int) -> None:
+def _expand_environment(
+    snapcraft_yaml: Dict[str, Any], *, parallel_build_count: int
+) -> None:
     """Expand global variables in the provided dictionary values.
 
     :param snapcraft_yaml: A dictionary containing the contents of the

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -109,6 +109,11 @@ class PartsLifecycle:
         return self._lcm.project_info.target_arch
 
     @property
+    def target_arch_triplet(self) -> str:
+        """Return the parts project target architecture."""
+        return self._lcm.project_info.arch_triplet
+
+    @property
     def project_vars(self) -> Dict[str, str]:
         """Return the value of project variable ``version``."""
         return {

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -388,42 +388,6 @@ class Project(ProjectModel):
 
         return epoch
 
-    @pydantic.validator("environment", always=True)
-    @classmethod
-    def _validate_environment(cls, environment):
-        """Validate app environmental variables.
-
-        Three cases for LD_LIBRARY_PATH and PATH variables:
-          - If LD_LIBRARY_PATH or PATH are defined, keep user-defined values.
-          - If LD_LIBRARY_PATH or PATH are not defined, set to default values.
-          - If LD_LIBRARY_PATH or PATH are null, do not use default values.
-        """
-        if environment is None:
-            return {
-                "LD_LIBRARY_PATH": "$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH",
-                "PATH": "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH",
-            }
-
-        try:
-            if not environment["LD_LIBRARY_PATH"]:
-                environment.pop("LD_LIBRARY_PATH")
-        except KeyError:
-            environment["LD_LIBRARY_PATH"] = "$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH"
-
-        try:
-            if not environment["PATH"]:
-                environment.pop("PATH")
-        except KeyError:
-            environment[
-                "PATH"
-            ] = "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
-
-        if len(environment):
-            return environment
-
-        # if the environment only contained a null LD_LIBRARY_PATH and a null PATH, return None
-        return None
-
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]) -> "Project":
         """Create and populate a new ``Project`` object from dictionary data.

--- a/tests/spread/core22/appstream-desktop/expected_snap.yaml
+++ b/tests/spread/core22/appstream-desktop/expected_snap.yaml
@@ -23,5 +23,5 @@ apps:
 confinement: strict
 grade: devel
 environment:
-  LD_LIBRARY_PATH: $SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
   PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH

--- a/tests/spread/general/unicode-metadata/task.yaml
+++ b/tests/spread/general/unicode-metadata/task.yaml
@@ -12,7 +12,7 @@ prepare: |
   sed -e "s/base: {{BASE}}/base: ${base}/g" expected_snap_tmpl.yaml > expected_snap.yaml
   if [[ "$base" =~ "core22" ]]; then
     # shellcheck disable=SC2016
-    echo -e 'environment:\n  LD_LIBRARY_PATH: $SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n  PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH' >> expected_snap.yaml
+    echo -e 'environment:\n  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\n  PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH' >> expected_snap.yaml
   fi
 
 restore: |

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -56,6 +56,7 @@ def test_simple_snap_yaml(simple_project, new_dir):
         simple_project(),
         prime_dir=Path(new_dir),
         arch="amd64",
+        arch_triplet="x86_64-linux-gnu",
     )
     yaml_file = Path("meta/snap.yaml")
     assert yaml_file.is_file()
@@ -202,6 +203,7 @@ def test_complex_snap_yaml(complex_project, new_dir):
         complex_project,
         prime_dir=Path(new_dir),
         arch="amd64",
+        arch_triplet="x86_64-linux-gnu",
     )
     yaml_file = Path("meta/snap.yaml")
     assert yaml_file.is_file()
@@ -330,6 +332,7 @@ def test_hook_command_chain_assumes(simple_project, new_dir):
         simple_project(hooks=hooks),
         prime_dir=Path(new_dir),
         arch="amd64",
+        arch_triplet="x86_64-linux-gnu",
     )
     yaml_file = Path("meta/snap.yaml")
     assert yaml_file.is_file()
@@ -372,6 +375,7 @@ def test_project_environment_ld_library_path_and_path_defined(simple_project, ne
         simple_project(environment=environment),
         prime_dir=Path(new_dir),
         arch="amd64",
+        arch_triplet="x86_64-linux-gnu",
     )
     yaml_file = Path("meta/snap.yaml")
     assert yaml_file.is_file()
@@ -406,6 +410,7 @@ def test_project_environment_ld_library_path_defined(simple_project, new_dir):
         simple_project(environment=environment),
         prime_dir=Path(new_dir),
         arch="amd64",
+        arch_triplet="x86_64-linux-gnu",
     )
     yaml_file = Path("meta/snap.yaml")
     assert yaml_file.is_file()
@@ -439,6 +444,7 @@ def test_project_environment_path_defined(simple_project, new_dir):
         simple_project(environment=environment),
         prime_dir=Path(new_dir),
         arch="amd64",
+        arch_triplet="x86_64-linux-gnu",
     )
     yaml_file = Path("meta/snap.yaml")
     assert yaml_file.is_file()
@@ -472,6 +478,7 @@ def test_project_environment_ld_library_path_null(simple_project, new_dir):
         simple_project(environment=environment),
         prime_dir=Path(new_dir),
         arch="amd64",
+        arch_triplet="x86_64-linux-gnu",
     )
     yaml_file = Path("meta/snap.yaml")
     assert yaml_file.is_file()

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -97,10 +97,7 @@ class TestProjectDefaults:
         assert project.plugs is None
         assert project.slots is None
         assert project.epoch is None
-        assert project.environment == {
-            "LD_LIBRARY_PATH": "$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH",
-            "PATH": "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH",
-        }
+        assert project.environment is None
         assert project.adopt_info is None
 
     def test_app_defaults(self, project_yaml_data):
@@ -430,60 +427,6 @@ class TestProjectValidation:
         error = ".*value is not a valid dict"
         with pytest.raises(errors.ProjectValidationError, match=error):
             Project.unmarshal(project_yaml_data(environment=environment))
-
-    def test_project_environment_ld_library_path_and_path_defined(
-        self, project_yaml_data
-    ):
-        """Test behavior of defining LD_LIBRARY_PATH and PATH variables."""
-        environment = {
-            "LD_LIBRARY_PATH": "test-1",
-            "PATH": "test-2",
-        }
-        data = project_yaml_data(environment=environment)
-        project = Project.unmarshal(data)
-
-        assert project.environment is not None
-        assert project.environment == environment
-
-    def test_project_environment_ld_library_path_defined(self, project_yaml_data):
-        """LD_LIBRARY_PATH can be overridden without affecting PATH."""
-        environment = {"LD_LIBRARY_PATH": "test-1"}
-        data = project_yaml_data(environment=environment)
-        project = Project.unmarshal(data)
-
-        assert project.environment is not None
-        assert project.environment["LD_LIBRARY_PATH"] == "test-1"
-        assert (
-            project.environment["PATH"]
-            == "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
-        )
-
-    def test_project_environment_path_defined(self, project_yaml_data):
-        """PATH can be overridden without affecting LD_LIBRARY_PATH."""
-        environment = {"PATH": "test-2"}
-        data = project_yaml_data(environment=environment)
-        project = Project.unmarshal(data)
-
-        assert project.environment is not None
-        assert project.environment is not None
-        assert (
-            project.environment["LD_LIBRARY_PATH"]
-            == "$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH"
-        )
-        assert project.environment["PATH"] == "test-2"
-
-    def test_project_environment_ld_library_path_null(self, project_yaml_data):
-        """LD_LIBRARY_PATH can be overridden without affecting PATH."""
-        environment = {"LD_LIBRARY_PATH": None}
-        data = project_yaml_data(environment=environment)
-        project = Project.unmarshal(data)
-
-        assert project.environment is not None
-        assert project.environment.get("LD_LIBRARY_PATH") is None
-        assert (
-            project.environment["PATH"]
-            == "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
-        )
 
     @pytest.mark.parametrize(
         "plugs",

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -275,3 +275,82 @@ def test_get_parallel_build_count_limited(mocker, max_count, count):
 )
 def test_humanize_list(items, conjunction, expected):
     assert utils.humanize_list(items, conjunction) == expected
+
+
+#################
+# Library Paths #
+#################
+
+
+@pytest.fixture
+def library_config_file(tmp_path):
+    config_file = tmp_path / "usr/lib/i286-other-other/mesa/ld.so.conf"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text(
+        dedent(
+            """\
+        # This is a comment
+        /foo/bar
+        /colon:/separated,/comma\t/tab /space # This is another comment
+        /baz"""
+        )
+    )
+
+    return config_file
+
+
+def test_extract_ld_library_paths(tmp_path, library_config_file):
+    assert utils._extract_ld_library_paths(library_config_file) == [
+        "/foo/bar",
+        "/colon",
+        "/separated",
+        "/comma",
+        "/tab",
+        "/space",
+        "/baz",
+    ]
+
+
+@pytest.mark.parametrize(
+    "lib_dirs,expected_env",
+    [
+        (["lib"], "$SNAP/lib"),
+        (["lib", "usr/lib"], "$SNAP/lib:$SNAP/usr/lib"),
+        (
+            ["lib/i286-none-none", "usr/lib/i286-none-none"],
+            "$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/i286-none-none:$SNAP/usr/lib/i286-none-none",
+        ),
+    ],
+)
+def test_get_ld_library_paths(tmp_path, lib_dirs, expected_env):
+    for d in lib_dirs:
+        (tmp_path / d).mkdir(parents=True)
+
+    expected_env = (
+        f"${{SNAP_LIBRARY_PATH}}${{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}}:{expected_env}"
+    )
+    assert utils.get_ld_library_paths(tmp_path, "i286-none-none") == expected_env
+
+
+@pytest.mark.parametrize(
+    "lib_dirs,expected_env",
+    [
+        (["lib", "usr/lib"], "$SNAP/lib:$SNAP/usr/lib"),
+        (
+            ["lib/i286-none-none", "usr/lib/i286-none-none"],
+            "$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/i286-none-none:$SNAP/usr/lib/i286-none-none",
+        ),
+    ],
+)
+def test_get_ld_library_paths_with_conf(
+    tmp_path, lib_dirs, expected_env, library_config_file
+):
+    for d in lib_dirs:
+        (tmp_path / d).mkdir(parents=True, exist_ok=True)
+
+    expected_env = (
+        "${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}:"
+        f"{expected_env}:"
+        "$SNAP/foo/bar:$SNAP/colon:$SNAP/separated:$SNAP/comma:$SNAP/tab:$SNAP/space:$SNAP/baz"
+    )
+    assert utils.get_ld_library_paths(tmp_path, "i286-none-none") == expected_env


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
Properly determine path for LD_LIBRARY_PATH for core22.  The behavior should be identical to core20.

This is a hasty PR.  I still have a few changes to make, perhaps they can be in a follow up PR if this one needs to get merged ASAP.  
Changes to make:
1. More unit tests
2. Some cleanup/refactoring (documentation, comments, types)

(CRAFT-1095)
LP: # [1975498](https://bugs.launchpad.net/snapcraft/+bug/1975498)