### PR TITLE
fix(ROS-core18): distro-info-data is not available by default in LXD

### DIFF
--- a/snapcraft_legacy/plugins/v1/catkin.py
+++ b/snapcraft_legacy/plugins/v1/catkin.py
@@ -308,7 +308,16 @@ class CatkinPlugin(PluginV1):
         base = self.project._get_build_base()
         self._rosdistro = _BASE_TO_ROS_RELEASE_MAP[base]
 
-        self.build_packages.extend(["gcc", "g++", "libc6-dev", "make", "python-pip"])
+        self.build_packages.extend(
+            [
+                "distro-info-data",
+                "gcc",
+                "g++",
+                "libc6-dev",
+                "make",
+                "python-pip",
+            ]
+        )
         self.__pip = None
 
         # roslib is the base requiremet to actually create a workspace with


### PR DESCRIPTION
The package `distro-info-data` is not available by default in LXD. This package is necessary for `catkin`.
This enables core18 ROS snap to be built with LXD (and remote-build).

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
