### PR TITLE
meta: fix snap.yaml app slots

### DIFF
--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -81,6 +81,7 @@ class SnapApp(_SnapMetadataModel):
     restart_condition: Optional[str]
     install_mode: Optional[str]
     plugs: Optional[List[str]]
+    slots: Optional[List[str]]
     aliases: Optional[List[str]]
     environment: Optional[Dict[str, Any]]
     command_chain: Optional[List[str]]
@@ -326,6 +327,7 @@ def _create_snap_app(app: App, assumes: Set[str]) -> SnapApp:
         restart_condition=app.restart_condition,
         install_mode=app.install_mode,
         plugs=app.plugs,
+        slots=app.slots,
         aliases=app.aliases,
         environment=app.environment,
         command_chain=app.command_chain or None,

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -144,6 +144,8 @@ def complex_project():
             restart-condition: on-success
             install-mode: enable
             aliases: [test-alias-1, test-alias-2]
+            plugs: [test-plug-1, test-plug-2]
+            slots: [test-slot-1, test-slot-2]
             environment:
               APP_VARIABLE: test-app-variable
             command-chain:
@@ -264,6 +266,12 @@ def test_complex_snap_yaml(complex_project, new_dir):
             stop-mode: sigterm
             restart-condition: on-success
             install-mode: enable
+            plugs:
+            - test-plug-1
+            - test-plug-2
+            slots:
+            - test-slot-1
+            - test-slot-2
             aliases:
             - test-alias-1
             - test-alias-2


### PR DESCRIPTION
Add missing slots definition in snap.yaml apps.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
