### PR TITLE
lint: support the existence of 'venv'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ target
 tests/unit/snap/
 tests/unit/stage/
 .vscode
+venv

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test-black:
 
 .PHONY: test-codespell
 test-codespell:
-	codespell --quiet-level 4 --ignore-words-list crate,keyserver,comandos --skip '*.tar,*.xz,*.zip,*.bz2,*.7z,*.gz,*.deb,*.rpm,*.snap,*.gpg,*.pyc,*.png,*.ico,*.jar,*.so,changelog,.git,.hg,.mypy_cache,.tox,.venv,_build,buck-out,__pycache__,build,dist,.vscode,parts,stage,prime,test_appstream.py,./snapcraft.spec,./.direnv,./.pytest_cache'
+	codespell --quiet-level 4 --ignore-words-list crate,keyserver,comandos --skip '*.tar,*.xz,*.zip,*.bz2,*.7z,*.gz,*.deb,*.rpm,*.snap,*.gpg,*.pyc,*.png,*.ico,*.jar,*.so,changelog,.git,.hg,.mypy_cache,.tox,.venv,venv,_build,buck-out,__pycache__,build,dist,.vscode,parts,stage,prime,test_appstream.py,./snapcraft.spec,./.direnv,./.pytest_cache'
 
 .PHONY: test-flake8
 test-flake8:


### PR DESCRIPTION
I think 'venv' is a very common virtual-env name, so add it to gitignore and have codespell skip it. I'm actually not sure if this type of change is desirable, so feel free to reject it!