### PR TITLE
parts: install dirmngr earlier

### DIFF
--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, List, Optional
 
 import craft_parts
 from craft_cli import emit
-from craft_parts import ActionType, Part, ProjectDirs, Step
+from craft_parts import ActionType, Part, ProjectDirs, Step, packages
 from xdg import BaseDirectory  # type: ignore
 
 from snapcraft import errors, repo
@@ -77,11 +77,10 @@ class PartsLifecycle:
         # set the cache dir for parts package management
         cache_dir = BaseDirectory.save_cache_path("snapcraft")
 
-        extra_build_packages = []
         if self._package_repositories:
             # Install pre-requisite packages for apt-key, if not installed.
             # FIXME: package names should be platform-specific
-            extra_build_packages.extend(["gnupg", "dirmngr"])
+            packages.Repository.install_packages(["gnupg", "dirmngr"])
 
         try:
             self._lcm = craft_parts.LifecycleManager(
@@ -91,7 +90,7 @@ class PartsLifecycle:
                 cache_dir=cache_dir,
                 base=base,
                 ignore_local_sources=["*.snap"],
-                extra_build_packages=extra_build_packages,
+                extra_build_packages=[],
                 extra_build_snaps=extra_build_snaps,
                 parallel_build_count=parallel_build_count,
                 project_name=project_name,

--- a/tests/unit/parts/test_parts.py
+++ b/tests/unit/parts/test_parts.py
@@ -172,7 +172,9 @@ def test_parts_lifecycle_initialize_with_package_repositories(
     parts_data,
     new_dir,
 ):
+    install_packages_mock = mocker.patch("craft_parts.packages.Repository.install_packages")
     lcm_spy = mocker.spy(craft_parts, "LifecycleManager")
+
     PartsLifecycle(
         parts_data,
         work_dir=new_dir,
@@ -192,6 +194,11 @@ def test_parts_lifecycle_initialize_with_package_repositories(
         project_vars={"version": "1", "grade": "stable"},
         extra_build_snaps=["core22"],
     )
+
+    assert install_packages_mock.mock_calls == [
+        call(["gnupg", "dirmngr"])
+    ]
+
     assert lcm_spy.mock_calls == [
         call(
             {"parts": {"p1": {"plugin": "nil"}}},
@@ -200,7 +207,7 @@ def test_parts_lifecycle_initialize_with_package_repositories(
             cache_dir=ANY,
             base="core22",
             ignore_local_sources=["*.snap"],
-            extra_build_packages=["gnupg", "dirmngr"],
+            extra_build_packages=[],
             extra_build_snaps=["core22"],
             parallel_build_count=8,
             project_name="test-project",


### PR DESCRIPTION
If package repositories are specified, install prerequisite packages
directly instead of extra build packages (it's too late).
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
