### PR TITLE
requirements: update craft-parts to 1.19.6

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -14,7 +14,7 @@ coverage==7.2.5
 craft-archives==0.0.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
-craft-parts==1.19.5
+craft-parts==1.19.6
 craft-providers==1.10.0
 craft-store==2.4.0
 cryptography==40.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.3
 craft-archives==0.0.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
-craft-parts==1.19.5
+craft-parts==1.19.6
 craft-providers==1.10.0
 craft-store==2.4.0
 cryptography==40.0.2

--- a/snapcraft/commands/account.py
+++ b/snapcraft/commands/account.py
@@ -23,7 +23,7 @@ import pathlib
 import stat
 import textwrap
 from datetime import datetime
-from typing import TYPE_CHECKING, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict
 
 from craft_cli import BaseCommand, emit
 from craft_cli.errors import ArgumentParsingError
@@ -192,7 +192,7 @@ class StoreExportLoginCommand(BaseCommand):
                 f"Set {store.constants.ENVIRONMENT_STORE_AUTH}=candid instead",
             )
 
-        kwargs: Dict[str, Union[str, int]] = {}
+        kwargs: Dict[str, Any] = {}
         if parsed_args.snaps:
             kwargs["packages"] = parsed_args.snaps.split(",")
         if parsed_args.channels:


### PR DESCRIPTION
Craft Parts 1.19.6 reverts subdir changes in pull and build steps.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
