### PR TITLE
build(deps): bump craft-providers to 1.19.1

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -15,7 +15,7 @@ craft-archives==1.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.7
-craft-providers==1.10.1
+craft-providers==1.19.1
 craft-store==2.4.0
 cryptography==40.0.2
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ craft-archives==1.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.7
-craft-providers==1.10.1
+craft-providers==1.19.1
 craft-store==2.4.0
 cryptography==40.0.2
 Deprecated==1.2.13

--- a/snapcraft/commands/lint.py
+++ b/snapcraft/commands/lint.py
@@ -23,7 +23,7 @@ import subprocess
 import tempfile
 import textwrap
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Iterator, Optional
 
 from craft_cli import BaseCommand, emit
@@ -310,7 +310,7 @@ class LintCommand(BaseCommand):
         is_dangerous = not bool(assert_file)
 
         if assert_file:
-            ack_command = snap_cmd.formulate_ack_command(assert_file)
+            ack_command = snap_cmd.formulate_ack_command(PurePosixPath(assert_file))
             emit.progress(
                 f"Installing assertion file with {shlex.join(ack_command)!r}."
             )
@@ -328,7 +328,7 @@ class LintCommand(BaseCommand):
         install_command = snap_cmd.formulate_local_install_command(
             classic=bool(snap_metadata.confinement == "classic"),
             dangerous=is_dangerous,
-            snap_path=snap_file,
+            snap_path=PurePosixPath(snap_file),
         )
         if snap_metadata.grade == "devel":
             install_command.append("--devmode")

--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -24,6 +24,7 @@ from typing import Dict, Optional
 
 from craft_cli import emit
 from craft_providers import Provider, ProviderError, bases, executor
+from craft_providers.actions.snap_installer import Snap
 from craft_providers.lxd import LXDProvider
 from craft_providers.multipass import MultipassProvider
 
