### PR TITLE
providers: move mount logic to lifecycle.py

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -12,7 +12,7 @@ coverage==6.4.2
 craft-cli==1.1.0
 craft-grammar==1.1.1
 craft-parts==1.14.2
-craft-providers==1.4.2
+craft-providers==1.5.1
 craft-store==2.2.1
 cryptography==3.4
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.3
 craft-cli==1.1.0
 craft-grammar==1.1.1
 craft-parts==1.14.2
-craft-providers==1.4.2
+craft-providers==1.5.1
 craft-store==2.2.1
 cryptography==3.4
 Deprecated==1.2.13

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -519,21 +519,20 @@ def _run_in_provider(
         http_proxy=parsed_args.http_proxy,
         https_proxy=parsed_args.https_proxy,
     ) as instance:
+        # mount project
+        instance.mount(
+            host_source=project_path,
+            target=utils.get_managed_environment_project_path(),
+        )
+
+        # mount ssh directory
+        if parsed_args.bind_ssh:
+            instance.mount(
+                host_source=Path.home() / ".ssh",
+                target=utils.get_managed_environment_home_path() / ".ssh",
+            )
         try:
             with emit.pause():
-                # mount project
-                instance.mount(
-                    host_source=project_path,
-                    target=utils.get_managed_environment_project_path(),
-                )
-
-                # mount ssh directory
-                if parsed_args.bind_ssh:
-                    instance.mount(
-                        host_source=Path.home() / ".ssh",
-                        target=utils.get_managed_environment_home_path() / ".ssh",
-                    )
-
                 # run snapcraft inside the instance
                 instance.execute_run(cmd, check=True, cwd=output_dir)
         except subprocess.CalledProcessError as err:

--- a/snapcraft/providers/_lxd.py
+++ b/snapcraft/providers/_lxd.py
@@ -111,7 +111,6 @@ class LXDProvider(Provider):
         project_name: str,
         project_path: pathlib.Path,
         base: str,
-        bind_ssh: bool,
         build_on: str,
         build_for: str,
         http_proxy: Optional[str] = None,
@@ -168,19 +167,6 @@ class LXDProvider(Provider):
             )
         except (bases.BaseConfigurationError, lxd.LXDError) as error:
             raise ProviderError(str(error)) from error
-
-        # Mount project.
-        instance.mount(
-            host_source=project_path,
-            target=utils.get_managed_environment_project_path(),
-        )
-
-        # Mount ssh directory.
-        if bind_ssh:
-            instance.mount(
-                host_source=pathlib.Path.home() / ".ssh",
-                target=utils.get_managed_environment_home_path() / ".ssh",
-            )
 
         try:
             yield instance

--- a/snapcraft/providers/_multipass.py
+++ b/snapcraft/providers/_multipass.py
@@ -102,7 +102,6 @@ class MultipassProvider(Provider):
         project_name: str,
         project_path: pathlib.Path,
         base: str,
-        bind_ssh: bool,
         build_on: str,
         build_for: str,
         http_proxy: Optional[str] = None,
@@ -149,23 +148,6 @@ class MultipassProvider(Provider):
                 auto_clean=True,
             )
         except (bases.BaseConfigurationError, MultipassError) as error:
-            raise ProviderError(str(error)) from error
-
-        try:
-            # Mount project.
-            instance.mount(
-                host_source=project_path,
-                target=utils.get_managed_environment_project_path(),
-            )
-
-            # Mount ssh directory.
-            if bind_ssh:
-                instance.mount(
-                    host_source=pathlib.Path.home() / ".ssh",
-                    target=utils.get_managed_environment_home_path() / ".ssh",
-                )
-
-        except MultipassError as error:
             raise ProviderError(str(error)) from error
 
         try:

--- a/snapcraft/providers/_provider.py
+++ b/snapcraft/providers/_provider.py
@@ -116,7 +116,6 @@ class Provider(ABC):
         project_name: str,
         project_path: pathlib.Path,
         base: str,
-        bind_ssh: bool,
         build_on: str,
         build_for: str,
         http_proxy: Optional[str] = None,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -351,7 +351,6 @@ def fake_provider(mock_instance):
             project_name: str,
             project_path: Path,
             base: str,
