### PR TITLE
meta: use build-for in snap.yaml architecture

### DIFF
--- a/snapcraft/elf/elf_utils.py
+++ b/snapcraft/elf/elf_utils.py
@@ -21,7 +21,7 @@ import os
 import platform
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Set
+from typing import Iterable, List, Optional, Set
 
 from craft_cli import emit
 from elftools.common.exceptions import ELFError
@@ -127,9 +127,17 @@ def get_dynamic_linker(*, root_path: Path, snap_path: Path) -> str:
     return str(snap_path / arch_config.dynamic_linker)
 
 
-def get_arch_triplet() -> str:
-    """Inform the arch triplet string for the current architecture."""
-    arch = platform.machine()
+def get_arch_triplet(arch: Optional[str] = None) -> str:
+    """Get the arch triplet string for an architecture.
+
+    :param arch: Architecture to get the triplet of. If None, then get the arch triplet
+    of the host.
+
+    :returns: The arch triplet.
+    """
+    if not arch:
+        arch = platform.machine()
+
     arch_config = _ARCH_CONFIG.get(arch)
     if not arch_config:
         raise RuntimeError(f"Arch triplet not defined for arch {arch!r}")

--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -374,13 +374,12 @@ def _get_grade(grade: Optional[str], build_base: Optional[str]) -> str:
     return grade
 
 
-def write(project: Project, prime_dir: Path, *, arch: str, arch_triplet: str):
+def write(project: Project, prime_dir: Path, *, arch: str):
     """Create a snap.yaml file.
 
     :param project: Snapcraft project.
     :param prime_dir: The directory containing the content to be snapped.
     :param arch: Target architecture the snap project is built to.
-    :param arch_triplet: Architecture triplet of the platform.
     """
     meta_dir = prime_dir / "meta"
     meta_dir.mkdir(parents=True, exist_ok=True)
@@ -394,6 +393,9 @@ def write(project: Project, prime_dir: Path, *, arch: str, arch_triplet: str):
 
     if project.hooks and any(h for h in project.hooks.values() if h.command_chain):
         assumes.add("command-chain")
+
+    # if arch is "all", do not include architecture-specific paths in the environment
+    arch_triplet = None if arch == "all" else project.get_build_for_arch_triplet()
 
     environment = _populate_environment(project.environment, prime_dir, arch_triplet)
     version = process_version(project.version)
