### PR TITLE
Fix gtk3 test

### DIFF
--- a/extensions/desktop/command-chain/Makefile
+++ b/extensions/desktop/command-chain/Makefile
@@ -1,0 +1,10 @@
+#!/usr/bin/make -f
+
+BIN_DIR              := $(DESTDIR)/snap/command-chain
+
+*:
+	install -D -m755 "$@" "$(BIN_DIR)"/"$@"
+
+install: hooks-configure-fonts desktop-launch run
+
+.PHONY: hooks-configure-fonts desktop-launch run

--- a/extensions/desktop/command-chain/desktop-launch
+++ b/extensions/desktop/command-chain/desktop-launch
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec "${SNAP}/snap/command-chain/run" "${SNAP}/gnome-platform/command-chain/desktop-launch" "$@"

--- a/extensions/desktop/command-chain/hooks-configure-fonts
+++ b/extensions/desktop/command-chain/hooks-configure-fonts
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec "${SNAP}/snap/command-chain/run" "${SNAP}/gnome-platform/command-chain/hooks-configure-fonts" "$@"

--- a/extensions/desktop/command-chain/run
+++ b/extensions/desktop/command-chain/run
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+if [ -z "$1" ]; then
+  echo "run <command>"
+  exit 1
+fi
+
+if [ -z "${SNAP}" ]; then
+  echo "Not running inside a snap context: SNAP not declared"
+  exit
+fi
+
+
+if [ ! -f "$1" ]; then
+  echo "Content snap command-chain for $1 not found: ensure slot is connected"
+  exit
+fi
+
+exec "$@"

--- a/snapcraft/extensions/extension.py
+++ b/snapcraft/extensions/extension.py
@@ -20,7 +20,7 @@ import abc
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, Optional, Sequence, Tuple, final
+from typing import Any, Dict, List, Optional, Sequence, Tuple, final
 
 from craft_cli import emit
 
@@ -60,6 +60,18 @@ def prepend_to_env(
                   a separator token at the end.
     """
     return separator.join(paths) + f"${{{env_variable}:+{separator}${env_variable}}}"
+
+
+def get_build_snaps(parts_yaml_data: Optional[Dict[str, Any]]) -> List[str]:
+    """Return build-snaps from yaml_data."""
+    if parts_yaml_data is None:
+        return []
+
+    build_snaps: List[str] = []
+    for part in parts_yaml_data.values():
+        build_snaps.extend(part.get("build-snaps", []))
+
+    return build_snaps
 
 
 class Extension(abc.ABC):

--- a/snapcraft/extensions/extension.py
+++ b/snapcraft/extensions/extension.py
@@ -18,11 +18,18 @@
 
 import abc
 import os
+import sys
+from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, final
 
 from craft_cli import emit
 
 from snapcraft import errors
+
+
+def get_extensions_data_dir() -> Path:
+    """Return the path to the extension data directory."""
+    return Path(sys.prefix) / "share" / "snapcraft" / "extensions"
 
 
 class Extension(abc.ABC):

--- a/snapcraft/extensions/extension.py
+++ b/snapcraft/extensions/extension.py
@@ -20,7 +20,7 @@ import abc
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, final
+from typing import Any, Dict, Optional, Sequence, Tuple, final
 
 from craft_cli import emit
 
@@ -30,6 +30,36 @@ from snapcraft import errors
 def get_extensions_data_dir() -> Path:
     """Return the path to the extension data directory."""
     return Path(sys.prefix) / "share" / "snapcraft" / "extensions"
+
+
+def append_to_env(env_variable: str, paths: Sequence[str], separator: str = ":") -> str:
+    """Return a string for env_variable with one of more paths appended.
+
+    :param env_variable: the variable to operate on.
+    :param paths: one or more paths to append.
+    :param separator: the separator to use.
+    :returns: a shell string where one or more paths are appended
+                  to env_variable. The code takes into account the case
+                  where the environment variable is empty, to avoid putting
+                  a separator token at the start.
+    """
+    return f"${{{env_variable}:+${env_variable}{separator}}}" + separator.join(paths)
+
+
+def prepend_to_env(
+    env_variable: str, paths: Sequence[str], separator: str = ":"
+) -> str:
+    """Return a string for env_variable with one of more paths prepended.
+
+    :param env_variable: the variable to operate on.
+    :param paths: one or more paths to append.
+    :param separator: the separator to use.
+    :returns: a shell string where one or more paths are prepended
+                  before env_variable. The code takes into account the case
+                  where the environment variable is empty, to avoid putting
+                  a separator token at the end.
+    """
+    return separator.join(paths) + f"${{{env_variable}:+{separator}${env_variable}}}"
 
 
 class Extension(abc.ABC):

--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -15,16 +15,31 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Generic GNOME extension to support core22 and onwards."""
-
-
+import dataclasses
+import functools
+import re
 from typing import Any, Dict, Optional, Tuple
 
 from overrides import overrides
 
-from .extension import Extension, get_extensions_data_dir, prepend_to_env
+from .extension import (
+    Extension,
+    get_build_snaps,
+    get_extensions_data_dir,
+    prepend_to_env,
+)
 
-_PLATFORM_SNAP = dict(core22="gnome-42-2204")
-_SDK_SNAP = dict(core22="gnome-42-2204-sdk")
+_SDK_SNAP = {"core22": "gnome-42-2204-sdk"}
+_PLATFORM_TRANSLATION = {"core22": "2204"}
+
+
+@dataclasses.dataclass
+class GNOMESnaps:
+    """A structure of GNOME related snaps."""
+
+    sdk: str
+    content: str
+    builtin: bool = True
 
 
 class GNOME(Extension):
@@ -83,10 +98,27 @@ class GNOME(Extension):
             ],
         }
 
