### PR TITLE
legacy: fix deprecation warning about `multipass --mem`

### DIFF
--- a/snapcraft_legacy/internal/build_providers/_multipass/_multipass_command.py
+++ b/snapcraft_legacy/internal/build_providers/_multipass/_multipass_command.py
@@ -168,7 +168,7 @@ class MultipassCommand:
         if cpus is not None:
             cmd.extend(["--cpus", cpus])
         if mem is not None:
-            cmd.extend(["--mem", mem])
+            cmd.extend(["--memory", mem])
         if disk is not None:
             cmd.extend(["--disk", disk])
         try:

--- a/spread.yaml
+++ b/spread.yaml
@@ -77,7 +77,7 @@ backends:
         FATAL "$SPREAD_SYSTEM is not supported!"
       fi
 
-      multipass launch --disk 20G --mem 2G --name "$instance_name" "$image"
+      multipass launch --disk 20G --memory 2G --name "$instance_name" "$image"
 
       # Get the IP from the instance
       ip=$(multipass info --format csv "$instance_name" | tail -1 | cut -d\, -f3)

--- a/tests/legacy/unit/build_providers/multipass/test_multipass_command.py
+++ b/tests/legacy/unit/build_providers/multipass/test_multipass_command.py
@@ -206,7 +206,7 @@ class MultipassCommandLaunchTest(MultipassCommandPassthroughBaseTest):
                 "16.04",
                 "--name",
                 self.instance_name,
-                "--mem",
+                "--memory",
                 "2G",
             ],
             stdin=subprocess.DEVNULL,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
The fixes the warning.

    warning: "--mem" long option will be deprecated in favour of "--memory" in a future release.Please update any scripts, etc.