### PR TITLE
feat: implement core24 "pack" command

### DIFF
--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -189,7 +189,7 @@ def main() -> int:
     app.add_command_group(
         "Lifecycle",
         [
-            unimplemented.Clean,
+            craft_app_commands.lifecycle.CleanCommand,
             unimplemented.Pull,
             unimplemented.Build,
             unimplemented.Stage,

--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -24,6 +24,7 @@ import signal
 import sys
 from typing import Any
 
+import craft_application.commands as craft_app_commands
 import craft_cli
 from craft_application import Application, AppMetadata, util
 from craft_cli import emit
@@ -193,7 +194,7 @@ def main() -> int:
             unimplemented.Build,
             unimplemented.Stage,
             unimplemented.Prime,
-            unimplemented.Pack,
+            craft_app_commands.lifecycle.PackCommand,
             unimplemented.RemoteBuild,
             unimplemented.Snap,  # Hidden (legacy compatibility)
             unimplemented.Plugins,

--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -15,37 +15,41 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Create snap.yaml metadata file."""
+from __future__ import annotations
 
 import re
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Set, Union, cast
 
+import pydantic
 import yaml
-from craft_application.models import UniqueStrList
+from craft_application.models import BaseMetadata, constraints
 from craft_cli import emit
-from pydantic import Extra, ValidationError, validator
-from pydantic_yaml import YamlModel
+from pydantic import ValidationError, validator
+from typing_extensions import override
 
 from snapcraft import errors, models
 from snapcraft.utils import get_ld_library_paths, process_version
 
 
-class _SnapMetadataModel(YamlModel):
-    class Config:  # pylint: disable=too-few-public-methods
-        """Pydantic model configuration."""
+class SnapcraftMetadata(BaseMetadata):
+    """Snapcraft-specific metadata base model."""
 
-        allow_population_by_field_name = True
-        alias_generator = lambda s: s.replace("_", "-")  # noqa: E731
+    def marshal(self) -> dict[str, str | list[str] | dict[str, Any]]:
+        """Convert to a dictionary."""
+        return self.dict(
+            by_alias=True, exclude_unset=True, exclude_none=True, exclude_defaults=True
+        )
 
 
-class Socket(_SnapMetadataModel):
+class Socket(SnapcraftMetadata):
     """snap.yaml app socket entry."""
 
     listen_stream: Union[int, str]
     socket_mode: Optional[int]
 
 
-class SnapApp(_SnapMetadataModel):
+class SnapApp(SnapcraftMetadata):
     """Snap.yaml app entry.
 
     This is currently a partial implementation, see
@@ -54,11 +58,6 @@ class SnapApp(_SnapMetadataModel):
     TODO: implement desktop (CRAFT-804)
     TODO: implement extensions (CRAFT-805)
     """
-
-    class Config:  # type: ignore[reportIncompatibleVariableOverride]
-        """Pydantic model configuration."""
-
-        extra = Extra.allow
 
     command: str
     autostart: Optional[str]
@@ -90,8 +89,14 @@ class SnapApp(_SnapMetadataModel):
     activates_on: Optional[List[str]]
 
 
-class ContentPlug(_SnapMetadataModel):
+class ContentPlug(SnapcraftMetadata):  # type: ignore # (pydantic plugin is crashing)
     """Content plug definition in the snap metadata."""
+
+    @override
+    class Config(BaseMetadata.Config):
+        """Allow extra parameters in content plugs."""
+
+        extra = pydantic.Extra.ignore
 
     interface: Literal["content"]
     target: str
@@ -141,7 +146,7 @@ class ContentPlug(_SnapMetadataModel):
         return self.default_provider
 
 
-class ContentSlot(_SnapMetadataModel):
+class ContentSlot(SnapcraftMetadata):
     """Content slot definition in the snap metadata."""
 
     interface: Literal["content"]
@@ -176,22 +181,25 @@ class ContentSlot(_SnapMetadataModel):
         return content_dirs
 
 
-class Links(_SnapMetadataModel):
+class Links(SnapcraftMetadata):
     """Metadata links used in snaps."""
 
-    contact: Optional[UniqueStrList]
-    donation: Optional[UniqueStrList]
-    issues: Optional[UniqueStrList]
-    source_code: Optional[UniqueStrList]
-    website: Optional[UniqueStrList]
+    contact: Optional[constraints.UniqueStrList]
+    donation: Optional[constraints.UniqueStrList]
+    issues: Optional[constraints.UniqueStrList]
+    source_code: Optional[constraints.UniqueStrList]
+    website: Optional[constraints.UniqueStrList]
 
     @staticmethod
     def _normalize_value(
-        value: Optional[Union[str, UniqueStrList]]
-    ) -> Optional[UniqueStrList]:
+        value: str | constraints.UniqueStrList | None,
+    ) -> constraints.UniqueStrList | None:
+        result: constraints.UniqueStrList | None
         if isinstance(value, str):
-            value = cast(UniqueStrList, [value])
-        return value
+            result = cast(constraints.UniqueStrList, [value])
+        else:
+            result = value
+        return result
 
     @classmethod
     def from_project(cls, project: models.Project) -> "Links":
@@ -211,17 +219,12 @@ class Links(_SnapMetadataModel):
         )
 
 
-class SnapMetadata(_SnapMetadataModel):
+class SnapMetadata(SnapcraftMetadata):
     """The snap.yaml model.
 
     This is currently a partial implementation, see
     https://snapcraft.io/docs/snap-format for details.
     """
-
-    class Config:  # type: ignore[reportIncompatibleVariableOverride]
-        """Pydantic model configuration."""
-
-        extra = Extra.allow
 
     name: str
     title: Optional[str]
@@ -410,16 +413,15 @@ def _get_grade(grade: Optional[str], build_base: Optional[str]) -> str:
     return grade
 
 
-def write(project: models.Project, prime_dir: Path, *, arch: str):
-    """Create a snap.yaml file.
+def get_metadata_from_project(
+    project: models.Project, prime_dir: Path, *, arch: str
+) -> SnapMetadata:
+    """Get a SnapMetadata object from a project.
 
     :param project: Snapcraft project.
     :param prime_dir: The directory containing the content to be snapped.
     :param arch: Target architecture the snap project is built to.
     """
-    meta_dir = prime_dir / "meta"
-    meta_dir.mkdir(parents=True, exist_ok=True)
-
     assumes: Set[str] = set()
 
     snap_apps: Dict[str, SnapApp] = {}
@@ -471,17 +473,22 @@ def write(project: models.Project, prime_dir: Path, *, arch: str):
         for name, value in project.passthrough.items():
             setattr(snap_metadata, name, value)
 
-    yaml.add_representer(str, _repr_str, Dumper=yaml.SafeDumper)
-    yaml_data = snap_metadata.yaml(
-        by_alias=True,
-        exclude_none=True,
-        allow_unicode=True,
-        sort_keys=False,
-        width=1000,
-    )
+    return snap_metadata
 
-    snap_yaml = meta_dir / "snap.yaml"
-    snap_yaml.write_text(yaml_data)
+
+def write(project: models.Project, prime_dir: Path, *, arch: str):
+    """Create a snap.yaml file.
+
+    :param project: Snapcraft project.
+    :param prime_dir: The directory containing the content to be snapped.
+    :param arch: Target architecture the snap project is built to.
+    """
+    snap_metadata = get_metadata_from_project(project, prime_dir, arch=arch)
+
+    meta_dir = prime_dir / "meta"
+    meta_dir.mkdir(parents=True, exist_ok=True)
+
+    snap_metadata.to_yaml_file(meta_dir / "snap.yaml")
 
 
 def _repr_str(dumper, data):

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -25,11 +25,13 @@ from craft_application.models import BuildInfo, UniqueStrList
 from craft_archives import repo
 from craft_cli import emit
 from craft_grammar.models import GrammarSingleEntryDictList, GrammarStr, GrammarStrList
+from craft_providers import bases
 from pydantic import PrivateAttr, constr
 
 from snapcraft import parts, utils
 from snapcraft.elf.elf_utils import get_arch_triplet
 from snapcraft.errors import ProjectValidationError
+from snapcraft.providers import SNAPCRAFT_BASE_TO_PROVIDER_BASE
 from snapcraft.utils import (
     convert_architecture_deb_to_platform,
     get_effective_base,
@@ -737,8 +739,31 @@ class Project(models.Project):
 
     def get_build_plan(self) -> List[BuildInfo]:
         """Get the build plan for this project."""
-        # TODO
-        raise NotImplementedError("Not implemented yet!")
+        build_plan: List[BuildInfo] = []
+
+        architectures = cast(List[Architecture], self.architectures)
+
+        for arch in architectures:
+            # build_for will be a single element list
+            build_for = cast(list, arch.build_for)[0]
+
+            # TODO: figure out when to filter `all`
+            if build_for == "all":
+                build_for = get_host_architecture()
+
+            # build on will be a list of archs
+            for build_on in arch.build_on:
+                base = SNAPCRAFT_BASE_TO_PROVIDER_BASE[self.get_effective_base()]
+                build_plan.append(
+                    BuildInfo(
+                        platform=f"ubuntu@{base.value}",
+                        build_on=build_on,
+                        build_for=build_for,
+                        base=bases.BaseName("ubuntu", base.value),
+                    )
+                )
+
+        return build_plan
 
 
 class _GrammarAwareModel(pydantic.BaseModel):

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -19,13 +19,37 @@
 from __future__ import annotations
 
 import pathlib
+from typing import TYPE_CHECKING
 
-from craft_application import PackageService, models
+from craft_application import AppMetadata, PackageService
 from overrides import override
+
+from snapcraft import errors, linters, models, pack
+from snapcraft.linters import LinterStatus
+from snapcraft.meta import snap_yaml
+from snapcraft.utils import process_version
+
+if TYPE_CHECKING:
+    from snapcraft.services import SnapcraftServiceFactory
 
 
 class Package(PackageService):
     """Package service subclass for Snapcraft."""
+
+    _project: models.Project
+
+    def __init__(
+        self,
+        app: AppMetadata,
+        services: SnapcraftServiceFactory,
+        *,
+        project: models.Project,
+        platform: str | None,
+        build_for: str,
+    ) -> None:
+        super().__init__(app, services, project=project)
+        self._platform = platform
+        self._build_for = build_for
 
     @override
     def pack(self, prime_dir: pathlib.Path, dest: pathlib.Path) -> list[pathlib.Path]:
@@ -33,13 +57,27 @@ class Package(PackageService):
 
         :param prime_dir: Path to the directory to pack.
         :param dest: Directory into which to write the package(s).
-
         :returns: A list of paths to created packages.
         """
-        # TODO
-        raise NotImplementedError(
-            "Packing using the package service not yet implemented."
-        )
+        issues = linters.run_linters(prime_dir, lint=self._project.lint)
+        status = linters.report(issues, intermediate=True)
+
+        # In case of linter errors, stop execution and return the error code.
+        if status in (LinterStatus.ERRORS, LinterStatus.FATAL):
+            raise errors.LinterError("Linter errors found", exit_code=status)
+
+        return [
+            pathlib.Path(
+                pack.pack_snap(
+                    prime_dir,
+                    output=str(dest),
+                    compression=self._project.compression,
+                    name=self._project.name,
+                    version=process_version(self._project.version),
+                    target_arch=self._project.get_build_for(),
+                )
+            )
+        ]
 
     @override
     def write_metadata(self, path: pathlib.Path) -> None:
@@ -47,11 +85,14 @@ class Package(PackageService):
 
         :param path: The path to the prime directory.
         """
-        # TODO
-        raise NotImplementedError("Writing metadata not yet implemented.")
+        meta_dir = path / "meta"
+        meta_dir.mkdir(parents=True, exist_ok=True)
+
+        self.metadata.to_yaml_file(meta_dir / "snap.yaml")
 
     @property
-    def metadata(self) -> models.BaseMetadata:
+    def metadata(self) -> snap_yaml.SnapMetadata:
         """Get the metadata model for this project."""
-        # TODO: get metadata from project
-        return models.BaseMetadata()
+        return snap_yaml.get_metadata_from_project(
+            self._project, self._services.lifecycle.prime_dir, arch=self._build_for
+        )

--- a/tests/spread/core24/architectures/task.yaml
+++ b/tests/spread/core24/architectures/task.yaml
@@ -17,9 +17,7 @@ prepare: |
 
 restore: |
   cd "./snaps/$SNAP"
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
@@ -38,16 +36,11 @@ execute: |
     eval $(cat "environmental-variables.txt") snapcraft pack --destructive-mode
   # if the arguments variable file exists, then call snapcraft with the arguments
   elif [[ -e "arguments.txt" ]]; then
-    # If this next line fails, delete it and replace it with the one following it
-    # shellcheck disable=SC2046
-    snapcraft pack --destructive-mode $(cat "arguments.txt") 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
     # shellcheck disable=SC2046
     eval snapcraft pack --destructive-mode $(cat "arguments.txt")
   # otherwise, just call `snapcraft pack`
   else
-    # If this next line fails, delete it and replace it with the one following it
-    snapcraft pack --destructive-mode 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
-    # snapcraft pack --destructive-mode
+    snapcraft pack --destructive-mode
   fi
 
   # confirm the snaps with the expected architectures were built

--- a/tests/spread/core24/architectures/task.yaml
+++ b/tests/spread/core24/architectures/task.yaml
@@ -29,9 +29,6 @@ execute: |
 
   # if the environmental variable file exists, then call snapcraft with the environmental variables
   if [[ -e "environmental-variables.txt" ]]; then
-    # If this next line fails, delete it and replace it with the one following it
-    # shellcheck disable=SC2046
-    eval $(cat "environmental-variables.txt") snapcraft pack --destructive-mode 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
     # shellcheck disable=SC2046
     eval $(cat "environmental-variables.txt") snapcraft pack --destructive-mode
   # if the arguments variable file exists, then call snapcraft with the arguments

--- a/tests/spread/core24/chisel-base/task.yaml
+++ b/tests/spread/core24/chisel-base/task.yaml
@@ -4,15 +4,11 @@ environment:
   SNAPCRAFT_BUILD_ENVIRONMENT: ""
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap
 
 execute: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft pack 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
-  # snapcraft pack
+  snapcraft pack
   snap install core2x_*.snap --dangerous
 
   # verify that the chisel packages made it to the base

--- a/tests/spread/core24/clean/task.yaml
+++ b/tests/spread/core24/clean/task.yaml
@@ -24,9 +24,7 @@ execute: |
   # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host.
   unset SNAPCRAFT_BUILD_ENVIRONMENT
 
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft pack 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
-  # snapcraft pack
+  snapcraft pack
   snapcraft clean part1
   lxc --project=snapcraft list | grep snapcraft-clean
 

--- a/tests/spread/core24/craftctl/task.yaml
+++ b/tests/spread/core24/craftctl/task.yaml
@@ -21,9 +21,8 @@ restore: |
 
 execute: |
   cd "$SNAP"
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft --verbose --destructive-mode 2>&1 | MATCH 'command is not implemented for core24!'; exit 0
-  # snapcraft --verbose --destructive-mode
+  snapcraft --verbose --destructive-mode
   TESTBIN="${SNAP##*test-}"
+  snap install --edge core24
   snap install craftctl-*.snap --dangerous
   $TESTBIN | grep hello

--- a/tests/spread/core24/environment/paths/task.yaml
+++ b/tests/spread/core24/environment/paths/task.yaml
@@ -13,9 +13,7 @@ prepare: |
 
 restore: |
   cd "../snaps/$SNAP"
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh

--- a/tests/spread/core24/invalid-utf8/task.yaml
+++ b/tests/spread/core24/invalid-utf8/task.yaml
@@ -1,12 +1,8 @@
 summary: Handle invalid utf-8 text during the build
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap
 
 execute: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft pack -v 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
-  # snapcraft pack -v 2>&1 | MATCH ":: hi � bye"
+  snapcraft pack -v 2>&1 | MATCH ":: hi � bye"

--- a/tests/spread/core24/linters/classic-libc/task.yaml
+++ b/tests/spread/core24/linters/classic-libc/task.yaml
@@ -5,9 +5,7 @@ restore: |
   rm -f ./*.snap ./*.txt
 
 execute: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
-  # snapcraft 2> output.txt
+  snapcraft 2> output.txt
 
   test -f classic-linter-test_0.1_*.snap
 

--- a/tests/spread/core24/linters/classic-libc/task.yaml
+++ b/tests/spread/core24/linters/classic-libc/task.yaml
@@ -1,9 +1,7 @@
 summary: Test classic linter output
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap ./*.txt
 
 execute: |

--- a/tests/spread/core24/linters/classic/task.yaml
+++ b/tests/spread/core24/linters/classic/task.yaml
@@ -5,9 +5,7 @@ restore: |
   rm -f ./*.snap ./*.txt
 
 execute: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
-  # snapcraft 2> output.txt
+  snapcraft 2> output.txt
 
   test -f classic-linter-test_0.1_*.snap
 

--- a/tests/spread/core24/linters/classic/task.yaml
+++ b/tests/spread/core24/linters/classic/task.yaml
@@ -1,9 +1,7 @@
 summary: Test classic linter output
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap ./*.txt
 
 execute: |

--- a/tests/spread/core24/linters/library-ignore-missing/task.yaml
+++ b/tests/spread/core24/linters/library-ignore-missing/task.yaml
@@ -1,9 +1,7 @@
 summary: Ignore missing library linter issues
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap ./*.txt
 
 execute: |

--- a/tests/spread/core24/linters/library-ignore-missing/task.yaml
+++ b/tests/spread/core24/linters/library-ignore-missing/task.yaml
@@ -5,9 +5,7 @@ restore: |
   rm -f ./*.snap ./*.txt
 
 execute: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
-  # snapcraft 2> output.txt
+  snapcraft 2> output.txt
 
   test -f library-ignore-missing_0.1_*.snap
 

--- a/tests/spread/core24/linters/library-ignore-unused/task.yaml
+++ b/tests/spread/core24/linters/library-ignore-unused/task.yaml
@@ -1,9 +1,7 @@
 summary: Ignore unused library linter issues
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap ./*.txt
 
 execute: |

--- a/tests/spread/core24/linters/library-ignore-unused/task.yaml
+++ b/tests/spread/core24/linters/library-ignore-unused/task.yaml
@@ -5,9 +5,7 @@ restore: |
   rm -f ./*.snap ./*.txt
 
 execute: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
-  # snapcraft 2> output.txt
+  snapcraft 2> output.txt
 
   test -f library-ignore-unused_0.1_*.snap
 

--- a/tests/spread/core24/linters/library-ignored-mixed/task.yaml
+++ b/tests/spread/core24/linters/library-ignored-mixed/task.yaml
@@ -5,9 +5,7 @@ restore: |
   rm -f ./*.snap ./*.txt
 
 execute: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
-  # snapcraft 2> output.txt
+  snapcraft 2> output.txt
 
   test -f library-ignore-mixed_0.1_*.snap
 

--- a/tests/spread/core24/linters/library-ignored-mixed/task.yaml
+++ b/tests/spread/core24/linters/library-ignored-mixed/task.yaml
@@ -1,9 +1,7 @@
 summary: Ignore mixed library linter issues
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap ./*.txt
 
 execute: |

--- a/tests/spread/core24/linters/library-missing/task.yaml
+++ b/tests/spread/core24/linters/library-missing/task.yaml
@@ -5,9 +5,7 @@ restore: |
   rm -f ./*.snap ./*.txt
 
 execute: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
-  # snapcraft 2> output.txt
+  snapcraft 2> output.txt
 
   test -f library-missing_0.1_*.snap
 

--- a/tests/spread/core24/linters/library-missing/task.yaml
+++ b/tests/spread/core24/linters/library-missing/task.yaml
@@ -1,9 +1,7 @@
 summary: Raise linter warnings for missing libraries
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap ./*.txt
 
 execute: |

--- a/tests/spread/core24/linters/library-unused/task.yaml
+++ b/tests/spread/core24/linters/library-unused/task.yaml
@@ -1,9 +1,7 @@
 summary: Raise linter warnings for unused libraries.
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap ./*.txt
 
 execute: |

--- a/tests/spread/core24/linters/library-unused/task.yaml
+++ b/tests/spread/core24/linters/library-unused/task.yaml
@@ -5,9 +5,7 @@ restore: |
   rm -f ./*.snap ./*.txt
 
 execute: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
-  # snapcraft 2> output.txt
+  snapcraft 2> output.txt
 
   test -f library-unused_0.1_*.snap
 

--- a/tests/spread/core24/linters/library/task.yaml
+++ b/tests/spread/core24/linters/library/task.yaml
@@ -1,9 +1,7 @@
 summary: Test library linter output
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap ./*.txt
 
 execute: |

--- a/tests/spread/core24/linters/library/task.yaml
+++ b/tests/spread/core24/linters/library/task.yaml
@@ -1,12 +1,13 @@
 summary: Test library linter output
 
 restore: |
-  snapcraft clean
+  snapcraft clean 2>&1 | MATCH 'snapcraft internal error: KeyError'; exit 0
+  # snapcraft clean
   rm -f ./*.snap ./*.txt
 
 execute: |
   # If this next line fails, delete it and replace it with the one following it
-  snapcraft 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
+  snapcraft 2>&1 | MATCH 'snapcraft internal error: KeyError'; exit 0
   # snapcraft 2> output.txt
 
   test -f gnome-calculator_*.snap

--- a/tests/spread/core24/linters/lint-file/task.yaml
+++ b/tests/spread/core24/linters/lint-file/task.yaml
@@ -5,10 +5,7 @@ restore: |
 
 execute: |
   # build the test snap destructively to save time
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
-  # snapcraft
-
+  snapcraft
   # test the linter using a build provider
   unset SNAPCRAFT_BUILD_ENVIRONMENT
   snapcraft lint lint-file_0.1_*.snap 2> output.txt

--- a/tests/spread/core24/linters/linter-ros2-humble-mixed/task.yaml
+++ b/tests/spread/core24/linters/linter-ros2-humble-mixed/task.yaml
@@ -1,9 +1,7 @@
 summary: Check linter warnings ros2-humble extension plus user ignores.
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap ./*.txt
 
 execute: |

--- a/tests/spread/core24/linters/linter-ros2-humble-mixed/task.yaml
+++ b/tests/spread/core24/linters/linter-ros2-humble-mixed/task.yaml
@@ -1,12 +1,14 @@
 summary: Check linter warnings ros2-humble extension plus user ignores.
 
 restore: |
-  snapcraft clean
+  # If this next line fails, delete it and replace it with the one following it
+  snapcraft clean 2>&1 | MATCH "extra field 'extensions' not permitted"; exit 0
+  # snapcraft clean
   rm -f ./*.snap ./*.txt
 
 execute: |
   # If this next line fails, delete it and replace it with the one following it
-  snapcraft 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
+  snapcraft 2>&1 | MATCH "extra field 'extensions' not permitted"; exit 0
   # snapcraft 2> output.txt
 
   test -f linter-ros2-humble-mixed_1.0_*.snap

--- a/tests/spread/core24/linters/linter-ros2-humble/task.yaml
+++ b/tests/spread/core24/linters/linter-ros2-humble/task.yaml
@@ -1,9 +1,7 @@
 summary: Ignore unused library linter issues
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap ./*.txt
 
 execute: |

--- a/tests/spread/core24/linters/linter-ros2-humble/task.yaml
+++ b/tests/spread/core24/linters/linter-ros2-humble/task.yaml
@@ -1,12 +1,14 @@
 summary: Ignore unused library linter issues
 
 restore: |
-  snapcraft clean
+  # If this next line fails, delete it and replace it with the one following it
+  snapcraft clean 2>&1 | MATCH "extra field 'extensions' not permitted"; exit 0
+  # snapcraft clean
   rm -f ./*.snap ./*.txt
 
 execute: |
   # If this next line fails, delete it and replace it with the one following it
-  snapcraft 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
+  snapcraft 2>&1 | MATCH "extra field 'extensions' not permitted"; exit 0
   # snapcraft 2> output.txt
 
   test -f linter-ros2-humble_1.0_*.snap

--- a/tests/spread/core24/manifest/manifest-creation/task.yaml
+++ b/tests/spread/core24/manifest/manifest-creation/task.yaml
@@ -8,9 +8,7 @@ prepare: |
   snap install review-tools
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap
   rm -f ~/manifest_0.1_*.snap
 

--- a/tests/spread/core24/manifest/manifest-creation/task.yaml
+++ b/tests/spread/core24/manifest/manifest-creation/task.yaml
@@ -14,7 +14,7 @@ restore: |
 
 execute: |
   # If this next line fails, delete it and replace it with the one following it
-  $CMD 2>&1 | MATCH 'command is not implemented for core24!'; exit 0
+  $CMD 2>&1 | MATCH 'unrecognized arguments: --enable-manifest'; exit 0
   # $CMD
 
   test -f manifest_0.1_*.snap

--- a/tests/spread/core24/manifest/manifest-info-cmdline/task.yaml
+++ b/tests/spread/core24/manifest/manifest-info-cmdline/task.yaml
@@ -11,7 +11,7 @@ restore: |
 execute: |
   unset SNAPCRAFT_BUILD_ENVIRONMENT
   # If this next line fails, delete it and replace it with the one following it
-  snapcraft --use-lxd --enable-manifest --manifest-image-information='{"test-var": "value"}' 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
+  snapcraft --use-lxd --enable-manifest --manifest-image-information='{"test-var": "value"}' 2>&1 | MATCH "unrecognized arguments: --use-lxd --enable-manifest"; exit 0
   # snapcraft --use-lxd --enable-manifest --manifest-image-information='{"test-var": "value"}'
 
   unsquashfs manifest_0.1_*.snap

--- a/tests/spread/core24/manifest/manifest-info-cmdline/task.yaml
+++ b/tests/spread/core24/manifest/manifest-info-cmdline/task.yaml
@@ -4,9 +4,7 @@ prepare: |
   snap install review-tools
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap
   rm -f ~/manifest_0.1_*.snap
 

--- a/tests/spread/core24/manifest/manifest-info-envvars/task.yaml
+++ b/tests/spread/core24/manifest/manifest-info-envvars/task.yaml
@@ -13,7 +13,7 @@ execute: |
   export SNAPCRAFT_IMAGE_INFO='{"test-var": "value"}'
 
   # If this next line fails, delete it and replace it with the one following it
-  snapcraft --use-lxd 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
+  snapcraft --use-lxd 2>&1 | MATCH 'unrecognized arguments: --use-lxd'; exit 0
   # snapcraft --use-lxd
 
   unsquashfs manifest_0.1_*.snap

--- a/tests/spread/core24/manifest/manifest-info-envvars/task.yaml
+++ b/tests/spread/core24/manifest/manifest-info-envvars/task.yaml
@@ -4,9 +4,7 @@ prepare: |
   snap install review-tools
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap
   rm -f ~/manifest_0.1_*.snap
 

--- a/tests/spread/core24/package-repo-archs/task.yaml
+++ b/tests/spread/core24/package-repo-archs/task.yaml
@@ -6,9 +6,7 @@ environment:
   SNAPCRAFT_BUILD_ENVIRONMENT: ""
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
 
 execute: |
   # The task works by copying one of the arch-specific yaml files as

--- a/tests/spread/core24/package-repositories/task.yaml
+++ b/tests/spread/core24/package-repositories/task.yaml
@@ -21,7 +21,7 @@ execute: |
 
   # Build what we have.
   # If this next line fails, delete it and replace it with the one following it
-  snapcraft --verbose --use-lxd 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
+  snapcraft --verbose --use-lxd 2>&1 | MATCH 'unrecognized arguments: --use-lxd'; exit 0
   # snapcraft --verbose --use-lxd
 
   # And verify the snap runs as expected.

--- a/tests/spread/core24/package-repositories/task.yaml
+++ b/tests/spread/core24/package-repositories/task.yaml
@@ -12,9 +12,7 @@ environment:
 restore: |
   cd "$SNAP"
   rm -f ./*.snap
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   snapcraft clean --destructive-mode
   snap remove "${SNAP}"
 

--- a/tests/spread/core24/packing/task.yaml
+++ b/tests/spread/core24/packing/task.yaml
@@ -17,9 +17,7 @@ prepare: |
   # set_base "$SNAP_DIR/snap/snapcraft.yaml"
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -Rf subdir ./*.snap
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh

--- a/tests/spread/core24/packing/task.yaml
+++ b/tests/spread/core24/packing/task.yaml
@@ -25,11 +25,8 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 execute: |
-  # If this next line fails, delete it and replace it with the one following it
   # shellcheck disable=SC2086
-  snapcraft $CMD 2>&1 | MATCH 'command is not implemented for core24!'; exit 0
-  # shellcheck disable=SC2086
-  # snapcraft $CMD
+  snapcraft $CMD
 
   if echo "$CMD" | grep subdir/output; then
     test -f subdir/output.snap

--- a/tests/spread/core24/patchelf/classic-patchelf/task.yaml
+++ b/tests/spread/core24/patchelf/classic-patchelf/task.yaml
@@ -9,9 +9,7 @@ prepare: |
   apt-mark auto patchelf dpkg-dev
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh

--- a/tests/spread/core24/patchelf/classic-python/task.yaml
+++ b/tests/spread/core24/patchelf/classic-python/task.yaml
@@ -42,7 +42,5 @@ execute: |
 
 restore: |
   cd python-ctypes-example
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap

--- a/tests/spread/core24/patchelf/strict-patchelf/task.yaml
+++ b/tests/spread/core24/patchelf/strict-patchelf/task.yaml
@@ -8,9 +8,7 @@ prepare: |
   apt-get install patchelf dpkg-dev -y
   apt-mark auto patchelf dpkg-dev
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh

--- a/tests/spread/core24/plugs-warn/task.yaml
+++ b/tests/spread/core24/plugs-warn/task.yaml
@@ -1,9 +1,7 @@
 summary: Check warnings for top-level enabling of slots and plugs
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean --destructive-mode 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean --destructive-mode
+  snapcraft clean --destructive-mode
   rm -f ./*.snap
 
 execute: |

--- a/tests/spread/core24/root-packages/task.yaml
+++ b/tests/spread/core24/root-packages/task.yaml
@@ -1,9 +1,7 @@
 summary: Test build-snaps and build-packages at the root
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean --destructive-mode 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean --destructive-mode 
+  snapcraft clean --destructive-mode
 
 execute: |
   # If this next line fails, delete it and replace it with the one following it

--- a/tests/spread/core24/scriptlets/empty-overrides/task.yaml
+++ b/tests/spread/core24/scriptlets/empty-overrides/task.yaml
@@ -1,9 +1,7 @@
 summary: Execute empty scriptlets
 
 restore: |
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean --destructive-mode 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean --destructive-mode 
+  snapcraft clean --destructive-mode 
 
 execute: |
   # If this next line fails, delete it and replace it with the one following it

--- a/tests/spread/core24/scriptlets/scriptlet-failures/task.yaml
+++ b/tests/spread/core24/scriptlets/scriptlet-failures/task.yaml
@@ -1,8 +1,7 @@
 summary: Validate scriptlet failures
 
 restore: |  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap
 
 execute: |

--- a/tests/spread/core24/set-version-twice/task.yaml
+++ b/tests/spread/core24/set-version-twice/task.yaml
@@ -5,8 +5,7 @@ prepare: |
   . "$TOOLS_DIR/snapcraft-yaml.sh"
 
 restore: |  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -Rf subdir ./*.snap
   rm -f snap/*.yaml
 

--- a/tests/spread/core24/simple-snap/task.yaml
+++ b/tests/spread/core24/simple-snap/task.yaml
@@ -5,16 +5,12 @@ environment:
 
 restore: |
   snap remove simple-snap
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft clean 2>&1 | MATCH '"clean" command is not implemented for core24!'; exit 0
-  # snapcraft clean
+  snapcraft clean
   rm -f ./*.snap
 
 execute: |
   cd "./snap"
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft pack 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
-  # snapcraft pack
+  snapcraft pack
   snap install --edge core24
   snap install --dangerous ./*.snap
   /snap/bin/simple-snap.hello

--- a/tests/spread/core24/snap-creation/task.yaml
+++ b/tests/spread/core24/snap-creation/task.yaml
@@ -19,5 +19,7 @@ restore: |
 
 execute: |
   cd "$SNAP"
-  snapcraft 2>&1 | tee progress.txt
+  # If this next line fails, delete it and replace it with the one following it
+  snapcraft 2>&1 | MATCH 'parts list the same file with different contents or permissions'; exit 0
+  # snapcraft 2>&1 | tee progress.txt 
   grep "Created snap package ${SNAP}_1.0_amd64.snap" progress.txt

--- a/tests/spread/core24/snap-creation/task.yaml
+++ b/tests/spread/core24/snap-creation/task.yaml
@@ -19,7 +19,5 @@ restore: |
 
 execute: |
   cd "$SNAP"
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft 2>&1 | MATCH '"pack" command is not implemented for core24!'; exit 0
-  # snapcraft 2>&1 | tee progress.txt
+  snapcraft 2>&1 | tee progress.txt
   grep "Created snap package ${SNAP}_1.0_amd64.snap" progress.txt


### PR DESCRIPTION
As before, this PR is split over multiple commits:

- First one is mostly a cherry-pick of @lengau and @mr-cal 's prototype. I had to do some minor changes to satisfy linters but nothing major;
- Second commit adds the "clean" command, just because it's so easy to implement and used by basically every spread test;
- Third commit re-enables "pack" and "clean" in a bunch of spread tests;
- Final commit updates the expected error messages for those tests that are still failing due to _other_ missing features.

One unfortunate consequence of the spread parametrization that we do in some tests is that now there's no easy way to handle some tests; for instance, `tests/spread/core24/craftctl` has three "subtests" as spread parameters; one is passing and two are failing (because they need adopt-info). Rather than doing a complicated logic in bash to handle this, I think we might just accept these failures in this feature-branch while we work on the issues. If that's acceptable, it means we'll need someone with admin access to ultimately merge this when it's approved.