### PR TITLE
kernel plugin: call deb rules clean

### DIFF
--- a/snapcraft/parts/plugins/kernel.py
+++ b/snapcraft/parts/plugins/kernel.py
@@ -385,6 +385,7 @@ class KernelPlugin(plugins.Plugin):
         build_packages = {
             "bc",
             "binutils",
+            "fakeroot",
             "gcc",
             "cmake",
             "cryptsetup",

--- a/snapcraft_legacy/plugins/v2/_kernel_build.py
+++ b/snapcraft_legacy/plugins/v2/_kernel_build.py
@@ -284,8 +284,13 @@ def _do_base_config_cmd(
 	ubuntuconfig=${{baseconfigdir}}/config.common.ubuntu
 	archconfig=${{archconfigdir}}/config.common.${{DEB_ARCH}}
 	flavourconfig=${{archconfigdir}}/config.flavour.{config_flavour}
-    cat ${{ubuntuconfig}} ${{archconfig}} ${{flavourconfig}} \
-> {dest_dir}/.config 2>/dev/null || true""".format(
+	cat ${{ubuntuconfig}} ${{archconfig}} ${{flavourconfig}} \
+> {dest_dir}/.config 2>/dev/null || true
+	if [ -f ${{KERNEL_SRC}}/debian/rules ] && [ -x ${{KERNEL_SRC}}/debian/rules ]; then
+		pushd ${{KERNEL_SRC}}
+		fakeroot debian/rules clean
+		popd
+	fi""".format(
                 config_flavour=config_flavour, dest_dir=dest_dir
             )
         )

--- a/snapcraft_legacy/plugins/v2/kernel.py
+++ b/snapcraft_legacy/plugins/v2/kernel.py
@@ -430,6 +430,7 @@ class KernelPlugin(PluginV2):
         build_packages = {
             "bc",
             "binutils",
+            "fakeroot",
             "gcc",
             "cmake",
             "cryptsetup",

--- a/tests/legacy/unit/plugins/v2/test_kernel.py
+++ b/tests/legacy/unit/plugins/v2/test_kernel.py
@@ -266,6 +266,7 @@ class TestPluginKernel(TestCase):
             {
                 "bc",
                 "binutils",
+                "fakeroot",
                 "gcc",
                 "cmake",
                 "cryptsetup",
@@ -284,6 +285,7 @@ class TestPluginKernel(TestCase):
             {
                 "bc",
                 "binutils",
+                "fakeroot",
                 "gcc",
                 "cmake",
                 "cryptsetup",
@@ -302,6 +304,7 @@ class TestPluginKernel(TestCase):
             {
                 "bc",
                 "binutils",
+                "fakeroot",
                 "gcc",
                 "cmake",
                 "cryptsetup",
@@ -320,6 +323,7 @@ class TestPluginKernel(TestCase):
             {
                 "bc",
                 "binutils",
+                "fakeroot",
                 "gcc",
                 "cmake",
                 "cryptsetup",
@@ -343,6 +347,7 @@ class TestPluginKernel(TestCase):
             {
                 "bc",
                 "binutils",
+                "fakeroot",
                 "gcc",
                 "cmake",
                 "cryptsetup",
@@ -1000,6 +1005,7 @@ class TestPluginKernel(TestCase):
             {
                 "bc",
                 "binutils",
+                "fakeroot",
                 "gcc",
                 "cmake",
                 "cryptsetup",
@@ -1031,6 +1037,7 @@ class TestPluginKernel(TestCase):
             {
                 "bc",
                 "binutils",
+                "fakeroot",
                 "gcc",
                 "cmake",
                 "cryptsetup",
@@ -1297,8 +1304,13 @@ _prepare_config_flavour_cmd = [
 	ubuntuconfig=${baseconfigdir}/config.common.ubuntu
 	archconfig=${archconfigdir}/config.common.${DEB_ARCH}
 	flavourconfig=${archconfigdir}/config.flavour.raspi
-    cat ${ubuntuconfig} ${archconfig} ${flavourconfig} \
-> ${SNAPCRAFT_PART_BUILD}/.config 2>/dev/null || true"""
+	cat ${ubuntuconfig} ${archconfig} ${flavourconfig} \
+> ${SNAPCRAFT_PART_BUILD}/.config 2>/dev/null || true
+	if [ -f ${KERNEL_SRC}/debian/rules ] && [ -x ${KERNEL_SRC}/debian/rules ]; then
+		pushd ${KERNEL_SRC}
+		fakeroot debian/rules clean
+		popd
+	fi"""
     ),
     "fi",
 ]

--- a/tests/unit/parts/plugins/test_kernel.py
+++ b/tests/unit/parts/plugins/test_kernel.py
@@ -71,6 +71,7 @@ class TestPluginKernel:
         assert plugin.get_build_packages() == {
             "bc",
             "binutils",
+            "fakeroot",
             "gcc",
             "cmake",
             "cryptsetup",
@@ -91,6 +92,7 @@ class TestPluginKernel:
         assert plugin.get_build_packages() == {
             "bc",
             "binutils",
+            "fakeroot",
             "gcc",
             "cmake",
             "cryptsetup",
@@ -111,6 +113,7 @@ class TestPluginKernel:
         assert plugin.get_build_packages() == {
             "bc",
             "binutils",
+            "fakeroot",
             "gcc",
             "cmake",
             "cryptsetup",
@@ -131,6 +134,7 @@ class TestPluginKernel:
         assert plugin.get_build_packages() == {
             "bc",
             "binutils",
+            "fakeroot",
             "gcc",
             "cmake",
             "cryptsetup",
@@ -157,6 +161,7 @@ class TestPluginKernel:
         assert plugin.get_build_packages() == {
             "bc",
             "binutils",
+            "fakeroot",
             "gcc",
             "cmake",
             "cryptsetup",
@@ -183,6 +188,7 @@ class TestPluginKernel:
         assert plugin.get_build_packages() == {
             "bc",
             "binutils",
+            "fakeroot",
             "gcc",
             "cmake",
             "cryptsetup",
@@ -1091,6 +1097,7 @@ class TestPluginKernel:
         assert plugin.get_build_packages() == {
             "bc",
             "binutils",
+            "fakeroot",
             "gcc",
             "cmake",
             "cryptsetup",
@@ -1124,6 +1131,7 @@ class TestPluginKernel:
         assert plugin.get_build_packages() == {
             "bc",
             "binutils",
+            "fakeroot",
             "gcc",
             "cmake",
             "cryptsetup",
@@ -1394,8 +1402,13 @@ _prepare_config_flavour_cmd = [
 	ubuntuconfig=${baseconfigdir}/config.common.ubuntu
 	archconfig=${archconfigdir}/config.common.${DEB_ARCH}
 	flavourconfig=${archconfigdir}/config.flavour.raspi
-    cat ${ubuntuconfig} ${archconfig} ${flavourconfig} \
-> ${CRAFT_PART_BUILD}/.config 2>/dev/null || true"""
+	cat ${ubuntuconfig} ${archconfig} ${flavourconfig} \
+> ${CRAFT_PART_BUILD}/.config 2>/dev/null || true
+	if [ -f ${KERNEL_SRC}/debian/rules ] && [ -x ${KERNEL_SRC}/debian/rules ]; then
+		pushd ${KERNEL_SRC}
+		fakeroot debian/rules clean
+		popd
+	fi"""
     ),
     "fi",
 ]


### PR DESCRIPTION
when building kernel with `kconfigflavour` Ubuntu config option, the kernel tree should also contain `debian/rules`
call `debian/rules clean` if `debian/rules` exist so `SYSTEM_TRUSTED_KEYS` and `SYSTEM_REVOCATION_KEYS` configs do not need to be modded.