### PR TITLE
snapcraft/meta: make Manifest.base optional

### DIFF
--- a/snapcraft/meta/manifest.py
+++ b/snapcraft/meta/manifest.py
@@ -19,7 +19,7 @@
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional
 
 from pydantic_yaml import YamlModel
 
@@ -41,7 +41,7 @@ class Manifest(YamlModel):
     version: str
     summary: str
     description: str
-    base: str
+    base: Optional[str]
     grade: str
     confinement: str
     apps: Optional[Dict[str, Any]]
@@ -103,7 +103,7 @@ def write(
         version=version,
         summary=project.summary,  # type: ignore
         description=project.description,  # type: ignore
-        base=cast(str, project.base),
+        base=project.base,
         grade=project.grade or "stable",
         confinement=project.confinement,
         apps=project.apps,


### PR DESCRIPTION
I recently ran into a problem building a core22 based base snap that had been working fine last week:

https://github.com/canonical/ubuntu-core-desktop/runs/7294752999?check_suite_focus=true

```
Generating snap manifest...                                                    Traceback (most recent call last):
...
  File "/snap/snapcraft/x1/lib/python3.8/site-packages/snapcraft/parts/lifecycle.py", line 308, in _generate_manifest
    manifest.write(
  File "/snap/snapcraft/x1/lib/python3.8/site-packages/snapcraft/meta/manifest.py", line 97, in write
    manifest = Manifest(
  File "pydantic/main.py", line 331, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for Manifest
base
  none is not an allowed value (type=type_error.none.not_allowed)
Failed to execute pack in instance.                                            
```

The conditions to reproduce seem to be:
* The snap mustn't use legacy snapcraft (in this case, we have `build-base: core22`)
* The snap must be missing the "base" attribute (in this case, because we're building a base snap)
* Snapcraft must be asked to generate a manifest (which the Github action does by default)

It looks like the problem was introduced in #3824, where the manifest generation feature was reintroduced. The validation logic expects the base attribute to be a string, which is not always going to be the case.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
