### PR TITLE
build: drop python3-pkg-resources

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -130,7 +130,6 @@ parts:
       - python3-wheel
       - python3-venv
       - python3-minimal
-      - python3-pkg-resources
       - python3.12-minimal
       - squashfs-tools
       - xdelta3


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---

`pkg_resources` was dropped in #4490 but `python3-pkg-resources` was overlooked. This PR removes the stage package.