### PR TITLE
ua: specify and enable ua services

### DIFF
--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -81,6 +81,11 @@ class _LifecycleCommand(BaseCommand, abc.ABC):
             default=os.getenv("SNAPCRAFT_UA_TOKEN"),
             help="Configure build environment with ESM using specified UA token",
         )
+        parser.add_argument(
+            "--enable-experimental-ua-services",
+            action="store_true",
+            help="Allow selection of UA services to enable.",
+        )
 
         # --enable-experimental-extensions is only available in legacy
         parser.add_argument(

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -172,10 +172,14 @@ def run(command_name: str, parsed_args: "argparse.Namespace") -> None:
     snap_project = get_snap_project()
     yaml_data = process_yaml(snap_project.project_file)
     start_time = datetime.now()
-    build_plan = get_build_plan(yaml_data, parsed_args)
 
     if parsed_args.provider:
         raise errors.SnapcraftError("Option --provider is not supported.")
+
+    if yaml_data.get("ua-services") and not parsed_args.ua_token:
+        raise errors.SnapcraftError("UA services require a UA token to be specified.")
+
+    build_plan = get_build_plan(yaml_data, parsed_args)
 
     # Register our own callbacks
     callbacks.register_prologue(_set_global_environment)
@@ -275,7 +279,7 @@ def _run_command(
         lifecycle.clean(part_names=part_names)
         return
 
-    with ua_manager.ua_manager(parsed_args.ua_token):
+    with ua_manager.ua_manager(parsed_args.ua_token, services=project.ua_services):
         lifecycle.run(
             step_name,
             debug=parsed_args.debug,

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -176,8 +176,16 @@ def run(command_name: str, parsed_args: "argparse.Namespace") -> None:
     if parsed_args.provider:
         raise errors.SnapcraftError("Option --provider is not supported.")
 
-    if yaml_data.get("ua-services") and not parsed_args.ua_token:
-        raise errors.SnapcraftError("UA services require a UA token to be specified.")
+    if yaml_data.get("ua-services"):
+        if not parsed_args.ua_token:
+            raise errors.SnapcraftError(
+                "UA services require a UA token to be specified."
+            )
+
+        if not parsed_args.enable_experimental_ua_services:
+            raise errors.SnapcraftError(
+                "Using UA services requires --enable-experimental-ua-services."
+            )
 
     build_plan = get_build_plan(yaml_data, parsed_args)
 
@@ -469,6 +477,9 @@ def _run_in_provider(
     ua_token = getattr(parsed_args, "ua_token", "")
     if ua_token:
         cmd.extend(["--ua-token", ua_token])
+
+    if getattr(parsed_args, "enable_experimental_ua_services", False):
+        cmd.append("--enable-experimental-ua-services")
 
     output_dir = utils.get_managed_environment_project_path()
 

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -382,6 +382,7 @@ class Project(ProjectModel):
     environment: Optional[Dict[str, Optional[str]]]
     build_packages: Optional[GrammarStrList]
     build_snaps: Optional[GrammarStrList]
+    ua_services: Optional[UniqueStrList]
 
     @pydantic.validator("plugs")
     @classmethod

--- a/tests/unit/cli/test_default_command.py
+++ b/tests/unit/cli/test_default_command.py
@@ -43,6 +43,7 @@ def test_default_command(mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -70,6 +71,7 @@ def test_default_command_destructive_mode(mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -97,6 +99,7 @@ def test_default_command_use_lxd(mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -125,6 +128,7 @@ def test_default_command_output(mocker, option):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )

--- a/tests/unit/cli/test_lifecycle.py
+++ b/tests/unit/cli/test_lifecycle.py
@@ -54,6 +54,7 @@ def test_lifecycle_command(cmd, run_method, mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -100,6 +101,7 @@ def test_lifecycle_command_arguments(cmd, run_method, mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -147,6 +149,7 @@ def test_lifecycle_command_arguments_destructive_mode(cmd, run_method, mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -194,6 +197,7 @@ def test_lifecycle_command_arguments_use_lxd(cmd, run_method, mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -239,6 +243,7 @@ def test_lifecycle_command_arguments_bind_ssh(cmd, run_method, mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -264,6 +269,7 @@ def test_lifecycle_command_arguments_ua_token(cmd, run_method, mocker):
             cmd,
             "--ua-token",
             "my-ua-token",
+            "--enable-experimental-ua-services",
         ],
     )
     mock_lifecycle_cmd = mocker.patch(run_method)
@@ -285,6 +291,7 @@ def test_lifecycle_command_arguments_ua_token(cmd, run_method, mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=True,
                 target_arch=None,
                 provider=None,
             )
@@ -330,6 +337,7 @@ def test_lifecycle_command_arguments_debug(cmd, run_method, mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -375,6 +383,7 @@ def test_lifecycle_command_arguments_shell(cmd, run_method, mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -420,6 +429,7 @@ def test_lifecycle_command_arguments_shell_after(cmd, run_method, mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -451,6 +461,7 @@ def test_lifecycle_command_pack(mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -482,6 +493,7 @@ def test_lifecycle_command_pack_destructive_mode(mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -513,6 +525,7 @@ def test_lifecycle_command_pack_use_lxd(mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -544,6 +557,7 @@ def test_lifecycle_command_pack_enable_manifest(mocker):
                 build_for=None,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -576,6 +590,7 @@ def test_lifecycle_command_pack_env_enable_manifest(mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -607,6 +622,7 @@ def test_lifecycle_command_pack_manifest_image_information(mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -639,6 +655,7 @@ def test_lifecycle_command_pack_env_manifest_image_information(mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -670,6 +687,7 @@ def test_lifecycle_command_pack_bind_ssh(mocker):
                 ua_token=None,
                 build_for=None,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -681,7 +699,13 @@ def test_lifecycle_command_pack_ua_token(mocker):
     mocker.patch.object(
         sys,
         "argv",
-        ["cmd", "pack", "--ua-token", "my-ua-token"],
+        [
+            "cmd",
+            "pack",
+            "--ua-token",
+            "my-ua-token",
+            "--enable-experimental-ua-services",
+        ],
     )
     mock_pack_cmd = mocker.patch("snapcraft.commands.lifecycle.PackCommand.run")
     cli.run()
@@ -701,6 +725,7 @@ def test_lifecycle_command_pack_ua_token(mocker):
                 ua_token="my-ua-token",
                 build_for=None,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=True,
                 target_arch=None,
                 provider=None,
             )
@@ -733,6 +758,7 @@ def test_lifecycle_command_pack_env_ua_token(mocker):
                 ua_token="my-ua-token",
                 build_for=None,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -764,6 +790,7 @@ def test_lifecycle_command_pack_build_for(mocker):
                 ua_token=None,
                 build_for="armhf",
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -796,6 +823,7 @@ def test_lifecycle_command_pack_env_build_for(mocker):
                 ua_token=None,
                 build_for="armhf",
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -827,6 +855,7 @@ def test_lifecycle_command_pack_debug(mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -855,6 +884,7 @@ def test_lifecycle_command_pack_output(mocker, option):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )
@@ -882,6 +912,7 @@ def test_lifecycle_command_pack_directory(mocker):
                 enable_experimental_extensions=False,
                 enable_developer_debug=False,
                 enable_experimental_target_arch=False,
+                enable_experimental_ua_services=False,
                 target_arch=None,
                 provider=None,
             )

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -213,6 +213,38 @@ def test_lifecycle_run_ua_services_without_token(cmd, snapcraft_yaml, new_dir, m
 
 
 @pytest.mark.parametrize(
+    "cmd", ["pull", "build", "stage", "prime", "pack", "snap", "clean"]
+)
+def test_lifecycle_run_ua_services_without_experimental_flag(
+    cmd, snapcraft_yaml, new_dir, mocker
+):
+    """UA services require --ua-token."""
+    snapcraft_yaml(base="core22", **{"ua-services": ["svc1", "svc2"]})
+    run_mock = mocker.patch("snapcraft.parts.PartsLifecycle.run")
+    mocker.patch(
+        "snapcraft.providers.Provider.is_base_available", return_value=(True, None)
+    )
+
+    with pytest.raises(errors.SnapcraftError) as raised:
+        parts_lifecycle.run(
+            cmd,
+            parsed_args=argparse.Namespace(
+                destructive_mode=False,
+                use_lxd=False,
+                provider=None,
+                ua_token="my-token",
+                build_for=get_host_architecture(),
+                enable_experimental_ua_services=False,
+            ),
+        )
+
+    assert run_mock.mock_calls == []
+    assert str(raised.value) == (
+        "Using UA services requires --enable-experimental-ua-services."
+    )
+
+
+@pytest.mark.parametrize(
     "cmd,step",
     [
         ("pull", "pull"),

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -103,6 +103,7 @@ class TestProjectDefaults:
                 build_on=[get_host_architecture()], build_for=[get_host_architecture()]
             )
         ]
+        assert project.ua_services is None
 
     def test_app_defaults(self, project_yaml_data):
         data = project_yaml_data(apps={"app1": {"command": "/bin/true"}})

--- a/tests/unit/test_ua_manager.py
+++ b/tests/unit/test_ua_manager.py
@@ -19,6 +19,13 @@ import pytest
 from snapcraft import ua_manager
 
 
+@pytest.fixture(autouse=True)
+def _setup_fixture(mocker):
+    mocker.patch(
+        "craft_parts.packages.Repository.is_package_installed", return_value=True
+    )
+
+
 def test_ua_manager(fake_process):
     ua_token = "test-ua-token"
 
@@ -29,7 +36,7 @@ def test_ua_manager(fake_process):
     fake_process.register_subprocess(["ua", "attach", "test-ua-token"])
     fake_process.register_subprocess(["ua", "detach", "--assume-yes"])
 
-    with ua_manager.ua_manager(ua_token):
+    with ua_manager.ua_manager(ua_token, services=None):
         pass
 
     assert list(fake_process.calls) == [
@@ -45,7 +52,7 @@ def test_ua_manager_already_attached(fake_process):
         stdout='{"attached": true, "_doc": "Content..."}',
     )
 
-    with ua_manager.ua_manager("ua-token"):
+    with ua_manager.ua_manager("ua-token", services=None):
         pass
 
     assert list(fake_process.calls) == [["ua", "status", "--format", "json"]]
@@ -61,7 +68,7 @@ def test_ua_manager_attach_error(fake_process):
     fake_process.register_subprocess(["ua", "attach", "test-ua-token"], returncode=23)
 
     with pytest.raises(ua_manager.UATokenAttachError) as raised:
-        with ua_manager.ua_manager(ua_token):
+        with ua_manager.ua_manager(ua_token, services=None):
             pass
 
     assert list(fake_process.calls) == [
@@ -69,6 +76,54 @@ def test_ua_manager_attach_error(fake_process):
         ["ua", "attach", "test-ua-token"],
     ]
     assert str(raised.value) == "Error attaching UA token."
+
+
+def test_ua_manager_enable_services(fake_process):
+    ua_token = "test-ua-token"
+
+    fake_process.register_subprocess(
+        ["ua", "status", "--format", "json"],
+        stdout='{"attached": false, "_doc": "Content..."}',
+    )
+    fake_process.register_subprocess(["ua", "attach", "test-ua-token"])
+    fake_process.register_subprocess(["ua", "enable", "svc1", "svc2", "--beta"])
+    fake_process.register_subprocess(["ua", "detach", "--assume-yes"])
+
+    with ua_manager.ua_manager(ua_token, services=["svc1", "svc2"]):
+        pass
+
+    assert list(fake_process.calls) == [
+        ["ua", "status", "--format", "json"],
+        ["ua", "attach", "test-ua-token"],
+        ["ua", "enable", "svc1", "svc2", "--beta"],
+        ["ua", "detach", "--assume-yes"],
+    ]
+
+
+def test_ua_manager_enable_services_error(fake_process):
+    ua_token = "test-ua-token"
+
+    fake_process.register_subprocess(
+        ["ua", "status", "--format", "json"],
+        stdout='{"attached": false, "_doc": "Content..."}',
+    )
+    fake_process.register_subprocess(["ua", "attach", "test-ua-token"])
+    fake_process.register_subprocess(
+        ["ua", "enable", "svc1", "svc2", "--beta"], returncode=1
+    )
+    fake_process.register_subprocess(["ua", "detach", "--assume-yes"])
+
+    with pytest.raises(ua_manager.UAEnableServicesError) as raised:
+        with ua_manager.ua_manager(ua_token, services=["svc1", "svc2"]):
+            pass
+
+    assert list(fake_process.calls) == [
+        ["ua", "status", "--format", "json"],
+        ["ua", "attach", "test-ua-token"],
+        ["ua", "enable", "svc1", "svc2", "--beta"],
+        ["ua", "detach", "--assume-yes"],
+    ]
+    assert str(raised.value) == "Error enabling UA services."
 
 
 def test_ua_manager_detaches_on_error(fake_process):
@@ -80,7 +135,7 @@ def test_ua_manager_detaches_on_error(fake_process):
     fake_process.register_subprocess(["ua", "detach", "--assume-yes"])
 
     with pytest.raises(RuntimeError):
-        with ua_manager.ua_manager("test-ua-token"):
+        with ua_manager.ua_manager("test-ua-token", services=None):
             raise RuntimeError("whoopsie")
 
     assert list(fake_process.calls) == [
@@ -99,7 +154,7 @@ def test_ua_manager_detach_error(fake_process):
     fake_process.register_subprocess(["ua", "detach", "--assume-yes"], returncode=34)
 
     with pytest.raises(ua_manager.UATokenDetachError) as raised:
-        with ua_manager.ua_manager("test-ua-token"):
+        with ua_manager.ua_manager("test-ua-token", services=None):
             pass
 
     assert list(fake_process.calls) == [


### PR DESCRIPTION
UA services can be specified in the project yaml file under the optional
`ua-services` key. These services will be enabled during the execution
of the parts lifecycle.

Note: this handles ua services for core22. Support for legacy snapcraft
will be added in a separate PR.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1289