### PR TITLE
cli: fix help message for the "upload" command

### DIFF
--- a/snapcraft/commands/upload.py
+++ b/snapcraft/commands/upload.py
@@ -36,7 +36,7 @@ class StoreUploadCommand(BaseCommand):
     """Command to upload a snap to the Snap Store."""
 
     name = "upload"
-    help_msg = "Login to the Snap Store"
+    help_msg = "Upload a snap to the Snap Store"
     overview = textwrap.dedent(
         """
         By passing --release with a comma separated list of channels the snap would


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [] Have you successfully run `pytest tests/unit`?
Failing:

```
FAILED tests/unit/extensions/test_extensions.py::test_get_extensions_data_dir - AssertionError: assert False
```


-----
Just a small fix on a wrong help message possibly driven by a bad copy&paste.