### PR TITLE
lint: apply black to parts directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ exclude = '''
   | dist
 
   # specific to snapcraft
-  | parts
-  | stage
-  | prime
+  | ^/parts
+  | ^/stage
+  | ^/prime
 )/
 '''
 

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -178,7 +178,8 @@ def _run_command(
 
         if command_name == "snap":
             emit.message(
-                "The 'snap' command is deprecated, use 'pack' instead.", intermediate=True
+                "The 'snap' command is deprecated, use 'pack' instead.",
+                intermediate=True,
             )
 
     if parsed_args.use_lxd and providers.get_platform_default_provider() == "lxd":

--- a/snapcraft/parts/project_check.py
+++ b/snapcraft/parts/project_check.py
@@ -74,7 +74,7 @@ def _check_snap_dir(snap_dir_path: Path) -> None:
                 snap_dir_local=str(snap_dir_relpath / "local"),
                 unexpected_files="\n- ".join(sorted(unexpected_paths)),
             ),
-            intermediate=True
+            intermediate=True,
         )
 
 

--- a/snapcraft/parts/update_metadata.py
+++ b/snapcraft/parts/update_metadata.py
@@ -97,7 +97,10 @@ def _update_project_variables(project: Project, project_vars: Dict[str, str]):
 
 
 def _update_project_icon(
-    project: Project, *, metadata: ExtractedMetadata, assets_dir: Path,
+    project: Project,
+    *,
+    metadata: ExtractedMetadata,
+    assets_dir: Path,
 ) -> None:
     """Look for icons files and update project.
 

--- a/tests/unit/parts/test_desktop_file.py
+++ b/tests/unit/parts/test_desktop_file.py
@@ -34,23 +34,18 @@ class TestDesktopExec:
             ("foo", "--arg", "foo --arg"),
             ("foo", "--arg %U", "foo --arg %U"),
             ("foo", "%U", "foo %U"),
-
             # snap name != app name
             ("bar", "", "foo.bar"),
             ("bar", "--arg", "foo.bar --arg"),
-        ]
+        ],
     )
-    def test_generate_desktop_file(
-        self, new_dir, app_name, app_args, expected_exec
-    ):
+    def test_generate_desktop_file(self, new_dir, app_name, app_args, expected_exec):
         snap_name = "foo"
 
         desktop_file_path = new_dir / "app.desktop"
         with desktop_file_path.open("w") as desktop_file:
             print("[Desktop Entry]", file=desktop_file)
-            print(
-                f"Exec={' '.join(['in-snap-exe', app_args])}", file=desktop_file
-            )
+            print(f"Exec={' '.join(['in-snap-exe', app_args])}", file=desktop_file)
 
         d = DesktopFile(
             snap_name=snap_name,
@@ -80,16 +75,13 @@ class TestDesktopIcon:
         [
             # icon_path preferred
             ("other.png", "foo.png", "${SNAP}/foo.png"),
-
             # icon_path with / preferred
             ("/foo.png", "foo.png", "${SNAP}/foo.png"),
-
             # icon path with ${SNAP}
             ("${SNAP}/foo.png", None, "${SNAP}/foo.png"),
-
             # icon name
             ("foo", None, "foo"),
-        ]
+        ],
     )
     def test_generate_desktop_file(self, new_dir, icon, icon_path, expected_icon):
         snap_name = app_name = "foo"
@@ -136,16 +128,13 @@ class TestDesktopIcon:
         [
             # icon_path preferred
             ("other.png", "foo.png", "${SNAP}/foo.png"),
-
             # icon_path with / preferred
             ("/foo.png", "foo.png", "${SNAP}/foo.png"),
-
             # icon path with ${SNAP}
             ("${SNAP}/foo.png", None, "${SNAP}/foo.png"),
-
             # icon name
             ("foo", None, "foo"),
-        ]
+        ],
     )
     def test_generate_desktop_file_multisection(
         self, new_dir, icon, icon_path, expected_icon

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -965,7 +965,11 @@ def test_lifecycle_run_permission_denied(new_dir):
         parts_lifecycle.run(
             "prime",
             argparse.Namespace(
-                parts=[], destructive_mode=True, use_lxd=False, provider=None, debug=False
+                parts=[],
+                destructive_mode=True,
+                use_lxd=False,
+                provider=None,
+                debug=False,
             ),
         )
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

`snapcraft/parts/` and `tests/unit/parts/` were ignored by black.