### PR TITLE
fix(clean): non host cleaning shouldn't load the project

### DIFF
--- a/snapcraft_legacy/cli/lifecycle.py
+++ b/snapcraft_legacy/cli/lifecycle.py
@@ -468,9 +468,9 @@ def clean(ctx, parts, unprime, **kwargs):
                 instance.clean_parts(part_names=parts)
         else:
             build_provider_class(project=project, echoer=echo).clean_project()
-            # Clear the prime directory on the host, unless on Windows.
+            # Clear the prime directory on the host in case snapcraft try was used, unless on Windows.
             if sys.platform != "win32":
-                lifecycle.clean(project, parts, steps.PRIME)
+                lifecycle.clean_try_dir(project)
 
 
 if __name__ == "__main__":

--- a/snapcraft_legacy/internal/lifecycle/__init__.py
+++ b/snapcraft_legacy/internal/lifecycle/__init__.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from ._clean import clean  # noqa: F401
+from ._clean import clean, clean_try_dir  # noqa: F401
 from ._init import init  # noqa: F401
 from ._runner import execute  # noqa: F401
 from ._status_cache import StatusCache  # noqa: F401

--- a/snapcraft_legacy/internal/lifecycle/_clean.py
+++ b/snapcraft_legacy/internal/lifecycle/_clean.py
@@ -201,6 +201,7 @@ def clean(project: "Project", parts, step=None):
         # If we've been asked to clean stage or prime without being given
         # specific parts, just blow away those directories instead of
         # doing it per part (it would just be a waste of time).
+        print("Calling the cleanup prime part but the project is not loaded")
         _cleanup_common_directories_for_step(step, project, parts=config.all_parts)
 
         # No need to continue if that's all that was required
@@ -218,3 +219,10 @@ def clean(project: "Project", parts, step=None):
     _clean_parts(parts, step, config, staged_state, primed_state)
 
     _cleanup_common_directories(config, project)
+
+def clean_try_dir(project: "Project"):
+    # Attempt to clean the "try" directory on the host without loading the project
+    # since we are not on the normal provider
+
+    _cleanup_common_directories_for_step(steps.PRIME, project)
+    return

--- a/spread.yaml
+++ b/spread.yaml
@@ -72,7 +72,7 @@ backends:
           # SPREAD_SYSTEM has the following format here 'ubuntu-XX.YY-64' and gets
           # translated to an image XX.YY.
           image=$(echo $SPREAD_SYSTEM | sed -e 's/ubuntu-\(.*\)-64/\1/')
-          instance_name="spread-${image}"
+          instance_name="spread-$(echo $image | sed "s/\./\-/")"
       fi
 
       if [ -z "${image}" ]; then
@@ -101,7 +101,7 @@ backends:
           # SPREAD_SYSTEM has the following format here 'ubuntu-XX.YY-64' and gets
           # translated to an image XX.YY.
           image=$(echo $SPREAD_SYSTEM | sed -e 's/ubuntu-\(.*\)-64/\1/')
-          instance_name="spread-${image}"
+          instance_name="spread-$(echo $image | sed "s/\./\-/")"
       fi
 
       if [ -z "${image}" ]; then

--- a/spread.yaml
+++ b/spread.yaml
@@ -227,7 +227,15 @@ prepare: |
   fi
   # install and setup the lxd snap - use 'retry' to workaround aa-exec issue
   # see https://bugs.launchpad.net/snapd/+bug/1870201
-  retry -n 5 --wait 5 sh -c 'snap install lxd'
+  for _ in {1..5}
+  do
+    if [[ $(sh -c 'snap install lxd') ]]
+    then
+      break
+    else
+      sleep 5
+    fi
+  done
   # Add the ubuntu user to the lxd group.
   adduser ubuntu lxd
   lxd init --auto

--- a/spread.yaml
+++ b/spread.yaml
@@ -32,6 +32,8 @@ environment:
   # Git environment for commits
   GIT_AUTHOR_NAME: "Test User"
   GIT_AUTHOR_EMAIL: "test-user@email.com"
+  GIT_COMMITTER_NAME: "Test User"
+  GIT_COMMITTER_EMAIL: "test-user@email.com"
 
 backends:
   lxd:

--- a/tests/legacy/unit/commands/__init__.py
+++ b/tests/legacy/unit/commands/__init__.py
@@ -123,6 +123,11 @@ class LifecycleCommandsBaseTestCase(CommandBaseTestCase):
         )
         self.useFixture(self.fake_lifecycle_clean)
 
+        self.fake_lifecycle_clean_try_dir = fixtures.MockPatch(
+            "snapcraft_legacy.internal.lifecycle.clean_try_dir"
+        )
+        self.useFixture(self.fake_lifecycle_clean_try_dir)
+
         self.fake_lifecycle_execute = fixtures.MockPatch(
             "snapcraft_legacy.internal.lifecycle.execute"
         )

