### PR TITLE
requirements: update craft-parts to 1.12.0

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -11,7 +11,7 @@ codespell==2.1.0
 coverage==6.4.2
 craft-cli==1.1.0
 craft-grammar==1.1.1
-craft-parts==1.11.0
+craft-parts==1.12.0
 craft-providers==1.3.1
 craft-store==2.1.1
 cryptography==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ charset-normalizer==2.1.0
 click==8.1.3
 craft-cli==1.1.0
 craft-grammar==1.1.1
-craft-parts==1.11.0
+craft-parts==1.12.0
 craft-providers==1.3.1
 craft-store==2.1.1
 cryptography==3.4

--- a/tests/spread/extensions/gnome/task.yaml
+++ b/tests/spread/extensions/gnome/task.yaml
@@ -16,7 +16,6 @@ prepare: |
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
   sed -i 's/gnome-3-28/gnome/' "$SNAP_DIR/snap/snapcraft.yaml"
-  sed -i 's/bin\/gtk3-hello/usr\/local\/bin\/gtk3-hello/' "$SNAP_DIR/snap/snapcraft.yaml"
 
   # Temporarily use snaps from edge
   echo '    build-snaps: [gnome-42-2204-sdk/latest/edge, gnome-42-2204/latest/edge]' >> "$SNAP_DIR/snap/snapcraft.yaml"


### PR DESCRIPTION
Use craft-parts 1.12.0 with changes to the cmake plugin to fix the
prefix path and install prefix. This allows libraries built using
cmake and staged from a different part to be recognized without
defining cmake plugin parameters such as `CMAKE_INCLUDE_PATH` or
`CMAKE_LIBRARY_PATH`.

LP: #1978859

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
