### PR TITLE
requirements: update to craft-parts 1.18.0

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -13,7 +13,7 @@ colorama==0.4.6
 coverage==7.0.4
 craft-cli==1.2.0
 craft-grammar==1.1.1
-craft-parts==1.17.1
+craft-parts==1.18.0
 craft-providers==1.7.1
 craft-store==2.3.0
 cryptography==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ charset-normalizer==2.1.1
 click==8.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
-craft-parts==1.17.1
+craft-parts==1.18.0
 craft-providers==1.7.1
 craft-store==2.3.0
 cryptography==3.4

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -261,6 +261,8 @@ def _run_command(
 
     step_name = "prime" if command_name in ("pack", "snap", "try") else command_name
 
+    track_stage_packages = getattr(parsed_args, "enable_manifest", False)
+
     lifecycle = PartsLifecycle(
         project.parts,
         work_dir=work_dir,
@@ -278,6 +280,7 @@ def _run_command(
         },
         extra_build_snaps=project.get_extra_build_snaps(),
         target_arch=project.get_build_for(),
+        track_stage_packages=track_stage_packages,
     )
 
     if command_name == "clean":

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -67,6 +67,7 @@ class PartsLifecycle:
         project_vars: Dict[str, str],
         extra_build_snaps: Optional[List[str]] = None,
         target_arch: str,
+        track_stage_packages: bool,
     ):
         self._work_dir = work_dir
         self._assets_dir = assets_dir
@@ -96,6 +97,7 @@ class PartsLifecycle:
                 base=base,
                 ignore_local_sources=["*.snap"],
                 extra_build_snaps=extra_build_snaps,
+                track_stage_packages=track_stage_packages,
                 parallel_build_count=parallel_build_count,
                 project_name=project_name,
                 project_vars_part_name=adopt_info,

--- a/tests/unit/parts/test_parts.py
+++ b/tests/unit/parts/test_parts.py
@@ -48,6 +48,7 @@ def test_parts_lifecycle_run(mocker, parts_data, step_name, new_dir, emitter):
         parse_info={},
         project_vars={"version": "1", "grade": "stable"},
         extra_build_snaps=["core22"],
+        track_stage_packages=True,
         target_arch="amd64",
     )
     lifecycle.run(step_name)
@@ -63,6 +64,7 @@ def test_parts_lifecycle_run(mocker, parts_data, step_name, new_dir, emitter):
             base="core22",
             ignore_local_sources=["*.snap"],
             extra_build_snaps=["core22"],
+            track_stage_packages=True,
             parallel_build_count=8,
             project_name="test-project",
             project_vars_part_name=None,
@@ -86,6 +88,7 @@ def test_parts_lifecycle_run_bad_step(parts_data, new_dir):
         project_name="test-project",
         project_vars={"version": "1", "grade": "stable"},
         target_arch="amd64",
+        track_stage_packages=True,
     )
     with pytest.raises(RuntimeError) as raised:
         lifecycle.run("invalid")
@@ -106,6 +109,7 @@ def test_parts_lifecycle_run_internal_error(parts_data, new_dir, mocker):
         parse_info={},
         project_vars={"version": "1", "grade": "stable"},
         target_arch="amd64",
+        track_stage_packages=True,
     )
     mocker.patch("craft_parts.LifecycleManager.plan", side_effect=RuntimeError("crash"))
     with pytest.raises(RuntimeError) as raised:
@@ -127,6 +131,7 @@ def test_parts_lifecycle_run_parts_error(new_dir):
         parse_info={},
         project_vars={"version": "1", "grade": "stable"},
         target_arch="amd64",
+        track_stage_packages=True,
     )
     with pytest.raises(errors.PartsLifecycleError) as raised:
         lifecycle.run("prime")
@@ -149,6 +154,7 @@ def test_parts_lifecycle_clean(parts_data, new_dir, emitter):
         parse_info={},
         project_vars={"version": "1", "grade": "stable"},
         target_arch="amd64",
+        track_stage_packages=True,
     )
     lifecycle.clean(part_names=None)
     emitter.assert_progress("Cleaning all parts")
@@ -168,6 +174,7 @@ def test_parts_lifecycle_clean_parts(parts_data, new_dir, emitter):
         parse_info={},
         project_vars={"version": "1", "grade": "stable"},
         target_arch="amd64",
+        track_stage_packages=True,
     )
     lifecycle.clean(part_names=["p1"])
     emitter.assert_progress("Cleaning parts: p1")
@@ -211,6 +218,7 @@ def test_parts_lifecycle_initialize_with_package_repositories_deps_not_installed
         parse_info={},
         project_vars={"version": "1", "grade": "stable"},
         extra_build_snaps=["core22"],
+        track_stage_packages=True,
         target_arch="amd64",
     )
 
@@ -259,6 +267,7 @@ def test_parts_lifecycle_initialize_with_package_repositories_deps_installed(
         parse_info={},
         project_vars={"version": "1", "grade": "stable"},
         extra_build_snaps=["core22"],
+        track_stage_packages=True,
         target_arch="amd64",
     )
 
@@ -275,6 +284,7 @@ def test_parts_lifecycle_bad_architecture(parts_data, new_dir):
             assets_dir=new_dir,
             base="core22",
             parallel_build_count=8,
+            track_stage_packages=True,
             part_names=[],
             package_repositories=[],
             adopt_info=None,
@@ -298,6 +308,7 @@ def test_parts_lifecycle_run_with_all_architecture(mocker, parts_data, new_dir):
         assets_dir=new_dir,
         base="core22",
         parallel_build_count=8,
+        track_stage_packages=True,
         part_names=[],
         package_repositories=[],
         adopt_info=None,
@@ -318,6 +329,7 @@ def test_parts_lifecycle_run_with_all_architecture(mocker, parts_data, new_dir):
             base="core22",
             ignore_local_sources=["*.snap"],
             extra_build_snaps=None,
+            track_stage_packages=True,
             parallel_build_count=8,
             project_name="test-project",
             project_vars_part_name=None,


### PR DESCRIPTION
Use craft-parts' optional stage package tracking only when manifest is enabled. This allows Snapcraft to run on instances based on tmpfs, for faster builds and snap development cycles.

This release also adds plugins for SCons, Ant, and Maven, and fixes directory cleaning. See the Craft-parts project changelog for a complete list of changes.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
