### PR TITLE
lint: fix multi-part imports

### DIFF
--- a/snapcraft/elf/elf_utils.py
+++ b/snapcraft/elf/elf_utils.py
@@ -23,9 +23,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List, Set
 
-import elftools.common.exceptions
-import elftools.elf.elffile
 from craft_cli import emit
+from elftools.common.exceptions import ELFError
 
 from . import ElfFile, errors
 
@@ -77,7 +76,7 @@ def get_elf_files_from_list(root: Path, file_list: Iterable[str]) -> List[ElfFil
 
         try:
             elf_file = ElfFile(path=path)
-        except elftools.common.exceptions.ELFError:
+        except ELFError:
             # Ignore invalid ELF files.
             continue
         except errors.CorruptedElfFile as exception:

--- a/snapcraft/store/_legacy_account.py
+++ b/snapcraft/store/_legacy_account.py
@@ -25,10 +25,10 @@ from typing import Dict, Optional, Sequence
 
 import craft_store
 import pymacaroons
-import xdg.BaseDirectory
 from craft_cli import emit
 from overrides import overrides
 from urllib3.util import parse_url
+from xdg import BaseDirectory
 
 from snapcraft import errors
 
@@ -117,7 +117,7 @@ def set_legacy_env() -> None:
 class LegacyUbuntuOne(craft_store.UbuntuOneStoreClient):
     """Legacy client to easily transition existing CI users."""
 
-    CONFIG_PATH = Path(xdg.BaseDirectory.xdg_config_home) / "snapcraft/snapcraft.cfg"
+    CONFIG_PATH = Path(BaseDirectory.xdg_config_home) / "snapcraft/snapcraft.cfg"
 
     @classmethod
     def env_has_legacy_credentials(cls) -> bool:


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Update from [`pyright 1.1.299`](https://github.com/microsoft/pyright/releases/tag/1.1.299):
> Fixed a recent regression that resulted in multi-part imports being evaluated as unknown if a namespace package was used for an intermediate part of the module path and useLibraryCodeForTypes was set to false.

In other words, pyright now complains if you do this:
```python
import xdg.BaseDirectory
CONFIG_PATH = Path(xdg.BaseDirectory.xdg_config_home) / "snapcraft/snapcraft.cfg"
```