### PR TITLE
tests: remove unused go dependencies in generated hook spread tests

### DIFF
--- a/tests/spread/general/hooks/generated-and-project-hooks/snap/snapcraft.yaml
+++ b/tests/spread/general/hooks/generated-and-project-hooks/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ parts:
   hooks:
     source: src/
     plugin: make
-    build-snaps: [go/1.17/stable]
+    build-snaps: [go/1.20/stable]
     override-build: |
       cd $SNAPCRAFT_PART_SRC
       make build

--- a/tests/spread/general/hooks/generated-and-project-hooks/src/Makefile
+++ b/tests/spread/general/hooks/generated-and-project-hooks/src/Makefile
@@ -6,7 +6,7 @@ build:
 	$(GO) build $(GOFLAGS) -o install install.go
 
 tidy:
-	go mod tidy -compat=1.17
+	go mod tidy -compat=1.20
 
 clean:
 	rm -f configure install

--- a/tests/spread/general/hooks/generated-and-project-hooks/src/go.mod
+++ b/tests/spread/general/hooks/generated-and-project-hooks/src/go.mod
@@ -1,8 +1,3 @@
 module github.com/snapcore/snapcraft/tests/spread/general/hooks/generated-hooks
 
-go 1.17
-
-require (
-	golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c // indirect
-	rsc.io/sampler v1.3.0 // indirect
-)
+go 1.20

--- a/tests/spread/general/hooks/generated-hooks/snap/snapcraft.yaml
+++ b/tests/spread/general/hooks/generated-hooks/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ parts:
   hooks:
     source: src/
     plugin: make
-    build-snaps: [go/1.17/stable]
+    build-snaps: [go/1.20/stable]
     override-build: |
       cd $SNAPCRAFT_PART_SRC
       make build

--- a/tests/spread/general/hooks/generated-hooks/src/Makefile
+++ b/tests/spread/general/hooks/generated-hooks/src/Makefile
@@ -6,7 +6,7 @@ build:
 	$(GO) build $(GOFLAGS) -o install install.go
 
 tidy:
-	go mod tidy -compat=1.17
+	go mod tidy -compat=1.20
 
 clean:
 	rm -f configure install

--- a/tests/spread/general/hooks/generated-hooks/src/go.mod
+++ b/tests/spread/general/hooks/generated-hooks/src/go.mod
@@ -1,8 +1,3 @@
 module github.com/snapcore/snapcraft/tests/spread/general/hooks/generated-hooks
 
-go 1.17
-
-require (
-	golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c // indirect
-	rsc.io/sampler v1.3.0 // indirect
-)
+go 1.20

--- a/tests/spread/general/hooks/generated-then-project-hooks/snap/snapcraft.yaml
+++ b/tests/spread/general/hooks/generated-then-project-hooks/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ parts:
   hooks:
     source: src/
     plugin: make
-    build-snaps: [go/1.17/stable]
+    build-snaps: [go/1.20/stable]
     override-build: |
       cd $SNAPCRAFT_PART_SRC
       make build

--- a/tests/spread/general/hooks/generated-then-project-hooks/src/Makefile
+++ b/tests/spread/general/hooks/generated-then-project-hooks/src/Makefile
@@ -6,7 +6,7 @@ build:
 	$(GO) build $(GOFLAGS) -o install install.go
 
 tidy:
-	go mod tidy -compat=1.17
+	go mod tidy -compat=1.20
 
 clean:
 	rm -f configure install

--- a/tests/spread/general/hooks/generated-then-project-hooks/src/go.mod
+++ b/tests/spread/general/hooks/generated-then-project-hooks/src/go.mod
@@ -1,8 +1,3 @@
 module github.com/snapcore/snapcraft/tests/spread/general/hooks/generated-hooks
 
-go 1.17
-
-require (
-	golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c // indirect
-	rsc.io/sampler v1.3.0 // indirect
-)
+go 1.20


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Some unused go dependencies triggered `dependabot` in:
- https://github.com/snapcore/snapcraft/pull/4049
- https://github.com/snapcore/snapcraft/pull/4050
- https://github.com/snapcore/snapcraft/pull/4051


I removed the deps and bumped the go version.  These tests aren't meant to exercise the Go plugin, they are testing hooks (which happen to be written in Go) generated during the build step.