### PR TITLE
fix(legacy): export sources method to local plugins

### DIFF
--- a/snapcraft/sources.py
+++ b/snapcraft/sources.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,23 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Publish your app for Linux users for desktop, cloud, and IoT."""
+"""Legacy support for local plugins."""
 
-import os
+import sys as _sys
 
-import pkg_resources
+if _sys.platform == "linux":
+    from snapcraft_legacy.sources import get
 
-# For legacy compatibility
-import snapcraft.sources  # noqa: F401
-
-
-def _get_version():
-    if os.environ.get("SNAP_NAME") == "snapcraft":
-        return os.environ["SNAP_VERSION"]
-    try:
-        return pkg_resources.require("snapcraft")[0].version
-    except pkg_resources.DistributionNotFound:
-        return "devel"
-
-
-__version__ = _get_version()
+    __all__ = [
+        "get",
+    ]

--- a/tests/spread/plugins/v1/x-local/local-plugin/task.yaml
+++ b/tests/spread/plugins/v1/x-local/local-plugin/task.yaml
@@ -4,6 +4,7 @@ environment:
   SNAP_DIR/baseplugin: ../snaps/from-baseplugin
   SNAP_DIR/nilplugin: ../snaps/from-nilplugin
   SNAP_DIR/pluginv1: ../snaps/from-pluginv1
+  SNAP_DIR/sourceget: ../snaps/source-get
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh

--- a/tests/spread/plugins/v1/x-local/snaps/source-get/snap/plugins/x_local_plugin.py
+++ b/tests/spread/plugins/v1/x-local/snaps/source-get/snap/plugins/x_local_plugin.py
@@ -37,7 +37,7 @@ class LocalPlugin(PluginV1):
 
     def pull(self):
         super().pull()
-        x = snapcraft.sources.get
+        print(snapcraft.sources.get)
 
     def build(self):
         return self.run(["touch", "build-stamp"], self.installdir)

--- a/tests/spread/plugins/v1/x-local/snaps/source-get/snap/plugins/x_local_plugin.py
+++ b/tests/spread/plugins/v1/x-local/snaps/source-get/snap/plugins/x_local_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,23 +14,30 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Publish your app for Linux users for desktop, cloud, and IoT."""
-
-import os
-
-import pkg_resources
-
-# For legacy compatibility
-import snapcraft.sources  # noqa: F401
+import snapcraft
+from snapcraft.plugins.v1 import PluginV1
 
 
-def _get_version():
-    if os.environ.get("SNAP_NAME") == "snapcraft":
-        return os.environ["SNAP_VERSION"]
-    try:
-        return pkg_resources.require("snapcraft")[0].version
-    except pkg_resources.DistributionNotFound:
-        return "devel"
+class LocalPlugin(PluginV1):
+    @classmethod
+    def schema(cls):
+        schema = super().schema()
 
+        schema["properties"]["foo"] = {"type": "string"}
 
-__version__ = _get_version()
+        return schema
+
+    @classmethod
+    def get_pull_properties(cls):
+        return ["foo", "stage-packages"]
+
+    @classmethod
+    def get_build_properties(cls):
+        return ["foo", "stage-packages"]
+
+    def pull(self):
+        super().pull()
+        x = snapcraft.sources.get
+
+    def build(self):
+        return self.run(["touch", "build-stamp"], self.installdir)

--- a/tests/spread/plugins/v1/x-local/snaps/source-get/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/x-local/snaps/source-get/snap/snapcraft.yaml
@@ -1,0 +1,12 @@
+name: test-local-plugins
+base: core18
+version: "0.1"
+summary: local plugin using snapcraft.sources.get
+description: Tests if local plugins load and can build
+confinement: strict
+grade: devel
+
+parts:
+    x-local-plugin:
+      plugin: x-local-plugin
+      source: .


### PR DESCRIPTION
Support legacy local plugins that invoke `snapcraft.sources.get`
by redirecting imports to `snapcraft_legacy`. This is similar
to the strategy used for V1 and V2 plugins.



- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
Fixes #4285