### PR TITLE
projects: warn on "global" assign of plugs and slots

### DIFF
--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -377,14 +377,6 @@ class ContentPlug(ProjectModel):
 
 MANDATORY_ADOPTABLE_FIELDS = ("version", "summary", "description")
 
-GLOBAL_PLUGS_SLOTS_WARNING = (
-    "Implicit {lowercase} assignment in {culprits}. "
-    "{uppercase}s should be assigned to the app that they apply, "
-    "and not implicitly assigned via the global '{lowercase}s:' "
-    "stanza which is intended for configuration only."
-    "\n(Reference: https://snapcraft.io/docs/snapcraft-interfaces)"
-)
-
 
 class Project(ProjectModel):
     """Snapcraft project definition.
@@ -456,10 +448,7 @@ class Project(ProjectModel):
                     empty_plugs.append(plug_name)
 
         if empty_plugs:
-            culprits = utils.humanize_list(empty_plugs, "and")
-            message = GLOBAL_PLUGS_SLOTS_WARNING.format(
-                lowercase="plug", uppercase="Plug", culprits=culprits
-            )
+            message = _format_global_keyword_warning("plug", empty_plugs)
             emit.message(message)
 
         return plugs
@@ -474,10 +463,7 @@ class Project(ProjectModel):
                     empty_slots.append(slot_name)
 
         if empty_slots:
-            culprits = utils.humanize_list(empty_slots, "and")
-            message = GLOBAL_PLUGS_SLOTS_WARNING.format(
-                lowercase="slot", uppercase="Slot", culprits=culprits
-            )
+            message = _format_global_keyword_warning("slot", empty_slots)
             emit.message(message)
 
         return slots
@@ -862,3 +848,24 @@ def _printable_field_location_split(location: str) -> Tuple[str, str]:
         return field_name, repr(".".join(loc_split))
 
     return field_name, "top-level"
+
+
+def _format_global_keyword_warning(keyword: str, empty_entries: List[str]) -> str:
+    """Create a warning message about global assignment in the ``keyword`` field.
+
+    :param keyword:
+        The top-level keyword that contains empty entries (currently either
+        "plug" or "slot").
+    :param empty_entries:
+        The entries inside the ``keyword`` dict that are empty.
+    :return:
+        A properly-formatted warning message.
+    """
+    culprits = utils.humanize_list(empty_entries, "and")
+    return (
+        f"Warning: implicit {keyword.lower()} assignment in {culprits}. "
+        f"{keyword.capitalize()}s should be assigned to the app to which they apply, "
+        f"and not implicitly assigned via the global '{keyword.lower()}s:' "
+        "stanza which is intended for configuration only."
+        "\n(Reference: https://snapcraft.io/docs/snapcraft-interfaces)"
+    )

--- a/tests/spread/core22/plugs-warn/expected_output.txt
+++ b/tests/spread/core22/plugs-warn/expected_output.txt
@@ -1,5 +1,5 @@
-Implicit plug assignment in 'desktop' and 'desktop-legacy'. Plugs should be assigned to the app that they apply, and not implicitly assigned via the global 'plugs:' stanza which is intended for configuration only.
+Warning: implicit plug assignment in 'desktop' and 'desktop-legacy'. Plugs should be assigned to the app to which they apply, and not implicitly assigned via the global 'plugs:' stanza which is intended for configuration only.
 (Reference: https://snapcraft.io/docs/snapcraft-interfaces)
-Implicit slot assignment in 'network' and 'opengl'. Slots should be assigned to the app that they apply, and not implicitly assigned via the global 'slots:' stanza which is intended for configuration only.
+Warning: implicit slot assignment in 'network' and 'opengl'. Slots should be assigned to the app to which they apply, and not implicitly assigned via the global 'slots:' stanza which is intended for configuration only.
 (Reference: https://snapcraft.io/docs/snapcraft-interfaces)
 Initializing parts lifecycle

--- a/tests/spread/core22/plugs-warn/expected_output.txt
+++ b/tests/spread/core22/plugs-warn/expected_output.txt
@@ -1,0 +1,5 @@
+Implicit plug assignment in 'desktop' and 'desktop-legacy'. Plugs should be assigned to the app that they apply, and not implicitly assigned via the global 'plugs:' stanza which is intended for configuration only.
+(Reference: https://snapcraft.io/docs/snapcraft-interfaces)
+Implicit slot assignment in 'network' and 'opengl'. Slots should be assigned to the app that they apply, and not implicitly assigned via the global 'slots:' stanza which is intended for configuration only.
+(Reference: https://snapcraft.io/docs/snapcraft-interfaces)
+Initializing parts lifecycle

--- a/tests/spread/core22/plugs-warn/snap/snapcraft.yaml
+++ b/tests/spread/core22/plugs-warn/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: plugs-warn
+base: core22
+version: '0.1'
+summary: Check warnings for top-level enabling of slots and plugs
+description: Check warnings for top-level enabling of slots and plugs.
+
+grade: stable
+confinement: strict
+
+plugs:
+  desktop:
+  desktop-legacy:
+
+slots:
+  network:
+  opengl:
+
+parts:
+  my-part:
+    plugin: nil

--- a/tests/spread/core22/plugs-warn/task.yaml
+++ b/tests/spread/core22/plugs-warn/task.yaml
@@ -1,0 +1,9 @@
+summary: Check warnings for top-level enabling of slots and plugs
+
+restore: |
+  snapcraft clean --destructive-mode
+  rm -f ./*.snap
+
+execute: |
+  expected_output=$(< expected_output.txt)
+  snapcraft pull -v --destructive-mode | MATCH "$expected_output"

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -563,6 +563,30 @@ class TestProjectValidation:
         with pytest.raises(errors.ProjectValidationError, match=error):
             Project.unmarshal(project_yaml_data(build_base="devel", grade="stable"))
 
+    def test_project_global_plugs_warning(self, project_yaml_data, emitter):
+        data = project_yaml_data(plugs={"desktop": None, "desktop-legacy": None})
+        Project.unmarshal(data)
+        expected_message = (
+            "Implicit plug assignment in 'desktop' and 'desktop-legacy'. "
+            "Plugs should be assigned to the app that they apply, and not "
+            "implicitly assigned via the global 'plugs:' stanza "
+            "which is intended for configuration only."
+            "\n(Reference: https://snapcraft.io/docs/snapcraft-interfaces)"
+        )
+        emitter.assert_message(expected_message)
+
+    def test_project_global_slots_warning(self, project_yaml_data, emitter):
+        data = project_yaml_data(slots={"home": None, "removable-media": None})
+        Project.unmarshal(data)
+        expected_message = (
+            "Implicit slot assignment in 'home' and 'removable-media'. "
+            "Slots should be assigned to the app that they apply, and not "
+            "implicitly assigned via the global 'slots:' stanza "
+            "which is intended for configuration only."
+            "\n(Reference: https://snapcraft.io/docs/snapcraft-interfaces)"
+        )
+        emitter.assert_message(expected_message)
+
 
 class TestHookValidation:
     """Validate hooks."""

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -567,8 +567,8 @@ class TestProjectValidation:
         data = project_yaml_data(plugs={"desktop": None, "desktop-legacy": None})
         Project.unmarshal(data)
         expected_message = (
-            "Implicit plug assignment in 'desktop' and 'desktop-legacy'. "
-            "Plugs should be assigned to the app that they apply, and not "
+            "Warning: implicit plug assignment in 'desktop' and 'desktop-legacy'. "
+            "Plugs should be assigned to the app to which they apply, and not "
             "implicitly assigned via the global 'plugs:' stanza "
             "which is intended for configuration only."
             "\n(Reference: https://snapcraft.io/docs/snapcraft-interfaces)"
@@ -579,8 +579,8 @@ class TestProjectValidation:
         data = project_yaml_data(slots={"home": None, "removable-media": None})
         Project.unmarshal(data)
         expected_message = (
-            "Implicit slot assignment in 'home' and 'removable-media'. "
-            "Slots should be assigned to the app that they apply, and not "
+            "Warning: implicit slot assignment in 'home' and 'removable-media'. "
+            "Slots should be assigned to the app to which they apply, and not "
             "implicitly assigned via the global 'slots:' stanza "
             "which is intended for configuration only."
             "\n(Reference: https://snapcraft.io/docs/snapcraft-interfaces)"


### PR DESCRIPTION
This commit adds a warning (via emit.message()) when a snapcraft.yaml project has top-level plugs and/or slots that are used for assignment and not per-plug/slot configuration. Thanks to lucyllewy for suggested wording of the warning.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
