### PR TITLE
elf: add elf file patcher

### DIFF
--- a/snapcraft/elf/__init__.py
+++ b/snapcraft/elf/__init__.py
@@ -17,8 +17,10 @@
 """ELF file handling."""
 
 from ._elf_file import ElfFile, SonameCache
+from ._patcher import Patcher
 
 __all__ = [
     "ElfFile",
     "SonameCache",
+    "Patcher",
 ]

--- a/snapcraft/elf/_patcher.py
+++ b/snapcraft/elf/_patcher.py
@@ -1,0 +1,150 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Use patchelf to patch ELF files."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import List, Set
+
+from craft_cli import emit
+
+from snapcraft import utils
+
+from ._elf_file import ElfFile
+from .errors import PatcherError
+
+
+class Patcher:
+    """Hold the necessary logic to patch elf files."""
+
+    def __init__(
+        self, *, dynamic_linker: str, root_path: str, preferred_patchelf=None
+    ) -> None:
+        """Create a Patcher instance.
+
+        :param dynamic_linker: The path to the dynamic linker to set the ELF file to.
+        :param root_path: The base path for the snap being processed.
+        :param preferred_patchelf: patch the necessary elf_files with this patchelf.
+        """
+        self._dynamic_linker = dynamic_linker
+        self._root_path = root_path
+        self._patchelf_cmd = preferred_patchelf or utils.get_snap_tool("patchelf")
+        self._strip_cmd = utils.get_snap_tool("strip")
+
+    def patch(self, *, elf_file: ElfFile) -> None:
+        """Patch elf_file with the Patcher instance configuration.
+
+        If the ELF is executable, patch it to use the configured linker.
+        If the ELF has dependencies (DT_NEEDED), set an rpath to them.
+
+        :param elf_file: a data object representing an elf file and its attributes.
+
+        :raises PatcherError: if the ELF file cannot be patched.
+        """
+        patchelf_args = []
+        if elf_file.interp:
+            patchelf_args.extend(["--set-interpreter", self._dynamic_linker])
+        if elf_file.dependencies:
+            rpath = self._get_rpath(elf_file)
+            # Due to https://github.com/NixOS/patchelf/issues/94 we need
+            # to first clear the current rpath
+            self._run_patchelf(
+                patchelf_args=["--remove-rpath"], elf_file_path=elf_file.path
+            )
+            # Parameters:
+            # --force-rpath: use RPATH instead of RUNPATH.
+            # --shrink-rpath: will remove unneeded entries, with the
+            #                 side effect of preferring host libraries
+            #                 so we simply do not use it.
+            # --set-rpath: set the RPATH to the colon separated argument.
+            patchelf_args.extend(["--force-rpath", "--set-rpath", rpath])
+
+        # no patchelf_args means there is nothing to do.
+        if not patchelf_args:
+            return
+
+        self._run_patchelf(patchelf_args=patchelf_args, elf_file_path=elf_file.path)
+
+    def _run_patchelf(self, *, patchelf_args: List[str], elf_file_path: Path) -> None:
+        # Run patchelf on a copy of the primed file and replace it
+        # after it is successful. This allows us to break the potential
+        # hard link created when migrating the file across the steps of
+        # the part.
+        with tempfile.NamedTemporaryFile() as temp_file:
+            shutil.copy2(elf_file_path, temp_file.name)
+
+            cmd = [self._patchelf_cmd] + patchelf_args + [temp_file.name]
+            try:
+                emit.debug(f"executing: {' '.join(cmd)}")
+                subprocess.check_call(cmd)
+            # There is no need to catch FileNotFoundError as patchelf should be
+            # bundled with snapcraft which means its lack of existence is a
+            # "packager" error.
+            except subprocess.CalledProcessError as call_error:
+                raise PatcherError(
+                    elf_file_path, cmd=call_error.cmd, code=call_error.returncode
+                ) from call_error
+
+            # We unlink to break the potential hard link
+            os.unlink(elf_file_path)
+            shutil.copy2(temp_file.name, elf_file_path)
+
+    def _get_existing_rpath(self, elf_file_path):
+        output = subprocess.check_output(
+            [self._patchelf_cmd, "--print-rpath", elf_file_path]
+        )
+        return output.decode().strip().split(":")
+
+    def _get_rpath(self, elf_file) -> str:
+        origin_rpaths: List[str] = []
+        base_rpaths: Set[str] = set()
+        existing_rpaths = self._get_existing_rpath(elf_file.path)
+
+        for dependency in elf_file.dependencies:
+            if dependency.path:
+                if dependency.in_base_snap:
+                    base_rpaths.add(os.path.dirname(dependency.path))
+                elif dependency.path.startswith(self._root_path):
+                    rel_library_path = os.path.relpath(dependency.path, elf_file.path)
+                    rel_library_path_dir = os.path.dirname(rel_library_path)
+                    # return the dirname, with the first .. replace
+                    # with $ORIGIN
+                    origin_rpath = rel_library_path_dir.replace("..", "$ORIGIN", 1)
+                    if origin_rpath not in origin_rpaths:
+                        origin_rpaths.append(origin_rpath)
+
+        if existing_rpaths:
+            # Only keep those that mention origin and are not already in our
+            # bundle.
+            existing_rpaths = [
+                r for r in existing_rpaths if "$ORIGIN" in r and r not in origin_rpaths
+            ]
+            origin_rpaths = existing_rpaths + origin_rpaths
+
+        formatted_origin_paths = ":".join((r for r in origin_rpaths if r))
+        formatted_base_rpaths = ":".join(sorted(base_rpaths))
+
+        if formatted_origin_paths and formatted_base_rpaths:
+            return f"{formatted_origin_paths}:{formatted_base_rpaths}"
+
+        if formatted_origin_paths and not formatted_base_rpaths:
+            return formatted_origin_paths
+
+        return formatted_base_rpaths

