### PR TITLE
Stop fontconfig from loading from host’s /etc/fonts/conf.d

### DIFF
--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -304,9 +304,6 @@ function make_user_fontconfig {
       echo "  <dir>${data_dirs_array[$i]}/fonts</dir>"
     fi
   done
-  # fix font render for modified fonts, that discussed on Snapcraft Forum:
-  # https://forum.snapcraft.io/t/snap-package-cannot-read-fonts-conf/16657
-  echo '  <include ignore_missing="yes">/etc/fonts/conf.d</include>'
   echo '  <include ignore_missing="yes">conf.d</include>'
   # We need to include a user-writable cachedir first to support
   # caching of per-user fonts.


### PR DESCRIPTION
Fixes: https://launchpad.net/bugs/2025651

At the moment the snaps in at least lunar and mantic load font configuration both from `gnome-42-2204` and from the host system’s `/etc/fonts/conf.d`. This has proved to confuse fontconfig and result in unexpected issues. Stopping the snaps from loading from `/etc/fonts/conf.d` seems to fix the issue.

This PR reverts part of https://github.com/snapcore/snapcraft/commit/407dc755, which is sad IMO. But it’s a result of the reluctance to use font configuration from the host system as expressed in [this comment](https://github.com/ubuntu/gnome-sdk/issues/49#issuecomment-1216321729), and for now the proposed change is the easiest way to stop fontconfig from being confused.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
