### PR TITLE
fix(lifecycle): return correct base when using devel for build-base

### DIFF
--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -432,7 +432,7 @@ def _run_in_provider(  # noqa PLR0915
     snapcraft_base = project.get_effective_base()
     build_base = providers.SNAPCRAFT_BASE_TO_PROVIDER_BASE[snapcraft_base]
 
-    if snapcraft_base == "devel":
+    if snapcraft_base in ("devel", "core24"):
         emit.progress(
             "Running snapcraft with a devel instance is for testing purposes only.",
             permanent=True,

--- a/snapcraft/parts/yaml_utils.py
+++ b/snapcraft/parts/yaml_utils.py
@@ -33,7 +33,7 @@ _CORE_PART_KEYS = ["build-packages", "build-snaps"]
 _CORE_PART_NAME = "snapcraft/core"
 
 # All bases recognized by snapcraft
-BASES = {"core", "core18", "core20", "core22", "devel"}
+BASES = {"core", "core18", "core20", "core22", "core24", "devel"}
 # Bases no longer supported by the current version of snapcraft
 ESM_BASES = {"core", "core18"}
 # Bases handled by the legacy snapcraft codebase

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -591,6 +591,15 @@ class Project(ProjectModel):
             raise ValueError("grade must be 'devel' when build-base is 'devel'")
         return values
 
+    @pydantic.validator("base", always=True)
+    @classmethod
+    def _validate_base(cls, base, values):
+        """Not allowed to use unsable base without devel build-base."""
+        if values.get("base") == "core24" and values.get("build_base") != "devel":
+            raise ValueError("build-base must be 'devel' when base is 'core24'")
+
+        return base
+
     @pydantic.validator("build_base", always=True)
     @classmethod
     def _validate_build_base(cls, build_base, values):

--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -594,7 +594,7 @@ class Project(ProjectModel):
     @pydantic.validator("base", always=True)
     @classmethod
     def _validate_base(cls, base, values):
-        """Not allowed to use unsable base without devel build-base."""
+        """Not allowed to use unstable base without devel build-base."""
         if values.get("base") == "core24" and values.get("build_base") != "devel":
             raise ValueError("build-base must be 'devel' when base is 'core24'")
 

--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -42,6 +42,7 @@ SNAPCRAFT_BASE_TO_PROVIDER_BASE = {
     "core18": bases.BuilddBaseAlias.BIONIC,
     "core20": bases.BuilddBaseAlias.FOCAL,
     "core22": bases.BuilddBaseAlias.JAMMY,
+    "core24": bases.BuilddBaseAlias.DEVEL,
     "devel": bases.BuilddBaseAlias.DEVEL,
 }
 

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -216,14 +216,20 @@ def get_effective_base(
 ) -> Optional[str]:
     """Return the base to use to create the snap.
 
-    Returns build-base if set, but if not, name is returned if the
-    snap is of type base. For all other snaps, the base is returned
-    as the build-base.
+    Return the build-base if set.
+    Exception:
+    "base" snaps will return name if build-base is not set.
+    "devel" snaps, return the base, where the true base is, except "base" snaps.
     """
+    if project_type == "base":
+        return build_base if build_base else name
+
     if build_base is not None:
+        if build_base == "devel":
+            return base
         return build_base
 
-    return name if project_type == "base" else base
+    return base
 
 
 def get_parallel_build_count() -> int:

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -277,7 +277,10 @@ def test_get_effective_base_with_build_base(
 
     cli.run()
 
-    mock_run_new_or_fallback_remote_build.assert_called_once_with(build_base)
+    if build_base == "devel":
+        mock_run_new_or_fallback_remote_build.assert_called_once_with(base)
+    else:
+        mock_run_new_or_fallback_remote_build.assert_called_once_with(build_base)
 
 
 @pytest.mark.usefixtures("mock_argv", "mock_confirm")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -118,6 +118,8 @@ def test_strtobool_value_error(value: str):
         (None, None, "other", "name", None),
         ("base", "build_base", "other", "name", "build_base"),
         ("base", None, "other", "name", "base"),
+        ("base", "devel", "other", "name", "base"),
+        ("base", "devel", "base", "name", "devel"),
     ],
 )
 def test_get_effective_base(base, build_base, project_type, name, expected_base):


### PR DESCRIPTION
`get_effective_base()` should not return "devel" and pass it to the `PartsLifecycle()`, which make the parts think the coreXX is "devel". Thus checking the wrong path for dynamic linking.

`LD_LIBRARY_PATH=...:/snap/core24/current/lib:/snap/core24/current/usr/lib:...`
become
`LD_LIBRARY_PATH=...:/snap/devel/current/lib:/snap/devel/current/usr/lib:...`
which not exists.

Fix: #4508
