### PR TITLE
extensions: fix neon-extension issues for core22

### DIFF
--- a/extensions/desktop/kde-neon/Makefile
+++ b/extensions/desktop/kde-neon/Makefile
@@ -7,7 +7,6 @@ BIN_DIR              := $(DESTDIR)/snap/command-chain
 LIB_DIR              := $(DESTDIR)/lib
 DEST_LAUNCHER        := desktop-launch
 LOCALE_GENERATOR     := locale-gen
-BINDTEXTDOMAIN       := bindtextdomain.so
 DEST_CONFIGURE_HOOK  := hooks-configure-desktop
 
 build: $(DEST_LAUNCHER) $(DEST_CONFIGURE_HOOK)
@@ -23,7 +22,6 @@ $(DEST_LAUNCHER):
 	@tail -n +2 $(SRC_DIR)/desktop-exports | sed -e "s/%PLATFORM_PLUG%/$${PLATFORM_PLUG:?}/" >> $(DEST_LAUNCHER)
 	@tail -n +2 $(SRC_DIR)/launcher-specific >> $(DEST_LAUNCHER)
 	@tail -n +2 $(SRC_DIR)/mark-and-exec >> $(DEST_LAUNCHER)
-	gcc -Wall -O2 -o $(BINDTEXTDOMAIN) -fPIC -shared $(SRC_DIR)/../src/bindtextdomain.c -ldl
 
 $(DEST_CONFIGURE_HOOK):
 	@cat $(SRC_DIR)/fonts > $(DEST_CONFIGURE_HOOK)
@@ -33,5 +31,4 @@ install: $(DEST_LAUNCHER) $(DEST_CONFIGURE_HOOK)
 	install -d $(DATA_DIR)/kf5
 	install -D -m755 $(DEST_LAUNCHER) "$(BIN_DIR)"/$(DEST_LAUNCHER)
 	install -D -m755 $(LOCALE_GENERATOR) "$(BIN_DIR)"/$(LOCALE_GENERATOR)
-	install -D -m644 $(BINDTEXTDOMAIN) "$(LIB_DIR)"/$(BINDTEXTDOMAIN)
 	install -D -m755 $(DEST_CONFIGURE_HOOK) "$(BIN_DIR)"/$(DEST_CONFIGURE_HOOK)

--- a/tests/spread/extensions/kde-neon/task.yaml
+++ b/tests/spread/extensions/kde-neon/task.yaml
@@ -7,6 +7,9 @@ systems:
   - ubuntu-20.04
   - ubuntu-20.04-64
   - ubuntu-20.04-amd64
+  - ubuntu-22.04
+  - ubuntu-22.04-64
+  - ubuntu-22.04-amd64
 
 environment:
   SNAP_DIR: ../snaps/neon-hello
@@ -15,11 +18,6 @@ prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
-
-  if [[ "$SPREAD_SYSTEM" =~ ubuntu-20.04 ]]; then
-    sed -i 's|command: bin/hello|command: usr/local/bin/hello|' "${SNAP_DIR}/snap/snapcraft.yaml"
-    sed '/build-snaps: .*/d' "${SNAP_DIR}/snap/snapcraft.yaml"
-  fi
 
 restore: |
   cd "$SNAP_DIR"
@@ -44,9 +42,15 @@ execute: |
   [ -f "$snap_user_data/.last_revision" ]
   [ "$(cat "$snap_user_data/.last_revision")" = "SNAP_DESKTOP_LAST_REVISION=x1" ]
 
+
   # Verify content snap was installed for dependency checks.
-  snap list kde-frameworks-5-99-qt-5-15-7-core20
   snap list gtk-common-themes
+  if [[ "$SPREAD_SYSTEM" =~ ubuntu-20.04 ]]; then
+    snap list kde-frameworks-5-99-qt-5-15-7-core20
+  elif [[ "$SPREAD_SYSTEM" =~ ubuntu-22.04 ]]; then
+    snap list kde-frameworks-5-102-qt-5-15-8-core22
+  fi
+
 
   # Verify all dependencies were found.
   if echo "$output" | grep -q "part is missing libraries"; then

