### PR TITLE
ua: do not re-enable enabled services for snapcraft_legacy

### DIFF
--- a/snapcraft_legacy/internal/repo/ua_manager.py
+++ b/snapcraft_legacy/internal/repo/ua_manager.py
@@ -87,16 +87,12 @@ def _is_service_enabled(service_name: str, service_data: List[Dict[str, str]]) -
     :return: True if the service is enabled. False is the service is disabled or not
     listed in the list of service data.
     """
-    service = next(
-        (service for service in service_data if service.get("name") == service_name),
-        None,
-    )
+    for service in service_data:
+        if service.get("name") == service_name:
+            # possible statuses are 'enabled', 'disabled', and 'n/a'
+            return service.get("status") == "enabled"
 
-    if service:
-        # possible statuses are 'enabled', 'disabled', and 'n/a'
-        return service.get("status") == "enabled"
-
-    logger.debug(f"Could not find service {service_name!r}.")
+    logger.debug("Could not find service %r.", service_name)
     return False
 
 

--- a/tests/legacy/unit/repo/test_ua_manager.py
+++ b/tests/legacy/unit/repo/test_ua_manager.py
@@ -14,11 +14,59 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import json
 import subprocess
 
 import pytest
 
 from snapcraft_legacy.internal.repo import ua_manager
+
+
+@pytest.fixture()
+def mock_status_data():
+    """Returns mock data from calling `ua status --all --format=json`.
+
+    Contains two disabled services (disabled-service-1 and disabled-service-2) and one enabled
+    service (enabled-service).
+    """
+    return json.dumps(
+        {
+            "_doc": "Content...",
+            "attached": False,
+            "services": [
+                {
+                    "available": "yes",
+                    "blocked_by": [],
+                    "description": "Common Criteria EAL2 Provisioning Packages",
+                    "description_override": None,
+                    "entitled": "yes",
+                    "name": "disabled-service-1",
+                    "status": "disabled",
+                    "status_details": "",
+                },
+                {
+                    "available": "yes",
+                    "blocked_by": [],
+                    "description": "Expanded Security Maintenance for Applications",
+                    "description_override": None,
+                    "entitled": "yes",
+                    "name": "disabled-service-2",
+                    "status": "n/a",
+                    "status_details": "Ubuntu Pro: ESM Apps is not configured",
+                },
+                {
+                    "available": "yes",
+                    "blocked_by": [],
+                    "description": "Expanded Security Maintenance for Infrastructure",
+                    "description_override": None,
+                    "entitled": "yes",
+                    "name": "enabled-service",
+                    "status": "enabled",
+                    "status_details": "Ubuntu Pro: ESM Infra is active",
+                },
+            ],
+        }
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -28,20 +76,18 @@ def _setup_fixture(mocker):
 
 
 def test_ua_manager(fake_process):
-    ua_token = "test-ua-token"
-
     fake_process.register_subprocess(
-        ["sudo", "ua", "status", "--format", "json"],
+        ["sudo", "ua", "status", "--all", "--format", "json"],
         stdout='{"attached": false, "_doc": "Content..."}',
     )
     fake_process.register_subprocess(["sudo", "ua", "attach", "test-ua-token"])
     fake_process.register_subprocess(["sudo", "ua", "detach", "--assume-yes"])
 
-    with ua_manager.ua_manager(ua_token, services=None):
+    with ua_manager.ua_manager("test-ua-token", services=None):
         pass
 
     assert list(fake_process.calls) == [
-        ["sudo", "ua", "status", "--format", "json"],
+        ["sudo", "ua", "status", "--all", "--format", "json"],
         ["sudo", "ua", "attach", "test-ua-token"],
         ["sudo", "ua", "detach", "--assume-yes"],
     ]
@@ -49,60 +95,143 @@ def test_ua_manager(fake_process):
 
 def test_ua_manager_already_attached(fake_process):
     fake_process.register_subprocess(
-        ["sudo", "ua", "status", "--format", "json"],
+        ["sudo", "ua", "status", "--all", "--format", "json"],
         stdout='{"attached": true, "_doc": "Content..."}',
     )
 
     with ua_manager.ua_manager("ua-token", services=None):
         pass
 
-    assert list(fake_process.calls) == [["sudo", "ua", "status", "--format", "json"]]
+    assert list(fake_process.calls) == [
+        ["sudo", "ua", "status", "--all", "--format", "json"]
+    ]
 
 
-def test_ua_manager_enable_services(fake_process):
-    ua_token = "test-ua-token"
-
+def test_ua_manager_enable_services(fake_process, mock_status_data):
+    """Test enabling of services:
+    - Disabled services are enabled.
+    - Services not in the status data are enabled.
+    - Enabled services are not re-enabled.
+    """
     fake_process.register_subprocess(
-        ["sudo", "ua", "status", "--format", "json"],
+        ["sudo", "ua", "status", "--all", "--format", "json"], stdout=mock_status_data
+    )
+    fake_process.register_subprocess(["sudo", "ua", "attach", "test-ua-token"])
+    fake_process.register_subprocess(
+        ["sudo", "ua", "status", "--all", "--format", "json"], stdout=mock_status_data
+    )
+    fake_process.register_subprocess(
+        [
+            "sudo",
+            "ua",
+            "enable",
+            "disabled-service-1",
+            "disabled-service-2",
+            "service-not-in-status-data",
+            "--beta",
+            "--assume-yes",
+        ]
+    )
+    fake_process.register_subprocess(["sudo", "ua", "detach", "--assume-yes"])
+
+    with ua_manager.ua_manager(
+        "test-ua-token",
+        services=[
+            "disabled-service-1",
+            "disabled-service-2",
+            "service-not-in-status-data",
+        ],
+    ):
+        pass
+
+    assert list(fake_process.calls) == [
+        ["sudo", "ua", "status", "--all", "--format", "json"],
+        ["sudo", "ua", "attach", "test-ua-token"],
+        ["sudo", "ua", "status", "--all", "--format", "json"],
+        [
+            "sudo",
+            "ua",
+            "enable",
+            "disabled-service-1",
+            "disabled-service-2",
+            "service-not-in-status-data",
+            "--beta",
+            "--assume-yes",
+        ],
+        ["sudo", "ua", "detach", "--assume-yes"],
+    ]
+
+
+def test_ua_manager_enable_services_no_services(fake_process):
+    """Assume services are disabled if the services node is not in the status data."""
+    fake_process.register_subprocess(
+        ["sudo", "ua", "status", "--all", "--format", "json"],
         stdout='{"attached": false, "_doc": "Content..."}',
     )
     fake_process.register_subprocess(["sudo", "ua", "attach", "test-ua-token"])
     fake_process.register_subprocess(
-        ["sudo", "ua", "enable", "svc1", "svc2", "--beta", "--assume-yes"]
+        ["sudo", "ua", "status", "--all", "--format", "json"],
+        stdout='{"attached": false, "_doc": "Content..."}',
+    )
+    fake_process.register_subprocess(
+        [
+            "sudo",
+            "ua",
+            "enable",
+            "disabled-service-1",
+            "disabled-service-2",
+            "--beta",
+            "--assume-yes",
+        ]
     )
     fake_process.register_subprocess(["sudo", "ua", "detach", "--assume-yes"])
 
-    with ua_manager.ua_manager(ua_token, services=["svc1", "svc2"]):
+    with ua_manager.ua_manager(
+        "test-ua-token", services=["disabled-service-1", "disabled-service-2"]
+    ):
         pass
 
     assert list(fake_process.calls) == [
-        ["sudo", "ua", "status", "--format", "json"],
+        ["sudo", "ua", "status", "--all", "--format", "json"],
         ["sudo", "ua", "attach", "test-ua-token"],
-        ["sudo", "ua", "enable", "svc1", "svc2", "--beta", "--assume-yes"],
+        ["sudo", "ua", "status", "--all", "--format", "json"],
+        [
+            "sudo",
+            "ua",
+            "enable",
+            "disabled-service-1",
+            "disabled-service-2",
+            "--beta",
+            "--assume-yes",
+        ],
         ["sudo", "ua", "detach", "--assume-yes"],
     ]
 
 
 def test_ua_manager_enable_services_error(fake_process):
-    ua_token = "test-ua-token"
-
+    """Raise a UAEnableServicesError when the `ua enable` command fails."""
     fake_process.register_subprocess(
-        ["sudo", "ua", "status", "--format", "json"],
+        ["sudo", "ua", "status", "--all", "--format", "json"],
         stdout='{"attached": false, "_doc": "Content..."}',
     )
     fake_process.register_subprocess(["sudo", "ua", "attach", "test-ua-token"])
+    fake_process.register_subprocess(
+        ["sudo", "ua", "status", "--all", "--format", "json"],
+        stdout='{"attached": false, "_doc": "Content..."}',
+    )
     fake_process.register_subprocess(
         ["sudo", "ua", "enable", "svc1", "svc2", "--beta", "--assume-yes"], returncode=1
     )
     fake_process.register_subprocess(["sudo", "ua", "detach", "--assume-yes"])
 
     with pytest.raises(subprocess.CalledProcessError) as raised:
-        with ua_manager.ua_manager(ua_token, services=["svc1", "svc2"]):
+        with ua_manager.ua_manager("test-ua-token", services=["svc1", "svc2"]):
             pass
 
     assert list(fake_process.calls) == [
-        ["sudo", "ua", "status", "--format", "json"],
+        ["sudo", "ua", "status", "--all", "--format", "json"],
         ["sudo", "ua", "attach", "test-ua-token"],
+        ["sudo", "ua", "status", "--all", "--format", "json"],
         ["sudo", "ua", "enable", "svc1", "svc2", "--beta", "--assume-yes"],
         ["sudo", "ua", "detach", "--assume-yes"],
     ]
@@ -111,7 +240,7 @@ def test_ua_manager_enable_services_error(fake_process):
 
 def test_ua_manager_detaches_on_error(fake_process):
     fake_process.register_subprocess(
-        ["sudo", "ua", "status", "--format", "json"],
+        ["sudo", "ua", "status", "--all", "--format", "json"],
         stdout='{"attached": false, "_doc": "Content..."}',
     )
     fake_process.register_subprocess(["sudo", "ua", "attach", "test-ua-token"])
@@ -122,7 +251,7 @@ def test_ua_manager_detaches_on_error(fake_process):
             raise RuntimeError("whoopsie")
 
     assert list(fake_process.calls) == [
-        ["sudo", "ua", "status", "--format", "json"],
+        ["sudo", "ua", "status", "--all", "--format", "json"],
         ["sudo", "ua", "attach", "test-ua-token"],
         ["sudo", "ua", "detach", "--assume-yes"],
     ]


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Same as https://github.com/snapcore/snapcraft/pull/3960, but for `snapcraft_legacy`.

If a UA service is already enabled, do not attempt to re-enable the service because UA will raise and error.

source: https://bugs.launchpad.net/bugs/1989500
(CRAFT-1451)