### PR TITLE
docs(architectures): remove shorthand notation for core22 architectures

### DIFF
--- a/docs/howto/architectures.rst
+++ b/docs/howto/architectures.rst
@@ -35,13 +35,6 @@ following snippet snippet will produce the same result:
   architectures:
     - build-on: [amd64]
 
-The shorthand format will also produce the same result:
-
-.. code-block:: yaml
-
-  architectures:
-    - amd64
-
 core20
 ^^^^^^
 
@@ -96,12 +89,6 @@ following snippet snippet will produce the same result:
   architectures:
     - build-on: [amd64]
     - build-on: [arm64]
-
-The shorthand format will also produce the same result:
-
-.. code-block:: yaml
-
-  architectures: [amd64, arm64]
 
 core20
 ^^^^^^

--- a/docs/reference/architectures.rst
+++ b/docs/reference/architectures.rst
@@ -71,11 +71,20 @@ use the ``all`` keyword.
 
 The same architecture cannot be defined in multiple ``build-for`` entries.
 
+core20
+^^^^^^
+
+The above syntax and rules for ``core22`` apply for ``core20`` except that
+``run-on`` is used in place of ``build-for``. Additionally, ``core20`` supports
+multiple architectures in the ``run-on`` field, which will create
+multi-architecture snaps.
+
 Shorthand format
 """"""""""""""""
 
-As an alternative to the explicit format described above, a shorthand format
-can be used for simple ``build-on/build-for`` pairs. The following shorthand:
+As an alternative to the explicit format described above, ``core20`` snaps
+support a shorthand format can be used for simple ``build-on/run-on``
+pairs. The following shorthand:
 
 .. code-block:: yaml
 
@@ -87,19 +96,12 @@ is equivalent to:
 
   architectures:
     - build-on: [amd64]
-      build-for: [amd64]
+      run-on: [amd64]
     - build-on: [arm64]
-      build-for: [arm64]
+      run-on: [arm64]
 
 The explicit and shorthand format cannot be mixed.
 
-core20
-^^^^^^
-
-The above syntax and rules for ``core22`` apply for ``core20`` except that
-``run-on`` is used in place of ``build-for``. Additionally, ``core20`` supports
-multiple architectures in the ``run-on`` field, which will create
-multi-architecture snaps.
 
 Project variables
 -----------------


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

Update documentation for architectures to discourage the use of the shorthand notation in core22 snaps.

This is because the shorthand notation for core22 snaps is not supported by Launchpad.  Removing support in snapcraft would be disruptive so instead we can discourage its usage by removing it from the documentation.

The documentation on snapcraft.io/docs has already been updated.

[LP #2042167](https://bugs.launchpad.net/snapcraft/+bug/2042167)