--- a/tests/spread/extensions/snaps/neon-hello/snap/snapcraft.yaml
+++ b/tests/spread/extensions/snaps/neon-hello/snap/snapcraft.yaml
@@ -5,15 +5,13 @@ description: It simply prints a hello world
 
 grade: devel
 confinement: strict
-base: core18
 
 apps:
   neon-hello:
-    command: bin/hello
+    command: usr/local/bin/hello
     extensions: [kde-neon]
 
 parts:
   hello:
-    build-snaps: [kde-frameworks-5-core18-sdk]
     plugin: cmake
     source: .

--- a/tests/unit/extensions/test_kde_neon.py
+++ b/tests/unit/extensions/test_kde_neon.py
@@ -297,31 +297,26 @@ def test_get_part_snippet_with_external_sdk(kde_neon_extension_with_build_snap):
 
 
 def test_get_parts_snippet(kde_neon_extension):
-    source = get_extensions_data_dir() / "desktop" / "command-chain"
+    source = get_extensions_data_dir() / "desktop" / "kde-neon"
 
     assert kde_neon_extension.get_parts_snippet() == {
-        "kde-neon-extension/sdk": {
+        "kde-neon/sdk": {
             "source": str(source),
-            "source-subdir": "kde-neon",
             "plugin": "make",
             "make-parameters": ["PLATFORM_PLUG=kde-frameworks-5-102-qt-5-15-8-core22"],
-            "build-packages": ["g++"],
-            "build-snaps": ["kde-frameworks-5-102-qt-5-15-8-core22-sd/current/stable"],
+            "build-snaps": ["kde-frameworks-5-102-qt-5-15-8-core22-sd"],
         }
     }
 
 
 def test_get_parts_snippet_with_external_sdk(kde_neon_extension_with_build_snap):
-    source = get_extensions_data_dir() / "desktop" / "command-chain"
+    source = get_extensions_data_dir() / "desktop" / "kde-neon"
 
     assert kde_neon_extension_with_build_snap.get_parts_snippet() == {
-        "kde-neon-extension/sdk": {
+        "kde-neon/sdk": {
             "source": str(source),
-            "source-subdir": "kde-neon",
             "plugin": "make",
             "make-parameters": ["PLATFORM_PLUG=kde-frameworks-5-102-qt-5-15-8-core22"],
-            "build-packages": ["g++"],
-            "build-snaps": ["kde-frameworks-5-102-qt-5-15-8-core22-sd/current/stable"],
         }
     }
 
@@ -329,20 +324,15 @@ def test_get_parts_snippet_with_external_sdk(kde_neon_extension_with_build_snap)
 def test_get_parts_snippet_with_external_sdk_different_channel(
     kde_neon_extension_with_default_build_snap_from_latest_edge,
 ):
-    source = get_extensions_data_dir() / "desktop" / "command-chain"
+    source = get_extensions_data_dir() / "desktop" / "kde-neon"
     assert (
         kde_neon_extension_with_default_build_snap_from_latest_edge.get_parts_snippet()
         == {
-            "kde-neon-extension/sdk": {
+            "kde-neon/sdk": {
                 "source": str(source),
-                "source-subdir": "kde-neon",
                 "plugin": "make",
                 "make-parameters": [
                     "PLATFORM_PLUG=kde-frameworks-5-102-qt-5-15-8-core22"
-                ],
-                "build-packages": ["g++"],
-                "build-snaps": [
-                    "kde-frameworks-5-102-qt-5-15-8-core22-sd/current/stable"
                 ],
             }
         }


### PR DESCRIPTION
- moved back to the full blown command-chain for KDE Neon
- removed dependency on bindtextdomain
- updated the pattern match for kde sdk snaps
- tests updated to consider core22
- fixed the added part names

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
