### PR TITLE
cli: set default verbosity level with environment variable

### DIFF
--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -148,21 +148,18 @@ def get_verbosity() -> EmitterMode:
         if utils.strtobool(os.getenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", "n").strip()):
             verbosity = EmitterMode.DEBUG
 
-    # XXX: Something is amiss. Try running:
-    #      `SNAPCRAFT_VERBOSITY_LEVEL=trace snapcraft pull --verbosity=quiet`
-    #      The trouble is that emit.init and dispatcher.pre_parse_args both run
-    #      `set_mode()`, which logs the greeting twice.
-
     # if defined, use environmental variable SNAPCRAFT_VERBOSITY_LEVEL
     verbosity_env = os.getenv("SNAPCRAFT_VERBOSITY_LEVEL")
     if verbosity_env:
         try:
             verbosity = EmitterMode[verbosity_env.strip().upper()]
         except KeyError:
+            values = utils.humanize_list(
+                [e.name.lower() for e in EmitterMode], "and", sort=False
+            )
             raise ArgumentParsingError(
-                f"cannot parse verbosity level {verbosity_env!r} from environmental "
-                "variable SNAPCRAFT_VERBOSITY_LEVEL (valid values are 'quiet', "
-                "'brief', 'verbose', 'debug' and 'trace')"
+                f"cannot parse verbosity level {verbosity_env!r} from environment "
+                f"variable SNAPCRAFT_VERBOSITY_LEVEL (valid values are {values})"
             ) from KeyError
 
     return verbosity
@@ -207,7 +204,6 @@ def get_dispatcher() -> craft_cli.Dispatcher:
 
 
 def _run_dispatcher(dispatcher: craft_cli.Dispatcher) -> None:
-    # XXX: how to pass SNAPCRAFT_VERBOSITY_LEVEL to dispatcher.pre_parse_args?
     global_args = dispatcher.pre_parse_args(sys.argv[1:])
     if global_args.get("version"):
         emit.message(f"snapcraft {__version__}")

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -301,7 +301,7 @@ def humanize_list(
     :param conjunction: the conjunction used to join the final element to
                         the rest of the list (e.g. 'and').
     :param item_format: format string to use per item.
-    :param sort: if true, sort the list
+    :param sort: if true, sort the list.
     """
     if not items:
         return ""

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -290,7 +290,10 @@ def prompt(prompt_text: str, *, hide: bool = False) -> str:
 
 
 def humanize_list(
-    items: Iterable[str], conjunction: str, item_format: str = "{!r}"
+    items: Iterable[str],
+    conjunction: str,
+    item_format: str = "{!r}",
+    sort: bool = True,
 ) -> str:
     """Format a list into a human-readable string.
 
@@ -298,11 +301,16 @@ def humanize_list(
     :param conjunction: the conjunction used to join the final element to
                         the rest of the list (e.g. 'and').
     :param item_format: format string to use per item.
+    :param sort: if true, sort the list
     """
     if not items:
         return ""
 
-    quoted_items = [item_format.format(item) for item in sorted(items)]
+    quoted_items = [item_format.format(item) for item in items]
+
+    if sort:
+        quoted_items = sorted(quoted_items)
+
     if len(quoted_items) == 1:
         return quoted_items[0]
 

--- a/tests/unit/cli/test_verbosity.py
+++ b/tests/unit/cli/test_verbosity.py
@@ -92,7 +92,7 @@ def test_env_var_invalid(monkeypatch):
         cli.get_verbosity()
 
     assert str(raised.value) == (
-        "cannot parse verbosity level 'invalid' from environmental "
+        "cannot parse verbosity level 'invalid' from environment "
         "variable SNAPCRAFT_VERBOSITY_LEVEL (valid values are 'quiet', 'brief', "
-        "'verbose', 'debug' and 'trace')"
+        "'verbose', 'debug', and 'trace')"
     )

--- a/tests/unit/cli/test_verbosity.py
+++ b/tests/unit/cli/test_verbosity.py
@@ -15,12 +15,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import pytest
+from craft_cli import ArgumentParsingError
 
 from snapcraft import cli
 
 
 @pytest.mark.parametrize("value", ["yes", "YES", "1", "y", "Y"])
 def test_developer_debug_in_env_sets_debug(monkeypatch, value):
+    """DEVELOPER_DEBUG sets verbosity level to 'debug'."""
     monkeypatch.setenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", value)
 
     assert cli.get_verbosity() == cli.EmitterMode.DEBUG
@@ -28,6 +30,7 @@ def test_developer_debug_in_env_sets_debug(monkeypatch, value):
 
 @pytest.mark.parametrize("value", ["no", "NO", "0", "n", "N"])
 def test_developer_debug_in_env_sets_brief(monkeypatch, value):
+    """Default verbosity is used when DEVELOPER_DEBUG=0."""
     monkeypatch.setenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", value)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
 
@@ -36,6 +39,7 @@ def test_developer_debug_in_env_sets_brief(monkeypatch, value):
 
 @pytest.mark.parametrize("value", ["foo", "BAR", "2"])
 def test_parse_issue_in_developer_debug_in_env_sets_brief(monkeypatch, value):
+    """Invalid values for DEVELOPER_DEBUG are silently ignored."""
     monkeypatch.setenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", value)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
 
@@ -43,6 +47,7 @@ def test_parse_issue_in_developer_debug_in_env_sets_brief(monkeypatch, value):
 
 
 def test_no_env_returns_brief(monkeypatch):
+    """Default verbosity is used when there is no value for DEVELOPER_DEBUG."""
     monkeypatch.delenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", False)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
 
@@ -50,6 +55,8 @@ def test_no_env_returns_brief(monkeypatch):
 
 
 def test_sdtin_no_tty_returns_verbose(monkeypatch):
+    """Default verbosity for environments with a closed stdin is used when there is no
+    value for DEVELOPER_DEBUG."""
     monkeypatch.delenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", False)
     monkeypatch.setattr("sys.stdin.isatty", lambda: False)
 
@@ -57,7 +64,35 @@ def test_sdtin_no_tty_returns_verbose(monkeypatch):
 
 
 def test_developer_debug_and_sdtin_no_tty_returns_debug(monkeypatch):
-    monkeypatch.setenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", True)
+    """DEVELOPER_DEBUG sets verbosity in an environment with a closed stdin."""
+    monkeypatch.setenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", "y")
     monkeypatch.setattr("sys.stdin.isatty", lambda: False)
 
     assert cli.get_verbosity() == cli.EmitterMode.DEBUG
+
+
+@pytest.mark.parametrize("developer_debug", ["n", "y"])
+@pytest.mark.parametrize("isatty", [False, True])
+@pytest.mark.parametrize("verbosity", ["quiet", "brief", "verbose", "debug", "trace"])
+def test_env_var(monkeypatch, developer_debug, isatty, verbosity):
+    """Environment variable sets verbosity, even when DEVELOPER_DEBUG is defined or
+    stdin is closed."""
+    monkeypatch.setenv("SNAPCRAFT_VERBOSITY_LEVEL", verbosity)
+    monkeypatch.setenv("SNAPCRAFT_ENABLE_DEVELOPER_DEBUG", developer_debug)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: isatty)
+
+    assert cli.get_verbosity() == cli.EmitterMode[verbosity.upper()]
+
+
+def test_env_var_invalid(monkeypatch):
+    """Error is raised when environmental variable is invalid."""
+    monkeypatch.setenv("SNAPCRAFT_VERBOSITY_LEVEL", "invalid")
+
+    with pytest.raises(ArgumentParsingError) as raised:
+        cli.get_verbosity()
+
+    assert str(raised.value) == (
+        "cannot parse verbosity level 'invalid' from environmental "
+        "variable SNAPCRAFT_VERBOSITY_LEVEL (valid values are 'quiet', 'brief', "
+        "'verbose', 'debug' and 'trace')"
+    )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -281,6 +281,21 @@ def test_humanize_list(items, conjunction, expected):
     assert utils.humanize_list(items, conjunction) == expected
 
 
+def test_humanize_list_sorted():
+    """Verify `sort` parameter."""
+    input_list = ["z", "a", "m test", "1"]
+
+    # unsorted list is in the same order as the original list
+    expected_list_unsorted = "'z', 'a', 'm test', and '1'"
+
+    # sorted list is sorted alphanumerically
+    expected_list_sorted = "'1', 'a', 'm test', and 'z'"
+
+    assert utils.humanize_list(input_list, "and") == expected_list_sorted
+    assert utils.humanize_list(input_list, "and", sort=True) == expected_list_sorted
+    assert utils.humanize_list(input_list, "and", sort=False) == expected_list_unsorted
+
+
 #################
 # Library Paths #
 #################


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

The default verbosity level can be set with the environment variable `SNAPCRAFT_VERBOSITY_LEVEL`, where valid values are `quiet`, `brief`, `verbose`, `debug`, and `trace`.

The implementation I chose for this PR isn't correct.  Running `SNAPCRAFT_VERBOSITY_LEVEL=trace snapcraft pull --verbosity=quiet` produces the output
```
2022-10-24 15:36:28.919 Starting Snapcraft 7.1.1.post1+git6934c0ba
2022-10-24 15:36:28.919 Logging execution to '/home/developer/.cache/snapcraft/log/snapcraft-20221024-153628.919185.log'
```

Running `SNAPCRAFT_VERBOSITY_LEVEL=trace snapcraft pull --verbosity=trace` outputs the greeting message twice:
```
2022-10-24 15:36:44.269 Starting Snapcraft 7.1.1.post1+git6934c0ba
2022-10-24 15:36:44.269 Logging execution to '/home/developer/.cache/snapcraft/log/snapcraft-20221024-153644.268436.log'
2022-10-24 15:36:44.269 Starting Snapcraft 7.1.1.post1+git6934c0ba
2022-10-24 15:36:44.269 Logging execution to '/home/developer/.cache/snapcraft/log/snapcraft-20221024-153644.268436.log'
2022-10-24 15:36:44.269 Raw pre-parsed sysargs: args={'help': False, 'verbose': False, 'quiet': False, 'verbosity': 'trace', 'version': False, 'trace': False} filtered=['pull']
2022-10-24 15:36:44.269 General parsed sysargs: command='pull' args=[]
... (logs continue in 'trace' mode)
```

I'd like to talk to @facundobatista this week about a better solution.  I'm thinking about adding an optional parameter to `craft_cli.dispatcher.pre_parse_args()`.

Another option would be allowing snapcraft to call `pre_parse_args()` (or another subset of this method) to parse the verbosity level before initializing the emitter.

Update: Facundo and I talked about a solution and raised a non-blocking craft-cli issue: https://github.com/canonical/craft-cli/issues/128


(CRAFT-1420)