### PR TITLE
meta: add support for s390x

### DIFF
--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -57,6 +57,7 @@ _ARCH_TRANSLATIONS_PLATFORM_TO_DEB = {
     "ppc64le": "ppc64el",
     "x86_64": "amd64",
     "AMD64": "amd64",  # Windows support
+    "s390x": "s390x",
 }
 
 # architecture translations from the deb/snap syntax to the platform syntax
@@ -67,6 +68,7 @@ _ARCH_TRANSLATIONS_DEB_TO_PLATFORM = {
     "powerpc": "ppc",
     "ppc64el": "ppc64le",
     "amd64": "x86_64",
+    "s390x": "s390x",
 }
 
 _32BIT_USERSPACE_ARCHITECTURE = {

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -210,6 +210,7 @@ def test_get_os_platform_windows(mocker):
         ("ppc64le", ("64bit", "ELF"), "ppc64el"),
         ("x86_64", ("64bit", "ELF"), "amd64"),
         ("x86_64", ("32bit", "ELF"), "i386"),
+        ("s390x", ("64bit", "ELF"), "s390x"),
         ("unknown-arch", ("64bit", "ELF"), "unknown-arch"),
     ],
 )
@@ -439,6 +440,7 @@ def test_process_version_git(mocker):
         ("powerpc", "ppc"),
         ("ppc64el", "ppc64le"),
         ("amd64", "x86_64"),
+        ("s390x", "s390x"),
     ],
 )
 def test_convert_architectures_valid(deb_arch, platform_arch):


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

I added `s390x` to snapcraft 7, to align with snapcraft_legacy.