### PR TITLE
fix(remote-build): improve logging and catch exceptions

### DIFF
--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -32,6 +32,7 @@ import snapcraft
 import snapcraft_legacy
 from snapcraft import __version__, errors, store, utils
 from snapcraft.parts import plugins
+from snapcraft.remote import RemoteBuildError
 from snapcraft_legacy.cli import legacy
 
 from . import commands
@@ -243,7 +244,8 @@ def _emit_error(error, cause=None):
     emit.error(error)
 
 
-def run():  # noqa: C901
+# pylint: disable-next=too-many-statements
+def run():  # noqa: C901 (complex-structure)
     """Run the CLI."""
     dispatcher = get_dispatcher()
     retcode = 1
@@ -298,6 +300,9 @@ def run():  # noqa: C901
     except errors.LinterError as err:
         emit.error(craft_cli.errors.CraftError(f"linter error: {err}"))
         retcode = err.exit_code
+    except RemoteBuildError as err:
+        emit.error(craft_cli.errors.CraftError(f"remote-build error: {err}"))
+        retcode = 1
     except errors.SnapcraftError as err:
         _emit_error(err)
         retcode = 1

--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -171,7 +171,7 @@ class RemoteBuildCommand(BaseCommand):
         """
         # bases newer than core22 must use the new remote-build
         if base in yaml_utils.CURRENT_BASES - {"core22"}:
-            emit.debug("Running new remote-build because base is newer than core22.")
+            emit.debug("Running new remote-build because base is newer than core22")
             self._run_new_remote_build()
             return
 
@@ -180,7 +180,7 @@ class RemoteBuildCommand(BaseCommand):
         if strategy == _Strategies.DISABLE_FALLBACK:
             emit.debug(
                 "Running new remote-build because environment variable "
-                f"{_STRATEGY_ENVVAR!r} is {_Strategies.DISABLE_FALLBACK.value!r}."
+                f"{_STRATEGY_ENVVAR!r} is {_Strategies.DISABLE_FALLBACK.value!r}"
             )
             self._run_new_remote_build()
             return
@@ -188,19 +188,19 @@ class RemoteBuildCommand(BaseCommand):
         if strategy == _Strategies.FORCE_FALLBACK:
             emit.debug(
                 "Running fallback remote-build because environment variable "
-                f"{_STRATEGY_ENVVAR!r} is {_Strategies.FORCE_FALLBACK.value!r}."
+                f"{_STRATEGY_ENVVAR!r} is {_Strategies.FORCE_FALLBACK.value!r}"
             )
             run_legacy()
             return
 
         if is_repo(Path().absolute()):
             emit.debug(
-                "Running new remote-build because project is in a git repository."
+                "Running new remote-build because project is in a git repository"
             )
             self._run_new_remote_build()
             return
 
-        emit.debug("Running fallback remote-build.")
+        emit.debug("Running fallback remote-build")
         run_legacy()
 
     def _get_project_name(self) -> str:
@@ -218,7 +218,7 @@ class RemoteBuildCommand(BaseCommand):
         if project_name:
             emit.debug(
                 f"Using project name {project_name!r} from "
-                f"{str(self._snapcraft_yaml)!r}."
+                f"{str(self._snapcraft_yaml)!r}"
             )
             return project_name
 
@@ -228,7 +228,7 @@ class RemoteBuildCommand(BaseCommand):
 
     def _run_new_remote_build(self) -> None:
         """Run new remote-build code."""
-        emit.progress("Setting up launchpad environment.")
+        emit.progress("Setting up launchpad environment")
         remote_builder = RemoteBuilder(
             app_name="snapcraft",
             build_id=self._parsed_args.build_id,
@@ -242,14 +242,14 @@ class RemoteBuildCommand(BaseCommand):
             remote_builder.print_status()
             return
 
-        emit.progress("Looking for existing builds.")
+        emit.progress("Looking for existing build")
         has_outstanding_build = remote_builder.has_outstanding_build()
         if self._parsed_args.recover and not has_outstanding_build:
-            emit.message("No build found.")
+            emit.progress("No build found", permanent=True)
             return
 
         if has_outstanding_build:
-            emit.message("Found previously started build.")
+            emit.progress("Found existing build", permanent=True)
             remote_builder.print_status()
 
             # If recovery specified, monitor build and exit.
@@ -260,15 +260,19 @@ class RemoteBuildCommand(BaseCommand):
                 remote_builder.monitor_build()
                 emit.progress("Cleaning")
                 remote_builder.clean_build()
+                emit.progress("Build completed", permanent=True)
                 return
 
             # Otherwise clean running build before we start a new one.
-            emit.progress("Cleaning previously existing build.")
+            emit.progress("Cleaning existing build")
             remote_builder.clean_build()
+        else:
+            emit.progress("No existing build found", permanent=True)
 
-        emit.message(
+        emit.progress(
             "If interrupted, resume with: 'snapcraft remote-build --recover "
-            f"--build-id {remote_builder.build_id}'."
+            f"--build-id {remote_builder.build_id}'",
+            permanent=True,
         )
         emit.progress("Starting build")
         remote_builder.start_build()
@@ -276,6 +280,7 @@ class RemoteBuildCommand(BaseCommand):
         remote_builder.monitor_build()
         emit.progress("Cleaning")
         remote_builder.clean_build()
+        emit.progress("Build completed", permanent=True)
 
     def _get_build_strategy(self) -> Optional[_Strategies]:
         """Get the build strategy from the envvar `SNAPCRAFT_REMOTE_BUILD_STRATEGY`.