@@ -446,7 +448,9 @@ def _repr_str(dumper, data):
 
 
 def _populate_environment(
-    environment: Optional[Dict[str, Optional[str]]], prime_dir: Path, arch_triplet: str
+    environment: Optional[Dict[str, Optional[str]]],
+    prime_dir: Path,
+    arch_triplet: Optional[str],
 ):
     """Populate default app environmental variables.
 
@@ -454,6 +458,11 @@ def _populate_environment(
         - If LD_LIBRARY_PATH or PATH are defined, keep user-defined values.
         - If LD_LIBRARY_PATH or PATH are not defined, set to default values.
         - If LD_LIBRARY_PATH or PATH are null, do not use default values.
+
+    :param environment: Dictionary of environment variables from the project.
+    :param prime_dir: The directory containing the content to be snapped.
+    :param arch_triplet: Architecture triplet of the target arch. If None, the
+    environment will not contain architecture-specific paths.
     """
     if environment is None:
         return {

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -410,12 +410,7 @@ def _generate_metadata(
     )
 
     emit.progress("Generating snap metadata...")
-    snap_yaml.write(
-        project,
-        lifecycle.prime_dir,
-        arch=project.get_build_for(),
-        arch_triplet=lifecycle.target_arch_triplet,
-    )
+    snap_yaml.write(project, lifecycle.prime_dir, arch=project.get_build_for())
     emit.progress("Generated snap metadata", permanent=True)
 
     if parsed_args.enable_manifest:

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -413,7 +413,7 @@ def _generate_metadata(
     snap_yaml.write(
         project,
         lifecycle.prime_dir,
-        arch=lifecycle.target_arch,
+        arch=project.get_build_for(),
         arch_triplet=lifecycle.target_arch_triplet,
     )
     emit.progress("Generated snap metadata", permanent=True)
@@ -449,7 +449,7 @@ def _generate_manifest(
     manifest.write(
         project,
         lifecycle.prime_dir,
-        arch=lifecycle.target_arch,
+        arch=project.get_build_for(),
         parts=parts,
         start_time=start_time,
         image_information=image_information,

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -26,8 +26,13 @@ from craft_grammar.models import GrammarSingleEntryDictList, GrammarStr, Grammar
 from pydantic import PrivateAttr, conlist, constr
 
 from snapcraft import parts, utils
+from snapcraft.elf.elf_utils import get_arch_triplet
 from snapcraft.errors import ProjectValidationError
-from snapcraft.utils import get_effective_base, get_host_architecture
+from snapcraft.utils import (
+    convert_architecture_deb_to_platform,
+    get_effective_base,
+    get_host_architecture,
+)
 
 
 class ProjectModel(pydantic.BaseModel):
@@ -712,6 +717,18 @@ class Project(ProjectModel):
 
         # will not happen after schema validation
         raise RuntimeError("cannot determine build-for architecture")
+
+    def get_build_for_arch_triplet(self) -> Optional[str]:
+        """Get the architecture triplet for the first build-for architecture.
+
+        :returns: The build-for arch triplet. If build-for is "all", then return None.
+        """
+        arch = self.get_build_for()
+
+        if arch != "all":
+            return get_arch_triplet(convert_architecture_deb_to_platform(arch))
+
+        return None
 
 
 class _GrammarAwareModel(pydantic.BaseModel):

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -329,20 +329,42 @@ def humanize_list(
     return f"{humanized} {conjunction} {quoted_items[-1]}"
 
 
-def get_common_ld_library_paths(prime_dir: Path, arch_triplet: str) -> List[str]:
-    """Return common existing PATH entries for a snap."""
+def get_common_ld_library_paths(
+    prime_dir: Path, arch_triplet: Optional[str]
+) -> List[str]:
+    """Return common existing PATH entries for a snap.
+
+    :param prime_dir: Path to the prime directory.
+    :param arch_triplet: Architecture triplet of target arch. If None, the list of paths
+    will not contain architecture-specific paths.
+
+    :returns: List of common library paths in the prime directory that exist.
+    """
     paths = [
         prime_dir / "lib",
         prime_dir / "usr" / "lib",
-        prime_dir / "lib" / arch_triplet,
-        prime_dir / "usr" / "lib" / arch_triplet,
     ]
+
+    if arch_triplet:
+        paths.extend(
+            [
+                prime_dir / "lib" / arch_triplet,
+                prime_dir / "usr" / "lib" / arch_triplet,
+            ]
+        )
 
     return [str(p) for p in paths if p.exists()]
 
 
-def get_ld_library_paths(prime_dir: Path, arch_triplet: str) -> str:
-    """Return a usable in-snap LD_LIBRARY_PATH variable."""
+def get_ld_library_paths(prime_dir: Path, arch_triplet: Optional[str]) -> str:
+    """Return a usable in-snap LD_LIBRARY_PATH variable.
+
+    :param prime_dir: Path to the prime directory.
+    :param arch_triplet: Architecture triplet of target arch. If None, LD_LIBRARY_PATH
+    will not contain architecture-specific paths.
+
+    :returns: The LD_LIBRARY_PATH environment variable to be used for the snap.
+    """
     paths = ["${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"]
     # Add the default LD_LIBRARY_PATH
     paths += get_common_ld_library_paths(prime_dir, arch_triplet)

--- a/tests/unit/elf/test_elf_utils.py
+++ b/tests/unit/elf/test_elf_utils.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2016-2022 Canonical Ltd.
+# Copyright 2016-2023 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -159,10 +159,27 @@ class TestArchConfig:
             ("x86_64", "x86_64-linux-gnu"),
         ],
     )
-    def test_get_arch_triplet(self, mocker, machine, expected_arch_triplet):
+    def test_get_arch_triplet_host(self, mocker, machine, expected_arch_triplet):
         """Verify `get_arch_triplet()` gets the host's architecture triplet."""
         mocker.patch("snapcraft.elf.elf_utils.platform.machine", return_value=machine)
         arch_triplet = elf_utils.get_arch_triplet()
+
+        assert arch_triplet == expected_arch_triplet
+
+    @pytest.mark.parametrize(
+        "machine, expected_arch_triplet",
+        [
+            ("aarch64", "aarch64-linux-gnu"),
+            ("armv7l", "arm-linux-gnueabihf"),
+            ("ppc64le", "powerpc64le-linux-gnu"),
+            ("riscv64", "riscv64-linux-gnu"),
+            ("s390x", "s390x-linux-gnu"),
+            ("x86_64", "x86_64-linux-gnu"),
+        ],
+    )
+    def test_get_arch_triplet(self, mocker, machine, expected_arch_triplet):
+        """Get the architecture triplet from the architecture passed as a parameter."""
+        arch_triplet = elf_utils.get_arch_triplet(machine)
 
         assert arch_triplet == expected_arch_triplet
 

--- a/tests/unit/linters/test_classic_linter.py
+++ b/tests/unit/linters/test_classic_linter.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022-2023 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -64,12 +64,7 @@ def test_classic_linter(mocker, new_dir, confinement, stage_libc, text):
     }
 
     project = projects.Project.unmarshal(yaml_data)
-    snap_yaml.write(
-        project,
-        prime_dir=Path(new_dir),
-        arch="amd64",
-        arch_triplet="x86_64-linux-gnu",
-    )
+    snap_yaml.write(project, prime_dir=Path(new_dir), arch="amd64")
 
     issues = linters.run_linters(new_dir, lint=None)
 
@@ -131,12 +126,7 @@ def test_classic_linter_filter(mocker, new_dir):
     }
 
     project = projects.Project.unmarshal(yaml_data)
-    snap_yaml.write(
-        project,
-        prime_dir=Path(new_dir),
-        arch="amd64",
-        arch_triplet="x86_64-linux-gnu",
-    )
+    snap_yaml.write(project, prime_dir=Path(new_dir), arch="amd64")
 
     issues = linters.run_linters(
         new_dir, lint=projects.Lint(ignore=[{"classic": ["elf.*"]}])

--- a/tests/unit/linters/test_library_linter.py
+++ b/tests/unit/linters/test_library_linter.py
@@ -54,12 +54,7 @@ def test_library_linter_missing_library(mocker, new_dir):
     }
 
     project = projects.Project.unmarshal(yaml_data)
-    snap_yaml.write(
-        project,
-        prime_dir=Path(new_dir),
-        arch="amd64",
-        arch_triplet="x86_64-linux-gnu",
-    )
+    snap_yaml.write(project, prime_dir=Path(new_dir), arch="amd64")
 
     issues = linters.run_linters(new_dir, lint=None)
     assert issues == [
@@ -114,12 +109,7 @@ def test_library_linter_unused_library(mocker, new_dir):
     }
 
     project = projects.Project.unmarshal(yaml_data)
-    snap_yaml.write(
-        project,
-        prime_dir=Path(new_dir),
-        arch="amd64",
-        arch_triplet="x86_64-linux-gnu",
-    )
+    snap_yaml.write(project, prime_dir=Path(new_dir), arch="amd64")
 
     issues = linters.run_linters(new_dir, lint=None)
     assert issues == [
@@ -160,12 +150,7 @@ def test_library_linter_filter_missing_library(mocker, new_dir, filter_name):
     }
 
     project = projects.Project.unmarshal(yaml_data)
-    snap_yaml.write(
-        project,
-        prime_dir=Path(new_dir),
-        arch="amd64",
-        arch_triplet="x86_64-linux-gnu",
-    )
+    snap_yaml.write(project, prime_dir=Path(new_dir), arch="amd64")
 
     issues = linters.run_linters(
         new_dir, lint=projects.Lint(ignore=[{filter_name: ["elf.*"]}])
@@ -210,12 +195,7 @@ def test_library_linter_filter_unused_library(mocker, new_dir, filter_name):
     }
 
     project = projects.Project.unmarshal(yaml_data)
-    snap_yaml.write(
-        project,
-        prime_dir=Path(new_dir),
-        arch="amd64",
-        arch_triplet="x86_64-linux-gnu",
-    )
+    snap_yaml.write(project, prime_dir=Path(new_dir), arch="amd64")
 
     issues = linters.run_linters(
         new_dir, lint=projects.Lint(ignore=[{filter_name: ["lib/libfoo.*"]}])
@@ -252,12 +232,7 @@ def test_library_linter_mixed_filters(mocker, new_dir):
     }
 
     project = projects.Project.unmarshal(yaml_data)
-    snap_yaml.write(
-        project,
-        prime_dir=Path(new_dir),
-        arch="amd64",
-        arch_triplet="x86_64-linux-gnu",
-    )
+    snap_yaml.write(project, prime_dir=Path(new_dir), arch="amd64")
 
     # lib/libfoo.so is an *unused* library, but here we filter out *missing* library
     # issues for this path.

--- a/tests/unit/linters/test_linters.py
+++ b/tests/unit/linters/test_linters.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022-2023 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -169,7 +169,6 @@ class TestLinterRun:
             project,
             prime_dir=Path(new_dir),
             arch="amd64",
-            arch_triplet="x86_64-linux-gnu",
         )
 
         issues = linters.run_linters(new_dir, lint=None)
