### PR TITLE
lint: bump pylint

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -64,7 +64,7 @@ pydocstyle==6.1.1
 pyelftools==0.28
 pyflakes==2.4.0
 pyftpdlib==1.5.6
-pylint==2.14.1
+pylint==2.14.3
 pylint-fixme-info==1.0.3
 pylint-pytest==1.1.2
 pylxd==2.3.1

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -28,8 +28,6 @@ from snapcraft.parts import lifecycle as parts_lifecycle
 from snapcraft.parts.update_metadata import update_project_metadata
 from snapcraft.projects import MANDATORY_ADOPTABLE_FIELDS, Project
 
-# pylint: disable=too-many-lines
-
 _SNAPCRAFT_YAML_FILENAMES = [
     "snap/snapcraft.yaml",
     "build-aux/snap/snapcraft.yaml",

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -28,8 +28,6 @@ from snapcraft.projects import (
     Project,
 )
 
-# pylint: disable=too-many-lines
-
 
 @pytest.fixture
 def project_yaml_data():


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
Bump pylint to latest version, remove redundant `disable: too-many-lines`.

Part 2 of supporting architectures for `core22`. Full code change is proposed [here](https://github.com/snapcore/snapcraft/pull/3712).

This is no longer strictly required for architectures support since Claudio bumped the major version (2.13->2.14) last week.  I'm still pushing it, as it's a simple update.

(CRAFT-1164)