### PR TITLE
[DRAFT] feat: enable partitions

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -14,7 +14,7 @@ coverage==7.3.2
 craft-archives==1.1.3
 craft-cli==2.5.0
 craft-grammar==1.1.1
-craft-parts==1.26.0
+git+https://github.com/canonical/craft-parts@feature/namespaced-partitions-patch#egg=craft-parts
 craft-providers==1.20.1
 craft-store==2.5.0
 cryptography==41.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.7
 craft-archives==1.1.3
 craft-cli==2.5.0
 craft-grammar==1.1.1
-craft-parts==1.26.0
+git+https://github.com/canonical/craft-parts@feature/namespaced-partitions-patch#egg=craft-parts
 craft-providers==1.20.1
 craft-store==2.5.0
 cryptography==41.0.7

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ install_requires = [
     "craft-archives",
     "craft-cli",
     "craft-grammar",
-    "craft-parts",
+    "craft-parts @ git+https://github.com/canonical/craft-parts@feature/namespaced-partitions-patch#egg=craft-parts",
     "craft-providers",
     "craft-store",
     "docutils<0.20",  # Frozen until we can update sphinx dependencies.

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -486,7 +486,7 @@ def _expose_prime(project_path: Path, instance: Executor):
     host_prime.mkdir(exist_ok=True)
 
     managed_root = utils.get_managed_environment_home_path()
-    dirs = craft_parts.ProjectDirs(work_dir=managed_root)
+    dirs = craft_parts.ProjectDirs(work_dir=managed_root, partitions=["default"])
 
     instance.mount(host_source=project_path / "prime", target=dirs.prime_dir)
 
@@ -612,7 +612,7 @@ def _expand_environment(
     if target_arch == "all":
         target_arch = get_host_architecture()
 
-    dirs = craft_parts.ProjectDirs(work_dir=work_dir)
+    dirs = craft_parts.ProjectDirs(work_dir=work_dir, partitions=["default"])
     info = craft_parts.ProjectInfo(
         application_name="snapcraft",  # not used in environment expansion
         cache_dir=Path(),  # not used in environment expansion
@@ -621,6 +621,7 @@ def _expand_environment(
         project_name=snapcraft_yaml.get("name", ""),
         project_dirs=dirs,
         project_vars=project_vars,
+        partitions=["default"],
     )
     _set_global_environment(info)
 

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, List, Optional, Set
 import craft_parts
 from craft_archives import repo
 from craft_cli import emit
-from craft_parts import Action, ActionType, Part, ProjectDirs, Step
+from craft_parts import Action, ActionType, Features, Part, ProjectDirs, Step
 from craft_parts.packages import Repository
 from xdg import BaseDirectory  # type: ignore
 
@@ -39,6 +39,9 @@ _LIFECYCLE_STEPS = {
     "stage": Step.STAGE,
     "prime": Step.PRIME,
 }
+
+# Enable the craft-parts features that we use
+Features(enable_partitions=True)
 
 
 class PartsLifecycle:
@@ -109,6 +112,7 @@ class PartsLifecycle:
                 # custom arguments
                 project_base=project_base,
                 confinement=confinement,
+                partitions=["default"],
             )
         except craft_parts.PartsError as err:
             raise errors.PartsLifecycleError(str(err)) from err
@@ -244,8 +248,8 @@ class PartsLifecycle:
         if self._adopt_info is None or self._adopt_info not in self._parse_info:
             return []
 
-        dirs = ProjectDirs(work_dir=self._work_dir)
-        part = Part(self._adopt_info, {}, project_dirs=dirs)
+        dirs = ProjectDirs(work_dir=self._work_dir, partitions=["default"])
+        part = Part(self._adopt_info, {}, project_dirs=dirs, partitions=["default"])
         locations = (
             part.part_src_dir,
             part.part_build_dir,

--- a/tests/spread/core22/environment/paths/task.yaml
+++ b/tests/spread/core22/environment/paths/task.yaml
@@ -25,7 +25,7 @@ execute: |
 
   snapcraft prime --destructive-mode
 
-  if ! diff -U10 prime/meta/snap.yaml expected_snap.yaml; then
+  if ! diff -U10 prime/default/meta/snap.yaml expected_snap.yaml; then
       echo "The formatting for snap.yaml is incorrect"
       exit 1
   fi

--- a/tests/spread/core22/environment/test-variables/task.yaml
+++ b/tests/spread/core22/environment/test-variables/task.yaml
@@ -35,9 +35,11 @@ execute: |
       "^CRAFT_PART_SRC_WORK=${root}/parts/hello/src$" \
       "^CRAFT_PART_BUILD=${root}/parts/hello/build$" \
       "^CRAFT_PART_BUILD_WORK=${root}/parts/hello/build$" \
-      "^CRAFT_PART_INSTALL=${root}/parts/hello/install$" \
-      "^CRAFT_STAGE=${root}/stage$" \
-      "^CRAFT_PRIME=${root}/prime$"; do
+      "^CRAFT_PART_INSTALL=${root}/parts/hello/install/default$" \
+      "^CRAFT_STAGE=${root}/stage/default$" \
+      "^CRAFT_PRIME=${root}/prime/default$" \
+      "^CRAFT_DEFAULT_STAGE=${root}/stage/default$" \
+      "^CRAFT_DEFAULT_PRIME=${root}/prime/default$"; do
       grep -q "$exp" < "$file"
     done
   }

--- a/tests/spread/core22/manifest/manifest-creation/task.yaml
+++ b/tests/spread/core22/manifest/manifest-creation/task.yaml
@@ -16,9 +16,9 @@ execute: |
   $CMD
 
   test -f manifest_0.1_*.snap
-  test -f prime/snap/manifest.yaml
-  test "$(grep -c -- '^ *- hello=[0-9]' prime/snap/manifest.yaml)" -eq 2
-  cmp snap/snapcraft.yaml prime/snap/snapcraft.yaml
+  test -f prime/default/snap/manifest.yaml
+  test "$(grep -c -- '^ *- hello=[0-9]' prime/default/snap/manifest.yaml)" -eq 2
+  cmp snap/snapcraft.yaml prime/default/snap/snapcraft.yaml
 
   cp manifest_0.1_*.snap ~
   review-tools.snap-review ~/manifest_0.1_*.snap

--- a/tests/spread/core22/manifest/manifest-info-cmdline/task.yaml
+++ b/tests/spread/core22/manifest/manifest-info-cmdline/task.yaml
@@ -23,7 +23,7 @@ execute: |
   # also test in destructive mode
   snapcraft --destructive-mode --enable-manifest --manifest-image-information='{"test-var": "value"}'
 
-  grep '^  test-var: value' prime/snap/manifest.yaml
+  grep '^  test-var: value' prime/default/snap/manifest.yaml
 
   cp manifest_0.1_*.snap ~
   review-tools.snap-review ~/manifest_0.1_*.snap

--- a/tests/spread/core22/manifest/manifest-info-envvars/task.yaml
+++ b/tests/spread/core22/manifest/manifest-info-envvars/task.yaml
@@ -24,7 +24,7 @@ execute: |
   # also test in destructive mode
   snapcraft --destructive-mode
 
-  grep '^  test-var: value' prime/snap/manifest.yaml
+  grep '^  test-var: value' prime/default/snap/manifest.yaml
 
   cp manifest_0.1_*.snap ~
   review-tools.snap-review ~/manifest_0.1_*.snap

--- a/tests/spread/core22/patchelf/classic-patchelf/task.yaml
+++ b/tests/spread/core22/patchelf/classic-patchelf/task.yaml
@@ -30,16 +30,16 @@ execute: |
   RPATH_ORIGIN_MATCH="^\\\$ORIGIN/../fake-lib:/snap/$base/current/lib/$arch_triplet"
 
   # Verify typical binary.
-  patchelf --print-interpreter prime/bin/hello-classic | MATCH "^/snap/$base/current/lib.*ld.*.so.*"
-  patchelf --print-rpath prime/bin/hello-classic | MATCH "${RPATH_MATCH}"
+  patchelf --print-interpreter prime/default/bin/hello-classic | MATCH "^/snap/$base/current/lib.*ld.*.so.*"
+  patchelf --print-rpath prime/default/bin/hello-classic | MATCH "${RPATH_MATCH}"
 
   # Verify binary w/ existing rpath.
-  patchelf --print-interpreter prime/bin/hello-classic-existing-rpath | MATCH "^/snap/$base/current/lib.*ld.*.so.*"
-  patchelf --print-rpath prime/bin/hello-classic-existing-rpath | MATCH "${RPATH_ORIGIN_MATCH}"
+  patchelf --print-interpreter prime/default/bin/hello-classic-existing-rpath | MATCH "^/snap/$base/current/lib.*ld.*.so.*"
+  patchelf --print-rpath prime/default/bin/hello-classic-existing-rpath | MATCH "${RPATH_ORIGIN_MATCH}"
 
   # Verify untouched no-patchelf.
-  patchelf --print-interpreter prime/bin/hello-classic-no-patchelf | MATCH "^/lib.*ld.*.so.*"
-  rpath="$(patchelf --print-rpath prime/bin/hello-classic-no-patchelf)"
+  patchelf --print-interpreter prime/default/bin/hello-classic-no-patchelf | MATCH "^/lib.*ld.*.so.*"
+  rpath="$(patchelf --print-rpath prime/default/bin/hello-classic-no-patchelf)"
   if [[ -n "${rpath}" ]]; then
      echo "found rpath with no-patchelf: ${rpath}"
      exit 1

--- a/tests/spread/core22/patchelf/strict-patchelf/task.yaml
+++ b/tests/spread/core22/patchelf/strict-patchelf/task.yaml
@@ -26,8 +26,8 @@ execute: |
   arch_triplet="$(dpkg-architecture -q DEB_HOST_MULTIARCH)"
 
   # Verify typical strict binary has an untouched rpath
-  patchelf --print-interpreter prime/bin/hello-strict | MATCH "^/lib.*ld.*.so.*"
-  rpath="$(patchelf --print-rpath prime/bin/hello-strict)"
+  patchelf --print-interpreter prime/default/bin/hello-strict | MATCH "^/lib.*ld.*.so.*"
+  rpath="$(patchelf --print-rpath prime/default/bin/hello-strict)"
   if [[ -n "${rpath}" ]]; then
      echo "found rpath on strict binary: ${rpath}"
      exit 1
@@ -38,10 +38,10 @@ execute: |
   RPATH_ORIGIN_MATCH="^\\\$ORIGIN/../fake-lib:/snap/$base/current/lib/$arch_triplet"
 
   # Verify binary rpath patching with existing rpath
-  patchelf --print-interpreter prime/bin/hello-strict-existing-rpath | MATCH "^/snap/$base/current/lib.*ld.*.so.*"
-  patchelf --print-rpath prime/bin/hello-strict-existing-rpath | MATCH "${RPATH_ORIGIN_MATCH}"
+  patchelf --print-interpreter prime/default/bin/hello-strict-existing-rpath | MATCH "^/snap/$base/current/lib.*ld.*.so.*"
+  patchelf --print-rpath prime/default/bin/hello-strict-existing-rpath | MATCH "${RPATH_ORIGIN_MATCH}"
 
   # Verify binary rpath patching without existing rpath
-  patchelf --print-interpreter prime/bin/hello-strict-enable-patchelf | MATCH "^/snap/$base/current/lib.*ld.*.so.*"
-  patchelf --print-rpath prime/bin/hello-strict-enable-patchelf | MATCH "${RPATH_MATCH}"
+  patchelf --print-interpreter prime/default/bin/hello-strict-enable-patchelf | MATCH "^/snap/$base/current/lib.*ld.*.so.*"
+  patchelf --print-rpath prime/default/bin/hello-strict-enable-patchelf | MATCH "${RPATH_MATCH}"
 

--- a/tests/spread/core22/scriptlets/empty-overrides/task.yaml
+++ b/tests/spread/core22/scriptlets/empty-overrides/task.yaml
@@ -5,9 +5,9 @@ restore: |
 
 execute: |
   snapcraft prime --destructive-mode
-  test -d prime
+  test -d prime/default
 
-  if [ -f prime/foo.bar ]; then
+  if [ -f prime/default/foo.bar ]; then
       echo "prime directory should be empty"
       false
   fi

--- a/tests/spread/core22/try/task.yaml
+++ b/tests/spread/core22/try/task.yaml
@@ -12,8 +12,8 @@ execute: |
   # Followed by the actual try
   snapcraft try --use-lxd
   
-  find prime/meta/snap.yaml
-  find prime/usr/bin/hello
+  find prime/default/meta/snap.yaml
+  find prime/default/usr/bin/hello
   
   snap try prime
   hello-try | MATCH "Hello, world"

--- a/tests/spread/general/appstream-desktop/task.yaml
+++ b/tests/spread/general/appstream-desktop/task.yaml
@@ -37,14 +37,14 @@ execute: |
       expected_snap_yaml="$PWD/../../appstream-desktop/expected_snap.yaml"
   fi
 
-  if ! diff -U10 prime/meta/snap.yaml "$expected_snap_yaml"; then
+  if ! diff -U10 prime/default/meta/snap.yaml "$expected_snap_yaml"; then
       echo "The formatting for snap.yaml is incorrect"
       exit 1
   fi
 
   expected_desktop="$PWD/../../appstream-desktop/expected_appstream-desktop.desktop"
 
-  if ! diff -U10 prime/meta/gui/appstream-desktop.desktop "$expected_desktop"; then
+  if ! diff -U10 prime/default/meta/gui/appstream-desktop.desktop "$expected_desktop"; then
       echo "The formatting for appstream-desktop.desktop is incorrect"
       exit 1
   fi

--- a/tests/spread/general/appstream-icon-from-desktop/task.yaml
+++ b/tests/spread/general/appstream-icon-from-desktop/task.yaml
@@ -33,14 +33,14 @@ execute: |
       expected_snap_yaml="$PWD/../../appstream-icon-from-desktop/expected_snap.yaml"
   fi
 
-  if ! diff -U10 prime/meta/snap.yaml "$expected_snap_yaml"; then
+  if ! diff -U10 prime/default/meta/snap.yaml "$expected_snap_yaml"; then
       echo "The formatting for snap.yaml is incorrect"
       exit 1
   fi
 
   expected_desktop="$PWD/../../appstream-desktop/expected_appstream-desktop.desktop"
 
-  if ! diff -U10 prime/meta/gui/appstream-desktop.desktop "$expected_desktop"; then
+  if ! diff -U10 prime/default/meta/gui/appstream-desktop.desktop "$expected_desktop"; then
       echo "The formatting for appstream-desktop.desktop is incorrect"
       exit 1
   fi

--- a/tests/spread/general/appstream-remote-gfx/task.yaml
+++ b/tests/spread/general/appstream-remote-gfx/task.yaml
@@ -29,19 +29,19 @@ execute: |
       expected_snap_yaml="$PWD/../../appstream-remote-gfx/expected_snap.yaml"
   fi
 
-  if ! diff -U10 prime/meta/snap.yaml "$expected_snap_yaml"; then
+  if ! diff -U10 prime/default/meta/snap.yaml "$expected_snap_yaml"; then
       echo "The formatting for snap.yaml is incorrect"
       exit 1
   fi
 
   expected_desktop="$PWD/../../appstream-remote-gfx/expected_appstream-desktop.desktop"
 
-  if ! diff -U10 prime/meta/gui/appstream-desktop.desktop "$expected_desktop"; then
+  if ! diff -U10 prime/default/meta/gui/appstream-desktop.desktop "$expected_desktop"; then
       echo "The formatting for appstream-desktop.desktop is incorrect"
       exit 1
   fi
 
-  if [ ! -f prime/meta/gui/icon.png ]; then
+  if [ ! -f prime/default/meta/gui/icon.png ]; then
       echo "Failed to fetch remote icon."
       exit 1
   fi

--- a/tests/spread/general/grammar/task.yaml
+++ b/tests/spread/general/grammar/task.yaml
@@ -16,6 +16,10 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 execute: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  prime_dir="$(get_prime_dir)"
+
   # first, run `snapcraft prime` for amd64
   if [[ "$SPREAD_SYSTEM" =~ ubuntu-18.04 ]] || [[ "$SPREAD_SYSTEM" =~ ubuntu-20.04 ]]; then
       # for core18 and core20, replace architectures block with
@@ -30,7 +34,7 @@ execute: |
 
 
   # verify `on amd64 to amd64` grammar was processed
-  if ! grep "I was built on amd64 and built for amd64." prime/hello-world.sh; then
+  if ! grep "I was built on amd64 and built for amd64." "${prime_dir}/hello-world.sh"; then
     echo "Grammar was not processed as expected!"
     exit 1
   fi
@@ -43,7 +47,7 @@ execute: |
   fi
 
   # verify `on amd64 to arm64` grammar was processed
-  if ! grep "I was built on amd64 and built for arm64." prime/hello-world.sh; then
+  if ! grep "I was built on amd64 and built for arm64." "${prime_dir}/hello-world.sh"; then
     echo "Grammar was not processed as expected!"
     exit 1
   fi

--- a/tests/spread/general/hooks/generated-and-project-hooks/task.yaml
+++ b/tests/spread/general/hooks/generated-and-project-hooks/task.yaml
@@ -16,17 +16,21 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 execute: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  prime_dir="$(get_prime_dir)"
+
   snapcraft --destructive-mode
 
   # verify hooks were staged
-  if [[ ! -f prime/meta/hooks/configure ]] && [[ ! -f prime/meta/hooks/install ]]; then
-      echo "no hook found in prime/meta/hooks/"
+  if [[ ! -f "${prime_dir}/meta/hooks/configure" ]] && [[ ! -f "${prime_dir}/meta/hooks/install" ]]; then
+      echo "no hook found in ${prime_dir}/meta/hooks/"
       exit 1
   fi
 
   # verify hooks can execute
-  if ! prime/snap/hooks/install | grep "I am a project install hook" && \
-     ! prime/snap/hooks/configure | grep "I am a project configure hook"; then
+  if ! "${prime_dir}/snap/hooks/install" | grep "I am a project install hook" && \
+     ! "${prime_dir}/snap/hooks/configure" | grep "I am a project configure hook"; then
     echo "Unexpected content in hook"
     exit 1
   fi

--- a/tests/spread/general/hooks/generated-hooks/task.yaml
+++ b/tests/spread/general/hooks/generated-hooks/task.yaml
@@ -16,17 +16,21 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 execute: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  prime_dir="$(get_prime_dir)"
+
   snapcraft --destructive-mode
 
   # verify wrappers were created for generated hooks
-  if [[ ! -f prime/meta/hooks/configure ]] && [[ ! -f prime/meta/hooks/install ]]; then
-      echo "no hook wrappers found in prime/meta/hooks/"
+  if [[ ! -f "${prime_dir}/meta/hooks/configure" ]] && [[ ! -f "${prime_dir}/meta/hooks/install" ]]; then
+      echo "no hook wrappers found in ${prime_dir}/meta/hooks/"
       exit 1
   fi
 
   # verify hook wrappers execute their corresponding hooks
-  if ! prime/snap/hooks/install | grep "I am a code generated install hook" && \
-     ! prime/snap/hooks/configure | grep "I am a code generated configure hook"; then
+  if ! "${prime_dir}/snap/hooks/install" | grep "I am a code generated install hook" && \
+     ! "${prime_dir}/snap/hooks/configure" | grep "I am a code generated configure hook"; then
     echo "Unexpected content in hook"
     exit 1
   fi

--- a/tests/spread/general/hooks/generated-then-project-hooks/task.yaml
+++ b/tests/spread/general/hooks/generated-then-project-hooks/task.yaml
@@ -16,17 +16,21 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 execute: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  prime_dir=$(get_prime_dir)
+
   snapcraft --destructive-mode
 
   # verify hooks were staged
-  if [[ ! -f prime/meta/hooks/configure ]] && [[ ! -f prime/meta/hooks/install ]]; then
-      echo "no hook found in prime/meta/hooks/"
+  if [[ ! -f "${prime_dir}/meta/hooks/configure" ]] && [[ ! -f "${prime_dir}/meta/hooks/install" ]]; then
+      echo "no hook found in ${prime_dir}/meta/hooks/"
       exit 1
   fi
 
   # verify hooks can execute
-  if ! prime/snap/hooks/install | grep "I am a code generated install hook" && \
-     ! prime/snap/hooks/configure | grep "I am a code generated configure hook"; then
+  if ! "${prime_dir}/snap/hooks/install" | grep "I am a code generated install hook" && \
+     ! "${prime_dir}/snap/hooks/configure" | grep "I am a code generated configure hook"; then
     echo "Unexpected content in hook"
     exit 1
   fi
@@ -44,14 +48,14 @@ execute: |
   snapcraft --destructive-mode
 
   # verify hooks are still staged
-  if [[ ! -f prime/meta/hooks/configure ]] && [[ ! -f prime/meta/hooks/install ]]; then
-      echo "no hook found in prime/meta/hooks/"
+  if [[ ! -f "${prime_dir}/meta/hooks/configure" ]] && [[ ! -f "${prime_dir}/meta/hooks/install" ]]; then
+      echo "no hook found in ${prime_dir}/meta/hooks/"
       exit 1
   fi
 
   # verify hooks have been updated
-  if ! prime/snap/hooks/install | grep "I am a project install hook" && \
-     ! prime/snap/hooks/configure | grep "I am a project configure hook"; then
+  if ! "${prime_dir}/snap/hooks/install" | grep "I am a project install hook" && \
+     ! "${prime_dir}/snap/hooks/configure" | grep "I am a project configure hook"; then
     echo "Unexpected content in hook"
     exit 1
   fi

--- a/tests/spread/general/hooks/project-hooks-updated/task.yaml
+++ b/tests/spread/general/hooks/project-hooks-updated/task.yaml
@@ -16,17 +16,21 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 execute: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  prime_dir="$(get_prime_dir)"
+
   snapcraft --destructive-mode
 
   # verify hooks were staged
-  if [[ ! -f prime/meta/hooks/configure ]] && [[ ! -f prime/meta/hooks/install ]]; then
+  if [[ ! -f "${prime_dir}/meta/hooks/configure" ]] && [[ ! -f "${prime_dir}/meta/hooks/install" ]]; then
       echo "no hook found in prime/meta/hooks/"
       exit 1
   fi
 
   # verify hooks can execute
-  if ! prime/snap/hooks/install | grep "I am a project install hook" && \
-     ! prime/snap/hooks/configure | grep "I am a project configure hook"; then
+  if ! "${prime_dir}/snap/hooks/install" | grep "I am a project install hook" && \
+     ! "${prime_dir}/snap/hooks/configure" | grep "I am a project configure hook"; then
     echo "Unexpected content in hook"
     exit 1
   fi
@@ -41,14 +45,14 @@ execute: |
   snapcraft --destructive-mode
 
   # verify hooks are still staged
-  if [[ ! -f prime/meta/hooks/configure ]] && [[ ! -f prime/meta/hooks/install ]]; then
+  if [[ ! -f "${prime_dir}/meta/hooks/configure" ]] && [[ ! -f "${prime_dir}/meta/hooks/install" ]]; then
       echo "no hook found in prime/meta/hooks/"
       exit 1
   fi
 
   # verify hooks have been updated
-  if ! prime/snap/hooks/install | grep "I am an updated project install hook" && \
-     ! prime/snap/hooks/configure | grep "I am an updated project configure hook"; then
+  if ! "${prime_dir}/snap/hooks/install" | grep "I am an updated project install hook" && \
+     ! "${prime_dir}/snap/hooks/configure" | grep "I am an updated project configure hook"; then
     echo "Unexpected content in hook"
     exit 1
   fi

--- a/tests/spread/general/hooks/project-hooks/task.yaml
+++ b/tests/spread/general/hooks/project-hooks/task.yaml
@@ -16,17 +16,21 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 execute: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  prime_dir=$(get_prime_dir)
+
   snapcraft --destructive-mode
 
   # verify hooks were staged
-  if [[ ! -f prime/meta/hooks/configure ]] && [[ ! -f prime/meta/hooks/install ]]; then
-      echo "no hook found in prime/meta/hooks/"
+  if [[ ! -f "${prime_dir}/meta/hooks/configure" ]] && [[ ! -f "${prime_dir}/meta/hooks/install" ]]; then
+      echo "no hook found in ${prime_dir}/meta/hooks/"
       exit 1
   fi
 
   # verify hooks can execute
-  if ! prime/snap/hooks/install | grep "I am a project install hook" && \
-     ! prime/snap/hooks/configure | grep "I am a project configure hook"; then
+  if ! "${prime_dir}/snap/hooks/install" | grep "I am a project install hook" && \
+     ! "${prime_dir}/snap/hooks/configure" | grep "I am a project configure hook"; then
     echo "Unexpected content in hook"
     exit 1
   fi

--- a/tests/spread/general/hooks/stub-hooks/task.yaml
+++ b/tests/spread/general/hooks/stub-hooks/task.yaml
@@ -24,16 +24,20 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 execute: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  prime_dir="$(get_prime_dir)"
+
   snapcraft snap --destructive-mode
 
   # Verify that the hook is there
-  if [ ! -f prime/meta/hooks/install ]; then
+  if [ ! -f "${prime_dir}/meta/hooks/install" ]; then
       echo "Stub hook missing"
       exit 1
   fi
   
   # Verify stub hook content
-  hook_content=$(cat prime/meta/hooks/install)
+  hook_content=$(cat "${prime_dir}/meta/hooks/install")
   if [ "${hook_content}" != "#!/bin/true" ]; then
       echo "Unexpected hook content:"
       echo "${hook_content}"

--- a/tests/spread/general/license-valid/task.yaml
+++ b/tests/spread/general/license-valid/task.yaml
@@ -15,8 +15,12 @@ restore: |
   rm -rf test-snap
 
 execute: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  prime_dir="$(get_prime_dir)"
+
   cd test-snap
 
   snapcraft  
 
-  MATCH -v "license: MIT" < prime/meta/snap.yaml
+  MATCH -v "license: MIT" < "${prime_dir}/meta/snap.yaml"

--- a/tests/spread/general/metadata-links/task.yaml
+++ b/tests/spread/general/metadata-links/task.yaml
@@ -1,8 +1,5 @@
 summary: Metadata links transformation from snapcraft.yaml to snap.yaml
 
-environment:
-  SNAP_YAML: prime/meta/snap.yaml
-
 prepare: |
   snap install yq
 
@@ -19,6 +16,10 @@ restore: |
   restore_yaml snapcraft.yaml
 
 execute: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  SNAP_YAML="$(get_prime_dir)/meta/snap.yaml"
+
   # Create a snap to trigger `snap pack`.
   snapcraft
 

--- a/tests/spread/general/snap_local_dir/task.yaml
+++ b/tests/spread/general/snap_local_dir/task.yaml
@@ -24,6 +24,10 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 execute: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  stage_dir="$(get_stage_dir)"
+
   compare_dir_contents()
   {
       find "$1" ! -path "$1" -printf '%P\n' | sort > found.txt
@@ -41,4 +45,5 @@ execute: |
 
   # Verify that the parts can now be staged, and end up as expected
   snapcraft stage | MATCH -v "unsupported"
-  [ -z "$(compare_dir_contents stage expected_stage.txt)" ]
+
+  [ -z "$(compare_dir_contents "${stage_dir}" expected_stage.txt)" ]

--- a/tests/spread/general/stage_snaps/task.yaml
+++ b/tests/spread/general/stage_snaps/task.yaml
@@ -20,16 +20,20 @@ restore: |
   rm -rf test-snap
 
 execute: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  stage_dir="$(get_stage_dir)"
+
   cd test-snap
 
   snapcraft stage
 
-  if [ ! -f stage/meta.hello/snap.yaml ]; then
+  if [ ! -f "${stage_dir}/meta.hello/snap.yaml" ]; then
       echo "Missing expected stage-snaps payload from hello"
       exit 1
   fi
 
-  if grep black snap/snapcraft.yaml && [ ! -f stage/meta.black/snap.yaml ]; then
+  if grep black snap/snapcraft.yaml && [ ! -f "${stage_dir}/meta.black/snap.yaml" ]; then
       echo "Missing expected stage-snaps payload from black"
       exit 1
   fi

--- a/tests/spread/general/unicode-metadata/task.yaml
+++ b/tests/spread/general/unicode-metadata/task.yaml
@@ -25,9 +25,13 @@ restore: |
   rm -rf expected_snap.yaml
 
 execute: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  prime_dir="$(get_prime_dir)"
+
   snapcraft prime
 
-  if ! diff prime/meta/snap.yaml expected_snap.yaml; then
+  if ! diff "${prime_dir}/meta/snap.yaml" expected_snap.yaml; then
       echo "The formatting for snap.yaml is incorrect"
       exit 1
   fi

--- a/tests/spread/plugins/craft-parts/colcon-msg-package/task.yaml
+++ b/tests/spread/plugins/craft-parts/colcon-msg-package/task.yaml
@@ -39,6 +39,6 @@ execute: |
 
   # Build the snap and verify that a message only package could be build
   snapcraft
-  [ -d parts/test-part/install/opt/ros/snap/share/pendulum_msgs ]
+  [ -d parts/test-part/install/default/opt/ros/snap/share/pendulum_msgs ]
 
   snap install "${SNAP}"_1.0_*.snap --dangerous

--- a/tests/spread/plugins/craft-parts/colcon-packages-ignore/task.yaml
+++ b/tests/spread/plugins/craft-parts/colcon-packages-ignore/task.yaml
@@ -40,9 +40,9 @@ execute: |
 
   # Build the snap and verify that only package1 was included
   snapcraft
-  [ -d parts/test-part/install/opt/ros/snap/lib/package1 ]
-  [ ! -d parts/test-part/install/opt/ros/snap/lib/package2 ]
-  [ ! -d parts/test-part/install/opt/ros/snap/lib/package3 ]
+  [ -d parts/test-part/install/default/opt/ros/snap/lib/package1 ]
+  [ ! -d parts/test-part/install/default/opt/ros/snap/lib/package2 ]
+  [ ! -d parts/test-part/install/default/opt/ros/snap/lib/package3 ]
 
   snap install "${SNAP}"_1.0_*.snap --dangerous
   [ "$($SNAP)" = "I am package1" ]

--- a/tests/spread/plugins/craft-parts/python-symlinks/task.yaml
+++ b/tests/spread/plugins/craft-parts/python-symlinks/task.yaml
@@ -31,13 +31,17 @@ restore: |
   rm -f ./*.snap
 
 execute: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  prime_dir="$(get_prime_dir)"
+
   cd "${SNAP}"
 
   if [ -f expected-symlink ]; then
     snapcraft prime
-    ls -l prime/bin
-    [ -x prime/bin/hello ]
-    [ "$(readlink prime/bin/python3)" == "$(cat expected-symlink)" ]
+    ls -l "${prime_dir}/bin"
+    [ -x "${prime_dir}/bin/hello" ]
+    [ "$(readlink "${prime_dir}/bin/python3")" == "$(cat expected-symlink)" ]
   else
     snapcraft prime 2>&1 | MATCH "No suitable Python interpreter found, giving up."
   fi 

--- a/tests/spread/tools/snapcraft-yaml.sh
+++ b/tests/spread/tools/snapcraft-yaml.sh
@@ -79,3 +79,29 @@ restore_yaml()
     # Restoration only really works for git committed snapcraft.yaml's
     git checkout "$snapcraft_yaml_path"
 }
+
+get_stage_dir()
+{
+    if [[ "$SPREAD_SYSTEM" =~ ubuntu-24.04 ]]; then
+        echo "stage/default"
+    elif [[ "$SPREAD_SYSTEM" =~ ubuntu-22.04 ]]; then
+        echo "stage/default"
+    elif [[ "$SPREAD_SYSTEM" =~ ubuntu-20.04 ]]; then
+        echo "stage"
+    else
+        exit 1
+    fi
+}
+
+get_prime_dir()
+{
+    if [[ "$SPREAD_SYSTEM" =~ ubuntu-24.04 ]]; then
+        echo "prime/default"
+    elif [[ "$SPREAD_SYSTEM" =~ ubuntu-22.04 ]]; then
+        echo "prime/default"
+    elif [[ "$SPREAD_SYSTEM" =~ ubuntu-20.04 ]]; then
+        echo "prime"
+    else
+        exit 1
+    fi
+}

--- a/tests/unit/parts/plugins/test_colcon.py
+++ b/tests/unit/parts/plugins/test_colcon.py
@@ -46,10 +46,13 @@ def setup_method_fixture():
             properties = {}
         properties["source"] = "."
         plugin_properties = colcon.ColconPlugin.properties_class.unmarshal(properties)
-        part = Part("foo", {})
+        part = Part("foo", {}, partitions=["default"])
 
         project_info = ProjectInfo(
-            application_name="test", base="core22", cache_dir=new_dir
+            application_name="test",
+            base="core22",
+            cache_dir=new_dir,
+            partitions=["default"],
         )
         project_info._parallel_build_count = 42
 

--- a/tests/unit/parts/plugins/test_conda_plugin.py
+++ b/tests/unit/parts/plugins/test_conda_plugin.py
@@ -29,9 +29,12 @@ from snapcraft.parts.plugins.conda_plugin import _get_miniconda_source
 def part_info(new_dir):
     yield PartInfo(
         project_info=ProjectInfo(
-            application_name="test", project_name="test-snap", cache_dir=new_dir
+            application_name="test",
+            project_name="test-snap",
+            cache_dir=new_dir,
+            partitions=["default"],
         ),
-        part=Part("my-part", {}),
+        part=Part("my-part", {}, partitions=["default"]),
     )
 
 

--- a/tests/unit/parts/plugins/test_flutter_plugin.py
+++ b/tests/unit/parts/plugins/test_flutter_plugin.py
@@ -25,9 +25,12 @@ from snapcraft.parts.plugins import FlutterPlugin
 def part_info(new_dir):
     yield PartInfo(
         project_info=ProjectInfo(
-            application_name="test", project_name="test-snap", cache_dir=new_dir
+            application_name="test",
+            project_name="test-snap",
+            cache_dir=new_dir,
+            partitions=["default"],
         ),
-        part=Part("my-part", {}),
+        part=Part("my-part", {}, partitions=["default"]),
     )
 
 

--- a/tests/unit/parts/plugins/test_kernel.py
+++ b/tests/unit/parts/plugins/test_kernel.py
@@ -41,13 +41,18 @@ def setup_method_fixture():
         # Ensure that the PPA is not added so we don't cause side-effects
         properties["kernel-add-ppa"] = kernel_add_ppa
 
-        part = Part("kernel", {})
+        part = Part("kernel", {}, partitions=["default"])
 
         if arch is None:
-            project_info = ProjectInfo(application_name="test", cache_dir=new_dir)
+            project_info = ProjectInfo(
+                application_name="test", cache_dir=new_dir, partitions=["default"]
+            )
         else:
             project_info = ProjectInfo(
-                application_name="test", cache_dir=new_dir, arch=arch
+                application_name="test",
+                cache_dir=new_dir,
+                arch=arch,
+                partitions=["default"],
             )
 
         part_info = PartInfo(project_info=project_info, part=part)

--- a/tests/unit/parts/plugins/test_python_plugin.py
+++ b/tests/unit/parts/plugins/test_python_plugin.py
@@ -32,8 +32,9 @@ def part_info(new_dir):
             confinement="strict",
             project_base="core22",
             cache_dir=new_dir,
+            partitions=["default"],
         ),
-        part=Part("my-part", {}),
+        part=Part("my-part", {}, partitions=["default"]),
     )
 
 
@@ -55,26 +56,26 @@ def test_get_build_environment(plugin, new_dir):
     assert plugin.get_build_environment() == {
         "PARTS_PYTHON_INTERPRETER": "python3",
         "PARTS_PYTHON_VENV_ARGS": "",
-        "PATH": f"{str(new_dir)}/parts/my-part/install/bin:${{PATH}}",
+        "PATH": f"{str(new_dir)}/parts/my-part/install/default/bin:${{PATH}}",
     }
 
 
 def test_get_build_commands(plugin, new_dir):
     # pylint: disable=line-too-long
     assert plugin.get_build_commands() == [
-        f'"${{PARTS_PYTHON_INTERPRETER}}" -m venv ${{PARTS_PYTHON_VENV_ARGS}} "{new_dir}/parts/my-part/install"',
-        f'PARTS_PYTHON_VENV_INTERP_PATH="{new_dir}/parts/my-part/install/bin/${{PARTS_PYTHON_INTERPRETER}}"',
-        f"{new_dir}/parts/my-part/install/bin/pip install  -U pip setuptools wheel",
-        f"[ -f setup.py ] || [ -f pyproject.toml ] && {new_dir}/parts/my-part/install/bin/pip install  -U .",
-        f'find "{new_dir}/parts/my-part/install" -type f -executable -print0 | xargs -0 \\\n'
+        f'"${{PARTS_PYTHON_INTERPRETER}}" -m venv ${{PARTS_PYTHON_VENV_ARGS}} "{new_dir}/parts/my-part/install/default"',
+        f'PARTS_PYTHON_VENV_INTERP_PATH="{new_dir}/parts/my-part/install/default/bin/${{PARTS_PYTHON_INTERPRETER}}"',
+        f"{new_dir}/parts/my-part/install/default/bin/pip install  -U pip setuptools wheel",
+        f"[ -f setup.py ] || [ -f pyproject.toml ] && {new_dir}/parts/my-part/install/default/bin/pip install  -U .",
+        f'find "{new_dir}/parts/my-part/install/default" -type f -executable -print0 | xargs -0 \\\n'
         '    sed -i "1 s|^#\\!${PARTS_PYTHON_VENV_INTERP_PATH}.*$|#!/usr/bin/env ${PARTS_PYTHON_INTERPRETER}|"\n',
         dedent(
             f"""\
             # look for a provisioned python interpreter
             opts_state="$(set +o|grep errexit)"
             set +e
-            install_dir="{new_dir}/parts/my-part/install/usr/bin"
-            stage_dir="{new_dir}/stage/usr/bin"
+            install_dir="{new_dir}/parts/my-part/install/default/usr/bin"
+            stage_dir="{new_dir}/stage/default/usr/bin"
 
             # look for the right Python version - if the venv was created with python3.10,
             # look for python3.10
@@ -85,10 +86,10 @@ def test_get_build_commands(plugin, new_dir):
             if [ -n "$payload_python" ]; then
                 # We found a provisioned interpreter, use it.
                 echo Found interpreter in payload: \\"${{payload_python}}\\"
-                installed_python="${{payload_python##{new_dir}/parts/my-part/install}}"
+                installed_python="${{payload_python##{new_dir}/parts/my-part/install/default}}"
                 if [ "$installed_python" = "$payload_python" ]; then
                     # Found a staged interpreter.
-                    symlink_target="..${{payload_python##{new_dir}/stage}}"
+                    symlink_target="..${{payload_python##{new_dir}/stage/default}}"
                 else
                     # The interpreter was installed but not staged yet.
                     symlink_target="..$installed_python"
@@ -135,8 +136,9 @@ def test_get_system_python_interpreter(confinement, interpreter, new_dir):
             confinement=confinement,
             project_base="core22",
             cache_dir=new_dir,
+            partitions=["default"],
         ),
-        part=Part("my-part", {}),
+        part=Part("my-part", {}, partitions=["default"]),
     )
     properties = PythonPlugin.properties_class.unmarshal({"source": "."})
     plugin = PythonPlugin(properties=properties, part_info=part_info)
@@ -162,8 +164,9 @@ def test_get_system_python_interpreter_base_bare(confinement, interpreter, new_d
             confinement=confinement,
             project_base="bare",
             cache_dir=new_dir,
+            partitions=["default"],
         ),
-        part=Part("my-part", {}),
+        part=Part("my-part", {}, partitions=["default"]),
     )
     properties = PythonPlugin.properties_class.unmarshal({"source": "."})
     plugin = PythonPlugin(properties=properties, part_info=part_info)

--- a/tests/unit/parts/test_parts.py
+++ b/tests/unit/parts/test_parts.py
@@ -54,7 +54,7 @@ def test_parts_lifecycle_run(mocker, parts_data, step_name, new_dir, emitter):
         target_arch="amd64",
     )
     lifecycle.run(step_name)
-    assert lifecycle.prime_dir == Path(new_dir, "prime")
+    assert lifecycle.prime_dir == Path(new_dir, "prime/default")
     assert lifecycle.prime_dir.is_dir()
     assert lcm_spy.mock_calls == [
         call(
@@ -73,6 +73,7 @@ def test_parts_lifecycle_run(mocker, parts_data, step_name, new_dir, emitter):
             project_vars={"version": "1", "grade": "stable"},
             confinement="strict",
             project_base="core22",
+            partitions=["default"],
         )
     ]
 
@@ -366,5 +367,6 @@ def test_parts_lifecycle_run_with_all_architecture(mocker, parts_data, new_dir):
             project_vars={"version": "1", "grade": "stable"},
             project_base="core22",
             confinement="strict",
+            partitions=["default"],
         )
     ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----

Enable the partitions feature for `craft-parts` and use the `default` partition.


### Known issues
- [ ] patchelf unit test is [failing](https://github.com/snapcore/snapcraft/actions/runs/7145879806/job/19462461133?pr=4487#step:6:352) because something is changing the ownership of `prime/default/`
- [ ] patchelf spread tests are [failing](https://github.com/snapcore/snapcraft/actions/runs/7145879807/job/19462618378?pr=4487#step:4:450) and the logs are not informative
- [ ] conda hello-world spread test is [timing out](https://github.com/snapcore/snapcraft/actions/runs/7145879807/job/19462618378?pr=4487#step:4:17611) because the contents of `stage/default` is somehow getting nested within itself and it takes twice as long to package the snap
- [ ] this [bug fix](https://github.com/canonical/craft-parts/pull/607) in craft-parts
- [ ] `snapcraft try` [failing](https://github.com/snapcore/snapcraft/actions/runs/7145879807/job/19462618378?pr=4487#step:4:1408) spread tests

Fixes #4463
(CRAFT-2307)