### PR TITLE
fix: remove unnecessary snapd_snap flag (#5316)

### DIFF
--- a/snapcraft_legacy/internal/build_providers/_snap.py
+++ b/snapcraft_legacy/internal/build_providers/_snap.py
@@ -345,14 +345,6 @@ class SnapInjector:
         logger.debug("Waiting for pending snap auto refreshes.")
         self._runner(["snap", "watch", "--last=auto-refresh?"], hide_output=True)
 
-    def _enable_snapd_snap(self) -> None:
-        # Required to not install the core snap when building using
-        # other bases.
-        logger.debug("Enable use of snapd snap.")
-        self._runner(
-            ["snap", "set", "system", "experimental.snapd-snap=true"], hide_output=True
-        )
-
     def _get_latest_revision(self, snap_name) -> Optional[str]:
         try:
             return self._registry_data[snap_name][-1]["revision"]
@@ -380,10 +372,6 @@ class SnapInjector:
     def apply(self) -> None:
         if all((s.get_op() == _SnapOp.NOP for s in self._snaps)):
             return
-
-        # Allow using snapd from the snapd snap to leverage newer snapd features.
-        if any(s.snap_instance_name == "snapd" for s in self._snaps):
-            self._enable_snapd_snap()
 
         # Disable refreshes so they do not interfere with installation ops.
         self._disable_and_wait_for_refreshes()

--- a/tests/legacy/unit/build_providers/test_snap.py
+++ b/tests/legacy/unit/build_providers/test_snap.py
@@ -123,7 +123,6 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_has_calls(get_assertion_calls)
         self.provider.run_mock.assert_has_calls(
             [
-                call(["snap", "set", "system", "experimental.snapd-snap=true"]),
                 call(["snap", "set", "system", ANY]),
                 call(["snap", "watch", "--last=auto-refresh?"]),
                 call(["snap", "ack", "/var/tmp/snapd.assert"]),
@@ -241,7 +240,6 @@ class SnapInjectionTest(unit.TestCase):
         self.get_assertion_mock.assert_has_calls(get_assertion_calls)
         self.provider.run_mock.assert_has_calls(
             [
-                call(["snap", "set", "system", "experimental.snapd-snap=true"]),
                 call(["snap", "set", "system", ANY]),
                 call(["snap", "watch", "--last=auto-refresh?"]),
                 call(["snap", "ack", "/var/tmp/snapd.assert"]),


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---
Discussing with @mr-cal we decided this could safely be removed.

[SNAPCRAFT-1193](https://warthogs.atlassian.net/browse/SNAPCRAFT-1193)

[SNAPCRAFT-1193]: https://warthogs.atlassian.net/browse/SNAPCRAFT-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