### PR TITLE
feat(projects): validate component names do not begin with 'snap-'

### DIFF
--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -216,6 +216,11 @@ def _validate_component_name(name: str) -> None:
             "Component names can only use ASCII lowercase letters and hyphens"
         )
 
+    if name.startswith("snap-"):
+        raise ValueError(
+            "Component names cannot start with the reserved namespace 'snap-'"
+        )
+
     if name.startswith("-"):
         raise ValueError("Component names cannot start with a hyphen")
 

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -1846,11 +1846,11 @@ class TestComponents:
         [
             (
                 "snap-",
-                "Component names cannot start with the reserved namespace 'snap-'"
+                "Component names cannot start with the reserved namespace 'snap-'",
             ),
             (
                 "snap-foo",
-                "Component names cannot start with the reserved namespace 'snap-'"
+                "Component names cannot start with the reserved namespace 'snap-'",
             ),
             ("123456", "Component names can only use"),
             ("name-ends-with-digits-0123", "Component names can only use"),

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -1828,7 +1828,9 @@ class TestComponents:
         with pytest.raises(errors.ProjectValidationError, match=error):
             project.unmarshal(project_yaml_data(components=component))
 
-    @pytest.mark.parametrize("name", ["name", "name-with-dashes", "x" * 40])
+    @pytest.mark.parametrize(
+        "name", ["name", "name-with-dashes", "x" * 40, "foo-snap-bar"]
+    )
     def test_component_name_valid(
         self, project, name, project_yaml_data, stub_component_data
     ):
@@ -1842,6 +1844,14 @@ class TestComponents:
     @pytest.mark.parametrize(
         "name,error",
         [
+            (
+                "snap-",
+                "Component names cannot start with the reserved namespace 'snap-'"
+            ),
+            (
+                "snap-foo",
+                "Component names cannot start with the reserved namespace 'snap-'"
+            ),
             ("123456", "Component names can only use"),
             ("name-ends-with-digits-0123", "Component names can only use"),
             ("456-name-starts-with-digits", "Component names can only use"),


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Components beginning with `snap-` are reserved for future use by `snapd`.

Fixes #4538
(CRAFT-2419)