### PR TITLE
grammar fixes: a number of grammar-type cleanups, no functional mods

### DIFF
--- a/snapcraft/commands/account.py
+++ b/snapcraft/commands/account.py
@@ -54,14 +54,14 @@ def _read_config(config_path) -> str:
 
 
 class StoreLoginCommand(BaseCommand):
-    """Command to login to the Snap Store."""
+    """Command to log in to the Snap Store."""
 
     name = "login"
-    help_msg = "Login to the Snap Store"
+    help_msg = "Log in to the Snap Store"
     overview = textwrap.dedent(
         f"""
-        Login to the Snap Store with your Ubuntu One SSO credentials.
-        If you do not have any, you can create them on https://login.ubuntu.com
+        Log in to the Snap Store with your Ubuntu One SSO credentials.
+        If you do not have any, you can create them at https://login.ubuntu.com
 
         To use the alternative authentication mechanism (Candid), set the
         environment variable {store.constants.ENVIRONMENT_STORE_AUTH!r} to 'candid'.
@@ -119,11 +119,11 @@ class StoreExportLoginCommand(BaseCommand):
     """Command to export login to use with the Snap Store."""
 
     name = "export-login"
-    help_msg = "Login to the Snap Store exporting the credentials"
+    help_msg = "Log in to the Snap Store exporting the credentials"
     overview = textwrap.dedent(
         f"""
-        Login to the Snap Store with your Ubuntu One SSO credentials.
-        If you do not have any, you can create them on https://login.ubuntu.com
+        Log in to the Snap Store with your Ubuntu One SSO credentials.
+        If you do not have any, you can create them at https://login.ubuntu.com
 
         To use the alternative authentication mechanism (Candid), set the
         environment variable {store.constants.ENVIRONMENT_STORE_AUTH!r} to 'candid'.
@@ -288,7 +288,7 @@ class StoreWhoAmICommand(BaseCommand):
 
 
 class StoreLogoutCommand(BaseCommand):
-    """Command to logout from the Snap Store."""
+    """Command to log out from the Snap Store."""
 
     name = "logout"
     help_msg = "Clear Snap Store credentials."

--- a/snapcraft/commands/legacy.py
+++ b/snapcraft/commands/legacy.py
@@ -211,7 +211,7 @@ class StoreLegacyCreateKeyCommand(LegacyBaseCommand):
     overview = textwrap.dedent(
         """
         Create a key and store it locally. Use the register-key command to register
-        it on the store."""
+        it in the store."""
     )
 
     @overrides

--- a/snapcraft/commands/manage.py
+++ b/snapcraft/commands/manage.py
@@ -36,9 +36,9 @@ class StoreReleaseCommand(BaseCommand):
     overview = textwrap.dedent(
         """
         Release <name> on <revision> to the selected store <channels>.
-        <channels> is a comma separated list of valid channels on the store.
+        <channels> is a comma-separated list of valid channels in the store.
 
-        The <revision> must exist on the store, to see available revisions run
+        The <revision> must exist in the store, to see available revisions run
         `snapcraft list-revisions <name>`.
 
         The channel map will be displayed after the operation takes place. To see
@@ -78,7 +78,7 @@ class StoreReleaseCommand(BaseCommand):
         parser.add_argument(
             "channels",
             type=str,
-            help="The comma separated list of channels to release to",
+            help="The comma-separated list of channels to release to",
         )
         parser.add_argument(
             "--progressive",
@@ -111,7 +111,7 @@ class StoreCloseCommand(BaseCommand):
     """Command to close a channel for a snap in the Snap Store."""
 
     name = "close"
-    help_msg = "Close <channel> for <name> on the store"
+    help_msg = "Close <channel> for <name> in the store"
     overview = textwrap.dedent(
         """
         Closing a channel allows the <channel> that is closed to track the

--- a/snapcraft/commands/upload.py
+++ b/snapcraft/commands/upload.py
@@ -39,7 +39,7 @@ class StoreUploadCommand(BaseCommand):
     help_msg = "Upload a snap to the Snap Store"
     overview = textwrap.dedent(
         """
-        By passing --release with a comma separated list of channels the snap would
+        By passing --release with a comma-separated list of channels the snap would
         be released to the selected channels if the store review passes for this
         <snap-file>.
 
@@ -65,7 +65,7 @@ class StoreUploadCommand(BaseCommand):
             dest="channels",
             type=str,
             default=None,
-            help="Optional comma separated list of channels to release to",
+            help="Optional comma-separated list of channels to release to",
         )
 
     @overrides

--- a/snapcraft/store/client.py
+++ b/snapcraft/store/client.py
@@ -188,7 +188,7 @@ class LegacyStoreClientCLI:
         channels: Optional[Sequence[str]] = None,
         **kwargs,
     ) -> str:
-        """Login to the Snap Store and prompt if required."""
+        """Log in to the Snap Store and prompt if required."""
         if os.getenv(constants.ENVIRONMENT_STORE_CREDENTIALS):
             raise errors.SnapcraftError(
                 f"Cannot login with {constants.ENVIRONMENT_STORE_CREDENTIALS!r} set.",

--- a/snapcraft_legacy/storeapi/errors.py
+++ b/snapcraft_legacy/storeapi/errors.py
@@ -510,7 +510,7 @@ class StoreReleaseError(StoreError):
 class StoreMetadataError(StoreError):
 
     __FMT_NOT_FOUND = (
-        "Sorry, updating the information on the store has failed, first run "
+        "Sorry, updating the information in the store has failed, first run "
         "`snapcraft register {snap_name}` and then "
         "`snapcraft upload <snap-file>`."
     )


### PR DESCRIPTION
Some innocuous grammar fixes, including (among other things):

  - "login" and "logout" are nouns, "log in" and "log out" are verbs
  - hyphenate "comma-separated" to be consistent with rest of code

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
