### PR TITLE
commands: make help message consistent

### DIFF
--- a/snapcraft/commands/manage.py
+++ b/snapcraft/commands/manage.py
@@ -32,17 +32,17 @@ class StoreReleaseCommand(BaseCommand):
     """Command to release a snap on the Snap Store."""
 
     name = "release"
-    help_msg = "Release <snap-name> to the store"
+    help_msg = "Release <name> to the store"
     overview = textwrap.dedent(
         """
-        Release <snap-name> on <revision> to the selected store <channels>.
+        Release <name> on <revision> to the selected store <channels>.
         <channels> is a comma separated list of valid channels on the store.
 
         The <revision> must exist on the store, to see available revisions run
-        `snapcraft list-revisions <snap_name>`.
+        `snapcraft list-revisions <name>`.
 
         The channel map will be displayed after the operation takes place. To see
-        the status map at any other time run `snapcraft status <snap-name>`.
+        the status map at any other time run `snapcraft status <name>`.
 
         The format for channels is `[<track>/]<risk>[/<branch>]` where
 


### PR DESCRIPTION
Run `snapcraft release --help`. Note that name, snap-name and snap_name are meaning to refer to the same thing.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
It already errors out with
```
./tests/spread/plugins/v1/godeps/snaps/godeps-with-go-packages/snap/snapcraft.yaml:5: unsing ==> using
./tests/legacy/unit/conftest.py:85: Simualte ==> Simulate
./tests/legacy/unit/test_mountinfo.py:40: ro ==> to, row, rob, rod, roe, rot
./tests/legacy/unit/test_mountinfo.py:40: ro ==> to, row, rob, rod, roe, rot
./tests/legacy/unit/test_mountinfo.py:41: ro ==> to, row, rob, rod, roe, rot
./tests/legacy/unit/test_mountinfo.py:64: ro ==> to, row, rob, rod, roe, rot
./tests/legacy/unit/test_mountinfo.py:64: ro ==> to, row, rob, rod, roe, rot
./tests/legacy/unit/test_mountinfo.py:65: ro ==> to, row, rob, rod, roe, rot
./tests/legacy/unit/test_mountinfo.py:89: ro ==> to, row, rob, rod, roe, rot
./tests/legacy/unit/test_mountinfo.py:93: ro ==> to, row, rob, rod, roe, rot
./tests/legacy/unit/test_mountinfo.py:101: ro ==> to, row, rob, rod, roe, rot
./snapcraft_legacy/cli/lifecycle.py:224: outpout ==> output
./snapcraft_legacy/internal/build_providers/_multipass/_multipass_command.py:233: exectute ==> execute
./snapcraft_legacy/internal/lifecycle/_runner.py:116: prerequesite ==> prerequisite
./snapcraft_legacy/plugins/v1/_plugin.py:147: repetetive ==> repetitive
./snapcraft/errors.py:101: isses ==> issues
./snapcraft/providers/_buildd.py:123: warmup ==> warm up, warm-up
./snapcraft/providers/_buildd.py:142: warmup ==> warm up, warm-up
make: *** [Makefile:18: test-codespell] Error 65
```
- [ ] Have you successfully run `pytest tests/unit`?
```
E   ModuleNotFoundError: No module named 'craft_store'
```
-----
