### PR TITLE
tests: allow local git submodules

### DIFF
--- a/tests/legacy/unit/sources/test_git.py
+++ b/tests/legacy/unit/sources/test_git.py
@@ -721,7 +721,7 @@ class TestGitConflicts(GitBaseTestCase):
         call(["git", "init", "--bare"])
 
         self.clone_repo(repo, working_tree)
-        call(["git", "submodule", "add", sub_repo])
+        call(["git", "-c", "protocol.file.allow=always", "submodule", "add", sub_repo])
         call(["git", "commit", "-am", "added submodule"])
         call(["git", "push", repo])
 
@@ -747,7 +747,18 @@ class TestGitConflicts(GitBaseTestCase):
 
         # update the submodule
         self.clone_repo(repo, working_tree_two)
-        call(["git", "submodule", "update", "--init", "--recursive", "--remote"])
+        call(
+            [
+                "git",
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "update",
+                "--init",
+                "--recursive",
+                "--remote",
+            ]
+        )
         call(["git", "add", "subrepo"])
         call(["git", "commit", "-am", "updated submodule"])
         call(["git", "push"])


### PR DESCRIPTION
git v2.34.1 requires the config `protocol.file.allow=always` when adding a local submodule

Co-authored-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
