### PR TITLE
store: improve error message for 401 error

### DIFF
--- a/snapcraft/errors.py
+++ b/snapcraft/errors.py
@@ -115,3 +115,14 @@ class ProjectMissing(SnapcraftError):
 
 class LegacyFallback(Exception):
     """Fall back to legacy snapcraft implementation."""
+
+
+class StoreCredentialsUnauthorizedError(SnapcraftError):
+    """Error raised for 401 responses from the Snap Store."""
+
+    def __init__(self, message: str, *, resolution: str) -> None:
+        super().__init__(
+            message,
+            resolution=resolution,
+            docs_url="https://snapcraft.io/docs/snapcraft-authentication",
+        )


### PR DESCRIPTION
When the store returns a 401, Snapcraft tries to do the right thing to prompt for a new login, but the error messages where confusing for the cases it cannot, when this original code was added the concept of a legacy client was not in place.

A logout is done to enforce using the new client if the credentials are the configparser based ones.

LP: #1980533

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1181