### PR TITLE
linters: allow ignoring files per-linter

### DIFF
--- a/snapcraft/linters/base.py
+++ b/snapcraft/linters/base.py
@@ -94,7 +94,7 @@ class Linter(abc.ABC):
     ):
         self._name = name
         self._snap_metadata = snap_metadata
-        self._lint = lint or projects.Lint(ignore=projects.LintIgnore())
+        self._lint = lint or projects.Lint(ignore=[])
 
     @abc.abstractmethod
     def run(self) -> List[LinterIssue]:
@@ -105,7 +105,7 @@ class Linter(abc.ABC):
 
     def _is_file_ignored(self, elf_file: ElfFile) -> bool:
         """Check if the file name matches an ignored file pattern."""
-        for pattern in self._lint.ignore.files:
+        for pattern in self._lint.ignored_files(self._name):
             if fnmatch.fnmatch(str(elf_file.path), pattern):
                 emit.debug(
                     f"{self._name} linter: skip file {str(elf_file.path)!r} "

--- a/snapcraft/linters/linters.py
+++ b/snapcraft/linters/linters.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 LinterType = Type[Linter]
 
 
-_LINTERS: Dict[str, LinterType] = {
+LINTERS: Dict[str, LinterType] = {
     "classic": ClassicLinter,
     "library": LibraryLinter,
 }
@@ -137,8 +137,8 @@ def run_linters(location: Path, *, lint: Optional[projects.Lint]) -> List[Linter
         snap_metadata = snap_yaml.read(Path())
 
         emit.progress("Running linters...")
-        for name, linter_class in _LINTERS.items():
-            if lint and name in lint.ignore.linters:
+        for name, linter_class in LINTERS.items():
+            if lint and lint.all_ignored(name):
                 continue
 
             linter = linter_class(name=name, lint=lint, snap_metadata=snap_metadata)
@@ -157,17 +157,21 @@ def _ignore_matching_filenames(
     issues: List[LinterIssue], *, lint: Optional[projects.Lint]
 ) -> None:
     """Mark any remaining filename match as ignored."""
-    if lint and lint.ignore.files:
-        for issue in issues:
-            for pattern in lint.ignore.files:
-                if (
-                    issue.filename
-                    and issue.result != LinterResult.IGNORED
-                    and fnmatch.fnmatch(issue.filename, pattern)
-                ):
-                    emit.verbose(
-                        f"Ignore {issue.name!r} linter issue ({issue.filename!r} "
-                        f"matches {pattern!r})"
-                    )
-                    issue.result = LinterResult.IGNORED
-                    break
+    if lint is None:
+        return
+
+    for issue in issues:
+
+        files = lint.ignored_files(issue.name)
+        for pattern in files:
+            if (
+                issue.filename
+                and issue.result != LinterResult.IGNORED
+                and fnmatch.fnmatch(issue.filename, pattern)
+            ):
+                emit.verbose(
+                    f"Ignore {issue.name!r} linter issue ({issue.filename!r} "
+                    f"matches {pattern!r})"
+                )
+                issue.result = LinterResult.IGNORED
+                break

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Uni
 
 import pydantic
 from craft_grammar.models import GrammarSingleEntryDictList, GrammarStr, GrammarStrList
-from pydantic import conlist, constr
+from pydantic import PrivateAttr, conlist, constr
 
 from snapcraft import parts, repo
 from snapcraft.errors import ProjectValidationError
@@ -180,17 +180,56 @@ class Socket(ProjectModel):
         return listen_stream
 
 
-class LintIgnore(ProjectModel):
-    """Lists of specific linters or globbed filenames to ignore."""
-
-    linters: List[str] = []
-    files: List[str] = []
-
-
 class Lint(ProjectModel):
-    """Linter configuration."""
+    """Linter configuration.
 
-    ignore: LintIgnore
+    :ivar ignore: A list describing which files should have issues ignored for given linters.
+        The items in the list can be either:
+        - a string, which must be the name of one of the known linters (see below). All issues
+          from this linter will be ignored.
+        - a dict containing exactly one key, which must be the name of one of the known linters.
+            The value is then a list of strings corresponding to the filenames/patterns that
+            should be ignored for that linter.
+        The "known" linter names are the keys in :ref:`LINTERS`
+    """
+
+    ignore: List[Union[str, Dict[str, List[str]]]]
+
+    # A private field to simplify lookup.
+    _lint_ignores: Dict[str, List[str]] = PrivateAttr(default_factory=dict)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        for item in self.ignore:
+            if isinstance(item, str):
+                self._lint_ignores[item] = []
+            else:
+                assert len(item) == 1, "Expected exactly one key in lint ignore entry."
+                name, files = list(item.items())[0]
+                self._lint_ignores[name] = files
+
+    def all_ignored(self, linter_name: str) -> bool:
+        """Whether all issues for linter `lint_name` should be ignored."""
+        return (
+            linter_name in self._lint_ignores
+            and len(self._lint_ignores[linter_name]) == 0
+        )
+
+    def ignored_files(self, linter_name: str) -> List[str]:
+        """Get a list of filenames/patterns to ignore for `lint_name`.
+
+        Since the main usecase for this method is a for-loop with `fnmatch()`, it will
+        return `['*']` when *all* files should be ignored for `linter_name`, and `[]`
+        when *no* files should be ignored.
+        """
+        if linter_name not in self._lint_ignores:
+            return []
+
+        if self.all_ignored(linter_name):
+            return ["*"]
+
+        return self._lint_ignores[linter_name]
 
 
 class App(ProjectModel):

--- a/tests/spread/core22/linters/classic-libc/snap/snapcraft.yaml
+++ b/tests/spread/core22/linters/classic-libc/snap/snapcraft.yaml
@@ -13,8 +13,7 @@ confinement: strict
 
 lint:
   ignore:
-    linters:
-      - library
+    - library
 
 parts:
   my-part:

--- a/tests/spread/core22/linters/classic/snap/snapcraft.yaml
+++ b/tests/spread/core22/linters/classic/snap/snapcraft.yaml
@@ -13,8 +13,7 @@ confinement: classic
 
 lint:
   ignore:
-    linters:
-      - library
+    - library
 
 parts:
   my-part:

--- a/tests/unit/linters/test_classic_linter.py
+++ b/tests/unit/linters/test_classic_linter.py
@@ -40,7 +40,7 @@ def test_classic_linter(mocker, new_dir, confinement, stage_libc, text):
         Path("lib64").mkdir()
         Path("lib64/ld-linux-x86-64.so.2").touch()
 
-    mocker.patch("snapcraft.linters.linters._LINTERS", {"classic": ClassicLinter})
+    mocker.patch("snapcraft.linters.linters.LINTERS", {"classic": ClassicLinter})
     mocker.patch(
         "snapcraft.elf._elf_file._determine_libraries",
         return_value={
@@ -98,7 +98,7 @@ def test_classic_linter(mocker, new_dir, confinement, stage_libc, text):
 def test_classic_linter_filter(mocker, new_dir):
     shutil.copy("/bin/true", "elf.bin")
 
-    mocker.patch("snapcraft.linters.linters._LINTERS", {"classic": ClassicLinter})
+    mocker.patch("snapcraft.linters.linters.LINTERS", {"classic": ClassicLinter})
     mocker.patch(
         "snapcraft.elf._elf_file._determine_libraries",
         return_value={
@@ -124,7 +124,7 @@ def test_classic_linter_filter(mocker, new_dir):
     )
 
     issues = linters.run_linters(
-        new_dir, lint=projects.Lint(ignore=projects.LintIgnore(files=["elf.*"]))
+        new_dir, lint=projects.Lint(ignore=[{"classic": ["elf.*"]}])
     )
     assert issues == [
         LinterIssue(

--- a/tests/unit/linters/test_library_linter.py
+++ b/tests/unit/linters/test_library_linter.py
@@ -26,7 +26,7 @@ from snapcraft.meta import snap_yaml
 def test_library_linter(mocker, new_dir):
     shutil.copy("/bin/true", "elf.bin")
 
-    mocker.patch("snapcraft.linters.linters._LINTERS", {"library": LibraryLinter})
+    mocker.patch("snapcraft.linters.linters.LINTERS", {"library": LibraryLinter})
     mocker.patch(
         "snapcraft.elf._elf_file._determine_libraries",
         return_value={
@@ -72,7 +72,7 @@ def test_library_linter(mocker, new_dir):
 def test_library_linter_filter(mocker, new_dir):
     shutil.copy("/bin/true", "elf.bin")
 
-    mocker.patch("snapcraft.linters.linters._LINTERS", {"library": LibraryLinter})
+    mocker.patch("snapcraft.linters.linters.LINTERS", {"library": LibraryLinter})
     mocker.patch(
         "snapcraft.elf._elf_file._determine_libraries",
         return_value={
@@ -99,6 +99,6 @@ def test_library_linter_filter(mocker, new_dir):
     )
 
     issues = linters.run_linters(
-        new_dir, lint=projects.Lint(ignore=projects.LintIgnore(files=["elf.*"]))
+        new_dir, lint=projects.Lint(ignore=[{"library": ["elf.*"]}])
     )
     assert issues == []

--- a/tests/unit/linters/test_linters.py
+++ b/tests/unit/linters/test_linters.py
@@ -146,7 +146,7 @@ class TestLinterRun:
 
     def test_run_linters(self, mocker, new_dir, linter_issue):
         mocker.patch(
-            "snapcraft.linters.linters._LINTERS", {"test": TestLinterRun._TestLinter}
+            "snapcraft.linters.linters.LINTERS", {"test": TestLinterRun._TestLinter}
         )
         yaml_data = {
             "name": "mytest",
@@ -178,7 +178,7 @@ class TestLinterRun:
 
     def test_run_linters_ignore(self, mocker, new_dir, linter_issue):
         mocker.patch(
-            "snapcraft.linters.linters._LINTERS", {"test": TestLinterRun._TestLinter}
+            "snapcraft.linters.linters.LINTERS", {"test": TestLinterRun._TestLinter}
         )
         yaml_data = {
             "name": "mytest",
@@ -198,12 +198,12 @@ class TestLinterRun:
             arch_triplet="x86_64-linux-gnu",
         )
 
-        lint = projects.Lint(ignore=projects.LintIgnore(linters=["test"]))
+        lint = projects.Lint(ignore=["test"])
         issues = linters.run_linters(new_dir, lint=lint)
         assert issues == []
 
     def test_ignore_matching_filenames(self, linter_issue):
-        lint = projects.Lint(ignore=projects.LintIgnore(files=["foo*", "some/dir/*"]))
+        lint = projects.Lint(ignore=[{"test": ["foo*", "some/dir/*"]}])
         issues = [
             linter_issue(filename="foo.txt", result=LinterResult.WARNING),
             linter_issue(filename="bar.txt", result=LinterResult.WARNING),


### PR DESCRIPTION
This commit restructures the lint.ignore project section to allow ignoring files on a per-linter basis. This still lets the user disable all issues for a given linter, but allows for finer-grained control.

This is the current scheme (before this PR):

```yaml
lint:
  ignore:
    linters:
      - library
      - classic
    files:
      - "elf.*"
      - lib/libfoo.so.1
```

The two entries (`linters` and `files`) are unrelated and complementary: If `linters` has e.g. `library`, then all `library` linting is ignored, regardless of `files`. If `files` has e.g. "elf.*", then any linting issue found matching that glob will be ignored, regardless of `linters`.

This is the new scheme implemented in this PR:

```yaml
lint:
  ignore:
    library:
      - lib/libfoo.so.1     # Disable "library" linter only for lib/libfoo.so.1
    classic:                # Disable "classic" linter for all files
```
Since the way that this is described in the Pydantic model is a bit "less-than-intuive" in the way that `classic` being a key with `None` as value actually means "all" files, I added a couple of methods to use as the "public" API to hopefully hide that complexity a bit.