-            bind_ssh: bool,
             build_on: str,
             build_for: str,
             http_proxy: Optional[str] = None,

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from pathlib import Path
 from unittest.mock import call, patch
 
 import pytest
@@ -58,45 +57,6 @@ def mock_lxd_exists():
 class TestLxdLaunchedEnvironment:
     """LXD provider instance setup and launching."""
 
-    def test_mount_project(self, mocker, new_dir, lxd_instance_mock):
-        mocker.patch(
-            "snapcraft.providers._lxd.lxd.launch", return_value=lxd_instance_mock
-        )
-
-        prov = providers.LXDProvider()
-
-        with prov.launched_environment(
-            project_name="test",
-            project_path=new_dir,
-            base="core22",
-            bind_ssh=False,
-            build_on="test",
-            build_for="test",
-        ):
-            assert lxd_instance_mock.mount.mock_calls == [
-                call(host_source=new_dir, target=Path("/root/project")),
-            ]
-
-    def test_bind_ssh(self, mocker, new_dir, lxd_instance_mock):
-        mocker.patch(
-            "snapcraft.providers._lxd.lxd.launch", return_value=lxd_instance_mock
-        )
-
-        prov = providers.LXDProvider()
-
-        with prov.launched_environment(
-            project_name="test",
-            project_path=new_dir,
-            base="core22",
-            bind_ssh=True,
-            build_on="test",
-            build_for="test",
-        ):
-            assert lxd_instance_mock.mount.mock_calls == [
-                call(host_source=new_dir, target=Path("/root/project")),
-                call(host_source=Path.home() / ".ssh", target=Path("/root/.ssh")),
-            ]
-
     def test_get_command_environment(self, mocker, new_dir, lxd_instance_mock):
         """Verify launched_environment calls get_command_environment."""
         mocker.patch(
@@ -112,7 +72,6 @@ class TestLxdLaunchedEnvironment:
             project_name="test",
             project_path=new_dir,
             base="core22",
-            bind_ssh=True,
             build_on="test",
             build_for="test",
             http_proxy="test-http",

--- a/tests/unit/providers/test_multipass.py
+++ b/tests/unit/providers/test_multipass.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from pathlib import Path
 from unittest.mock import call, patch
 
 import pytest
@@ -54,47 +53,6 @@ def mock_multipass_exists():
 class TestMultipassLaunchedEnvironment:
     """Multipass provider instance setup and launching."""
 
-    def test_mount_project(self, mocker, new_dir, multipass_instance_mock):
-        mocker.patch(
-            "snapcraft.providers._multipass.multipass.launch",
-            return_value=multipass_instance_mock,
-        )
-
-        prov = providers.MultipassProvider()
-
-        with prov.launched_environment(
-            project_name="test",
-            project_path=new_dir,
-            base="core22",
-            bind_ssh=False,
-            build_on="test",
-            build_for="test",
-        ):
-            assert multipass_instance_mock.mount.mock_calls == [
-                call(host_source=new_dir, target=Path("/root/project")),
-            ]
-
-    def test_bind_ssh(self, mocker, new_dir, multipass_instance_mock):
-        mocker.patch(
-            "snapcraft.providers._multipass.multipass.launch",
-            return_value=multipass_instance_mock,
-        )
-
-        prov = providers.MultipassProvider()
-
-        with prov.launched_environment(
-            project_name="test",
-            project_path=new_dir,
-            base="core22",
-            bind_ssh=True,
-            build_on="test",
-            build_for="test",
-        ):
-            assert multipass_instance_mock.mount.mock_calls == [
-                call(host_source=new_dir, target=Path("/root/project")),
-                call(host_source=Path.home() / ".ssh", target=Path("/root/.ssh")),
-            ]
-
     def test_get_command_environment(self, mocker, new_dir, multipass_instance_mock):
         """Verify launched_environment calls get_command_environment."""
         mocker.patch(
@@ -111,7 +69,6 @@ class TestMultipassLaunchedEnvironment:
             project_name="test",
             project_path=new_dir,
             base="core22",
-            bind_ssh=True,
             build_on="test",
             build_for="test",
             http_proxy="test-http",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Moves the snapcraft-specific calls for mounting directories to `parts/lifecycle.py`.

Similar to https://github.com/canonical/rockcraft/pull/82

(CRAFT-1397)