### PR TITLE
requirements: update craft-parts to 1.10.2

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -11,7 +11,7 @@ codespell==2.1.0
 coverage==6.4.2
 craft-cli==1.1.0
 craft-grammar==1.1.1
-craft-parts==1.10.1
+craft-parts==1.10.2
 craft-providers==1.3.1
 craft-store==2.1.1
 cryptography==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ charset-normalizer==2.1.0
 click==8.1.3
 craft-cli==1.1.0
 craft-grammar==1.1.1
-craft-parts==1.10.1
+craft-parts==1.10.2
 craft-providers==1.3.1
 craft-store==2.1.1
 cryptography==3.4

--- a/snapcraft/parts/plugins/_ros.py
+++ b/snapcraft/parts/plugins/_ros.py
@@ -265,7 +265,7 @@ def stage_runtime_dependencies(
         fetched_stage_packages = Repo.fetch_stage_packages(
             cache_dir=Path(stage_cache_dir),
             package_names=package_names,
-            target_arch=target_arch,
+            arch=target_arch,
             base=base,
             stage_packages_path=stage_packages_path,
         )

--- a/tests/spread/general/stage-packages/snaps/stage-packages-with-arch/snap/snapcraft.yaml
+++ b/tests/spread/general/stage-packages/snaps/stage-packages-with-arch/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: hello-world
+version: "1.0"
+summary: Test staging packages during cross-compilation.
+description: test
+grade: stable
+confinement: strict
+
+base: core22
+architectures:
+  - build-on: amd64
+    build-for: arm64
+
+parts:
+  hello-world:
+    plugin: nil
+    source: .
+    stage-packages:
+      - grep

--- a/tests/spread/general/stage-packages/snaps/stage-packages/snap/snapcraft.yaml
+++ b/tests/spread/general/stage-packages/snaps/stage-packages/snap/snapcraft.yaml
@@ -1,0 +1,15 @@
+name: hello-world
+version: "1.0"
+summary: Test staging packages during cross-compilation.
+description: test
+grade: stable
+confinement: strict
+
+base: core22
+
+parts:
+  hello-world:
+    plugin: nil
+    source: .
+    stage-packages:
+      - grep

--- a/tests/spread/general/stage-packages/task.yaml
+++ b/tests/spread/general/stage-packages/task.yaml
@@ -1,0 +1,30 @@
+summary: verify that stage-packages are pulled without errors
+
+environment:
+  SNAP/stage_packages: stage-packages
+  SNAP/stage_packages_with_arch: stage-packages-with-arch
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "./snaps/$SNAP/snap/snapcraft.yaml"
+
+  base=$(get_base)
+  if [[ "$base" =~ "core18" ]] || [[ "$base" =~ "core20" ]]; then
+    # shellcheck disable=SC2016
+    sed -i "s/build-for/run-on/" "./snaps/$SNAP/snap/snapcraft.yaml"
+  fi
+
+restore: |
+  cd "./snaps/$SNAP"
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  cd "./snaps/$SNAP"
+
+  snapcraft --destructive-mode


### PR DESCRIPTION
Craft-parts 1.10.2 fixes local git source cloning with depth and stage
packages installation when building for a different architecture.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
