### PR TITLE
fix: support abstract socket listen-streams

### DIFF
--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -187,7 +187,9 @@ class Socket(ProjectModel):
                     f"{listen_stream!r} is not an integer between 1 and 65535 (inclusive)."
                 )
         elif isinstance(listen_stream, str):
-            if not re.match(r"^[A-Za-z0-9/._#:$-]*$", listen_stream):
+            if not listen_stream.startswith("@snap.") and not re.match(
+                r"^[A-Za-z0-9/._#:$-]*$", listen_stream
+            ):
                 raise ValueError(
                     f"{listen_stream!r} is not a valid socket path (e.g. /tmp/mysocket.sock)."
                 )

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -1053,7 +1053,9 @@ class TestAppValidation:
             assert project.apps is not None
             assert project.apps["app1"].command_chain == command_chain
 
-    @pytest.mark.parametrize("listen_stream", [1, 100, 65535, "/tmp/mysocket.sock"])
+    @pytest.mark.parametrize(
+        "listen_stream", [1, 100, 65535, "/tmp/mysocket.sock", "@snap.foo"]
+    )
     def test_app_sockets_valid_listen_stream(self, listen_stream, socket_yaml_data):
         data = socket_yaml_data(listen_stream=listen_stream)
 
@@ -1063,10 +1065,22 @@ class TestAppValidation:
         assert project.apps["app1"].sockets["socket1"].listen_stream == listen_stream
 
     @pytest.mark.parametrize("listen_stream", [-1, 0, 65536])
-    def test_app_sockets_invalid_listen_stream(self, listen_stream, socket_yaml_data):
+    def test_app_sockets_invalid_int_listen_stream(
+        self, listen_stream, socket_yaml_data
+    ):
         data = socket_yaml_data(listen_stream=listen_stream)
 
         error = f".*{listen_stream} is not an integer between 1 and 65535"
+        with pytest.raises(errors.ProjectValidationError, match=error):
+            Project.unmarshal(data)
+
+    @pytest.mark.parametrize("listen_stream", ["@foo"])
+    def test_app_sockets_invalid_socket_listen_stream(
+        self, listen_stream, socket_yaml_data
+    ):
+        data = socket_yaml_data(listen_stream=listen_stream)
+
+        error = f".*{listen_stream!r} is not a valid socket path.*"
         with pytest.raises(errors.ProjectValidationError, match=error):
             Project.unmarshal(data)
 


### PR DESCRIPTION
Rudimentary support for validating abstract sockets in listen-streams. The complete check will take place at `snap pack --check-skeleton` at the end of the process.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
Fixes #4287 