### PR TITLE
style: ignore legacy folder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,7 @@ line-length = 88
 extend-exclude = [
     "docs",
     "__pycache__",
-    "legacy",
+    "snapcraft_legacy",
     "tests/legacy",
     "snapcraft/_version.py", # setuptools_scm generates old-style type annotations and single quotes
 ]


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---

The legacy folder wasn't being ignored correctly. When testing with `make lint`, this didn't really matter, but any well-meaning individual running `ruff check` would be presented with lint errors from the legacy codebase that didn't actually matter.