### PR TITLE
fix(ROS): rosdep init executed as root need to forward proxy env var

### DIFF
--- a/snapcraft/parts/plugins/_ros.py
+++ b/snapcraft/parts/plugins/_ros.py
@@ -177,8 +177,11 @@ class RosPlugin(plugins.Plugin):
         return (
             self._get_workspace_activation_commands()
             + [
-                "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; "
-                "then sudo rosdep init; fi",
+                "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then",
+                # Preserve http(s)_proxy env var in root for remote-build proxy since rosdep
+                # doesn't support proxy
+                # https://github.com/ros-infrastructure/rosdep/issues/271
+                "sudo --preserve-env=http_proxy,https_proxy rosdep init; fi",
                 'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
                 "rosdep install --default-yes --ignore-packages-from-source "
                 '--from-paths "${CRAFT_PART_SRC_WORK}"',

--- a/snapcraft_legacy/plugins/v2/_ros.py
+++ b/snapcraft_legacy/plugins/v2/_ros.py
@@ -120,7 +120,11 @@ class RosPlugin(PluginV2):
         return (
             self._get_workspace_activation_commands()
             + [
-                "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep init; fi",
+                "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then",
+                # Preserve http(s)_proxy env var in root for remote-build proxy since rosdep
+                # doesn't support proxy
+                # https://github.com/ros-infrastructure/rosdep/issues/271
+                "sudo --preserve-env=http_proxy,https_proxy rosdep init; fi",
                 'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
                 'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
             ]

--- a/tests/legacy/unit/plugins/v2/test_catkin.py
+++ b/tests/legacy/unit/plugins/v2/test_catkin.py
@@ -95,8 +95,8 @@ def test_get_build_commands(monkeypatch):
         "fi",
         '. /opt/ros/"${ROS_DISTRO}"/setup.sh',
         'eval "${state}"',
-        "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
-        "init; fi",
+        "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then",
+        "sudo --preserve-env=http_proxy,https_proxy rosdep init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
         'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         'state="$(set +o); set -$-"',
@@ -159,8 +159,8 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "fi",
         '. /opt/ros/"${ROS_DISTRO}"/setup.sh',
         'eval "${state}"',
-        "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
-        "init; fi",
+        "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then",
+        "sudo --preserve-env=http_proxy,https_proxy rosdep init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
         'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         'state="$(set +o); set -$-"',

--- a/tests/legacy/unit/plugins/v2/test_catkin_tools.py
+++ b/tests/legacy/unit/plugins/v2/test_catkin_tools.py
@@ -90,8 +90,8 @@ def test_get_build_commands(monkeypatch):
         "fi",
         '. /opt/ros/"${ROS_DISTRO}"/setup.sh',
         'eval "${state}"',
-        "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
-        "init; fi",
+        "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then",
+        "sudo --preserve-env=http_proxy,https_proxy rosdep init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
         'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         'state="$(set +o); set -$-"',
@@ -155,8 +155,8 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "fi",
         '. /opt/ros/"${ROS_DISTRO}"/setup.sh',
         'eval "${state}"',
-        "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
-        "init; fi",
+        "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then",
+        "sudo --preserve-env=http_proxy,https_proxy rosdep init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
         'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         'state="$(set +o); set -$-"',

--- a/tests/legacy/unit/plugins/v2/test_colcon.py
+++ b/tests/legacy/unit/plugins/v2/test_colcon.py
@@ -115,8 +115,8 @@ def test_get_build_commands(monkeypatch):
         "fi",
         '. /opt/ros/"${ROS_DISTRO}"/local_setup.sh',
         'eval "${state}"',
-        "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
-        "init; fi",
+        "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then",
+        "sudo --preserve-env=http_proxy,https_proxy rosdep init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
         'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         'state="$(set +o); set -$-"',
@@ -182,8 +182,8 @@ def test_get_build_commands_with_all_properties(monkeypatch):
         "fi",
         '. /opt/ros/"${ROS_DISTRO}"/local_setup.sh',
         'eval "${state}"',
-        "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
-        "init; fi",
+        "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then",
+        "sudo --preserve-env=http_proxy,https_proxy rosdep init; fi",
         'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
         'rosdep install --default-yes --ignore-packages-from-source --from-paths "${SNAPCRAFT_PART_SRC_WORK}"',
         'state="$(set +o); set -$-"',

--- a/tests/unit/parts/plugins/test_colcon.py
+++ b/tests/unit/parts/plugins/test_colcon.py
@@ -139,8 +139,8 @@ class TestPluginColconPlugin:
             "fi",
             '. "/opt/ros/${ROS_DISTRO}/local_setup.sh"',
             'eval "${state}"',
-            "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
-            "init; fi",
+            "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then",
+            "sudo --preserve-env=http_proxy,https_proxy rosdep init; fi",
             'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
             "rosdep install --default-yes --ignore-packages-from-source "
             '--from-paths "${CRAFT_PART_SRC_WORK}"',
@@ -218,8 +218,8 @@ class TestPluginColconPlugin:
             "fi",
             '. "/opt/ros/${ROS_DISTRO}/local_setup.sh"',
             'eval "${state}"',
-            "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then sudo rosdep "
-            "init; fi",
+            "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then",
+            "sudo --preserve-env=http_proxy,https_proxy rosdep init; fi",
             'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
             "rosdep install --default-yes --ignore-packages-from-source "
             '--from-paths "${CRAFT_PART_SRC_WORK}"',


### PR DESCRIPTION
In remote-build a proxy is used and passed as env var. When calling rosdep init as root those env var were not forwarded. This was causing core20 and core22 ROS snap to be unbuildable on remote-build
rosdep doesn't support proxy:
https://github.com/ros-infrastructure/rosdep/issues/271

- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----
