### PR TITLE
requirements: bump craft-archives

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -11,7 +11,7 @@ click==8.1.3
 codespell==2.2.4
 colorama==0.4.6
 coverage==7.2.5
-craft-archives==1.1.1
+craft-archives==1.1.2
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cffi==1.15.1
 chardet==5.1.0
 charset-normalizer==3.1.0
 click==8.1.3
-craft-archives==1.1.1
+craft-archives==1.1.2
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.6


### PR DESCRIPTION
Version 1.1.2 allows local package repositories (those with scheme `url: file:///...`) again.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
