### PR TITLE
ua: enable ua services in legacy

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -1159,6 +1159,17 @@
         },
         "slots": {
             "type": "object"
+        },
+        "ua-services": {
+            "type": "array",
+            "description": "UA services to enable.",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": [
+                {
+                    "type": "string"
+                }
+            ]
         }
     },
     "allOf": [

--- a/snapcraft/ua_manager.py
+++ b/snapcraft/ua_manager.py
@@ -78,7 +78,9 @@ def _enable_services(services: List[str]) -> None:
     try:
         with emit.open_stream("Enable UA services") as stream:
             subprocess.check_call(
-                ["ua", "enable", *services, "--beta"], stdout=stream, stderr=stream
+                ["ua", "enable", *services, "--beta", "--assume-yes"],
+                stdout=stream,
+                stderr=stream,
             )
     except subprocess.CalledProcessError as error:
         raise UAEnableServicesError from error

--- a/snapcraft_legacy/cli/_options.py
+++ b/snapcraft_legacy/cli/_options.py
@@ -200,6 +200,13 @@ _PROVIDER_OPTIONS: List[Dict[str, Any]] = [
         envvar="SNAPCRAFT_UA_TOKEN",
         supported_providers=["host", "lxd", "managed-host", "multipass"],
     ),
+    dict(
+        param_decls="--enable-experimental-ua-services",
+        is_flag=True,
+        help="Allow selection of UA services to enable.",
+        envvar="SNAPCRAFT_ENABLE_EXPERIMENTAL_UA_SERVICES",
+        supported_providers=["host", "lxd", "managed-host", "multipass"],
+    ),
 ]
 
 

--- a/tests/legacy/unit/repo/test_ua_manager.py
+++ b/tests/legacy/unit/repo/test_ua_manager.py
@@ -14,9 +14,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import subprocess
+
 import pytest
 
 from snapcraft_legacy.internal.repo import ua_manager
+
+
+@pytest.fixture(autouse=True)
+def _setup_fixture(mocker):
+    mocker.patch("snapcraft_legacy.internal.repo.Repo.refresh_build_packages")
+    mocker.patch("snapcraft_legacy.internal.repo.Repo._install_packages")
 
 
 def test_ua_manager(fake_process):
@@ -29,7 +37,7 @@ def test_ua_manager(fake_process):
     fake_process.register_subprocess(["sudo", "ua", "attach", "test-ua-token"])
     fake_process.register_subprocess(["sudo", "ua", "detach", "--assume-yes"])
 
-    with ua_manager.ua_manager(ua_token):
+    with ua_manager.ua_manager(ua_token, services=None):
         pass
 
     assert list(fake_process.calls) == [
@@ -45,10 +53,60 @@ def test_ua_manager_already_attached(fake_process):
         stdout='{"attached": true, "_doc": "Content..."}',
     )
 
-    with ua_manager.ua_manager("ua-token"):
+    with ua_manager.ua_manager("ua-token", services=None):
         pass
 
     assert list(fake_process.calls) == [["sudo", "ua", "status", "--format", "json"]]
+
+
+def test_ua_manager_enable_services(fake_process):
+    ua_token = "test-ua-token"
+
+    fake_process.register_subprocess(
+        ["sudo", "ua", "status", "--format", "json"],
+        stdout='{"attached": false, "_doc": "Content..."}',
+    )
+    fake_process.register_subprocess(["sudo", "ua", "attach", "test-ua-token"])
+    fake_process.register_subprocess(
+        ["sudo", "ua", "enable", "svc1", "svc2", "--beta", "--assume-yes"]
+    )
+    fake_process.register_subprocess(["sudo", "ua", "detach", "--assume-yes"])
+
+    with ua_manager.ua_manager(ua_token, services=["svc1", "svc2"]):
+        pass
+
+    assert list(fake_process.calls) == [
+        ["sudo", "ua", "status", "--format", "json"],
+        ["sudo", "ua", "attach", "test-ua-token"],
+        ["sudo", "ua", "enable", "svc1", "svc2", "--beta", "--assume-yes"],
+        ["sudo", "ua", "detach", "--assume-yes"],
+    ]
+
+
+def test_ua_manager_enable_services_error(fake_process):
+    ua_token = "test-ua-token"
+
+    fake_process.register_subprocess(
+        ["sudo", "ua", "status", "--format", "json"],
+        stdout='{"attached": false, "_doc": "Content..."}',
+    )
+    fake_process.register_subprocess(["sudo", "ua", "attach", "test-ua-token"])
+    fake_process.register_subprocess(
+        ["sudo", "ua", "enable", "svc1", "svc2", "--beta", "--assume-yes"], returncode=1
+    )
+    fake_process.register_subprocess(["sudo", "ua", "detach", "--assume-yes"])
+
+    with pytest.raises(subprocess.CalledProcessError) as raised:
+        with ua_manager.ua_manager(ua_token, services=["svc1", "svc2"]):
+            pass
+
+    assert list(fake_process.calls) == [
+        ["sudo", "ua", "status", "--format", "json"],
+        ["sudo", "ua", "attach", "test-ua-token"],
+        ["sudo", "ua", "enable", "svc1", "svc2", "--beta", "--assume-yes"],
+        ["sudo", "ua", "detach", "--assume-yes"],
+    ]
+    assert raised.value.returncode == 1
 
 
 def test_ua_manager_detaches_on_error(fake_process):
