### PR TITLE
projects: Add support for custom data

### DIFF
--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -32,6 +32,7 @@ from snapcraft.utils import (
     convert_architecture_deb_to_platform,
     get_effective_base,
     get_host_architecture,
+    remove_custom_data,
 )
 
 
@@ -639,6 +640,7 @@ class Project(ProjectModel):
         if not isinstance(data, dict):
             raise TypeError("Project data is not a dictionary")
 
+        data = remove_custom_data(data)
         try:
             project = Project(**data)
         except pydantic.ValidationError as err:

--- a/snapcraft_legacy/project/_project_info.py
+++ b/snapcraft_legacy/project/_project_info.py
@@ -17,6 +17,7 @@
 from copy import deepcopy
 
 import snapcraft_legacy.yaml_utils.errors
+from snapcraft.utils import remove_custom_data
 from snapcraft_legacy import yaml_utils
 
 from . import _schema
@@ -27,7 +28,8 @@ class ProjectInfo:
 
     def __init__(self, *, snapcraft_yaml_file_path) -> None:
         self.snapcraft_yaml_file_path = snapcraft_yaml_file_path
-        self.__raw_snapcraft = yaml_utils.load_yaml_file(snapcraft_yaml_file_path)
+        self.__raw_snapcraft = remove_custom_data(
+            yaml_utils.load_yaml_file(snapcraft_yaml_file_path))
 
         try:
             self.name = self.__raw_snapcraft["name"]


### PR DESCRIPTION
This patch implements proposal ST090. It allows to add custom metadata into the snapcraft.yaml files without interferring with snapcraft. It works both in legacy and modern files.

This is useful for adding extra data for tools that manage snap files, like updatesnap.py, which searches for new versions of the parts in a snapcraft.yaml file.

Proposal document: https://docs.google.com/document/d/1QX0moP6V709D7L267pIT5AREQetbPb7KsFrpgvCLKVM

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
