### PR TITLE
ci: run spread on push to main/hotfix

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -1,6 +1,11 @@
 name: Spread Tests
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "hotfix/**"
 
 jobs:
   build:


### PR DESCRIPTION
This allows non-admins with write access (the Starcraft team) to create hotfix branches

- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---
