### PR TITLE
requirements: update craft-parts to 1.20.0

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -14,7 +14,7 @@ coverage==7.2.5
 craft-archives==0.0.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
-craft-parts==1.19.3
+craft-parts==1.20.0
 craft-providers==1.10.0
 craft-store==2.4.0
 cryptography==40.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.3
 craft-archives==0.0.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
-craft-parts==1.19.3
+craft-parts==1.20.0
 craft-providers==1.10.0
 craft-store==2.4.0
 cryptography==40.0.2


### PR DESCRIPTION
Craft Parts 1.20.0 adds support for pyproject.toml projects in the
Python plugin and fixes subdirs in pull and build steps.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
