### PR TITLE
spread: increase parallel-install kill timeout for 18.04

### DIFF
--- a/tests/spread/general/parallel-install/task.yaml
+++ b/tests/spread/general/parallel-install/task.yaml
@@ -1,4 +1,5 @@
 summary: Verify snapcraft can be installed in parallel
+kill-timeout: 45m  # Needed for 18.04 - newer distros should be fine at 30m.
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
18.04 parallel-install tests are sometimes timing out. This should fix that.