### PR TITLE
ci: fix weekly spread tests, add status badge

### DIFF
--- a/.github/workflows/spread-scheduled.yaml
+++ b/.github/workflows/spread-scheduled.yaml
@@ -47,4 +47,4 @@ jobs:
           name: snap
       - name: Kernel plugin test
         run: |
-          spread google:ubuntu-22.04-64:tests/spread/plugin/${{ matrix.type }}/kernel
+          spread google:ubuntu-22.04-64:tests/spread/plugins/${{ matrix.type }}/kernel

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![snapcraft](https://snapcraft.io/snapcraft/badge.svg)](https://snapcraft.io/snapcraft)
 [![Build Status][travis-image]][travis-url]
 [![Documentation Status](https://readthedocs.com/projects/canonical-snapcraft/badge/?version=latest)](https://canonical-snapcraft.readthedocs-hosted.com/en/latest/?badge=latest)
+[![Scheduled spread tests](https://github.com/snapcore/snapcraft/actions/workflows/spread-scheduled.yaml/badge.svg?branch=main)](https://github.com/snapcore/snapcraft/actions/workflows/spread-scheduled.yaml)
 [![Coverage Status][codecov-image]][codecov-url]
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

The scheduled spread tests have never run successfully due to a minor typo.

The badge can be previewed here: https://github.com/snapcore/snapcraft/blob/weekly-spread/README.md