### PR TITLE
providers: push .bashrc to Multipass instances

### DIFF
--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -42,6 +42,7 @@ SNAPCRAFT_BASE_TO_PROVIDER_BASE = {
     "core22": bases.BuilddBaseAlias.JAMMY,
 }
 
+# TODO: move to a package data file for shellcheck and syntax highlighting
 # pylint: disable=line-too-long
 BASHRC = dedent(
     """\

--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -15,10 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Snapcraft-specific code to interface with craft-providers."""
-
+import io
 import os
 import sys
-import tempfile
 from pathlib import Path
 from textwrap import dedent
 from typing import Dict, Optional
@@ -26,7 +25,7 @@ from typing import Dict, Optional
 from craft_cli import emit
 from craft_providers import Provider, ProviderError, bases, executor
 from craft_providers.lxd import LXDProvider
-from craft_providers.multipass import MultipassInstance, MultipassProvider
+from craft_providers.multipass import MultipassProvider
 
 from snapcraft.snap_config import get_snap_config
 from snapcraft.utils import (
@@ -42,6 +41,65 @@ SNAPCRAFT_BASE_TO_PROVIDER_BASE = {
     "core20": bases.BuilddBaseAlias.FOCAL,
     "core22": bases.BuilddBaseAlias.JAMMY,
 }
+
+# pylint: disable=line-too-long
+BASHRC = dedent(
+    """\
+    #!/bin/bash
+
+    env_file="$HOME/environment.sh"
+
+    # save default environment on first login
+    if [[ ! -e $env_file ]]; then
+        env > "$env_file"
+        sed -i 's/^/export /' "$env_file"      # prefix 'export' to variables
+        sed -i 's/=/="/; s/$/"/' "$env_file"   # surround values with quotes
+        sed -i '1i#! /bin/bash\\n' "$env_file" # add shebang
+        fi
+        previous_pwd=$PWD
+
+    function set_environment {
+        # only update the environment when the directory changes
+        if [[ ! $PWD = "$previous_pwd" ]]; then
+            # set part's environment when inside a part's build directory
+            if [[ "$PWD" =~ $HOME/parts/.*/build ]] && [[ -e "${PWD/build*/run/environment.sh}" ]] ; then
+                part_name=$(echo "${PWD#$"HOME"}" | cut -d "/" -f 3)
+                echo "build environment set for part '$part_name'"
+                # shellcheck disable=SC1090
+                source "${PWD/build*/run/environment.sh}"
+
+            # else clear and set the default environment
+            else
+                # shellcheck disable=SC2046
+                unset $(/usr/bin/env | /usr/bin/cut -d= -f1)
+                # shellcheck disable=SC1090
+                source "$env_file"
+                PWD="$(pwd)"
+                export PWD
+            fi
+        fi
+        previous_pwd=$PWD
+    }
+
+    function set_prompt {
+        # do not show path in HOME directory
+        if [[ "$PWD" = "$HOME" ]]; then
+            export PS1="\\h # "
+
+        # show relative path inside a subdirectory of HOME
+        elif [[ "$PWD" =~ ^$HOME/* ]]; then
+            export PS1="\\h ..${PWD/$HOME/}# "
+
+        # show full path outside the home directory
+        else
+            export PS1="\\h $PWD# "
+        fi
+    }
+
+    PROMPT_COMMAND="set_environment; set_prompt"
+    """
+)
+# pylint: enable=line-too-long
 
 
 def capture_logs_from_instance(instance: executor.Executor) -> None:
@@ -276,72 +334,8 @@ def prepare_instance(
             target=get_managed_environment_home_path() / ".ssh",
         )
 
-    # set up .bashrc
-    # do not push .bashrc to Multipass instances due to craft-providers limitation
-    # (see https://github.com/canonical/craft-providers/issues/169)
-    if isinstance(instance, MultipassInstance):
-        return
-
-    with tempfile.NamedTemporaryFile(mode="w+t") as bashrc:
-        bashrc.write(
-            # pylint: disable=line-too-long
-            dedent(
-                """\
-                #!/bin/bash
-
-                env_file="$HOME/environment.sh"
-
-                # save default environment on first login
-                if [[ ! -e $env_file ]]; then
-                    env > "$env_file"
-                    sed -i 's/^/export /' "$env_file"      # prefix 'export' to variables
-                    sed -i 's/=/="/; s/$/"/' "$env_file"   # surround values with quotes
-                    sed -i '1i#! /bin/bash\\n' "$env_file" # add shebang
-                fi
-
-                previous_pwd=$PWD
-
-                function set_environment {
-                    # only update the environment when the directory changes
-                    if [[ ! $PWD = "$previous_pwd" ]]; then
-                        # set part's environment when inside a part's build directory
-                        if [[ "$PWD" =~ $HOME/parts/.*/build ]] && [[ -e "${PWD/build*/run/environment.sh}" ]] ; then
-                            part_name=$(echo "${PWD#$"HOME"}" | cut -d "/" -f 3)
-                            echo "build environment set for part '$part_name'"
-                            # shellcheck disable=SC1090
-                            source "${PWD/build*/run/environment.sh}"
-
-                        # else clear and set the default environment
-                        else
-                            # shellcheck disable=SC2046
-                            unset $(/usr/bin/env | /usr/bin/cut -d= -f1)
-                            # shellcheck disable=SC1090
-                            source "$env_file"
-                            PWD="$(pwd)"
-                            export PWD
-                        fi
-                    fi
-                    previous_pwd=$PWD
-                }
-
-                function set_prompt {
-                    # do not show path in HOME directory
-                    if [[ "$PWD" = "$HOME" ]]; then
-                        export PS1="\\h # "
-
-                    # show relative path inside a subdirectory of HOME
-                    elif [[ "$PWD" =~ ^$HOME/* ]]; then
-                        export PS1="\\h ..${PWD/$HOME/}# "
-
-                    # show full path outside the home directory
-                    else
-                        export PS1="\\h $PWD# "
-                    fi
-                }
-
-                PROMPT_COMMAND="set_environment; set_prompt"
-                """
-            )
-        )
-        bashrc.flush()
-        instance.push_file(source=Path(bashrc.name), destination=Path("/root/.bashrc"))
+    instance.push_file_io(
+        destination=Path("/root/.bashrc"),
+        content=io.BytesIO(BASHRC.encode()),
+        file_mode="644",
+    )

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -15,8 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pathlib import Path
-from textwrap import dedent
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import pytest
 from craft_providers import ProviderError, bases
@@ -505,14 +504,8 @@ def test_get_provider_snap_config_default(mocker, platform, expected_provider):
 @pytest.mark.parametrize("bind_ssh", [False, True])
 def test_prepare_instance(bind_ssh, mock_instance, mocker, tmp_path):
     """Verify instance is properly prepared."""
-    mock_temp_file = MagicMock()
-    mock_named_temporary_file = mocker.patch(
-        "snapcraft.providers.tempfile.NamedTemporaryFile"
-    )
-    mock_named_temporary_file.return_value.__enter__.return_value = mock_temp_file
-
     providers.prepare_instance(
-        instance=mock_instance, host_project_path=tmp_path, bind_ssh=True
+        instance=mock_instance, host_project_path=tmp_path, bind_ssh=bind_ssh
     )
 
     mock_instance.mount.assert_has_calls(
@@ -524,69 +517,6 @@ def test_prepare_instance(bind_ssh, mock_instance, mocker, tmp_path):
             [call(host_source=Path().home() / ".ssh", target=Path("/root/.ssh"))]
         )
 
-    mock_temp_file.write.assert_called_once_with(
-        # pylint: disable=line-too-long
-        dedent(
-            """\
-            #!/bin/bash
-
-            env_file="$HOME/environment.sh"
-
-            # save default environment on first login
-            if [[ ! -e $env_file ]]; then
-                env > "$env_file"
-                sed -i 's/^/export /' "$env_file"      # prefix 'export' to variables
-                sed -i 's/=/="/; s/$/"/' "$env_file"   # surround values with quotes
-                sed -i '1i#! /bin/bash\\n' "$env_file" # add shebang
-            fi
-
-            previous_pwd=$PWD
-
-            function set_environment {
-                # only update the environment when the directory changes
-                if [[ ! $PWD = "$previous_pwd" ]]; then
-                    # set part's environment when inside a part's build directory
-                    if [[ "$PWD" =~ $HOME/parts/.*/build ]] && [[ -e "${PWD/build*/run/environment.sh}" ]] ; then
-                        part_name=$(echo "${PWD#$"HOME"}" | cut -d "/" -f 3)
-                        echo "build environment set for part '$part_name'"
-                        # shellcheck disable=SC1090
-                        source "${PWD/build*/run/environment.sh}"
-
-                    # else clear and set the default environment
-                    else
-                        # shellcheck disable=SC2046
-                        unset $(/usr/bin/env | /usr/bin/cut -d= -f1)
-                        # shellcheck disable=SC1090
-                        source "$env_file"
-                        PWD="$(pwd)"
-                        export PWD
-                    fi
-                fi
-                previous_pwd=$PWD
-            }
-
-            function set_prompt {
-                # do not show path in HOME directory
-                if [[ "$PWD" = "$HOME" ]]; then
-                    export PS1="\\h # "
-
-                # show relative path inside a subdirectory of HOME
-                elif [[ "$PWD" =~ ^$HOME/* ]]; then
-                    export PS1="\\h ..${PWD/$HOME/}# "
-
-                # show full path outside the home directory
-                else
-                    export PS1="\\h $PWD# "
-                fi
-            }
-
-            PROMPT_COMMAND="set_environment; set_prompt"
-            """
-        )
-    )
-
-    mock_temp_file.flush.assert_called_once()
-
-    mock_instance.push_file.assert_has_calls(
-        [call(source=Path(mock_temp_file.name), destination=Path("/root/.bashrc"))]
+    mock_instance.push_file_io.assert_called_with(
+        content=ANY, destination=Path("/root/.bashrc"), file_mode="644"
     )


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

1. Allow `.bashrc` to be pushed into Multipass instances.  This is now possible due to [this `craft-providers` PR](https://github.com/canonical/craft-providers/pull/193) being merged.
2. Stop writing `.bashrc` to a temporary file on the host.  Instead, use `craft-providers` method `push_file_io`.


(CRAFT-1545)