### PR TITLE
fix(remote-build): warn instead of error when using unsupported bases

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -51,11 +51,9 @@ jobs:
     strategy:
       fail-fast: false  # Run all the tests to their conclusions.
       matrix:
-        platform: [ubuntu-20.04, ubuntu-22.04]
-        python_version: ["3.8", "3.10"]
+        platform: [ubuntu-22.04]
+        python_version: ["3.10"]
         include:
-          - python_version: "3.8"
-            tox_python: py38
           - python_version: "3.10"
             tox_python: py310
     runs-on: ${{ matrix.platform }}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   TIMESTAMP_SERVICE: http://timestamp.digicert.com
 
   matrix:
-  - PYTHON: C:\Python38-x64
+  - PYTHON: C:\Python310-x64
 
 cache:
 - '%LOCALAPPDATA%\pip\Cache\http'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ load-plugins = "pylint_fixme_info,pylint_pytest"
 min-similarity-lines=10
 
 [tool.mypy]
-python_version = 3.8
+python_version = 3.10
 ignore_missing_imports = true
 follow_imports = "silent"
 exclude = [
@@ -74,7 +74,7 @@ exclude = [
     "tests/legacy",
     "tests/spread",
 ]
-pythonVersion = "3.8"
+pythonVersion = "3.10"
 
 [tool.pytest.ini_options]
 minversion = 7.0

--- a/snapcraft/errors.py
+++ b/snapcraft/errors.py
@@ -138,6 +138,7 @@ class MaintenanceBase(SnapcraftError):
             resolution=resolution,
             docs_url="https://snapcraft.io/docs/base-snaps",
         )
+        self.base = base
 
 
 class StoreCredentialsUnauthorizedError(SnapcraftError):

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -220,7 +220,7 @@ def test_get_effective_base_with_build_base(
 
 
 @pytest.mark.usefixtures("mock_argv", "mock_confirm")
-@pytest.mark.parametrize("base", CURRENT_BASES | LEGACY_BASES)
+@pytest.mark.parametrize("base", CURRENT_BASES | LEGACY_BASES | ESM_BASES)
 def test_get_effective_base_type(
     base, snapcraft_yaml, mock_run_new_or_fallback_remote_build
 ):
@@ -255,15 +255,37 @@ def test_get_effective_base_none(capsys, snapcraft_yaml):
 
 
 @pytest.mark.usefixtures("mock_argv", "mock_confirm")
-@pytest.mark.parametrize("base", ESM_BASES)
-def test_get_effective_base_esm(base, capsys, snapcraft_yaml):
-    """Raise an error if an ESM base is used."""
-    snapcraft_yaml(base=base)
+def test_get_effective_base_core_esm_warning(
+    emitter, snapcraft_yaml, mock_run_new_or_fallback_remote_build
+):
+    """Warn if core, an ESM base, is used."""
+    snapcraft_yaml(base="core")
 
     cli.run()
 
-    _, err = capsys.readouterr()
-    assert f"{base!r} is not supported on this version of Snapcraft." in err
+    mock_run_new_or_fallback_remote_build.assert_called_once_with("core")
+    emitter.assert_progress(
+        "WARNING: base 'core' was last supported on Snapcraft 4 available on the "
+        "'4.x' channel.",
+        permanent=True,
+    )
+
+
+@pytest.mark.usefixtures("mock_argv", "mock_confirm")
+def test_get_effective_base_core18_esm_warning(
+    emitter, snapcraft_yaml, mock_run_new_or_fallback_remote_build
+):
+    """Warn if core18, an ESM base, is used."""
+    snapcraft_yaml(base="core18")
+
+    cli.run()
+
+    mock_run_new_or_fallback_remote_build.assert_called_once_with("core18")
+    emitter.assert_progress(
+        "WARNING: base 'core18' was last supported on Snapcraft 7 available on the "
+        "'7.x' channel.",
+        permanent=True,
+    )
 
 
 #######################

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@
 [tox]
 env_list =  # Environments to run when called with no parameters.
     lint-{black,ruff,isort,mypy,pylint,pyright,shellcheck,codespell,yaml}
-    test-py38
-    test-legacy-py38
+    test-py310
+    test-legacy-py310
 minversion = 4.5
 # Tox will use these requirements to bootstrap a venv if necessary.
 # tox-igore-env-name-mismatch allows us to have one virtualenv for all linting.
@@ -48,18 +48,18 @@ package = wheel
 allowlist_externals = mkdir
 commands_pre = mkdir -p results
 
-[testenv:test-{py38,py39,py310,py311,py312}]  # Configuration for all tests using pytest
+[testenv:test-{py39,py310,py311,py312}]  # Configuration for all tests using pytest
 base = testenv, test
 description = Run unit tests with pytest
 labels =
-    py38, py310, py311: tests, unit-tests
+    py310, py311: tests, unit-tests
 commands = pytest {tty:--color=yes} --cov=snapcraft --cov-report=xml:results/coverage-{env_name}.xml --junit-xml=results/test-results-{env_name}.xml {posargs:tests/unit}
 
-[testenv:test-legacy-{py38,py39,py310,py311,py312}]
+[testenv:test-legacy-{py39,py310,py311,py312}]
 base = testenv, test
 description = Run legacy tests with pytest
 labels =
-    py38, py310, py311: tests, integration-tests
+    py310, py311: tests, integration-tests
 commands = pytest {tty:--color=yes} --cov=snapcraft_legacy --cov-report=xml:results/coverage-{env_name}.xml --junit-xml=results/test-results-{env_name}.xml {posargs:tests/legacy}
 
 [testenv:test-noreq]


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
Fixes #4357