### PR TITLE
requirements: update craft-parts to 1.19.7

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -14,7 +14,7 @@ coverage==7.2.5
 craft-archives==1.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
-craft-parts==1.19.6
+git+https://github.com/cmatsuoka/craft-parts@6a59b6f64c94bfb12a3d14b8c32ace2adf25983d
 craft-providers==1.10.1
 craft-store==2.4.0
 cryptography==40.0.2

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -14,7 +14,7 @@ coverage==7.2.5
 craft-archives==1.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
-git+https://github.com/cmatsuoka/craft-parts@6a59b6f64c94bfb12a3d14b8c32ace2adf25983d
+craft-parts==1.19.7
 craft-providers==1.10.1
 craft-store==2.4.0
 cryptography==40.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.3
 craft-archives==1.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
-git+https://github.com/cmatsuoka/craft-parts@6a59b6f64c94bfb12a3d14b8c32ace2adf25983d
+craft-parts==1.19.7
 craft-providers==1.10.1
 craft-store==2.4.0
 cryptography==40.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.3
 craft-archives==1.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
-craft-parts==1.19.6
+git+https://github.com/cmatsuoka/craft-parts@6a59b6f64c94bfb12a3d14b8c32ace2adf25983d
 craft-providers==1.10.1
 craft-store==2.4.0
 cryptography==40.0.2

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ install_requires = [
     "craft-archives",
     "craft-cli",
     "craft-grammar",
-    "craft-parts",
+    "craft-parts @ git+https://github.com/cmatsuoka/craft-parts@6a59b6f64c94bfb12a3d14b8c32ace2adf25983d",
     "craft-providers",
     "craft-store",
     "docutils<0.20",  # Frozen until we can update sphinx dependencies.

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ install_requires = [
     "craft-archives",
     "craft-cli",
     "craft-grammar",
-    "craft-parts @ git+https://github.com/cmatsuoka/craft-parts@6a59b6f64c94bfb12a3d14b8c32ace2adf25983d",
+    "craft-parts",
     "craft-providers",
     "craft-store",
     "docutils<0.20",  # Frozen until we can update sphinx dependencies.

--- a/tests/spread/core22/linters/linter-ros2-humble-mixed/task.yaml
+++ b/tests/spread/core22/linters/linter-ros2-humble-mixed/task.yaml
@@ -10,4 +10,16 @@ execute: |
   test -f linter-ros2-humble-mixed_1.0_*.snap
 
   sed -n '/^Running linters/,/^Creating snap/p' < output.txt > linter_output.txt
-  diff -u linter_output.txt expected_linter_output.txt
+
+  # diff everything except the list of libraries
+  diff --ignore-matching-lines "^- library: lib" expected_linter_output.txt linter_output.txt
+
+  # `|| true` is used because grep will error if there is no output from the `diff` call
+  NUM_DIFFERENCES=$(diff expected_linter_output.txt linter_output.txt | grep --count "[<>]" || true)
+
+  # the list of unused libraries may change from time to time, so check the output is similar but not identical
+  if [[ $NUM_DIFFERENCES -gt 10 ]]; then
+    echo "Error: linter warnings are significantly different:"
+    diff --unified expected_linter_output.txt linter_output.txt
+    exit 1
+  fi

--- a/tests/spread/core22/set-version-twice/modified-snapcraft.yaml
+++ b/tests/spread/core22/set-version-twice/modified-snapcraft.yaml
@@ -1,0 +1,24 @@
+name: test-set-version-twice
+base: core22
+version: '0.1'
+summary: Test fix for set version and out of order step execution
+description: |
+  As described in https://bugs.launchpad.net/snapcraft/+bug/1831135/comments/10,
+  a bug in craft-parts caused unexpected double setting of project variables
+  such as `version`. Make sure this scenario builds correctly.
+adopt-info: part1
+
+grade: devel
+confinement: devmode
+
+parts:
+  part1:
+    plugin: nil
+    override-pull: |
+      craftctl default
+      craftctl set version=xx
+      echo
+
+  part2:
+    plugin: nil
+    after: [part1]

--- a/tests/spread/core22/set-version-twice/original-snapcraft.yaml
+++ b/tests/spread/core22/set-version-twice/original-snapcraft.yaml
@@ -1,0 +1,23 @@
+name: test-set-version-twice
+base: core22
+version: '0.1'
+summary: Test fix for set version and out of order step execution
+description: |
+  As described in https://bugs.launchpad.net/snapcraft/+bug/1831135/comments/10,
+  a bug in craft-parts caused unexpected double setting of project variables
+  such as `version`. Make sure this scenario builds correctly.
+adopt-info: part1
+
+grade: devel
+confinement: devmode
+
+parts:
+  part1:
+    plugin: nil
+    override-pull: |
+      craftctl default
+      craftctl set version=xx
+
+  part2:
+    plugin: nil
+    after: [part1]

--- a/tests/spread/core22/set-version-twice/task.yaml
+++ b/tests/spread/core22/set-version-twice/task.yaml
@@ -1,0 +1,29 @@
+summary: Test fix for version setting corner case
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+
+restore: |
+  snapcraft clean
+  rm -Rf subdir ./*.snap
+  rm -f snap/*.yaml
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+
+execute: |
+  mkdir -p snap
+  cp original-snapcraft.yaml snap/snapcraft.yaml
+
+  snapcraft prime
+
+  cp modified-snapcraft.yaml snap/snapcraft.yaml
+
+  snapcraft build part2
+  snapcraft prime
+
+  cp original-snapcraft.yaml snap/snapcraft.yaml
+
+  snapcraft build part2
+  snapcraft prime


### PR DESCRIPTION
Craft Parts 1.19.7 addresses issues related to version being set
twice during rebuilds.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
