### PR TITLE
plugins: kernel: remove use of deprecated config.common.ports config

### DIFF
--- a/snapcraft_legacy/plugins/v2/_kernel_build.py
+++ b/snapcraft_legacy/plugins/v2/_kernel_build.py
@@ -281,11 +281,10 @@ def _do_base_config_cmd(
 	branch=$(cut -d'.' -f 2- < ${{KERNEL_SRC}}/debian/debian.env)
 	baseconfigdir=${{KERNEL_SRC}}/debian.${{branch}}/config
 	archconfigdir=${{KERNEL_SRC}}/debian.${{branch}}/config/${{DEB_ARCH}}
-	commonconfig=${{baseconfigdir}}/config.common.ports
 	ubuntuconfig=${{baseconfigdir}}/config.common.ubuntu
 	archconfig=${{archconfigdir}}/config.common.${{DEB_ARCH}}
 	flavourconfig=${{archconfigdir}}/config.flavour.{config_flavour}
-    cat ${{commonconfig}} ${{ubuntuconfig}} ${{archconfig}} ${{flavourconfig}} \
+    cat ${{ubuntuconfig}} ${{archconfig}} ${{flavourconfig}} \
 > {dest_dir}/.config 2>/dev/null || true""".format(
                 config_flavour=config_flavour, dest_dir=dest_dir
             )

--- a/tests/legacy/unit/plugins/v2/test_kernel.py
+++ b/tests/legacy/unit/plugins/v2/test_kernel.py
@@ -1294,11 +1294,10 @@ _prepare_config_flavour_cmd = [
 	branch=$(cut -d'.' -f 2- < ${KERNEL_SRC}/debian/debian.env)
 	baseconfigdir=${KERNEL_SRC}/debian.${branch}/config
 	archconfigdir=${KERNEL_SRC}/debian.${branch}/config/${DEB_ARCH}
-	commonconfig=${baseconfigdir}/config.common.ports
 	ubuntuconfig=${baseconfigdir}/config.common.ubuntu
 	archconfig=${archconfigdir}/config.common.${DEB_ARCH}
 	flavourconfig=${archconfigdir}/config.flavour.raspi
-    cat ${commonconfig} ${ubuntuconfig} ${archconfig} ${flavourconfig} \
+    cat ${ubuntuconfig} ${archconfig} ${flavourconfig} \
 > ${SNAPCRAFT_PART_BUILD}/.config 2>/dev/null || true"""
     ),
     "fi",

--- a/tests/unit/parts/plugins/test_kernel.py
+++ b/tests/unit/parts/plugins/test_kernel.py
@@ -1391,11 +1391,10 @@ _prepare_config_flavour_cmd = [
 	branch=$(cut -d'.' -f 2- < ${KERNEL_SRC}/debian/debian.env)
 	baseconfigdir=${KERNEL_SRC}/debian.${branch}/config
 	archconfigdir=${KERNEL_SRC}/debian.${branch}/config/${DEB_ARCH}
-	commonconfig=${baseconfigdir}/config.common.ports
 	ubuntuconfig=${baseconfigdir}/config.common.ubuntu
 	archconfig=${archconfigdir}/config.common.${DEB_ARCH}
 	flavourconfig=${archconfigdir}/config.flavour.raspi
-    cat ${commonconfig} ${ubuntuconfig} ${archconfig} ${flavourconfig} \
+    cat ${ubuntuconfig} ${archconfig} ${flavourconfig} \
 > ${CRAFT_PART_BUILD}/.config 2>/dev/null || true"""
     ),
     "fi",


### PR DESCRIPTION
'config.common.ports' config file is deprecated and not used anymore by the Ubuntu kernel, it might disappear in the future altogether, remove use of it when using Ubuntu `kconfigflavour` option, so builds do not break in the future.