### PR TITLE
Fix kde-neon-6 LD_LIBRARY_PATH

### DIFF
--- a/snapcraft/extensions/kde_neon_6.py
+++ b/snapcraft/extensions/kde_neon_6.py
@@ -239,12 +239,13 @@ class KDENeon6(Extension):
                 "PLATFORM_PLUG": platform_kf6_snap,
                 "LD_LIBRARY_PATH": (
                     "${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}:"
-                    f"$SNAP/usr/lib:$SNAP/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}:"
-                    f"$SNAP/{lxqt_support_snap}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}"
+                    f"$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:"
+                    f"$SNAP/{lxqt_support_snap}/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR"
                 ),
                 "QT_PLUGIN_PATH": (
+                    "${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}:"
                     f"$SNAP/{lxqt_support_snap}/usr/lib/"
-                    "${CRAFT_ARCH_TRIPLET_BUILD_FOR}/qt6/plugins:${QT_PLUGIN_PATH}"
+                    "$CRAFT_ARCH_TRIPLET_BUILD_FOR/qt6/plugins"
                 ),
             },
             "hooks": {


### PR DESCRIPTION
I noticed that in Snapcraft, before the lxqt-support changes, the LD_LIBRARY_PATH looked something like this:

```LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}:$SNAP/usr/lib:$SNAP/usr/lib/x86_64-linux-gnu```

However, after the lxqt-support changes, this was replaced, and instead of the lxqt-support paths being added.

```LD_LIBRARY_PATH: $SNAP/lxqt-support-core24/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}```

Now the LD_LIBRARY_PATH should look something like this:

```LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}:$SNAP/usr/lib:$SNAP/usr/lib/x86_64-linux-gnu:$SNAP/lxqt-support-core24/usr/lib/x86_64-linux-gnu```

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
