### PR TITLE
extensions: prepend and append functions for ENV

### DIFF
--- a/snapcraft/extensions/extension.py
+++ b/snapcraft/extensions/extension.py
@@ -20,7 +20,7 @@ import abc
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, final
+from typing import Any, Dict, Optional, Sequence, Tuple, final
 
 from craft_cli import emit
 
@@ -30,6 +30,36 @@ from snapcraft import errors
 def get_extensions_data_dir() -> Path:
     """Return the path to the extension data directory."""
     return Path(sys.prefix) / "share" / "snapcraft" / "extensions"
+
+
+def append_to_env(env_variable: str, paths: Sequence[str], separator: str = ":") -> str:
+    """Return a string for env_variable with one of more paths appended.
+
+    :param env_variable: the variable to operate on.
+    :param paths: one or more paths to append.
+    :param separator: the separator to use.
+    :returns: a shell string where one or more paths are appended
+                  to env_variable. The code takes into account the case
+                  where the environment variable is empty, to avoid putting
+                  a separator token at the start.
+    """
+    return f"${{{env_variable}:+${env_variable}{separator}}}" + separator.join(paths)
+
+
+def prepend_to_env(
+    env_variable: str, paths: Sequence[str], separator: str = ":"
+) -> str:
+    """Return a string for env_variable with one of more paths prepended.
+
+    :param env_variable: the variable to operate on.
+    :param paths: one or more paths to append.
+    :param separator: the separator to use.
+    :returns: a shell string where one or more paths are prepended
+                  before env_variable. The code takes into account the case
+                  where the environment variable is empty, to avoid putting
+                  a separator token at the end.
+    """
+    return separator.join(paths) + f"${{{env_variable}:+{separator}${env_variable}}}"
 
 
 class Extension(abc.ABC):

--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from overrides import overrides
 
-from .extension import Extension, get_extensions_data_dir
+from .extension import Extension, get_extensions_data_dir, prepend_to_env
 
 _PLATFORM_SNAP = dict(core22="gnome-42-2204")
 _SDK_SNAP = dict(core22="gnome-42-2204-sdk")
@@ -141,60 +141,74 @@ class GNOME(Extension):
 
         return {
             "build-environment": [
-                {"PATH": f"/snap/{sdk_snap}/current/usr/bin:$PATH"},
                 {
-                    "XDG_DATA_DIRS": (
-                        f"$SNAPCRAFT_STAGE/usr/share:/snap/{sdk_snap}"
-                        "/current/usr/share:/usr/share:$XDG_DATA_DIRS"
-                    )
+                    "PATH": prepend_to_env(
+                        "PATH", [f"/snap/{sdk_snap}/current/usr/bin"]
+                    ),
                 },
                 {
-                    "LD_LIBRARY_PATH": ":".join(
+                    "XDG_DATA_DIRS": prepend_to_env(
+                        "XDG_DATA_DIRS",
+                        [
+                            f"$SNAPCRAFT_STAGE/usr/share:/snap/{sdk_snap}/current/usr/share",
+                            "/usr/share",
+                        ],
+                    ),
+                },
+                {
+                    "LD_LIBRARY_PATH": prepend_to_env(
+                        "LD_LIBRARY_PATH",
                         [
                             f"/snap/{sdk_snap}/current/lib/$CRAFT_ARCH_TRIPLET",
                             f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET",
                             f"/snap/{sdk_snap}/current/usr/lib",
                             f"/snap/{sdk_snap}/current/usr/lib/vala-current",
                             f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio",
-                        ]
-                    )
-                    + "${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+                        ],
+                    ),
                 },
                 {
-                    "PKG_CONFIG_PATH": (
-                        f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:"
-                        f"/snap/{sdk_snap}/current/usr/lib/pkgconfig:"
-                        f"/snap/{sdk_snap}/current/usr/share/pkgconfig:$PKG_CONFIG_PATH"
-                    )
+                    "PKG_CONFIG_PATH": prepend_to_env(
+                        "PKG_CONFIG_PATH",
+                        [
+                            f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig",
+                            f"/snap/{sdk_snap}/current/usr/lib/pkgconfig",
+                            f"/snap/{sdk_snap}/current/usr/share/pkgconfig",
+                        ],
+                    ),
                 },
                 {
-                    "GETTEXTDATADIRS": (
-                        f"/snap/{sdk_snap}/current/usr/share/gettext-current:"
-                        "$GETTEXTDATADIRS"
-                    )
+                    "GETTEXTDATADIRS": prepend_to_env(
+                        "GETTEXTDATADIRS",
+                        [
+                            f"/snap/{sdk_snap}/current/usr/share/gettext-current",
+                        ],
+                    ),
                 },
                 {
                     "GDK_PIXBUF_MODULE_FILE": (
                         f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET"
                         "/gdk-pixbuf-current/loaders.cache"
-                    )
+                    ),
                 },
                 {
-                    "ACLOCAL_PATH": (
-                        f"/snap/{sdk_snap}/current/usr/share/aclocal"
-                        "${ACLOCAL_PATH:+:$ACLOCAL_PATH}"
-                    )
+                    "ACLOCAL_PATH": prepend_to_env(
+                        "ACLOCAL_PATH",
+                        [
+                            f"/snap/{sdk_snap}/current/usr/share/aclocal",
+                        ],
+                    ),
                 },
                 {
-                    "PYTHONPATH": ":".join(
+                    "PYTHONPATH": prepend_to_env(
+                        "PYTHONPATH",
                         [
                             f"/snap/{sdk_snap}/current/usr/lib/python3.10",
                             f"/snap/{sdk_snap}/current/usr/lib/python3/dist-packages",
-                        ]
-                    )
-                    + "${PYTHONPATH:+:$PYTHONPATH}"
+                        ],
+                    ),
                 },
