### PR TITLE
store: on prem base client

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -13,7 +13,7 @@ craft-cli==1.1.0
 craft-grammar==1.1.1
 craft-parts==1.11.0
 craft-providers==1.3.1
-craft-store==2.1.1
+craft-store==2.2.0
 cryptography==3.4
 Deprecated==1.2.13
 dill==0.3.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ craft-cli==1.1.0
 craft-grammar==1.1.1
 craft-parts==1.11.0
 craft-providers==1.3.1
-craft-store==2.1.1
+craft-store==2.2.0
 cryptography==3.4
 Deprecated==1.2.13
 distro==1.7.0

--- a/snapcraft/store/constants.py
+++ b/snapcraft/store/constants.py
@@ -22,11 +22,16 @@ ENVIRONMENT_STORE_CREDENTIALS: Final[str] = "SNAPCRAFT_STORE_CREDENTIALS"
 """Environment variable where credentials can be picked up from."""
 
 ENVIRONMENT_STORE_AUTH: Final[str] = "SNAPCRAFT_STORE_AUTH"
-"""Environment variable used to set an alterntive login method.
+"""Environment variable used to set an alternative login method.
 
 The only setting that changes the behavior is `candid`, every
 other value uses Ubuntu SSO.
 """
+
+ENVIRONMENT_ADMIN_MACAROON: Final[str] = "SNAPCRAFT_ADMIN_MACAROON"
+"""Environment variable used for onprem to login.
+
+This value holds a valid path to a file with the macaroon contents."""
 
 STORE_URL: Final[str] = "https://dashboard.snapcraft.io"
 """Default store backend URL."""

--- a/snapcraft/store/onprem_client.py
+++ b/snapcraft/store/onprem_client.py
@@ -1,0 +1,64 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""On premises Store Client implementation."""
+
+import os
+from typing import Any, Dict, Final
+
+from craft_store import BaseClient, endpoints, models
+from overrides import overrides
+
+from snapcraft import errors
+
+from . import constants
+
+ON_PREM_ENDPOINTS: Final = endpoints.Endpoints(
+    namespace="snap",
+    whoami="/v1/tokens/whoami",
+    tokens="",
+    tokens_exchange="/v1/tokens/offline/exchange",
+    valid_package_types=["snap"],
+    list_releases_model=models.charm_list_releases_model.ListReleasesModel,
+)
+
+
+class OnPremClient(BaseClient):
+    """On Premises Snapcraft Store Client."""
+
+    @overrides
+    def _get_macaroon(self, token_request: Dict[str, Any]) -> str:
+        macaroon_env = os.getenv(constants.ENVIRONMENT_ADMIN_MACAROON)
+        if macaroon_env is None:
+            raise errors.SnapcraftError(
+                f"{constants.ENVIRONMENT_ADMIN_MACAROON!r} needs to be setup with a valid macaroon"
+            )
+        return macaroon_env
+
+    @overrides
+    def _get_discharged_macaroon(self, root_macaroon: str, **kwargs) -> str:
+        response = self.http_client.request(
+            "POST",
+            self._base_url + self._endpoints.tokens_exchange,
+            json={"macaroon": root_macaroon},
+        )
+
+        return response.json()["macaroon"]
+
+    @overrides
+    def _get_authorization_header(self) -> str:
+        auth = self._auth.get_credentials()
+        return f"macaroon {auth}"

--- a/tests/legacy/unit/commands/__init__.py
+++ b/tests/legacy/unit/commands/__init__.py
@@ -375,5 +375,7 @@ class FakeResponse(requests.Response):
 
 
 FAKE_UNAUTHORIZED_ERROR = craft_store.errors.StoreServerError(
-    FakeResponse(status_code=requests.codes.unauthorized, content="error")
+    FakeResponse(
+        status_code=requests.codes.unauthorized, content=json.dumps({"error": "error"})
+    )
 )

--- a/tests/unit/store/test_onprem_client.py
+++ b/tests/unit/store/test_onprem_client.py
@@ -1,0 +1,99 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""On premises Store Client unit tests."""
+
+from unittest.mock import call
+
+import pytest
+
+from snapcraft import errors
+from snapcraft.store import constants
+from snapcraft.store.onprem_client import ON_PREM_ENDPOINTS, OnPremClient
+
+
+@pytest.fixture
+def on_prem_client():
+    """Return an instance of the OnPremClient"""
+    return OnPremClient(
+        base_url="https://fake-store.io",
+        storage_base_url="",
+        endpoints=ON_PREM_ENDPOINTS,
+        application_name="onprem-test",
+        user_agent="agent",
+        environment_auth=constants.ENVIRONMENT_STORE_CREDENTIALS,
+        ephemeral=False,
+    )
+
+
+def test_get_macaroon(on_prem_client, monkeypatch):
+    """Retrieve the admin macaroon from the environment."""
+    monkeypatch.setenv(constants.ENVIRONMENT_ADMIN_MACAROON, "some-macaroon")
+
+    assert on_prem_client._get_macaroon(token_request={}) == "some-macaroon"
+
+
+def test_get_macaroon_not_in_environment(on_prem_client, monkeypatch):
+    """Raise an error if the environment is not setup correctly."""
+    monkeypatch.delenv(constants.ENVIRONMENT_ADMIN_MACAROON, raising=False)
+
+    with pytest.raises(errors.SnapcraftError) as raised:
+        on_prem_client._get_macaroon(token_request={})
+
+    assert (
+        str(raised.value)
+        == "'SNAPCRAFT_ADMIN_MACAROON' needs to be setup with a valid macaroon"
+    )
+
+
+def test_get_discharged_macaroon(on_prem_client, mocker):
+    """Check that the backend is called correctly."""
+
+    class FakeResponse:
+        """Fake response for a discharged macaroon."""
+
+        def json(self):
+            return {"macaroon": "discharged-macaroon"}
+
+    request_mock = mocker.patch.object(
+        on_prem_client.http_client, "request", return_value=FakeResponse()
+    )
+
+    assert (
+        on_prem_client._get_discharged_macaroon("root-macaroon")
+        == "discharged-macaroon"
+    )
+
+    assert request_mock.mock_calls == [
+        call(
+            "POST",
+            "https://fake-store.io/v1/tokens/offline/exchange",
+            json={"macaroon": "root-macaroon"},
+        )
+    ]
+
+
+def test_get_authorization_header(on_prem_client, mocker):
+    """Ensure the correct authorization header is formed for requests"""
+    mocker.patch.object(
+        on_prem_client._auth,
+        "get_credentials",
+        return_value="serialized-macaroon-string",
+    )
+    assert (
+        on_prem_client._get_authorization_header()
+        == "macaroon serialized-macaroon-string"
+    )


### PR DESCRIPTION
Derivation from craft-store's BaseClient to support the OnPrem store.

This implementation is specific enough to Snapcraft to be implemented
here.

This includes an update to the test mock in legacy pertaining to the
change of where JSONDecoder comes from now (requests).

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1243