### PR TITLE
feat(remote-build): add LaunchpadClient

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ ignore_missing_imports = true
 follow_imports = "silent"
 exclude = [
     "build",
+    # launchpadlib is not typed
+    "snapcraft/remote/launchpad.py",
     "snapcraft_legacy",
     "tests/spread",
     "tests/legacy",
@@ -65,7 +67,13 @@ plugins = [
 
 [tool.pyright]
 include = ["snapcraft", "tests"]
-exclude = ["tests/legacy", "tests/spread", "build"]
+exclude = [
+    "build",
+    # launchpadlib is not typed
+    "snapcraft/remote/launchpad.py",
+    "tests/legacy",
+    "tests/spread",
+]
 pythonVersion = "3.8"
 
 [tool.pytest.ini_options]

--- a/snapcraft/remote/__init__.py
+++ b/snapcraft/remote/__init__.py
@@ -18,11 +18,12 @@
 
 from .errors import GitError, RemoteBuildError
 from .git import GitRepo, is_repo
-from .utils import get_build_id
+from .utils import get_build_id, rmtree
 
 __all__ = [
     "get_build_id",
     "is_repo",
+    "rmtree",
     "GitError",
     "GitRepo",
     "RemoteBuildError",

--- a/snapcraft/remote/__init__.py
+++ b/snapcraft/remote/__init__.py
@@ -23,6 +23,7 @@ from .errors import (
     RemoteBuildTimeoutError,
 )
 from .git import GitRepo, is_repo
+from .launchpad import LaunchpadClient
 from .utils import get_build_id, rmtree
 
 __all__ = [
@@ -31,6 +32,7 @@ __all__ = [
     "rmtree",
     "GitError",
     "GitRepo",
+    "LaunchpadClient",
     "LaunchpadHttpsError",
     "RemoteBuildError",
     "RemoteBuildTimeoutError",

--- a/snapcraft/remote/__init__.py
+++ b/snapcraft/remote/__init__.py
@@ -16,7 +16,12 @@
 
 """Remote-build and related utilities."""
 
-from .errors import GitError, RemoteBuildError
+from .errors import (
+    GitError,
+    LaunchpadHttpsError,
+    RemoteBuildError,
+    RemoteBuildTimeoutError,
+)
 from .git import GitRepo, is_repo
 from .utils import get_build_id, rmtree
 
@@ -26,5 +31,7 @@ __all__ = [
     "rmtree",
     "GitError",
     "GitRepo",
+    "LaunchpadHttpsError",
     "RemoteBuildError",
+    "RemoteBuildTimeoutError",
 ]

--- a/snapcraft/remote/errors.py
+++ b/snapcraft/remote/errors.py
@@ -50,3 +50,22 @@ class GitError(RemoteBuildError):
         details = message
 
         super().__init__(brief=brief, details=details)
+
+
+class RemoteBuildTimeoutError(RemoteBuildError):
+    """Remote-build timed out."""
+
+    def __init__(self) -> None:
+        brief = "Remote build timed out."
+
+        super().__init__(brief=brief)
+
+
+class LaunchpadHttpsError(RemoteBuildError):
+    """Launchpad connectivity error."""
+
+    def __init__(self) -> None:
+        brief = "Failed to connect to Launchpad API service."
+        details = "Verify connectivity to https://api.launchpad.net and retry build."
+
+        super().__init__(brief=brief, details=details)

--- a/snapcraft/remote/git.py
+++ b/snapcraft/remote/git.py
@@ -17,7 +17,9 @@
 """Git repository class and helper utilities."""
 
 import logging
+import re
 from pathlib import Path
+from typing import Optional
 
 import pygit2
 
@@ -145,27 +147,40 @@ class GitRepo:
                 f"Could not initialize a git repository in {str(self.path)!r}."
             ) from error
 
-    def push_url(self, remote_url: str, remote_branch: str, ref: str = "HEAD") -> None:
+    def push_url(
+        self,
+        remote_url: str,
+        remote_branch: str,
+        ref: str = "HEAD",
+        token: Optional[str] = None,
+    ) -> None:
         """Push a reference to a branch on a remote url.
 
         :param remote_url: the remote repo URL to push to
         :param remote_branch: the branch on the remote to push to
         :param ref: name of shorthand ref to push (i.e. a branch, tag, or `HEAD`)
+        :param token: token in the url to hide in logs and errors
 
         :raises GitError: if the ref cannot be resolved or pushed
         """
         resolved_ref = self._resolve_ref(ref)
         refspec = f"{resolved_ref}:refs/heads/{remote_branch}"
 
+        # hide secret tokens embedded in a url
+        if token:
+            stripped_url = re.sub(token, "<token>", remote_url)
+        else:
+            stripped_url = remote_url
+
         logger.debug(
-            "Pushing %r to remote %r with refspec %r.", ref, remote_url, refspec
+            "Pushing %r to remote %r with refspec %r.", ref, stripped_url, refspec
         )
 
         try:
             self._repo.remotes.create_anonymous(remote_url).push([refspec])
         except pygit2.GitError as error:
             raise GitError(
-                f"Could not push {ref!r} to {remote_url!r} with refspec {refspec!r} "
+                f"Could not push {ref!r} to {stripped_url!r} with refspec {refspec!r} "
                 f"for the git repository in {str(self.path)!r}."
             ) from error
 

--- a/snapcraft/remote/launchpad.py
+++ b/snapcraft/remote/launchpad.py
@@ -1,0 +1,489 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import gzip
+import logging
+import os
+import shutil
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Sequence, Type
+from urllib.parse import unquote, urlsplit
+
+import requests
+from launchpadlib.launchpad import Launchpad
+from lazr import restfulclient
+from lazr.restfulclient.resource import Entry
+from xdg import BaseDirectory
+
+import snapcraft_legacy
+from snapcraft_legacy.internal.sources._git import Git
+from snapcraft_legacy.internal.sources.errors import SnapcraftPullError
+from snapcraft_legacy.project import Project
+
+from . import errors
+
+_LP_POLL_INTERVAL = 30
+_LP_SUCCESS_STATUS = "Successfully built"
+_LP_FAIL_STATUS = "Failed to build"
+
+logger = logging.getLogger(__name__)
+
+
+def _is_build_pending(build: Dict[str, Any]) -> bool:
+    # Possible values according to API documentation:
+    # - "Needs building"
+    # - "Successfully built"
+    # - "Failed to build"
+    # - "Dependency wait"
+    # - "Chroot problem"
+    # - "Build for superseded Source"
+    # - "Currently building"
+    # - "Failed to upload"
+    # - "Uploading build"
+    # - "Cancelling build"
+    # - "Cancelled build"
+    if _is_build_status_success(build) or _is_build_status_failure(build):
+        return False
+
+    return True
+
+
+def _is_build_status_success(build: Dict[str, Any]) -> bool:
+    build_state = build["buildstate"]
+    return build_state == "Successfully built"
+
+
+def _is_build_status_failure(build: Dict[str, Any]) -> bool:
+    build_state = build["buildstate"]
+    return build_state in ["Failed to build", "Cancelled build"]
+
+
+def _get_url_basename(url: str):
+    path = urlsplit(url).path
+    return unquote(path).split("/")[-1]
+
+
+class LaunchpadClient:
+    """Launchpad remote builder operations."""
+
+    def __init__(
+        self,
+        *,
+        project: Project,
+        build_id: str,
+        architectures: Sequence[str],
+        git_branch: str = "master",
+        core18_channel: str = "stable",
+        snapcraft_channel: str = "stable",
+        deadline: int = 0,
+        git_class: Type[Git] = Git,
+        running_snapcraft_version: str = snapcraft_legacy.__version__,
+    ) -> None:
+        self._git_class = git_class
+        if not self._git_class.check_command_installed():
+            raise errors.GitNotFoundProviderError(provider="Launchpad")
+
+        self._snap_name = project.info.name
+        self._build_id = build_id
+
+        self.architectures = architectures
+
+        self._lp_name = build_id
+        self._lp_git_branch = git_branch
+
+        self._core18_channel = core18_channel
+        self._snapcraft_channel = snapcraft_channel
+        self._running_snapcraft_version = running_snapcraft_version
+
+        self._cache_dir = self._create_cache_directory()
+        self._data_dir = self._create_data_directory()
+        self._credentials = os.path.join(self._data_dir, "credentials")
+
+        self._lp: Launchpad = self.login()
+        self.user = self._lp.me.name
+
+        self.deadline = deadline
+
+    @property
+    def architectures(self) -> Sequence[str]:
+        return self._architectures
+
+    @architectures.setter
+    def architectures(self, architectures: Sequence[str]) -> None:
+        self._lp_processors: Optional[Sequence[str]] = None
+
+        if architectures:
+            self._lp_processors = ["/+processors/" + a for a in architectures]
+
+        self._architectures = architectures
+
+    @property
+    def user(self) -> str:
+        return self._lp_user
+
+    @user.setter
+    def user(self, user: str) -> None:
+        self._lp_user = user
+        self._lp_owner = f"/~{user}"
+
+    def _check_timeout_deadline(self) -> None:
+        if self.deadline <= 0:
+            return
+
+        if int(time.time()) >= self.deadline:
+            raise errors.RemoteBuildTimeoutError()
+
+    def _create_data_directory(self) -> str:
+        data_dir = BaseDirectory.save_data_path("snapcraft", "provider", "launchpad")
+        os.makedirs(data_dir, mode=0o700, exist_ok=True)
+        return data_dir
+
+    def _create_cache_directory(self) -> str:
+        cache_dir = BaseDirectory.save_cache_path("snapcraft", "provider", "launchpad")
+        os.makedirs(cache_dir, mode=0o700, exist_ok=True)
+        return cache_dir
+
+    def _fetch_artifacts(self, snap: Entry) -> None:
+        """Fetch build arftifacts (logs and snaps)."""
+        builds = self._get_builds(snap)
+
+        logger.debug("Downloading artifacts...")
+        for build in builds:
+            self._download_build_artifacts(build)
+            self._download_log(build)
+
+    def _get_builds_collection_entry(self, snap: Entry) -> Optional[Entry]:
+        logger.debug("Fetching builds collection information from Launchpad...")
+        url = snap.builds_collection_link
+        return self._lp_load_url(url)
+
+    def _get_builds(self, snap: Entry) -> List[Dict[str, Any]]:
+        bc = self._get_builds_collection_entry(snap)
+        if bc is None:
+            return []
+
+        return bc.entries
+
+    def _get_snap(self) -> Optional[Entry]:
+        try:
+            return self._lp.snaps.getByName(name=self._lp_name, owner=self._lp_owner)
+        except restfulclient.errors.NotFound:
+            return None
+
+    def _issue_build_request(self, snap: Entry) -> Entry:
+        dist = self._lp.distributions["ubuntu"]
+        archive = dist.main_archive
+        return snap.requestBuilds(
+            archive=archive,
+            pocket="Updates",
+        )
+
+    def _lp_load_url(self, url: str) -> Entry:
+        """Load Launchpad url with a retry in case the connection is lost."""
+        try:
+            return self._lp.load(url)
+        except ConnectionResetError:
+            self._lp = self.login()
+            return self._lp.load(url)
+
+    def _wait_for_build_request_acceptance(
+        self, build_request: Entry, timeout: int = 0
+    ) -> None:
+        # Not be be confused with the actual build(s), this is
+        # ensuring that Launchpad accepts the build request.
+        while build_request.status == "Pending":
+            # Check to see if we've run out of time.
+            self._check_timeout_deadline()
+
+            logger.debug("Waiting on Launchpad build request...")
+            logger.debug(
+                f"status={build_request.status} error={build_request.error_message}"
+            )
+
+            time.sleep(1)
+
+            # Refresh status.
+            build_request.lp_refresh()
+
+        if build_request.status == "Failed":
+            # Build request failed.
+            self.cleanup()
+            raise errors.RemoteBuilderError(builder_error=build_request.error_message)
+        elif build_request.status != "Completed":
+            # Shouldn't end up here.
+            self.cleanup()
+            raise errors.RemoteBuilderError(
+                builder_error="Unknown builder error - reported status: {}".format(
+                    build_request.status
+                )
+            )
+        elif not build_request.builds.entries:
+            # Shouldn't end up here either.
+            self.cleanup()
+            raise errors.RemoteBuilderError(
+                builder_error="Unknown builder error - no build entries found."
+            )
+
+        build_number = _get_url_basename(build_request.self_link)
+        logger.debug(f"Build request accepted: {build_number}")
+
+    def login(self) -> Launchpad:
+        try:
+            return Launchpad.login_with(
+                "snapcraft remote-build {}".format(snapcraft_legacy.__version__),
+                "production",
+                self._cache_dir,
+                credentials_file=self._credentials,
+                version="devel",
+            )
+        except (ConnectionRefusedError, TimeoutError):
+            raise errors.LaunchpadHttpsError()
+
+    def get_git_repo_path(self) -> str:
+        return f"~{self._lp_user}/+git/{self._lp_name}"
+
+    def get_git_https_url(self, token: Optional[str] = None) -> str:
+        if token:
+            return f"https://{self._lp_user}:{token}@git.launchpad.net/~{self._lp_user}/+git/{self._lp_name}/"
+        else:
+            return f"https://{self._lp_user}@git.launchpad.net/~{self._lp_user}/+git/{self._lp_name}/"
+
+    def _create_git_repository(self, force=False) -> Entry:
+        """Create git repository."""
+        if force:
+            self._delete_git_repository()
+
+        logger.debug(
+            f"creating git repo: name={self._lp_name}, owner={self._lp_owner}, target={self._lp_owner}"
+        )
+        return self._lp.git_repositories.new(
+            name=self._lp_name, owner=self._lp_owner, target=self._lp_owner
+        )
+
+    def _delete_git_repository(self) -> None:
+        """Delete git repository."""
+        git_path = self.get_git_repo_path()
+        git_repo = self._lp.git_repositories.getByPath(path=git_path)
+
+        # git_repositories.getByPath returns None if git repo does not exist.
+        if git_repo is None:
+            return
+
+        logger.debug("Deleting source repository from Launchpad...")
+        git_repo.lp_delete()
+
+    def _create_snap(self, force=False) -> Entry:
+        """Create a snap recipe. Use force=true to replace existing snap."""
+        git_url = self.get_git_https_url()
+
+        if force:
+            self._delete_snap()
+
+        optional_kwargs = dict()
+        if self._lp_processors:
+            optional_kwargs["processors"] = self._lp_processors
+
+        logger.debug("Registering snap job on Launchpad...")
+        logger.debug(f"url=https://launchpad.net{self._lp_owner}/+snap/{self._lp_name}")
+
+        return self._lp.snaps.new(
+            name=self._lp_name,
+            owner=self._lp_owner,
+            git_repository_url=git_url,
+            git_path=self._lp_git_branch,
+            auto_build=False,
+            auto_build_archive="/ubuntu/+archive/primary",
+            auto_build_pocket="Updates",
+            **optional_kwargs,
+        )
+
+    def _delete_snap(self) -> None:
+        """Remove snap info and all associated files."""
+        snap = self._get_snap()
+        if snap is None:
+            return
+
+        logger.debug("Removing snap job from Launchpad...")
+        snap.lp_delete()
+
+    def cleanup(self) -> None:
+        """Delete snap and git repository from launchpad."""
+        self._delete_snap()
+        self._delete_git_repository()
+
+    def start_build(self, timeout: int = 0) -> None:
+        """Start build with specified timeout (time.time() in seconds)."""
+        snap = self._create_snap(force=True)
+
+        logger.debug("Issuing build request on Launchpad...")
+        build_request = self._issue_build_request(snap)
+        self._wait_for_build_request_acceptance(build_request, timeout=timeout)
+
+    def monitor_build(
+        self, interval: int = _LP_POLL_INTERVAL, timeout: int = 0
+    ) -> None:
+        """Check build progress, and download artifacts when ready."""
+        snap = self._get_snap()
+
+        while True:
+            # Check to see if we've run out of time.
+            self._check_timeout_deadline()
+
+            builds = self._get_builds(snap)
+            pending = False
+            timestamp = str(datetime.now())
+            logger.info(f"Build status as of {timestamp}:")
+            for build in builds:
+                state = build["buildstate"]
+                arch = build["arch_tag"]
+                logger.info(f"\tarch={arch}\tstate={state}")
+
+                if _is_build_pending(build):
+                    pending = True
+
+            if pending is False:
+                break
+
+            time.sleep(interval)
+
+        # Build is complete - download build artifacts.
+        self._fetch_artifacts(snap)
+
+    def get_build_status(self) -> Dict[str, str]:
+        """Get status of builds."""
+        snap = self._get_snap()
+        builds = self._get_builds(snap)
+        build_status: Dict[str, str] = dict()
+        for build in builds:
+            state = build["buildstate"]
+            arch = build["arch_tag"]
+            build_status[arch] = state
+
+        return build_status
+
+    def _get_logfile_name(self, arch: str) -> str:
+        n = 0
+        base_name = "{}_{}".format(self._snap_name, arch)
+        log_name = f"{base_name}.txt"
+
+        while os.path.isfile(log_name):
+            n += 1
+            log_name = f"{base_name}.{n}.txt"
+
+        return log_name
+
+    def _download_log(self, build: Dict[str, Any]) -> None:
+        url = build["build_log_url"]
+        arch = build["arch_tag"]
+        if url is None:
+            logger.info(f"No build log available for {arch!r}.")
+        else:
+            log_name = self._get_logfile_name(arch)
+            self._download_file(url=url, dst=log_name, gunzip=True)
+            logger.info(f"Build log available at {log_name!r}")
+
+        if _is_build_status_failure(build):
+            logger.error(f"Build failed for arch {arch!r}.")
+
+    def _download_file(self, *, url: str, dst: str, gunzip: bool = False) -> None:
+        # TODO: consolidate with, and use indicators.download_requests_stream
+        logger.debug(f"Downloading: {url}")
+        try:
+            with requests.get(url, stream=True) as response:
+                # Wrap response with gzipfile if gunzip is requested.
+                stream = response.raw
+                if gunzip:
+                    stream = gzip.GzipFile(fileobj=stream)
+                with open(dst, "wb") as f_dst:
+                    shutil.copyfileobj(stream, f_dst)
+                response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Error downloading {url}: {str(e)}")
+
+    def _download_build_artifacts(self, build: Dict[str, Any]) -> None:
+        arch = build["arch_tag"]
+        snap_build = self._lp_load_url(build["self_link"])
+        urls = snap_build.getFileUrls()
+
+        if not urls:
+            logger.error(f"Snap file not available for arch {arch!r}.")
+            return
+
+        for url in urls:
+            file_name = _get_url_basename(url)
+
+            self._download_file(url=url, dst=file_name)
+
+            if file_name.endswith(".snap"):
+                logger.info(f"Snapped {file_name}")
+            else:
+                logger.info(f"Fetched {file_name}")
+
+    def _gitify_repository(self, repo_dir: str) -> Git:
+        """Git-ify source repository tree.
+
+        :return: Git handler instance to git repository.
+        """
+        git_handler = self._git_class(repo_dir, repo_dir, silent=True)
+
+        # Init repo.
+        git_handler.init()
+
+        # Add all files found in repo.
+        for f in os.listdir(repo_dir):
+            if f != ".git":
+                git_handler.add(f)
+
+        # Commit files.
+        git_handler.commit(
+            f"committed by snapcraft version: {self._running_snapcraft_version}"
+        )
+
+        return git_handler
+
+    def has_outstanding_build(self) -> bool:
+        """Check if there is an existing build configured on Launchpad."""
+        snap = self._get_snap()
+        return snap is not None
+
+    def push_source_tree(self, repo_dir: str) -> None:
+        """Push source tree to Launchpad."""
+        git_handler = self._gitify_repository(repo_dir)
+        lp_repo = self._create_git_repository(force=True)
+        # This token will only be used once, immediately after issuing it,
+        # so it can have a short expiry time.  It's not a problem if it
+        # expires before the build completes, or even before the push
+        # completes.
+        date_expires = datetime.now(timezone.utc) + timedelta(minutes=1)
+        token = lp_repo.issueAccessToken(
+            description=f"snapcraft remote-build for {self._build_id}",
+            scopes=["repository:push"],
+            date_expires=date_expires.isoformat(),
+        )
+
+        url = self.get_git_https_url(token=token)
+        stripped_url = self.get_git_https_url(token="<token>")
+
+        logger.info(f"Sending build data to Launchpad... ({stripped_url})")
+
+        try:
+            git_handler.push(url, f"HEAD:{self._lp_git_branch}", force=True)
+        except SnapcraftPullError as error:
+            # Strip token from command.
+            command = error.command.replace(token, "<token>")  # type: ignore
+            exit_code = error.exit_code  # type: ignore
+            raise errors.LaunchpadGitPushError(command=command, exit_code=exit_code)

--- a/snapcraft/remote/utils.py
+++ b/snapcraft/remote/utils.py
@@ -16,6 +16,8 @@
 
 """Remote build utilities."""
 
+import shutil
+import stat
 from functools import partial
 from hashlib import md5
 from pathlib import Path
@@ -76,3 +78,27 @@ def _compute_hash(directory: Path) -> str:
 
     all_hashes = "".join(hashes).encode()
     return md5(all_hashes).hexdigest()  # noqa: S324 (insecure-hash-function)
+
+
+def rmtree(directory: Path) -> None:
+    """Cross-platform rmtree implementation.
+
+    :param directory: Directory to remove.
+    """
+    shutil.rmtree(
+        str(directory.resolve()),
+        onerror=_remove_readonly,  # type: ignore
+    )
+
+
+def _remove_readonly(func, filepath):
+    """Shutil onerror function to make read-only files writable.
+
+    Try setting file to writeable if error occurs during rmtree. Known to be required
+    on Windows where file is not writeable, but it is owned by the user (who can
+    set file permissions).
+
+    :param filepath: filepath to make writable
+    """
+    filepath.chmod(stat.S_IWRITE)
+    func(filepath)

--- a/tests/unit/remote/test_errors.py
+++ b/tests/unit/remote/test_errors.py
@@ -28,3 +28,34 @@ def test_git_error():
     )
     assert error.brief == "Git operation failed."
     assert error.details == "Error details."
+
+
+def test_remote_build_timeout_error():
+    """Test RemoteBuildTimeoutError."""
+    error = errors.RemoteBuildTimeoutError()
+
+    assert str(error) == "Remote build timed out."
+    assert (
+        repr(error)
+        == "RemoteBuildTimeoutError(brief='Remote build timed out.', details=None)"
+    )
+    assert error.brief == "Remote build timed out."
+
+
+def test_launchpad_https_error():
+    """Test LaunchpadHttpsError."""
+    error = errors.LaunchpadHttpsError()
+
+    assert str(error) == (
+        "Failed to connect to Launchpad API service.\n"
+        "Verify connectivity to https://api.launchpad.net and retry build."
+    )
+    assert repr(error) == (
+        "LaunchpadHttpsError(brief='Failed to connect to Launchpad API service.', "
+        "details='Verify connectivity to https://api.launchpad.net and retry build.')"
+    )
+
+    assert error.brief == "Failed to connect to Launchpad API service."
+    assert error.details == (
+        "Verify connectivity to https://api.launchpad.net and retry build."
+    )

--- a/tests/unit/remote/test_git.py
+++ b/tests/unit/remote/test_git.py
@@ -358,6 +358,51 @@ def test_push_url_refspec_unknown_ref(new_dir):
     )
 
 
+@pytest.mark.parametrize(
+    ("url", "expected_url"),
+    [
+        # no-op if token is not in url
+        ("fake-url", "fake-url"),
+        # hide single occurrence of the token
+        ("fake-url/test-token", "fake-url/<token>"),
+        # hide multiple occurrences of the token
+        ("fake-url/test-token/test-token", "fake-url/<token>/<token>"),
+    ],
+)
+def test_push_url_hide_token(url, expected_url, mocker, new_dir):
+    """Hide the token in the log and error output."""
+    mock_logs = mocker.patch("logging.Logger.debug")
+
+    repo = GitRepo(new_dir)
+    (repo.path / "test-file").touch()
+    repo.add_all()
+    repo.commit()
+    expected_error_details = (
+        f"Could not push 'HEAD' to {expected_url!r} with refspec "
+        "'.*:refs/heads/test-branch' for the git repository "
+        f"in {str(new_dir)!r}."
+    )
+
+    with pytest.raises(GitError) as raised:
+        repo.push_url(
+            remote_url=url,
+            remote_branch="test-branch",
+            token="test-token",
+        )
+
+    # token should be hidden in the log output
+    mock_logs.assert_called_with(
+        "Pushing %r to remote %r with refspec %r.",
+        "HEAD",
+        expected_url,
+        "refs/heads/main:refs/heads/test-branch",
+    )
+
+    # token should be hidden in the error message
+    assert raised.value.details is not None
+    assert re.match(expected_error_details, raised.value.details)
+
+
 def test_push_url_refspec_git_error(mocker, new_dir):
     """Raise an error if git fails when looking for a refspec."""
     mocker.patch(

--- a/tests/unit/remote/test_launchpad.py
+++ b/tests/unit/remote/test_launchpad.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2019 Canonical Ltd
+# Copyright (C) 2019, 2023 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,20 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import textwrap
 from datetime import datetime, timedelta, timezone
-from unittest import mock
+from pathlib import Path
+from typing import Optional
+from unittest.mock import ANY, MagicMock, Mock, call, patch
 
-import fixtures
-from testtools.matchers import Contains, Equals
+import pytest
 
-import snapcraft_legacy
-from snapcraft_legacy.internal.remote_build import LaunchpadClient, errors
-from snapcraft_legacy.internal.sources._git import Git
-from snapcraft_legacy.internal.sources.errors import SnapcraftPullError
-from tests.legacy import unit
-
-from . import TestDir
+from snapcraft.remote import LaunchpadClient, errors
 
 
 class FakeLaunchpadObject:
@@ -44,9 +38,11 @@ class FakeLaunchpadObject:
 
 
 class BuildImpl(FakeLaunchpadObject):
+    """Fake build implementation."""
+
     def __init__(self, fake_arch="i386"):
         self._fake_arch = fake_arch
-        self.getFileUrls_mock = mock.Mock(
+        self.getFileUrls_mock = Mock(
             return_value=[f"url_for/snap_file_{self._fake_arch}.snap"]
         )
 
@@ -55,7 +51,15 @@ class BuildImpl(FakeLaunchpadObject):
 
 
 class SnapBuildEntryImpl(FakeLaunchpadObject):
-    def __init__(self, arch_tag="", buildstate="", self_link="", build_log_url=""):
+    """Fake snap build entry."""
+
+    def __init__(
+        self,
+        arch_tag="",
+        buildstate="",
+        self_link="",
+        build_log_url: Optional[str] = "",
+    ):
         self.arch_tag = arch_tag
         self.buildstate = buildstate
         self.self_link = self_link
@@ -63,9 +67,10 @@ class SnapBuildEntryImpl(FakeLaunchpadObject):
 
 
 class SnapBuildsImpl(FakeLaunchpadObject):
-    def __init__(
-        self,
-        entries=[
+    """Fake snap builds."""
+
+    def __init__(self):
+        self.entries = [
             SnapBuildEntryImpl(
                 arch_tag="i386",
                 buildstate="Successfully built",
@@ -84,12 +89,12 @@ class SnapBuildsImpl(FakeLaunchpadObject):
                 self_link="http://build_self_link_2",
                 build_log_url=None,
             ),
-        ],
-    ):
-        self.entries = entries
+        ]
 
 
 class SnapBuildReqImpl(FakeLaunchpadObject):
+    """Fake snap build requests."""
+
     def __init__(
         self,
         status="Completed",
@@ -108,10 +113,12 @@ class SnapBuildReqImpl(FakeLaunchpadObject):
 
 
 class SnapImpl(FakeLaunchpadObject):
+    """Fake snap."""
+
     def __init__(self, builds_collection_link="http://builds_collection_link"):
         self._req = SnapBuildReqImpl()
-        self.lp_delete_mock = mock.Mock()
-        self.requestBuilds_mock = mock.Mock(return_value=self._req)
+        self.lp_delete_mock = Mock()
+        self.requestBuilds_mock = Mock(return_value=self._req)
         self.builds_collection_link = builds_collection_link
 
     def lp_delete(self, *args, **kw):
@@ -122,10 +129,12 @@ class SnapImpl(FakeLaunchpadObject):
 
 
 class SnapsImpl(FakeLaunchpadObject):
+    """Fake snaps."""
+
     def __init__(self):
         self._snap = SnapImpl()
-        self.getByName_mock = mock.Mock(return_value=self._snap)
-        self.new_mock = mock.Mock(return_value=self._snap)
+        self.getByName_mock = Mock(return_value=self._snap)
+        self.new_mock = Mock(return_value=self._snap)
 
     def getByName(self, *args, **kw):
         return self.getByName_mock(*args, **kw)
@@ -135,9 +144,11 @@ class SnapsImpl(FakeLaunchpadObject):
 
 
 class GitImpl(FakeLaunchpadObject):
+    """Fake git."""
+
     def __init__(self):
-        self.issueAccessToken_mock = mock.Mock(return_value="access-token")
-        self.lp_delete_mock = mock.Mock()
+        self.issueAccessToken_mock = Mock(return_value="access-token")
+        self.lp_delete_mock = Mock()
 
     def issueAccessToken(self, *args, **kw):
         return self.issueAccessToken_mock(*args, **kw)
@@ -147,10 +158,12 @@ class GitImpl(FakeLaunchpadObject):
 
 
 class GitRepositoriesImpl(FakeLaunchpadObject):
+    """Fake git repositories."""
+
     def __init__(self):
         self._git = GitImpl()
-        self.new_mock = mock.Mock(return_value=self._git)
-        self.getByPath_mock = mock.Mock(return_value=self._git)
+        self.new_mock = Mock(return_value=self._git)
+        self.getByPath_mock = Mock(return_value=self._git)
 
     def getByPath(self, *args, **kw):
         return self.getByPath_mock(*args, **kw)
@@ -160,19 +173,25 @@ class GitRepositoriesImpl(FakeLaunchpadObject):
 
 
 class DistImpl(FakeLaunchpadObject):
+    """Fake distributions."""
+
     def __init__(self):
         self.main_archive = "main_archive"
 
 
 class MeImpl(FakeLaunchpadObject):
+    """Fake 'me' object."""
+
     def __init__(self):
         self.name = "user"
 
 
 class LaunchpadImpl(FakeLaunchpadObject):
+    """Fake implementation of the Launchpad object."""
+
     def __init__(self):
-        self._login_mock = mock.Mock()
-        self._load_mock = mock.Mock()
+        self._login_mock = Mock()
+        self._load_mock = Mock()
         self._rbi = SnapBuildReqImpl()
 
         self.git_repositories = GitRepositoriesImpl()
@@ -186,306 +205,296 @@ class LaunchpadImpl(FakeLaunchpadObject):
         self._load_mock(url, *args, **kw)
         if "/+build-request/" in url:
             return self._rbi
-        elif "http://build_self_link_1" in url:
+        if "http://build_self_link_1" in url:
             return BuildImpl(fake_arch="i386")
-        elif "http://build_self_link_2" in url:
+        if "http://build_self_link_2" in url:
             return BuildImpl(fake_arch="amd64")
-        else:
-            return self._rbi.builds
+        return self._rbi.builds
 
 
-class LaunchpadTestCase(unit.TestCase):
-    def setUp(self):
-        super().setUp()
-        self._project = self._make_snapcraft_project()
-        self.lp = LaunchpadImpl()
-        self.fake_login_with = fixtures.MockPatch(
-            "launchpadlib.launchpad.Launchpad.login_with", return_value=self.lp
-        )
-        self.useFixture(self.fake_login_with)
+@pytest.fixture()
+def mock_git_repo(mocker):
+    """Returns a mocked GitRepo."""
+    return mocker.patch("snapcraft.remote.launchpad.GitRepo")
 
-        self.mock_git_class = mock.Mock(spec=Git)
-        self.mock_git_class.check_command_installed.return_value = True
 
-        self.lpc = LaunchpadClient(
-            project=self._project,
+@pytest.fixture()
+def mock_login_with(mocker):
+    """Mock for launchpadlib's `login_with()`."""
+    lp = LaunchpadImpl()
+    return mocker.patch("launchpadlib.launchpad.Launchpad.login_with", return_value=lp)
+
+
+@pytest.fixture()
+def launchpad_client(mock_login_with):
+    """Returns a LaunchpadClient object."""
+    return LaunchpadClient(
+        app_name="test-app",
+        build_id="id",
+        project_name="test-project",
+        architectures=[],
+    )
+
+
+def test_login(mock_login_with):
+    lpc = LaunchpadClient(
+        app_name="test-app",
+        build_id="id",
+        project_name="test-project",
+        architectures=[],
+    )
+
+    assert lpc.user == "user"
+
+    assert mock_login_with.called_with(
+        "test-app remote-build",
+        "production",
+        ANY,
+        credentials_file=ANY,
+        version="devel",
+    )
+
+
+@pytest.mark.parametrize("error", [ConnectionRefusedError, TimeoutError])
+def test_login_connection_issues(error, mock_login_with):
+    mock_login_with.side_effect = error
+
+    with pytest.raises(errors.LaunchpadHttpsError):
+        LaunchpadClient(
+            app_name="test-app",
             build_id="id",
+            project_name="test-project",
             architectures=[],
-            git_class=self.mock_git_class,
-            running_snapcraft_version="100.1234",
         )
 
-    def test_login(self):
-        self.assertThat(self.lpc.user, Equals("user"))
-        self.fake_login_with.mock.assert_called_with(
-            "snapcraft remote-build {}".format(snapcraft_legacy.__version__),
-            "production",
-            mock.ANY,
-            credentials_file=mock.ANY,
-            version="devel",
-        )
+    mock_login_with.assert_called()
 
-    def test_login_connection_issues(self):
-        self.fake_login_with.mock.side_effect = ConnectionRefusedError()
-        self.assertRaises(errors.LaunchpadHttpsError, self.lpc.login)
 
-        self.fake_login_with.mock.side_effect = TimeoutError()
-        self.assertRaises(errors.LaunchpadHttpsError, self.lpc.login)
+def test_load_connection_refused(launchpad_client, mock_login_with):
+    """ConnectionRefusedError should surface."""
+    launchpad_client._lp._load_mock.side_effect = ConnectionRefusedError
 
-    def test_load_connection_refused(self):
-        # ConnectionRefusedError should surface.
-        self.fake_login_with.mock.reset_mock()
-        self.lpc._lp._load_mock.side_effect = ConnectionRefusedError
-        self.assertRaises(ConnectionRefusedError, self.lpc._lp_load_url, "foo")
-        self.fake_login_with.mock.assert_not_called()
+    with pytest.raises(ConnectionRefusedError):
+        launchpad_client._lp_load_url("foo")
 
-    def test_load_connection_reset_once(self):
-        # Load URL should work OK after single connection reset.
-        self.fake_login_with.mock.reset_mock()
-        self.lpc._lp._load_mock.side_effect = [ConnectionResetError, None]
-        self.lpc._lp_load_url(url="foo")
-        self.fake_login_with.mock.assert_called()
+    mock_login_with.assert_called()
 
-    def test_load_connection_reset_twice(self):
-        # Load URL should fail with two connection resets.
-        self.fake_login_with.mock.reset_mock()
-        self.lpc._lp._load_mock.side_effect = [
-            ConnectionResetError,
-            ConnectionResetError,
-        ]
-        self.assertRaises(ConnectionResetError, self.lpc._lp_load_url, "foo")
-        self.fake_login_with.mock.assert_called()
 
-    def test_create_snap(self):
-        self.lpc._create_snap()
-        self.lpc._lp.snaps.new_mock.assert_called_with(
-            auto_build=False,
-            auto_build_archive="/ubuntu/+archive/primary",
-            auto_build_pocket="Updates",
-            git_path="master",
-            git_repository_url="https://user@git.launchpad.net/~user/+git/id/",
-            name="id",
-            owner="/~user",
-        )
+def test_load_connection_reset_once(launchpad_client, mock_login_with):
+    """Load URL should work OK after single connection reset."""
+    launchpad_client._lp._load_mock.side_effect = [ConnectionResetError, None]
+    launchpad_client._lp_load_url(url="foo")
 
-    def test_create_snap_with_archs(self):
-        self.lpc.architectures = ["arch1", "arch2"]
-        self.lpc._create_snap()
-        self.lpc._lp.snaps.new_mock.assert_called_with(
-            auto_build=False,
-            auto_build_archive="/ubuntu/+archive/primary",
-            auto_build_pocket="Updates",
-            git_path="master",
-            git_repository_url="https://user@git.launchpad.net/~user/+git/id/",
-            name="id",
-            owner="/~user",
-            processors=["/+processors/arch1", "/+processors/arch2"],
-        )
+    mock_login_with.assert_called()
 
-    def test_delete_snap(self):
-        self.lpc._delete_snap()
-        self.lpc._lp.snaps.getByName_mock.assert_called_with(name="id", owner="/~user")
 
-    def test_start_build(self):
-        self.lpc.start_build()
+def test_load_connection_reset_twice(launchpad_client, mock_login_with):
+    """Load URL should fail with two connection resets."""
+    launchpad_client._lp._load_mock.side_effect = [
+        ConnectionResetError,
+        ConnectionResetError,
+    ]
 
-    @mock.patch(
-        "tests.legacy.unit.remote_build.test_launchpad.SnapImpl.requestBuilds",
+    with pytest.raises(ConnectionResetError):
+        launchpad_client._lp_load_url("foo")
+
+    mock_login_with.assert_called()
+
+
+def test_create_snap(launchpad_client):
+    launchpad_client._create_snap()
+    launchpad_client._lp.snaps.new_mock.assert_called_with(
+        auto_build=False,
+        auto_build_archive="/ubuntu/+archive/primary",
+        auto_build_pocket="Updates",
+        git_path="main",
+        git_repository_url="https://user@git.launchpad.net/~user/+git/id/",
+        name="id",
+        owner="/~user",
+    )
+
+
+def test_create_snap_with_archs(launchpad_client):
+    launchpad_client.architectures = ["arch1", "arch2"]
+    launchpad_client._create_snap()
+    launchpad_client._lp.snaps.new_mock.assert_called_with(
+        auto_build=False,
+        auto_build_archive="/ubuntu/+archive/primary",
+        auto_build_pocket="Updates",
+        git_path="main",
+        git_repository_url="https://user@git.launchpad.net/~user/+git/id/",
+        name="id",
+        owner="/~user",
+        processors=["/+processors/arch1", "/+processors/arch2"],
+    )
+
+
+def test_delete_snap(launchpad_client):
+    launchpad_client._delete_snap()
+    launchpad_client._lp.snaps.getByName_mock.assert_called_with(
+        name="id", owner="/~user"
+    )
+
+
+def test_start_build(launchpad_client):
+    launchpad_client.start_build()
+
+
+def test_start_build_error(mocker, launchpad_client):
+    mocker.patch(
+        "tests.unit.remote.test_launchpad.SnapImpl.requestBuilds",
         return_value=SnapBuildReqImpl(
             status="Failed", error_message="snapcraft.yaml not found..."
         ),
     )
-    def test_start_build_error(self, mock_rb):
-        raised = self.assertRaises(errors.RemoteBuilderError, self.lpc.start_build)
-        self.assertThat(str(raised), Contains("snapcraft.yaml not found..."))
+    with pytest.raises(errors.RemoteBuildError) as raised:
+        launchpad_client.start_build()
 
-    @mock.patch(
-        "tests.legacy.unit.remote_build.test_launchpad.SnapImpl.requestBuilds",
+    assert str(raised.value) == "snapcraft.yaml not found..."
+
+
+def test_start_build_error_timeout(mocker, launchpad_client):
+    mocker.patch(
+        "tests.unit.remote.test_launchpad.SnapImpl.requestBuilds",
         return_value=SnapBuildReqImpl(status="Pending", error_message=""),
     )
-    @mock.patch("time.time", return_value=500)
-    def test_start_build_error_timeout(self, mock_time, mock_rb):
-        self.lpc.deadline = 499
-        raised = self.assertRaises(errors.RemoteBuildTimeoutError, self.lpc.start_build)
-        self.assertThat(
-            str(raised), Equals("Remote build exceeded configured timeout.")
+    mocker.patch("time.time", return_value=500)
+    launchpad_client._deadline = 499
+
+    with pytest.raises(errors.RemoteBuildTimeoutError) as raised:
+        launchpad_client.start_build()
+
+    assert str(raised.value) == "Remote build timed out."
+
+
+def test_issue_build_request_defaults(launchpad_client):
+    fake_snap = MagicMock()
+
+    launchpad_client._issue_build_request(fake_snap)
+
+    assert fake_snap.mock_calls == [
+        call.requestBuilds(
+            archive="main_archive",
+            pocket="Updates",
         )
+    ]
 
-    def test_issue_build_request_defaults(self):
-        fake_snap = mock.MagicMock()
 
-        self.lpc._issue_build_request(fake_snap)
+@patch("snapcraft.remote.LaunchpadClient._download_file")
+def test_monitor_build(mock_download_file, new_dir, launchpad_client):
+    Path("test-project_i386.txt", encoding="utf-8").touch()
+    Path("test-project_i386.1.txt", encoding="utf-8").touch()
 
-        self.assertThat(
-            fake_snap.mock_calls,
-            Equals(
-                [
-                    mock.call.requestBuilds(
-                        archive="main_archive",
-                        pocket="Updates",
-                    )
-                ]
-            ),
-        )
+    launchpad_client.start_build()
+    launchpad_client.monitor_build(interval=0)
 
-    @mock.patch("snapcraft_legacy.internal.remote_build.LaunchpadClient._download_file")
-    def test_monitor_build(self, mock_download_file):
-        open("test_i386.txt", "w").close()
-        open("test_i386.1.txt", "w").close()
+    assert mock_download_file.mock_calls == [
+        call(url="url_for/snap_file_i386.snap", dst="snap_file_i386.snap"),
+        call(
+            url="url_for/build_log_file_1", dst="test-project_i386.2.txt", gunzip=True
+        ),
+        call(url="url_for/snap_file_amd64.snap", dst="snap_file_amd64.snap"),
+        call(url="url_for/build_log_file_2", dst="test-project_amd64.txt", gunzip=True),
+        call(url="url_for/snap_file_amd64.snap", dst="snap_file_amd64.snap"),
+    ]
 
-        self.lpc.start_build()
-        self.lpc.monitor_build(interval=0)
-        self.assertThat(
-            mock_download_file.mock_calls,
-            Equals(
-                [
-                    mock.call(
-                        dst="snap_file_i386.snap", url="url_for/snap_file_i386.snap"
-                    ),
-                    mock.call(
-                        dst="test_i386.2.txt",
-                        gunzip=True,
-                        url="url_for/build_log_file_1",
-                    ),
-                    mock.call(
-                        dst="snap_file_amd64.snap", url="url_for/snap_file_amd64.snap"
-                    ),
-                    mock.call(
-                        dst="test_amd64.txt",
-                        gunzip=True,
-                        url="url_for/build_log_file_2",
-                    ),
-                    mock.call(
-                        dst="snap_file_amd64.snap", url="url_for/snap_file_amd64.snap"
-                    ),
-                ]
-            ),
-        )
 
-    @mock.patch("snapcraft_legacy.internal.remote_build.LaunchpadClient._download_file")
-    @mock.patch(
-        "tests.legacy.unit.remote_build.test_launchpad.BuildImpl.getFileUrls",
-        return_value=[],
+@patch("snapcraft.remote.LaunchpadClient._download_file")
+@patch("logging.Logger.error")
+def test_monitor_build_error(mock_log, mock_download_file, mocker, launchpad_client):
+    mocker.patch(
+        "tests.unit.remote.test_launchpad.BuildImpl.getFileUrls", return_value=[]
     )
-    @mock.patch("logging.Logger.error")
-    def test_monitor_build_error(self, mock_log, mock_urls, mock_download_file):
-        self.lpc.start_build()
-        self.lpc.monitor_build(interval=0)
-        mock_download_file.assert_has_calls(
-            [
-                mock.call(
-                    url="url_for/build_log_file_2", gunzip=True, dst="test_amd64.txt"
-                )
-            ]
-        )
-        self.assertThat(
-            mock_log.mock_calls,
-            Equals(
-                [
-                    mock.call("Snap file not available for arch 'i386'."),
-                    mock.call("Snap file not available for arch 'amd64'."),
-                    mock.call("Build failed for arch 'amd64'."),
-                    mock.call("Snap file not available for arch 'arm64'."),
-                    mock.call("Build failed for arch 'arm64'."),
-                ]
-            ),
-        )
+    launchpad_client.start_build()
+    launchpad_client.monitor_build(interval=0)
 
-    @mock.patch("snapcraft_legacy.internal.remote_build.LaunchpadClient._download_file")
-    @mock.patch("time.time", return_value=500)
-    def test_monitor_build_error_timeout(self, mock_time, mock_rb):
-        self.lpc.deadline = 499
-        self.lpc.start_build()
-        raised = self.assertRaises(
-            errors.RemoteBuildTimeoutError, self.lpc.monitor_build, interval=0
-        )
-        self.assertThat(
-            str(raised), Equals("Remote build exceeded configured timeout.")
-        )
+    assert mock_download_file.mock_calls == [
+        call(url="url_for/build_log_file_1", dst="test-project_i386.txt", gunzip=True),
+        call(url="url_for/build_log_file_2", dst="test-project_amd64.txt", gunzip=True),
+    ]
 
-    def test_get_build_status(self):
-        self.lpc.start_build()
-        build_status = self.lpc.get_build_status()
-        self.assertThat(
-            build_status,
-            Equals(
-                {
-                    "amd64": "Failed to build",
-                    "arm64": "Failed to build",
-                    "i386": "Successfully built",
-                }
-            ),
-        )
+    assert mock_log.mock_calls == [
+        call("Snap file not available for arch %r.", "i386"),
+        call("Snap file not available for arch %r.", "amd64"),
+        call("Build failed for arch %r.", "amd64"),
+        call("Snap file not available for arch %r.", "arm64"),
+        call("Build failed for arch %r.", "arm64"),
+    ]
 
-    def _make_snapcraft_project(self):
-        yaml = textwrap.dedent(
-            """\
-            name: test
-            base: core18
-            version: "1.0"
-            summary: test
-            description: test
-            confinement: strict
-            grade: stable
-            """
-        )
-        snapcraft_yaml_file_path = self.make_snapcraft_yaml(yaml)
-        project = snapcraft_legacy.project.Project(
-            snapcraft_yaml_file_path=snapcraft_yaml_file_path
-        )
-        return project
 
-    def test_git_repository_creation(self):
-        source_testdir = self.useFixture(TestDir())
-        source_testdir.create_file("foo")
-        repo_dir = source_testdir.path
+def test_monitor_build_error_timeout(mocker, launchpad_client):
+    mocker.patch("snapcraft.remote.LaunchpadClient._download_file")
+    mocker.patch("time.time", return_value=500)
+    launchpad_client._deadline = 499
+    launchpad_client.start_build()
 
-        self.lpc._gitify_repository(repo_dir)
+    with pytest.raises(errors.RemoteBuildTimeoutError) as raised:
+        launchpad_client.monitor_build(interval=0)
 
-        assert self.mock_git_class.mock_calls == [
-            mock.call.check_command_installed(),
-            mock.call(repo_dir, repo_dir, silent=True),
-            mock.call().init(),
-            mock.call().add("foo"),
-            mock.call().commit("committed by snapcraft version: 100.1234"),
+    assert str(raised.value) == "Remote build timed out."
+
+
+def test_get_build_status(launchpad_client):
+    launchpad_client.start_build()
+    build_status = launchpad_client.get_build_status()
+
+    assert build_status == {
+        "amd64": "Failed to build",
+        "arm64": "Failed to build",
+        "i386": "Successfully built",
+    }
+
+
+def test_git_repository_create_clean(mock_git_repo, launchpad_client):
+    mock_git_repo.return_value.is_clean.return_value = True
+    launchpad_client._gitify_repository(Path())
+
+    assert mock_git_repo.mock_calls == [
+        call(Path()),
+        call().is_clean(),
+    ]
+
+
+def test_git_repository_create_dirty(mock_git_repo, launchpad_client):
+    mock_git_repo.return_value.is_clean.return_value = False
+
+    launchpad_client._gitify_repository(Path())
+
+    assert mock_git_repo.mock_calls == [
+        call(Path()),
+        call().is_clean(),
+        call().add_all(),
+        call().commit(),
+    ]
+
+
+def test_push_source_tree(new_dir, mock_git_repo, launchpad_client):
+    now = datetime.now(timezone.utc)
+
+    with patch("snapcraft.remote.launchpad.datetime") as mock_datetime:
+        mock_datetime.now = lambda tz: now
+        launchpad_client.push_source_tree(Path())
+
+    launchpad_client._lp.git_repositories._git.issueAccessToken_mock.assert_called_once_with(
+        description="test-app remote-build for id",
+        scopes=["repository:push"],
+        date_expires=(now + timedelta(minutes=1)).isoformat(),
+    )
+
+    mock_git_repo.assert_has_calls(
+        [
+            call.push_url(
+                "https://user:access-token@git.launchpad.net/~user/+git/id/",
+                "main",
+                "HEAD",
+                "access-token",
+            )
         ]
+    )
 
-    def test_push_source_tree(self):
-        source_testdir = self.useFixture(TestDir())
-        repo_dir = source_testdir.path
-        now = datetime.now(timezone.utc)
 
-        with mock.patch(
-            "snapcraft_legacy.internal.remote_build._launchpad.datetime"
-        ) as mock_datetime:
-            mock_datetime.now = lambda tz: now
-            self.lpc.push_source_tree(repo_dir)
+def test_push_source_tree_error(new_dir, mock_git_repo, launchpad_client):
+    mock_git_repo.push_url.side_effect = errors.GitError("test error")
 
-        self.lpc._lp.git_repositories._git.issueAccessToken_mock.assert_called_once_with(
-            description="snapcraft remote-build for id",
-            scopes=["repository:push"],
-            date_expires=(now + timedelta(minutes=1)).isoformat(),
-        )
-        self.mock_git_class.assert_has_calls(
-            [
-                mock.call().push(
-                    "https://user:access-token@git.launchpad.net/~user/+git/id/",
-                    "HEAD:master",
-                    force=True,
-                )
-            ]
-        )
-
-    def test_push_source_tree_error(self):
-        self.mock_git_class.return_value.push.side_effect = (
-            SnapcraftPullError(
-                command="git push HEAD:master https://user:access-token@url",
-                exit_code=128,
-            ),
-        )
-        source_testdir = self.useFixture(TestDir())
-        repo_dir = source_testdir.path
-
-        self.assertRaises(
-            errors.LaunchpadGitPushError, self.lpc.push_source_tree, repo_dir
-        )
+    with pytest.raises(errors.GitError):
+        launchpad_client.push_source_tree(Path())

--- a/tests/unit/remote/test_launchpad.py
+++ b/tests/unit/remote/test_launchpad.py
@@ -1,0 +1,491 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+import fixtures
+from testtools.matchers import Contains, Equals
+
+import snapcraft_legacy
+from snapcraft_legacy.internal.remote_build import LaunchpadClient, errors
+from snapcraft_legacy.internal.sources._git import Git
+from snapcraft_legacy.internal.sources.errors import SnapcraftPullError
+from tests.legacy import unit
+
+from . import TestDir
+
+
+class FakeLaunchpadObject:
+    """Mimic behavior of many launchpad objects."""
+
+    def __init__(self):
+        pass
+
+    def __setitem__(self, key, value):
+        self.__setattr__(key, value)
+
+    def __getitem__(self, key):
+        return self.__getattribute__(key)
+
+
+class BuildImpl(FakeLaunchpadObject):
+    def __init__(self, fake_arch="i386"):
+        self._fake_arch = fake_arch
+        self.getFileUrls_mock = mock.Mock(
+            return_value=[f"url_for/snap_file_{self._fake_arch}.snap"]
+        )
+
+    def getFileUrls(self, *args, **kw):
+        return self.getFileUrls_mock(*args, **kw)
+
+
+class SnapBuildEntryImpl(FakeLaunchpadObject):
+    def __init__(self, arch_tag="", buildstate="", self_link="", build_log_url=""):
+        self.arch_tag = arch_tag
+        self.buildstate = buildstate
+        self.self_link = self_link
+        self.build_log_url = build_log_url
+
+
+class SnapBuildsImpl(FakeLaunchpadObject):
+    def __init__(
+        self,
+        entries=[
+            SnapBuildEntryImpl(
+                arch_tag="i386",
+                buildstate="Successfully built",
+                self_link="http://build_self_link_1",
+                build_log_url="url_for/build_log_file_1",
+            ),
+            SnapBuildEntryImpl(
+                arch_tag="amd64",
+                buildstate="Failed to build",
+                self_link="http://build_self_link_2",
+                build_log_url="url_for/build_log_file_2",
+            ),
+            SnapBuildEntryImpl(
+                arch_tag="arm64",
+                buildstate="Failed to build",
+                self_link="http://build_self_link_2",
+                build_log_url=None,
+            ),
+        ],
+    ):
+        self.entries = entries
+
+
+class SnapBuildReqImpl(FakeLaunchpadObject):
+    def __init__(
+        self,
+        status="Completed",
+        error_message="",
+        self_link="http://request_self_link/1234",
+        builds_collection_link="http://builds_collection_link",
+    ):
+        self.status = status
+        self.error_message = error_message
+        self.self_link = self_link
+        self.builds_collection_link = builds_collection_link
+        self.builds = SnapBuildsImpl()
+
+    def lp_refresh(self):
+        pass
+
+
+class SnapImpl(FakeLaunchpadObject):
+    def __init__(self, builds_collection_link="http://builds_collection_link"):
+        self._req = SnapBuildReqImpl()
+        self.lp_delete_mock = mock.Mock()
+        self.requestBuilds_mock = mock.Mock(return_value=self._req)
+        self.builds_collection_link = builds_collection_link
+
+    def lp_delete(self, *args, **kw):
+        return self.lp_delete_mock(*args, **kw)
+
+    def requestBuilds(self, *args, **kw):
+        return self.requestBuilds_mock(*args, **kw)
+
+
+class SnapsImpl(FakeLaunchpadObject):
+    def __init__(self):
+        self._snap = SnapImpl()
+        self.getByName_mock = mock.Mock(return_value=self._snap)
+        self.new_mock = mock.Mock(return_value=self._snap)
+
+    def getByName(self, *args, **kw):
+        return self.getByName_mock(*args, **kw)
+
+    def new(self, *args, **kw):
+        return self.new_mock(*args, **kw)
+
+
+class GitImpl(FakeLaunchpadObject):
+    def __init__(self):
+        self.issueAccessToken_mock = mock.Mock(return_value="access-token")
+        self.lp_delete_mock = mock.Mock()
+
+    def issueAccessToken(self, *args, **kw):
+        return self.issueAccessToken_mock(*args, **kw)
+
+    def lp_delete(self, *args, **kw):
+        return self.lp_delete_mock(*args, **kw)
+
+
+class GitRepositoriesImpl(FakeLaunchpadObject):
+    def __init__(self):
+        self._git = GitImpl()
+        self.new_mock = mock.Mock(return_value=self._git)
+        self.getByPath_mock = mock.Mock(return_value=self._git)
+
+    def getByPath(self, *args, **kw):
+        return self.getByPath_mock(*args, **kw)
+
+    def new(self, *args, **kw):
+        return self.new_mock(*args, **kw)
+
+
+class DistImpl(FakeLaunchpadObject):
+    def __init__(self):
+        self.main_archive = "main_archive"
+
+
+class MeImpl(FakeLaunchpadObject):
+    def __init__(self):
+        self.name = "user"
+
+
+class LaunchpadImpl(FakeLaunchpadObject):
+    def __init__(self):
+        self._login_mock = mock.Mock()
+        self._load_mock = mock.Mock()
+        self._rbi = SnapBuildReqImpl()
+
+        self.git_repositories = GitRepositoriesImpl()
+        self.snaps = SnapsImpl()
+        self.people = {"user": "/~user"}
+        self.distributions = {"ubuntu": DistImpl()}
+        self.rbi = self._rbi
+        self.me = MeImpl()
+
+    def load(self, url: str, *args, **kw):
+        self._load_mock(url, *args, **kw)
+        if "/+build-request/" in url:
+            return self._rbi
+        elif "http://build_self_link_1" in url:
+            return BuildImpl(fake_arch="i386")
+        elif "http://build_self_link_2" in url:
+            return BuildImpl(fake_arch="amd64")
+        else:
+            return self._rbi.builds
+
+
+class LaunchpadTestCase(unit.TestCase):
+    def setUp(self):
+        super().setUp()
+        self._project = self._make_snapcraft_project()
+        self.lp = LaunchpadImpl()
+        self.fake_login_with = fixtures.MockPatch(
+            "launchpadlib.launchpad.Launchpad.login_with", return_value=self.lp
+        )
+        self.useFixture(self.fake_login_with)
+
+        self.mock_git_class = mock.Mock(spec=Git)
+        self.mock_git_class.check_command_installed.return_value = True
+
+        self.lpc = LaunchpadClient(
+            project=self._project,
+            build_id="id",
+            architectures=[],
+            git_class=self.mock_git_class,
+            running_snapcraft_version="100.1234",
+        )
+
+    def test_login(self):
+        self.assertThat(self.lpc.user, Equals("user"))
+        self.fake_login_with.mock.assert_called_with(
+            "snapcraft remote-build {}".format(snapcraft_legacy.__version__),
+            "production",
+            mock.ANY,
+            credentials_file=mock.ANY,
+            version="devel",
+        )
+
+    def test_login_connection_issues(self):
+        self.fake_login_with.mock.side_effect = ConnectionRefusedError()
+        self.assertRaises(errors.LaunchpadHttpsError, self.lpc.login)
+
+        self.fake_login_with.mock.side_effect = TimeoutError()
+        self.assertRaises(errors.LaunchpadHttpsError, self.lpc.login)
+
+    def test_load_connection_refused(self):
+        # ConnectionRefusedError should surface.
+        self.fake_login_with.mock.reset_mock()
+        self.lpc._lp._load_mock.side_effect = ConnectionRefusedError
+        self.assertRaises(ConnectionRefusedError, self.lpc._lp_load_url, "foo")
+        self.fake_login_with.mock.assert_not_called()
+
+    def test_load_connection_reset_once(self):
+        # Load URL should work OK after single connection reset.
+        self.fake_login_with.mock.reset_mock()
+        self.lpc._lp._load_mock.side_effect = [ConnectionResetError, None]
+        self.lpc._lp_load_url(url="foo")
+        self.fake_login_with.mock.assert_called()
+
+    def test_load_connection_reset_twice(self):
+        # Load URL should fail with two connection resets.
+        self.fake_login_with.mock.reset_mock()
+        self.lpc._lp._load_mock.side_effect = [
+            ConnectionResetError,
+            ConnectionResetError,
+        ]
+        self.assertRaises(ConnectionResetError, self.lpc._lp_load_url, "foo")
+        self.fake_login_with.mock.assert_called()
+
+    def test_create_snap(self):
+        self.lpc._create_snap()
+        self.lpc._lp.snaps.new_mock.assert_called_with(
+            auto_build=False,
+            auto_build_archive="/ubuntu/+archive/primary",
+            auto_build_pocket="Updates",
+            git_path="master",
+            git_repository_url="https://user@git.launchpad.net/~user/+git/id/",
+            name="id",
+            owner="/~user",
+        )
+
+    def test_create_snap_with_archs(self):
+        self.lpc.architectures = ["arch1", "arch2"]
+        self.lpc._create_snap()
+        self.lpc._lp.snaps.new_mock.assert_called_with(
+            auto_build=False,
+            auto_build_archive="/ubuntu/+archive/primary",
+            auto_build_pocket="Updates",
+            git_path="master",
+            git_repository_url="https://user@git.launchpad.net/~user/+git/id/",
+            name="id",
+            owner="/~user",
+            processors=["/+processors/arch1", "/+processors/arch2"],
+        )
+
+    def test_delete_snap(self):
+        self.lpc._delete_snap()
+        self.lpc._lp.snaps.getByName_mock.assert_called_with(name="id", owner="/~user")
+
+    def test_start_build(self):
+        self.lpc.start_build()
+
+    @mock.patch(
+        "tests.legacy.unit.remote_build.test_launchpad.SnapImpl.requestBuilds",
+        return_value=SnapBuildReqImpl(
+            status="Failed", error_message="snapcraft.yaml not found..."
+        ),
+    )
+    def test_start_build_error(self, mock_rb):
+        raised = self.assertRaises(errors.RemoteBuilderError, self.lpc.start_build)
+        self.assertThat(str(raised), Contains("snapcraft.yaml not found..."))
+
+    @mock.patch(
+        "tests.legacy.unit.remote_build.test_launchpad.SnapImpl.requestBuilds",
+        return_value=SnapBuildReqImpl(status="Pending", error_message=""),
+    )
+    @mock.patch("time.time", return_value=500)
+    def test_start_build_error_timeout(self, mock_time, mock_rb):
+        self.lpc.deadline = 499
+        raised = self.assertRaises(errors.RemoteBuildTimeoutError, self.lpc.start_build)
+        self.assertThat(
+            str(raised), Equals("Remote build exceeded configured timeout.")
+        )
+
+    def test_issue_build_request_defaults(self):
+        fake_snap = mock.MagicMock()
+
+        self.lpc._issue_build_request(fake_snap)
+
+        self.assertThat(
+            fake_snap.mock_calls,
+            Equals(
+                [
+                    mock.call.requestBuilds(
+                        archive="main_archive",
+                        pocket="Updates",
+                    )
+                ]
+            ),
+        )
+
+    @mock.patch("snapcraft_legacy.internal.remote_build.LaunchpadClient._download_file")
+    def test_monitor_build(self, mock_download_file):
+        open("test_i386.txt", "w").close()
+        open("test_i386.1.txt", "w").close()
+
+        self.lpc.start_build()
+        self.lpc.monitor_build(interval=0)
+        self.assertThat(
+            mock_download_file.mock_calls,
+            Equals(
+                [
+                    mock.call(
+                        dst="snap_file_i386.snap", url="url_for/snap_file_i386.snap"
+                    ),
+                    mock.call(
+                        dst="test_i386.2.txt",
+                        gunzip=True,
+                        url="url_for/build_log_file_1",
+                    ),
+                    mock.call(
+                        dst="snap_file_amd64.snap", url="url_for/snap_file_amd64.snap"
+                    ),
+                    mock.call(
+                        dst="test_amd64.txt",
+                        gunzip=True,
+                        url="url_for/build_log_file_2",
+                    ),
+                    mock.call(
+                        dst="snap_file_amd64.snap", url="url_for/snap_file_amd64.snap"
+                    ),
+                ]
+            ),
+        )
+
+    @mock.patch("snapcraft_legacy.internal.remote_build.LaunchpadClient._download_file")
+    @mock.patch(
+        "tests.legacy.unit.remote_build.test_launchpad.BuildImpl.getFileUrls",
+        return_value=[],
+    )
+    @mock.patch("logging.Logger.error")
+    def test_monitor_build_error(self, mock_log, mock_urls, mock_download_file):
+        self.lpc.start_build()
+        self.lpc.monitor_build(interval=0)
+        mock_download_file.assert_has_calls(
+            [
+                mock.call(
+                    url="url_for/build_log_file_2", gunzip=True, dst="test_amd64.txt"
+                )
+            ]
+        )
+        self.assertThat(
+            mock_log.mock_calls,
+            Equals(
+                [
+                    mock.call("Snap file not available for arch 'i386'."),
+                    mock.call("Snap file not available for arch 'amd64'."),
+                    mock.call("Build failed for arch 'amd64'."),
+                    mock.call("Snap file not available for arch 'arm64'."),
+                    mock.call("Build failed for arch 'arm64'."),
+                ]
+            ),
+        )
+
+    @mock.patch("snapcraft_legacy.internal.remote_build.LaunchpadClient._download_file")
+    @mock.patch("time.time", return_value=500)
+    def test_monitor_build_error_timeout(self, mock_time, mock_rb):
+        self.lpc.deadline = 499
+        self.lpc.start_build()
+        raised = self.assertRaises(
+            errors.RemoteBuildTimeoutError, self.lpc.monitor_build, interval=0
+        )
+        self.assertThat(
+            str(raised), Equals("Remote build exceeded configured timeout.")
+        )
+
+    def test_get_build_status(self):
+        self.lpc.start_build()
+        build_status = self.lpc.get_build_status()
+        self.assertThat(
+            build_status,
+            Equals(
+                {
+                    "amd64": "Failed to build",
+                    "arm64": "Failed to build",
+                    "i386": "Successfully built",
+                }
+            ),
+        )
+
+    def _make_snapcraft_project(self):
+        yaml = textwrap.dedent(
+            """\
+            name: test
+            base: core18
+            version: "1.0"
+            summary: test
+            description: test
+            confinement: strict
+            grade: stable
+            """
+        )
+        snapcraft_yaml_file_path = self.make_snapcraft_yaml(yaml)
+        project = snapcraft_legacy.project.Project(
+            snapcraft_yaml_file_path=snapcraft_yaml_file_path
+        )
+        return project
+
+    def test_git_repository_creation(self):
+        source_testdir = self.useFixture(TestDir())
+        source_testdir.create_file("foo")
+        repo_dir = source_testdir.path
+
+        self.lpc._gitify_repository(repo_dir)
+
+        assert self.mock_git_class.mock_calls == [
+            mock.call.check_command_installed(),
+            mock.call(repo_dir, repo_dir, silent=True),
+            mock.call().init(),
+            mock.call().add("foo"),
+            mock.call().commit("committed by snapcraft version: 100.1234"),
+        ]
+
+    def test_push_source_tree(self):
+        source_testdir = self.useFixture(TestDir())
+        repo_dir = source_testdir.path
+        now = datetime.now(timezone.utc)
+
+        with mock.patch(
+            "snapcraft_legacy.internal.remote_build._launchpad.datetime"
+        ) as mock_datetime:
+            mock_datetime.now = lambda tz: now
+            self.lpc.push_source_tree(repo_dir)
+
+        self.lpc._lp.git_repositories._git.issueAccessToken_mock.assert_called_once_with(
+            description="snapcraft remote-build for id",
+            scopes=["repository:push"],
+            date_expires=(now + timedelta(minutes=1)).isoformat(),
+        )
+        self.mock_git_class.assert_has_calls(
+            [
+                mock.call().push(
+                    "https://user:access-token@git.launchpad.net/~user/+git/id/",
+                    "HEAD:master",
+                    force=True,
+                )
+            ]
+        )
+
+    def test_push_source_tree_error(self):
+        self.mock_git_class.return_value.push.side_effect = (
+            SnapcraftPullError(
+                command="git push HEAD:master https://user:access-token@url",
+                exit_code=128,
+            ),
+        )
+        source_testdir = self.useFixture(TestDir())
+        repo_dir = source_testdir.path
+
+        self.assertRaises(
+            errors.LaunchpadGitPushError, self.lpc.push_source_tree, repo_dir
+        )

--- a/tests/unit/remote/test_utils.py
+++ b/tests/unit/remote/test_utils.py
@@ -21,7 +21,11 @@ from pathlib import Path
 
 import pytest
 
-from snapcraft.remote import get_build_id
+from snapcraft.remote import get_build_id, rmtree
+
+##################
+# build id tests #
+##################
 
 
 @pytest.mark.usefixtures("new_dir")
@@ -103,3 +107,36 @@ def test_get_build_id_directory_is_not_a_directory_error():
         f"Could not compute hash because {str(Path('regular-file').absolute())} "
         "is not a directory."
     )
+
+
+################
+# rmtree tests #
+################
+
+
+@pytest.fixture()
+def stub_directory_tree(new_dir):
+    """Creates a tree of directories and files."""
+    root_dir = Path("root-dir")
+    (root_dir / "dir1/dir2").mkdir(parents=True, exist_ok=True)
+    (root_dir / "dir3").mkdir(parents=True, exist_ok=True)
+    (root_dir / "file1").touch()
+    (root_dir / "dir1/file2").touch()
+    (root_dir / "dir1/dir2/file3").touch()
+    return root_dir
+
+
+def test_rmtree(stub_directory_tree):
+    """Remove a directory tree."""
+    rmtree(stub_directory_tree)
+
+    assert not Path(stub_directory_tree).exists()
+
+
+def test_rmtree_readonly(stub_directory_tree):
+    """Remove a directory tree that contains a read-only file."""
+    (stub_directory_tree / "read-only-file").touch(mode=0o444)
+
+    rmtree(stub_directory_tree)
+
+    assert not Path(stub_directory_tree).exists()


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

Migrate `WorkTree`, `LaunchpadClient`, and their tests from `snapcraft_legacy`.  Reviewing by commit is the easiest.

Scope:
- Add extra errors and utilities
- Tweak the `GitRepo` class
- Migrate `WorkTree`, `LaunchpadClient`, and their unit tests
- Modernize to current code conventions and style
- Update tests from `unit.TestCase` to `pytest`

Note that the WorkTree class is pretty empty now.  It will get populated more as part of #4324.

Fixes #4323 
(CRAFT-1978)