### PR TITLE
ci: ignore unresolvable OSV

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -20,3 +20,4 @@ jobs:
       # 3. Docs contain requirements.txt files that don't specify versions.
       requirements-find-args: '! -name requirements-noble.txt ! -path "./tests/spread*" ! -path "./docs/**"'
       trivy-extra-args: "--severity HIGH,CRITICAL --ignore-unfixed --skip-dirs tests/spread/"
+      osv-extra-args: "--config source/osv-scanner.toml"

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,4 @@
+[[IgnoredVulns]]
+id = "GHSA-4xh5-x5gv-qwph"
+ignoreUntil = 2025-11-01
+reason = "pip 25.3 isn't due for release until the end of October"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---

This OSV has been failing on every PR, and won't be fixed until pip 25.3, which isn't scheduled for release until at least Oct. 30th