### PR TITLE
Suggest an arguably simpler alternative

### DIFF
--- a/tools/environment-setup.sh
+++ b/tools/environment-setup.sh
@@ -42,4 +42,4 @@ lxc exec snapcraft-dev -- sudo -iu ubuntu bash -c \
     "echo 'source /home/ubuntu/.venv/snapcraft/bin/activate' >> .bashrc"
 
 echo "Container ready, enter it by running: "
-echo "lxc exec snapcraft-dev -- sudo -iu ubuntu bash"
+echo "lxc exec snapcraft-dev -- su --login ubuntu"


### PR DESCRIPTION
The dev container can also be accessed via `su - ubuntu`. This suggestion does not have a lot of practical relevance, the command is slightly shorter though :)

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
