### PR TITLE
linters: add linting infrastructure

### DIFF
--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -215,6 +215,9 @@ def run():
     except craft_store.errors.CraftStoreError as err:
         emit.error(craft_cli.errors.CraftError(f"craft-store error: {err}"))
         retcode = 1
+    except errors.LinterError as err:
+        emit.error(craft_cli.errors.CraftError(f"linter error: {err}"))
+        retcode = err.exit_code
     except errors.SnapcraftError as err:
         emit.error(err)
         retcode = 1

--- a/snapcraft/errors.py
+++ b/snapcraft/errors.py
@@ -87,5 +87,20 @@ class InvalidArchitecture(SnapcraftError):
         )
 
 
+class LinterError(SnapcraftError):
+    """Snap linting returned an error.
+
+    :param message: The error description.
+    :exit_code: The shell return code to use.
+    """
+
+    def __init__(self, message: str, *, exit_code: int):
+        self.exit_code = exit_code
+        super().__init__(
+            message,
+            resolution="Make sure the issues are addressed or ignore the isses in snapcraft.yaml.",
+        )
+
+
 class LegacyFallback(Exception):
     """Fall back to legacy snapcraft implementation."""

--- a/snapcraft/linters/__init__.py
+++ b/snapcraft/linters/__init__.py
@@ -1,0 +1,28 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Extension processor and related utilities."""
+
+from .base import LinterIssue
+from .linters import LinterStatus, lint_command, report, run_linters
+
+__all__ = [
+    "LinterIssue",
+    "LinterStatus",
+    "lint_command",
+    "report",
+    "run_linters",
+]

--- a/snapcraft/linters/base.py
+++ b/snapcraft/linters/base.py
@@ -69,7 +69,7 @@ class LinterIssue(pydantic.BaseModel):
 
         return msg
 
-    class Config:  # pylint: disable=too-few-public-methods
+    class Config:
         """Pydantic model configuration."""
 
         validate_assignment = True

--- a/snapcraft/linters/base.py
+++ b/snapcraft/linters/base.py
@@ -1,0 +1,93 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Snapcraft linting infrastructure."""
+
+import abc
+import enum
+from typing import TYPE_CHECKING, List, Literal, Optional
+
+import pydantic
+
+from snapcraft import projects
+
+if TYPE_CHECKING:
+    from snapcraft.meta.snap_yaml import SnapMetadata
+
+
+@enum.unique
+class LinterResult(str, enum.Enum):
+    """Valid linting results."""
+
+    OK = "ok"
+    WARNING = "warning"
+    ERROR = "error"
+    FATAL = "fatal"
+    IGNORED = "ignored"
+
+    def __str__(self):
+        """Use the enum value as the string representation."""
+        return self.value
+
+
+class LinterIssue(pydantic.BaseModel):
+    """Linter issue with type "lint"."""
+
+    type: Literal["lint"]
+    name: str
+    result: LinterResult
+    filename: Optional[str]
+    text: str
+    url: str
+    suggested_changes: Optional[str]  # XXX: pending definition
+
+    def __init__(self, **kwargs):
+        super().__init__(type="lint", **kwargs)
+
+    def __str__(self):
+        """Use short formatted issue as the string representation."""
+        if not self.filename:
+            return f"{self.name!s}: {self.text} ({self.url})"
+
+        return f"{self.name!s}: {self.filename}: {self.text} ({self.url})"
+
+    class Config:  # pylint: disable=too-few-public-methods
+        """Pydantic model configuration."""
+
+        validate_assignment = True
+        extra = "forbid"
+        alias_generator = lambda s: s.replace("_", "-")  # noqa: E731
+
+
+class Linter(abc.ABC):
+    """Base class for linters.
+
+    :param project: The snap project information.
+    """
+
+    def __init__(
+        self, name: str, snap_metadata: "SnapMetadata", lint: Optional[projects.Lint]
+    ):
+        self._name = name
+        self._snap_metadata = snap_metadata
+        self._lint = lint or projects.Lint(ignore=projects.LintIgnore())
+
+    @abc.abstractmethod
+    def run(self) -> List[LinterIssue]:
+        """Execute linting.
+
+        :return: A list of linter issues flagged by this linter.
+        """

