### PR TITLE
test: correct usage of pytest mark

### DIFF
--- a/tests/unit/commands/test_status.py
+++ b/tests/unit/commands/test_status.py
@@ -216,10 +216,8 @@ def fake_store_list_revisions(mocker, list_revisions_result):
 @pytest.fixture(autouse=True)
 def stdout_tty(request, mocker):
     """Present stdout as a tty."""
-    if "stdout_not_tty" in request.keywords:
-        mocker.patch("sys.stdout.isatty", return_value=False)
-    else:
-        mocker.patch("sys.stdout.isatty", return_value=True)
+    is_tty = getattr(request, "param", True)
+    mocker.patch("sys.stdout.isatty", return_value=is_tty)
 
 
 ##################
@@ -253,7 +251,7 @@ def test_default(emitter, fake_app_config):
 
 
 @pytest.mark.usefixtures("memory_keyring", "fake_store_get_status_map")
-@pytest.mark.stdout_not_tty
+@pytest.mark.parametrize("stdout_tty", [False], indirect=True)
 def test_stdout_not_a_tty(emitter, fake_app_config):
     cmd = commands.StoreStatusCommand(fake_app_config)
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---

Fixes a warning message that appears during testing:
```
tests/unit/commands/test_status.py:256
  /home/imani/work/snapcraft/tests/unit/commands/test_status.py:256: PytestUnknownMarkWarning: Unknown pytest.mark.stdout_not_tty - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.stdout_not_tty
```