### PR TITLE
cli: add option to enable experimental plugins for snapcraft_legacy

### DIFF
--- a/snapcraft_legacy/cli/_options.py
+++ b/snapcraft_legacy/cli/_options.py
@@ -187,6 +187,13 @@ _PROVIDER_OPTIONS: List[Dict[str, Any]] = [
         supported_providers=["host", "lxd", "managed-host", "multipass"],
     ),
     dict(
+        param_decls=["--enable-experimental-plugins"],
+        is_flag=True,
+        help="Enable plugins that are experimental and not considered stable.",
+        envvar="SNAPCRAFT_ENABLE_EXPERIMENTAL_PLUGINS",
+        supported_providers=["host", "lxd", "managed-host", "multipass"],
+    ),
+    dict(
         param_decls=["--enable-experimental-target-arch"],
         is_flag=True,
         help="Enable experimental `--target-arch` support for core20.",

--- a/snapcraft_legacy/cli/lifecycle.py
+++ b/snapcraft_legacy/cli/lifecycle.py
@@ -39,6 +39,7 @@ from snapcraft_legacy.internal import (
 )
 from snapcraft_legacy.internal.errors import SnapcraftEnvironmentError
 from snapcraft_legacy.internal.repo import ua_manager
+from snapcraft_legacy.plugins.v2.kernel import KernelPlugin
 from snapcraft_legacy.project._sanity_checks import conduct_project_sanity_check
 
 from . import echo
@@ -103,6 +104,15 @@ def _execute(  # noqa: C901
 
     if build_provider in ["host", "managed-host"]:
         project_config = project_loader.load_config(project)
+
+        # validate experimental plugins
+        plugins = [part.plugin for part in project_config.parts.all_parts]
+        if not kwargs.get("enable_experimental_plugins") and any(isinstance(plugin, KernelPlugin) for plugin in plugins):
+            raise SnapcraftEnvironmentError(
+                "*EXPERIMENTAL* 'kernel' plugin used, but not enabled. "
+                "Enable with '--enable-experimental-plugins' flag."
+            )
+
         ua_services = project_config.data.get("ua-services")
 
         if ua_services:


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----

Adds core18|20 support for `--enable-experimental-extensions` and `SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS`.

Similar to https://github.com/snapcore/snapcraft/pull/4085 and https://github.com/snapcore/snapcraft/pull/4092.


(CRAFT-1619)