### PR TITLE
fix: reprime for try

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -234,6 +234,9 @@ def _run_lifecycle_and_pack(
             step_name,
             shell=getattr(parsed_args, "shell", False),
             shell_after=getattr(parsed_args, "shell_after", False),
+            # Repriming needs to happen to take into account any changes to
+            # the actual target directory.
+            rerun_step=command_name == "try",
         )
 
     # Extract metadata and generate snap.yaml

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -141,10 +141,14 @@ class PartsLifecycle:
         *,
         shell: bool = False,
         shell_after: bool = False,
+        rerun_step: bool = False,
     ) -> None:
         """Run the parts lifecycle.
 
         :param target_step: The final step to execute.
+        :param shell: Enter a shell instead of running step_name.
+        :param shell: Enter a shell after running step_name.
+        :param rerun_step: Force running step_name.
 
         :raises PartsLifecycleError: On error during lifecycle.
         :raises RuntimeError: On unexpected error.
@@ -171,6 +175,15 @@ class PartsLifecycle:
 
             with self._lcm.action_executor() as aex:
                 for action in actions:
+                    if action.step == target_step and rerun_step:
+                        action = craft_parts.Action(
+                            part_name=action.part_name,
+                            step=action.step,
+                            action_type=ActionType.RERUN,
+                            reason="forced rerun",
+                            project_vars=action.project_vars,
+                            properties=action.properties,
+                        )
                     message = _action_message(action)
                     emit.progress(f"Executing parts lifecycle: {message}")
                     with emit.open_stream("Executing action") as stream:


### PR DESCRIPTION
This solves the case where prime was run before try, where a subsequent run of try would mask the contents of the existing prime directory with a newly mounted one from the host. In legacy we had the concept of `clean --unprime` to solve this.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
Fixes #4219 (in not the cleanest way)