### PR TITLE
requirements: update craft-parts to 1.19.0

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -14,7 +14,7 @@ coverage==7.0.4
 craft-archives==0.0.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
-craft-parts==1.18.3
+craft-parts==1.19.0
 craft-providers==1.9.0
 craft-store==2.3.0
 cryptography==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.3
 craft-archives==0.0.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
-craft-parts==1.18.3
+craft-parts==1.19.0
 craft-providers==1.9.0
 craft-store==2.3.0
 cryptography==3.4

--- a/tests/spread/core22/clean/task.yaml
+++ b/tests/spread/core22/clean/task.yaml
@@ -32,8 +32,6 @@ execute: |
 
   grep "Executing parts lifecycle: pull part1" < output.txt
   grep "Executing parts lifecycle: skip pull part2 (already ran)" < output.txt
-  grep "Executing parts lifecycle: overlay part1" < output.txt
-  grep "Executing parts lifecycle: skip overlay part2 (already ran)" < output.txt
   grep "Executing parts lifecycle: build part1" < output.txt
   grep "Executing parts lifecycle: skip build part2 (already ran)" < output.txt
   grep "Executing parts lifecycle: stage part1" < output.txt

--- a/tests/spread/core22/environment/test-variables/task.yaml
+++ b/tests/spread/core22/environment/test-variables/task.yaml
@@ -36,7 +36,6 @@ execute: |
       "^CRAFT_PART_BUILD=${root}/parts/hello/build$" \
       "^CRAFT_PART_BUILD_WORK=${root}/parts/hello/build$" \
       "^CRAFT_PART_INSTALL=${root}/parts/hello/install$" \
-      "^CRAFT_OVERLAY=${root}/overlay/overlay$" \
       "^CRAFT_STAGE=${root}/stage$" \
       "^CRAFT_PRIME=${root}/prime$"; do
       grep -q "$exp" < "$file"

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -761,7 +761,7 @@ def test_lifecycle_post_lifecycle_debug_shell(snapcraft_yaml, new_dir, mocker):
     "cmd,expected_last_step",
     [
         ("pull", None),
-        ("build", Step.OVERLAY),
+        ("build", Step.PULL),
         ("stage", Step.BUILD),
         ("prime", Step.STAGE),
     ],

--- a/tests/unit/parts/test_parts.py
+++ b/tests/unit/parts/test_parts.py
@@ -31,7 +31,7 @@ def parts_data():
     }
 
 
-@pytest.mark.parametrize("step_name", ["pull", "overlay", "build", "stage", "prime"])
+@pytest.mark.parametrize("step_name", ["pull", "build", "stage", "prime"])
 def test_parts_lifecycle_run(mocker, parts_data, step_name, new_dir, emitter):
     mocker.patch("craft_parts.executor.executor.Executor._install_build_snaps")
     lcm_spy = mocker.spy(craft_parts, "LifecycleManager")


### PR DESCRIPTION
Craft-parts 1.19.0 introduces feature selection, making the overlay step optional, and checks if plugin-specific properties changed when verifying if a part is dirty.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
