### PR TITLE
docs(architectures): reword how to section

### DIFF
--- a/docs/howto/architectures.rst
+++ b/docs/howto/architectures.rst
@@ -162,8 +162,8 @@ core20
     - build-on: [amd64]
       run-on: [all]
 
-How to create a cross-compiling snap
-------------------------------------
+How to build a snap for a different architecture
+------------------------------------------------
 
 core22
 ^^^^^^


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

Use more accurate wording for building for a different architecture.  Remove 'cross-compiling' because snapcraft doesn't automatically cross-compile.

From @cmatsuoka's suggestion in https://github.com/snapcore/snapcraft/issues/4336#issuecomment-1712592331