### PR TITLE
docs: fix example for `snapcraft close` (Fixes #5737)

### DIFF
--- a/snapcraft/commands/manage.py
+++ b/snapcraft/commands/manage.py
@@ -125,7 +125,7 @@ class StoreCloseCommand(AppCommand):
 
         Examples::
 
-            snapcraft close my-snap --channel beta
+            snapcraft close my-snap beta
         """
     )
 


### PR DESCRIPTION
The help text used `--channel` but `<channel>` is positional.
Update example to:
  snapcraft close my-snap beta

Fixes #5737
