### PR TITLE
chore: clarify that tasks can be used for documentation requests too

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -1,5 +1,5 @@
 name: Task
-description: File an enhancement proposal (such as feature requests or documentation improvements)
+description: File an enhancement proposal, such as feature requests or documentation improvements
 labels: "Enhancement"
 body:
   - type: markdown


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---

Comes from a suggestion by @farshidtz in https://github.com/canonical/snapcraft/issues/5511. After some discussion with @mr-cal, it was decided that the "task" category's headers were fine for documentation changes, but it needed to be more explicit that that was an intended usage.