### PR TITLE
legacy: install unpinned build packages

### DIFF
--- a/snapcraft_legacy/internal/repo/_deb.py
+++ b/snapcraft_legacy/internal/repo/_deb.py
@@ -458,6 +458,16 @@ class Ubuntu(BaseRepo):
         except subprocess.CalledProcessError:
             raise errors.BuildPackagesNotInstalledError(packages=package_names)
 
+        versionless_names = [get_pkg_name_parts(p)[0] for p in package_names]
+        try:
+            subprocess.check_call(
+                ["sudo", "apt-mark", "auto"] + versionless_names, env=env
+            )
+        except subprocess.CalledProcessError as e:
+            logger.warning(
+                "Impossible to mark packages as auto-installed: {}".format(e)
+            )
+
     @classmethod
     def fetch_stage_packages(
         cls,

--- a/snapcraft_legacy/internal/repo/_deb.py
+++ b/snapcraft_legacy/internal/repo/_deb.py
@@ -23,7 +23,7 @@ import re
 import subprocess
 import sys
 import tempfile
-from typing import Dict, List, Optional, Set, Tuple  # noqa: F401
+from typing import Dict, List, Optional, Sequence, Set, Tuple  # noqa: F401
 
 from xdg import BaseDirectory
 
@@ -356,6 +356,27 @@ class Ubuntu(BaseRepo):
         return True
 
     @classmethod
+    def _get_installed_package_versions(cls, package_names: Sequence[str]) -> List[str]:
+        packages: List[str] = []
+
+        with AptCache() as apt_cache:
+            for package_name in package_names:
+                package_version = apt_cache.get_installed_version(
+                    package_name, resolve_virtual_packages=True
+                )
+                if package_version is None:
+                    logger.debug("Expected package %s not installed", package_name)
+                    continue
+                logger.debug(
+                    "Found installed version %s for package %s",
+                    package_version,
+                    package_name,
+                )
+                packages.append(f"{package_name}={package_version}")
+
+        return packages
+
+    @classmethod
     def _get_packages_marked_for_installation(
         cls, package_names: List[str]
     ) -> List[Tuple[str, str]]:
@@ -393,15 +414,20 @@ class Ubuntu(BaseRepo):
             install_required = True
             cls.refresh_build_packages()
 
+        # Collect the list of marked packages to later construct a manifest
         marked_packages = cls._get_packages_marked_for_installation(package_names)
-        packages = [f"{name}={version}" for name, version in sorted(marked_packages)]
+        marked_package_names = [name for name, _ in sorted(marked_packages)]
 
         if install_required:
-            cls._install_packages(packages)
+            cls._install_packages(package_names)
         else:
-            logger.debug(f"Requested build-packages already installed: {packages!r}")
+            logger.debug(
+                f"Requested build-packages already installed: {package_names!r}"
+            )
 
-        return packages
+        # This result is a best effort approach for deps and virtual packages
+        # as they are not part of the installation list.
+        return cls._get_installed_package_versions(marked_package_names)
 
     @classmethod
     def _install_packages(cls, package_names: List[str]) -> None:
@@ -431,16 +457,6 @@ class Ubuntu(BaseRepo):
             subprocess.check_call(apt_command + package_names, env=env)
         except subprocess.CalledProcessError:
             raise errors.BuildPackagesNotInstalledError(packages=package_names)
-
-        versionless_names = [get_pkg_name_parts(p)[0] for p in package_names]
-        try:
-            subprocess.check_call(
-                ["sudo", "apt-mark", "auto"] + versionless_names, env=env
-            )
-        except subprocess.CalledProcessError as e:
-            logger.warning(
-                "Impossible to mark packages as auto-installed: {}".format(e)
-            )
 
     @classmethod
     def fetch_stage_packages(

--- a/tests/legacy/unit/repo/test_deb.py
+++ b/tests/legacy/unit/repo/test_deb.py
@@ -308,6 +308,21 @@ class BuildPackagesTestCase(unit.TestCase):
                             "DEBIAN_PRIORITY": "critical",
                         },
                     ),
+                    call(
+                        [
+                            "sudo",
+                            "apt-mark",
+                            "auto",
+                            "package",
+                            "package-installed",
+                            "versioned-package",
+                        ],
+                        env={
+                            "DEBIAN_FRONTEND": "noninteractive",
+                            "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                            "DEBIAN_PRIORITY": "critical",
+                        },
+                    ),
                 ]
             ),
         )
@@ -363,6 +378,14 @@ class BuildPackagesTestCase(unit.TestCase):
                             "DEBIAN_PRIORITY": "critical",
                         },
                     ),
