### PR TITLE
chore: use pathlib to interact with craft-parts

### DIFF
--- a/snapcraft/elf/elf_utils.py
+++ b/snapcraft/elf/elf_utils.py
@@ -36,21 +36,21 @@ def get_elf_files(root_path: Path) -> list[ElfFile]:
     :param root_path: The root of the subtree to list ELF files from.
     :return: A set of ELF files found in the given subtree.
     """
-    file_list: list[str] = []
-    for root, _, files in os.walk(str(root_path)):
+    file_list: list[Path] = []
+    for root, _, files in os.walk(root_path):
         for file_name in files:
             # Filter out object files
             if file_name.endswith(".o"):
                 continue
 
-            file_path = os.path.join(root, file_name)
-            if not os.path.islink(file_path):
+            file_path = Path(root, file_name)
+            if not file_path.is_symlink():
                 file_list.append(file_path)
 
     return get_elf_files_from_list(root_path, file_list)
 
 
-def get_elf_files_from_list(root: Path, file_list: Iterable[str]) -> list[ElfFile]:
+def get_elf_files_from_list(root: Path, file_list: Iterable[Path]) -> list[ElfFile]:
     """Return a list of ELF files from file_list prepended with root.
 
     :param str root: the root directory from where the file_list is generated.
@@ -61,12 +61,12 @@ def get_elf_files_from_list(root: Path, file_list: Iterable[str]) -> list[ElfFil
 
     for part_file in file_list:
         # Filter out object (*.o) files-- we only care about binaries.
-        if part_file.endswith(".o"):
+        if part_file.suffix == ".o":
             continue
 
         # No need to crawl links-- the original should be here, too.
-        path = Path(root, part_file)
-        if os.path.islink(path):
+        path = root / part_file
+        if path.is_symlink():
             emit.debug(f"Skipped link {path!r} while finding dependencies")
             continue
 

--- a/tests/unit/elf/test_elf_file.py
+++ b/tests/unit/elf/test_elf_file.py
@@ -71,7 +71,7 @@ class TestElfFileSmoketest:
 
     def test_invalid_elf_file(self, new_dir):
         Path("invalid-elf").write_bytes(b"\x7fELF\x00")
-        elf_files = elf_utils.get_elf_files_from_list(new_dir, ["invalid-elf"])
+        elf_files = elf_utils.get_elf_files_from_list(new_dir, [Path("invalid-elf")])
         assert elf_files == []
 
 

--- a/tests/unit/elf/test_elf_utils.py
+++ b/tests/unit/elf/test_elf_utils.py
@@ -43,7 +43,7 @@ class TestGetElfFiles:
 
     def test_get_elf_files_from_list_from_list(self, new_dir, fake_elf):
         fake_elf("fake_elf-2.23")
-        elf_files = elf_utils.get_elf_files_from_list(new_dir, ["fake_elf-2.23"])
+        elf_files = elf_utils.get_elf_files_from_list(new_dir, [Path("fake_elf-2.23")])
         assert len(elf_files) == 1
 
         elf_file = elf_files.pop()
@@ -51,53 +51,55 @@ class TestGetElfFiles:
 
     def test_skip_object_files(self, new_dir, fake_elf):
         fake_elf("object_file.o")
-        elf_files = elf_utils.get_elf_files_from_list(new_dir, ["object_file.o"])
+        elf_files = elf_utils.get_elf_files_from_list(new_dir, [Path("object_file.o")])
         assert elf_files == []
 
     def test_no_find_dependencies_statically_linked(self, new_dir, fake_elf):
         fake_elf("fake_elf-static")
-        elf_files = elf_utils.get_elf_files_from_list(new_dir, ["fake_elf-static"])
+        elf_files = elf_utils.get_elf_files_from_list(
+            new_dir, [Path("fake_elf-static")]
+        )
         assert elf_files == []
 
     def test_elf_with_execstack(self, new_dir, fake_elf):
         fake_elf("fake_elf-with-execstack")
         elf_files = elf_utils.get_elf_files_from_list(
-            new_dir, {"fake_elf-with-execstack"}
+            new_dir, {Path("fake_elf-with-execstack")}
         )
         elf_file = elf_files.pop()
         assert elf_file.execstack_set is True
 
     def test_elf_without_execstack(self, new_dir, fake_elf):
         fake_elf("fake_elf-2.23")
-        elf_files = elf_utils.get_elf_files_from_list(new_dir, {"fake_elf-2.23"})
+        elf_files = elf_utils.get_elf_files_from_list(new_dir, {Path("fake_elf-2.23")})
         elf_file = elf_files.pop()
         assert elf_file.execstack_set is False
 
     def test_non_elf_files(self, new_dir):
         # A bz2 header
         Path("non-elf").write_bytes(b"\x42\x5a\x68")
-        elf_files = elf_utils.get_elf_files_from_list(new_dir, {"non-elf"})
+        elf_files = elf_utils.get_elf_files_from_list(new_dir, {Path("non-elf")})
         assert elf_files == []
 
     def test_symlinks(self, new_dir):
         symlinked_path = Path(new_dir, "symlinked")
         symlinked_path.symlink_to("/bin/dash")
-        elf_files = elf_utils.get_elf_files_from_list(new_dir, {"symlinked"})
+        elf_files = elf_utils.get_elf_files_from_list(new_dir, {Path("symlinked")})
         assert elf_files == []
 
     def test_device_files(self):
-        elf_files = elf_utils.get_elf_files_from_list(Path("/dev"), {"null"})
+        elf_files = elf_utils.get_elf_files_from_list(Path("/dev"), {Path("null")})
         assert elf_files == []
 
     def test_fifo(self, new_dir):
-        fifo_path = os.path.join(new_dir, "fifo")
+        fifo_path = Path(new_dir, "fifo")
         os.mkfifo(fifo_path)
 
         try:
-            elf_files = elf_utils.get_elf_files_from_list(new_dir, {"fifo"})
+            elf_files = elf_utils.get_elf_files_from_list(new_dir, {Path("fifo")})
             assert elf_files == []
         finally:
-            os.unlink(fifo_path)
+            fifo_path.unlink()
 
 
 class TestGetDynamicLinker:

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -113,7 +113,7 @@ def test_post_prime_patchelf(
         **{
             "base": "core24",
             "build_attributes": ["enable-patchelf"],
-            "state.files": ["usr/bin/ls"],
+            "state.files": [Path("usr/bin/ls")],
             "prime_dir": tmp_path / "prime",
             "part_name": "my-part",
         }


### PR DESCRIPTION
Adjust calls to functions of craft-parts to use pathlib after [change in craft-parts API](https://github.com/canonical/craft-parts/pull/1424).

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [X] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
