### PR TITLE
lint: use `git ls-files` for shellcheck

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -116,11 +116,8 @@ commands =
 description = Check spelling with shellcheck
 labels = lint
 skip_install = true
-allowlist_externals = bash
-commands =
-    bash -c "find . \( -name .git -o -name gradlew -o -name .tox -o -name .ruff_cache -o \
-    -path ./tests/spread/tools/snapd-testing-tools \) -prune -o -print0 | xargs -0 file -N \
-    | grep shell.script | cut -f1 -d: | xargs shellcheck"
+allowlist_externals = bash, git
+commands = bash -c "git ls-files | xargs file -N | grep shell.script | cut -f1 -d: | xargs shellcheck"
 
 [testenv:spread-shellcheck]
 description = Run shellcheck on spread's test.yaml files using spread-shellcheck.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,7 +117,7 @@ description = Check spelling with shellcheck
 labels = lint
 skip_install = true
 allowlist_externals = bash, git
-commands = bash -c "git ls-files | xargs file -N | grep shell.script | cut -f1 -d: | xargs shellcheck"
+commands = bash -c "git ls-files | file --mime-type -Nnf- | grep shellscript | cut -f1 -d: | xargs shellcheck"
 
 [testenv:spread-shellcheck]
 description = Run shellcheck on spread's test.yaml files using spread-shellcheck.py

--- a/tests/spread/plugins/v1/gradle/snaps/gradlew-hello/gradlew
+++ b/tests/spread/plugins/v1/gradle/snaps/gradlew-hello/gradlew
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=all
+
 ##############################################################################
 ##
 ##  Gradle start up script for UN*X


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

:heavy_check_mark: shellcheck linter execution time reduced from 20 seconds to 3 seconds
:heavy_check_mark: Ignore files in `.gitignore`
:heavy_check_mark: Ignore submodules (i.e. `test/spread/tools/snapd-testing-tools`)




