### PR TITLE
onprem store: support new credentials format

### DIFF
--- a/snapcraft/commands/account.py
+++ b/snapcraft/commands/account.py
@@ -232,7 +232,7 @@ class StoreExportLoginCommand(BaseCommand):
 
             message = f"Exported login credentials to {parsed_args.login_file!r}"
 
-        message += "\n\nThese credentials must be used on Snapcraft 7.0 or greater."
+        message += "\n\nThese credentials must be used on Snapcraft 7.2 or greater."
         if os.getenv(store.constants.ENVIRONMENT_STORE_AUTH) == "candid":
             message += (
                 f"\nSet '{store.constants.ENVIRONMENT_STORE_AUTH}=candid' for "

--- a/snapcraft/store/onprem_client.py
+++ b/snapcraft/store/onprem_client.py
@@ -19,6 +19,7 @@
 import os
 from typing import Any, Dict, Final
 
+import craft_store.creds
 from craft_store import BaseClient, endpoints, models
 from overrides import overrides
 
@@ -56,9 +57,11 @@ class OnPremClient(BaseClient):
             json={"macaroon": root_macaroon},
         )
 
-        return response.json()["macaroon"]
+        return craft_store.creds.marshal_candid_credentials(response.json()["macaroon"])
 
     @overrides
     def _get_authorization_header(self) -> str:
-        auth = self._auth.get_credentials()
+        auth = craft_store.creds.unmarshal_candid_credentials(
+            self._auth.get_credentials()
+        )
         return f"macaroon {auth}"

--- a/tests/unit/commands/test_account.py
+++ b/tests/unit/commands/test_account.py
@@ -114,7 +114,7 @@ def test_export_login(emitter, fake_store_login):
     ]
     emitter.assert_message(
         "Exported login credentials:\nsecret"
-        "\n\nThese credentials must be used on Snapcraft 7.0 or greater."
+        "\n\nThese credentials must be used on Snapcraft 7.2 or greater."
     )
 
 
@@ -139,7 +139,7 @@ def test_export_login_file(new_dir, emitter, fake_store_login):
     ]
     emitter.assert_message(
         "Exported login credentials to 'target_file'"
-        "\n\nThese credentials must be used on Snapcraft 7.0 or greater."
+        "\n\nThese credentials must be used on Snapcraft 7.2 or greater."
     )
     login_file = new_dir / "target_file"
     assert login_file.exists()
@@ -171,7 +171,7 @@ def test_export_login_with_params(emitter, fake_store_login):
     ]
     emitter.assert_message(
         "Exported login credentials:\nsecret"
-        "\n\nThese credentials must be used on Snapcraft 7.0 or greater."
+        "\n\nThese credentials must be used on Snapcraft 7.2 or greater."
     )
 
 
@@ -202,7 +202,7 @@ def test_export_login_with_candid(emitter, fake_store_login, monkeypatch):
     ]
     emitter.assert_message(
         "Exported login credentials:\nsecret"
-        "\n\nThese credentials must be used on Snapcraft 7.0 or greater."
+        "\n\nThese credentials must be used on Snapcraft 7.2 or greater."
         "\nSet 'SNAPCRAFT_STORE_AUTH=candid' for these credentials to work."
     )
 

--- a/tests/unit/store/test_onprem_client.py
+++ b/tests/unit/store/test_onprem_client.py
@@ -74,7 +74,7 @@ def test_get_discharged_macaroon(on_prem_client, mocker):
 
     assert (
         on_prem_client._get_discharged_macaroon("root-macaroon")
-        == "discharged-macaroon"
+        == '{"t": "macaroon", "v": "discharged-macaroon"}'
     )
 
     assert request_mock.mock_calls == [
@@ -97,3 +97,13 @@ def test_get_authorization_header(on_prem_client, mocker):
         on_prem_client._get_authorization_header()
         == "macaroon serialized-macaroon-string"
     )
+
+
+def test_get_authorization_header_json(on_prem_client, mocker):
+    """Ensure the correct authorization header is formed for requests"""
+    mocker.patch.object(
+        on_prem_client._auth,
+        "get_credentials",
+        return_value='{"t": "macaroon", "v": "discharged-macaroon"}',
+    )
+    assert on_prem_client._get_authorization_header() == "macaroon discharged-macaroon"


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1446