### PR TITLE
whoami command: account for missing expires

### DIFF
--- a/snapcraft/commands/account.py
+++ b/snapcraft/commands/account.py
@@ -267,6 +267,13 @@ class StoreWhoAmICommand(BaseCommand):
             channels = "no restrictions"
 
         account = whoami["account"]
+
+        # onprem store does not have expires
+        try:
+            expires = f"{whoami['expires']}Z"
+        except KeyError:
+            expires = "N/A"
+
         message = textwrap.dedent(
             f"""\
             email: {account["email"]}
@@ -274,7 +281,7 @@ class StoreWhoAmICommand(BaseCommand):
             id: {account["id"]}
             permissions: {permissions}
             channels: {channels}
-            expires: {whoami["expires"]}Z"""
+            expires: {expires}"""
         )
 
         emit.message(message)

--- a/tests/unit/commands/test_account.py
+++ b/tests/unit/commands/test_account.py
@@ -280,6 +280,28 @@ def test_who_with_attenuations(emitter, fake_client):
     emitter.assert_message(expected_message)
 
 
+def test_who_no_expires(emitter, fake_client):
+    fake_client.whoami.return_value = {
+        "account": {"email": "user@acme.org", "id": "id", "username": "user"},
+    }
+
+    cmd = commands.StoreWhoAmICommand(None)
+
+    cmd.run(argparse.Namespace())
+
+    assert fake_client.whoami.mock_calls == [call()]
+    expected_message = dedent(
+        """\
+        email: user@acme.org
+        username: user
+        id: id
+        permissions: no restrictions
+        channels: no restrictions
+        expires: N/A"""
+    )
+    emitter.assert_message(expected_message)
+
+
 ##################
 # Logout Command #
 ##################


### PR DESCRIPTION
Take into consideration that the On Premises Snap Store does not return
an expires key.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1241