### PR TITLE
packaging: allow installing without git

### DIFF
--- a/tools/version.py
+++ b/tools/version.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import fileinput
+import os
 import pathlib
 import subprocess
 import sys
@@ -32,12 +33,14 @@ def determine_version():
     desc = (
         subprocess.run(
             ["git", "describe", "--always", "--long"],
-            check=True,
             stdout=subprocess.PIPE,
         )
         .stdout.decode()
         .strip()
     )
+
+    if not desc:
+        return os.environ.get("SNAP_VERSION", "0.0.0+devel")
 
     split_desc = desc.split("-")
     assert (


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

---

Related to #4145

This allows building/installing `snapcraft` from non-git clones. It would be useful to Homebrew, as we prefer to build from lightweight tarballs.
If `git describe` fails, it first checks if the version is defined in the environment via `SNAP_VERSION` or falls back to a [PEP440-compliant](https://peps.python.org/pep-0440/) version string `0.0.0+devel` (this is similar to the fallback in [`snapcraft/__init__.py`](https://github.com/snapcore/snapcraft/blob/91a18b3128de4971edfc090a8683a64ff1679f2e/snapcraft/__init__.py#L24), but updated for PEP440).

Before:

```console
$ pip3 install https://github.com/snapcore/snapcraft/archive/refs/tags/7.5.0.tar.gz
...
      subprocess.CalledProcessError: Command '['git', 'describe', '--always', '--long']' returned non-zero exit status 128.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error
...
```

After:

```console
$ pip3 install https://github.com/branchvincent/snapcraft/archive/refs/heads/build-no-git.tar.gz
...
Successfully installed snapcraft-0.0.0+devel
$ pip3 uninstall -y snapcraft
$ SNAP_VERSION=7.5.0 pip3 install https://github.com/branchvincent/snapcraft/archive/refs/heads/build-no-git.tar.gz
...
Successfully installed snapcraft-7.5.0
```
