### PR TITLE
tests: fix electron spread test

### DIFF
--- a/tests/spread/electron-builder/no-template/expected_snap.yaml
+++ b/tests/spread/electron-builder/no-template/expected_snap.yaml
@@ -21,7 +21,6 @@ apps:
     - raw-usb
     environment:
       DISABLE_WAYLAND: '1'
-      TMPDIR: $XDG_RUNTIME_DIR
       PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
       SNAP_DESKTOP_RUNTIME: $SNAP/gnome-platform
       LD_LIBRARY_PATH: $SNAP_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu

--- a/tests/spread/electron-builder/no-template/expected_snapcraft.yaml
+++ b/tests/spread/electron-builder/no-template/expected_snapcraft.yaml
@@ -175,7 +175,6 @@ apps:
     adapter: none
     environment:
       DISABLE_WAYLAND: '1'
-      TMPDIR: $XDG_RUNTIME_DIR
       PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
       SNAP_DESKTOP_RUNTIME: $SNAP/gnome-platform
       LD_LIBRARY_PATH: $SNAP_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu


### PR DESCRIPTION
Signed-off-by: Callahan Kovacs <callahan.kovacs@canonical.com>

- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

I'm not sure if this is a "fix" or a "hack", nor why it started failing, but [this spread test](https://github.com/snapcore/snapcraft/tree/main/tests/spread/electron-builder/no-template) is failing with the error:

```
+ diff -U10 /snap/electron-builder-hello-world/x1/meta/snap.yaml /snapcraft/tests/spread/electron-builder/no-template/expected_snap.yaml
--- /snap/electron-builder-hello-world/x1/meta/snap.yaml	2022-10-07 18:27:23.000000000 +0000
+++ /snapcraft/tests/spread/electron-builder/no-template/expected_snap.yaml	2021-04-29 15:11:51.000000000 +0000
@@ -14,20 +14,21 @@
     - unity7
     - browser-support
     - network
     - gsettings
     - audio-playback
     - pulseaudio
     - opengl
     - raw-usb
     environment:
       DISABLE_WAYLAND: '1'
+      TMPDIR: $XDG_RUNTIME_DIR
       PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
       SNAP_DESKTOP_RUNTIME: $SNAP/gnome-platform
       LD_LIBRARY_PATH: $SNAP_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu
 architectures:
 - amd64
 base: core18
 confinement: strict
 grade: stable
 plugs:
   gnome-3-28-1804:
+ echo 'snap.yaml does not match expected:'
snap.yaml does not match expected:
```