--- a/snapcraft/linters/base.py
+++ b/snapcraft/linters/base.py
@@ -51,7 +51,7 @@ class LinterIssue(pydantic.BaseModel):
     result: LinterResult
     filename: Optional[str]
     text: str
-    url: str
+    url: Optional[str]
     suggested_changes: Optional[str]  # XXX: pending definition
 
     def __init__(self, **kwargs):
@@ -59,10 +59,15 @@ class LinterIssue(pydantic.BaseModel):
 
     def __str__(self):
         """Use short formatted issue as the string representation."""
-        if not self.filename:
-            return f"{self.name!s}: {self.text} ({self.url})"
+        if self.filename:
+            msg = f"{self.name!s}: {self.filename}: {self.text}"
+        else:
+            msg = f"{self.name!s}: {self.text}"
 
-        return f"{self.name!s}: {self.filename}: {self.text} ({self.url})"
+        if self.url:
+            msg += f" ({self.url})"
+
+        return msg
 
     class Config:  # pylint: disable=too-few-public-methods
         """Pydantic model configuration."""
@@ -79,7 +84,10 @@ class Linter(abc.ABC):
     """
 
     def __init__(
-        self, name: str, snap_metadata: "SnapMetadata", lint: Optional[projects.Lint]
+        self,
+        name: str,
+        snap_metadata: "SnapMetadata",
+        lint: Optional[projects.Lint],
     ):
         self._name = name
         self._snap_metadata = snap_metadata

--- a/snapcraft/linters/linters.py
+++ b/snapcraft/linters/linters.py
@@ -119,7 +119,9 @@ def lint_command(parsed_args: "argparse.Namespace") -> None:
 def run_linters(location: Path, *, lint: Optional[projects.Lint]) -> List[LinterIssue]:
     """Run all the defined linters.
 
