### PR TITLE
fix: confirm provider install when using experiental extension

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -426,7 +426,8 @@ def _run_in_provider(
     emit.debug("Checking build provider availability")
     provider_name = "lxd" if parsed_args.use_lxd else None
     provider = providers.get_provider(provider_name)
-    provider.ensure_provider_is_available()
+    with emit.pause():
+        provider.ensure_provider_is_available()
 
     cmd = ["snapcraft", command_name]
 


### PR DESCRIPTION
Bug reported here: https://bugs.launchpad.net/snapcraft/+bug/1984172

When experimental extension is on and LXD not installed
we don't see the prompt and the snapcraft command hangs forever

Pausing the `emit` while we `ensure_provider_is_available` fix the issue.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
