### PR TITLE
utils: log envvar SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT when invalid

### DIFF
--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -233,12 +233,13 @@ def get_parallel_build_count() -> int:
             )
             build_count = 1
 
+    max_count_env = os.environ.get("SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT", "")
     try:
-        max_count = int(os.environ.get("SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT", ""))
+        max_count = int(max_count_env)
         if max_count > 0:
             build_count = min(build_count, max_count)
     except ValueError:
-        emit.debug("Invalid SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT value")
+        emit.debug(f"Invalid SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT {max_count_env!r}")
 
     return build_count
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

No functional changes.

Minor logging improvement to log the environment variable `SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT` when it is invalid.  