### PR TITLE
fix: improve lifecycle messages

### DIFF
--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -185,7 +185,8 @@ class PartsLifecycle:
                             properties=action.properties,
                         )
                     message = _get_parts_action_message(action)
-                    with emit.open_stream(message) as stream:
+                    emit.progress(message)
+                    with emit.open_stream() as stream:
                         aex.execute(action, stdout=stream, stderr=stream)
 
             if shell_after:


### PR DESCRIPTION
Wipe "Initializing lifecycle" when parts steps start making progress by moving the action message from the emit.open_stream call to an explicit emit.progress.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
