### PR TITLE
chore(pyproject): quote versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ load-plugins = "pylint_fixme_info,pylint_pytest"
 min-similarity-lines=10
 
 [tool.mypy]
-python_version = 3.10
+python_version = "3.10"
 ignore_missing_imports = true
 follow_imports = "silent"
 exclude = [
@@ -69,7 +69,7 @@ exclude = ["build", "tests/legacy", "tests/spread"]
 pythonVersion = "3.10"
 
 [tool.pytest.ini_options]
-minversion = 7.0
+minversion = "7.0"
 required_plugins = ["pytest-cov>=4.0", "pytest-mock>=3.10", "pytest-subprocess>=1.4"]
 addopts = ["--cov=snapcraft"]
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

X.Y versions in a `pyproject.toml` need to be quoted to avoid being treated as an integer to avoid warnings like this:
```
 pyproject.toml: [mypy]: python_version: Python 3.1 is not supported (must be 3.4 or higher). You may need to put quotes around your Python version
```