### PR TITLE
manifest: correctly handle unspecified stage packages

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -301,7 +301,7 @@ def _generate_manifest(
     for name, part in parts.items():
         assets = lifecycle.get_part_pull_assets(part_name=name)
         if assets:
-            part["stage-packages"] = assets.get("stage-packages", [])
+            part["stage-packages"] = assets.get("stage-packages", []) or []
         for key in ("stage", "prime", "stage-packages", "build-packages"):
             part.setdefault(key, [])
 

--- a/tests/spread/core22/manifest/manifest-creation/snap/snapcraft.yaml
+++ b/tests/spread/core22/manifest/manifest-creation/snap/snapcraft.yaml
@@ -16,3 +16,5 @@ parts:
     plugin: nil
     stage-packages:
       - hello
+  other-part:
+    plugin: nil


### PR DESCRIPTION
Stage packages in manifest used the values from the state assets and
was populated with null when no stage packages were defined in the
part. Fixed to use empty list in this case.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
