### PR TITLE
fix: push tags for remote-build

### DIFF
--- a/snapcraft/remote/launchpad.py
+++ b/snapcraft/remote/launchpad.py
@@ -484,4 +484,4 @@ class LaunchpadClient:
         logger.info("Sending build data to Launchpad: %s", stripped_url)
 
         repo = GitRepo(repo_dir)
-        repo.push_url(url, "main", "HEAD", token)
+        repo.push_url(url, "main", "HEAD", token, push_tags=True)

--- a/tests/unit/remote/test_launchpad.py
+++ b/tests/unit/remote/test_launchpad.py
@@ -531,6 +531,7 @@ def test_push_source_tree(new_dir, mock_git_repo, launchpad_client):
                 "main",
                 "HEAD",
                 "access-token",
+                push_tags=True,
             ),
         ]
     )


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
