### PR TITLE
store: correct login for register-key

### DIFF
--- a/snapcraft_legacy/_store.py
+++ b/snapcraft_legacy/_store.py
@@ -508,6 +508,23 @@ def _maybe_prompt_for_key(name):
     return _select_key(keys)
 
 
+def save_key(func):
+    def wrapped_env(*args, **kwargs):
+        credentials = os.getenv(storeapi.constants.ENVIRONMENT_STORE_CREDENTIALS)
+        if credentials:
+            del os.environ[storeapi.constants.ENVIRONMENT_STORE_CREDENTIALS]
+        try:
+            return func(*args, **kwargs)
+        finally:
+            if credentials:
+                os.environ[
+                    storeapi.constants.ENVIRONMENT_STORE_CREDENTIALS
+                ] = credentials
+
+    return wrapped_env
+
+
+@save_key
 def register_key(name) -> None:
     key = _maybe_prompt_for_key(name)
 

--- a/snapcraft_legacy/cli/legacy.py
+++ b/snapcraft_legacy/cli/legacy.py
@@ -18,11 +18,16 @@
 
 import sys
 
+from ._errors import exception_handler
 from ._runner import run  # noqa: F401
 
 
 def legacy_run():
-    run()
+    try:
+        run()
+    # Workaround to catch errors.
+    except Exception as err:
+        exception_handler(type(err), err, err.__traceback__)
 
     # ensure this call never returns
     sys.exit()


### PR DESCRIPTION
Additional measures for proper exit handling on errors

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
