### PR TITLE
enviroment: deprecate ld.conf.so library path searching for libgl1-mesa

### DIFF
--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Utilities for snapcraft."""
-import glob
 import multiprocessing
 import os
 import pathlib
@@ -280,47 +279,6 @@ def humanize_list(
     return f"{humanized} {conjunction} {quoted_items[-1]}"
 
 
-def _extract_ld_library_paths(ld_conf_file: str) -> List[str]:
-    # From the ldconfig manpage, paths can be colon-, space-, tab-, newline-,
-    # or comma-separated.
-    path_delimiters = re.compile(r"[:\s,]")
-    comments = re.compile(r"#.*$")
-
-    paths = []
-    with open(ld_conf_file, "r", encoding="utf-8") as ld_config:
-        for line in ld_config:
-            # Remove comments from line
-            line = comments.sub("", line).strip()
-
-            if line:
-                paths.extend(path_delimiters.split(line))
-
-    return paths
-
-
-def _get_configured_ld_library_paths(prime_dir: Path) -> List[str]:
-    """Determine additional library paths needed for the linker loader.
-
-    This is a workaround until full library searching is implemented which
-    works by searching for ld.so.conf in specific hard coded locations
-    within root.
-
-    :param prime_dir str: the directory to search for specific ld.so.conf
-                          entries.
-    :returns: a list of strings of library paths where relevant libraries
-              can be found within prime_dir.
-    """
-    # If more ld.so.conf files need to be supported, add them here.
-    ld_config_globs = {f"{str(prime_dir)}/usr/lib/*/mesa*/ld.so.conf"}
-
-    ld_library_paths = []
-    for this_glob in ld_config_globs:
-        for ld_conf_file in glob.glob(this_glob):
-            ld_library_paths.extend(_extract_ld_library_paths(ld_conf_file))
-
-    return [str(prime_dir / path.lstrip("/")) for path in ld_library_paths]
-
-
 def _get_common_ld_library_paths(prime_dir: Path, arch_triplet: str) -> List[str]:
     """Return common existing PATH entries for a snap."""
     paths = [
@@ -338,8 +296,6 @@ def get_ld_library_paths(prime_dir: Path, arch_triplet: str) -> str:
     paths = ["${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"]
     # Add the default LD_LIBRARY_PATH
     paths += _get_common_ld_library_paths(prime_dir, arch_triplet)
-    # Add more specific LD_LIBRARY_PATH from staged packages if necessary
-    paths += _get_configured_ld_library_paths(prime_dir)
 
     ld_library_path = ":".join(paths)
 

--- a/tests/spread/core22/environment/paths/task.yaml
+++ b/tests/spread/core22/environment/paths/task.yaml
@@ -4,6 +4,7 @@ environment:
   SNAP/paths_one_null: paths-one-null
   SNAP/paths_all_null: paths-all-null
   SNAP/paths_user_defined: paths-user-defined
+  SNAP/staged_common_library: staged-common-library
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh

--- a/tests/spread/core22/environment/snaps/staged-common-library/expected_snap.yaml
+++ b/tests/spread/core22/environment/snaps/staged-common-library/expected_snap.yaml
@@ -1,0 +1,17 @@
+name: staged-common-library
+version: '1'
+summary: test
+description: |
+  Staging a standard library causes common library paths
+  to be included in the LD_LIBRARY_PATH environmental variable.
+architectures:
+- amd64
+base: core22
+apps:
+  staged-common-library:
+    command: test-cmd
+confinement: strict
+grade: devel
+environment:
+  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu
+  PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH

--- a/tests/spread/core22/environment/snaps/staged-common-library/snap/snapcraft.yaml
+++ b/tests/spread/core22/environment/snaps/staged-common-library/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: staged-common-library
+version: "1"
+summary: test
+description: |
+  Staging a standard library causes common library paths
+  to be included in the LD_LIBRARY_PATH environmental variable.
+grade: devel
+confinement: strict
+base: core22
+
+apps:
+  staged-common-library:
+    command: test-cmd
+
+parts:
+  hello:
+    plugin: dump
+    source: .
+    stage-packages:
+      - libc6

--- a/tests/spread/core22/environment/snaps/staged-common-library/test-cmd
+++ b/tests/spread/core22/environment/snaps/staged-common-library/test-cmd
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "hi"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -282,35 +282,6 @@ def test_humanize_list(items, conjunction, expected):
 #################
 
 
-@pytest.fixture
-def library_config_file(tmp_path):
-    config_file = tmp_path / "usr/lib/i286-other-other/mesa/ld.so.conf"
-    config_file.parent.mkdir(parents=True)
-    config_file.write_text(
-        dedent(
-            """\
-        # This is a comment
-        /foo/bar
-        /colon:/separated,/comma\t/tab /space # This is another comment
-        /baz"""
-        )
-    )
-
-    return config_file
-
-
-def test_extract_ld_library_paths(tmp_path, library_config_file):
-    assert utils._extract_ld_library_paths(library_config_file) == [
-        "/foo/bar",
-        "/colon",
-        "/separated",
-        "/comma",
-        "/tab",
-        "/space",
-        "/baz",
-    ]
-
-
 @pytest.mark.parametrize(
     "lib_dirs,expected_env",
     [
@@ -328,29 +299,5 @@ def test_get_ld_library_paths(tmp_path, lib_dirs, expected_env):
 
     expected_env = (
         f"${{SNAP_LIBRARY_PATH}}${{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}}:{expected_env}"
-    )
-    assert utils.get_ld_library_paths(tmp_path, "i286-none-none") == expected_env
-
-
-@pytest.mark.parametrize(
-    "lib_dirs,expected_env",
-    [
-        (["lib", "usr/lib"], "$SNAP/lib:$SNAP/usr/lib"),
-        (
-            ["lib/i286-none-none", "usr/lib/i286-none-none"],
-            "$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/i286-none-none:$SNAP/usr/lib/i286-none-none",
-        ),
-    ],
-)
-def test_get_ld_library_paths_with_conf(
-    tmp_path, lib_dirs, expected_env, library_config_file
-):
-    for d in lib_dirs:
-        (tmp_path / d).mkdir(parents=True, exist_ok=True)
-
-    expected_env = (
-        "${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}:"
-        f"{expected_env}:"
-        "$SNAP/foo/bar:$SNAP/colon:$SNAP/separated:$SNAP/comma:$SNAP/tab:$SNAP/space:$SNAP/baz"
     )
     assert utils.get_ld_library_paths(tmp_path, "i286-none-none") == expected_env


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
1. Add another spread test for LD_LIBRARY_PATH
2. Deprecate `ld.conf.so` library path searching for `libgl1-mesa`.

[This code](https://github.com/snapcore/snapcraft/pull/204) was original merged in 2016 for `libopencv-dev`, which pulled in the `libgl1-mesa` as a dependency.
It is no longer needed because:
1. `/usr/lib/<arch>/mesa/ld.conf.so` was removed from the `libgl1-mesa` libraries in version 18.2.8, in 2018
2. Ubuntu started using `libgl1-mesa` >= 18.2.8 in 18.04
3. `/usr/lib/<arch>/mesa/ld.conf.so` still doesn't exist in 22.04 / core22

