### PR TITLE
chore(merge): merge/8.12 into hotfix/8.14

### DIFF
--- a/docs/release-notes/snapcraft-8-12.rst
+++ b/docs/release-notes/snapcraft-8-12.rst
@@ -91,6 +91,11 @@ Snapcraft 8.12.0
 
 - `#5696`_ YAML structure is not validated before preprocessing
 
+Snapcraft 8.12.1
+~~~~~~~~~~~~~~~~
+
+- Launchpad requests ignore ``HTTP_PROXY``
+
 Contributors
 ------------
 


### PR DESCRIPTION
Merges the `hotfix/8.12` tag into `hotfix/8.14`, to bring in the 8.12.1 tag and release notes.

There was only one change in 8.12.1 and it's outdated, so there are no code changes here.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
