### PR TITLE
build(deps): bump craft-providers to 1.19.1 (#4421)

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -15,7 +15,7 @@ craft-archives==1.1.3
 craft-cli==2.1.0
 craft-grammar==1.1.1
 craft-parts==1.25.1
-craft-providers==1.18.0
+craft-providers==1.19.1
 craft-store==2.4.0
 cryptography==41.0.4
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ craft-archives==1.1.3
 craft-cli==2.1.0
 craft-grammar==1.1.1
 craft-parts==1.25.1
-craft-providers==1.18.0
+craft-providers==1.19.1
 craft-store==2.4.0
 cryptography==41.0.4
 Deprecated==1.2.13

--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -199,7 +199,13 @@ def get_base_configuration(
         compatibility_tag=f"snapcraft-{bases.BuilddBase.compatibility_tag}.0",
         environment=environment,
         hostname=instance_name,
-        snaps=[Snap(name=snap_name, channel=snap_channel, classic=True)],
+        snaps=[
+            Snap(
+                name=snap_name,
+                channel=snap_channel,
+                classic=True,
+            )
+        ],
         # Requirement for apt gpg and version:git
         packages=["gnupg", "dirmngr", "git"],
     )

--- a/spread.yaml
+++ b/spread.yaml
@@ -67,7 +67,8 @@ backends:
           # SPREAD_SYSTEM has the following format here 'ubuntu-XX.YY-64' and gets
           # translated to an image XX.YY.
           image=$(echo $SPREAD_SYSTEM | sed -e 's/ubuntu-\(.*\)-64/\1/')
-          instance_name="spread-${image}"
+          spread_name=$(echo ${image} | sed -e 's/\.//g')
+          instance_name="spread-${spread_name}"
       fi
 
       if [ -z "${image}" ]; then
@@ -96,7 +97,8 @@ backends:
           # SPREAD_SYSTEM has the following format here 'ubuntu-XX.YY-64' and gets
           # translated to an image XX.YY.
           image=$(echo $SPREAD_SYSTEM | sed -e 's/ubuntu-\(.*\)-64/\1/')
-          instance_name="spread-${image}"
+          spread_name=$(echo ${image} | sed -e 's/\.//g')
+          instance_name="spread-${spread_name}"
       fi
 
       if [ -z "${image}" ]; then
@@ -227,6 +229,8 @@ prepare: |
   install_snapcraft
 
   pushd /snapcraft
+  git config --global user.email "you@example.com"
+  git config --global user.name "Your Name"
   git init
   git add .
   git commit -m "Testing Commit"
@@ -282,6 +286,11 @@ suites:
    systems:
      - ubuntu-22.04*
 
+ tests/spread/core24/:
+   summary: core24 tests
+   systems:
+     - ubuntu-22.04*
+
  # General, core suite
  tests/spread/general/:
    summary: tests of snapcraft core functionality
@@ -299,6 +308,11 @@ suites:
 
  tests/spread/general/hooks/:
    summary: tests of snapcraft hook functionality
+
+ tests/spread/core-devel/:
+   summary: tests of devel base snaps
+   environment:
+     SNAPCRAFT_BUILD_ENVIRONMENT: ""
 
  # General, core suite
  tests/spread/cross-compile/:

--- a/tests/spread/core-devel/basic/snap/snapcraft.yaml
+++ b/tests/spread/core-devel/basic/snap/snapcraft.yaml
@@ -1,0 +1,16 @@
+name: build-base-devel
+version: '1.0'
+summary: build-base-devel
+description: Build a base snap with a build-base of devel
+confinement: strict
+
+type: base
+build-base: devel
+
+# grade must be devel when build-base is devel
+grade: devel
+
+parts:
+  build-base-devel:
+    plugin: nil
+    stage-packages: [base-files]

--- a/tests/spread/core-devel/basic/task.yaml
+++ b/tests/spread/core-devel/basic/task.yaml
@@ -1,0 +1,19 @@
+summary: Test basic build for devel base
+
+environment:
+  SNAPCRAFT_BUILD_ENVIRONMENT: ""
+
+restore: |
+  cd "./snap"
+  snapcraft clean
+  rm -f ./*.snap
+  snap remove build-base-devel
+
+execute: |
+  cd "./snap"
+
+  snapcraft pack
+
+  snap install --dangerous ./*.snap
+
+  grep -i "devel" /snap/build-base-devel/current/etc/os-release || { echo "Devel image not found" ; exit 1; }

--- a/tests/spread/core24/simple-snap/snap/Makefile
+++ b/tests/spread/core24/simple-snap/snap/Makefile
@@ -1,0 +1,11 @@
+# -*- Mode: Makefile; indent-tabs-mode:t; tab-width: 4 -*-
+.PHONY: all
+
+all: hello
+
+install: hello
+	install -d $(DESTDIR)/bin/
+	install -D $^ $(DESTDIR)/bin/
+
+hello: hello.c
+	$(CC) hello.c -o hello -lcurl

--- a/tests/spread/core24/simple-snap/snap/hello.c
+++ b/tests/spread/core24/simple-snap/snap/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include <curl/curl.h>
+
+int main() {
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+}

--- a/tests/spread/core24/simple-snap/snap/snapcraft.yaml
+++ b/tests/spread/core24/simple-snap/snap/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: simple-snap
+version: "1.0"
+summary: Build a simple confined snap
+description: |
+  Build a simple confined snap to test the build process.
+
+base: core24
+build-base: devel
+
+grade: devel
+confinement: strict
+
+apps:
+  hello:
+    command: bin/hello
+
+parts:
+  hello:
+    source: .
+    plugin: make
+    build-packages:
+      - gcc
+      - libc-dev
+      - libcurl4-openssl-dev
+    stage-packages: [libcurl4]

--- a/tests/spread/core24/simple-snap/task.yaml
+++ b/tests/spread/core24/simple-snap/task.yaml
@@ -1,0 +1,16 @@
+summary: Build a simple snap
+
+environment:
+  SNAPCRAFT_BUILD_ENVIRONMENT: ""
+
+restore: |
+  snap remove simple-snap
+  snapcraft clean
+  rm -f ./*.snap
+
+execute: |
+  cd "./snap"
+  snapcraft pack
+  snap install --edge core24
+  snap install --dangerous ./*.snap
+  /snap/bin/simple-snap.hello


### PR DESCRIPTION
Adds spread tests for `base: devel` spread tests and fixes multipass spread tests.