### PR TITLE
Setup snapd for snapcraft_legacy providers

### DIFF
--- a/snapcraft_legacy/internal/build_providers/_base_provider.py
+++ b/snapcraft_legacy/internal/build_providers/_base_provider.py
@@ -262,6 +262,8 @@ class Provider(abc.ABC):
         # what is on the host.
         self._setup_snapcraft()
 
+        self._setup_snapd()
+
         # Always update snapd proxy settings to match current http(s) proxy
         # settings.
         self._setup_snapd_proxy()
@@ -506,6 +508,16 @@ class Provider(abc.ABC):
         snap_injector.add(snap_name="snapcraft")
 
         snap_injector.apply()
+
+    def _setup_snapd(self) -> None:
+        """Configure snapd and wait until ready."""
+        self._run(["systemctl", "start", "snapd.socket"])
+
+        # Restart, not start, the service in case the environment
+        # has changed and the service is already running.
+        self._run(["systemctl", "restart", "snapd.service"])
+
+        self._run(["snap", "wait", "system", "seed.loaded"])
 
     def _setup_snapd_proxy(self) -> None:
         """Configure snapd proxy settings from http(s)_proxy."""

--- a/tests/legacy/unit/build_providers/lxd/test_lxd.py
+++ b/tests/legacy/unit/build_providers/lxd/test_lxd.py
@@ -281,6 +281,9 @@ class LXDInitTest(LXDBaseTest):
             ["apt-get", "update"],
             ["apt-get", "dist-upgrade", "--yes"],
             ["apt-get", "install", "--yes", "apt-transport-https"],
+            ["systemctl", "start", "snapd.socket"],
+            ["systemctl", "restart", "snapd.service"],
+            ["snap", "wait", "system", "seed.loaded"],
             ["snap", "unset", "system", "proxy.http"],
             ["snap", "unset", "system", "proxy.https"],
         ]

--- a/tests/legacy/unit/build_providers/test_base_provider.py
+++ b/tests/legacy/unit/build_providers/test_base_provider.py
@@ -189,6 +189,9 @@ class BaseProviderTest(BaseProviderBaseTest):
                     call(["apt-get", "update"]),
                     call(["apt-get", "dist-upgrade", "--yes"]),
                     call(["apt-get", "install", "--yes", "apt-transport-https"]),
+                    call(["systemctl", "start", "snapd.socket"]),
+                    call(["systemctl", "restart", "snapd.service"]),
+                    call(["snap", "wait", "system", "seed.loaded"]),
                     call(["snap", "unset", "system", "proxy.http"]),
                     call(["snap", "unset", "system", "proxy.https"]),
                 ]
@@ -320,6 +323,17 @@ class BaseProviderTest(BaseProviderBaseTest):
         # Given the way we constructe this test, this directory should not exist
         # TODO add robustness to start. (LP: #1792242)
         self.assertThat(provider.provider_project_dir, Not(DirExists()))
+
+    def test_setup_snapd(self):
+        provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)
+        provider.launch_instance()
+
+        # False.
+        provider.run_mock.assert_has_calls == [
+            call(["systemctl", "start", "snapd.socket"]),
+            call(["systemctl", "restart", "snapd.service"]),
+            call(["snap", "wait", "system", "seed.loaded"]),
+        ]
 
     def test_clean_part(self):
         provider = ProviderImpl(project=self.project, echoer=self.echoer_mock)


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

## Issue

A spread test on core18 started [consistently failing](https://github.com/snapcore/snapcraft/actions/runs/3329677836/jobs/5510607616) today.

The error is:
```
 + sudo -iu ubuntu env -i PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin bash -c 'cd /snapcraft/tests/spread/plugins/v2/snaps/make-hello && snapcraft try --use-lxd'
Launching a container.
Waiting for container to be ready
Waiting for network to be ready...
error: cannot communicate with server: Put http://localhost/v2/snaps/system/conf: dial unix /run/snapd.socket: connect: no such file or directory
Starting Snapcraft 7.2.1.post6+git822e6686
Logging execution to '/home/ubuntu/.cache/snapcraft/log/snapcraft-20221026-173239.952534.log'
An error occurred when trying to execute 'snap unset system proxy.http' with 'LXD': returned exit code 1.
```

I'm not sure why the snapd socket isn't open.  I wonder if it's due to an update to snapd.  Snapcraft_legacy injects a copy of snapd from the host into the container.  It's currently injecting snapd v`2.57.5`.  I'm not sure why it's failing only on this particular spread test that calls `snapcraft try`.  

## Solution
I copied the [snapd setup code](https://github.com/canonical/craft-providers/blob/ab325f27215ae669e6a9f41c507fa79a28f33b19/craft_providers/bases/buildd.py#L695) from `craft-providers`, which appears to solve the problem.  (Although a `sleep()` function fixes the error too, the `craft-providers` code is a safer solution)