### PR TITLE
cli: disable log filename report in managed hosts

### DIFF
--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -198,6 +198,15 @@ def _run_dispatcher(dispatcher: craft_cli.Dispatcher) -> None:
     emit.ended_ok()
 
 
+def _emit_error(error):
+    """Emit the error in a centralized way so we can alter it consistently."""
+    # Do not report the internal logpath if running inside instance
+    if utils.is_managed_mode():
+        error.logpath_report = False
+
+    emit.error(error)
+
+
 def run():
     """Run the CLI."""
     # Register our own plugins
@@ -226,7 +235,7 @@ def run():
     except errors.LegacyFallback as err:
         run_legacy(err)
     except craft_store.errors.NoKeyringError as err:
-        emit.error(
+        _emit_error(
             craft_cli.errors.CraftError(
                 f"craft-store error: {err}",
                 resolution=(
@@ -239,10 +248,10 @@ def run():
         )
         retcode = 1
     except craft_store.errors.CraftStoreError as err:
-        emit.error(craft_cli.errors.CraftError(f"craft-store error: {err}"))
+        _emit_error(craft_cli.errors.CraftError(f"craft-store error: {err}"))
         retcode = 1
     except errors.SnapcraftError as err:
-        emit.error(err)
+        _emit_error(err)
         retcode = 1
 
     return retcode

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -28,7 +28,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Tuple
 import craft_parts
 from craft_cli import EmitterMode, emit
 from craft_parts import ProjectInfo, StepInfo, callbacks
-from craft_providers import ProviderError
 
 from snapcraft import errors, extensions, pack, providers, utils
 from snapcraft.meta import manifest, snap_yaml
@@ -449,7 +448,7 @@ def _run_in_provider(
             capture_logs_from_instance(instance)
         except subprocess.CalledProcessError as err:
             capture_logs_from_instance(instance)
-            raise ProviderError(
+            raise errors.SnapcraftError(
                 f"Failed to execute {command_name} in instance."
             ) from err
 

--- a/tests/unit/cli/test_exit.py
+++ b/tests/unit/cli/test_exit.py
@@ -19,6 +19,8 @@ import sys
 from unittest.mock import call
 
 import craft_store.errors
+import pytest
+from craft_cli import CraftError
 
 from snapcraft import cli
 
@@ -46,3 +48,14 @@ def test_no_keyring_error(capsys, mocker):
     assert stderr[2].startswith(
         "For more information, check out: https://snapcraft.io/docs/snapcraft-authentication"
     )
+
+
+@pytest.mark.parametrize("is_managed,report_errors", [(True, False), (False, True)])
+def test_emit_error(emitter, mocker, is_managed, report_errors):
+    mocker.patch("snapcraft.utils.is_managed_mode", return_value=is_managed)
+    mocker.patch("craft_cli.messages.Emitter.error")
+
+    my_error = CraftError("Something wrong happened.")
+    cli._emit_error(my_error)
+
+    assert my_error.logpath_report == report_errors


### PR DESCRIPTION
Don't show the log file name when exiting on error in a managed host,
preventing confusing duplicate log filename reports.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1285