### PR TITLE
cli: prioritize `--use-lxd` over `SNAPCRAFT_BUILD_ENVIRONMENT`

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -251,11 +251,10 @@ def _run_command(
                 permanent=True,
             )
 
-    if (
+    if parsed_args.use_lxd or (
         not managed_mode
         and not parsed_args.destructive_mode
         and not os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT") == "host"
-        or parsed_args.use_lxd
     ):
         if command_name == "clean" and not part_names:
             _clean_provider(project, parsed_args)

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -255,6 +255,7 @@ def _run_command(
         not managed_mode
         and not parsed_args.destructive_mode
         and not os.getenv("SNAPCRAFT_BUILD_ENVIRONMENT") == "host"
+        or parsed_args.use_lxd
     ):
         if command_name == "clean" and not part_names:
             _clean_provider(project, parsed_args)

--- a/tests/spread/providers/use-lxd/task.yaml
+++ b/tests/spread/providers/use-lxd/task.yaml
@@ -1,0 +1,29 @@
+summary: Test --use-lxd takes priority over environment variables
+systems:
+  - ubuntu-22.04*
+
+prepare: |
+  snapcraft init
+
+restore: |
+  rm -rf ./*.snap
+
+execute: |
+  export SNAPCRAFT_BUILD_ENVIRONMENT="host"
+
+  snapcraft pull --use-lxd
+
+  if [[ -d parts ]]; then
+    echo "snapcraft did not run inside a lxd instance"
+    exit 1
+  fi
+
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+  export SNAPCRAFT_MANAGED_MODE=1
+
+  snapcraft pull --use-lxd
+
+  if [[ -d parts ]]; then
+    echo "snapcraft did not run inside a lxd instance"
+    exit 1
+  fi


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

Prioritize the command line argument `--use-lxd` over the environment variable `SNAPCRAFT_BUILD_ENVIRONMENT=host`.

Resolves #4307 
(CRAFT-1956)