### PR TITLE
refactor(parts): move yaml utils out of lifecycle

### DIFF
--- a/snapcraft/commands/discovery.py
+++ b/snapcraft/commands/discovery.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022-2023 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -25,7 +25,7 @@ from craft_parts.plugins import get_registered_plugins
 from overrides import overrides
 
 from snapcraft import errors
-from snapcraft.parts.lifecycle import (
+from snapcraft.parts.yaml_utils import (
     apply_yaml,
     extract_parse_info,
     get_snap_project,

--- a/snapcraft/commands/extensions.py
+++ b/snapcraft/commands/extensions.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022-2023 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -27,7 +27,7 @@ from overrides import overrides
 from pydantic import BaseModel
 
 from snapcraft import extensions
-from snapcraft.parts.lifecycle import (
+from snapcraft.parts.yaml_utils import (
     apply_yaml,
     extract_parse_info,
     get_snap_project,

--- a/snapcraft/commands/init.py
+++ b/snapcraft/commands/init.py
@@ -24,7 +24,7 @@ from craft_cli import BaseCommand, emit
 from overrides import overrides
 
 from snapcraft import errors
-from snapcraft.parts.lifecycle import get_snap_project
+from snapcraft.parts.yaml_utils import get_snap_project
 
 _TEMPLATE_YAML = dedent(
     """\

--- a/snapcraft/commands/lint.py
+++ b/snapcraft/commands/lint.py
@@ -34,7 +34,7 @@ from overrides import overrides
 
 from snapcraft import errors, linters, projects, providers
 from snapcraft.meta import snap_yaml
-from snapcraft.parts.lifecycle import apply_yaml, extract_parse_info, process_yaml
+from snapcraft.parts.yaml_utils import apply_yaml, extract_parse_info, process_yaml
 from snapcraft.utils import (
     get_host_architecture,
     get_managed_environment_home_path,

--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022-2023 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -25,7 +25,7 @@ from craft_cli.helptexts import HIDDEN
 from overrides import overrides
 
 from snapcraft.legacy_cli import run_legacy
-from snapcraft.parts.lifecycle import get_snap_project, process_yaml
+from snapcraft.parts.yaml_utils import get_snap_project, process_yaml
 from snapcraft.utils import confirm_with_user
 from snapcraft_legacy.internal.remote_build.errors import AcceptPublicUploadError
 

--- a/snapcraft/parts/yaml_utils.py
+++ b/snapcraft/parts/yaml_utils.py
@@ -16,15 +16,40 @@
 
 """YAML utilities for Snapcraft."""
 
-from typing import Any, Dict, TextIO
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, TextIO
 
 import yaml
 import yaml.error
 
 from snapcraft import errors, utils
+from snapcraft.extensions import apply_extensions
+from snapcraft.projects import Architecture, GrammarAwareProject
 
+from . import grammar
+
+_CORE_PART_KEYS = ["build-packages", "build-snaps"]
+_CORE_PART_NAME = "snapcraft/core"
 _ESM_BASES = {"core", "core18"}
 _LEGACY_BASES = {"core20"}
+
+
+@dataclass
+class _SnapProject:
+    project_file: Path
+    assets_dir: Path = Path("snap")
+
+
+_SNAP_PROJECT_FILES = [
+    _SnapProject(project_file=Path("snapcraft.yaml")),
+    _SnapProject(project_file=Path("snap/snapcraft.yaml")),
+    _SnapProject(
+        project_file=Path("build-aux/snap/snapcraft.yaml"),
+        assets_dir=Path("build-aux/snap"),
+    ),
+    _SnapProject(project_file=Path(".snapcraft.yaml")),
+]
 
 
 def _check_duplicate_keys(node):
@@ -107,3 +132,89 @@ def load(filestream: TextIO) -> Dict[str, Any]:
         )
     except yaml.error.YAMLError as err:
         raise errors.SnapcraftError(f"snapcraft.yaml parsing error: {err!s}") from err
+
+
+def apply_yaml(
+    yaml_data: Dict[str, Any], build_on: str, build_for: str
+) -> Dict[str, Any]:
+    """Apply Snapcraft logic to yaml_data.
+
+    Extensions are applied and advanced grammar is processed.
+    The architectures data is reduced to architectures in the current build plan.
+
+    :param yaml_data: The project YAML data.
+    :param build_on: Architecture the snap project will be built on.
+    :param build_for: Target architecture the snap project will be built to.
+
+    :return: A dictionary of yaml data with snapcraft logic applied.
+    """
+    # validate project grammar
+    GrammarAwareProject.validate_grammar(yaml_data)
+
+    # Special Snapcraft Part
+    core_part = {k: yaml_data.pop(k) for k in _CORE_PART_KEYS if k in yaml_data}
+    if core_part:
+        core_part["plugin"] = "nil"
+        yaml_data["parts"][_CORE_PART_NAME] = core_part
+
+    yaml_data = apply_extensions(yaml_data, arch=build_on, target_arch=build_for)
+
+    if "parts" in yaml_data:
+        yaml_data["parts"] = grammar.process_parts(
+            parts_yaml_data=yaml_data["parts"], arch=build_on, target_arch=build_for
+        )
+
+    # replace all architectures with the architectures in the current build plan
+    yaml_data["architectures"] = [Architecture(build_on=build_on, build_for=build_for)]
+
+    return yaml_data
+
+
+def get_snap_project() -> _SnapProject:
+    """Find the snapcraft.yaml to load.
+
+    :raises SnapcraftError: if the project yaml file cannot be found.
+    """
+    for snap_project in _SNAP_PROJECT_FILES:
+        if snap_project.project_file.exists():
+            return snap_project
+
+    raise errors.ProjectMissing()
+
+
+def extract_parse_info(yaml_data: Dict[str, Any]) -> Dict[str, List[str]]:
+    """Remove parse-info data from parts.
+
+    :param yaml_data: The project YAML data.
+
+    :return: The extracted parse info for each part.
+    """
+    parse_info: Dict[str, List[str]] = {}
+
+    if "parts" in yaml_data:
+        for name, data in yaml_data["parts"].items():
+            if "parse-info" in data:
+                parse_info[name] = data.pop("parse-info")
+
+    return parse_info
+
+
+def process_yaml(project_file: Path) -> Dict[str, Any]:
+    """Process yaml data from file into a dictionary.
+
+    :param project_file: Path to project.
+
+    :raises SnapcraftError: if the project yaml file cannot be loaded.
+
+    :return: The processed YAML data.
+    """
+    try:
+        with open(project_file, encoding="utf-8") as yaml_file:
+            yaml_data = load(yaml_file)
+    except OSError as err:
+        msg = err.strerror
+        if err.filename:
+            msg = f"{msg}: {err.filename!r}."
+        raise errors.SnapcraftError(msg) from err
+
+    return yaml_data

--- a/tests/unit/commands/test_init.py
+++ b/tests/unit/commands/test_init.py
@@ -22,7 +22,7 @@ from unittest.mock import call
 import pytest
 
 from snapcraft import cli
-from snapcraft.parts.lifecycle import _SNAP_PROJECT_FILES, apply_yaml, process_yaml
+from snapcraft.parts.yaml_utils import _SNAP_PROJECT_FILES, apply_yaml, process_yaml
 from snapcraft.projects import Project
 
 

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -31,7 +31,7 @@ from snapcraft.elf import ElfFile
 from snapcraft.parts import lifecycle as parts_lifecycle
 from snapcraft.parts.plugins import KernelPlugin
 from snapcraft.parts.update_metadata import update_project_metadata
-from snapcraft.projects import MANDATORY_ADOPTABLE_FIELDS, Architecture, Project
+from snapcraft.projects import MANDATORY_ADOPTABLE_FIELDS, Project
 from snapcraft.utils import get_host_architecture
 
 _SNAPCRAFT_YAML_FILENAMES = [
@@ -1003,16 +1003,6 @@ def test_lifecycle_adopt_project_vars(snapcraft_yaml, new_dir):
     assert project.grade == "devel"
 
 
-def test_extract_parse_info():
-    yaml_data = {
-        "name": "foo",
-        "parts": {"p1": {"plugin": "nil", "parse-info": "foo/metadata.xml"}, "p2": {}},
-    }
-    parse_info = parts_lifecycle.extract_parse_info(yaml_data)
-    assert yaml_data == {"name": "foo", "parts": {"p1": {"plugin": "nil"}, "p2": {}}}
-    assert parse_info == {"p1": "foo/metadata.xml"}
-
-
 def test_check_experimental_plugins_disabled(snapcraft_yaml, mocker):
     mocker.patch("craft_parts.plugins.plugins._PLUGINS", {"kernel": KernelPlugin})
     project = Project.unmarshal(
@@ -1585,41 +1575,6 @@ def test_lifecycle_run_in_provider_devel_base(
         "Running snapcraft with a devel instance is for testing purposes only.",
         permanent=True,
     )
-
-
-@pytest.fixture
-def minimal_yaml_data():
-    return {
-        "name": "name",
-        "base": "core22",
-        "confinement": "strict",
-        "grade": "devel",
-        "version": "1.0",
-        "summary": "summary",
-        "description": "description",
-        "parts": {"nil": {}},
-    }
-
-
-@pytest.mark.parametrize("key", ("build-packages", "build-snaps"))
-@pytest.mark.parametrize("value", (["foo"], [{"on amd64": ["foo"]}]))
-def test_root_packages(minimal_yaml_data, key, value):
-    minimal_yaml_data[key] = value
-    arch = get_host_architecture()
-
-    assert parts_lifecycle.apply_yaml(
-        minimal_yaml_data, build_on=arch, build_for=arch
-    ) == {
-        "name": "name",
-        "base": "core22",
-        "confinement": "strict",
-        "grade": "devel",
-        "version": "1.0",
-        "summary": "summary",
-        "description": "description",
-        "architectures": [Architecture(build_on=arch, build_for=arch)],
-        "parts": {"nil": {}, "snapcraft/core": {"plugin": "nil", key: ["foo"]}},
-    }
 
 
 def test_get_build_plan_single_element_matching(snapcraft_yaml, mocker, new_dir):

--- a/tests/unit/parts/test_yaml_utils.py
+++ b/tests/unit/parts/test_yaml_utils.py
@@ -22,6 +22,7 @@ import pytest
 
 from snapcraft import errors
 from snapcraft.parts import yaml_utils
+from snapcraft.projects import Architecture
 
 
 def test_yaml_load():
@@ -154,3 +155,47 @@ def test_yaml_load_no_base():
         )
 
     assert str(raised.value) == "no base defined"
+
+
+def test_extract_parse_info():
+    yaml_data = {
+        "name": "foo",
+        "parts": {"p1": {"plugin": "nil", "parse-info": "foo/metadata.xml"}, "p2": {}},
+    }
+    parse_info = yaml_utils.extract_parse_info(yaml_data)
+    assert yaml_data == {"name": "foo", "parts": {"p1": {"plugin": "nil"}, "p2": {}}}
+    assert parse_info == {"p1": "foo/metadata.xml"}
+
+
+@pytest.fixture
+def minimal_yaml_data():
+    return {
+        "name": "name",
+        "base": "core22",
+        "confinement": "strict",
+        "grade": "devel",
+        "version": "1.0",
+        "summary": "summary",
+        "description": "description",
+        "parts": {"nil": {}},
+    }
+
+
+@pytest.mark.parametrize("key", ("build-packages", "build-snaps"))
+@pytest.mark.parametrize("value", (["foo"], [{"on amd64": ["foo"]}]))
+def test_apply_yaml_defines_root_packages(minimal_yaml_data, key, value):
+    minimal_yaml_data[key] = value
+
+    assert yaml_utils.apply_yaml(
+        minimal_yaml_data, build_on="amd64", build_for="amd64"
+    ) == {
+        "name": "name",
+        "base": "core22",
+        "confinement": "strict",
+        "grade": "devel",
+        "version": "1.0",
+        "summary": "summary",
+        "description": "description",
+        "architectures": [Architecture(build_on="amd64", build_for="amd64")],
+        "parts": {"nil": {}, "snapcraft/core": {"plugin": "nil", key: ["foo"]}},
+    }


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `pytest tests/unit`?

-----

Move 4 `snapcraft.yaml` utility functions out of `lifecycle` module into the `yaml_utils` module.  No functional changes.

I've been wanting to do this for some time.  Working on #4318 is an excuse to get it done since it requires importing these functions.