### PR TITLE
chore(legacy): remove script entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,6 @@ python-apt = { index = "python-apt-wheels" }
 
 [project.scripts]
 snapcraft = "snapcraft.application:main"
-snapcraft_legacy = "snapcraft_legacy.cli.__main__:run"
 
 [build-system]
 requires = ["setuptools>=69.0", "setuptools_scm[toml]>=7.1"]


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---
This removes an old legacy entry point that caused some confusion (see #5778).