### PR TITLE
providers: refactor clean_project_environments

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -39,6 +39,7 @@ from snapcraft.projects import (
     Project,
 )
 from snapcraft.providers import capture_logs_from_instance
+from snapcraft.providers.providers import get_instance_name
 from snapcraft.utils import (
     convert_architecture_deb_to_platform,
     get_host_architecture,
@@ -453,12 +454,14 @@ def _clean_provider(project: Project, parsed_args: "argparse.Namespace") -> None
     emit.progress("Cleaning build provider")
     provider_name = "lxd" if parsed_args.use_lxd else None
     provider = providers.get_provider(provider_name)
-    provider.clean_project_environments(
+    instance_name = get_instance_name(
         project_name=project.name,
         project_path=Path().absolute(),
         build_on=project.get_build_on(),
         build_for=project.get_build_for(),
     )
+    emit.debug(f"Cleaning instance {instance_name}")
+    provider.clean_project_environments(instance_name=instance_name)
     emit.progress("Cleaned build provider", permanent=True)
 
 

--- a/snapcraft/providers/_lxd.py
+++ b/snapcraft/providers/_lxd.py
@@ -83,8 +83,8 @@ class LXDProvider(Provider):
             raise ProviderError(str(error)) from error
 
     @classmethod
-    def is_provider_available(cls) -> bool:
-        """Check if provider is installed and available for use.
+    def is_provider_installed(cls) -> bool:
+        """Check if provider is installed.
 
         :returns: True if installed.
         """

--- a/snapcraft/providers/_multipass.py
+++ b/snapcraft/providers/_multipass.py
@@ -79,8 +79,8 @@ class MultipassProvider(Provider):
             raise ProviderError(str(error)) from error
 
     @classmethod
-    def is_provider_available(cls) -> bool:
-        """Check if provider is installed and available for use.
+    def is_provider_installed(cls) -> bool:
+        """Check if provider is installed.
 
         :returns: True if installed.
         """

--- a/snapcraft/providers/_provider.py
+++ b/snapcraft/providers/_provider.py
@@ -24,44 +24,24 @@ from typing import Generator, Optional, Tuple, Union
 
 from craft_providers import Executor
 
-from .providers import get_instance_name
-
 logger = logging.getLogger(__name__)
 
 
 class Provider(ABC):
     """Snapcraft's build environment provider."""
 
-    def clean_project_environments(
-        self,
-        *,
-        project_name: str,
-        project_path: pathlib.Path,
-        build_on: str,
-        build_for: str,
-    ) -> None:
-        """Clean up a build environment created for project.
+    def clean_project_environments(self, *, instance_name: str) -> None:
+        """Clean the provider environment.
 
-        :param project_name: Name of the project.
-        :param project_path: Directory of the project.
-        :param build_on: Host architecture.
-        :param build_for: Target architecture.
+        :param instance_name: name of the instance to clean
         """
         # Nothing to do if provider is not installed.
-        if not self.is_provider_available():
+        if not self.is_provider_installed():
             logger.debug(
                 "Not cleaning environment because the provider is not installed."
             )
             return
 
-        instance_name = get_instance_name(
-            project_name=project_name,
-            project_path=project_path,
-            build_on=build_on,
-            build_for=build_for,
-        )
-
-        logger.debug("Cleaning environment %r", instance_name)
         environment = self.create_environment(instance_name=instance_name)
         if environment.exists():
             environment.delete()
@@ -93,8 +73,8 @@ class Provider(ABC):
 
     @classmethod
     @abstractmethod
-    def is_provider_available(cls) -> bool:
-        """Check if provider is installed and available for use.
+    def is_provider_installed(cls) -> bool:
+        """Check if provider is installed.
 
         :returns: True if installed.
         """

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -323,14 +323,7 @@ def fake_provider(mock_instance):
     class FakeProvider(Provider):
         """Fake provider."""
 
-        def clean_project_environments(
-            self,
-            *,
-            project_name: str,
-            project_path: Path,
-            build_on: str,
-            build_for: str,
-        ):
+        def clean_project_environments(self, *, instance_name: str):
             pass
 
         @classmethod
@@ -338,7 +331,7 @@ def fake_provider(mock_instance):
             pass
 
         @classmethod
-        def is_provider_available(cls) -> bool:
+        def is_provider_installed(cls) -> bool:
             return True
 
         def create_environment(self, *, instance_name: str):

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -550,6 +550,9 @@ def test_lifecycle_run_command_clean(snapcraft_yaml, project_vars, new_dir, mock
     clean_mock = mocker.patch(
         "snapcraft.providers.LXDProvider.clean_project_environments"
     )
+    mocker.patch(
+        "snapcraft.parts.lifecycle.get_instance_name", return_value="test-instance-name"
+    )
 
     parts_lifecycle._run_command(
         "clean",
@@ -567,14 +570,7 @@ def test_lifecycle_run_command_clean(snapcraft_yaml, project_vars, new_dir, mock
         ),
     )
 
-    assert clean_mock.mock_calls == [
-        call(
-            project_name="mytest",
-            project_path=new_dir,
-            build_on=get_host_architecture(),
-            build_for=get_host_architecture(),
-        )
-    ]
+    assert clean_mock.mock_calls == [call(instance_name="test-instance-name")]
 
 
 def test_lifecycle_clean_destructive_mode(

--- a/tests/unit/providers/test_provider.py
+++ b/tests/unit/providers/test_provider.py
@@ -64,12 +64,7 @@ def test_clean_project_environment_exists(
 ):
     """Assert instance is deleted if it exists."""
     provider = providers.LXDProvider()
-    provider.clean_project_environments(
-        project_name="test",
-        project_path=new_dir,
-        build_on="test",
-        build_for="test",
-    )
+    provider.clean_project_environments(instance_name="test-instance-name")
 
     assert mock_lxd_delete.mock_calls == [call()]
 
@@ -84,12 +79,7 @@ def test_clean_project_environment_does_not_exist(
     mock_lxd_exists.return_value = False
 
     provider = providers.LXDProvider()
-    provider.clean_project_environments(
-        project_name="test",
-        project_path=new_dir,
-        build_on="test",
-        build_for="test",
-    )
+    provider.clean_project_environments(instance_name="test-instance-name")
 
     assert mock_lxd_delete.mock_calls == []
 
@@ -103,12 +93,7 @@ def test_clean_project_environment_lxd_not_installed(
     mock_lxd_is_installed.return_value = False
 
     provider = providers.LXDProvider()
-    provider.clean_project_environments(
-        project_name="test",
-        project_path=new_dir,
-        build_on="test",
-        build_for="test",
-    )
+    provider.clean_project_environments(instance_name="test-instance-name")
 
     assert mock_lxd_delete.mock_calls == []
 
@@ -122,12 +107,7 @@ def test_clean_project_environment_exists_error(
     provider = providers.LXDProvider()
 
     with pytest.raises(ProviderError) as raised:
-        provider.clean_project_environments(
-            project_name="test",
-            project_path=new_dir,
-            build_on="test",
-            build_for="test",
-        )
+        provider.clean_project_environments(instance_name="test-instance-name")
 
     assert str(raised.value) == "fail"
 
@@ -141,11 +121,6 @@ def test_clean_project_environment_delete_error(
     provider = providers.LXDProvider()
 
     with pytest.raises(ProviderError) as raised:
-        provider.clean_project_environments(
-            project_name="test",
-            project_path=new_dir,
-            build_on="test",
-            build_for="test",
-        )
+        provider.clean_project_environments(instance_name="test-instance-name")
 
     assert str(raised.value) == "fail"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
Two changes to the `craft-providers()` interface:
1. Move the snapcraft-specific call `get_instance_name()` out of `clean_project_environments()`
2. Rename `is_provider_available()` to `is_provider_installed()`


These changes match what was done for [rockcraft](https://github.com/canonical/rockcraft/blob/5d7ed67646a10e5b35319c12d664df7b1e1a14b9/rockcraft/providers/_provider.py#L33).

(CRAFT-1396)