### PR TITLE
providers: move `confirm_with_user()` call to providers.py (#91)

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -41,6 +41,7 @@ from snapcraft.projects import (
 from snapcraft.providers.providers import (
     SNAPCRAFT_BASE_TO_PROVIDER_BASE,
     capture_logs_from_instance,
+    ensure_provider_is_available,
     get_base_configuration,
     get_instance_name,
 )
@@ -477,7 +478,7 @@ def _run_in_provider(
     emit.debug("Checking build provider availability")
     provider_name = "lxd" if parsed_args.use_lxd else None
     provider = providers.get_provider(provider_name)
-    provider.ensure_provider_is_available()
+    ensure_provider_is_available(provider)
 
     cmd = ["snapcraft", command_name]
 

--- a/snapcraft/providers/_lxd.py
+++ b/snapcraft/providers/_lxd.py
@@ -24,8 +24,6 @@ from typing import Generator
 
 from craft_providers import Executor, ProviderError, base, bases, lxd
 
-from snapcraft import utils
-
 from ._provider import Provider
 
 logger = logging.getLogger(__name__)
@@ -59,28 +57,18 @@ class LXDProvider(Provider):
 
     @classmethod
     def ensure_provider_is_available(cls) -> None:
-        """Ensure provider is available, prompting the user to install it if required.
+        """Ensure provider is available and ready, installing if required.
 
         :raises ProviderError: if provider is not available.
         """
         if not lxd.is_installed():
-            if utils.confirm_with_user(
-                "LXD is required, but not installed. Do you wish to install LXD "
-                "and configure it with the defaults?",
-                default=False,
-            ):
-                try:
-                    lxd.install()
-                except lxd.LXDInstallationError as error:
-                    raise ProviderError(
-                        "Failed to install LXD. Visit https://snapcraft.io/lxd for "
-                        "instructions on how to install the LXD snap for your distribution",
-                    ) from error
-            else:
+            try:
+                lxd.install()
+            except lxd.LXDInstallationError as error:
                 raise ProviderError(
-                    "LXD is required, but not installed. Visit https://snapcraft.io/lxd "
-                    "for instructions on how to install the LXD snap for your distribution",
-                )
+                    "Failed to install LXD. Visit https://snapcraft.io/lxd for "
+                    "instructions on how to install the LXD snap for your distribution",
+                ) from error
 
         try:
             lxd.ensure_lxd_is_ready()

--- a/snapcraft/providers/_multipass.py
+++ b/snapcraft/providers/_multipass.py
@@ -21,11 +21,8 @@ import logging
 import pathlib
 from typing import Generator
 
-from craft_cli import emit
 from craft_providers import Executor, ProviderError, base, bases, multipass
 from craft_providers.multipass.errors import MultipassError
-
-from snapcraft import utils
 
 from ._provider import Provider
 
@@ -58,25 +55,13 @@ class MultipassProvider(Provider):
         :raises ProviderError: if provider is not available.
         """
         if not multipass.is_installed():
-            with emit.pause():
-                confirmation = utils.confirm_with_user(
-                    "Multipass is required, but not installed. Do you wish to install Multipass "
-                    "and configure it with the defaults?",
-                    default=False,
-                )
-            if confirmation:
-                try:
-                    multipass.install()
-                except multipass.MultipassInstallationError as error:
-                    raise ProviderError(
-                        "Failed to install Multipass. Visit https://multipass.run/ for "
-                        "instructions on installing Multipass for your operating system.",
-                    ) from error
-            else:
+            try:
+                multipass.install()
+            except multipass.MultipassInstallationError as error:
                 raise ProviderError(
-                    "Multipass is required, but not installed. Visit https://multipass.run/ for "
+                    "Failed to install Multipass. Visit https://multipass.run/ for "
                     "instructions on installing Multipass for your operating system.",
-                )
+                ) from error
 
         try:
             multipass.ensure_multipass_is_ready()

--- a/snapcraft/providers/providers.py
+++ b/snapcraft/providers/providers.py
@@ -22,12 +22,17 @@ from pathlib import Path
 from typing import Dict, Optional
 
 from craft_cli import emit
-from craft_providers import bases, executor
+from craft_providers import ProviderError, bases, executor
 
 from snapcraft.utils import (
+    confirm_with_user,
     get_managed_environment_log_path,
     get_managed_environment_snap_channel,
 )
+
+from ._lxd import LXDProvider
+from ._multipass import MultipassProvider
+from ._provider import Provider
 
 SNAPCRAFT_BASE_TO_PROVIDER_BASE = {
     "core18": bases.BuilddBaseAlias.BIONIC,
@@ -54,6 +59,42 @@ def capture_logs_from_instance(instance: executor.Executor) -> None:
             emit.trace(
                 f"Could not find log file {source_log_path.as_posix()} in instance."
             )
+
+
+def ensure_provider_is_available(provider: Provider) -> None:
+    """Ensure provider is installed, running, and properly configured.
+
+    If the provider is not installed, the user is prompted to install it.
+
+    :param instance: the provider to ensure is available
+
+    :raises ProviderError: if provider is unknown, not available, or if the user
+    chooses not to install the provider.
+    """
+    if isinstance(provider, LXDProvider):
+        if not LXDProvider.is_provider_installed() and not confirm_with_user(
+            "LXD is required but not installed. Do you wish to install LXD and configure "
+            "it with the defaults?",
+            default=False,
+        ):
+            raise ProviderError(
+                "LXD is required, but not installed. Visit https://snapcraft.io/lxd "
+                "for instructions on how to install the LXD snap for your distribution",
+            )
+        LXDProvider.ensure_provider_is_available()
+    elif isinstance(provider, MultipassProvider):
+        if not MultipassProvider.is_provider_installed() and not confirm_with_user(
+            "Multipass is required but not installed. Do you wish to install Multipass"
+            " and configure it with the defaults?",
+            default=False,
+        ):
+            raise ProviderError(
+                "Multipass is required, but not installed. Visit https://multipass.run/"
+                "for instructions on installing Multipass for your operating system."
+            )
+        MultipassProvider.ensure_provider_is_available()
+    else:
+        raise ProviderError("cannot install unknown provider")
 
 
 def get_base_configuration(

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -1114,6 +1114,9 @@ def test_lifecycle_run_in_provider_default(
     mock_capture_logs_from_instance = mocker.patch(
         "snapcraft.parts.lifecycle.capture_logs_from_instance"
     )
+    mock_ensure_provider_is_available = mocker.patch(
+        "snapcraft.parts.lifecycle.ensure_provider_is_available"
+    )
     mocker.patch("snapcraft.projects.Project.get_build_on", return_value="test-arch-1")
     mocker.patch("snapcraft.projects.Project.get_build_for", return_value="test-arch-2")
 
@@ -1138,7 +1141,7 @@ def test_lifecycle_run_in_provider_default(
         ),
     )
 
-    mock_provider.ensure_provider_is_available.assert_called_once()
+    mock_ensure_provider_is_available.assert_called_once_with(mock_provider)
     mock_get_instance_name.assert_called_once_with(
         project_name="mytest",
         project_path=tmp_path,
@@ -1198,6 +1201,9 @@ def test_lifecycle_run_in_provider_all_options(
     mock_capture_logs_from_instance = mocker.patch(
         "snapcraft.parts.lifecycle.capture_logs_from_instance"
     )
+    mock_ensure_provider_is_available = mocker.patch(
+        "snapcraft.parts.lifecycle.ensure_provider_is_available"
+    )
     mocker.patch("snapcraft.projects.Project.get_build_on", return_value="test-arch-1")
     mocker.patch("snapcraft.projects.Project.get_build_for", return_value="test-arch-2")
 
@@ -1256,7 +1262,7 @@ def test_lifecycle_run_in_provider_all_options(
         ),
     )
 
-    mock_provider.ensure_provider_is_available.assert_called_once()
+    mock_ensure_provider_is_available.assert_called_once_with(mock_provider)
     mock_get_instance_name.assert_called_once_with(
         project_name="mytest",
         project_path=tmp_path,
@@ -1276,8 +1282,6 @@ def test_lifecycle_run_in_provider_all_options(
         build_base="22.04",
         instance_name="test-instance-name",
     )
-
-    mock_provider.ensure_provider_is_available.assert_called_once()
     mock_instance.mount.assert_has_calls(
         [
             call(host_source=tmp_path, target=Path("/root/project")),

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -66,13 +66,6 @@ def mock_lxd_launch(mocker):
     yield mocker.patch("craft_providers.lxd.launch", autospec=True)
 
 
-@pytest.fixture
-def mock_confirm_with_user(mocker):
-    yield mocker.patch(
-        "snapcraft.providers._lxd.utils.confirm_with_user", return_value=True
-    )
-
-
 def test_ensure_provider_is_available_ok_when_installed(mock_lxd_is_installed):
     mock_lxd_is_installed.return_value = True
     provider = providers.LXDProvider()
@@ -80,25 +73,8 @@ def test_ensure_provider_is_available_ok_when_installed(mock_lxd_is_installed):
     provider.ensure_provider_is_available()
 
 
-def test_ensure_provider_is_available_errors_when_user_says_no(
-    mock_lxd_is_installed, mock_lxd_install, mock_confirm_with_user
-):
-    mock_confirm_with_user.return_value = False
-    mock_lxd_is_installed.return_value = False
-    provider = providers.LXDProvider()
-
-    with pytest.raises(
-        ProviderError,
-        match=re.escape(
-            "LXD is required, but not installed. Visit https://snapcraft.io/lxd for "
-            "instructions on how to install the LXD snap for your distribution"
-        ),
-    ):
-        provider.ensure_provider_is_available()
-
-
 def test_ensure_provider_is_available_errors_when_lxd_install_fails(
-    mock_lxd_is_installed, mock_lxd_install, mock_confirm_with_user
+    mock_lxd_is_installed, mock_lxd_install
 ):
     error = LXDInstallationError("foo")
     mock_lxd_is_installed.return_value = False

--- a/tests/unit/providers/test_multipass.py
+++ b/tests/unit/providers/test_multipass.py
@@ -60,13 +60,6 @@ def mock_multipass_launch(mocker):
     yield mocker.patch("craft_providers.multipass.launch", autospec=True)
 
 
-@pytest.fixture
-def mock_confirm_with_user(mocker):
-    yield mocker.patch(
-        "snapcraft.providers._multipass.utils.confirm_with_user", return_value=True
-    )
-
-
 def test_ensure_provider_is_available_ok_when_installed(mock_multipass_is_installed):
     mock_multipass_is_installed.return_value = True
     provider = providers.MultipassProvider()
@@ -74,25 +67,8 @@ def test_ensure_provider_is_available_ok_when_installed(mock_multipass_is_instal
     provider.ensure_provider_is_available()
 
 
-def test_ensure_provider_is_available_errors_when_user_says_no(
-    mock_multipass_is_installed, mock_multipass_install, mock_confirm_with_user
-):
-    mock_confirm_with_user.return_value = False
-    mock_multipass_is_installed.return_value = False
-    provider = providers.MultipassProvider()
-
-    with pytest.raises(
-        ProviderError,
-        match=re.escape(
-            "Multipass is required, but not installed. Visit https://multipass.run/ "
-            "for instructions on installing Multipass for your operating system."
-        ),
-    ):
-        provider.ensure_provider_is_available()
-
-
 def test_ensure_provider_is_available_errors_when_multipass_install_fails(
-    mock_multipass_is_installed, mock_multipass_install, mock_confirm_with_user
+    mock_multipass_is_installed, mock_multipass_install
 ):
     error = MultipassInstallationError("foo")
     mock_multipass_is_installed.return_value = False
@@ -113,7 +89,6 @@ def test_ensure_provider_is_available_errors_when_multipass_not_ready(
     mock_multipass_is_installed,
     mock_multipass_install,
     mock_multipass_ensure_multipass_is_ready,
-    mock_confirm_with_user,
 ):
     error = MultipassError(
         brief="some error", details="some details", resolution="some resolution"

--- a/tests/unit/providers/test_providers.py
+++ b/tests/unit/providers/test_providers.py
@@ -18,9 +18,9 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
-from craft_providers import bases
+from craft_providers import ProviderError, bases
 
-from snapcraft.providers import providers
+from snapcraft.providers import LXDProvider, MultipassProvider, providers
 
 
 @pytest.fixture()
@@ -69,6 +69,106 @@ def test_capture_log_from_instance_not_found(mocker, emitter, mock_instance, new
     mock_instance.temporarily_pull_file.assert_called_with(
         source=Path("/tmp/snapcraft.log"), missing_ok=True
     )
+
+
+@pytest.mark.parametrize(
+    "is_provider_installed, confirm_with_user",
+    [(True, True), (True, False), (False, True)],
+)
+def test_ensure_provider_is_available_lxd(
+    is_provider_installed, confirm_with_user, mocker
+):
+    """Verify LXD is ensured to be available when LXD is installed or the user chooses
+    to install LXD."""
+    mock_lxd_provider = Mock(spec=LXDProvider)
+    mocker.patch(
+        "snapcraft.providers.providers.LXDProvider.is_provider_installed",
+        return_value=is_provider_installed,
+    )
+    mocker.patch(
+        "snapcraft.providers.providers.confirm_with_user",
+        return_value=confirm_with_user,
+    )
+    mock_ensure_provider_is_available = mocker.patch(
+        "snapcraft.providers.providers.ensure_provider_is_available"
+    )
+
+    providers.ensure_provider_is_available(mock_lxd_provider)
+
+    mock_ensure_provider_is_available.assert_called_once()
+
+
+def test_ensure_provider_is_available_lxd_error(mocker):
+    """Raise an error if the user does not choose to install LXD."""
+    mock_lxd_provider = Mock(spec=LXDProvider)
+    mocker.patch(
+        "snapcraft.providers.providers.LXDProvider.is_provider_installed",
+        return_value=False,
+    )
+    mocker.patch("snapcraft.providers.providers.confirm_with_user", return_value=False)
+
+    with pytest.raises(ProviderError) as error:
+        providers.ensure_provider_is_available(mock_lxd_provider)
+
+    assert error.value.brief == (
+        "LXD is required, but not installed. Visit https://snapcraft.io/lxd for "
+        "instructions on how to install the LXD snap for your distribution"
+    )
+
+
+@pytest.mark.parametrize(
+    "is_provider_installed, confirm_with_user",
+    [(True, True), (True, False), (False, True)],
+)
+def test_ensure_provider_is_available_multipass(
+    is_provider_installed, confirm_with_user, mocker
+):
+    """Verify Multipass is ensured to be available when Multipass is installed or the
+    user chooses to install Multipass."""
+    mock_multipass_provider = Mock(spec=MultipassProvider)
+    mocker.patch(
+        "snapcraft.providers.providers.MultipassProvider.is_provider_installed",
+        return_value=is_provider_installed,
+    )
+    mocker.patch(
+        "snapcraft.providers.providers.confirm_with_user",
+        return_value=confirm_with_user,
+    )
+    mock_ensure_provider_is_available = mocker.patch(
+        "snapcraft.providers.providers.ensure_provider_is_available"
+    )
+
+    providers.ensure_provider_is_available(mock_multipass_provider)
+
+    mock_ensure_provider_is_available.assert_called_once()
+
+
+def test_ensure_provider_is_available_multipass_error(mocker):
+    """Raise an error if the user does not choose to install Multipass."""
+    mock_multipass_provider = Mock(spec=MultipassProvider)
+    mocker.patch(
+        "snapcraft.providers.providers.MultipassProvider.is_provider_installed",
+        return_value=False,
+    )
+    mocker.patch("snapcraft.providers.providers.confirm_with_user", return_value=False)
+
+    with pytest.raises(ProviderError) as error:
+        providers.ensure_provider_is_available(mock_multipass_provider)
+
+    assert error.value.brief == (
+        "Multipass is required, but not installed. Visit https://multipass.run/for "
+        "instructions on installing Multipass for your operating system."
+    )
+
+
+def test_ensure_provider_is_available_unknown_error():
+    """Raise an error if the provider type is unknown."""
+    mock_multipass_provider = Mock()
+
+    with pytest.raises(ProviderError) as error:
+        providers.ensure_provider_is_available(mock_multipass_provider)
+
+    assert error.value.brief == "cannot install unknown provider"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

`confirm_with_user()` is a snapcraft-specific call, so it is moved out of the craft-providers interface.

Similar to [this rockcraft PR](https://github.com/canonical/rockcraft/pull/91)

(CRAFT-1400)