### PR TITLE
ci: download snap to tests dir

### DIFF
--- a/.github/workflows/spread-scheduled.yaml
+++ b/.github/workflows/spread-scheduled.yaml
@@ -22,6 +22,9 @@ jobs:
         with:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}
+      - name: Verify snapcraft snap
+        run: |
+          sudo snap install --dangerous --classic ${{ steps.snapcraft.outputs.snap }}
 
   kernel-plugins:
     runs-on: self-hosted
@@ -30,7 +33,6 @@ jobs:
       fail-fast: false
       matrix:
         type: [craft-parts, v2]
-
     steps:
       - name: Cleanup job workspace
         run: |
@@ -45,6 +47,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: snap
+          path: tests
       - name: Kernel plugin test
         run: |
           spread google:ubuntu-22.04-64:tests/spread/plugins/${{ matrix.type }}/kernel


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

The scheduled spread tests were not downloading the snap to the `tests/` directory.

I triggered a run and it is working now. See logs here: https://github.com/snapcore/snapcraft/actions/runs/6313456368