### PR TITLE
tests: allow local git submodules

### DIFF
--- a/tests/legacy/unit/sources/test_git.py
+++ b/tests/legacy/unit/sources/test_git.py
@@ -747,7 +747,18 @@ class TestGitConflicts(GitBaseTestCase):
 
         # update the submodule
         self.clone_repo(repo, working_tree_two)
-        call(["git", "submodule", "update", "--init", "--recursive", "--remote"])
+        call(
+            [
+                "git",
+                "submodule",
+                "-c",
+                "protocol.file.allow=always",
+                "update",
+                "--init",
+                "--recursive",
+                "--remote",
+            ]
+        )
         call(["git", "add", "subrepo"])
         call(["git", "commit", "-am", "updated submodule"])
         call(["git", "push"])

--- a/tests/legacy/unit/sources/test_git.py
+++ b/tests/legacy/unit/sources/test_git.py
@@ -750,9 +750,9 @@ class TestGitConflicts(GitBaseTestCase):
         call(
             [
                 "git",
-                "submodule",
                 "-c",
                 "protocol.file.allow=always",
+                "submodule",
                 "update",
                 "--init",
                 "--recursive",

--- a/tests/legacy/unit/sources/test_git.py
+++ b/tests/legacy/unit/sources/test_git.py
@@ -721,7 +721,7 @@ class TestGitConflicts(GitBaseTestCase):
         call(["git", "init", "--bare"])
 
         self.clone_repo(repo, working_tree)
-        call(["git", "submodule", "add", sub_repo])
+        call(["git", "-c", "protocol.file.allow=always", "submodule", "add", sub_repo])
         call(["git", "commit", "-am", "added submodule"])
         call(["git", "push", repo])
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

git v2.34.1 requires the config `protocol.file.allow=always` when adding a local submodule