### PR TITLE
parts: correct spelling of build-base in yaml_utils.load

### DIFF
--- a/snapcraft/parts/yaml_utils.py
+++ b/snapcraft/parts/yaml_utils.py
@@ -81,7 +81,7 @@ def load(filestream: TextIO) -> Dict[str, Any]:
         data = yaml.safe_load(filestream)
         build_base = utils.get_effective_base(
             base=data.get("base"),
-            build_base=data.get("build_base"),
+            build_base=data.get("build-base"),
             project_type=data.get("type"),
             name=data.get("name"),
         )

--- a/tests/unit/parts/test_yaml_utils.py
+++ b/tests/unit/parts/test_yaml_utils.py
@@ -94,6 +94,25 @@ def test_yaml_load_unhashable_errors():
     )
 
 
+def test_yaml_load_build_base():
+    assert (
+        yaml_utils.load(
+            io.StringIO(
+                dedent(
+                    """\
+        base: foo
+        build-base: core22
+    """
+                )
+            )
+        )
+        == {
+            "base": "foo",
+            "build-base": "core22",
+        }
+    )
+
+
 def test_yaml_load_not_core22_base():
     with pytest.raises(errors.LegacyFallback) as raised:
         yaml_utils.load(


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
I was trying to build a snap with the following in its snapcraft.yaml:

```yaml
base: whatever
build-base: core22
```

... and Snapcraft fell back to its legacy mode, printing the following in the trace log:

```
2022-06-13 19:58:20.422 run legacy implementation: base is not core22
```

The build then fails because legacy Snapcraft does not support building on core22.

After a quick poke around, it looks like `snapcraft.parts.yaml_utils.load` misspells `build-base` as `build_base`, causing the project to be misidentified as legacy. It's possible there are further problems, but fixing this is a necessary first step.