### PR TITLE
feat: pack components

### DIFF
--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022,2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -101,6 +101,8 @@ def pack_snap(
 ) -> str:
     """Pack snap contents with `snap pack`.
 
+    Calls `snap pack <options> <snap-dir> <output-dir>`.
+
     `output` may either be a directory, a file path, or just a file name.
       - directory: write snap to directory with default snap name
       - file path: write snap to specified directory with specified snap name
@@ -115,13 +117,16 @@ def pack_snap(
     :param name: Name of snap project.
     :param version: Version of snap project.
     :param target_arch: Target architecture the snap project is built to.
+
+    :returns: The filename of the packed snap.
+
+    :raises SnapcraftError: If the directory cannot be packed.
     """
     emit.debug(f"pack_snap: output={output!r}, compression={compression!r}")
 
     # TODO remove workaround once LP: #1950465 is fixed
     _verify_snap(directory)
 
-    # create command formatted as `snap pack <options> <snap-dir> <output-dir>`
     command: List[Union[str, Path]] = ["snap", "pack"]
     output_file = _get_filename(output, name, version, target_arch)
     if output_file is not None:

--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -116,6 +116,38 @@ def _pack(command: List[Union[str, Path]]) -> str:
     return filename
 
 
+def pack_component(
+    directory: Path, output_dir: Path, compression: Optional[str] = None
+) -> str:
+    """Pack a directory containing component data.
+
+    Calls `snap pack <options> <component-dir> <output-dir>`.
+
+    Requires snapd to be installed from the `latest/edge` channel.
+
+    :param directory: Directory to pack.
+    :param compression: Compression type to use, None for default.
+    :param output_dir: Directory to output component to.
+
+    :returns: The filename of the packed component.
+
+    :raises SnapcraftError: If the component cannot be packed.
+    """
+    command: List[Union[str, Path]] = ["snap", "pack"]
+    if compression:
+        command.extend(["--compression", compression])
+    command.extend([directory, output_dir])
+
+    try:
+        return _pack(command)
+    except errors.SnapcraftError as err:
+        err.resolution = (
+            "Packing components is experimental and requires `snapd` "
+            "to be installed from the `latest/edge` channel."
+        )
+        raise
+
+
 def pack_snap(
     directory: Path,
     *,

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -285,14 +285,12 @@ def _run_lifecycle_and_pack(  # noqa PLR0913
         emit.progress(f"Created snap package {snap_filename}", permanent=True)
 
         if project.components:
-            _pack_components(lifecycle, project, parsed_args)
+            _pack_components(lifecycle, project, parsed_args.output)
 
 
 def _pack_components(
-    lifecycle: PartsLifecycle,
-    project: Project,
-    parsed_args: "argparse.Namespace",
-):
+    lifecycle: PartsLifecycle, project: Project, output: Optional[str]
+) -> None:
     """Pack components.
 
     `--output` can be used to set the output directory, the name of the snap, or both.
@@ -303,16 +301,15 @@ def _pack_components(
 
     :param lifecycle: The part lifecycle.
     :param project: The snapcraft project.
-    :param parsed_args: Snapcraft's argument namespace.
+    :param output: Output filepath of snap.
     """
     emit.progress("Creating component packages...")
 
-    if parsed_args.output:
-        output = Path(parsed_args.output)
-        if output.is_dir():
-            output_dir = output.resolve()
+    if output:
+        if Path(output).is_dir():
+            output_dir = Path(output).resolve()
         else:
-            output_dir = output.parent.resolve()
+            output_dir = Path(output).parent.resolve()
     else:
         output_dir = Path.cwd()
 

--- a/tests/spread/core22/components/file-migration/task.yaml
+++ b/tests/spread/core22/components/file-migration/task.yaml
@@ -3,6 +3,11 @@ summary: Test file migratation with components
 restore: |
   snapcraft clean
   rm -f ./*.snap
+  snap revert snapd
+
+prepare: |
+  # `snap pack` for components is only supported in the `latest/edge` channel
+  snap refresh snapd --channel=latest/edge
 
 execute: |
   cd "./snap"

--- a/tests/spread/core22/components/file-migration/task.yaml
+++ b/tests/spread/core22/components/file-migration/task.yaml
@@ -2,7 +2,7 @@ summary: Test file migratation with components
 
 restore: |
   snapcraft clean
-  rm -f ./*.snap
+  rm -rf ./*.snap ./*.comp
   snap revert snapd
 
 prepare: |
@@ -14,32 +14,34 @@ execute: |
 
   snapcraft pack --destructive-mode
 
-  # assert file1-new and file2-new are in the default partition
-  if [[ ! -e "prime/default/file1-new" ]] || \
-    [[ ! -e "prime/default/file2-new" ]]; then
+  # assert file1-new and file2-new are in the snap
+  unsquashfs -dest "snap-contents" "snap-with-components_1.0_amd64.snap"
+  if [[ ! -e "snap-contents/file1-new" ]] || \
+    [[ ! -e "snap-contents/file2-new" ]]; then
     echo "Expected file to exist but is does not exist."
     exit 1
   fi
 
-  # assert other files do not exist in the default partition
-  if [[ -e "prime/default/file3" ]] || \
-    [[ -e "prime/default/file4" ]] || \
-    [[ -e "prime/default/file5" ]]; then
+  # assert other files do not exist in the snap
+  if [[ -e "snap-contents/file3" ]] || \
+    [[ -e "snap-contents/file4" ]] || \
+    [[ -e "snap-contents/file5" ]]; then
     echo "Expected file not to exist but is does exist."
     exit 1
   fi
 
   # assert file3 is in the component
-  if [[ ! -e "prime/component/bar-baz/file3" ]]; then
+  unsquashfs -dest "component-contents" "snap-with-components+bar-baz_1.0.comp"
+  if [[ ! -e "component-contents/file3" ]]; then
     echo "Expected file to exist but is does not exist."
     exit 1
   fi
 
   # assert other files do not exist in the component
-  if [[ -e "prime/component/bar-baz/file1-new" ]] || \
-    [[ -e "prime/component/bar-baz/file2-new" ]] || \
-    [[ -e "prime/component/bar-baz/file4" ]] || \
-    [[ -e "prime/component/bar-baz/file5" ]]; then
+  if [[ -e "component-contents/file1-new" ]] || \
+    [[ -e "component-contents/file2-new" ]] || \
+    [[ -e "component-contents/file4" ]] || \
+    [[ -e "component-contents/file5" ]]; then
     echo "Expected file to exist but is does not exist."
     exit 1
   fi

--- a/tests/spread/core22/components/simple/task.yaml
+++ b/tests/spread/core22/components/simple/task.yaml
@@ -3,10 +3,15 @@ summary: Build a snap with components
 restore: |
   snapcraft clean
   rm -f ./*.snap
+  snap revert snapd
+
+prepare: |
+  # `snap pack` for components is only supported in the `latest/edge` channel
+  snap refresh snapd --channel=latest/edge
 
 execute: |
   cd "./snap"
-
+  
   snapcraft pack --destructive-mode
 
   # assert contents of default partition
@@ -15,14 +20,22 @@ execute: |
     exit 1
   fi
 
+  # assert component was packed
+  component_file="snap-with-components+man-pages_1.0.comp"
+  if [[ ! -e "${component_file}" ]]; then
+    echo "Expected component to exist but is does not exist."
+    exit 1
+  fi
+
   # assert contents of component/man-pages
-  if [[ ! -d "prime/component/man-pages/man1" ]]; then
+  unsquashfs "$component_file"
+  if [[ ! -d "squashfs-root/man1" ]]; then
     echo "Expected directory to exist but is does not exist."
     exit 1
   fi
 
   # assert contents of component metadata
-  if ! diff prime/component/man-pages/meta/component.yaml expected-man-pages-component.yaml; then
+  if ! diff squashfs-root/meta/component.yaml expected-man-pages-component.yaml; then
     echo "Metadata for the man-pages component is incorrect."
     exit 1
   fi

--- a/tests/spread/core22/components/simple/task.yaml
+++ b/tests/spread/core22/components/simple/task.yaml
@@ -2,7 +2,7 @@ summary: Build a snap with components
 
 restore: |
   snapcraft clean
-  rm -f ./*.snap
+  rm -f ./*.snap ./*.comp
   snap revert snapd
 
 prepare: |

--- a/tests/unit/test_pack.py
+++ b/tests/unit/test_pack.py
@@ -301,3 +301,57 @@ def test_pack_snap_error(mocker, new_dir, fake_process):
         """app description field 'command' contains illegal "pack-error foo=bar" """
         """(legal: '^[A-Za-z0-9/. _#:$-]*$')"""
     )
+
+
+def test_pack_component(fake_process, new_dir):
+    fake_process.register_subprocess(
+        ["snap", "pack", str(new_dir / "in"), str(new_dir / "out")],
+        stdout="built: my-snap+component_1.0.comp",
+    )
+
+    name = pack.pack_component(
+        directory=new_dir / "in",
+        output_dir=new_dir / "out",
+    )
+
+    assert name == "my-snap+component_1.0.comp"
+
+
+def test_pack_component_with_compression(fake_process, new_dir):
+    fake_process.register_subprocess(
+        [
+            "snap",
+            "pack",
+            "--compression",
+            "test",
+            str(new_dir / "in"),
+            str(new_dir / "out"),
+        ],
+        stdout="built: my-snap+component_1.0.comp",
+    )
+
+    name = pack.pack_component(
+        directory=new_dir / "in",
+        output_dir=new_dir / "out",
+        compression="test",
+    )
+
+    assert name == "my-snap+component_1.0.comp"
+
+
+def test_pack_component_error(fake_process, new_dir):
+    fake_process.register_subprocess(
+        ["snap", "pack", str(new_dir / "in"), str(new_dir / "out")],
+        returncode=1,
+    )
+
+    with pytest.raises(errors.SnapcraftError) as raised:
+        pack.pack_component(
+            directory=new_dir / "in",
+            output_dir=new_dir / "out",
+        )
+
+    assert raised.value.resolution == (
+        "Packing components is experimental and requires `snapd` "
+        "to be installed from the `latest/edge` channel."
+    )


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

Pack components with `snap pack`.

Snaps can have custom filenames using `--output`  (i.e. `snapcraft pack --output my-dir/my-snap.snap`)

However, components cannot.  Their names are determined by `snap pack`.  They will still be placed in the same output directory (`my-dir` in the example above).

Fixes #4467
(CRAFT-2313)