### PR TITLE
fix: redirect snapcraft.io links in cli messages (#5921)

### DIFF
--- a/snapcraft/commands/validation_sets.py
+++ b/snapcraft/commands/validation_sets.py
@@ -78,7 +78,7 @@ class StoreEditValidationSetsCommand(AppCommand):
     help_msg = "Edit the list of validations for <snap-name>"
     overview = textwrap.dedent(
         """
-        Refer to https://snapcraft.io/docs/validation-sets for further information
+        Refer to https://documentation.ubuntu.com/snapcraft/stable/reference/commands/validation-sets/ for further information
         on Validation Sets.
         """
     )

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -862,5 +862,5 @@ def _warn_on_multiple_builds(
         )
         emit.message(
             "For more information, check out: "
-            "https://snapcraft.io/docs/explanation-architectures#core22-8"
+            "https://documentation.ubuntu.com/snapcraft/stable/explanation/architectures/#core22"
         )

--- a/snapcraft_legacy/cli/assertions.py
+++ b/snapcraft_legacy/cli/assertions.py
@@ -129,7 +129,7 @@ def list_validation_sets(name, sequence, **kwargs):
         snapcraft validation-sets --sequence all
         snapcraft validation-sets --name my-set --sequence 1
 
-    Refer to https://snapcraft.io/docs/validation-sets for further information
+    Refer to https://documentation.ubuntu.com/snapcraft/stable/reference/commands/validation-sets/ for further information
     on Validation Sets.
     """
     store_client = StoreClientCLI()

--- a/snapcraft_legacy/internal/deprecations.py
+++ b/snapcraft_legacy/internal/deprecations.py
@@ -43,7 +43,7 @@ _DEPRECATION_MESSAGES = {
     # dn14 is the next available slot.
 }
 
-_DEPRECATION_URL_FMT = "http://snapcraft.io/docs/deprecation-notices/{id}"
+_DEPRECATION_URL_FMT = "https://documentation.ubuntu.com/snapcraft/stable/release-notes/"
 
 logger = logging.getLogger(__name__)
 

--- a/tests/legacy/unit/meta/test_meta.py
+++ b/tests/legacy/unit/meta/test_meta.py
@@ -286,7 +286,7 @@ class CreateTestCase(CreateBaseTestCase):
             fake_logger.output,
         )
         self.assertIn(
-            "See http://snapcraft.io/docs/deprecation-notices/dn3", fake_logger.output
+            "See https://documentation.ubuntu.com/snapcraft/stable/release-notes/", fake_logger.output
         )
 
     @patch("os.link", side_effect=OSError("Invalid cross-device link"))

--- a/tests/legacy/unit/project_loader/test_schema.py
+++ b/tests/legacy/unit/project_loader/test_schema.py
@@ -257,7 +257,7 @@ class AliasesTest(ProjectLoaderBaseTest):
         )
         self.assertThat(
             fake_logger.output,
-            Contains("See http://snapcraft.io/docs/deprecation-notices/dn5"),
+            Contains("See https://documentation.ubuntu.com/snapcraft/stable/release-notes/"),
         )
 
     def test_duplicate_aliases(self):

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -2342,5 +2342,5 @@ def test_lifecycle_warn_on_multiple_builds(
     )
     emitter.assert_message(
         "For more information, check out: "
-        "https://snapcraft.io/docs/explanation-architectures#core22-8"
+        "https://documentation.ubuntu.com/snapcraft/stable/explanation/architectures/#core22"
     )


### PR DESCRIPTION
Cherry-picks #5921 into hotfix/8.14, so it can be included in the docs for 8.14.1.  (I meant to land that PR on hotfix/8.14 originally and forgot)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
