### PR TITLE
Spread multipass tests

### DIFF
--- a/tests/spread/providers/multipass-basic/task.yaml
+++ b/tests/spread/providers/multipass-basic/task.yaml
@@ -1,8 +1,10 @@
 summary: Build a basic snap using multipass and ensure that it runs
+
+# this test does not work on google's spread runners due to a lack of virtualization support
 manual: true
 
 environment:
-  SNAP_DIR: ../../snaps/make-hello
+  SNAP_DIR: ../snaps/make-hello
 
 prepare: |
   snap list multipass || snap install --classic multipass
@@ -14,8 +16,7 @@ prepare: |
 restore: |
   cd "$SNAP_DIR"
 
-  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host.
-  unset SNAPCRAFT_BUILD_ENVIRONMENT
+  export SNAPCRAFT_BUILD_ENVIRONMENT=multipass
 
   snapcraft clean
   rm -f ./*.snap
@@ -27,8 +28,7 @@ restore: |
 execute: |
   cd "$SNAP_DIR"
 
-  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host.
-  unset SNAPCRAFT_BUILD_ENVIRONMENT
+  export SNAPCRAFT_BUILD_ENVIRONMENT=multipass
 
   snapcraft
   sudo snap install make-hello_*.snap --dangerous

--- a/tests/spread/providers/multipass-error-handling/task.yaml
+++ b/tests/spread/providers/multipass-error-handling/task.yaml
@@ -1,8 +1,10 @@
 summary: A faulty snap to test error handling
+
+# this test does not work on google's spread runners due to a lack of virtualization support
 manual: true
 
 environment:
-  SNAP_DIR: ../../snaps/exit1
+  SNAP_DIR: ../snaps/exit1
 
 prepare: |
   snap list multipass || snap install --classic multipass
@@ -14,8 +16,7 @@ prepare: |
 restore: |
   cd "$SNAP_DIR"
 
-  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host.
-  unset SNAPCRAFT_BUILD_ENVIRONMENT
+  export SNAPCRAFT_BUILD_ENVIRONMENT=multipass
 
   snapcraft clean
   rm -f ./*.snap
@@ -27,8 +28,7 @@ restore: |
 execute: |
   cd "$SNAP_DIR"
 
-  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host.
-  unset SNAPCRAFT_BUILD_ENVIRONMENT
+  export SNAPCRAFT_BUILD_ENVIRONMENT=multipass
 
   # Building this snap returns an error inside the provider. This error must
   # be handled by the outer environment and return code 2 instead of raising


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Move manual multipass tests out of the legacy directory.  

It's not a very meaningful PR, since they are manual tests that don't work on the google spread infrastructure, but this PR is still a tiny improvement.