### PR TITLE
feat(assertions): add yaml suffix to temp files

### DIFF
--- a/snapcraft/services/assertions.py
+++ b/snapcraft/services/assertions.py
@@ -223,7 +223,7 @@ class Assertion(base.AppService):
 
     @staticmethod
     def _write_to_file(yaml_data: str) -> pathlib.Path:
-        with tempfile.NamedTemporaryFile() as temp_file:
+        with tempfile.NamedTemporaryFile(suffix=".yaml") as temp_file:
             filepath = pathlib.Path(temp_file.name)
         craft_cli.emit.trace(f"Writing yaml data to temporary file '{filepath}'.")
         filepath.write_text(yaml_data, encoding="utf-8")


### PR DESCRIPTION
When editing a confdbs assertion, the temp file now gets a `.yaml` suffix.  This allows editors to apply syntax highlighting.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
