### PR TITLE
chore(merge): merge/8.13 into hotfix/8.14

### DIFF
--- a/docs/explanation/build-overrides.rst
+++ b/docs/explanation/build-overrides.rst
@@ -1,0 +1,18 @@
+.. |app| replace:: Snapcraft
+
+.. _how-to-override-the-default-build:
+
+.. _explanation-build-overrides:
+
+Build overrides
+===============
+
+.. include:: /common/craft-parts/how-to/override_build.rst
+    :start-line: 4
+
+
+See also
+--------
+
+:ref:`how-to-customize-the-build-and-part-variables` provides an example of an override
+for both the build and pull steps.

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -71,6 +71,7 @@ communicating with local processes, and storing user credentials.
     extensions
     components
     snap-configurations
+    build-overrides
     remote-build
     /common/craft-parts/explanation/filesets
     classic-confinement

--- a/docs/how-to/crafting/create-a-component.rst
+++ b/docs/how-to/crafting/create-a-component.rst
@@ -88,6 +88,6 @@ and the component file for the ``translations`` component.
    snapcraft upload hello-components_1.0_amd64.snap \
      --component translations=hello-components+translations_1.0.comp
 
-The store expects a snap and its components to be uploaded together. However, the component
-may have a different version than the snap. To dynamically set the component version,
-see :ref:`how-to-customize-the-build-and-part-variables-access-project-variables`.
+The store expects a snap and its components to be uploaded together. However, the
+component may have a different version than the snap. To dynamically set the component
+version, see :ref:`how-to-override-the-parts-lifecycle-access-project-variables`.

--- a/docs/how-to/crafting/index.rst
+++ b/docs/how-to/crafting/index.rst
@@ -15,8 +15,7 @@ Crafting
     use-layouts
     manage-data-compatibility
     include-local-files-and-remote-resources
-    override-the-default-build
-    customize-lifecycle-steps-and-part-variables
+    override-the-parts-lifecycle
     reuse-packages-between-builds
     create-a-component
     enable-classic-confinement

--- a/docs/how-to/crafting/override-the-default-build.rst
+++ b/docs/how-to/crafting/override-the-default-build.rst
@@ -1,9 +1,0 @@
-.. |app| replace:: Snapcraft
-
-.. _how-to-override-the-default-build:
-
-Override the default build
-==========================
-
-.. include:: /common/craft-parts/how-to/override_build.rst
-    :start-line: 4

--- a/docs/how-to/crafting/override-the-parts-lifecycle.rst
+++ b/docs/how-to/crafting/override-the-parts-lifecycle.rst
@@ -4,8 +4,10 @@
 
 .. _how-to-customize-the-build-and-part-variables:
 
-Customize lifecycle steps and project variables
-===============================================
+.. _how-to-override-the-parts-lifecycle:
+
+Override the parts lifecycle
+============================
 
 .. include:: /common/craft-parts/how-to/customise-the-build-with-craftctl.rst
     :start-line: 7
@@ -26,7 +28,10 @@ Example solutions
     :start-after: craftctl get <key>
     :end-before: Expose part variables in apps
 
+
 .. _how-to-customize-the-build-and-part-variables-access-project-variables:
+
+.. _how-to-override-the-parts-lifecycle-access-project-variables:
 
 Access project variables across parts and components
 ----------------------------------------------------

--- a/docs/how-to/debugging/use-the-classic-linter.rst
+++ b/docs/how-to/debugging/use-the-classic-linter.rst
@@ -106,7 +106,7 @@ Or, to set the ELF interpreter, the following command can be used:
 
 This can be done using override scripts in order to patch the binaries as part of the
 packaging of the snap. For more information, see
-:ref:`how-to-override-the-default-build`.
+:ref:`how-to-override-the-parts-lifecycle`.
 
 Enable automatic ELF file patching
 ----------------------------------

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -43,6 +43,8 @@
 "howto/craft-a-snap/example-ros-1-app.rst" "how-to/integrations/craft-an-ros-1-app.rst"
 "howto/craft-a-snap/example-ros-2-app.rst" "how-to/integrations/craft-an-ros-2-app.rst"
 "howto/craft-a-snap/example-ruby-app.rst" "how-to/integrations/index.rst"
+"how-to/crafting/override-the-default-build.rst" "explanation/build-overrides.rst"
+"how-to/crafting/customize-lifecycle-steps-and-part-variables.rst" "how-to/crafting/override-the-parts-lifecycle.rst"
 "how-to/integrations/craft-a-ruby-app.rst" "how-to/integrations/index.rst"
 "howto/craft-a-snap/example-rust-app.rst" "how-to/integrations/craft-a-rust-app.rst"
 "how-to/setup/select-a-build-provider.rst" "how-to/select-a-build-provider.rst"

--- a/docs/reference/layouts.rst
+++ b/docs/reference/layouts.rst
@@ -45,8 +45,7 @@ Layouts and their defintitions must satisfy the following requirements.
 **Strictly-confined snaps**. Layouts only work with `strictly-confined
 <https://snapcraft.io/docs/snap-confinement>`_ snaps, and not with classic confinement.
 
-
-**Allowed target paths**. The target path in a layout definition can't be any of:
+**Disallowed target paths**. The target path in a layout definition can't be:
 
 - ``/boot``
 - ``/dev``
