### PR TITLE
build(deps): bump craft-providers to 1.22.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.1.1
 craft-parts==1.26.0
-craft-providers==1.21.0
+craft-providers==1.22.0
 craft-store==2.5.0
 Deprecated==1.2.14
 distro==1.8.0

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -15,7 +15,7 @@ craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.1.2
 craft-parts==1.26.1
-craft-providers==1.21.0
+craft-providers==1.22.0
 craft-store==2.6.0
 cryptography==41.0.7
 Deprecated==1.2.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.1.2
 craft-parts==1.26.1
-craft-providers==1.21.0
+craft-providers==1.22.0
 craft-store==2.6.0
 cryptography==41.0.7
 Deprecated==1.2.14


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Resolves https://bugs.launchpad.net/snapcraft/+bug/2051567

## Changelog

### 1.22.0 (2024-01-30)
- Do not update apt sources for Ubuntu devel images