### PR TITLE
extensions: fix gnome run environment

### DIFF
--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -117,6 +117,16 @@ class GNOME(Extension):
             "environment": {
                 "SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform",
                 "GTK_USE_PORTAL": "1",
+                "LD_LIBRARY_PATH": ":".join(
+                    [
+                        f"/snap/{platform_snap}/current/lib/$CRAFT_ARCH_TRIPLET",
+                        f"/snap/{platform_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET",
+                        f"/snap/{platform_snap}/current/usr/lib",
+                        f"/snap/{platform_snap}/current/usr/lib/vala-current",
+                        f"/snap/{platform_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio",
+                    ]
+                )
+                + "${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}",
             },
             "hooks": {
                 "configure": {

--- a/tests/unit/extensions/test_gnome.py
+++ b/tests/unit/extensions/test_gnome.py
@@ -58,6 +58,7 @@ def test_get_root_snippet(gnome_extension):
         "environment": {
             "GTK_USE_PORTAL": "1",
             "SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform",
+            "LD_LIBRARY_PATH": "/snap/gnome-42-2204/current/lib/$CRAFT_ARCH_TRIPLET:/snap/gnome-42-2204/current/usr/lib/$CRAFT_ARCH_TRIPLET:/snap/gnome-42-2204/current/usr/lib:/snap/gnome-42-2204/current/usr/lib/vala-current:/snap/gnome-42-2204/current/usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}",
         },
         "hooks": {
             "configure": {


### PR DESCRIPTION
The snaps generated with the gnome-42 extension didn't have the
LD_LIBRARY_PATH correctly set.

This patch fixes it.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
