### PR TITLE
Replacing bind with symlink in webkit2gtk layouts

### DIFF
--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -196,13 +196,13 @@ class GNOME(Extension):
             },
             "layout": {
                 "/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/webkit2gtk-4.0": {
-                    "bind": (
+                    "symlink": (
                         "$SNAP/gnome-platform/usr/lib/"
                         "$CRAFT_ARCH_TRIPLET_BUILD_FOR/webkit2gtk-4.0"
                     )
                 },
                 "/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/webkit2gtk-4.1": {
-                    "bind": (
+                    "symlink": (
                         "$SNAP/gnome-platform/usr/lib/"
                         "$CRAFT_ARCH_TRIPLET_BUILD_FOR/webkit2gtk-4.1"
                     )


### PR DESCRIPTION
<!-- Describe your changes -->
I replaced `bind` with `symlink` in the webkit2gtk layouts.

The reason for this is that using `bind` caused this type of error in Hytale, Minigalaxy, and other apps:

```** (hytale-launcher:112344): ERROR **: 10:20:51.039: Unable to spawn a new child process: Falha ao criar processo filho “/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1/WebKitNetworkProcess” (No such file or directory)```

I built Hytale without using the gnome extension directly, so I could manually add these layouts. When I replaced `bind` with `symlink`, Hytale stopped giving the error and opened without problems.

I saw that this problem has existed for quite some time; I saw this post from February 2025 on the Snapcraft forum:

https://forum.snapcraft.io/t/snap-not-working-after-snap-refresh/45802

It's a very serious problem; please merge this change as soon as possible.
---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
