### PR TITLE
spread: set colcon for 18.04 to manual

### DIFF
--- a/tests/spread/plugins/v1/colcon/run/task.yaml
+++ b/tests/spread/plugins/v1/colcon/run/task.yaml
@@ -1,6 +1,7 @@
 summary: Build and run a basic colcon snap
 warn-timeout: 9m  # Keep less than 10 minutes so Travis can't timeout
 priority: 100  # Run this test early so we're not waiting for it
+manual: true
 
 environment:
   SNAP_DIR: ../snaps/colcon-talker-listener


### PR DESCRIPTION
Temporarily disable until test or code is fixed.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
