### PR TITLE
providers: install snaps and packages via craft-providers API

### DIFF
--- a/snapcraft/providers/providers.py
+++ b/snapcraft/providers/providers.py
@@ -46,13 +46,24 @@ def get_base_configuration(
     )
 
     # injecting a snap on a non-linux system is not supported, so default to
-    # install rockcraft from the store's stable channel
+    # install snapcraft from the store's stable channel
     snap_channel = get_managed_environment_snap_channel()
     if sys.platform != "linux" and not snap_channel:
         snap_channel = "stable"
 
     return SnapcraftBuilddBaseConfiguration(
-        alias=alias, environment=environment, hostname=instance_name
+        alias=alias,
+        environment=environment,
+        hostname=instance_name,
+        snaps=[
+            bases.buildd.Snap(
+                name="snapcraft",
+                channel=snap_channel,
+                classic=True,
+            )
+        ],
+        # Requirement for apt gpg and version:git
+        packages=["gnupg", "dirmngr", "git"],
     )
 
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Install snaps and packages via `craft-providers`.

(CRAFT-1281, CRAFT-1283)