@@ -68,7 +67,7 @@ Layouts and their defintitions must satisfy the following requirements.
 **Non-root filesystem objects**. The file or directory in a layout definition can't be
 at the root of the snap filesystem.
 
-**Like for like replacement**. Layouts can only replace filesystem objects of the same
+**Like-for-like replacement**. Layouts can only replace filesystem objects of the same
 type. This means that, for example, you can route a file to a file, a directory with a
 directory, and so on. You can't, on the other hand, replace directories with symbolic
 links.

--- a/docs/reference/project-file/anatomy-of-snapcraft-yaml.rst
+++ b/docs/reference/project-file/anatomy-of-snapcraft-yaml.rst
@@ -257,7 +257,7 @@ The ``override-pull`` key is an inline Bash script that runs during the pull ste
 that can't be satisfied by the default pull operation in the lifecycle. In the wethr
 example, the listed commands are used to derive the correct version of the app, and set
 it using the craftctl scriptlet. More details about overrides can be found in
-:ref:`how-to-override-the-default-build`.
+:ref:`explanation-build-overrides`.
 
 The ``build-packages`` key defines the list of tools and libraries required to
 successfully build or compile the part. The build packages are obtained from

--- a/docs/reference/snapshots.rst
+++ b/docs/reference/snapshots.rst
@@ -38,5 +38,5 @@ Including ``snapshots.yaml`` in a snap
 
 The ``snapshots.yaml`` file must be located within a snap's ``meta`` directory. This is
 typically done by creating a part that uses either the :ref:`craft_parts_dump_plugin` or
-a :ref:`build step override <how-to-override-the-default-build>` to copy
+a :ref:`build step override <how-to-override-the-parts-lifecycle>` to copy
 ``snapshots.yaml`` from another directory.

--- a/docs/release-notes/snapcraft-8-13.rst
+++ b/docs/release-notes/snapcraft-8-13.rst
@@ -42,7 +42,7 @@ Parts can now set a component versions dynamically. If a component points to a p
 the ``adopt-info`` key, the part can call craftctl to set the version.
 
 For detailed guidance, see
-:ref:`how-to-customize-the-build-and-part-variables-access-project-variables`.
+:ref:`how-to-override-the-parts-lifecycle-access-project-variables`.
 
 
 Documentation submodule name change

--- a/docs/tutorials/craft-a-snap.rst
+++ b/docs/tutorials/craft-a-snap.rst
@@ -149,13 +149,15 @@ sometimes informally referred to as its metadata. This information tells both hu
 machines about the snap, such as its purpose, authors, license, and so on. The comments
 in the template describe how to use these keys.
 
-Replace the top section with:
+Replace the first four keys with:
 
 .. literalinclude:: code/craft-a-snap/snapcraft.yaml
     :language: yaml
     :caption: snapcraft.yaml
     :start-at: name: ukuzama-pyfiglet
     :end-at: This snap is not endorsed by the pyfiglet project.
+
+Take care *not* to erase the ``grade`` and ``confinement`` keys.
 
 As this is a personal snap, we prepended the project name with a user name. Replace
 ``ukuzama`` with your own user name. You might encounter other snaps in the Snap Store
@@ -237,7 +239,7 @@ snap:
 
 After a few seconds, the final result is:
 
-.. terminal::
+.. code-block:: bash
 
     Packed ukuzama-pyfiglet_0.1_amd64.snap
 
@@ -270,7 +272,7 @@ by hand.
 The ``prime`` directory contains the state of the final files before they're packed. If
 we take a look at what's inside, we'll see:
 
-.. terminal::
+.. code-block:: text
 
     /root/prime
     ├── bin
@@ -362,22 +364,17 @@ these flags.
 
 At long last, let's try running our snap.
 
-.. literalinclude:: code/craft-a-snap/task.yaml
-    :language: bash
-    :start-at: ukuzama-pyfiglet hello, world!
-    :end-at: ukuzama-pyfiglet hello, world!
-    :dedent: 2
-
-You should see the successful result:
-
 .. terminal::
+    :input: ukuzama-pyfiglet hello, world!
+    :user: crafter
+    :host: home
 
-    _          _ _                             _     _ _
-   | |__   ___| | | ___    __      _____  _ __| | __| | |
-   | '_ \ / _ \ | |/ _ \   \ \ /\ / / _ \| '__| |/ _` | |
-   | | | |  __/ | | (_) |   \ V  V / (_) | |  | | (_| |_|
-   |_| |_|\___|_|_|\___( )   \_/\_/ \___/|_|  |_|\__,_(_)
-                       |/
+     _          _ _                             _     _ _
+    | |__   ___| | | ___    __      _____  _ __| | __| | |
+    | '_ \ / _ \ | |/ _ \   \ \ /\ / / _ \| '__| |/ _` | |
+    | | | |  __/ | | (_) |   \ V  V / (_) | |  | | (_| |_|
+    |_| |_|\___|_|_|\___( )   \_/\_/ \___/|_|  |_|\__,_(_)
+                        |/
 
 Pyfiglet can draw with different typeface styles, too. It's a fun little command.
 


### PR DESCRIPTION
There were 3 commits on `hotfix/8.13` that hadn't been part of a tagged released. I overlooked these when creating `hotfix/8.14`.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
