### PR TITLE
setup assets: ensure hooks when command-chain is present

### DIFF
--- a/snapcraft/meta/appstream.py
+++ b/snapcraft/meta/appstream.py
@@ -203,7 +203,7 @@ def _extract_icon(dom, workdir: str, desktop_file_paths: List[str]) -> Optional[
     if icon_node_type == "remote":
         return icon
 
-    if icon_node_type == "stock":
+    if icon_node_type == "stock" and icon is not None:
         return _get_icon_from_theme(workdir, "hicolor", icon)
 
     # If an icon path is specified and the icon file exists, we'll use that, otherwise

--- a/snapcraft_legacy/internal/meta/_snap_packaging.py
+++ b/snapcraft_legacy/internal/meta/_snap_packaging.py
@@ -705,7 +705,7 @@ class _SnapPackaging:
         for hook in hooks_with_command_chain:
             hook_path = pathlib.Path(hooks_dir) / hook.hook_name
             if not hook_path.exists():
-                hook_path.write_text("#!/bin/sh\n")
+                hook_path.write_text("#!/bin/true\n")
                 hook_path.chmod(0o755)
 
         # Write wrapper hooks as necessary.

--- a/tests/legacy/unit/meta/test_meta.py
+++ b/tests/legacy/unit/meta/test_meta.py
@@ -1126,7 +1126,7 @@ class WriteSnapDirectoryTestCase(CreateBaseTestCase):
         # The hook should be empty, because the one in snap/hooks is empty, and
         # no wrapper is generated (i.e. that hook is copied to both locations).
         self.assertThat(
-            os.path.join(self.hooks_dir, "configure"), FileContains("#!/bin/sh\n")
+            os.path.join(self.hooks_dir, "configure"), FileContains("#!/bin/true\n")
         )
 
     def test_snap_hooks_stubs_not_created_stubs_from_command_chain(self):

--- a/tests/legacy/unit/meta/test_snap_packaging.py
+++ b/tests/legacy/unit/meta/test_snap_packaging.py
@@ -188,7 +188,7 @@ class SnapPackagingRunnerTests(unit.TestCase):
 
         hook = Path(sp._prime_dir, "meta", "hooks", "configure")
         assert hook.exists()
-        assert hook.read_text() == "#!/bin/sh\n"
+        assert hook.read_text() == "#!/bin/true\n"
         assert hook.stat().st_mode & 0xFFF == 0o755
 
     def test_no_stub_for_preconfigured_hook(self):

--- a/tests/spread/general/stub-hooks/snap/snapcraft.yaml
+++ b/tests/spread/general/stub-hooks/snap/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: hooks-stub
+version: "1.0"
+summary: command-chain for the install hook with no hook
+description: ensure a stub hook is created
+base: core22
+confinement: strict
+
+hooks:
+  install:
+    command-chain:
+      - install-chain
+
+parts:
+  nil:
+    plugin: nil
+    override-build: |
+      echo "#!/bin/sh" > $SNAPCRAFT_PART_INSTALL/install-chain
+      echo 'exec "$@"' >> $SNAPCRAFT_PART_INSTALL/install-chain
+      chmod +x $SNAPCRAFT_PART_INSTALL/install-chain

--- a/tests/spread/general/stub-hooks/task.yaml
+++ b/tests/spread/general/stub-hooks/task.yaml
@@ -1,0 +1,44 @@
+summary: Check if a default hook is created for a snap with a command-chain entry
+
+# command-chain was introduced in core20
+systems:
+  - -ubuntu-18.04
+  - -ubuntu-18.04-64
+  - -ubuntu-18.04-amd64
+  - -ubuntu-18.04-arm64
+  - -ubuntu-18.04-armhf
+  - -ubuntu-18.04-s390x
+  - -ubuntu-18.04-ppc64el
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "snap/snapcraft.yaml"
+
+restore: |
+  snapcraft clean  --destructive-mode
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  snapcraft snap --destructive-mode
+
+  # Verify that the hook is there
+  if [ ! -f prime/meta/hooks/install ]; then
+      echo "Stub hook missing"
+      exit 1
+  fi
+  
+  # Verify stub hook content
+  hook_content=$(cat prime/meta/hooks/install)
+  if [ "${hook_content}" != "#!/bin/true" ]; then
+      echo "Unexpected hook content:"
+      echo "${hook_content}"
+      exit 1
+  fi
+
+  # Verify that the snap is installable
+  snap install --dangerous hooks-stub_1.0_*.snap


### PR DESCRIPTION
This is mostly relevant for when using extensions (like the
desktop ones that add a "configure" hook to set up the font
cache).

The original implementation lives in
snapcraft_legacy/internal/meta/_snap_packaging
.py::_SnapPackaging::generate_hook_wrappers

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