--- a/snapcraft/elf/errors.py
+++ b/snapcraft/elf/errors.py
@@ -17,8 +17,23 @@
 """Helpers to parse and handle ELF binary files."""
 
 from pathlib import Path
+from typing import List
 
 from snapcraft import errors
+
+
+class PatcherError(errors.SnapcraftError):
+    """Failed to patch an ELF file."""
+
+    def __init__(self, path: Path, *, cmd: List[str], code: int) -> None:
+        self.path = path
+        self.cmd = cmd
+        self.code = code
+
+        super().__init__(
+            f"{str(path)!r} cannot be patched to function properly in a classic"
+            f"confined snap: {cmd} failed with exit code {code}"
+        )
 
 
 class CorruptedElfFile(errors.SnapcraftError):

--- a/tests/unit/elf/test_patcher.py
+++ b/tests/unit/elf/test_patcher.py
@@ -1,0 +1,50 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+
+from snapcraft import elf
+from snapcraft.elf import errors
+
+
+def test_patcher(fake_elf, fake_tools):
+    elf_file = fake_elf("fake_elf-2.23")
+    # The base_path does not matter here as there are not files to
+    # be crawled for.
+    elf_patcher = elf.Patcher(dynamic_linker="/lib/fake-ld", root_path="/fake")
+    elf_patcher.patch(elf_file=elf_file)
+
+
+def test_patcher_does_nothing_if_no_interpreter(fake_elf, fake_tools):
+    elf_file = fake_elf("fake_elf-static")
+    # The base_path does not matter here as there are not files to
+    # be crawled for.
+    elf_patcher = elf.Patcher(dynamic_linker="/lib/fake-ld", root_path="/fake")
+    elf_patcher.patch(elf_file=elf_file)
+
+
+def test_patcher_fails_raises_patcherror_exception(fake_elf, fake_tools):
+    elf_file = fake_elf("fake_elf-bad-patchelf")
+    # The base_path does not matter here as there are not files to
+    # be crawled for.
+    elf_patcher = elf.Patcher(dynamic_linker="/lib/fake-ld", root_path="/fake")
+
+    with pytest.raises(errors.PatcherError) as raised:
+        elf_patcher.patch(elf_file=elf_file)
+    assert raised.value.path == Path("fake_elf-bad-patchelf")
+    assert raised.value.code == 1

--- a/tests/unit/elf/test_patcher.py
+++ b/tests/unit/elf/test_patcher.py
@@ -14,7 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import shutil
 from pathlib import Path
+from unittest.mock import ANY, call
 
 import pytest
 
@@ -48,3 +50,147 @@ def test_patcher_fails_raises_patcherror_exception(fake_elf, fake_tools):
         elf_patcher.patch(elf_file=elf_file)
     assert raised.value.path == Path("fake_elf-bad-patchelf")
     assert raised.value.code == 1
