### PR TITLE
chore(deps): bump version of Chisel

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -186,10 +186,11 @@ parts:
     after: [snapcraft-libs, libgit2]
 
   chisel:
-    plugin: go
-    source: https://github.com/canonical/chisel.git
-    source-commit: bd27f8700cd7d2a6b4e0df6b10c3761c83a70485
-    build-snaps:
-      - go/1.18/stable
+    plugin: nil
+    stage-snaps:
+      - chisel/latest/candidate
     organize:
       bin/chisel: libexec/snapcraft/chisel
+    stage:
+      - libexec/snapcraft/chisel
+


### PR DESCRIPTION
Upcoming Chisel (and chisel-releases) changes will break older versions of the tool; update it to v0.8.1 which is compatible with this change and gives us some breathing room before we change the way Chisel is provisioned.

Ref: https://github.com/canonical/rockcraft/pull/449

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