@@ -60,7 +118,7 @@ def test_ua_manager_detaches_on_error(fake_process):
     fake_process.register_subprocess(["sudo", "ua", "detach", "--assume-yes"])
 
     with pytest.raises(RuntimeError):
-        with ua_manager.ua_manager("test-ua-token"):
+        with ua_manager.ua_manager("test-ua-token", services=None):
             raise RuntimeError("whoopsie")
 
     assert list(fake_process.calls) == [

--- a/tests/unit/test_ua_manager.py
+++ b/tests/unit/test_ua_manager.py
@@ -86,7 +86,9 @@ def test_ua_manager_enable_services(fake_process):
         stdout='{"attached": false, "_doc": "Content..."}',
     )
     fake_process.register_subprocess(["ua", "attach", "test-ua-token"])
-    fake_process.register_subprocess(["ua", "enable", "svc1", "svc2", "--beta"])
+    fake_process.register_subprocess(
+        ["ua", "enable", "svc1", "svc2", "--beta", "--assume-yes"]
+    )
     fake_process.register_subprocess(["ua", "detach", "--assume-yes"])
 
     with ua_manager.ua_manager(ua_token, services=["svc1", "svc2"]):
@@ -95,7 +97,7 @@ def test_ua_manager_enable_services(fake_process):
     assert list(fake_process.calls) == [
         ["ua", "status", "--format", "json"],
         ["ua", "attach", "test-ua-token"],
-        ["ua", "enable", "svc1", "svc2", "--beta"],
+        ["ua", "enable", "svc1", "svc2", "--beta", "--assume-yes"],
         ["ua", "detach", "--assume-yes"],
     ]
 
@@ -109,7 +111,7 @@ def test_ua_manager_enable_services_error(fake_process):
     )
     fake_process.register_subprocess(["ua", "attach", "test-ua-token"])
     fake_process.register_subprocess(
-        ["ua", "enable", "svc1", "svc2", "--beta"], returncode=1
+        ["ua", "enable", "svc1", "svc2", "--beta", "--assume-yes"], returncode=1
     )
     fake_process.register_subprocess(["ua", "detach", "--assume-yes"])
 
@@ -120,7 +122,7 @@ def test_ua_manager_enable_services_error(fake_process):
     assert list(fake_process.calls) == [
         ["ua", "status", "--format", "json"],
         ["ua", "attach", "test-ua-token"],
-        ["ua", "enable", "svc1", "svc2", "--beta"],
+        ["ua", "enable", "svc1", "svc2", "--beta", "--assume-yes"],
         ["ua", "detach", "--assume-yes"],
     ]
     assert str(raised.value) == "Error enabling UA services."


### PR DESCRIPTION
Backport UA services support from core22 to legacy snapcraft. Services
are defined in the project yaml under the `ua-services` key. Parameter
`--enable-experimental-ua-services` is required if you define UA services.

**Note:** This is a baseline implementation that may require improvements
in service management, such as keeping track of services that are already
enabled to avoid re-enabling them. This will be done in future PRs.

Example output:
```
$ snapcraft --ua-token=$MYTOKEN --use-lxd --enable-experimental-ua-services
Launching a container.
Waiting for container to be ready
Waiting for network to be ready...
Attaching specified UA token...
Enabling default service esm-infra
Updating package lists
UA Infra: ESM enabled
Unable to determine current instance-id
This machine is now attached to 'claudio.matsuoka@canonical.com'                                                                                                           SERVICE          ENTITLED  STATUS    DESCRIPTION
cc-eal           yes       n/a       Common Criteria EAL2 Provisioning Packages
esm-infra        yes       enabled   UA Infra: Extended Security Maintenance (ESM)
fips             yes       disabled  NIST-certified core packages
fips-updates     yes       disabled  NIST-certified core packages with priority security updates
livepatch        yes       n/a       Canonical Livepatch service
usg              yes       disabled  Security compliance and audit tools
NOTICES                                                                                                                                                                                Operation in progress: ua attach
Enable services with: ua enable <service>
Account: claudio.matsuoka@canonical.com
Subscription: claudio.matsuoka@canonical.com
Enabling specified UA services...
One moment, checking your subscription first
Updating package lists
Installing FIPS packages
FIPS enabled
Please run `apt upgrade` to ensure all FIPS packages are updated to the correct
version.                                                                                                                                                                              Skipping pull figlet (already ran)
Skipping build figlet (already ran)
Skipping stage figlet (already ran)
Skipping prime figlet (already ran)
The requested action has already been taken. Consider
specifying parts, or clean the steps you want to run again.
Snapping |
Snapped mytest_0.2_amd64.snap
Detaching specified UA token...Detach will disable the following services:
    fips
    esm-infra
Updating package lists
Updating package lists
This machine is now detached.
```
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1301