### PR TITLE
style(docs): fix linter errors for auto-generated commands

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -37,7 +37,10 @@ jobs:
           python -m pip install 'tox<5.0' tox-gh
           echo "::endgroup::"
           echo "::group::Create virtual environments for linting processes."
-          tox run -m lint --notest
+          tox run -m lint build-docs --notest
+          echo "::endgroup::"
+          echo "::group::Build docs."
+          tox run -e build-docs
           echo "::endgroup::"
           echo "::group::Wait for snap to complete"
           snap watch --last=install

--- a/snapcraft/commands/account.py
+++ b/snapcraft/commands/account.py
@@ -88,7 +88,7 @@ class StoreLoginCommand(BaseCommand):
             action="store_true",
             default=False,
             help=(
-                "Deprecated option to enable candid login. "
+                "(deprecated) Enable candid login. "
                 f"Set {store.constants.ENVIRONMENT_STORE_AUTH}=candid instead"
             ),
         )
@@ -179,7 +179,7 @@ class StoreExportLoginCommand(BaseCommand):
             action="store_true",
             default=False,
             help=(
-                "Deprecated option to enable candid login. "
+                "(deprecated) Enable candid login. "
                 f"Set {store.constants.ENVIRONMENT_STORE_AUTH}=candid instead"
             ),
         )

--- a/snapcraft/commands/legacy.py
+++ b/snapcraft/commands/legacy.py
@@ -98,12 +98,12 @@ class StoreLegacyPromoteCommand(LegacyBaseCommand):
 
         Prior to releasing, visual confirmation shall be required.
 
-        The format for channels is `[<track>/]<risk>[/<branch>]` where
+        The format for channels is ``[<track>/]<risk>[/<branch>]`` where
 
         - <track> is used to support long-term release channels. It is
           implicitly set to the default.
-        - <risk> is mandatory and must be one of `stable`, `candidate`,
-          `beta` or `edge`.
+        - <risk> is mandatory and must be one of ``stable``, ``candidate``,
+          ``beta`` or ``edge``.
         - <branch> is optional and dynamically creates a channel with a
           specific expiration date. Branches are specifically designed
           to support short-term hot fixes.

--- a/snapcraft/commands/lint.py
+++ b/snapcraft/commands/lint.py
@@ -53,7 +53,7 @@ class LintCommand(BaseCommand):
 
         The snap is installed and linted inside a build environment. If an assertion
         file exists in the same directory as the snap file with the name
-        `<snap-name>.assert`, it will be used to install the snap in the instance.
+        ``<snap-name>.assert``, it will be used to install the snap in the instance.
         """
     )
 

--- a/snapcraft/commands/manage.py
+++ b/snapcraft/commands/manage.py
@@ -39,19 +39,19 @@ class StoreReleaseCommand(BaseCommand):
         <channels> is a comma-separated list of valid channels in the store.
 
         The <revision> must exist in the store; to see available revisions,
-        run `snapcraft list-revisions <name>`.
+        run ``snapcraft list-revisions <name>``.
 
         The channel map will be displayed after the operation takes place. To see
-        the status map at any other time run `snapcraft status <name>`.
+        the status map at any other time run ``snapcraft status <name>``.
 
-        The format for a channel is `[<track>/]<risk>[/<branch>]` where
+        The format for a channel is ``[<track>/]<risk>[/<branch>]`` where
 
             - <track> is used to have long-term release channels. It is implicitly
-              set to `latest`. If this snap requires one, it can be created by
+              set to ``latest``. If this snap requires one, it can be created by
               request by having a conversation on https://forum.snapcraft.io
               under the *store* category.
-            - <risk> is mandatory and must be one of `stable`, `candidate`, `beta`
-              or `edge`.
+            - <risk> is mandatory and must be one of ``stable``, ``candidate``, ``beta``
+              or ``edge``.
             - <branch> is optional and dynamically creates a channel with a
               specific expiration date.
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

Autogenerated documentation needs to be created before running the linters.

You should be able to reproduce this problem on `main`:
```
tox run -e build-docs
tox run -e lint-docs # fails on autogenerated commands
```

2 separate commits so this is a rebase-and-merge.