### PR TITLE
chore(deps): update craft-providers to 1.18.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ craft-archives==1.1.3
 craft-cli==2.1.0
 craft-grammar==1.1.1
 craft-parts==1.25.1
-craft-providers==1.15.0
+craft-providers==1.18.0
 craft-store==2.4.0
 Deprecated==1.2.13
 distro==1.8.0

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -15,7 +15,7 @@ craft-archives==1.1.3
 craft-cli==2.1.0
 craft-grammar==1.1.1
 craft-parts==1.25.1
-craft-providers==1.15.0
+craft-providers==1.18.0
 craft-store==2.4.0
 cryptography==41.0.4
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ craft-archives==1.1.3
 craft-cli==2.1.0
 craft-grammar==1.1.1
 craft-parts==1.25.1
-craft-providers==1.15.0
+craft-providers==1.18.0
 craft-store==2.4.0
 cryptography==41.0.4
 Deprecated==1.2.13


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

Update craft-providers to 1.18.0.  The primary motivation for this PR is to capture stdout and stderr when installing a snap inside an instance fails.  There are some other performance improvements when creating base instances for LXD.

1.17.0 introduces the global pip cache, but this is an opt-in feature so snapcraft's behavior is unchanged.

### Changelog

#### 1.18.0 (2023-09-28)
- Check if base instance status before copying
- Fail quickly when LXD errors do not involve instance creation
- Add check parameter to execute_run

#### 1.17.0 (2023-09-22)
- Use a shared pip cache across instances
- Remove Ubuntu 22.10 (Kinetic) support
- Capture details for snap errors

#### 1.16.0 (2023-08-25)
- Improve LXD instance creation process to avoid race conditions. The base instance is now created first and copied to an instance. Retry, timeout, and locking mechanisms prevent multiple processes from creating the same base instance.
 - Add LXD functions check_instance_status(), config_set(), config_get(), and restart()