### PR TITLE
requirements: update craft-providers to 1.4.1

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -12,7 +12,7 @@ coverage==6.4.2
 craft-cli==1.1.0
 craft-grammar==1.1.1
 craft-parts==1.12.1
-craft-providers==1.4.0
+craft-providers==1.4.1
 craft-store==2.1.1
 cryptography==3.4
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.3
 craft-cli==1.1.0
 craft-grammar==1.1.1
 craft-parts==1.12.1
-craft-providers==1.4.0
+craft-providers==1.4.1
 craft-store==2.1.1
 cryptography==3.4
 Deprecated==1.2.13


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----

Bump `craft-providers` to `1.4.1` to fix a bug in the truncation of long hostnames when creating an instance.