### PR TITLE
style: remove redundant casts

### DIFF
--- a/snapcraft/parts/plugins/colcon_plugin.py
+++ b/snapcraft/parts/plugins/colcon_plugin.py
@@ -55,7 +55,7 @@ specific to the ROS distro. If not using the extension, set these in your
       - ROS_DISTRO: "humble"
 """
 
-from typing import Literal, cast
+from typing import Literal
 
 from craft_parts import plugins
 from craft_parts.packages.snaps import _get_parsed_snap
@@ -159,7 +159,7 @@ class ColconPlugin(_ros.RosPlugin):
 
     @overrides
     def _get_build_commands(self) -> list[str]:
-        options = cast(ColconPluginProperties, self._options)
+        options = self._options
 
         build_command = [
             "colcon",

--- a/snapcraft/store/client.py
+++ b/snapcraft/store/client.py
@@ -21,7 +21,7 @@ import platform
 import time
 from collections.abc import Sequence
 from datetime import timedelta
-from typing import Any, cast
+from typing import Any
 
 import craft_store
 import distro
@@ -647,12 +647,10 @@ class OnPremStoreClientCLI(LegacyStoreClientCLI):
             f"Ignoring snap_file_size of {snap_file_size!r} and built_at {built_at!r}"
         )
 
-        revision_request = cast(
-            craft_store.models.RevisionsRequestModel,
-            craft_store.models.RevisionsRequestModel.unmarshal(
-                {"upload-id": upload_id}
-            ),
+        revision_request = craft_store.models.RevisionsRequestModel.unmarshal(
+            {"upload-id": upload_id}
         )
+
         revision_response = self.store_client.notify_revision(
             name=snap_name, revision_request=revision_request
         )
@@ -709,10 +707,7 @@ class OnPremStoreClientCLI(LegacyStoreClientCLI):
         )
 
         return channel_map.ChannelMap.from_list_releases(
-            cast(
-                craft_store.models.SnapListReleasesModel,
-                craft_store.models.SnapListReleasesModel.unmarshal(response.json()),
-            )
+            craft_store.models.SnapListReleasesModel.unmarshal(response.json())
         )
 
     @overrides

--- a/tests/unit/store/test_channel_map.py
+++ b/tests/unit/store/test_channel_map.py
@@ -14,8 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import cast
-
 import pytest
 from craft_store.models import SnapListReleasesModel
 
@@ -454,9 +452,7 @@ def test_channel_map_from_list_releases_model():
         }
     )
 
-    cm = channel_map.ChannelMap.from_list_releases(
-        cast(SnapListReleasesModel, list_releases)
-    )
+    cm = channel_map.ChannelMap.from_list_releases(list_releases)
 
     # Check "channel-map".
     assert len(cm.channel_map) == 1


### PR DESCRIPTION
This PR removes redundant typing.cast calls flagged by ty.

No runtime behavior changes are introduced.

Related to #5970.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
