### PR TITLE
lint: prepare instance for linting a snap file

### DIFF
--- a/snapcraft/commands/lint.py
+++ b/snapcraft/commands/lint.py
@@ -30,7 +30,7 @@ from overrides import overrides
 
 from snapcraft import providers
 from snapcraft.errors import SnapcraftError
-from snapcraft.utils import is_managed_mode
+from snapcraft.utils import get_managed_environment_home_path, is_managed_mode
 
 
 class LintCommand(BaseCommand):
@@ -164,12 +164,14 @@ class LintCommand(BaseCommand):
             allow_unstable=False,
         ) as instance:
             # push snap file
-            snap_file_instance = Path("/root") / snap_file.name
+            snap_file_instance = get_managed_environment_home_path() / snap_file.name
             instance.push_file(source=snap_file, destination=snap_file_instance)
 
             # push assert file
             if assert_file:
-                assert_file_instance = Path("/root") / assert_file.name
+                assert_file_instance = (
+                    get_managed_environment_home_path() / assert_file.name
+                )
                 instance.push_file(source=assert_file, destination=assert_file_instance)
 
             # run linter inside the instance

--- a/snapcraft/commands/lint.py
+++ b/snapcraft/commands/lint.py
@@ -163,15 +163,15 @@ class LintCommand(BaseCommand):
             instance_name=instance_name,
             allow_unstable=False,
         ) as instance:
+            home_path = get_managed_environment_home_path()
+
             # push snap file
-            snap_file_instance = get_managed_environment_home_path() / snap_file.name
+            snap_file_instance = home_path / snap_file.name
             instance.push_file(source=snap_file, destination=snap_file_instance)
 
             # push assert file
             if assert_file:
-                assert_file_instance = (
-                    get_managed_environment_home_path() / assert_file.name
-                )
+                assert_file_instance = home_path / assert_file.name
                 instance.push_file(source=assert_file, destination=assert_file_instance)
 
             # run linter inside the instance

