### PR TITLE
repo: raise error when populating the apt cache directory fails

### DIFF
--- a/snapcraft_legacy/internal/repo/apt_cache.py
+++ b/snapcraft_legacy/internal/repo/apt_cache.py
@@ -110,6 +110,7 @@ class AptCache(ContextDecorator):
             return
 
         # Copy apt configuration from host.
+        etc_apt_path = Path("/etc/apt")
         cache_etc_apt_path = Path(self.stage_cache, "etc", "apt")
 
         # Delete potentially outdated cache configuration.
@@ -121,14 +122,20 @@ class AptCache(ContextDecorator):
         # Copy current cache configuration.
         cache_etc_apt_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # systems with ubuntu pro have an auth file in /etc/apt readable only by root
-        # this may raise an error when copying /etc/apt into the cache directory
+        # systems with ubuntu pro have an auth file inside the /etc/apt directory.
+        # this auth file is readable only by root, so the copytree call below may
+        # fail when attempting to copy this file into the cache directory
         try:
-            shutil.copytree("/etc/apt", cache_etc_apt_path)
+            shutil.copytree(etc_apt_path, cache_etc_apt_path)
         except shutil.Error as error:
             # copytree is a multi-file operation, so it generates a list of exceptions
             # each exception in the list is a 3-element tuple: (source, dest, reason)
             raise errors.PopulateCacheDirError(error.args[0]) from error
+        except PermissionError as error:
+            # catch the PermissionError raised when `/etc/apt` is unreadable
+            raise errors.PopulateCacheDirError(
+                [(etc_apt_path, cache_etc_apt_path, error)]
+            ) from error
 
         # Specify default arch (if specified).
         if self.stage_cache_arch is not None:

--- a/snapcraft_legacy/internal/repo/errors.py
+++ b/snapcraft_legacy/internal/repo/errors.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pathlib import Path
-from typing import List, Optional, Sequence
+from typing import List, Optional, Sequence, Tuple
 
 from snapcraft_legacy import formatting_utils
 from snapcraft_legacy.internal import errors
@@ -55,6 +55,27 @@ class CacheUpdateFailedError(RepoError):
         else:
             errors = " "
         super().__init__(errors=errors)
+
+
+class PopulateCacheDirError(SnapcraftException):
+    def __init__(self, copy_errors: List[Tuple]) -> None:
+        """:param copy_errors: A list of tuples containing the copy errors, where each
+        tuple is ordered as (source, destination, reason)."""
+        self.copy_errors = copy_errors
+
+    def get_brief(self) -> str:
+        return "Could not populate apt cache directory."
+
+    def get_details(self) -> str:
+        """Build a readable list of errors."""
+        details = ""
+        for error in self.copy_errors:
+            source, dest, reason = error
+            details += f"Unable to copy {source} to {dest}: {reason}\n"
+        return details
+
+    def get_resolution(self) -> str:
+        return "Verify user has read access to contents of /etc/apt."
 
 
 class FileProviderNotFound(RepoError):

--- a/tests/legacy/unit/repo/test_apt_cache.py
+++ b/tests/legacy/unit/repo/test_apt_cache.py
@@ -15,14 +15,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import shutil
 import unittest
 from pathlib import Path
 from unittest.mock import call
 
 import fixtures
+import pytest
 from testtools.matchers import Equals
 
 from snapcraft_legacy.internal.repo.apt_cache import AptCache
+from snapcraft_legacy.internal.repo.errors import PopulateCacheDirError
 from tests.legacy import unit
 
 
@@ -191,3 +194,40 @@ class TestAptReadonlyHostCache(unit.TestCase):
             self.assertThat(
                 apt_cache.get_installed_version("fake-news-bears"), Equals(None)
             )
+
+
+def test_populate_stage_cache_dir_error(mocker, tmp_path):
+    """Raise an error when the apt cache directory cannot be populated."""
+    mock_copytree = mocker.patch(
+        "snapcraft_legacy.internal.repo.apt_cache.shutil.copytree",
+        side_effect=shutil.Error(
+            [
+                (
+                    "/etc/apt/source-file-1",
+                    "/root/.cache/dest-file-1",
+                    "[Errno 13] Permission denied: '/etc/apt/source-file-1'",
+                ),
+                (
+                    "/etc/apt/source-file-2",
+                    "/root/.cache/dest-file-2",
+                    "[Errno 13] Permission denied: '/etc/apt/source-file-2'",
+                ),
+            ]
+        ),
+    )
+
+    with pytest.raises(PopulateCacheDirError) as raised:
+        with AptCache() as apt_cache:
+            # set stage_cache directory so method does not return early
+            apt_cache.stage_cache = tmp_path
+            apt_cache._populate_stage_cache_dir()
+
+    assert mock_copytree.mock_calls == [call("/etc/apt", tmp_path / "etc/apt")]
+
+    # verify the data inside the shutil error was passed to PopulateCacheDirError
+    assert raised.value.get_details() == (
+        "Unable to copy /etc/apt/source-file-1 to /root/.cache/dest-file-1: "
+        "[Errno 13] Permission denied: '/etc/apt/source-file-1'\n"
+        "Unable to copy /etc/apt/source-file-2 to /root/.cache/dest-file-2: "
+        "[Errno 13] Permission denied: '/etc/apt/source-file-2'\n"
+    )

--- a/tests/legacy/unit/repo/test_errors.py
+++ b/tests/legacy/unit/repo/test_errors.py
@@ -181,3 +181,33 @@ def test_multiple_packages_not_found_error():
     assert exception.get_details() is None
     assert exception.get_docs_url() is None
     assert exception.get_reportable() is False
+
+
+def test_snapcraft_exception_handling():
+    exception = errors.PopulateCacheDirError(
+        [
+            (
+                "/etc/apt/source-file-1",
+                "/root/.cache/dest-file-1",
+                "[Errno 13] Permission denied: '/etc/apt/source-file-1'",
+            ),
+            (
+                "/etc/apt/source-file-2",
+                "/root/.cache/dest-file-2",
+                "[Errno 13] Permission denied: '/etc/apt/source-file-2'",
+            ),
+        ]
+    )
+
+    assert exception.get_brief() == "Could not populate apt cache directory."
+    assert exception.get_resolution() == (
+        "Verify user has read access to contents of /etc/apt."
+    )
+    assert exception.get_details() == (
+        "Unable to copy /etc/apt/source-file-1 to /root/.cache/dest-file-1: "
+        "[Errno 13] Permission denied: '/etc/apt/source-file-1'\n"
+        "Unable to copy /etc/apt/source-file-2 to /root/.cache/dest-file-2: "
+        "[Errno 13] Permission denied: '/etc/apt/source-file-2'\n"
+    )
+    assert exception.get_docs_url() is None
+    assert exception.get_reportable() is False


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

If the contents of `/etc/apt` cannot be copied to the cache directory, snapcraft will now produce a helpful error.

This can occur on a system where Ubuntu Pro is enabled, snapcraft is run in destructive mode, and snapcraft is not being run with sudo nor as root.

(CRAFT-1421)