### PR TITLE
ci: update deprecated node12-based actions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - if: steps.decisions.outputs.PUBLISH == 'true'
         name: Checkout Snapcraft
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Fetch all of history so Snapcraft can determine its own version from git.
           fetch-depth: 0

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout snapcraft
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -17,7 +17,7 @@ jobs:
         uses: snapcore/action-build@v1
 
       - name: Upload snapcraft snap
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: snap
           path: ${{ steps.build-snapcraft.outputs.snap }}
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout snapcraft
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
@@ -94,7 +94,7 @@ jobs:
 
       - if: steps.decisions.outputs.RUN == 'true'
         name: Checkout snapcraft
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
