### PR TITLE
chore: drop flutter git plugin's workaround

### DIFF
--- a/snapcraft/parts/plugins/flutter_plugin.py
+++ b/snapcraft/parts/plugins/flutter_plugin.py
@@ -86,10 +86,6 @@ class FlutterPlugin(plugins.Plugin):
         return [
             # TODO detect changes to plugin properties
             f"git clone --depth 1 -b {options.flutter_channel} {FLUTTER_REPO} {self.flutter_dir}",
-            # Workaround for flutter#163308
-            # Deletion of this file avoids an if statement that causes the following commands to
-            # fail
-            f"rm {self.flutter_dir}/engine/src/.gn",
             "flutter precache --linux",
             "flutter pub get",
         ]

--- a/tests/unit/parts/plugins/test_flutter_plugin.py
+++ b/tests/unit/parts/plugins/test_flutter_plugin.py
@@ -65,7 +65,6 @@ def test_get_build_commands(part_info):
     assert plugin.get_build_commands() == [
         "git clone --depth 1 -b stable https://github.com/flutter/flutter.git "
         f"{plugin.flutter_dir}",
-        f"rm {plugin.flutter_dir}/engine/src/.gn",
         "flutter precache --linux",
         "flutter pub get",
         "flutter build linux --release --verbose --target lib/main.dart",
@@ -82,7 +81,6 @@ def test_get_build_commands_alternative_target(part_info):
     assert plugin.get_build_commands() == [
         f"git clone --depth 1 -b stable https://github.com/flutter/flutter.git "
         f"{plugin.flutter_dir}",
-        f"rm {plugin.flutter_dir}/engine/src/.gn",
         "flutter precache --linux",
         "flutter pub get",
         "flutter build linux --release --verbose --target lib/not-main.dart",
@@ -100,7 +98,6 @@ def test_get_build_commands_different_channels(part_info, value):
     assert plugin.get_build_commands() == [
         f"git clone --depth 1 -b {value} https://github.com/flutter/flutter.git "
         f"{plugin.flutter_dir}",
-        f"rm {plugin.flutter_dir}/engine/src/.gn",
         "flutter precache --linux",
         "flutter pub get",
         "flutter build linux --release --verbose --target lib/main.dart",


### PR DESCRIPTION
- [ X] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ X] Have you successfully run `make lint`?
- [ X] Have you successfully run `make test`?

---
Dropped the changes in #5264 since the upstream bug has been fixed.