### PR TITLE
enable "streaming brief" CLI mode

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -12,10 +12,10 @@ codespell==2.2.4
 colorama==0.4.6
 coverage==7.2.5
 craft-archives==1.1.3
-craft-cli==2.0.0
+craft-cli==2.1.0
 craft-grammar==1.1.1
-craft-parts==1.23.1
-craft-providers==1.13.0
+craft-parts==1.24.0
+craft-providers==1.15.0
 craft-store==2.4.0
 cryptography==41.0.3
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,10 @@ chardet==5.1.0
 charset-normalizer==3.1.0
 click==8.1.3
 craft-archives==1.1.3
-craft-cli==2.0.0
+craft-cli==2.1.0
 craft-grammar==1.1.1
-craft-parts==1.23.1
-craft-providers==1.13.0
+craft-parts==1.24.0
+craft-providers==1.15.0
 craft-store==2.4.0
 cryptography==41.0.3
 Deprecated==1.2.13

--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -201,6 +201,7 @@ def get_dispatcher() -> craft_cli.Dispatcher:
         appname="snapcraft",
         greeting=f"Starting Snapcraft {__version__}",
         log_filepath=log_filepath,
+        streaming_brief=True,
     )
 
     return craft_cli.Dispatcher(

--- a/snapcraft/commands/lint.py
+++ b/snapcraft/commands/lint.py
@@ -23,7 +23,7 @@ import subprocess
 import tempfile
 import textwrap
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Iterator, Optional
 
 from craft_cli import BaseCommand, emit
@@ -309,7 +309,7 @@ class LintCommand(BaseCommand):
         is_dangerous = not bool(assert_file)
 
         if assert_file:
-            ack_command = snap_cmd.formulate_ack_command(assert_file)
+            ack_command = snap_cmd.formulate_ack_command(PurePosixPath(assert_file))
             emit.progress(
                 f"Installing assertion file with {shlex.join(ack_command)!r}."
             )
@@ -327,7 +327,7 @@ class LintCommand(BaseCommand):
         install_command = snap_cmd.formulate_local_install_command(
             classic=bool(snap_metadata.confinement == "classic"),
             dangerous=is_dangerous,
-            snap_path=snap_file,
+            snap_path=PurePosixPath(snap_file),
         )
         if snap_metadata.grade == "devel":
             install_command.append("--devmode")

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -377,7 +377,7 @@ def _run_lifecycle_and_pack(
             version=process_version(project.version),
             target_arch=project.get_build_for(),
         )
-        emit.message(f"Created snap package {snap_filename}")
+        emit.progress(f"Created snap package {snap_filename}", permanent=True)
 
 
 def _generate_metadata(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -25,6 +25,7 @@ import pytest
 import yaml
 from craft_providers import Executor, Provider
 from craft_providers.base import Base
+from overrides import override
 from pymacaroons import Caveat, Macaroon
 
 from snapcraft.extensions import extension, register, unregister
@@ -325,6 +326,16 @@ def fake_provider(mock_instance):
 
     class FakeProvider(Provider):
         """Fake provider."""
+
+        @property
+        @override
+        def name(self) -> str:
+            return "fake"
+
+        @property
+        @override
+        def install_recommendation(self) -> str:
+            return "uninstallable"
 
         def clean_project_environments(self, *, instance_name: str):
             pass


### PR DESCRIPTION
The first commit has the version bumps and fixes from the craft-providers bump (not sure if those were expected)
Second commit has the actual enablement of the feature

The changes themselves are ready for review, but still need to:
- [x] update from main once #4327 is merged
- [x] update to correct craft-parts version once a new one is released.

... so I'm keeping it as a draft for now. The test failures are related to the needed merge

Fixes #4317