### PR TITLE
kernel plugin: do not copy extra-modules.conf

### DIFF
--- a/snapcraft/parts/plugins/kernel.py
+++ b/snapcraft/parts/plugins/kernel.py
@@ -861,14 +861,6 @@ class KernelPlugin(plugins.Plugin):
                     ],
                 ),
                 "done",
-                " ".join(
-                    [
-                        "cp",
-                        "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/kernel-modules/extra-modules.conf",
-                        "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/modules/main/extra-modules.conf",
-                    ],
-                ),
-                "",
             ],
         )
         firmware_dir = "${CRAFT_PART_INSTALL}/lib/firmware"

--- a/tests/unit/parts/plugins/test_kernel.py
+++ b/tests/unit/parts/plugins/test_kernel.py
@@ -1795,13 +1795,6 @@ _initrd_tool_workaroud_cmd = [
         ],
     ),
     "done",
-    " ".join(
-        [
-            "cp",
-            "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/kernel-modules/extra-modules.conf",
-            "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/modules/main/extra-modules.conf",
-        ],
-    ),
 ]
 
 _create_inird_cmd = [


### PR DESCRIPTION
Fixes failure to copy due to non-existent source file. Source file no longer exists upstream, and intended target already exists. See https://github.com/snapcore/core-initrd/tree/main/modules

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
