### PR TITLE
providers: pass SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT to instance

### DIFF
--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -157,6 +157,7 @@ def get_command_environment(
         "SNAPCRAFT_BUILD_FOR",
         "SNAPCRAFT_BUILD_INFO",
         "SNAPCRAFT_IMAGE_INFO",
+        "SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT",
     ]:
         if env_key in os.environ:
             env[env_key] = os.environ[env_key]

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -255,6 +255,7 @@ def test_get_command_environment_passthrough(
     monkeypatch.setenv("SNAPCRAFT_BUILD_FOR", "test-build-for")
     monkeypatch.setenv("SNAPCRAFT_BUILD_INFO", "test-build-info")
     monkeypatch.setenv("SNAPCRAFT_IMAGE_INFO", "test-image-info")
+    monkeypatch.setenv("SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT", "test-build-count")
 
     # ensure other variables are not being passed
     monkeypatch.setenv("other_var", "test-other-var")
@@ -271,6 +272,7 @@ def test_get_command_environment_passthrough(
         "SNAPCRAFT_BUILD_FOR": "test-build-for",
         "SNAPCRAFT_BUILD_INFO": "test-build-info",
         "SNAPCRAFT_IMAGE_INFO": "test-image-info",
+        "SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT": "test-build-count",
     }
 
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Report from https://bugs.launchpad.net/snapcraft/+bug/1997874

`SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT` was not being passed into the build environment.

Inside the build environment, the [default build count](https://github.com/snapcore/snapcraft/blob/0f49a754d515ffd26cd95404c0891c2dbf1de2a7/snapcraft/utils.py#L205) would be used, since the user's environment variable did not exist.