+    @functools.cached_property
+    def gnome_snaps(self) -> GNOMESnaps:
+        """Return the GNOME related snaps to use to construct the environment."""
+        base = self.yaml_data["base"]
+        sdk_snap = _SDK_SNAP[base]
+        build_snaps = get_build_snaps(parts_yaml_data=self.yaml_data.get("parts"))
+        matcher = re.compile(r"gnome-\d+-" + _PLATFORM_TRANSLATION[base] + r"-sdk.*")
+        sdk_snap_candidates = [s for s in build_snaps if matcher.match(s)]
+        if sdk_snap_candidates:
+            sdk_snap = sdk_snap_candidates[0].split("/")[0]
+            builtin = False
+        else:
+            builtin = True
+        # The same except the trailing -sdk
+        content = sdk_snap[:-4]
+
+        return GNOMESnaps(sdk=sdk_snap, content=content, builtin=builtin)
+
     @overrides
     def get_root_snippet(self) -> Dict[str, Any]:
-        base = self.yaml_data["base"]
-        platform_snap = _PLATFORM_SNAP[base]
+        platform_snap = self.gnome_snaps.content
 
         return {
             "assumes": ["snapd2.43"],  # for 'snapctl is-connected'
@@ -135,8 +167,7 @@ class GNOME(Extension):
 
     @overrides
     def get_part_snippet(self) -> Dict[str, Any]:
-        base = self.yaml_data["base"]
-        sdk_snap = _SDK_SNAP[base]
+        sdk_snap = self.gnome_snaps.sdk
 
         return {
             "build-environment": [
@@ -213,13 +244,21 @@ class GNOME(Extension):
     @overrides
     def get_parts_snippet(self) -> Dict[str, Any]:
         source = get_extensions_data_dir() / "desktop" / "command-chain"
-        base = self.yaml_data["base"]
-        sdk_snap = _SDK_SNAP[base]
+
+        if self.gnome_snaps.builtin:
+            base = self.yaml_data["base"]
+            sdk_snap = _SDK_SNAP[base]
+            return {
+                "gnome/sdk": {
+                    "source": str(source),
+                    "plugin": "make",
+                    "build-snaps": [sdk_snap],
+                }
+            }
 
         return {
             "gnome/sdk": {
                 "source": str(source),
                 "plugin": "make",
-                "build-snaps": [sdk_snap],
             }
         }

--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from overrides import overrides
 
-from .extension import Extension, get_extensions_data_dir
+from .extension import Extension, get_extensions_data_dir, prepend_to_env
 
 _PLATFORM_SNAP = dict(core22="gnome-42-2204")
 _SDK_SNAP = dict(core22="gnome-42-2204-sdk")
@@ -140,60 +140,74 @@ class GNOME(Extension):
 
         return {
             "build-environment": [
-                {"PATH": f"/snap/{sdk_snap}/current/usr/bin:$PATH"},
                 {
-                    "XDG_DATA_DIRS": (
-                        f"$SNAPCRAFT_STAGE/usr/share:/snap/{sdk_snap}"
-                        "/current/usr/share:/usr/share:$XDG_DATA_DIRS"
-                    )
+                    "PATH": prepend_to_env(
+                        "PATH", [f"/snap/{sdk_snap}/current/usr/bin"]
+                    ),
                 },
                 {
-                    "LD_LIBRARY_PATH": ":".join(
+                    "XDG_DATA_DIRS": prepend_to_env(
+                        "XDG_DATA_DIRS",
+                        [
+                            f"$SNAPCRAFT_STAGE/usr/share:/snap/{sdk_snap}/current/usr/share",
+                            "/usr/share",
+                        ],
+                    ),
+                },
+                {
+                    "LD_LIBRARY_PATH": prepend_to_env(
+                        "LD_LIBRARY_PATH",
                         [
                             f"/snap/{sdk_snap}/current/lib/$CRAFT_ARCH_TRIPLET",
                             f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET",
                             f"/snap/{sdk_snap}/current/usr/lib",
                             f"/snap/{sdk_snap}/current/usr/lib/vala-current",
                             f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio",
-                        ]
-                    )
-                    + "${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+                        ],
+                    ),
                 },
                 {
-                    "PKG_CONFIG_PATH": (
-                        f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:"
-                        f"/snap/{sdk_snap}/current/usr/lib/pkgconfig:"
-                        f"/snap/{sdk_snap}/current/usr/share/pkgconfig:$PKG_CONFIG_PATH"
-                    )
+                    "PKG_CONFIG_PATH": prepend_to_env(
+                        "PKG_CONFIG_PATH",
+                        [
+                            f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig",
+                            f"/snap/{sdk_snap}/current/usr/lib/pkgconfig",
+                            f"/snap/{sdk_snap}/current/usr/share/pkgconfig",
+                        ],
+                    ),
                 },
                 {
-                    "GETTEXTDATADIRS": (
-                        f"/snap/{sdk_snap}/current/usr/share/gettext-current:"
-                        "$GETTEXTDATADIRS"
-                    )
+                    "GETTEXTDATADIRS": prepend_to_env(
+                        "GETTEXTDATADIRS",
+                        [
+                            f"/snap/{sdk_snap}/current/usr/share/gettext-current",
+                        ],
+                    ),
                 },
                 {
                     "GDK_PIXBUF_MODULE_FILE": (
                         f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET"
                         "/gdk-pixbuf-current/loaders.cache"
-                    )
+                    ),
                 },
                 {
-                    "ACLOCAL_PATH": (
-                        f"/snap/{sdk_snap}/current/usr/share/aclocal"
-                        "${ACLOCAL_PATH:+:$ACLOCAL_PATH}"
-                    )
+                    "ACLOCAL_PATH": prepend_to_env(
+                        "ACLOCAL_PATH",
+                        [
+                            f"/snap/{sdk_snap}/current/usr/share/aclocal",
+                        ],
+                    ),
                 },
                 {
-                    "PYTHONPATH": ":".join(
+                    "PYTHONPATH": prepend_to_env(
+                        "PYTHONPATH",
                         [
                             f"/snap/{sdk_snap}/current/usr/lib/python3.10",
                             f"/snap/{sdk_snap}/current/usr/lib/python3/dist-packages",
-                        ]
-                    )
-                    + "${PYTHONPATH:+:$PYTHONPATH}"
+                        ],
+                    ),
                 },
-            ]
+            ],
         }
 
     @overrides

