### PR TITLE
extensions: Do not default to Nvidia VDPAU

### DIFF
--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -95,8 +95,11 @@ append_dir LIBVA_DRIVERS_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/dri"
 export VDPAU_DRIVER_PATH="/usr/lib/$ARCH/vdpau/"
 if [ -e "/var/lib/snapd/lib/gl/vdpau/libvdpau_nvidia.so" ]; then
   export VDPAU_DRIVER_PATH="/var/lib/snapd/lib/gl/vdpau"
-  # Prevent picking VA-API (Intel/AMD) over NVIDIA VDPAU; on PRIME systems for example
-  unset LIBVA_DRIVERS_PATH
+  if [ "$__NV_PRIME_RENDER_OFFLOAD" = 1 ]; then
+    # Prevent picking VA-API (Intel/AMD) over NVIDIA VDPAU
+    # https://download.nvidia.com/XFree86/Linux-x86_64/510.54/README/primerenderoffload.html#configureapplications
+    unset LIBVA_DRIVERS_PATH
+  fi
 fi
 
 # Workaround in snapd for proprietary nVidia drivers mounts the drivers in


### PR DESCRIPTION
In a hybrid Intel + Nvidia setup, it is costumary to use Intel-Vaapi for
hardware acceleration instead of Nvidia-Vdpau (unless the user chooses
otherwise); this avoids unecessary power consumption.

Moreover, for software that don't work with Vdpau yet, the previous changes
would hard lock to Vdpau nonetheless (e.g. Chromium [LP: #1816497](https://bugs.launchpad.net/ubuntu/+source/chromium-browser/+bug/1816497)), resulting
in no hardware acceleration where Vaapi is available.

- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
  ```
  snapcraft/projects.py:320: error: Unexpected keyword argument "extra" for "__init_subclass__" of "object"
  snapcraft/projects.py:639: error: Unexpected keyword argument "extra" for "__init_subclass__" of "object"
  Found 2 errors in 1 file (checked 153 source files)
  make: *** [Makefile:29: test-mypy] Error 1
  ```
- [ ] Have you successfully run `pytest tests/unit`?
  ```
  ImportError while loading conftest '/home/nteodosio/canonical/snaps/snapcraft/tests/conftest.py'.
  tests/conftest.py:22: in <module>
      from craft_store.auth import MemoryKeyring
  E   ModuleNotFoundError: No module named 'craft_store'
  ```
