### PR TITLE
providers: move `get_instance_name()` to providers.py

### DIFF
--- a/snapcraft/providers/_lxd.py
+++ b/snapcraft/providers/_lxd.py
@@ -28,6 +28,7 @@ from snapcraft import utils
 
 from ._buildd import BASE_TO_BUILDD_IMAGE_ALIAS, SnapcraftBuilddBaseConfiguration
 from ._provider import Provider
+from .providers import get_instance_name
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +131,7 @@ class LXDProvider(Provider):
         """
         alias = BASE_TO_BUILDD_IMAGE_ALIAS[base]
 
-        instance_name = self.get_instance_name(
+        instance_name = get_instance_name(
             project_name=project_name,
             project_path=project_path,
             build_on=build_on,

--- a/snapcraft/providers/_multipass.py
+++ b/snapcraft/providers/_multipass.py
@@ -29,6 +29,7 @@ from snapcraft import utils
 
 from ._buildd import BASE_TO_BUILDD_IMAGE_ALIAS, SnapcraftBuilddBaseConfiguration
 from ._provider import Provider
+from .providers import get_instance_name
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +122,7 @@ class MultipassProvider(Provider):
         """
         alias = BASE_TO_BUILDD_IMAGE_ALIAS[base]
 
-        instance_name = self.get_instance_name(
+        instance_name = get_instance_name(
             project_name=project_name,
             project_path=project_path,
             build_on=build_on,

--- a/snapcraft/providers/_provider.py
+++ b/snapcraft/providers/_provider.py
@@ -25,6 +25,8 @@ from typing import Dict, Generator, Optional, Tuple, Union
 
 from craft_providers import Executor, bases
 
+from .providers import get_instance_name
+
 logger = logging.getLogger(__name__)
 
 
@@ -53,7 +55,7 @@ class Provider(ABC):
             )
             return
 
-        instance_name = self.get_instance_name(
+        instance_name = get_instance_name(
             project_name=project_name,
             project_path=project_path,
             build_on=build_on,
@@ -109,35 +111,6 @@ class Provider(ABC):
             env["https_proxy"] = https_proxy
 
         return env
-
-    @staticmethod
-    def get_instance_name(
-        *,
-        project_name: str,
-        project_path: pathlib.Path,
-        build_on: str,
-        build_for: str,
-    ) -> str:
-        """Formulate the name for an instance using each of the given parameters.
-
-        Incorporate each of the parameters into the name to come up with a
-        predictable naming schema that avoids name collisions across multiple
-        projects.
-
-        :param project_name: Name of the project.
-        :param project_path: Directory of the project.
-        """
-        return "-".join(
-            [
-                "snapcraft",
-                project_name,
-                "on",
-                build_on,
-                "for",
-                build_for,
-                str(project_path.stat().st_ino),
-            ]
-        )
 
     @classmethod
     def is_base_available(cls, base: str) -> Tuple[bool, Union[str, None]]:

--- a/snapcraft/providers/providers.py
+++ b/snapcraft/providers/providers.py
@@ -1,0 +1,44 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Snapcraft-specific code to interface with craft-providers."""
+
+from pathlib import Path
+
+
+def get_instance_name(
+    *, project_name: str, project_path: Path, build_on: str, build_for: str
+) -> str:
+    """Formulate the name for an instance using each of the given parameters.
+
+    Incorporate each of the parameters into the name to come up with a
+    predictable naming schema that avoids name collisions across multiple
+    projects.
+
+    :param project_name: Name of the project.
+    :param project_path: Directory of the project.
+    """
+    return "-".join(
+        [
+            "snapcraft",
+            project_name,
+            "on",
+            build_on,
+            "for",
+            build_for,
+            str(project_path.stat().st_ino),
+        ]
+    )

--- a/tests/unit/providers/test_provider.py
+++ b/tests/unit/providers/test_provider.py
@@ -65,19 +65,6 @@ def mock_default_command_environment():
         yield mock_environment
 
 
-def test_get_instance_name(new_dir):
-    """Test formatting of instance name."""
-    inode_number = str(new_dir.stat().st_ino)
-    expected_name = f"snapcraft-hello-world-on-arm64-for-armhf-{inode_number}"
-    actual_name = providers.Provider.get_instance_name(
-        project_name="hello-world",
-        project_path=new_dir,
-        build_on="arm64",
-        build_for="armhf",
-    )
-    assert expected_name == actual_name
-
-
 def test_clean_project_environment_exists(
     mock_lxd_exists,
     mock_lxd_delete,

--- a/tests/unit/providers/test_providers.py
+++ b/tests/unit/providers/test_providers.py
@@ -1,0 +1,31 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from snapcraft.providers import providers
+
+
+def test_get_instance_name(new_dir):
+    """Test formatting of instance name."""
+    inode_number = str(new_dir.stat().st_ino)
+    expected_name = f"snapcraft-hello-world-on-arm64-for-armhf-{inode_number}"
+    actual_name = providers.get_instance_name(
+        project_name="hello-world",
+        project_path=new_dir,
+        build_on="arm64",
+        build_for="armhf",
+    )
+    assert expected_name == actual_name


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
`get_instance_name()` is a snapcraft-specific call, so it is moved out of the craft-providers interface.  See [this PR](https://github.com/canonical/rockcraft/pull/74) in rockcraft for reference.

This is the first out of a series of PRs to prepare for the new `craft-providers` API.  The goals are simple:
1. `_provider.py`, `_lxd.py`, and `_multipass.py` contain no snapcraft-specific code
2. All snapcraft-specific code related to `craft-providers` is moved into `snapcraft/providers/providers.py`

This preparation is complete in `rockcraft`.  The new interface will be migrated from `rockcraft` to `craft-providers` in the coming week.

(CRAFT-1305)