### PR TITLE
extensions: prepend and append functions for ENV

### DIFF
--- a/snapcraft/extensions/extension.py
+++ b/snapcraft/extensions/extension.py
@@ -20,7 +20,7 @@ import abc
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, final
+from typing import Any, Dict, Optional, Sequence, Tuple, final
 
 from craft_cli import emit
 
@@ -129,3 +129,33 @@ class Extension(abc.ABC):
 def get_extensions_data_dir() -> Path:
     """Return the path to the extension data directory."""
     return Path(sys.prefix) / "share" / "snapcraft" / "extensions"
+
+
+def append_to_env(env_variable: str, paths: Sequence[str], separator: str = ":") -> str:
+    """Return a string for env_variable with one of more paths appended.
+
+    :param env_variable: the variable to operate on.
+    :param paths: one or more paths to append.
+    :param separator: the separator to use.
+    :returns: a shell string where one or more paths are appended
+                  to env_variable. The code takes into account the case
+                  where the environment variable is empty, to avoid putting
+                  a separator token at the start.
+    """
+    return f"${{{env_variable}:+${env_variable}{separator}}}" + separator.join(paths)
+
+
+def prepend_to_env(
+    env_variable: str, paths: Sequence[str], separator: str = ":"
+) -> str:
+    """Return a string for env_variable with one of more paths prepended.
+
+    :param env_variable: the variable to operate on.
+    :param paths: one or more paths to append.
+    :param separator: the separator to use.
+    :returns: a shell string where one or more paths are prepended
+                  before env_variable. The code takes into account the case
+                  where the environment variable is empty, to avoid putting
+                  a separator token at the end.
+    """
+    return separator.join(paths) + f"${{{env_variable}:+{separator}${env_variable}}}"

--- a/tests/unit/extensions/test_extensions.py
+++ b/tests/unit/extensions/test_extensions.py
@@ -18,7 +18,11 @@
 import pytest
 
 from snapcraft import errors, extensions
-from snapcraft.extensions.extension import get_extensions_data_dir
+from snapcraft.extensions.extension import (
+    append_to_env,
+    get_extensions_data_dir,
+    prepend_to_env,
+)
 
 
 @pytest.mark.usefixtures("fake_extension")
@@ -230,3 +234,31 @@ def test_get_extensions_data_dir():
     assert (get_extensions_data_dir() / "desktop").is_dir()
     assert (get_extensions_data_dir() / "ros1").is_dir()
     assert (get_extensions_data_dir() / "ros2").is_dir()
+
+
+def test_prepend_path():
+    assert (
+        prepend_to_env("TEST_ENV", ["/usr/bin", "/usr/local/bin"])
+        == "/usr/bin:/usr/local/bin${TEST_ENV:+:$TEST_ENV}"
+    )
+
+
+def test_append_path():
+    assert (
+        append_to_env("TEST_ENV", ["/usr/bin", "/usr/local/bin"])
+        == "${TEST_ENV:+$TEST_ENV:}/usr/bin:/usr/local/bin"
+    )
+
+
+def test_prepend_path_with_separator():
+    assert (
+        prepend_to_env("TEST_ENV", ["/usr/bin", "/usr/local/bin"], separator=";")
+        == "/usr/bin;/usr/local/bin${TEST_ENV:+;$TEST_ENV}"
+    )
+
+
+def test_append_path_with_separator():
+    assert (
+        append_to_env("TEST_ENV", ["/usr/bin", "/usr/local/bin"], separator=";")
+        == "${TEST_ENV:+$TEST_ENV;}/usr/bin;/usr/local/bin"
+    )


### PR DESCRIPTION
Simplify the management of environment variables, allowing to just pass
the name of one variable and one or more paths, and they will return a
piece of shell code that prepends or appends the paths to the variable,
taking into account the case when the variable is empty, to avoid adding
a trailing or leading colon.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1113
From #3798