### PR TITLE
requirements: update craft-parts to 1.24.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ click==8.1.3
 craft-archives==1.1.0
 craft-cli==2.0.0
 craft-grammar==1.1.1
-craft-parts==1.23.1
+craft-parts==1.24.1
 craft-providers==1.13.0
 craft-store==2.4.0
 Deprecated==1.2.13

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -14,7 +14,7 @@ coverage==7.2.5
 craft-archives==1.1.3
 craft-cli==2.1.0
 craft-grammar==1.1.1
-craft-parts==1.24.0
+craft-parts==1.24.1
 craft-providers==1.15.0
 craft-store==2.4.0
 cryptography==41.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.3
 craft-archives==1.1.3
 craft-cli==2.1.0
 craft-grammar==1.1.1
-craft-parts==1.24.0
+craft-parts==1.24.1
 craft-providers==1.15.0
 craft-store==2.4.0
 cryptography==41.0.3


### PR DESCRIPTION
Craft Parts 1.24.1 includes a workaround for a craft-cli spinner
deadlock issue.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
