### PR TITLE
DONTMERGE: try 'cloud' package repo

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -11,7 +11,8 @@ click==8.1.3
 codespell==2.2.2
 colorama==0.4.6
 coverage==7.0.4
-craft-archives==0.0.3
+#craft-archives==0.0.3
+git+https://github.com/gboutry/craft-archives.git@uca-repo#egg=craft_archives
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ cffi==1.15.1
 chardet==5.1.0
 charset-normalizer==2.1.1
 click==8.1.3
-craft-archives==0.0.3
+#craft-archives==0.0.3
+git+https://github.com/gboutry/craft-archives.git@uca-repo#egg=craft_archives
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.0

--- a/tests/spread/core22/package-repositories/test-pin/snap/snapcraft.yaml
+++ b/tests/spread/core22/package-repositories/test-pin/snap/snapcraft.yaml
@@ -11,9 +11,11 @@ parts:
     plugin: nil
     stage-packages:
       - test-ppa
+      - keystone
     override-build: |
       apt-cache policy test-ppa
       apt-cache policy test-ppa | grep -F "999 http://ppa.launchpad.net/snappy-dev/snapcraft-daily/ubuntu"
+      apt-cache policy keystone | grep -F "888 http://ubuntu-cloud.archive.canonical.com/ubuntu jammy-proposed/antelope/main amd64 Packages"      
       craftctl default
 
 package-repositories:
@@ -24,6 +26,10 @@ package-repositories:
     key-id: 78E1918602959B9C59103100F1831DDAFC42E99D
     url: http://ppa.launchpad.net/snappy-dev/snapcraft-daily/ubuntu
     priority: 999
+  - type: apt
+    cloud: antelope
+    pocket: proposed
+    priority: 888
 
 apps:
     test-ppa:


### PR DESCRIPTION
This branch is just to check that the work-in-progress support for 'cloud' package repos in craft-archives works as expected.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
