### PR TITLE
ci: update label for manual spread tests

### DIFF
--- a/.github/workflows/spread-scheduled.yaml
+++ b/.github/workflows/spread-scheduled.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   snap-build:
-    if: ${{ github.event.label.name == 'run-manual-spread' || github.event_name == 'schedule' }}
+    if: "${{ github.event.label.name == 'PR: Run Manual Spread' || github.event_name == 'schedule' }}"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -33,7 +33,7 @@ jobs:
           sudo snap install --dangerous --classic ${{ steps.snapcraft.outputs.snap }}
 
   kernel-plugins:
-    if: ${{ github.event.label.name == 'run-manual-spread' || github.event_name == 'schedule' }}
+    if: "${{ github.event.label.name == 'PR: Run Manual Spread' || github.event_name == 'schedule' }}"
     runs-on: [spread-installed]
     needs: [snap-build]
     strategy:
@@ -60,7 +60,7 @@ jobs:
           spread google:ubuntu-22.04-64:tests/spread/${{ matrix.type }}/kernel
 
   remote-build:
-    if: ${{ github.event.label.name == 'run-manual-spread' || github.event_name == 'schedule' }}
+    if: "${{ github.event.label.name == 'PR: Run Manual Spread' || github.event_name == 'schedule' }}"
     runs-on: [spread-installed]
     needs: [snap-build]
     steps:
@@ -89,7 +89,7 @@ jobs:
             google:fedora-39-64:tests/spread/core24/remote-build:no_platforms
 
   matter-sdk:
-    if: ${{ github.event.label.name == 'run-manual-spread' || github.event_name == 'schedule' }}
+    if: "${{ github.event.label.name == 'PR: Run Manual Spread' || github.event_name == 'schedule' }}"
     runs-on: [spread-installed]
     needs: [snap-build]
     steps:
@@ -114,7 +114,7 @@ jobs:
               google:ubuntu-22.04-64:tests/spread/core24-suites/plugins/matter-sdk
 
   colcon-plugins:
-    if: ${{ github.event.label.name == 'run-manual-spread' || github.event_name == 'schedule' }}
+    if: "${{ github.event.label.name == 'PR: Run Manual Spread' || github.event_name == 'schedule' }}"
     runs-on: [spread-installed]
     needs: [snap-build]
     steps:
@@ -141,7 +141,7 @@ jobs:
             google:ubuntu-22.04-64:tests/spread/plugins/craft-parts/colcon-hello
 
   extensions:
-    if: ${{ github.event.label.name == 'run-manual-spread' || github.event_name == 'schedule' }}
+    if: "${{ github.event.label.name == 'PR: Run Manual Spread' || github.event_name == 'schedule' }}"
     runs-on: [spread-installed]
     needs: [snap-build]
     steps:
@@ -164,7 +164,7 @@ jobs:
           spread google.*:tests/spread/extensions/
 
   core20-plugins:
-    if: ${{ github.event.label.name == 'run-manual-spread' || github.event_name == 'schedule' }}
+    if: "${{ github.event.label.name == 'PR: Run Manual Spread' || github.event_name == 'schedule' }}"
     runs-on: [spread-installed]
     needs: [snap-build]
     steps:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Updates the manual spread job to use the new terraform-managed label.