### PR TITLE
snap config: do not crash when config cannot be retrieved

### DIFF
--- a/snapcraft_legacy/internal/common.py
+++ b/snapcraft_legacy/internal/common.py
@@ -30,7 +30,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
 
-from snaphelpers import SnapConfigOptions
+from snaphelpers import SnapConfigOptions, SnapCtlError
 
 from snapcraft_legacy.internal import errors
 
@@ -384,7 +384,16 @@ def get_snap_config() -> Optional[Dict[str, str]]:
         )
         return None
 
-    snap_config = SnapConfigOptions(keys=["provider"])
+    try:
+        snap_config = SnapConfigOptions(keys=["provider"])
+    except (AttributeError, SnapCtlError) as error:
+        # snaphelpers raises an error (either AttributeError or SnapCtlError) when
+        # it fails to get the snap config. this can occur when running inside a
+        # docker or podman container where snapd is not available
+        logger.debug("Could not retrieve the snap config. Is snapd running?")
+        logger.debug("snaphelpers error: {%r}", error)
+        return None
+
     snap_config.fetch()
 
     logger.debug("Retrieved snap config: %s", snap_config.as_dict())

--- a/tests/unit/test_snap_config.py
+++ b/tests/unit/test_snap_config.py
@@ -15,9 +15,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Unit tests for SnapConfig class."""
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from snaphelpers import SnapCtlError
 
 from snapcraft.snap_config import SnapConfig, get_snap_config
 
@@ -32,7 +33,7 @@ def mock_config():
 
 @pytest.fixture()
 def mock_is_running_from_snap(mocker):
-    mocker.patch(
+    yield mocker.patch(
         "snapcraft.snap_config.is_snapcraft_running_from_snap", return_value=True
     )
 
@@ -102,8 +103,18 @@ def test_get_snap_config_empty(mock_config, mock_is_running_from_snap):
     assert config == SnapConfig()
 
 
-def test_get_snap_config_not_from_snap(mocker):
+def test_get_snap_config_not_from_snap(mocker, mock_is_running_from_snap):
     """Verify None is returned when snapcraft is not running from a snap."""
-    mocker.patch("snapcraft.utils.is_snapcraft_running_from_snap", return_value=False)
+    mock_is_running_from_snap.return_value = False
+
+    assert get_snap_config() is None
+
+
+@pytest.mark.parametrize("error", [AttributeError, SnapCtlError(process=MagicMock())])
+def test_get_snap_config_handle_error(
+    error, mock_config, mock_is_running_from_snap, mocker
+):
+    """An error when retrieving the snap config should return None."""
+    mock_config.side_effect = error
 
     assert get_snap_config() is None


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Make the `get_snap_config()` function more robust.

In docker containers, snapcraft appears to be installed as a snap, but `snapd` is not available and it causes `snaphelpers` to raise an error when fetching the snap config.  Now, those errors are caught and logged without crashing.

https://github.com/snapcore/snapcraft/pull/3903 broke snapcraft in docker, which was reported [here](https://forum.snapcraft.io/t/snapcraft-7-2-depends-on-snapd-socket-at-runtime/32382) and [here](https://forum.snapcraft.io/t/call-for-testing-snapcraft-7-2-0/32171/16).