### PR TITLE
pack: specify snap filename

### DIFF
--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -81,7 +81,7 @@ def _get_filename(
         if not output_path.is_dir():
             return output_path.name
 
-    if name is not None and version is not None and target_arch is not None:
+    if all(i is not None for i in [name, version, target_arch]):
         return f"{name}_{version}_{target_arch}.snap"
 
     return None

--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -41,48 +41,92 @@ def _verify_snap(directory: Path) -> None:
         raise errors.SnapcraftError(msg)
 
 
+def _get_directory(output: Optional[str]) -> Path:
+    """Get directory to output the snap file to.
+
+    If no directory is provided, return current working directory.
+
+    :param output: Snap output file name or directory.
+
+    :return: The directory to output the snap file to.
+    """
+    if output:
+        output_path = Path(output)
+        if output_path.is_dir():
+            return output_path.resolve()
+        return output_path.parent.resolve()
+
+    return Path.cwd()
+
+
+def _get_filename(
+    output: Optional[str],
+    name: Optional[str] = None,
+    version: Optional[str] = None,
+    target_arch: Optional[str] = None,
+) -> Optional[str]:
+    """Get output filename of the snap file.
+
+    If `output` is not a file, then the filename will be <name>_<version>_<target_arch>.snap
+
+    :param output: Snap file name or directory.
+    :param name: Name of snap project.
+    :param version: Version of snap project.
+    :param target_arch: Target architecture the snap project is built to.
+
+    :return: The filename of the snap file if output or name/version/target_arch are specified.
+    """
+    if output:
+        output_path = Path(output)
+        if not output_path.is_dir():
+            return output_path.name
+
+    if name is not None and version is not None and target_arch is not None:
+        return f"{name}_{version}_{target_arch}.snap"
+
+    return None
+
+
 def pack_snap(
-    directory: Path, *, output: Optional[str], compression: Optional[str] = None
+    directory: Path,
+    *,
+    output: Optional[str],
+    compression: Optional[str] = None,
+    name: Optional[str] = None,
+    version: Optional[str] = None,
+    target_arch: Optional[str] = None,
 ) -> None:
-    """Pack snap contents.
+    """Pack snap contents with `snap pack`.
+
+    `output` may either be a directory, a file path, or just a file name.
+      - directory: write snap to directory with default snap name
+      - file path: write snap to specified directory with specified snap name
+      - file name: write snap to cwd with specified snap name
+
+    If name, version, and target architecture are not specified, then snap
+    will use its default naming convention.
 
     :param directory: Directory to pack.
     :param output: Snap file name or directory.
     :param compression: Compression type to use, None for defaults.
+    :param name: Name of snap project.
+    :param version: Version of snap project.
+    :param target_arch: Target architecture the snap project is built to.
     """
     emit.trace(f"pack_snap: output={output!r}, compression={compression!r}")
 
     # TODO remove workaround once LP: #1950465 is fixed
     _verify_snap(directory)
 
-    output_file = None
-    output_dir = None
-
-    if output:
-        output_path = Path(output)
-        output_parent = output_path.parent
-        if output_path.is_dir():
-            # do not define a snap name if the output is a directory
-            output_dir = str(output_path)
-        elif output_parent and output_parent.resolve() != Path(".").resolve():
-            output_dir = str(output_parent)
-            output_file = output_path.name
-        else:
-            # do not define a directory if the output parent directory is the cwd
-            output_file = output_path.name
-
+    # create command formatted as `snap pack <options> <snap-dir> <output-dir>`
     command: List[Union[str, Path]] = ["snap", "pack"]
+    output_file = _get_filename(output, name, version, target_arch)
     if output_file is not None:
         command.extend(["--filename", output_file])
-
-    # When None, just use snap pack's default settings.
     if compression is not None:
         command.extend(["--compression", compression])
-
     command.append(directory)
-
-    if output_dir is not None:
-        command.append(output_dir)
+    command.append(_get_directory(output))
 
     emit.progress("Creating snap package...")
     emit.trace(f"Pack command: {command}")

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -30,7 +30,7 @@ from snapcraft import errors, extensions, pack, providers, utils
 from snapcraft.meta import snap_yaml
 from snapcraft.projects import GrammarAwareProject, Project
 from snapcraft.providers import capture_logs_from_instance
-from snapcraft.utils import get_host_architecture
+from snapcraft.utils import get_host_architecture, process_version
 
 from . import grammar, plugins, yaml_utils
 from .parts import PartsLifecycle
@@ -282,6 +282,9 @@ def _run_command(
             lifecycle.prime_dir,
             output=parsed_args.output,
             compression=project.compression,
+            name=project.name,
+            version=process_version(project.version),
+            target_arch=lifecycle.target_arch,
         )
 
 

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -229,7 +229,14 @@ def test_lifecycle_run_command_pack(cmd, snapcraft_yaml, project_vars, new_dir, 
         call("prime", debug=False, shell=False, shell_after=False)
     ]
     assert pack_mock.mock_calls == [
-        call(new_dir / "prime", output=None, compression="xz")
+        call(
+            new_dir / "prime",
+            output=None,
+            compression="xz",
+            name="mytest",
+            version="0.1",
+            target_arch=get_host_architecture(),
+        )
     ]
 
 
@@ -271,7 +278,14 @@ def test_lifecycle_pack_destructive_mode(
         call("prime", debug=False, shell=False, shell_after=False)
     ]
     assert pack_mock.mock_calls == [
-        call(new_dir / "home/prime", output=None, compression="xz")
+        call(
+            new_dir / "home/prime",
+            output=None,
+            compression="xz",
+            name="mytest",
+            version="0.1",
+            target_arch=get_host_architecture(),
+        )
     ]
 
 
@@ -311,7 +325,14 @@ def test_lifecycle_pack_managed(cmd, snapcraft_yaml, project_vars, new_dir, mock
         call("prime", debug=False, shell=False, shell_after=False)
     ]
     assert pack_mock.mock_calls == [
-        call(new_dir / "home/prime", output=None, compression="xz")
+        call(
+            new_dir / "home/prime",
+            output=None,
+            compression="xz",
+            name="mytest",
+            version="0.1",
+            target_arch=get_host_architecture(),
+        )
     ]
 
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
Allow snapcraft to specify the output snap name from the project's name, version, and target architecture.  

This will be used when building snaps where the target architecture is different than the host architecture.

Part 5 of supporting architectures for `core22`. Full code change is proposed [here](https://github.com/snapcore/snapcraft/pull/3712).

(CRAFT-1171)