### PR TITLE
feat(remote-build): get build id

### DIFF
--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -131,6 +131,8 @@ class RemoteBuildCommand(BaseCommand):
         ):
             raise AcceptPublicUploadError()
 
+        # pylint: disable=attribute-defined-outside-init
+        self._snapcraft_yaml = yaml_utils.get_snap_project().project_file
         base = self._get_effective_base()
         self._run_new_or_fallback_remote_build(base)
 
@@ -219,26 +221,25 @@ class RemoteBuildCommand(BaseCommand):
 
         :returns: The project's effective base.
 
-        :raises SnapcraftError: If the base is unknown or missing or if the
-        snapcraft.yaml cannot be loaded.
+        :raises SnapcraftError: If the base is unknown or missing.
         :raises MaintenanceBase: If the base is not supported
         """
-        snapcraft_yaml = yaml_utils.get_snap_project().project_file
-
-        with open(snapcraft_yaml, encoding="utf-8") as file:
+        with open(self._snapcraft_yaml, encoding="utf-8") as file:
             base = yaml_utils.get_base(file)
 
         if base is None:
             raise SnapcraftError(
-                f"Could not determine base from {str(snapcraft_yaml)!r}."
+                f"Could not determine base from {str(self._snapcraft_yaml)!r}."
             )
 
-        emit.debug(f"Got base {base!r} from {str(snapcraft_yaml)!r}.")
+        emit.debug(f"Got base {base!r} from {str(self._snapcraft_yaml)!r}.")
 
         if base in yaml_utils.ESM_BASES:
             raise MaintenanceBase(base)
 
         if base not in yaml_utils.BASES:
-            raise SnapcraftError(f"Unknown base {base!r} in {str(snapcraft_yaml)!r}.")
+            raise SnapcraftError(
+                f"Unknown base {base!r} in {str(self._snapcraft_yaml)!r}."
+            )
 
         return base

--- a/snapcraft/parts/yaml_utils.py
+++ b/snapcraft/parts/yaml_utils.py
@@ -104,6 +104,19 @@ class _SafeLoader(yaml.SafeLoader):  # pylint: disable=too-many-ancestors
         )
 
 
+def safe_load(filestream: TextIO) -> Dict[str, Any]:
+    """Safe load and parse YAML-formatted file to a dictionary.
+
+    :returns: A dictionary containing the yaml data.
+
+    :raises SnapcraftError: if the file could not be loaded and parsed.
+    """
+    try:
+        return yaml.safe_load(filestream)
+    except yaml.error.YAMLError as err:
+        raise errors.SnapcraftError(f"snapcraft.yaml parsing error: {err!s}") from err
+
+
 def get_base(filestream: TextIO) -> Optional[str]:
     """Get the effective base from a snapcraft.yaml file.
 
@@ -113,16 +126,13 @@ def get_base(filestream: TextIO) -> Optional[str]:
 
     :raises SnapcraftError: If the yaml could not be loaded.
     """
-    try:
-        data = yaml.safe_load(filestream)
-        return utils.get_effective_base(
-            base=data.get("base"),
-            build_base=data.get("build-base"),
-            project_type=data.get("type"),
-            name=data.get("name"),
-        )
-    except yaml.error.YAMLError as err:
-        raise errors.SnapcraftError(f"snapcraft.yaml parsing error: {err!s}") from err
+    data = safe_load(filestream)
+    return utils.get_effective_base(
+        base=data.get("base"),
+        build_base=data.get("build-base"),
+        project_type=data.get("type"),
+        name=data.get("name"),
+    )
 
 
 def load(filestream: TextIO) -> Dict[str, Any]:

--- a/snapcraft/remote/__init__.py
+++ b/snapcraft/remote/__init__.py
@@ -18,8 +18,10 @@
 
 from .errors import GitError, RemoteBuildError
 from .git import GitRepo, is_repo
+from .utils import get_build_id
 
 __all__ = [
+    "get_build_id",
     "is_repo",
     "GitError",
     "GitRepo",

--- a/snapcraft/remote/utils.py
+++ b/snapcraft/remote/utils.py
@@ -1,0 +1,70 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Remote build utilities."""
+
+from functools import partial
+from hashlib import md5
+from pathlib import Path
+
+
+def get_build_id(app_name: str, project_name: str, project_path: Path) -> str:
+    """Get the build id for a project.
+
+    The build id is formatted as `snapcraft-<project-name>-<hash>`.
+    The hash is a hash of all files in the project directory.
+
+    :returns: The build id.
+
+    :raises SnapcraftError: If the snapcraft.yaml does not contain a 'name' keyword.
+    """
+    project_hash = _compute_hash(project_path)
+
+    return f"{app_name}-{project_name}-{project_hash}"
+
+
+def _compute_hash(directory: Path) -> str:
+    """Compute an md5 hash from the contents of the files in a directory.
+
+    If a file or its contents within the directory are modified, then the hash
+    will be different.
+
+    :returns: A string containing the md5 hash.
+
+    :raises FileNotFoundError: If the path is not a directory or does not exist.
+    """
+    if not directory.exists():
+        raise FileNotFoundError(
+            f"Could not compute hash because directory {str(directory.absolute())} "
+            "does not exist."
+        )
+    if not directory.is_dir():
+        raise FileNotFoundError(
+            f"Could not compute hash because {str(directory.absolute())} is not "
+            "a directory."
+        )
+
+    # sort the list of files for reproducibility
+    files = sorted([file for file in directory.glob("**/*") if file.is_file()])
+    md5_hash = md5()  # noqa: S324 (insecure-hash-function)
+
+    for file_path in files:
+        with open(file_path, "rb") as file:
+            # read files in chunks in case they are large
+            for block in iter(partial(file.read, 4096), b""):
+                md5_hash.update(block)
+
+    return md5_hash.hexdigest()

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -158,6 +158,18 @@ def test_remote_build_sudo_warns(emitter, mock_run_new_or_fallback_remote_build)
     mock_run_new_or_fallback_remote_build.assert_called_once()
 
 
