### PR TITLE
providers: refactor `launched_environment()`

### DIFF
--- a/snapcraft/providers/_buildd.py
+++ b/snapcraft/providers/_buildd.py
@@ -25,11 +25,6 @@ from overrides import overrides
 
 from snapcraft import utils
 
-# TODO fix this overengineered configuration
-BASE_TO_BUILDD_IMAGE_ALIAS = {
-    "core22": bases.BuilddBaseAlias.JAMMY,
-}
-
 
 class SnapcraftBuilddBaseConfiguration(bases.BuilddBase):
     """Base configuration for Snapcraft.

--- a/snapcraft/providers/_lxd.py
+++ b/snapcraft/providers/_lxd.py
@@ -20,17 +20,22 @@ import contextlib
 import logging
 import os
 import pathlib
-from typing import Generator, Optional
+from typing import Generator
 
-from craft_providers import Executor, ProviderError, bases, lxd
+from craft_providers import Executor, ProviderError, base, bases, lxd
 
 from snapcraft import utils
 
-from ._buildd import BASE_TO_BUILDD_IMAGE_ALIAS, SnapcraftBuilddBaseConfiguration
 from ._provider import Provider
-from .providers import get_command_environment, get_instance_name
 
 logger = logging.getLogger(__name__)
+
+
+PROVIDER_BASE_TO_LXD_BASE = {
+    bases.BuilddBaseAlias.BIONIC.value: "core18",
+    bases.BuilddBaseAlias.FOCAL.value: "core20",
+    bases.BuilddBaseAlias.JAMMY.value: "core22",
+}
 
 
 class LXDProvider(Provider):
@@ -99,7 +104,6 @@ class LXDProvider(Provider):
         """
         return lxd.LXDInstance(
             name=instance_name,
-            default_command_environment=get_command_environment(),
             project=self.lxd_project,
             remote=self.lxd_remote,
         )
@@ -110,52 +114,32 @@ class LXDProvider(Provider):
         *,
         project_name: str,
         project_path: pathlib.Path,
-        base: str,
-        build_on: str,
-        build_for: str,
-        http_proxy: Optional[str] = None,
-        https_proxy: Optional[str] = None,
+        base_configuration: base.Base,
+        build_base: str,
+        instance_name: str,
     ) -> Generator[Executor, None, None]:
-        """Launch environment for specified base.
+        """Configure and launch environment for specified base.
 
-        The environment is launched and configured using the base configuration.
-        Upon exit, drives are unmounted and the environment is stopped.
+        When this method loses context, all directories are unmounted and the
+        environment is stopped. For more control of environment setup and teardown,
+        use `create_environment()` instead.
 
         :param project_name: Name of project.
         :param project_path: Path to project.
-        :param base: Base to create.
-        :param bind_ssh: If true, mount the host's ssh directory in the environment.
-        :param build_on: host architecture
-        :param build_for: target architecture
+        :param base_configuration: Base configuration to apply to instance.
+        :param build_base: Base to build from.
+        :param instance_name: Name of the instance to launch.
         """
-        alias = BASE_TO_BUILDD_IMAGE_ALIAS[base]
-
-        instance_name = get_instance_name(
-            project_name=project_name,
-            project_path=project_path,
-            build_on=build_on,
-            build_for=build_for,
-        )
-        alias = BASE_TO_BUILDD_IMAGE_ALIAS[base]
         try:
             image_remote = lxd.configure_buildd_image_remote()
         except lxd.LXDError as error:
             raise ProviderError(str(error)) from error
 
-        environment = get_command_environment(
-            http_proxy=http_proxy, https_proxy=https_proxy
-        )
-
-        base_configuration = SnapcraftBuilddBaseConfiguration(
-            alias=alias,
-            environment=environment,
-            hostname=instance_name,
-        )
         try:
             instance = lxd.launch(
                 name=instance_name,
                 base_configuration=base_configuration,
-                image_name=base,
+                image_name=PROVIDER_BASE_TO_LXD_BASE[build_base],
                 image_remote=image_remote,
                 auto_clean=True,
                 auto_create_project=True,

--- a/snapcraft/providers/_provider.py
+++ b/snapcraft/providers/_provider.py
@@ -20,9 +20,10 @@ import contextlib
 import logging
 import pathlib
 from abc import ABC, abstractmethod
-from typing import Generator, Optional, Tuple, Union
+from typing import Generator, Tuple, Union
 
 from craft_providers import Executor
+from craft_providers.base import Base
 
 logger = logging.getLogger(__name__)
 
@@ -95,21 +96,19 @@ class Provider(ABC):
         *,
         project_name: str,
         project_path: pathlib.Path,
-        base: str,
-        build_on: str,
-        build_for: str,
-        http_proxy: Optional[str] = None,
-        https_proxy: Optional[str] = None,
+        base_configuration: Base,
+        build_base: str,
+        instance_name: str,
     ) -> Generator[Executor, None, None]:
-        """Launch environment for specified base.
+        """Configure and launch environment for specified base.
 
-        The environment is launched and configured using the base configuration.
-        Upon exit, drives are unmounted and the environment is stopped.
+        When this method loses context, all directories are unmounted and the
+        environment is stopped. For more control of environment setup and teardown,
+        use `create_environment()` instead.
 
-        :param project_name: Name of the project.
-        :param project_path: Path to the project.
-        :param base: Base to create.
-        :param bind_ssh: If true, mount the host's ssh directory in the environment.
-        :param build_on: host architecture
-        :param build_for: target architecture
+        :param project_name: Name of project.
+        :param project_path: Path to project.
+        :param base_configuration: Base configuration to apply to instance.
+        :param build_base: Base to build from.
+        :param instance_name: Name of the instance to launch.
         """

