### PR TITLE
store: export-login with legacy

### DIFF
--- a/snapcraft/commands/store/client.py
+++ b/snapcraft/commands/store/client.py
@@ -107,7 +107,7 @@ def get_client(ephemeral: bool) -> craft_store.BaseClient:
     store_upload_url = get_store_upload_url()
     user_agent = build_user_agent()
 
-    if LegacyUbuntuOne.has_legacy_credentials():
+    if not ephemeral and LegacyUbuntuOne.has_legacy_credentials():
         emit.message("This login method is not longer supported", intermediate=True)
         client: craft_store.BaseClient = LegacyUbuntuOne(
             base_url=store_url,

--- a/tests/unit/commands/store/test_client.py
+++ b/tests/unit/commands/store/test_client.py
@@ -248,7 +248,10 @@ def test_get_legacy_ubuntu_client(new_dir, legacy_config_path, ephemeral):
 
     store_client = client.get_client(ephemeral)
 
-    assert isinstance(store_client, LegacyUbuntuOne)
+    if ephemeral:
+        assert isinstance(store_client, craft_store.UbuntuOneStoreClient)
+    else:
+        assert isinstance(store_client, LegacyUbuntuOne)
 
 
 ##################


### PR DESCRIPTION
Existence of legacy credentials should not have preference
when performing a login export.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1146