+@pytest.mark.usefixtures("mock_argv", "mock_confirm")
+def test_cannot_load_snapcraft_yaml(capsys):
+    """Raise an error if the snapcraft.yaml does not exist."""
+    cli.run()
+
+    _, err = capsys.readouterr()
+    assert (
+        "Could not find snap/snapcraft.yaml. "
+        "Are you sure you are in the right directory?" in err
+    )
+
+
 ################################
 # Snapcraft project base tests #
 ################################
@@ -207,18 +219,6 @@ def test_get_effective_base_type(
     cli.run()
 
     mock_run_new_or_fallback_remote_build.assert_called_once_with(base)
-
-
-@pytest.mark.usefixtures("mock_argv", "mock_confirm")
-def test_get_effective_base_cannot_load_snapcraft_yaml(capsys):
-    """Raise an error if the snapcraft.yaml does not exist."""
-    cli.run()
-
-    _, err = capsys.readouterr()
-    assert (
-        "Could not find snap/snapcraft.yaml. "
-        "Are you sure you are in the right directory?" in err
-    )
 
 
 @pytest.mark.usefixtures("mock_argv", "mock_confirm")

--- a/tests/unit/remote/test_utils.py
+++ b/tests/unit/remote/test_utils.py
@@ -1,0 +1,105 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Remote-build utility tests."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from snapcraft.remote import get_build_id
+
+
+@pytest.mark.usefixtures("new_dir")
+def test_get_build_id():
+    """Get the build id."""
+    Path("test").write_text("Hello, World!", encoding="utf-8")
+
+    build_id = get_build_id("test-app", "test-project", Path())
+
+    assert re.match("test-app-test-project-[0-9a-f]{32}", build_id)
+
+
+@pytest.mark.usefixtures("new_dir")
+def test_get_build_id_empty_dir():
+    """An empty directory should still produce a valid build id."""
+    build_id = get_build_id("test-app", "test-project", Path())
+
+    assert re.match("test-app-test-project-[0-9a-f]{32}", build_id)
+
+
+@pytest.mark.usefixtures("new_dir")
+def test_get_build_id_is_reproducible():
+    """The build id should be the same when there are no changes to the directory."""
+    Path("test").write_text("Hello, World!", encoding="utf-8")
+
+    build_id_1 = get_build_id("test-app", "test-project", Path())
+    build_id_2 = get_build_id("test-app", "test-project", Path())
+
+    assert build_id_1 == build_id_2
+
+
+@pytest.mark.usefixtures("new_dir")
+def test_get_build_id_computed_is_unique_file_modified():
+    """The build id should change when a file is modified."""
+    Path("test1").write_text("Hello, World!", encoding="utf-8")
+    build_id_1 = get_build_id("test-app", "test-project", Path())
+
+    # adding a new file should change the build-id
+    Path("test2").write_text("Hello, World!", encoding="utf-8")
+    build_id_2 = get_build_id("test-app", "test-project", Path())
+
+    assert build_id_1 != build_id_2
+
+
+@pytest.mark.usefixtures("new_dir")
+def test_get_build_id_computed_is_unique_file_contents_modified():
+    """The build id should change when the contents of a file is modified."""
+    Path("test").write_text("Hello, World!", encoding="utf-8")
+    build_id_1 = get_build_id("test-app", "test-project", Path())
+
+    # modifying the contents of a file should change the build-id
+    Path("test").write_text("Goodbye, World!", encoding="utf-8")
+    build_id_2 = get_build_id("test-app", "test-project", Path())
+
+    assert build_id_1 != build_id_2
+
+
+@pytest.mark.usefixtures("new_dir")
+def test_get_build_id_directory_does_not_exist_error():
+    """Raise an error if the directory does not exist."""
+    with pytest.raises(FileNotFoundError) as raised:
+        get_build_id("test-app", "test-project", Path("does-not-exist"))
+
+    assert str(raised.value) == (
+        "Could not compute hash because directory "
+        f"{str(Path('does-not-exist').absolute())} does not exist."
+    )
+
+
+@pytest.mark.usefixtures("new_dir")
+def test_get_build_id_directory_is_not_a_directory_error():
+    """Raise an error if the directory is not a directory."""
+    Path("regular-file").touch()
+
+    with pytest.raises(FileNotFoundError) as raised:
+        get_build_id("test-app", "test-project", Path("regular-file"))
+
+    assert str(raised.value) == (
+        f"Could not compute hash because {str(Path('regular-file').absolute())} "
+        "is not a directory."
+    )


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

4 commits.  It's easiest to review one commit at a time.

Generates a build-id or uses the build-id provided at the command line.

Fixes #4322 
(CRAFT-1977)