### PR TITLE
parts: allow debug shell after the lifecycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ disable = "too-few-public-methods,fixme,use-implicit-booleaness-not-comparison,d
 max-attributes = 15
 max-args = 6
 max-locals = 20
+max-branches = 16
 good-names = "id"
 
 [tool.pylint.MASTER]

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -490,9 +490,11 @@ def _run_in_provider(
         except subprocess.CalledProcessError as err:
             capture_logs_from_instance(instance)
             raise errors.SnapcraftError(
-                f"Failed to execute {command_name} in instance. "
-                "Run the same command again with --debug to shell into "
-                "the environment if you wish to introspect this failure."
+                f"Failed to execute {command_name} in instance.",
+                details=(
+                    "Run the same command again with --debug to shell into "
+                    "the environment if you wish to introspect this failure."
+                ),
             ) from err
 
 

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -45,7 +45,7 @@ from snapcraft.utils import (
 )
 
 from . import grammar, yaml_utils
-from .parts import PartsLifecycle
+from .parts import PartsLifecycle, launch_shell
 from .project_check import run_project_checks
 from .setup_assets import setup_assets
 from .update_metadata import update_project_metadata
@@ -197,18 +197,15 @@ def run(command_name: str, parsed_args: "argparse.Namespace") -> None:
         )
         project = Project.unmarshal(yaml_data_for_arch)
 
-        try:
-            _run_command(
-                command_name,
-                project=project,
-                parse_info=parse_info,
-                parallel_build_count=build_count,
-                assets_dir=snap_project.assets_dir,
-                start_time=start_time,
-                parsed_args=parsed_args,
-            )
-        except PermissionError as err:
-            raise errors.FilePermissionError(err.filename, reason=err.strerror)
+        _run_command(
+            command_name,
+            project=project,
+            parse_info=parse_info,
+            parallel_build_count=build_count,
+            assets_dir=snap_project.assets_dir,
+            start_time=start_time,
+            parsed_args=parsed_args,
+        )
 
 
 def _run_command(
@@ -279,15 +276,59 @@ def _run_command(
         lifecycle.clean(part_names=part_names)
         return
 
+    try:
+        _run_lifecycle_and_pack(
+            lifecycle,
+            command_name=command_name,
+            step_name=step_name,
+            project=project,
+            project_dir=project_dir,
+            assets_dir=assets_dir,
+            start_time=start_time,
+            parsed_args=parsed_args,
+        )
+    except PermissionError as err:
+        if parsed_args.debug:
+            emit.progress(str(err), permanent=True)
+            launch_shell()
+        raise errors.FilePermissionError(err.filename, reason=err.strerror)
+    except OSError as err:
+        msg = err.strerror
+        if err.filename:
+            msg = f"{err.filename}: {msg}"
+        if parsed_args.debug:
+            emit.progress(msg, permanent=True)
+            launch_shell()
+        raise errors.SnapcraftError(msg) from err
+    except Exception as err:
+        if parsed_args.debug:
+            emit.progress(str(err), permanent=True)
+            launch_shell()
+        raise errors.SnapcraftError(str(err)) from err
+
+
+def _run_lifecycle_and_pack(
+    lifecycle: PartsLifecycle,
+    *,
+    command_name: str,
+    step_name: str,
+    project: Project,
+    project_dir: Path,
+    assets_dir: Path,
+    start_time: datetime,
+    parsed_args: "argparse.Namespace",
+) -> None:
+    """Execute the parts lifecycle, generate metadata, and create the snap."""
     lifecycle.run(
         step_name,
-        debug=parsed_args.debug,
         shell=getattr(parsed_args, "shell", False),
         shell_after=getattr(parsed_args, "shell_after", False),
     )
 
     # Extract metadata and generate snap.yaml
     project_vars = lifecycle.project_vars
+    part_names = getattr(parsed_args, "part_names", None)
+
     if step_name == "prime" and not part_names:
         emit.progress("Extracting and updating metadata...")
         metadata_list = lifecycle.extract_metadata()
@@ -449,7 +490,9 @@ def _run_in_provider(
         except subprocess.CalledProcessError as err:
             capture_logs_from_instance(instance)
             raise errors.SnapcraftError(
-                f"Failed to execute {command_name} in instance."
+                f"Failed to execute {command_name} in instance. "
+                "Run the same command again with --debug to shell into "
+                "the environment if you wish to introspect this failure."
             ) from err
 
 

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -131,7 +131,6 @@ class PartsLifecycle:
         self,
         step_name: str,
         *,
-        debug: bool = False,
         shell: bool = False,
         shell_after: bool = False,
     ) -> None:
@@ -171,21 +170,17 @@ class PartsLifecycle:
                     emit.progress(f"Executed: {message}", permanent=True)
 
             if shell_after:
-                _launch_shell()
+                launch_shell()
 
             emit.progress("Executed parts lifecycle", permanent=True)
         except RuntimeError as err:
             raise RuntimeError(f"Parts processing internal error: {err}") from err
         except OSError as err:
-            if debug:
-                _launch_shell()
             msg = err.strerror
             if err.filename:
                 msg = f"{err.filename}: {msg}"
             raise errors.PartsLifecycleError(msg) from err
         except Exception as err:
-            if debug:
-                _launch_shell()
             raise errors.PartsLifecycleError(str(err)) from err
 
     def _install_package_repositories(self) -> None:
@@ -271,7 +266,7 @@ class PartsLifecycle:
         return self._lcm.get_pull_assets(part_name=part_name)
 
 
-def _launch_shell(*, cwd: Optional[pathlib.Path] = None) -> None:
+def launch_shell(*, cwd: Optional[pathlib.Path] = None) -> None:
     """Launch a user shell for debugging environment.
 
     :param cwd: Working directory to start user in.


### PR DESCRIPTION
Shell into the instance if `--debug` is used and a packing error happens
after the execution of the parts lifecycle.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1286