### PR TITLE
requirements: update craft-providers to 1.10.0

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -15,7 +15,7 @@ craft-archives==0.0.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.0
-craft-providers==1.9.0
+craft-providers==1.10.0
 craft-store==2.3.0
 cryptography==3.4
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ craft-archives==0.0.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.0
-craft-providers==1.9.0
+craft-providers==1.10.0
 craft-store==2.3.0
 cryptography==3.4
 Deprecated==1.2.13


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

craft-providers 1.10.0 allows using devel images with Multipass.


### Changelog
- Add support for kinetic, lunar, and devel images with Multipass
- Remove unused import suppressions in init files
- Update github actions