### PR TITLE
plugins: early registration of application plugins

### DIFF
--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -29,6 +29,7 @@ from craft_cli import ArgumentParsingError, EmitterMode, ProvideHelpException, e
 import snapcraft
 import snapcraft_legacy
 from snapcraft import __version__, errors, utils
+from snapcraft.parts import plugins
 from snapcraft_legacy.cli import legacy
 
 from . import commands
@@ -177,6 +178,9 @@ def _run_dispatcher(dispatcher: craft_cli.Dispatcher) -> None:
 
 def run():
     """Run the CLI."""
+    # Register our own plugins
+    plugins.register()
+
     dispatcher = get_dispatcher()
     try:
         _run_dispatcher(dispatcher)

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -44,7 +44,7 @@ from snapcraft.utils import (
     process_version,
 )
 
-from . import grammar, plugins, yaml_utils
+from . import grammar, yaml_utils
 from .parts import PartsLifecycle
 from .project_check import run_project_checks
 from .setup_assets import setup_assets
@@ -180,8 +180,7 @@ def run(command_name: str, parsed_args: "argparse.Namespace") -> None:
     if parsed_args.provider:
         raise errors.SnapcraftError("Option --provider is not supported.")
 
-    # Register our own plugins and callbacks
-    plugins.register()
+    # Register our own callbacks
     callbacks.register_prologue(_set_global_environment)
     callbacks.register_pre_step(_set_step_environment)
 

--- a/tests/spread/plugins/craft-parts/build-and-run-hello/task.yaml
+++ b/tests/spread/plugins/craft-parts/build-and-run-hello/task.yaml
@@ -34,6 +34,9 @@ restore: |
 execute: |
   cd "${SNAP}"
 
+  # Make sure expand-extensions works
+  snapcraft expand-extensions
+
   # Build what we have and verify the snap runs as expected.
   snapcraft
   snap install "${SNAP}"_1.0_*.snap --dangerous


### PR DESCRIPTION
Register application plugins as soon as possible, to allow plugins
to be available to all commands (not only lifecycle commands). This
fixes plugin-related issues when expanding the ros2-humble extension.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1221