### PR TITLE
tests: mock and test provider calls from lifecycle.py

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple
 
 import craft_parts
-from craft_cli import EmitterMode, emit
+from craft_cli import emit
 from craft_parts import ProjectInfo, StepInfo, callbacks
 
 from snapcraft import errors, extensions, linters, pack, providers, ua_manager, utils
@@ -462,9 +462,7 @@ def _clean_provider(project: Project, parsed_args: "argparse.Namespace") -> None
     emit.progress("Cleaned build provider", permanent=True)
 
 
-# pylint: disable=too-many-branches
-
-
+# pylint: disable-next=too-many-branches
 def _run_in_provider(
     project: Project, command_name: str, parsed_args: "argparse.Namespace"
 ) -> None:
@@ -482,14 +480,8 @@ def _run_in_provider(
     if getattr(parsed_args, "output", None):
         cmd.extend(["--output", parsed_args.output])
 
-    if emit.get_mode() == EmitterMode.VERBOSE:
-        cmd.append("--verbose")
-    elif emit.get_mode() == EmitterMode.QUIET:
-        cmd.append("--quiet")
-    elif emit.get_mode() == EmitterMode.DEBUG:
-        cmd.append("--verbosity=debug")
-    elif emit.get_mode() == EmitterMode.TRACE:
-        cmd.append("--verbosity=trace")
+    mode = emit.get_mode().name.lower()
+    cmd.append(f"--verbosity={mode}")
 
     if parsed_args.debug:
         cmd.append("--debug")
@@ -502,8 +494,7 @@ def _run_in_provider(
         cmd.append("--enable-manifest")
     build_information = getattr(parsed_args, "manifest_build_information", None)
     if build_information:
-        cmd.append("--manifest-build-information")
-        cmd.append(build_information)
+        cmd.extend(["--manifest-build-information", build_information])
 
     cmd.append("--build-for")
     cmd.append(project.get_build_for())
@@ -541,9 +532,6 @@ def _run_in_provider(
             ) from err
         finally:
             capture_logs_from_instance(instance)
-
-
-# pylint: enable=too-many-branches
 
 
 def _set_global_environment(info: ProjectInfo) -> None:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -15,15 +15,19 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import base64
+import contextlib
 import textwrap
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
+from unittest.mock import Mock
 
 import pytest
 import yaml
+from craft_providers import Executor
 from pymacaroons import Caveat, Macaroon
 
 from snapcraft.extensions import extension, register, unregister
+from snapcraft.providers import Provider
 
 
 @pytest.fixture
@@ -304,3 +308,55 @@ def legacy_config_path(
     config_file.write_text(legacy_config_credentials)
 
     return config_file
+
+
+@pytest.fixture
+def mock_instance():
+    """Provide a mock instance (Executor)."""
+    yield Mock(spec=Executor)
+
+
+@pytest.fixture(autouse=True)
+def fake_provider(mock_instance):
+    """Fixture to provide a minimal fake provider."""
+
+    class FakeProvider(Provider):
+        """Fake provider."""
+
+        def clean_project_environments(
+            self,
+            *,
+            project_name: str,
+            project_path: Path,
+            build_on: str,
+            build_for: str,
+        ):
+            pass
+
+        @classmethod
+        def ensure_provider_is_available(cls) -> None:
+            pass
+
+        @classmethod
+        def is_provider_available(cls) -> bool:
+            return True
+
+        def create_environment(self, *, instance_name: str):
+            yield mock_instance
+
+        @contextlib.contextmanager
+        def launched_environment(
+            self,
+            *,
+            project_name: str,
+            project_path: Path,
+            base: str,
+            bind_ssh: bool,
+            build_on: str,
+            build_for: str,
+            http_proxy: Optional[str] = None,
+            https_proxy: Optional[str] = None,
+        ):
+            yield mock_instance
+
+    return FakeProvider()


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
### Overview
Mock and test calls made to `craft-providers` from `lifecycle.py`.  This code was not being tested.

I also simplified the `verbosity` call to match [charmcraft](https://github.com/canonical/charmcraft/blob/b22fcdba3b894004468abfbf45caa54d93fbf7d0/charmcraft/commands/build.py#L321) and [rockcraft](https://github.com/canonical/rockcraft/blob/5d7ed67646a10e5b35319c12d664df7b1e1a14b9/rockcraft/lifecycle.py#L197).

### Details
3 weeks ago, I [added some unit tests](https://github.com/snapcore/snapcraft/pull/3906) for `run_in_provider()`.  Today, I am extending those tests further.

The test fixtures are copies of the implementations in [charmcraft](https://github.com/canonical/charmcraft/blob/b22fcdba3b894004468abfbf45caa54d93fbf7d0/tests/conftest.py#L133) and [rockcraft](https://github.com/canonical/rockcraft/blob/5d7ed67646a10e5b35319c12d664df7b1e1a14b9/tests/unit/conftest.py#L28).

I'll be using these tests next week when I pull code out of the providers directory.