### PR TITLE
config: add snap config model

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -90,6 +90,7 @@ semantic-version==2.10.0
 semver==2.13.0
 simplejson==3.17.6
 six==1.16.0
+snap-helpers==0.2.0
 snowballstemmer==2.2.0
 tabulate==0.8.10
 testscenarios==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,7 @@ semantic-version==2.10.0
 semver==2.13.0
 simplejson==3.17.6
 six==1.16.0
+snap-helpers==0.2.0
 tabulate==0.8.10
 tinydb==4.7.0
 toml==0.10.2

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,7 @@ install_requires = [
     "requests-unixsocket",
     "requests",
     "simplejson",
+    "snap-helpers",
     "tabulate",
     "toml",
     "tinydb",

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import sys
+
+import snaphelpers
+
+from snapcraft.snap_config import SnapConfig
+
+
+def validate_snap_config() -> None:
+    """Validate snap configuration."""
+    snap_config = snaphelpers.SnapConfigOptions(keys=["provider"])
+    snap_config.fetch()
+
+    try:
+        SnapConfig.unmarshal(snap_config.as_dict())
+    except (TypeError, ValueError) as error:
+        reason = str(error)
+        print(f"Could not configure snapcraft: {reason}.", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    validate_snap_config()

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -140,3 +140,9 @@ parts:
         mv $SNAPCRAFT_PART_INSTALL/bin/craftctl $SNAPCRAFT_PART_INSTALL/libexec/snapcraft/
         sed -i -e '1 s|^#!/.*|#!/snap/snapcraft/current/bin/python -E|' $SNAPCRAFT_PART_INSTALL/libexec/snapcraft/craftctl
     after: [snapcraft-libs]
+
+hooks:
+  configure:
+    passthrough:
+      environment:
+        PATH: "$SNAP/bin"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -143,6 +143,5 @@ parts:
 
 hooks:
   configure:
-    passthrough:
-      environment:
-        PATH: "$SNAP/bin"
+    environment:
+      PATH: "$SNAP/bin"

--- a/snapcraft/snap_config.py
+++ b/snapcraft/snap_config.py
@@ -1,0 +1,83 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Snap config file definitions and helpers."""
+from typing import Any, Dict, Literal, Optional
+
+import pydantic
+from craft_cli import emit
+from snaphelpers import SnapConfigOptions
+
+from snapcraft.utils import is_snapcraft_running_from_snap
+
+
+class SnapConfig(pydantic.BaseModel, extra=pydantic.Extra.forbid):
+    """Data stored in a snap config.
+
+    :param provider: provider to use. Valid values are 'lxd' and 'multipass'.
+    """
+
+    provider: Optional[Literal["lxd", "multipass"]] = None
+
+    @pydantic.validator("provider", pre=True)
+    @classmethod
+    def convert_to_lower(cls, provider):
+        """Convert provider value to lowercase."""
+        return provider.lower()
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]) -> "SnapConfig":
+        """Create and populate a new ``SnapConfig`` object from dictionary data.
+
+        The unmarshal method validates entries in the input dictionary, populating
+        the corresponding fields in the data object.
+
+        :param data: The dictionary data to unmarshal.
+
+        :return: The newly created object.
+
+        :raise TypeError: If data is not a dictionary.
+        :raise ValueError: If data is invalid.
+        """
+        if not isinstance(data, dict):
+            raise TypeError("snap config data is not a dictionary")
+
+        try:
+            snap_config = cls(**data)
+        except pydantic.ValidationError as error:
+            # TODO: use `_format_pydantic_errors()` from projects.py
+            raise ValueError(f"error parsing snap config: {error}") from error
+
+        return snap_config
+
+
+def get_snap_config() -> Optional[SnapConfig]:
+    """Get validated snap configuration.
+
+    :return: SnapConfig. If not running as a snap, return None.
+    """
+    if not is_snapcraft_running_from_snap():
+        emit.debug(
+            "Not loading snap config because snapcraft is not running as a snap."
+        )
+        return None
+
+    snap_config = SnapConfigOptions(keys=["provider"])
+    snap_config.fetch()
+
+    emit.debug(f"Retrieved snap config: {snap_config.as_dict()}")
+
+    return SnapConfig.unmarshal(snap_config.as_dict())

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -413,3 +413,8 @@ def process_version(version: Optional[str]) -> str:
         emit.progress(f"Version has been set to {new_version!r}", permanent=True)
 
     return new_version
+
+
+def is_snapcraft_running_from_snap() -> bool:
+    """Check if snapcraft is running from the snap."""
+    return os.getenv("SNAP_NAME") == "snapcraft" and os.getenv("SNAP") is not None

--- a/tests/spread/general/snap-config/snap/snapcraft.yaml
+++ b/tests/spread/general/snap-config/snap/snapcraft.yaml
@@ -1,0 +1,13 @@
+name: hello-world
+base: core22
+version: '1.0'
+summary: 'hello-world'
+description: |
+  Run `cat` on a config file.
+grade: stable
+confinement: strict
+
+parts:
+  hello-world:
+    plugin: nil
+    source: .

--- a/tests/spread/general/snap-config/task.yaml
+++ b/tests/spread/general/snap-config/task.yaml
@@ -23,7 +23,7 @@ execute: |
   fi
 
   # verify snapcraft executes
-  snapcraft
+  snapcraft pull
 
   # unset the value
   snap unset snapcraft provider
@@ -37,7 +37,7 @@ execute: |
   fi
 
   # again, verify snapcraft executes
-  snapcraft
+  snapcraft pull
 
   # finally, set an invalid value and verify the configure hook exits with an error
   output="$(sudo snap set snapcraft provider=invalid-value 2>&1 || true)"

--- a/tests/spread/general/snap-config/task.yaml
+++ b/tests/spread/general/snap-config/task.yaml
@@ -1,0 +1,48 @@
+summary: Verify snap configuration and configure hook functionality
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "snap/snapcraft.yaml"
+
+restore: |
+  snapcraft clean
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  # configure default provider
+  snap set snapcraft provider=lxd
+
+  # verify the value was set
+  if ! [[ $(snap get snapcraft provider) == "lxd" ]]; then
+      echo "configure hook did not run as expected"
+      exit 1
+  fi
+
+  # verify snapcraft executes
+  snapcraft
+
+  # unset the value
+  snap unset snapcraft provider
+
+  # 'snap get' should now return an error
+  output="$(snap get snapcraft 2>&1 || true)"
+
+  if ! [[ $output == 'error: snap "snapcraft" has no configuration' ]]; then
+      echo "configure hook did not run as expected"
+      exit 1
+  fi
+
+  # again, verify snapcraft executes
+  snapcraft
+
+  # finally, set an invalid value and verify the configure hook exits with an error
+  output="$(sudo snap set snapcraft provider=invalid-value 2>&1 || true)"
+
+  if ! [[ $output =~ "unexpected value; permitted: 'lxd', 'multipass'" ]]; then
+      echo "configure hook did not exit with the expected error message"
+      exit 1
+  fi

--- a/tests/unit/test_snap_config.py
+++ b/tests/unit/test_snap_config.py
@@ -1,0 +1,109 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for SnapConfig class."""
+from unittest.mock import patch
+
+import pytest
+
+from snapcraft.snap_config import SnapConfig, get_snap_config
+
+
+@pytest.fixture
+def mock_config():
+    with patch(
+        "snapcraft.snap_config.SnapConfigOptions", autospec=True
+    ) as mock_snap_config:
+        yield mock_snap_config
+
+
+@pytest.fixture()
+def mock_is_running_from_snap(mocker):
+    mocker.patch(
+        "snapcraft.snap_config.is_snapcraft_running_from_snap", return_value=True
+    )
+
+
+def test_unmarshal():
+    """Verify unmarshalling works as expected."""
+    config = SnapConfig.unmarshal({"provider": "lxd"})
+
+    assert config.provider == "lxd"
+
+
+def test_unmarshal_not_a_dictionary():
+    """Verify unmarshalling with data that is not a dictionary raises an error."""
+    with pytest.raises(TypeError) as raised:
+        SnapConfig.unmarshal("provider=lxd")  # type: ignore
+
+    assert str(raised.value) == "snap config data is not a dictionary"
+
+
+def test_unmarshal_invalid_provider_error():
+    """Verify unmarshalling with an invalid provider raises an error."""
+    with pytest.raises(ValueError) as raised:
+        SnapConfig.unmarshal({"provider": "invalid-value"})
+
+    assert str(raised.value) == (
+        "error parsing snap config: 1 validation error for SnapConfig\n"
+        "provider\n"
+        "  unexpected value; permitted: 'lxd', 'multipass' "
+        "(type=value_error.const; given=invalid-value; permitted=('lxd', 'multipass'))"
+    )
+
+
+def test_unmarshal_extra_data_error():
+    """Verify unmarshalling with extra data raises an error."""
+    with pytest.raises(ValueError) as raised:
+        SnapConfig.unmarshal({"provider": "lxd", "test": "test"})
+
+    assert str(raised.value) == (
+        "error parsing snap config: 1 validation error for SnapConfig\n"
+        "test\n"
+        "  extra fields not permitted (type=value_error.extra)"
+    )
+
+
+@pytest.mark.parametrize("provider", ["lxd", "multipass"])
+def test_get_snap_config(mock_config, mock_is_running_from_snap, provider):
+    """Verify getting a valid snap config."""
+
+    def fake_as_dict():
+        return {"provider": provider}
+
+    mock_config.return_value.as_dict.side_effect = fake_as_dict
+    config = get_snap_config()
+
+    assert config == SnapConfig(provider=provider)
+
+
+def test_get_snap_config_empty(mock_config, mock_is_running_from_snap):
+    """Verify getting an empty config returns a default SnapConfig."""
+
+    def fake_as_dict():
+        return {}
+
+    mock_config.return_value.as_dict.side_effect = fake_as_dict
+    config = get_snap_config()
+
+    assert config == SnapConfig()
+
+
+def test_get_snap_config_not_from_snap(mocker):
+    """Verify None is returned when snapcraft is not running from a snap."""
+    mocker.patch("snapcraft.utils.is_snapcraft_running_from_snap", return_value=False)
+
+    assert get_snap_config() is None

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -458,3 +458,31 @@ def test_convert_architectures_invalid():
         utils.convert_architecture_deb_to_platform("unknown")
 
     assert str(raised.value) == "Architecture 'unknown' is not supported."
+
+
+########################
+# Is running from snap #
+########################
+
+
+@pytest.mark.parametrize(
+    "snap_name,snap,result",
+    [
+        (None, None, False),
+        (None, "/snap/snapcraft/x1", False),
+        ("snapcraft", None, False),
+        ("snapcraft", "/snap/snapcraft/x1", True),
+    ],
+)
+def test_is_snapcraft_running_from_snap(monkeypatch, snap_name, snap, result):
+    if snap_name is None:
+        monkeypatch.delenv("SNAP_NAME", raising=False)
+    else:
+        monkeypatch.setenv("SNAP_NAME", snap_name)
+
+    if snap is None:
+        monkeypatch.delenv("SNAP", raising=False)
+    else:
+        monkeypatch.setenv("SNAP", snap)
+
+    assert utils.is_snapcraft_running_from_snap() == result


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Allows Snapcraft to parse data set via `snap set snapcraft <key>=<value>`.  Follows same paradigm as charmcraft.

(CRAFT-1321)