### PR TITLE
fix(metadata): add f-string to debug message

### DIFF
--- a/snapcraft/parts/update_metadata.py
+++ b/snapcraft/parts/update_metadata.py
@@ -137,7 +137,7 @@ def _update_project_app_desktop_file(
             return
 
         if project.apps[app_name].desktop:
-            emit.debug("app {app_name!r} already declares a desktop file")
+            emit.debug(f"app {app_name!r} already declares a desktop file")
             return
 
         emit.debug(


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

Add a missing f-string to a debug message