### PR TITLE
requirements: update craft-parts to 1.12.1

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -11,7 +11,7 @@ codespell==2.1.0
 coverage==6.4.2
 craft-cli==1.1.0
 craft-grammar==1.1.1
-craft-parts==1.10.2
+craft-parts==1.12.1
 craft-providers==1.3.1
 craft-store==2.1.1
 cryptography==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ charset-normalizer==2.1.0
 click==8.1.3
 craft-cli==1.1.0
 craft-grammar==1.1.1
-craft-parts==1.10.2
+craft-parts==1.12.1
 craft-providers==1.3.1
 craft-store==2.1.1
 cryptography==3.4


### PR DESCRIPTION
Use craft-parts 1.12.1 with fixes to cmake plugin prefix path.

Note: this doesn't change the cmake plugin behavior and only fixes a
bug in the `CMAKE_PREFIX_PATH` variable value, so it's targeting
7.1.2 instead of main.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
