### PR TITLE
style(remote): reword git error messages

### DIFF
--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -301,7 +301,12 @@ def run():  # noqa: C901 (complex-structure)
         emit.error(craft_cli.errors.CraftError(f"linter error: {err}"))
         retcode = err.exit_code
     except RemoteBuildError as err:
-        emit.error(craft_cli.errors.CraftError(f"remote-build error: {err}"))
+        emit.error(
+            craft_cli.errors.CraftError(
+                message=f"remote-build error: {err}",
+                docs_url="https://snapcraft.io/docs/remote-build",
+            )
+        )
         retcode = 1
     except errors.SnapcraftError as err:
         _emit_error(err)

--- a/snapcraft/remote/errors.py
+++ b/snapcraft/remote/errors.py
@@ -107,7 +107,6 @@ class AcceptPublicUploadError(RemoteBuildError):
 class RemoteBuildFailedError(RemoteBuildError):
     """Remote build failed.
 
-    :param brief: Brief description of error.
     :param details: Detailed information.
     """
 
@@ -120,7 +119,6 @@ class RemoteBuildFailedError(RemoteBuildError):
 class RemoteBuildInvalidGitRepoError(RemoteBuildError):
     """The Git repository is invalid for remote build.
 
-    :param brief: Brief description of error.
     :param details: Detailed information.
     """
 

--- a/snapcraft/remote/git.py
+++ b/snapcraft/remote/git.py
@@ -103,12 +103,14 @@ def check_git_repo_for_remote_build(path: Path) -> None:
 
     if git_type == GitType.INVALID:
         raise RemoteBuildInvalidGitRepoError(
-            f"Could not find a git repository in {str(path)!r}"
+            f"Could not find a git repository in {str(path.absolute())!r}. "
+            "The project must be in the top-level of a git repository."
         )
 
     if git_type == GitType.SHALLOW:
         raise RemoteBuildInvalidGitRepoError(
-            "Remote build for shallow cloned git repos are no longer supported"
+            "Remote builds are not supported for projects in shallowly cloned "
+            "git repositories."
         )
 
 

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -621,7 +621,10 @@ def test_run_in_shallow_repo_unsupported(capsys, new_dir):
     assert ret != 0
     _, err = capsys.readouterr()
 
-    assert "Remote build for shallow cloned git repos are no longer supported" in err
+    assert (
+        "Remote builds are not supported for projects in shallowly cloned "
+        "git repositories."
+    ) in err
 
 
 ######################

--- a/tests/unit/remote/test_git.py
+++ b/tests/unit/remote/test_git.py
@@ -538,7 +538,11 @@ def test_push_url_push_error(new_dir):
 def test_check_git_repo_for_remote_build_invalid(new_dir):
     """Check if directory is an invalid repo."""
     with pytest.raises(
-        RemoteBuildInvalidGitRepoError, match="Could not find a git repository in"
+        RemoteBuildInvalidGitRepoError,
+        match=(
+            f"Could not find a git repository in {str(new_dir.absolute())!r}. "
+            "The project must be in the top-level of a git repository."
+        ),
     ):
         check_git_repo_for_remote_build(new_dir)
 
@@ -584,6 +588,9 @@ def test_check_git_repo_for_remote_build_shallow(new_dir):
 
     with pytest.raises(
         RemoteBuildInvalidGitRepoError,
-        match="Remote build for shallow cloned git repos are no longer supported",
+        match=(
+            "Remote builds are not supported for projects in shallowly cloned "
+            "git repositories."
+        ),
     ):
         check_git_repo_for_remote_build(git_shallow_path)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

### Tasks

- [x] reword errors and link to documentation
- [x] create a git repo in the remote-build spread tests (already done in https://github.com/snapcore/snapcraft/pull/4529)
- [x] update documentation with git repo requirement (https://snapcraft.io/docs/remote-build)
- [x] update snapcraft 8 release notes with git repo requirement (https://github.com/snapcore/snapcraft/releases/tag/8.0.0)

Fixes #4517 
(CRAFT-2387)