### PR TITLE
cli: parse http-proxy and https-proxy

### DIFF
--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -74,6 +74,18 @@ class _LifecycleCommand(BaseCommand, abc.ABC):
             default=os.getenv("SNAPCRAFT_BUILD_FOR"),
             help="Set target architecture to build for",
         )
+        parser.add_argument(
+            "--http-proxy",
+            type=str,
+            default=os.getenv("http_proxy"),
+            help="Set http proxy",
+        )
+        parser.add_argument(
+            "--https-proxy",
+            type=str,
+            default=os.getenv("https_proxy"),
+            help="Set https proxy",
+        )
 
         # --enable-experimental-extensions is only available in legacy
         parser.add_argument(

--- a/tests/unit/cli/test_default_command.py
+++ b/tests/unit/cli/test_default_command.py
@@ -44,6 +44,8 @@ def test_default_command(mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -70,6 +72,8 @@ def test_default_command_destructive_mode(mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -96,6 +100,8 @@ def test_default_command_use_lxd(mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -123,6 +129,64 @@ def test_default_command_output(mocker, option):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
+            )
+        )
+    ]
+
+
+def test_default_command_http_proxy(mocker):
+    mocker.patch.object(sys, "argv", ["cmd", "--http-proxy", "test-http"])
+    mock_pack_cmd = mocker.patch("snapcraft.commands.lifecycle.PackCommand.run")
+    cli.run()
+    assert mock_pack_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                directory=None,
+                output=None,
+                debug=False,
+                destructive_mode=False,
+                use_lxd=False,
+                enable_manifest=False,
+                manifest_image_information=None,
+                bind_ssh=False,
+                build_for=None,
+                enable_experimental_extensions=False,
+                enable_developer_debug=False,
+                enable_experimental_target_arch=False,
+                target_arch=None,
+                provider=None,
+                http_proxy="test-http",
+                https_proxy=None,
+            )
+        )
+    ]
+
+
+def test_default_command_https_proxy(mocker):
+    mocker.patch.object(sys, "argv", ["cmd", "--https-proxy", "test-https"])
+    mock_pack_cmd = mocker.patch("snapcraft.commands.lifecycle.PackCommand.run")
+    cli.run()
+    assert mock_pack_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                directory=None,
+                output=None,
+                debug=False,
+                destructive_mode=False,
+                use_lxd=False,
+                enable_manifest=False,
+                manifest_image_information=None,
+                bind_ssh=False,
+                build_for=None,
+                enable_experimental_extensions=False,
+                enable_developer_debug=False,
+                enable_experimental_target_arch=False,
+                target_arch=None,
+                provider=None,
+                http_proxy=None,
+                https_proxy="test-https",
             )
         )
     ]

