### PR TITLE
build(deps): bump craft-cli to 2.5.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ attrs==23.1.0
 catkin-pkg==0.5.2
 click==8.1.7
 craft-archives==1.1.3
-craft-cli==2.5.0
+craft-cli==2.5.1
 craft-grammar==1.1.1
 craft-parts==1.26.0
 craft-providers==1.20.1

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -12,7 +12,7 @@ codespell==2.2.6
 colorama==0.4.6
 coverage==7.4.0
 craft-archives==1.1.3
-git+https://github.com/canonical/craft-cli.git@CRAFT-2393-utf8-error#egg=craft_cli
+craft-cli==2.5.1
 craft-grammar==1.1.2
 craft-parts==1.26.1
 craft-providers==1.20.1

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -12,7 +12,7 @@ codespell==2.2.6
 colorama==0.4.6
 coverage==7.4.0
 craft-archives==1.1.3
-craft-cli==2.5.0
+git+https://github.com/canonical/craft-cli.git@CRAFT-2393-utf8-error#egg=craft_cli
 craft-grammar==1.1.2
 craft-parts==1.26.1
 craft-providers==1.20.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
 craft-archives==1.1.3
-craft-cli==2.5.0
+git+https://github.com/canonical/craft-cli.git@CRAFT-2393-utf8-error#egg=craft_cli
 craft-grammar==1.1.2
 craft-parts==1.26.1
 craft-providers==1.20.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
 craft-archives==1.1.3
-git+https://github.com/canonical/craft-cli.git@CRAFT-2393-utf8-error#egg=craft_cli
+craft-cli==2.5.1
 craft-grammar==1.1.2
 craft-parts==1.26.1
 craft-providers==1.20.1

--- a/tests/spread/core22/invalid-utf8/snapcraft.yaml
+++ b/tests/spread/core22/invalid-utf8/snapcraft.yaml
@@ -1,0 +1,12 @@
+name: invalid-utf8
+base: core22
+summary: a project that echos invalid utf-8 text
+description: a project that echos invalid utf-8 text
+version: "1.0"
+confinement: strict
+
+parts:
+  my-part:
+    plugin: nil
+    override-build: |
+      echo -e "hi \x96 bye"

--- a/tests/spread/core22/invalid-utf8/task.yaml
+++ b/tests/spread/core22/invalid-utf8/task.yaml
@@ -1,0 +1,8 @@
+summary: Handle invalid utf-8 text during the build
+
+restore: |
+  snapcraft clean
+  rm -f ./*.snap
+
+execute: |
+  snapcraft pack -v 2>&1 | MATCH ":: hi � bye"


### PR DESCRIPTION
This new version fixes decoding issues when parsing malformed output from other processes (typically during the build step)

Fixes #4515

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
