### PR TITLE
store: support login --with

### DIFF
--- a/snapcraft/commands/account.py
+++ b/snapcraft/commands/account.py
@@ -19,6 +19,7 @@
 import contextlib
 import functools
 import os
+import pathlib
 import stat
 import textwrap
 from datetime import datetime
@@ -40,6 +41,18 @@ _VALID_DATE_FORMATS = [
     "%Y-%m-%d",
     "%Y-%m-%dT%H:%M:%SZ",
 ]
+
+
+def _read_config(config_path) -> str:
+    if config_path == "-":
+        config_path = "/dev/stdin"
+
+    config_file = pathlib.Path(config_path)
+
+    if not config_file.exists():
+        raise ArgumentParsingError(f"<login-file> {config_path!r} does not exist")
+
+    return config_file.read_text(encoding="utf-8")
 
 
 class StoreLoginCommand(BaseCommand):
@@ -69,7 +82,6 @@ class StoreLoginCommand(BaseCommand):
             metavar="<login-file>",
             dest="login_with",
             type=str,
-            nargs=1,
             default=None,
             help="File to use for imported credentials",
         )
@@ -92,12 +104,16 @@ class StoreLoginCommand(BaseCommand):
             )
 
         if parsed_args.login_with:
-            raise ArgumentParsingError(
+            config_content = _read_config(parsed_args.login_with)
+            emit.message(
                 "--with is no longer supported, export the auth to the environment "
                 f"variable {store.constants.ENVIRONMENT_STORE_CREDENTIALS!r} instead",
+                intermediate=True,
             )
+            store.LegacyUbuntuOne.store_credentials(config_content)
+        else:
+            store.StoreClientCLI().login()
 
-        store.StoreClientCLI().login()
         emit.message("Login successful")
 
 

--- a/snapcraft/commands/store/__init__.py
+++ b/snapcraft/commands/store/__init__.py
@@ -18,11 +18,13 @@
 
 
 from . import constants
+from ._legacy_account import LegacyUbuntuOne
 from .channel_map import ChannelMap
 from .client import StoreClientCLI
 
 __all__ = [
     "ChannelMap",
     "StoreClientCLI",
+    "LegacyUbuntuOne",
     "constants",
 ]

--- a/snapcraft/commands/store/_legacy_account.py
+++ b/snapcraft/commands/store/_legacy_account.py
@@ -1,0 +1,164 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Backwards compatibility for login --with."""
+
+import base64
+import configparser
+import os
+from pathlib import Path
+from typing import Optional, Sequence
+
+import craft_store
+import pymacaroons
+import xdg.BaseDirectory
+from overrides import overrides
+from urllib3.util import parse_url
+
+from snapcraft import errors
+
+from . import constants
+
+
+def _load_potentially_base64_config(config_content: str) -> configparser.ConfigParser:
+    parser = configparser.ConfigParser()
+    try:
+        parser.read_string(config_content)
+    except configparser.Error as parser_error:
+        # The config may be base64-encoded, try decoding it
+        try:
+            decoded_config_content = base64.b64decode(config_content).decode()
+        except base64.binascii.Error as b64_error:  # type: ignore
+            # It wasn't base64, so use the original error
+            raise errors.SnapcraftError(
+                f"Cannot parse config: {parser_error}"
+            ) from b64_error
+
+        try:
+            parser.read_string(decoded_config_content)
+        except configparser.Error as new_parser_error:
+            raise errors.SnapcraftError(
+                f"Cannot parse config: {parser_error}"
+            ) from new_parser_error
+
+    return parser
+
+
+def _deserialize_macaroon(value) -> pymacaroons.Macaroon:
+    try:
+        return pymacaroons.Macaroon.deserialize(value)
+    except:  # noqa LP: #1733004
+        raise errors.SnapcraftError(  # pylint: disable=raise-missing-from
+            "Failed to deserialize macaroon"
+        )
+
+
+def _macaroon_auth(conf) -> str:
+    """Format a macaroon and its associated discharge.
+
+    :return: A string suitable to use in an Authorization header.
+    """
+    host = parse_url(constants.UBUNTU_ONE_SSO_URL).host
+    root_macaroon_raw = conf.get(host, "macaroon")
+    if root_macaroon_raw is None:
+        raise errors.SnapcraftError("Root macaroon not in the config file")
+    unbound_raw = conf.get(host, "unbound_discharge")
+    if unbound_raw is None:
+        raise errors.SnapcraftError("Unbound discharge not in the config file")
+
+    root_macaroon = _deserialize_macaroon(root_macaroon_raw)
+    unbound = _deserialize_macaroon(unbound_raw)
+    bound = root_macaroon.prepare_for_request(unbound)
+    discharge_macaroon_raw = bound.serialize()
+    auth = f"Macaroon root={root_macaroon_raw}, discharge={discharge_macaroon_raw}"
+
+    return base64.b64encode(auth.encode()).decode()
+
+
+def get_auth(config_content: str) -> str:
+    """Return a legacy authorization header."""
+    conf = _load_potentially_base64_config(config_content)
+    auth = _macaroon_auth(conf)
+
+    return auth
+
+
+class LegacyUbuntuOne(craft_store.UbuntuOneStoreClient):
+    """Legacy client to easily transition existing CI users."""
+
+    _CONFIG_PATH = Path(xdg.BaseDirectory.xdg_config_home) / "snapcraft/legacy_auth.cfg"
+
+    @classmethod
+    def has_legacy_credentials(cls) -> bool:
+        """Return True if legacy credentials are stored."""
+        return cls._CONFIG_PATH.exists()
+
+    @classmethod
+    def store_credentials(cls, config_content) -> None:
+        """Store legacy credentials."""
+        auth = get_auth(config_content=config_content)
+        cls._CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        cls._CONFIG_PATH.write_text(auth)
+
+    @overrides
+    def _get_authorization_header(self) -> str:
+        return self._auth.get_credentials()
+
+    @overrides
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        storage_base_url: str,
+        auth_url: str,
+        endpoints: craft_store.endpoints.Endpoints,  # pylint: disable=W0621
+        application_name: str,
+        user_agent: str,
+        environment_auth: Optional[str] = None,
+        ephemeral: bool = False,
+    ) -> None:
+        if self.has_legacy_credentials():
+            auth = self._CONFIG_PATH.read_text()
+            os.environ[constants.ENVIRONMENT_STORE_CREDENTIALS] = auth
+
+        super().__init__(
+            base_url=base_url,
+            storage_base_url=storage_base_url,
+            auth_url=auth_url,
+            application_name=application_name,
+            user_agent=user_agent,
+            endpoints=endpoints,
+            environment_auth=constants.ENVIRONMENT_STORE_CREDENTIALS,
+            ephemeral=True,
+        )
+
+    @overrides
+    def login(
+        self,
+        *,
+        permissions: Sequence[str],
+        description: str,
+        ttl: int,
+        packages: Optional[Sequence[craft_store.endpoints.Package]] = None,
+        channels: Optional[Sequence[str]] = None,
+        **kwargs,
+    ) -> str:
+        raise NotImplementedError("Cannot login with legacy")
+
+    @overrides
+    def logout(self) -> None:
+        """Logout by removing legacy credentials."""
+        self._CONFIG_PATH.unlink(missing_ok=True)

--- a/snapcraft/commands/store/client.py
+++ b/snapcraft/commands/store/client.py
@@ -29,6 +29,7 @@ from craft_cli import emit
 from snapcraft import __version__, errors, utils
 
 from . import channel_map, constants
+from ._legacy_account import LegacyUbuntuOne
 
 _TESTING_ENV_PREFIXES = ["TRAVIS", "AUTOPKGTEST_TMP"]
 
@@ -106,8 +107,20 @@ def get_client(ephemeral: bool) -> craft_store.BaseClient:
     store_upload_url = get_store_upload_url()
     user_agent = build_user_agent()
 
-    if use_candid() is True:
-        client: craft_store.BaseClient = craft_store.StoreClient(
+    if LegacyUbuntuOne.has_legacy_credentials():
+        emit.message("This login method is not longer supported", intermediate=True)
+        client: craft_store.BaseClient = LegacyUbuntuOne(
+            base_url=store_url,
+            storage_base_url=store_upload_url,
+            auth_url=get_store_login_url(),
+            application_name="snapcraft",
+            user_agent=user_agent,
+            endpoints=craft_store.endpoints.U1_SNAP_STORE,
+            environment_auth=constants.ENVIRONMENT_STORE_CREDENTIALS,
+            ephemeral=ephemeral,
+        )
+    elif use_candid() is True:
+        client = craft_store.StoreClient(
             base_url=store_url,
             storage_base_url=store_upload_url,
             application_name="snapcraft",

--- a/tests/unit/commands/conftest.py
+++ b/tests/unit/commands/conftest.py
@@ -32,3 +32,14 @@ def fake_confirmation_prompt(mocker):
     return mocker.patch(
         "snapcraft.utils.confirm_with_user", return_value=False, autospec=True
     )
+
+
+@pytest.fixture
+def legacy_config_path(monkeypatch, new_dir):
+    config_file = new_dir / "ci.cfg"
+    monkeypatch.setattr(
+        "snapcraft.commands.store._legacy_account.LegacyUbuntuOne._CONFIG_PATH",
+        config_file,
+    )
+
+    return config_file

--- a/tests/unit/commands/store/test_client.py
+++ b/tests/unit/commands/store/test_client.py
@@ -25,7 +25,7 @@ import requests
 from craft_store import endpoints
 
 from snapcraft import errors
-from snapcraft.commands.store import client
+from snapcraft.commands.store import LegacyUbuntuOne, client
 from snapcraft.commands.store.channel_map import ChannelMap
 from snapcraft.utils import OSPlatform
 
@@ -223,6 +223,7 @@ def test_get_hostname():
 #######################
 
 
+@pytest.mark.usefixtures("legacy_config_path")
 @pytest.mark.parametrize("ephemeral", (True, False))
 def test_get_store_client(monkeypatch, ephemeral):
     monkeypatch.setenv("SNAPCRAFT_STORE_AUTH", "candid")
@@ -232,11 +233,21 @@ def test_get_store_client(monkeypatch, ephemeral):
     assert isinstance(store_client, craft_store.StoreClient)
 
 
+@pytest.mark.usefixtures("legacy_config_path")
 @pytest.mark.parametrize("ephemeral", (True, False))
 def test_get_ubuntu_client(ephemeral):
     store_client = client.get_client(ephemeral)
 
     assert isinstance(store_client, craft_store.UbuntuOneStoreClient)
+
+
+@pytest.mark.parametrize("ephemeral", (True, False))
+def test_get_legacy_ubuntu_client(new_dir, legacy_config_path, ephemeral):
+    legacy_config_path.touch()
+
+    store_client = client.get_client(ephemeral)
+
+    assert isinstance(store_client, LegacyUbuntuOne)
 
 
 ##################

--- a/tests/unit/commands/store/test_legacy_account.py
+++ b/tests/unit/commands/store/test_legacy_account.py
@@ -1,0 +1,165 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import base64
+from textwrap import dedent
+
+import craft_store.endpoints
+import pymacaroons
+import pytest
+
+from snapcraft import errors
+from snapcraft.commands.store._legacy_account import LegacyUbuntuOne, get_auth
+
+############
+# Fixtures #
+############
+
+
+@pytest.fixture
+def fake_auth(monkeypatch):
+    monkeypatch.setattr(
+        "snapcraft.commands.store._legacy_account.get_auth",
+        lambda config_content: base64.b64encode(b"Macaroon root=secret").decode(),
+    )
+
+
+#############
+# Macaroons #
+#############
+
+
+def test_invalid_macaroon_root_raises_exception(new_dir):
+    config_content = dedent(
+        """\
+        [login.ubuntu.com]
+        macaroon=inval'id
+        unbound_discharge=ssssssssssssssssssssssss
+        """
+    )
+
+    with pytest.raises(errors.SnapcraftError):
+        get_auth(config_content)
+
+
+def test_invalid_discharge_raises_exception():
+    config_content = dedent(
+        f"""\
+        [login.ubuntu.com]
+        macaroon={pymacaroons.Macaroon().serialize()}
+        unbound_discharge=inval'id
+        """
+    )
+
+    with pytest.raises(errors.SnapcraftError):
+        get_auth(config_content)
+
+
+########################
+# LegacyStoreClientCLI #
+########################
+
+
+def test_store_credentials(legacy_config_path, fake_auth):
+    LegacyUbuntuOne.store_credentials("secret")
+
+    assert legacy_config_path.read_text() == "TWFjYXJvb24gcm9vdD1zZWNyZXQ="
+
+
+@pytest.mark.usefixtures("fake_auth")
+def test_logout(legacy_config_path):
+    LegacyUbuntuOne.store_credentials("secret")
+    assert LegacyUbuntuOne.has_legacy_credentials() is True
+
+    client = LegacyUbuntuOne(
+        base_url="",
+        storage_base_url="",
+        auth_url="",
+        endpoints=craft_store.endpoints.U1_SNAP_STORE,
+        application_name="snapcraft",
+        user_agent="",
+    )
+    client.logout()
+
+    assert legacy_config_path.exists() is False
+
+
+def test_logout_file_missing(legacy_config_path):
+    u1_client = LegacyUbuntuOne(
+        base_url="",
+        storage_base_url="",
+        auth_url="",
+        endpoints=craft_store.endpoints.U1_SNAP_STORE,
+        application_name="snapcraft",
+        user_agent="",
+    )
+    u1_client.logout()
+
+    assert legacy_config_path.exists() is False
+
+
+def test_login(legacy_config_path, fake_auth):
+    client = LegacyUbuntuOne(
+        base_url="",
+        storage_base_url="",
+        auth_url="",
+        endpoints=craft_store.endpoints.U1_SNAP_STORE,
+        application_name="snapcraft",
+        user_agent="",
+    )
+    with pytest.raises(NotImplementedError):
+        client.login(
+            ttl=31536000,
+            permissions=[
+                "package_access",
+                "package_manage",
+                "package_metrics",
+                "package_push",
+                "package_register",
+                "package_release",
+                "package_update",
+            ],
+            channels=None,
+            packages=[],
+            description="snapcraft@fake-host",
+            email="fake-username@acme.com",
+            password="fake-password",
+        )
+
+
+def test_request(mocker, legacy_config_path, fake_auth):
+    request_mock = mocker.patch(
+        "craft_store.base_client.HTTPClient.request",
+        autospec=True,
+    )
+    LegacyUbuntuOne.store_credentials("secret")
+    assert LegacyUbuntuOne.has_legacy_credentials() is True
+
+    client = LegacyUbuntuOne(
+        base_url="",
+        storage_base_url="",
+        auth_url="",
+        endpoints=craft_store.endpoints.U1_SNAP_STORE,
+        application_name="snapcraft",
+        user_agent="",
+    )
+    client.request("GET", "https://foo.com")
+    request_mock.assert_called_once_with(
+        client.http_client,
+        "GET",
+        "https://foo.com",
+        headers={"Authorization": "Macaroon root=secret"},
+        params=None,
+    )


### PR DESCRIPTION
This is the simplest implementation for backwards compatibility.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1103

The new code here is LegacyUbuntuOne, the get_auth code path is brought back from legacy snapcraft (6.1) with the tests it had.