-    :param snap_file: The path to the snap file or payload directory to lint.
+    :param location: The root of the snap payload subtree to run linters on.
+    :param lint: The linter configuration defined for this project.
+    :return: A list of linter issues.
     """
     all_issues: List[LinterIssue] = []
     previous_dir = os.getcwd()

--- a/snapcraft/linters/linters.py
+++ b/snapcraft/linters/linters.py
@@ -53,8 +53,8 @@ class LinterStatus(enum.IntEnum):
 
 _lint_reports: Dict[LinterResult, str] = {
     LinterResult.OK: "Lint OK",
-    LinterResult.WARNING: "Lint Warnings",
-    LinterResult.ERROR: "Lint Errors",
+    LinterResult.WARNING: "Lint warnings",
+    LinterResult.ERROR: "Lint errors",
 }
 
 

--- a/snapcraft/linters/linters.py
+++ b/snapcraft/linters/linters.py
@@ -1,0 +1,166 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Snapcraft linting execution and reporting."""
+
+import enum
+import fnmatch
+import json
+import os
+from functools import partial
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, List, Optional, Type
+
+from craft_cli import emit
+
+from snapcraft import projects
+from snapcraft.meta import snap_yaml
+
+from .base import Linter, LinterIssue, LinterResult
+
+if TYPE_CHECKING:
+    import argparse
+
+
+LinterType = Type[Linter]
+
+
+_LINTERS: Dict[str, LinterType] = {}
+
+
+@enum.unique
+class LinterStatus(enum.IntEnum):
+    """Status codes for the linter execution."""
+
+    OK = 0
+    FATAL = 1
+    ERRORS = 2
+    WARNINGS = 3
+
+
+_lint_reports: Dict[LinterResult, str] = {
+    LinterResult.OK: "Lint OK",
+    LinterResult.WARNING: "Lint Warnings",
+    LinterResult.ERROR: "Lint Errors",
+}
+
+
+def report(
+    issues: List[LinterIssue], *, json_output: bool = False, intermediate: bool = False
+) -> LinterStatus:
+    """Display the linter report in textual or json formats.
+
+    :param issues: The list of issues to display.
+    :param json_output: Display issues in json format.
+    :param intermediate: Set if the linter output are is not the main
+        outcome of the command execution.
+    """
+    if intermediate:
+        display = partial(emit.progress, permanent=True)
+    else:
+        display = emit.message
+
+    status = LinterStatus.OK
+
+    # split dictionary based on result
+    issues_by_result: Dict[LinterResult, List[LinterIssue]] = {}
+    for issue in issues:
+        status = _update_status(status, issue.result)
+        if status == LinterStatus.FATAL:
+            break
+
+        if issue.result in _lint_reports:
+            issues_by_result.setdefault(issue.result, []).append(issue)
+
+    if json_output:
+        display(json.dumps([x.dict(exclude_none=True) for x in issues]))
+    else:
+        # show issues by result
+        for result, header in _lint_reports.items():
+            if issues_by_result.get(result):
+                display(f"{header}:")
+                for issue in issues_by_result[result]:
+                    display(f"- {issue!s}")
+
+    return status
+
+
+def _update_status(status: LinterStatus, result: LinterResult) -> LinterStatus:
+    """Compute the consolitated status based on individual linter results."""
+    if result == LinterResult.FATAL:
+        status = LinterStatus.FATAL
+    elif result == LinterResult.ERROR and status != LinterStatus.FATAL:
+        status = LinterStatus.ERRORS
+    elif result == LinterResult.WARNING and status == LinterStatus.OK:
+        status = LinterStatus.WARNINGS
+
+    return status
+
+
+def lint_command(parsed_args: "argparse.Namespace") -> None:
+    """``snapcraft lint`` command handler."""
+    # XXX: obtain lint configuration
+    run_linters(parsed_args.snap_file, lint=None)
+
+
+def run_linters(location: Path, *, lint: Optional[projects.Lint]) -> List[LinterIssue]:
+    """Run all the defined linters.
+
+    :param snap_file: The path to the snap file or payload directory to lint.
+    """
+    all_issues: List[LinterIssue] = []
+    previous_dir = os.getcwd()
+    try:
+        os.chdir(location)
+
+        emit.progress("Reading snap metadata...")
+        snap_metadata = snap_yaml.read(Path())
+
+        emit.progress("Running linters...")
+        for name, linter_class in _LINTERS.items():
+            if lint and name in lint.ignore.linters:
+                continue
+
+            linter = linter_class(name=name, lint=lint, snap_metadata=snap_metadata)
+            emit.progress(f"Running linter: {name}")
+            issues = linter.run()
+            all_issues += issues
+    finally:
+        os.chdir(previous_dir)
+
+    _ignore_matching_filenames(all_issues, lint=lint)
+
+    return all_issues
+
+
+def _ignore_matching_filenames(
+    issues: List[LinterIssue], *, lint: Optional[projects.Lint]
+) -> None:
+    """Mark any remaining filename match as ignored."""
+    if lint and lint.ignore.files:
+        for issue in issues:
+            for pattern in lint.ignore.files:
+                if (
+                    issue.filename
+                    and issue.result != LinterResult.IGNORED
+                    and fnmatch.fnmatch(issue.filename, pattern)
+                ):
+                    emit.verbose(
+                        f"Ignore {issue.name!r} linter issue ({issue.filename!r} "
+                        f"matches {pattern!r})"
+                    )
+                    issue.result = LinterResult.IGNORED
+                    break

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -181,6 +181,19 @@ class Socket(ProjectModel):
         return listen_stream
 
 
+class LintIgnore(ProjectModel):
+    """Lists of specific linters or globbed filenames to ignore."""
+
+    linters: List[str] = []
+    files: List[str] = []
+
+
+class Lint(ProjectModel):
+    """Linter configuration."""
+
+    ignore: LintIgnore
+
+
 class App(ProjectModel):
     """Snapcraft project app definition."""
 
@@ -361,6 +374,7 @@ class Project(ProjectModel):
     apps: Optional[Dict[str, App]]
     plugs: Optional[Dict[str, Union[ContentPlug, Any]]]
     slots: Optional[Dict[str, Any]]
+    lint: Optional[Lint]
     parts: Dict[str, Any]  # parts are handled by craft-parts
     epoch: Optional[str]
     adopt_info: Optional[str]

--- a/tests/unit/linters/conftest.py
+++ b/tests/unit/linters/conftest.py
@@ -27,14 +27,15 @@ def linter_issue():
         *,
         result: LinterResult = LinterResult.OK,
         filename: Optional[str] = None,
