### PR TITLE
repo: fix_pkg_config removes prefixes from staged snap's .pc files.

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -11,7 +11,7 @@ codespell==2.1.0
 coverage==6.4.2
 craft-cli==1.1.0
 craft-grammar==1.1.1
-craft-parts==1.9.0
+craft-parts==1.10.1
 craft-providers==1.3.1
 craft-store==2.1.1
 cryptography==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ charset-normalizer==2.1.0
 click==8.1.3
 craft-cli==1.1.0
 craft-grammar==1.1.1
-craft-parts==1.9.0
+craft-parts==1.10.1
 craft-providers==1.3.1
 craft-store==2.1.1
 cryptography==3.4

--- a/snapcraft/parts/plugins/_ros.py
+++ b/snapcraft/parts/plugins/_ros.py
@@ -94,8 +94,8 @@ class RosPlugin(plugins.Plugin):
     def get_build_environment(self) -> Dict[str, str]:
         return {"ROS_PYTHON_VERSION": "3"}
 
-    @property
-    def out_of_source_build(self):
+    @classmethod
+    def get_out_of_source_build(cls) -> bool:
         """Return whether the plugin performs out-of-source-tree builds."""
         return True
 

--- a/tests/unit/parts/plugins/test_colcon.py
+++ b/tests/unit/parts/plugins/test_colcon.py
@@ -116,7 +116,7 @@ class TestPluginColconPlugin:
         }
 
     def test_out_of_source_build_property(self):
-        assert colcon.ColconPlugin.out_of_source_build
+        assert colcon.ColconPlugin.get_out_of_source_build
 
     def test_get_build_commands(self, setup_method_fixture, new_dir, monkeypatch):
         plugin = setup_method_fixture(new_dir)


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

When normalizing pkg-config (.pc) files from staged snaps, directories previously prepended to the prefix parameter will be removed:
- `/build/<snap-name>/stage` from snaps built via launchpad
- `/root/stage` from snaps built via a provider

LP: #[1916281](https://bugs.launchpad.net/snapcraft/+bug/1916281)
(CRAFT-1214)