### PR TITLE
Add 'groups' statement to parts

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -26,7 +26,7 @@ import craft_parts
 from craft_cli import EmitterMode, emit
 from craft_parts import ProjectInfo, StepInfo, callbacks, infos
 
-from snapcraft import errors, extensions, pack, providers, utils
+from snapcraft import errors, extensions, pack, preprocessors, providers, utils
 from snapcraft.meta import snap_yaml
 from snapcraft.projects import GrammarAwareProject, Project
 from snapcraft.providers import capture_logs_from_instance
@@ -108,7 +108,7 @@ def process_yaml(project_file: Path) -> Dict[str, Any]:
     """
     try:
         with open(project_file, encoding="utf-8") as yaml_file:
-            yaml_data = yaml_utils.load(yaml_file)
+            yaml_data = preprocessors.preprocessor(yaml_utils.load(yaml_file))
     except OSError as err:
         msg = err.strerror
         if err.filename:

--- a/snapcraft/preprocessors.py
+++ b/snapcraft/preprocessors.py
@@ -1,0 +1,96 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2018-2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Contains the configuration pre-processor."""
+
+from typing import Any, Dict, List
+
+from snapcraft_legacy.yaml_utils.errors import YamlValidationError
+
+
+def preprocessor(configuration: Dict[str, Any]) -> Dict[str, Any]:
+    """Apply all the preprocessors to the configuration file."""
+    return _manage_groups(configuration)
+
+
+def _manage_groups(configuration: Dict[str, Any]) -> Dict[str, Any]:
+    """Manage the 'groups' entry.
+
+    :param configuration: the configuration as processed by the YAML module.
+    :return: the modified configuration.
+    """
+    if "parts" in configuration:
+        _check_groups_syntax(configuration)
+
+        groups_list: Dict[str, List] = {}
+
+        for part in configuration["parts"]:
+            data = configuration["parts"][part]
+            if "groups" not in data:
+                continue
+            for group in data["groups"]:
+                if group not in groups_list:
+                    groups_list[group] = []
+                groups_list[group].append(part)
+
+            # remove the 'groups' key because the rest of the code doesn't understand it
+            del data["groups"]
+
+        for part in configuration["parts"]:
+            data = configuration["parts"][part]
+            if "after" not in data:
+                continue
+
+            new_deps = []
+            for dependency in data["after"]:
+                if dependency not in groups_list:
+                    new_deps.append(dependency)
+                    continue
+                new_deps.extend(groups_list[dependency])
+
+            # apply the new dependencies removing duplicates
+            data["after"] = list(dict.fromkeys(new_deps))
+
+    return configuration
+
+
+def _check_groups_syntax(configuration: Dict[str, Any]):
+    """Check the syntax in the 'groups' elements.
+
+    :param configuration: the configuration as processed by the YAML module.
+
+    :raises YamlValidationError: if there are syntax errors.
+    """
+    for part in configuration["parts"]:
+        data = configuration["parts"][part]
+        if "groups" not in data:
+            continue
+
+        if not isinstance(data["groups"], list):
+            raise YamlValidationError(
+                f"The group entry in part '{part}' is not a list but"
+                f"a {type(data['groups'])}. Aborting."
+            )
+        for group in data["groups"]:
+            if not isinstance(group, str):
+                raise YamlValidationError(
+                    "There are entries in 'groups' in the part"
+                    f"'{part}' that aren't strings. Aborting."
+                )
+            if group in configuration["parts"]:
+                raise YamlValidationError(
+                    f"The group {group} is already used as a part name. Aborting."
+                )

