### PR TITLE
tests: update ruby bundle v1 spread test

### DIFF
--- a/tests/spread/plugins/v1/ruby/snaps/ruby-bundle-install/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/ruby/snaps/ruby-bundle-install/snap/snapcraft.yaml
@@ -1,8 +1,7 @@
 name: ruby-bundle-install
 version: "1.0"
 summary: Test bundle install
-description: |
-  Snap to test 'bundle install' command
+description: Snap to test 'bundle install' command
 
 grade: devel
 base: core18
@@ -17,3 +16,6 @@ parts:
     plugin: ruby
     source: .
     use-bundler: true
+    ruby-version: "2.6.10" # bundler requires ruby >= 2.6.0
+    build-environment:
+      - BUNDLE_GEMFILE: "$SNAPCRAFT_PART_SRC/Gemfile"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Ruby's `bundler v3.4.0` [dropped support](https://github.com/rubygems/rubygems/releases/tag/v3.4.0) for Ruby < `v2.6`, which broke one of our spread tests for the core18 / v1 Ruby plugin. 