### PR TITLE
requirements: bump craft-archives 

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -11,7 +11,7 @@ click==8.1.3
 codespell==2.2.4
 colorama==0.4.6
 coverage==7.2.5
-craft-archives==1.1.2
+craft-archives==1.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cffi==1.15.1
 chardet==5.1.0
 charset-normalizer==3.1.0
 click==8.1.3
-craft-archives==1.1.2
+craft-archives==1.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.6

--- a/tests/spread/core22/package-repo-archs/armhf.yaml
+++ b/tests/spread/core22/package-repo-archs/armhf.yaml
@@ -1,0 +1,38 @@
+name: test-archs
+version: '1.0'
+summary: test package repos with different architectures
+description: test package repos with different architectures
+grade: stable
+confinement: strict
+base: core22
+architectures:
+  - build-on: amd64
+
+package-repositories:
+  # The repo that contains libpython3.11-minimal:armhf
+  - type: apt
+    formats: [deb]
+    architectures: [armhf]
+    components: [main]
+    suites: [jammy]
+    key-id: F23C5A6CF475977595C89F51BA6932366A755776
+    url: https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu
+  # Also add the armhf arch for the "ports" repo, to fetch python's deps. We
+  # need to do this because the default archives don't have armhf.
+  - type: apt
+    architectures: [ armhf ]
+    components: [ main ]
+    suites: [ jammy, jammy-security, jammy-updates ]
+    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
+    url: http://ports.ubuntu.com/ubuntu-ports
+
+parts:
+  mypart:
+    plugin: nil
+    build-packages:
+      - file
+    stage-packages:
+      - libpython3.11-minimal:armhf
+    override-build: |
+      file ${CRAFT_PART_INSTALL}/usr/lib/arm-linux-gnueabihf/libssl.so.3 | grep "ARM"
+      craftctl default

--- a/tests/spread/core22/package-repo-archs/i386.yaml
+++ b/tests/spread/core22/package-repo-archs/i386.yaml
@@ -1,0 +1,33 @@
+name: test-archs
+version: '1.0'
+summary: test package repos with different architectures
+description: test package repos with different architectures
+grade: stable
+confinement: strict
+base: core22
+architectures:
+  - build-on: amd64
+
+package-repositories:
+  # The repo that contains libpython3.11-minimal:i386
+  - type: apt
+    formats: [deb]
+    architectures: [i386]
+    components: [main]
+    suites: [jammy]
+    key-id: F23C5A6CF475977595C89F51BA6932366A755776
+    url: https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu
+  # We don't need to add the i386 architecture for the official archives,
+  # because the host building this (amd64) is compatible so Snapcraft will add
+  # the i386 platform "globally".
+
+parts:
+  mypart:
+    plugin: nil
+    build-packages:
+      - file
+    stage-packages:
+      - libpython3.11-minimal:i386
+    override-build: |
+      file ${CRAFT_PART_INSTALL}/usr/lib/i386-linux-gnu/libssl.so.3 | grep "ELF 32-bit"
+      craftctl default

--- a/tests/spread/core22/package-repo-archs/task.yaml
+++ b/tests/spread/core22/package-repo-archs/task.yaml
@@ -1,0 +1,19 @@
+summary: Test using package-repositories with different architectures on core22
+
+environment:
+  SNAP_ARCH/i386: i386
+  SNAP_ARCH/armhf: armhf
+  SNAPCRAFT_BUILD_ENVIRONMENT: ""
+
+restore: |
+  snapcraft clean
+
+execute: |
+  # The task works by copying one of the arch-specific yaml files as
+  # "snapcraft.yaml", and then building it.
+  rm -rf snap/
+  mkdir snap
+  cp "$SNAP_ARCH".yaml snap/snapcraft.yaml
+
+  # The part's build script does the checking.
+  snapcraft build --verbose --use-lxd


### PR DESCRIPTION
Version 1.1.3 fixes the issue with package-repositories that declare
architectures. In addition to addressing the wrong parameter order, the
new version also improves the handling of architectures.

The summary of the change is: if the host system is amd64 and the arch
of the package repository is i386, _or_ if the host is arm64 and the
repo armhf, then `dpkg --add-architecture <repo_arch>` will be called.
Otherwise, the command is not called. This lets us preserve the
behavior of enabling i386 in the official repositories when a repo
using i386 is added, with the improvement of _not breaking_ apt update
when an "incompatible" architecture combination is declared.

The new spread tests reflect this. Both run in amd64 and add the
deadsnakes ppa to fetch Python in a foreign arch:

- For i386, only the deadsnakes ppa is necessary, as the architecture
will be added "globally" and Python's dependencies are found in the
default archives;
- For armhf, the ports.ubuntu.com repo is necessary in addition to the
deadsnakes one. This lets the dependencies be found in the ports repo,
_and_ doesn't break the build (this combination is broken in Snapcraft
7.2, 7.3 and 7.4).

Fixes #4289 and #4298