@@ -199,7 +198,6 @@ class TestLinterRun:
             project,
             prime_dir=Path(new_dir),
             arch="amd64",
-            arch_triplet="x86_64-linux-gnu",
         )
 
         lint = projects.Lint(ignore=["test"])
@@ -221,12 +219,7 @@ class TestLinterRun:
         }
 
         project = projects.Project.unmarshal(yaml_data)
-        snap_yaml.write(
-            project,
-            prime_dir=Path(new_dir),
-            arch="amd64",
-            arch_triplet="x86_64-linux-gnu",
-        )
+        snap_yaml.write(project, prime_dir=Path(new_dir), arch="amd64")
 
         lint = projects.Lint(ignore=["test-1", "test-2"])
         issues = linters.run_linters(new_dir, lint=lint)

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -1692,7 +1692,7 @@ def test_patch_elf(snapcraft_yaml, mocker, new_dir):
 def test_lifecycle_write_metadata(
     build_for, snapcraft_yaml, project_vars, new_dir, mocker
 ):
-    """Verify metadata and manifest are written during the lifecycle."""
+    """Metadata and manifest should be written during the lifecycle."""
     yaml_data = {
         "base": "core22",
         "architectures": [{"build-on": "amd64", "build-for": build_for}],
@@ -1723,12 +1723,7 @@ def test_lifecycle_write_metadata(
     )
 
     assert mock_write_metadata.mock_calls == [
-        call(
-            project,
-            new_dir / "prime",
-            arch=build_for,
-            arch_triplet=mocker.ANY,
-        )
+        call(project, new_dir / "prime", arch=build_for)
     ]
     assert mock_write_manifest.mock_calls == [
         call(

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -1684,3 +1684,29 @@ class TestArchitecture:
         )
         project = Project.unmarshal(data)
         assert project.get_build_for() == "armhf"
+
+    def test_project_get_build_for_arch_triplet(self, project_yaml_data):
+        """Get architecture triplet for the build-for architecture."""
+        data = project_yaml_data(
+            architectures=[
+                {"build-on": ["arm64"], "build-for": ["armhf"]},
+            ]
+        )
+
+        project = Project.unmarshal(data)
+        arch_triplet = project.get_build_for_arch_triplet()
+
+        assert arch_triplet == "arm-linux-gnueabihf"
+
+    def test_project_get_build_for_arch_triplet_all(self, project_yaml_data):
+        """When build-for = "all", the build-for arch triplet should be None."""
+        data = project_yaml_data(
+            architectures=[
+                {"build-on": ["arm64"], "build-for": ["all"]},
+            ]
+        )
+
+        project = Project.unmarshal(data)
+        arch_triplet = project.get_build_for_arch_triplet()
+
+        assert not arch_triplet

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022-2023 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -336,6 +336,26 @@ def test_get_ld_library_paths(tmp_path, lib_dirs, expected_env):
         f"${{SNAP_LIBRARY_PATH}}${{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}}:{expected_env}"
     )
     assert utils.get_ld_library_paths(tmp_path, "i286-none-none") == expected_env
+
+
+@pytest.mark.parametrize(
+    ["lib_dirs", "expected_env"],
+    [
+        (["lib"], "$SNAP/lib"),
+        (["lib", "usr/lib"], "$SNAP/lib:$SNAP/usr/lib"),
+        (["lib/i286-none-none", "usr/lib/i286-none-none"], "$SNAP/lib:$SNAP/usr/lib"),
+    ],
+)
+def test_get_ld_library_paths_no_architecture(tmp_path, lib_dirs, expected_env):
+    """Do not include architecture-specfic paths if an architecture is not provided."""
+    for lib_dir in lib_dirs:
+        (tmp_path / lib_dir).mkdir(parents=True)
+
+    env = utils.get_ld_library_paths(tmp_path, None)
+
+    assert env == (
+        f"${{SNAP_LIBRARY_PATH}}${{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}}:{expected_env}"
+    )
 
 
 #################


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
### Details

Previously, using `build-for: all` in a snapcraft project would cause `meta/snap.yaml` to contain the `build-on` architecture, due to [this line](https://github.com/snapcore/snapcraft/blob/2f2d1eac63de39dbd4f9bbfab8ffa5df0ac9ca62/snapcraft/parts/parts.py#L88) from my first implementation of adding support for the `architectures` keyword.

Now, `build-for: all` will cause `meta/snap.yaml` to use `architectures: all`. 


### Source
https://bugs.launchpad.net/snapcraft/+bug/1999580
https://forum.snapcraft.io/t/incorrect-architecture-with-snapcraft-7-x-and-build-for-build-on/34130
(CRAFT-1535)