### PR TITLE
Tests: Make test_patcher not require a real patchelf in /usr/bin

### DIFF
--- a/tests/unit/elf/test_patcher.py
+++ b/tests/unit/elf/test_patcher.py
@@ -190,7 +190,6 @@ def test_patcher_patch_rpath_already_set(mocker, patcher, elf_file):
     )
 
     patcher.patch(elf_file=elf_file)
-    # raise Exception(os.environ['PATH'])
     assert run_mock.mock_calls == [
         call(
             [

--- a/tests/unit/elf/test_patcher.py
+++ b/tests/unit/elf/test_patcher.py
@@ -13,7 +13,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 import shutil
 from pathlib import Path
 from unittest.mock import ANY, call
@@ -22,6 +21,8 @@ import pytest
 
 from snapcraft import elf
 from snapcraft.elf import errors
+
+PATCHELF_PATH = "/path/to/patchelf"
 
 
 @pytest.mark.usefixtures("fake_tools")
@@ -75,16 +76,17 @@ def elf_file(new_dir):
 
 
 @pytest.fixture
-def patcher():
+def patcher(mocker):
     yield elf.Patcher(
         dynamic_linker="/my/dynamic/linker",
         root_path=Path("/snap/foo/current"),
+        preferred_patchelf=PATCHELF_PATH,
     )
 
 
 def test_patcher_patch_rpath(mocker, patcher, elf_file):
     run_mock = mocker.patch("subprocess.check_call")
-
+    run_rpath_mock = mocker.patch("subprocess.check_output", return_value=b"\n")
     expected_proposed_rpath = list(elf_file.dependencies)[0].path.parent
     assert patcher.get_current_rpath(elf_file) == []
 
@@ -92,7 +94,7 @@ def test_patcher_patch_rpath(mocker, patcher, elf_file):
     assert run_mock.mock_calls == [
         call(
             [
-                "/usr/bin/patchelf",
+                PATCHELF_PATH,
                 "--set-interpreter",
                 "/my/dynamic/linker",
                 "--force-rpath",
@@ -118,7 +120,7 @@ def test_patcher_patch_existing_rpath_origin(mocker, patcher, elf_file):
     assert run_mock.mock_calls == [
         call(
             [
-                "/usr/bin/patchelf",
+                PATCHELF_PATH,
                 "--set-interpreter",
                 "/my/dynamic/linker",
                 "--force-rpath",
@@ -144,7 +146,7 @@ def test_patcher_patch_existing_rpath_not_origin(mocker, patcher, elf_file):
     assert run_mock.mock_calls == [
         call(
             [
-                "/usr/bin/patchelf",
+                PATCHELF_PATH,
                 "--set-interpreter",
                 "/my/dynamic/linker",
                 "--force-rpath",
@@ -158,6 +160,7 @@ def test_patcher_patch_existing_rpath_not_origin(mocker, patcher, elf_file):
 
 def test_patcher_patch_rpath_same_interpreter(mocker, patcher, elf_file):
     run_mock = mocker.patch("subprocess.check_call")
+    run_rpath_mock = mocker.patch("subprocess.check_output", return_value=b"\n")
     patcher._dynamic_linker = elf_file.interp
 
     expected_proposed_rpath = list(elf_file.dependencies)[0].path.parent
@@ -167,7 +170,7 @@ def test_patcher_patch_rpath_same_interpreter(mocker, patcher, elf_file):
     assert run_mock.mock_calls == [
         call(
             [
-                "/usr/bin/patchelf",
+                PATCHELF_PATH,
                 "--force-rpath",
                 "--set-rpath",
                 str(expected_proposed_rpath),
@@ -187,10 +190,11 @@ def test_patcher_patch_rpath_already_set(mocker, patcher, elf_file):
     )
 
     patcher.patch(elf_file=elf_file)
+    # raise Exception(os.environ['PATH'])
     assert run_mock.mock_calls == [
         call(
             [
-                "/usr/bin/patchelf",
+                PATCHELF_PATH,
                 "--set-interpreter",
                 "/my/dynamic/linker",
                 ANY,

--- a/tests/unit/elf/test_patcher.py
+++ b/tests/unit/elf/test_patcher.py
@@ -76,7 +76,7 @@ def elf_file(new_dir):
 
 
 @pytest.fixture
-def patcher(mocker):
+def patcher():
     yield elf.Patcher(
         dynamic_linker="/my/dynamic/linker",
         root_path=Path("/snap/foo/current"),

--- a/tests/unit/elf/test_patcher.py
+++ b/tests/unit/elf/test_patcher.py
@@ -86,7 +86,7 @@ def patcher():
 
 def test_patcher_patch_rpath(mocker, patcher, elf_file):
     run_mock = mocker.patch("subprocess.check_call")
-    run_rpath_mock = mocker.patch("subprocess.check_output", return_value=b"\n")
+    mocker.patch("subprocess.check_output", return_value=b"\n")
     expected_proposed_rpath = list(elf_file.dependencies)[0].path.parent
     assert patcher.get_current_rpath(elf_file) == []
 
@@ -160,7 +160,7 @@ def test_patcher_patch_existing_rpath_not_origin(mocker, patcher, elf_file):
 
 def test_patcher_patch_rpath_same_interpreter(mocker, patcher, elf_file):
     run_mock = mocker.patch("subprocess.check_call")
-    run_rpath_mock = mocker.patch("subprocess.check_output", return_value=b"\n")
+    mocker.patch("subprocess.check_output", return_value=b"\n")
     patcher._dynamic_linker = elf_file.interp
 
     expected_proposed_rpath = list(elf_file.dependencies)[0].path.parent


### PR DESCRIPTION
Discovered this accidentally thanks to a `~/.bashrc` that put `/bin` before `/usr/bin` in `$PATH`.

I'm not entirely sure this was unintentional, so unless someone else knows we should probably wait for @sergiusens.