### PR TITLE
pack: display snap filename

### DIFF
--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -87,13 +87,14 @@ def pack_snap(
     emit.progress("Creating snap package...")
     emit.trace(f"Pack command: {command}")
     try:
-        subprocess.run(
+        proc = subprocess.run(
             command, capture_output=True, check=True, universal_newlines=True
-        )  # type: ignore
+        )
     except subprocess.CalledProcessError as err:
         msg = f"Cannot pack snap file: {err!s}"
         if err.stderr:
             msg += f" ({err.stderr.strip()!s})"
         raise errors.SnapcraftError(msg)
 
-    emit.message("Created snap package", intermediate=True)
+    snap_filename = str(proc.stdout).partition(":")[2].strip()
+    emit.message(f"Created snap package {snap_filename}", intermediate=True)

--- a/tests/spread/core22/snap-creation/task.yaml
+++ b/tests/spread/core22/snap-creation/task.yaml
@@ -1,4 +1,4 @@
-summary: Test base package cutoff
+summary: Test snap file creation
 
 environment:
   SNAP/package_cutoff: package-cutoff
@@ -19,4 +19,5 @@ restore: |
 
 execute: |
   cd "$SNAP"
-  snapcraft --verbose
+  snapcraft 2>&1 | tee progress.txt
+  grep "Created snap package ${SNAP}_1.0_amd64.snap" progress.txt

--- a/tests/unit/test_pack.py
+++ b/tests/unit/test_pack.py
@@ -25,7 +25,7 @@ from snapcraft import errors, pack
 def test_pack_snap(mocker, new_dir):
     mock_run = mocker.patch("subprocess.run")
     pack.pack_snap(new_dir, output=None)
-    assert mock_run.mock_calls == [
+    assert mock_run.mock_calls[:2] == [
         call(
             ["snap", "pack", "--check-skeleton", new_dir],
             capture_output=True,
@@ -44,7 +44,7 @@ def test_pack_snap(mocker, new_dir):
 def test_pack_snap_compression_none(mocker, new_dir):
     mock_run = mocker.patch("subprocess.run")
     pack.pack_snap(new_dir, output=None, compression=None)
-    assert mock_run.mock_calls == [
+    assert mock_run.mock_calls[:2] == [
         call(
             ["snap", "pack", "--check-skeleton", new_dir],
             capture_output=True,
@@ -63,7 +63,7 @@ def test_pack_snap_compression_none(mocker, new_dir):
 def test_pack_snap_compression(mocker, new_dir):
     mock_run = mocker.patch("subprocess.run")
     pack.pack_snap(new_dir, output=None, compression="zz")
-    assert mock_run.mock_calls == [
+    assert mock_run.mock_calls[:2] == [
         call(
             ["snap", "pack", "--check-skeleton", new_dir],
             capture_output=True,
@@ -83,7 +83,7 @@ def test_pack_snap_output_file_output_directory_cwd(mocker, new_dir):
     """Test `snap pack` when it outputs to the current working directory."""
     mock_run = mocker.patch("subprocess.run")
     pack.pack_snap(new_dir, output=f"{new_dir}/test.snap")
-    assert mock_run.mock_calls == [
+    assert mock_run.mock_calls[:2] == [
         call(
             ["snap", "pack", "--check-skeleton", new_dir],
             capture_output=True,
@@ -108,7 +108,7 @@ def test_pack_snap_output_file_output_directory_existing(mocker, new_dir):
 
     pack.pack_snap(new_dir, output=output_directory / "test.snap")
 
-    assert mock_run.mock_calls == [
+    assert mock_run.mock_calls[:2] == [
         call(
             ["snap", "pack", "--check-skeleton", new_dir],
             capture_output=True,
@@ -132,7 +132,7 @@ def test_pack_snap_output_file_output_directory_non_existant(mocker, new_dir):
 
     pack.pack_snap(new_dir, output=output_directory / "test.snap")
 
-    assert mock_run.mock_calls == [
+    assert mock_run.mock_calls[:2] == [
         call(
             ["snap", "pack", "--check-skeleton", new_dir],
             capture_output=True,
@@ -159,7 +159,7 @@ def test_pack_snap_output_directory_not_specified(mocker, new_dir):
     """Test `snap pack` executes when no output directory is specified."""
     mock_run = mocker.patch("subprocess.run")
     pack.pack_snap(new_dir, output=str(new_dir))
-    assert mock_run.mock_calls == [
+    assert mock_run.mock_calls[:2] == [
         call(
             ["snap", "pack", "--check-skeleton", new_dir],
             capture_output=True,
@@ -185,7 +185,7 @@ def test_pack_snap_output_file_output_directory_existing_no_file_name(mocker, ne
 
     pack.pack_snap(new_dir, output=output_directory)
 
-    assert mock_run.mock_calls == [
+    assert mock_run.mock_calls[:2] == [
         call(
             ["snap", "pack", "--check-skeleton", new_dir],
             capture_output=True,


### PR DESCRIPTION
When packing a snap, show the packed snap filename upon completion.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
