### PR TITLE
meta: fix content plug detection

### DIFF
--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -244,7 +244,7 @@ class SnapMetadata(_SnapMetadataModel):
                 if not plug.content:
                     plug.content = name
                 content_plugs.append(plug)
-            except ValidationError:
+            except (TypeError, ValidationError):
                 continue
         return content_plugs
 
@@ -260,7 +260,7 @@ class SnapMetadata(_SnapMetadataModel):
                 if not slot.content:
                     slot.content = name
                 content_slots.append(slot)
-            except ValidationError:
+            except (TypeError, ValidationError):
                 continue
         return content_slots
 

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -641,6 +641,7 @@ def test_get_content_plugs():
           plug3:
             interface: content
             target: target3
+          plug4:
         """
     )
 
@@ -717,6 +718,7 @@ def test_get_content_slots():
             read:
               - read1
               - read2
+          slot4:
         """
     )
 


### PR DESCRIPTION
Don't fail on type errors when detecting content plugs and slots,
allowing empty definitions. Snap metadata contents are validated at
a later point when packaging the snap file.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
