### PR TITLE
meta: get content provider dirs from snap metadata

### DIFF
--- a/snapcraft/elf/_elf_file.py
+++ b/snapcraft/elf/_elf_file.py
@@ -353,7 +353,7 @@ class ElfFile:
         self,
         root_path: Path,
         base_path: Optional[Path],
-        content_dirs: Set[Path],
+        content_dirs: List[Path],
         arch_triplet: str,
         soname_cache: Optional[SonameCache] = None,
     ) -> Set[str]:

--- a/snapcraft/linters/classic_linter.py
+++ b/snapcraft/linters/classic_linter.py
@@ -91,7 +91,7 @@ class ClassicLinter(Linter):
             elf_file.load_dependencies(
                 root_path=current_path.absolute(),
                 base_path=installed_base_path,
-                content_dirs=set(),  # FIXME: obtain content dirs
+                content_dirs=self._snap_metadata.get_provider_content_directories(),
                 arch_triplet=arch_triplet,
                 soname_cache=soname_cache,
             )

--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -16,10 +16,12 @@
 
 """Create snap.yaml metadata file."""
 
+import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Set, Union, cast
 
 import yaml
+from pydantic import ValidationError, validator
 from pydantic_yaml import YamlModel
 
 from snapcraft import errors
@@ -27,12 +29,7 @@ from snapcraft.projects import Project
 from snapcraft.utils import get_ld_library_paths, process_version
 
 
-class Socket(YamlModel):
-    """snap.yaml app socket entry."""
-
-    listen_stream: Union[int, str]
-    socket_mode: Optional[int]
-
+class _SnapMetadataModel(YamlModel):
     class Config:  # pylint: disable=too-few-public-methods
         """Pydantic model configuration."""
 
@@ -40,7 +37,14 @@ class Socket(YamlModel):
         alias_generator = lambda s: s.replace("_", "-")  # noqa: E731
 
 
-class SnapApp(YamlModel):
+class Socket(_SnapMetadataModel):
+    """snap.yaml app socket entry."""
+
+    listen_stream: Union[int, str]
+    socket_mode: Optional[int]
+
+
+class SnapApp(_SnapMetadataModel):
     """Snap.yaml app entry.
 
     This is currently a partial implementation, see
@@ -77,14 +81,83 @@ class SnapApp(YamlModel):
     command_chain: Optional[List[str]]
     sockets: Optional[Dict[str, Socket]]
 
-    class Config:  # pylint: disable=too-few-public-methods
-        """Pydantic model configuration."""
 
-        allow_population_by_field_name = True
-        alias_generator = lambda s: s.replace("_", "-")  # noqa: E731
+class ContentPlug(_SnapMetadataModel):
+    """Content plug definition in the snap metadata."""
+
+    interface: Literal["content"]
+    target: str
+    content: Optional[str]
+    default_provider: Optional[str]
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]) -> "ContentPlug":
+        """Create and populate a new ``ContentPlug`` object from dictionary data.
+
+        :param data: The dictionary data to unmarshal.
+        :return: The newly created object.
+        :raise TypeError: If data is not a dictionary.
+        """
+        if not isinstance(data, dict):
+            raise TypeError("data is not a dictionary")
+
+        return cls(**data)
+
+    @validator("target")
+    @classmethod
+    def _validate_target_not_empty(cls, val):
+        if val == "":
+            raise ValueError("value cannot be empty")
+        return val
+
+    @property
+    def provider(self) -> Optional[str]:
+        """Return the default content provider name."""
+        if self.default_provider is None:
+            return None
+
+        if ":" in self.default_provider:
+            return self.default_provider.split(":")[0]
+
+        return self.default_provider
 
 
-class SnapMetadata(YamlModel):
+class ContentSlot(_SnapMetadataModel):
+    """Content slot definition in the snap metadata."""
+
+    interface: Literal["content"]
+    content: Optional[str]
+    read: List[str] = []
+    write: List[str] = []
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]) -> "ContentSlot":
+        """Create and populate a new ``ContentSlot`` object from dictionary data.
+
+        :param data: The dictionary data to unmarshal.
+        :return: The newly created object.
+        :raise TypeError: If data is not a dictionary.
+        """
+        if not isinstance(data, dict):
+            raise TypeError("data is not a dictionary")
+
+        return cls(**data)
+
+    def get_content_dirs(self, installed_path: Path) -> Set[Path]:
+        """Obtain the slot's content directories."""
+        content_dirs: Set[Path] = set()
+
+        for path in self.read + self.write:
+            # Strip leading "$SNAP" and "/".
+            path = re.sub(r"^\$SNAP", "", path)
+            path = re.sub(r"^/", "", path)
+            path = re.sub(r"^./", "", path)
+            content_dirs.add(installed_path / path)
+
+        return content_dirs
+
+
+class SnapMetadata(_SnapMetadataModel):
     """The snap.yaml model.
 
     This is currently a partial implementation, see
@@ -115,12 +188,6 @@ class SnapMetadata(YamlModel):
     layout: Optional[Dict[str, Dict[str, str]]]
     system_usernames: Optional[Dict[str, Any]]
 
-    class Config:  # pylint: disable=too-few-public-methods
-        """Pydantic model configuration."""
-
-        allow_population_by_field_name = True
-        alias_generator = lambda s: s.replace("_", "-")  # noqa: E731
-
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]) -> "SnapMetadata":
         """Create and populate a new ``SnapMetadata`` object from dictionary data.
