### PR TITLE
chore(deps): add pygit to doc requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -26,6 +26,7 @@ psutil==5.9.5
 pydantic==1.10.7
 pydantic-yaml==0.11.2
 pyelftools==0.29
+pygit2==1.13.0
 pylxd==2.3.1
 python-debian==0.1.49
 pyxdg==0.28


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

#4368 broke sphinx:

```
 python -m sphinx -T -E -W --keep-going -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
Running Sphinx v7.2.6
making output directory... done
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/canonical-snapcraft/checkouts/latest/tools/docs/gen_cli_docs.py", line 13, in <module>
    from snapcraft import cli
  File "/home/docs/checkouts/readthedocs.org/user_builds/canonical-snapcraft/checkouts/latest/tools/docs/../../snapcraft/cli.py", line 37, in <module>
    from . import commands
  File "/home/docs/checkouts/readthedocs.org/user_builds/canonical-snapcraft/checkouts/latest/tools/docs/../../snapcraft/commands/__init__.py", line 63, in <module>
    from .remote import RemoteBuildCommand
  File "/home/docs/checkouts/readthedocs.org/user_builds/canonical-snapcraft/checkouts/latest/tools/docs/../../snapcraft/commands/remote.py", line 33, in <module>
    from snapcraft.remote import is_repo
  File "/home/docs/checkouts/readthedocs.org/user_builds/canonical-snapcraft/checkouts/latest/tools/docs/../../snapcraft/remote/__init__.py", line 20, in <module>
    from .git import GitRepo, is_repo
  File "/home/docs/checkouts/readthedocs.org/user_builds/canonical-snapcraft/checkouts/latest/tools/docs/../../snapcraft/remote/git.py", line 22, in <module>
    import pygit2
ModuleNotFoundError: No module named 'pygit2'
```