### PR TITLE
extensions: add no_extension entry for parts

### DIFF
--- a/snapcraft_legacy/internal/project_loader/_extensions/_utils.py
+++ b/snapcraft_legacy/internal/project_loader/_extensions/_utils.py
@@ -141,7 +141,7 @@ def _load_extension(
     )
 
 
-def _apply_extension(
+def _apply_extension(  # noqa: C901
     yaml_data: Dict[str, Any],
     app_names: Set[str],
     extension_name: str,
@@ -167,6 +167,14 @@ def _apply_extension(
     part_extension = extension.part_snippet
     parts = yaml_data["parts"]
     for part_name, part_definition in parts.items():
+        if "no_extension" in part_definition:
+            if not isinstance(part_definition["no_extension"], bool):
+                raise snapcraft_legacy.yaml_utils.errors.YamlValidationError(
+                    "Entry 'no_extension' must be a bool."
+                )
+            if part_definition.pop("no_extension"):
+                continue
+
         for property_name, property_value in part_extension.items():
             part_definition[property_name] = _apply_extension_property(
                 part_definition.get(property_name), property_value

--- a/tests/unit/extensions/test_extensions.py
+++ b/tests/unit/extensions/test_extensions.py
@@ -230,6 +230,96 @@ def test_apply_extension_experimental_with_environment(emitter, monkeypatch):
     )
 
 
+@pytest.mark.usefixtures("fake_extension")
+def test_no_extension():
+    yaml_data = {
+        "base": "core22",
+        "grade": "fake-grade",
+        "apps": {
+            "fake-command": {
+                "command": "bin/fake-command",
+                "extensions": ["fake-extension"],
+            }
+        },
+        "parts": {
+            "part1": {"plugin": "nil"},
+            "part2": {
+                "plugin": "dump",
+                "source": ".",
+                "no_extension": True,
+            },
+        },
+    }
+
+    assert extensions.apply_extensions(
+        yaml_data, arch="amd64", target_arch="amd64"
+    ) == {
+        "base": "core22",
+        "grade": "fake-grade",
+        "apps": {
+            "fake-command": {
+                "command": "bin/fake-command",
+                "plugs": ["fake-plug"],
+            }
+        },
+        "parts": {
+            "part1": {
+                "plugin": "nil",
+                "after": ["fake-extension/fake-part"],
+            },
+            "part2": {
+                "plugin": "dump",
+                "source": ".",
+            },
+            "fake-extension/fake-part": {"plugin": "nil"},
+        },
+    }
+
+    yaml_data = {
+        "base": "core22",
+        "grade": "fake-grade",
+        "apps": {
+            "fake-command": {
+                "command": "bin/fake-command",
+                "extensions": ["fake-extension"],
+            }
+        },
+        "parts": {
+            "part1": {"plugin": "nil"},
+            "part2": {
+                "plugin": "dump",
+                "source": ".",
+                "no_extension": False,
+            },
+        },
+    }
+
+    assert extensions.apply_extensions(
+        yaml_data, arch="amd64", target_arch="amd64"
+    ) == {
+        "base": "core22",
+        "grade": "fake-grade",
+        "apps": {
+            "fake-command": {
+                "command": "bin/fake-command",
+                "plugs": ["fake-plug"],
+            }
+        },
+        "parts": {
+            "part1": {
+                "plugin": "nil",
+                "after": ["fake-extension/fake-part"],
+            },
+            "part2": {
+                "plugin": "dump",
+                "source": ".",
+                "after": ["fake-extension/fake-part"],
+            },
+            "fake-extension/fake-part": {"plugin": "nil"},
+        },
+    }
+
+
 def test_get_extensions_data_dir():
     assert (get_extensions_data_dir() / "desktop").is_dir()
     assert (get_extensions_data_dir() / "ros1").is_dir()


### PR DESCRIPTION
Add a new parts entry, `no_extension`, that prevent extensions from being applied to a part that sets this new entry to true. 

Extensions' `part_snippet` are applied to all parts systematically. However in a multi-part snap, this behavior can cause issues, e.g. if the extension defines entries that are specific to a given plugin resulting in an `Additional properties are not allowed` error. This PR introduces a new entry that allows for explicitely shielding a part from having *any* extension applied to it, e.g. see [here](https://github.com/snapcore/snapcraft/compare/main...artivis:feature/no_extension?expand=1#diff-cf7cd4f4450e2eb36d0a44171d9ea8dae69312340c8b8901f2591a41b9f11e07R522).

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
