### PR TITLE
linters: specify which package offers a missing library

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "type": "python",
             "request": "launch",
             "stopOnEntry": true,
-            "pythonPath": "${config.python.pythonPath}",
+            "python": "${config.python.pythonPath}",
             "program": "${file}",
             "cwd": "${workspaceRoot}",
             "debugOptions": [
@@ -20,7 +20,7 @@
             "type": "python",
             "request": "launch",
             "stopOnEntry": false,
-            "pythonPath": "${config.python.pythonPath}",
+            "python": "${config.python.pythonPath}",
             "program": "${workspaceRoot}/units.py",
             "cwd": "${workspaceRoot}",
             "debugOptions": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "type": "python",
             "request": "launch",
             "stopOnEntry": true,
-            "python": "${config.python.pythonPath}",
+            "pythonPath": "${config.python.pythonPath}",
             "program": "${file}",
             "cwd": "${workspaceRoot}",
             "debugOptions": [
@@ -20,7 +20,7 @@
             "type": "python",
             "request": "launch",
             "stopOnEntry": false,
-            "python": "${config.python.pythonPath}",
+            "pythonPath": "${config.python.pythonPath}",
             "program": "${workspaceRoot}/units.py",
             "cwd": "${workspaceRoot}",
             "debugOptions": [

--- a/snapcraft/linters/library_linter.py
+++ b/snapcraft/linters/library_linter.py
@@ -15,8 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Library linter implementation."""
-import glob
-import os
 import subprocess
 from pathlib import Path
 from typing import List, Set
@@ -109,7 +107,11 @@ class LibraryLinter(Linter):
             if path.name == library_name:
                 try:
                     output = subprocess.run(
-                        ["dpkg", "-S", path.absolute().as_posix()], check=True, stdout=subprocess.PIPE
+                        ["dpkg",
+                         "-S",
+                         path.absolute().as_posix()],
+                         check=True,
+                         stdout=subprocess.PIPE
                     )
                 except subprocess.CalledProcessError:
                     # If the specified file doesn't belong to any package, the

--- a/snapcraft/linters/library_linter.py
+++ b/snapcraft/linters/library_linter.py
@@ -27,7 +27,7 @@ from overrides import overrides
 from snapcraft.elf import ElfFile, SonameCache, elf_utils
 from snapcraft.elf import errors as elf_errors
 
-from .base import Linter, LinterIssue, LinterResult
+from .base import Linter, LinterIssue, LinterResult, Optional
 
 
 class LibraryLinter(Linter):
@@ -109,11 +109,11 @@ class LibraryLinter(Linter):
             if os.path.basename(path) == library_name:
                 try:
                     output = subprocess.run(
-                        ["dpkg", "-S", path], check=False, stdout=subprocess.PIPE
+                        ["dpkg", "-S", path], check=True, stdout=subprocess.PIPE
                     )
                 except:  # pylint: disable=bare-except
-                    return None
-                if output.returncode != 0:
+                    # If the specified file doesn't belong to any package, the
+                    # call will trigger an exception.
                     return None
                 return output.stdout.decode("utf-8").split(":")[0]
         return None

--- a/snapcraft/linters/library_linter.py
+++ b/snapcraft/linters/library_linter.py
@@ -107,9 +107,7 @@ class LibraryLinter(Linter):
             if path.name == library_name:
                 try:
                     output = subprocess.run(
-                        ["dpkg",
-                         "-S",
-                         path.absolute().as_posix()],
+                        ["dpkg", "-S", path.absolute().as_posix()],
                          check=True,
                          stdout=subprocess.PIPE
                     )

--- a/snapcraft/linters/library_linter.py
+++ b/snapcraft/linters/library_linter.py
@@ -108,8 +108,8 @@ class LibraryLinter(Linter):
                 try:
                     output = subprocess.run(
                         ["dpkg", "-S", path.absolute().as_posix()],
-                         check=True,
-                         stdout=subprocess.PIPE
+                        check=True,
+                        stdout=subprocess.PIPE
                     )
                 except subprocess.CalledProcessError:
                     # If the specified file doesn't belong to any package, the

--- a/snapcraft/linters/library_linter.py
+++ b/snapcraft/linters/library_linter.py
@@ -104,7 +104,7 @@ class LibraryLinter(Linter):
 
         return issues
 
-    def _find_deb_package(self, library_name):
+    def _find_deb_package(self, library_name: str) -> Optional[str]:
         for path in glob.glob("/usr/lib/**", recursive=True):
             if os.path.basename(path) == library_name:
                 try:

--- a/snapcraft/linters/library_linter.py
+++ b/snapcraft/linters/library_linter.py
@@ -105,11 +105,11 @@ class LibraryLinter(Linter):
         return issues
 
     def _find_deb_package(self, library_name: str) -> Optional[str]:
-        for path in glob.glob("/usr/lib/**", recursive=True):
-            if os.path.basename(path) == library_name:
+        for path in Path("/usr/lib").glob("**/*"):
+            if path.name == library_name:
                 try:
                     output = subprocess.run(
-                        ["dpkg", "-S", path], check=True, stdout=subprocess.PIPE
+                        ["dpkg", "-S", path.absolute().as_posix()], check=True, stdout=subprocess.PIPE
                     )
                 except subprocess.CalledProcessError:
                     # If the specified file doesn't belong to any package, the

--- a/snapcraft/linters/library_linter.py
+++ b/snapcraft/linters/library_linter.py
@@ -115,8 +115,8 @@ class LibraryLinter(Linter):
                     # If the specified file doesn't belong to any package, the
                     # call will trigger an exception.
                     return None
-                    # In case that dpkg isn't available
                 except FileNotFoundError:
+                    # In case that dpkg isn't available
                     return None
                 return output.stdout.decode("utf-8").split(":")[0]
         return None

--- a/snapcraft/linters/library_linter.py
+++ b/snapcraft/linters/library_linter.py
@@ -109,7 +109,7 @@ class LibraryLinter(Linter):
                     output = subprocess.run(
                         ["dpkg", "-S", path.absolute().as_posix()],
                         check=True,
-                        stdout=subprocess.PIPE
+                        stdout=subprocess.PIPE,
                     )
                 except subprocess.CalledProcessError:
                     # If the specified file doesn't belong to any package, the

--- a/snapcraft/linters/library_linter.py
+++ b/snapcraft/linters/library_linter.py
@@ -111,9 +111,12 @@ class LibraryLinter(Linter):
                     output = subprocess.run(
                         ["dpkg", "-S", path], check=True, stdout=subprocess.PIPE
                     )
-                except:  # pylint: disable=bare-except
+                except subprocess.CalledProcessError:
                     # If the specified file doesn't belong to any package, the
                     # call will trigger an exception.
+                    return None
+                    # In case that dpkg isn't available
+                except FileNotFoundError:
                     return None
                 return output.stdout.decode("utf-8").split(":")[0]
         return None

--- a/tests/spread/core22/linters/library-missing/expected_linter_output.txt
+++ b/tests/spread/core22/linters/library-missing/expected_linter_output.txt
@@ -2,6 +2,6 @@ Running linters...
 Running linter: classic
 Running linter: library
 Lint warnings:
-- library: linter-test: missing dependency 'libcaca.so.0'. (https://snapcraft.io/docs/linters-library)
-- library: linter-test: missing dependency 'libslang.so.2'. (https://snapcraft.io/docs/linters-library)
+- library: linter-test: missing dependency 'libcaca.so.0' (provided by libcaca0). (https://snapcraft.io/docs/linters-library)
+- library: linter-test: missing dependency 'libslang.so.2' (provided by libslang2). (https://snapcraft.io/docs/linters-library)
 Creating snap package...

--- a/tests/unit/linters/test_library_linter.py
+++ b/tests/unit/linters/test_library_linter.py
@@ -285,3 +285,19 @@ def test_is_library_path_directory(mocker):
     result = linter._is_library_path(path=Path("/test/dir"))
 
     assert not result
+
+def test_find_deb_package():
+    """Check that searching the .deb package for a library that is installed
+       in the system works as expected."""
+    linter = LibraryLinter(name="library", snap_metadata=Mock(), lint=None)
+    # /usr/lib/x86_64-linux-gnu/gconv/libCNS.so must be available,
+    # because it is part of libc6
+    result = linter._find_deb_package('libCNS.so')
+    assert result.startswith('libc6')
+
+def test_find_deb_package_no_available():
+    """Check that finding the .deb package for a library not installed works
+       as expected."""
+    linter = LibraryLinter(name="library", snap_metadata=Mock(), lint=None)
+    result = linter._find_deb_package('thisLibraryCantExistInALinuxSystemBecauseItWouldMakeNoSense.so')
+    assert not result

--- a/tests/unit/linters/test_library_linter.py
+++ b/tests/unit/linters/test_library_linter.py
@@ -286,18 +286,22 @@ def test_is_library_path_directory(mocker):
 
     assert not result
 
+
 def test_find_deb_package():
     """Check that searching the .deb package for a library that is installed
-       in the system works as expected."""
+    in the system works as expected."""
     linter = LibraryLinter(name="library", snap_metadata=Mock(), lint=None)
     # /usr/lib/x86_64-linux-gnu/gconv/libCNS.so must be available,
     # because it is part of libc6
-    result = linter._find_deb_package('libCNS.so')
-    assert result.startswith('libc6')
+    result = linter._find_deb_package("libCNS.so")
+    assert result.startswith("libc6")
+
 
 def test_find_deb_package_no_available():
     """Check that finding the .deb package for a library not installed works
-       as expected."""
+    as expected."""
     linter = LibraryLinter(name="library", snap_metadata=Mock(), lint=None)
-    result = linter._find_deb_package('thisLibraryCantExistInALinuxSystemBecauseItWouldMakeNoSense.so')
+    result = linter._find_deb_package(
+        "thisLibraryCantExistInALinuxSystemBecauseItWouldMakeNoSense.so"
+    )
     assert not result


### PR DESCRIPTION
Currently, when an ELF binary in a created snap lacks a required library, snapcraft notifies the user about it; unfortunately, it is the user who has to check which package (if any) includes that/those missing library/libraries.

Since it is common that the "libXXX-dev" package used during build also installs the corresponding "libXXX" package, the missing library is usually installed in the building system. This patch takes advantage of that to search each missing library in the build system and check which package contains that file, appending that information to the warning message.

Here is an example of the new output:

```
Running linter: library
Lint warnings:
- library: usr/bin/gnome-control-center: missing dependency 'libaccountsservice.so.0' (provided by libaccountsservice0). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libcrack.so.2' (provided by libcrack2). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libdcerpc-binding.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libgnome-bluetooth-ui-3.0.so.13' (provided by libgnome-bluetooth-ui-3.0-13). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libgtop-2.0.so.11' (provided by libgtop-2.0-11). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libjansson.so.4' (provided by libjansson4). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libldb.so.2' (provided by libldb2). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libmm-glib.so.0' (provided by libmm-glib0). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libndr-krb5pac.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libndr-nbt.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libndr-standard.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libndr.so.2' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libnm.so.0' (provided by libnm0). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libpwquality.so.1' (provided by libpwquality1). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsamba-credentials.so.1' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsamba-errors.so.1' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsamba-hostconfig.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsamba-util.so.0' (provided by libwbclient0). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsamdb.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsmbclient.so.0' (provided by libsmbclient). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsmbconf.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libtalloc.so.2' (provided by libtalloc2). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libtevent-util.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libtevent.so.0' (provided by libtevent0). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libudisks2.so.0' (provided by libudisks2-0). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libupower-glib.so.3' (provided by libupower-glib3). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libwbclient.so.0' (provided by libwbclient0). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libCHARSET3.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libMESSAGING-SEND.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libaddns.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libasn1-samba4.so.8' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libasn1util.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libauthkrb5.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libcli-cldap.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libcli-ldap-common.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libcli-nbt.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libcli-smb-common.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libcliauth.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libclidns.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libcom_err-samba4.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libcommon-auth.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libdbwrap.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libdcerpc-samba.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libflag-mapping.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libgenrand.so.0' (provided by libwbclient0). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libgensec.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libgse.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libgssapi-samba4.so.2' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libhcrypto-samba4.so.5' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libheimbase-samba4.so.1' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libhx509-samba4.so.5' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libinterfaces.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libiov-buf.so.0' (provided by libwbclient0). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libkrb5-samba4.so.26' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libkrb5samba.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libldbsamba.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'liblibcli-lsa3.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'liblibsmb.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libmessages-dgm.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libmessages-util.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libmsghdr.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libmsrpc3.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libndr-samba.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libreplace.so.0' (provided by libwbclient0). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libroken-samba4.so.19' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsamba-debug.so.0' (provided by libwbclient0). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsamba-modules.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsamba-security.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsamba-sockets.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsamba3-util.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsamdb-common.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsecrets3.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libserver-id-db.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libserver-role.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsmb-transport.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsmbd-shim.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsocket-blocking.so.0' (provided by libwbclient0). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libsys-rw.so.0' (provided by libwbclient0). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libtalloc-report-printf.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libtdb-wrap.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libtime-basic.so.0' (provided by libwbclient0). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libutil-reg.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libutil-setid.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libutil-tdb.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libwinbind-client.so.0' (provided by libwbclient0). (https://snapcraft.io/docs/linters-library)
- library: usr/bin/gnome-control-center: missing dependency 'libwind-samba4.so.0' (provided by samba-libs). (https://snapcraft.io/docs/linters-library)
- library: usr/lib/x86_64-linux-gnu/libnma-gtk4.so.0.0.0: missing dependency 'libnm.so.0' (provided by libnm0). (https://snapcraft.io/docs/linters-library)
- library: usr/lib/x86_64-linux-gnu/libnma.so.0.0.0: missing dependency 'libnm.so.0' (provided by libnm0). (https://snapcraft.io/docs/linters-library)
- library: usr/libexec/gnome-control-center-goa-helper: missing dependency 'libgoa-backend-1.0.so.1' (provided by libgoa-backend-1.0-1). (https://snapcraft.io/docs/linters-library)
- library: usr/libexec/gnome-control-center-goa-helper: missing dependency 'libsnapd-glib.so.1' (provided by libsnapd-glib1). (https://snapcraft.io/docs/linters-library)

```
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
