### PR TITLE
docs: fix default-configure hook example

### DIFF
--- a/docs/how-to/crafting/add-a-snap-configuration.rst
+++ b/docs/how-to/crafting/add-a-snap-configuration.rst
@@ -70,6 +70,7 @@ server and making sure the changes have taken hold:
         # Restart example-server to apply new config
         snapctl restart example-server
     }
+    handle_port_config
 
 
 .. _how-to-add-a-snap-configuration-default-configure-hook:


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---
Resolves https://github.com/canonical/snapcraft/issues/5803

Replaces the default-configure hook script with the example from the [original forum post](https://forum.snapcraft.io/t/adding-snap-configuration/15246).