### PR TITLE
Remove trailing slash from staging  STORE_UPLOAD_URL.

### DIFF
--- a/tools/staging_env.sh
+++ b/tools/staging_env.sh
@@ -13,7 +13,7 @@ deactivate() {
 
 export STORE_DASHBOARD_URL="https://dashboard.staging.snapcraft.io/"
 export STORE_API_URL="https://api.staging.snapcraft.io/"
-export STORE_UPLOAD_URL="https://storage.staging.snapcraftcontent.com/"
+export STORE_UPLOAD_URL="https://storage.staging.snapcraftcontent.com"
 export UBUNTU_ONE_SSO_URL="https://login.staging.ubuntu.com/"
 export TEST_STORE="staging"
 


### PR DESCRIPTION
The trailing slash results in:

simplejson.errors.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

because the upload path contains a double slash, in the server logs we
see:

POST //unscanned-upload/ HTTP/1.1...

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
