### PR TITLE
build(deps): bump craft-providers to 1.19.2

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -15,7 +15,7 @@ craft-archives==1.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.7
-craft-providers==1.19.1
+craft-providers==1.19.2
 craft-store==2.4.0
 cryptography==40.0.2
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ craft-archives==1.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.7
-craft-providers==1.19.1
+craft-providers==1.19.2
 craft-store==2.4.0
 cryptography==40.0.2
 Deprecated==1.2.13


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

### Changelog

#### 1.19.2 (2023-11-02)
- Update base compatibility tag from ``base-v2`` to ``base-v3``
  This fixes an issue where LXD instances created with
  ``craft-providers==1.16.0`` may fail to start with
  ``craft-providers>=1.17.0``.