### PR TITLE
provider: forward SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS

### DIFF
--- a/snapcraft/providers/_provider.py
+++ b/snapcraft/providers/_provider.py
@@ -60,7 +60,12 @@ class Provider(ABC):
         env["SNAPCRAFT_MANAGED_MODE"] = "1"
 
         # Pass-through host environment that target may need.
-        for env_key in ["http_proxy", "https_proxy", "no_proxy"]:
+        for env_key in [
+            "http_proxy",
+            "https_proxy",
+            "no_proxy",
+            "SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS",
+        ]:
             if env_key in os.environ:
                 env[env_key] = os.environ[env_key]
 


### PR DESCRIPTION
Signed-off-by: artivis <jeremie.deray@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

Forward `SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS` to providers allowing to actually enable experimental extensions.