--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -1,0 +1,211 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Generic GNOME extension to support core22 and onwards."""
+
+
+from typing import Any, Dict, Optional, Tuple
+
+from overrides import overrides
+
+from .extension import Extension, get_extensions_data_dir
+
+_PLATFORM_SNAP = dict(core22="gnome-42-2204")
+_SDK_SNAP = dict(core22="gnome-42-2204-sdk")
+
+
+class GNOME(Extension):
+    """An extension that eases the creation of snaps that integrate with GNOME.
+
+    When used with core22 GNOME 42 will be used.
+
+    At build time it ensures the right build dependencies are setup and for
+    the runtime it ensures the application is run in an environment catered
+    for GNOME applications.
+
+    It configures each application with the following plugs:
+
+    - GTK3 Themes.
+    - Common Icon Themes.
+    - Common Sound Themes.
+    - The GNOME runtime libraries and utilities corresponding to 3.38.
+
+    For easier desktop integration, it also configures each application
+    entry with these additional plugs:
+
+    - desktop (https://snapcraft.io/docs/desktop-interface)
+    - desktop-legacy (https://snapcraft.io/docs/desktop-legacy-interface)
+    - gsettings (https://snapcraft.io/docs/gsettings-interface)
+    - opengl (https://snapcraft.io/docs/opengl-interface)
+    - wayland (https://snapcraft.io/docs/wayland-interface)
+    - x11 (https://snapcraft.io/docs/x11-interface)
+    """
+
+    @staticmethod
+    @overrides
+    def get_supported_bases() -> Tuple[str, ...]:
+        return ("core22",)
+
+    @staticmethod
+    @overrides
+    def get_supported_confinement() -> Tuple[str, ...]:
+        return "strict", "devmode"
+
+    @staticmethod
+    @overrides
+    def is_experimental(base: Optional[str]) -> bool:
+        return False
+
+    @overrides
+    def get_app_snippet(self) -> Dict[str, Any]:
+        return {
+            "command-chain": ["snap/command-chain/desktop-launch"],
+            "plugs": [
+                "desktop",
+                "desktop-legacy",
+                "gsettings",
+                "opengl",
+                "wayland",
+                "x11",
+            ],
+        }
+
+    @overrides
+    def get_root_snippet(self) -> Dict[str, Any]:
+        base = self.yaml_data["base"]
+        platform_snap = _PLATFORM_SNAP[base]
+
+        return {
+            "assumes": ["snapd2.43"],  # for 'snapctl is-connected'
+            "plugs": {
+                "desktop": {"mount-host-font-cache": False},
+                "gtk-3-themes": {
+                    "interface": "content",
+                    "target": "$SNAP/data-dir/themes",
+                    "default-provider": "gtk-common-themes",
+                },
+                "icon-themes": {
+                    "interface": "content",
+                    "target": "$SNAP/data-dir/icons",
+                    "default-provider": "gtk-common-themes",
+                },
+                "sound-themes": {
+                    "interface": "content",
+                    "target": "$SNAP/data-dir/sounds",
+                    "default-provider": "gtk-common-themes",
+                },
+                platform_snap: {
+                    "interface": "content",
+                    "target": "$SNAP/gnome-platform",
+                    "default-provider": platform_snap,
+                },
+            },
+            "environment": {
+                "SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform",
+                "GTK_USE_PORTAL": "1",
+            },
+            "hooks": {
+                "configure": {
+                    "plugs": ["desktop"],
+                    "command-chain": ["snap/command-chain/hooks-configure-fonts"],
+                }
+            },
+            "layout": {
+                "/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.0": {
+                    "bind": "$SNAP/gnome-platform/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.0"
+                },
+                "/usr/share/xml/iso-codes": {
+                    "bind": "$SNAP/gnome-platform/usr/share/xml/iso-codes"
+                },
+            },
+        }
+
+    @overrides
+    def get_part_snippet(self) -> Dict[str, Any]:
+        base = self.yaml_data["base"]
+        sdk_snap = _SDK_SNAP[base]
+
+        return {
+            "build-environment": [
+                {"PATH": f"/snap/{sdk_snap}/current/usr/bin:$PATH"},
+                {
+                    "XDG_DATA_DIRS": (
+                        f"$SNAPCRAFT_STAGE/usr/share:/snap/{sdk_snap}"
+                        "/current/usr/share:/usr/share:$XDG_DATA_DIRS"
+                    )
+                },
+                {
+                    "LD_LIBRARY_PATH": ":".join(
+                        [
+                            f"/snap/{sdk_snap}/current/lib/$CRAFT_ARCH_TRIPLET",
+                            f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET",
+                            f"/snap/{sdk_snap}/current/usr/lib",
+                            f"/snap/{sdk_snap}/current/usr/lib/vala-current",
+                            f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio",
+                        ]
+                    )
+                    + "${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+                },
+                {
+                    "PKG_CONFIG_PATH": (
+                        f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:"
+                        f"/snap/{sdk_snap}/current/usr/lib/pkgconfig:"
+                        f"/snap/{sdk_snap}/current/usr/share/pkgconfig:$PKG_CONFIG_PATH"
+                    )
+                },
+                {
+                    "GETTEXTDATADIRS": (
+                        f"/snap/{sdk_snap}/current/usr/share/gettext-current:"
+                        "$GETTEXTDATADIRS"
+                    )
+                },
+                {
+                    "GDK_PIXBUF_MODULE_FILE": (
+                        f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET"
+                        "/gdk-pixbuf-current/loaders.cache"
+                    )
+                },
+                {
+                    "ACLOCAL_PATH": (
+                        f"/snap/{sdk_snap}/current/usr/share/aclocal"
+                        "${ACLOCAL_PATH:+:$ACLOCAL_PATH}"
+                    )
+                },
+                {
+                    "PYTHONPATH": ":".join(
+                        [
+                            f"/snap/{sdk_snap}/current/usr/lib/python3.10",
+                            f"/snap/{sdk_snap}/current/usr/lib/python3/dist-packages",
+                        ]
+                    )
+                    + "${PYTHONPATH:+:$PYTHONPATH}"
+                },
+            ]
+        }
+
+    @overrides
+    def get_parts_snippet(self) -> Dict[str, Any]:
+        source = get_extensions_data_dir() / "desktop" / "command-chain"
+        base = self.yaml_data["base"]
+        sdk_snap = _SDK_SNAP[base]
+
+        return {
+            "gnome/sdk": {
+                "source": str(source),
+                "plugin": "make",
+                "build-snaps": [sdk_snap],
+            }
+        }

--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -24,6 +24,7 @@ from overrides import overrides
 
 from .extension import (
     Extension,
+    append_to_env,
     get_build_snaps,
     get_extensions_data_dir,
     prepend_to_env,
@@ -88,6 +89,7 @@ class GNOME(Extension):
     def get_app_snippet(self) -> Dict[str, Any]:
         return {
             "command-chain": ["snap/command-chain/desktop-launch"],
+            #"command-chain": ["$SNAP/gnome-platform/command-chain/desktop-launch"],
             "plugs": [
                 "desktop",
                 "desktop-legacy",
@@ -148,6 +150,23 @@ class GNOME(Extension):
             "environment": {
                 "SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform",
                 "GTK_USE_PORTAL": "1",
+                "LD_LIBRARY_PATH": append_to_env(
+                    "LD_LIBRARY_PATH",
+                    [
+                        f"/snap/{platform_snap}/current/lib/$CRAFT_ARCH_TRIPLET",
+                        f"/snap/{platform_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET",
+                        f"/snap/{platform_snap}/current/usr/lib",
+                        f"/snap/{platform_snap}/current/usr/lib/vala-current",
+                        f"/snap/{platform_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio",
+                    ],
+                ),
+                "GTK_PATH": append_to_env(
+                    "GTK_PATH",
+                    [
+                        f"/snap/{platform_snap}/current/usr/lib/gtk-3.0",
+                        f"/snap/{platform_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET/gtk-3.0",
+                    ],
+                ),
             },
             "hooks": {
                 "configure": {

--- a/snapcraft/extensions/registry.py
+++ b/snapcraft/extensions/registry.py
@@ -20,12 +20,15 @@ from typing import TYPE_CHECKING, Dict, List, Type
 
 from snapcraft import errors
 
+from .gnome import GNOME
+
 if TYPE_CHECKING:
     from .extension import Extension
 
     ExtensionType = Type[Extension]
 
-_EXTENSIONS: Dict[str, "ExtensionType"] = {}
+
+_EXTENSIONS: Dict[str, "ExtensionType"] = {"gnome": GNOME}
 
 
 def get_extension_names() -> List[str]:

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -419,15 +419,13 @@ class Project(ProjectModel):
             ]
         return []
 
-    def get_content_snaps(self) -> Optional[List[str]]:
+    def get_content_snaps(self) -> List[str]:
         """Get list of snaps from ContentPlug `default-provider` fields."""
-        content_snaps = [
+        return [
             x.default_provider
             for x in self._get_content_plugs()
             if x.default_provider is not None
         ]
-
-        return content_snaps if content_snaps else None
 
     def get_effective_base(self) -> str:
         """Return the base to use to create the snap."""

--- a/tests/spread/extensions/gnome/task.yaml
+++ b/tests/spread/extensions/gnome/task.yaml
@@ -1,0 +1,56 @@
+summary: Build and run a basic gnome snap using extensions
+
+# The content snap required for the test to succeed is only
+# available on a subset of all the architectures this testbed
+# can run on.
+systems:
+  - ubuntu-22.04
+  - ubuntu-22.04-64
+  - ubuntu-22.04-amd64
+
+environment:
+  SNAP_DIR: ../snaps/gtk3-hello
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "$SNAP_DIR/snap/snapcraft.yaml"
+  sed -i 's/gnome-3-28/gnome/' "$SNAP_DIR/snap/snapcraft.yaml"
+  sed -i 's/bin\/gtk3-hello/usr\/local\/bin\/gtk3-hello/' "$SNAP_DIR/snap/snapcraft.yaml"
+
+restore: |
+  cd "$SNAP_DIR"
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "$SNAP_DIR"
+
+  output="$(snapcraft pack)"
+
+  snap install gtk3-hello_*.snap --dangerous
+  snap connect gtk3-hello:gnome-42-2204 gnome-42-2204
+  [ "$(gtk3-hello)" = "hello world" ]
+
+  # Verify that the extension command chain went through the proper setup procedure
+  snap_user_data="$HOME/snap/gtk3-hello/current"
+  [ -d "$snap_user_data/.config" ]
+  [ -d "$snap_user_data/.local" ]
+  [ -h "$snap_user_data/.themes" ]
+
+  [ -f "$snap_user_data/.last_revision" ]
+  [ "$(cat "$snap_user_data/.last_revision")" = "SNAP_DESKTOP_LAST_REVISION=x1" ]
+
+  # Verify content snap was installed for dependency checks.
+  snap list gnome-42-2204
+  snap list gtk-common-themes
+
+  # Verify all dependencies were found.
+  if echo "$output" | grep -q "part is missing libraries"; then
+    echo "failed to find content snaps' libraries"
+    exit 1
+  fi

--- a/tests/spread/extensions/gnome/task.yaml
+++ b/tests/spread/extensions/gnome/task.yaml
@@ -18,6 +18,9 @@ prepare: |
   sed -i 's/gnome-3-28/gnome/' "$SNAP_DIR/snap/snapcraft.yaml"
   sed -i 's/bin\/gtk3-hello/usr\/local\/bin\/gtk3-hello/' "$SNAP_DIR/snap/snapcraft.yaml"
 
+  # Temporarily use snaps from edge
+  echo '    build-snaps: [gnome-42-2204-sdk/latest/edge, gnome-42-2204/latest/edge]' >> "$SNAP_DIR/snap/snapcraft.yaml"
+
 restore: |
   cd "$SNAP_DIR"
   snapcraft clean

--- a/tests/unit/commands/test_list_extensions.py
+++ b/tests/unit/commands/test_list_extensions.py
@@ -37,6 +37,7 @@ def test_command(emitter, command):
         flutter-dev       core18
         flutter-master    core18
         flutter-stable    core18
+        gnome             core22
         gnome-3-28        core18
         gnome-3-34        core18
         gnome-3-38        core20
@@ -61,6 +62,7 @@ def test_command_extension_dups(emitter, command):
         flutter-dev       core18
         flutter-master    core18
         flutter-stable    core18
+        gnome             core22
         gnome-3-28        core18
         gnome-3-34        core18
         gnome-3-38        core20

--- a/tests/unit/extensions/test_extensions.py
+++ b/tests/unit/extensions/test_extensions.py
@@ -18,6 +18,7 @@
 import pytest
 
 from snapcraft import errors, extensions
+from snapcraft.extensions import extension
 
 
 @pytest.mark.usefixtures("fake_extension")
@@ -222,4 +223,36 @@ def test_apply_extension_experimental_with_environment(emitter, monkeypatch):
     emitter.assert_message(
         "*EXPERIMENTAL* extension 'fake-extension-experimental' enabled",
         intermediate=True,
+    )
+
+
+def test_prepend_path():
+    assert (
+        extension.prepend_to_env("TEST_ENV", ["/usr/bin", "/usr/local/bin"])
+        == "/usr/bin:/usr/local/bin${TEST_ENV:+:$TEST_ENV}"
+    )
+
+
+def test_append_path():
+    assert (
+        extension.append_to_env("TEST_ENV", ["/usr/bin", "/usr/local/bin"])
+        == "${TEST_ENV:+$TEST_ENV:}/usr/bin:/usr/local/bin"
+    )
+
+
+def test_prepend_path_with_separator():
+    assert (
+        extension.prepend_to_env(
+            "TEST_ENV", ["/usr/bin", "/usr/local/bin"], separator=";"
+        )
+        == "/usr/bin;/usr/local/bin${TEST_ENV:+;$TEST_ENV}"
+    )
+
+
+def test_append_path_with_separator():
+    assert (
+        extension.append_to_env(
+            "TEST_ENV", ["/usr/bin", "/usr/local/bin"], separator=";"
+        )
+        == "${TEST_ENV:+$TEST_ENV;}/usr/bin;/usr/local/bin"
     )

--- a/tests/unit/extensions/test_gnome.py
+++ b/tests/unit/extensions/test_gnome.py
@@ -1,0 +1,170 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from snapcraft.extensions import gnome
+from snapcraft.extensions.extension import get_extensions_data_dir
+
+############
+# Fixtures #
+############
+
+
+@pytest.fixture
+def gnome_extension():
+    return gnome.GNOME(yaml_data={"base": "core22"}, arch="amd64", target_arch="amd64")
+
+
+###################
+# GNOME Extension #
+###################
+
+
+def test_get_supported_bases(gnome_extension):
+    assert gnome_extension.get_supported_bases() == ("core22",)
+
+
+def test_get_supported_confinement(gnome_extension):
+    assert gnome_extension.get_supported_confinement() == ("strict", "devmode")
+
+
+def test_is_experimental():
+    assert gnome.GNOME.is_experimental(base="core22") is False
+
+
+def test_get_app_snippet(gnome_extension):
+    assert gnome_extension.get_app_snippet() == {
+        "command-chain": ["snap/command-chain/desktop-launch"],
+        "plugs": ["desktop", "desktop-legacy", "gsettings", "opengl", "wayland", "x11"],
+    }
+
+
+def test_get_root_snippet(gnome_extension):
+    assert gnome_extension.get_root_snippet() == {
+        "assumes": ["snapd2.43"],
+        "environment": {
+            "GTK_USE_PORTAL": "1",
+            "SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform",
+        },
+        "hooks": {
+            "configure": {
+                "command-chain": ["snap/command-chain/hooks-configure-fonts"],
+                "plugs": ["desktop"],
+            }
+        },
+        "layout": {
+            "/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.0": {
+                "bind": "$SNAP/gnome-platform/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.0"
+            },
+            "/usr/share/xml/iso-codes": {
+                "bind": "$SNAP/gnome-platform/usr/share/xml/iso-codes"
+            },
+        },
+        "plugs": {
+            "desktop": {"mount-host-font-cache": False},
+            "gnome-42-2204": {
+                "default-provider": "gnome-42-2204",
+                "interface": "content",
+                "target": "$SNAP/gnome-platform",
+            },
+            "gtk-3-themes": {
+                "default-provider": "gtk-common-themes",
+                "interface": "content",
+                "target": "$SNAP/data-dir/themes",
+            },
+            "icon-themes": {
+                "default-provider": "gtk-common-themes",
+                "interface": "content",
+                "target": "$SNAP/data-dir/icons",
+            },
+            "sound-themes": {
+                "default-provider": "gtk-common-themes",
+                "interface": "content",
+                "target": "$SNAP/data-dir/sounds",
+            },
+        },
+    }
+
+
+def test_get_part_snippet(gnome_extension):
+    assert gnome_extension.get_part_snippet() == {
+        "build-environment": [
+            {"PATH": "/snap/gnome-42-2204-sdk/current/usr/bin:$PATH"},
+            {
+                "XDG_DATA_DIRS": (
+                    "$SNAPCRAFT_STAGE/usr/share:/snap/gnome-42-2204-sdk"
+                    "/current/usr/share:/usr/share:$XDG_DATA_DIRS"
+                )
+            },
+            {
+                "LD_LIBRARY_PATH": ":".join(
+                    [
+                        "/snap/gnome-42-2204-sdk/current/lib/$CRAFT_ARCH_TRIPLET",
+                        "/snap/gnome-42-2204-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET",
+                        "/snap/gnome-42-2204-sdk/current/usr/lib",
+                        "/snap/gnome-42-2204-sdk/current/usr/lib/vala-current",
+                        "/snap/gnome-42-2204-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio",
+                    ]
+                )
+                + "${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            },
+            {
+                "PKG_CONFIG_PATH": (
+                    "/snap/gnome-42-2204-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:"
+                    "/snap/gnome-42-2204-sdk/current/usr/lib/pkgconfig:"
+                    "/snap/gnome-42-2204-sdk/current/usr/share/pkgconfig:$PKG_CONFIG_PATH"
+                )
+            },
+            {
+                "GETTEXTDATADIRS": (
+                    "/snap/gnome-42-2204-sdk/current/usr/share/gettext-current:"
+                    "$GETTEXTDATADIRS"
+                )
+            },
+            {
+                "GDK_PIXBUF_MODULE_FILE": (
+                    "/snap/gnome-42-2204-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET"
+                    "/gdk-pixbuf-current/loaders.cache"
+                )
+            },
+            {
+                "ACLOCAL_PATH": (
+                    "/snap/gnome-42-2204-sdk/current/usr/share/aclocal"
+                    "${ACLOCAL_PATH:+:$ACLOCAL_PATH}"
+                )
+            },
+            {
+                "PYTHONPATH": ":".join(
+                    [
+                        "/snap/gnome-42-2204-sdk/current/usr/lib/python3.10",
+                        "/snap/gnome-42-2204-sdk/current/usr/lib/python3/dist-packages",
+                    ]
+                )
+                + "${PYTHONPATH:+:$PYTHONPATH}"
+            },
+        ]
+    }
+
+
+def test_get_parts_snippet(gnome_extension):
+    assert gnome_extension.get_parts_snippet() == {
+        "gnome/sdk": {
+            "source": str(get_extensions_data_dir() / "desktop" / "command-chain"),
+            "plugin": "make",
+            "build-snaps": ["gnome-42-2204-sdk"],
+        }
+    }

--- a/tests/unit/extensions/test_gnome.py
+++ b/tests/unit/extensions/test_gnome.py
@@ -103,11 +103,11 @@ def test_get_root_snippet(gnome_extension):
 def test_get_part_snippet(gnome_extension):
     assert gnome_extension.get_part_snippet() == {
         "build-environment": [
-            {"PATH": "/snap/gnome-42-2204-sdk/current/usr/bin:$PATH"},
+            {"PATH": "/snap/gnome-42-2204-sdk/current/usr/bin${PATH:+:$PATH}"},
             {
                 "XDG_DATA_DIRS": (
                     "$SNAPCRAFT_STAGE/usr/share:/snap/gnome-42-2204-sdk"
-                    "/current/usr/share:/usr/share:$XDG_DATA_DIRS"
+                    "/current/usr/share:/usr/share${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
                 )
             },
             {
@@ -126,13 +126,14 @@ def test_get_part_snippet(gnome_extension):
                 "PKG_CONFIG_PATH": (
                     "/snap/gnome-42-2204-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:"
                     "/snap/gnome-42-2204-sdk/current/usr/lib/pkgconfig:"
-                    "/snap/gnome-42-2204-sdk/current/usr/share/pkgconfig:$PKG_CONFIG_PATH"
+                    "/snap/gnome-42-2204-sdk/current/usr/share/pkgconfig"
+                    "${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
                 )
             },
             {
                 "GETTEXTDATADIRS": (
-                    "/snap/gnome-42-2204-sdk/current/usr/share/gettext-current:"
-                    "$GETTEXTDATADIRS"
+                    "/snap/gnome-42-2204-sdk/current/usr/share/gettext-current"
+                    "${GETTEXTDATADIRS:+:$GETTEXTDATADIRS}"
                 )
             },
             {

--- a/tests/unit/extensions/test_registry.py
+++ b/tests/unit/extensions/test_registry.py
@@ -24,6 +24,7 @@ from snapcraft import errors, extensions
 @pytest.mark.usefixtures("fake_extension_experimental")
 def test_get_extension_names():
     assert extensions.get_extension_names() == [
+        "gnome",
         "fake-extension-experimental",
         "fake-extension-extra",
         "fake-extension",

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -28,6 +28,8 @@ from snapcraft.parts import lifecycle as parts_lifecycle
 from snapcraft.parts.update_metadata import update_project_metadata
 from snapcraft.projects import MANDATORY_ADOPTABLE_FIELDS, Project
 
+# pylint: disable=too-many-lines
+
 _SNAPCRAFT_YAML_FILENAMES = [
     "snap/snapcraft.yaml",
     "build-aux/snap/snapcraft.yaml",
@@ -798,9 +800,47 @@ def test_get_snap_project_with_content_plugs(snapcraft_yaml, new_dir):
     project = Project(**yaml_data)
 
     assert parts_lifecycle._get_extra_build_snaps(project) == [
+        "core22",
         "test-snap-1",
         "test-snap-2",
+    ]
+
+
+def test_get_snap_project_with_content_plugs_does_not_add_extension(
+    snapcraft_yaml, new_dir
+):
+    yaml_data = {
+        "name": "mytest",
+        "version": "0.1",
+        "base": "core22",
+        "summary": "Just some test data",
+        "description": "This is just some test data.",
+        "grade": "stable",
+        "confinement": "strict",
+        "plugs": {
+            "test-plug-1": {
+                "content": "content-interface",
+                "interface": "content",
+                "target": "$SNAP/content",
+                "default-provider": "test-snap-1",
+            },
+            "test-plug-2": {
+                "content": "content-interface",
+                "interface": "content",
+                "target": "$SNAP/content",
+                "default-provider": "test-snap-2",
+            },
+        },
+        "parts": {
+            "part1": {"plugin": "nil", "build-snaps": ["test-snap-2", "test-snap-3"]}
+        },
+    }
+
+    project = Project(**yaml_data)
+
+    assert parts_lifecycle._get_extra_build_snaps(project) == [
         "core22",
+        "test-snap-1",
     ]
 
 
@@ -965,7 +1005,11 @@ def test_lifecycle_run_permission_denied(new_dir):
         parts_lifecycle.run(
             "prime",
             argparse.Namespace(
-                parts=[], destructive_mode=True, use_lxd=False, provider=None, debug=False
+                parts=[],
+                destructive_mode=True,
+                use_lxd=False,
+                provider=None,
+                debug=False,
             ),
         )
 


### PR DESCRIPTION
This is just a test MR where to add the changes required to be able to run a GTK application using the Gnome-42-2204 extension. It is not meant to be merged, but to test and add here all the changes needed, and extract from it specific MRs for each change. Once achieved the goal and all the MRs had been merged, this one should be closed.

To test this, just go to `tests/spread/extensions/snaps/gtk3-hello_new`, and run:

    snapcraft
    sudo snap install --dangerous gtk3-hello_1.0_amd64.snap
    sudo snap connect gtk3-hello:gnome-42-2204 gnome-42-2204:gnome-42-2204
    sudo snap run gtk3-hello

A Gtk window should be shown, and the text "Activated" should be written in the terminal. When closing the window, the text "hello world" should be shown in the terminal, and the snap should finalize.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
