### PR TITLE
schema: allow the gnome extension

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -909,6 +909,7 @@
                                     "flutter-beta",
                                     "flutter-dev",
                                     "flutter-master",
+                                    "gnome",
                                     "gnome-3-28",
                                     "gnome-3-34",
                                     "gnome-3-38",


### PR DESCRIPTION
core22 is currently using the legacy implementation of remote-build and needs to allow gnome in order to work.

The legacy code is safe, it will gracefully fail if used with the gnome extension at loading time

LP: #1986962

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1385