### PR TITLE
remote-build: Add riscv64

### DIFF
--- a/docs/reference/architectures.rst
+++ b/docs/reference/architectures.rst
@@ -202,6 +202,7 @@ The following architectures are supported by Launchpad for remote building.
 * arm64
 * armhf
 * ppc64el
+* riscv64
 * s390x
 
 Environment variables and command line arguments

--- a/snapcraft/remote/utils.py
+++ b/snapcraft/remote/utils.py
@@ -25,7 +25,7 @@ from typing import Iterable, List
 
 from .errors import UnsupportedArchitectureError
 
-_SUPPORTED_ARCHS = ["amd64", "arm64", "armhf", "i386", "ppc64el", "s390x"]
+_SUPPORTED_ARCHS = ["amd64", "arm64", "armhf", "i386", "ppc64el", "riscv64", "s390x"]
 
 
 def validate_architectures(architectures: List[str]) -> None:

--- a/snapcraft_legacy/cli/remote.py
+++ b/snapcraft_legacy/cli/remote.py
@@ -27,7 +27,7 @@ from snapcraft_legacy.project import Project
 from . import echo
 from ._options import PromptOption, get_project
 
-_SUPPORTED_ARCHS = ["amd64", "arm64", "armhf", "i386", "ppc64el", "s390x"]
+_SUPPORTED_ARCHS = ["amd64", "arm64", "armhf", "i386", "ppc64el", "riscv64", "s390x"]
 
 
 @click.group()
@@ -113,7 +113,7 @@ def remote_build(
     Examples:
         snapcraft remote-build
         snapcraft remote-build --build-on=amd64
-        snapcraft remote-build --build-on=amd64,arm64,armhf,i386,ppc64el,s390x
+        snapcraft remote-build --build-on=amd64,arm64,armhf,i386,ppc64el,riscv64,s390x
         snapcraft remote-build --recover
         snapcraft remote-build --recover --build-id snapcraft-my-snap-b98a6bd3
         snapcraft remote-build --status


### PR DESCRIPTION
This architecture is now virtualized and unrestricted in Launchpad, so remote-build can support it.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
