### PR TITLE
commands: add init option for git initialization

### DIFF
--- a/snapcraft_legacy/cli/lifecycle.py
+++ b/snapcraft_legacy/cli/lifecycle.py
@@ -296,9 +296,17 @@ def lifecyclecli(ctx, **kwargs):
 
 
 @lifecyclecli.command()
-def init():
+@click.option(
+    "--no-vcs",
+    "vcs",
+    flag_value="none",
+    default=True,
+    help="Initialize a project without VCS.",
+)
+@click.option("--git", "vcs", flag_value="git", help="Initialize git repository.")
+def init(vcs):
     """Initialize a snapcraft project."""
-    snapcraft_yaml_path = lifecycle.init()
+    snapcraft_yaml_path = lifecycle.init(vcs)
     echo.info("Created {}.".format(snapcraft_yaml_path))
     echo.wrapped(
         "Go to https://docs.snapcraft.io/the-snapcraft-format/8337 for more "


### PR DESCRIPTION
Add --no-vcs and --git options for the init subcommand to allow initialization of git and generation of a default .gitignore file in the project directory.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
