### PR TITLE
docs: fix a typo in craft-a-rust-app.rst

### DIFF
--- a/docs/how-to/integrations/craft-a-rust-app.rst
+++ b/docs/how-to/integrations/craft-a-rust-app.rst
@@ -44,6 +44,6 @@ To declare a Rust part:
 
 #. Declare the general part keys, such as ``source``, ``override-build``,
    ``build-packages``, and so on.
-#. Set ``plugin: python``.
+#. Set ``plugin: rust``.
 #. If the snap uses core18, you can override the Rust toolchain version with
    the ``rust-revision`` list key.


### PR DESCRIPTION
Rust integration docs incorrectly referred to the python plugin.

- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---
