### PR TITLE
feat(remote-build): new command logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,6 @@ ignore_missing_imports = true
 follow_imports = "silent"
 exclude = [
     "build",
-    # launchpadlib is not typed
-    "snapcraft/remote/launchpad.py",
     "snapcraft_legacy",
     "tests/spread",
     "tests/legacy",
@@ -67,13 +65,7 @@ plugins = [
 
 [tool.pyright]
 include = ["snapcraft", "tests"]
-exclude = [
-    "build",
-    # launchpadlib is not typed
-    "snapcraft/remote/launchpad.py",
-    "tests/legacy",
-    "tests/spread",
-]
+exclude = ["build", "tests/legacy", "tests/spread"]
 pythonVersion = "3.10"
 
 [tool.pytest.ini_options]

--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -314,7 +314,7 @@ class RemoteBuildCommand(BaseCommand):
 
         return base
 
-    def _get_project_architectures(self) -> List[str]:
+    def _get_project_build_on_architectures(self) -> List[str]:
         """Get a list of build-on architectures from the project's snapcraft.yaml.
 
         :returns: A list of architectures.
@@ -347,11 +347,11 @@ class RemoteBuildCommand(BaseCommand):
         :raises SnapcraftError: If `--build-on` was provided and architectures are
         defined in the project's snapcraft.yaml.
         """
-        project_architectures = self._get_project_architectures()
+        project_architectures = self._get_project_build_on_architectures()
         if project_architectures and self._parsed_args.build_for:
             raise SnapcraftError(
                 "Cannot use `--build-on` because architectures are already defined in "
-                "the snapcraft.yaml."
+                "snapcraft.yaml."
             )
 
         if project_architectures:

--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -242,20 +242,25 @@ class RemoteBuildCommand(BaseCommand):
             if self._parsed_args.recover or confirm_with_user(
                 "Do you wish to recover this build?", default=True
             ):
+                emit.progress("Building")
                 remote_builder.monitor_build()
+                emit.progress("Cleaning")
                 remote_builder.clean_build()
                 return
 
             # Otherwise clean running build before we start a new one.
-            emit.progress("Cleaning previously existing build.", permanent=True)
+            emit.progress("Cleaning previously existing build.")
             remote_builder.clean_build()
 
         emit.message(
             "If interrupted, resume with: 'snapcraft remote-build --recover "
             f"--build-id {remote_builder.build_id}'."
         )
+        emit.progress("Starting build")
         remote_builder.start_build()
+        emit.progress("Building")
         remote_builder.monitor_build()
+        emit.progress("Cleaning")
         remote_builder.clean_build()
 
     def _get_build_strategy(self) -> Optional[_Strategies]:

--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -30,9 +30,8 @@ from overrides import overrides
 from snapcraft.errors import MaintenanceBase, SnapcraftError
 from snapcraft.legacy_cli import run_legacy
 from snapcraft.parts import yaml_utils
-from snapcraft.remote import get_build_id, is_repo
+from snapcraft.remote import AcceptPublicUploadError, get_build_id, is_repo
 from snapcraft.utils import confirm_with_user, humanize_list
-from snapcraft_legacy.internal.remote_build.errors import AcceptPublicUploadError
 
 _CONFIRMATION_PROMPT = (
     "All data sent to remote builders will be publicly available. "

--- a/snapcraft/legacy_cli.py
+++ b/snapcraft/legacy_cli.py
@@ -25,7 +25,7 @@ import snapcraft
 import snapcraft_legacy
 from snapcraft_legacy.cli import legacy
 
-_LIB_NAMES = ("craft_parts", "craft_providers", "craft_store")
+_LIB_NAMES = ("craft_parts", "craft_providers", "craft_store", "snapcraft.remote")
 _ORIGINAL_LIB_NAME_LOG_LEVEL: Dict[str, int] = {}
 
 

--- a/snapcraft/remote/__init__.py
+++ b/snapcraft/remote/__init__.py
@@ -26,6 +26,7 @@ from .errors import (
 )
 from .git import GitRepo, is_repo
 from .launchpad import LaunchpadClient
+from .remote_builder import RemoteBuilder
 from .utils import get_build_id, humanize_list, rmtree, validate_architectures
 from .worktree import WorkTree
 
@@ -40,6 +41,7 @@ __all__ = [
     "GitRepo",
     "LaunchpadClient",
     "LaunchpadHttpsError",
+    "RemoteBuilder",
     "RemoteBuildError",
     "RemoteBuildTimeoutError",
     "UnsupportedArchitectureError",

--- a/snapcraft/remote/__init__.py
+++ b/snapcraft/remote/__init__.py
@@ -26,11 +26,12 @@ from .errors import (
 )
 from .git import GitRepo, is_repo
 from .launchpad import LaunchpadClient
-from .utils import get_build_id, rmtree, validate_architectures
+from .utils import get_build_id, humanize_list, rmtree, validate_architectures
 from .worktree import WorkTree
 
 __all__ = [
     "get_build_id",
+    "humanize_list",
     "is_repo",
     "rmtree",
     "validate_architectures",

--- a/snapcraft/remote/__init__.py
+++ b/snapcraft/remote/__init__.py
@@ -17,10 +17,12 @@
 """Remote-build and related utilities."""
 
 from .errors import (
+    AcceptPublicUploadError,
     GitError,
     LaunchpadHttpsError,
     RemoteBuildError,
     RemoteBuildTimeoutError,
+    UnsupportedArchitectureError,
 )
 from .git import GitRepo, is_repo
 from .launchpad import LaunchpadClient
@@ -31,11 +33,13 @@ __all__ = [
     "get_build_id",
     "is_repo",
     "rmtree",
+    "AcceptPublicUploadError",
     "GitError",
     "GitRepo",
     "LaunchpadClient",
     "LaunchpadHttpsError",
     "RemoteBuildError",
     "RemoteBuildTimeoutError",
+    "UnsupportedArchitectureError",
     "WorkTree",
 ]

--- a/snapcraft/remote/__init__.py
+++ b/snapcraft/remote/__init__.py
@@ -26,13 +26,14 @@ from .errors import (
 )
 from .git import GitRepo, is_repo
 from .launchpad import LaunchpadClient
-from .utils import get_build_id, rmtree
+from .utils import get_build_id, rmtree, validate_architectures
 from .worktree import WorkTree
 
 __all__ = [
     "get_build_id",
     "is_repo",
     "rmtree",
+    "validate_architectures",
     "AcceptPublicUploadError",
     "GitError",
     "GitRepo",

--- a/snapcraft/remote/errors.py
+++ b/snapcraft/remote/errors.py
@@ -17,7 +17,7 @@
 """Remote build errors."""
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 
 
 @dataclass(repr=True)
@@ -67,5 +67,34 @@ class LaunchpadHttpsError(RemoteBuildError):
     def __init__(self) -> None:
         brief = "Failed to connect to Launchpad API service."
         details = "Verify connectivity to https://api.launchpad.net and retry build."
+
+        super().__init__(brief=brief, details=details)
+
+
+class UnsupportedArchitectureError(RemoteBuildError):
+    """Unsupported architecture error."""
+
+    def __init__(self, architectures: List[str]) -> None:
+        brief = "Architecture not supported by the remote builder."
+        details = (
+            "The following architectures are not supported by the remote builder: "
+            f"{architectures}.\nPlease remove them from the "
+            "architecture list and try again."
+        )
+
+        super().__init__(brief=brief, details=details)
+
+
+class AcceptPublicUploadError(RemoteBuildError):
+    """Accept public upload error."""
+
+    def __init__(self) -> None:
+        brief = "Cannot upload data to build servers."
+        details = (
+            "Remote build needs explicit acknowledgement that data sent to build "
+            "servers is public.\n"
+            "In non-interactive runs, please use the option "
+            "`--launchpad-accept-public-upload`."
+        )
 
         super().__init__(brief=brief, details=details)

--- a/snapcraft/remote/git.py
+++ b/snapcraft/remote/git.py
@@ -137,7 +137,7 @@ class GitRepo:
 
         :raises GitError: if the repo cannot be initialized
         """
-        logger.debug("Initializing git repository in {str(self.path)!r}")
+        logger.debug("Initializing git repository in %r", str(self.path))
 
         try:
             pygit2.init_repository(self.path)

--- a/snapcraft/remote/launchpad.py
+++ b/snapcraft/remote/launchpad.py
@@ -162,8 +162,10 @@ class LaunchpadClient:
 
     def _get_builds_collection_entry(self, snap: Optional[Entry]) -> Optional[Entry]:
         logger.debug("Fetching builds collection information from Launchpad...")
-        url = snap.builds_collection_link  # type: ignore
-        return self._lp_load_url(cast(str, url))
+        if snap:
+            url = cast(str, snap.builds_collection_link)
+            return self._lp_load_url(url)
+        return None
 
     def _get_builds(self, snap: Optional[Entry]) -> List[Dict[str, Any]]:
         builds_collection = self._get_builds_collection_entry(snap)

--- a/snapcraft/remote/launchpad.py
+++ b/snapcraft/remote/launchpad.py
@@ -437,17 +437,6 @@ class LaunchpadClient:
             else:
                 logger.info("Fetched %s", file_name)
 
-    def _gitify_repository(self, repo_dir: Path) -> GitRepo:
-        """Git-ify source repository tree.
-
-        :return: Git handler instance to git repository.
-        """
-        repo = GitRepo(repo_dir)
-        if not repo.is_clean():
-            repo.add_all()
-            repo.commit()
-        return GitRepo
-
     def has_outstanding_build(self) -> bool:
         """Check if there is an existing build configured on Launchpad."""
         snap = self._get_snap()
@@ -455,7 +444,6 @@ class LaunchpadClient:
 
     def push_source_tree(self, repo_dir: Path) -> None:
         """Push source tree to Launchpad."""
-        git_handler = self._gitify_repository(repo_dir)
         lp_repo = self._create_git_repository(force=True)
         # This token will only be used once, immediately after issuing it,
         # so it can have a short expiry time.  It's not a problem if it
@@ -475,4 +463,5 @@ class LaunchpadClient:
 
         logger.info("Sending build data to Launchpad: %s", stripped_url)
 
-        git_handler.push_url(url, "main", "HEAD", token)
+        repo = GitRepo(repo_dir)
+        repo.push_url(url, "main", "HEAD", token)

--- a/snapcraft/remote/launchpad.py
+++ b/snapcraft/remote/launchpad.py
@@ -350,14 +350,16 @@ class LaunchpadClient:
             builds = self._get_builds(snap)
             pending = False
             timestamp = str(datetime.now())
-            logger.info("Build status as of %s:", timestamp)
+            status = f"Build status as of {timestamp}: "
             for build in builds:
                 state = build["buildstate"]
                 arch = build["arch_tag"]
-                logger.info("\tarch=%s\tstate=%s", arch, state)
+                status += f" {arch=} {state=}"
 
                 if _is_build_pending(build):
                     pending = True
+
+            logger.info(status)
 
             if pending is False:
                 break

--- a/snapcraft/remote/remote_builder.py
+++ b/snapcraft/remote/remote_builder.py
@@ -1,0 +1,133 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Manager for creating, monitoring, and cleaning remote builds."""
+
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+from .launchpad import LaunchpadClient
+from .utils import get_build_id, humanize_list, validate_architectures
+from .worktree import WorkTree
+
+logger = logging.getLogger(__name__)
+
+
+class RemoteBuilder:
+    """Remote builder class.
+
+    :param app_name: Name of the application.
+    :param build_id: Unique identifier for the build.
+    :param project_name: Name of the project.
+    :param architectures: List of architectures to build on.
+    :param project_dir: Path of the project.
+
+    :raises UnsupportedArchitectureError: if any architecture is not supported
+    for remote building.
+    :raises LaunchpadHttpsError: If a connection to Launchpad cannot be established.
+    """
+
+    def __init__(
+        self,
+        app_name: str,
+        build_id: Optional[str],
+        project_name: str,
+        architectures: List[str],
+        project_dir: Path,
+    ):
+        self._app_name = app_name
+        self._project_name = project_name
+        self._project_dir = project_dir
+
+        if build_id:
+            self._build_id = build_id
+        else:
+            self._build_id = get_build_id(
+                app_name=self._app_name,
+                project_name=self._project_name,
+                project_path=self._project_dir,
+            )
+
+        validate_architectures(architectures)
+        self._architectures = architectures
+
+        self._worktree = WorkTree(
+            app_name=self._app_name,
+            build_id=self._build_id,
+            project_dir=self._project_dir,
+        )
+
+        logger.debug("Setting up launchpad environment.")
+
+        self._lpc = LaunchpadClient(
+            app_name=self._app_name,
+            build_id=self._build_id,
+            project_name=self._project_name,
+            architectures=self._architectures,
+        )
+
+    @property
+    def build_id(self) -> str:
+        """Get the build id."""
+        return self._build_id
+
+    def print_status(self) -> None:
+        """Print the status of a remote build in Launchpad."""
+        if self._lpc.has_outstanding_build():
+            build_status = self._lpc.get_build_status()
+            for arch, status in build_status.items():
+                logger.info("Build status for arch %s: %s", arch, status)
+        else:
+            logger.info("No build found.")
+
+    def has_outstanding_build(self) -> bool:
+        """Check if there is an existing build on Launchpad.
+
+        :returns: True if there is an existing (incomplete) build on Launchpad.
+        """
+        return self._lpc.has_outstanding_build()
+
+    def monitor_build(self) -> None:
+        """Monitor and periodically log the status of a remote build in Launchpad."""
+        logger.info(
+            "Building snap package for %s. This may take some time to finish.",
+            humanize_list(self._lpc.architectures, "and", "{}"),
+        )
+
+        logger.info("Building...")
+        self._lpc.monitor_build()
+
+        logger.info("Build complete.")
+
+    def clean_build(self) -> None:
+        """Clean the cache and Launchpad build."""
+        logger.info("Cleaning existing builds and artefacts.")
+        self._lpc.cleanup()
+        self._worktree.clean_cache()
+        logger.info("Done.")
+
+    def start_build(self) -> None:
+        """Start a build in Launchpad.
+
+        A local copy of the project is created and pushed to Launchpad via git.
+        """
+        self._worktree.init_repo()
+
+        logger.debug("Cached project at %s", self._worktree.repo_dir)
+        self._lpc.push_source_tree(repo_dir=self._worktree.repo_dir)
+
+        self._lpc.start_build()

--- a/snapcraft/remote/utils.py
+++ b/snapcraft/remote/utils.py
@@ -21,7 +21,7 @@ import stat
 from functools import partial
 from hashlib import md5
 from pathlib import Path
-from typing import List
+from typing import Iterable, List
 
 from .errors import UnsupportedArchitectureError
 
@@ -98,6 +98,39 @@ def _compute_hash(directory: Path) -> str:
 
     all_hashes = "".join(hashes).encode()
     return md5(all_hashes).hexdigest()  # noqa: S324 (insecure-hash-function)
+
+
+def humanize_list(
+    items: Iterable[str],
+    conjunction: str,
+    item_format: str = "{!r}",
+    sort: bool = True,
+) -> str:
+    """Format a list into a human-readable string.
+
+    :param items: list to humanize.
+    :param conjunction: the conjunction used to join the final element to
+                        the rest of the list (e.g. 'and').
+    :param item_format: format string to use per item.
+    :param sort: if true, sort the list.
+    """
+    if not items:
+        return ""
+
+    quoted_items = [item_format.format(item) for item in items]
+
+    if sort:
+        quoted_items = sorted(quoted_items)
+
+    if len(quoted_items) == 1:
+        return quoted_items[0]
+
+    humanized = ", ".join(quoted_items[:-1])
+
+    if len(quoted_items) > 2:
+        humanized += ","
+
+    return f"{humanized} {conjunction} {quoted_items[-1]}"
 
 
 def rmtree(directory: Path) -> None:

--- a/snapcraft/remote/utils.py
+++ b/snapcraft/remote/utils.py
@@ -47,7 +47,7 @@ def validate_architectures(architectures: List[str]) -> None:
 def get_build_id(app_name: str, project_name: str, project_path: Path) -> str:
     """Get the build id for a project.
 
-    The build id is formatted as `snapcraft-<project-name>-<hash>`.
+    The build id is formatted as `<app_name>-<project-name>-<hash>`.
     The hash is a hash of all files in the project directory.
 
     :param app_name: Name of the application.

--- a/snapcraft/remote/utils.py
+++ b/snapcraft/remote/utils.py
@@ -23,6 +23,26 @@ from hashlib import md5
 from pathlib import Path
 from typing import List
 
+from .errors import UnsupportedArchitectureError
+
+_SUPPORTED_ARCHS = ["amd64", "arm64", "armhf", "i386", "ppc64el", "s390x"]
+
+
+def validate_architectures(architectures: List[str]) -> None:
+    """Validate that architectures are supported for remote building.
+
+    :param architectures: list of architectures to Validate
+
+    :raises UnsupportedArchitectureError: if any architecture in the list in not
+    supported for remote building.
+    """
+    unsupported_archs = []
+    for arch in architectures:
+        if arch not in _SUPPORTED_ARCHS:
+            unsupported_archs.append(arch)
+    if unsupported_archs:
+        raise UnsupportedArchitectureError(architectures=unsupported_archs)
+
 
 def get_build_id(app_name: str, project_name: str, project_path: Path) -> str:
     """Get the build id for a project.

--- a/snapcraft/remote/utils.py
+++ b/snapcraft/remote/utils.py
@@ -31,7 +31,7 @@ _SUPPORTED_ARCHS = ["amd64", "arm64", "armhf", "i386", "ppc64el", "s390x"]
 def validate_architectures(architectures: List[str]) -> None:
     """Validate that architectures are supported for remote building.
 
-    :param architectures: list of architectures to Validate
+    :param architectures: list of architectures to validate
 
     :raises UnsupportedArchitectureError: if any architecture in the list in not
     supported for remote building.
@@ -138,10 +138,7 @@ def rmtree(directory: Path) -> None:
 
     :param directory: Directory to remove.
     """
-    shutil.rmtree(
-        str(directory.resolve()),
-        onerror=_remove_readonly,  # type: ignore
-    )
+    shutil.rmtree(str(directory.resolve()), onerror=_remove_readonly)
 
 
 def _remove_readonly(func, filepath, _):

--- a/snapcraft/remote/worktree.py
+++ b/snapcraft/remote/worktree.py
@@ -14,25 +14,54 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Manages tree for remote builds."""
+"""Manages trees for remote builds."""
 
 from pathlib import Path
+from shutil import copytree
 
+from xdg import BaseDirectory
+
+from snapcraft.remote import GitRepo
 from snapcraft.remote.utils import rmtree
 
 
 class WorkTree:
-    """Class to manages tree for remote builds."""
+    """Class to manage trees for remote builds.
 
-    def __init__(self, worktree_dir: Path) -> None:
-        """Create remote-build WorkTree.
+    :param app_name: Name of the application.
+    :param build_id: Unique identifier for the build.
+    :param project_dir: Path to project directory.
+    """
 
-        :param worktree_dir: Directory to use for working tree.
-        """
-        # Working tree base directory.
-        self._base_dir = worktree_dir
-
-        # Initialize clean repo to ship to remote builder.
+    def __init__(self, app_name: str, build_id: str, project_dir: Path) -> None:
+        self._project_dir = project_dir
+        self._base_dir = Path(
+            BaseDirectory.save_cache_path(app_name, "remote-build", build_id)
+        )
         self._repo_dir = self._base_dir / "repo"
+
+    @property
+    def repo_dir(self) -> Path:
+        """Get path the cached repository."""
+        return self._repo_dir
+
+    def init_repo(self) -> None:
+        """Initialize a clean repo."""
         if self._repo_dir.exists():
             rmtree(self._repo_dir)
+
+        copytree(self._project_dir, self._repo_dir)
+
+        self._gitify_repository()
+
+    def _gitify_repository(self) -> None:
+        """Git-ify source repository tree."""
+        repo = GitRepo(self._repo_dir)
+        if not repo.is_clean():
+            repo.add_all()
+            repo.commit()
+
+    def clean_cache(self):
+        """Clean the cache."""
+        if self._base_dir.exists():
+            rmtree(self._base_dir)

--- a/snapcraft/remote/worktree.py
+++ b/snapcraft/remote/worktree.py
@@ -21,8 +21,8 @@ from shutil import copytree
 
 from xdg import BaseDirectory
 
-from snapcraft.remote import GitRepo
-from snapcraft.remote.utils import rmtree
+from .git import GitRepo
+from .utils import rmtree
 
 
 class WorkTree:

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -24,8 +24,7 @@ from yaml import safe_dump
 
 from snapcraft import cli
 from snapcraft.parts.yaml_utils import CURRENT_BASES, ESM_BASES, LEGACY_BASES
-from snapcraft.remote import GitRepo
-from snapcraft_legacy.internal.remote_build.errors import AcceptPublicUploadError
+from snapcraft.remote import AcceptPublicUploadError, GitRepo
 
 # remote-build control logic may check if the working dir is a git repo,
 # so execute all tests inside a test directory

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -469,6 +469,13 @@ def test_run_in_repo_newer_than_core22(emitter, mock_run_legacy, monkeypatch, ne
     )
 
 
+######################
+# Architecture tests #
+######################
+
+# TODO: add unit tests once control logic is added
+
+
 ##################
 # Build id tests #
 ##################

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -611,7 +611,7 @@ def test_determine_architectures_error(base, capsys, snapcraft_yaml, mocker):
     _, err = capsys.readouterr()
     assert (
         "Cannot use `--build-on` because architectures are already defined in "
-        "the snapcraft.yaml."
+        "snapcraft.yaml."
     ) in err
 
 

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -18,6 +18,7 @@
 
 import sys
 from pathlib import Path
+from unittest.mock import ANY, call
 
 import pytest
 from yaml import safe_dump
@@ -43,7 +44,7 @@ def use_new_remote_build(monkeypatch):
     monkeypatch.setenv("SNAPCRAFT_REMOTE_BUILD_STRATEGY", "disable-fallback")
 
 
-@pytest.fixture
+@pytest.fixture()
 def fake_sudo(monkeypatch):
     monkeypatch.setenv("SUDO_USER", "fake")
     monkeypatch.setattr("os.geteuid", lambda: 0)
@@ -55,7 +56,7 @@ def mock_argv(mocker):
     return mocker.patch.object(sys, "argv", ["snapcraft", "remote-build"])
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_confirm(mocker):
     return mocker.patch(
         "snapcraft.commands.remote.confirm_with_user", return_value=True
@@ -63,9 +64,23 @@ def mock_confirm(mocker):
 
 
 @pytest.fixture()
+def mock_remote_builder(mocker):
+    _mock_remote_builder = mocker.patch("snapcraft.commands.remote.RemoteBuilder")
+    _mock_remote_builder.return_value.has_outstanding_build.return_value = False
+    return _mock_remote_builder
+
+
+@pytest.fixture()
 def mock_run_new_or_fallback_remote_build(mocker):
     return mocker.patch(
         "snapcraft.commands.remote.RemoteBuildCommand._run_new_or_fallback_remote_build"
+    )
+
+
+@pytest.fixture()
+def mock_run_new_remote_build(mocker):
+    return mocker.patch(
+        "snapcraft.commands.remote.RemoteBuildCommand._run_new_remote_build"
     )
 
 
@@ -296,15 +311,12 @@ def test_get_effective_base_core18_esm_warning(
     "create_snapcraft_yaml", CURRENT_BASES - {"core22"}, indirect=True
 )
 @pytest.mark.usefixtures("create_snapcraft_yaml", "mock_confirm", "mock_argv")
-def test_run_newer_than_core_22(emitter, mock_run_legacy):
+def test_run_newer_than_core_22(emitter, mock_run_new_remote_build):
     """Bases newer than core22 must use new remote-build."""
     cli.run()
 
-    # this should fail when new remote-build code is used (#4323)
-    mock_run_legacy.assert_called_once()
-    emitter.assert_debug(
-        "Running fallback remote-build because new remote-build is not available."
-    )
+    mock_run_new_remote_build.assert_called_once()
+    emitter.assert_debug("Running new remote-build because base is newer than core22.")
 
 
 @pytest.mark.parametrize(
@@ -326,7 +338,9 @@ def test_run_core22_and_older(emitter, mock_run_legacy):
     "envvar", ["force-fallback", "disable-fallback", "badvalue", None]
 )
 @pytest.mark.usefixtures("create_snapcraft_yaml", "mock_confirm", "mock_argv")
-def test_run_envvar_newer_than_core22(envvar, emitter, mock_run_legacy, monkeypatch):
+def test_run_envvar_newer_than_core22(
+    envvar, emitter, mock_run_new_remote_build, monkeypatch
+):
     """Bases newer than core22 run new remote-build regardless of envvar."""
     if envvar:
         monkeypatch.setenv("SNAPCRAFT_REMOTE_BUILD_STRATEGY", envvar)
@@ -335,23 +349,21 @@ def test_run_envvar_newer_than_core22(envvar, emitter, mock_run_legacy, monkeypa
 
     cli.run()
 
-    mock_run_legacy.assert_called_once()
-    emitter.assert_debug(
-        "Running fallback remote-build because new remote-build is not available."
-    )
+    mock_run_new_remote_build.assert_called_once()
+    emitter.assert_debug("Running new remote-build because base is newer than core22.")
 
 
 @pytest.mark.parametrize(
     "create_snapcraft_yaml", LEGACY_BASES | {"core22"}, indirect=True
 )
 @pytest.mark.usefixtures("create_snapcraft_yaml", "mock_confirm", "mock_argv")
-def test_run_envvar_disable_fallback(emitter, mock_run_legacy, monkeypatch):
+def test_run_envvar_disable_fallback(emitter, mock_run_new_remote_build, monkeypatch):
     """core22 and older bases run new remote-build if envvar is `disable-fallback`."""
     monkeypatch.setenv("SNAPCRAFT_REMOTE_BUILD_STRATEGY", "disable-fallback")
 
     cli.run()
 
-    mock_run_legacy.assert_called_once()
+    mock_run_new_remote_build.assert_called_once()
     emitter.assert_debug(
         "Running new remote-build because environment variable "
         "'SNAPCRAFT_REMOTE_BUILD_STRATEGY' is 'disable-fallback'."
@@ -425,15 +437,14 @@ def test_run_envvar_invalid(capsys, emitter, mock_run_legacy, monkeypatch):
     "create_snapcraft_yaml", LEGACY_BASES | {"core22"}, indirect=True
 )
 @pytest.mark.usefixtures("create_snapcraft_yaml", "mock_confirm", "mock_argv")
-def test_run_in_repo(emitter, mock_run_legacy, new_dir):
+def test_run_in_repo(emitter, mock_run_new_remote_build, new_dir):
     """core22 and older bases run new remote-build if in a git repo."""
     # initialize a git repo
     GitRepo(new_dir)
 
     cli.run()
 
-    # this should fail when new remote-build code is used (#4323)
-    mock_run_legacy.assert_called_once()
+    mock_run_new_remote_build.assert_called_once()
     emitter.assert_debug(
         "Running new remote-build because project is in a git repository."
     )
@@ -455,75 +466,200 @@ def test_run_not_in_repo(emitter, mock_run_legacy):
     "create_snapcraft_yaml", CURRENT_BASES - {"core22"}, indirect=True
 )
 @pytest.mark.usefixtures("create_snapcraft_yaml", "mock_confirm", "mock_argv")
-def test_run_in_repo_newer_than_core22(emitter, mock_run_legacy, monkeypatch, new_dir):
+def test_run_in_repo_newer_than_core22(
+    emitter, mock_run_new_remote_build, monkeypatch, new_dir
+):
     """Bases newer than core22 run new remote-build regardless of being in a repo."""
     # initialize a git repo
     GitRepo(new_dir)
 
     cli.run()
 
-    # this should fail when new remote-build code is used (#4323)
-    mock_run_legacy.assert_called_once()
-    emitter.assert_debug(
-        "Running fallback remote-build because new remote-build is not available."
-    )
+    mock_run_new_remote_build.assert_called_once()
+    emitter.assert_debug("Running new remote-build because base is newer than core22.")
 
 
 ######################
 # Architecture tests #
 ######################
 
-# TODO: add unit tests once control logic is added
+
+@pytest.mark.parametrize("base", CURRENT_BASES | LEGACY_BASES)
+@pytest.mark.parametrize(
+    ["archs", "expected_archs"],
+    [
+        # single arch as scalar
+        ([{"build-on": "arm64", "build-for": "arm64"}], ["arm64"]),
+        # single arch as list
+        ([{"build-on": ["arm64"], "build-for": ["arm64"]}], ["arm64"]),
+        # no build-for as scalar
+        ([{"build-on": "arm64"}], ["arm64"]),
+        # no build-for as list
+        ([{"build-on": ["arm64"]}], ["arm64"]),
+        # multiple archs as scalars
+        (
+            [
+                {"build-on": "amd64", "build-for": "amd64"},
+                {"build-on": "arm64", "build-for": "arm64"},
+            ],
+            ["amd64", "arm64"],
+        ),
+        # multiple archs as lists
+        (
+            [
+                {"build-on": ["amd64"], "build-for": ["amd64"]},
+                {"build-on": ["arm64"], "build-for": ["arm64"]},
+            ],
+            ["amd64", "arm64"],
+        ),
+        # multiple build-ons
+        (
+            [
+                {"build-on": ["amd64", "arm64"], "build-for": "amd64"},
+                {"build-on": ["armhf", "powerpc"], "build-for": "arm64"},
+            ],
+            ["amd64", "arm64", "armhf", "powerpc"],
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_argv", "mock_confirm", "use_new_remote_build")
+def test_determine_architectures_from_snapcraft_yaml(
+    archs, expected_archs, base, snapcraft_yaml, mock_remote_builder
+):
+    """Parse `build-on` architectures from a snapcraft.yaml file."""
+    snapcraft_yaml(base=base, architectures=archs)
+
+    cli.run()
+
+    mock_remote_builder.assert_called_with(
+        app_name="snapcraft",
+        build_id=None,
+        project_name="mytest",
+        architectures=expected_archs,
+        project_dir=Path(),
+    )
+
+
+@pytest.mark.parametrize(
+    "create_snapcraft_yaml", CURRENT_BASES | LEGACY_BASES, indirect=True
+)
+@pytest.mark.usefixtures(
+    "create_snapcraft_yaml", "mock_argv", "mock_confirm", "use_new_remote_build"
+)
+def test_determine_architectures_host_arch(mocker, mock_remote_builder):
+    """Use host architecture if not defined in the snapcraft.yaml."""
+    mocker.patch(
+        "snapcraft.commands.remote.get_host_architecture", return_value="arm64"
+    )
+
+    cli.run()
+
+    mock_remote_builder.assert_called_with(
+        app_name="snapcraft",
+        build_id=None,
+        project_name="mytest",
+        architectures=["arm64"],
+        project_dir=Path(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_archs"),
+    [
+        (["--build-for", "amd64"], ["amd64"]),
+        (["--build-for", "amd64", "arm64"], ["amd64", "arm64"]),
+        # launchpad will accept and ignore duplicates
+        (["--build-for", "amd64", "amd64"], ["amd64", "amd64"]),
+    ],
+)
+@pytest.mark.parametrize(
+    "create_snapcraft_yaml", CURRENT_BASES | LEGACY_BASES, indirect=True
+)
+@pytest.mark.usefixtures(
+    "create_snapcraft_yaml", "mock_confirm", "use_new_remote_build"
+)
+def test_determine_architectures_provided_by_user(
+    args, expected_archs, mocker, mock_remote_builder
+):
+    """Use architectures provided by the user."""
+    mocker.patch.object(sys, "argv", ["snapcraft", "remote-build"] + args)
+
+    cli.run()
+
+    mock_remote_builder.assert_called_with(
+        app_name="snapcraft",
+        build_id=None,
+        project_name="mytest",
+        architectures=expected_archs,
+        project_dir=Path(),
+    )
+
+
+@pytest.mark.parametrize("base", CURRENT_BASES | LEGACY_BASES)
+@pytest.mark.usefixtures("mock_confirm", "use_new_remote_build")
+def test_determine_architectures_error(base, capsys, snapcraft_yaml, mocker):
+    """Error if `--build-for` is provided and archs are in the snapcraft.yaml."""
+    mocker.patch.object(
+        sys, "argv", ["snapcraft", "remote-build", "--build-for", "amd64"]
+    )
+    snapcraft_yaml(
+        base=base, architectures=[{"build-on": "arm64", "build-for": "arm64"}]
+    )
+
+    cli.run()
+
+    _, err = capsys.readouterr()
+    assert (
+        "Cannot use `--build-on` because architectures are already defined in "
+        "the snapcraft.yaml."
+    ) in err
 
 
 ##################
 # Build id tests #
 ##################
 
-# The build-id is not currently used, so these unit tests test the log output.
-# When #4323 is complete, these tests can be rewritten to verify the build-id passed
-# to the new remote-build code.
-
 
 @pytest.mark.parametrize(
     "create_snapcraft_yaml", CURRENT_BASES | LEGACY_BASES, indirect=True
 )
 @pytest.mark.usefixtures(
-    "create_snapcraft_yaml",
-    "mock_confirm",
-    "mock_argv",
-    "mock_run_legacy",
-    "use_new_remote_build",
+    "create_snapcraft_yaml", "mock_confirm", "use_new_remote_build"
 )
-def test_build_id_provided(emitter, mocker):
-    """Use the build id provided as an argument."""
+def test_build_id_provided(mocker, mock_remote_builder):
+    """Pass the build id provided as an argument."""
     mocker.patch.object(
         sys, "argv", ["snapcraft", "remote-build", "--build-id", "test-build-id"]
     )
 
     cli.run()
 
-    emitter.assert_debug("Using build ID 'test-build-id' passed as a parameter.")
+    mock_remote_builder.assert_called_with(
+        app_name="snapcraft",
+        build_id="test-build-id",
+        project_name="mytest",
+        architectures=ANY,
+        project_dir=Path(),
+    )
 
 
 @pytest.mark.parametrize(
     "create_snapcraft_yaml", CURRENT_BASES | LEGACY_BASES, indirect=True
 )
 @pytest.mark.usefixtures(
-    "create_snapcraft_yaml",
-    "mock_confirm",
-    "mock_argv",
-    "mock_run_legacy",
-    "use_new_remote_build",
+    "create_snapcraft_yaml", "mock_confirm", "mock_argv", "use_new_remote_build"
 )
-def test_build_id_computed(emitter):
-    """Compute the build id."""
+def test_build_id_not_provided(mock_remote_builder):
+    """Pass `None` for the build id if it is not provided as an argument."""
+
     cli.run()
 
-    # The create_snapcraft_yaml fixture uses the project name 'mytest'.
-    # Look for an md5 hash (a 32 character lowercase hex string).
-    emitter.assert_debug(
-        "Using computed build ID 'snapcraft-mytest-[0-9a-f]{32}'.", regex=True
+    mock_remote_builder.assert_called_with(
+        app_name="snapcraft",
+        build_id=None,
+        project_name="mytest",
+        architectures=ANY,
+        project_dir=Path(),
     )
 
 
@@ -551,3 +687,119 @@ def test_build_id_no_project_name_error(base, capsys):
 
     _, err = capsys.readouterr()
     assert "Could not get project name from 'snapcraft.yaml'." in err
+
+
+########################
+# Remote builder tests #
+########################
+
+
+@pytest.mark.parametrize(
+    "create_snapcraft_yaml", CURRENT_BASES | LEGACY_BASES, indirect=True
+)
+@pytest.mark.usefixtures(
+    "create_snapcraft_yaml", "mock_confirm", "use_new_remote_build"
+)
+def test_status(mocker, mock_remote_builder):
+    """Print the status when `--status` is provided."""
+    mocker.patch.object(sys, "argv", ["snapcraft", "remote-build", "--status"])
+
+    cli.run()
+
+    assert mock_remote_builder.mock_calls[-1] == call().print_status()
+
+
+@pytest.mark.parametrize(
+    "create_snapcraft_yaml", CURRENT_BASES | LEGACY_BASES, indirect=True
+)
+@pytest.mark.usefixtures(
+    "create_snapcraft_yaml",
+    "mock_confirm",
+    "mock_remote_builder",
+    "use_new_remote_build",
+)
+def test_recover_no_build(emitter, mocker):
+    """Warn if no build is found when `--recover` is provided."""
+    mocker.patch.object(sys, "argv", ["snapcraft", "remote-build", "--recover"])
+
+    cli.run()
+
+    emitter.assert_message("No build found.")
+
+
+@pytest.mark.parametrize(
+    "create_snapcraft_yaml", CURRENT_BASES | LEGACY_BASES, indirect=True
+)
+@pytest.mark.usefixtures(
+    "create_snapcraft_yaml", "mock_confirm", "use_new_remote_build"
+)
+def test_recover_build(emitter, mocker, mock_remote_builder):
+    """Recover a build when `--recover` is provided."""
+    mocker.patch.object(sys, "argv", ["snapcraft", "remote-build", "--recover"])
+    mock_remote_builder.return_value.has_outstanding_build.return_value = True
+
+    cli.run()
+
+    assert mock_remote_builder.mock_calls[-3:] == [
+        call().print_status(),
+        call().monitor_build(),
+        call().clean_build(),
+    ]
+
+
+@pytest.mark.parametrize(
+    "create_snapcraft_yaml", CURRENT_BASES | LEGACY_BASES, indirect=True
+)
+@pytest.mark.usefixtures(
+    "create_snapcraft_yaml", "mock_argv", "mock_confirm", "use_new_remote_build"
+)
+def test_recover_build_user_confirms(emitter, mocker, mock_remote_builder):
+    """Recover a build when a user confirms."""
+    mock_remote_builder.return_value.has_outstanding_build.return_value = True
+
+    cli.run()
+
+    assert mock_remote_builder.mock_calls[-3:] == [
+        call().print_status(),
+        call().monitor_build(),
+        call().clean_build(),
+    ]
+
+
+@pytest.mark.parametrize(
+    "create_snapcraft_yaml", CURRENT_BASES | LEGACY_BASES, indirect=True
+)
+@pytest.mark.usefixtures("create_snapcraft_yaml", "mock_argv", "use_new_remote_build")
+def test_recover_build_user_denies(emitter, mocker, mock_remote_builder):
+    """Clean and start a new build when a user denies to recover an existing build."""
+    mocker.patch(
+        # confirm data upload, deny build recovery
+        "snapcraft.commands.remote.confirm_with_user",
+        side_effect=[True, False],
+    )
+    mock_remote_builder.return_value.has_outstanding_build.return_value = True
+
+    cli.run()
+
+    assert mock_remote_builder.mock_calls[-3:] == [
+        call().start_build(),
+        call().monitor_build(),
+        call().clean_build(),
+    ]
+
+
+@pytest.mark.parametrize(
+    "create_snapcraft_yaml", CURRENT_BASES | LEGACY_BASES, indirect=True
+)
+@pytest.mark.usefixtures(
+    "create_snapcraft_yaml", "mock_argv", "mock_confirm", "use_new_remote_build"
+)
+def test_remote_build(emitter, mocker, mock_remote_builder):
+    """Clean and start a new build."""
+    cli.run()
+
+    assert mock_remote_builder.mock_calls[-3:] == [
+        call().start_build(),
+        call().monitor_build(),
+        call().clean_build(),
+    ]

--- a/tests/unit/remote/test_errors.py
+++ b/tests/unit/remote/test_errors.py
@@ -59,3 +59,54 @@ def test_launchpad_https_error():
     assert error.details == (
         "Verify connectivity to https://api.launchpad.net and retry build."
     )
+
+
+def test_unsupported_architecture_error():
+    """Test UnsupportedArchitectureError."""
+    error = errors.UnsupportedArchitectureError(architectures=["amd64", "arm64"])
+
+    assert str(error) == (
+        "Architecture not supported by the remote builder.\nThe following "
+        "architectures are not supported by the remote builder: ['amd64', 'arm64'].\n"
+        "Please remove them from the architecture list and try again."
+    )
+    assert repr(error) == (
+        "UnsupportedArchitectureError(brief='Architecture not supported by the remote "
+        "builder.', details=\"The following architectures are not supported by the "
+        "remote builder: ['amd64', 'arm64'].\\nPlease remove them from the "
+        'architecture list and try again.")'
+    )
+
+    assert error.brief == "Architecture not supported by the remote builder."
+    assert error.details == (
+        "The following architectures are not supported by the remote builder: "
+        "['amd64', 'arm64'].\nPlease remove them from the architecture list and "
+        "try again."
+    )
+
+
+def test_accept_public_upload_error():
+    """Test AcceptPublicUploadError."""
+    error = errors.AcceptPublicUploadError()
+
+    assert str(error) == (
+        "Cannot upload data to build servers.\nRemote build needs explicit "
+        "acknowledgement that data sent to build servers is public.\n"
+        "In non-interactive runs, please use the option "
+        "`--launchpad-accept-public-upload`."
+    )
+    assert repr(error) == (
+        "AcceptPublicUploadError(brief='Cannot upload data to build servers.', "
+        "details='Remote build needs explicit acknowledgement that data sent to build "
+        "servers is public.\\n"
+        "In non-interactive runs, please use the option "
+        "`--launchpad-accept-public-upload`.')"
+    )
+
+    assert error.brief == "Cannot upload data to build servers."
+    assert error.details == (
+        "Remote build needs explicit acknowledgement that data sent to build servers "
+        "is public.\n"
+        "In non-interactive runs, please use the option "
+        "`--launchpad-accept-public-upload`."
+    )

--- a/tests/unit/remote/test_remote_builder.py
+++ b/tests/unit/remote/test_remote_builder.py
@@ -1,0 +1,186 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Remote builder tests."""
+
+import re
+from pathlib import Path
+from unittest.mock import call, patch
+
+import pytest
+
+from snapcraft.remote import RemoteBuilder, UnsupportedArchitectureError
+from snapcraft.remote.utils import _SUPPORTED_ARCHS
+
+
+@pytest.fixture(autouse=True)
+def mock_launchpad_client(mocker):
+    """Returns a mocked LaunchpadClient."""
+    _mock_launchpad_client = mocker.patch(
+        "snapcraft.remote.remote_builder.LaunchpadClient"
+    )
+    _mock_launchpad_client.return_value.has_outstanding_build.return_value = False
+    _mock_launchpad_client.return_value.architectures = ["amd64"]
+    return _mock_launchpad_client
+
+
+@pytest.fixture(autouse=True)
+def mock_worktree(mocker):
+    """Returns a mocked WorkTree."""
+    return mocker.patch("snapcraft.remote.remote_builder.WorkTree")
+
+
+@pytest.fixture()
+def fake_remote_builder(new_dir, mock_launchpad_client, mock_worktree):
+    """Returns a fake RemoteBuilder."""
+    return RemoteBuilder(
+        app_name="test-app",
+        build_id="test-build-id",
+        project_name="test-project",
+        architectures=["amd64"],
+        project_dir=Path(),
+    )
+
+
+def test_remote_builder_init(mock_launchpad_client, mock_worktree):
+    """Verify remote builder is properly initialized."""
+    RemoteBuilder(
+        app_name="test-app",
+        build_id="test-build-id",
+        project_name="test-project",
+        architectures=["amd64"],
+        project_dir=Path(),
+    )
+
+    assert mock_launchpad_client.mock_calls == [
+        call(
+            app_name="test-app",
+            build_id="test-build-id",
+            project_name="test-project",
+            architectures=["amd64"],
+        )
+    ]
+    assert mock_worktree.mock_calls == [
+        call(app_name="test-app", build_id="test-build-id", project_dir=Path())
+    ]
+
+
+@pytest.mark.usefixtures("new_dir")
+def test_build_id_computed():
+    """Compute a build id if it is not provided."""
+    remote_builder = RemoteBuilder(
+        app_name="test-app",
+        build_id=None,
+        project_name="test-project",
+        architectures=["amd64"],
+        project_dir=Path(),
+    )
+
+    assert re.match("test-app-test-project-[0-9a-f]{32}", remote_builder.build_id)
+
+
+@pytest.mark.parametrize("archs", (["amd64"], _SUPPORTED_ARCHS))
+def test_validate_architectures_supported(archs):
+    """Supported architectures should not raise an error."""
+    RemoteBuilder(
+        app_name="test-app",
+        build_id="test-build-id",
+        project_name="test-project",
+        architectures=archs,
+        project_dir=Path(),
+    )
+
+
+@pytest.mark.parametrize(
+    "archs",
+    [
+        # unsupported
+        ["bad"],
+        # supported and unsupported
+        ["amd64", "bad"],
+        # multiple supported and unsupported
+        ["bad", "amd64", "bad2", "arm64"],
+    ],
+)
+def test_validate_architectures_unsupported(archs):
+    """Raise an error for unsupported architectures."""
+    with pytest.raises(UnsupportedArchitectureError):
+        RemoteBuilder(
+            app_name="test-app",
+            build_id="test-build-id",
+            project_name="test-project",
+            architectures=archs,
+            project_dir=Path(),
+        )
+
+
+@patch("logging.Logger.info")
+def test_print_status_builds_found(
+    mock_log, mock_launchpad_client, fake_remote_builder
+):
+    """Print the status of a remote build."""
+    mock_launchpad_client.return_value.has_outstanding_build.return_value = True
+    mock_launchpad_client.return_value.get_build_status.return_value = {
+        "amd64": "Needs building",
+        "arm64": "Currently building",
+    }
+
+    fake_remote_builder.print_status()
+
+    assert mock_log.mock_calls == [
+        call("Build status for arch %s: %s", "amd64", "Needs building"),
+        call("Build status for arch %s: %s", "arm64", "Currently building"),
+    ]
+
+
+@patch("logging.Logger.info")
+def test_print_status_no_build_found(mock_log, fake_remote_builder):
+    """Print the status of a remote build."""
+    fake_remote_builder.print_status()
+
+    assert mock_log.mock_calls == [call("No build found.")]
+
+
+@pytest.mark.parametrize("has_builds", (True, False))
+def test_has_outstanding_build(has_builds, fake_remote_builder, mock_launchpad_client):
+    """Check for outstanding builds."""
+    mock_launchpad_client.return_value.has_outstanding_build.return_value = has_builds
+
+    assert fake_remote_builder.has_outstanding_build() == has_builds
+
+
+def test_monitor_build(fake_remote_builder, mock_launchpad_client):
+    """Monitor a build."""
+    fake_remote_builder.monitor_build()
+
+    mock_launchpad_client.return_value.monitor_build.assert_called_once()
+
+
+def test_clean_build(fake_remote_builder, mock_launchpad_client, mock_worktree):
+    """Clean a build."""
+    fake_remote_builder.clean_build()
+
+    mock_launchpad_client.return_value.cleanup.assert_called_once()
+    mock_worktree.return_value.clean_cache.assert_called_once()
+
+
+def test_start_build(fake_remote_builder, mock_launchpad_client, mock_worktree):
+    """Start a build."""
+    fake_remote_builder.start_build()
+
+    mock_worktree.return_value.init_repo.assert_called_once()
+    mock_launchpad_client.return_value.push_source_tree.assert_called_once()
+    mock_launchpad_client.return_value.start_build.assert_called_once()

--- a/tests/unit/remote/test_utils.py
+++ b/tests/unit/remote/test_utils.py
@@ -24,6 +24,7 @@ import pytest
 from snapcraft.remote import (
     UnsupportedArchitectureError,
     get_build_id,
+    humanize_list,
     rmtree,
     validate_architectures,
 )
@@ -62,6 +63,46 @@ def test_validate_architectures_error(archs, expected_archs):
         "The following architectures are not supported by the remote builder: "
         f"{expected_archs}"
     ) in str(raised.value)
+
+
+#################
+# Humanize List #
+#################
+
+
+@pytest.mark.parametrize(
+    "items,conjunction,expected",
+    (
+        ([], "and", ""),
+        (["foo"], "and", "'foo'"),
+        (["foo", "bar"], "and", "'bar' and 'foo'"),
+        (["foo", "bar", "baz"], "and", "'bar', 'baz', and 'foo'"),
+        (["foo", "bar", "baz", "qux"], "and", "'bar', 'baz', 'foo', and 'qux'"),
+        ([], "or", ""),
+        (["foo"], "or", "'foo'"),
+        (["foo", "bar"], "or", "'bar' or 'foo'"),
+        (["foo", "bar", "baz"], "or", "'bar', 'baz', or 'foo'"),
+        (["foo", "bar", "baz", "qux"], "or", "'bar', 'baz', 'foo', or 'qux'"),
+    ),
+)
+def test_humanize_list(items, conjunction, expected):
+    """Test humanize_list."""
+    assert humanize_list(items, conjunction) == expected
+
+
+def test_humanize_list_sorted():
+    """Verify `sort` parameter."""
+    input_list = ["z", "a", "m test", "1"]
+
+    # unsorted list is in the same order as the original list
+    expected_list_unsorted = "'z', 'a', 'm test', and '1'"
+
+    # sorted list is sorted alphanumerically
+    expected_list_sorted = "'1', 'a', 'm test', and 'z'"
+
+    assert humanize_list(input_list, "and") == expected_list_sorted
+    assert humanize_list(input_list, "and", sort=True) == expected_list_sorted
+    assert humanize_list(input_list, "and", sort=False) == expected_list_unsorted
 
 
 ##################

--- a/tests/unit/remote/test_worktree.py
+++ b/tests/unit/remote/test_worktree.py
@@ -17,12 +17,75 @@
 """Unit tests for the worktree module."""
 
 from pathlib import Path
+from unittest.mock import call
+
+import pytest
 
 from snapcraft.remote import WorkTree
 
 
-def test_worktree_init(new_dir):
-    """Test initialization of WorkTree."""
-    worktree = WorkTree(Path())
+@pytest.fixture(autouse=True)
+def mock_git_repo(mocker):
+    """Returns a mocked GitRepo."""
+    return mocker.patch("snapcraft.remote.worktree.GitRepo")
+
+
+@pytest.fixture(autouse=True)
+def mock_base_directory(mocker, new_dir):
+    """Returns a mocked `xdg.BaseDirectory`."""
+    _mock_base_directory = mocker.patch("snapcraft.remote.worktree.BaseDirectory")
+    _mock_base_directory.save_cache_path.return_value = new_dir
+    return _mock_base_directory
+
+
+@pytest.fixture(autouse=True)
+def mock_copytree(mocker):
+    """Returns a mocked `shutil.copytree()`."""
+    return mocker.patch("snapcraft.remote.worktree.copytree")
+
+
+def test_worktree_init_clean(
+    mock_base_directory, mock_copytree, mock_git_repo, new_dir
+):
+    """Test initialization of a WorkTree with a clean git repository."""
+    mock_git_repo.return_value.is_clean.return_value = True
+
+    worktree = WorkTree(app_name="test-app", build_id="test-id", project_dir=Path())
+    worktree.init_repo()
 
     assert isinstance(worktree, WorkTree)
+    mock_base_directory.save_cache_path.assert_called_with(
+        "test-app", "remote-build", "test-id"
+    )
+    assert mock_git_repo.mock_calls == [
+        call(Path().resolve() / "repo"),
+        call().is_clean(),
+    ]
+
+
+def test_worktree_init_dirty(
+    mock_base_directory, mock_copytree, mock_git_repo, new_dir
+):
+    """Test initialization of a WorkTree with a clean git repository."""
+    mock_git_repo.return_value.is_clean.return_value = False
+
+    worktree = WorkTree(app_name="test-app", build_id="test-id", project_dir=Path())
+    worktree.init_repo()
+
+    assert isinstance(worktree, WorkTree)
+    mock_base_directory.save_cache_path.assert_called_with(
+        "test-app", "remote-build", "test-id"
+    )
+    assert mock_git_repo.mock_calls == [
+        call(Path().resolve() / "repo"),
+        call().is_clean(),
+        call().add_all(),
+        call().commit(),
+    ]
+
+
+def test_worktree_repo_dir(new_dir):
+    """Verify the `repo_dir` property."""
+    worktree = WorkTree(app_name="test-app", build_id="test-id", project_dir=Path())
+
+    assert worktree.repo_dir == Path().resolve() / "repo"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

- Migrate the command logic used to orchestrate a remote build.
  - Some of this code was moved to a new class, `RemoteBuild`
- Store a copy of the project directory in the local cache
- Clean up the cache after a build completes
- Typing and linting updates

Builds on #4390, so "only" the last 8 commits are for this PR (update: #4390 was landed and this PR is rebased onto main).  The new remote-build should be functional, so I encourage you to give it try.

Fixes #4324 
(CRAFT-1979)