### PR TITLE
tests: remove arch_triplet from unit test

### DIFF
--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -96,7 +96,6 @@ def test_assumes(simple_project, new_dir):
         simple_project(assumes=["foossumes"]),
         prime_dir=Path(new_dir),
         arch="amd64",
-        arch_triplet="x86_64-linux-gnu",
     )
     yaml_file = Path("meta/snap.yaml")
     assert yaml_file.is_file()
@@ -425,7 +424,6 @@ def test_hook_command_chain_assumes_with_existing_assumes(simple_project, new_di
         simple_project(hooks=hooks, assumes=["foossumes", "barssumes"]),
         prime_dir=Path(new_dir),
         arch="amd64",
-        arch_triplet="x86_64-linux-gnu",
     )
     yaml_file = Path("meta/snap.yaml")
     assert yaml_file.is_file()


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Minor fix for unit tests.

Two PRs ([1](https://github.com/snapcore/snapcraft/pull/4150) and [2](https://github.com/snapcore/snapcraft/pull/4152)) touched the same unit test file.  One removed all references to `arch_triplet` and the other added 2 more tests with `arch_triplet` still present.