### PR TITLE
lint: fix for pyright 1.1.312

### DIFF
--- a/snapcraft/commands/account.py
+++ b/snapcraft/commands/account.py
@@ -23,7 +23,7 @@ import pathlib
 import stat
 import textwrap
 from datetime import datetime
-from typing import TYPE_CHECKING, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict
 
 from craft_cli import BaseCommand, emit
 from craft_cli.errors import ArgumentParsingError
@@ -192,7 +192,7 @@ class StoreExportLoginCommand(BaseCommand):
                 f"Set {store.constants.ENVIRONMENT_STORE_AUTH}=candid instead",
             )
 
-        kwargs: Dict[str, Union[str, int]] = {}
+        kwargs: Dict[str, Any] = {}
         if parsed_args.snaps:
             kwargs["packages"] = parsed_args.snaps.split(",")
         if parsed_args.channels:


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----

[Pyright 1.1.312](https://github.com/microsoft/pyright/releases/tag/1.1.312) now type-checks `kwargs`.  This started causing the following error:
```shell
lint-pyright: commands[0]> pyright

added 1 package, and audited 2 packages in 2s

found 0 vulnerabilities
/home/developer/dev/snapcraft/snapcraft/commands/account.py
  /home/developer/dev/snapcraft/snapcraft/commands/account.py:215:68 - error: Argument of type "str | int" cannot be assigned to parameter "ttl" of type "int" in function "login"
    Type "str | int" cannot be assigned to type "int"
      "str" is incompatible with "int" (reportGeneralTypeIssues)
  /home/developer/dev/snapcraft/snapcraft/commands/account.py:215:68 - error: Argument of type "str | int" cannot be assigned to parameter "acls" of type "Sequence[str] | None" in function "login"
    Type "str | int" cannot be assigned to type "Sequence[str] | None"
      Type "int" cannot be assigned to type "Sequence[str] | None"
        "int" is incompatible with "Sequence[str]"
        Type cannot be assigned to type "None" (reportGeneralTypeIssues)
  /home/developer/dev/snapcraft/snapcraft/commands/account.py:215:68 - error: Argument of type "str | int" cannot be assigned to parameter "packages" of type "Sequence[str] | None" in function "login"
    Type "str | int" cannot be assigned to type "Sequence[str] | None"
      Type "int" cannot be assigned to type "Sequence[str] | None"
        "int" is incompatible with "Sequence[str]"
        Type cannot be assigned to type "None" (reportGeneralTypeIssues)
  /home/developer/dev/snapcraft/snapcraft/commands/account.py:215:68 - error: Argument of type "str | int" cannot be assigned to parameter "channels" of type "Sequence[str] | None" in function "login"
    Type "str | int" cannot be assigned to type "Sequence[str] | None"
      Type "int" cannot be assigned to type "Sequence[str] | None"
        "int" is incompatible with "Sequence[str]"
        Type cannot be assigned to type "None" (reportGeneralTypeIssues)
4 errors, 0 warnings, 0 informations
```