+                    call(
+                        ["sudo", "apt-mark", "auto", "new-version"],
+                        env={
+                            "DEBIAN_FRONTEND": "noninteractive",
+                            "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                            "DEBIAN_PRIORITY": "critical",
+                        },
+                    ),
                 ]
             ),
         )
@@ -392,6 +415,14 @@ class BuildPackagesTestCase(unit.TestCase):
                             "install",
                             "virtual-package",
                         ],
+                        env={
+                            "DEBIAN_FRONTEND": "noninteractive",
+                            "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                            "DEBIAN_PRIORITY": "critical",
+                        },
+                    ),
+                    call(
+                        ["sudo", "apt-mark", "auto", "virtual-package"],
                         env={
                             "DEBIAN_FRONTEND": "noninteractive",
                             "DEBCONF_NONINTERACTIVE_SEEN": "true",
@@ -429,6 +460,14 @@ class BuildPackagesTestCase(unit.TestCase):
                             "install",
                             "package",
                         ],
+                        env={
+                            "DEBIAN_FRONTEND": "noninteractive",
+                            "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                            "DEBIAN_PRIORITY": "critical",
+                        },
+                    ),
+                    call(
+                        ["sudo", "apt-mark", "auto", "package"],
                         env={
                             "DEBIAN_FRONTEND": "noninteractive",
                             "DEBCONF_NONINTERACTIVE_SEEN": "true",

--- a/tests/legacy/unit/repo/test_deb.py
+++ b/tests/legacy/unit/repo/test_deb.py
@@ -38,6 +38,28 @@ def mock_env_copy():
         yield m
 
 
+@pytest.fixture
+def fake_all_packages_installed(mocker):
+    mocker.patch(
+        "snapcraft_legacy.internal.repo._deb.Ubuntu._check_if_all_packages_installed",
+        return_value=False,
+    )
+
+
+def _fake_get_installed_version(package_name, resolve_virtual_packages=False):
+    if "installed" in package_name:
+        return "1.0"
+    if "new-version" in package_name:
+        return "3.0"
+    if "resolved-virtual-package" in package_name:
+        return "1.0"
+    if package_name == "versioned-package":
+        return "2.0"
+    if package_name.endswith("package"):
+        return "1.0"
+    return None
+
+
 class TestPackages(unit.TestCase):
     def setUp(self):
         super().setUp()
@@ -217,6 +239,10 @@ class BuildPackagesTestCase(unit.TestCase):
             fixtures.MockPatch("snapcraft_legacy.internal.repo._deb.AptCache")
         ).mock
 
+        self.fake_apt_cache.return_value.__enter__.return_value.get_installed_version = (
+            _fake_get_installed_version
+        )
+
         self.fake_run = self.useFixture(
             fixtures.MockPatch("subprocess.check_call")
         ).mock
@@ -234,7 +260,8 @@ class BuildPackagesTestCase(unit.TestCase):
             )
         ).mock
 
-    def test_install_build_package(self):
+    @pytest.mark.usefixtures("fake_all_packages_installed")
+    def test_install_build_packages(self):
         self.fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
             ("package", "1.0"),
             ("package-installed", "1.0"),
@@ -271,26 +298,9 @@ class BuildPackagesTestCase(unit.TestCase):
                             "-y",
                             "--allow-downgrades",
                             "install",
-                            "dependency-package=1.0",
-                            "package=1.0",
-                            "package-installed=1.0",
-                            "versioned-package=2.0",
-                        ],
-                        env={
-                            "DEBIAN_FRONTEND": "noninteractive",
-                            "DEBCONF_NONINTERACTIVE_SEEN": "true",
-                            "DEBIAN_PRIORITY": "critical",
-                        },
-                    ),
-                    call(
-                        [
-                            "sudo",
-                            "apt-mark",
-                            "auto",
-                            "dependency-package",
                             "package",
                             "package-installed",
-                            "versioned-package",
+                            "versioned-package=2.0",
                         ],
                         env={
                             "DEBIAN_FRONTEND": "noninteractive",
@@ -322,14 +332,15 @@ class BuildPackagesTestCase(unit.TestCase):
         self.assertThat(build_packages, Equals(["package-installed=1.0"]))
         self.assertThat(self.fake_run.mock_calls, Equals([]))
 
+    @pytest.mark.usefixtures("fake_all_packages_installed")
     def test_already_installed_with_different_version(self):
         self.fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
-            ("package-installed", "3.0")
+            ("new-version", "3.0")
         ]
 
-        build_packages = repo.Ubuntu.install_build_packages(["package-installed=3.0"])
+        build_packages = repo.Ubuntu.install_build_packages(["new-version=3.0"])
 
-        self.assertThat(build_packages, Equals(["package-installed=3.0"]))
+        self.assertThat(build_packages, Equals(["new-version=3.0"]))
         self.assertThat(
             self.fake_run.mock_calls,
             Equals(
@@ -344,16 +355,8 @@ class BuildPackagesTestCase(unit.TestCase):
                             "-y",
                             "--allow-downgrades",
                             "install",
-                            "package-installed=3.0",
+                            "new-version=3.0",
                         ],
-                        env={
-                            "DEBIAN_FRONTEND": "noninteractive",
-                            "DEBCONF_NONINTERACTIVE_SEEN": "true",
-                            "DEBIAN_PRIORITY": "critical",
-                        },
-                    ),
-                    call(
-                        ["sudo", "apt-mark", "auto", "package-installed"],
                         env={
                             "DEBIAN_FRONTEND": "noninteractive",
                             "DEBCONF_NONINTERACTIVE_SEEN": "true",
@@ -364,14 +367,15 @@ class BuildPackagesTestCase(unit.TestCase):
             ),
         )
 
+    @pytest.mark.usefixtures("fake_all_packages_installed")
     def test_install_virtual_build_package(self):
         self.fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
-            ("package", "1.0")
+            ("resolved-virtual-package", "1.0")
         ]
 
         build_packages = repo.Ubuntu.install_build_packages(["virtual-package"])
 
