### PR TITLE
elf: add handling and patching helpers

### DIFF
--- a/snapcraft/elf/elf_utils.py
+++ b/snapcraft/elf/elf_utils.py
@@ -1,0 +1,101 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Helpers to handle ELF files."""
+
+import os
+import platform
+from pathlib import Path
+from typing import FrozenSet, Set
+
+import elftools.common.exceptions
+import elftools.elf.elffile
+from craft_cli import emit
+
+from snapcraft.errors import SnapcraftError
+
+from . import ElfFile, errors
+
+
+def get_elf_files(root: str, file_list: Set[str]) -> FrozenSet[ElfFile]:
+    """Return a frozenset of ELF files from file_list prepended with root.
+
+    :param str root: the root directory from where the file_list is generated.
+    :param file_list: a list of file in root.
+    :returns: a frozentset of ElfFile objects.
+    """
+    elf_files: Set[ElfFile] = set()
+
+    for part_file in file_list:
+        # Filter out object (*.o) files-- we only care about binaries.
+        if part_file.endswith(".o"):
+            continue
+
+        # No need to crawl links-- the original should be here, too.
+        path = Path(root, part_file)
+        if os.path.islink(path):
+            emit.debug(f"Skipped link {path!r} while finding dependencies")
+            continue
+
+        # Ignore if file does not have ELF header.
+        if not ElfFile.is_elf(path):
+            continue
+
+        try:
+            elf_file = ElfFile(path=path)
+        except elftools.common.exceptions.ELFError:
+            # Ignore invalid ELF files.
+            continue
+        except errors.CorruptedElfFile as exception:
+            # Log if the ELF file seems corrupted
+            emit.message(str(exception))
+            continue
+
+        # If ELF has dynamic symbols, add it.
+        if elf_file.needed:
+            elf_files.add(elf_file)
+
+    return frozenset(elf_files)
+
+
+_PLATFORM_DYNAMIC_LINKER = {
+    "aarch64": "lib/ld-linux-aarch64.so.1",
+    "armv7l": "lib/ld-linux-armhf.so.3",
+    "ppc64le": "lib64/ld64.so.2",
+    "riscv64": "lib/ld-linux-riscv64-lp64d.so.1",
+    "s390x": "lib/ld64.so.1",
+    "x86_64": "lib64/ld-linux-x86-64.so.2",
+}
+
+
+def get_dynamic_linker(*, root_path: Path, snap_path: Path) -> str:
+    """Obtain the dynamic linker that would be seen at runtime.
+
+    :param root_path: The root path of a snap payload tree.
+    :param snap_path: Absolute path to the snap once installed.
+
+    :return: The path to the dynamic linker to use.
+    """
+    arch = platform.machine()
+    linker = _PLATFORM_DYNAMIC_LINKER.get(arch)
+    if not linker:
+        raise RuntimeError(f"Dynamic linker not defined for arch {arch!r}")
+
+    linker_path = root_path / linker
+    if not linker_path.exists():
+        raise SnapcraftError(f"Dynamic linker {str(linker_path)!r} not found.")
+
+    return str(snap_path / linker)

--- a/tests/unit/elf/test_elf_file.py
+++ b/tests/unit/elf/test_elf_file.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import pytest
 
 from snapcraft import elf
-from snapcraft.elf import errors
+from snapcraft.elf import elf_utils, errors
 from snapcraft.elf._elf_file import _Library
 
 
@@ -69,11 +69,10 @@ class TestElfFileSmoketest:
         # Ensure type is detered as executable.
         assert elf_file.elf_type == "ET_DYN"
 
-    # XXX: uncomment after adding elf_utils
-    # def test_invalid_elf_file(self, new_dir):
-    #    Path("invalid-elf").write_bytes(b"\x7fELF\x00")
-    #    elf_files = elf_utils.get_elf_files(new_dir, {"invalid-elf"})
-    #    assert elf_files == set()
+    def test_invalid_elf_file(self, new_dir):
+        Path("invalid-elf").write_bytes(b"\x7fELF\x00")
+        elf_files = elf_utils.get_elf_files(new_dir, {"invalid-elf"})
+        assert elf_files == set()
 
 
 class TestGetLibraries:

--- a/tests/unit/elf/test_elf_utils.py
+++ b/tests/unit/elf/test_elf_utils.py
@@ -1,0 +1,128 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from pathlib import Path
+
+import pytest
+
+from snapcraft.elf import elf_utils
+from snapcraft.errors import SnapcraftError
+
+
+class TestGetElfFiles:
+    """get_elf_files functionality."""
+
+    def test_get_elf_files(self, new_dir, fake_elf):
+        fake_elf("fake_elf-2.23")
+        elf_files = elf_utils.get_elf_files(new_dir, {"fake_elf-2.23"})
+        assert len(elf_files) == 1
+
+        elf_file = set(elf_files).pop()
+        assert elf_file.interp == "/lib64/ld-linux-x86-64.so.2"
+
+    def test_skip_object_files(self, new_dir, fake_elf):
+        fake_elf("object_file.o")
+        elf_files = elf_utils.get_elf_files(new_dir, {"object_file.o"})
+        assert elf_files == set()
+
+    def test_no_find_dependencies_statically_linked(self, new_dir, fake_elf):
+        fake_elf("fake_elf-static")
+        elf_files = elf_utils.get_elf_files(new_dir, {"fake_elf-static"})
+        assert elf_files == set()
+
+    def test_elf_with_execstack(self, new_dir, fake_elf):
+        fake_elf("fake_elf-with-execstack")
+        elf_files = elf_utils.get_elf_files(new_dir, {"fake_elf-with-execstack"})
+        elf_file = set(elf_files).pop()
+        assert elf_file.execstack_set is True
+
+    def test_elf_without_execstack(self, new_dir, fake_elf):
+        fake_elf("fake_elf-2.23")
+        elf_files = elf_utils.get_elf_files(new_dir, {"fake_elf-2.23"})
+        elf_file = set(elf_files).pop()
+        assert elf_file.execstack_set is False
+
+    def test_non_elf_files(self, new_dir):
+        # A bz2 header
+        Path("non-elf").write_bytes(b"\x42\x5a\x68")
+        elf_files = elf_utils.get_elf_files(new_dir, {"non-elf"})
+        assert elf_files == set()
+
+    def test_symlinks(self, new_dir):
+        symlinked_path = Path(new_dir, "symlinked")
+        symlinked_path.symlink_to("/bin/dash")
+        elf_files = elf_utils.get_elf_files(new_dir, {"symlinked"})
+        assert elf_files == set()
+
+    def test_device_files(self):
+        elf_files = elf_utils.get_elf_files("/dev", {"null"})
+        assert elf_files == set()
+
+    def test_fifo(self, new_dir):
+        fifo_path = os.path.join(new_dir, "fifo")
+        os.mkfifo(fifo_path)
+        elf_files = elf_utils.get_elf_files(new_dir, {"fifo"})
+        assert elf_files == set()
+
+
+class TestGetDynamicLinker:
+    """find_linker functionality."""
+
+    @pytest.mark.parametrize(
+        "arch,linker",
+        [
+            ("x86_64", "lib64/ld-linux-x86-64.so.2"),
+            ("aarch64", "lib/ld-linux-aarch64.so.1"),
+            ("armv7l", "lib/ld-linux-armhf.so.3"),
+            ("riscv64", "lib/ld-linux-riscv64-lp64d.so.1"),
+            ("ppc64le", "lib64/ld64.so.2"),
+            ("s390x", "lib/ld64.so.1"),
+        ],
+    )
+    def test_get_dynamic_linker(self, mocker, new_dir, arch, linker):
+        mocker.patch("platform.machine", return_value=arch)
+
+        lpath = Path(linker)
+        lpath.parent.mkdir(parents=True)
+        lpath.touch()
+
+        dynamic_linker = elf_utils.get_dynamic_linker(
+            root_path=new_dir, snap_path=Path("/snap/foo/current")
+        )
+        assert dynamic_linker == f"/snap/foo/current/{linker}"
+
+    def test_get_dynamic_linker_undefined(self, mocker):
+        mocker.patch("platform.machine", return_value="z80")
+
+        with pytest.raises(RuntimeError) as err:
+            elf_utils.get_dynamic_linker(
+                root_path=Path("prime"), snap_path=Path("/snap/foo/current")
+            )
+
+        assert str(err.value) == "Dynamic linker not defined for arch 'z80'"
+
+    def test_get_dynamic_linker_not_found(self, mocker):
+        mocker.patch("platform.machine", return_value="x86_64")
+
+        with pytest.raises(SnapcraftError) as err:
+            elf_utils.get_dynamic_linker(
+                root_path=Path("prime"), snap_path=Path("/snap/foo/current")
+            )
+
+        assert str(err.value) == (
+            "Dynamic linker 'prime/lib64/ld-linux-x86-64.so.2' not found."
+        )


### PR DESCRIPTION
Implement functions to list ELF binaries in a given directory and to
locate the ELF dynamic linker.

Co-authored-by: Kyle Fazzari <kyrofa@ubuntu.com>
Co-authored-by: Chris Patterson <chris.patterson@canonical.com>
Co-authored-by: Sergio Schvezov <sergio.schvezov@canonical.com>
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1190