### PR TITLE
Add binding for amdgpu.ids

### DIFF
--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -161,6 +161,7 @@ class GNOME(Extension):
                 "/usr/share/xml/iso-codes": {
                     "bind": "$SNAP/gnome-platform/usr/share/xml/iso-codes"
                 },
+                "/usr/share/libdrm": {"bind": "$SNAP/gnome-platform/usr/share/libdrm"},
             },
         }
 

--- a/tests/unit/extensions/test_gnome.py
+++ b/tests/unit/extensions/test_gnome.py
@@ -99,6 +99,7 @@ def test_get_root_snippet(gnome_extension):
             "/usr/share/xml/iso-codes": {
                 "bind": "$SNAP/gnome-platform/usr/share/xml/iso-codes"
             },
+            "/usr/share/libdrm": {"bind": "$SNAP/gnome-platform/usr/share/libdrm"},
         },
         "plugs": {
             "desktop": {"mount-host-font-cache": False},
@@ -146,6 +147,7 @@ def test_get_root_snippet_with_external_sdk(gnome_extension_with_build_snap):
             "/usr/share/xml/iso-codes": {
                 "bind": "$SNAP/gnome-platform/usr/share/xml/iso-codes"
             },
+            "/usr/share/libdrm": {"bind": "$SNAP/gnome-platform/usr/share/libdrm"},
         },
         "plugs": {
             "desktop": {"mount-host-font-cache": False},


### PR DESCRIPTION
The libdrm library expects to find the amdgpu.ids file at
/usr/share/libdrm. Although the file is already available in
Gnome-42-2204, it wasn't binded.

This patch fixes this.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
