### PR TITLE
providers: inject current snapcraft snap into instances

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ adopt-info: snapcraft
 confinement: classic
 license: GPL-3.0
 assumes:
-  - snapd2.39
+  - snapd2.43
 
 apps:
   snapcraft:

--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -176,7 +176,19 @@ def get_base_configuration(
     # install snapcraft from the store's stable channel
     snap_channel = get_managed_environment_snap_channel()
     if sys.platform != "linux" and not snap_channel:
+        emit.progress(
+            "Using snapcraft from snap store channel 'latest/stable' in instance "
+            "because snap injection is only supported on Linux hosts.",
+            permanent=True,
+        )
+        snap_name = "snapcraft"
         snap_channel = "stable"
+    else:
+        # Use SNAP_INSTANCE_NAME for snapcraft's snap name, as it may not be 'snapcraft'
+        # if the '--name' parameter was used to install snapcraft.
+        # If snapcraft is not running as a snap, then envvar will not exist so default
+        # to 'snapcraft'.
+        snap_name = os.getenv("SNAP_INSTANCE_NAME", "snapcraft")
 
     return bases.BuilddBase(
         alias=alias,
@@ -185,7 +197,7 @@ def get_base_configuration(
         hostname=instance_name,
         snaps=[
             bases.buildd.Snap(
-                name="snapcraft",
+                name=snap_name,
                 channel=snap_channel,
                 classic=True,
             )

--- a/spread.yaml
+++ b/spread.yaml
@@ -188,6 +188,9 @@ backends:
 exclude: [snaps-cache/]
 
 prepare: |
+  #shellcheck source=tests/spread/tools/prepare.sh
+  . "$TOOLS_DIR/prepare.sh"
+
   # This unfortunately cannot be extracted into a standalone script since this
   # portion of of YAML runs before the source code has been fetched.
 
@@ -223,12 +226,10 @@ prepare: |
       # nicely handle the snap and deb being installed at the same time.
       apt-get remove --purge --yes lxd lxd-client
   fi
-  # install and setup the lxd snap - use 'retry' to workaround aa-exec issue
-  # see https://bugs.launchpad.net/snapd/+bug/1870201
-  retry -n 5 --wait 5 sh -c 'snap install lxd'
+
+  install_lxd
   # Add the ubuntu user to the lxd group.
   adduser ubuntu lxd
-  lxd init --auto
 
   # Hold snap refreshes for 24h.
   snap set system refresh.hold="$(date --date=tomorrow +%Y-%m-%dT%H:%M:%S%:z)"
@@ -244,8 +245,6 @@ prepare: |
       /snap/bin/lxd init --auto
   fi
 
-  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
-  . "$TOOLS_DIR/prepare.sh"
   install_snapcraft
 
   pushd /snapcraft

--- a/tests/spread/core22/parallel-install/snap/snapcraft.yaml
+++ b/tests/spread/core22/parallel-install/snap/snapcraft.yaml
@@ -1,0 +1,12 @@
+name: parallel-install
+base: core22
+version: '1.0'
+summary: 'remove-hook'
+description: Verify snapcraft can be installed in parallel.
+grade: stable
+confinement: strict
+
+parts:
+  hello-world:
+    plugin: nil
+    source: .

--- a/tests/spread/core22/parallel-install/task.yaml
+++ b/tests/spread/core22/parallel-install/task.yaml
@@ -1,0 +1,39 @@
+summary: Verify snapcraft can be installed in parallel
+
+prepare: |
+  #shellcheck source=tests/spread/tools/prepare.sh
+  . "$TOOLS_DIR/prepare.sh"
+
+  # enabling parallel installs requires a reboot
+  # see https://snapcraft.io/docs/parallel-installs
+  if [[ $SPREAD_REBOOT = 0 ]]; then
+    snap set system experimental.parallel-instances=true
+    REBOOT
+  fi
+
+  # install snapcraft using snapd's parallel-instances feature
+  install_snapcraft_as snapcraft_a
+
+restore: |
+  #shellcheck source=tests/spread/tools/prepare.sh
+  . "$TOOLS_DIR/prepare.sh"
+
+  if [[ $SPREAD_REBOOT = 0 ]]; then
+    # remove the parallel installed snapcraft
+    snap remove snapcraft_a --purge
+
+    # unset parallel instance support
+    snap set system experimental.parallel-instances=null
+    REBOOT
+  fi
+
+  # reinstall snapcraft after reboot
+  install_snapcraft
+
+execute: |
+  # remove snapcraft to ensure it is not injected into the instance
+  snap remove snapcraft --purge
+
+  # use lxd so snapcraft_a gets injected
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+  snapcraft_a pull --use-lxd --verbosity=trace

--- a/tests/spread/tools/prepare.sh
+++ b/tests/spread/tools/prepare.sh
@@ -16,3 +16,29 @@ install_snapcraft()
     snap install --classic snapcraft --channel="$SNAPCRAFT_CHANNEL"
   fi
 }
+
+install_snapcraft_as()
+{
+  # install snapcraft with a particular name
+  # If $SNAPCRAFT_CHANNEL is defined, install snapcraft from that channel.
+  # Otherwise, look for it in /snapcraft/.
+  if [ -z "$SNAPCRAFT_CHANNEL" ]; then
+    if stat /snapcraft/tests/*.snap 2>/dev/null; then
+      snap install --classic --dangerous /snapcraft/tests/*.snap --name "$1"
+    else
+      echo "Expected a snap to exist in /snapcraft/tests/. If your intention"\
+           "was to install from the store, set \$SNAPCRAFT_CHANNEL."
+      exit 1
+    fi
+  else
+    snap install --classic snapcraft --channel="$SNAPCRAFT_CHANNEL" --name "$1"
+  fi
+}
+
+install_lxd()
+{
+  # install and setup the lxd snap - use 'retry' to workaround aa-exec issue
+  # see https://bugs.launchpad.net/snapd/+bug/1870201
+  retry -n 5 --wait 5 sh -c 'snap install lxd'
+  lxd init --auto
+}

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -174,37 +174,18 @@ def test_ensure_provider_is_available_unknown_error():
     assert error.value.brief == "cannot install unknown provider"
 
 
-@pytest.mark.parametrize(
-    "platform, snap_channel, expected_snap_channel",
-    [
-        ("linux", None, None),
-        ("linux", "edge", "edge"),
-        ("darwin", "edge", "edge"),
-        # default to stable on non-linux system
-        ("darwin", None, "stable"),
-    ],
-)
-@pytest.mark.parametrize(
-    "alias",
-    [
-        bases.BuilddBaseAlias.BIONIC,
-        bases.BuilddBaseAlias.FOCAL,
-        bases.BuilddBaseAlias.JAMMY,
-    ],
-)
+@pytest.mark.parametrize("alias", providers.SNAPCRAFT_BASE_TO_PROVIDER_BASE.values())
 def test_get_base_configuration(
-    platform,
-    snap_channel,
-    expected_snap_channel,
     alias,
     tmp_path,
     mocker,
+    monkeypatch,
 ):
-    """Verify the snapcraft snap is installed from the correct channel."""
-    mocker.patch("sys.platform", platform)
+    """Verify the base configuration is properly configured."""
+    mocker.patch("sys.platform", "linux")
     mocker.patch(
         "snapcraft.providers.get_managed_environment_snap_channel",
-        return_value=snap_channel,
+        return_value="test-channel",
     )
     mocker.patch(
         "snapcraft.providers.get_command_environment",
@@ -216,6 +197,7 @@ def test_get_base_configuration(
     )
     mock_buildd_base = mocker.patch("snapcraft.providers.bases.BuilddBase")
     mock_buildd_base.compatibility_tag = "buildd-base-v0"
+    monkeypatch.setenv("SNAP_INSTANCE_NAME", "test-snap-name")
 
     providers.get_base_configuration(
         alias=alias,
@@ -229,10 +211,84 @@ def test_get_base_configuration(
         hostname="test-instance-name",
         snaps=[
             bases.buildd.Snap(
-                name="snapcraft", channel=expected_snap_channel, classic=True
+                name="test-snap-name", channel="test-channel", classic=True
             )
         ],
         packages=["gnupg", "dirmngr", "git"],
+    )
+
+
+@pytest.mark.parametrize(
+    ["platform", "snap_channel"],
+    [
+        # default to snapcraft from the stable channel on non-linux systems
+        ("darwin", "stable"),
+        ("win32", "stable"),
+        # Linux hosts support snap injection, so there should be no default channel
+        ("linux", None),
+    ],
+)
+def test_get_base_configuration_snap_channel(
+    platform,
+    snap_channel,
+    tmp_path,
+    mocker,
+    monkeypatch,
+):
+    """Verify the correct snap channel is chosen for different host OS's."""
+    mocker.patch("sys.platform", platform)
+    mocker.patch(
+        "snapcraft.providers.get_managed_environment_snap_channel",
+        return_value=None,
+    )
+    mocker.patch("snapcraft.providers.get_command_environment")
+    mocker.patch("snapcraft.providers.get_instance_name")
+    mock_buildd_base = mocker.patch("snapcraft.providers.bases.BuilddBase")
+    monkeypatch.setenv("SNAP_INSTANCE_NAME", "snapcraft")
+
+    providers.get_base_configuration(
+        alias=bases.BuilddBaseAlias.JAMMY,
+        instance_name="test-instance-name",
+    )
+
+    mock_buildd_base.assert_called_with(
+        alias=ANY,
+        compatibility_tag=ANY,
+        environment=ANY,
+        hostname=ANY,
+        snaps=[bases.buildd.Snap(name="snapcraft", channel=snap_channel, classic=True)],
+        packages=ANY,
+    )
+
+
+def test_get_base_configuration_snap_instance_name_default(
+    tmp_path,
+    mocker,
+    monkeypatch,
+):
+    """If `SNAP_INSTANCE_NAME` does not exist, use the default name 'snapcraft'."""
+    mocker.patch("sys.platform", "linux")
+    mocker.patch(
+        "snapcraft.providers.get_managed_environment_snap_channel",
+        return_value=None,
+    )
+    mocker.patch("snapcraft.providers.get_command_environment")
+    mocker.patch("snapcraft.providers.get_instance_name")
+    mock_buildd_base = mocker.patch("snapcraft.providers.bases.BuilddBase")
+    monkeypatch.delenv("SNAP_INSTANCE_NAME", raising=False)
+
+    providers.get_base_configuration(
+        alias=bases.BuilddBaseAlias.JAMMY,
+        instance_name="test-instance-name",
+    )
+
+    mock_buildd_base.assert_called_with(
+        alias=ANY,
+        compatibility_tag=ANY,
+        environment=ANY,
+        hostname=ANY,
+        snaps=[bases.buildd.Snap(name="snapcraft", channel=None, classic=True)],
+        packages=ANY,
     )
 
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Allows for core22 snaps to be built using a parallel-installed instance of snapcraft.

A subsequent PR will support core18|20 snaps.

(CRAFT-1660)