### PR TITLE
linters: add classic confinement linter

### DIFF
--- a/snapcraft/elf/errors.py
+++ b/snapcraft/elf/errors.py
@@ -43,3 +43,10 @@ class CorruptedElfFile(errors.SnapcraftError):
         self.path = path
 
         super().__init__(f"Error parsing ELF file {str(path)!r}: {str(error)}")
+
+
+class DynamicLinkerNotFound(errors.SnapcraftError):
+    """Failed to find the dynamic linker for this platform."""
+
+    def __init__(self, path: Path) -> None:
+        super().__init__(f"Dynamic linker {str(path)!r} not found.")

--- a/snapcraft/linters/classic_linter.py
+++ b/snapcraft/linters/classic_linter.py
@@ -89,7 +89,7 @@ class ClassicLinter(Linter):
             arch_triplet = elf_utils.get_arch_triplet()
 
             elf_file.load_dependencies(
-                root_path=current_path,
+                root_path=current_path.absolute(),
                 base_path=installed_base_path,
                 content_dirs=set(),  # FIXME: obtain content dirs
                 arch_triplet=arch_triplet,

--- a/snapcraft/linters/classic_linter.py
+++ b/snapcraft/linters/classic_linter.py
@@ -1,0 +1,136 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Classic linter implementation."""
+
+import fnmatch
+from pathlib import Path
+from typing import List
+
+from craft_cli import emit
+from overrides import overrides
+
+from snapcraft.elf import ElfFile, Patcher, SonameCache, elf_utils, errors
+
+from .base import Linter, LinterIssue, LinterResult
+
+
+class ClassicLinter(Linter):
+    """Linter for classic snaps."""
+
+    @overrides
+    def run(self) -> List[LinterIssue]:
+        if not self._snap_metadata.base or self._snap_metadata.base == "bare":
+            return []
+
+        current_path = Path()
+        installed_snap_path = Path(f"/snap/{self._snap_metadata.name}/current")
+        installed_base_path = Path(f"/snap/{self._snap_metadata.base}/current")
+
+        # ELF files must be patched if confinement is classic or libc is staged
+        try:
+            # If libc is staged we'll find a dynamic linker in the current path
+            # (which contains the unpackaged primed payload). In this case, at
+            # runtime the linker will be in the installed snap path.
+            linker = elf_utils.get_dynamic_linker(
+                root_path=current_path, snap_path=installed_snap_path
+            )
+            is_libc_staged = True
+            issue = LinterIssue(
+                name=self._name,
+                result=LinterResult.OK,
+                text="Snap contains staged libc.",
+            )
+        except errors.DynamicLinkerNotFound:
+            # Otherwise look for the host linker, which should match the base
+            # system linker. At runtime use the linker from the installed base
+            # snap.
+            linker = elf_utils.get_dynamic_linker(
+                root_path=Path("/"), snap_path=installed_base_path
+            )
+            is_libc_staged = False
+            issue = LinterIssue(
+                name=self._name,
+                result=LinterResult.OK,
+                text="Snap confinement is set to classic.",
+            )
+
+        # No issues to report if confinement is not classic and libc is not staged.
+        if not is_libc_staged and self._snap_metadata.confinement != "classic":
+            return []
+
+        issues = [issue]
+        elf_files = elf_utils.get_elf_files(current_path)
+        patcher = Patcher(dynamic_linker=linker, root_path=current_path.absolute())
+        soname_cache = SonameCache()
+
+        for elf_file in elf_files:
+            # Skip linting files listed in the ignore list.
+            for pattern in self._lint.ignore.files:
+                if fnmatch.fnmatch(str(elf_file.path), pattern):
+                    emit.debug(
+                        f"ClassicLinter: skip file {str(elf_file.path)!r} "
+                        f"(matches {pattern!r})"
+                    )
+
+            arch_triplet = elf_utils.get_arch_triplet()
+
+            elf_file.load_dependencies(
+                root_path=current_path,
+                base_path=installed_base_path,
+                content_dirs=set(),  # FIXME: obtain content dirs
+                arch_triplet=arch_triplet,
+                soname_cache=soname_cache,
+            )
+
+            self._check_elf_interpreter(elf_file, linker=linker, issues=issues)
+            self._check_elf_rpath(elf_file, patcher=patcher, issues=issues)
+
+        return issues
+
+    def _check_elf_interpreter(
+        self, elf_file: ElfFile, *, linker: str, issues: List[LinterIssue]
+    ) -> None:
+        """Check ELF executable interpreter is set to base or snap linker."""
+        if elf_file.interp != linker:
+            issue = LinterIssue(
+                name=self._name,
+                result=LinterResult.WARNING,
+                filename=str(elf_file.path),
+                text=f"ELF interpreter should be set to {linker!r}.",
+            )
+            issues.append(issue)
+
+    def _check_elf_rpath(
+        self,
+        elf_file: ElfFile,
+        *,
+        patcher: Patcher,
+        issues: List[LinterIssue],
+    ) -> None:
+        """Check if the ELF executable rpath points to base or current snap."""
+        current_rpath = patcher.get_current_rpath(elf_file)
+        proposed_rpath = patcher.get_proposed_rpath(elf_file)
+
+        if not set(proposed_rpath).issubset(set(current_rpath)):
+            formatted_rpath = ":".join(proposed_rpath)
+            issue = LinterIssue(
+                name=self._name,
+                result=LinterResult.WARNING,
+                filename=str(elf_file.path),
+                text=f"ELF rpath should be set to {formatted_rpath!r}.",
+            )
+            issues.append(issue)

--- a/snapcraft/linters/linters.py
+++ b/snapcraft/linters/linters.py
@@ -30,6 +30,7 @@ from snapcraft import projects
 from snapcraft.meta import snap_yaml
 
 from .base import Linter, LinterIssue, LinterResult
+from .classic_linter import ClassicLinter
 
 if TYPE_CHECKING:
     import argparse
@@ -38,7 +39,7 @@ if TYPE_CHECKING:
 LinterType = Type[Linter]
 
 
-_LINTERS: Dict[str, LinterType] = {}
+_LINTERS: Dict[str, LinterType] = {"classic": ClassicLinter}
 
 
 @enum.unique

--- a/spread.yaml
+++ b/spread.yaml
@@ -285,6 +285,11 @@ suites:
      - ubuntu-22.04-64
      - ubuntu-22.04-amd64
 
+ tests/spread/core22/linters/:
+   summary: core22 linter tests
+   systems:
+     - ubuntu-22.04*
+
  # General, core suite
  tests/spread/general/:
    summary: tests of snapcraft core functionality

--- a/tests/spread/core22/linters/classic-libc/expected_linter_output.txt
+++ b/tests/spread/core22/linters/classic-libc/expected_linter_output.txt
@@ -1,0 +1,47 @@
+Running linters...
+Running linter: classic
+Lint OK:
+- classic: Snap contains staged libc.
+Lint warnings:
+- classic: lib/x86_64-linux-gnu/libBrokenLocale.so.1: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libBrokenLocale.so.1: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/libanl.so.1: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libanl.so.1: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/libc.so.6: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libc_malloc_debug.so.0: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libc_malloc_debug.so.0: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/libdl.so.2: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libdl.so.2: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/libm.so.6: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libm.so.6: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/libmemusage.so: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libmemusage.so: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/libmvec.so.1: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libmvec.so.1: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/libnsl.so.1: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libnsl.so.1: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/libnss_compat.so.2: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libnss_compat.so.2: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/libnss_dns.so.2: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libnss_dns.so.2: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/libnss_files.so.2: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libnss_files.so.2: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/libnss_hesiod.so.2: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libnss_hesiod.so.2: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/libpcprofile.so: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libpcprofile.so: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/libpthread.so.0: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libpthread.so.0: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/libresolv.so.2: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libresolv.so.2: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/librt.so.1: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/librt.so.1: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/libthread_db.so.1: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libthread_db.so.1: ELF rpath should be set to '$ORIGIN'.
+- classic: lib/x86_64-linux-gnu/libutil.so.1: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: lib/x86_64-linux-gnu/libutil.so.1: ELF rpath should be set to '$ORIGIN'.
+- classic: usr/bin/hello: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: usr/bin/hello: ELF rpath should be set to '$ORIGIN/../../lib/x86_64-linux-gnu'.
+- classic: usr/lib/x86_64-linux-gnu/audit/sotruss-lib.so: ELF interpreter should be set to '/snap/classic-linter-test/current/lib64/ld-linux-x86-64.so.2'.
+- classic: usr/lib/x86_64-linux-gnu/audit/sotruss-lib.so: ELF rpath should be set to '$ORIGIN/../../../../lib/x86_64-linux-gnu'.
+Creating snap package...

--- a/tests/spread/core22/linters/classic-libc/snap/snapcraft.yaml
+++ b/tests/spread/core22/linters/classic-libc/snap/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: classic-linter-test
+base: core22
+version: '0.1'
+summary: Single-line elevator pitch for your amazing snap
+description: |
+  This is my-snap's description. You have a paragraph or two to tell the
+  most important story about your snap. Keep it under 100 words though,
+  we live in tweetspace and your description wants to look good in the snap
+  store.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+parts:
+  my-part:
+    plugin: nil
+    stage-packages:
+      - hello
+      - libc6
+    prime:
+      - -usr/lib/x86_64-linux-gnu/gconv

--- a/tests/spread/core22/linters/classic-libc/task.yaml
+++ b/tests/spread/core22/linters/classic-libc/task.yaml
@@ -1,0 +1,13 @@
+summary: Test classic linter output
+
+restore: |
+  snapcraft clean
+  rm -f ./*.snap ./*.txt
+
+execute: |
+  snapcraft 2> output.txt
+
+  test -f classic-linter-test_0.1_*.snap
+
+  sed -n '/^Running linters/,/^Creating snap/p' < output.txt > linter_output.txt
+  diff -u linter_output.txt expected_linter_output.txt

--- a/tests/spread/core22/linters/classic/expected_linter_output.txt
+++ b/tests/spread/core22/linters/classic/expected_linter_output.txt
@@ -1,0 +1,18 @@
+Running linters...
+Running linter: classic
+Lint OK:
+- classic: Snap confinement is set to classic.
+Lint warnings:
+- classic: usr/bin/toilet: ELF interpreter should be set to '/snap/core22/current/lib64/ld-linux-x86-64.so.2'.
+- classic: usr/bin/toilet: ELF rpath should be set to '$ORIGIN/../lib/x86_64-linux-gnu:/snap/core22/current/lib/x86_64-linux-gnu'.
+- classic: usr/lib/x86_64-linux-gnu/caca/libgl_plugin.so.0.0.0: ELF interpreter should be set to '/snap/core22/current/lib64/ld-linux-x86-64.so.2'.
+- classic: usr/lib/x86_64-linux-gnu/caca/libgl_plugin.so.0.0.0: ELF rpath should be set to '$ORIGIN/..:/snap/core22/current/lib/x86_64-linux-gnu'.
+- classic: usr/lib/x86_64-linux-gnu/caca/libx11_plugin.so.0.0.0: ELF interpreter should be set to '/snap/core22/current/lib64/ld-linux-x86-64.so.2'.
+- classic: usr/lib/x86_64-linux-gnu/caca/libx11_plugin.so.0.0.0: ELF rpath should be set to '$ORIGIN/..:/snap/core22/current/lib/x86_64-linux-gnu'.
+- classic: usr/lib/x86_64-linux-gnu/libcaca++.so.0.99.19: ELF interpreter should be set to '/snap/core22/current/lib64/ld-linux-x86-64.so.2'.
+- classic: usr/lib/x86_64-linux-gnu/libcaca++.so.0.99.19: ELF rpath should be set to '$ORIGIN:/snap/core22/current/lib/x86_64-linux-gnu'.
+- classic: usr/lib/x86_64-linux-gnu/libcaca.so.0.99.19: ELF interpreter should be set to '/snap/core22/current/lib64/ld-linux-x86-64.so.2'.
+- classic: usr/lib/x86_64-linux-gnu/libcaca.so.0.99.19: ELF rpath should be set to '$ORIGIN:/snap/core22/current/lib/x86_64-linux-gnu'.
+- classic: usr/lib/x86_64-linux-gnu/libslang.so.2.3.2: ELF interpreter should be set to '/snap/core22/current/lib64/ld-linux-x86-64.so.2'.
+- classic: usr/lib/x86_64-linux-gnu/libslang.so.2.3.2: ELF rpath should be set to '/snap/core22/current/lib/x86_64-linux-gnu'.
+Creating snap package...

--- a/tests/spread/core22/linters/classic/snap/snapcraft.yaml
+++ b/tests/spread/core22/linters/classic/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: classic-linter-test
+base: core22
+version: '0.1'
+summary: Single-line elevator pitch for your amazing snap
+description: |
+  This is my-snap's description. You have a paragraph or two to tell the
+  most important story about your snap. Keep it under 100 words though,
+  we live in tweetspace and your description wants to look good in the snap
+  store.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: classic
+
+parts:
+  my-part:
+    plugin: nil
+    stage-packages:
+      - toilet

--- a/tests/spread/core22/linters/classic/task.yaml
+++ b/tests/spread/core22/linters/classic/task.yaml
@@ -1,0 +1,13 @@
+summary: Test classic linter output
+
+restore: |
+  snapcraft clean
+  rm -f ./*.snap ./*.txt
+
+execute: |
+  snapcraft 2> output.txt
+
+  test -f classic-linter-test_0.1_*.snap
+
+  sed -n '/^Running linters/,/^Creating snap/p' < output.txt > linter_output.txt
+  diff -u linter_output.txt expected_linter_output.txt

--- a/tests/unit/elf/test_elf_file.py
+++ b/tests/unit/elf/test_elf_file.py
@@ -71,8 +71,8 @@ class TestElfFileSmoketest:
 
     def test_invalid_elf_file(self, new_dir):
         Path("invalid-elf").write_bytes(b"\x7fELF\x00")
-        elf_files = elf_utils.get_elf_files(new_dir, {"invalid-elf"})
-        assert elf_files == set()
+        elf_files = elf_utils.get_elf_files_from_list(new_dir, ["invalid-elf"])
+        assert elf_files == []
 
 
 class TestGetLibraries:

--- a/tests/unit/elf/test_patcher.py
+++ b/tests/unit/elf/test_patcher.py
@@ -28,7 +28,7 @@ def test_patcher(fake_elf, fake_tools):
     elf_file = fake_elf("fake_elf-2.23")
     # The base_path does not matter here as there are not files to
     # be crawled for.
-    elf_patcher = elf.Patcher(dynamic_linker="/lib/fake-ld", root_path="/fake")
+    elf_patcher = elf.Patcher(dynamic_linker="/lib/fake-ld", root_path=Path("/fake"))
     elf_patcher.patch(elf_file=elf_file)
 
 
@@ -36,7 +36,7 @@ def test_patcher_does_nothing_if_no_interpreter(fake_elf, fake_tools):
     elf_file = fake_elf("fake_elf-static")
     # The base_path does not matter here as there are not files to
     # be crawled for.
-    elf_patcher = elf.Patcher(dynamic_linker="/lib/fake-ld", root_path="/fake")
+    elf_patcher = elf.Patcher(dynamic_linker="/lib/fake-ld", root_path=Path("/fake"))
     elf_patcher.patch(elf_file=elf_file)
 
 
@@ -44,7 +44,7 @@ def test_patcher_fails_raises_patcherror_exception(fake_elf, fake_tools):
     elf_file = fake_elf("fake_elf-bad-patchelf")
     # The base_path does not matter here as there are not files to
     # be crawled for.
-    elf_patcher = elf.Patcher(dynamic_linker="/lib/fake-ld", root_path="/fake")
+    elf_patcher = elf.Patcher(dynamic_linker="/lib/fake-ld", root_path=Path("/fake"))
 
     with pytest.raises(errors.PatcherError) as raised:
         elf_patcher.patch(elf_file=elf_file)
@@ -75,7 +75,7 @@ def elf_file(new_dir):
 def patcher():
     yield elf.Patcher(
         dynamic_linker="/my/dynamic/linker",
-        root_path="/snap/foo/current",
+        root_path=Path("/snap/foo/current"),
     )
 
 
@@ -83,7 +83,7 @@ def test_patcher_patch_rpath(mocker, patcher, elf_file):
     run_mock = mocker.patch("subprocess.check_call")
 
     expected_proposed_rpath = list(elf_file.dependencies)[0].path.parent
-    assert patcher._get_current_rpath(elf_file) == []
+    assert patcher.get_current_rpath(elf_file) == []
 
     patcher.patch(elf_file=elf_file)
     assert run_mock.mock_calls == [
@@ -104,12 +104,12 @@ def test_patcher_patch_rpath(mocker, patcher, elf_file):
 def test_patcher_patch_existing_rpath_origin(mocker, patcher, elf_file):
     run_mock = mocker.patch("subprocess.check_call")
     mocker.patch(
-        "snapcraft.elf._patcher.Patcher._get_current_rpath",
+        "snapcraft.elf._patcher.Patcher.get_current_rpath",
         return_value=["$ORIGIN/current/rpath"],
     )
 
     expected_proposed_rpath = list(elf_file.dependencies)[0].path.parent
-    assert patcher._get_current_rpath(elf_file) == ["$ORIGIN/current/rpath"]
+    assert patcher.get_current_rpath(elf_file) == ["$ORIGIN/current/rpath"]
 
     patcher.patch(elf_file=elf_file)
     assert run_mock.mock_calls == [
@@ -130,12 +130,12 @@ def test_patcher_patch_existing_rpath_origin(mocker, patcher, elf_file):
 def test_patcher_patch_existing_rpath_not_origin(mocker, patcher, elf_file):
     run_mock = mocker.patch("subprocess.check_call")
     mocker.patch(
-        "snapcraft.elf._patcher.Patcher._get_current_rpath",
+        "snapcraft.elf._patcher.Patcher.get_current_rpath",
         return_value=["/current/rpath"],
     )
 
     expected_proposed_rpath = list(elf_file.dependencies)[0].path.parent
-    assert patcher._get_current_rpath(elf_file) == ["/current/rpath"]
+    assert patcher.get_current_rpath(elf_file) == ["/current/rpath"]
 
     patcher.patch(elf_file=elf_file)
     assert run_mock.mock_calls == [
@@ -158,7 +158,7 @@ def test_patcher_patch_rpath_same_interpreter(mocker, patcher, elf_file):
     patcher._dynamic_linker = elf_file.interp
 
     expected_proposed_rpath = list(elf_file.dependencies)[0].path.parent
-    assert patcher._get_current_rpath(elf_file) == []
+    assert patcher.get_current_rpath(elf_file) == []
 
     patcher.patch(elf_file=elf_file)
     assert run_mock.mock_calls == [
@@ -179,7 +179,7 @@ def test_patcher_patch_rpath_already_set(mocker, patcher, elf_file):
 
     expected_proposed_rpath = list(elf_file.dependencies)[0].path.parent
     mocker.patch(
-        "snapcraft.elf._patcher.Patcher._get_current_rpath",
+        "snapcraft.elf._patcher.Patcher.get_current_rpath",
         return_value=["$ORIGIN/current/rpath", str(expected_proposed_rpath)],
     )
 

--- a/tests/unit/linters/test_classic_linter.py
+++ b/tests/unit/linters/test_classic_linter.py
@@ -1,0 +1,95 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from snapcraft import linters, projects
+from snapcraft.linters.base import LinterIssue, LinterResult
+from snapcraft.linters.classic_linter import ClassicLinter
+from snapcraft.meta import snap_yaml
+
+
+@pytest.mark.parametrize(
+    "confinement,stage_libc,text",
+    [
+        ("classic", False, "Snap confinement is set to classic."),
+        ("strict", True, "Snap contains staged libc."),
+        ("strict", False, None),
+    ],
+)
+def test_classic_linter(mocker, new_dir, confinement, stage_libc, text):
+    shutil.copy("/bin/true", "elf.bin")
+
+    if stage_libc:
+        Path("lib64").mkdir()
+        Path("lib64/ld-linux-x86-64.so.2").touch()
+
+    mocker.patch("snapcraft.linters.linters._LINTERS", {"classic": ClassicLinter})
+    mocker.patch(
+        "snapcraft.elf._elf_file._determine_libraries",
+        return_value={
+            "libc.so.6": "/snap/core22/current/lib/x86_64-linux-gnu/libc.so.6"
+        },
+    )
+    yaml_data = {
+        "name": "mytest",
+        "version": "1.29.3",
+        "base": "core22",
+        "summary": "Single-line elevator pitch for your amazing snap",
+        "description": "test-description",
+        "confinement": confinement,
+        "parts": {},
+    }
+
+    project = projects.Project.unmarshal(yaml_data)
+    snap_yaml.write(
+        project,
+        prime_dir=Path(new_dir),
+        arch="amd64",
+        arch_triplet="x86_64-linux-gnu",
+    )
+
+    issues = linters.run_linters(new_dir, lint=None)
+
+    if confinement == "classic" or stage_libc:
+        snap_name = "mytest" if stage_libc else "core22"
+        assert issues == [
+            LinterIssue(
+                name="classic",
+                result=LinterResult.OK,
+                text=text,
+            ),
+            LinterIssue(
+                name="classic",
+                result=LinterResult.WARNING,
+                filename="elf.bin",
+                text=(
+                    f"ELF interpreter should be set to "
+                    f"'/snap/{snap_name}/current/lib64/ld-linux-x86-64.so.2'."
+                ),
+            ),
+            LinterIssue(
+                name="classic",
+                result=LinterResult.WARNING,
+                filename="elf.bin",
+                text="ELF rpath should be set to '/snap/core22/current/lib/x86_64-linux-gnu'.",
+            ),
+        ]
+    else:
+        assert issues == []

--- a/tests/unit/linters/test_linters.py
+++ b/tests/unit/linters/test_linters.py
@@ -176,6 +176,32 @@ class TestLinterRun:
             )
         ]
 
+    def test_run_linters_ignore(self, mocker, new_dir, linter_issue):
+        mocker.patch(
+            "snapcraft.linters.linters._LINTERS", {"test": TestLinterRun._TestLinter}
+        )
+        yaml_data = {
+            "name": "mytest",
+            "version": "1.29.3",
+            "base": "core22",
+            "summary": "Single-line elevator pitch for your amazing snap",
+            "description": "test-description",
+            "confinement": "strict",
+            "parts": {},
+        }
+
+        project = projects.Project.unmarshal(yaml_data)
+        snap_yaml.write(
+            project,
+            prime_dir=Path(new_dir),
+            arch="amd64",
+            arch_triplet="x86_64-linux-gnu",
+        )
+
+        lint = projects.Lint(ignore=projects.LintIgnore(linters=["test"]))
+        issues = linters.run_linters(new_dir, lint=lint)
+        assert issues == []
+
     def test_ignore_matching_filenames(self, linter_issue):
         lint = projects.Lint(ignore=projects.LintIgnore(files=["foo*", "some/dir/*"]))
         issues = [


### PR DESCRIPTION
The classic linter warns if elf binary interpreter or rpath values
are not set to expected values for classic confinement or if libc
is staged. In this case, values from the base snap or `$ORIGIN`
should be used.

Note: this PR includes many adjustments to the existing elf
infrastructure used by the classic linter.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1090