### PR TITLE
ci: colorize tox and collapse sections

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -37,16 +37,16 @@ jobs:
           python -m pip install 'tox<5.0' tox-gh
           echo "::endgroup::"
           echo "::group::Create virtual environments for linting processes."
-          tox run -m lint build-docs --notest
+          tox run --colored yes -m lint build-docs --notest
           echo "::endgroup::"
           echo "::group::Build docs."
-          tox run -e build-docs
+          tox run --colored yes -e build-docs
           echo "::endgroup::"
           echo "::group::Wait for snap to complete"
           snap watch --last=install
           echo "::endgroup::"
       - name: Run Linters
-        run: tox run --skip-pkg-install -m lint
+        run: tox run --colored yes --skip-pkg-install -m lint
   tests:
     strategy:
       fail-fast: false  # Run all the tests to their conclusions.
@@ -78,9 +78,9 @@ jobs:
           echo "::endgroup::"
           mkdir -p results
       - name: Setup Tox environments
-        run: tox run-parallel --parallel auto --parallel-no-spinner --parallel-live -e test-${{ matrix.tox_python }},test-legacy-${{ matrix.tox_python }} --notest
+        run: tox run-parallel --parallel auto --parallel-no-spinner --parallel-live --colored yes -e test-${{ matrix.tox_python }},test-legacy-${{ matrix.tox_python }} --notest
       - name: Test with tox
-        run: tox run --skip-pkg-install --result-json results/tox-${{ matrix.platform }}.json -e test-${{ matrix.tox_python }},test-legacy-${{ matrix.tox_python }}
+        run: tox run --skip-pkg-install --result-json results/tox-${{ matrix.platform }}.json --colored yes -e test-${{ matrix.tox_python }},test-legacy-${{ matrix.tox_python }}
       - name: Upload code coverage
         uses: codecov/codecov-action@v3
         with:

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,8 @@ minversion = 4.5
 requires =
     # renovate: datasource=pypi
     tox-ignore-env-name-mismatch==0.2.0.post2
+    # renovate: datasource=pypi
+    tox-gh==1.3.1
 # Allow tox to access the user's $TMPDIR environment variable if set.
 # This workaround is required to avoid circular dependencies for TMPDIR,
 # since tox will otherwise attempt to use the environment's TMPDIR variable.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

- Add [`tox-gh`](https://github.com/tox-dev/tox-gh) from starbase, which adds collapsing sections in CI logs
- Colorize the output of tox (similar to https://github.com/canonical/craft-providers/pull/442)

Replaces https://github.com/snapcore/snapcraft/pull/4422


[Before](https://github.com/snapcore/snapcraft/actions/runs/6721498228/job/18267360658#step:5:1)
[After](https://github.com/snapcore/snapcraft/actions/runs/6734011448/job/18303944002?pr=4435#step:5:1)