-        self.assertThat(build_packages, Equals(["package=1.0"]))
+        self.assertThat(build_packages, Equals(["resolved-virtual-package=1.0"]))
         self.assertThat(
             self.fake_run.mock_calls,
             Equals(
@@ -386,16 +390,8 @@ class BuildPackagesTestCase(unit.TestCase):
                             "-y",
                             "--allow-downgrades",
                             "install",
-                            "package=1.0",
+                            "virtual-package",
                         ],
-                        env={
-                            "DEBIAN_FRONTEND": "noninteractive",
-                            "DEBCONF_NONINTERACTIVE_SEEN": "true",
-                            "DEBIAN_PRIORITY": "critical",
-                        },
-                    ),
-                    call(
-                        ["sudo", "apt-mark", "auto", "package"],
                         env={
                             "DEBIAN_FRONTEND": "noninteractive",
                             "DEBCONF_NONINTERACTIVE_SEEN": "true",
@@ -406,6 +402,7 @@ class BuildPackagesTestCase(unit.TestCase):
             ),
         )
 
+    @pytest.mark.usefixtures("fake_all_packages_installed")
     def test_smart_terminal(self):
         self.fake_is_dumb_terminal.return_value = False
         self.fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
@@ -430,16 +427,8 @@ class BuildPackagesTestCase(unit.TestCase):
                             "-o",
                             "Dpkg::Progress-Fancy=1",
                             "install",
-                            "package=1.0",
+                            "package",
                         ],
-                        env={
-                            "DEBIAN_FRONTEND": "noninteractive",
-                            "DEBCONF_NONINTERACTIVE_SEEN": "true",
-                            "DEBIAN_PRIORITY": "critical",
-                        },
-                    ),
-                    call(
-                        ["sudo", "apt-mark", "auto", "package"],
                         env={
                             "DEBIAN_FRONTEND": "noninteractive",
                             "DEBCONF_NONINTERACTIVE_SEEN": "true",
@@ -450,6 +439,7 @@ class BuildPackagesTestCase(unit.TestCase):
             ),
         )
 
+    @pytest.mark.usefixtures("fake_all_packages_installed")
     def test_invalid_package_requested(self):
         self.fake_apt_cache.return_value.__enter__.return_value.mark_packages.side_effect = errors.PackageNotFoundError(
             "package-invalid"
@@ -461,6 +451,7 @@ class BuildPackagesTestCase(unit.TestCase):
             ["package-invalid"],
         )
 
+    @pytest.mark.usefixtures("fake_all_packages_installed")
     def test_broken_package_apt_install(self):
         self.fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
             ("package", "1.0")
@@ -479,7 +470,7 @@ class BuildPackagesTestCase(unit.TestCase):
         )
         self.assertThat(raised.packages, Equals("package=1.0"))
 
-    def test_refresh_buid_packages(self):
+    def test_refresh_build_packages(self):
         repo.Ubuntu.refresh_build_packages()
 
         self.fake_run.assert_called_once_with(


### PR DESCRIPTION
Collect installed package versions after the installation.

This allows us to collect the real version whilst avoiding a bug in apt where it would downgrade or remove a package in cases where the pinned version cannot be satisfied.

This is a backport of the corresponding change in craft-parts.

Co-authored-by: Sergio Schvezov <sergio.schvezov@canonical.com>
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1328