### PR TITLE
_options.py: use "_ALL_PROVIDERS" as the shorter form for all providers

### DIFF
--- a/snapcraft_legacy/cli/_options.py
+++ b/snapcraft_legacy/cli/_options.py
@@ -191,7 +191,7 @@ _PROVIDER_OPTIONS: List[Dict[str, Any]] = [
         is_flag=True,
         help="Enable plugins that are experimental and not considered stable.",
         envvar="SNAPCRAFT_ENABLE_EXPERIMENTAL_PLUGINS",
-        supported_providers=["host", "lxd", "managed-host", "multipass"],
+        supported_providers=_ALL_PROVIDERS,
     ),
     dict(
         param_decls=["--enable-experimental-target-arch"],


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
