### PR TITLE
cli: accept snap file in legacy upload-metadata command

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -6,14 +6,14 @@ We want to make sure everyone develops using a consistent base, to ensure that t
 
 Clone these sources and make it your working directory:
 
-```
+```shell
 git clone https://github.com/snapcore/snapcraft.git
 cd snapcraft
 ```
 
 If you already have LXD setup you can skip this part, if not, run:
 
-```
+```shell
 sudo snap install lxd
 sudo lxd init --auto --storage-backend=dir
 sudo adduser "$USER" lxd
@@ -22,17 +22,17 @@ newgrp lxd
 
 Setup the environment by running:
 
-```
+```shell
 ./tools/environment-setup.sh
 ```
 
 To work inside this environment, run:
 
-```
+```shell
 lxc exec snapcraft-dev -- sudo -iu ubuntu bash
 ```
 
-Import your keys (`ssh-import-id`) and add a `Host` entry to your ssh config if you are interested in [Code's](https://snapcraft.io/code) [Remote-SSH]() plugin.
+Import your keys (`ssh-import-id`) and add a `Host` entry to your ssh config if you are interested in [Code's](https://snapcraft.io/code) [Remote-SSH](https://code.visualstudio.com/docs/remote/ssh) plugin.
 
 ### Testing
 

--- a/snapcraft/commands/legacy.py
+++ b/snapcraft/commands/legacy.py
@@ -71,6 +71,12 @@ class StoreLegacyUploadMetadataCommand(LegacyBaseCommand):
     @overrides
     def fill_parser(self, parser: "argparse.ArgumentParser") -> None:
         parser.add_argument(
+            "snap_file",
+            metavar="snap-file",
+            type=str,
+            help="Snap to upload metadata from",
+        )
+        parser.add_argument(
             "--force",
             action="store_true",
             default=False,

--- a/tools/environment-setup-local.sh
+++ b/tools/environment-setup-local.sh
@@ -47,5 +47,8 @@ sudo snap install black --beta
 # Install shellcheck for static tests.
 sudo snap install shellcheck
 
+# Install pyright for static tests.
+sudo snap install pyright --classic
+
 echo "Virtual environment may be activated by running:"
 echo "source ${SNAPCRAFT_VIRTUAL_ENV_DIR}/bin/activate"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

fxes: https://bugs.launchpad.net/snapcraft/+bug/1995857


The legacy upload-metadata command didn't have a location argument for the snap file itself. This PR adds that argument, and fixes some issues with the hacking doc and environment setup.


```shell
$snapcraft upload-metadata signal-desktop_5.57.0_amd64-core18.snap
Usage: snapcraft [options] command [args]...
Try 'snapcraft upload-metadata -h' for help.

Error: unrecognized arguments: signal-desktop_5.57.0_amd64-core18.snap
```