### PR TITLE
spread: bump storage for Google 22.04 spread hosts

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -54,6 +54,7 @@ backends:
           storage: 40G
       - ubuntu-22.04-64:
           workers: 6
+          storage: 20G
           image: ubuntu-2204-64
       - ubuntu-24.04-64:
           image: ubuntu-23.04-64


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
Looks like the spread tests on 22.04 are failing due to insufficient storage (see: https://github.com/snapcore/snapcraft/actions/runs/4708550869/jobs/8352897128). The default is 10 gigs.