### PR TITLE
refactor: replace `pkg_resources` with `packaging`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ dev_requires = [
     "pycodestyle",
     "pydocstyle",
     "pyftpdlib",
+    "pyinstaller; sys_platform == 'win32'",
     "pylint",
     "pylint-fixme-info",
     "pylint-pytest",
@@ -93,11 +94,9 @@ dev_requires = [
     "yamllint",
 ]
 
-if sys.platform == "win32":
-    dev_requires.append("pyinstaller")
-
 install_requires = [
     "attrs",
+    "catkin-pkg; sys_platform == 'linux'",
     "click",
     "craft-archives",
     "craft-cli",
@@ -119,7 +118,10 @@ install_requires = [
     # Pygit2 and libgit2 need to match versions.
     # Further info: https://www.pygit2.org/install.html#version-numbers
     "pygit2~=1.13.0",
+    "pylxd; sys_platform == 'linux'",
     "pymacaroons",
+    "python-apt @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.4.0ubuntu1/python-apt_2.4.0ubuntu1.tar.xz ; sys_platform == 'linux'",
+    "python-debian; sys_platform == 'linux'",
     "pyxdg",
     "pyyaml",
     "raven",
@@ -136,29 +138,6 @@ install_requires = [
     "typing-extensions",
     "urllib3<2",  # requests-unixsocket does not yet work with urllib3 v2.0+
 ]
-
-try:
-    ubuntu = bool(
-        re.search(
-            r"^ID(?:_LIKE)?=.*\bubuntu\b.*$",
-            open("/etc/os-release").read(),
-            re.MULTILINE,
-        )
-    )
-except FileNotFoundError:
-    ubuntu = False
-
-if sys.platform == "linux":
-    install_requires += [
-        "pylxd",
-    ]
-
-if ubuntu:
-    install_requires += [
-        "catkin-pkg",
-        "python-apt@https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.4.0ubuntu1/python-apt_2.4.0ubuntu1.tar.xz",
-        "python-debian",
-    ]
 
 extras_requires = {
     "dev": dev_requires,
@@ -185,6 +164,7 @@ setup(
         + recursive_data_files("keyrings", "share/snapcraft")
         + recursive_data_files("extensions", "share/snapcraft")
     ),
+    python_requires=">=3.10",
     install_requires=install_requires,
     extras_require=extras_requires,
     test_suite="tests.unit",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import re
 import sys
 
 from setuptools import find_namespace_packages, setup
@@ -113,6 +112,7 @@ install_requires = [
     "macaroonbakery",
     "mypy-extensions",
     "overrides",
+    "packaging",
     "progressbar",
     "pyelftools",
     # Pygit2 and libgit2 need to match versions.
@@ -128,8 +128,6 @@ install_requires = [
     "requests-toolbelt",
     "requests-unixsocket",
     "requests",
-    # pin setuptools<66 (CRAFT-1598)
-    "setuptools<66",
     "simplejson",
     "snap-helpers",
     "tabulate",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -151,9 +151,6 @@ parts:
     python-packages:
         - wheel
         - pip
-        # Limited to < 66 because we need `pkg_resources` and because `python-apt`
-        # does not build with the latest.
-        - setuptools<66
     python-constraints:
         - constraints.txt
     python-requirements:

--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -17,8 +17,7 @@
 """Publish your app for Linux users for desktop, cloud, and IoT."""
 
 import os
-
-import pkg_resources
+from importlib import metadata
 
 # For legacy compatibility
 import snapcraft.sources  # noqa: F401
@@ -28,9 +27,9 @@ def _get_version():
     if os.environ.get("SNAP_NAME") == "snapcraft":
         return os.environ["SNAP_VERSION"]
     try:
-        return pkg_resources.require("snapcraft")[0].version
-    except pkg_resources.DistributionNotFound:
-        return "devel"
+        return metadata.version("snapcraft")
+    except metadata.PackageNotFoundError:
+        return "0.0.0+devel"
 
 
 __version__ = _get_version()

--- a/snapcraft/elf/_elf_file.py
+++ b/snapcraft/elf/_elf_file.py
@@ -26,7 +26,7 @@ from typing import Dict, List, Optional, Set, Tuple, cast
 from craft_cli import emit
 from elftools.construct import ConstructError
 from elftools.elf import constants, dynamic, elffile, gnuversions, sections, segments
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from snapcraft import utils
 
@@ -321,9 +321,8 @@ class ElfFile:
     def is_linker_compatible(self, *, linker_version: str) -> bool:
         """Determine if the linker will work given the required glibc version."""
         version_required = self.get_required_glibc()
-        # TODO: pkg_resources is deprecated in setuptools>66 (CRAFT-1598)
-        parsed_version_required = parse_version(version_required)  # type: ignore
-        parsed_linker_version = parse_version(linker_version)  # type: ignore
+        parsed_version_required = parse_version(version_required)
+        parsed_linker_version = parse_version(linker_version)
         is_compatible = parsed_version_required <= parsed_linker_version
         emit.debug(
             f"Check if linker {linker_version!r} works with GLIBC_{version_required} "
@@ -342,8 +341,9 @@ class ElfFile:
                 if not _version.startswith("GLIBC_"):
                     continue
                 version = _version[6:]
-                # TODO: pkg_resources is deprecated in setuptools>66 (CRAFT-1598)
-                if parse_version(version) > parse_version(version_required):  # type: ignore
+                if not version_required or parse_version(version) > parse_version(
+                    version_required
+                ):
                     version_required = version
 
         self._required_glibc = version_required

--- a/snapcraft_legacy/__init__.py
+++ b/snapcraft_legacy/__init__.py
@@ -319,8 +319,7 @@ of the choice of plugin.
 """
 
 from collections import OrderedDict  # noqa
-
-import pkg_resources  # noqa
+from importlib import metadata
 
 
 def _get_version():
@@ -329,9 +328,9 @@ def _get_version():
     if _os.environ.get("SNAP_NAME") == "snapcraft":
         return _os.environ["SNAP_VERSION"]
     try:
-        return pkg_resources.require("snapcraft")[0].version
-    except pkg_resources.DistributionNotFound:
-        return "devel"
+        return metadata.version("snapcraft")
+    except metadata.PackageNotFoundError:
+        return "0.0.0+devel"
 
 
 # Set this early so that the circular imports aren't too painful

--- a/snapcraft_legacy/cli/_metrics.py
+++ b/snapcraft_legacy/cli/_metrics.py
@@ -17,7 +17,7 @@
 import logging
 from typing import List, Union
 
-import pkg_resources
+from packaging import version
 
 from snapcraft_legacy.storeapi import metrics as metrics_module
 
@@ -64,7 +64,10 @@ def convert_metrics_to_table(
     # Sort series sensibly, using a version sort.
     def key_as_version(series):
         """Key series as versions, if possible."""
-        return pkg_resources.parse_version(series.name)
+        try:
+            return version.parse(series.name)
+        except version.InvalidVersion:
+            return version.Version("0.0")
 
     series = sorted(results.series, key=key_as_version)
 

--- a/snapcraft_legacy/internal/build_providers/_base_provider.py
+++ b/snapcraft_legacy/internal/build_providers/_base_provider.py
@@ -27,7 +27,7 @@ import tempfile
 from textwrap import dedent
 from typing import Any, Dict, Optional, Sequence
 
-import pkg_resources
+from packaging.version import parse as parse_version
 from xdg import BaseDirectory
 
 import snapcraft_legacy
@@ -311,9 +311,7 @@ class Provider(abc.ABC):
                 f"Project base changed from {provider_base!r} to {build_base!r}, cleaning first."
             )
             return True
-        elif pkg_resources.parse_version(
-            snapcraft_legacy._get_version()
-        ) < pkg_resources.parse_version(built_by):
+        elif parse_version(snapcraft_legacy._get_version()) < parse_version(built_by):
             self.echoer.warning(
                 f"Build environment was created with newer snapcraft version {built_by!r}, cleaning first."
             )

--- a/snapcraft_legacy/internal/elf.py
+++ b/snapcraft_legacy/internal/elf.py
@@ -28,7 +28,7 @@ from typing import Dict, FrozenSet, List, Optional, Sequence, Set, Tuple, Union
 import elftools.common.exceptions
 import elftools.elf.elffile
 from elftools.construct import ConstructError
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from snapcraft_legacy import file_utils
 from snapcraft_legacy.internal import common, errors, repo
@@ -466,7 +466,9 @@ class ElfFile:
                 if not version.startswith("GLIBC_"):
                     continue
                 version = version[6:]
-                if parse_version(version) > parse_version(version_required):
+                if not version_required or parse_version(version) > parse_version(
+                    version_required
+                ):
                     version_required = version
 
         self._required_glibc = version_required

--- a/tools/freeze-requirements.sh
+++ b/tools/freeze-requirements.sh
@@ -10,10 +10,6 @@ requirements_fixups() {
   # https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1635463
   sed -i '/pkg[-_]resources==0.0.0/d' "$req_file"
 
-  # Keep setuptools < 66
-  sed -i '/^setuptools/d' "$req_file"
-  echo 'setuptools<66' >> "$req_file"
-
   # Pinned pyinstaller for windows.
   if [[ "$req_file" == "requirements-devel.txt" ]]; then
       sed -i '/pyinstaller/d' "$req_file"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

---

Fixes #4407

This removes the `setuptools<66` pin (which also unblocks python 3.12 support):

- `pkg_resources.parse_version` is replaced with `packaging.version.parse` (which now only accepts PEP 440-compliant version strings. I only made the changes needed to pass the unit tests, but maybe we should be more defensive)
- `pkg_resources.require` is replaced with `importlib.metadata.version` (added in [python 3.8](https://docs.python.org/3/library/importlib.metadata.html))

I've also updated `setup.py` with env markers (see the caveat in the commit message, lmk if that's not ok) and a minimum python (not sure if this should be `3.9` or `3.10`)
