### PR TITLE
extensions: plugin aware part_snippet values

### DIFF
--- a/snapcraft/extensions/_utils.py
+++ b/snapcraft/extensions/_utils.py
@@ -87,10 +87,13 @@ def _apply_extension(
                 app_definition.get(property_name), property_value
             )
 
-    # Next, apply the part-specific components
-    part_extension = extension.get_part_snippet()
+    # Next, apply the part-specific components, this can be plugin
+    # aware.
     parts = yaml_data["parts"]
-    for _part_name, part_definition in parts.items():
+    for _, part_definition in parts.items():
+        part_extension = extension.get_part_snippet(
+            plugin_name=part_definition["plugin"]
+        )
         for property_name, property_value in part_extension.items():
             part_definition[property_name] = _apply_extension_property(
                 part_definition.get(property_name), property_value

--- a/snapcraft/extensions/extension.py
+++ b/snapcraft/extensions/extension.py
@@ -70,7 +70,7 @@ class Extension(abc.ABC):
         """Return the app snippet to apply."""
 
     @abc.abstractmethod
-    def get_part_snippet(self) -> Dict[str, Any]:
+    def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
         """Return the part snippet to apply to existing parts."""
 
     @abc.abstractmethod

--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -166,7 +166,7 @@ class GNOME(Extension):
         }
 
     @overrides
-    def get_part_snippet(self) -> Dict[str, Any]:
+    def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
         sdk_snap = self.gnome_snaps.sdk
 
         return {

--- a/snapcraft/extensions/kde_neon.py
+++ b/snapcraft/extensions/kde_neon.py
@@ -157,7 +157,7 @@ class KDENeon(Extension):
         }
 
     @overrides
-    def get_part_snippet(self) -> Dict[str, Any]:
+    def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
         sdk_snap = self.kde_snaps.sdk
         cmake_args = self.ext_info.cmake_args
 

--- a/snapcraft/extensions/ros2_humble.py
+++ b/snapcraft/extensions/ros2_humble.py
@@ -106,7 +106,7 @@ class ROS2HumbleExtension(Extension):
         }
 
     @overrides