-            ]
+            ],
         }
 
     @overrides

--- a/tests/unit/extensions/test_extensions.py
+++ b/tests/unit/extensions/test_extensions.py
@@ -18,6 +18,7 @@
 import pytest
 
 from snapcraft import errors, extensions
+from snapcraft.extensions import extension
 
 
 @pytest.mark.usefixtures("fake_extension")
@@ -222,4 +223,36 @@ def test_apply_extension_experimental_with_environment(emitter, monkeypatch):
     emitter.assert_message(
         "*EXPERIMENTAL* extension 'fake-extension-experimental' enabled",
         intermediate=True,
+    )
+
+
+def test_prepend_path():
+    assert (
+        extension.prepend_to_env("TEST_ENV", ["/usr/bin", "/usr/local/bin"])
+        == "/usr/bin:/usr/local/bin${TEST_ENV:+:$TEST_ENV}"
+    )
+
+
+def test_append_path():
+    assert (
+        extension.append_to_env("TEST_ENV", ["/usr/bin", "/usr/local/bin"])
+        == "${TEST_ENV:+$TEST_ENV:}/usr/bin:/usr/local/bin"
+    )
+
+
+def test_prepend_path_with_separator():
+    assert (
+        extension.prepend_to_env(
+            "TEST_ENV", ["/usr/bin", "/usr/local/bin"], separator=";"
+        )
+        == "/usr/bin;/usr/local/bin${TEST_ENV:+;$TEST_ENV}"
+    )
+
+
+def test_append_path_with_separator():
+    assert (
+        extension.append_to_env(
+            "TEST_ENV", ["/usr/bin", "/usr/local/bin"], separator=";"
+        )
+        == "${TEST_ENV:+$TEST_ENV;}/usr/bin;/usr/local/bin"
     )

--- a/tests/unit/extensions/test_gnome.py
+++ b/tests/unit/extensions/test_gnome.py
@@ -102,11 +102,11 @@ def test_get_root_snippet(gnome_extension):
 def test_get_part_snippet(gnome_extension):
     assert gnome_extension.get_part_snippet() == {
         "build-environment": [
-            {"PATH": "/snap/gnome-42-2204-sdk/current/usr/bin:$PATH"},
+            {"PATH": "/snap/gnome-42-2204-sdk/current/usr/bin${PATH:+:$PATH}"},
             {
                 "XDG_DATA_DIRS": (
                     "$SNAPCRAFT_STAGE/usr/share:/snap/gnome-42-2204-sdk"
-                    "/current/usr/share:/usr/share:$XDG_DATA_DIRS"
+                    "/current/usr/share:/usr/share${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
                 )
             },
             {
@@ -125,13 +125,14 @@ def test_get_part_snippet(gnome_extension):
                 "PKG_CONFIG_PATH": (
                     "/snap/gnome-42-2204-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:"
                     "/snap/gnome-42-2204-sdk/current/usr/lib/pkgconfig:"
-                    "/snap/gnome-42-2204-sdk/current/usr/share/pkgconfig:$PKG_CONFIG_PATH"
+                    "/snap/gnome-42-2204-sdk/current/usr/share/pkgconfig"
+                    "${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
                 )
             },
             {
                 "GETTEXTDATADIRS": (
-                    "/snap/gnome-42-2204-sdk/current/usr/share/gettext-current:"
-                    "$GETTEXTDATADIRS"
+                    "/snap/gnome-42-2204-sdk/current/usr/share/gettext-current"
+                    "${GETTEXTDATADIRS:+:$GETTEXTDATADIRS}"
                 )
             },
             {


### PR DESCRIPTION
This MR adds two functions that simplifies the management of environment variables, allowing to just pass the name of one variable and one or more paths, and they will return a piece of shell code that prepends or appends the paths to the variable, taking into account the case when the variable is empty, to avoid adding a trailing or leading colon.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
