### PR TITLE
tests: update kde-frameworks sdk snap

### DIFF
--- a/snapcraft_legacy/internal/project_loader/_extensions/kde_neon.py
+++ b/snapcraft_legacy/internal/project_loader/_extensions/kde_neon.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2018-2019 Canonical Ltd
+# Copyright (C) 2018-2023 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -26,9 +26,9 @@ _ExtensionInfo = namedtuple("ExtensionInfo", "cmake_args content provider build_
 _Info = dict(
     core18=_ExtensionInfo(
         cmake_args=None,
-        content="kde-frameworks-5-core18-all",
-        provider="kde-frameworks-5-core18",
-        build_snaps=["kde-frameworks-5-core18-sdk/latest/stable"],
+        content="kde-frameworks-5-qt-5-14-core18-all",
+        provider="kde-frameworks-5-qt-5-14-core18",
+        build_snaps=["kde-frameworks-5-qt-5-14-core18-sdk/latest/stable"],
     ),
     core20=_ExtensionInfo(
         cmake_args="-DCMAKE_FIND_ROOT_PATH=/snap/kde-frameworks-5-99-qt-5-15-7-core20-sdk/current",

--- a/tests/legacy/unit/project_loader/extensions/test_kde_neon.py
+++ b/tests/legacy/unit/project_loader/extensions/test_kde_neon.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2019 Canonical Ltd
+# Copyright (C) 2019-2023 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -37,11 +37,11 @@ def test_extension_core18():
                 "target": "$SNAP/data-dir/sounds",
                 "default-provider": "gtk-common-themes",
             },
-            "kde-frameworks-5-core18": {
-                "content": "kde-frameworks-5-core18-all",
+            "kde-frameworks-5-qt-5-14-core18": {
+                "content": "kde-frameworks-5-qt-5-14-core18-all",
                 "interface": "content",
                 "target": "$SNAP/kf5",
-                "default-provider": "kde-frameworks-5-core18",
+                "default-provider": "kde-frameworks-5-qt-5-14-core18",
             },
         },
         "environment": {"SNAP_DESKTOP_RUNTIME": "$SNAP/kf5"},
@@ -63,9 +63,9 @@ def test_extension_core18():
             "source": "$SNAPCRAFT_EXTENSIONS_DIR/desktop",
             "source-subdir": "kde-neon",
             "plugin": "make",
-            "make-parameters": ["PLATFORM_PLUG=kde-frameworks-5-core18"],
+            "make-parameters": ["PLATFORM_PLUG=kde-frameworks-5-qt-5-14-core18"],
             "build-packages": ["g++"],
-            "build-snaps": ["kde-frameworks-5-core18-sdk/latest/stable"],
+            "build-snaps": ["kde-frameworks-5-qt-5-14-core18-sdk/latest/stable"],
         }
     }
 

--- a/tests/spread/extensions/snaps/neon-hello/snap/snapcraft.yaml
+++ b/tests/spread/extensions/snaps/neon-hello/snap/snapcraft.yaml
@@ -14,6 +14,6 @@ apps:
 
 parts:
   hello:
-    build-snaps: [kde-frameworks-5-core18-sdk]
+    build-snaps: [kde-frameworks-5-qt-5-14-core18-sdk]
     plugin: cmake
     source: .


### PR DESCRIPTION
Replace non-existing kde-frameworks-5-core18-sdk snap with kde-frameworks-5-qt-5-14-core18-sdk.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
