### PR TITLE
meta: support top-level `provenance` keyword for on-prem support

### DIFF
--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -200,6 +200,7 @@ class SnapMetadata(_SnapMetadataModel):
     hooks: Optional[Dict[str, Any]]
     layout: Optional[Dict[str, Dict[str, str]]]
     system_usernames: Optional[Dict[str, Any]]
+    provenance: Optional[str]
 
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]) -> "SnapMetadata":
@@ -386,6 +387,7 @@ def write(project: Project, prime_dir: Path, *, arch: str, arch_triplet: str):
         hooks=project.hooks,
         layout=project.layout,
         system_usernames=project.system_usernames,
+        provenance=project.provenance,
     )
     if project.passthrough:
         for name, value in project.passthrough.items():

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -553,7 +553,7 @@ class Project(ProjectModel):
     def _validate_provenance(cls, provenance):
         if provenance and not re.match(r"^[a-zA-Z0-9-]+$", provenance):
             raise ValueError(
-                "provenance must consist of alphanumeric characters and hyphens."
+                "provenance must consist of alphanumeric characters and/or hyphens."
             )
 
         return provenance

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -423,6 +423,7 @@ class Project(ProjectModel):
     build_packages: Optional[GrammarStrList]
     build_snaps: Optional[GrammarStrList]
     ua_services: Optional[UniqueStrList]
+    provenance: Optional[str]
 
     @pydantic.validator("plugs")
     @classmethod
@@ -546,6 +547,16 @@ class Project(ProjectModel):
     def _validate_architecture_data(cls, architectures):
         """Validate architecture data."""
         return _validate_architectures(architectures)
+
+    @pydantic.validator("provenance")
+    @classmethod
+    def _validate_provenance(cls, provenance):
+        if provenance and not re.match(r"^[a-zA-Z0-9-]+$", provenance):
+            raise ValueError(
+                "provenance must consist of alphanumeric characters and hyphens."
+            )
+
+        return provenance
 
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]) -> "Project":

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -205,6 +205,8 @@ def complex_project():
             bind: $SNAP/gnome-platform/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0
           /usr/share/xml/iso-codes:
             bind: $SNAP/gnome-platform/usr/share/xml/iso-codes
+
+        provenance: test-provenance-1
         """
     )
     data = yaml.safe_load(snapcraft_yaml)
@@ -330,6 +332,7 @@ def test_complex_snap_yaml(complex_project, new_dir):
           snap_daemon:
             scope: shared
           snap_microk8s: shared
+        provenance: test-provenance-1
         """
     )
 

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -104,6 +104,8 @@ class TestProjectDefaults:
             )
         ]
         assert project.ua_services is None
+        assert project.system_usernames is None
+        assert project.provenance is None
 
     def test_app_defaults(self, project_yaml_data):
         data = project_yaml_data(apps={"app1": {"command": "/bin/true"}})
@@ -1018,6 +1020,43 @@ class TestAppValidation:
             with pytest.raises(errors.ProjectValidationError, match=error):
                 Project.unmarshal(data)
 
+    @pytest.mark.parametrize(
+        "system_username",
+        [
+            {"snap_daemon": {"scope": "shared"}},
+            {"snap_microk8s": {"scope": "shared"}},
+            {"snap_daemon": "shared"},
+            {"snap_microk8s": "shared"},
+        ],
+    )
+    def test_project_system_usernames_valid(self, system_username, project_yaml_data):
+        project = Project.unmarshal(project_yaml_data(system_usernames=system_username))
+        assert project.system_usernames == system_username
+
+    @pytest.mark.parametrize(
+        "system_username",
+        [
+            0,
+            "string",
+        ],
+    )
+    def test_project_system_usernames_invalid(self, system_username, project_yaml_data):
+        error = "- value is not a valid dict"
+        with pytest.raises(errors.ProjectValidationError, match=error):
+            Project.unmarshal(project_yaml_data(system_usernames=system_username))
+
+    def test_project_provenance(self, project_yaml_data):
+        """Verify provenance is parsed."""
+        project = Project.unmarshal(project_yaml_data(provenance="test-provenance-1"))
+        assert project.provenance == "test-provenance-1"
+
+    @pytest.mark.parametrize("provenance", ["invalid$", "invalid_invalid"])
+    def test_project_provenance_invalid(self, provenance, project_yaml_data):
+        """Verify invalid provenance values raises an error."""
+        error = "provenance must consist of alphanumeric characters and hyphens."
+        with pytest.raises(errors.ProjectValidationError, match=error):
+            Project.unmarshal(project_yaml_data(provenance=provenance))
+
 
 class TestGrammarValidation:
     """Basic grammar validation testing."""
@@ -1147,31 +1186,6 @@ class TestGrammarValidation:
         error = r".*- syntax error in 'on' selector"
         with pytest.raises(errors.ProjectValidationError, match=error):
             GrammarAwareProject.validate_grammar(data)
-
-    @pytest.mark.parametrize(
-        "system_username",
-        [
-            {"snap_daemon": {"scope": "shared"}},
-            {"snap_microk8s": {"scope": "shared"}},
-            {"snap_daemon": "shared"},
-            {"snap_microk8s": "shared"},
-        ],
-    )
-    def test_project_system_usernames_valid(self, system_username, project_yaml_data):
-        project = Project.unmarshal(project_yaml_data(system_usernames=system_username))
-        assert project.system_usernames == system_username
-
-    @pytest.mark.parametrize(
-        "system_username",
-        [
-            0,
-            "string",
-        ],
-    )
-    def test_project_system_usernames_invalid(self, system_username, project_yaml_data):
-        error = "- value is not a valid dict"
-        with pytest.raises(errors.ProjectValidationError, match=error):
-            Project.unmarshal(project_yaml_data(system_usernames=system_username))
 
 
 def test_get_snap_project_with_base(snapcraft_yaml):

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -1053,7 +1053,7 @@ class TestAppValidation:
     @pytest.mark.parametrize("provenance", ["invalid$", "invalid_invalid"])
     def test_project_provenance_invalid(self, provenance, project_yaml_data):
         """Verify invalid provenance values raises an error."""
-        error = "provenance must consist of alphanumeric characters and hyphens."
+        error = "provenance must consist of alphanumeric characters and/or hyphens."
         with pytest.raises(errors.ProjectValidationError, match=error):
             Project.unmarshal(project_yaml_data(provenance=provenance))
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

The `provenance` key in snapcraft.yaml can now be moved from underneath `passthrough` to a top-level key.


(CRAFT-1423)