### PR TITLE
docs: fix typo in ROS version names

### DIFF
--- a/docs/reference/extensions/ros-2-extensions.rst
+++ b/docs/reference/extensions/ros-2-extensions.rst
@@ -290,7 +290,7 @@ The files are based on the :ref:`ros2-talker-listener
                 :lines: 3-
                 :emphasize-lines: 24-34, 39-59
 
-    .. group-tab:: ROS 2 Humble
+    .. group-tab:: ROS 2 Jazzy
 
         .. collapse:: Expanded project file for ros2-talker-listener
 


### PR DESCRIPTION
<!-- Describe your changes -->

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
