### PR TITLE
lint: ignore snapd-testing-tools, venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ test-ruff:
 
 .PHONY: test-shellcheck
 test-shellcheck:
-	tox run -e spellcheck
+	tox run -e shellcheck
+	tox run -e spread-shellcheck
 
 .PHONY: test-legacy-units
 test-legacy-units:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
 line_length = 88
+skip_gitignore = true
+skip = ["tests/spread/tools/snapd-testing-tools"]
 
 [tool.pylint.main]
 ignore-paths = ["tests/legacy"]
@@ -68,6 +70,7 @@ exclude = [
     "tests/spread",
     "tests/legacy",
     "tools",
+    "venv",
 ]
 
 [tool.pyright]

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,10 +117,12 @@ labels = lint
 skip_install = true
 allowlist_externals = bash
 commands =
-    bash -c "find . \( -name .git -o -name gradlew -o -name .tox \) -prune -o -print0 | xargs -0 file -N | grep shell.script | cut -f1 -d: | xargs shellcheck"
+    bash -c "find . \( -name .git -o -name gradlew -o -name .tox -o -name .ruff_cache -o \
+    -path ./tests/spread/tools/snapd-testing-tools \) -prune -o -print0 | xargs -0 file -N \
+    | grep shell.script | cut -f1 -d: | xargs shellcheck"
 
-[testenv:spellcheck]
-description = Check spelling using spread-shellcheck.py
+[testenv:spread-shellcheck]
+description = Run shellcheck on spread's test.yaml files using spread-shellcheck.py
 labels = lint
 deps = pyyaml
 skip_install = true


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Some minor fixes to the snapcraft linters that fail in a developer environment but not on CI (due to the dev environment having directories like `./build/`, `./venv/`, and submodules.
1. mypy - ignore `venv`
2. isort - ignore `snapd-testing-tools` and files in `.gitignore`
3. shellcheck - ignore `snapd-testing-tools` and `.ruff-cache`
4. Rename `spellcheck` to `spread-shellcheck`