### PR TITLE
extensions, ros: remove experimental flag

### DIFF
--- a/snapcraft/extensions/ros2_humble.py
+++ b/snapcraft/extensions/ros2_humble.py
@@ -45,7 +45,7 @@ class ROS2HumbleExtension(Extension):
     @staticmethod
     @overrides
     def is_experimental(base: Optional[str]) -> bool:
-        return True
+        return False
 
     @overrides
     def get_root_snippet(self) -> Dict[str, Any]:

--- a/snapcraft_legacy/internal/project_loader/_extensions/ros1_noetic.py
+++ b/snapcraft_legacy/internal/project_loader/_extensions/ros1_noetic.py
@@ -39,7 +39,7 @@ class ExtensionImpl(Extension):
 
     @staticmethod
     def is_experimental(base: Optional[str]) -> bool:
-        return True
+        return False
 
     def __init__(self, *, extension_name: str, yaml_data: Dict[str, Any]) -> None:
         super().__init__(extension_name=extension_name, yaml_data=yaml_data)

--- a/snapcraft_legacy/internal/project_loader/_extensions/ros2_foxy.py
+++ b/snapcraft_legacy/internal/project_loader/_extensions/ros2_foxy.py
@@ -41,7 +41,7 @@ class ExtensionImpl(Extension):
 
     @staticmethod
     def is_experimental(base: Optional[str]) -> bool:
-        return True
+        return False
 
     def __init__(self, *, extension_name: str, yaml_data: Dict[str, Any]) -> None:
         super().__init__(extension_name=extension_name, yaml_data=yaml_data)

--- a/tests/spread/plugins/v2/catkin-ros1-catkin-packages-ignore/task.yaml
+++ b/tests/spread/plugins/v2/catkin-ros1-catkin-packages-ignore/task.yaml
@@ -5,7 +5,6 @@ kill-timeout: 180m
 
 environment:
   SNAP/catkin_catkin_packages_ignore: catkin-catkin-packages-ignore
-  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
 systems:
   - ubuntu-20.04

--- a/tests/spread/plugins/v2/catkin-ros1-run/task.yaml
+++ b/tests/spread/plugins/v2/catkin-ros1-run/task.yaml
@@ -4,7 +4,6 @@ kill-timeout: 180m
 
 environment:
   SNAP/catkin_ros1_run: catkin-ros1-run
-  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
 systems:
   - ubuntu-20.04

--- a/tests/spread/plugins/v2/colcon-ros2-daemon/task.yaml
+++ b/tests/spread/plugins/v2/colcon-ros2-daemon/task.yaml
@@ -4,7 +4,6 @@ priority: 100  # Run this test early so we're not waiting for it
 
 environment:
   SNAP_DIR: ../snaps/colcon-daemon
-  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh

--- a/tests/spread/plugins/v2/colcon-ros2-hello/task.yaml
+++ b/tests/spread/plugins/v2/colcon-ros2-hello/task.yaml
@@ -7,7 +7,6 @@ kill-timeout: 180m
 environment:
   SNAP/colcon_ros2_foxy_rlcpp_hello: colcon-ros2-foxy-rlcpp-hello
   SNAP/colcon_subdir: colcon-subdir
-  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
 systems:
   - ubuntu-20.04

--- a/tests/spread/plugins/v2/colcon-ros2-stage-snap/task.yaml
+++ b/tests/spread/plugins/v2/colcon-ros2-stage-snap/task.yaml
@@ -6,7 +6,6 @@ kill-timeout: 180m
 
 environment:
   SNAP/colcon_stage_snaps: colcon-stage-snaps
-  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
 systems:
   - ubuntu-20.04

--- a/tests/spread/plugins/v2/ros-plugins-error-code/task.yaml
+++ b/tests/spread/plugins/v2/ros-plugins-error-code/task.yaml
@@ -7,7 +7,6 @@ environment:
   SNAP/catkin_noetic_hello: catkin-noetic-hello
   SNAP/catkin_tools_noetic_hello: catkin-tools-noetic-hello
   SNAP/colcon_ros2_foxy_rlcpp_hello: colcon-ros2-foxy-rlcpp-hello
-  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
 systems:
   - ubuntu-20.04

--- a/tests/spread/plugins/v2/ros1-cmake-args/task.yaml
+++ b/tests/spread/plugins/v2/ros1-cmake-args/task.yaml
@@ -6,7 +6,6 @@ kill-timeout: 180m
 environment:
   SNAP/catkin_cmake_args: catkin-cmake-args
   SNAP/catkin_tools_cmake_args: catkin-tools-cmake-args
-  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
 systems:
   - ubuntu-20.04

--- a/tests/spread/plugins/v2/ros1-hello/task.yaml
+++ b/tests/spread/plugins/v2/ros1-hello/task.yaml
@@ -9,7 +9,6 @@ environment:
   SNAP/catkin_noetic_subdir: catkin-noetic-subdir
   SNAP/catkin_tools_noetic_hello: catkin-tools-noetic-hello
   SNAP/catkin_tools_noetic_subdir: catkin-tools-noetic-subdir
-  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
 systems:
   - ubuntu-20.04

--- a/tests/spread/plugins/v2/ros1-in-source-hello/task.yaml
+++ b/tests/spread/plugins/v2/ros1-in-source-hello/task.yaml
@@ -7,7 +7,6 @@ kill-timeout: 180m
 environment:
   SNAP/catkin_noetic_in_source_hello: catkin-noetic-in-source-hello
   SNAP/catkin_tools_noetic_in_source_hello: catkin-tools-noetic-in-source-hello
-  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
 systems:
   - ubuntu-20.04

--- a/tests/spread/plugins/v2/ros1-specific-packages/task.yaml
+++ b/tests/spread/plugins/v2/ros1-specific-packages/task.yaml
@@ -6,7 +6,6 @@ kill-timeout: 180m
 environment:
   SNAP/catkin_specific_packages: catkin-specific-packages
   SNAP/catkin_tools_specific_packages: catkin-tools-specific-packages
-  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
 systems:
   - ubuntu-20.04


### PR DESCRIPTION
If applied, this commit will allow users to build ros snaps without using the SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS flag.

This would help our ROS snap workshops run smoother and avoid the user's feeling that ROS is not currently at in a stable stage.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
