### PR TITLE
providers: capture logs with debug-level logging

### DIFF
--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -50,12 +50,12 @@ def capture_logs_from_instance(instance: executor.Executor) -> None:
         source=source_log_path, missing_ok=True
     ) as log_path:
         if log_path:
-            emit.trace("Logs retrieved from managed instance:")
+            emit.debug("Logs retrieved from managed instance:")
             with open(log_path, "r", encoding="utf8") as log_file:
                 for line in log_file:
-                    emit.trace(":: " + line.rstrip())
+                    emit.debug(":: " + line.rstrip())
         else:
-            emit.trace(
+            emit.debug(
                 f"Could not find log file {source_log_path.as_posix()} in instance."
             )
 

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -50,10 +50,10 @@ def test_capture_logs_from_instance(mocker, emitter, mock_instance, new_dir):
         call.temporarily_pull_file(source=Path("/tmp/snapcraft.log"), missing_ok=True)
     ]
     expected = [
-        call("trace", "Logs retrieved from managed instance:"),
-        call("trace", ":: some"),
-        call("trace", ":: log data"),
-        call("trace", ":: here"),
+        call("debug", "Logs retrieved from managed instance:"),
+        call("debug", ":: some"),
+        call("debug", ":: log data"),
+        call("debug", ":: here"),
     ]
     emitter.assert_interactions(expected)
 
@@ -68,7 +68,7 @@ def test_capture_log_from_instance_not_found(mocker, emitter, mock_instance, new
 
     providers.capture_logs_from_instance(mock_instance)
 
-    emitter.assert_trace("Could not find log file /tmp/snapcraft.log in instance.")
+    emitter.assert_debug("Could not find log file /tmp/snapcraft.log in instance.")
     mock_instance.temporarily_pull_file.assert_called_with(
         source=Path("/tmp/snapcraft.log"), missing_ok=True
     )


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Captured logs were not being saved to the log file because they were emitted as trace-level messages instead of debug-level.

Previously, they were debug level ([see here](https://github.com/snapcore/snapcraft/blob/f6abc2efd7c665a2df9577499bb022491d36cfc9/snapcraft/providers/_logs.py#L50)).

[Reported](https://forum.snapcraft.io/t/call-for-testing-snapcraft-7-2-0/32171/2?u=mr_cal) by @diddledani