-        text: str = "Linter message text"
+        text: str = "Linter message text",
+        url: Optional[str] = "https://some/url",
     ):
         return LinterIssue(
             name="test",
             result=result,
             filename=filename,
             text=text,
-            url="https://some/url",
+            url=url,
         )
 
     yield _create_issue

--- a/tests/unit/linters/conftest.py
+++ b/tests/unit/linters/conftest.py
@@ -1,0 +1,40 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Optional
+
+import pytest
+
+from snapcraft.linters.base import LinterIssue, LinterResult
+
+
+@pytest.fixture
+def linter_issue():
+    def _create_issue(
+        *,
+        result: LinterResult = LinterResult.OK,
+        filename: Optional[str] = None,
+        text: str = "Linter message text"
+    ):
+        return LinterIssue(
+            name="test",
+            result=result,
+            filename=filename,
+            text=text,
+            url="https://some/url",
+        )
+
+    yield _create_issue

--- a/tests/unit/linters/test_base.py
+++ b/tests/unit/linters/test_base.py
@@ -49,3 +49,11 @@ class TestLinterIssue:
     def test_linter_issue_string_filename(self, linter_issue):
         issue = linter_issue(filename="foo.txt")
         assert f"{issue}" == "test: foo.txt: Linter message text (https://some/url)"
+
+    def test_linter_issue_string_no_url(self, linter_issue):
+        issue = linter_issue(url=None)
+        assert f"{issue}" == "test: Linter message text"
+
+    def test_linter_issue_string_filename_no_url(self, linter_issue):
+        issue = linter_issue(filename="foo.txt", url=None)
+        assert f"{issue}" == "test: foo.txt: Linter message text"

--- a/tests/unit/linters/test_base.py
+++ b/tests/unit/linters/test_base.py
@@ -1,0 +1,51 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from snapcraft.linters.base import LinterResult
+
+
+class TestLinterResult:
+    """Linter result presentation."""
+
+    def test_linter_result(self):
+        assert f"{LinterResult.OK}" == "ok"
+        assert f"{LinterResult.WARNING}" == "warning"
+        assert f"{LinterResult.ERROR}" == "error"
+        assert f"{LinterResult.FATAL}" == "fatal"
+        assert f"{LinterResult.IGNORED}" == "ignored"
+
+
+class TestLinterIssue:
+    """Linter issue creation and presentation."""
+
+    @pytest.mark.parametrize("result", list(LinterResult))
+    def test_linter_issue(self, linter_issue, result):
+        issue = linter_issue(result=result, filename="foo.txt")
+        assert issue.name == "test"
+        assert issue.filename == "foo.txt"
+        assert issue.text == "Linter message text"
+        assert issue.result == result
+        assert issue.url == "https://some/url"
+
+    def test_linter_issue_string(self, linter_issue):
+        issue = linter_issue()
+        assert f"{issue}" == "test: Linter message text (https://some/url)"
+
+    def test_linter_issue_string_filename(self, linter_issue):
+        issue = linter_issue(filename="foo.txt")
+        assert f"{issue}" == "test: foo.txt: Linter message text (https://some/url)"

