### PR TITLE
requirements: pin setuptools<66

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,8 @@ install_requires = [
     "requests-toolbelt",
     "requests-unixsocket",
     "requests",
+    # pin setuptools<66 (CRAFT-1598)
+    "setuptools<66",
     "simplejson",
     "snap-helpers",
     "tabulate",

--- a/snapcraft/elf/_elf_file.py
+++ b/snapcraft/elf/_elf_file.py
@@ -324,6 +324,7 @@ class ElfFile:
     def is_linker_compatible(self, *, linker_version: str) -> bool:
         """Determine if the linker will work given the required glibc version."""
         version_required = self.get_required_glibc()
+        # TODO: pkg_resources is deprecated in setuptools>66 (CRAFT-1598)
         is_compatible = parse_version(version_required) <= parse_version(linker_version)
         emit.debug(
             f"Check if linker {linker_version!r} works with GLIBC_{version_required} "
@@ -342,6 +343,7 @@ class ElfFile:
                 if not version.startswith("GLIBC_"):
                     continue
                 version = version[6:]
+                # TODO: pkg_resources is deprecated in setuptools>66 (CRAFT-1598)
                 if parse_version(version) > parse_version(version_required):
                     version_required = version
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

[`setuptools>=66`](https://setuptools.pypa.io/en/stable/history.html#v66-0-0) enforces versioning requirements from [PEP 440](https://peps.python.org/pep-0440/), which causes some of the unit tests to fail.

Added comments and a TODO so it can be resolved in the future.


