### PR TITLE
requirements: update craft-providers to v1.6.1

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -12,7 +12,7 @@ coverage==6.5.0
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.16.0
-craft-providers==1.6.0
+craft-providers==1.6.1
 craft-store==2.3.0
 cryptography==3.4
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.16.0
-craft-providers==1.6.0
+craft-providers==1.6.1
 craft-store==2.3.0
 cryptography==3.4
 Deprecated==1.2.13


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Resolves [an error](https://forum.snapcraft.io/t/call-for-testing-snapcraft-7-2-0/32171/10) when Multipass attempts to write to a directory outside of the user's home directory.

Blocked by https://github.com/canonical/craft-providers/pull/168, which is required before releasing `craft-providers 1.6.1`.