### PR TITLE
lifecycle: fix double emit.pause() call

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -471,8 +471,7 @@ def _run_in_provider(
     emit.debug("Checking build provider availability")
     provider_name = "lxd" if parsed_args.use_lxd else None
     provider = providers.get_provider(provider_name)
-    with emit.pause():
-        providers.ensure_provider_is_available(provider)
+    providers.ensure_provider_is_available(provider)
 
     cmd = ["snapcraft", command_name]
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

This resolves an issue where `emit.pause()` is called twice when the build provider is not installed and raises a RuntimeError (reported [here](https://bugs.launchpad.net/snapcraft/+bug/1995877) and [here](https://forum.snapcraft.io/t/call-for-testing-snapcraft-7-2-0/32171/30))

This also resolves a smaller issue with log output from craft-providers not being logged.  The setup of the instance was behind the paused emitter and not being logged properly.

This double `emit.pause()` bug happened because two PRs added `emit.pause()` in different places at different times (https://github.com/snapcore/snapcraft/pull/3919 and https://github.com/snapcore/snapcraft/pull/3866).  I merged the second PR without realizing the first PR already solved the problem.