--- a/snapcraft/providers/providers.py
+++ b/snapcraft/providers/providers.py
@@ -17,10 +17,43 @@
 """Snapcraft-specific code to interface with craft-providers."""
 
 import os
+import sys
 from pathlib import Path
 from typing import Dict, Optional
 
 from craft_providers import bases
+
+from snapcraft.providers import SnapcraftBuilddBaseConfiguration
+from snapcraft.utils import get_managed_environment_snap_channel
+
+SNAPCRAFT_BASE_TO_PROVIDER_BASE = {
+    "core18": bases.BuilddBaseAlias.BIONIC,
+    "core20": bases.BuilddBaseAlias.FOCAL,
+    "core22": bases.BuilddBaseAlias.JAMMY,
+}
+
+
+def get_base_configuration(
+    *,
+    alias: bases.BuilddBaseAlias,
+    instance_name: str,
+    http_proxy: Optional[str] = None,
+    https_proxy: Optional[str] = None,
+) -> bases.BuilddBase:
+    """Create a BuilddBase configuration for rockcraft."""
+    environment = get_command_environment(
+        http_proxy=http_proxy, https_proxy=https_proxy
+    )
+
+    # injecting a snap on a non-linux system is not supported, so default to
+    # install rockcraft from the store's stable channel
+    snap_channel = get_managed_environment_snap_channel()
+    if sys.platform != "linux" and not snap_channel:
+        snap_channel = "stable"
+
+    return SnapcraftBuilddBaseConfiguration(
+        alias=alias, environment=environment, hostname=instance_name
+    )
 
 
 def get_command_environment(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -24,6 +24,7 @@ from unittest.mock import Mock
 import pytest
 import yaml
 from craft_providers import Executor
+from craft_providers.base import Base
 from pymacaroons import Caveat, Macaroon
 
 from snapcraft.extensions import extension, register, unregister
@@ -343,11 +344,9 @@ def fake_provider(mock_instance):
             *,
             project_name: str,
             project_path: Path,
-            base: str,
-            build_on: str,
-            build_for: str,
-            http_proxy: Optional[str] = None,
-            https_proxy: Optional[str] = None,
+            base_configuration: Base,
+            build_base: str,
+            instance_name: str,
         ):
             yield mock_instance
 

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -23,6 +23,7 @@ from unittest.mock import ANY, Mock, PropertyMock, call
 import pytest
 from craft_cli import EmitterMode, emit
 from craft_parts import Action, Step, callbacks
+from craft_providers.bases.buildd import BuilddBaseAlias
 
 from snapcraft import errors
 from snapcraft.parts import lifecycle as parts_lifecycle
@@ -1102,6 +1103,14 @@ def test_lifecycle_run_in_provider_default(
     mock_instance, mock_provider, mocker, snapcraft_yaml, tmp_path
 ):
     """Verify default calls made in `run_in_provider()`"""
+    mock_base_configuration = Mock()
+    mock_get_base_configuration = mocker.patch(
+        "snapcraft.parts.lifecycle.get_base_configuration",
+        return_value=mock_base_configuration,
+    )
+    mock_get_instance_name = mocker.patch(
+        "snapcraft.parts.lifecycle.get_instance_name", return_value="test-instance-name"
+    )
     mock_capture_logs_from_instance = mocker.patch(
         "snapcraft.parts.lifecycle.capture_logs_from_instance"
     )
