### PR TITLE
docs: fix canonical URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,13 +133,17 @@ exclude_patterns = [
 rediraffe_redirects = "redirects.txt"
 
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
-html_baseurl = "https://documentation.ubuntu.com/snapcraft/"
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
 
-if "READTHEDOCS_VERSION" in os.environ:
-    version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = "{version}{link}"
-else:
-    sitemap_url_scheme = "latest/{link}"
+# Builds URLs as {html_baseurl}/<page-location>
+sitemap_url_scheme = "{link}"
+
+# Exclude generated pages from the sitemap:
+sitemap_excludes = [
+    '404/',
+    'genindex/',
+    'search/',
+]
 
 # endregion
 


### PR DESCRIPTION
The canonical URLs in our documentation currently don't specify a version.

```
<link rel="canonical" href="https://documentation.ubuntu.com/snapcraft/">
```

This is detrimental to getting our stable docs indexed by search engines. I've updated the conf.py file to:

* pull the correct canonical URL from RTD
* append only the page's path, as the canonical URL will include the correct version
* exclude certain generated pages from the sitemap

I'll be opening similar PRs in the other craft apps.

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
