### PR TITLE
nil.py: enhance the explanation of when the nil plugin is useful

### DIFF
--- a/snapcraft_legacy/plugins/v2/nil.py
+++ b/snapcraft_legacy/plugins/v2/nil.py
@@ -14,10 +14,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""The nil plugin is useful for parts with no source.
+"""The nil plugin is useful in two contexts.
 
-Using this, parts can be defined purely by utilizing properties automatically
-included by Snapcraft, e.g. stage-packages.
+First, it can be used for parts that identify no source, and can
+be defined purely by using properties automatically included
+by Snapcraft, such as "stage-packages".
+
+The second use is for parts that do define a source (which will be
+fetched), but for which the build step then needs to be explicitly
+defined using "override-build"; otherwise, even though the source is
+fetched, while it is copied to the build/ directory, nothing will be
+further copied to the install/ directory.
+
+In short, for the case of a part that uses the nil plugin and defines
+a "source", it is up to the developer to then define the "override-build"
+step that, in some way, populates the $SNAPCRAFT_PART_INSTALL or
+(core22) $CRAFT_PART_INSTALL directory.
+
 """
 
 from typing import Any, Dict, List, Set


### PR DESCRIPTION
The current docstring explanation is incomplete, and ignores the scenario where a part with a nil plugin can still define a source.

No functional change.

Signed-off-by: Robert P. J. Day <robert.day@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
