### PR TITLE
parts: show the current part lifecycle in the window title

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ chardet==5.1.0
 charset-normalizer==3.1.0
 click==8.1.3
 craft-archives==1.0.0
-craft-cli==2.0.0
+git+https://github.com/sergio-costas/craft-cli@UDENG-832-allow-to-set-the-window-title#craft-cli
 craft-grammar==1.1.1
 craft-parts==1.21.1
 craft-providers==1.13.0

--- a/snapcraft/commands/lint.py
+++ b/snapcraft/commands/lint.py
@@ -236,7 +236,9 @@ class LintCommand(BaseCommand):
         snap_file = snap_file.resolve()
 
         with tempfile.TemporaryDirectory(prefix=str(snap_file.parent)) as temp_dir:
-            emit.progress(f"Unsquashing snap file {snap_file.name!r}.", update_titlebar=True)
+            emit.progress(
+                f"Unsquashing snap file {snap_file.name!r}.", update_titlebar=True
+            )
 
             # unsquashfs [options] filesystem [directories or files to extract] options:
             # -force: if file already exists then overwrite
@@ -313,7 +315,7 @@ class LintCommand(BaseCommand):
             ack_command = snap_cmd.formulate_ack_command(assert_file)
             emit.progress(
                 f"Installing assertion file with {shlex.join(ack_command)!r}.",
-                update_titlebar=True
+                update_titlebar=True,
             )
 
             try:
@@ -334,7 +336,10 @@ class LintCommand(BaseCommand):
         if snap_metadata.grade == "devel":
             install_command.append("--devmode")
 
-        emit.progress(f"Installing snap with {shlex.join(install_command)!r}.", update_titlebar=True)
+        emit.progress(
+            f"Installing snap with {shlex.join(install_command)!r}.",
+            update_titlebar=True,
+        )
 
         try:
             subprocess.run(install_command, capture_output=True, check=True)

--- a/snapcraft/commands/lint.py
+++ b/snapcraft/commands/lint.py
@@ -87,7 +87,7 @@ class LintCommand(BaseCommand):
 
         :raises ArgumentParsingError: If the snap file does not exist or is not valid.
         """
-        emit.progress("Running linter.", permanent=True)
+        emit.progress("Running linter.", permanent=True, update_titlebar=True)
 
         snap_file = parsed_args.snap_file
 
@@ -150,7 +150,7 @@ class LintCommand(BaseCommand):
 
         :raises SnapcraftError: If `snapcraft lint` fails inside the instance.
         """
-        emit.progress("Checking build provider availability.")
+        emit.progress("Checking build provider availability.", update_titlebar=True)
 
         provider = providers.get_provider()
         if isinstance(provider, MultipassProvider):
@@ -170,7 +170,7 @@ class LintCommand(BaseCommand):
             https_proxy=https_proxy,
         )
 
