### PR TITLE
fix(snap): add missing build-packages for git

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -26,7 +26,7 @@ psutil==5.9.5
 pydantic==1.10.7
 pydantic-yaml==0.11.2
 pyelftools==0.29
-pygit2==1.13.0
+pygit2==1.6.1
 pylxd==2.3.1
 python-debian==0.1.49
 pyxdg==0.28

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -71,7 +71,7 @@ pydocstyle==6.3.0
 pyelftools==0.29
 pyflakes==3.0.1
 pyftpdlib==1.5.7
-pygit2==1.13.0
+pygit2==1.6.1
 pylint==2.17.4
 pylint-fixme-info==1.0.3
 pylint-pytest==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ pycparser==2.21
 pydantic==1.10.7
 pydantic-yaml==0.11.2
 pyelftools==0.29
-pygit2==1.13.0
+pygit2==1.6.1
 pylxd==2.3.1
 pymacaroons==0.13.0
 PyNaCl==1.5.0

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,8 @@ install_requires = [
     "overrides",
     "progressbar",
     "pyelftools",
+    # https://www.pygit2.org/install.html#version-numbers
+    "pygit2<1.7",
     "pymacaroons",
     "pyxdg",
     "pyyaml",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,6 +31,7 @@ build-packages:
   - intltool
   - libapt-pkg-dev
   - libffi-dev
+  - libgit2-dev
   - libssl-dev
   - libsodium-dev
   - liblzma-dev


### PR DESCRIPTION
::       src/types.h:36:2: error: #error You need a compatible libgit2 version (1.7.x)
::          36 | #error You need a compatible libgit2 version (1.7.x)

Match version with table on
https://www.pygit2.org/install.html#version-numbers

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
