### PR TITLE
snapcraft: Allow equal sign in commands

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -857,7 +857,7 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "pattern": "^[A-Za-z0-9/._#:$-]*$",
+                                "pattern": "^[A-Za-z0-9/._#:$-=]*$",
                                 "validation-failure": "{.instance!r} is not a valid command-chain entry. Command chain entries must be strings, and can only use ASCII alphanumeric characters and the following special characters: / . _ # : $ -"
                             }
                         },
@@ -944,7 +944,7 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "pattern": "^[A-Za-z0-9/._#:$-]*$",
+                                "pattern": "^[A-Za-z0-9/._#:$-=]*$",
                                 "validation-failure": "{.instance!r} is not a valid command-chain entry. Command chain entries must be strings, and can only use ASCII alphanumeric characters and the following special characters: / . _ # : $ -"
                             }
                         },

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -72,11 +72,11 @@ def _validate_command_chain(command_chains: Optional[List[str]]) -> Optional[Lis
     """Validate command_chain."""
     if command_chains is not None:
         for command_chain in command_chains:
-            if not re.match(r"^[A-Za-z0-9/._#:$-]*$", command_chain):
+            if not re.match(r"^[A-Za-z0-9/._#:$-=]*$", command_chain):
                 raise ValueError(
                     f"{command_chain!r} is not a valid command chain. Command chain entries must "
                     "be strings, and can only use ASCII alphanumeric characters and the following "
-                    "special characters: / . _ # : $ -"
+                    "special characters: / . _ # : $ - ="
                 )
     return command_chains
 

--- a/snapcraft_legacy/internal/meta/hooks.py
+++ b/snapcraft_legacy/internal/meta/hooks.py
@@ -73,7 +73,7 @@ class Hook:
 
         # Would normally get caught/handled by schema validation.
         for command in self.command_chain:
-            if not re.match("^[A-Za-z0-9/._#:$-]*$", command):
+            if not re.match("^[A-Za-z0-9/._#:$-=]*$", command):
                 raise HookValidationError(
                     hook_name=self.hook_name,
                     message=f"{command!r} is not a valid command-chain command.",


### PR DESCRIPTION
In various cases applications require to use --option=value syntax but this is  currently blocked by snapcraft syntax checker.

So add the equal sign as a valid value in the regex since it does seems to be harmful.

See also: https://forum.snapcraft.io/t/please-allow-equals-symbol-in-snapcraft-yaml/36709

---

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----
