### PR TITLE
fix(remote-build): parse `--launchpad-timeout` argument

### DIFF
--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -55,7 +55,13 @@ class RemoteBuildCommand(BaseCommand):
         option, followed by the build number informed when the remote
         build was originally dispatched. The current state of the
         remote build for each architecture can be checked using the
-        --status option."""
+        --status option.
+
+        To set a timeout on the remote-build command, use the option
+        ``--launchpad-timeout=<seconds>``. The timeout is local, so the build on
+        launchpad will continue even if the local instance of snapcraft is
+        interrupted or times out.
+        """
     )
 
     @overrides
@@ -86,6 +92,13 @@ class RemoteBuildCommand(BaseCommand):
             "--launchpad-accept-public-upload",
             action="store_true",
             help="acknowledge that uploaded code will be publicly available.",
+        )
+        parser.add_argument(
+            "--launchpad-timeout",
+            type=int,
+            default=0,
+            metavar="<seconds>",
+            help="Time in seconds to wait for launchpad to build.",
         )
 
     @overrides


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

Fix a regression where `--launchpad-timeout` was not parsed and could not be used by the fallback remote builder.

Note - I made 2 PRs (this one and #4426) because the remote build code is very different between `main` and the `hotfix/7.5` branches (`main` has the new remote builder code, `hotfix/7.5` does not).

Fixes #4397 
(CRAFT-2094)