### PR TITLE
tests(spread): add remote-build spread test

### DIFF
--- a/.github/workflows/spread-scheduled.yaml
+++ b/.github/workflows/spread-scheduled.yaml
@@ -3,7 +3,6 @@ on:
   schedule:
     # At 03:00 on Wednesday and Sunday.
     - cron: "0 3 * * WED,SUN"
-
   workflow_dispatch:
 
 jobs:
@@ -51,3 +50,29 @@ jobs:
       - name: Kernel plugin test
         run: |
           spread google:ubuntu-22.04-64:tests/spread/plugins/${{ matrix.type }}/kernel
+
+  remote-build:
+    runs-on: self-hosted
+    needs: [snap-build]
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Cleanup job workspace
+        run: |
+          rm -rf "${{ github.workspace }}"
+          mkdir "${{ github.workspace }}"
+      - name: Checkout snapcraft
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Download snap artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: snap
+          path: tests
+      - name: remote-build test
+        env:
+          LAUNCHPAD_TOKEN: "${{ secrets.LAUNCHPAD_TOKEN }}"
+        run: |
+          spread google:ubuntu-20.04-64:tests/spread/general/remote-build

--- a/tests/spread/general/remote-build/task.yaml
+++ b/tests/spread/general/remote-build/task.yaml
@@ -1,0 +1,30 @@
+summary: Test the remote builder
+manual: true
+kill-timeout: 180m
+systems:
+  - -ubuntu-22.04
+  - -ubuntu-22.04-64
+  - -ubuntu-22.04-amd64
+
+environment:
+  LAUNCHPAD_TOKEN: "$(HOST: echo ${LAUNCHPAD_TOKEN})"
+  STRATEGY/DISABLE_FALLBACK: "disable-fallback"
+  STRATEGY/FORCE_FALLBACK: "force-fallback"
+
+prepare: |
+  if [[ -z "$LAUNCHPAD_TOKEN" ]]; then
+    echo "No credentials set in env LAUNCHPAD_TOKEN"
+    exit 1
+  fi
+
+  snapcraft init
+  mkdir -p ~/.local/share/snapcraft/provider/launchpad/
+  echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/provider/launchpad/credentials
+
+restore: |
+  rm -f ./*.snap ./*.txt
+
+execute: |
+  export SNAPCRAFT_REMOTE_BUILD_STRATEGY="$STRATEGY"
+
+  snapcraft remote-build --launchpad-accept-public-upload


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

Test the new and legacy remote-build in the weekly spread test.

See a successful workflow job [here](https://github.com/snapcore/snapcraft/actions/runs/6711140620/job/18238067023)


Fixes #4398
(CRAFT-2095)