### PR TITLE
Return 1 if any remote-build failed

### DIFF
--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -128,8 +128,8 @@ class RemoteBuildCommand(BaseCommand):
         :param parsed_args: Snapcraft's argument namespace.
 
         :raises AcceptPublicUploadError: If the user does not agree to upload data.
-        :raises SnapcraftError: If the project cannot be loaded and parsed.
-        :raises SnapcraftError: If any build fails to complete.
+        :raises SnapcraftError: If the project cannot be loaded and parsed or if any
+        build fails to complete.
         """
         if os.getenv("SUDO_USER") and os.geteuid() == 0:
             emit.message(

--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -113,10 +113,11 @@ class RemoteBuildCommand(BaseCommand):
             default=0,
             metavar="<seconds>",
             help="Time in seconds to wait for launchpad to build.",
+        )
         parser.add_argument(
-            "--exit-fail-any-failure",
+            "--allow-failure",
             action="store_true",
-            help="return 1 if any of the builds fail"
+            help="return 0 even when builds fail"
         )
 
     @overrides
@@ -160,13 +161,14 @@ class RemoteBuildCommand(BaseCommand):
 
         success = self._run_new_or_fallback_remote_build(base)
         if not success:
-            if parsed_args.exit_fail_any_failure:
-                raise SnapcraftError("Some remote build failed to complete")
-            else:
+            if parsed_args.allow_failure:
                 emit.debug(
                     "Some build failed to complete but "
-                    "--exit-fail-any-failure was not provided"
+                    "--allow-failure was provided"
                 )
+            else:
+                raise SnapcraftError("Some remote build failed to complete")
+
 
 
     def _run_new_or_fallback_remote_build(self, base: str) -> bool:

--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -117,7 +117,8 @@ class RemoteBuildCommand(BaseCommand):
         parser.add_argument(
             "--allow-failure",
             action="store_true",
-            help="return 0 even when builds fail"
+            default=os.getenv("SNAPCRAFT_REMOTE_BUILD_ALLOW_FAILURE"),
+            help="return 0 even when builds fail",
         )
 
     @overrides
@@ -163,13 +164,10 @@ class RemoteBuildCommand(BaseCommand):
         if not success:
             if parsed_args.allow_failure:
                 emit.debug(
-                    "Some build failed to complete but "
-                    "--allow-failure was provided"
+                    "Some build failed to complete but --allow-failure was provided"
                 )
             else:
                 raise SnapcraftError("Some remote build failed to complete")
-
-
 
     def _run_new_or_fallback_remote_build(self, base: str) -> bool:
         """Run the new or fallback remote-build.
@@ -205,7 +203,7 @@ class RemoteBuildCommand(BaseCommand):
                 f"{_STRATEGY_ENVVAR!r} is {_Strategies.FORCE_FALLBACK.value!r}"
             )
             run_legacy()
