### PR TITLE
snapcraft commands: change "snap on snap store" to "snap in snap store"

### DIFF
--- a/snapcraft/commands/manage.py
+++ b/snapcraft/commands/manage.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 
 class StoreReleaseCommand(BaseCommand):
-    """Command to release a snap on the Snap Store."""
+    """Command to release a snap in the Snap Store."""
 
     name = "release"
     help_msg = "Release <name> to the store"
@@ -108,7 +108,7 @@ class StoreReleaseCommand(BaseCommand):
 
 
 class StoreCloseCommand(BaseCommand):
-    """Command to close a channel for a snap on the Snap Store."""
+    """Command to close a channel for a snap in the Snap Store."""
 
     name = "close"
     help_msg = "Close <channel> for <name> on the store"

--- a/snapcraft/commands/status.py
+++ b/snapcraft/commands/status.py
@@ -34,13 +34,13 @@ if TYPE_CHECKING:
 
 
 class StoreStatusCommand(BaseCommand):
-    """Command to check the status of a snap on the Snap Store."""
+    """Command to check the status of a snap in the Snap Store."""
 
     name = "status"
-    help_msg = "Show the status of a snap on the Snap Store"
+    help_msg = "Show the status of a snap in the Snap Store"
     overview = textwrap.dedent(
         """
-        Show the status of a snap on the Snap Store.
+        Show the status of a snap in the Snap Store.
         The name must be accessible from the requesting account by being
         the owner or a collaborator of the snap."""
     )
@@ -359,10 +359,10 @@ def get_tabulated_channel_map(  # pylint: disable=too-many-branches, too-many-lo
 
 
 class StoreListTracksCommand(BaseCommand):
-    """Command to list the tracks from a snap on the Snap Store."""
+    """Command to list the tracks from a snap in the Snap Store."""
 
     name = "list-tracks"
-    help_msg = "Show the available tracks for a snap on the Snap Store"
+    help_msg = "Show the available tracks for a snap in the Snap Store"
     overview = textwrap.dedent(
         """
         Track status, creation dates and version patterns are returned alongside the
@@ -415,7 +415,7 @@ class StoreListTracksCommand(BaseCommand):
 
 
 class StoreTracksCommand(StoreListTracksCommand):
-    """Command alias to list the tracks from a snap on the Snap Store."""
+    """Command alias to list the tracks from a snap in the Snap Store."""
 
     name = "tracks"
     hidden = True


### PR DESCRIPTION
"snap in snap store" just reads better.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
