### PR TITLE
ua: do not re-enable enabled services

### DIFF
--- a/snapcraft/ua_manager.py
+++ b/snapcraft/ua_manager.py
@@ -137,14 +137,10 @@ def _is_service_enabled(service_name: str, service_data: List[Dict[str, str]]) -
     :return: True if the service is enabled. False is the service is disabled or not
     listed in the list of service data.
     """
-    service = next(
-        (service for service in service_data if service.get("name") == service_name),
-        None,
-    )
-
-    if service:
-        # possible statuses are 'enabled', 'disabled', and 'n/a'
-        return service.get("status") == "enabled"
+    for service in service_data:
+        if service.get("name") == service_name:
+            # possible statuses are 'enabled', 'disabled', and 'n/a'
+            return service.get("status") == "enabled"
 
     emit.debug(f"Could not find service {service_name!r}.")
     return False

--- a/snapcraft/ua_manager.py
+++ b/snapcraft/ua_manager.py
@@ -74,16 +74,43 @@ def _attach(ua_token: str) -> None:
 
 
 def _enable_services(services: List[str]) -> None:
-    """Enable the specified UA services."""
-    try:
-        with emit.open_stream("Enable UA services") as stream:
-            subprocess.check_call(
-                ["ua", "enable", *services, "--beta", "--assume-yes"],
-                stdout=stream,
-                stderr=stream,
+    """Enable the specified UA services.
+
+    If a service is already enabled, it will not be re-enabled because UA will raise
+    an error.
+    """
+    with emit.open_stream("Enable UA services") as stream:
+        service_data = _status().get("services")
+        enabled_services = []
+        disabled_services = []
+
+        if service_data:
+            # sort services into enabled and disabled
+            for service in services:
+                if _is_service_enabled(service, service_data):
+                    enabled_services.append(service)
+                else:
+                    disabled_services.append(service)
+        else:
+            # assume all services are disabled if they are not in the status data
+            disabled_services = services
+
+        if enabled_services:
+            emit.debug(
+                f"Not re-enabling services {enabled_services} because the "
+                "services are already enabled."
             )
-    except subprocess.CalledProcessError as error:
-        raise UAEnableServicesError from error
+
+        if disabled_services:
+            emit.debug(f"Enabling services {disabled_services}.")
+            try:
+                subprocess.check_call(
+                    ["ua", "enable", *disabled_services, "--beta", "--assume-yes"],
+                    stdout=stream,
+                    stderr=stream,
+                )
+            except subprocess.CalledProcessError as error:
+                raise UAEnableServicesError from error
 
 
 def _detach() -> None:
@@ -101,8 +128,30 @@ def _is_attached() -> bool:
     return _status()["attached"]
 
 
+def _is_service_enabled(service_name: str, service_data: List[Dict[str, str]]) -> bool:
+    """Check if a service is enabled.
+
+    :param service_name: name of service to check
+    :param service_data: list of dictionaries containing data for each service
+
+    :return: True if the service is enabled. False is the service is disabled or not
+    listed in the list of service data.
+    """
+    service = next(
+        (service for service in service_data if service.get("name") == service_name),
+        None,
+    )
+
+    if service:
+        # possible statuses are 'enabled', 'disabled', and 'n/a'
+        return service.get("status") == "enabled"
+
+    emit.debug(f"Could not find service {service_name!r}.")
+    return False
+
+
 def _status() -> Dict[str, Any]:
-    stdout = subprocess.check_output(["ua", "status", "--format", "json"])
+    stdout = subprocess.check_output(["ua", "status", "--all", "--format", "json"])
     return json.loads(stdout)
 
 

--- a/tests/unit/test_ua_manager.py
+++ b/tests/unit/test_ua_manager.py
@@ -14,9 +14,58 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import json
+
 import pytest
 
 from snapcraft import ua_manager
+
+
+@pytest.fixture()
+def mock_status_data():
+    """Returns mock data from calling `ua status --all --format=json`.
+
+    Contains two disabled services (disabled-service-1 and disabled-service-2) and one enabled
+    service (enabled-service).
+    """
+    return json.dumps(
+        {
+            "_doc": "Content...",
+            "attached": False,
+            "services": [
+                {
+                    "available": "yes",
+                    "blocked_by": [],
+                    "description": "Common Criteria EAL2 Provisioning Packages",
+                    "description_override": None,
+                    "entitled": "yes",
+                    "name": "disabled-service-1",
+                    "status": "disabled",
+                    "status_details": "",
+                },
+                {
+                    "available": "yes",
+                    "blocked_by": [],
+                    "description": "Expanded Security Maintenance for Applications",
+                    "description_override": None,
+                    "entitled": "yes",
+                    "name": "disabled-service-2",
+                    "status": "n/a",
+                    "status_details": "Ubuntu Pro: ESM Apps is not configured",
+                },
+                {
+                    "available": "yes",
+                    "blocked_by": [],
+                    "description": "Expanded Security Maintenance for Infrastructure",
+                    "description_override": None,
+                    "entitled": "yes",
+                    "name": "enabled-service",
+                    "status": "enabled",
+                    "status_details": "Ubuntu Pro: ESM Infra is active",
+                },
+            ],
+        }
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -27,20 +76,18 @@ def _setup_fixture(mocker):
 
 
 def test_ua_manager(fake_process):
-    ua_token = "test-ua-token"
-
     fake_process.register_subprocess(
-        ["ua", "status", "--format", "json"],
+        ["ua", "status", "--all", "--format", "json"],
         stdout='{"attached": false, "_doc": "Content..."}',
     )
     fake_process.register_subprocess(["ua", "attach", "test-ua-token"])
     fake_process.register_subprocess(["ua", "detach", "--assume-yes"])
 
-    with ua_manager.ua_manager(ua_token, services=None):
+    with ua_manager.ua_manager("test-ua-token", services=None):
         pass
 
     assert list(fake_process.calls) == [
-        ["ua", "status", "--format", "json"],
+        ["ua", "status", "--all", "--format", "json"],
         ["ua", "attach", "test-ua-token"],
         ["ua", "detach", "--assume-yes"],
     ]
@@ -48,80 +95,155 @@ def test_ua_manager(fake_process):
 
 def test_ua_manager_already_attached(fake_process):
     fake_process.register_subprocess(
-        ["ua", "status", "--format", "json"],
+        ["ua", "status", "--all", "--format", "json"],
         stdout='{"attached": true, "_doc": "Content..."}',
     )
 
     with ua_manager.ua_manager("ua-token", services=None):
         pass
 
-    assert list(fake_process.calls) == [["ua", "status", "--format", "json"]]
+    assert list(fake_process.calls) == [["ua", "status", "--all", "--format", "json"]]
 
 
 def test_ua_manager_attach_error(fake_process):
-    ua_token = "test-ua-token"
-
     fake_process.register_subprocess(
-        ["ua", "status", "--format", "json"],
+        ["ua", "status", "--all", "--format", "json"],
         stdout='{"attached": false, "_doc": "Content..."}',
     )
     fake_process.register_subprocess(["ua", "attach", "test-ua-token"], returncode=23)
 
     with pytest.raises(ua_manager.UATokenAttachError) as raised:
-        with ua_manager.ua_manager(ua_token, services=None):
+        with ua_manager.ua_manager("test-ua-token", services=None):
             pass
 
     assert list(fake_process.calls) == [
-        ["ua", "status", "--format", "json"],
+        ["ua", "status", "--all", "--format", "json"],
         ["ua", "attach", "test-ua-token"],
     ]
     assert str(raised.value) == "Error attaching UA token."
 
 
-def test_ua_manager_enable_services(fake_process):
-    ua_token = "test-ua-token"
-
+def test_ua_manager_enable_services(fake_process, mock_status_data):
+    """Test enabling of services:
+    - Disabled services are enabled.
+    - Services not in the status data are enabled.
+    - Enabled services are not re-enabled.
+    """
     fake_process.register_subprocess(
-        ["ua", "status", "--format", "json"],
+        ["ua", "status", "--all", "--format", "json"], stdout=mock_status_data
+    )
+    fake_process.register_subprocess(["ua", "attach", "test-ua-token"])
+    fake_process.register_subprocess(
+        ["ua", "status", "--all", "--format", "json"], stdout=mock_status_data
+    )
+    fake_process.register_subprocess(
+        [
+            "ua",
+            "enable",
+            "disabled-service-1",
+            "disabled-service-2",
+            "service-not-in-status-data",
+            "--beta",
+            "--assume-yes",
+        ]
+    )
+    fake_process.register_subprocess(["ua", "detach", "--assume-yes"])
+
+    with ua_manager.ua_manager(
+        "test-ua-token",
+        services=[
+            "disabled-service-1",
+            "disabled-service-2",
+            "service-not-in-status-data",
+        ],
+    ):
+        pass
+
+    assert list(fake_process.calls) == [
+        ["ua", "status", "--all", "--format", "json"],
+        ["ua", "attach", "test-ua-token"],
+        ["ua", "status", "--all", "--format", "json"],
+        [
+            "ua",
+            "enable",
+            "disabled-service-1",
+            "disabled-service-2",
+            "service-not-in-status-data",
+            "--beta",
+            "--assume-yes",
+        ],
+        ["ua", "detach", "--assume-yes"],
+    ]
+
+
+def test_ua_manager_enable_services_no_services(fake_process):
+    """Assume services are disabled if the services node is not in the status data."""
+    fake_process.register_subprocess(
+        ["ua", "status", "--all", "--format", "json"],
         stdout='{"attached": false, "_doc": "Content..."}',
     )
     fake_process.register_subprocess(["ua", "attach", "test-ua-token"])
     fake_process.register_subprocess(
-        ["ua", "enable", "svc1", "svc2", "--beta", "--assume-yes"]
+        ["ua", "status", "--all", "--format", "json"],
+        stdout='{"attached": false, "_doc": "Content..."}',
+    )
+    fake_process.register_subprocess(
+        [
+            "ua",
+            "enable",
+            "disabled-service-1",
+            "disabled-service-2",
+            "--beta",
+            "--assume-yes",
+        ]
     )
     fake_process.register_subprocess(["ua", "detach", "--assume-yes"])
 
-    with ua_manager.ua_manager(ua_token, services=["svc1", "svc2"]):
+    with ua_manager.ua_manager(
+        "test-ua-token", services=["disabled-service-1", "disabled-service-2"]
+    ):
         pass
 
     assert list(fake_process.calls) == [
-        ["ua", "status", "--format", "json"],
+        ["ua", "status", "--all", "--format", "json"],
         ["ua", "attach", "test-ua-token"],
-        ["ua", "enable", "svc1", "svc2", "--beta", "--assume-yes"],
+        ["ua", "status", "--all", "--format", "json"],
+        [
+            "ua",
+            "enable",
+            "disabled-service-1",
+            "disabled-service-2",
+            "--beta",
+            "--assume-yes",
+        ],
         ["ua", "detach", "--assume-yes"],
     ]
 
 
 def test_ua_manager_enable_services_error(fake_process):
-    ua_token = "test-ua-token"
-
+    """Raise a UAEnableServicesError when the `ua enable` command fails."""
     fake_process.register_subprocess(
-        ["ua", "status", "--format", "json"],
+        ["ua", "status", "--all", "--format", "json"],
         stdout='{"attached": false, "_doc": "Content..."}',
     )
     fake_process.register_subprocess(["ua", "attach", "test-ua-token"])
+    fake_process.register_subprocess(
+        ["ua", "status", "--all", "--format", "json"],
+        stdout='{"attached": false, "_doc": "Content..."}',
+    )
     fake_process.register_subprocess(
         ["ua", "enable", "svc1", "svc2", "--beta", "--assume-yes"], returncode=1
     )
     fake_process.register_subprocess(["ua", "detach", "--assume-yes"])
 
     with pytest.raises(ua_manager.UAEnableServicesError) as raised:
-        with ua_manager.ua_manager(ua_token, services=["svc1", "svc2"]):
+        with ua_manager.ua_manager("test-ua-token", services=["svc1", "svc2"]):
             pass
 
     assert list(fake_process.calls) == [
-        ["ua", "status", "--format", "json"],
+        ["ua", "status", "--all", "--format", "json"],
         ["ua", "attach", "test-ua-token"],
+        ["ua", "status", "--all", "--format", "json"],
         ["ua", "enable", "svc1", "svc2", "--beta", "--assume-yes"],
         ["ua", "detach", "--assume-yes"],
     ]
@@ -130,7 +252,7 @@ def test_ua_manager_enable_services_error(fake_process):
 
 def test_ua_manager_detaches_on_error(fake_process):
     fake_process.register_subprocess(
-        ["ua", "status", "--format", "json"],
+        ["ua", "status", "--all", "--format", "json"],
         stdout='{"attached": false, "_doc": "Content..."}',
     )
     fake_process.register_subprocess(["ua", "attach", "test-ua-token"])
@@ -141,7 +263,7 @@ def test_ua_manager_detaches_on_error(fake_process):
             raise RuntimeError("whoopsie")
 
     assert list(fake_process.calls) == [
-        ["ua", "status", "--format", "json"],
+        ["ua", "status", "--all", "--format", "json"],
         ["ua", "attach", "test-ua-token"],
         ["ua", "detach", "--assume-yes"],
     ]
@@ -149,7 +271,7 @@ def test_ua_manager_detaches_on_error(fake_process):
 
 def test_ua_manager_detach_error(fake_process):
     fake_process.register_subprocess(
-        ["ua", "status", "--format", "json"],
+        ["ua", "status", "--all", "--format", "json"],
         stdout='{"attached": false, "_doc": "Content..."}',
     )
     fake_process.register_subprocess(["ua", "attach", "test-ua-token"])
@@ -160,7 +282,7 @@ def test_ua_manager_detach_error(fake_process):
             pass
 
     assert list(fake_process.calls) == [
-        ["ua", "status", "--format", "json"],
+        ["ua", "status", "--all", "--format", "json"],
         ["ua", "attach", "test-ua-token"],
         ["ua", "detach", "--assume-yes"],
     ]


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

If a UA service is already enabled, do not attempt to re-enable the service because UA will raise and error.

source: https://bugs.launchpad.net/bugs/1989500
(CRAFT-1450)