### PR TITLE
extensions: Add environment variables for runtime

### DIFF
--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -24,6 +24,7 @@ from overrides import overrides
 
 from .extension import (
     Extension,
+    append_to_env,
     get_build_snaps,
     get_extensions_data_dir,
     prepend_to_env,
@@ -148,6 +149,16 @@ class GNOME(Extension):
             "environment": {
                 "SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform",
                 "GTK_USE_PORTAL": "1",
+                "LD_LIBRARY_PATH": append_to_env(
+                    "LD_LIBRARY_PATH",
+                    [
+                        f"/snap/{platform_snap}/current/lib/$CRAFT_ARCH_TRIPLET",
+                        f"/snap/{platform_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET",
+                        f"/snap/{platform_snap}/current/usr/lib",
+                        f"/snap/{platform_snap}/current/usr/lib/vala-current",
+                        f"/snap/{platform_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio",
+                    ],
+                ),
             },
             "hooks": {
                 "configure": {

--- a/tests/unit/extensions/test_gnome.py
+++ b/tests/unit/extensions/test_gnome.py
@@ -81,6 +81,12 @@ def test_get_root_snippet(gnome_extension):
     assert gnome_extension.get_root_snippet() == {
         "assumes": ["snapd2.43"],
         "environment": {
+            "LD_LIBRARY_PATH": "${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}"
+            "/snap/gnome-42-2204/current/lib/$CRAFT_ARCH_TRIPLET:"
+            "/snap/gnome-42-2204/current/usr/lib/$CRAFT_ARCH_TRIPLET:"
+            "/snap/gnome-42-2204/current/usr/lib:"
+            "/snap/gnome-42-2204/current/usr/lib/vala-current:"
+            "/snap/gnome-42-2204/current/usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio",
             "GTK_USE_PORTAL": "1",
             "SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform",
         },
@@ -128,6 +134,12 @@ def test_get_root_snippet_with_external_sdk(gnome_extension_with_build_snap):
     assert gnome_extension_with_build_snap.get_root_snippet() == {
         "assumes": ["snapd2.43"],
         "environment": {
+            "LD_LIBRARY_PATH": "${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}"
+            "/snap/gnome-44-2204/current/lib/$CRAFT_ARCH_TRIPLET:"
+            "/snap/gnome-44-2204/current/usr/lib/$CRAFT_ARCH_TRIPLET:"
+            "/snap/gnome-44-2204/current/usr/lib:"
+            "/snap/gnome-44-2204/current/usr/lib/vala-current:"
+            "/snap/gnome-44-2204/current/usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio",
             "GTK_USE_PORTAL": "1",
             "SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform",
         },


### PR DESCRIPTION
The current Gnome extension lacks the environment variables for the runtime libraries.

This MR adds them.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
