### PR TITLE
project: use correct host arch when target arch is set

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -301,7 +301,7 @@ def _generate_manifest(
     for name, part in parts.items():
         assets = lifecycle.get_part_pull_assets(part_name=name)
         if assets:
-            part["stage-packages"] = assets.get("stage-packages", [])
+            part["stage-packages"] = assets.get("stage-packages", []) or []
         for key in ("stage", "prime", "stage-packages", "build-packages"):
             part.setdefault(key, [])
 

--- a/snapcraft_legacy/internal/project_loader/_config.py
+++ b/snapcraft_legacy/internal/project_loader/_config.py
@@ -213,7 +213,7 @@ class Config:
         self._ensure_no_duplicate_app_aliases()
 
         self._global_grammar_processor = grammar_processing.GlobalGrammarProcessor(
-            properties=self.data, arch=project.deb_arch, target_arch=project.target_arch
+            properties=self.data, arch=project.host_deb_arch, target_arch=project.target_arch,
         )
 
         # XXX: Resetting snap_meta due to above mangling of data.

--- a/snapcraft_legacy/internal/project_loader/_parts_config.py
+++ b/snapcraft_legacy/internal/project_loader/_parts_config.py
@@ -194,7 +194,7 @@ class PartsConfig:
         grammar_processor = grammar_processing.PartGrammarProcessor(
             plugin=plugin,
             properties=part_properties,
-            arch=self._project.deb_arch,
+            arch=self._project.host_deb_arch,
             target_arch=self._project.target_arch,
             repo=stage_packages_repo,
         )

--- a/snapcraft_legacy/project/_project_options.py
+++ b/snapcraft_legacy/project/_project_options.py
@@ -205,6 +205,10 @@ class ProjectOptions:
         return self.__machine_info["kernel"]
 
     @property
+    def host_deb_arch(self):
+        return self.__host_info["deb"]
+
+    @property
     def parts_dir(self) -> str:
         return self._parts_dir
 
@@ -359,6 +363,7 @@ class ProjectOptions:
             logger.info("Setting target machine to {!r}".format(target_deb_arch))
 
         self.__machine_info = _ARCH_TRANSLATIONS[self.__target_machine]
+        self.__host_info = _ARCH_TRANSLATIONS[self.__platform_arch]
 
         # Set target arch to match the host if unspecified.
         if target_deb_arch is None:

--- a/tests/spread/core22/manifest/manifest-creation/snap/snapcraft.yaml
+++ b/tests/spread/core22/manifest/manifest-creation/snap/snapcraft.yaml
@@ -16,3 +16,5 @@ parts:
     plugin: nil
     stage-packages:
       - hello
+  other-part:
+    plugin: nil

--- a/tests/spread/cross-compile/stage-packages/snap/snapcraft.yaml
+++ b/tests/spread/cross-compile/stage-packages/snap/snapcraft.yaml
@@ -18,6 +18,7 @@ parts:
       - xxd
     - to armhf:
       - tar:armhf
+    - on amd64 to armhf:
       - xxd
     - on amd64:
       - grep


### PR DESCRIPTION
The deb arch in project configuration is set to the target architecture
when --target-arch is used. Create a new project property holding the
host deb architecture instead of obtaining it from freshly instantiated
project options to avoid problems later when converting `ProjectOptions`
to a singleton.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