-    def get_part_snippet(self) -> Dict[str, Any]:
+    def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
         return {
             "build-environment": [
                 {"ROS_VERSION": self.ROS_VERSION},

--- a/snapcraft_legacy/internal/project_loader/_extensions/_extension.py
+++ b/snapcraft_legacy/internal/project_loader/_extensions/_extension.py
@@ -63,6 +63,10 @@ class Extension(metaclass=abc.ABCMeta):
         self.part_snippet = dict()  # type: Dict[str, Any]
         self.parts = dict()  # type: Dict[str, Any]
 
+    def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+        """Return the part snippet to apply to a part."""
+        return self.part_snippet
+
     def _sanity_check(self, *, extension_name: str, yaml_data: Dict[str, Any]) -> None:
         base = yaml_data.get("base")
 

--- a/snapcraft_legacy/internal/project_loader/_extensions/_utils.py
+++ b/snapcraft_legacy/internal/project_loader/_extensions/_utils.py
@@ -163,10 +163,13 @@ def _apply_extension(
                 app_definition.get(property_name), property_value
             )
 
-    # Next, apply the part-specific components
-    part_extension = extension.part_snippet
+    # Next, apply the part-specific components, this can be plugin
+    # aware.
     parts = yaml_data["parts"]
-    for part_name, part_definition in parts.items():
+    for _, part_definition in parts.items():
+        part_extension = extension.get_part_snippet(
+            plugin_name=part_definition["plugin"]
+        )
         for property_name, property_value in part_extension.items():
             part_definition[property_name] = _apply_extension_property(
                 part_definition.get(property_name), property_value

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -86,7 +86,10 @@ def fake_extension():
         def get_app_snippet(self) -> Dict[str, Any]:
             return {"plugs": ["fake-plug"]}
 
-        def get_part_snippet(self) -> Dict[str, Any]:
+        def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+            if plugin_name == "catkin":
+                return {}
+
             return {"after": ["fake-extension/fake-part"]}
 
         def get_parts_snippet(self) -> Dict[str, Any]:
@@ -122,7 +125,7 @@ def fake_extension_extra():
         def get_app_snippet(self) -> Dict[str, Any]:
             return {"plugs": ["fake-plug", "fake-plug-extra"]}
 
-        def get_part_snippet(self) -> Dict[str, Any]:
+        def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
             return {"after": ["fake-extension-extra/fake-part"]}
 
         def get_parts_snippet(self) -> Dict[str, Any]:
@@ -156,7 +159,7 @@ def fake_extension_invalid_parts():
         def get_app_snippet(self) -> Dict[str, Any]:
             return {"plugs": ["fake-plug"]}
 
-        def get_part_snippet(self) -> Dict[str, Any]:
+        def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
             return {"after": ["fake-extension/fake-part"]}
 
         def get_parts_snippet(self) -> Dict[str, Any]:
@@ -192,7 +195,7 @@ def fake_extension_experimental():
         def get_app_snippet(self) -> Dict[str, Any]:
             return {}
 
-        def get_part_snippet(self) -> Dict[str, Any]:
+        def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
             return {}
 
         def get_parts_snippet(self) -> Dict[str, Any]:
@@ -228,7 +231,7 @@ def fake_extension_name_from_legacy():
         def get_app_snippet(self) -> Dict[str, Any]:
             return {"plugs": ["fake-plug", "fake-plug-extra"]}
 
-        def get_part_snippet(self) -> Dict[str, Any]:
+        def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
             return {"after": ["fake-extension-extra/fake-part"]}
 
         def get_parts_snippet(self) -> Dict[str, Any]:

--- a/tests/unit/extensions/test_gnome.py
+++ b/tests/unit/extensions/test_gnome.py
@@ -190,7 +190,7 @@ class TestGetPartSnippet:
 
     @staticmethod
     def assert_get_part_snippet(gnome_instance):
-        assert gnome_instance.get_part_snippet() == {
+        assert gnome_instance.get_part_snippet(plugin_name="autotools") == {
             "build-environment": [
                 {"PATH": "/snap/gnome-42-2204-sdk/current/usr/bin${PATH:+:$PATH}"},
                 {
@@ -254,7 +254,7 @@ class TestGetPartSnippet:
 
 
 def test_get_part_snippet_with_external_sdk(gnome_extension_with_build_snap):
-    assert gnome_extension_with_build_snap.get_part_snippet() == {
+    assert gnome_extension_with_build_snap.get_part_snippet(plugin_name="meson") == {
         "build-environment": [
             {"PATH": "/snap/gnome-44-2204-sdk/current/usr/bin${PATH:+:$PATH}"},
             {

--- a/tests/unit/extensions/test_kde_neon.py
+++ b/tests/unit/extensions/test_kde_neon.py
@@ -168,7 +168,7 @@ class TestGetPartSnippet:
 
     @staticmethod
     def assert_get_part_snippet(kde_neon_instance):
-        assert kde_neon_instance.get_part_snippet() == {
+        assert kde_neon_instance.get_part_snippet(plugin_name="cmake") == {
             "build-environment": [
                 {
                     "PATH": (
@@ -193,7 +193,7 @@ class TestGetPartSnippet:
 
 
 def test_get_part_snippet_with_external_sdk(kde_neon_extension_with_build_snap):
-    assert kde_neon_extension_with_build_snap.get_part_snippet() == {
+    assert kde_neon_extension_with_build_snap.get_part_snippet(plugin_name="cmake") == {
         "build-environment": [
             {
                 "PATH": (

--- a/tests/unit/parts/extensions/test_ros2_humble.py
+++ b/tests/unit/parts/extensions/test_ros2_humble.py
@@ -122,7 +122,7 @@ class TestExtensionROS2HumbleExtension:
 
     def test_get_part_snippet(self, setup_method_fixture):
         extension = setup_method_fixture()
-        assert extension.get_part_snippet() == {
+        assert extension.get_part_snippet(plugin_name="colcon") == {
             "build-environment": [{"ROS_VERSION": "2"}, {"ROS_DISTRO": "humble"}]
         }
 


### PR DESCRIPTION
Extend the API to take a plugin_name, for legacy do the same, but as an optional method in the base class.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
