### PR TITLE
discovery.py: correct comment, "extensions" should say "plugins"

### DIFF
--- a/snapcraft/commands/discovery.py
+++ b/snapcraft/commands/discovery.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 
 class ListPluginsCommand(BaseCommand, abc.ABC):
-    """A command to list the available extensions."""
+    """A command to list the available plugins."""
 
     name = "list-plugins"
     help_msg = "List the available plugins that handle different types of part"


### PR DESCRIPTION
No functional change.

Signed-off-by: Robert P. J. Day <robert.day@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
