### PR TITLE
elf: patch elf files for classic mode

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -11,7 +11,7 @@ codespell==2.2.1
 coverage==6.5.0
 craft-cli==1.2.0
 craft-grammar==1.1.1
-craft-parts==1.16.0
+craft-parts==1.17.0
 craft-providers==1.6.1
 craft-store==2.3.0
 cryptography==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ charset-normalizer==2.1.1
 click==8.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
-craft-parts==1.16.0
+craft-parts==1.17.0
 craft-providers==1.6.1
 craft-store==2.3.0
 cryptography==3.4

--- a/snapcraft/elf/_patcher.py
+++ b/snapcraft/elf/_patcher.py
@@ -62,13 +62,14 @@ class Patcher:
         patchelf_args = []
         if elf_file.interp and elf_file.interp != self._dynamic_linker:
             patchelf_args.extend(["--set-interpreter", self._dynamic_linker])
+            emit.progress(f"  Interpreter={self._dynamic_linker!r}")
 
         if elf_file.dependencies:
             current_rpath = self.get_current_rpath(elf_file)
             proposed_rpath = self.get_proposed_rpath(elf_file)
 
-            emit.debug(f"Patcher.patch: current_rpath={current_rpath!r}")
-            emit.debug(f"Patcher.patch: proposed_rpath={proposed_rpath!r}")
+            emit.progress(f"  Current rpath={current_rpath}")
+            emit.progress(f"  Proposed rpath={proposed_rpath}")
 
             # Removing the current rpath should not be necessary after patchelf 0.11,
             # see https://github.com/NixOS/patchelf/issues/94

--- a/snapcraft/elf/_patcher.py
+++ b/snapcraft/elf/_patcher.py
@@ -41,7 +41,7 @@ class Patcher:
         """Create a Patcher instance.
 
         :param dynamic_linker: The path to the dynamic linker to set the ELF file to.
-        :param snap_path: The base path for the snap being processed.
+        :param root_path: The base path for the snap being processed.
         :param preferred_patchelf: patch the necessary elf_files with this patchelf.
         """
         self._dynamic_linker = dynamic_linker
@@ -66,6 +66,9 @@ class Patcher:
         if elf_file.dependencies:
             current_rpath = self.get_current_rpath(elf_file)
             proposed_rpath = self.get_proposed_rpath(elf_file)
+
+            emit.debug(f"Patcher.patch: current_rpath={current_rpath!r}")
+            emit.debug(f"Patcher.patch: proposed_rpath={proposed_rpath!r}")
 
             # Removing the current rpath should not be necessary after patchelf 0.11,
             # see https://github.com/NixOS/patchelf/issues/94

--- a/snapcraft/elf/errors.py
+++ b/snapcraft/elf/errors.py
@@ -30,10 +30,7 @@ class PatcherError(errors.SnapcraftError):
         self.cmd = cmd
         self.code = code
 
-        super().__init__(
-            f"{str(path)!r} cannot be patched to function properly in a classic"
-            f"confined snap: {cmd} failed with exit code {code}"
-        )
+        super().__init__(f"Error patching ELF file: {cmd} failed with exit code {code}")
 
 
 class CorruptedElfFile(errors.SnapcraftError):

--- a/snapcraft/linters/classic_linter.py
+++ b/snapcraft/linters/classic_linter.py
@@ -76,13 +76,12 @@ class ClassicLinter(Linter):
         elf_files = elf_utils.get_elf_files(current_path)
         patcher = Patcher(dynamic_linker=linker, root_path=current_path.absolute())
         soname_cache = SonameCache()
+        arch_triplet = elf_utils.get_arch_triplet()
 
         for elf_file in elf_files:
             # Skip linting files listed in the ignore list.
             if self._is_file_ignored(elf_file):
                 continue
