### PR TITLE
meta: handle version git

### DIFF
--- a/snapcraft/providers/_buildd.py
+++ b/snapcraft/providers/_buildd.py
@@ -62,9 +62,9 @@ class SnapcraftBuilddBaseConfiguration(bases.BuilddBase):
 
         :raises BaseConfigurationError: on error.
         """
-        # Requirement for apt gpg
+        # Requirement for apt gpg and version:git
         executor.execute_run(
-            ["apt-get", "install", "-y", "dirmngr"],
+            ["apt-get", "install", "-y", "dirmngr", "git"],
             capture_output=True,
             check=True,
         )

--- a/tests/spread/general/version-git/task.yaml
+++ b/tests/spread/general/version-git/task.yaml
@@ -1,0 +1,40 @@
+summary: Use version git
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+
+  mkdir test-snap
+  cd test-snap
+  snapcraft init
+
+  sed -i -e 's/version:.*/version: git/' snap/snapcraft.yaml
+  set_base snap/snapcraft.yaml
+
+  # create an annotated tag
+  git init-db
+  git add .
+  git commit -m msg
+  git tag -a 5.5 -m msg
+  echo >> snap/snapcraft.yaml
+
+restore: |
+  rm -rf test-snap
+  rm -rf ./*.snap
+
+execute: |
+  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host.
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
+  cd test-snap
+
+  # First with lxd
+  snapcraft --use-lxd
+  ls -l
+  test -f my-snap-name_5.5-dirty_amd64.snap
+  rm ./*.snap
+
+  # Then on host.
+  snapcraft --destructive-mode
+  ls -l
+  test -f my-snap-name_5.5-dirty_amd64.snap

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -502,3 +502,24 @@ def test_project_environment_ld_library_path_null(simple_project, new_dir):
           PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
         """
     )
+
+
+def test_version_git(simple_project, new_dir, mocker):
+    """Version in projects with ``version:git`` must be correctly handled."""
+    mocker.patch(
+        "craft_parts.sources.git_source.GitSource.generate_version",
+        return_value="1.2.3",
+    )
+
+    snap_yaml.write(
+        simple_project(version="git"),
+        prime_dir=Path(new_dir),
+        arch="amd64",
+        arch_triplet="x86_64-linux-gnu",
+    )
+
+    yaml_file = Path("meta/snap.yaml")
+    content = yaml_file.read_text()
+
+    data = yaml.safe_load(content)
+    assert data["version"] == "1.2.3"


### PR DESCRIPTION
Add special handling for projects with `version: git` so that the
snap version is set to the result of `git describe --dirty`.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
