### PR TITLE
requirements: bump craft-providers

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -15,7 +15,7 @@ craft-archives==1.0.0
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.5
-craft-providers==1.10.0
+craft-providers==1.13.0
 craft-store==2.4.0
 cryptography==40.0.2
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ craft-archives==1.0.0
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.5
-craft-providers==1.10.0
+craft-providers==1.13.0
 craft-store==2.4.0
 cryptography==40.0.2
 Deprecated==1.2.13

--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -24,6 +24,7 @@ from typing import Dict, Optional
 
 from craft_cli import emit
 from craft_providers import Provider, ProviderError, bases, executor
+from craft_providers.actions.snap_installer import Snap
 from craft_providers.lxd import LXDProvider
 from craft_providers.multipass import MultipassProvider
 
@@ -198,13 +199,7 @@ def get_base_configuration(
         compatibility_tag=f"snapcraft-{bases.BuilddBase.compatibility_tag}.0",
         environment=environment,
         hostname=instance_name,
-        snaps=[
-            bases.buildd.Snap(
-                name=snap_name,
-                channel=snap_channel,
-                classic=True,
-            )
-        ],
+        snaps=[Snap(name=snap_name, channel=snap_channel, classic=True)],
         # Requirement for apt gpg and version:git
         packages=["gnupg", "dirmngr", "git"],
     )

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -24,7 +24,7 @@ from unittest.mock import ANY, Mock, PropertyMock, call
 import pytest
 from craft_cli import EmitterMode, emit
 from craft_parts import Action, Step, callbacks
-from craft_providers.bases.buildd import BuilddBaseAlias
+from craft_providers.bases.ubuntu import BuilddBaseAlias
 
 from snapcraft import errors
 from snapcraft.elf import ElfFile

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -19,6 +19,7 @@ from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import pytest
 from craft_providers import ProviderError, bases
+from craft_providers.actions.snap_installer import Snap
 from craft_providers.lxd import LXDProvider
 from craft_providers.multipass import MultipassProvider
 
@@ -212,11 +213,7 @@ def test_get_base_configuration(
         compatibility_tag="snapcraft-buildd-base-v0.0",
         environment="test-env",
         hostname="test-instance-name",
-        snaps=[
-            bases.buildd.Snap(
-                name="test-snap-name", channel="test-channel", classic=True
-            )
-        ],
+        snaps=[Snap(name="test-snap-name", channel="test-channel", classic=True)],
         packages=["gnupg", "dirmngr", "git"],
     )
 
@@ -259,7 +256,7 @@ def test_get_base_configuration_snap_channel(
         compatibility_tag=ANY,
         environment=ANY,
         hostname=ANY,
-        snaps=[bases.buildd.Snap(name="snapcraft", channel=snap_channel, classic=True)],
+        snaps=[Snap(name="snapcraft", channel=snap_channel, classic=True)],
         packages=ANY,
     )
 
@@ -293,7 +290,7 @@ def test_get_base_configuration_snap_instance_name_default(
         compatibility_tag=ANY,
         environment=ANY,
         hostname=ANY,
-        snaps=[bases.buildd.Snap(name="snapcraft", channel=None, classic=True)],
+        snaps=[Snap(name="snapcraft", channel=None, classic=True)],
         packages=ANY,
     )
 
@@ -327,7 +324,7 @@ def test_get_base_configuration_snap_instance_name_not_running_as_snap(
         compatibility_tag=ANY,
         environment=ANY,
         hostname=ANY,
-        snaps=[bases.buildd.Snap(name="snapcraft", channel=None, classic=True)],
+        snaps=[Snap(name="snapcraft", channel=None, classic=True)],
         packages=ANY,
     )
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

<details>
  <summary>Changelog</summary>

1.13.0 (2023-05-31)
-------------------
- Push files to any location in Multipass instances
- Refactor base setup and warmup
- Replace timeout for entire base setup with granular per-step timeouts
- Add option to not install default packages during base setup
- Install build-essentials and python3 in CentOS and AlmaLinux
- Update PATH for CentOS

1.12.0 (2023-05-18)
-------------------
- Add AlmaLinux 9 base
- Add stricter typing for base names
- Refactor CI workflow
- Refactor Multipass `push_file_io`
- Pin dependency urllib3<2

1.11.0 (2023-04-19)
-------------------
- Move Snap pydantic model from `bases.buildd` to `actions.snap_installer`
- Rename `bases.buildd` module to `bases.ubuntu`
- Determine base alias from base configuration in `provider.launched_environment()`
- Add new functions `get_base_alias()` and `get_base_from_alias()`
- Add CentOS 7 base
- Add default for `launched_environment()` parameter `allow_unstable=False`
- Trim suffixes from snap names when installing snaps.


</details>

(CRAFT-1719)