### PR TITLE
providers: specify build-on and build-for in instance name

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -30,6 +30,7 @@ from snapcraft import errors, extensions, pack, providers, utils
 from snapcraft.meta import snap_yaml
 from snapcraft.projects import GrammarAwareProject, Project
 from snapcraft.providers import capture_logs_from_instance
+from snapcraft.utils import get_host_architecture
 
 from . import grammar, plugins, yaml_utils
 from .parts import PartsLifecycle
@@ -293,7 +294,10 @@ def _clean_provider(project: Project, parsed_args: "argparse.Namespace") -> None
     provider_name = "lxd" if parsed_args.use_lxd else None
     provider = providers.get_provider(provider_name)
     instance_names = provider.clean_project_environments(
-        project_name=project.name, project_path=Path().absolute()
+        project_name=project.name,
+        project_path=Path().absolute(),
+        build_on=get_host_architecture(),
+        build_for=get_host_architecture(),
     )
     if instance_names:
         emit.message(f"Removed instance: {', '.join(instance_names)}")
@@ -340,6 +344,8 @@ def _run_in_provider(
         project_path=Path().absolute(),
         base=project.get_effective_base(),
         bind_ssh=parsed_args.bind_ssh,
+        build_on=get_host_architecture(),
+        build_for=get_host_architecture(),
     ) as instance:
         try:
             with emit.pause():

--- a/snapcraft/providers/_lxd.py
+++ b/snapcraft/providers/_lxd.py
@@ -52,7 +52,12 @@ class LXDProvider(Provider):
         self.lxd_remote = lxd_remote
 
     def clean_project_environments(
-        self, *, project_name: str, project_path: pathlib.Path
+        self,
+        *,
+        project_name: str,
+        project_path: pathlib.Path,
+        build_on: str,
+        build_for: str,
     ) -> List[str]:
         """Clean up any build environments created for project.
 
@@ -69,6 +74,8 @@ class LXDProvider(Provider):
         instance_name = self.get_instance_name(
             project_name=project_name,
             project_path=project_path,
+            build_on=build_on,
+            build_for=build_for,
         )
 
         try:
@@ -142,6 +149,8 @@ class LXDProvider(Provider):
         project_path: pathlib.Path,
         base: str,
         bind_ssh: bool,
+        build_on: str,
+        build_for: str,
     ) -> Generator[Executor, None, None]:
         """Launch environment for specified base.
 
@@ -154,6 +163,8 @@ class LXDProvider(Provider):
         instance_name = self.get_instance_name(
             project_name=project_name,
             project_path=project_path,
+            build_on=build_on,
+            build_for=build_for,
         )
         alias = BASE_TO_BUILDD_IMAGE_ALIAS[base]
         try:

--- a/snapcraft/providers/_multipass.py
+++ b/snapcraft/providers/_multipass.py
@@ -46,7 +46,12 @@ class MultipassProvider(Provider):
         self.multipass = instance
 
     def clean_project_environments(
-        self, *, project_name: str, project_path: pathlib.Path
+        self,
+        *,
+        project_name: str,
+        project_path: pathlib.Path,
+        build_on: str,
+        build_for: str,
     ) -> List[str]:
         """Clean up any build environments created for project.
 
@@ -133,6 +138,8 @@ class MultipassProvider(Provider):
         project_path: pathlib.Path,
         base: str,
         bind_ssh: bool,
+        build_on: str,
+        build_for: str,
     ) -> Generator[Executor, None, None]:
         """Launch environment for specified base.
 
@@ -145,6 +152,8 @@ class MultipassProvider(Provider):
         instance_name = self.get_instance_name(
             project_name=project_name,
             project_path=project_path,
+            build_on=build_on,
+            build_for=build_for,
         )
 
         environment = self.get_command_environment()

--- a/snapcraft/providers/_provider.py
+++ b/snapcraft/providers/_provider.py
@@ -36,7 +36,12 @@ class Provider(ABC):
 
     @abstractmethod
     def clean_project_environments(
-        self, *, project_name: str, project_path: pathlib.Path
+        self,
+        *,
+        project_name: str,
+        project_path: pathlib.Path,
+        build_on: str,
+        build_for: str,
     ) -> List[str]:
         """Clean up any environments created for project.
 
@@ -76,6 +81,8 @@ class Provider(ABC):
         *,
         project_name: str,
         project_path: pathlib.Path,
+        build_on: str,
+        build_for: str,
     ) -> str:
         """Formulate the name for an instance using each of the given parameters.
 
