### PR TITLE
tests: retry installing lxd snap

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          submodules: true
 
       - name: Download snapcraft snap
         uses: actions/download-artifact@v2
@@ -96,6 +97,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          submodules: true
 
       - if: steps.decisions.outputs.RUN == 'true'
         name: Download snapcraft snap

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "docs"]
 	path = docs
 	url = https://github.com/CanonicalLtd/snappy-docs.git
+[submodule "tests/spread/tools/snapd-testing-tools"]
+	path = tests/spread/tools/snapd-testing-tools
+	url = https://github.com/snapcore/snapd-testing-tools.git

--- a/spread.yaml
+++ b/spread.yaml
@@ -27,6 +27,7 @@ environment:
   DEBIAN_PRIORITY: critical
 
   TOOLS_DIR: /snapcraft/tests/spread/tools
+  PATH: $PATH:$TOOLS_DIR/snapd-testing-tools/tools/
 
   # Git environment for commits
   GIT_AUTHOR_NAME: "Test User"
@@ -208,8 +209,9 @@ prepare: |
       # nicely handle the snap and deb being installed at the same time.
       apt-get remove --purge --yes lxd lxd-client
   fi
-  # Install and setup the lxd snap
-  snap install lxd
+  # install and setup the lxd snap - use 'retry' to workaround aa-exec issue
+  # see https://bugs.launchpad.net/snapd/+bug/1870201
+  retry -n 5 --wait 5 sh -c 'snap install lxd'
   # Add the ubuntu user to the lxd group.
   adduser ubuntu lxd
   lxd init --auto


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Use the `retry` function from [snapd-testing-tools](https://github.com/snapcore/snapd-testing-tools) when installing the lxd snap.

This is to workaround an intermittent and hard-to-reproduce [snapd bug](https://bugs.launchpad.net/snapd/+bug/1870201).