-
-            arch_triplet = elf_utils.get_arch_triplet()
 
             elf_file.load_dependencies(
                 root_path=current_path.absolute(),

--- a/snapcraft/linters/library_linter.py
+++ b/snapcraft/linters/library_linter.py
@@ -19,9 +19,11 @@
 from pathlib import Path, PurePath
 from typing import List
 
+from craft_cli import emit
 from overrides import overrides
 
 from snapcraft.elf import ElfFile, SonameCache, elf_utils
+from snapcraft.elf import errors as elf_errors
 
 from .base import Linter, LinterIssue, LinterResult
 
@@ -87,8 +89,20 @@ class LibraryLinter(Linter):
         :param root_path: The absolute path to the payload directory.
         :param issues: The list of linter issues.
         """
+        try:
+            linker = elf_utils.get_dynamic_linker(root_path=Path("/"), snap_path=Path())
+            linker_name = Path(linker).name
+        except elf_errors.DynamicLinkerNotFound:
+            linker_name = None
+
+        emit.debug(f"dynamic linker name is: {linker_name}")
+
         for dependency in dependencies:
             dependency_path = PurePath(dependency)
+
+            # the dynamic linker is not a regular library
+            if linker_name == dependency_path.name:
+                continue
 
             for path in search_paths:
                 if path in dependency_path.parents:

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -643,7 +643,8 @@ def _patch_elf(step_info: StepInfo) -> bool:
             soname_cache=soname_cache,
         )
 
-        emit.progress(f"Patch ELF file: {str(elf_file.path)!r}")
+        relative_path = elf_file.path.relative_to(step_info.prime_dir)
+        emit.progress(f"Patch ELF file: {str(relative_path)!r}")
         patcher.patch(elf_file=elf_file)
 
     return True

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -27,10 +27,12 @@ from typing import TYPE_CHECKING, Any, Dict, List, Tuple
 
 import craft_parts
 from craft_cli import emit
-from craft_parts import ProjectInfo, StepInfo, callbacks
+from craft_parts import ProjectInfo, Step, StepInfo, callbacks
 from craft_providers import Executor
 
 from snapcraft import errors, extensions, linters, pack, providers, ua_manager, utils
+from snapcraft.elf import Patcher, SonameCache, elf_utils
+from snapcraft.elf import errors as elf_errors
 from snapcraft.linters import LinterStatus
 from snapcraft.meta import manifest, snap_yaml
 from snapcraft.projects import (
@@ -192,6 +194,7 @@ def run(command_name: str, parsed_args: "argparse.Namespace") -> None:
     # Register our own callbacks
     callbacks.register_prologue(_set_global_environment)
     callbacks.register_pre_step(_set_step_environment)
+    callbacks.register_post_step(_patch_elf, step_list=[Step.PRIME])
 
     build_count = utils.get_parallel_build_count()
 
@@ -597,6 +600,52 @@ def _set_step_environment(step_info: StepInfo) -> bool:
             "SNAPCRAFT_PART_INSTALL": str(step_info.part_install_dir),
         }
     )
+    return True
+
+
+def _patch_elf(step_info: StepInfo) -> bool:
+    """Patch rpath and interpreter in ELF files for classic mode."""
+    if "enable-patchelf" not in step_info.build_attributes:
+        emit.debug(f"patch_elf: not enabled for part {step_info.part_name!r}")
+        return True
+
+    if not step_info.state:
+        emit.debug("patch_elf: no state information")
+        return True
+
+    try:
+        # If libc is staged we'll find a dynamic linker in the payload. At
+        # runtime the linker will be in the installed snap path.
+        linker = elf_utils.get_dynamic_linker(
+            root_path=step_info.prime_dir,
+            snap_path=Path(f"/snap/{step_info.project_name}/current"),
+        )
+    except elf_errors.DynamicLinkerNotFound:
+        # Otherwise look for the host linker, which should match the base
+        # system linker. At runtime use the linker from the installed base
+        # snap.
+        linker = elf_utils.get_dynamic_linker(
+            root_path=Path("/"), snap_path=Path(f"/snap/{step_info.base}/current")
+        )
+
+    migrated_files = step_info.state.files
+    patcher = Patcher(dynamic_linker=linker, root_path=step_info.prime_dir)
+    elf_files = elf_utils.get_elf_files_from_list(step_info.prime_dir, migrated_files)
+    soname_cache = SonameCache()
+    arch_triplet = elf_utils.get_arch_triplet()
+
+    for elf_file in elf_files:
+        elf_file.load_dependencies(
+            root_path=step_info.prime_dir,
+            base_path=Path(f"/snap/{step_info.base}/current"),
+            content_dirs=[],  # classic snaps don't use content providers
+            arch_triplet=arch_triplet,
+            soname_cache=soname_cache,
+        )
+
+        emit.progress(f"Patch ELF file: {str(elf_file.path)!r}")
+        patcher.patch(elf_file=elf_file)
+
     return True
 
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -295,6 +295,11 @@ suites:
    systems:
      - ubuntu-22.04*
 
+ tests/spread/core22/patchelf/:
+   summary: core22 patchelf tests
+   systems:
+     - ubuntu-22.04*
+
  # General, core suite
  tests/spread/general/:
    summary: tests of snapcraft core functionality

--- a/tests/spread/core22/patchelf/classic-patchelf/Makefile
+++ b/tests/spread/core22/patchelf/classic-patchelf/Makefile
@@ -1,0 +1,11 @@
+# -*- Mode: Makefile; indent-tabs-mode:t; tab-width: 4 -*-
+.PHONY: all
+
+all: hello-classic
+
+install: hello-classic
+	install -d $(DESTDIR)/bin/
+	install -D $^ $(DESTDIR)/bin/
+
+hello-classic: hello-classic.c
+	$(CC) hello-classic.c -o hello-classic -lcurl

--- a/tests/spread/core22/patchelf/classic-patchelf/hello-classic.c
+++ b/tests/spread/core22/patchelf/classic-patchelf/hello-classic.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include <curl/curl.h>
+
+int main() {
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+}

--- a/tests/spread/core22/patchelf/classic-patchelf/snap/snapcraft.yaml
+++ b/tests/spread/core22/patchelf/classic-patchelf/snap/snapcraft.yaml
@@ -1,0 +1,42 @@
+name: classic-patchelf
+version: "0.1"
+summary: Build a classic confined snap
+description: |
+  Build a classic confined snap, mostly used to test the provisioning
+  of `core` inside a snap.
+base: core22
+
+grade: devel
+confinement: classic
+
+parts:
+  hello:
+    source: .
+    plugin: make
+    build-attributes:
+      - enable-patchelf
+    build-packages:
+      - gcc
+      - libcurl4-openssl-dev
+  hello-existing-rpath:
+    source: .
+    plugin: make
+    build-attributes:
+      - enable-patchelf
+    build-packages:
+      - gcc
+      - libcurl4-openssl-dev
+      - patchelf
+    override-build: |
+      snapcraftctl build
+      mv $CRAFT_PART_INSTALL/bin/hello-classic $CRAFT_PART_INSTALL/bin/hello-classic-existing-rpath
+      patchelf --force-rpath --set-rpath "\$ORIGIN/../fake-lib" $CRAFT_PART_INSTALL/bin/hello-classic-existing-rpath
+  hello-no-patchelf:
+    source: .
+    plugin: make
+    build-packages:
+      - gcc
+      - libcurl4-openssl-dev
+    override-build: |
+      snapcraftctl build
+      mv $CRAFT_PART_INSTALL/bin/hello-classic $CRAFT_PART_INSTALL/bin/hello-classic-no-patchelf

--- a/tests/spread/core22/patchelf/classic-patchelf/task.yaml
+++ b/tests/spread/core22/patchelf/classic-patchelf/task.yaml
@@ -1,0 +1,46 @@
+summary: Build a classic snap and validates elf patching
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base snap/snapcraft.yaml
+
+  apt-get install patchelf dpkg-dev -y
+  apt-mark auto patchelf dpkg-dev
+
+restore: |
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  base="$(get_base)"
+
+  snapcraft prime
+
+  arch_triplet="$(dpkg-architecture -q DEB_HOST_MULTIARCH)"
+
+  # Account for /usr merge.
+  RPATH_MATCH="^/snap/$base/current/lib/$arch_triplet"
+  RPATH_ORIGIN_MATCH="^\\\$ORIGIN/../fake-lib:/snap/$base/current/lib/$arch_triplet"
+
+  # Verify typical binary.
+  patchelf --print-interpreter prime/bin/hello-classic | MATCH "^/snap/$base/current/lib.*ld.*.so.*"
+  patchelf --print-rpath prime/bin/hello-classic | MATCH "${RPATH_MATCH}"
+
+  # Verify binary w/ existing rpath.
+  patchelf --print-interpreter prime/bin/hello-classic-existing-rpath | MATCH "^/snap/$base/current/lib.*ld.*.so.*"
+  patchelf --print-rpath prime/bin/hello-classic-existing-rpath | MATCH "${RPATH_ORIGIN_MATCH}"
+
+  # Verify untouched no-patchelf.
+  patchelf --print-interpreter prime/bin/hello-classic-no-patchelf | MATCH "^/lib.*ld.*.so.*"
+  rpath="$(patchelf --print-rpath prime/bin/hello-classic-no-patchelf)"
+  if [[ -n "${rpath}" ]]; then
+     echo "found rpath with no-patchelf: ${rpath}"
+     exit 1
+  fi

--- a/tests/spread/core22/patchelf/strict-patchelf/Makefile
+++ b/tests/spread/core22/patchelf/strict-patchelf/Makefile
@@ -1,0 +1,11 @@
+# -*- Mode: Makefile; indent-tabs-mode:t; tab-width: 4 -*-
+.PHONY: all
+
+all: hello-strict
+
+install: hello-strict
+	install -d $(DESTDIR)/bin/
+	install -D $^ $(DESTDIR)/bin/
+
+hello-strict: hello-strict.c
+	$(CC) hello-strict.c -o hello-strict -lcurl

--- a/tests/spread/core22/patchelf/strict-patchelf/hello-strict.c
+++ b/tests/spread/core22/patchelf/strict-patchelf/hello-strict.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include <curl/curl.h>
+
+int main() {
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+}

--- a/tests/spread/core22/patchelf/strict-patchelf/snap/snapcraft.yaml
+++ b/tests/spread/core22/patchelf/strict-patchelf/snap/snapcraft.yaml
@@ -1,0 +1,41 @@
+name: strict-patchelf
+version: "0.1"
+summary: Build a strictly confined snap
+description: |
+  Build a strictly confined snap to test ELF patching
+base: core22
+
+grade: devel
+confinement: strict
+
+parts:
+  hello:
+    source: .
+    plugin: make
+    build-packages:
+      - gcc
+      - libcurl4-openssl-dev
+  hello-existing-rpath:
+    source: .
+    plugin: make
+    build-packages:
+      - gcc
+      - libcurl4-openssl-dev
+      - patchelf
+    build-attributes:
+      - enable-patchelf
+    override-build: |
+      snapcraftctl build
+      mv $CRAFT_PART_INSTALL/bin/hello-strict $CRAFT_PART_INSTALL/bin/hello-strict-existing-rpath
+      patchelf --force-rpath --set-rpath "\$ORIGIN/../fake-lib" $CRAFT_PART_INSTALL/bin/hello-strict-existing-rpath
+  hello-enable-patchelf:
+    source: .
+    plugin: make
+    build-packages:
+      - gcc
+      - libcurl4-openssl-dev
+    build-attributes:
+      - enable-patchelf
+    override-build: |
+      snapcraftctl build
+      mv $CRAFT_PART_INSTALL/bin/hello-strict $CRAFT_PART_INSTALL/bin/hello-strict-enable-patchelf

--- a/tests/spread/core22/patchelf/strict-patchelf/task.yaml
+++ b/tests/spread/core22/patchelf/strict-patchelf/task.yaml
@@ -1,0 +1,47 @@
+summary: Build a strict snap and validate elf patching
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "snap/snapcraft.yaml"
+
+  apt-get install patchelf dpkg-dev -y
+  apt-mark auto patchelf dpkg-dev
+restore: |
+  snapcraft clean
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  base="$(get_base)"
+
+  cat snap/snapcraft.yaml
+  snapcraft prime
+
+  arch_triplet="$(dpkg-architecture -q DEB_HOST_MULTIARCH)"
+
+  # Verify typical strict binary has an untouched rpath
+  patchelf --print-interpreter prime/bin/hello-strict | MATCH "^/lib.*ld.*.so.*"
+  rpath="$(patchelf --print-rpath prime/bin/hello-strict)"
+  if [[ -n "${rpath}" ]]; then
+     echo "found rpath on strict binary: ${rpath}"
+     exit 1
+  fi
+
+  # Account for /usr merge.
+  RPATH_MATCH="^/snap/$base/current/lib/$arch_triplet"
+  RPATH_ORIGIN_MATCH="^\\\$ORIGIN/../fake-lib:/snap/$base/current/lib/$arch_triplet"
+
+  # Verify binary rpath patching with existing rpath
+  patchelf --print-interpreter prime/bin/hello-strict-existing-rpath | MATCH "^/snap/$base/current/lib.*ld.*.so.*"
+  patchelf --print-rpath prime/bin/hello-strict-existing-rpath | MATCH "${RPATH_ORIGIN_MATCH}"
+
+  # Verify binary rpath patching without existing rpath
+  patchelf --print-interpreter prime/bin/hello-strict-enable-patchelf | MATCH "^/snap/$base/current/lib.*ld.*.so.*"
+  patchelf --print-rpath prime/bin/hello-strict-enable-patchelf | MATCH "${RPATH_MATCH}"
+


### PR DESCRIPTION
If `enable-patchelf` is listed in the part's build attributes, patch the part's ELF binaries to use the interpreter and libraries from the base snap (or use bundled components if libc is staged).

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
CRAFT-1460