### PR TITLE
build(deps): bump craft-providers to 1.20.1

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -15,7 +15,7 @@ craft-archives==1.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.7
-craft-providers==1.19.2
+craft-providers==1.20.1
 craft-store==2.5.0
 cryptography==40.0.2
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ craft-archives==1.1.3
 craft-cli==1.2.0
 craft-grammar==1.1.1
 craft-parts==1.19.7
-craft-providers==1.19.2
+craft-providers==1.20.1
 craft-store==2.5.0
 cryptography==40.0.2
 Deprecated==1.2.13


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

This resolves a bug introduced in `1.16.0` where improperly set-up base instances would cause snapcraft to fail with the error `Instance setup failed. Check LXD logs for more details`.

### Changelog

#### 1.20.1

- Update base compatibility tag from ``base-v3`` to ``base-v4``
- If an existing base instance is not setup, then it is auto-cleaned.
  If the process that created the not setup base instance is inactive, then
  ``craft-providers`` will immediately auto-clean the instance.

#### 1.20.0
- Snaps injected from the host will have their base snap injected into
  the instance.
