### PR TITLE
extensions: replace execs with source

### DIFF
--- a/extensions/desktop/command-chain/desktop-launch
+++ b/extensions/desktop/command-chain/desktop-launch
@@ -1,3 +1,5 @@
-#!/bin/sh
+#!/bin/bash
 
-exec "${SNAP}/snap/command-chain/run" "${SNAP}/gnome-platform/command-chain/desktop-launch" "$@"
+set -- "${SNAP}/gnome-platform/command-chain/desktop-launch" "$@"
+# shellcheck source=/dev/null
+source "${SNAP}/snap/command-chain/run"

--- a/extensions/desktop/command-chain/hooks-configure-fonts
+++ b/extensions/desktop/command-chain/hooks-configure-fonts
@@ -1,3 +1,5 @@
-#!/bin/sh
+#!/bin/bash
 
-exec "${SNAP}/snap/command-chain/run" "${SNAP}/gnome-platform/command-chain/hooks-configure-fonts" "$@"
+set -- "${SNAP}/gnome-platform/command-chain/hooks-configure-fonts" "$@"
+# shellcheck source=/dev/null
+source "${SNAP}/snap/command-chain/run"

--- a/extensions/desktop/command-chain/run
+++ b/extensions/desktop/command-chain/run
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ -z "$1" ]; then
   echo "run <command>"
@@ -16,4 +16,10 @@ if [ ! -f "$1" ]; then
   exit
 fi
 
-exec "$@"
+# emulate "exec $@" using "source"
+# have to disable "unused variables" because checkshell doesn't know that $BASH_ARGV0 is $0
+# shellcheck disable=SC2034  # Unused variables left for readability
+BASH_ARGV0=$1
+shift
+# shellcheck source=/dev/null
+source "$0"


### PR DESCRIPTION
Using source it is possible to simplify the chain, reduce memory usage and make execution faster.

This MR emulates "exec $@" using "source", thus avoiding to create a new process and launching a new shell each time a shell script must be executed from another shell script.

- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
DT-504