### PR TITLE
ci: ensure workflows are cancellable

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -86,7 +86,7 @@ jobs:
           directory: ./results/
           files: coverage*.xml
       - name: Upload test results
-        if: always()
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: test-results-${{ matrix.platform }}


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
