### PR TITLE
pack: only print the basename of the snap filename

### DIFF
--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -140,5 +140,6 @@ def pack_snap(
             msg += f" ({err.stderr.strip()!s})"
         raise errors.SnapcraftError(msg)
 
-    snap_filename = str(proc.stdout).partition(":")[2].strip()
+    snap_filename = Path(str(proc.stdout).partition(":")[2].strip()).name
+    # TODO: intermediate? if not, move to the relevant cli module
     emit.message(f"Created snap package {snap_filename}", intermediate=True)


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
