### PR TITLE
requirements: update craft-providers to 1.7.2

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -14,7 +14,7 @@ coverage==7.0.4
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.18.0
-craft-providers==1.7.1
+craft-providers==1.7.2
 craft-store==2.3.0
 cryptography==3.4
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.18.0
-craft-providers==1.7.1
+craft-providers==1.7.2
 craft-store==2.3.0
 cryptography==3.4
 Deprecated==1.2.13


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

craft-providers 1.7.2 checks the id map for LXD instances for core22 snaps. 

Previously, when the same instance was launched by different users, it had the potential to raise errors. The most common error was the git error "dubious ownership detected in repository".