### PR TITLE
providers: move `get_command_environment()` to providers.py

### DIFF
--- a/snapcraft/providers/_lxd.py
+++ b/snapcraft/providers/_lxd.py
@@ -28,7 +28,7 @@ from snapcraft import utils
 
 from ._buildd import BASE_TO_BUILDD_IMAGE_ALIAS, SnapcraftBuilddBaseConfiguration
 from ._provider import Provider
-from .providers import get_instance_name
+from .providers import get_command_environment, get_instance_name
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +99,7 @@ class LXDProvider(Provider):
         """
         return lxd.LXDInstance(
             name=instance_name,
-            default_command_environment=self.get_command_environment(),
+            default_command_environment=get_command_environment(),
             project=self.lxd_project,
             remote=self.lxd_remote,
         )
@@ -143,7 +143,7 @@ class LXDProvider(Provider):
         except lxd.LXDError as error:
             raise ProviderError(str(error)) from error
 
-        environment = self.get_command_environment(
+        environment = get_command_environment(
             http_proxy=http_proxy, https_proxy=https_proxy
         )
 

--- a/snapcraft/providers/_multipass.py
+++ b/snapcraft/providers/_multipass.py
@@ -29,7 +29,7 @@ from snapcraft import utils
 
 from ._buildd import BASE_TO_BUILDD_IMAGE_ALIAS, SnapcraftBuilddBaseConfiguration
 from ._provider import Provider
-from .providers import get_instance_name
+from .providers import get_command_environment, get_instance_name
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +129,7 @@ class MultipassProvider(Provider):
             build_for=build_for,
         )
 
-        environment = self.get_command_environment(
+        environment = get_command_environment(
             http_proxy=http_proxy, https_proxy=https_proxy
         )
         base_configuration = SnapcraftBuilddBaseConfiguration(

--- a/snapcraft/providers/_provider.py
+++ b/snapcraft/providers/_provider.py
@@ -18,12 +18,11 @@
 
 import contextlib
 import logging
-import os
 import pathlib
 from abc import ABC, abstractmethod
-from typing import Dict, Generator, Optional, Tuple, Union
+from typing import Generator, Optional, Tuple, Union
 
-from craft_providers import Executor, bases
+from craft_providers import Executor
 
 from .providers import get_instance_name
 
@@ -74,43 +73,6 @@ class Provider(ABC):
 
         :raises ProviderError: if provider is not available.
         """
-
-    @staticmethod
-    def get_command_environment(
-        http_proxy: Optional[str] = None,
-        https_proxy: Optional[str] = None,
-    ) -> Dict[str, Optional[str]]:
-        """Construct an environment needed to execute a command.
-
-        :param http_proxy: http proxy to add to environment
-        :param https_proxy: https proxy to add to environment
-
-        :return: Dictionary of environmental variables.
-        """
-        env = bases.buildd.default_command_environment()
-        env["SNAPCRAFT_MANAGED_MODE"] = "1"
-
-        # Pass-through host environment that target may need.
-        for env_key in [
-            "http_proxy",
-            "https_proxy",
-            "no_proxy",
-            "SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS",
-            "SNAPCRAFT_BUILD_FOR",
-            "SNAPCRAFT_BUILD_INFO",
-            "SNAPCRAFT_IMAGE_INFO",
-        ]:
-            if env_key in os.environ:
-                env[env_key] = os.environ[env_key]
-
-        # if http[s]_proxy was specified as an argument, then prioritize this proxy
-        # over the proxy from the host's environment.
-        if http_proxy:
-            env["http_proxy"] = http_proxy
-        if https_proxy:
-            env["https_proxy"] = https_proxy
-
-        return env
 
     @classmethod
     def is_base_available(cls, base: str) -> Tuple[bool, Union[str, None]]:

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -97,13 +97,13 @@ class TestLxdLaunchedEnvironment:
                 call(host_source=Path.home() / ".ssh", target=Path("/root/.ssh")),
             ]
 
-    def test_command_environment(self, mocker, new_dir, lxd_instance_mock):
+    def test_get_command_environment(self, mocker, new_dir, lxd_instance_mock):
         """Verify launched_environment calls get_command_environment."""
         mocker.patch(
             "snapcraft.providers._lxd.lxd.launch", return_value=lxd_instance_mock
         )
-        mock_base_config = mocker.patch(
-            "snapcraft.providers._lxd.LXDProvider.get_command_environment",
+        mock_get_command_environment = mocker.patch(
+            "snapcraft.providers._lxd.get_command_environment",
         )
 
         prov = providers.LXDProvider()
@@ -118,6 +118,6 @@ class TestLxdLaunchedEnvironment:
             http_proxy="test-http",
             https_proxy="test-https",
         ):
