### PR TITLE
ci: remove deleted set-output GH Action command

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,9 +13,9 @@ jobs:
           # Secrets cannot be used in conditionals, so this is our dance:
           # https://github.com/actions/runner/issues/520
           if [[ -n "${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}" ]]; then
-            echo "::set-output name=PUBLISH::true"
+            echo PUBLISH=true >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=PUBLISH::"
+            echo PUBLISH= >> $GITHUB_OUTPUT
           fi
 
       - if: steps.decisions.outputs.PUBLISH == 'true'

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -87,9 +87,9 @@ jobs:
           # Secrets cannot be used in conditionals, so this is our dance:
           # https://github.com/actions/runner/issues/520
           if [[ -n "${{ secrets.SNAPCRAFT_STORE_CREDENTIALS_STAGING }}" ]]; then
-            echo "::set-output name=RUN::true"
+            echo RUN=true >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=RUN::"
+            echo RUN= >> $GITHUB_OUTPUT
           fi
 
       - if: steps.decisions.outputs.RUN == 'true'


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