@@ -86,7 +93,17 @@ class Provider(ABC):
         :param project_name: Name of the project.
         :param project_path: Directory of the project.
         """
-        return "-".join(["snapcraft", project_name, str(project_path.stat().st_ino)])
+        return "-".join(
+            [
+                "snapcraft",
+                project_name,
+                "on",
+                build_on,
+                "for",
+                build_for,
+                str(project_path.stat().st_ino),
+            ]
+        )
 
     @classmethod
     def is_base_available(cls, base: str) -> Tuple[bool, Union[str, None]]:
@@ -122,6 +139,8 @@ class Provider(ABC):
         project_path: pathlib.Path,
         base: str,
         bind_ssh: bool,
+        build_on: str,
+        build_for: str,
     ) -> Generator[Executor, None, None]:
         """Launch environment for specified base.
 

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -26,6 +26,7 @@ from snapcraft import errors
 from snapcraft.parts import lifecycle as parts_lifecycle
 from snapcraft.parts.update_metadata import update_project_metadata
 from snapcraft.projects import MANDATORY_ADOPTABLE_FIELDS, Project
+from snapcraft.utils import get_host_architecture
 
 _SNAPCRAFT_YAML_FILENAMES = [
     "snap/snapcraft.yaml",
@@ -440,7 +441,14 @@ def test_lifecycle_run_command_clean(snapcraft_yaml, project_vars, new_dir, mock
         ),
     )
 
-    assert clean_mock.mock_calls == [call(project_name="mytest", project_path=new_dir)]
+    assert clean_mock.mock_calls == [
+        call(
+            project_name="mytest",
+            project_path=new_dir,
+            build_on=get_host_architecture(),
+            build_for=get_host_architecture(),
+        )
+    ]
 
 
 def test_lifecycle_clean_destructive_mode(

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -44,7 +44,12 @@ class TestLxdLaunchedEnvironment:
         prov = providers.LXDProvider()
 
         with prov.launched_environment(
-            project_name="test", project_path=new_dir, base="core22", bind_ssh=False
+            project_name="test",
+            project_path=new_dir,
+            base="core22",
+            bind_ssh=False,
+            build_on="test",
+            build_for="test",
         ):
             assert lxd_instance_mock.mount.mock_calls == [
                 call(host_source=new_dir, target=Path("/root/project")),
@@ -58,7 +63,12 @@ class TestLxdLaunchedEnvironment:
         prov = providers.LXDProvider()
 
         with prov.launched_environment(
-            project_name="test", project_path=new_dir, base="core22", bind_ssh=True
+            project_name="test",
+            project_path=new_dir,
+            base="core22",
+            bind_ssh=True,
+            build_on="test",
+            build_for="test",
         ):
             assert lxd_instance_mock.mount.mock_calls == [
                 call(host_source=new_dir, target=Path("/root/project")),

--- a/tests/unit/providers/test_multipass.py
+++ b/tests/unit/providers/test_multipass.py
@@ -41,7 +41,12 @@ class TestMultipassLaunchedEnvironment:
         prov = providers.MultipassProvider()
 
         with prov.launched_environment(
-            project_name="test", project_path=new_dir, base="core22", bind_ssh=False
+            project_name="test",
+            project_path=new_dir,
+            base="core22",
+            bind_ssh=False,
+            build_on="test",
+            build_for="test",
         ):
             assert multipass_instance_mock.mount.mock_calls == [
                 call(host_source=new_dir, target=Path("/root/project")),
@@ -56,7 +61,12 @@ class TestMultipassLaunchedEnvironment:
         prov = providers.MultipassProvider()
 
         with prov.launched_environment(
-            project_name="test", project_path=new_dir, base="core22", bind_ssh=True
+            project_name="test",
+            project_path=new_dir,
+            base="core22",
+            bind_ssh=True,
+            build_on="test",
+            build_for="test",
         ):
             assert multipass_instance_mock.mount.mock_calls == [
                 call(host_source=new_dir, target=Path("/root/project")),

--- a/tests/unit/providers/test_provider.py
+++ b/tests/unit/providers/test_provider.py
@@ -1,0 +1,30 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from snapcraft import providers
+
+
+def test_get_instance_name(new_dir):
+    """Test formatting of instance name."""
+    inode_number = str(new_dir.stat().st_ino)
+    expected_name = f"snapcraft-hello-world-on-arm64-for-armhf-{inode_number}"
+    actual_name = providers.Provider.get_instance_name(
+        project_name="hello-world",
+        project_path=new_dir,
+        build_on="arm64",
+        build_for="armhf",
+    )
+    assert expected_name == actual_name


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
New naming convention for instances.

Part 6 of supporting architectures for `core22`. Full code change is proposed [here](https://github.com/snapcore/snapcraft/pull/3712).

#### Previous naming convention
`snapcraft-<project_name>-<inode-number>`
`snapcraft-hello-world-10488157`

#### New naming convention
`snapcraft-<project_name>-on-<build_on>-for-<build_for>-<inode-number>`
`snapcraft-hello-world-on-amd64-for-arm64-10488157`

#### Reference: Charmcraft naming convention
`charmcraft-<project_name>-<inode-number>-<bases_index>-<build_on_index>-<target_arch>`
`charmcraft-hello-world-20846552-2-1-amd64`
Where `bases_index` and `build_on_index` are the indices of each base and architecture defined in the charmcraft config.

For snapcraft, I chose to use the architectures names themselves, rather than indices.  It's more descriptive and is not affected by the re-ordering of architectures in `snapcraft.yaml`.

(CRAFT-1172)