### PR TITLE
names command: move presentation logic to StoreClientCLI

### DIFF
--- a/snapcraft/commands/names.py
+++ b/snapcraft/commands/names.py
@@ -130,22 +130,9 @@ class StoreNamesCommand(BaseCommand):
 
     @overrides
     def run(self, parsed_args):
-        account_info = store.StoreClientCLI().get_account_info()
+        store_client = store.StoreClientCLI()
+        snaps = store_client.get_names()
 
-        snaps = [
-            (
-                name,
-                info["since"],
-                "private" if info["private"] else "public",
-                "-",
-            )
-            for name, info in account_info["snaps"]
-            .get(store.constants.DEFAULT_SERIES, {})
-            .items()
-            # Presenting only approved snap registrations, which means name
-            # disputes will be displayed/sorted some other way.
-            if info["status"] == "Approved"
-        ]
         if not snaps:
             emit.message("No registered snaps")
         else:

--- a/snapcraft/store/client.py
+++ b/snapcraft/store/client.py
@@ -20,7 +20,7 @@ import os
 import platform
 import time
 from datetime import timedelta
-from typing import Any, Dict, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import craft_store
 import requests
@@ -293,6 +293,26 @@ class StoreClientCLI:
             self._base_url + "/dev/api/account",
             headers={"Accept": "application/json"},
         ).json()
+
+    def get_names(self) -> List[Tuple[str, str, str, str]]:
+        """Return a table with the registered names and status."""
+        account_info = self.get_account_info()
+
+        snaps: List[Tuple[str, str, str, str]] = [
+            (
+                name,
+                info["since"],
+                "private" if info["private"] else "public",
+                "-",
+            )
+            for name, info in account_info["snaps"]
+            .get(constants.DEFAULT_SERIES, {})
+            .items()
+            # Presenting only approved snap registrations, which means name
+            # disputes will be displayed/sorted some other way.
+            if info["status"] == "Approved"
+        ]
+        return snaps
 
     def release(
         self,

--- a/tests/unit/commands/test_names.py
+++ b/tests/unit/commands/test_names.py
@@ -37,31 +37,14 @@ def fake_store_register(mocker):
 
 
 @pytest.fixture
-def fake_store_get_account_info(mocker):
-    # reduced payload
-    data = {
-        "snaps": {
-            "16": {
-                "test-snap-public": {
-                    "private": False,
-                    "since": "2016-07-26T20:18:32Z",
-                    "status": "Approved",
-                },
-                "test-snap-private": {
-                    "private": True,
-                    "since": "2016-07-26T20:18:32Z",
-                    "status": "Approved",
-                },
-                "test-snap-not-approved": {
-                    "private": False,
-                    "since": "2016-07-26T20:18:32Z",
-                    "status": "Dispute",
-                },
-            }
-        }
-    }
+def fake_store_get_names(mocker):
+    data = [
+        ("test-snap-public", "2016-07-26T20:18:32Z", "public", "-"),
+        ("test-snap-private", "2016-07-26T20:18:32Z", "private", "-"),
+    ]
+
     fake_client = mocker.patch(
-        "snapcraft.store.StoreClientCLI.get_account_info",
+        "snapcraft.store.StoreClientCLI.get_names",
         autospec=True,
         return_value=data,
     )
@@ -216,7 +199,7 @@ def test_register_store_id(emitter, fake_store_register):
     ],
 )
 @pytest.mark.usefixtures("memory_keyring")
-def test_names(emitter, fake_store_get_account_info, command_class):
+def test_names(emitter, fake_store_get_names, command_class):
     cmd = command_class(None)
 
     cmd.run(
@@ -225,7 +208,6 @@ def test_names(emitter, fake_store_get_account_info, command_class):
         )
     )
 
-    assert fake_store_get_account_info.mock_calls == [call(ANY)]
     if command_class.hidden:
         emitter.assert_progress("This command is deprecated: use 'names' instead")
     emitter.assert_message(

--- a/tests/unit/store/test_client.py
+++ b/tests/unit/store/test_client.py
@@ -536,6 +536,45 @@ def test_get_account_info(fake_client):
     ]
 
 
+#########
+# Names #
+#########
+
+
+def test_get_names(fake_client):
+    fake_client.request.return_value = FakeResponse(
+        status_code=200,
+        content=json.dumps(
+            {
+                "snaps": {
+                    "16": {
+                        "test-snap-public": {
+                            "private": False,
+                            "since": "2016-07-26T20:18:32Z",
+                            "status": "Approved",
+                        },
+                        "test-snap-private": {
+                            "private": True,
+                            "since": "2016-07-26T20:18:32Z",
+                            "status": "Approved",
+                        },
+                        "test-snap-not-approved": {
+                            "private": False,
+                            "since": "2016-07-26T20:18:32Z",
+                            "status": "Dispute",
+                        },
+                    }
+                }
+            },
+        ),
+    )
+
+    assert client.StoreClientCLI().get_names() == [
+        ("test-snap-public", "2016-07-26T20:18:32Z", "public", "-"),
+        ("test-snap-private", "2016-07-26T20:18:32Z", "private", "-"),
+    ]
+
+
 ###########
 # Release #
 ###########


### PR DESCRIPTION
The names presentation logic is tied to SCA which is incompatible with
the PublisherGW

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1242