### PR TITLE
tests: check for submodules before running spread

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -191,6 +191,11 @@ prepare: |
   #shellcheck source=tests/spread/tools/prepare.sh
   . "$TOOLS_DIR/prepare.sh"
 
+  if [[ -z $(ls -A "$TOOLS_DIR/snapd-testing-tools") ]]; then
+    echo "Cannot run spread because submodule 'snapd-testing-tools' does not exist. Fetch with 'git submodule update --init' and rerun spread."
+    exit 1
+  fi
+
   # This unfortunately cannot be extracted into a standalone script since this
   # portion of of YAML runs before the source code has been fetched.
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Spread tests require the `snapd-testing-tools` submodule. If the submodule has not been fetched, then a useful error is provided.

If approved, I'll make similar PR's for the other starcraft repos using spread.