### PR TITLE
providers: choose default provider from snap config for core 22

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -239,9 +239,6 @@ def _run_command(
                 permanent=True,
             )
 
-    if parsed_args.use_lxd and providers.get_platform_default_provider() == "lxd":
-        emit.progress("LXD is used by default on this platform.", permanent=True)
-
     if (
         not managed_mode
         and not parsed_args.destructive_mode

--- a/snapcraft/providers/__init__.py
+++ b/snapcraft/providers/__init__.py
@@ -17,7 +17,7 @@
 """Build provider support."""
 
 from ._buildd import SnapcraftBuilddBaseConfiguration  # noqa: F401
-from ._get_provider import get_platform_default_provider, get_provider  # noqa: F401
+from ._get_provider import get_provider  # noqa: F401
 from ._logs import capture_logs_from_instance  # noqa: F401
 from ._lxd import LXDProvider  # noqa: F401
 from ._multipass import MultipassProvider  # noqa: F401

--- a/snapcraft/providers/_get_provider.py
+++ b/snapcraft/providers/_get_provider.py
@@ -34,7 +34,7 @@ def get_provider(provider: Optional[str] = None) -> Provider:
 
     To determine the appropriate provider,
     (1) use provider specified in the function argument,
-    (2) get the provider from the environment if valid,
+    (2) get the provider from the environment,
     (3) use provider specified with snap configuration,
     (4) default to platform default (LXD on Linux, otherwise Multipass).
 
@@ -45,17 +45,14 @@ def get_provider(provider: Optional[str] = None) -> Provider:
 
     # load snap config file
     snap_config = get_snap_config()
-    if snap_config:
-        snap_provider = snap_config.provider
-    else:
-        snap_provider = None
+    snap_provider = snap_config.provider if snap_config else None
 
     # (1) use provider specified in the function argument
     if provider:
         emit.debug(f"Using provider {provider!r} passed as an argument.")
         chosen_provider = provider
 
-    # (2) get the provider from the environment if valid
+    # (2) get the provider from the environment
     elif env_provider:
         emit.debug(
             f"Using provider {env_provider!r} from environmental "
@@ -79,10 +76,10 @@ def get_provider(provider: Optional[str] = None) -> Provider:
     # ignore case
     chosen_provider = chosen_provider.lower()
 
-    if chosen_provider not in ("lxd", "multipass"):
-        raise RuntimeError(f"unsupported provider specified: {chosen_provider!r}")
-
     # return the chosen provider
     if chosen_provider == "lxd":
         return LXDProvider()
-    return MultipassProvider()
+    if chosen_provider == "multipass":
+        return MultipassProvider()
+
+    raise ValueError(f"unsupported provider specified: {chosen_provider!r}")

--- a/tests/unit/providers/test_get_provider.py
+++ b/tests/unit/providers/test_get_provider.py
@@ -40,7 +40,7 @@ def test_get_provider_passed_argument(provider, expected_provider):
 
 def test_get_provider_passed_argument_invalid():
     """Verify an invalid provider raises an error."""
-    with pytest.raises(RuntimeError) as raised:
+    with pytest.raises(ValueError) as raised:
         get_provider("invalid-provider")
 
     assert str(raised.value) == "unsupported provider specified: 'invalid-provider'"
@@ -95,7 +95,7 @@ def test_get_provider_env_var(monkeypatch, provider, expected_provider):
 def test_get_provider_env_var_invalid(monkeypatch):
     """Verify an invalid environmental variable raises an error."""
     monkeypatch.setenv("SNAPCRAFT_BUILD_ENVIRONMENT", "invalid-provider")
-    with pytest.raises(RuntimeError) as raised:
+    with pytest.raises(ValueError) as raised:
         get_provider()
 
     assert str(raised.value) == "unsupported provider specified: 'invalid-provider'"
@@ -158,7 +158,7 @@ def test_get_provider_snap_config_invalid(mocker):
         "snapcraft.providers._get_provider.get_snap_config", return_value=snap_config
     )
 
-    with pytest.raises(RuntimeError) as raised:
+    with pytest.raises(ValueError) as raised:
         get_provider()
 
     assert str(raised.value) == "unsupported provider specified: 'invalid-provider'"

--- a/tests/unit/providers/test_get_provider.py
+++ b/tests/unit/providers/test_get_provider.py
@@ -1,0 +1,199 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from snapcraft.providers import LXDProvider, MultipassProvider, get_provider
+from snapcraft.snap_config import SnapConfig
+
+
+@pytest.mark.parametrize(
+    "provider, expected_provider",
+    [
+        ("lxd", LXDProvider),
+        ("Lxd", LXDProvider),
+        ("LXD", LXDProvider),
+        ("multipass", MultipassProvider),
+        ("Multipass", MultipassProvider),
+        ("MULTIPASS", MultipassProvider),
+    ],
+)
+def test_get_provider_passed_argument(provider, expected_provider):
+    """Verify the provider passed into the function argument is chosen."""
+    actual_provider = get_provider(provider)
+
+    assert isinstance(actual_provider, expected_provider)
+
+
+def test_get_provider_passed_argument_invalid():
+    """Verify an invalid provider raises an error."""
+    with pytest.raises(RuntimeError) as raised:
+        get_provider("invalid-provider")
+
+    assert str(raised.value) == "unsupported provider specified: 'invalid-provider'"
+
+
+def test_get_provider_passed_argument_priority(mocker, monkeypatch):
+    """Verify provider passed into the function argument has the correct priority.
+
+    This takes priority over:
+    - environmental variable
+    - snap config
+    - default
+    """
+    # set `sys.platform` to verify the default provider 'lxd' is not chosen
+    mocker.patch("sys.platform", "linux")
+
+    # set snap config provider to 'lxd' to verify it is not chosen
+    mocker.patch(
+        "snapcraft.providers._get_provider.get_snap_config",
+        return_value=SnapConfig(provider="lxd"),
+    )
+
+    # set the env var to 'lxd' to verify it is not chosen
+    monkeypatch.setenv("SNAPCRAFT_BUILD_ENVIRONMENT", "lxd")
+
+    # set function argument to multipass
+    provider = get_provider("multipass")
+
+    # provider defined by function argument is chosen
+    assert isinstance(provider, MultipassProvider)
+
+
+@pytest.mark.parametrize(
+    "provider, expected_provider",
+    [
+        ("lxd", LXDProvider),
+        ("Lxd", LXDProvider),
+        ("LXD", LXDProvider),
+        ("multipass", MultipassProvider),
+        ("Multipass", MultipassProvider),
+        ("MULTIPASS", MultipassProvider),
+    ],
+)
+def test_get_provider_env_var(monkeypatch, provider, expected_provider):
+    """Verify the provider defined in SNAPCRAFT_BUILD_ENVIRONMENT is chosen."""
+    monkeypatch.setenv("SNAPCRAFT_BUILD_ENVIRONMENT", provider)
+    actual_provider = get_provider()
+
+    assert isinstance(actual_provider, expected_provider)
+
+
+def test_get_provider_env_var_invalid(monkeypatch):
+    """Verify an invalid environmental variable raises an error."""
+    monkeypatch.setenv("SNAPCRAFT_BUILD_ENVIRONMENT", "invalid-provider")
+    with pytest.raises(RuntimeError) as raised:
+        get_provider()
+
+    assert str(raised.value) == "unsupported provider specified: 'invalid-provider'"
+
+
+def test_get_provider_env_var_priority(mocker, monkeypatch):
+    """Verify provider defined by SNAPCRAFT_BUILD_ENVIRONMENT has the correct priority.
+
+    This takes priority over:
+    - snap config
+    - default
+    """
+    # set `sys.platform` to verify the default provider 'lxd' is not chosen
+    mocker.patch("sys.platform", "linux")
+
+    # set snap config provider to 'lxd' to verify it is not chosen
+    mocker.patch(
+        "snapcraft.providers._get_provider.get_snap_config",
+        return_value=SnapConfig(provider="lxd"),
+    )
+
+    # set env var to multipass
+    monkeypatch.setenv("SNAPCRAFT_BUILD_ENVIRONMENT", "multipass")
+
+    # provider defined by env var is chosen
+    assert isinstance(get_provider(), MultipassProvider)
+
+
+@pytest.mark.parametrize(
+    "provider, expected_provider",
+    [
+        ("lxd", LXDProvider),
+        ("Lxd", LXDProvider),
+        ("LXD", LXDProvider),
+        ("multipass", MultipassProvider),
+        ("Multipass", MultipassProvider),
+        ("MULTIPASS", MultipassProvider),
+    ],
+)
+def test_get_provider_snap_config(mocker, provider, expected_provider):
+    """Verify the provider defined in snap config is chosen."""
+    # set `sys.platform` to verify the default provider 'lxd' is not chosen
+    mocker.patch("sys.platform", "linux")
+
+    # set snap config
+    mocker.patch(
+        "snapcraft.providers._get_provider.get_snap_config",
+        return_value=SnapConfig(provider=provider),
+    )
+    actual_provider = get_provider()
+
+    assert isinstance(actual_provider, expected_provider)
+
+
+def test_get_provider_snap_config_invalid(mocker):
+    """Verify an invalid environmental variable raises an error."""
+    snap_config = SnapConfig()
+    snap_config.provider = "invalid-provider"  # type: ignore
+    mocker.patch(
+        "snapcraft.providers._get_provider.get_snap_config", return_value=snap_config
+    )
+
+    with pytest.raises(RuntimeError) as raised:
+        get_provider()
+
+    assert str(raised.value) == "unsupported provider specified: 'invalid-provider'"
+
+
+def test_get_provider_snap_config_priority(mocker):
+    """Verify provider defined by SNAPCRAFT_BUILD_ENVIRONMENT has the correct priority.
+
+    This takes priority over the default.
+    """
+    # set `sys.platform` to verify the default provider 'lxd' is not chosen
+    mocker.patch("sys.platform", "linux")
+
+    # set snap config to multipass
+    mocker.patch(
+        "snapcraft.providers._get_provider.get_snap_config",
+        return_value=SnapConfig(provider="multipass"),
+    )
+
+    # provider defined by snap config is chosen
+    assert isinstance(get_provider(), MultipassProvider)
+
+
+@pytest.mark.parametrize(
+    "platform, expected_provider",
+    [
+        ("linux", LXDProvider),
+        ("darwin", MultipassProvider),
+        ("win32", MultipassProvider),
+        ("unknown", MultipassProvider),
+    ],
+)
+def test_get_provider_snap_config_default(mocker, platform, expected_provider):
+    """Verify the default provider is chosen."""
+    mocker.patch("sys.platform", platform)
+    actual_provider = get_provider()
+
+    assert isinstance(actual_provider, expected_provider)


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

The default provider can be set via `snapd`'s config.

It can be set with `snap set snapcraft provider=<provider>` where valid providers are 'lxd' and 'multipass'.
To unset, run `snap unset snapcraft provider`.

This PR depends on https://github.com/snapcore/snapcraft/pull/3898, so the tests will fail until that PR is merged.

(CRAFT-1322)