### PR TITLE
lint: ignore files in .gitignore for black

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,14 +19,14 @@ htmlcov
 .mypy_cache
 /parts
 pip-wheel-metadata/
-prime
+/prime
 *.pyc
 __pycache__
 .pytest_cache
 *.snap
 snap/.snapcraft/
 .spread-reuse.*
-stage
+/stage
 *.swp
 target
 tests/unit/snap/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,23 +1,6 @@
 [tool.black]
-exclude = '''
+extend-exclude = '''
 /(
-    \.git
-  | \.direnv
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | \.vscode
-  | _build
-  | buck-out
-  | __pycache__
-  | build
-  | dist
-
-  # specific to snapcraft
-  | ^/parts
-  | ^/stage
-  | ^/prime
   | snapcraft_legacy
   | tools
 )/


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

1. Replace `exclude` with `extend-exclude` for `black`:

    From [black docs](https://black.readthedocs.io/en/stable/usage_and_configuration/file_collection_and_discovery.html#gitignore):

    > .gitignore
    >
    > If --exclude is not set, Black will automatically ignore files and directories in .gitignore file(s), if present.
    >
    > If you want Black to continue using .gitignore while also configuring the exclusion rules, please use --extend-exclude.

2. Only ignore `prime/` and `stage/` in the root of the project.  This is already done for `parts/`.  All 3 directories come from building snapcraft in destructive mode)
 