### PR TITLE
meta: disallow Snap channel in default_provider

### DIFF
--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -123,7 +123,7 @@ class ContentPlug(_SnapMetadataModel):
     def _validate_default_provider(cls, default_provider):
         if default_provider and "/" in default_provider:
             raise ValueError(
-                "Specifying a Snap channel in 'default_provider' is not supported: "
+                "Specifying a snap channel in 'default_provider' is not supported: "
                 f"{default_provider}"
             )
         return default_provider

--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -118,6 +118,16 @@ class ContentPlug(_SnapMetadataModel):
             raise ValueError("value cannot be empty")
         return val
 
+    @validator("default_provider")
+    @classmethod
+    def _validate_default_provider(cls, default_provider):
+        if default_provider and "/" in default_provider:
+            raise ValueError(
+                "Specifying a Snap channel in 'default_provider' is not supported: "
+                f"{default_provider}"
+            )
+        return default_provider
+
     @property
     def provider(self) -> Optional[str]:
         """Return the default content provider name."""

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -379,7 +379,7 @@ class ContentPlug(ProjectModel):
     def _validate_default_provider(cls, default_provider):
         if default_provider and "/" in default_provider:
             raise ValueError(
-                "Specifying a Snap channel in 'default_provider' is not supported: "
+                "Specifying a snap channel in 'default_provider' is not supported: "
                 f"{default_provider}"
             )
         return default_provider
@@ -459,7 +459,7 @@ class Project(ProjectModel):
                     default_provider: str = plug.get("default-provider", "")
                     if "/" in default_provider:
                         raise ValueError(
-                            "Specifying a Snap channel in 'default_provider' is not supported: "
+                            "Specifying a snap channel in 'default_provider' is not supported: "
                             f"{default_provider}"
                         )
 

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -374,6 +374,16 @@ class ContentPlug(ProjectModel):
     target: str
     default_provider: Optional[str]
 
+    @pydantic.validator("default_provider")
+    @classmethod
+    def _validate_default_provider(cls, default_provider):
+        if default_provider and "/" in default_provider:
+            raise ValueError(
+                "Specifying a Snap channel in 'default_provider' is not supported: "
+                f"{default_provider}"
+            )
+        return default_provider
+
 
 MANDATORY_ADOPTABLE_FIELDS = ("version", "summary", "description")
 
@@ -441,8 +451,17 @@ class Project(ProjectModel):
                     raise ValueError(
                         f"ContentPlug '{plug_name}' must have a 'target' parameter."
                     )
+
                 if isinstance(plug, list):
                     raise ValueError(f"Plug '{plug_name}' cannot be a list.")
+
+                if isinstance(plug, dict) and plug.get("default-provider"):
+                    default_provider: str = plug.get("default-provider", "")
+                    if "/" in default_provider:
+                        raise ValueError(
+                            "Specifying a Snap channel in 'default_provider' is not supported: "
+                            f"{default_provider}"
+                        )
 
                 if plug is None:
                     empty_plugs.append(plug_name)

--- a/snapcraft_legacy/internal/meta/plugs.py
+++ b/snapcraft_legacy/internal/meta/plugs.py
@@ -149,6 +149,15 @@ class ContentPlug(Plug):
                 message="`target` is required for content slot",
             )
 
+        if self._default_provider and "/" in self._default_provider:
+            raise PlugValidationError(
+                plug_name=self.plug_name,
+                message=(
+                    "Specifying a Snap channel in 'default_provider' is not supported: "
+                    f"{self._default_provider}"
+                )
+            )
+
     @classmethod
     def from_dict(cls, *, plug_dict: Dict[str, str], plug_name: str) -> "ContentPlug":
         interface = plug_dict.get("interface")

--- a/snapcraft_legacy/internal/meta/plugs.py
+++ b/snapcraft_legacy/internal/meta/plugs.py
@@ -153,7 +153,7 @@ class ContentPlug(Plug):
             raise PlugValidationError(
                 plug_name=self.plug_name,
                 message=(
-                    "Specifying a Snap channel in 'default_provider' is not supported: "
+                    "Specifying a snap channel in 'default_provider' is not supported: "
                     f"{self._default_provider}"
                 )
             )

--- a/tests/legacy/unit/meta/test_plugs.py
+++ b/tests/legacy/unit/meta/test_plugs.py
@@ -127,3 +127,20 @@ class ContentPlugTests(unit.TestCase):
         plug = ContentPlug.from_dict(plug_dict=plug_dict, plug_name=plug_name)
 
         self.assertThat(plug.provider, Is(None))
+
+    def test_basic_default_provider_with_channel(self):
+        plug_dict = OrderedDict(
+            {
+                "interface": "content",
+                "content": "content",
+                "target": "target",
+                "default-provider": "gtk-common-themes:gtk-3-themes/edge",
+            }
+        )
+        plug_name = "plug-test"
+
+        plug = ContentPlug.from_dict(
+            plug_dict=plug_dict,
+            plug_name=plug_name,
+        )
+        self.assertRaises(errors.PlugValidationError, plug.validate)

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -708,7 +708,7 @@ def test_content_plug_provider_with_channel():
     }
 
     error = (
-        "Specifying a Snap channel in 'default_provider' is not supported: "
+        "Specifying a snap channel in 'default_provider' is not supported: "
         "gtk-common-themes:gtk-3-themes/edge"
     )
 

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -699,6 +699,23 @@ def test_content_plug_provider():
     assert plug.provider == "gtk-common-themes"
 
 
+def test_content_plug_provider_with_channel():
+    plug_dict = {
+        "interface": "content",
+        "content": "foo",
+        "target": "target",
+        "default-provider": "gtk-common-themes:gtk-3-themes/edge",
+    }
+
+    error = (
+        "Specifying a Snap channel in 'default_provider' is not supported: "
+        "gtk-common-themes:gtk-3-themes/edge"
+    )
+
+    with pytest.raises(pydantic.ValidationError, match=error):
+        ContentPlug.unmarshal(plug_dict)
+
+
 def test_get_content_plugs():
     yaml_data = textwrap.dedent(
         """\

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -501,6 +501,24 @@ class TestProjectValidation:
         project = Project.unmarshal(project_yaml_data(plugs=content_plug_data))
         assert project.get_content_snaps() == ["test-provider"]
 
+    def test_project_default_provider_with_channel(self, project_yaml_data):
+        content_plug_data = {
+            "content-interface": {
+                "interface": "content",
+                "target": "test-target",
+                "content": "test-content",
+                "default-provider": "test-provider/edge",
+            }
+        }
+
+        error = (
+            "Specifying a Snap channel in 'default_provider' is not supported: "
+            "test-provider/edge"
+        )
+
+        with pytest.raises(errors.ProjectValidationError, match=error):
+            Project.unmarshal(project_yaml_data(plugs=content_plug_data))
+
     @pytest.mark.parametrize("decl_type", ["symlink", "bind", "bind-file", "type"])
     def test_project_layout(self, decl_type, project_yaml_data):
         project = Project.unmarshal(

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -512,7 +512,7 @@ class TestProjectValidation:
         }
 
         error = (
-            "Specifying a Snap channel in 'default_provider' is not supported: "
+            "Specifying a snap channel in 'default_provider' is not supported: "
             "test-provider/edge"
         )
 


### PR DESCRIPTION
Add extra validations for default_provider.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
