### PR TITLE
build(deps): bump craft-store to 2.5.0

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -16,7 +16,7 @@ craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.7
 craft-providers==1.19.2
-craft-store==2.4.0
+craft-store==2.5.0
 cryptography==40.0.2
 Deprecated==1.2.13
 dill==0.3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.7
 craft-providers==1.19.2
-craft-store==2.4.0
+craft-store==2.5.0
 cryptography==40.0.2
 Deprecated==1.2.13
 distro==1.8.0


### PR DESCRIPTION
Allows headless systems to fallback to a file based keyring backend.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----

To verify, the following would fail
```
multipass shell
snap install snapcraft
snapcraft login
```
but,
```
snap refresh snapcraft edge/pr-4455
snapcraft login
snapcraft whoami
```
would work