@@ -199,7 +200,7 @@ def get_base_configuration(
         environment=environment,
         hostname=instance_name,
         snaps=[
-            bases.buildd.Snap(
+            Snap(
                 name=snap_name,
                 channel=snap_channel,
                 classic=True,

--- a/spread.yaml
+++ b/spread.yaml
@@ -71,7 +71,8 @@ backends:
           # SPREAD_SYSTEM has the following format here 'ubuntu-XX.YY-64' and gets
           # translated to an image XX.YY.
           image=$(echo $SPREAD_SYSTEM | sed -e 's/ubuntu-\(.*\)-64/\1/')
-          instance_name="spread-${image}"
+          spread_name=$(echo ${image} | sed -e 's/\.//g')
+          instance_name="spread-${spread_name}"
       fi
 
       if [ -z "${image}" ]; then
@@ -100,7 +101,8 @@ backends:
           # SPREAD_SYSTEM has the following format here 'ubuntu-XX.YY-64' and gets
           # translated to an image XX.YY.
           image=$(echo $SPREAD_SYSTEM | sed -e 's/ubuntu-\(.*\)-64/\1/')
-          instance_name="spread-${image}"
+          spread_name=$(echo ${image} | sed -e 's/\.//g')
+          instance_name="spread-${spread_name}"
       fi
 
       if [ -z "${image}" ]; then
@@ -254,6 +256,8 @@ prepare: |
   install_snapcraft
 
   pushd /snapcraft
+  git config --global user.email "you@example.com"
+  git config --global user.name "Your Name"
   git init
   git add .
   git commit -m "Testing Commit"
@@ -309,6 +313,11 @@ suites:
    systems:
      - ubuntu-22.04*
 
+ tests/spread/core24/:
+   summary: core24 tests
+   systems:
+     - ubuntu-22.04*
+
  # General, core suite
  tests/spread/general/:
    summary: tests of snapcraft core functionality
@@ -329,6 +338,11 @@ suites:
 
  tests/spread/general/hooks/:
    summary: tests of snapcraft hook functionality
+
+ tests/spread/core-devel/:
+   summary: tests of devel base snaps
+   environment:
+     SNAPCRAFT_BUILD_ENVIRONMENT: ""
 
  # General, core suite
  tests/spread/cross-compile/:

--- a/tests/spread/core-devel/basic/snap/snapcraft.yaml
+++ b/tests/spread/core-devel/basic/snap/snapcraft.yaml
@@ -1,0 +1,16 @@
+name: build-base-devel
+version: '1.0'
+summary: build-base-devel
+description: Build a base snap with a build-base of devel
+confinement: strict
+
+type: base
+build-base: devel
+
+# grade must be devel when build-base is devel
+grade: devel
+
+parts:
+  build-base-devel:
+    plugin: nil
+    stage-packages: [base-files]

--- a/tests/spread/core-devel/basic/task.yaml
+++ b/tests/spread/core-devel/basic/task.yaml
@@ -1,0 +1,19 @@
+summary: Test basic build for devel base
+
+environment:
+  SNAPCRAFT_BUILD_ENVIRONMENT: ""
+
+restore: |
+  cd "./snap"
+  snapcraft clean
+  rm -f ./*.snap
+  snap remove build-base-devel
+
+execute: |
+  cd "./snap"
+
+  snapcraft pack
+
+  snap install --dangerous ./*.snap
+
+  grep -i "devel" /snap/build-base-devel/current/etc/os-release || { echo "Devel image not found" ; exit 1; }

--- a/tests/spread/core24/simple-snap/snap/Makefile
+++ b/tests/spread/core24/simple-snap/snap/Makefile
@@ -1,0 +1,11 @@
+# -*- Mode: Makefile; indent-tabs-mode:t; tab-width: 4 -*-
+.PHONY: all
+
+all: hello
+
+install: hello
+	install -d $(DESTDIR)/bin/
+	install -D $^ $(DESTDIR)/bin/
+
+hello: hello.c
+	$(CC) hello.c -o hello -lcurl

--- a/tests/spread/core24/simple-snap/snap/hello.c
+++ b/tests/spread/core24/simple-snap/snap/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include <curl/curl.h>
+
+int main() {
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+}

--- a/tests/spread/core24/simple-snap/snap/snapcraft.yaml
+++ b/tests/spread/core24/simple-snap/snap/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: simple-snap
+version: "1.0"
+summary: Build a simple confined snap
+description: |
+  Build a simple confined snap to test the build process.
+
+base: core24
+build-base: devel
+
+grade: devel
+confinement: strict
+
+apps:
+  hello:
+    command: bin/hello
+
+parts:
+  hello:
+    source: .
+    plugin: make
+    build-packages:
+      - gcc
+      - libc-dev
+      - libcurl4-openssl-dev
+    stage-packages: [libcurl4]

--- a/tests/spread/core24/simple-snap/task.yaml
+++ b/tests/spread/core24/simple-snap/task.yaml
@@ -1,0 +1,16 @@
+summary: Build a simple snap
+
+environment:
+  SNAPCRAFT_BUILD_ENVIRONMENT: ""
+
+restore: |
+  snap remove simple-snap
+  snapcraft clean
+  rm -f ./*.snap
+
+execute: |
+  cd "./snap"
+  snapcraft pack
+  snap install --edge core24
+  snap install --dangerous ./*.snap
+  /snap/bin/simple-snap.hello

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -323,6 +323,16 @@ def fake_provider(mock_instance):
     class FakeProvider(Provider):
         """Fake provider."""
 
+        @property
+        def name(self) -> str:
+            """Name of the provider."""
+            return "fake"
+
+        @property
+        def install_recommendation(self) -> str:
+            """Recommended way to install the provider."""
+            return "snap"
+
         def clean_project_environments(self, *, instance_name: str):
             pass
 

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -24,7 +24,7 @@ from unittest.mock import ANY, Mock, PropertyMock, call
 import pytest
 from craft_cli import EmitterMode, emit
 from craft_parts import Action, Step, callbacks
-from craft_providers.bases.buildd import BuilddBaseAlias
+from craft_providers.bases.ubuntu import BuilddBaseAlias
 
 from snapcraft import errors
 from snapcraft.elf import ElfFile

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -19,6 +19,7 @@ from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import pytest
 from craft_providers import ProviderError, bases
+from craft_providers.actions.snap_installer import Snap
 from craft_providers.lxd import LXDProvider
 from craft_providers.multipass import MultipassProvider
 
@@ -212,11 +213,7 @@ def test_get_base_configuration(
         compatibility_tag="snapcraft-buildd-base-v0.0",
         environment="test-env",
         hostname="test-instance-name",
-        snaps=[
-            bases.buildd.Snap(
-                name="test-snap-name", channel="test-channel", classic=True
-            )
-        ],
+        snaps=[Snap(name="test-snap-name", channel="test-channel", classic=True)],
         packages=["gnupg", "dirmngr", "git"],
     )
 
@@ -259,7 +256,7 @@ def test_get_base_configuration_snap_channel(
         compatibility_tag=ANY,
         environment=ANY,
         hostname=ANY,
-        snaps=[bases.buildd.Snap(name="snapcraft", channel=snap_channel, classic=True)],
+        snaps=[Snap(name="snapcraft", channel=snap_channel, classic=True)],
         packages=ANY,
     )
 
@@ -293,7 +290,7 @@ def test_get_base_configuration_snap_instance_name_default(
         compatibility_tag=ANY,
         environment=ANY,
         hostname=ANY,
-        snaps=[bases.buildd.Snap(name="snapcraft", channel=None, classic=True)],
+        snaps=[Snap(name="snapcraft", channel=None, classic=True)],
         packages=ANY,
     )
 
@@ -327,7 +324,7 @@ def test_get_base_configuration_snap_instance_name_not_running_as_snap(
         compatibility_tag=ANY,
         environment=ANY,
         hostname=ANY,
-        snaps=[bases.buildd.Snap(name="snapcraft", channel=None, classic=True)],
+        snaps=[Snap(name="snapcraft", channel=None, classic=True)],
         packages=ANY,
     )
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
Also included devel base tests.
And a fix to run tests in multipass.


Fixes: #4412
CRAFT-2171