### PR TITLE
chore(log): hide details error in the log when pack failed

### DIFF
--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -35,10 +35,13 @@ def _verify_snap(directory: Path) -> None:
             universal_newlines=True,
         )
     except subprocess.CalledProcessError as err:
-        msg = f"Cannot pack snap file: {err!s}"
+        stderr = None
         if err.stderr:
-            msg += f" ({err.stderr.strip()!s})"
-        raise errors.SnapcraftError(msg)
+            stderr = err.stderr.strip()
+            msg = f"Cannot pack snap: {stderr!s}"
+        else:
+            msg = "Cannot pack snap"
+        raise errors.SnapcraftError(msg, details=f"{err!s}") from err
 
 
 def _get_directory(output: Optional[str]) -> Path:
@@ -135,10 +138,11 @@ def pack_snap(
             command, capture_output=True, check=True, universal_newlines=True
         )
     except subprocess.CalledProcessError as err:
-        msg = f"Cannot pack snap file: {err!s}"
+        msg = f"{err!s}"
+        details = None
         if err.stderr:
-            msg += f" ({err.stderr.strip()!s})"
-        raise errors.SnapcraftError(msg)
+            details = err.stderr.strip()
+        raise errors.SnapcraftError(msg, details=details) from err
 
     snap_filename = Path(str(proc.stdout).partition(":")[2].strip()).name
     return snap_filename

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -224,7 +224,7 @@ def run(command_name: str, parsed_args: "argparse.Namespace") -> None:
         )
 
 
-def _run_command(
+def _run_command(  # pylint: disable=too-many-branches, too-many-statements
     command_name: str,
     *,
     project: Project,
@@ -322,6 +322,11 @@ def _run_command(
             emit.progress(msg, permanent=True)
             launch_shell()
         raise errors.SnapcraftError(msg) from err
+    except errors.SnapcraftError as err:
+        if parsed_args.debug:
+            emit.progress(str(err), permanent=True)
+            launch_shell()
+        raise
     except Exception as err:
         if parsed_args.debug:
             emit.progress(str(err), permanent=True)
@@ -578,7 +583,8 @@ def _run_in_provider(
         except subprocess.CalledProcessError as err:
             raise errors.SnapcraftError(
                 f"Failed to execute {command_name} in instance.",
-                details=(
+                details=err.stderr.strip() if err.stderr else None,
+                resolution=(
                     "Run the same command again with --debug to shell into "
                     "the environment if you wish to introspect this failure."
                 ),


### PR DESCRIPTION
The error will looks like this instead of long stderr output.
```
Command '['snap', 'pack', '--check-skeleton', PosixPath('/root/prime')]' returned non-zero exit status 1.
Failed to execute pack in instance.
```

The stderr output will be saved in the logs.