### PR TITLE
Freeze ruff version

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -89,7 +89,7 @@ raven==6.10.0
 requests==2.28.1
 requests-toolbelt==0.10.0
 requests-unixsocket==0.3.0
-ruff==0.0.215
+ruff==0.0.220
 SecretStorage==3.3.3
 semantic-version==2.10.0
 semver==2.13.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,10 +94,9 @@ skip_install = true
 commands = black setup.py snapcraft tests
 
 [testenv:format-ruff]
+base = ruff
 description = Autoformat with ruff
 labels = fix
-deps = ruff
-skip_install = true
 commands =
     ruff --fix setup.py snapcraft tests tools
     ruff --fix --config snapcraft_legacy/ruff.toml snapcraft_legacy tests/legacy
@@ -157,7 +156,7 @@ commands = codespell
 description = Lint with ruff
 skip_install = true
 labels = lint
-deps = ruff
+deps = ruff==0.0.220
 # This runs all commands even if the first fails.
 # Not to be confused with ignore_outcome, which turns errors into warnings.
 ignore_errors = true

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ dev_requires = [
     "pytest-cov",
     "pytest-mock",
     "pytest-subprocess",
-    "ruff",
+    "ruff==0.0.220",
     "tox>=4.0",
     "types-PyYAML",
     "types-requests",


### PR DESCRIPTION
Ruff is currently iterating quickly and adding many tests in each new version. This change will move ruff breakages into the renovate update PRs rather than random PRs.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
