### PR TITLE
fix(snapcraft): do not fetch git submodules during build (Fixes #5837)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -183,6 +183,8 @@ parts:
 
   snapcraft:
     source: .
+    source-type: git
+    source-submodules: []
     plugin: python
     python-packages:
       - wheel


### PR DESCRIPTION
### **Summary**

This PR disables fetching or initializing Git submodules during the Snapcraft snap build process.

### **Context**

As per [(https://github.com/canonical/snapcraft/issues/5837)](https://github.com/canonical/snapcraft/issues/5837), the current Snapcraft build unnecessarily downloads Git submodules that are not required for building the snap itself.
This wastes time and network resources during the build process.

### **Change Details**

* Set `source-type: git` and `source-submodules: []` for the `snapcraft` part in `snap/snapcraft.yaml`.
* No other changes were made to unrelated parts of the project.

### **Verification**

All commands executed successfully ✅

**Environment**

* Ubuntu 24.04 (core24 base)
* Snapcraft 8.13.0.post1
* Verified using `SNAPCRAFT_VERBOSITY=trace`

**Build validation**

* ✅ `snapcraft pack` completes successfully
* ✅ No submodule initialization occurs (`git submodule` commands absent in logs)
* ✅ Built snap installs and runs correctly (`snapcraft --version`, `snapcraft --help` both succeed)

### **Checklist**

* [x] Followed the [[guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)
* [x] Signed the [[Canonical CLA](http://www.ubuntu.com/legal/contributors/)](http://www.ubuntu.com/legal/contributors/)
* [x] Verified successful `snapcraft pack` build
* [x] Ran smoke test to confirm functional snap

### **Fixes**

Fixes #5837

