### PR TITLE
snap config: catch more errors when config cannot be retrieved

### DIFF
--- a/snapcraft/snap_config.py
+++ b/snapcraft/snap_config.py
@@ -77,6 +77,9 @@ def get_snap_config() -> Optional[SnapConfig]:
 
     try:
         snap_config = SnapConfigOptions(keys=["provider"])
+        # even if the initialization of SnapConfigOptions succeeds, `fetch()` may
+        # raise the same errors since it makes calls to snapd
+        snap_config.fetch()
     except (AttributeError, SnapCtlError) as error:
         # snaphelpers raises an error (either AttributeError or SnapCtlError) when
         # it fails to get the snap config. this can occur when running inside a
@@ -84,8 +87,6 @@ def get_snap_config() -> Optional[SnapConfig]:
         emit.debug("Could not retrieve the snap config. Is snapd running?")
         emit.trace(f"snaphelpers error: {error!r}")
         return None
-
-    snap_config.fetch()
 
     emit.debug(f"Retrieved snap config: {snap_config.as_dict()}")
 

--- a/snapcraft_legacy/internal/common.py
+++ b/snapcraft_legacy/internal/common.py
@@ -386,6 +386,9 @@ def get_snap_config() -> Optional[Dict[str, str]]:
 
     try:
         snap_config = SnapConfigOptions(keys=["provider"])
+        # even if the initialization of SnapConfigOptions succeeds, `fetch()` may
+        # raise the same errors since it makes calls to snapd
+        snap_config.fetch()
     except (AttributeError, SnapCtlError) as error:
         # snaphelpers raises an error (either AttributeError or SnapCtlError) when
         # it fails to get the snap config. this can occur when running inside a
@@ -393,8 +396,6 @@ def get_snap_config() -> Optional[Dict[str, str]]:
         logger.debug("Could not retrieve the snap config. Is snapd running?")
         logger.debug("snaphelpers error: {%r}", error)
         return None
-
-    snap_config.fetch()
 
     logger.debug("Retrieved snap config: %s", snap_config.as_dict())
     return snap_config.as_dict()

--- a/tests/legacy/unit/test_common.py
+++ b/tests/legacy/unit/test_common.py
@@ -246,8 +246,16 @@ def test_get_snap_config_not_from_snap(mock_is_snap, mocker):
 
 
 @pytest.mark.parametrize("error", [AttributeError, SnapCtlError(process=MagicMock())])
-def test_get_snap_config_handle_error(error, mock_config, mock_is_snap, mocker):
-    """An error when retrieving the snap config should return None."""
+def test_get_snap_config_handle_init_error(error, mock_config, mock_is_snap):
+    """An error when initializing the snap config object should return None."""
     mock_config.side_effect = error
+
+    assert common.get_snap_config() is None
+
+
+@pytest.mark.parametrize("error", [AttributeError, SnapCtlError(process=MagicMock())])
+def test_get_snap_config_handle_fetch_error(error, mock_config, mock_is_snap):
+    """An error when fetching the snap config should return None."""
+    mock_config.return_value.fetch.side_effect = error
 
     assert common.get_snap_config() is None

--- a/tests/unit/test_snap_config.py
+++ b/tests/unit/test_snap_config.py
@@ -103,7 +103,7 @@ def test_get_snap_config_empty(mock_config, mock_is_running_from_snap):
     assert config == SnapConfig()
 
 
-def test_get_snap_config_not_from_snap(mocker, mock_is_running_from_snap):
+def test_get_snap_config_not_from_snap(mock_is_running_from_snap):
     """Verify None is returned when snapcraft is not running from a snap."""
     mock_is_running_from_snap.return_value = False
 
@@ -111,10 +111,20 @@ def test_get_snap_config_not_from_snap(mocker, mock_is_running_from_snap):
 
 
 @pytest.mark.parametrize("error", [AttributeError, SnapCtlError(process=MagicMock())])
-def test_get_snap_config_handle_error(
-    error, mock_config, mock_is_running_from_snap, mocker
+def test_get_snap_config_handle_init_error(
+    error, mock_config, mock_is_running_from_snap
 ):
-    """An error when retrieving the snap config should return None."""
+    """An error when initializing the snap config object should return None."""
     mock_config.side_effect = error
+
+    assert get_snap_config() is None
+
+
+@pytest.mark.parametrize("error", [AttributeError, SnapCtlError(process=MagicMock())])
+def test_get_snap_config_handle_fetch_error(
+    error, mock_config, mock_is_running_from_snap
+):
+    """An error when fetching the snap config should return None."""
+    mock_config.return_value.fetch.side_effect = error
 
     assert get_snap_config() is None


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Follow up to https://github.com/snapcore/snapcraft/pull/3971 to catch another error reported [here](https://forum.snapcraft.io/t/call-for-testing-snapcraft-7-2-0/32171/27).