### PR TITLE
manifest: use `--enable-image-information` inside instances

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -506,9 +506,9 @@ def _run_in_provider(
 
     if getattr(parsed_args, "enable_manifest", False):
         cmd.append("--enable-manifest")
-    build_information = getattr(parsed_args, "manifest_build_information", None)
-    if build_information:
-        cmd.extend(["--manifest-build-information", build_information])
+    image_information = getattr(parsed_args, "manifest_image_information", None)
+    if image_information:
+        cmd.extend(["--manifest-image-information", image_information])
 
     cmd.append("--build-for")
     cmd.append(project.get_build_for())

--- a/tests/spread/core22/manifest/manifest-info-cmdline/task.yaml
+++ b/tests/spread/core22/manifest/manifest-info-cmdline/task.yaml
@@ -9,6 +9,7 @@ restore: |
   rm -f ~/manifest_0.1_*.snap
 
 execute: |
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
   snapcraft --use-lxd --enable-manifest --manifest-image-information='{"test-var": "value"}'
 
   unsquashfs manifest_0.1_*.snap

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -1240,7 +1240,7 @@ def test_lifecycle_run_in_provider_all_options(
     # build the expected command to be executed in the provider
     parts = ["test-part-1", "test-part-2"]
     output = "test-output"
-    manifest_build_information = "test-build-info"
+    manifest_image_information = "test-image-info"
     ua_token = "test-ua-token"
     http_proxy = "1.2.3.4"
     https_proxy = "5.6.7.8"
@@ -1255,8 +1255,8 @@ def test_lifecycle_run_in_provider_all_options(
             "--shell",
             "--shell-after",
             "--enable-manifest",
-            "--manifest-build-information",
-            manifest_build_information,
+            "--manifest-image-information",
+            manifest_image_information,
             "--build-for",
             "test-arch-2",
             "--ua-token",
@@ -1279,7 +1279,7 @@ def test_lifecycle_run_in_provider_all_options(
             use_lxd=False,
             provider=None,
             enable_manifest=True,
-            manifest_build_information=manifest_build_information,
+            manifest_image_information=manifest_image_information,
             bind_ssh=True,
             ua_token=ua_token,
             enable_experimental_ua_services=True,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

This fixes a bug that has been present since manifests were [added to core22](https://github.com/snapcore/snapcraft/pull/3824/files#diff-81bf1b8cfa88289a0432d3e12f4b4c1c104d4463a49dbc0e6c431d4e444a35cdR372-R378).  

The bug is that `--enable-image-information` was not passed into LXD/Multipass instances.  This flag only got used when running in destructive mode.  During the implementation, there was probably a typo/mix-up between the envvar `SNAPCRAFT_BUILD_INFO` and `--enable-image-information`.

This bug was uncovered by #4329, which prevented the spread test from running inside a LXD container.