-            assert mock_base_config.mock_calls == [
+            assert mock_get_command_environment.mock_calls == [
                 call(http_proxy="test-http", https_proxy="test-https")
             ]

--- a/tests/unit/providers/test_multipass.py
+++ b/tests/unit/providers/test_multipass.py
@@ -95,14 +95,14 @@ class TestMultipassLaunchedEnvironment:
                 call(host_source=Path.home() / ".ssh", target=Path("/root/.ssh")),
             ]
 
-    def test_command_environment(self, mocker, new_dir, multipass_instance_mock):
+    def test_get_command_environment(self, mocker, new_dir, multipass_instance_mock):
         """Verify launched_environment calls get_command_environment."""
         mocker.patch(
             "snapcraft.providers._multipass.multipass.launch",
             return_value=multipass_instance_mock,
         )
-        mock_base_config = mocker.patch(
-            "snapcraft.providers._multipass.MultipassProvider.get_command_environment",
+        mock_get_command_environment = mocker.patch(
+            "snapcraft.providers._multipass.get_command_environment",
         )
 
         prov = providers.MultipassProvider()
@@ -117,6 +117,6 @@ class TestMultipassLaunchedEnvironment:
             http_proxy="test-http",
             https_proxy="test-https",
         ):
-            assert mock_base_config.mock_calls == [
+            assert mock_get_command_environment.mock_calls == [
                 call(http_proxy="test-http", https_proxy="test-https")
             ]

--- a/tests/unit/providers/test_provider.py
+++ b/tests/unit/providers/test_provider.py
@@ -56,15 +56,6 @@ def mock_lxd_exists():
         yield mock_exists
 
 
-@pytest.fixture()
-def mock_default_command_environment():
-    with patch(
-        "craft_providers.bases.buildd.default_command_environment",
-        return_value=dict(PATH="test-path"),
-    ) as mock_environment:
-        yield mock_environment
-
-
 def test_clean_project_environment_exists(
     mock_lxd_exists,
     mock_lxd_delete,
@@ -158,80 +149,3 @@ def test_clean_project_environment_delete_error(
         )
 
     assert str(raised.value) == "fail"
-
-
-def test_get_command_environment(mocker, mock_default_command_environment):
-    """Verify command environment is properly constructed."""
-    provider = providers.LXDProvider()
-    command_environment = provider.get_command_environment()
-
-    assert command_environment == {"PATH": "test-path", "SNAPCRAFT_MANAGED_MODE": "1"}
-
-
-def test_get_command_environment_http_https_proxy(
-    mocker, mock_default_command_environment
-):
-    """Verify http and https proxies are added to the environment."""
-    provider = providers.LXDProvider()
-    command_environment = provider.get_command_environment(
-        http_proxy="test-http", https_proxy="test-https"
-    )
-
-    assert command_environment == {
-        "PATH": "test-path",
-        "SNAPCRAFT_MANAGED_MODE": "1",
-        "http_proxy": "test-http",
-        "https_proxy": "test-https",
-    }
-
-
-def test_get_command_environment_passthrough(
-    mocker, mock_default_command_environment, monkeypatch
-):
-    """Verify variables from the environment are passed to the command environment."""
-    monkeypatch.setenv("http_proxy", "test-http")
-    monkeypatch.setenv("https_proxy", "test-https")
-    monkeypatch.setenv("no_proxy", "test-no-proxy")
-    monkeypatch.setenv("SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS", "test-extensions")
-    monkeypatch.setenv("SNAPCRAFT_BUILD_FOR", "test-build-for")
-    monkeypatch.setenv("SNAPCRAFT_BUILD_INFO", "test-build-info")
-    monkeypatch.setenv("SNAPCRAFT_IMAGE_INFO", "test-image-info")
-
-    # ensure other variables are not being passed
-    monkeypatch.setenv("other_var", "test-other-var")
-
-    provider = providers.LXDProvider()
-    command_environment = provider.get_command_environment()
-
-    assert command_environment == {
-        "PATH": "test-path",
-        "SNAPCRAFT_MANAGED_MODE": "1",
-        "http_proxy": "test-http",
-        "https_proxy": "test-https",
-        "no_proxy": "test-no-proxy",
-        "SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS": "test-extensions",
-        "SNAPCRAFT_BUILD_FOR": "test-build-for",
-        "SNAPCRAFT_BUILD_INFO": "test-build-info",
-        "SNAPCRAFT_IMAGE_INFO": "test-image-info",
-    }
-
-
-def test_get_command_environment_http_https_priority(
-    mocker, mock_default_command_environment, monkeypatch
-):
-    """Verify http and https proxies from the function argument take priority over the
-    proxies defined in the environment."""
-    monkeypatch.setenv("http_proxy", "test-http-from-env")
-    monkeypatch.setenv("https_proxy", "test-https-from-env")
-
-    provider = providers.LXDProvider()
-    command_environment = provider.get_command_environment(
-        http_proxy="test-http-from-arg", https_proxy="test-https-from-arg"
-    )
-
-    assert command_environment == {
-        "PATH": "test-path",
-        "SNAPCRAFT_MANAGED_MODE": "1",
-        "http_proxy": "test-http-from-arg",
-        "https_proxy": "test-https-from-arg",
-    }

--- a/tests/unit/providers/test_providers.py
+++ b/tests/unit/providers/test_providers.py
@@ -14,8 +14,93 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from unittest.mock import patch
+
+import pytest
 
 from snapcraft.providers import providers
+
+
+@pytest.fixture()
+def mock_default_command_environment():
+    with patch(
+        "craft_providers.bases.buildd.default_command_environment",
+        return_value=dict(PATH="test-path"),
+    ) as mock_environment:
+        yield mock_environment
+
+
+def test_get_command_environment(mocker, mock_default_command_environment):
+    """Verify command environment is properly constructed."""
+    command_environment = providers.get_command_environment()
+
+    assert command_environment == {"PATH": "test-path", "SNAPCRAFT_MANAGED_MODE": "1"}
+
+
+def test_get_command_environment_passthrough(
+    mocker, mock_default_command_environment, monkeypatch
+):
+    """Verify variables from the environment are passed to the command environment."""
+    monkeypatch.setenv("http_proxy", "test-http")
+    monkeypatch.setenv("https_proxy", "test-https")
+    monkeypatch.setenv("no_proxy", "test-no-proxy")
+    monkeypatch.setenv("SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS", "test-extensions")
+    monkeypatch.setenv("SNAPCRAFT_BUILD_FOR", "test-build-for")
+    monkeypatch.setenv("SNAPCRAFT_BUILD_INFO", "test-build-info")
+    monkeypatch.setenv("SNAPCRAFT_IMAGE_INFO", "test-image-info")
+
+    # ensure other variables are not being passed
+    monkeypatch.setenv("other_var", "test-other-var")
+
+    command_environment = providers.get_command_environment()
+
+    assert command_environment == {
+        "PATH": "test-path",
+        "SNAPCRAFT_MANAGED_MODE": "1",
+        "http_proxy": "test-http",
+        "https_proxy": "test-https",
+        "no_proxy": "test-no-proxy",
+        "SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS": "test-extensions",
+        "SNAPCRAFT_BUILD_FOR": "test-build-for",
+        "SNAPCRAFT_BUILD_INFO": "test-build-info",
+        "SNAPCRAFT_IMAGE_INFO": "test-image-info",
+    }
+
+
+def test_get_command_environment_http_https_proxy(
+    mocker, mock_default_command_environment
+):
+    """Verify http and https proxies are added to the environment."""
+    command_environment = providers.get_command_environment(
+        http_proxy="test-http", https_proxy="test-https"
+    )
+
+    assert command_environment == {
+        "PATH": "test-path",
+        "SNAPCRAFT_MANAGED_MODE": "1",
+        "http_proxy": "test-http",
+        "https_proxy": "test-https",
+    }
+
+
+def test_get_command_environment_http_https_priority(
+    mocker, mock_default_command_environment, monkeypatch
+):
+    """Verify http and https proxies from the function argument take priority over the
+    proxies defined in the environment."""
+    monkeypatch.setenv("http_proxy", "test-http-from-env")
+    monkeypatch.setenv("https_proxy", "test-https-from-env")
+
+    command_environment = providers.get_command_environment(
+        http_proxy="test-http-from-arg", https_proxy="test-https-from-arg"
+    )
+
+    assert command_environment == {
+        "PATH": "test-path",
+        "SNAPCRAFT_MANAGED_MODE": "1",
+        "http_proxy": "test-http-from-arg",
+        "https_proxy": "test-https-from-arg",
+    }
 
 
 def test_get_instance_name(new_dir):


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

`get_command_environment()` is a snapcraft-specific call, so it is moved out of the craft-providers interface.

Similar to https://github.com/canonical/rockcraft/pull/75

(CRAFT-1352)