@@ -138,6 +205,59 @@ class SnapMetadata(YamlModel):
             raise TypeError("data is not a dictionary")
 
         return cls(**data)
+
+    def get_provider_content_directories(self) -> List[Path]:
+        """Get provider content directories from installed snaps."""
+        provider_dirs: Set[Path] = set()
+
+        for plug in self.get_content_plugs():
+            # Get matching slot provider for plug
+            if not plug.provider:
+                continue
+
+            provider_path = Path("/snap", plug.provider, "current")
+            provider_yaml_path = provider_path / "meta" / "snap.yaml"
+
+            if not provider_yaml_path.exists():
+                continue
+
+            provider_metadata = read(provider_path)
+            for slot in provider_metadata.get_content_slots():
+                provider_dirs |= slot.get_content_dirs(installed_path=provider_path)
+
+        return sorted(provider_dirs)
+
+    def get_content_plugs(self) -> List[ContentPlug]:
+        """Return a list of content plugs from the snap metadata plugs."""
+        if not self.plugs:
+            return []
+
+        content_plugs: List[ContentPlug] = []
+        for name, data in self.plugs.items():
+            try:
+                plug = ContentPlug.unmarshal(data)
+                if not plug.content:
+                    plug.content = name
+                content_plugs.append(plug)
+            except ValidationError:
+                continue
+        return content_plugs
+
+    def get_content_slots(self) -> List[ContentSlot]:
+        """Return a list of content slots from the snap metadata slots."""
+        if not self.slots:
+            return []
+
+        content_slots: List[ContentSlot] = []
+        for name, slot_data in self.slots.items():
+            try:
+                slot = ContentSlot.unmarshal(slot_data)
+                if not slot.content:
+                    slot.content = name
+                content_slots.append(slot)
+            except ValidationError:
+                continue
+        return content_slots
 
 
 def read(prime_dir: Path) -> SnapMetadata:

--- a/tests/unit/elf/test_patcher.py
+++ b/tests/unit/elf/test_patcher.py
@@ -65,7 +65,7 @@ def elf_file(new_dir):
     elf_file.load_dependencies(
         root_path=Path("/snap/foo/current"),
         base_path=Path("/"),
-        content_dirs=set(),
+        content_dirs=[],
         arch_triplet="x86_64-linux-gnu",
     )
     yield elf_file

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -17,10 +17,12 @@
 import textwrap
 from pathlib import Path
 
+import pydantic
 import pytest
 import yaml
 
 from snapcraft.meta import snap_yaml
+from snapcraft.meta.snap_yaml import ContentPlug, ContentSlot, SnapMetadata
 from snapcraft.projects import Project
 
 
@@ -523,3 +525,215 @@ def test_version_git(simple_project, new_dir, mocker):
 
     data = yaml.safe_load(content)
     assert data["version"] == "1.2.3"
