### PR TITLE
chore(deps): bump craft-parts to 1.26.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ click==8.1.7
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.1.1
-craft-parts==1.26.0
+craft-parts==1.26.2
 craft-providers==1.22.0
 craft-store==2.5.0
 Deprecated==1.2.14

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -14,7 +14,7 @@ coverage==7.4.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.1.2
-craft-parts==1.26.1
+craft-parts==1.26.2
 craft-providers==1.22.0
 craft-store==2.6.0
 cryptography==41.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.7
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.1.2
-craft-parts==1.26.1
+craft-parts==1.26.2
 craft-providers==1.22.0
 craft-store==2.6.0
 cryptography==41.0.7


### PR DESCRIPTION
Craft Parts 1.26.2 fixes proxy support in the ant plugin and
the default values of aliased fields in parts.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
