### PR TITLE
cli: add KeyAlreadyExists error

### DIFF
--- a/snapcraft/commands/legacy.py
+++ b/snapcraft/commands/legacy.py
@@ -268,7 +268,7 @@ class StoreLegacyListKeysCommand(LegacyBaseCommand):
     help_msg = "List the keys available to sign assertions"
     overview = textwrap.dedent(
         """
-        List the available keys to sign assertions together with they
+        List the available keys to sign assertions together with their
         local availability."""
     )
 

--- a/snapcraft_legacy/_store.py
+++ b/snapcraft_legacy/_store.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2016-2020 Canonical Ltd
+# Copyright 2016-2022 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -435,6 +435,7 @@ def _export_key(name, account_id):
 
 
 def list_keys():
+    """Lists keys available to sign assertions."""
     keys = list(_get_usable_keys())
     account_info = StoreClientCLI().get_account_information()
     enabled_keys = {
@@ -479,7 +480,7 @@ def create_key(name):
         # `snap create-key` would eventually fail, but we can save the user
         # some time in this obvious error case by not bothering to talk to
         # the store first.
-        raise storeapi.errors.KeyAlreadyRegisteredError(name)
+        raise storeapi.errors.KeyAlreadyExistsError(name)
     try:
         account_info = StoreClientCLI().get_account_information()
         enabled_names = {

--- a/snapcraft_legacy/storeapi/_dashboard_api.py
+++ b/snapcraft_legacy/storeapi/_dashboard_api.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2016-2021 Canonical Ltd
+# Copyright 2016-2022 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -34,7 +34,7 @@ class DashboardAPI(Requests):
     """The Dashboard API is used to publish and manage snaps.
 
     This is an interface to query that API which is documented
-    at https://dashboard.snapcraft.io/docs/.
+    at https://dashboard.snapcraft.io/docs/index.html.
     """
 
     def __init__(self, auth_client: craft_store.BaseClient) -> None:

--- a/snapcraft_legacy/storeapi/errors.py
+++ b/snapcraft_legacy/storeapi/errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2016-2020 Canonical Ltd
+# Copyright 2016-2022 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -792,6 +792,14 @@ class StoreBuildAssertionPermissionError(StoreError):
 class StoreAssertionError(StoreError):
 
     fmt = "Error signing {endpoint} assertion for {snap_name}: {error!s}"
+
+
+class KeyAlreadyExistsError(StoreError):
+
+    fmt = "The key {key_name!r} already exists"
+
+    def __init__(self, key_name):
+        super().__init__(key_name=key_name)
 
 
 class KeyAlreadyRegisteredError(StoreError):

--- a/tests/legacy/unit/commands/test_create_key.py
+++ b/tests/legacy/unit/commands/test_create_key.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2016-2019 Canonical Ltd
+# Copyright (C) 2016-2022 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -31,11 +31,11 @@ class CreateKeyTestCase(FakeStoreCommandsBaseTestCase):
 
     def test_create_key_already_exists(self):
         raised = self.assertRaises(
-            storeapi.errors.KeyAlreadyRegisteredError, self.run_command, ["create-key"]
+            storeapi.errors.KeyAlreadyExistsError, self.run_command, ["create-key"]
         )
 
         self.assertThat(
-            str(raised), Equals("You have already registered a key named 'default'")
+            str(raised), Equals("The key 'default' already exists")
         )
 
     def test_create_key_already_registered(self):

--- a/tests/legacy/unit/store/test_errors.py
+++ b/tests/legacy/unit/store/test_errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2020 Canonical Ltd
+# Copyright (C) 2020-2022 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -16,10 +16,13 @@
 
 from textwrap import dedent
 
+from snapcraft_legacy.storeapi.channels import Channel
+from snapcraft_legacy.storeapi.status import SnapStatusChannelDetails
+
 from snapcraft_legacy.storeapi import errors
 
 
-class TestSnapcraftException:
+class TestSnapNotFoundException:
     scenarios = (
         (
             "SnapNotFoundError snap_name",
@@ -113,3 +116,186 @@ class TestSnapcraftException:
         assert exception.get_details() == expected_details
         assert exception.get_docs_url() == expected_docs_url
         assert exception.get_reportable() == expected_reportable
+
+
+class TestErrorFormatting:
+
+    scenarios = [
+        (
+            "NoSnapIdError",
+            dict(
+                exception_class=errors.NoSnapIdError,
+                kwargs=dict(snap_name="test-1"),
+                expected_message=(
+                    "Failed to get snap ID for snap 'test-1'. This is an error in "
+                    "the store, please open a new topic in the 'store' category in the "
+                    "forum: https://forum.snapcraft.io/c/store"
+                ),
+            ),
+        ),
+        (
+            "DownloadNotFoundError",
+            dict(
+                exception_class=errors.DownloadNotFoundError,
+                kwargs=dict(path="test-1"),
+                expected_message="Downloaded file not found 'test-1'.",
+            ),
+        ),
+        (
+            "SHAMismatchError",
+            dict(
+                exception_class=errors.SHAMismatchError,
+                kwargs=dict(path="test-1", expected="test-2", calculated="test-3"),
+                expected_message=(
+                    "The SHA3-384 checksum for 'test-1' was 'test-3': expected 'test-2'."
+                ),
+            ),
+        ),
+        (
+            "StoreDeltaApplicationError",
+            dict(
+                exception_class=errors.StoreDeltaApplicationError,
+                kwargs=dict(message="test-1"),
+                expected_message="test-1",
+            ),
+        ),
+        (
+            "StoreChannelClosingPermissionError",
+            dict(
+                exception_class=errors.StoreChannelClosingPermissionError,
+                kwargs=dict(snap_name="test-1", snap_series="test-2"),
+                expected_message=(
+                    "Your account lacks permission to close channels for this snap. Make "
+                    "sure the logged in account has upload permissions on 'test-1' "
+                    "in series 'test-2'."
+                ),
+            ),
+        ),
+        (
+            "StoreBuildAssertionPermissionError",
+            dict(
+                exception_class=errors.StoreBuildAssertionPermissionError,
+                kwargs=dict(snap_name="test-1", snap_series="test-2"),
+                expected_message=(
+                    "Your account lacks permission to assert builds for this snap. "
+                    "Make sure you are logged in as the publisher of 'test-1' for series 'test-2'."
+                ),
+            ),
+        ),
+        (
+            "StoreAssertionError",
+            dict(
+                exception_class=errors.StoreAssertionError,
+                kwargs=dict(endpoint="test-1", snap_name="test-2", error="test-3"),
+                expected_message="Error signing test-1 assertion for test-2: test-3",
+            ),
+        ),
+        (
+            "KeyAlreadyExistsError",
+            dict(
+                exception_class=errors.KeyAlreadyExistsError,
+                kwargs=dict(key_name="test-1"),
+                expected_message="The key 'test-1' already exists",
+            ),
+        ),
+        (
+            "KeyAlreadyRegisteredError",
+            dict(
+                exception_class=errors.KeyAlreadyRegisteredError,
+                kwargs=dict(key_name="test-1"),
+                expected_message="You have already registered a key named 'test-1'",
+            ),
+        ),
+        (
+            "NoKeysError",
+            dict(
+                exception_class=errors.NoKeysError,
+                kwargs={},
+                expected_message=(
+                    "You have no usable keys.\nPlease create at least one key with "
+                    "`snapcraft create-key` for use with snap."
+                ),
+            ),
+        ),
+        (
+            "NoSuchKeyError",
+            dict(
+                exception_class=errors.NoSuchKeyError,
+                kwargs=dict(key_name="test-1"),
+                expected_message=(
+                    "You have no usable key named 'test-1'.\nSee the keys available "
+                    "in your system with `snapcraft keys`."
+                ),
+            ),
+        ),
+        (
+            "KeyNotRegisteredError",
+            dict(
+                exception_class=errors.KeyNotRegisteredError,
+                kwargs=dict(key_name="test-1"),
+                expected_message=(
+                    "The key 'test-1' is not registered in the Store.\nPlease "
+                    "register it with `snapcraft register-key 'test-1'` before "
+                    "signing and uploading signatures to the Store."
+                ),
+            ),
+        ),
+        (
+            "InvalidValidationRequestsError",
+            dict(
+                exception_class=errors.InvalidValidationRequestsError,
+                kwargs=dict(requests=["test-1"]),
+                expected_message=(
+                    "Invalid validation requests (format must be name=revision): test-1"
+                ),
+            ),
+        ),
+        (
+            "SignBuildAssertionError",
+            dict(
+                exception_class=errors.SignBuildAssertionError,
+                kwargs=dict(snap_name="test-1"),
+                expected_message="Failed to sign build assertion for 'test-1'",
+            ),
+        ),
+        (
+            "ChannelNotAvailableOnArchError",
+            dict(
+                exception_class=errors.ChannelNotAvailableOnArchError,
+                kwargs=dict(snap_name="test-1", channel=Channel, arch="test-2"),
+                expected_message=(
+                    f"No releases available for 'test-1' on channel {Channel!r} "
+                    "for architecture 'test-2'.\n"
+                    "Ensure the selected channel contains released revisions "
+                    "for this architecture."
+                ),
+            ),
+        ),
+        (
+            "InvalidChannelSet",
+            dict(
+                exception_class=errors.InvalidChannelSet,
+                kwargs=dict(
+                    snap_name="test-1",
+                    channel=Channel(channel="stable"),
+                    channel_outliers=[
+                        SnapStatusChannelDetails(
+                            snap_name="test-2",
+                            arch="test-3",
+                            payload={"test-4": "test-5"},
+                        )
+                    ],
+                ),
+                expected_message=(
+                    f"The '{Channel(channel='stable')}' channel for 'test-1' does"
+                    " not form a complete set.\n"
+                    "There is no revision released for the following"
+                    " architectures: \"'test-3'\".\n"
+                    "Ensure the selected channel contains released revisions for all architectures."
+                ),
+            ),
+        ),
+    ]
+
+    def test_error_formatting(self, exception_class, kwargs, expected_message):
+        assert str(exception_class(**kwargs)) == expected_message


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
#### Overview
Raise new `KeyAlreadyExists` error when `snapcraft create-key` attempts to create an existing key.

#### Changes
1. Add new error `KeyAlreadyExists`
2. Add unit tests for some other `storeapi` errors.  

#### Source

- https://bugs.launchpad.net/snapcraft/+bug/1979907



(CRAFT-1161)