### PR TITLE
ci: do not check coverage of tests dir

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -53,14 +53,14 @@ base = testenv, test
 description = Run unit tests with pytest
 labels =
     py38, py310, py311: tests, unit-tests
-commands = pytest {tty:--color=yes} --cov --cov-report=xml:results/coverage-{env_name}.xml --junit-xml=results/test-results-{env_name}.xml {posargs:tests/unit}
+commands = pytest {tty:--color=yes} --cov=snapcraft --cov-report=xml:results/coverage-{env_name}.xml --junit-xml=results/test-results-{env_name}.xml {posargs:tests/unit}
 
 [testenv:test-legacy-{py38,py39,py310,py311,py312}]
 base = testenv, test
 description = Run legacy tests with pytest
 labels =
     py38, py310, py311: tests, integration-tests
-commands = pytest {tty:--color=yes} --cov --cov-report=xml:results/coverage-{env_name}.xml --junit-xml=results/test-results-{env_name}.xml {posargs:tests/legacy}
+commands = pytest {tty:--color=yes} --cov=snapcraft_legacy --cov-report=xml:results/coverage-{env_name}.xml --junit-xml=results/test-results-{env_name}.xml {posargs:tests/legacy}
 
 [testenv:test-noreq]
 base = testenv
@@ -71,7 +71,7 @@ extras = dev
 allowlist_externals = mkdir
 commands_pre = mkdir -p results
 commands =
-    pytest {tty:--color=yes} --cov --cov-report=xml:results/coverage-{env_name}.xml --junit-xml=results/test-results-{env_name}.xml tests/unit {posargs}
+    pytest {tty:--color=yes} --cov=snapcraft --cov-report=xml:results/coverage-{env_name}.xml --junit-xml=results/test-results-{env_name}.xml tests/unit {posargs}
     pytest {tty:--color=yes} --junit-xml=results/legacy-test-results-{env_name}.xml tests/legacy {posargs}
 
 [lint]  # Standard linting configuration


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

`pytest` was checking the coverage of the `tests` dir. 

For example:
![image](https://github.com/snapcore/snapcraft/assets/60674096/7c451c21-ebde-4878-bb3b-39c5fb0a7c56)