--- a/tests/unit/cli/test_lifecycle.py
+++ b/tests/unit/cli/test_lifecycle.py
@@ -55,6 +55,8 @@ def test_lifecycle_command(cmd, run_method, mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -100,6 +102,8 @@ def test_lifecycle_command_arguments(cmd, run_method, mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -146,6 +150,8 @@ def test_lifecycle_command_arguments_destructive_mode(cmd, run_method, mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -192,6 +198,8 @@ def test_lifecycle_command_arguments_use_lxd(cmd, run_method, mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -236,6 +244,8 @@ def test_lifecycle_command_arguments_bind_ssh(cmd, run_method, mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -280,6 +290,8 @@ def test_lifecycle_command_arguments_debug(cmd, run_method, mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -324,6 +336,8 @@ def test_lifecycle_command_arguments_shell(cmd, run_method, mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -368,6 +382,84 @@ def test_lifecycle_command_arguments_shell_after(cmd, run_method, mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
+            )
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "cmd,run_method",
+    [
+        ("pull", "snapcraft.commands.lifecycle.PullCommand.run"),
+        ("build", "snapcraft.commands.lifecycle.BuildCommand.run"),
+        ("stage", "snapcraft.commands.lifecycle.StageCommand.run"),
+        ("prime", "snapcraft.commands.lifecycle.PrimeCommand.run"),
+    ],
+)
+def test_lifecycle_command_arguments_http_proxy(cmd, run_method, mocker):
+    mocker.patch.object(sys, "argv", ["cmd", cmd, "--http-proxy", "test-http"])
+    mock_lifecycle_cmd = mocker.patch(run_method)
+    cli.run()
+    assert mock_lifecycle_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                parts=[],
+                debug=False,
+                destructive_mode=False,
+                shell=False,
+                shell_after=False,
+                use_lxd=False,
+                enable_manifest=False,
+                manifest_image_information=None,
+                bind_ssh=False,
+                build_for=None,
+                enable_experimental_extensions=False,
+                enable_developer_debug=False,
+                enable_experimental_target_arch=False,
+                target_arch=None,
+                provider=None,
+                http_proxy="test-http",
+                https_proxy=None,
+            )
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "cmd,run_method",
+    [
+        ("pull", "snapcraft.commands.lifecycle.PullCommand.run"),
+        ("build", "snapcraft.commands.lifecycle.BuildCommand.run"),
+        ("stage", "snapcraft.commands.lifecycle.StageCommand.run"),
+        ("prime", "snapcraft.commands.lifecycle.PrimeCommand.run"),
+    ],
+)
+def test_lifecycle_command_arguments_https_proxy(cmd, run_method, mocker):
+    mocker.patch.object(sys, "argv", ["cmd", cmd, "--https-proxy", "test-https"])
+    mock_lifecycle_cmd = mocker.patch(run_method)
+    cli.run()
+    assert mock_lifecycle_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                parts=[],
+                debug=False,
+                destructive_mode=False,
+                shell=False,
+                shell_after=False,
+                use_lxd=False,
+                enable_manifest=False,
+                manifest_image_information=None,
+                bind_ssh=False,
+                build_for=None,
+                enable_experimental_extensions=False,
+                enable_developer_debug=False,
+                enable_experimental_target_arch=False,
+                target_arch=None,
+                provider=None,
+                http_proxy=None,
+                https_proxy="test-https",
             )
         )
     ]
@@ -398,6 +490,8 @@ def test_lifecycle_command_pack(mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -428,6 +522,8 @@ def test_lifecycle_command_pack_destructive_mode(mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -458,6 +554,8 @@ def test_lifecycle_command_pack_use_lxd(mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -488,6 +586,8 @@ def test_lifecycle_command_pack_enable_manifest(mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -519,6 +619,8 @@ def test_lifecycle_command_pack_env_enable_manifest(mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -549,6 +651,8 @@ def test_lifecycle_command_pack_manifest_image_information(mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -580,6 +684,8 @@ def test_lifecycle_command_pack_env_manifest_image_information(mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -610,6 +716,8 @@ def test_lifecycle_command_pack_bind_ssh(mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -640,9 +748,15 @@ def test_lifecycle_command_pack_build_for(mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
+
+
+def test_lifecycle_command_http_proxy(mocker):
+    pass
 
 
 def test_lifecycle_command_pack_env_build_for(mocker):
@@ -671,6 +785,8 @@ def test_lifecycle_command_pack_env_build_for(mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -701,6 +817,8 @@ def test_lifecycle_command_pack_debug(mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -728,6 +846,8 @@ def test_lifecycle_command_pack_output(mocker, option):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
             )
         )
     ]
@@ -754,6 +874,64 @@ def test_lifecycle_command_pack_directory(mocker):
                 enable_experimental_target_arch=False,
                 target_arch=None,
                 provider=None,
+                http_proxy=None,
+                https_proxy=None,
+            )
+        )
+    ]
+
+
+def test_lifecycle_command_pack_http_proxy(mocker):
+    mocker.patch.object(sys, "argv", ["cmd", "pack", "--http-proxy", "test-http"])
+    mock_pack_cmd = mocker.patch("snapcraft.commands.lifecycle.PackCommand.run")
+    cli.run()
+    assert mock_pack_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                directory=None,
+                output=None,
+                debug=False,
+                destructive_mode=False,
+                use_lxd=False,
+                enable_experimental_extensions=False,
+                enable_developer_debug=False,
+                enable_manifest=False,
+                manifest_image_information=None,
+                bind_ssh=False,
+                build_for=None,
+                enable_experimental_target_arch=False,
+                target_arch=None,
+                provider=None,
+                http_proxy="test-http",
+                https_proxy=None,
+            )
+        )
+    ]
+
+
+def test_lifecycle_command_pack_https_proxy(mocker):
+    mocker.patch.object(sys, "argv", ["cmd", "pack", "--https-proxy", "test-https"])
+    mock_pack_cmd = mocker.patch("snapcraft.commands.lifecycle.PackCommand.run")
+    cli.run()
+    assert mock_pack_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                directory=None,
+                output=None,
+                debug=False,
+                destructive_mode=False,
+                use_lxd=False,
+                enable_experimental_extensions=False,
+                enable_developer_debug=False,
+                enable_manifest=False,
+                manifest_image_information=None,
+                bind_ssh=False,
+                build_for=None,
+                enable_experimental_target_arch=False,
+                target_arch=None,
+                provider=None,
+                http_proxy=None,
+                https_proxy="test-https",
             )
         )
     ]

--- a/tests/unit/cli/test_lifecycle.py
+++ b/tests/unit/cli/test_lifecycle.py
@@ -755,10 +755,6 @@ def test_lifecycle_command_pack_build_for(mocker):
     ]
 
 
-def test_lifecycle_command_http_proxy(mocker):
-    pass
-
-
 def test_lifecycle_command_pack_env_build_for(mocker):
     mocker.patch.dict(os.environ, {"SNAPCRAFT_BUILD_FOR": "armhf"})
     mocker.patch.object(


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
Parse the command line arguments `--http-proxy` and `--https-proxy`.

source: https://forum.snapcraft.io/t/error-unrecognized-arguments-http-proxy/30967

(CRAFT-1217)