### PR TITLE
utils: move process_version to utils.py

### DIFF
--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -20,12 +20,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Union, cast
 
 import yaml
-from craft_cli import emit
-from craft_parts.sources.git_source import GitSource
 from pydantic_yaml import YamlModel
 
 from snapcraft.projects import Project
-from snapcraft.utils import get_ld_library_paths
+from snapcraft.utils import get_ld_library_paths, process_version
 
 
 class Socket(YamlModel):
@@ -124,7 +122,13 @@ class SnapMetadata(YamlModel):
 
 
 def write(project: Project, prime_dir: Path, *, arch: str, arch_triplet: str):
-    """Create a snap.yaml file."""
+    """Create a snap.yaml file.
+
+    :param project: Snapcraft project.
+    :param prime_dir: The directory containing the content to be snapped.
+    :param arch: Target architecture the snap project is built to.
+    :param arch_triplet: Architecture triplet of the platform.
+    """
     meta_dir = prime_dir / "meta"
     meta_dir.mkdir(parents=True, exist_ok=True)
 
@@ -177,7 +181,7 @@ def write(project: Project, prime_dir: Path, *, arch: str, arch_triplet: str):
         assumes.add("command-chain")
 
     environment = _populate_environment(project.environment, prime_dir, arch_triplet)
-    version = _process_version(project.version)
+    version = process_version(project.version)
 
     snap_metadata = SnapMetadata(
         name=project.name,
@@ -255,19 +259,3 @@ def _populate_environment(
 
     # if the environment only contained a null LD_LIBRARY_PATH and a null PATH, return None
     return None
-
-
-def _process_version(version: Optional[str]) -> str:
-    """Handle special version strings."""
-    if version is None:
-        raise ValueError("version cannot be None")
-
-    new_version = version
-    if version == "git":
-        emit.progress("Determining the version from the project repo (version: git).")
-        new_version = GitSource.generate_version()
-
-    if new_version != version:
-        emit.message(f"Version has been set to {new_version!r}", intermediate=True)
-
-    return new_version

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Iterable, List, Optional
 
 from craft_cli import emit
+from craft_parts.sources.git_source import GitSource
 
 from snapcraft import errors
 
@@ -300,3 +301,19 @@ def get_ld_library_paths(prime_dir: Path, arch_triplet: str) -> str:
     ld_library_path = ":".join(paths)
 
     return re.sub(str(prime_dir), "$SNAP", ld_library_path)
+
+
+def process_version(version: Optional[str]) -> str:
+    """Handle special version strings."""
+    if version is None:
+        raise ValueError("version cannot be None")
+
+    new_version = version
+    if version == "git":
+        emit.progress("Determining the version from the project repo (version: git).")
+        new_version = GitSource.generate_version()
+
+    if new_version != version:
+        emit.message(f"Version has been set to {new_version!r}", intermediate=True)
+
+    return new_version

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -301,3 +301,29 @@ def test_get_ld_library_paths(tmp_path, lib_dirs, expected_env):
         f"${{SNAP_LIBRARY_PATH}}${{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}}:{expected_env}"
     )
     assert utils.get_ld_library_paths(tmp_path, "i286-none-none") == expected_env
+
+
+###################
+# Process Version #
+###################
+
+
+def test_process_version_empty(mocker):
+    """``version:None`` raises an error."""
+    with pytest.raises(ValueError):
+        utils.process_version(None)
+
+
+def test_process_version_dirty(mocker):
+    """A version string should be returned unmodified."""
+    assert utils.process_version("1.2.3") == "1.2.3"
+
+
+def test_process_version_git(mocker):
+    """``version:git`` must be correctly handled."""
+    mocker.patch(
+        "craft_parts.sources.git_source.GitSource.generate_version",
+        return_value="1.2.3-dirty",
+    )
+
+    assert utils.process_version("git") == "1.2.3-dirty"


### PR DESCRIPTION
Signed-off-by: Callahan Kovacs <callahan.kovacs@canonical.com>

- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
Move `process_version()` to `utils.py`, because other files will need to use this function in an upcoming PR.

Part 4 of supporting architectures for `core22`. Full code change is proposed [here](https://github.com/snapcore/snapcraft/pull/3712).

(CRAFT-1166)