### PR TITLE
style: fix pending lints from snapcraft itself

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,6 +21,16 @@ source-code:
   - https://github.com/canonical/snapcraft
 website:
   - https://documentation.ubuntu.com/snapcraft
+contact:
+  - https://matrix.to/#/#snapcraft:ubuntu.com
+  - https://forum.snapcraft.io/c/snapcraft/13
+
+lint:
+  ignore:
+    - metadata:
+        - donation
+    - library:
+        - usr/lib/**/libicu*.so*
 
 # https://github.com/canonical/snapcraft/issues/4187
 environment:


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---

Fixes the following lint warnings (except for the classic linter):
```
❯ /snap/bin/snapcraft pack
Lint OK:
- classic: Snap confinement is set to classic.
Lint warnings:
- library: libicuio.so.74: unused library 'usr/lib/x86_64-linux-gnu/libicuio.so.74.2'. (https://documentation.ubuntu.com/snapcraft/stable/how-to/debugging/use-the-library-linter)
- library: libicutest.so.74: unused library 'usr/lib/x86_64-linux-gnu/libicutest.so.74.2'. (https://documentation.ubuntu.com/snapcraft/stable/how-to/debugging/use-the-library-linter)
Lint information:
- metadata: Metadata field 'contact' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#contact)
- metadata: Metadata field 'donation' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#donation)
```