### PR TITLE
plugins: add riscv into kernel plugin for build dtbs

### DIFF
--- a/snapcraft/parts/plugins/kernel_plugin.py
+++ b/snapcraft/parts/plugins/kernel_plugin.py
@@ -343,7 +343,7 @@ class KernelPlugin(plugins.Plugin):
             self.dtbs = [f"{i}.dtb" for i in self.options.kernel_device_trees]
             if self.dtbs:
                 self._make_targets.extend(self.dtbs)
-        elif self._kernel_arch in ("arm", "arm64", "riscv64"):
+        elif self._kernel_arch in ("arm", "arm64", "riscv", "riscv64"):
             self._make_targets.append("dtbs")
             self._make_install_targets.extend(
                 ["dtbs_install", "INSTALL_DTBS_PATH=${CRAFT_PART_INSTALL}/dtbs"]


### PR DESCRIPTION
Hi,

I was using kernel plugin to build a  RISC-V kernel, but it won't build `dtbs`, and I found it will append `dtbs` only if `ARCH` matches `arm`, `arm64` or `riscv64`, however, the `ARCH` in my case is `riscv`. The following are some logs


Before the code change:
```
2023-07-01 23:03:45.814 :: Building kernel...
2023-07-01 23:03:45.814 :: ++ nproc
2023-07-01 23:03:45.816 :: + make -j8 -C /home/vagrant/aristo/UbuntuCoreOS/cache/starfive_visionfive2_backup/kernel_snap/parts/kernel/src O=/home/vagrant/aristo/UbuntuCoreOS/cache/starfive_visionfive2_backup/kernel_snap/parts/kernel/build ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- Image modules
```

After the code change:
```
2023-07-01 23:27:34.931 :: Building kernel...
2023-07-01 23:27:34.931 :: ++ nproc
2023-07-01 23:27:34.932 :: + make -j8 -C /home/vagrant/aristo/UbuntuCoreOS/cache/starfive_visionfive2_backup/kernel_snap/parts/kernel/src O=/home/vagrant/aristo/UbuntuCoreOS/cache/starfive_visionfive2_backup/kernel_snap/parts/kernel/build ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- Image modules dtbs
```

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [] Have you successfully run `pytest tests/unit`?

-----