+
+
+def test_get_provider_content_directories(new_dir, mocker):
+    mocker.patch(
+        "snapcraft.meta.snap_yaml.read",
+        return_value=SnapMetadata.unmarshal(
+            {
+                "name": "provider-snap",
+                "version": "1",
+                "summary": "summary",
+                "description": "description",
+                "confinement": "strict",
+                "grade": "stable",
+                "architectures": ["amd64"],
+                "slots": {
+                    "slot1": {
+                        "interface": "content",
+                        "content": "content-text",
+                        "read": ["read"],
+                        "write": ["write"],
+                    }
+                },
+            }
+        ),
+    )
+    mocker.patch("pathlib.Path.exists", return_value=True)
+
+    yaml_data = textwrap.dedent(
+        """\
+        name: mytest
+        version: 1.29.3
+        summary: Single-line elevator pitch for your amazing snap
+        description: test-description
+        architectures:
+        - amd64
+        confinement: strict
+        grade: stable
+        plugs:
+          test-plug:
+            interface: content
+            content: content-test
+            target: target
+            default_provider: my-test-provider
+        """
+    )
+
+    metadata = SnapMetadata.unmarshal(yaml.safe_load(yaml_data))
+    content_dirs = metadata.get_provider_content_directories()
+
+    assert content_dirs == [
+        Path("/snap/my-test-provider/current/read"),
+        Path("/snap/my-test-provider/current/write"),
+    ]
+
+
+#####################
+# Test content plug #
+#####################
+
+
+def test_content_plug_unmarshal():
+    plug_dict = {"interface": "content", "content": "foo", "target": "target"}
+    plug = ContentPlug.unmarshal(plug_dict)
+
+    assert plug.interface == "content"
+    assert plug.content == "foo"
+    assert plug.target == "target"
+    assert plug.provider is None
+
+
+def test_content_plug_invalid_target():
+    with pytest.raises(pydantic.ValidationError) as raised:
+        ContentPlug.unmarshal({"interface": "content", "target": ""})
+
+    err = raised.value.errors()
+    assert len(err) == 1
+    assert err[0]["loc"] == ("target",)
+    assert err[0]["type"] == "value_error"
+    assert err[0]["msg"] == "value cannot be empty"
+
+
+def test_content_plug_provider():
+    plug_dict = {
+        "interface": "content",
+        "content": "foo",
+        "target": "target",
+        "default-provider": "gtk-common-themes:gtk-3-themes",
+    }
+    plug = ContentPlug.unmarshal(plug_dict)
+
+    assert plug.provider == "gtk-common-themes"
+
+
+def test_get_content_plugs():
+    yaml_data = textwrap.dedent(
+        """\
+        name: mytest
+        version: 1.29.3
+        summary: Single-line elevator pitch for your amazing snap
+        description: test-description
+        architectures:
+        - amd64
+        confinement: strict
+        grade: stable
+        plugs:
+          plug1:
+            interface: foo
+          plug2:
+            interface: content
+            content: test
+            target: target2
+            default_provider: gtk-common-themes
+            extra-stuff: anything
+          plug3:
+            interface: content
+            target: target3
+        """
+    )
+
+    metadata = SnapMetadata.unmarshal(yaml.safe_load(yaml_data))
+    content_plugs = metadata.get_content_plugs()
+
+    assert content_plugs == [
+        ContentPlug(
+            interface="content",
+            target="target2",
+            content="test",
+            default_provider="gtk-common-themes",
+        ),
+        ContentPlug(
+            interface="content",
+            target="target3",
+            content="plug3",
+            default_provider=None,
+        ),
+    ]
+
+
+#####################
+# Test content slot #
+#####################
+
+
+def test_content_slot_empty():
+    slot = ContentSlot.unmarshal({"interface": "content"})
+
+    assert slot.interface == "content"
+    assert slot.read == []
+    assert slot.write == []
+
+
+def test_content_slot_explicit_content():
+    slot_dict = {
+        "interface": "content",
+        "content": "content-test",
+        "read": ["read1", "read2"],
+        "write": ["write1", "write2"],
+    }
+    slot = ContentSlot.unmarshal(slot_dict)
+
+    assert slot.interface == "content"
+    assert slot.content == "content-test"
+    assert slot.read == ["read1", "read2"]
+    assert slot.write == ["write1", "write2"]
+
+
+def test_get_content_slots():
+    yaml_data = textwrap.dedent(
+        """\
+        name: mytest
+        version: 1.29.3
+        summary: Single-line elevator pitch for your amazing snap
+        description: test-description
+        architectures:
+        - amd64
+        confinement: strict
+        grade: stable
+        slots:
+          slot1:
+            interface: foo
+          slot2:
+            interface: content
+            content: test
+            read:
+              - read1
+            write:
+              - write1
+          slot3:
+            interface: content
+            read:
+              - read1
+              - read2
+        """
+    )
+
+    metadata = SnapMetadata.unmarshal(yaml.safe_load(yaml_data))
+    content_slots = metadata.get_content_slots()
+
+    assert content_slots == [
+        ContentSlot(
+            interface="content",
+            content="test",
+            read=["read1"],
+            write=["write1"],
+        ),
+        ContentSlot(
+            interface="content",
+            content="slot3",
+            read=["read1", "read2"],
+            write=[],
+        ),
+    ]


### PR DESCRIPTION
Obtain the list of directories exposed by content providers listed
in snap.yaml (provided that the corresponding snaps are installed
on the system).

Co-authored-by: Chris Patterson <chris.patterson@canonical.com>
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1246