### PR TITLE
cli: update craft-cli to comply with UX guidelines

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -9,7 +9,7 @@ charset-normalizer==2.0.12
 click==8.1.3
 codespell==2.1.0
 coverage==6.4.1
-craft-cli==0.6.0
+craft-cli==1.0.0
 craft-grammar==1.1.1
 craft-parts==1.8.1
 craft-providers==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cffi==1.15.0
 chardet==4.0.0
 charset-normalizer==2.0.12
 click==8.1.3
-craft-cli==0.6.0
+craft-cli==1.0.0
 craft-grammar==1.1.1
 craft-parts==1.8.1
 craft-providers==1.3.1

--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -142,7 +142,7 @@ def get_dispatcher() -> craft_cli.Dispatcher:
         log_filepath = None
 
     emit.init(
-        mode=EmitterMode.NORMAL,
+        mode=EmitterMode.BRIEF,
         appname="snapcraft",
         greeting=f"Starting Snapcraft {__version__}",
         log_filepath=log_filepath,

--- a/snapcraft/commands/account.py
+++ b/snapcraft/commands/account.py
@@ -105,10 +105,10 @@ class StoreLoginCommand(BaseCommand):
 
         if parsed_args.login_with:
             config_content = _read_config(parsed_args.login_with)
-            emit.message(
+            emit.progress(
                 "--with is no longer supported, export the auth to the environment "
                 f"variable {store.constants.ENVIRONMENT_STORE_CREDENTIALS!r} instead",
-                intermediate=True,
+                permanent=True,
             )
             store.LegacyUbuntuOne.store_credentials(config_content)
         else:

--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -97,7 +97,7 @@ class _LifecycleCommand(BaseCommand, abc.ABC):
         if not self.name:
             raise RuntimeError("command name not specified")
 
-        emit.trace(f"lifecycle command: {self.name!r}, arguments: {parsed_args!r}")
+        emit.debug(f"lifecycle command: {self.name!r}, arguments: {parsed_args!r}")
         parts_lifecycle.run(self.name, parsed_args)
 
 
@@ -220,7 +220,10 @@ class PackCommand(_LifecycleCommand):
     def run(self, parsed_args):
         """Run the command."""
         if parsed_args.directory:
-            pack.pack_snap(parsed_args.directory, output=parsed_args.output)
+            snap_filename = pack.pack_snap(
+                parsed_args.directory, output=parsed_args.output
+            )
+            emit.message(f"Created snap package {snap_filename}")
         else:
             super().run(parsed_args)
 

--- a/snapcraft/commands/manage.py
+++ b/snapcraft/commands/manage.py
@@ -150,7 +150,7 @@ class StoreCloseCommand(BaseCommand):
                 parsed_args.name
             ]["snap-id"]
         except KeyError as key_error:
-            emit.trace(f"{key_error!r} no found in {account_info!r}")
+            emit.debug(f"{key_error!r} no found in {account_info!r}")
             raise errors.SnapcraftError(
                 f"{parsed_args.name!r} not found or not owned by this account"
             ) from key_error

--- a/snapcraft/commands/names.py
+++ b/snapcraft/commands/names.py
@@ -104,9 +104,9 @@ class StoreRegisterCommand(BaseCommand):
         snap_name = getattr(parsed_args, "snap-name")
 
         if parsed_args.private:
-            emit.message(
+            emit.progress(
                 _MESSAGE_REGISTER_PRIVATE.format(snap_name),
-                intermediate=True,
+                permanent=True,
             )
         if parsed_args.yes or utils.confirm_with_user(
             _MESSAGE_REGISTER_CONFIRM.format(snap_name)

--- a/snapcraft/commands/store/client.py
+++ b/snapcraft/commands/store/client.py
@@ -80,13 +80,10 @@ def get_store_login_url() -> str:
 
 
 def _prompt_login() -> Tuple[str, str]:
-    emit.message(
-        "Enter your Ubuntu One e-mail address and password.", intermediate=True
-    )
+    emit.message("Enter your Ubuntu One e-mail address and password.")
     emit.message(
         "If you do not have an Ubuntu One account, you can create one "
         "at https://snapcraft.io/account",
-        intermediate=True,
     )
     email = utils.prompt("Email: ")
     password = utils.prompt("Password: ", hide=True)
@@ -240,17 +237,12 @@ class StoreClientCLI:
                         resolution="Regenerate them and try again.",
                     ) from store_error
 
-                emit.message(
-                    "You are required to re-login before continuing",
-                    intermediate=True,
-                )
+                emit.message("You are required to re-login before continuing")
                 self.store_client.logout()
             else:
                 raise
         except craft_store.errors.CredentialsUnavailable:
-            emit.message(
-                "You are required to login before continuing", intermediate=True
-            )
+            emit.message("You are required to login before continuing")
 
         self.login()
         return self.store_client.request(*args, **kwargs)

--- a/snapcraft/extensions/extension.py
+++ b/snapcraft/extensions/extension.py
@@ -96,9 +96,9 @@ class Extension(abc.ABC):
             )
 
         if self.is_experimental(base):
-            emit.message(
+            emit.progress(
                 f"*EXPERIMENTAL* extension {extension_name!r} enabled",
-                intermediate=True,
+                permanent=True,
             )
 
         if base not in self.get_supported_bases():

--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -26,7 +26,7 @@ from snapcraft import errors
 
 
 def _verify_snap(directory: Path) -> None:
-    emit.trace("pack_snap: check skeleton")
+    emit.debug("pack_snap: check skeleton")
     try:
         subprocess.run(
             ["snap", "pack", "--check-skeleton", directory],
@@ -95,7 +95,7 @@ def pack_snap(
     name: Optional[str] = None,
     version: Optional[str] = None,
     target_arch: Optional[str] = None,
-) -> None:
+) -> str:
     """Pack snap contents with `snap pack`.
 
     `output` may either be a directory, a file path, or just a file name.
@@ -113,7 +113,7 @@ def pack_snap(
     :param version: Version of snap project.
     :param target_arch: Target architecture the snap project is built to.
     """
-    emit.trace(f"pack_snap: output={output!r}, compression={compression!r}")
+    emit.debug(f"pack_snap: output={output!r}, compression={compression!r}")
 
     # TODO remove workaround once LP: #1950465 is fixed
     _verify_snap(directory)
@@ -129,7 +129,7 @@ def pack_snap(
     command.append(_get_directory(output))
 
     emit.progress("Creating snap package...")
-    emit.trace(f"Pack command: {command}")
+    emit.debug(f"Pack command: {command}")
     try:
         proc = subprocess.run(
             command, capture_output=True, check=True, universal_newlines=True
@@ -141,5 +141,4 @@ def pack_snap(
         raise errors.SnapcraftError(msg)
 
     snap_filename = Path(str(proc.stdout).partition(":")[2].strip()).name
-    # TODO: intermediate? if not, move to the relevant cli module
-    emit.message(f"Created snap package {snap_filename}", intermediate=True)
+    return snap_filename

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -160,12 +160,12 @@ class PartsLifecycle:
                     emit.progress(f"Executing parts lifecycle: {message}")
                     with emit.open_stream("Executing action") as stream:
                         aex.execute(action, stdout=stream, stderr=stream)
-                    emit.message(f"Executed: {message}", intermediate=True)
+                    emit.progress(f"Executed: {message}", permanent=True)
 
             if shell_after:
                 _launch_shell()
 
-            emit.message("Executed parts lifecycle", intermediate=True)
+            emit.progress("Executed parts lifecycle", permanent=True)
         except RuntimeError as err:
             raise RuntimeError(f"Parts processing internal error: {err}") from err
         except OSError as err:
@@ -198,7 +198,7 @@ class PartsLifecycle:
             # TODO: craft-parts API for: force_refresh=refresh_required
             deb.Ubuntu.refresh_packages_list.cache_clear()
             self._lcm.refresh_packages_list()
-        emit.message("Installed package repositories", intermediate=True)
+        emit.progress("Installed package repositories", permanent=True)
 
     def clean(self, *, part_names: Optional[List[str]] = None) -> None:
         """Remove lifecycle artifacts.
@@ -211,7 +211,7 @@ class PartsLifecycle:
         else:
             message = "Cleaning all parts"
 
-        emit.message(message, intermediate=True)
+        emit.progress(message)
         self._lcm.clean(part_names=part_names)
 
     def extract_metadata(self) -> List[ExtractedMetadata]:
@@ -238,8 +238,8 @@ class PartsLifecycle:
                         metadata_list.append(metadata)
                         break
 
-                    emit.message(
-                        f"No metadata extracted from {metadata_file}", intermediate=True
+                    emit.progress(
+                        f"No metadata extracted from {metadata_file}", permanent=True
                     )
 
         return metadata_list
@@ -265,7 +265,7 @@ def _launch_shell(*, cwd: Optional[pathlib.Path] = None) -> None:
 
     :param cwd: Working directory to start user in.
     """
-    emit.message("Launching shell on build environment...", intermediate=True)
+    emit.progress("Launching shell on build environment...", permanent=True)
     with emit.pause():
         subprocess.run(["bash"], check=False, cwd=cwd)
 

--- a/snapcraft/parts/project_check.py
+++ b/snapcraft/parts/project_check.py
@@ -63,7 +63,7 @@ def _check_snap_dir(snap_dir_path: Path) -> None:
 
     if unexpected_paths:
         snap_dir_relpath = snap_dir_path.relative_to(Path())
-        emit.message(
+        emit.progress(
             "The {snap_dir!r} directory is meant specifically for snapcraft, but it contains\n"
             "the following non-snapcraft-related paths:"
             "\n- {unexpected_files}\n\n"
@@ -74,7 +74,7 @@ def _check_snap_dir(snap_dir_path: Path) -> None:
                 snap_dir_local=str(snap_dir_relpath / "local"),
                 unexpected_files="\n- ".join(sorted(unexpected_paths)),
             ),
-            intermediate=True,
+            permanent=True,
         )
 
 

--- a/snapcraft/parts/setup_assets.py
+++ b/snapcraft/parts/setup_assets.py
@@ -81,7 +81,7 @@ def setup_assets(
             icon_path = icon_path.relative_to(prime_dir)
         relative_icon_path = str(icon_path)
 
-    emit.trace(f"relative icon path: {relative_icon_path!r}")
+    emit.debug(f"relative icon path: {relative_icon_path!r}")
 
     for app_name, app in project.apps.items():
         _validate_command_chain(
@@ -106,7 +106,7 @@ def _finalize_icon(
     Fetch from a remote URL, if required, and place in the meta/gui
     directory.
     """
-    emit.trace(f"finalize icon: {icon!r}")
+    emit.debug(f"finalize icon: {icon!r}")
 
     # Nothing to do if no icon is configured, search for existing icon.
     if icon is None:
@@ -240,7 +240,7 @@ def ensure_hook(hook_path: Path) -> None:
 def _copy_file(source: Path, destination: Path, **kwargs) -> None:
     """Copy file if source and destination are not the same file."""
     if destination.exists() and source.samefile(destination):
-        emit.trace(
+        emit.debug(
             f"skip copying {str(source)!r}: source and destination are the same file"
         )
     else:

--- a/snapcraft/parts/update_metadata.py
+++ b/snapcraft/parts/update_metadata.py
@@ -66,8 +66,8 @@ def update_project_metadata(
         if metadata.grade and not project.grade:
             project.grade = metadata.grade  # type: ignore
 
-        emit.trace(f"project icon: {project.icon!r}")
-        emit.trace(f"metadata icon: {metadata.icon!r}")
+        emit.debug(f"project icon: {project.icon!r}")
+        emit.debug(f"metadata icon: {metadata.icon!r}")
 
         if not project.icon:
             _update_project_icon(project, metadata=metadata, assets_dir=assets_dir)
@@ -115,7 +115,7 @@ def _update_project_icon(
         if metadata.icon:
             project.icon = metadata.icon
 
-    emit.trace(f"updated project icon: {project.icon}")
+    emit.debug(f"updated project icon: {project.icon}")
 
 
 def _update_project_app_desktop_file(
@@ -133,27 +133,27 @@ def _update_project_app_desktop_file(
                 break
 
         if not app_name:
-            emit.trace(f"no app declares id {metadata.common_id!r}")
+            emit.debug(f"no app declares id {metadata.common_id!r}")
             return
 
         if project.apps[app_name].desktop:
-            emit.trace("app {app_name!r} already declares a desktop file")
+            emit.debug("app {app_name!r} already declares a desktop file")
             return
 
-        emit.trace(
+        emit.debug(
             f"look for desktop file with id {metadata.common_id!r} in app {app_name!r}"
         )
 
         desktop_file = f"{assets_dir}/gui/{app_name}.desktop"
         if Path(desktop_file).is_file():
-            emit.trace(f"use already existing desktop file {desktop_file!r}")
+            emit.debug(f"use already existing desktop file {desktop_file!r}")
             return
 
         if metadata.desktop_file_paths:
             for filename in metadata.desktop_file_paths:
                 if Path(prime_dir, filename.lstrip("/")).is_file():
                     project.apps[app_name].desktop = filename
-                    emit.trace(f"use desktop file {filename!r}")
+                    emit.debug(f"use desktop file {filename!r}")
                     break
 
 

--- a/snapcraft/providers/_logs.py
+++ b/snapcraft/providers/_logs.py
@@ -41,11 +41,11 @@ def capture_logs_from_instance(instance: Executor) -> None:
     try:
         instance.pull_file(source=instance_log_path, destination=local_log_path)
     except FileNotFoundError:
-        emit.trace("No logs found in instance.")
+        emit.debug("No logs found in instance.")
         return
 
-    emit.trace("Logs captured from managed instance:")
+    emit.debug("Logs captured from managed instance:")
     with local_log_path.open("rt", encoding="utf8") as logfile:
         for line in logfile:
-            emit.trace(":: " + line.rstrip())
+            emit.debug(":: " + line.rstrip())
     local_log_path.unlink()

--- a/snapcraft/repo/apt_key_manager.py
+++ b/snapcraft/repo/apt_key_manager.py
@@ -97,9 +97,7 @@ class AptKeyManager:
         except subprocess.CalledProcessError as error:
             # Export shouldn't exit with failure based on testing,
             # but assume the key is not installed and log a warning.
-            emit.message(
-                f"Unexpected apt-key failure: {error.output}", intermediate=True
-            )
+            emit.progress(f"Unexpected apt-key failure: {error.output}", permanent=True)
             return False
 
         apt_key_output = proc.stdout.decode()
@@ -113,7 +111,7 @@ class AptKeyManager:
         # The two strings above have worked in testing, but if neither is
         # present for whatever reason, assume the key is not installed
         # and log a warning.
-        emit.message(f"Unexpected apt-key output: {apt_key_output}", intermediate=True)
+        emit.progress(f"Unexpected apt-key output: {apt_key_output}", permanent=True)
         return False
 
     def install_key(self, *, key: str) -> None:
@@ -132,7 +130,7 @@ class AptKeyManager:
         ]
 
         try:
-            emit.trace(f"Executing: {cmd!r}")
+            emit.debug(f"Executing: {cmd!r}")
             env = {}
             env["LANG"] = "C.UTF-8"
             subprocess.run(
@@ -146,7 +144,7 @@ class AptKeyManager:
         except subprocess.CalledProcessError as error:
             raise errors.AptGPGKeyInstallError(error.output.decode(), key=key)
 
-        emit.trace(f"Installed apt repository key:\n{key}")
+        emit.debug(f"Installed apt repository key:\n{key}")
 
     def install_key_from_keyserver(
         self, *, key_id: str, key_server: str = "keyserver.ubuntu.com"
@@ -173,7 +171,7 @@ class AptKeyManager:
         ]
 
         try:
-            emit.trace(f"Executing: {cmd!r}")
+            emit.debug(f"Executing: {cmd!r}")
             subprocess.run(
                 cmd,
                 stdout=subprocess.PIPE,

--- a/snapcraft/repo/apt_ppa.py
+++ b/snapcraft/repo/apt_ppa.py
@@ -39,12 +39,12 @@ def get_launchpad_ppa_key_id(*, ppa: str) -> str:
     launchpad = Launchpad.login_anonymously("snapcraft", "production")
     launchpad_url = f"~{owner}/+archive/{name}"
 
-    emit.trace(f"Loading launchpad url: {launchpad_url}")
+    emit.debug(f"Loading launchpad url: {launchpad_url}")
     try:
         key_id = launchpad.load(launchpad_url).signing_key_fingerprint
     except lazr.restfulclient.errors.NotFound as error:
         raise errors.AptPPAInstallError(ppa, "not found on launchpad") from error
 
-    emit.trace(f"Retrieved launchpad PPA key ID: {key_id}")
+    emit.debug(f"Retrieved launchpad PPA key ID: {key_id}")
 
     return key_id

--- a/snapcraft/repo/apt_sources_manager.py
+++ b/snapcraft/repo/apt_sources_manager.py
@@ -110,11 +110,11 @@ class AptSourcesManager:
         config_path = self._sources_list_d / f"{name}.sources"
         if config_path.exists() and config_path.read_text() == config:
             # Already installed and matches, nothing to do.
-            emit.trace(f"Ignoring unchanged sources: {config_path!s}")
+            emit.debug(f"Ignoring unchanged sources: {config_path!s}")
             return False
 
         config_path.write_text(config)
-        emit.trace(f"Installed sources: {config_path!s}")
+        emit.debug(f"Installed sources: {config_path!s}")
         return True
 
     def _install_sources_apt(
@@ -202,7 +202,7 @@ class AptSourcesManager:
 
         :returns: True if source configuration was changed.
         """
-        emit.trace(f"Processing repo: {package_repo!r}")
+        emit.debug(f"Processing repo: {package_repo!r}")
         if isinstance(package_repo, package_repository.PackageRepositoryAptPPA):
             return self._install_sources_ppa(package_repo=package_repo)
 
@@ -221,5 +221,5 @@ class AptSourcesManager:
 def _add_architecture(architectures: List[str]):
     """Add package repository architecture."""
     for arch in architectures:
-        emit.message(f"Add repository architecture: {arch}", intermediate=True)
+        emit.progress(f"Add repository architecture: {arch}", permanent=True)
         subprocess.run(["dpkg", "--add-architecture", arch], check=True)

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -76,7 +76,7 @@ def get_os_platform(filepath=pathlib.Path("/etc/os-release")):
             with filepath.open("rt", encoding="utf-8") as release_file:
                 lines = release_file.readlines()
         except FileNotFoundError:
-            emit.trace("Unable to locate 'os-release' file, using default values")
+            emit.debug("Unable to locate 'os-release' file, using default values")
         else:
             os_release = {}
             for line in lines:
@@ -182,16 +182,16 @@ def get_parallel_build_count() -> int:
     """
     try:
         build_count = len(os.sched_getaffinity(0))
-        emit.trace(f"CPU count (from process affinity): {build_count}")
+        emit.debug(f"CPU count (from process affinity): {build_count}")
     except AttributeError:
         # Fall back to multiprocessing.cpu_count()...
         try:
             build_count = multiprocessing.cpu_count()
-            emit.trace(f"CPU count (from multiprocessing): {build_count}")
+            emit.debug(f"CPU count (from multiprocessing): {build_count}")
         except NotImplementedError:
-            emit.message(
+            emit.progress(
                 "Unable to determine CPU count; disabling parallel builds",
-                intermediate=True,
+                permanent=True,
             )
             build_count = 1
 
@@ -200,7 +200,7 @@ def get_parallel_build_count() -> int:
         if max_count > 0:
             build_count = min(build_count, max_count)
     except ValueError:
-        emit.trace("Invalid SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT value")
+        emit.debug("Invalid SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT value")
 
     return build_count
 
@@ -314,6 +314,6 @@ def process_version(version: Optional[str]) -> str:
         new_version = GitSource.generate_version()
 
     if new_version != version:
-        emit.message(f"Version has been set to {new_version!r}", intermediate=True)
+        emit.progress(f"Version has been set to {new_version!r}", permanent=True)
 
     return new_version

--- a/tests/unit/commands/test_account.py
+++ b/tests/unit/commands/test_account.py
@@ -70,10 +70,10 @@ def test_login_with_file(emitter, mocker, legacy_config_path):
     )
 
     store_credentials_mock.assert_called_once_with("secretb64")
-    emitter.assert_message(
+    emitter.assert_progress(
         "--with is no longer supported, export the auth to the environment "
         "variable 'SNAPCRAFT_STORE_CREDENTIALS' instead",
-        intermediate=True,
+        permanent=True,
     )
 
 

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -94,4 +94,4 @@ def test_pack_command_with_directory(mocker):
     cmd = PackCommand(None)
     cmd.run(argparse.Namespace(directory=".", output=None, compression=None))
     assert lifecycle_run_mock.mock_calls == []
-    assert pack_mock.mock_calls == [call(".", output=None)]
+    assert pack_mock.mock_calls[0] == call(".", output=None)

--- a/tests/unit/commands/test_manage.py
+++ b/tests/unit/commands/test_manage.py
@@ -172,7 +172,7 @@ def test_close_no_snap_id(emitter):
         "'test-unknown-snap' not found or not owned by this account"
     )
 
-    emitter.assert_trace(
+    emitter.assert_debug(
         "KeyError('test-unknown-snap') no found in "
         "{'snaps': {'16': {'test-snap': {'snap-id': '12345678'}}}}"
     )

--- a/tests/unit/commands/test_names.py
+++ b/tests/unit/commands/test_names.py
@@ -170,7 +170,7 @@ def test_register_private(emitter, fake_store_register):
     )
 
     assert fake_store_register.mock_calls == []
-    emitter.assert_message(
+    emitter.assert_progress(
         dedent(
             """\
             Even though this is private snap, you should think carefully about
@@ -179,7 +179,7 @@ def test_register_private(emitter, fake_store_register):
             then we suggest you prefix the name with your developer identity,
             As '$username-yoyodyne-www-site-content'."""
         ),
-        intermediate=True,
+        permanent=True,
     )
     emitter.assert_message(
         "Snap name 'test-snap' not registered",

--- a/tests/unit/extensions/test_extensions.py
+++ b/tests/unit/extensions/test_extensions.py
@@ -224,9 +224,9 @@ def test_apply_extension_experimental_with_environment(emitter, monkeypatch):
     # Should not raise.
     extensions.apply_extensions(yaml_data, arch="amd64", target_arch="amd64")
 
-    emitter.assert_message(
+    emitter.assert_progress(
         "*EXPERIMENTAL* extension 'fake-extension-experimental' enabled",
-        intermediate=True,
+        permanent=True,
     )
 
 

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -243,7 +243,7 @@ def test_lifecycle_run_command_pack(cmd, snapcraft_yaml, project_vars, new_dir, 
     assert run_mock.mock_calls == [
         call("prime", debug=False, shell=False, shell_after=False)
     ]
-    assert pack_mock.mock_calls == [
+    assert pack_mock.mock_calls[:1] == [
         call(
             new_dir / "prime",
             output=None,
@@ -294,7 +294,7 @@ def test_lifecycle_pack_destructive_mode(
     assert run_mock.mock_calls == [
         call("prime", debug=False, shell=False, shell_after=False)
     ]
-    assert pack_mock.mock_calls == [
+    assert pack_mock.mock_calls[:1] == [
         call(
             new_dir / "home/prime",
             output=None,
@@ -345,7 +345,7 @@ def test_lifecycle_pack_managed(cmd, snapcraft_yaml, project_vars, new_dir, mock
     assert run_mock.mock_calls == [
         call("prime", debug=False, shell=False, shell_after=False)
     ]
-    assert pack_mock.mock_calls == [
+    assert pack_mock.mock_calls[:1] == [
         call(
             new_dir / "home/prime",
             output=None,

--- a/tests/unit/parts/test_parts.py
+++ b/tests/unit/parts/test_parts.py
@@ -145,7 +145,7 @@ def test_parts_lifecycle_clean(parts_data, new_dir, emitter):
         project_vars={"version": "1", "grade": "stable"},
     )
     lifecycle.clean(part_names=None)
-    emitter.assert_message("Cleaning all parts", intermediate=True)
+    emitter.assert_progress("Cleaning all parts")
 
 
 def test_parts_lifecycle_clean_parts(parts_data, new_dir, emitter):
@@ -163,7 +163,7 @@ def test_parts_lifecycle_clean_parts(parts_data, new_dir, emitter):
         project_vars={"version": "1", "grade": "stable"},
     )
     lifecycle.clean(part_names=["p1"])
-    emitter.assert_message("Cleaning parts: p1", intermediate=True)
+    emitter.assert_progress("Cleaning parts: p1")
 
 
 def test_parts_lifecycle_initialize_with_package_repositories_deps_not_installed(

--- a/tests/unit/parts/test_project_check.py
+++ b/tests/unit/parts/test_project_check.py
@@ -137,7 +137,7 @@ def test_unexpected_things(new_dir, emitter, snapcraft_yaml):
         asset_path.touch()
 
     run_project_checks(project, assets_dir=Path("snap"))
-    assert emitter.assert_message(
+    assert emitter.assert_progress(
         "The 'snap' directory is meant specifically for snapcraft, but it contains\n"
         "the following non-snapcraft-related paths:\n"
         "- dir1\n"
@@ -162,5 +162,5 @@ def test_unexpected_things(new_dir, emitter, snapcraft_yaml):
         "This is unsupported and may cause unexpected behavior. If you must store\n"
         "these files within the 'snap' directory, move them to 'snap/local'\n"
         "which is ignored by snapcraft.",
-        intermediate=True,
+        permanent=True,
     )


### PR DESCRIPTION
Craft-cli 1.0.0 updates CLI verbosity levels to follow the UX standard
to be used across *craft tools. It makes output to stdout and stderr more
consistent and makes the verbose output less verbose by removing debug
messages and timestamps.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1144