### PR TITLE
fix(remote): fallback to legacy snapcraft if under shallow git clone

### DIFF
--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -216,7 +216,7 @@ class RemoteBuildCommand(BaseCommand):
             )
             # fall-through to legacy remote-build
 
-        emit.progress("Running fallback remote-build", permanent=True)
+        emit.debug("Running fallback remote-build")
         run_legacy()
 
     def _get_project_name(self) -> str:

--- a/snapcraft/remote/__init__.py
+++ b/snapcraft/remote/__init__.py
@@ -25,22 +25,30 @@ from .errors import (
     RemoteBuildTimeoutError,
     UnsupportedArchitectureError,
 )
-from .git import GitRepo, is_repo, is_shallow_repo
+from .git import (
+    GitRepo,
+    GitType,
+    check_git_repo_for_remote_build,
+    get_git_repo_type,
+    is_repo,
+)
 from .launchpad import LaunchpadClient
 from .remote_builder import RemoteBuilder
 from .utils import get_build_id, humanize_list, rmtree, validate_architectures
 from .worktree import WorkTree
 
 __all__ = [
+    "check_git_repo_for_remote_build",
     "get_build_id",
+    "get_git_repo_type",
     "humanize_list",
     "is_repo",
-    "is_shallow_repo",
     "rmtree",
     "validate_architectures",
     "AcceptPublicUploadError",
     "GitError",
     "GitRepo",
+    "GitType",
     "LaunchpadClient",
     "LaunchpadHttpsError",
     "RemoteBuilder",

--- a/snapcraft/remote/__init__.py
+++ b/snapcraft/remote/__init__.py
@@ -22,6 +22,7 @@ from .errors import (
     LaunchpadHttpsError,
     RemoteBuildError,
     RemoteBuildFailedError,
+    RemoteBuildInvalidGitRepoError,
     RemoteBuildTimeoutError,
     UnsupportedArchitectureError,
 )
@@ -54,6 +55,7 @@ __all__ = [
     "RemoteBuilder",
     "RemoteBuildError",
     "RemoteBuildFailedError",
+    "RemoteBuildInvalidGitRepoError",
     "RemoteBuildTimeoutError",
     "UnsupportedArchitectureError",
     "WorkTree",

--- a/snapcraft/remote/__init__.py
+++ b/snapcraft/remote/__init__.py
@@ -25,7 +25,7 @@ from .errors import (
     RemoteBuildTimeoutError,
     UnsupportedArchitectureError,
 )
-from .git import GitRepo, is_repo
+from .git import GitRepo, is_repo, is_shallow_repo
 from .launchpad import LaunchpadClient
 from .remote_builder import RemoteBuilder
 from .utils import get_build_id, humanize_list, rmtree, validate_architectures
@@ -35,6 +35,7 @@ __all__ = [
     "get_build_id",
     "humanize_list",
     "is_repo",
+    "is_shallow_repo",
     "rmtree",
     "validate_architectures",
     "AcceptPublicUploadError",

--- a/snapcraft/remote/errors.py
+++ b/snapcraft/remote/errors.py
@@ -115,3 +115,16 @@ class RemoteBuildFailedError(RemoteBuildError):
         brief = "Remote build failed."
 
         super().__init__(brief=brief, details=details)
+
+
+class RemoteBuildInvalidGitRepoError(RemoteBuildError):
+    """The Git repository is invalid for remote build.
+
+    :param brief: Brief description of error.
+    :param details: Detailed information.
+    """
+
+    def __init__(self, details: str) -> None:
+        brief = "The Git repository is invalid for remote build."
+
+        super().__init__(brief=brief, details=details)

--- a/snapcraft/remote/git.py
+++ b/snapcraft/remote/git.py
@@ -26,9 +26,7 @@ from typing import Optional
 
 import pygit2
 
-from snapcraft.errors import SnapcraftError
-
-from .errors import GitError
+from .errors import GitError, RemoteBuildInvalidGitRepoError
 
 logger = logging.getLogger(__name__)
 
@@ -82,17 +80,18 @@ def check_git_repo_for_remote_build(path: Path) -> None:
 
     :param path: filepath to check
 
-    :raises SnapcraftError: if incompatible git repo is found
+    :raises RemoteBuildInvalidGitRepoError: if incompatible git repo is found
     """
     git_type = get_git_repo_type(path.absolute())
 
     if git_type == GitType.INVALID:
-        raise SnapcraftError(f"Could not find a git repository in {str(path)!r}")
+        raise RemoteBuildInvalidGitRepoError(
+            f"Could not find a git repository in {str(path)!r}"
+        )
 
     if git_type == GitType.SHALLOW:
-        raise SnapcraftError(
-            "Remote build for shallow cloned git repos are no longer supported "
-            "for core24 and beyond."
+        raise RemoteBuildInvalidGitRepoError(
+            "Remote build for shallow cloned git repos are no longer supported"
         )
 
 

--- a/snapcraft/remote/git.py
+++ b/snapcraft/remote/git.py
@@ -50,6 +50,22 @@ def is_repo(path: Path) -> bool:
         ) from error
 
 
+def is_shallow_repo(path: Path) -> bool:
+    """Check if a directory is a shallow cloned git repo.
+
+    :param path: filepath to check
+
+    :returns: True if path is a shallow cloned git repo.
+
+    :raises GitError: if git fails while checking for a repository
+    """
+    if is_repo(path):
+        repo = pygit2.Repository(path)
+        return repo.is_shallow
+
+    return False
+
+
 class GitRepo:
     """Git repository class."""
 

--- a/snapcraft/remote/git.py
+++ b/snapcraft/remote/git.py
@@ -82,7 +82,7 @@ def check_git_repo_for_remote_build(path: Path) -> None:
 
     :param path: filepath to check
 
-    :raises GitError: if incompatible git repo is found
+    :raises SnapcraftError: if incompatible git repo is found
     """
     git_type = get_git_repo_type(path.absolute())
 

--- a/snapcraft/remote/remote_builder.py
+++ b/snapcraft/remote/remote_builder.py
@@ -20,6 +20,7 @@ import logging
 from pathlib import Path
 from typing import List, Optional
 
+from .git import check_git_repo_for_remote_build
 from .launchpad import LaunchpadClient
 from .utils import get_build_id, humanize_list, validate_architectures
 from .worktree import WorkTree
@@ -54,6 +55,8 @@ class RemoteBuilder:
         self._app_name = app_name
         self._project_name = project_name
         self._project_dir = project_dir
+
+        check_git_repo_for_remote_build(self._project_dir)
 
         if build_id:
             self._build_id = build_id

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -531,7 +531,7 @@ def test_run_in_repo_newer_than_core22(
 )
 @pytest.mark.usefixtures("create_snapcraft_yaml", "mock_confirm", "mock_argv")
 def test_run_in_shallow_repo(emitter, mock_run_legacy, new_dir):
-    """core22 and older bases run new remote-build if in a git repo."""
+    """core22 and older bases fall back to legacy remote-build if in a shallow git repo."""
     root_path = Path(new_dir)
     git_normal_path = root_path / "normal"
     git_normal_path.mkdir()
@@ -580,7 +580,7 @@ def test_run_in_shallow_repo(emitter, mock_run_legacy, new_dir):
     "create_snapcraft_yaml", "mock_confirm", "mock_argv", "use_new_remote_build"
 )
 def test_run_in_shallow_repo_unsupported(capsys, new_dir):
-    """core22 and older bases run new remote-build if in a git repo."""
+    """devel / core24 and newer bases run new remote-build in a shallow git repo."""
     root_path = Path(new_dir)
     git_normal_path = root_path / "normal"
     git_normal_path.mkdir()

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -375,7 +375,7 @@ def test_run_core22_and_older(emitter, mock_run_legacy):
     cli.run()
 
     mock_run_legacy.assert_called_once()
-    emitter.assert_debug("Running fallback remote-build")
+    emitter.assert_progress("Running fallback remote-build", permanent=True)
 
 
 @pytest.mark.parametrize(
@@ -445,7 +445,7 @@ def test_run_envvar_force_fallback_unset(emitter, mock_run_legacy, monkeypatch):
     cli.run()
 
     mock_run_legacy.assert_called_once()
-    emitter.assert_debug("Running fallback remote-build")
+    emitter.assert_progress("Running fallback remote-build", permanent=True)
 
 
 @pytest.mark.parametrize(
@@ -459,7 +459,7 @@ def test_run_envvar_force_fallback_empty(emitter, mock_run_legacy, monkeypatch):
     cli.run()
 
     mock_run_legacy.assert_called_once()
-    emitter.assert_debug("Running fallback remote-build")
+    emitter.assert_progress("Running fallback remote-build", permanent=True)
 
 
 @pytest.mark.parametrize(
@@ -506,7 +506,7 @@ def test_run_not_in_repo(emitter, mock_run_legacy):
     cli.run()
 
     mock_run_legacy.assert_called_once()
-    emitter.assert_debug("Running fallback remote-build")
+    emitter.assert_progress("Running fallback remote-build", permanent=True)
 
 
 @pytest.mark.parametrize(
@@ -570,14 +570,16 @@ def test_run_in_shallow_repo(emitter, mock_run_legacy, new_dir):
 
     mock_run_legacy.assert_called_once()
     emitter.assert_debug("Current git repository is shallow cloned.")
-    emitter.assert_progress("Fallback to legacy remote-build", permanent=True)
+    emitter.assert_progress("Running fallback remote-build", permanent=True)
 
 
-@pytest.mark.parametrize("create_snapcraft_yaml", {"devel"}, indirect=True)
+@pytest.mark.parametrize(
+    "create_snapcraft_yaml", CURRENT_BASES - {"core22"}, indirect=True
+)
 @pytest.mark.usefixtures(
     "create_snapcraft_yaml", "mock_confirm", "mock_argv", "use_new_remote_build"
 )
-def test_run_in_shallow_repo_unsupported(emitter, new_dir, mock_remote_builder):
+def test_run_in_shallow_repo_unsupported(capsys, new_dir):
     """core22 and older bases run new remote-build if in a git repo."""
     root_path = Path(new_dir)
     git_normal_path = root_path / "normal"
@@ -617,8 +619,9 @@ def test_run_in_shallow_repo_unsupported(emitter, new_dir, mock_remote_builder):
     # no exception because run() catches it
     ret = cli.run()
     assert ret != 0
+    _, err = capsys.readouterr()
 
-    mock_remote_builder.assert_not_called()
+    assert "Remote build for shallow cloned git repos are no longer supported" in err
 
 
 ######################

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -559,8 +559,8 @@ def test_run_in_shallow_repo(emitter, mock_run_legacy, new_dir):
             "clone",
             "--depth",
             "1",
-            "file://" + str(git_normal_path.absolute()),
-            str(git_shallow_path.absolute()),
+            git_normal_path.absolute().as_uri(),
+            git_shallow_path.absolute().as_posix(),
         ],
         check=True,
     )
@@ -606,8 +606,8 @@ def test_run_in_shallow_repo_unsupported(emitter, new_dir, mock_remote_builder):
             "clone",
             "--depth",
             "1",
-            "file://" + str(git_normal_path.absolute()),
-            str(git_shallow_path.absolute()),
+            git_normal_path.absolute().as_uri(),
+            git_shallow_path.absolute().as_posix(),
         ],
         check=True,
     )

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -375,7 +375,7 @@ def test_run_core22_and_older(emitter, mock_run_legacy):
     cli.run()
 
     mock_run_legacy.assert_called_once()
-    emitter.assert_progress("Running fallback remote-build", permanent=True)
+    emitter.assert_debug("Running fallback remote-build")
 
 
 @pytest.mark.parametrize(
@@ -445,7 +445,7 @@ def test_run_envvar_force_fallback_unset(emitter, mock_run_legacy, monkeypatch):
     cli.run()
 
     mock_run_legacy.assert_called_once()
-    emitter.assert_progress("Running fallback remote-build", permanent=True)
+    emitter.assert_debug("Running fallback remote-build")
 
 
 @pytest.mark.parametrize(
@@ -459,7 +459,7 @@ def test_run_envvar_force_fallback_empty(emitter, mock_run_legacy, monkeypatch):
     cli.run()
 
     mock_run_legacy.assert_called_once()
-    emitter.assert_progress("Running fallback remote-build", permanent=True)
+    emitter.assert_debug("Running fallback remote-build")
 
 
 @pytest.mark.parametrize(
@@ -506,7 +506,7 @@ def test_run_not_in_repo(emitter, mock_run_legacy):
     cli.run()
 
     mock_run_legacy.assert_called_once()
-    emitter.assert_progress("Running fallback remote-build", permanent=True)
+    emitter.assert_debug("Running fallback remote-build")
 
 
 @pytest.mark.parametrize(
@@ -570,7 +570,7 @@ def test_run_in_shallow_repo(emitter, mock_run_legacy, new_dir):
 
     mock_run_legacy.assert_called_once()
     emitter.assert_debug("Current git repository is shallow cloned.")
-    emitter.assert_progress("Running fallback remote-build", permanent=True)
+    emitter.assert_debug("Running fallback remote-build")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/remote/test_git.py
+++ b/tests/unit/remote/test_git.py
@@ -67,8 +67,8 @@ def test_is_shallow_repo(new_dir):
             "clone",
             "--depth",
             "1",
-            "file://" + str(git_normal_path.absolute()),
-            str(git_shallow_path.absolute()),
+            git_normal_path.absolute().as_uri(),
+            git_shallow_path.absolute().as_posix(),
         ],
         check=True,
     )

--- a/tests/unit/remote/test_git.py
+++ b/tests/unit/remote/test_git.py
@@ -25,11 +25,11 @@ from unittest.mock import ANY
 import pygit2
 import pytest
 
-from snapcraft.errors import SnapcraftError
 from snapcraft.remote import (
     GitError,
     GitRepo,
     GitType,
+    RemoteBuildInvalidGitRepoError,
     check_git_repo_for_remote_build,
     get_git_repo_type,
     is_repo,
@@ -537,7 +537,9 @@ def test_push_url_push_error(new_dir):
 
 def test_check_git_repo_for_remote_build_invalid(new_dir):
     """Check if directory is an invalid repo."""
-    with pytest.raises(SnapcraftError, match="Could not find a git repository in"):
+    with pytest.raises(
+        RemoteBuildInvalidGitRepoError, match="Could not find a git repository in"
+    ):
         check_git_repo_for_remote_build(new_dir)
 
 
@@ -581,7 +583,7 @@ def test_check_git_repo_for_remote_build_shallow(new_dir):
     )
 
     with pytest.raises(
-        SnapcraftError,
+        RemoteBuildInvalidGitRepoError,
         match="Remote build for shallow cloned git repos are no longer supported",
     ):
         check_git_repo_for_remote_build(git_shallow_path)

--- a/tests/unit/remote/test_remote_builder.py
+++ b/tests/unit/remote/test_remote_builder.py
@@ -22,7 +22,7 @@ from unittest.mock import call, patch
 
 import pytest
 
-from snapcraft.remote import RemoteBuilder, UnsupportedArchitectureError
+from snapcraft.remote import GitType, RemoteBuilder, UnsupportedArchitectureError
 from snapcraft.remote.utils import _SUPPORTED_ARCHS
 
 
@@ -56,6 +56,24 @@ def fake_remote_builder(new_dir, mock_launchpad_client, mock_worktree):
     )
 
 
+@pytest.fixture()
+def mock_git_check(mocker):
+    """Ignore git check."""
+    mock_git_check = mocker.patch(
+        "snapcraft.remote.git.check_git_repo_for_remote_build"
+    )
+    mock_git_check.return_value = None
+    return mock_git_check
+
+
+@pytest.fixture()
+def mock_git_type_check(mocker):
+    """Ignore git type check."""
+    mock_git_type = mocker.patch("snapcraft.remote.git.get_git_repo_type")
+    mock_git_type.return_value = GitType.NORMAL
+    return mock_git_type
+
+
 def test_remote_builder_init(mock_launchpad_client, mock_worktree):
     """Verify remote builder is properly initialized."""
     RemoteBuilder(
@@ -81,7 +99,8 @@ def test_remote_builder_init(mock_launchpad_client, mock_worktree):
     ]
 
 
-@pytest.mark.usefixtures("new_dir")
+@pytest.mark.usefixtures("mock_git_check", "mock_git_type_check")
+@pytest.mark.usefixtures("new_dir", "mock_git_check")
 def test_build_id_computed():
     """Compute a build id if it is not provided."""
     remote_builder = RemoteBuilder(
@@ -133,6 +152,7 @@ def test_validate_architectures_unsupported(archs):
         )
 
 
+@pytest.mark.usefixtures("mock_git_check", "mock_git_type_check")
 @patch("logging.Logger.info")
 def test_print_status_builds_found(
     mock_log, mock_launchpad_client, fake_remote_builder
@@ -152,6 +172,7 @@ def test_print_status_builds_found(
     ]
 
 
+@pytest.mark.usefixtures("mock_git_check", "mock_git_type_check")
 @patch("logging.Logger.info")
 def test_print_status_no_build_found(mock_log, fake_remote_builder):
     """Print the status of a remote build."""
@@ -160,6 +181,7 @@ def test_print_status_no_build_found(mock_log, fake_remote_builder):
     assert mock_log.mock_calls == [call("No build task(s) found.")]
 
 
+@pytest.mark.usefixtures("mock_git_check", "mock_git_type_check")
 @pytest.mark.parametrize("has_builds", (True, False))
 def test_has_outstanding_build(has_builds, fake_remote_builder, mock_launchpad_client):
     """Check for outstanding builds."""
@@ -168,6 +190,7 @@ def test_has_outstanding_build(has_builds, fake_remote_builder, mock_launchpad_c
     assert fake_remote_builder.has_outstanding_build() == has_builds
 
 
+@pytest.mark.usefixtures("mock_git_check", "mock_git_type_check")
 def test_monitor_build(fake_remote_builder, mock_launchpad_client):
     """Monitor a build."""
     fake_remote_builder.monitor_build()
@@ -175,6 +198,7 @@ def test_monitor_build(fake_remote_builder, mock_launchpad_client):
     mock_launchpad_client.return_value.monitor_build.assert_called_once()
 
 
+@pytest.mark.usefixtures("mock_git_check", "mock_git_type_check")
 def test_clean_build(fake_remote_builder, mock_launchpad_client, mock_worktree):
     """Clean a build."""
     fake_remote_builder.clean_build()
@@ -183,6 +207,7 @@ def test_clean_build(fake_remote_builder, mock_launchpad_client, mock_worktree):
     mock_worktree.return_value.clean_cache.assert_called_once()
 
 
+@pytest.mark.usefixtures("mock_git_check", "mock_git_type_check")
 def test_start_build(fake_remote_builder, mock_launchpad_client, mock_worktree):
     """Start a build."""
     fake_remote_builder.start_build()


### PR DESCRIPTION
Git shallow clone is not pushable by design. Fallback to legacy remote build which has workaround. This only support core20 and core22. Any other bases and devel will report error.

