### PR TITLE
fix(craft-test): enable spread tests with 26.04 backends

### DIFF
--- a/snapcraft/templates/test/spread/.extension
+++ b/snapcraft/templates/test/spread/.extension
@@ -64,6 +64,9 @@ restore_each() {
     true
 }
 
+# If you want to allocate LXD VMs from remotes other than
+# "ubuntu", such as "ubuntu-daily", this function should be
+# modified to point there.
 allocate_lxdvm() {
     name=$(echo "$SPREAD_SYSTEM" | tr '[:punct:]' -)
     system=$(echo "$SPREAD_SYSTEM" | tr / -)


### PR DESCRIPTION
Uses the `ubuntu-daily` remote when a 26.04 image is requested. This is only a temporary workaround, with a long-term fix to be researched in [CRAFT-5002](https://warthogs.atlassian.net/browse/CRAFT-5002).

Tested by hand by running `snapcraft init --profile=test` an existing spread test snap, updating it to run on 26.04, and running it. Since this should be temporary, I'm not adding any tests right now, but I can create a spread test here if that's wanted.

CRAFT-4996.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.


[CRAFT-5002]: https://warthogs.atlassian.net/browse/CRAFT-5002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