### PR TITLE
requirements: update craft-parts to 1.18.1

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -13,7 +13,7 @@ colorama==0.4.6
 coverage==7.0.4
 craft-cli==1.2.0
 craft-grammar==1.1.1
-craft-parts==1.18.0
+craft-parts==1.18.1
 craft-providers==1.7.2
 craft-store==2.3.0
 cryptography==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ charset-normalizer==2.1.1
 click==8.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
-craft-parts==1.18.0
+craft-parts==1.18.1
 craft-providers==1.7.2
 craft-store==2.3.0
 cryptography==3.4


### PR DESCRIPTION
Craft-parts 1.18.1 fixes ignored file patterns when processing local sources.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