--- a/tests/unit/linters/test_linters.py
+++ b/tests/unit/linters/test_linters.py
@@ -1,0 +1,194 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+from typing import List
+from unittest.mock import call
+
+import pytest
+from overrides import overrides
+
+from snapcraft import linters, projects
+from snapcraft.linters.base import Linter, LinterResult
+from snapcraft.linters.linters import _ignore_matching_filenames
+from snapcraft.meta import snap_yaml
+
+
+class TestLinterReport:
+    """Linter report output."""
+
+    def test_linter_report(self, emitter, linter_issue):
+        issues = [
+            linter_issue(result=LinterResult.WARNING, text="Without filename"),
+            linter_issue(filename="foo.txt", text="With filename"),
+            linter_issue(
+                result=LinterResult.ERROR, filename="bar.txt", text="Some error"
+            ),
+        ]
+        linters.report(issues)
+        assert emitter.interactions == [
+            call("message", "Lint OK:"),
+            call("message", "- test: foo.txt: With filename (https://some/url)"),
+            call("message", "Lint Warnings:"),
+            call("message", "- test: Without filename (https://some/url)"),
+            call("message", "Lint Errors:"),
+            call("message", "- test: bar.txt: Some error (https://some/url)"),
+        ]
+
+    def test_linter_report_intermediate(self, emitter, linter_issue):
+        issues = [
+            linter_issue(result=LinterResult.WARNING, text="Without filename"),
+            linter_issue(filename="foo.txt", text="With filename"),
+            linter_issue(
+                result=LinterResult.ERROR, filename="bar.txt", text="Some error"
+            ),
+        ]
+        linters.report(issues, intermediate=True)
+        assert emitter.interactions == [
+            call("progress", "Lint OK:", permanent=True),
+            call(
+                "progress",
+                "- test: foo.txt: With filename (https://some/url)",
+                permanent=True,
+            ),
+            call("progress", "Lint Warnings:", permanent=True),
+            call(
+                "progress",
+                "- test: Without filename (https://some/url)",
+                permanent=True,
+            ),
+            call("progress", "Lint Errors:", permanent=True),
+            call(
+                "progress",
+                "- test: bar.txt: Some error (https://some/url)",
+                permanent=True,
+            ),
+        ]
+
+    def test_linter_report_json(self, emitter, linter_issue):
+        issues = [
+            linter_issue(result=LinterResult.WARNING),
+            linter_issue(filename="foo.txt"),
+        ]
+        linters.report(issues, json_output=True)
+        assert emitter.interactions == [
+            call(
+                "message",
+                '[{"type": "lint", "name": "test", "result": "warning", "text": '
+                '"Linter message text", "url": "https://some/url"}, {"type": '
+                '"lint", "name": "test", "result": "ok", "filename": "foo.txt", '
+                '"text": "Linter message text", "url": "https://some/url"}]',
+            )
+        ]
+
+
+class TestLinterStatus:
+    """Check report status according to issues reported."""
+
+    # Expected results:
+    # 0: found no errors or warnings
+    # 1: checks not run due to fatal error
+    # 2: found only errors or errors and warnings
+    # 3: found only warnings
+
+    @pytest.mark.parametrize(
+        "results,expected_status",
+        [
+            ([], 0),
+            ([LinterResult.OK], 0),
+            ([LinterResult.IGNORED], 0),
+            ([LinterResult.WARNING], 3),
+            ([LinterResult.ERROR], 2),
+            ([LinterResult.FATAL], 1),
+            ([LinterResult.OK, LinterResult.WARNING], 3),
+            ([LinterResult.IGNORED, LinterResult.WARNING], 3),
+            ([LinterResult.OK, LinterResult.WARNING, LinterResult.ERROR], 2),
+            ([LinterResult.OK, LinterResult.ERROR, LinterResult.FATAL], 1),
+        ],
+    )
+    def test_linter_status(self, linter_issue, results, expected_status):
+        issues = []
+        for result in results:
+            issues.append(linter_issue(result=result))
+
+        status = linters.report(issues)
+        assert status == expected_status
+
+
+class TestLinterRun:
+    """Check linter execution."""
+
+    class _TestLinter(Linter):
+        @overrides
+        def run(self) -> List[linters.LinterIssue]:
+            assert self._snap_metadata.name == "mytest"
+            return [
+                linters.LinterIssue(
+                    name="test",
+                    result=LinterResult.WARNING,
+                    text="Something wrong.",
+                    url="https://some/url",
+                )
+            ]
+
+    def test_run_linters(self, mocker, new_dir, linter_issue):
+        mocker.patch(
+            "snapcraft.linters.linters._LINTERS", {"test": TestLinterRun._TestLinter}
+        )
+        yaml_data = {
+            "name": "mytest",
+            "version": "1.29.3",
+            "base": "core22",
+            "summary": "Single-line elevator pitch for your amazing snap",
+            "description": "test-description",
+            "confinement": "strict",
+            "parts": {},
+        }
+
+        project = projects.Project.unmarshal(yaml_data)
+        snap_yaml.write(
+            project,
+            prime_dir=Path(new_dir),
+            arch="amd64",
+            arch_triplet="x86_64-linux-gnu",
+        )
+
+        issues = linters.run_linters(new_dir, lint=None)
+        assert issues == [
+            linters.LinterIssue(
+                name="test",
+                result=LinterResult.WARNING,
+                text="Something wrong.",
+                url="https://some/url",
+            )
+        ]
+
+    def test_ignore_matching_filenames(self, linter_issue):
+        lint = projects.Lint(ignore=projects.LintIgnore(files=["foo*", "some/dir/*"]))
+        issues = [
+            linter_issue(filename="foo.txt", result=LinterResult.WARNING),
+            linter_issue(filename="bar.txt", result=LinterResult.WARNING),
+            linter_issue(filename="some/dir/baz.txt", result=LinterResult.ERROR),
+            linter_issue(filename="other/dir/quux.txt", result=LinterResult.ERROR),
+        ]
+
+        _ignore_matching_filenames(issues, lint=lint)
+        assert issues == [
+            linter_issue(filename="foo.txt", result=LinterResult.IGNORED),
+            linter_issue(filename="bar.txt", result=LinterResult.WARNING),
+            linter_issue(filename="some/dir/baz.txt", result=LinterResult.IGNORED),
+            linter_issue(filename="other/dir/quux.txt", result=LinterResult.ERROR),
+        ]