@@ -316,7 +321,7 @@ class RemoteBuildCommand(BaseCommand):
                 f"Could not determine base from {str(self._snapcraft_yaml)!r}."
             )
 
-        emit.debug(f"Got base {base!r} from {str(self._snapcraft_yaml)!r}.")
+        emit.debug(f"Got base {base!r} from {str(self._snapcraft_yaml)!r}")
 
         if base in yaml_utils.ESM_BASES:
             raise MaintenanceBase(base)

--- a/snapcraft/remote/remote_builder.py
+++ b/snapcraft/remote/remote_builder.py
@@ -121,7 +121,6 @@ class RemoteBuilder:
         logger.info("Cleaning existing builds and artefacts.")
         self._lpc.cleanup()
         self._worktree.clean_cache()
-        logger.info("Done.")
 
     def start_build(self) -> None:
         """Start a build in Launchpad.

--- a/tests/unit/cli/test_exit.py
+++ b/tests/unit/cli/test_exit.py
@@ -24,6 +24,7 @@ from craft_cli import CraftError
 from craft_providers import ProviderError
 
 from snapcraft import cli
+from snapcraft.remote import RemoteBuildError
 
 
 def test_no_keyring_error(capsys, mocker):
@@ -72,6 +73,24 @@ def test_craft_providers_error(capsys, mocker):
     assert stderr[0].startswith("craft-providers error: test brief")
     assert stderr[1].startswith("test details")
     assert stderr[2].startswith("test resolution")
+
+
+def test_remote_build_error(capsys, mocker):
+    """Catch remote-build errors."""
+    mocker.patch.object(sys, "argv", ["cmd", "pull"])
+    mocker.patch.object(sys.stdin, "isatty", return_value=True)
+    mocker.patch(
+        "snapcraft.commands.lifecycle.PullCommand.run",
+        side_effect=RemoteBuildError(brief="test brief", details="test details"),
+    )
+
+    cli.run()
+
+    stderr = capsys.readouterr().err.splitlines()
+
+    # Simple verification that our expected message is being printed
+    assert stderr[0].startswith("remote-build error: test brief")
+    assert stderr[1].startswith("test details")
 
 
 @pytest.mark.parametrize("is_managed,report_errors", [(True, False), (False, True)])


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

Catch `RemoteBuildErrors` and improve the UX for remote building.

The launchpad authorization message (see below) still doesn't look great because it adds its own newlines.  It is directly printed by `launchpadlib` and I'm not sure there is a straightforward way to make it look better.
```python
"Please open this authorization page:\n"
" (%s)\n"
"in your browser. Use your browser to authorize\n"
"this program to access Launchpad on your behalf."
```

Fixes #4399 
(CRAFT-2096)