### PR TITLE
providers: pass http-proxy and https-proxy to craft-providers

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -525,8 +525,8 @@ def _run_in_provider(
         bind_ssh=parsed_args.bind_ssh,
         build_on=project.get_build_on(),
         build_for=project.get_build_for(),
-        http_proxy=getattr(parsed_args, "http_proxy", None),
-        https_proxy=getattr(parsed_args, "https_proxy", None),
+        http_proxy=parsed_args.http_proxy,
+        https_proxy=parsed_args.https_proxy,
     ) as instance:
         try:
             with emit.pause():

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -525,6 +525,8 @@ def _run_in_provider(
         bind_ssh=parsed_args.bind_ssh,
         build_on=project.get_build_on(),
         build_for=project.get_build_for(),
+        http_proxy=getattr(parsed_args, "http_proxy", None),
+        https_proxy=getattr(parsed_args, "https_proxy", None),
     ) as instance:
         try:
             with emit.pause():

--- a/snapcraft/providers/_lxd.py
+++ b/snapcraft/providers/_lxd.py
@@ -20,7 +20,7 @@ import contextlib
 import logging
 import os
 import pathlib
-from typing import Generator
+from typing import Generator, Optional
 
 from craft_providers import Executor, ProviderError, bases, lxd
 
@@ -113,6 +113,8 @@ class LXDProvider(Provider):
         bind_ssh: bool,
         build_on: str,
         build_for: str,
+        http_proxy: Optional[str] = None,
+        https_proxy: Optional[str] = None,
     ) -> Generator[Executor, None, None]:
         """Launch environment for specified base.
 
@@ -140,7 +142,9 @@ class LXDProvider(Provider):
         except lxd.LXDError as error:
             raise ProviderError(str(error)) from error
 
-        environment = self.get_command_environment()
+        environment = self.get_command_environment(
+            http_proxy=http_proxy, https_proxy=https_proxy
+        )
 
         base_configuration = SnapcraftBuilddBaseConfiguration(
             alias=alias,

--- a/snapcraft/providers/_multipass.py
+++ b/snapcraft/providers/_multipass.py
@@ -19,7 +19,7 @@
 import contextlib
 import logging
 import pathlib
-from typing import Generator
+from typing import Generator, Optional
 
 from craft_cli import emit
 from craft_providers import Executor, ProviderError, bases, multipass
@@ -104,6 +104,8 @@ class MultipassProvider(Provider):
         bind_ssh: bool,
         build_on: str,
         build_for: str,
+        http_proxy: Optional[str] = None,
+        https_proxy: Optional[str] = None,
     ) -> Generator[Executor, None, None]:
         """Launch environment for specified base.
 
@@ -126,7 +128,9 @@ class MultipassProvider(Provider):
             build_for=build_for,
         )
 
-        environment = self.get_command_environment()
+        environment = self.get_command_environment(
+            http_proxy=http_proxy, https_proxy=https_proxy
+        )
         base_configuration = SnapcraftBuilddBaseConfiguration(
             alias=alias,  # type: ignore
             environment=environment,

--- a/snapcraft/providers/_provider.py
+++ b/snapcraft/providers/_provider.py
@@ -74,8 +74,17 @@ class Provider(ABC):
         """
 
     @staticmethod
-    def get_command_environment() -> Dict[str, Optional[str]]:
-        """Construct the required environment."""
+    def get_command_environment(
+        http_proxy: Optional[str] = None,
+        https_proxy: Optional[str] = None,
+    ) -> Dict[str, Optional[str]]:
+        """Construct an environment needed to execute a command.
+
+        :param http_proxy: http proxy to add to environment
+        :param https_proxy: https proxy to add to environment
+
+        :return: Dictionary of environmental variables.
+        """
         env = bases.buildd.default_command_environment()
         env["SNAPCRAFT_MANAGED_MODE"] = "1"
 
@@ -91,6 +100,13 @@ class Provider(ABC):
         ]:
             if env_key in os.environ:
                 env[env_key] = os.environ[env_key]
+
+        # if http[s]_proxy was specified as an argument, then prioritize this proxy
+        # over the proxy from the host's environment.
+        if http_proxy:
+            env["http_proxy"] = http_proxy
+        if https_proxy:
+            env["https_proxy"] = https_proxy
 
         return env
 
@@ -168,6 +184,8 @@ class Provider(ABC):
         bind_ssh: bool,
         build_on: str,
         build_for: str,
+        http_proxy: Optional[str] = None,
+        https_proxy: Optional[str] = None,
     ) -> Generator[Executor, None, None]:
         """Launch environment for specified base.
 

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -96,3 +96,28 @@ class TestLxdLaunchedEnvironment:
                 call(host_source=new_dir, target=Path("/root/project")),
                 call(host_source=Path.home() / ".ssh", target=Path("/root/.ssh")),
             ]
+
+    def test_command_environment(self, mocker, new_dir, lxd_instance_mock):
+        """Verify launched_environment calls get_command_environment."""
+        mocker.patch(
+            "snapcraft.providers._lxd.lxd.launch", return_value=lxd_instance_mock
+        )
+        mock_base_config = mocker.patch(
+            "snapcraft.providers._lxd.LXDProvider.get_command_environment",
+        )
+
+        prov = providers.LXDProvider()
+
+        with prov.launched_environment(
+            project_name="test",
+            project_path=new_dir,
+            base="core22",
+            bind_ssh=True,
+            build_on="test",
+            build_for="test",
+            http_proxy="test-http",
+            https_proxy="test-https",
+        ):
+            assert mock_base_config.mock_calls == [
+                call(http_proxy="test-http", https_proxy="test-https")
+            ]

--- a/tests/unit/providers/test_multipass.py
+++ b/tests/unit/providers/test_multipass.py
@@ -94,3 +94,29 @@ class TestMultipassLaunchedEnvironment:
                 call(host_source=new_dir, target=Path("/root/project")),
                 call(host_source=Path.home() / ".ssh", target=Path("/root/.ssh")),
             ]
+
+    def test_command_environment(self, mocker, new_dir, multipass_instance_mock):
+        """Verify launched_environment calls get_command_environment."""
+        mocker.patch(
+            "snapcraft.providers._multipass.multipass.launch",
+            return_value=multipass_instance_mock,
+        )
+        mock_base_config = mocker.patch(
+            "snapcraft.providers._multipass.MultipassProvider.get_command_environment",
+        )
+
+        prov = providers.MultipassProvider()
+
+        with prov.launched_environment(
+            project_name="test",
+            project_path=new_dir,
+            base="core22",
+            bind_ssh=True,
+            build_on="test",
+            build_for="test",
+            http_proxy="test-http",
+            https_proxy="test-https",
+        ):
+            assert mock_base_config.mock_calls == [
+                call(http_proxy="test-http", https_proxy="test-https")
+            ]


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Follow up to https://github.com/snapcore/snapcraft/pull/3884.  This PR allows proxies to be used in core22 by passing `http_proxy` and `https_proxy` to `craft-providers` as environmental variables.

`craft-providers` sets the snapd proxy in [this PR](https://github.com/canonical/craft-providers/pull/149).

I tested this manually.  I used working http and https proxies from [this site](https://www.freeproxylists.net/) and checked they were set in the instance.  Then I chose an invalid proxy and received a network error inside the instance when snapcraft attempted to download and install a snap.

(CRAFT-1334)