@@ -1130,14 +1139,24 @@ def test_lifecycle_run_in_provider_default(
     )
 
     mock_provider.ensure_provider_is_available.assert_called_once()
+    mock_get_instance_name.assert_called_once_with(
+        project_name="mytest",
+        project_path=tmp_path,
+        build_on="test-arch-1",
+        build_for="test-arch-2",
+    )
+    mock_get_base_configuration.assert_called_once_with(
+        alias=BuilddBaseAlias.JAMMY,
+        instance_name="test-instance-name",
+        http_proxy=None,
+        https_proxy=None,
+    )
     mock_provider.launched_environment.assert_called_with(
         project_name="mytest",
         project_path=ANY,
-        base="core22",
-        build_on="test-arch-1",
-        build_for="test-arch-2",
-        http_proxy=None,
-        https_proxy=None,
+        base_configuration=mock_base_configuration,
+        build_base="22.04",
+        instance_name="test-instance-name",
     )
     mock_instance.mount.assert_called_with(
         host_source=tmp_path, target=Path("/root/project")
@@ -1168,11 +1187,19 @@ def test_lifecycle_run_in_provider_all_options(
     verbosity,
 ):
     """Verify all project options are parsed in `run_in_provider()`."""
+    mock_base_configuration = Mock()
+    mock_get_base_configuration = mocker.patch(
+        "snapcraft.parts.lifecycle.get_base_configuration",
+        return_value=mock_base_configuration,
+    )
+    mock_get_instance_name = mocker.patch(
+        "snapcraft.parts.lifecycle.get_instance_name", return_value="test-instance-name"
+    )
     mock_capture_logs_from_instance = mocker.patch(
         "snapcraft.parts.lifecycle.capture_logs_from_instance"
     )
-    mocker.patch("snapcraft.projects.Project.get_build_for", return_value="test-arch-1")
-    mocker.patch("snapcraft.projects.Project.get_build_on", return_value="test-arch-2")
+    mocker.patch("snapcraft.projects.Project.get_build_on", return_value="test-arch-1")
+    mocker.patch("snapcraft.projects.Project.get_build_for", return_value="test-arch-2")
 
     # build the expected command to be executed in the provider
     parts = ["test-part-1", "test-part-2"]
@@ -1180,7 +1207,7 @@ def test_lifecycle_run_in_provider_all_options(
     manifest_build_information = "test-build-info"
     ua_token = "test-ua-token"
     http_proxy = "1.2.3.4"
-    https_proxy = "1.2.3.4"
+    https_proxy = "5.6.7.8"
     expected_command = (
         ["snapcraft", "test"]
         + parts
@@ -1195,7 +1222,7 @@ def test_lifecycle_run_in_provider_all_options(
             "--manifest-build-information",
             manifest_build_information,
             "--build-for",
-            "test-arch-1",
+            "test-arch-2",
             "--ua-token",
             ua_token,
             "--enable-experimental-ua-services",
@@ -1229,14 +1256,25 @@ def test_lifecycle_run_in_provider_all_options(
         ),
     )
 
+    mock_provider.ensure_provider_is_available.assert_called_once()
+    mock_get_instance_name.assert_called_once_with(
+        project_name="mytest",
+        project_path=tmp_path,
+        build_on="test-arch-1",
+        build_for="test-arch-2",
+    )
+    mock_get_base_configuration.assert_called_once_with(
+        alias=BuilddBaseAlias.JAMMY,
+        instance_name="test-instance-name",
+        http_proxy="1.2.3.4",
+        https_proxy="5.6.7.8",
+    )
     mock_provider.launched_environment.assert_called_with(
         project_name="mytest",
         project_path=ANY,
-        base="core22",
-        build_on="test-arch-2",
-        build_for="test-arch-1",
-        http_proxy=http_proxy,
-        https_proxy=https_proxy,
+        base_configuration=mock_base_configuration,
+        build_base="22.04",
+        instance_name="test-instance-name",
     )
 
     mock_provider.ensure_provider_is_available.assert_called_once()

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -14,69 +14,304 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from unittest.mock import call, patch
+import re
+from unittest.mock import call
 
 import pytest
+from craft_providers import ProviderError, bases
+from craft_providers.lxd import LXDError, LXDInstallationError
 
 from snapcraft import providers
 
 
 @pytest.fixture
-def lxd_instance_mock(mocker):
-    instance_mock = mocker.patch(
-        "craft_providers.lxd.launcher.LXDInstance", autospec=True
+def mock_buildd_base_configuration(mocker):
+    mock_base_config = mocker.patch(
+        "snapcraft.providers._lxd.bases.BuilddBase", autospec=True
     )
-    instance_mock.return_value.name = "test-instance"
-    instance_mock.return_value.project = "test-project"
-    instance_mock.return_value.remote = "test-remote"
-    yield instance_mock
+    mock_base_config.compatibility_tag = "buildd-base-v0"
+    yield mock_base_config
 
 
-@pytest.fixture()
-def mock_lxd_is_installed():
-    with patch(
-        "craft_providers.lxd.is_installed", return_value=True
-    ) as mock_is_installed:
-        yield mock_is_installed
+@pytest.fixture
+def mock_configure_buildd_image_remote(mocker):
+    yield mocker.patch(
+        "craft_providers.lxd.configure_buildd_image_remote",
+        return_value="buildd-remote",
+    )
 
 
-@pytest.fixture()
-def mock_lxd_delete():
-    with patch("craft_providers.lxd.LXDInstance.delete") as mock_delete:
-        yield mock_delete
+@pytest.fixture
+def mock_lxc(mocker):
+    yield mocker.patch("craft_providers.lxd.LXC", autospec=True)
 
 
-@pytest.fixture()
-def mock_lxd_exists():
-    with patch(
-        "craft_providers.lxd.LXDInstance.exists", return_value=True
-    ) as mock_exists:
-        yield mock_exists
+@pytest.fixture(autouse=True)
+def mock_lxd_ensure_lxd_is_ready(mocker):
+    yield mocker.patch("craft_providers.lxd.ensure_lxd_is_ready", return_value=None)
 
 
-class TestLxdLaunchedEnvironment:
-    """LXD provider instance setup and launching."""
+@pytest.fixture
+def mock_lxd_install(mocker):
+    yield mocker.patch("craft_providers.lxd.install")
 
-    def test_get_command_environment(self, mocker, new_dir, lxd_instance_mock):
-        """Verify launched_environment calls get_command_environment."""
-        mocker.patch(
-            "snapcraft.providers._lxd.lxd.launch", return_value=lxd_instance_mock
-        )
-        mock_get_command_environment = mocker.patch(
-            "snapcraft.providers._lxd.get_command_environment",
-        )
 
-        prov = providers.LXDProvider()
+@pytest.fixture(autouse=True)
+def mock_lxd_is_installed(mocker):
+    yield mocker.patch("craft_providers.lxd.is_installed", return_value=True)
 
-        with prov.launched_environment(
-            project_name="test",
-            project_path=new_dir,
-            base="core22",
-            build_on="test",
-            build_for="test",
-            http_proxy="test-http",
-            https_proxy="test-https",
+
+@pytest.fixture
+def mock_lxd_launch(mocker):
+    yield mocker.patch("craft_providers.lxd.launch", autospec=True)
+
+
+@pytest.fixture
+def mock_confirm_with_user(mocker):
+    yield mocker.patch(
+        "snapcraft.providers._lxd.utils.confirm_with_user", return_value=True
+    )
+
+
+def test_ensure_provider_is_available_ok_when_installed(mock_lxd_is_installed):
+    mock_lxd_is_installed.return_value = True
+    provider = providers.LXDProvider()
+
+    provider.ensure_provider_is_available()
+
+
+def test_ensure_provider_is_available_errors_when_user_says_no(
+    mock_lxd_is_installed, mock_lxd_install, mock_confirm_with_user
+):
+    mock_confirm_with_user.return_value = False
+    mock_lxd_is_installed.return_value = False
+    provider = providers.LXDProvider()
+
+    with pytest.raises(
+        ProviderError,
+        match=re.escape(
+            "LXD is required, but not installed. Visit https://snapcraft.io/lxd for "
+            "instructions on how to install the LXD snap for your distribution"
+        ),
+    ):
+        provider.ensure_provider_is_available()
+
+
+def test_ensure_provider_is_available_errors_when_lxd_install_fails(
+    mock_lxd_is_installed, mock_lxd_install, mock_confirm_with_user
+):
+    error = LXDInstallationError("foo")
+    mock_lxd_is_installed.return_value = False
+    mock_lxd_install.side_effect = error
+    provider = providers.LXDProvider()
+
+    with pytest.raises(
+        ProviderError,
+        match=re.escape(
+            "Failed to install LXD. Visit https://snapcraft.io/lxd for "
+            "instructions on how to install the LXD snap for your distribution"
+        ),
+    ) as raised:
+        provider.ensure_provider_is_available()
+
+    assert raised.value.__cause__ is error
+
+
+def test_ensure_provider_is_available_errors_when_lxd_not_ready(
+    mock_lxd_is_installed,
+    mock_lxd_install,
+    mock_lxd_ensure_lxd_is_ready,
+):
+    error = LXDError(
+        brief="some error", details="some details", resolution="some resolution"
+    )
+    mock_lxd_is_installed.return_value = True
+    mock_lxd_ensure_lxd_is_ready.side_effect = error
+    provider = providers.LXDProvider()
+
+    with pytest.raises(
+        ProviderError,
+        match=re.escape("some error\nsome details\nsome resolution"),
+    ) as raised:
+        provider.ensure_provider_is_available()
+
+    assert raised.value.__cause__ is error
+
+
+@pytest.mark.parametrize("is_installed", [True, False])
+def test_is_provider_installed(is_installed, mock_lxd_is_installed):
+    mock_lxd_is_installed.return_value = is_installed
+    provider = providers.LXDProvider()
+
+    assert provider.is_provider_installed() == is_installed
+
+
+def test_create_environment(mocker):
+    mock_lxd_instance = mocker.patch("snapcraft.providers._lxd.lxd.LXDInstance")
+
+    provider = providers.LXDProvider()
+    provider.create_environment(instance_name="test-name")
+
+    mock_lxd_instance.assert_called_once_with(
+        name="test-name",
+        project="snapcraft",
+        remote="local",
+    )
+
+
+def test_launched_environment(
+    mock_buildd_base_configuration,
+    mock_configure_buildd_image_remote,
+    mock_lxd_launch,
+    tmp_path,
+):
+    provider = providers.LXDProvider()
+
+    with provider.launched_environment(
+        project_name="test-project",
+        project_path=tmp_path,
+        base_configuration=mock_buildd_base_configuration,
+        build_base=bases.BuilddBaseAlias.JAMMY.value,
+        instance_name="test-instance-name",
+    ) as instance:
+        assert instance is not None
+        assert mock_configure_buildd_image_remote.mock_calls == [call()]
+        assert mock_lxd_launch.mock_calls == [
+            call(
+                name="test-instance-name",
+                base_configuration=mock_buildd_base_configuration,
+                image_name="core22",
+                image_remote="buildd-remote",
+                auto_clean=True,
+                auto_create_project=True,
+                map_user_uid=True,
+                uid=tmp_path.stat().st_uid,
+                use_snapshots=True,
+                project="snapcraft",
+                remote="local",
+            ),
+        ]
+
+        mock_lxd_launch.reset_mock()
+
+    assert mock_lxd_launch.mock_calls == [
+        call().unmount_all(),
+        call().stop(),
+    ]
+
+
+def test_launched_environment_launch_base_configuration_error(
+    mock_buildd_base_configuration,
+    mock_configure_buildd_image_remote,
+    mock_lxd_launch,
+    tmp_path,
+):
+    error = bases.BaseConfigurationError(brief="fail")
+    mock_lxd_launch.side_effect = error
+    provider = providers.LXDProvider()
+
+    with pytest.raises(ProviderError, match="fail") as raised:
+        with provider.launched_environment(
+            project_name="test-project",
+            project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
+            instance_name="test-instance-name",
         ):
-            assert mock_get_command_environment.mock_calls == [
-                call(http_proxy="test-http", https_proxy="test-https")
-            ]
+            pass
+
+    assert raised.value.__cause__ is error
+
+
+def test_launched_environment_launch_lxd_error(
+    mock_buildd_base_configuration,
+    mock_configure_buildd_image_remote,
+    mock_lxd_launch,
+    tmp_path,
+):
+    error = LXDError(brief="fail")
+    mock_lxd_launch.side_effect = error
+    provider = providers.LXDProvider()
+
+    with pytest.raises(ProviderError, match="fail") as raised:
+        with provider.launched_environment(
+            project_name="test-project",
+            project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
+            instance_name="test-instance-name",
+        ):
+            pass
+
+    assert raised.value.__cause__ is error
+
+
+def test_launched_environment_unmounts_and_stops_after_error(
+    mock_buildd_base_configuration,
+    mock_configure_buildd_image_remote,
+    mock_lxd_launch,
+    tmp_path,
+):
+    provider = providers.LXDProvider()
+
+    with pytest.raises(RuntimeError):
+        with provider.launched_environment(
+            project_name="test-project",
+            project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
+            instance_name="test-instance-name",
+        ):
+            mock_lxd_launch.reset_mock()
+            raise RuntimeError("this is a test")
+
+    assert mock_lxd_launch.mock_calls == [
+        call().unmount_all(),
+        call().stop(),
+    ]
+
+
+def test_launched_environment_unmount_all_error(
+    mock_buildd_base_configuration,
+    mock_configure_buildd_image_remote,
+    mock_lxd_launch,
+    tmp_path,
+):
+    error = LXDError(brief="fail")
+    mock_lxd_launch.return_value.unmount_all.side_effect = error
+    provider = providers.LXDProvider()
+
+    with pytest.raises(ProviderError, match="fail") as raised:
+        with provider.launched_environment(
+            project_name="test-project",
+            project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
+            instance_name="test-instance-name",
+        ):
+            pass
+
+    assert raised.value.__cause__ is error
+
+
+def test_launched_environment_stop_error(
+    mock_buildd_base_configuration,
+    mock_configure_buildd_image_remote,
+    mock_lxd_launch,
+    tmp_path,
+):
+    error = LXDError(brief="fail")
+    mock_lxd_launch.return_value.stop.side_effect = error
+    provider = providers.LXDProvider()
+
+    with pytest.raises(ProviderError, match="fail") as raised:
+        with provider.launched_environment(
+            project_name="test-project",
+            project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
+            build_base=bases.BuilddBaseAlias.JAMMY.value,
+            instance_name="test-instance-name",
+        ):
+            pass
+
+    assert raised.value.__cause__ is error

--- a/tests/unit/providers/test_multipass.py
+++ b/tests/unit/providers/test_multipass.py
@@ -14,66 +14,273 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from unittest.mock import call, patch
+import re
+from unittest.mock import call
 
 import pytest
+from craft_providers import ProviderError, bases
+from craft_providers.multipass import MultipassError, MultipassInstallationError
 
 from snapcraft import providers
 
 
 @pytest.fixture
-def multipass_instance_mock(mocker):
+def mock_buildd_base_configuration(mocker):
+    mock_base_config = mocker.patch(
+        "snapcraft.providers._multipass.bases.BuilddBase", autospec=True
+    )
+    mock_base_config.compatibility_tag = "buildd-base-v0"
+    yield mock_base_config
+
+
+@pytest.fixture
+def mock_multipass(mocker):
+    yield mocker.patch("craft_providers.multipass.Multipass", autospec=True)
+
+
+@pytest.fixture(autouse=True)
+def mock_multipass_ensure_multipass_is_ready(mocker):
     yield mocker.patch(
-        "craft_providers.multipass._launch.MultipassInstance", autospec=True
+        "craft_providers.multipass.ensure_multipass_is_ready", return_value=None
     )
 
 
-@pytest.fixture()
-def mock_multipass_is_installed():
-    with patch(
-        "craft_providers.multipass.is_installed", return_value=True
-    ) as mock_is_installed:
-        yield mock_is_installed
+@pytest.fixture
+def mock_multipass_install(mocker):
+    yield mocker.patch("craft_providers.multipass.install")
 
 
-@pytest.fixture()
-def mock_multipass_delete():
-    with patch("craft_providers.multipass.MultipassInstance.delete") as mock_delete:
-        yield mock_delete
+@pytest.fixture(autouse=True)
+def mock_multipass_is_installed(mocker):
+    yield mocker.patch("craft_providers.multipass.is_installed", return_value=True)
 
 
-@pytest.fixture()
-def mock_multipass_exists():
-    with patch(
-        "craft_providers.multipass.MultipassInstance.exists", return_value=True
-    ) as mock_exists:
-        yield mock_exists
+@pytest.fixture
+def mock_multipass_launch(mocker):
+    yield mocker.patch("craft_providers.multipass.launch", autospec=True)
 
 
-class TestMultipassLaunchedEnvironment:
-    """Multipass provider instance setup and launching."""
+@pytest.fixture
+def mock_confirm_with_user(mocker):
+    yield mocker.patch(
+        "snapcraft.providers._multipass.utils.confirm_with_user", return_value=True
+    )
 
-    def test_get_command_environment(self, mocker, new_dir, multipass_instance_mock):
-        """Verify launched_environment calls get_command_environment."""
-        mocker.patch(
-            "snapcraft.providers._multipass.multipass.launch",
-            return_value=multipass_instance_mock,
-        )
-        mock_get_command_environment = mocker.patch(
-            "snapcraft.providers._multipass.get_command_environment",
-        )
 
-        prov = providers.MultipassProvider()
+def test_ensure_provider_is_available_ok_when_installed(mock_multipass_is_installed):
+    mock_multipass_is_installed.return_value = True
+    provider = providers.MultipassProvider()
 
-        with prov.launched_environment(
-            project_name="test",
-            project_path=new_dir,
-            base="core22",
-            build_on="test",
-            build_for="test",
-            http_proxy="test-http",
-            https_proxy="test-https",
+    provider.ensure_provider_is_available()
+
+
+def test_ensure_provider_is_available_errors_when_user_says_no(
+    mock_multipass_is_installed, mock_multipass_install, mock_confirm_with_user
+):
+    mock_confirm_with_user.return_value = False
+    mock_multipass_is_installed.return_value = False
+    provider = providers.MultipassProvider()
+
+    with pytest.raises(
+        ProviderError,
+        match=re.escape(
+            "Multipass is required, but not installed. Visit https://multipass.run/ "
+            "for instructions on installing Multipass for your operating system."
+        ),
+    ):
+        provider.ensure_provider_is_available()
+
+
+def test_ensure_provider_is_available_errors_when_multipass_install_fails(
+    mock_multipass_is_installed, mock_multipass_install, mock_confirm_with_user
+):
+    error = MultipassInstallationError("foo")
+    mock_multipass_is_installed.return_value = False
+    mock_multipass_install.side_effect = error
+    provider = providers.MultipassProvider()
+
+    match = re.escape(
+        "Failed to install Multipass. Visit https://multipass.run/ for "
+        "instructions on installing Multipass for your operating system."
+    )
+    with pytest.raises(ProviderError, match=match) as raised:
+        provider.ensure_provider_is_available()
+
+    assert raised.value.__cause__ is error
+
+
+def test_ensure_provider_is_available_errors_when_multipass_not_ready(
+    mock_multipass_is_installed,
+    mock_multipass_install,
+    mock_multipass_ensure_multipass_is_ready,
+    mock_confirm_with_user,
+):
+    error = MultipassError(
+        brief="some error", details="some details", resolution="some resolution"
+    )
+    mock_multipass_is_installed.return_value = True
+    mock_multipass_ensure_multipass_is_ready.side_effect = error
+    provider = providers.MultipassProvider()
+
+    with pytest.raises(
+        ProviderError,
+        match=re.escape("some error\nsome details\nsome resolution"),
+    ) as raised:
+        provider.ensure_provider_is_available()
+
+    assert raised.value.__cause__ is error
+
+
+@pytest.mark.parametrize("is_installed", [True, False])
+def test_is_provider_installed(is_installed, mock_multipass_is_installed):
+    mock_multipass_is_installed.return_value = is_installed
+    provider = providers.MultipassProvider()
+
+    assert provider.is_provider_installed() == is_installed
+
+
+def test_create_environment(mocker):
+    mock_multipass_instance = mocker.patch(
+        "snapcraft.providers._multipass.multipass.MultipassInstance"
+    )
+
+    provider = providers.MultipassProvider()
+    provider.create_environment(instance_name="test-name")
+
+    mock_multipass_instance.assert_called_once_with(name="test-name")
+
+
+def test_launched_environment(
+    mock_buildd_base_configuration,
+    mock_multipass_launch,
+    tmp_path,
+):
+    provider = providers.MultipassProvider()
+
+    with provider.launched_environment(
+        project_name="test-project",
+        project_path=tmp_path,
+        base_configuration=mock_buildd_base_configuration,
+        build_base=bases.BuilddBaseAlias.JAMMY.value,
+        instance_name="test-instance-name",
+    ) as instance:
+        assert instance is not None
+        assert mock_multipass_launch.mock_calls == [
+            call(
+                name="test-instance-name",
+                base_configuration=mock_buildd_base_configuration,
+                image_name="snapcraft:22.04",
+                cpus=2,
+                disk_gb=64,
+                mem_gb=2,
+                auto_clean=True,
+            ),
+        ]
+        mock_multipass_launch.reset_mock()
+
+    assert mock_multipass_launch.mock_calls == [
+        call().unmount_all(),
+        call().stop(),
+    ]
+
+
+def test_launched_environment_unmounts_and_stops_after_error(
+    mock_buildd_base_configuration, mock_multipass_launch, tmp_path
+):
+    provider = providers.MultipassProvider()
+
+    with pytest.raises(RuntimeError):
+        with provider.launched_environment(
+            project_name="test-project",
+            project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
+            instance_name="test-instance-name",
         ):
-            assert mock_get_command_environment.mock_calls == [
-                call(http_proxy="test-http", https_proxy="test-https")
-            ]
+            mock_multipass_launch.reset_mock()
+            raise RuntimeError("this is a test")
+
+    assert mock_multipass_launch.mock_calls == [
+        call().unmount_all(),
+        call().stop(),
+    ]
+
+
+def test_launched_environment_launch_base_configuration_error(
+    mock_buildd_base_configuration, mock_multipass_launch, tmp_path
+):
+    error = bases.BaseConfigurationError(brief="fail")
+    mock_multipass_launch.side_effect = error
+    provider = providers.MultipassProvider()
+
+    with pytest.raises(ProviderError, match="fail") as raised:
+        with provider.launched_environment(
+            project_name="test-project",
+            project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
+            instance_name="test-instance-name",
+        ):
+            pass
+
+    assert raised.value.__cause__ is error
+
+
+def test_launched_environment_launch_multipass_error(
+    mock_buildd_base_configuration, mock_multipass_launch, tmp_path
+):
+    error = MultipassError(brief="fail")
+    mock_multipass_launch.side_effect = error
+    provider = providers.MultipassProvider()
+
+    with pytest.raises(ProviderError, match="fail") as raised:
+        with provider.launched_environment(
+            project_name="test-project",
+            project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
+            instance_name="test-instance-name",
+        ):
+            pass
+
+    assert raised.value.__cause__ is error
+
+
+def test_launched_environment_unmount_all_error(
+    mock_buildd_base_configuration, mock_multipass_launch, tmp_path
+):
+    error = MultipassError(brief="fail")
+    mock_multipass_launch.return_value.unmount_all.side_effect = error
+    provider = providers.MultipassProvider()
+
+    with pytest.raises(ProviderError, match="fail") as raised:
+        with provider.launched_environment(
+            project_name="test-project",
+            project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
+            instance_name="test-instance-name",
+        ):
+            pass
+
+    assert raised.value.__cause__ is error
+
+
+def test_launched_environment_stop_error(
+    mock_buildd_base_configuration, mock_multipass_launch, tmp_path
+):
+    error = MultipassError(brief="fail")
+    mock_multipass_launch.return_value.stop.side_effect = error
+    provider = providers.MultipassProvider()
+
+    with pytest.raises(ProviderError, match="fail") as raised:
+        with provider.launched_environment(
+            project_name="test-project",
+            project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
+            instance_name="test-instance-name",
+        ):
+            pass
+
+    assert raised.value.__cause__ is error


### PR DESCRIPTION
snapcraft-specific code in `launched_environment()` is removed from the craft-providers interface.

- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
### Overview

Removes snapcraft-specific logic from `launched_environment()`.  This function is now matches the implementation in rockcraft ([lxd](https://github.com/canonical/rockcraft/blob/97306bc3d93c8a41f18432b1dadf4569c7f28854/rockcraft/providers/_lxd.py#L99) and [multipass](https://github.com/canonical/rockcraft/blob/97306bc3d93c8a41f18432b1dadf4569c7f28854/rockcraft/providers/_multipass.py#L89))

This is the most complex PR of the series, due to the translation of bases.  The base translation was added in [this PR](https://github.com/canonical/rockcraft/pull/85) to rockcraft.


### Base Translation

#### Background
*craft applications have a concept of a "base". This base is translated a `craft-providers` base and is passed to `craft-providers` so it can choose which base image (OS and release) to use for the instance.

#### Problem

Currently, each application translates its own base inside `_lxd.py` and `_multipass.py`. This application-specific code needs to be removed from these files.

#### Solution

To support this, I created a list of what bases craft-providers can accept. Right now, `18.04`, `20.04`, and `22.04` are supported. Other OSs and releases can be added in the future without breaking backwards compatibility.

The image below shows how an application can translates its base to a `craft-providers` base. It also shows `craft-providers` translating it to the specific name needed for LXD and Multipass to download the base image.

![image](https://user-images.githubusercontent.com/60674096/193860773-bee965ff-5017-4c94-9088-93c1489556b6.png)


### Note about the changeset
This PR shows ` 10 files changed, 768 insertions(+), 274 deletions(-)`, but it's much smaller.  It's really `8 files changed, 164 insertions(+), 122 deletions(-)`.

This is because I copied over rockcraft's files `tests/unit/providers/test_{lxd,multipass}.py`.  These files have already been reviewed and are going to be migrated to `craft-providers` later this week.  Thus, these unit test files probably don't need intense scrutiny.