### PR TITLE
Kernel plugin: multiple fixes

### DIFF
--- a/snapcraft/parts/plugins/kernel.py
+++ b/snapcraft/parts/plugins/kernel.py
@@ -861,6 +861,14 @@ class KernelPlugin(plugins.Plugin):
                     ],
                 ),
                 "done",
+                " ".join(
+                    [
+                        "cp",
+                        "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/kernel-modules/extra-modules.conf",
+                        "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/modules/main/extra-modules.conf",
+                    ],
+                ),
+                "",
             ],
         )
         firmware_dir = "${CRAFT_PART_INSTALL}/lib/firmware"

--- a/snapcraft/parts/plugins/kernel.py
+++ b/snapcraft/parts/plugins/kernel.py
@@ -879,6 +879,17 @@ class KernelPlugin(plugins.Plugin):
                 "",
                 " ".join(
                     [
+                        f'[ ! -d "{firmware_dir}" ]',
+                        "&&",
+                        f'echo -e "firmware directory {firmware_dir} does not exist, consider using'
+                        ' kernel-initrd-stage-firmware: true/false option"',
+                        "&&",
+                        "exit 1",
+                    ]
+                ),
+                "",
+                " ".join(
+                    [
                         "${ubuntu_core_initramfs}",
                         "create-initrd",
                         "--kernelver=${KERNEL_RELEASE}",

--- a/snapcraft/parts/plugins/kernel.py
+++ b/snapcraft/parts/plugins/kernel.py
@@ -24,17 +24,17 @@ The following kernel-specific options are provided by this plugin:
       defconfig target to use as the base configuration. default: "defconfig"
 
     - kernel-kconfigfile:
-      (filepath)
+      (filepath; default: none)
       path to file to use as base configuration. If provided this option wins
       over everything else. default: None
 
     - kernel-kconfigflavour:
-      (string)
+      (string; default: none)
       Ubuntu config flavour to use as base configuration. If provided this
       option wins over kernel-kdefconfig. default: None
 
     - kernel-kconfigs:
-      (list of strings)
+      (list of strings; default: none)
       explicit list of configs to force; this will override the configs that
       were set as base through kernel-kdefconfig and kernel-kconfigfile and dependent configs
       will be fixed using the defaults encoded in the kbuild config
@@ -55,7 +55,7 @@ The following kernel-specific options are provided by this plugin:
       use this flag to disable shipping binary firmwares.
 
     - kernel-device-trees:
-      (array of string)
+      (array of string, default: none)
       list of device trees to build, the format is <device-tree-name>.dts.
 
     - kernel-build-efi-image
@@ -63,12 +63,12 @@ The following kernel-specific options are provided by this plugin:
       by default).
 
     - kernel-compiler
-      (string; default:)
+      (string; default: none)
       Optional, define compiler to use, by default gcc compiler is used.
       Other permitted compilers: clang
 
     - kernel-compiler-paths
-      (array of strings)
+      (array of strings; default: none)
       Optional, define the compiler path to be added to the PATH.
       Path is relative to the stage directory.
       Default value is empty.
@@ -87,13 +87,13 @@ The following kernel-specific options are provided by this plugin:
       use this flag to build the perf binary
 
     - kernel-initrd-modules:
-      (array of string)
+      (array of string; default: none)
       list of modules to include in initrd; note that kernel snaps do not
       provide the core boot logic which comes from snappy Ubuntu Core
       OS snap. Include all modules you need for mounting rootfs here.
 
     - kernel-initrd-configured-modules:
-      (array of string)
+      (array of string; default: none)
       list of modules to be added to the initrd
       /lib/modules-load.d/ubuntu-core-initramfs.conf config
       to be automatically loaded.
@@ -109,7 +109,7 @@ The following kernel-specific options are provided by this plugin:
       from stage directory instead.
 
     - kernel-initrd-firmware:
-      (array of string)
+      (array of string; default: none)
       list of firmware files to be included in the initrd; these need to be
       relative paths to stage directory.
       <stage/part install dir>/firmware/* -> initrd:/lib/firmware/*
@@ -137,7 +137,7 @@ The following kernel-specific options are provided by this plugin:
       Default: none
 
     - kernel-initrd-addons
-      (array of string)
+      (array of string; default: none)
       Optional list of files to be added to the initrd.
       Function is similar to kernel-initrd-overlay, only it works on per file
       selection without a need to have overlay in dedicated directory.

--- a/snapcraft/parts/plugins/kernel.py
+++ b/snapcraft/parts/plugins/kernel.py
@@ -467,14 +467,14 @@ class KernelPlugin(plugins.Plugin):
             '\tif [ "${2}" = "*" ]; then',
             "\t\tfor f in $(ls ${1})",
             "\t\tdo",
-            "\t\t\tlink_files ${1} ${f} ${3}",
+            '\t\t\tlink_files "${1}" "${f}" "${3}"',
             "\t\tdone",
             "\t\treturn 0",
             "\tfi",
-            "\tif [ -d ${1}/${2} ]; then",
+            '\tif [ -d "${1}/${2}" ]; then',
             "\t\tfor f in $(ls ${1}/${2})",
             "\t\tdo",
-            "\t\t\tlink_files ${1} ${2}/${f} ${3}",
+            '\t\t\tlink_files "${1}" "${2}/${f}" "${3}"',
             "\t\tdone",
             "\t\treturn 0",
             "\tfi",
@@ -704,9 +704,9 @@ class KernelPlugin(plugins.Plugin):
                         [
                             "\tif !",
                             "link_files",
-                            "${CRAFT_PART_INSTALL}",
-                            "${f}",
-                            "${uc_initrd_feature_firmware}/lib",
+                            '"${CRAFT_PART_INSTALL}"',
+                            '"${f}"',
+                            '"${uc_initrd_feature_firmware}/lib"',
                             ";",
                             "then",
                         ]
@@ -715,9 +715,9 @@ class KernelPlugin(plugins.Plugin):
                         [
                             "\t\tif !",
                             "link_files",
-                            "${CRAFT_STAGE}",
-                            "${f}",
-                            "${uc_initrd_feature_firmware}/lib",
+                            '"${CRAFT_STAGE}"',
+                            '"${f}"',
+                            '"${uc_initrd_feature_firmware}/lib"',
                             ";",
                             "then",
                         ]
@@ -737,9 +737,9 @@ class KernelPlugin(plugins.Plugin):
                     " ".join(
                         [
                             "link_files",
-                            "${CRAFT_STAGE}",
-                            f"{self.options.kernel_initrd_overlay}",
-                            "${uc_initrd_feature_overlay}",
+                            f'"${{CRAFT_STAGE}}/{self.options.kernel_initrd_overlay}"',
+                            '""',
+                            '"${uc_initrd_feature_overlay}"',
                         ]
                     ),
                     "",
@@ -757,9 +757,9 @@ class KernelPlugin(plugins.Plugin):
                     " ".join(
                         [
                             "\tlink_files",
-                            "${CRAFT_STAGE}",
-                            "${a}",
-                            "${uc_initrd_feature_overlay}",
+                            '"${CRAFT_STAGE}"',
+                            '"${a}"',
+                            '"${uc_initrd_feature_overlay}"',
                         ]
                     ),
                     "done",
@@ -774,17 +774,17 @@ class KernelPlugin(plugins.Plugin):
             " ".join(
                 [
                     "link_files",
-                    "${SNAPD_UNPACKED_SNAP}",
-                    "usr/lib/snapd/snap-bootstrap",
-                    "${uc_initrd_feature_snap_bootstratp}",
+                    '"${SNAPD_UNPACKED_SNAP}"',
+                    '"usr/lib/snapd/snap-bootstrap"',
+                    '"${uc_initrd_feature_snap_bootstratp}"',
                 ]
             ),
             " ".join(
                 [
                     "link_files",
-                    "${SNAPD_UNPACKED_SNAP}",
-                    "usr/lib/snapd/info",
-                    "${uc_initrd_feature_snap_bootstratp}",
+                    '"${SNAPD_UNPACKED_SNAP}"',
+                    '"usr/lib/snapd/info"',
+                    '"${uc_initrd_feature_snap_bootstratp}"',
                 ]
             ),
             " ".join(
@@ -855,9 +855,9 @@ class KernelPlugin(plugins.Plugin):
                 " ".join(
                     [
                         "\tlink_files",
-                        "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/${feature}",
+                        '"${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/${feature}"',
                         '"*"',
-                        "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/main",
+                        '"${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/main"',
                     ],
                 ),
                 "done",

--- a/snapcraft/parts/plugins/kernel.py
+++ b/snapcraft/parts/plugins/kernel.py
@@ -628,6 +628,12 @@ class KernelPlugin(plugins.Plugin):
             "initramfs_ko_modules_conf=${uc_initrd_feature_kernel_modules}/extra-modules.conf",
             " ".join(
                 [
+                    "touch",
+                    "${initramfs_ko_modules_conf}",
+                ]
+            ),
+            " ".join(
+                [
                     "for",
                     "m",
                     "in",
@@ -864,7 +870,7 @@ class KernelPlugin(plugins.Plugin):
                 " ".join(
                     [
                         "cp",
-                        "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/kernel-modules/extra-modules.conf",
+                        "${initramfs_ko_modules_conf}",
                         "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/modules/main/extra-modules.conf",
                     ],
                 ),

--- a/snapcraft_legacy/plugins/v2/kernel.py
+++ b/snapcraft_legacy/plugins/v2/kernel.py
@@ -936,6 +936,17 @@ class KernelPlugin(PluginV2):
                 "",
                 " ".join(
                     [
+                        f'[ ! -d "{firmware_dir}" ]',
+                        "&&",
+                        f'echo -e "firmware directory {firmware_dir} does not exist, consider using'
+                        ' kernel-initrd-stage-firmware: true/false option"',
+                        "&&",
+                        "exit 1",
+                    ]
+                ),
+                "",
+                " ".join(
+                    [
                         "${ubuntu_core_initramfs}",
                         "create-initrd",
                         "--root",

--- a/snapcraft_legacy/plugins/v2/kernel.py
+++ b/snapcraft_legacy/plugins/v2/kernel.py
@@ -24,17 +24,17 @@ The following kernel-specific options are provided by this plugin:
       defconfig target to use as the base configuration. default: "defconfig"
 
     - kernel-kconfigfile:
-      (filepath)
+      (filepath; default: none)
       path to file to use as base configuration. If provided this option wins
       over everything else. default: None
 
     - kernel-kconfigflavour:
-      (string)
+      (string; default: none)
       Ubuntu config flavour to use as base configuration. If provided this
       option wins over kernel-kdefconfig. default: None
 
     - kernel-kconfigs:
-      (list of strings)
+      (list of strings; default: none)
       explicit list of configs to force; this will override the configs that
       were set as base through kernel-kdefconfig and kernel-kconfigfile and dependent configs
       will be fixed using the defaults encoded in the kbuild config
@@ -55,16 +55,16 @@ The following kernel-specific options are provided by this plugin:
       use this flag to disable shipping binary firmwares.
 
     - kernel-device-trees:
-      (array of string)
+      (array of string, default: none)
       list of device trees to build, the format is <device-tree-name>.dts.
 
     - kernel-compiler
-      (string; default:)
+      (string; default: none)
       Optional, define compiler to use, by default gcc compiler is used.
       Other permitted compilers: clang
 
     - kernel-compiler-paths
-      (array of strings)
+      (array of strings; default: none)
       Optional, define the compiler path to be added to the PATH.
       Path is relative to the stage directory.
       Default value is empty.
@@ -83,13 +83,13 @@ The following kernel-specific options are provided by this plugin:
       use this flag to build the perf binary
 
     - kernel-initrd-modules:
-      (array of string)
+      (array of string; default: none)
       list of modules to include in initrd; note that kernel snaps do not
       provide the core boot logic which comes from snappy Ubuntu Core
       OS snap. Include all modules you need for mounting rootfs here.
 
     - kernel-initrd-configured-modules:
-      (array of string)
+      (array of string; default: none)
       list of modules to be added to the initrd
       /lib/modules-load.d/ubuntu-core-initramfs.conf config
       to be automatically loaded.
@@ -105,7 +105,7 @@ The following kernel-specific options are provided by this plugin:
       from stage directory instead.
 
     - kernel-initrd-firmware:
-      (array of string)
+      (array of string; default: none)
       list of firmware files to be included in the initrd; these need to be
       relative paths to stage directory.
       <stage/part install dir>/firmware/* -> initrd:/lib/firmware/*
@@ -124,16 +124,16 @@ The following kernel-specific options are provided by this plugin:
         zstd: -1 -T0
 
     - kernel-initrd-overlay
+      (string; default: none)
       Optional overlay to be applied to built initrd.
       This option is designed to provide easy way to apply initrd overlay for
       cases modifies initrd scripts for pre uc20 initrds.
       Value is relative path, in stage directory. and related part needs to be
       built before initrd part. During build it will be expanded to
       ${SNAPCRAFT_STAGE}/{initrd-overlay}
-      Default: none
 
     - kernel-initrd-addons
-      (array of string)
+      (array of string; default: none)
       Optional list of files to be added to the initrd.
       Function is similar to kernel-initrd-overlay, only it works on per file
       selection without a need to have overlay in dedicated directory.

--- a/snapcraft_legacy/plugins/v2/kernel.py
+++ b/snapcraft_legacy/plugins/v2/kernel.py
@@ -531,14 +531,14 @@ class KernelPlugin(PluginV2):
             '\tif [ "${2}" = "*" ]; then',
             "\t\tfor f in $(ls ${1})",
             "\t\tdo",
-            "\t\t\tlink_files ${1} ${f} ${3}",
+            '\t\t\tlink_files "${1}" "${f}" "${3}"',
             "\t\tdone",
             "\t\treturn 0",
             "\tfi",
-            "\tif [ -d ${1}/${2} ]; then",
+            '\tif [ -d "${1}/${2}" ]; then',
             "\t\tfor f in $(ls ${1}/${2})",
             "\t\tdo",
-            "\t\t\tlink_files ${1} ${2}/${f} ${3}",
+            '\t\t\tlink_files "${1}" "${2}/${f}" "${3}"',
             "\t\tdone",
             "\t\treturn 0",
             "\tfi",
@@ -768,9 +768,9 @@ class KernelPlugin(PluginV2):
                         [
                             "\tif !",
                             "link_files",
-                            "${SNAPCRAFT_PART_INSTALL}",
-                            "${f}",
-                            "${uc_initrd_feature_firmware}/lib",
+                            '"${SNAPCRAFT_PART_INSTALL}"',
+                            '"${f}"',
+                            '"${uc_initrd_feature_firmware}/lib"',
                             ";",
                             "then",
                         ]
@@ -779,9 +779,9 @@ class KernelPlugin(PluginV2):
                         [
                             "\t\tif !",
                             "link_files",
-                            "${SNAPCRAFT_STAGE}",
-                            "${f}",
-                            "${uc_initrd_feature_firmware}/lib",
+                            '"${SNAPCRAFT_STAGE}"',
+                            '"${f}"',
+                            '"${uc_initrd_feature_firmware}/lib"',
                             ";",
                             "then",
                         ]
@@ -801,9 +801,9 @@ class KernelPlugin(PluginV2):
                     " ".join(
                         [
                             "link_files",
-                            "${SNAPCRAFT_STAGE}",
-                            f"{self.options.kernel_initrd_overlay}",
-                            "${uc_initrd_feature_overlay}",
+                            f'"${{SNAPCRAFT_STAGE}}/{self.options.kernel_initrd_overlay}"',
+                            '""',
+                            '"${uc_initrd_feature_overlay}"',
                         ]
                     ),
                     "",
@@ -821,9 +821,9 @@ class KernelPlugin(PluginV2):
                     " ".join(
                         [
                             "\tlink_files",
-                            "${SNAPCRAFT_STAGE}",
-                            "${a}",
-                            "${uc_initrd_feature_overlay}",
+                            '"${SNAPCRAFT_STAGE}"',
+                            '"${a}"',
+                            '"${uc_initrd_feature_overlay}"',
                         ]
                     ),
                     "done",
@@ -838,17 +838,17 @@ class KernelPlugin(PluginV2):
             " ".join(
                 [
                     "link_files",
-                    "${SNAPD_UNPACKED_SNAP}",
-                    "usr/lib/snapd/snap-bootstrap",
-                    "${uc_initrd_feature_snap_bootstratp}",
+                    '"${SNAPD_UNPACKED_SNAP}"',
+                    '"usr/lib/snapd/snap-bootstrap"',
+                    '"${uc_initrd_feature_snap_bootstratp}"',
                 ]
             ),
             " ".join(
                 [
                     "link_files",
-                    "${SNAPD_UNPACKED_SNAP}",
-                    "usr/lib/snapd/info",
-                    "${uc_initrd_feature_snap_bootstratp}",
+                    '"${SNAPD_UNPACKED_SNAP}"',
+                    '"usr/lib/snapd/info"',
+                    '"${uc_initrd_feature_snap_bootstratp}"',
                 ]
             ),
             " ".join(
@@ -919,9 +919,9 @@ class KernelPlugin(PluginV2):
                 " ".join(
                     [
                         "\tlink_files",
-                        "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/${feature}",
+                        '"${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/${feature}"',
                         '"*"',
-                        "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/main",
+                        '"${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/main"',
                     ],
                 ),
                 "done",

--- a/tests/legacy/unit/plugins/v2/test_kernel.py
+++ b/tests/legacy/unit/plugins/v2/test_kernel.py
@@ -571,6 +571,7 @@ class TestPluginKernel(TestCase):
         assert not _is_sub_array(build_commands, _intatll_initrd_overlay_cmd)
         assert _is_sub_array(build_commands, _prepare_ininird_features_cmd)
         assert _is_sub_array(build_commands, _clean_old_initrd_cmd)
+        assert _is_sub_array(build_commands, _initrd_check_firmware_part)
         assert _is_sub_array(build_commands, _initrd_tool_cmd)
         assert not _is_sub_array(build_commands, _update_initrd_compression_cmd)
         assert _is_sub_array(build_commands, _initrd_tool_workaroud_cmd)
@@ -634,6 +635,7 @@ class TestPluginKernel(TestCase):
         assert not _is_sub_array(build_commands, _intatll_initrd_overlay_cmd)
         assert _is_sub_array(build_commands, _prepare_ininird_features_cmd)
         assert _is_sub_array(build_commands, _clean_old_initrd_cmd)
+        assert _is_sub_array(build_commands, _initrd_check_firmware_stage)
         assert _is_sub_array(build_commands, _initrd_tool_cmd)
         assert _is_sub_array(build_commands, _update_initrd_compression_cmd)
         assert _is_sub_array(build_commands, _initrd_tool_workaroud_cmd)
@@ -686,6 +688,7 @@ class TestPluginKernel(TestCase):
         assert not _is_sub_array(build_commands, _intatll_initrd_overlay_cmd)
         assert _is_sub_array(build_commands, _prepare_ininird_features_cmd)
         assert _is_sub_array(build_commands, _clean_old_initrd_cmd)
+        assert _is_sub_array(build_commands, _initrd_check_firmware_part)
         assert _is_sub_array(build_commands, _initrd_tool_cmd)
         assert not _is_sub_array(build_commands, _update_initrd_compression_cmd)
         assert _is_sub_array(build_commands, _initrd_tool_workaroud_cmd)
@@ -738,6 +741,7 @@ class TestPluginKernel(TestCase):
         assert _is_sub_array(build_commands, _intatll_initrd_overlay_cmd)
         assert _is_sub_array(build_commands, _prepare_ininird_features_cmd)
         assert _is_sub_array(build_commands, _clean_old_initrd_cmd)
+        assert _is_sub_array(build_commands, _initrd_check_firmware_part)
         assert _is_sub_array(build_commands, _initrd_tool_cmd)
         assert _is_sub_array(build_commands, _update_initrd_compression_gz_cmd)
         assert _is_sub_array(build_commands, _initrd_tool_workaroud_cmd)
@@ -789,6 +793,7 @@ class TestPluginKernel(TestCase):
         assert _is_sub_array(build_commands, _intatll_initrd_overlay_cmd)
         assert _is_sub_array(build_commands, _prepare_ininird_features_cmd)
         assert _is_sub_array(build_commands, _clean_old_initrd_cmd)
+        assert _is_sub_array(build_commands, _initrd_check_firmware_part)
         assert _is_sub_array(build_commands, _initrd_tool_cmd)
         assert not _is_sub_array(build_commands, _update_initrd_compression_cmd)
         assert _is_sub_array(build_commands, _initrd_tool_workaroud_cmd)
@@ -1617,9 +1622,22 @@ _clean_old_initrd_cmd = [
     "fi",
 ]
 
+_initrd_check_firmware_stage = [
+    '[ ! -d "${SNAPCRAFT_STAGE}/firmware" ] && echo -e "firmware directory '
+    "${SNAPCRAFT_STAGE}/firmware does not exist, consider using "
+    'kernel-initrd-stage-firmware: true/false option" && exit 1'
+]
+
+_initrd_check_firmware_part = [
+    '[ ! -d "${SNAPCRAFT_PART_INSTALL}/lib/firmware" ] && echo -e "firmware directory '
+    "${SNAPCRAFT_PART_INSTALL}/lib/firmware does not exist, consider using "
+    'kernel-initrd-stage-firmware: true/false option" && exit 1'
+]
+
 _initrd_tool_cmd = [
     "ubuntu_core_initramfs=${UC_INITRD_DEB}/usr/bin/ubuntu-core-initramfs",
 ]
+
 _update_initrd_compression_cmd = [
     'echo "Updating compression command to be used for initrd"',
     "sed -i 's/lz4 -9 -l/lz4 -9 -l/g' ${ubuntu_core_initramfs}",

--- a/tests/legacy/unit/plugins/v2/test_kernel.py
+++ b/tests/legacy/unit/plugins/v2/test_kernel.py
@@ -1131,14 +1131,14 @@ _link_files_fnc = [
     '\tif [ "${2}" = "*" ]; then',
     "\t\tfor f in $(ls ${1})",
     "\t\tdo",
-    "\t\t\tlink_files ${1} ${f} ${3}",
+    '\t\t\tlink_files "${1}" "${f}" "${3}"',
     "\t\tdone",
     "\t\treturn 0",
     "\tfi",
-    "\tif [ -d ${1}/${2} ]; then",
+    '\tif [ -d "${1}/${2}" ]; then',
     "\t\tfor f in $(ls ${1}/${2})",
     "\t\tdo",
-    "\t\t\tlink_files ${1} ${2}/${f} ${3}",
+    '\t\t\tlink_files "${1}" "${2}/${f}" "${3}"',
     "\t\tdone",
     "\t\treturn 0",
     "\tfi",
@@ -1575,8 +1575,8 @@ _install_initrd_firmware_cmd = [
     'echo "Installing initrd overlay firmware..."',
     "for f in firmware/for/wifi firmware/for/webcam",
     "do",
-    "\tif ! link_files ${SNAPCRAFT_PART_INSTALL} ${f} ${uc_initrd_feature_firmware}/lib ; then",
-    "\t\tif ! link_files ${SNAPCRAFT_STAGE} ${f} ${uc_initrd_feature_firmware}/lib ; then",
+    '\tif ! link_files "${SNAPCRAFT_PART_INSTALL}" "${f}" "${uc_initrd_feature_firmware}/lib" ; then',
+    '\t\tif ! link_files "${SNAPCRAFT_STAGE}" "${f}" "${uc_initrd_feature_firmware}/lib" ; then',
     '\t\t\techo "Missing firmware [${f}], ignoring it"',
     "\t\tfi",
     "\tfi",
@@ -1588,12 +1588,12 @@ _install_initrd_addons_cmd = [
     "for a in usr/bin/cryptsetup usr/lib/my-arch/libcrypto.so",
     "do",
     '\techo "Copy overlay: ${a}"',
-    "\tlink_files ${SNAPCRAFT_STAGE} ${a} ${uc_initrd_feature_overlay}",
+    '\tlink_files "${SNAPCRAFT_STAGE}" "${a}" "${uc_initrd_feature_overlay}"',
     "done",
 ]
 
 _intatll_initrd_overlay_cmd = [
-    "link_files ${SNAPCRAFT_STAGE} my-overlay ${uc_initrd_feature_overlay}"
+    'link_files "${SNAPCRAFT_STAGE}/my-overlay" "" "${uc_initrd_feature_overlay}"'
 ]
 
 _prepare_ininird_features_cmd = [
@@ -1603,11 +1603,11 @@ _prepare_ininird_features_cmd = [
     " ".join(
         [
             "link_files",
-            "${SNAPD_UNPACKED_SNAP} usr/lib/snapd/snap-bootstrap",
-            "${uc_initrd_feature_snap_bootstratp}",
+            '"${SNAPD_UNPACKED_SNAP}" "usr/lib/snapd/snap-bootstrap"',
+            '"${uc_initrd_feature_snap_bootstratp}"',
         ],
     ),
-    "link_files ${SNAPD_UNPACKED_SNAP} usr/lib/snapd/info ${uc_initrd_feature_snap_bootstratp}",
+    'link_files "${SNAPD_UNPACKED_SNAP}" "usr/lib/snapd/info" "${uc_initrd_feature_snap_bootstratp}"',
     "cp ${SNAPD_UNPACKED_SNAP}/usr/lib/snapd/info ${SNAPCRAFT_PART_INSTALL}/snapd-info",
 ]
 
@@ -1635,9 +1635,9 @@ _initrd_tool_workaroud_cmd = [
     "do",
     " ".join(
         [
-            "\tlink_files ${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/${feature}",
+            '\tlink_files "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/${feature}"',
             '"*"',
-            "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/main",
+            '"${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/main"',
         ],
     ),
     "done",

--- a/tests/unit/parts/plugins/test_kernel.py
+++ b/tests/unit/parts/plugins/test_kernel.py
@@ -1265,14 +1265,14 @@ _link_files_fnc = [
     '\tif [ "${2}" = "*" ]; then',
     "\t\tfor f in $(ls ${1})",
     "\t\tdo",
-    "\t\t\tlink_files ${1} ${f} ${3}",
+    '\t\t\tlink_files "${1}" "${f}" "${3}"',
     "\t\tdone",
     "\t\treturn 0",
     "\tfi",
-    "\tif [ -d ${1}/${2} ]; then",
+    '\tif [ -d "${1}/${2}" ]; then',
     "\t\tfor f in $(ls ${1}/${2})",
     "\t\tdo",
-    "\t\t\tlink_files ${1} ${2}/${f} ${3}",
+    '\t\t\tlink_files "${1}" "${2}/${f}" "${3}"',
     "\t\tdone",
     "\t\treturn 0",
     "\tfi",
@@ -1728,8 +1728,8 @@ _install_initrd_firmware_cmd = [
     'echo "Installing initrd overlay firmware..."',
     "for f in firmware/for/wifi firmware/for/webcam",
     "do",
-    "\tif ! link_files ${CRAFT_PART_INSTALL} ${f} ${uc_initrd_feature_firmware}/lib ; then",
-    "\t\tif ! link_files ${CRAFT_STAGE} ${f} ${uc_initrd_feature_firmware}/lib ; then",
+    '\tif ! link_files "${CRAFT_PART_INSTALL}" "${f}" "${uc_initrd_feature_firmware}/lib" ; then',
+    '\t\tif ! link_files "${CRAFT_STAGE}" "${f}" "${uc_initrd_feature_firmware}/lib" ; then',
     '\t\t\techo "Missing firmware [${f}], ignoring it"',
     "\t\tfi",
     "\tfi",
@@ -1741,12 +1741,12 @@ _install_initrd_addons_cmd = [
     "for a in usr/bin/cryptsetup usr/lib/my-arch/libcrypto.so",
     "do",
     '\techo "Copy overlay: ${a}"',
-    "\tlink_files ${CRAFT_STAGE} ${a} ${uc_initrd_feature_overlay}",
+    '\tlink_files "${CRAFT_STAGE}" "${a}" "${uc_initrd_feature_overlay}"',
     "done",
 ]
 
 _intatll_initrd_overlay_cmd = [
-    "link_files ${CRAFT_STAGE} my-overlay ${uc_initrd_feature_overlay}"
+    'link_files "${CRAFT_STAGE}/my-overlay" "" "${uc_initrd_feature_overlay}"'
 ]
 
 _prepare_ininird_features_cmd = [
@@ -1757,11 +1757,12 @@ _prepare_ininird_features_cmd = [
     " ".join(
         [
             "link_files",
-            "${SNAPD_UNPACKED_SNAP} usr/lib/snapd/snap-bootstrap",
-            "${uc_initrd_feature_snap_bootstratp}",
+            '"${SNAPD_UNPACKED_SNAP}" "usr/lib/snapd/snap-bootstrap"',
+            '"${uc_initrd_feature_snap_bootstratp}"',
         ],
     ),
-    "link_files ${SNAPD_UNPACKED_SNAP} usr/lib/snapd/info ${uc_initrd_feature_snap_bootstratp}",
+    'link_files "${SNAPD_UNPACKED_SNAP}" "usr/lib/snapd/info"'
+    ' "${uc_initrd_feature_snap_bootstratp}"',
     "cp ${SNAPD_UNPACKED_SNAP}/usr/lib/snapd/info ${CRAFT_PART_INSTALL}/snapd-info",
 ]
 
@@ -1789,16 +1790,16 @@ _initrd_tool_workaroud_cmd = [
     "do",
     " ".join(
         [
-            "\tlink_files ${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/${feature}",
+            '\tlink_files "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/${feature}"',
             '"*"',
-            "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/main",
+            '"${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/main"',
         ],
     ),
     "done",
     " ".join(
         [
             "cp",
-            "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/kernel-modules/extra-modules.conf",
+            "${initramfs_ko_modules_conf}",
             "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/modules/main/extra-modules.conf",
         ],
     ),

--- a/tests/unit/parts/plugins/test_kernel.py
+++ b/tests/unit/parts/plugins/test_kernel.py
@@ -1795,6 +1795,13 @@ _initrd_tool_workaroud_cmd = [
         ],
     ),
     "done",
+    " ".join(
+        [
+            "cp",
+            "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/kernel-modules/extra-modules.conf",
+            "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/modules/main/extra-modules.conf",
+        ],
+    ),
 ]
 
 _create_inird_cmd = [

--- a/tests/unit/parts/plugins/test_kernel.py
+++ b/tests/unit/parts/plugins/test_kernel.py
@@ -1685,6 +1685,7 @@ _install_initrd_modules_cmd = [
     "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/kernel-modules",
     "mkdir -p ${uc_initrd_feature_kernel_modules}",
     "initramfs_ko_modules_conf=${uc_initrd_feature_kernel_modules}/extra-modules.conf",
+    "touch ${initramfs_ko_modules_conf}",
     "for m in ${initrd_installed_kernel_modules} ${initrd_configured_kernel_modules}",
     "do",
     "\techo ${m} >> ${initramfs_ko_modules_conf}",

--- a/tests/unit/parts/plugins/test_kernel.py
+++ b/tests/unit/parts/plugins/test_kernel.py
@@ -460,6 +460,7 @@ class TestPluginKernel:
         assert not _is_sub_array(build_commands, _intatll_initrd_overlay_cmd)
         assert _is_sub_array(build_commands, _prepare_ininird_features_cmd)
         assert _is_sub_array(build_commands, _clean_old_initrd_cmd)
+        assert _is_sub_array(build_commands, _initrd_check_firmware_part)
         assert _is_sub_array(build_commands, _initrd_tool_cmd)
         assert not _is_sub_array(build_commands, _update_initrd_compression_cmd)
         assert _is_sub_array(build_commands, _initrd_tool_workaroud_cmd)
@@ -528,6 +529,7 @@ class TestPluginKernel:
         assert not _is_sub_array(build_commands, _intatll_initrd_overlay_cmd)
         assert _is_sub_array(build_commands, _prepare_ininird_features_cmd)
         assert _is_sub_array(build_commands, _clean_old_initrd_cmd)
+        assert _is_sub_array(build_commands, _initrd_check_firmware_stage)
         assert _is_sub_array(build_commands, _initrd_tool_cmd)
         assert _is_sub_array(build_commands, _update_initrd_compression_cmd)
         assert _is_sub_array(build_commands, _initrd_tool_workaroud_cmd)
@@ -583,6 +585,7 @@ class TestPluginKernel:
         assert not _is_sub_array(build_commands, _intatll_initrd_overlay_cmd)
         assert _is_sub_array(build_commands, _prepare_ininird_features_cmd)
         assert _is_sub_array(build_commands, _clean_old_initrd_cmd)
+        assert _is_sub_array(build_commands, _initrd_check_firmware_part)
         assert _is_sub_array(build_commands, _initrd_tool_cmd)
         assert not _is_sub_array(build_commands, _update_initrd_compression_cmd)
         assert _is_sub_array(build_commands, _initrd_tool_workaroud_cmd)
@@ -645,6 +648,7 @@ class TestPluginKernel:
         assert _is_sub_array(build_commands, _intatll_initrd_overlay_cmd)
         assert _is_sub_array(build_commands, _prepare_ininird_features_cmd)
         assert _is_sub_array(build_commands, _clean_old_initrd_cmd)
+        assert _is_sub_array(build_commands, _initrd_check_firmware_part)
         assert _is_sub_array(build_commands, _initrd_tool_cmd)
         assert _is_sub_array(build_commands, _update_initrd_compression_gz_cmd)
         assert _is_sub_array(build_commands, _initrd_tool_workaroud_cmd)
@@ -700,6 +704,7 @@ class TestPluginKernel:
         assert _is_sub_array(build_commands, _intatll_initrd_overlay_cmd)
         assert _is_sub_array(build_commands, _prepare_ininird_features_cmd)
         assert _is_sub_array(build_commands, _clean_old_initrd_cmd)
+        assert _is_sub_array(build_commands, _initrd_check_firmware_part)
         assert _is_sub_array(build_commands, _initrd_tool_cmd)
         assert not _is_sub_array(build_commands, _update_initrd_compression_cmd)
         assert _is_sub_array(build_commands, _initrd_tool_workaroud_cmd)
@@ -1772,9 +1777,22 @@ _clean_old_initrd_cmd = [
     "fi",
 ]
 
+_initrd_check_firmware_stage = [
+    '[ ! -d "${CRAFT_STAGE}/firmware" ] && echo -e "firmware directory '
+    "${CRAFT_STAGE}/firmware does not exist, consider using "
+    'kernel-initrd-stage-firmware: true/false option" && exit 1'
+]
+
+_initrd_check_firmware_part = [
+    '[ ! -d "${CRAFT_PART_INSTALL}/lib/firmware" ] && echo -e "firmware directory '
+    "${CRAFT_PART_INSTALL}/lib/firmware does not exist, consider using "
+    'kernel-initrd-stage-firmware: true/false option" && exit 1'
+]
+
 _initrd_tool_cmd = [
     "ubuntu_core_initramfs=${UC_INITRD_DEB}/usr/bin/ubuntu-core-initramfs",
 ]
+
 _update_initrd_compression_cmd = [
     'echo "Updating compression command to be used for initrd"',
     "sed -i 's/zstd -1 -T0/lz4 -9 -l/g' ${ubuntu_core_initramfs}",


### PR DESCRIPTION
Multiple 
- fixing a regression introduced by #3973. Please do not remove features if not sure about their functionality
- fix crash if there are no defined kernel modules to be included in initramfs
- improve documentation of multiple options by clarifying default values
- fix warning and occasional error reported when linking initramfs overlays with wild cards
- updated unit tests for the above changes

