### PR TITLE
chore: remove deprecated parameter `build-base`

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -565,7 +565,6 @@ def _run_in_provider(
         project_name=project.name,
         project_path=project_path,
         base_configuration=base_configuration,
-        build_base=build_base.value,
         instance_name=instance_name,
         allow_unstable=allow_unstable,
     ) as instance:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -354,7 +354,7 @@ def fake_provider(mock_instance):
             project_name: str,
             project_path: Path,
             base_configuration: Base,
-            build_base: str,
+            build_base: Optional[str] = None,
             instance_name: str,
             allow_unstable: bool = False,
         ):

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -1226,7 +1226,6 @@ def test_lifecycle_run_in_provider_default(
         project_name="mytest",
         project_path=ANY,
         base_configuration=mock_base_configuration,
-        build_base="22.04",
         instance_name="test-instance-name",
         allow_unstable=False,
     )
@@ -1350,7 +1349,6 @@ def test_lifecycle_run_in_provider_all_options(
         project_name="mytest",
         project_path=ANY,
         base_configuration=mock_base_configuration,
-        build_base="22.04",
         instance_name="test-instance-name",
         allow_unstable=False,
     )
@@ -1452,7 +1450,6 @@ def test_lifecycle_run_in_provider(
         project_name="mytest",
         project_path=ANY,
         base_configuration=mock_base_configuration,
-        build_base=BuilddBaseAlias.JAMMY.value,
         instance_name="test-instance-name",
         allow_unstable=False,
     )


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

Stop passing the deprecated parameter `build_base` to craft-providers to avoid the warning intended for developers:
```
Deprecated: Parameter 'build_base' is deprecated and should not be used. The build base now comes from the base_configuration's alias.
```

Note this is already fixed on main.

Source: https://matrix.to/#/!GGqzbFAUQprdPgYYCM:ubuntu.com/$bxytvo9JAtlAkoLNJyXsaQ-4xUM0xRBMLxwP_f1jh34?via=ubuntu.com&via=matrix.org&via=xentonix.net