### PR TITLE
spread: disable godeps tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -416,10 +416,12 @@ suites:
    summary: tests of snapcraft's Go plugin
    systems:
    - ubuntu-18.04*
- tests/spread/plugins/v1/godeps/:
-   summary: tests of snapcraft's Godeps plugin
-   systems:
-   - ubuntu-18.04*
+ # godeps can no longer build due to:
+ #   https://github.com/golang/go/issues/57051
+ # tests/spread/plugins/v1/godeps/:
+ #   summary: tests of snapcraft's Godeps plugin
+ #   systems:
+ #   - ubuntu-18.04*
  tests/spread/plugins/v1/gradle/:
    summary: tests of snapcraft's Gradle plugin
    systems:


### PR DESCRIPTION
godeps can not longer build due to

   https://github.com/golang/go/issues/57051

Instead of removing the godeps feature, disable the tests in case the upstream fixes the problem.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
