### PR TITLE
spread: add build packages to package repository tests

### DIFF
--- a/tests/spread/core22/package-repositories/task.yaml
+++ b/tests/spread/core22/package-repositories/task.yaml
@@ -11,13 +11,27 @@ restore: |
   cd "$SNAP"
   rm -f ./*.snap
   snapcraft clean
-  snapcraft --destructive-mode
+  snapcraft clean --destructive-mode
+  ls -l /etc/apt/sources.list.d/
+  rm /etc/apt/sources.list.d/snapcraft-*
+  snap remove "${SNAP}"
 
 execute: |
   cd "$SNAP"
 
   # Build what we have.
   snapcraft --verbose --use-lxd
+
+  # And verify the snap runs as expected.
+  snap install "${SNAP}"_1.0_*.snap --dangerous
+  snap_executable="${SNAP}.test-ppa"
+  [ "$("${snap_executable}")" = "hello!" ]
+
+  snap remove "${SNAP}"
+  rm -f ./*.snap
+
+  # Also build in destructive mode.
+  snapcraft --verbose --destructive-mode
 
   # And verify the snap runs as expected.
   snap install "${SNAP}"_1.0_*.snap --dangerous

--- a/tests/spread/core22/package-repositories/test-apt-key-fingerprint/snap/snapcraft.yaml
+++ b/tests/spread/core22/package-repositories/test-apt-key-fingerprint/snap/snapcraft.yaml
@@ -9,6 +9,8 @@ base: core22
 parts:
   test-ppa:
     plugin: nil
+    build-packages:
+      - test-ppa
     stage-packages:
       - test-ppa
 

--- a/tests/spread/core22/package-repositories/test-apt-key-name/snap/snapcraft.yaml
+++ b/tests/spread/core22/package-repositories/test-apt-key-name/snap/snapcraft.yaml
@@ -9,6 +9,8 @@ base: core22
 parts:
   test-ppa:
     plugin: nil
+    build-packages:
+      - test-ppa
     stage-packages:
       - test-ppa
 

--- a/tests/spread/core22/package-repositories/test-apt-keyserver/snap/snapcraft.yaml
+++ b/tests/spread/core22/package-repositories/test-apt-keyserver/snap/snapcraft.yaml
@@ -9,6 +9,8 @@ base: core22
 parts:
   test-ppa:
     plugin: nil
+    build-packages:
+      - test-ppa
     stage-packages:
       - test-ppa
 

--- a/tests/spread/core22/package-repositories/test-apt-ppa/snap/snapcraft.yaml
+++ b/tests/spread/core22/package-repositories/test-apt-ppa/snap/snapcraft.yaml
@@ -9,6 +9,8 @@ base: core22
 parts:
   test-ppa:
     plugin: nil
+    build-packages:
+      - test-ppa
     stage-packages:
       - test-ppa
 


### PR DESCRIPTION
Ensure build packages are also installable using package repositories
specified in snapcraft.yaml, in both destructive mode and using a
build instance.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
