### PR TITLE
lint: lint snap files inside an instance

### DIFF
--- a/snapcraft/linters/__init__.py
+++ b/snapcraft/linters/__init__.py
@@ -17,12 +17,11 @@
 """Extension processor and related utilities."""
 
 from .base import LinterIssue
-from .linters import LinterStatus, lint_command, report, run_linters
+from .linters import LinterStatus, report, run_linters
 
 __all__ = [
     "LinterIssue",
     "LinterStatus",
-    "lint_command",
     "report",
     "run_linters",
 ]

--- a/snapcraft/linters/linters.py
+++ b/snapcraft/linters/linters.py
@@ -22,7 +22,7 @@ import json
 import os
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Type
+from typing import Dict, List, Optional, Type
 
 from craft_cli import emit
 
@@ -32,10 +32,6 @@ from snapcraft.meta import snap_yaml
 from .base import Linter, LinterIssue, LinterResult
 from .classic_linter import ClassicLinter
 from .library_linter import LibraryLinter
-
-if TYPE_CHECKING:
-    import argparse
-
 
 LinterType = Type[Linter]
 
@@ -113,12 +109,6 @@ def _update_status(status: LinterStatus, result: LinterResult) -> LinterStatus:
         status = LinterStatus.WARNINGS
 
     return status
-
-
-def lint_command(parsed_args: "argparse.Namespace") -> None:
-    """``snapcraft lint`` command handler."""
-    # XXX: obtain lint configuration
-    run_linters(parsed_args.snap_file, lint=None)
 
 
 def run_linters(location: Path, *, lint: Optional[projects.Lint]) -> List[LinterIssue]:

