### PR TITLE
meta: add support for riscv64

### DIFF
--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -58,6 +58,7 @@ _ARCH_TRANSLATIONS_PLATFORM_TO_DEB = {
     "x86_64": "amd64",
     "AMD64": "amd64",  # Windows support
     "s390x": "s390x",
+    "riscv64": "riscv64",
 }
 
 # architecture translations from the deb/snap syntax to the platform syntax
@@ -69,6 +70,7 @@ _ARCH_TRANSLATIONS_DEB_TO_PLATFORM = {
     "ppc64el": "ppc64le",
     "amd64": "x86_64",
     "s390x": "s390x",
+    "riscv64": "riscv64",
 }
 
 _32BIT_USERSPACE_ARCHITECTURE = {

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -211,6 +211,7 @@ def test_get_os_platform_windows(mocker):
         ("x86_64", ("64bit", "ELF"), "amd64"),
         ("x86_64", ("32bit", "ELF"), "i386"),
         ("s390x", ("64bit", "ELF"), "s390x"),
+        ("riscv64", ("64bit", "ELF"), "riscv64"),
         ("unknown-arch", ("64bit", "ELF"), "unknown-arch"),
     ],
 )
@@ -441,6 +442,7 @@ def test_process_version_git(mocker):
         ("ppc64el", "ppc64le"),
         ("amd64", "x86_64"),
         ("s390x", "s390x"),
+        ("riscv64", "riscv64"),
     ],
 )
 def test_convert_architectures_valid(deb_arch, platform_arch):


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
Similar to https://github.com/snapcore/snapcraft/pull/3850, but for `riscv64`.

I cross-checked with `craft-parts` and `snapcraft_legacy`, I believe this was the last missing architecture for core22 snaps.