### PR TITLE
parts: minor refactoring in instance log capture

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -532,9 +532,7 @@ def _run_in_provider(
         try:
             with emit.pause():
                 instance.execute_run(cmd, check=True, cwd=output_dir)
-            capture_logs_from_instance(instance)
         except subprocess.CalledProcessError as err:
-            capture_logs_from_instance(instance)
             raise errors.SnapcraftError(
                 f"Failed to execute {command_name} in instance.",
                 details=(
@@ -542,6 +540,8 @@ def _run_in_provider(
                     "the environment if you wish to introspect this failure."
                 ),
             ) from err
+        finally:
+            capture_logs_from_instance(instance)
 
 
 # pylint: enable=too-many-branches


### PR DESCRIPTION
Refactor to capture logs in finally block instead of calling the function twice.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