--- a/tests/legacy/unit/commands/test_build_providers.py
+++ b/tests/legacy/unit/commands/test_build_providers.py
@@ -522,12 +522,12 @@ class BuildProviderCleanCommandTestCase(LifecycleCommandsBaseTestCase):
 
         self.make_snapcraft_yaml("pull", base="core20")
 
-    @mock.patch("snapcraft_legacy.internal.lifecycle.clean")
-    def test_clean(self, lifecycle_clean_mock):
+    @mock.patch("snapcraft_legacy.internal.lifecycle.clean_try_dir")
+    def test_clean(self, lifecycle_clean_try_dir_mock):
         result = self.run_command(["clean"])
 
         self.assertThat(result.exit_code, Equals(0))
-        lifecycle_clean_mock.assert_called_once_with(mock.ANY, tuple(), steps.PRIME)
+        lifecycle_clean_try_dir_mock.assert_called_once_with(mock.ANY)
         self.clean_project_mock.assert_called_once_with()
         self.clean_mock.assert_not_called()
 

--- a/tests/legacy/unit/commands/test_clean.py
+++ b/tests/legacy/unit/commands/test_clean.py
@@ -18,8 +18,6 @@ from unittest import mock
 
 from testtools.matchers import Equals
 
-from snapcraft_legacy.internal import steps
-
 from . import LifecycleCommandsBaseTestCase
 
 
@@ -34,9 +32,7 @@ class CleanCommandTestCase(LifecycleCommandsBaseTestCase):
 
         self.assertThat(result.exit_code, Equals(0))
         self.fake_get_provider_for.mock.assert_called_once_with("multipass")
-        self.fake_lifecycle_clean.mock.assert_called_once_with(
-            mock.ANY, tuple(), steps.PRIME
-        )
+        self.fake_lifecycle_clean_try_dir.mock.assert_called_once_with(mock.ANY)
         self.provider_mock.clean_parts.assert_not_called()
         self.provider_class_mock().clean_project.assert_called_once_with()
 
@@ -56,9 +52,7 @@ class CleanCommandTestCase(LifecycleCommandsBaseTestCase):
 
         self.assertThat(result.exit_code, Equals(0))
         self.fake_get_provider_for.mock.assert_called_once_with("lxd")
-        self.fake_lifecycle_clean.mock.assert_called_once_with(
-            mock.ANY, tuple(), steps.PRIME
-        )
+        self.fake_lifecycle_clean_try_dir.mock.assert_called_once_with(mock.ANY)
         self.provider_mock.clean_parts.assert_not_called()
         self.provider_class_mock().clean_project.assert_called_once_with()
 

--- a/tests/legacy/unit/lifecycle/test_lifecycle.py
+++ b/tests/legacy/unit/lifecycle/test_lifecycle.py
@@ -401,6 +401,31 @@ class CleanTestCase(LifecycleTestBase):
         )
 
 
+class CleanTryDirTestCase(LifecycleTestBase):
+    def test_clean_removes_global_state(self):
+        project_config = self.make_snapcraft_project(
+            textwrap.dedent(
+                """\
+                parts:
+                  test-part:
+                    plugin: nil
+                """
+            )
+        )
+        lifecycle.execute(steps.PRIME, project_config)
+        self.assertThat(
+            steps.PRIME.name,
+            DirExists(),
+            "Expected prime directory to remain after cleaning for tried snap",
+        )
+        lifecycle.clean_try_dir(project_config.project)
+        self.assertThat(
+            steps.PRIME.name,
+            Not(DirExists()),
+            "Expected prime directory to be removed",
+        )
+
+
 class RecordSnapcraftYamlTestCase(LifecycleTestBase):
     def test_prime_without_build_info_does_not_record(self):
         self.useFixture(fixtures.EnvironmentVariable("SNAPCRAFT_BUILD_INFO", None))


### PR DESCRIPTION
The call to the `lifecycle.clean` method calls the
`project_loader.load_config` which calls the `pluginhandler.load_plugin`

This `load_plugin` method is using `sys.path` to load plugins. This is using the host `sys.path` (while cleaning a container/VM snap build).
If the host has a Python module with the same name as the snapcraft plugin, it will try to load the Python module from the host. The module from the host being something completely unrelated to snapcraft plugins, the load crashes.

A simple way to reproduce the error is to:
- source a [ROS Noetic](http://wiki.ros.org/noetic) environment (Expanding `PYTHONPATH` with a ROS dedicated path on the host)
- call `snapcraft --use-lxd` to build a ROS 1 Noetic snap
- run `snapcraft clean --use-lxd` to clean to snap build env
It will generate the following error:
```
Loaded local plugin for catkin
Failed to load plugin: unknown plugin: 'catkin'
```
It happens because it tries to load a local plugin found in the `PYTHONPATH`. The "local plugin" is simply a Python module from the host that was added to the `PYTHONPATH` when sourcing our environment.
The `PYTHONPATH` from the host shouldn't be used when cleaning a lxd environment


- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