--- a/tests/spread/core22/linters/lint-file/task.yaml
+++ b/tests/spread/core22/linters/lint-file/task.yaml
@@ -4,6 +4,8 @@ restore: |
   rm -f ./*.snap ./*.assert
 
 execute: |
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
   snap download hello
 
   # `snapcraft lint` is a no-op, but ensure it exits without error

--- a/tests/unit/commands/test_lint.py
+++ b/tests/unit/commands/test_lint.py
@@ -14,82 +14,238 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import argparse
+import sys
+from pathlib import Path
+from subprocess import CalledProcessError
+from unittest.mock import Mock, call
 
 import pytest
-from craft_cli.errors import ArgumentParsingError
+from craft_providers.bases import BuilddBaseAlias
 
-from snapcraft.commands import LintCommand
+from snapcraft import cli
 
 
-def test_lint_default(emitter, tmp_path):
+@pytest.fixture
+def mock_ensure_provider_is_available(mocker):
+    return mocker.patch(
+        "snapcraft.parts.lifecycle.providers.ensure_provider_is_available"
+    )
+
+
+@pytest.fixture
+def mock_get_base_configuration(mocker):
+    return mocker.patch("snapcraft.parts.lifecycle.providers.get_base_configuration")
+
+
+@pytest.fixture
+def mock_is_managed_mode(mocker):
+    return mocker.patch("snapcraft.commands.lint.is_managed_mode", return_value=False)
+
+
+@pytest.fixture()
+def mock_provider(mocker, mock_instance, fake_provider):
+    _mock_provider = Mock(wraps=fake_provider)
+    mocker.patch(
+        "snapcraft.commands.lint.providers.get_provider", return_value=_mock_provider
+    )
+    return _mock_provider
+
+
+def test_lint_default(
+    emitter,
+    mock_ensure_provider_is_available,
+    mock_get_base_configuration,
+    mock_instance,
+    mock_is_managed_mode,
+    mock_provider,
+    mocker,
+    tmp_path,
+):
     """Test the lint command."""
     # create a snap file
     snap_file = tmp_path / "test-snap.snap"
     snap_file.touch()
-
-    LintCommand(None).run(argparse.Namespace(snap_file=str(snap_file)))
-
-    emitter.assert_progress("Running linter.", permanent=True)
-    emitter.assert_progress("'snapcraft lint' not implemented.", permanent=True)
-
-
-def test_lint_default_snap_file_missing(emitter, tmp_path):
-    """Raise an error if the snap file does not exist."""
-    # do not create a snap file
-    snap_file = tmp_path / "test-snap.snap"
-
-    with pytest.raises(ArgumentParsingError) as raised:
-        LintCommand(None).run(argparse.Namespace(snap_file=str(snap_file)))
-
-    assert str(raised.value) == f"Snap file {str(snap_file)!r} does not exist."
-
-
-def test_lint_default_snap_file_not_valid(emitter, tmp_path):
-    """Raise an error if the snap file is not valid."""
-    # make the snap filepath a directory
-    snap_file = tmp_path / "test-snap.snap"
-    snap_file.mkdir()
-
-    with pytest.raises(ArgumentParsingError) as raised:
-        LintCommand(None).run(argparse.Namespace(snap_file=snap_file))
-
-    assert str(raised.value) == f"Snap file {str(snap_file)!r} is not a valid file."
-
-
-def test_lint_assert_file(emitter, tmp_path):
-    """Return the assertion file for a snap file."""
-    snap_file = tmp_path / "test-snap.snap"
+    mocker.patch.object(sys, "argv", ["snapcraft", "lint", str(snap_file)])
     # create an assertion file
     assert_file = tmp_path / "test-snap.assert"
     assert_file.touch()
 
-    result = LintCommand(None)._get_assert_file(snap_file=snap_file)
+    cli.run()
 
-    assert result == assert_file
-    emitter.assert_debug(f"Found assertion file {str(assert_file)!r}.")
+    mock_ensure_provider_is_available.assert_called_once()
+    mock_get_base_configuration.assert_called_once_with(
+        alias=BuilddBaseAlias.JAMMY,
+        http_proxy=None,
+        https_proxy=None,
+        instance_name="snapcraft-linter",
+    )
+    assert mock_instance.push_file.mock_calls == [
+        call(source=snap_file, destination=Path("/root/test-snap.snap")),
+        call(source=assert_file, destination=Path("/root/test-snap.assert")),
+    ]
+    mock_instance.execute_run.assert_called_once_with(
+        ["snapcraft", "lint", "/root/test-snap.snap"], check=True
+    )
+    emitter.assert_interactions(
+        [
+            call("progress", "Running linter.", permanent=True),
+            call(
+                "debug", f"Found assertion file {str(tmp_path / 'test-snap.assert')!r}."
+            ),
+            call("progress", "Checking build provider availability."),
+            call("progress", "Launching instance."),
+        ]
+    )
 
 
-def test_lint_assert_missing(emitter, tmp_path):
-    """Return None if the assertion file is missing."""
+def test_lint_http_https_proxy(
+    emitter,
+    mock_ensure_provider_is_available,
+    mock_get_base_configuration,
+    mock_instance,
+    mock_is_managed_mode,
+    mock_provider,
+    mocker,
+    tmp_path,
+):
+    """Pass the http and https proxies into the instance."""
+    # create a snap file
     snap_file = tmp_path / "test-snap.snap"
-    # do not create an assertion file
-    assert_file = tmp_path / "test-snap.assert"
+    snap_file.touch()
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "snapcraft",
+            "lint",
+            str(snap_file),
+            "--http-proxy",
+            "test-http-proxy",
+            "--https-proxy",
+            "test-https-proxy",
+        ],
+    )
 
-    result = LintCommand(None)._get_assert_file(snap_file=snap_file)
+    cli.run()
 
-    assert not result
-    emitter.assert_debug(f"Assertion file {str(assert_file)!r} does not exist.")
+    mock_get_base_configuration.assert_called_once_with(
+        alias=BuilddBaseAlias.JAMMY,
+        http_proxy="test-http-proxy",
+        https_proxy="test-https-proxy",
+        instance_name="snapcraft-linter",
+    )
 
 
-def test_lint_assert_file_not_valid(emitter, tmp_path):
-    """Return None if the assertion file is not valid."""
+def test_lint_assert_file_missing(
+    emitter,
+    mock_ensure_provider_is_available,
+    mock_get_base_configuration,
+    mock_instance,
+    mock_is_managed_mode,
+    mock_provider,
+    mocker,
+    tmp_path,
+):
+    """Do not push non-existent assertion files in the instance."""
+    # create a snap file
     snap_file = tmp_path / "test-snap.snap"
+    snap_file.touch()
+    mocker.patch.object(sys, "argv", ["snapcraft", "lint", str(snap_file)])
+
+    cli.run()
+
+    mock_instance.push_file.assert_called_once_with(
+        source=snap_file,
+        destination=Path("/root/test-snap.snap"),
+    )
+    mock_instance.execute_run.assert_called_once_with(
+        ["snapcraft", "lint", "/root/test-snap.snap"], check=True
+    )
+    emitter.assert_debug(
+        f"Assertion file {str(tmp_path / 'test-snap.assert')!r} does not exist."
+    )
+
+
+def test_lint_assert_file_not_valid(
+    emitter,
+    mock_ensure_provider_is_available,
+    mock_get_base_configuration,
+    mock_instance,
+    mock_is_managed_mode,
+    mock_provider,
+    mocker,
+    tmp_path,
+):
+    """Do not push invalid assertion files in the instance."""
+    # create a snap file
+    snap_file = tmp_path / "test-snap.snap"
+    snap_file.touch()
+    mocker.patch.object(sys, "argv", ["snapcraft", "lint", str(snap_file)])
     # make the assertion filepath a directory
     assert_file = tmp_path / "test-snap.assert"
     assert_file.mkdir()
 
-    result = LintCommand(None)._get_assert_file(snap_file=snap_file)
+    cli.run()
 
-    assert not result
-    emitter.assert_debug(f"Assertion file {str(assert_file)!r} is not a valid file.")
+    mock_instance.push_file.assert_called_once_with(
+        source=snap_file,
+        destination=Path("/root/test-snap.snap"),
+    )
+    mock_instance.execute_run.assert_called_once_with(
+        ["snapcraft", "lint", "/root/test-snap.snap"], check=True
+    )
+    emitter.assert_debug(
+        f"Assertion file {str(tmp_path / 'test-snap.assert')!r} is not a valid file."
+    )
+
+
+def test_lint_default_snap_file_missing(capsys, mocker, tmp_path):
+    """Raise an error if the snap file does not exist."""
+    # do not create a snap file
+    snap_file = tmp_path / "test-snap.snap"
+    mocker.patch.object(sys, "argv", ["snapcraft", "lint", str(snap_file)])
+
+    cli.run()
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert f"snap file {str(snap_file)!r} does not exist" in err
+
+
+def test_lint_default_snap_file_not_valid(capsys, mocker, tmp_path):
+    """Raise an error if the snap file is not valid."""
+    # make the snap filepath a directory
+    snap_file = tmp_path / "test-snap.snap"
+    snap_file.mkdir()
+    mocker.patch.object(sys, "argv", ["snapcraft", "lint", str(snap_file)])
+
+    cli.run()
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert f"snap file {str(snap_file)!r} is not a valid file" in err
+
+
+def test_lint_execute_run(
+    capsys,
+    emitter,
+    mock_ensure_provider_is_available,
+    mock_get_base_configuration,
+    mock_instance,
+    mock_is_managed_mode,
+    mock_provider,
+    mocker,
+    tmp_path,
+):
+    """Raise an error if running snapcraft in the instance fails."""
+    # create a snap file
+    snap_file = tmp_path / "test-snap.snap"
+    snap_file.touch()
+    mocker.patch.object(sys, "argv", ["snapcraft", "lint", str(snap_file)])
+    mock_instance.execute_run.side_effect = CalledProcessError(cmd="err", returncode=1)
+
+    cli.run()
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert "failed to execute 'snapcraft lint /root/test-snap.snap' in instance" in err


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

`snapcraft lint` now prepares an instance and re-executes `snapcraft lint` inside the instance.


(CRAFT-1690)