### PR TITLE
providers: choose legacy default provider from snap config

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -120,4 +120,4 @@ python-apt @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-a
 PyNaCl==1.4.0; sys.platform != "linux"
 PyNaCl @ https://files.pythonhosted.org/packages/61/ab/2ac6dea8489fa713e2b4c6c5b549cc962dd4a842b5998d9e80cf8440b7cd/PyNaCl-1.3.0.tar.gz; sys.platform == "linux"
 setuptools==49.6.0
-pyinstaller==4.3; sys.platform == "win32"
+pyinstaller==4.10; sys.platform == "win32"

--- a/snapcraft_legacy/internal/common.py
+++ b/snapcraft_legacy/internal/common.py
@@ -28,7 +28,9 @@ import tempfile
 import urllib
 from contextlib import suppress
 from pathlib import Path
-from typing import Callable, List, Union
+from typing import Callable, Dict, List, Optional, Union
+
+from snaphelpers import SnapConfigOptions
 
 from snapcraft_legacy.internal import errors
 
@@ -369,3 +371,21 @@ def get_pkg_config_paths(root, arch_triplet):
     ]
 
     return [p for p in paths if os.path.exists(p)]
+
+
+def get_snap_config() -> Optional[Dict[str, str]]:
+    """Get snap configuration data as a dictionary.
+
+    :return: snap config dictionary. If not running as a snap, return None.
+    """
+    if not is_snap():
+        logger.debug(
+            "Not loading snap config because snapcraft is not running as a snap."
+        )
+        return None
+
+    snap_config = SnapConfigOptions(keys=["provider"])
+    snap_config.fetch()
+
+    logger.debug("Retrieved snap config: %s", snap_config.as_dict())
+    return snap_config.as_dict()


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
The default provider for `snapcraft_legacy` can be set via snapd's config.

It can be set with `snap set snapcraft provider=<provider>` where valid providers are 'lxd' and 'multipass'.
To unset, run `snap unset snapcraft provider`.

The legacy implementation is much smaller than what is implemented for core22 in https://github.com/snapcore/snapcraft/pull/3899.
This is because the code for core22 validates the snap config during snapcraft's configure hook.  The legacy implementation doesn't need to re-validate the data.  It can just assume the config's data is valid.

(CRAFT-1323)