### PR TITLE
DT-500 Fix Cups for Gtk support in Gnome-42

### DIFF
--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -464,3 +464,6 @@ IBUS_CONFIG_PATH="$XDG_CONFIG_HOME/ibus"
 ensure_dir_exists "$IBUS_CONFIG_PATH"
 [ -d "$IBUS_CONFIG_PATH/bus" ] && rm -rf "$IBUS_CONFIG_PATH/bus"
 ln -sfn "$REALHOME/.config/ibus/bus" "$IBUS_CONFIG_PATH"
+
+# Set libgweather path
+export LIBGWEATHER_LOCATIONS_PATH="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/libgweather-4/Locations.bin"

--- a/extensions/desktop/gnome/launcher-specific
+++ b/extensions/desktop/gnome/launcher-specific
@@ -10,7 +10,12 @@ if [ "$wayland_available" = true ]; then
   # Does not hurt to specify this as well, just in case
   export QT_QPA_PLATFORM=wayland-egl
 fi
+append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gtk-2.0"
+append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/gtk-2.0"
 append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gtk-3.0"
+append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/gtk-3.0"
+append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gtk-4.0"
+append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/gtk-4.0"
 
 snap_python_version="%WITH_PYTHON%"
 if [ "$snap_python_version" = "3.6" ]; then


### PR DESCRIPTION
The printing support in Gtk is supported by several DLLs located
at /usr/lib/TRIPLET/gtk-X.0 (being X equal to 3 or 4).
Unfortunately, that wasn't configured in the layout for Gnome-42,
so some GTK programs (like gnome-text-editor) crashed when trying
to print something.

The first patch binded the modules folder into the root, but James commented that it could be fixed just with an environment variable.

This patch sets that variable for both GTK4 and GTK2, which were both missing (it was set only for GTK3).

It also sets the gweather environment variable, because it was sent only to snapcraft-desktop-integration.

- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