--- a/tests/unit/parts/test_groups.py
+++ b/tests/unit/parts/test_groups.py
@@ -1,0 +1,145 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from snapcraft import preprocessors
+from snapcraft_legacy.yaml_utils.errors import YamlValidationError
+
+
+def test_file_without_groups():
+    data = {
+        "name": "test",
+        "version": "1.0",
+        "summary": "A test yaml data",
+        "description": "A long description",
+        "parts": {
+            "part1": {"plugin": "nil", "source": "no source"},
+            "part2": {"plugin": "meson", "source": "no source", "after": ["part1"]},
+            "part3": {
+                "plugin": "cmake",
+                "source": "no source",
+                "after": ["part1", "part2"],
+            },
+        },
+    }
+
+    transformed_data = preprocessors.preprocessor(data)
+    assert data == transformed_data
+
+
+def test_file_with_groups():
+    data = {
+        "name": "test",
+        "version": "1.0",
+        "summary": "A test yaml data",
+        "description": "A long description",
+        "parts": {
+            "part1": {"plugin": "nil", "source": "no source", "groups": ["binaries"]},
+            "part2": {"plugin": "meson", "source": "no source", "groups": ["binaries"]},
+            "part3": {
+                "plugin": "cmake",
+                "source": "no source",
+                "after": ["part1", "binaries"],
+            },
+        },
+    }
+
+    expected_data = {
+        "name": "test",
+        "version": "1.0",
+        "summary": "A test yaml data",
+        "description": "A long description",
+        "parts": {
+            "part1": {"plugin": "nil", "source": "no source"},
+            "part2": {"plugin": "meson", "source": "no source"},
+            "part3": {
+                "plugin": "cmake",
+                "source": "no source",
+                "after": ["part1", "part2"],
+            },
+        },
+    }
+
+    transformed_data = preprocessors.preprocessor(data)
+    assert expected_data == transformed_data
+
+
+def test_group_with_part_name():
+    data = {
+        "name": "test",
+        "version": "1.0",
+        "summary": "A test yaml data",
+        "description": "A long description",
+        "parts": {
+            "part1": {"plugin": "nil", "source": "no source", "groups": ["binaries"]},
+            "part2": {"plugin": "meson", "source": "no source", "groups": ["part1"]},
+            "part3": {
+                "plugin": "cmake",
+                "source": "no source",
+                "after": ["part1", "binaries"],
+            },
+        },
+    }
+
+    with pytest.raises(YamlValidationError):
+        preprocessors.preprocessor(data)
+
+
+def test_wrong_groups_type():
+    data = {
+        "name": "test",
+        "version": "1.0",
+        "summary": "A test yaml data",
+        "description": "A long description",
+        "parts": {
+            "part1": {"plugin": "nil", "source": "no source", "groups": "binaries"},
+            "part2": {"plugin": "meson", "source": "no source", "groups": ["part1"]},
+            "part3": {
+                "plugin": "cmake",
+                "source": "no source",
+                "after": ["part1", "binaries"],
+            },
+        },
+    }
+
+    with pytest.raises(YamlValidationError):
+        preprocessors.preprocessor(data)
+
+
+def test_wrong_group_content_type():
+    data = {
+        "name": "test",
+        "version": "1.0",
+        "summary": "A test yaml data",
+        "description": "A long description",
+        "parts": {
+            "part1": {
+                "plugin": "nil",
+                "source": "no source",
+                "groups": [1, "binaries"],
+            },
+            "part2": {"plugin": "meson", "source": "no source", "groups": ["part1"]},
+            "part3": {
+                "plugin": "cmake",
+                "source": "no source",
+                "after": ["part1", "binaries"],
+            },
+        },
+    }
+
+    with pytest.raises(YamlValidationError):
+        preprocessors.preprocessor(data)


### PR DESCRIPTION
This patch allows to add a 'groups' statement to each part,
define one or more groups for each one, and use the groups for
dependency management.

This way, it is possible to add all the binaries and libraries
parts to a "binaries" group, and make another part deppend on
that group (just using the 'after' statement like with a part
name).

This is mainly useful in big snapcraft.yaml files with a lot
of parts, like the gnome-XX-sdk ones.

It is implemented as a preprocessor, like the one used in C,
that modifies on-the-fly the configuration file.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