-            return True # TODO: implement return of run_legacy
+            return True  # TODO: implement return of run_legacy
 
         if is_repo(Path().absolute()):
             emit.debug(
@@ -215,7 +213,7 @@ class RemoteBuildCommand(BaseCommand):
 
         emit.debug("Running fallback remote-build")
         run_legacy()
-        return True # TODO: implement return of run_legacy
+        return True  # TODO: implement return of run_legacy
 
     def _get_project_name(self) -> str:
         """Get the project name from the project's snapcraft.yaml.

--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -202,8 +202,7 @@ class RemoteBuildCommand(BaseCommand):
                 "Running fallback remote-build because environment variable "
                 f"{_STRATEGY_ENVVAR!r} is {_Strategies.FORCE_FALLBACK.value!r}"
             )
-            run_legacy()
-            return True  # TODO: implement return of run_legacy
+            return run_legacy()
 
         if is_repo(Path().absolute()):
             emit.debug(
@@ -212,8 +211,7 @@ class RemoteBuildCommand(BaseCommand):
             return self._run_new_remote_build()
 
         emit.debug("Running fallback remote-build")
-        run_legacy()
-        return True  # TODO: implement return of run_legacy
+        return run_legacy()
 
     def _get_project_name(self) -> str:
         """Get the project name from the project's snapcraft.yaml.

--- a/snapcraft/remote/remote_builder.py
+++ b/snapcraft/remote/remote_builder.py
@@ -104,7 +104,7 @@ class RemoteBuilder:
         """
         return self._lpc.has_outstanding_build()
 
-    def monitor_build(self) -> None:
+    def monitor_build(self) -> bool:
         """Monitor and periodically log the status of a remote build in Launchpad."""
         logger.info(
             "Building snap package for %s. This may take some time to finish.",
@@ -112,9 +112,10 @@ class RemoteBuilder:
         )
 
         logger.info("Building...")
-        self._lpc.monitor_build()
+        success = self._lpc.monitor_build()
 
         logger.info("Build complete.")
+        return success
 
     def clean_build(self) -> None:
         """Clean the cache and Launchpad build."""

--- a/snapcraft_legacy/cli/remote.py
+++ b/snapcraft_legacy/cli/remote.py
@@ -21,11 +21,7 @@ import click
 from xdg import BaseDirectory
 
 from snapcraft_legacy.formatting_utils import humanize_list
-from snapcraft_legacy.internal.remote_build import (
-    LaunchpadClient,
-    WorkTree,
-    errors,
-)
+from snapcraft_legacy.internal.remote_build import LaunchpadClient, WorkTree, errors
 from snapcraft_legacy.project import Project
 
 from . import echo

--- a/snapcraft_legacy/internal/remote_build/_launchpad.py
+++ b/snapcraft_legacy/internal/remote_build/_launchpad.py
@@ -335,9 +335,11 @@ class LaunchpadClient:
 
     def monitor_build(
         self, interval: int = _LP_POLL_INTERVAL, timeout: int = 0
-    ) -> None:
+    ) -> bool:
         """Check build progress, and download artifacts when ready."""
         snap = self._get_snap()
+
+        end_build_states = {}
 
         while True:
             # Check to see if we've run out of time.
@@ -351,6 +353,7 @@ class LaunchpadClient:
                 state = build["buildstate"]
                 arch = build["arch_tag"]
                 logger.info(f"\tarch={arch}\tstate={state}")
+                end_build_states[arch] = state
 
                 if _is_build_pending(build):
                     pending = True
@@ -362,6 +365,7 @@ class LaunchpadClient:
 
         # Build is complete - download build artifacts.
         self._fetch_artifacts(snap)
+        return all(x.strip() == "Successfully built" for x in end_build_states.values())
 
     def get_build_status(self) -> Dict[str, str]:
         """Get status of builds."""

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -785,17 +785,15 @@ def test_recover_no_build(emitter, mocker):
 def test_recover_build(emitter, mocker, mock_remote_builder):
     """Recover a build when `--recover` is provided."""
     mocker.patch.object(sys, "argv", ["snapcraft", "remote-build", "--recover"])
-    mock_remote_builder.return_value.has_outstanding_build.return_value = True
+    mock_remote_builder().monitor_build.return_value = True
+    mock_remote_builder().has_outstanding_build.return_value = True
 
     cli.run()
 
-    assert mock_remote_builder.mock_calls[-4:] == [
+    assert mock_remote_builder.mock_calls[-3:] == [
         call().print_status(),
         call().monitor_build(),
         call().clean_build(),
-        call()
-        .monitor_build()
-        .__bool__(),  # something is checking the output of monitor_build
     ]
 
 
@@ -807,17 +805,15 @@ def test_recover_build(emitter, mocker, mock_remote_builder):
 )
 def test_recover_build_user_confirms(emitter, mocker, mock_remote_builder):
     """Recover a build when a user confirms."""
-    mock_remote_builder.return_value.has_outstanding_build.return_value = True
+    mock_remote_builder().monitor_build.return_value = True
+    mock_remote_builder().has_outstanding_build.return_value = True
 
     cli.run()
 
-    assert mock_remote_builder.mock_calls[-4:] == [
+    assert mock_remote_builder.mock_calls[-3:] == [
         call().print_status(),
         call().monitor_build(),
         call().clean_build(),
-        call()
-        .monitor_build()
-        .__bool__(),  # something is checking the output of monitor_build
     ]
 
 
@@ -832,17 +828,15 @@ def test_recover_build_user_denies(emitter, mocker, mock_remote_builder):
         "snapcraft.commands.remote.confirm_with_user",
         side_effect=[True, False],
     )
-    mock_remote_builder.return_value.has_outstanding_build.return_value = True
+    mock_remote_builder().monitor_build.return_value = True
+    mock_remote_builder().has_outstanding_build.return_value = True
 
     cli.run()
 
-    assert mock_remote_builder.mock_calls[-4:] == [
+    assert mock_remote_builder.mock_calls[-3:] == [
         call().start_build(),
         call().monitor_build(),
         call().clean_build(),
-        call()
-        .monitor_build()
-        .__bool__(),  # something is checking the output of monitor_build
     ]
 
 

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -847,8 +847,9 @@ def test_remote_build(emitter, mocker, mock_remote_builder):
     """Clean and start a new build."""
     cli.run()
 
-    assert mock_remote_builder.mock_calls[-3:] == [
+    assert mock_remote_builder.mock_calls[-4:] == [
         call().start_build(),
         call().monitor_build(),
         call().clean_build(),
+        call().monitor_build().__bool__(),
     ]

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -793,7 +793,9 @@ def test_recover_build(emitter, mocker, mock_remote_builder):
         call().print_status(),
         call().monitor_build(),
         call().clean_build(),
-        call().monitor_build().__bool__(), # something is checking the output of monitor_build
+        call()
+        .monitor_build()
+        .__bool__(),  # something is checking the output of monitor_build
     ]
 
 
@@ -813,7 +815,9 @@ def test_recover_build_user_confirms(emitter, mocker, mock_remote_builder):
         call().print_status(),
         call().monitor_build(),
         call().clean_build(),
-        call().monitor_build().__bool__(), # something is checking the output of monitor_build
+        call()
+        .monitor_build()
+        .__bool__(),  # something is checking the output of monitor_build
     ]
 
 
@@ -836,7 +840,9 @@ def test_recover_build_user_denies(emitter, mocker, mock_remote_builder):
         call().start_build(),
         call().monitor_build(),
         call().clean_build(),
-        call().monitor_build().__bool__(), # something is checking the output of monitor_build
+        call()
+        .monitor_build()
+        .__bool__(),  # something is checking the output of monitor_build
     ]
 
 
@@ -857,6 +863,7 @@ def test_remote_build_ok(emitter, mocker, mock_remote_builder):
         call().clean_build(),
     ]
     assert return_value == 0
+
 
 @pytest.mark.parametrize(
     "create_snapcraft_yaml", CURRENT_BASES | LEGACY_BASES, indirect=True


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
# Description
When using `snapcraft remote-build` in CI, it would be useful to get a failure when any of the remote build fails. This is not the behaviour that we currently have (namely, even if some build fails, the return code is `0` and the workflow is marked as ok. See: [core16-failure](https://github.com/canonical/checkbox/actions/runs/6199930599/job/16833507894)). Currently we are resorting to counting artifacts, but this process is fragile and error prone (For instance, we have discovered that the snap counting mechanism was introduced [here](https://github.com/canonical/checkbox/actions/runs/6199930599/workflow#L55) but not [here](https://github.com/canonical/checkbox/actions/runs/6491088080/workflow), leading to some failures not being detected)

This PR introduces a new flag to `remote-build`: `--exit-fail-on-any-failure`. When the flag is given, the remote build command will return 1 if any build fails, if the flag is not given it will just produce a debug message signaling the failure.
# Bug

Fixes:  https://github.com/snapcore/snapcraft/issues/4142

# Testing
I can't run the following due to this exception:
- [ ] Have you successfully run `pytest tests/unit`?
```
(venv)  snapcraft (return_1_remote_builds_failed) >  pytest tests/unit
ImportError while loading conftest '/home/h25/prj/canonical/snapcraft/tests/conftest.py'.
tests/conftest.py:21: in <module>
    import xdg.BaseDirectory
E   ModuleNotFoundError: No module named 'xdg.BaseDirectory'
```
-----
