### PR TITLE
dependencies: update craft-providers to 1.6.2

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -12,7 +12,7 @@ coverage==6.5.0
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.15.2
-craft-providers==1.6.1
+craft-providers==1.6.2
 craft-store==2.3.0
 cryptography==3.4
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.15.2
-craft-providers==1.6.1
+craft-providers==1.6.2
 craft-store==2.3.0
 cryptography==3.4
 Deprecated==1.2.13


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

This disables [automatic snap refreshes](https://github.com/canonical/craft-providers/pull/182) inside of instances.

Source: https://bugs.launchpad.net/snapcraft/+bug/1998100

(CRAFT-1521)