--- a/tests/unit/linters/test_linters.py
+++ b/tests/unit/linters/test_linters.py
@@ -42,9 +42,9 @@ class TestLinterReport:
         assert emitter.interactions == [
             call("message", "Lint OK:"),
             call("message", "- test: foo.txt: With filename (https://some/url)"),
-            call("message", "Lint Warnings:"),
+            call("message", "Lint warnings:"),
             call("message", "- test: Without filename (https://some/url)"),
-            call("message", "Lint Errors:"),
+            call("message", "Lint errors:"),
             call("message", "- test: bar.txt: Some error (https://some/url)"),
         ]
 
@@ -64,13 +64,13 @@ class TestLinterReport:
                 "- test: foo.txt: With filename (https://some/url)",
                 permanent=True,
             ),
-            call("progress", "Lint Warnings:", permanent=True),
+            call("progress", "Lint warnings:", permanent=True),
             call(
                 "progress",
                 "- test: Without filename (https://some/url)",
                 permanent=True,
             ),
-            call("progress", "Lint Errors:", permanent=True),
+            call("progress", "Lint errors:", permanent=True),
             call(
                 "progress",
                 "- test: bar.txt: Some error (https://some/url)",

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -236,7 +236,6 @@ def test_lifecycle_run_command_step(
 def test_lifecycle_run_command_pack(cmd, snapcraft_yaml, project_vars, new_dir, mocker):
     project = Project.unmarshal(snapcraft_yaml(base="core22"))
     run_mock = mocker.patch("snapcraft.parts.PartsLifecycle.run")
-    mocker.patch("snapcraft.meta.snap_yaml.write")
     pack_mock = mocker.patch("snapcraft.pack.pack_snap")
 
     parts_lifecycle._run_command(
@@ -282,7 +281,6 @@ def test_lifecycle_pack_destructive_mode(
     run_in_provider_mock = mocker.patch("snapcraft.parts.lifecycle._run_in_provider")
     run_mock = mocker.patch("snapcraft.parts.PartsLifecycle.run")
     pack_mock = mocker.patch("snapcraft.pack.pack_snap")
-    mocker.patch("snapcraft.meta.snap_yaml.write")
     mocker.patch("snapcraft.utils.is_managed_mode", return_value=True)
     mocker.patch(
         "snapcraft.utils.get_managed_environment_home_path",
@@ -331,7 +329,6 @@ def test_lifecycle_pack_managed(cmd, snapcraft_yaml, project_vars, new_dir, mock
     run_in_provider_mock = mocker.patch("snapcraft.parts.lifecycle._run_in_provider")
     run_mock = mocker.patch("snapcraft.parts.PartsLifecycle.run")
     pack_mock = mocker.patch("snapcraft.pack.pack_snap")
-    mocker.patch("snapcraft.meta.snap_yaml.write")
     mocker.patch("snapcraft.utils.is_managed_mode", return_value=True)
     mocker.patch(
         "snapcraft.utils.get_managed_environment_home_path",


### PR DESCRIPTION
Create a basic framework for linting including the `lint` entry in
snapcraft.yaml to disable specific linters. Linters run before
packing a snap.

A specific `lint` command to lint a snap package file will be added
in a future PR. JSON-formatted output is implemented but will only
be used with the `lint` command.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1098