### PR TITLE
store: correctly logout when credentials are invalid for legacy

### DIFF
--- a/snapcraft/store/client.py
+++ b/snapcraft/store/client.py
@@ -249,9 +249,7 @@ class LegacyStoreClientCLI:
                 store_error.response.status_code
                 == requests.codes.unauthorized  # pylint: disable=no-member
             ):
-                if os.getenv(
-                    constants.ENVIRONMENT_STORE_CREDENTIALS
-                ) and not isinstance(self.store_client, LegacyUbuntuOne):
+                if os.getenv(constants.ENVIRONMENT_STORE_CREDENTIALS):
                     raise errors.StoreCredentialsUnauthorizedError(
                         "Exported credentials are no longer valid for the Snap Store.",
                         resolution=(
@@ -259,8 +257,6 @@ class LegacyStoreClientCLI:
                             f"{constants.ENVIRONMENT_STORE_CREDENTIALS}."
                         ),
                     ) from store_error
-
-                emit.message("You are required to re-login before continuing")
                 self.store_client.logout()
                 # Make it a manual process to login again as these older credentials
                 # might be part of some CI/CD workflow.
@@ -272,6 +268,7 @@ class LegacyStoreClientCLI:
                             "new credentials."
                         ),
                     ) from store_error
+                emit.message("You are required to re-login before continuing")
             else:
                 raise
         except craft_store.errors.CredentialsUnavailable:

--- a/tests/unit/store/test_legacy_account.py
+++ b/tests/unit/store/test_legacy_account.py
@@ -92,10 +92,17 @@ def test_get_auth_missing_discharge(new_dir, root_macaroon):
 ########################
 
 
-def test_store_credentials(legacy_config_path):
-    LegacyUbuntuOne.store_credentials("secret-config")
+def test_store_credentials(legacy_config_path, legacy_config_credentials):
+    LegacyUbuntuOne.store_credentials(legacy_config_credentials)
 
-    assert legacy_config_path.read_text() == "secret-config"
+    assert legacy_config_path.read_text() == legacy_config_credentials
+
+
+def test_store_credentials_not_configparser_based_fails(
+    legacy_config_path, legacy_config_credentials
+):
+    with pytest.raises(errors.LegacyCredentialsParseError):
+        LegacyUbuntuOne.store_credentials("not config parser")
 
 
 def test_legacy_credentials_in_env(monkeypatch, legacy_config_credentials):


### PR DESCRIPTION
There was a chance of not being able to logout when using legacy credentials as they got loaded into the environment regardless of what their origin was.

LP: #1980534
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1297