### PR TITLE
fix(legacy): accept --build-for on long-form architecture remote build

### DIFF
--- a/snapcraft_legacy/cli/remote.py
+++ b/snapcraft_legacy/cli/remote.py
@@ -265,16 +265,21 @@ def _determine_architectures(project: Project, user_specified_arch: str):
     # If build architectures not set in snapcraft.yaml, let the user override
     # Launchpad defaults using --build-on.
     project_architectures = _get_project_architectures(project)
-    if project_architectures and user_specified_arch:
+    split_user_archs = user_specified_arch.split(",")
+    if (
+        project_architectures
+        and user_specified_arch
+        and not set(split_user_archs).issubset(project_architectures)
+    ):
         raise click.BadOptionUsage(
             "--build-on",
             "Cannot use --build-on, architecture list is already set in snapcraft.yaml.",
         )
 
-    if project_architectures:
+    if user_specified_arch:
+        archs = split_user_archs
+    elif project_architectures:
         archs = project_architectures
-    elif user_specified_arch:
-        archs = user_specified_arch.split(",")
     else:
         # Default to typical snapcraft behavior (build for host).
         archs = [project.deb_arch]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---

Changes the behavior of the legacy remote builder to accept `--build-for` when using the long-form architecture notation.

The issue was that for the long-form, architectures were decoded from the project, and then an error would be raised even if `--build-for` narrowed the project to a valid subset of architectures. Now, `--build-for` is given priority and an error is only raised if the selected platforms aren't a subset of the available ones.

I know that the error message says `--build-on`, both flags had this issue and I don't see a way to raise a more generic error message with click - it seems to only allow raising for a single bad flag usage.

Fixes #5817.