### PR TITLE
cli: add legacy envvar for login and check stdin

### DIFF
--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -122,6 +122,28 @@ GLOBAL_ARGS = [
 ]
 
 
+def get_verbosity() -> EmitterMode:
+    """Return the verbosity level to use.
+
+    if SNAPCRAFT_ENABLE_DEVELOPER_DEBUG is set, the
+    default verbosity will be set to EmitterMode.DEBUG.
+
+    If stdin is closed, the default verbosity will be
+    set to EmitterMode.VERBOSE.
+    """
+    verbosity = EmitterMode.BRIEF
+
+    if not sys.stdin.isatty():
+        verbosity = EmitterMode.VERBOSE
+
+    with contextlib.suppress(ValueError):
+        # Parse environment variable for backwards compatibility with launchpad
+        if utils.strtobool(os.getenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", "n").strip()):
+            verbosity = EmitterMode.DEBUG
+
+    return verbosity
+
+
 def get_dispatcher() -> craft_cli.Dispatcher:
     """Return an instance of Dispatcher.
 
@@ -145,7 +167,7 @@ def get_dispatcher() -> craft_cli.Dispatcher:
         log_filepath = None
 
     emit.init(
-        mode=EmitterMode.BRIEF,
+        mode=get_verbosity(),
         appname="snapcraft",
         greeting=f"Starting Snapcraft {__version__}",
         log_filepath=log_filepath,

--- a/tests/unit/cli/test_exit.py
+++ b/tests/unit/cli/test_exit.py
@@ -25,6 +25,7 @@ from snapcraft import cli
 
 def test_no_keyring_error(capsys, mocker):
     mocker.patch.object(sys, "argv", ["cmd", "whoami"])
+    mocker.patch.object(sys.stdin, "isatty", return_value=True)
     mock_version_cmd = mocker.patch(
         "snapcraft.commands.account.StoreWhoAmICommand.run",
         side_effect=craft_store.errors.NoKeyringError,

--- a/tests/unit/cli/test_verbosity.py
+++ b/tests/unit/cli/test_verbosity.py
@@ -1,0 +1,63 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from snapcraft import cli
+
+
+@pytest.mark.parametrize("value", ["yes", "YES", "1", "y", "Y"])
+def test_developer_debug_in_env_sets_debug(monkeypatch, value):
+    monkeypatch.setenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", value)
+
+    assert cli.get_verbosity() == cli.EmitterMode.DEBUG
+
+
+@pytest.mark.parametrize("value", ["no", "NO", "0", "n", "N"])
+def test_developer_debug_in_env_sets_brief(monkeypatch, value):
+    monkeypatch.setenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", value)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+    assert cli.get_verbosity() == cli.EmitterMode.BRIEF
+
+
+@pytest.mark.parametrize("value", ["foo", "BAR", "2"])
+def test_parse_issue_in_developer_debug_in_env_sets_brief(monkeypatch, value):
+    monkeypatch.setenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", value)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+    assert cli.get_verbosity() == cli.EmitterMode.BRIEF
+
+
+def test_no_env_returns_brief(monkeypatch):
+    monkeypatch.delenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+    assert cli.get_verbosity() == cli.EmitterMode.BRIEF
+
+
+def test_sdtin_no_tty_returns_verbose(monkeypatch):
+    monkeypatch.delenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    assert cli.get_verbosity() == cli.EmitterMode.VERBOSE
+
+
+def test_developer_debug_and_sdtin_no_tty_returns_debug(monkeypatch):
+    monkeypatch.setenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", True)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    assert cli.get_verbosity() == cli.EmitterMode.DEBUG


### PR DESCRIPTION
Launchpad is no longer logging builds, we should allow for this by
checking if stdin is closed or not.

SNAPCRAFT_ENABLE_DEVELOPER_DEBUG is also analyzed for core22 projects
which is useful for Snapcraft's own spread tests.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
