### PR TITLE
requirements: update craft-parts to 1.19.3

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -14,7 +14,7 @@ coverage==7.0.4
 craft-archives==0.0.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
-craft-parts==1.19.0
+craft-parts==1.19.3
 craft-providers==1.10.0
 craft-store==2.3.0
 cryptography==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.3
 craft-archives==0.0.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
-craft-parts==1.19.0
+craft-parts==1.19.3
 craft-providers==1.10.0
 craft-store==2.3.0
 cryptography==3.4


### PR DESCRIPTION
Craft Parts 1.19.3 fixes plugin properties state during the planning phase.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
