### PR TITLE
cli: add option to enable experimental plugins

### DIFF
--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -21,6 +21,7 @@ import contextlib
 import logging
 import os
 import sys
+from typing import Any, Dict
 
 import craft_cli
 import craft_store
@@ -126,6 +127,13 @@ GLOBAL_ARGS = [
     craft_cli.GlobalArgument(
         "version", "flag", "-V", "--version", "Show the application version and exit"
     ),
+    craft_cli.GlobalArgument(
+        "enable-experimental-plugins",
+        "flag",
+        None,
+        "--enable-experimental-plugins",
+        "Allow using experimental (unstable) plugins",
+    ),
     craft_cli.GlobalArgument("trace", "flag", "-t", "--trace", argparse.SUPPRESS),
 ]
 
@@ -204,8 +212,9 @@ def get_dispatcher() -> craft_cli.Dispatcher:
     )
 
 
-def _run_dispatcher(dispatcher: craft_cli.Dispatcher) -> None:
-    global_args = dispatcher.pre_parse_args(sys.argv[1:])
+def _run_dispatcher(
+    dispatcher: craft_cli.Dispatcher, global_args: Dict[str, Any]
+) -> None:
     if global_args.get("version"):
         emit.message(f"snapcraft {__version__}")
     else:
@@ -235,13 +244,19 @@ def _emit_error(error, cause=None):
 
 def run():  # noqa: C901
     """Run the CLI."""
-    # Register our own plugins
-    plugins.register()
-
     dispatcher = get_dispatcher()
     retcode = 1
+
     try:
-        _run_dispatcher(dispatcher)
+        # Register our own plugins
+        global_args = dispatcher.pre_parse_args(sys.argv[1:])
+        enable_experimental = (
+            global_args.get("enable-experimental-plugins")
+            or os.getenv("SNAPCRAFT_ENABLE_EXPERIMENTAL_PLUGINS", "") != ""
+        )
+        plugins.register(enable_experimental)
+
+        _run_dispatcher(dispatcher, global_args)
         retcode = 0
     except ArgumentParsingError as err:
         # TODO https://github.com/canonical/craft-cli/issues/78

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -519,6 +519,13 @@ def _run_in_provider(
     if getattr(parsed_args, "enable_experimental_ua_services", False):
         cmd.append("--enable-experimental-ua-services")
 
+    if getattr(
+        parsed_args,
+        "enable_experimental_plugins",
+        os.getenv("SNAPCRAFT_ENABLE_EXPERIMENTAL_PLUGINS"),
+    ):
+        cmd.append("--enable-experimental-plugins")
+
     project_path = Path().absolute()
     output_dir = utils.get_managed_environment_project_path()
 

--- a/snapcraft/parts/plugins/register.py
+++ b/snapcraft/parts/plugins/register.py
@@ -17,6 +17,7 @@
 """Snapcraft provided plugin registration."""
 
 import craft_parts
+from craft_cli import emit
 
 from .colcon_plugin import ColconPlugin
 from .conda_plugin import CondaPlugin
@@ -25,10 +26,13 @@ from .kernel import KernelPlugin
 from .python_plugin import PythonPlugin
 
 
-def register() -> None:
+def register(enable_experimental: bool) -> None:
     """Register Snapcraft plugins."""
     craft_parts.plugins.register({"colcon": ColconPlugin})
     craft_parts.plugins.register({"conda": CondaPlugin})
     craft_parts.plugins.register({"flutter": FlutterPlugin})
-    craft_parts.plugins.register({"kernel": KernelPlugin})
     craft_parts.plugins.register({"python": PythonPlugin})
+
+    if enable_experimental:
+        craft_parts.plugins.register({"kernel": KernelPlugin})
+        emit.progress("*EXPERIMENTAL* plugin 'kernel' enabled", permanent=True)


### PR DESCRIPTION
Experimental plugins are registered only if the environment variable `SNAPCRAFT_ENABLE_EXPERIMENTAL_PLUGINS` is set to a non-empty value or if the `--enable-experimental-plugins` global argument is used.

Currently the kernel plugin is an experimental plugin.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
