### PR TITLE
test: re-enable core24 python test

### DIFF
--- a/tests/spread/core24-suites/plugins/build-and-run-hello/task.yaml
+++ b/tests/spread/core24-suites/plugins/build-and-run-hello/task.yaml
@@ -6,8 +6,7 @@ environment:
   SNAP/conda: conda-hello
   SNAP/flutter: flutter-hello
   SNAP/npm: npm-hello
-  # https://github.com/canonical/snapcraft/issues/5207
-  # SNAP/python: python-hello
+  SNAP/python: python-hello
   SNAP/poetry: poetry-hello
   SNAP/qmake: qmake-hello
   SNAP/maven: maven-hello


### PR DESCRIPTION
No changes needed, the test happens to be working again.

Fixes #5207 

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] I've updated the relevant release notes.
