### PR TITLE
fix: install snapd from edge inside build environments

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -15,7 +15,7 @@ craft-archives==1.1.3
 craft-cli==2.5.0
 craft-grammar==1.1.1
 git+https://github.com/canonical/craft-parts@feature/namespaced-partitions-patch#egg=craft-parts
-craft-providers==1.20.1
+git+https://github.com/canonical/craft-providers@main#egg=craft-providers
 craft-store==2.5.0
 cryptography==41.0.7
 Deprecated==1.2.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ craft-archives==1.1.3
 craft-cli==2.5.0
 craft-grammar==1.1.1
 git+https://github.com/canonical/craft-parts@feature/namespaced-partitions-patch#egg=craft-parts
-craft-providers==1.20.1
+git+https://github.com/canonical/craft-providers@main#egg=craft-providers
 craft-store==2.5.0
 cryptography==41.0.7
 Deprecated==1.2.14

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ install_requires = [
     "craft-cli",
     "craft-grammar",
     "craft-parts @ git+https://github.com/canonical/craft-parts@feature/namespaced-partitions-patch#egg=craft-parts",
-    "craft-providers",
+    "craft-providers @ git+https://github.com/canonical/craft-providers@main#egg=craft-providers",
     "craft-store",
     "docutils<0.20",  # Frozen until we can update sphinx dependencies.
     "gnupg",

--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -196,15 +196,20 @@ def get_base_configuration(
 
     return bases.BuilddBase(
         alias=alias,
-        compatibility_tag=f"snapcraft-{bases.BuilddBase.compatibility_tag}.0",
+        compatibility_tag=f"snapcraft-{bases.BuilddBase.compatibility_tag}.1",
         environment=environment,
         hostname=instance_name,
         snaps=[
             Snap(
+                name="snapd",
+                channel="latest/edge",
+                classic=True,
+            ),
+            Snap(
                 name=snap_name,
                 channel=snap_channel,
                 classic=True,
-            )
+            ),
         ],
         # Requirement for apt gpg and version:git
         packages=["gnupg", "dirmngr", "git"],

--- a/tests/spread/core22/components/environment/task.yaml
+++ b/tests/spread/core22/components/environment/task.yaml
@@ -5,6 +5,8 @@ restore: |
   rm -f ./*.snap
 
 execute: |
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
   check_vars() {
     file="$1"
     root="$(pwd)"
@@ -32,14 +34,14 @@ execute: |
     done
   }
 
-  snapcraft pull
+  snapcraft pull --destructive-mode
   check_vars pull.txt
 
-  snapcraft build
+  snapcraft build --destructive-mode
   check_vars build.txt
 
-  snapcraft stage
+  snapcraft stage --destructive-mode
   check_vars stage.txt
 
-  snapcraft prime
+  snapcraft prime --destructive-mode
   check_vars prime.txt

--- a/tests/spread/core22/components/file-migration/snap/snapcraft.yaml
+++ b/tests/spread/core22/components/file-migration/snap/snapcraft.yaml
@@ -6,13 +6,9 @@ description: |
 
   The snap should contain `file1-new` and `file2-new`.
   The `bar-baz` component should contain `file3`.
-
-base: core24
-build-base: devel
-
+base: core22
 grade: devel
 confinement: strict
-
 
 components:
   bar-baz:

--- a/tests/spread/core22/components/file-migration/task.yaml
+++ b/tests/spread/core22/components/file-migration/task.yaml
@@ -2,17 +2,14 @@ summary: Test file migratation with components
 
 restore: |
   snapcraft clean
-  rm -rf ./*.snap ./*.comp
-  snap revert snapd
-
-prepare: |
-  # `snap pack` for components is only supported in the `latest/edge` channel
-  snap refresh snapd --channel=latest/edge
+  rm -f ./*.snap ./*.comp
 
 execute: |
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
   cd "./snap"
 
-  snapcraft pack --destructive-mode
+  snapcraft pack --use-lxd
 
   # assert file1-new and file2-new are in the snap
   unsquashfs -dest "snap-contents" "snap-with-components_1.0_amd64.snap"

--- a/tests/spread/core22/components/simple/snap/expected-component.yaml
+++ b/tests/spread/core22/components/simple/snap/expected-component.yaml
@@ -1,4 +1,4 @@
-component: snap-with-components+man-pages
+component: snap-with-components+share
 type: test
 version: '1.0'
 summary: Hello World

--- a/tests/spread/core22/components/simple/snap/snapcraft.yaml
+++ b/tests/spread/core22/components/simple/snap/snapcraft.yaml
@@ -1,12 +1,8 @@
 name: snap-with-components
 version: "1.0"
 summary: Build a snap with components
-description: |
-  Build a snap with components to test components.
-
-base: core24
-build-base: devel
-
+description: Build a snap with components to test components.
+base: core22
 grade: devel
 confinement: strict
 
@@ -15,7 +11,7 @@ apps:
     command: bin/hello
 
 components:
-  man-pages:
+  share:
     type: test
     summary: Hello World
     description: Hello World
@@ -31,4 +27,4 @@ parts:
       - libcurl4-openssl-dev
     stage-packages: [libcurl4]
     organize:
-      (default)/usr/share/man: (component/man-pages)
+      (default)/usr/share: (component/share)/usr/share

--- a/tests/spread/core22/components/simple/task.yaml
+++ b/tests/spread/core22/components/simple/task.yaml
@@ -3,39 +3,37 @@ summary: Build a snap with components
 restore: |
   snapcraft clean
   rm -f ./*.snap ./*.comp
-  snap revert snapd
-
-prepare: |
-  # `snap pack` for components is only supported in the `latest/edge` channel
-  snap refresh snapd --channel=latest/edge
 
 execute: |
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
   cd "./snap"
   
-  snapcraft pack --destructive-mode
+  snapcraft pack --use-lxd
 
   # assert contents of default partition
-  if [[ ! -e "prime/default/bin/hello" ]]; then
+  unsquashfs -dest "snap-contents" "snap-with-components_1.0_amd64.snap"
+  if [[ ! -e "snap-contents/bin/hello" ]]; then
     echo "Expected file to exist but is does not exist."
     exit 1
   fi
 
   # assert component was packed
-  component_file="snap-with-components+man-pages_1.0.comp"
+  component_file="snap-with-components+share_1.0.comp"
   if [[ ! -e "${component_file}" ]]; then
     echo "Expected component to exist but is does not exist."
     exit 1
   fi
 
-  # assert contents of component/man-pages
-  unsquashfs "$component_file"
-  if [[ ! -d "squashfs-root/man1" ]]; then
+  # assert contents of component/share
+  unsquashfs -dest "component-contents" "${component_file}"
+  if [[ ! -d "component-contents/usr/share" ]]; then
     echo "Expected directory to exist but is does not exist."
     exit 1
   fi
 
   # assert contents of component metadata
-  if ! diff squashfs-root/meta/component.yaml expected-man-pages-component.yaml; then
-    echo "Metadata for the man-pages component is incorrect."
+  if ! diff component-contents/meta/component.yaml expected-component.yaml; then
+    echo "Metadata for the share component is incorrect."
     exit 1
   fi

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -210,10 +210,13 @@ def test_get_base_configuration(
 
     mock_buildd_base.assert_called_with(
         alias=alias,
-        compatibility_tag="snapcraft-buildd-base-v0.0",
+        compatibility_tag="snapcraft-buildd-base-v0.1",
         environment="test-env",
         hostname="test-instance-name",
-        snaps=[Snap(name="test-snap-name", channel="test-channel", classic=True)],
+        snaps=[
+            Snap(name="snapd", channel="latest/edge", classic=True),
+            Snap(name="test-snap-name", channel="test-channel", classic=True),
+        ],
         packages=["gnupg", "dirmngr", "git"],
     )
 
@@ -256,7 +259,10 @@ def test_get_base_configuration_snap_channel(
         compatibility_tag=ANY,
         environment=ANY,
         hostname=ANY,
-        snaps=[Snap(name="snapcraft", channel=snap_channel, classic=True)],
+        snaps=[
+            Snap(name="snapd", channel="latest/edge", classic=True),
+            Snap(name="snapcraft", channel=snap_channel, classic=True),
+        ],
         packages=ANY,
     )
 
@@ -290,7 +296,10 @@ def test_get_base_configuration_snap_instance_name_default(
         compatibility_tag=ANY,
         environment=ANY,
         hostname=ANY,
-        snaps=[Snap(name="snapcraft", channel=None, classic=True)],
+        snaps=[
+            Snap(name="snapd", channel="latest/edge", classic=True),
+            Snap(name="snapcraft", channel=None, classic=True),
+        ],
         packages=ANY,
     )
 
@@ -324,7 +333,10 @@ def test_get_base_configuration_snap_instance_name_not_running_as_snap(
         compatibility_tag=ANY,
         environment=ANY,
         hostname=ANY,
-        snaps=[Snap(name="snapcraft", channel=None, classic=True)],
+        snaps=[
+            Snap(name="snapd", channel="latest/edge", classic=True),
+            Snap(name="snapcraft", channel=None, classic=True),
+        ],
         packages=ANY,
     )
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `pytest tests/unit`?

-----

1. Install snapd from edge inside build environments
2. Update spread tests to exercise build environments (two tests use lxd, one uses destructive-mode)


Note: 
Installing `snapd` from edge exposed a minor bug in craft-providers `1.20.1`.  However, that bug was mercifully fixed in the `1.19.3` hotfix (which was released and merged to main after `1.20.1` and there hasn't been a release on main since).  So To get this prototype out the door, I'm just pointing to `main` for craft-providers and I'll do a [release](https://github.com/canonical/craft-providers/pull/493) soon.