### PR TITLE
docs(readme): add readthedocs build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-[![snapcraft](https://snapcraft.io/snapcraft/badge.svg)](https://snapcraft.io/snapcraft) [![Build Status][travis-image]][travis-url] [![Coverage Status][codecov-image]][codecov-url]
+[![snapcraft](https://snapcraft.io/snapcraft/badge.svg)](https://snapcraft.io/snapcraft)
+[![Build Status][travis-image]][travis-url]
+[![Documentation Status](https://readthedocs.com/projects/canonical-snapcraft/badge/?version=latest)](https://canonical-snapcraft.readthedocs-hosted.com/en/latest/?badge=latest)
+[![Coverage Status][codecov-image]][codecov-url]
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

Add build status badge for readthedocs.

I broke the badges into multiple lines for readability.

Preview here: https://github.com/snapcore/snapcraft/tree/docs-badge#readme