+
+
+@pytest.fixture
+def elf_file(new_dir):
+    base_path = new_dir / "core"
+    base_path.mkdir()
+
+    elf_path = Path(new_dir / "elf")
+    shutil.copy("/bin/true", elf_path)
+    elf_file = elf.ElfFile(path=elf_path)
+
+    # Use base path as / so that the elf file is inside the base
+    elf_file.load_dependencies(
+        root_path=Path("/snap/foo/current"),
+        base_path=Path("/"),
+        content_dirs=set(),
+        arch_triplet="x86_64-linux-gnu",
+    )
+    yield elf_file
+
+
+@pytest.fixture
+def patcher():
+    yield elf.Patcher(
+        dynamic_linker="/my/dynamic/linker",
+        root_path="/snap/foo/current",
+    )
+
+
+def test_patcher_patch_rpath(mocker, patcher, elf_file):
+    run_mock = mocker.patch("subprocess.check_call")
+
+    expected_proposed_rpath = list(elf_file.dependencies)[0].path.parent
+    assert patcher._get_current_rpath(elf_file) == []
+
+    patcher.patch(elf_file=elf_file)
+    assert run_mock.mock_calls == [
+        call(
+            [
+                "/usr/bin/patchelf",
+                "--set-interpreter",
+                "/my/dynamic/linker",
+                "--force-rpath",
+                "--set-rpath",
+                str(expected_proposed_rpath),
+                ANY,
+            ]
+        )
+    ]
+
+
+def test_patcher_patch_existing_rpath_origin(mocker, patcher, elf_file):
+    run_mock = mocker.patch("subprocess.check_call")
+    mocker.patch(
+        "snapcraft.elf._patcher.Patcher._get_current_rpath",
+        return_value=["$ORIGIN/current/rpath"],
+    )
+
+    expected_proposed_rpath = list(elf_file.dependencies)[0].path.parent
+    assert patcher._get_current_rpath(elf_file) == ["$ORIGIN/current/rpath"]
+
+    patcher.patch(elf_file=elf_file)
+    assert run_mock.mock_calls == [
+        call(
+            [
+                "/usr/bin/patchelf",
+                "--set-interpreter",
+                "/my/dynamic/linker",
+                "--force-rpath",
+                "--set-rpath",
+                f"$ORIGIN/current/rpath:{str(expected_proposed_rpath)}",
+                ANY,
+            ]
+        )
+    ]
+
+
+def test_patcher_patch_existing_rpath_not_origin(mocker, patcher, elf_file):
+    run_mock = mocker.patch("subprocess.check_call")
+    mocker.patch(
+        "snapcraft.elf._patcher.Patcher._get_current_rpath",
+        return_value=["/current/rpath"],
+    )
+
+    expected_proposed_rpath = list(elf_file.dependencies)[0].path.parent
+    assert patcher._get_current_rpath(elf_file) == ["/current/rpath"]
+
+    patcher.patch(elf_file=elf_file)
+    assert run_mock.mock_calls == [
+        call(
+            [
+                "/usr/bin/patchelf",
+                "--set-interpreter",
+                "/my/dynamic/linker",
+                "--force-rpath",
+                "--set-rpath",
+                str(expected_proposed_rpath),
+                ANY,
+            ]
+        )
+    ]
+
+
+def test_patcher_patch_rpath_same_interpreter(mocker, patcher, elf_file):
+    run_mock = mocker.patch("subprocess.check_call")
+    patcher._dynamic_linker = elf_file.interp
+
+    expected_proposed_rpath = list(elf_file.dependencies)[0].path.parent
+    assert patcher._get_current_rpath(elf_file) == []
+
+    patcher.patch(elf_file=elf_file)
+    assert run_mock.mock_calls == [
+        call(
+            [
+                "/usr/bin/patchelf",
+                "--force-rpath",
+                "--set-rpath",
+                str(expected_proposed_rpath),
+                ANY,
+            ]
+        )
+    ]
+
+
+def test_patcher_patch_rpath_already_set(mocker, patcher, elf_file):
+    run_mock = mocker.patch("subprocess.check_call")
+
+    expected_proposed_rpath = list(elf_file.dependencies)[0].path.parent
+    mocker.patch(
+        "snapcraft.elf._patcher.Patcher._get_current_rpath",
+        return_value=["$ORIGIN/current/rpath", str(expected_proposed_rpath)],
+    )
+
+    patcher.patch(elf_file=elf_file)
+    assert run_mock.mock_calls == [
+        call(
+            [
+                "/usr/bin/patchelf",
+                "--set-interpreter",
+                "/my/dynamic/linker",
+                ANY,
+            ]
+        )
+    ]


### PR DESCRIPTION
Patch ELF files using patchelf. This is a port of the corresponding
class from Snapcraft 6.x.

Co-authored-by: Kyle Fazzari <kyrofa@ubuntu.com>
Co-authored-by: Chris Patterson <chris.patterson@canonical.com>
Co-authored-by: Sergio Schvezov <sergio.schvezov@canonical.com>
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1191