--- a/tests/spread/core22/linters/lint-file-with-assert/task.yaml
+++ b/tests/spread/core22/linters/lint-file-with-assert/task.yaml
@@ -1,0 +1,34 @@
+summary: Run snapcraft lint on a snap file with a valid assert file.
+
+restore: |
+  rm -f ./*.snap ./*.assert
+
+execute: |
+  # download a snap and assertion with a core22 base
+  snap download core22
+
+  # give it a predictable name to simplify testing
+  mv core22_*.snap core22.snap
+  mv core22_*.assert core22.assert
+
+  # test the linter using a build provider
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
+  snapcraft lint core22.snap 2> output.txt
+
+  # confirm there was not an assertion error
+  if grep -q "Could not add assertions from file" output.txt; then
+    exit 1
+  fi
+  # confirm linter executed
+  grep "Running linters..." output.txt
+
+  # make a bad assert file
+  cp core22.snap core22.assert
+
+  # snapcraft should handle the bad assert file and still run the linter
+  snapcraft lint core22.snap 2> output.txt
+
+  # confirm there was an assertion error
+  grep "Could not add assertions from file" output.txt
+  grep "Running linters..." output.txt

--- a/tests/spread/core22/linters/lint-file/expected-linter-output.txt
+++ b/tests/spread/core22/linters/lint-file/expected-linter-output.txt
@@ -1,0 +1,5 @@
+Running linters...
+Running linter: library
+Lint warnings:
+- library: linter-test: missing dependency 'libcaca.so.0'. (https://snapcraft.io/docs/linters-library)
+- library: libpng16.so.16: unused library 'usr/lib/x86_64-linux-gnu/libpng16.so.16.37.0'. (https://snapcraft.io/docs/linters-library)

--- a/tests/spread/core22/linters/lint-file/snapcraft.yaml
+++ b/tests/spread/core22/linters/lint-file/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: lint-file
+base: core22
+version: '0.1'
+summary: Lint a packaged snapcraft file.
+description: spread test
+
+grade: devel
+confinement: strict
+
+parts:
+  my-part:
+    plugin: nil
+    source: src
+    build-packages:
+      - gcc
+      - libcaca-dev
+    stage-packages:
+      - libpng16-16
+    override-build:
+      gcc -o $CRAFT_PART_INSTALL/linter-test test.c -lcaca

--- a/tests/spread/core22/linters/lint-file/src/test.c
+++ b/tests/spread/core22/linters/lint-file/src/test.c
@@ -1,0 +1,7 @@
+#include "caca.h"
+
+int main()
+{
+    caca_create_canvas(80, 24);
+    return 0;
+}

--- a/tests/spread/core22/linters/lint-file/task.yaml
+++ b/tests/spread/core22/linters/lint-file/task.yaml
@@ -4,9 +4,14 @@ restore: |
   rm -f ./*.snap ./*.assert
 
 execute: |
+  # build the test snap destructively to save time
+  snapcraft
+
+  # test the linter using a build provider
   unset SNAPCRAFT_BUILD_ENVIRONMENT
+  snapcraft lint lint-file_0.1_*.snap 2> output.txt
 
-  snap download hello
+  # get the lint warnings at end of the log file
+  sed -n '/Running linters.../,+4 p' < output.txt > linter-output.txt
 
-  # `snapcraft lint` is a no-op, but ensure it exits without error
-  snapcraft lint hello_*.snap
+  diff -u linter-output.txt expected-linter-output.txt

--- a/tests/unit/commands/test_lint.py
+++ b/tests/unit/commands/test_lint.py
@@ -14,15 +14,74 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import shlex
 import sys
 from pathlib import Path
 from subprocess import CalledProcessError
+from textwrap import dedent
 from unittest.mock import Mock, call
 
 import pytest
 from craft_providers.bases import BuilddBaseAlias
+from craft_providers.multipass import MultipassProvider
 
 from snapcraft import cli
+from snapcraft.commands.lint import LintCommand
+from snapcraft.errors import SnapcraftError
+from snapcraft.meta.snap_yaml import SnapMetadata
+from snapcraft.projects import Lint, Project
+
+
+@pytest.fixture
+def fake_assert_file(tmp_path):
+    """Returns a path to a fake assertion file."""
+    return tmp_path / "test-snap.assert"
+
+
+@pytest.fixture
+def fake_snap_file(tmp_path):
+    """Return a path to a fake snap file."""
+    return tmp_path / "test-snap.snap"
+
+
+@pytest.fixture
+def fake_snap_metadata():
+    data = {
+        "name": "test",
+        "version": "1.0",
+        "summary": "test",
+        "description": "test",
+        "confinement": "strict",
+        "grade": "stable",
+        "architectures": ["test"],
+    }
+    return SnapMetadata.unmarshal(data)
+
+
+@pytest.fixture
+def fake_snapcraft_project():
+    data = {
+        "name": "test-name",
+        "base": "core22",
+        "grade": "stable",
+        "confinement": "strict",
+        "description": "test description",
+        "version": "1.0",
+        "summary": "test summary",
+        "parts": {"part1": {"plugin": "nil"}},
+    }
+    return Project.unmarshal(data)
+
+
+@pytest.fixture
+def mock_argv(mocker, fake_snap_file):
+    """Mock `snapcraft lint` cli for a snap named `test-snap.snap`."""
+    return mocker.patch.object(sys, "argv", ["snapcraft", "lint", str(fake_snap_file)])
+
+
+@pytest.fixture
+def mock_capture_logs_from_instance(mocker):
+    return mocker.patch("snapcraft.commands.lint.providers.capture_logs_from_instance")
 
 
 @pytest.fixture
@@ -42,7 +101,7 @@ def mock_is_managed_mode(mocker):
     return mocker.patch("snapcraft.commands.lint.is_managed_mode", return_value=False)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_provider(mocker, mock_instance, fake_provider):
     _mock_provider = Mock(wraps=fake_provider)
     mocker.patch(
@@ -51,24 +110,34 @@ def mock_provider(mocker, mock_instance, fake_provider):
     return _mock_provider
 
 
+@pytest.fixture
+def mock_run_linters(mocker):
+    return mocker.patch(
+        "snapcraft.commands.lint.linters.run_linters", return_value=Mock()
+    )
+
+
+@pytest.fixture
+def mock_report(mocker):
+    return mocker.patch("snapcraft.commands.lint.linters.report")
+
+
 def test_lint_default(
     emitter,
+    fake_assert_file,
+    fake_snap_file,
+    mock_argv,
+    mock_capture_logs_from_instance,
     mock_ensure_provider_is_available,
     mock_get_base_configuration,
     mock_instance,
     mock_is_managed_mode,
     mock_provider,
-    mocker,
-    tmp_path,
 ):
-    """Test the lint command."""
-    # create a snap file
-    snap_file = tmp_path / "test-snap.snap"
-    snap_file.touch()
-    mocker.patch.object(sys, "argv", ["snapcraft", "lint", str(snap_file)])
-    # create an assertion file
-    assert_file = tmp_path / "test-snap.assert"
-    assert_file.touch()
+    """Test the lint command prepares an instance."""
+    # create a snap file and assertion file
+    fake_snap_file.touch()
+    fake_assert_file.touch()
 
     cli.run()
 
@@ -80,45 +149,47 @@ def test_lint_default(
         instance_name="snapcraft-linter",
     )
     assert mock_instance.push_file.mock_calls == [
-        call(source=snap_file, destination=Path("/root/test-snap.snap")),
-        call(source=assert_file, destination=Path("/root/test-snap.assert")),
+        call(source=fake_snap_file, destination=Path("/root/test-snap.snap")),
+        call(source=fake_assert_file, destination=Path("/root/test-snap.assert")),
     ]
     mock_instance.execute_run.assert_called_once_with(
         ["snapcraft", "lint", "/root/test-snap.snap"], check=True
     )
+    mock_capture_logs_from_instance.assert_called_once()
     emitter.assert_interactions(
         [
             call("progress", "Running linter.", permanent=True),
-            call(
-                "debug", f"Found assertion file {str(tmp_path / 'test-snap.assert')!r}."
-            ),
+            call("debug", f"Found assertion file {str(fake_assert_file)!r}."),
             call("progress", "Checking build provider availability."),
             call("progress", "Launching instance."),
+            call("debug", "running 'snapcraft lint /root/test-snap.snap' in instance"),
         ]
     )
 
 
 def test_lint_http_https_proxy(
     emitter,
+    fake_snap_file,
+    mock_capture_logs_from_instance,
     mock_ensure_provider_is_available,
     mock_get_base_configuration,
     mock_instance,
     mock_is_managed_mode,
     mock_provider,
     mocker,
-    tmp_path,
 ):
     """Pass the http and https proxies into the instance."""
     # create a snap file
-    snap_file = tmp_path / "test-snap.snap"
-    snap_file.touch()
+    fake_snap_file.touch()
+
+    # mock command
     mocker.patch.object(
         sys,
         "argv",
         [
             "snapcraft",
             "lint",
-            str(snap_file),
+            str(fake_snap_file),
             "--http-proxy",
             "test-http-proxy",
             "--https-proxy",
@@ -138,114 +209,719 @@ def test_lint_http_https_proxy(
 
 def test_lint_assert_file_missing(
     emitter,
+    fake_assert_file,
+    fake_snap_file,
+    mock_argv,
+    mock_capture_logs_from_instance,
     mock_ensure_provider_is_available,
     mock_get_base_configuration,
     mock_instance,
     mock_is_managed_mode,
     mock_provider,
-    mocker,
-    tmp_path,
 ):
     """Do not push non-existent assertion files in the instance."""
     # create a snap file
-    snap_file = tmp_path / "test-snap.snap"
-    snap_file.touch()
-    mocker.patch.object(sys, "argv", ["snapcraft", "lint", str(snap_file)])
+    fake_snap_file.touch()
 
     cli.run()
 
     mock_instance.push_file.assert_called_once_with(
-        source=snap_file,
+        source=fake_snap_file,
         destination=Path("/root/test-snap.snap"),
     )
     mock_instance.execute_run.assert_called_once_with(
         ["snapcraft", "lint", "/root/test-snap.snap"], check=True
     )
-    emitter.assert_debug(
-        f"Assertion file {str(tmp_path / 'test-snap.assert')!r} does not exist."
-    )
+    emitter.assert_debug(f"Assertion file {str(fake_assert_file)!r} does not exist.")
 
 
 def test_lint_assert_file_not_valid(
     emitter,
+    fake_assert_file,
+    fake_snap_file,
+    mock_argv,
+    mock_capture_logs_from_instance,
     mock_ensure_provider_is_available,
     mock_get_base_configuration,
     mock_instance,
     mock_is_managed_mode,
     mock_provider,
-    mocker,
-    tmp_path,
 ):
     """Do not push invalid assertion files in the instance."""
     # create a snap file
-    snap_file = tmp_path / "test-snap.snap"
-    snap_file.touch()
-    mocker.patch.object(sys, "argv", ["snapcraft", "lint", str(snap_file)])
+    fake_snap_file.touch()
+
     # make the assertion filepath a directory
-    assert_file = tmp_path / "test-snap.assert"
-    assert_file.mkdir()
+    fake_assert_file.mkdir()
 
     cli.run()
 
     mock_instance.push_file.assert_called_once_with(
-        source=snap_file,
+        source=fake_snap_file,
         destination=Path("/root/test-snap.snap"),
     )
     mock_instance.execute_run.assert_called_once_with(
         ["snapcraft", "lint", "/root/test-snap.snap"], check=True
     )
     emitter.assert_debug(
-        f"Assertion file {str(tmp_path / 'test-snap.assert')!r} is not a valid file."
+        f"Assertion file {str(fake_assert_file)!r} is not a valid file."
     )
 
 
-def test_lint_default_snap_file_missing(capsys, mocker, tmp_path):
-    """Raise an error if the snap file does not exist."""
-    # do not create a snap file
-    snap_file = tmp_path / "test-snap.snap"
-    mocker.patch.object(sys, "argv", ["snapcraft", "lint", str(snap_file)])
+def test_lint_multipass_not_supported(
+    capsys,
+    fake_provider,
+    fake_snap_file,
+    mock_argv,
+    mock_ensure_provider_is_available,
+    mock_is_managed_mode,
+    mocker,
+):
+    """Raise an error if Multipass is used as the build provider."""
+    _mock_provider = Mock(wraps=fake_provider, spec=MultipassProvider)
+    mocker.patch(
+        "snapcraft.commands.lint.providers.get_provider", return_value=_mock_provider
+    )
+
+    # create a snap file
+    fake_snap_file.touch()
 
     cli.run()
 
     out, err = capsys.readouterr()
     assert not out
-    assert f"snap file {str(snap_file)!r} does not exist" in err
+    assert (
+        "'snapcraft lint' is not supported with Multipass as the build provider" in err
+    )
 
 
-def test_lint_default_snap_file_not_valid(capsys, mocker, tmp_path):
+def test_lint_default_snap_file_missing(capsys, fake_snap_file, mock_argv):
+    """Raise an error if the snap file does not exist."""
+    cli.run()
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert f"snap file {str(fake_snap_file)!r} does not exist" in err
+
+
+def test_lint_default_snap_file_not_valid(capsys, fake_snap_file, mock_argv):
     """Raise an error if the snap file is not valid."""
     # make the snap filepath a directory
-    snap_file = tmp_path / "test-snap.snap"
-    snap_file.mkdir()
-    mocker.patch.object(sys, "argv", ["snapcraft", "lint", str(snap_file)])
+    fake_snap_file.mkdir()
 
     cli.run()
 
     out, err = capsys.readouterr()
     assert not out
-    assert f"snap file {str(snap_file)!r} is not a valid file" in err
+    assert f"snap file {str(fake_snap_file)!r} is not a valid file" in err
 
 
-def test_lint_execute_run(
+def test_lint_execute_run_error(
     capsys,
     emitter,
+    fake_snap_file,
+    mock_argv,
+    mock_capture_logs_from_instance,
     mock_ensure_provider_is_available,
     mock_get_base_configuration,
     mock_instance,
     mock_is_managed_mode,
     mock_provider,
-    mocker,
-    tmp_path,
 ):
     """Raise an error if running snapcraft in the instance fails."""
     # create a snap file
-    snap_file = tmp_path / "test-snap.snap"
-    snap_file.touch()
-    mocker.patch.object(sys, "argv", ["snapcraft", "lint", str(snap_file)])
+    fake_snap_file.touch()
+
     mock_instance.execute_run.side_effect = CalledProcessError(cmd="err", returncode=1)
+
+    cli.run()
+
+    mock_capture_logs_from_instance.assert_called_once()
+    out, err = capsys.readouterr()
+    assert not out
+    assert "failed to execute 'snapcraft lint /root/test-snap.snap' in instance" in err
+
+
+@pytest.mark.parametrize("confinement", ["classic", "strict"])
+@pytest.mark.parametrize("grade", ["devel", "stable"])
+def test_lint_managed_mode(
+    confinement,
+    emitter,
+    fake_assert_file,
+    fake_process,
+    fake_snap_file,
+    fake_snap_metadata,
+    fake_snapcraft_project,
+    grade,
+    mock_argv,
+    mock_is_managed_mode,
+    mock_report,
+    mock_run_linters,
+    mocker,
+):
+    """Run the linter in managed mode."""
+    mock_is_managed_mode.return_value = True
+
+    # create a snap file
+    fake_snap_file.touch()
+
+    # register subprocess calls
+    fake_process.register_subprocess(
+        ["unsquashfs", "-force", "-dest", fake_process.any(), str(fake_snap_file)]
+    )
+
+    # build snap install command
+    command = ["snap", "install", str(fake_snap_file)]
+    if confinement == "classic":
+        command.append("--classic")
+    command.append("--dangerous")
+    if grade == "devel":
+        command.append("--devmode")
+    fake_process.register_subprocess(command)
+
+    # mock data from the unsquashed snap
+    fake_snap_metadata.confinement = confinement
+    fake_snap_metadata.grade = grade
+    mocker.patch(
+        "snapcraft.commands.lint.snap_yaml.read", return_value=fake_snap_metadata
+    )
+    mocker.patch(
+        "snapcraft.commands.lint.LintCommand._load_project",
+        return_value=fake_snapcraft_project,
+    )
+
+    cli.run()
+
+    mock_run_linters.assert_called_once_with(
+        lint=Lint(ignore=["classic"]),
+        location=Path("/snap/test/current"),
+    )
+    mock_report.assert_called_once_with(
+        mock_run_linters.return_value, intermediate=True
+    )
+    emitter.assert_interactions(
+        [
+            call("progress", "Running linter.", permanent=True),
+            call("debug", f"Assertion file {str(fake_assert_file)!r} does not exist."),
+            call("progress", f"Unsquashing snap file {fake_snap_file.name!r}."),
+            call("progress", f"Installing snap with {shlex.join(command)!r}."),
+            call("verbose", "No lint filters defined in 'snapcraft.yaml'."),
+        ]
+    )
+
+
+def test_lint_managed_mode_without_snapcraft_yaml(
+    emitter,
+    fake_assert_file,
+    fake_process,
+    fake_snap_file,
+    fake_snap_metadata,
+    fake_snapcraft_project,
+    mock_argv,
+    mock_is_managed_mode,
+    mock_report,
+    mock_run_linters,
+    mocker,
+):
+    """Run the linter in managed mode without a snapcraft.yaml file."""
+    mock_is_managed_mode.return_value = True
+
+    # create a snap file
+    fake_snap_file.touch()
+
+    # register subprocess calls
+    fake_process.register_subprocess(
+        ["unsquashfs", "-force", "-dest", fake_process.any(), str(fake_snap_file)]
+    )
+    fake_process.register_subprocess(
+        ["snap", "install", str(fake_snap_file), "--dangerous"]
+    )
+
+    # mock data from the unsquashed snap
+    mocker.patch(
+        "snapcraft.commands.lint.snap_yaml.read", return_value=fake_snap_metadata
+    )
+    mocker.patch(
+        "snapcraft.commands.lint.LintCommand._load_project",
+        return_value=None,
+    )
+
+    cli.run()
+
+    mock_run_linters.assert_called_once_with(
+        lint=Lint(ignore=["classic"]),
+        location=Path("/snap/test/current"),
+    )
+    mock_report.assert_called_once_with(
+        mock_run_linters.return_value, intermediate=True
+    )
+    emitter.assert_interactions(
+        [
+            call("progress", "Running linter.", permanent=True),
+            call("debug", f"Assertion file {str(fake_assert_file)!r} does not exist."),
+            call("progress", f"Unsquashing snap file {fake_snap_file.name!r}."),
+            call(
+                "progress",
+                f"Installing snap with 'snap install {str(fake_snap_file)} "
+                "--dangerous'.",
+            ),
+            call(
+                "verbose",
+                "Not loading lint filters from 'snapcraft.yaml' because the file does "
+                "not exist inside the snap file.",
+            ),
+            call(
+                "verbose",
+                "To include 'snapcraft.yaml' in a snap file, use the parameter "
+                "'--enable-manifest' when building the snap.",
+            ),
+        ]
+    )
+
+
+def test_lint_managed_mode_unsquash_error(
+    capsys,
+    emitter,
+    fake_process,
+    fake_snap_file,
+    fake_snap_metadata,
+    fake_snapcraft_project,
+    mock_argv,
+    mock_is_managed_mode,
+    mock_report,
+    mock_run_linters,
+    mocker,
+):
+    """Raise an error if the snap file cannot be installed."""
+    mock_is_managed_mode.return_value = True
+
+    # create a snap file
+    fake_snap_file.touch()
+
+    # register subprocess calls
+    fake_process.register_subprocess(
+        ["unsquashfs", "-force", "-dest", fake_process.any(), str(fake_snap_file)],
+        returncode=1,
+    )
+
+    # mock data from the unsquashed snap
+    mocker.patch(
+        "snapcraft.commands.lint.snap_yaml.read", return_value=fake_snap_metadata
+    )
+    mocker.patch(
+        "snapcraft.commands.lint.LintCommand._load_project",
+        return_value=fake_snapcraft_project,
+    )
 
     cli.run()
 
     out, err = capsys.readouterr()
     assert not out
-    assert "failed to execute 'snapcraft lint /root/test-snap.snap' in instance" in err
+    assert f"could not unsquash snap file {fake_snap_file.name!r}" in err
+
+
+def test_lint_managed_mode_snap_install_error(
+    capsys,
+    emitter,
+    fake_process,
+    fake_snap_file,
+    fake_snap_metadata,
+    fake_snapcraft_project,
+    mock_argv,
+    mock_is_managed_mode,
+    mock_report,
+    mock_run_linters,
+    mocker,
+):
+    """Raise an error if the snap file cannot be installed."""
+    mock_is_managed_mode.return_value = True
+
+    # create a snap file
+    fake_snap_file.touch()
+
+    # register subprocess calls
+    fake_process.register_subprocess(
+        ["unsquashfs", "-force", "-dest", fake_process.any(), str(fake_snap_file)]
+    )
+    fake_process.register_subprocess(
+        ["snap", "install", str(fake_snap_file), "--dangerous"], returncode=1
+    )
+
+    # mock data from the unsquashed snap
+    mocker.patch(
+        "snapcraft.commands.lint.snap_yaml.read", return_value=fake_snap_metadata
+    )
+    mocker.patch(
+        "snapcraft.commands.lint.LintCommand._load_project",
+        return_value=fake_snapcraft_project,
+    )
+
+    cli.run()
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert f"could not install snap file {fake_snap_file.name!r}" in err
+
+
+def test_lint_managed_mode_assert(
+    emitter,
+    fake_assert_file,
+    fake_process,
+    fake_snap_file,
+    fake_snap_metadata,
+    fake_snapcraft_project,
+    mock_argv,
+    mock_is_managed_mode,
+    mock_report,
+    mock_run_linters,
+    mocker,
+):
+    """Run the linter in managed mode with an assert file."""
+    mock_is_managed_mode.return_value = True
+
+    # create a snap file and assertion file
+    fake_snap_file.touch()
+    fake_assert_file.touch()
+
+    # register subprocess calls
+    fake_process.register_subprocess(
+        ["unsquashfs", "-force", "-dest", fake_process.any(), str(fake_snap_file)]
+    )
+    fake_process.register_subprocess(["snap", "ack", str(fake_assert_file)])
+    fake_process.register_subprocess(["snap", "install", str(fake_snap_file)])
+
+    # mock data from the unsquashed snap
+    mocker.patch(
+        "snapcraft.commands.lint.snap_yaml.read", return_value=fake_snap_metadata
+    )
+    mocker.patch(
+        "snapcraft.commands.lint.LintCommand._load_project",
+        return_value=fake_snapcraft_project,
+    )
+
+    cli.run()
+
+    mock_run_linters.assert_called_once_with(
+        lint=Lint(ignore=["classic"]),
+        location=Path("/snap/test/current"),
+    )
+    mock_report.assert_called_once_with(
+        mock_run_linters.return_value, intermediate=True
+    )
+    emitter.assert_interactions(
+        [
+            call("progress", "Running linter.", permanent=True),
+            call("debug", f"Found assertion file {str(fake_assert_file)!r}."),
+            call("progress", "Unsquashing snap file 'test-snap.snap'."),
+            call(
+                "progress",
+                f"Installing assertion file with 'snap ack {fake_assert_file}'.",
+            ),
+            call("progress", f"Installing snap with 'snap install {fake_snap_file}'."),
+            call("verbose", "No lint filters defined in 'snapcraft.yaml'."),
+        ]
+    )
+
+
+def test_lint_managed_mode_assert_error(
+    emitter,
+    fake_assert_file,
+    fake_process,
+    fake_snap_file,
+    fake_snap_metadata,
+    fake_snapcraft_project,
+    mock_argv,
+    mock_is_managed_mode,
+    mock_report,
+    mock_run_linters,
+    mocker,
+):
+    """If the assert file fails to be installed, install the snap dangerously."""
+    mock_is_managed_mode.return_value = True
+
+    # create a snap file and assertion file
+    fake_snap_file.touch()
+    fake_assert_file.touch()
+
+    # register subprocess calls
+    fake_process.register_subprocess(
+        ["unsquashfs", "-force", "-dest", fake_process.any(), str(fake_snap_file)]
+    )
+    fake_process.register_subprocess(
+        ["snap", "ack", str(fake_assert_file)], returncode=1
+    )
+    fake_process.register_subprocess(
+        ["snap", "install", str(fake_snap_file), "--dangerous"]
+    )
+
+    # mock data from the unsquashed snap
+    mocker.patch(
+        "snapcraft.commands.lint.snap_yaml.read", return_value=fake_snap_metadata
+    )
+    mocker.patch(
+        "snapcraft.commands.lint.LintCommand._load_project",
+        return_value=fake_snapcraft_project,
+    )
+
+    cli.run()
+
+    mock_run_linters.assert_called_once_with(
+        lint=Lint(ignore=["classic"]),
+        location=Path("/snap/test/current"),
+    )
+    mock_report.assert_called_once_with(
+        mock_run_linters.return_value, intermediate=True
+    )
+    emitter.assert_interactions(
+        [
+            call("progress", "Running linter.", permanent=True),
+            call("debug", f"Found assertion file {str(fake_assert_file)!r}."),
+            call("progress", "Unsquashing snap file 'test-snap.snap'."),
+            call(
+                "progress",
+                f"Installing assertion file with 'snap ack {fake_assert_file}'.",
+            ),
+            call(
+                "progress",
+                "Could not add assertions from file 'test-snap.assert'",
+                permanent=True,
+            ),
+            call(
+                "progress",
+                f"Installing snap with 'snap install {fake_snap_file} --dangerous'.",
+            ),
+            call("verbose", "No lint filters defined in 'snapcraft.yaml'."),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    ["project_lint", "expected_lint"],
+    [
+        (
+            Lint(ignore=[]),
+            Lint(ignore=["classic"]),
+        ),
+        (
+            Lint(ignore=["library"]),
+            Lint(ignore=["library", "classic"]),
+        ),
+        (
+            Lint(ignore=["library", "classic"]),
+            Lint(ignore=["library", "classic"]),
+        ),
+        (
+            Lint(ignore=[{"classic": ["bin/test1", "bin/test2"]}]),
+            Lint(ignore=["classic"]),
+        ),
+        (
+            Lint(ignore=["library", {"classic": ["bin/test1", "bin/test2"]}]),
+            Lint(ignore=["library", "classic"]),
+        ),
+        (
+            Lint(
+                ignore=["library", "classic", {"classic": ["bin/test1", "bin/test2"]}]
+            ),
+            Lint(ignore=["library", "classic"]),
+        ),
+    ],
+)
+def test_lint_managed_mode_with_lint_config(
+    emitter,
+    expected_lint,
+    fake_snap_file,
+    fake_snap_metadata,
+    fake_snapcraft_project,
+    mock_argv,
+    mock_is_managed_mode,
+    mock_report,
+    mock_run_linters,
+    mocker,
+    project_lint,
+):
+    """Run the linter in managed mode and process the lint config from the project."""
+    mock_is_managed_mode.return_value = True
+    mocker.patch("subprocess.run")
+
+    # create a snap file
+    fake_snap_file.touch()
+
+    # mock data from the unsquashed snap
+    mocker.patch(
+        "snapcraft.commands.lint.snap_yaml.read", return_value=fake_snap_metadata
+    )
+
+    # add a lint config to the project
+    fake_snapcraft_project.lint = project_lint
+    mocker.patch(
+        "snapcraft.commands.lint.LintCommand._load_project",
+        return_value=fake_snapcraft_project,
+    )
+
+    cli.run()
+
+    # lint config from project should be passed to `run_linter()`
+    mock_run_linters.assert_called_once_with(
+        lint=expected_lint, location=Path("/snap/test/current")
+    )
+    mock_report.assert_called_once_with(
+        mock_run_linters.return_value, intermediate=True
+    )
+    emitter.assert_verbose("Collected lint config from 'snapcraft.yaml'.")
+
+
+def test_load_project(fake_snapcraft_project, tmp_path):
+    """Load a simple snapcraft.yaml project.
+
+    To simplify the unit tests, the `_load_project()` method is mocked out of the other
+    tests and tested separately.
+    """
+    # create a simple snapcraft.yaml
+    (tmp_path / "snap").mkdir()
+    snap_file = tmp_path / "snap/snapcraft.yaml"
+    with snap_file.open("w") as yaml_file:
+        print(
+            dedent(
+                """\
+                name: test-name
+                version: "1.0"
+                summary: test summary
+                description: test description
+                base: core22
+                confinement: strict
+                grade: stable
+
+                parts:
+                  part1:
+                    plugin: nil
+                """
+            ),
+            file=yaml_file,
+        )
+
+    result = LintCommand(None)._load_project(snapcraft_yaml_file=snap_file)
+
+    assert result == fake_snapcraft_project
+
+
+@pytest.mark.usefixtures("fake_extension")
+def test_load_project_complex(mocker, tmp_path):
+    """Load a complex snapcraft file.
+
+    This includes lint, parse-info, architectures, and advanced grammar.
+    """
+    # mock for advanced grammar parsing (i.e. `on amd64:`)
+    mocker.patch("snapcraft.commands.lint.get_host_architecture", return_value="amd64")
+
+    # create a snap file
+    (tmp_path / "snap").mkdir()
+    snap_file = tmp_path / "snap/snapcraft.yaml"
+    with snap_file.open("w") as yaml_file:
+        print(
+            dedent(
+                """\
+                name: test-name
+                version: "1.0"
+                summary: test summary
+                description: test description
+                base: core22
+                confinement: strict
+                grade: stable
+                architectures: [amd64, arm64, armhf]
+
+                apps:
+                  app1:
+                    command: app1
+                    command-chain: [fake-command]
+                    extensions: [fake-extension]
+
+                parts:
+                  nil:
+                    plugin: nil
+                    parse-info:
+                      - usr/share/metainfo/app1.appdata.xml
+                    stage-packages:
+                      - mesa-opencl-icd
+                      - ocl-icd-libopencl1
+                      - on amd64:
+                        - intel-opencl-icd
+                """
+            ),
+            file=yaml_file,
+        )
+
+    result = LintCommand(None)._load_project(snapcraft_yaml_file=snap_file)
+    assert result == Project.unmarshal(
+        {
+            "name": "test-name",
+            "base": "core22",
+            "build_base": "core22",
+            "version": "1.0",
+            "summary": "test summary",
+            "description": "test description",
+            "confinement": "strict",
+            "grade": "stable",
+            "architectures": [{"build_on": ["amd64"], "build_for": ["amd64"]}],
+            "apps": {
+                "app1": {
+                    "command": "app1",
+                    "plugs": ["fake-plug"],
+                    "command-chain": ["fake-command"],
+                }
+            },
+            "parts": {
+                "nil": {
+                    "plugin": "nil",
+                    "stage-packages": [
+                        "mesa-opencl-icd",
+                        "ocl-icd-libopencl1",
+                        "intel-opencl-icd",
+                    ],
+                    "after": ["fake-extension/fake-part"],
+                },
+                "fake-extension/fake-part": {"plugin": "nil"},
+            },
+        }
+    )
+
+
+def test_load_project_no_file(emitter, tmp_path):
+    """Return None if there is no snapcraft.yaml file."""
+    snapcraft_yaml_file = tmp_path / "snap/snapcraft.yaml"
+
+    result = LintCommand(None)._load_project(snapcraft_yaml_file=snapcraft_yaml_file)
+
+    assert not result
+    emitter.assert_debug(f"Could not find {snapcraft_yaml_file.name!r}.")
+
+
+@pytest.mark.parametrize("base", ["core", "core18", "core20"])
+def test_load_project_unsupported_core_error(base, tmp_path):
+    """Raise an error if for snaps with core, core18, and core20 bases."""
+    # create a simple snapcraft.yaml
+    (tmp_path / "snap").mkdir()
+    snap_file = tmp_path / "snap/snapcraft.yaml"
+    with snap_file.open("w") as yaml_file:
+        print(
+            dedent(
+                f"""\
+                name: test-name
+                version: "1.0"
+                summary: test summary
+                description: test description
+                base: {base}
+                confinement: strict
+                grade: stable
+
+                parts:
+                  part1:
+                    plugin: nil
+                """
+            ),
+            file=yaml_file,
+        )
+
+    with pytest.raises(SnapcraftError) as raised:
+        LintCommand(None)._load_project(snapcraft_yaml_file=snap_file)
+
+    assert str(raised.value) == "can not lint snap using a base older than core22"

--- a/tests/unit/commands/test_lint.py
+++ b/tests/unit/commands/test_lint.py
@@ -901,25 +901,23 @@ def test_load_project_unsupported_core_error(base, tmp_path):
     # create a simple snapcraft.yaml
     (tmp_path / "snap").mkdir()
     snap_file = tmp_path / "snap/snapcraft.yaml"
-    with snap_file.open("w") as yaml_file:
-        print(
-            dedent(
-                f"""\
-                name: test-name
-                version: "1.0"
-                summary: test summary
-                description: test description
-                base: {base}
-                confinement: strict
-                grade: stable
+    snap_file.write_text(
+        dedent(
+            f"""\
+            name: test-name
+            version: "1.0"
+            summary: test summary
+            description: test description
+            base: {base}
+            confinement: strict
+            grade: stable
 
-                parts:
-                  part1:
-                    plugin: nil
-                """
-            ),
-            file=yaml_file,
+            parts:
+              part1:
+                plugin: nil
+            """
         )
+    )
 
     with pytest.raises(SnapcraftError) as raised:
         LintCommand(None)._load_project(snapcraft_yaml_file=snap_file)


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

So far, `snapcraft lint` parses the command line, prepares an instance, and re-executes snapcraft inside the instance.

This PR adds the code that is executed inside the instance:
1. Unsquash the snap
2. Collect the metadata from snap.yaml and lint filters from snapcraft.yaml
3. Install the snap
4. Run the linter on `/snap/<snap-name>/current`
5. Report the linter warnings

(CRAFT-1689)