### PR TITLE
kde-neon-extension: remove extra build environment variables that are…

### DIFF
--- a/snapcraft/extensions/kde_neon.py
+++ b/snapcraft/extensions/kde_neon.py
@@ -178,36 +178,6 @@ class KDENeon(Extension):
                     ),
                 },
                 {
-                    "LD_LIBRARY_PATH": prepend_to_env(
-                        "LD_LIBRARY_PATH",
-                        [
-                            f"/snap/{sdk_snap}/current/lib/$CRAFT_ARCH_TRIPLET",
-                            f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET",
-                            f"/snap/{sdk_snap}/current/usr/lib",
-                            f"/snap/{sdk_snap}/current/usr/lib/vala-current",
-                            f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio",
-                        ],
-                    ),
-                },
-                {
-                    "PKG_CONFIG_PATH": prepend_to_env(
-                        "PKG_CONFIG_PATH",
-                        [
-                            f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig",
-                            f"/snap/{sdk_snap}/current/usr/lib/pkgconfig",
-                            f"/snap/{sdk_snap}/current/usr/share/pkgconfig",
-                        ],
-                    ),
-                },
-                {
-                    "ACLOCAL_PATH": prepend_to_env(
-                        "ACLOCAL_PATH",
-                        [
-                            f"/snap/{sdk_snap}/current/usr/share/aclocal",
-                        ],
-                    ),
-                },
-                {
                     "SNAPCRAFT_CMAKE_ARGS": prepend_to_env(
                         "SNAPCRAFT_CMAKE_ARGS",
                         [

--- a/tests/unit/extensions/test_kde_neon.py
+++ b/tests/unit/extensions/test_kde_neon.py
@@ -182,40 +182,6 @@ class TestGetPartSnippet:
                     )
                 },
                 {
-                    "LD_LIBRARY_PATH": ":".join(
-                        [
-                            "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/"
-                            "lib/$CRAFT_ARCH_TRIPLET",
-                            "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/"
-                            "usr/lib/$CRAFT_ARCH_TRIPLET",
-                            "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/usr/lib",
-                            "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/"
-                            "usr/lib/vala-current",
-                            "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/"
-                            "usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio",
-                        ]
-                    )
-                    + "${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-                },
-                {
-                    "PKG_CONFIG_PATH": (
-                        "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/"
-                        "usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:"
-                        "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/"
-                        "usr/lib/pkgconfig:"
-                        "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/"
-                        "usr/share/pkgconfig"
-                    )
-                    + "${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
-                },
-                {
-                    "ACLOCAL_PATH": (
-                        "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/"
-                        "usr/share/aclocal"
-                    )
-                    + "${ACLOCAL_PATH:+:$ACLOCAL_PATH}"
-                },
-                {
                     "SNAPCRAFT_CMAKE_ARGS": (
                         "-DCMAKE_FIND_ROOT_PATH="
                         "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current"
@@ -240,39 +206,6 @@ def test_get_part_snippet_with_external_sdk(kde_neon_extension_with_build_snap):
                     "$CRAFT_STAGE/usr/share:/snap/kf5-5-105-qt-5-15-9-core22-sdk"
                     "/current/usr/share:/usr/share${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
                 )
-            },
-            {
-                "LD_LIBRARY_PATH": ":".join(
-                    [
-                        "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/"
-                        "lib/$CRAFT_ARCH_TRIPLET",
-                        "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/"
-                        "usr/lib/$CRAFT_ARCH_TRIPLET",
-                        "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/usr/lib",
-                        "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/"
-                        "usr/lib/vala-current",
-                        "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/"
-                        "usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio",
-                    ]
-                )
-                + "${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-            },
-            {
-                "PKG_CONFIG_PATH": (
-                    "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/"
-                    "usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:"
-                    "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/"
-                    "usr/lib/pkgconfig:"
-                    "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/"
-                    "usr/share/pkgconfig"
-                )
-                + "${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
-            },
-            {
-                "ACLOCAL_PATH": (
-                    "/snap/kf5-5-105-qt-5-15-9-core22-sdk/current/" "usr/share/aclocal"
-                )
-                + "${ACLOCAL_PATH:+:$ACLOCAL_PATH}"
             },
             {
                 "SNAPCRAFT_CMAKE_ARGS": (


### PR DESCRIPTION
… causing build failures.

- [x ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----

These build env variables are causing builds to fail in weird ways. Just remove them and let snapcrafters set them themselves.