### PR TITLE
fix: parse a snap file for the sign-build command

### DIFF
--- a/snapcraft/commands/legacy.py
+++ b/snapcraft/commands/legacy.py
@@ -262,9 +262,14 @@ class StoreLegacySignBuildCommand(LegacyAppCommand):
         )
         parser.add_argument(
             "--local",
-            "--local",
             action="store_true",
             help="sign assertion, but do not upload to the Snap Store",
+        )
+        parser.add_argument(
+            "snap_file",
+            metavar="snap-file",
+            type=str,
+            help="Snap file to sign",
         )
 
 

--- a/tests/unit/cli/test_legacy.py
+++ b/tests/unit/cli/test_legacy.py
@@ -108,3 +108,13 @@ def test_list_validation_sets_with_options(mocker, legacy_run):
     assert legacy_run.mock_calls == [
         call(argparse.Namespace(name="set-name", sequence="all"))
     ]
+
+
+def test_sign_build(mocker, legacy_run):
+    mocker.patch.object(sys, "argv", ["cmd", "sign-build", "--local", "foo.snap"])
+
+    cli.run()
+
+    assert legacy_run.mock_calls == [
+        call(argparse.Namespace(local=True, snap_file="foo.snap", key_name=None))
+    ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Snapcraft's legacy code passthrough requires that the modern Craft CLI implementations of legacy's CLI interfaces have the exact same arguments. For example, a legacy command with a click argument for `--foo` should have a corresponding `--foo` on its modern Craft CLI interface. This wasn't the case for the `sign-build` command, so following the advice of `--help` (generated by Craft CLI) would result in an error as the legacy backend expected `snap-file`, but providing a `snap-file` would result in an error as Craft CLI's validation of the argparse namespace would complain about `snap-file`.

This PR fixes that behavior, and as a drive-by, also removes this extra `--local` in the help text:
```
    --local, --local:  sign assertion, but do not upload to the Snap
                       Store
```

Fixes #5618.
SNAPCRAFT-1180