-        emit.progress("Launching instance.")
+        emit.progress("Launching instance.", update_titlebar=True)
 
         with provider.launched_environment(
             project_name="snapcraft-linter",
@@ -236,7 +236,7 @@ class LintCommand(BaseCommand):
         snap_file = snap_file.resolve()
 
         with tempfile.TemporaryDirectory(prefix=str(snap_file.parent)) as temp_dir:
-            emit.progress(f"Unsquashing snap file {snap_file.name!r}.")
+            emit.progress(f"Unsquashing snap file {snap_file.name!r}.", update_titlebar=True)
 
             # unsquashfs [options] filesystem [directories or files to extract] options:
             # -force: if file already exists then overwrite
@@ -312,7 +312,8 @@ class LintCommand(BaseCommand):
         if assert_file:
             ack_command = snap_cmd.formulate_ack_command(assert_file)
             emit.progress(
-                f"Installing assertion file with {shlex.join(ack_command)!r}."
+                f"Installing assertion file with {shlex.join(ack_command)!r}.",
+                update_titlebar=True
             )
 
             try:
@@ -333,7 +334,7 @@ class LintCommand(BaseCommand):
         if snap_metadata.grade == "devel":
             install_command.append("--devmode")
 
-        emit.progress(f"Installing snap with {shlex.join(install_command)!r}.")
+        emit.progress(f"Installing snap with {shlex.join(install_command)!r}.", update_titlebar=True)
 
         try:
             subprocess.run(install_command, capture_output=True, check=True)

--- a/snapcraft/linters/linters.py
+++ b/snapcraft/linters/linters.py
@@ -137,7 +137,7 @@ def run_linters(location: Path, *, lint: Optional[projects.Lint]) -> List[Linter
                 continue
 
             linter = linter_class(name=name, lint=lint, snap_metadata=snap_metadata)
-            emit.progress(f"Running linter: {name}")
+            emit.progress(f"Running linter: {name}", update_titlebar=True)
             issues = linter.run()
             all_issues += issues
     finally:

--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -128,7 +128,7 @@ def pack_snap(
     command.append(directory)
     command.append(_get_directory(output))
 
-    emit.progress("Creating snap package...")
+    emit.progress("Creating snap package...", update_titlebar=True)
     emit.debug(f"Pack command: {command}")
     try:
         proc = subprocess.run(

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -391,7 +391,7 @@ def _generate_metadata(
 ):
     project_vars = lifecycle.project_vars
 
-    emit.progress("Extracting and updating metadata...")
+    emit.progress("Extracting and updating metadata...", update_titlebar=True)
     metadata_list = lifecycle.extract_metadata()
     update_project_metadata(
         project,
@@ -401,7 +401,7 @@ def _generate_metadata(
         prime_dir=lifecycle.prime_dir,
     )
 
-    emit.progress("Copying snap assets...")
+    emit.progress("Copying snap assets...", update_titlebar=True)
     setup_assets(
         project,
         assets_dir=assets_dir,
@@ -409,7 +409,7 @@ def _generate_metadata(
         prime_dir=lifecycle.prime_dir,
     )
 
-    emit.progress("Generating snap metadata...")
+    emit.progress("Generating snap metadata...", update_titlebar=True)
     snap_yaml.write(project, lifecycle.prime_dir, arch=project.get_build_for())
     emit.progress("Generated snap metadata", permanent=True)
 
@@ -462,7 +462,7 @@ def _clean_provider(project: Project, parsed_args: "argparse.Namespace") -> None
 
     :param project: The project to clean.
     """
-    emit.progress("Cleaning build provider")
+    emit.progress("Cleaning build provider", update_titlebar=True)
     provider_name = "lxd" if parsed_args.use_lxd else None
     provider = providers.get_provider(provider_name)
     instance_name = providers.get_instance_name(
@@ -552,7 +552,7 @@ def _run_in_provider(
         https_proxy=parsed_args.https_proxy,
     )
 
-    emit.progress("Launching instance...")
+    emit.progress("Launching instance...", update_titlebar=True)
     with provider.launched_environment(
         project_name=project.name,
         project_path=project_path,

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -80,7 +80,7 @@ class PartsLifecycle:
         self._parse_info = parse_info
         self._all_part_names = [*all_parts]
 
-        emit.progress("Initializing parts lifecycle")
+        emit.progress("Initializing parts lifecycle", update_titlebar=True)
 
         # set the cache dir for parts package management
         cache_dir = BaseDirectory.save_cache_path("snapcraft")
@@ -172,8 +172,7 @@ class PartsLifecycle:
             with self._lcm.action_executor() as aex:
                 for action in actions:
                     message = _action_message(action)
-                    emit.progress(f"Executing parts lifecycle: {message}")
-                    print(f"\033]2;Executing parts lifecycle: {message}\007")
+                    emit.progress(f"Executing parts lifecycle: {message}", update_titlebar=True)
                     with emit.open_stream("Executing action") as stream:
                         aex.execute(action, stdout=stream, stderr=stream)
                     emit.progress(f"Executed: {message}", permanent=True)
@@ -201,12 +200,12 @@ class PartsLifecycle:
         if any(p for p in required_packages if not Repository.is_package_installed(p)):
             Repository.install_packages(required_packages, refresh_package_cache=True)
 
-        emit.progress("Installing package repositories...")
+        emit.progress("Installing package repositories...", update_titlebar=True)
         refresh_required = repo.install(
             self._package_repositories, key_assets=self._assets_dir / "keys"
         )
         if refresh_required:
-            emit.progress("Refreshing package repositories...")
+            emit.progress("Refreshing package repositories...", update_titlebar=True)
             # TODO: craft-parts API for: force_refresh=refresh_required
             # pylint: disable=C0415
             from craft_parts.packages import deb

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -167,12 +167,14 @@ class PartsLifecycle:
 
             self._install_package_repositories()
 
-            emit.progress("Executing parts lifecycle...")
+            emit.progress("Executing parts lifecycle...", update_titlebar=True)
 
             with self._lcm.action_executor() as aex:
                 for action in actions:
                     message = _action_message(action)
-                    emit.progress(f"Executing parts lifecycle: {message}", update_titlebar=True)
+                    emit.progress(
+                        f"Executing parts lifecycle: {message}", update_titlebar=True
+                    )
                     with emit.open_stream("Executing action") as stream:
                         aex.execute(action, stdout=stream, stderr=stream)
                     emit.progress(f"Executed: {message}", permanent=True)

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -173,6 +173,7 @@ class PartsLifecycle:
                 for action in actions:
                     message = _action_message(action)
                     emit.progress(f"Executing parts lifecycle: {message}")
+                    print(f"\033]2;Executing parts lifecycle: {message}\007")
                     with emit.open_stream("Executing action") as stream:
                         aex.execute(action, stdout=stream, stderr=stream)
                     emit.progress(f"Executed: {message}", permanent=True)

--- a/snapcraft/parts/setup_assets.py
+++ b/snapcraft/parts/setup_assets.py
@@ -132,7 +132,7 @@ def _finalize_icon(
     target_icon_path.parent.mkdir(parents=True, exist_ok=True)
     if parsed_url.scheme in ["http", "https"]:
         # Remote - fetch URL and write to target.
-        emit.progress(f"Fetching icon from {icon!r}")
+        emit.progress(f"Fetching icon from {icon!r}", update_titlebar=True)
         icon_data = requests.get(icon, timeout=120).content
         target_icon_path.write_bytes(icon_data)
     elif parsed_url.scheme == "":

--- a/snapcraft/ua_manager.py
+++ b/snapcraft/ua_manager.py
@@ -182,19 +182,19 @@ def ua_manager(
             )
         else:
             ua_needs_detach = True
-            emit.progress("Attaching specified UA token...")
+            emit.progress("Attaching specified UA token...", update_titlebar=True)
             _attach(ua_token)
             emit.progress("Attached specified UA token", permanent=True)
 
     try:
         if services:
-            emit.progress("Enabling UA services...")
+            emit.progress("Enabling UA services...", update_titlebar=True)
             _enable_services(services)
             emit.progress(f"Enabled UA services: {' '.join(services)}")
 
         yield
     finally:
         if ua_needs_detach:
-            emit.progress("Detaching specified UA token...")
+            emit.progress("Detaching specified UA token...", update_titlebar=True)
             _detach()
             emit.progress("Detached specified UA token", permanent=True)


### PR DESCRIPTION
When building a snap with several parts using -v, it's usually not possible to know which part is being built due to the long text output.

This patch shows in the window title the part lifecycle that is being executed.

Although maybe a better way would be to add a method "set_title" in craft_cli... but that would require two PRs.

- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
