### PR TITLE
fix(colcon-core18-test): use underscore instead of dash

### DIFF
--- a/tests/spread/plugins/v1/colcon/run/task.yaml
+++ b/tests/spread/plugins/v1/colcon/run/task.yaml
@@ -1,7 +1,6 @@
 summary: Build and run a basic colcon snap
 warn-timeout: 9m  # Keep less than 10 minutes so Travis can't timeout
 priority: 100  # Run this test early so we're not waiting for it
-manual: true
 
 environment:
   SNAP_DIR: ../snaps/colcon-talker-listener

--- a/tests/spread/plugins/v1/colcon/snaps/colcon-talker-listener/src/listener_py/setup.cfg
+++ b/tests/spread/plugins/v1/colcon/snaps/colcon-talker-listener/src/listener_py/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/listener_py
+script_dir=$base/lib/listener_py
 [install]
-install-scripts=$base/lib/listener_py
+install_scripts=$base/lib/listener_py


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

Due to a recent update on colcon-core: https://github.com/colcon/colcon-core/issues/518
