### PR TITLE
cli: move remote build out of legacy

### DIFF
--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -45,8 +45,8 @@ COMMAND_GROUPS = [
             commands.StageCommand,
             commands.PrimeCommand,
             commands.PackCommand,
+            commands.RemoteBuildCommand,
             commands.SnapCommand,  # hidden (legacy compatibility)
-            commands.StoreLegacyRemoteBuildCommand,
             commands.PluginsCommand,
             commands.ListPluginsCommand,
         ],

--- a/snapcraft/commands/__init__.py
+++ b/snapcraft/commands/__init__.py
@@ -37,7 +37,6 @@ from .legacy import (
     StoreLegacyMetricsCommand,
     StoreLegacyPromoteCommand,
     StoreLegacyRegisterKeyCommand,
-    StoreLegacyRemoteBuildCommand,
     StoreLegacySetDefaultTrackCommand,
     StoreLegacySignBuildCommand,
     StoreLegacyUploadMetadataCommand,
@@ -59,6 +58,7 @@ from .names import (
     StoreNamesCommand,
     StoreRegisterCommand,
 )
+from .remote import RemoteBuildCommand
 from .status import (
     StoreListRevisionsCommand,
     StoreListTracksCommand,
@@ -80,6 +80,7 @@ __all__ = [
     "PluginsCommand",
     "PrimeCommand",
     "PullCommand",
+    "RemoteBuildCommand",
     "SnapCommand",
     "StageCommand",
     "StoreCloseCommand",
@@ -94,7 +95,6 @@ __all__ = [
     "StoreLegacyPromoteCommand",
     "StoreLegacyPushCommand",
     "StoreLegacyRegisterKeyCommand",
-    "StoreLegacyRemoteBuildCommand",
     "StoreLegacySetDefaultTrackCommand",
     "StoreLegacySignBuildCommand",
     "StoreLegacyUploadMetadataCommand",

--- a/snapcraft/commands/legacy.py
+++ b/snapcraft/commands/legacy.py
@@ -180,55 +180,6 @@ class StoreLegacyMetricsCommand(LegacyBaseCommand):
         )
 
 
-#########
-# Build #
-#########
-
-
-class StoreLegacyRemoteBuildCommand(LegacyBaseCommand):
-    """Command passthrough for the remote-build command."""
-
-    name = "remote-build"
-    help_msg = "Dispatch a snap for remote build"
-    overview = textwrap.dedent(
-        """
-        Command remote-build sends the current project to be built remotely. After the build
-        is complete, packages for each architecture are retrieved and will be available in
-        the local filesystem.
-
-        If not specified in the snapcraft.yaml file, the list of architectures to build
-        can be set using the --build-on option. If both are specified, an error will occur.
-
-        Interrupted remote builds can be resumed using the --recover option, followed by
-        the build number informed when the remote build was originally dispatched. The
-        current state of the remote build for each architecture can be checked using the
-        --status option."""
-    )
-
-    @overrides
-    def fill_parser(self, parser: "argparse.ArgumentParser") -> None:
-        parser.add_argument(
-            "--recover", action="store_true", help="recover an interrupted build"
-        )
-        parser.add_argument(
-            "--status", action="store_true", help="display remote build status"
-        )
-        parser.add_argument(
-            "--build-on",
-            metavar="arch",
-            nargs="+",
-            help="architecture to build on",
-        )
-        parser.add_argument(
-            "--build-id", metavar="build-id", help="specific build id to retrieve"
-        )
-        parser.add_argument(
-            "--launchpad-accept-public-upload",
-            action="store_true",
-            help="acknowledge that uploaded code will be publicly available.",
-        )
-
-
 ##############
 # Assertions #
 ##############

--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -1,0 +1,118 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Snapcraft remote build command."""
+
+import argparse
+import os
+import textwrap
+
+from craft_cli import BaseCommand, emit
+from craft_cli.helptexts import HIDDEN
+from overrides import overrides
+
+from snapcraft.legacy_cli import run_legacy
+from snapcraft.parts.lifecycle import get_snap_project, process_yaml
+from snapcraft.utils import confirm_with_user
+from snapcraft_legacy.internal.remote_build.errors import AcceptPublicUploadError
+
+_CONFIRMATION_PROMPT = (
+    "All data sent to remote builders will be publicly available. "
+    "Are you sure you want to continue?"
+)
+
+
+class RemoteBuildCommand(BaseCommand):
+    """Command passthrough for the remote-build command."""
+
+    name = "remote-build"
+    help_msg = "Dispatch a snap for remote build"
+    overview = textwrap.dedent(
+        """
+        Command remote-build sends the current project to be built remotely. After the build
+        is complete, packages for each architecture are retrieved and will be available in
+        the local filesystem.
+
+        If not specified in the snapcraft.yaml file, the list of architectures to build
+        can be set using the --build-on option. If both are specified, an error will occur.
+
+        Interrupted remote builds can be resumed using the --recover option, followed by
+        the build number informed when the remote build was originally dispatched. The
+        current state of the remote build for each architecture can be checked using the
+        --status option."""
+    )
+
+    @overrides
+    def fill_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--recover", action="store_true", help="recover an interrupted build"
+        )
+        parser.add_argument(
+            "--status", action="store_true", help="display remote build status"
+        )
+        parser_target = parser.add_mutually_exclusive_group()
+        parser_target.add_argument(
+            "--build-on",
+            metavar="arch",
+            nargs="+",
+            help=HIDDEN,
+        )
+        parser_target.add_argument(
+            "--build-for",
+            metavar="arch",
+            nargs="+",
+            help="architecture to build for",
+        )
+        parser.add_argument(
+            "--build-id", metavar="build-id", help="specific build id to retrieve"
+        )
+        parser.add_argument(
+            "--launchpad-accept-public-upload",
+            action="store_true",
+            help="acknowledge that uploaded code will be publicly available.",
+        )
+
+    @overrides
+    def run(self, parsed_args):
+        if os.getenv("SUDO_USER") and os.geteuid() == 0:
+            emit.message(
+                "Running with 'sudo' may cause permission errors and is discouraged."
+            )
+
+        emit.message(
+            "snapcraft remote-build is experimental and is subject to change - use with caution."
+        )
+
+        if parsed_args.build_on:
+            emit.message("Use --build-for instead of --build-on")
+            parsed_args.build_for = parsed_args.build_on
+
+        if not parsed_args.launchpad_accept_public_upload and not confirm_with_user(
+            _CONFIRMATION_PROMPT
+        ):
+            raise AcceptPublicUploadError()
+
+        snap_project = get_snap_project()
+        # TODO proper core22 support would mean we need to load the project
+        # yaml_data = process_yaml(snap_project.project_file)
+        # for now, only log explicitly that we are falling back to legacy to
+        # remote build for core22
+        process_yaml(snap_project.project_file)
+
+        emit.debug(
+            "core22 not yet supported in new code base: re-executing into legacy for remote-build"
+        )
+        run_legacy()

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -256,7 +256,9 @@ def confirm_with_user(prompt_text, default=False) -> bool:
 
     choices = " [Y/n]: " if default else " [y/N]: "
 
-    reply = str(input(prompt_text + choices)).lower().strip()
+    with emit.pause():
+        reply = str(input(prompt_text + choices)).lower().strip()
+
     if reply and reply[0] == "y":
         return True
 

--- a/tests/legacy/unit/commands/test_remote.py
+++ b/tests/legacy/unit/commands/test_remote.py
@@ -54,25 +54,6 @@ class RemoteBuildTests(CommandBaseTestCase):
         )
 
     @mock.patch("snapcraft_legacy.cli.remote.echo.confirm")
-    def test_remote_build_prompts(self, mock_confirm):
-        result = self.run_command(["remote-build"])
-
-        self.mock_lc_init.assert_called_once_with(
-            project=mock.ANY,
-            architectures=mock.ANY,
-            deadline=mock.ANY,
-            build_id="snapcraft-test-snap-fakehash123",
-        )
-        self.mock_lc.start_build.assert_called_once()
-        self.mock_lc.cleanup.assert_called_once()
-        self.assertThat(result.output, Contains("Building snap package for i386."))
-        self.assertThat(result.exit_code, Equals(0))
-        mock_confirm.assert_called_once_with(
-            "All data sent to remote builders will be publicly available. Are you sure you want to continue?",
-            default=True,
-        )
-
-    @mock.patch("snapcraft_legacy.cli.remote.echo.confirm")
     def test_remote_build_with_accept_option_doesnt_prompt(self, mock_confirm):
         result = self.run_command(["remote-build", "--launchpad-accept-public-upload"])
 
@@ -81,13 +62,6 @@ class RemoteBuildTests(CommandBaseTestCase):
         self.assertThat(result.output, Contains("Building snap package for i386."))
         self.assertThat(result.exit_code, Equals(0))
         mock_confirm.assert_not_called()
-
-    @mock.patch("snapcraft_legacy.cli.remote.echo.confirm")
-    def test_remote_build_without_acceptance_raises(self, mock_confirm):
-        mock_confirm.return_value = False
-        self.assertRaises(
-            errors.AcceptPublicUploadError, self.run_command, ["remote-build"]
-        )
 
     def test_remote_build_with_build_id(self):
         result = self.run_command(
@@ -138,20 +112,6 @@ class RemoteBuildTests(CommandBaseTestCase):
 
         self.mock_lc.start_build.assert_not_called()
         self.mock_lc.cleanup.assert_not_called()
-
-    @mock.patch("snapcraft_legacy.cli.remote.echo")
-    def test_remote_build_sudo_errors(self, mock_echo):
-        self.useFixture(fixtures.EnvironmentVariable("SUDO_USER", "testuser"))
-        self.useFixture(fixtures.MockPatch("os.geteuid", return_value=0))
-
-        self.run_command(["remote-build", "--launchpad-accept-public-upload"])
-        mock_echo.assert_has_calls(
-            [
-                mock.call.warning(
-                    "Running with 'sudo' may cause permission errors and is discouraged."
-                )
-            ]
-        )
 
     @mock.patch("snapcraft_legacy.cli.remote.echo")
     def test_remote_build_recover_doesnt_prompt(self, mock_echo):

--- a/tests/unit/commands/test_remote_build.py
+++ b/tests/unit/commands/test_remote_build.py
@@ -1,0 +1,174 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import argparse
+from unittest.mock import call
+
+import pytest
+
+from snapcraft import errors
+from snapcraft.commands.remote import RemoteBuildCommand
+
+
+@pytest.fixture()
+def legacy_run_mock(mocker):
+    mock = mocker.patch("snapcraft.commands.remote.run_legacy")
+    return mock
+
+
+@pytest.fixture(autouse=True)
+def get_project_mock(mocker):
+    mocker.patch("snapcraft.commands.remote.get_snap_project")
+    return mocker.patch("snapcraft.commands.remote.process_yaml")
+
+
+@pytest.fixture
+def confirm_mock(mocker):
+    return mocker.patch(
+        "snapcraft.commands.remote.confirm_with_user", return_value=True
+    )
+
+
+@pytest.fixture
+def fake_sudo(monkeypatch):
+    monkeypatch.setenv("SUDO_USER", "fake")
+    monkeypatch.setattr("os.geteuid", lambda: 0)
+
+
+def test_command_accept_upload_runs_legacy(legacy_run_mock, emitter):
+    cmd = RemoteBuildCommand(None)
+    cmd.run(
+        argparse.Namespace(
+            status=None,
+            recover=None,
+            build_for=None,
+            build_on=None,
+            launchpad_accept_public_upload=True,
+        )
+    )
+
+    assert legacy_run_mock.mock_calls == [call()]
+    emitter.assert_message(
+        "snapcraft remote-build is experimental and is subject to change "
+        "- "
+        "use with caution."
+    )
+    emitter.assert_debug(
+        "core22 not yet supported in new code base: re-executing into legacy for remote-build"
+    )
+
+
+def test_command_user_confirms_upload_runs_legacy(
+    legacy_run_mock, emitter, confirm_mock
+):
+    cmd = RemoteBuildCommand(None)
+    cmd.run(
+        argparse.Namespace(
+            status=None,
+            recover=None,
+            build_for=None,
+            build_on=None,
+            launchpad_accept_public_upload=None,
+        )
+    )
+
+    assert legacy_run_mock.mock_calls == [call()]
+    assert confirm_mock.mock_calls == [
+        call(
+            "All data sent to remote builders will be publicly available. "
+            "Are you sure you want to continue?"
+        )
+    ]
+    emitter.assert_message(
+        "snapcraft remote-build is experimental and is subject to change "
+        "- "
+        "use with caution."
+    )
+
+
+def test_command_legacy_exec_on_project_fail_after_confirming_with_user(
+    emitter, confirm_mock, get_project_mock
+):
+    """Legacy fallback is raised after confirming with the user.
+
+    In this scenario, Snapcraft's exit handler handles the re-exec.
+    """
+    get_project_mock.side_effect = errors.LegacyFallback("Unsupported base")
+    cmd = RemoteBuildCommand(None)
+
+    with pytest.raises(errors.LegacyFallback):
+        cmd.run(
+            argparse.Namespace(
+                status=None,
+                recover=None,
+                build_for=None,
+                build_on=None,
+                launchpad_accept_public_upload=None,
+            )
+        )
+
+    assert confirm_mock.mock_calls == [
+        call(
+            "All data sent to remote builders will be publicly available. "
+            "Are you sure you want to continue?"
+        )
+    ]
+    emitter.assert_message(
+        "snapcraft remote-build is experimental and is subject to change "
+        "- "
+        "use with caution."
+    )
+
+
+def test_command_use_of_build_on_warns(legacy_run_mock, emitter):
+    cmd = RemoteBuildCommand(None)
+    cmd.run(
+        argparse.Namespace(
+            status=None,
+            recover=None,
+            build_for=None,
+            build_on="amd64",
+            launchpad_accept_public_upload=True,
+        )
+    )
+
+    assert legacy_run_mock.mock_calls == [call()]
+    emitter.assert_message(
+        "snapcraft remote-build is experimental and is subject to change "
+        "- "
+        "use with caution."
+    )
+    emitter.assert_debug(
+        "core22 not yet supported in new code base: re-executing into legacy for remote-build"
+    )
+    emitter.assert_message("Use --build-for instead of --build-on")
+
+
+@pytest.mark.usefixtures("fake_sudo", "legacy_run_mock")
+def test_remote_build_sudo_warns(emitter):
+    cmd = RemoteBuildCommand(None)
+    cmd.run(
+        argparse.Namespace(
+            status=None,
+            recover=None,
+            build_for=None,
+            build_on="amd64",
+            launchpad_accept_public_upload=True,
+        )
+    )
+
+    emitter.assert_message(
+        "Running with 'sudo' may cause permission errors and is discouraged."
+    )


### PR DESCRIPTION
- move the CLI logic out of legacy
- export --build-for and hide --build-on
- stop the emitter when calling confirm_with_user's prompt

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1384