### PR TITLE
extensions: parse snapcraft.yaml before expanding extensions

### DIFF
--- a/tests/spread/general/expand-extensions/snapcraft.yaml
+++ b/tests/spread/general/expand-extensions/snapcraft.yaml
@@ -1,0 +1,28 @@
+name: expand-extensions
+base: core22
+version: '0.1'
+summary: "Test `expand-extensions` expands extensions."
+description: |
+  This snapcraft.yaml includes regression tests to verify extensions, parse-info,
+  and advanced grammar are parsed.
+
+grade: stable
+confinement: strict
+architectures: [amd64, arm64, armhf]
+
+apps:
+  expand-extensions:
+    command: /bin/true
+    # kde-neon is available for core18|20|22
+    extensions: [kde-neon]
+
+parts:
+  nil:
+    plugin: nil
+    parse-info:
+    - usr/share/metainfo/app.appdata.xml
+    stage-packages:
+      - mesa-opencl-icd
+      - ocl-icd-libopencl1
+      - on amd64:
+          - intel-opencl-icd

--- a/tests/spread/general/expand-extensions/task.yaml
+++ b/tests/spread/general/expand-extensions/task.yaml
@@ -1,0 +1,15 @@
+summary: "Test `expand-extensions` can expand extensions."
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "snapcraft.yaml"
+
+restore: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snapcraft.yaml"
+
+execute: |
+  # verify command executes without error
+  snapcraft expand-extensions


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

`expand-extensions` command now parses core22 snaps containing parse-info and advanced grammar keywords.

#### source
* https://bugs.launchpad.net/snapcraft/+bug/2011719
* https://forum.snapcraft.io/t/parts-part-parse-info-broken/34335

(CRAFT-1701)